### PR TITLE
feat: integrate task directory store into execution flow

### DIFF
--- a/src/renderer/stores/cloneStore.ts
+++ b/src/renderer/stores/cloneStore.ts
@@ -1,5 +1,6 @@
 import { useTaskExecutionStore } from "@features/task-detail/stores/taskExecutionStore";
 import type { RepositoryConfig } from "@shared/types";
+import { useTaskDirectoryStore } from "@stores/taskDirectoryStore";
 import { create } from "zustand";
 
 type CloneStatus = "cloning" | "complete" | "error";
@@ -50,6 +51,12 @@ export const cloneStore = create<CloneStore>((set, get) => {
     const operation = get().operations[cloneId];
     if (operation) {
       updateTaskRepoExists(operation.targetPath, true);
+
+      // Save repo → directory mapping for future tasks
+      const repoKey = `${operation.repository.organization}/${operation.repository.repository}`;
+      useTaskDirectoryStore
+        .getState()
+        .setRepoDirectory(repoKey, operation.targetPath);
     }
 
     window.setTimeout(


### PR DESCRIPTION
## Summary
- Integrates `taskDirectoryStore` into task execution flow
- Tasks now check stored directory mappings before deriving paths from workspace
- Persists directory assignments when repos are set or cloned
- Enables per-task directory customization and repo sharing across tasks

## Changes
- **`taskExecutionStore.ts`**: Updated `initializeRepoPath()` to check `taskDirectoryStore` first, then fall back to workspace-based derivation. Updated `setRepoPath()` to persist task→directory mapping.
- **`cloneStore.ts`**: Updated `handleComplete()` to save repo→directory mapping after successful clone for future task reuse.

## Test Plan
- [ ] Clone a repo for a task → verify mapping is saved
- [ ] Run another task with the same repo → verify it reuses the cloned directory
- [ ] Manually set a directory for a task → verify it persists across app restarts
- [ ] Verify tasks without `repository_config` still work

---
**Stack**: Built on top of:
- PR #128: Clone progress UI
- PR #130: Task directory store foundation