### PR TITLE
Fix first run experience (for developers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "mprocs",
     "dev:vite": "vite",
-    "dev:node": "tsc -p tsconfig.node.json --watch",
+    "dev:node": "cp src/main/package.json dist/main/package.json && tsc -p tsconfig.node.json --watch",
     "dev:preload": "tsc -p tsconfig.preload.json --watch",
     "dev:electron": "wait-on tcp:5173 && wait-on dist/main/index.js && electron . --dev",
     "build": "pnpm run build:node && pnpm run build:vite && pnpm run build:electron",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - electron
   - esbuild


### PR DESCRIPTION
Couldn't run because the watcher wasn't catching `package.json`, which meant first run looked like this:

<img width="505" height="342" alt="Screenshot 2025-10-10 at 12 24 35 PM" src="https://github.com/user-attachments/assets/beb5af68-ef2f-4bd5-84b5-7641b3a3315e" />

also added a fix for `pnpm-workspace.yaml` so that `pnpm install` would actually work.