### PR TITLE
fix: don't use latest biome version, derive from dependencies instead

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,7 +15,5 @@ jobs:
           persist-credentials: false
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
-        with:
-          version: latest
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
Removed biome version from the action so it uses the project's version instead.