### PR TITLE
chore: Add task directory mapping store

### DIFF
--- a/src/renderer/features/task-detail/stores/taskExecutionStore.ts
+++ b/src/renderer/features/task-detail/stores/taskExecutionStore.ts
@@ -12,6 +12,7 @@ import type {
   TaskRun,
 } from "@shared/types";
 import { cloneStore } from "@stores/cloneStore";
+import { repositoryWorkspaceStore } from "@stores/repositoryWorkspaceStore";
 import { expandTildePath } from "@utils/path";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -503,10 +504,6 @@ export const useTaskExecutionStore = create<TaskExecutionStore>()(
           cloneStore
             .getState()
             .startClone(cloneId, task.repository_config, effectiveRepoPath);
-
-          const { repositoryWorkspaceStore } = await import(
-            "@stores/repositoryWorkspaceStore"
-          );
 
           try {
             await repositoryWorkspaceStore

--- a/src/renderer/stores/taskDirectoryStore.ts
+++ b/src/renderer/stores/taskDirectoryStore.ts
@@ -1,0 +1,82 @@
+import { expandTildePath } from "@utils/path";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface TaskDirectoryState {
+  taskDirectories: Record<string, string>;
+  repoDirectories: Record<string, string>;
+  getTaskDirectory: (taskId: string, repoKey?: string) => string | null;
+  setTaskDirectory: (taskId: string, directory: string) => void;
+  setRepoDirectory: (repoKey: string, directory: string) => void;
+  clearTaskDirectory: (taskId: string) => void;
+  clearRepoDirectory: (repoKey: string) => void;
+}
+
+export const useTaskDirectoryStore = create<TaskDirectoryState>()(
+  persist(
+    (set, get) => ({
+      taskDirectories: {},
+      repoDirectories: {},
+
+      getTaskDirectory: (taskId: string, repoKey?: string) => {
+        // 1. Check for direct task mapping
+        const taskDir = get().taskDirectories[taskId];
+        if (taskDir) {
+          return expandTildePath(taskDir);
+        }
+
+        // 2. Check for repo mapping (if repoKey provided)
+        if (repoKey) {
+          const repoDir = get().repoDirectories[repoKey];
+          if (repoDir) {
+            // Auto-map task to this directory for convenience
+            get().setTaskDirectory(taskId, repoDir);
+            return expandTildePath(repoDir);
+          }
+        }
+
+        // 3. No mapping found
+        return null;
+      },
+
+      setTaskDirectory: (taskId: string, directory: string) => {
+        set((state) => ({
+          taskDirectories: {
+            ...state.taskDirectories,
+            [taskId]: directory,
+          },
+        }));
+      },
+
+      setRepoDirectory: (repoKey: string, directory: string) => {
+        set((state) => ({
+          repoDirectories: {
+            ...state.repoDirectories,
+            [repoKey]: directory,
+          },
+        }));
+      },
+
+      clearTaskDirectory: (taskId: string) => {
+        set((state) => {
+          const { [taskId]: _, ...rest } = state.taskDirectories;
+          return { taskDirectories: rest };
+        });
+      },
+
+      clearRepoDirectory: (repoKey: string) => {
+        set((state) => {
+          const { [repoKey]: _, ...rest } = state.repoDirectories;
+          return { repoDirectories: rest };
+        });
+      },
+    }),
+    {
+      name: "task-directory-mappings",
+      partialize: (state) => ({
+        taskDirectories: state.taskDirectories,
+        repoDirectories: state.repoDirectories,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

Creates the foundation for task-to-directory mappings with localStorage persistence. This store enables tasks to remember which directory they should run in, and allows multiple tasks to share a single clone of a repository.

**Part of the task directory mapping refactor** - this is PR #2 in a stack of 5 PRs.

## Changes

- **New file**: `src/renderer/stores/taskDirectoryStore.ts`
- Two-level mapping:
  - `taskDirectories`: Direct task → directory assignments
  - `repoDirectories`: Repository → directory mappings (shared across tasks)
- `getTaskDirectory()`: Checks task mapping first, falls back to repo mapping, auto-saves if found
- Uses existing `expandTildePath` utility for tilde expansion
- Persists to localStorage via Zustand persist middleware

## Architecture

When resolving a directory for a task:
1. Check `taskDirectories[taskId]` - direct mapping
2. If not found and task has repo, check `repoDirectories[repoKey]` - shared clone
3. If found in step 2, auto-map task to that directory for future lookups
4. If not found, return null (will prompt user in future PRs)

## Next Steps

PR #3 will integrate this store into the task execution flow.

## Stack

- PR 1: ✅ Clone progress UI (#128)
- **PR 2: ← You are here**
- PR 3: Integrate directory store
- PR 4: UI enhancements
- PR 5: Cleanup and migration