### PR TITLE
feat: extract and display meeting participants

### DIFF
--- a/src/renderer/features/notetaker/components/RecordingView.tsx
+++ b/src/renderer/features/notetaker/components/RecordingView.tsx
@@ -47,17 +47,27 @@ export function RecordingView({ recordingItem }: RecordingViewProps) {
   const isPastRecording = recordingItem.type === "past";
   const hasSegments = segments.length > 0;
 
+  const participants =
+    recordingItem.type === "past"
+      ? (recordingItem.recording.participants as string[] | undefined)
+      : [
+          ...new Set(
+            segments
+              .map((s) => s.speaker)
+              .filter((s): s is string => s !== null && s !== undefined),
+          ),
+        ];
+
   return (
     <Box
       p="4"
       className="flex flex-1 flex-col gap-4 overflow-y-auto overflow-x-hidden"
     >
-      {/* Meeting Header */}
       <Flex direction="column" gap="2">
         <Text size="4" weight="bold">
           {recordingItem.recording.meeting_title || "Untitled meeting"}
         </Text>
-        <Flex gap="2">
+        <Flex gap="2" wrap="wrap">
           <Badge color="gray" variant="soft">
             {recordingItem.recording.platform}
           </Badge>
@@ -66,10 +76,29 @@ export function RecordingView({ recordingItem }: RecordingViewProps) {
               recordingItem.recording.created_at || new Date(),
             ).toLocaleString()}
           </Text>
+          {participants && participants.length > 0 && (
+            <>
+              <Text size="2" color="gray">
+                •
+              </Text>
+              <Text size="2" color="gray">
+                {participants.length} participant
+                {participants.length !== 1 ? "s" : ""}
+              </Text>
+            </>
+          )}
         </Flex>
+        {participants && participants.length > 0 && (
+          <Flex gap="1" wrap="wrap">
+            {participants.map((participant) => (
+              <Badge key={participant} color="blue" variant="soft" size="1">
+                {participant}
+              </Badge>
+            ))}
+          </Flex>
+        )}
       </Flex>
 
-      {/* Summary - only for past recordings */}
       {isPastRecording && (
         <Flex direction="column" gap="2">
           <Text size="2" weight="bold">
@@ -85,7 +114,6 @@ export function RecordingView({ recordingItem }: RecordingViewProps) {
         </Flex>
       )}
 
-      {/* Action items - only for past recordings */}
       {isPastRecording && (
         <Flex direction="column" gap="2">
           <Text size="2" weight="bold">
@@ -101,7 +129,6 @@ export function RecordingView({ recordingItem }: RecordingViewProps) {
         </Flex>
       )}
 
-      {/* Notes - only for past recordings */}
       {isPastRecording && (
         <Flex direction="column" gap="2">
           <Text size="2" weight="bold">
@@ -117,7 +144,6 @@ export function RecordingView({ recordingItem }: RecordingViewProps) {
         </Flex>
       )}
 
-      {/* Transcript */}
       <Flex direction="column" gap="2">
         <Flex justify="between" align="center">
           <Text size="2" weight="bold">


### PR DESCRIPTION
## Summary
- Extract unique participants from transcript segments when recording ends
- Display participant count and names in RecordingView header
- Show participants as blue badges below meeting metadata

## Implementation
**Client-side extraction** (`recordingService.ts`):
- When meeting ends, extract unique participants from all transcript segments
- Single-pass array operation with Set deduplication (efficient even for 1000+ segments)
- Update recording with participants list via API

**UI Display** (`RecordingView.tsx`):
- Show participant count in header metadata ("3 participants")
- Display participant names as blue badges
- For active recordings: extract from current segments
- For past recordings: use stored participants field

## Notes
Builds on #74 (live transcripts) which provides the RecordingView component.