### PR TITLE
feat: add directory prompt on run and cloud mode gating

### DIFF
--- a/src/renderer/features/task-detail/components/TaskActions.tsx
+++ b/src/renderer/features/task-detail/components/TaskActions.tsx
@@ -7,6 +7,7 @@ interface TaskActionsProps {
   isCloningRepo: boolean;
   cloneProgress: { message: string; percent: number } | null;
   runMode: "local" | "cloud";
+  hasRepositoryConfig: boolean;
   onRunTask: () => void;
   onCancel: () => void;
   onRunModeChange: (mode: "local" | "cloud") => void;
@@ -17,6 +18,7 @@ export const TaskActions: React.FC<TaskActionsProps> = ({
   isCloningRepo,
   cloneProgress,
   runMode,
+  hasRepositoryConfig,
   onRunTask,
   onCancel,
   onRunModeChange,
@@ -58,12 +60,18 @@ export const TaskActions: React.FC<TaskActionsProps> = ({
           >
             <span className="truncate">{getRunButtonLabel()}</span>
           </Button>
-          <Tooltip content="Toggle between Local or Cloud Agent">
+          <Tooltip
+            content={
+              !hasRepositoryConfig
+                ? "Cloud mode requires a connected repository"
+                : "Toggle between Local or Cloud Agent"
+            }
+          >
             <IconButton
               size="2"
               variant="classic"
               color={runMode === "cloud" ? "blue" : "gray"}
-              disabled={isRunning || isCloningRepo}
+              disabled={isRunning || isCloningRepo || !hasRepositoryConfig}
               onClick={() =>
                 onRunModeChange(runMode === "local" ? "cloud" : "local")
               }

--- a/src/renderer/features/task-detail/components/TaskDetailPanel.tsx
+++ b/src/renderer/features/task-detail/components/TaskDetailPanel.tsx
@@ -90,8 +90,6 @@ export function TaskDetailPanel({ taskId, task }: TaskDetailPanelProps) {
                 ? { status: execution.state.progress.status }
                 : undefined
             }
-            derivedPath={taskData.derivedPath}
-            defaultWorkspace={taskData.defaultWorkspace}
           />
         </Flex>
 
@@ -101,6 +99,7 @@ export function TaskDetailPanel({ taskId, task }: TaskDetailPanelProps) {
             isCloningRepo={repository.isCloning}
             cloneProgress={taskData.cloneProgress}
             runMode={execution.state.runMode}
+            hasRepositoryConfig={!!taskData.task.repository_config}
             onRunTask={execution.actions.run}
             onCancel={execution.actions.cancel}
             onRunModeChange={execution.actions.onRunModeChange}

--- a/src/renderer/features/task-detail/components/TaskMetadata.tsx
+++ b/src/renderer/features/task-detail/components/TaskMetadata.tsx
@@ -1,28 +1,40 @@
-import { Button, Code, DataList, Link, Text, Tooltip } from "@radix-ui/themes";
+import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
+import { useTaskExecutionStore } from "@features/task-detail/stores/taskExecutionStore";
+import { Cross2Icon } from "@radix-ui/react-icons";
+import {
+  Box,
+  Button,
+  Code,
+  DataList,
+  Flex,
+  IconButton,
+  Link,
+  Text,
+  Tooltip,
+} from "@radix-ui/themes";
 import type { Task } from "@shared/types";
 import { format, formatDistanceToNow } from "date-fns";
 import type React from "react";
-import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
-import { useTaskExecutionStore } from "@features/task-detail/stores/taskExecutionStore";
 
 interface TaskMetadataProps {
   task: Task;
   progress?: { status: string };
-  derivedPath: string | null;
-  defaultWorkspace: string | null;
 }
 
 export const TaskMetadata: React.FC<TaskMetadataProps> = ({
   task,
   progress,
-  derivedPath,
-  defaultWorkspace,
 }) => {
-  const { setRepoPath, revalidateRepo } = useTaskExecutionStore();
+  const { setRepoPath, revalidateRepo, getTaskState } = useTaskExecutionStore();
+  const taskState = getTaskState(task.id);
 
   const handleWorkingDirectoryChange = async (newPath: string) => {
     setRepoPath(task.id, newPath);
     await revalidateRepo(task.id);
+  };
+
+  const handleClearDirectory = () => {
+    setRepoPath(task.id, null);
   };
 
   return (
@@ -73,16 +85,28 @@ export const TaskMetadata: React.FC<TaskMetadataProps> = ({
         <DataList.Item>
           <DataList.Label>Working directory</DataList.Label>
           <DataList.Value>
-            <FolderPicker
-              value={derivedPath || ""}
-              onChange={handleWorkingDirectoryChange}
-              placeholder={
-                !defaultWorkspace
-                  ? "No workspace configured"
-                  : "Select working directory..."
-              }
-              size="2"
-            />
+            <Flex gap="2" align="center" width="100%">
+              <Box style={{ flex: 1, minWidth: 0 }}>
+                <FolderPicker
+                  value={taskState.repoPath || ""}
+                  onChange={handleWorkingDirectoryChange}
+                  placeholder="Not set - click Run to select"
+                  size="2"
+                />
+              </Box>
+              {taskState.repoPath && (
+                <Tooltip content="Clear directory selection">
+                  <IconButton
+                    size="2"
+                    variant="ghost"
+                    color="gray"
+                    onClick={handleClearDirectory}
+                  >
+                    <Cross2Icon />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Flex>
           </DataList.Value>
         </DataList.Item>
 


### PR DESCRIPTION
## Summary

Implements the frictionless directory selection flow: when clicking "Run" without a directory set, Array prompts the user to either select an existing directory or clone the repository.

## User Flow

### For tasks WITH `repository_config`:

When user clicks "Run (Local)" without a directory:

1. **Prompt**: "Do you have `org/repo` locally?"
2. **Options**:
    - **"I have it locally"** → Opens native folder picker → Saves mapping → Runs task
    - **"Clone for me"** → Triggers clone with progress UI → Saves mapping → User clicks Run again after clone
    - **"Cancel"** → Returns to task detail

### For tasks WITHOUT `repository_config`:

When user clicks "Run (Local)" without a directory:

1. **Prompt**: "Select a working directory for this task"
2. **Opens folder picker** → Saves mapping → Runs task

### Invalid Directory Handling:

- If user selects an invalid directory → Validation fails silently → Prompt appears again
- No error spam, seamless recovery
- User can clear directory with X button and retry

### Working Directory Field:

- Shows **actual** directory that will be used (not derived fallback)
- Empty with "Not set - click Run to select" when no directory
- Clear button (X) appears only when directory is set

### Cloud Mode Gating:

- Cloud mode toggle is **disabled** for tasks without `repository_config`
- Tooltip explains: "Cloud mode requires a connected repository"

## Benefits

1. **Frictionless onboarding**: No upfront workspace configuration required
2. **Supports existing workflows**: Engineers can point to repos they already have cloned
3. **On-demand cloning**: Clone only when needed, with visual progress
4. **Flexible**: Supports both git-based and directory-only tasks
5. **Persistent**: Directory mappings survive app restarts
6. **Graceful recovery**: Invalid paths automatically re-prompt instead of erroring
7. **Clear UI**: Always shows what will actually be used

## Test Plan

- [x] Task with repo, no directory set → Prompt appears with 3 buttons
- [x] "I have it locally" → Folder picker opens → Selection persists
- [x] "Clone for me" → Clone progress shows → Directory saved after clone
- [x] Task without repo → Prompt shows "Select directory" with 2 buttons
- [x] Cloud mode disabled when no `repository_config` → Tooltip shows
- [x] Select invalid directory → Auto-prompts again (no error spam)
- [x] Clear directory with X button → Working directory shows empty → Run shows prompt
- [x] Working directory field shows actual path only

---

**Stack**: Built on top of:

- PR #128: Clone progress UI
- PR #130: Task directory store foundation
- PR #131: Integrate directory store into execution flow