### PR TITLE
feat: Display real-time clone progress in UI

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -94,8 +94,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   cloneRepository: (
     repoUrl: string,
     targetPath: string,
+    cloneId: string,
   ): Promise<{ cloneId: string }> =>
-    ipcRenderer.invoke("clone-repository", repoUrl, targetPath),
+    ipcRenderer.invoke("clone-repository", repoUrl, targetPath, cloneId),
   onCloneProgress: (
     cloneId: string,
     listener: (event: {

--- a/src/renderer/features/task-detail/components/TaskDetailPanel.tsx
+++ b/src/renderer/features/task-detail/components/TaskDetailPanel.tsx
@@ -99,6 +99,7 @@ export function TaskDetailPanel({ taskId, task }: TaskDetailPanelProps) {
           <TaskActions
             isRunning={execution.state.isRunning}
             isCloningRepo={repository.isCloning}
+            cloneProgress={taskData.cloneProgress}
             runMode={execution.state.runMode}
             onRunTask={execution.actions.run}
             onCancel={execution.actions.cancel}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -51,6 +51,7 @@ export interface IElectronAPI {
   cloneRepository: (
     repoUrl: string,
     targetPath: string,
+    cloneId: string,
   ) => Promise<{ cloneId: string }>;
   onCloneProgress: (
     cloneId: string,


### PR DESCRIPTION
## Summary

Adds visual feedback for repository cloning operations to improve onboarding UX. Users now see real-time clone progress when clicking "Run (Local)" on a task that requires cloning a repository.

![CleanShot 2025-11-12 at 12 30 53](https://github.com/user-attachments/assets/3a880675-1bb8-4a37-ac51-99c1ae96eb82)

### UI Changes
- **Button text** shows current clone stage (e.g., "Receiving objects", "Resolving deltas", "Updating files")
- **Progress bar** underneath button displays percentage completion (0-100%)
- **Zero delay** - instant UI feedback when initiating clone (no waiting for IPC round-trip)

### Technical Implementation
- Frontend generates `cloneId` before IPC call to eliminate UI delay
- Added `--progress` flag to git clone for progress output in non-interactive environments
- Parse progress from git stderr using regex and update UI in real-time
- Clean architecture: frontend controls clone state creation, backend executes clone

### Test Plan
- [ ] Delete posthog repository folder
- [ ] Click "Run (Local)" on a task
- [ ] Verify button immediately shows "Cloning PostHog/posthog..."
- [ ] Verify progress bar appears and fills from 0% to 100%
- [ ] Verify button text updates through stages: "Receiving objects", "Resolving deltas", "Updating files"
- [ ] Verify task starts automatically after clone completes