### PR TITLE
feat: add logout button on failed request

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.web.json --noEmit",
     "lint:write": "biome check --write --unsafe",
-    "format:write": "biome format --write --unsafe",
+    "format:write": "biome format --write",
     "check:write": "pnpm run lint:write && pnpm run typecheck",
     "generate-client": "tsx scripts/update-openapi-client.ts"
   },

--- a/src/renderer/components/TaskList.tsx
+++ b/src/renderer/components/TaskList.tsx
@@ -281,11 +281,19 @@ export function TaskList({
   if (error) {
     return (
       <Box height="100%" p="6">
-        <Flex direction="column" align="center" justify="center" height="100%" gap="4">
+        <Flex
+          direction="column"
+          align="center"
+          justify="center"
+          height="100%"
+          gap="4"
+        >
           <Text color="red">{error}</Text>
           <Flex gap="2">
             <Button onClick={() => fetchTasks()}>Retry</Button>
-            <Button variant="outline" onClick={logout}>Logout</Button>
+            <Button variant="outline" onClick={logout}>
+              Logout
+            </Button>
           </Flex>
         </Flex>
       </Box>


### PR DESCRIPTION
No way to logout if your API key is invalid, this adds a button to do that.