### PR TITLE
refactor: replace task-specific panel store with centralized layout store

### DIFF
--- a/src/renderer/features/panels/constants/panelConstants.ts
+++ b/src/renderer/features/panels/constants/panelConstants.ts
@@ -1,0 +1,27 @@
+export const PANEL_SIZES = {
+  MIN_PANEL_SIZE: 15,
+  DEFAULT_SPLIT: [70, 30] as const,
+  EVEN_SPLIT: [50, 50] as const,
+  SIZE_DIFF_THRESHOLD: 0.1,
+} as const;
+
+export const UI_SIZES = {
+  TAB_HEIGHT: 40,
+  TAB_LABEL_MAX_WIDTH: 200,
+  DROP_ZONE_SIZE: "20%",
+} as const;
+
+export const DEFAULT_PANEL_IDS = {
+  ROOT: "root",
+  MAIN_PANEL: "main-panel",
+  RIGHT_GROUP: "right-group",
+  DETAILS_PANEL: "details-panel",
+  FILES_PANEL: "files-panel",
+} as const;
+
+export const DEFAULT_TAB_IDS = {
+  LOGS: "logs",
+  SHELL: "shell",
+  DETAILS: "details",
+  FILES: "files",
+} as const;

--- a/src/renderer/features/panels/store/panelLayoutStore.test.ts
+++ b/src/renderer/features/panels/store/panelLayoutStore.test.ts
@@ -1,0 +1,511 @@
+import {
+  assertActiveTab,
+  assertActiveTabInNestedPanel,
+  assertGroupStructure,
+  assertPanelLayout,
+  assertTabCount,
+  assertTabInNestedPanel,
+  closeMultipleTabs,
+  findPanelById,
+  type GroupNode,
+  getLayout,
+  getNestedPanel,
+  getPanelTree,
+  openMultipleFiles,
+  splitAndAssert,
+  testSizePreservation,
+  withRootGroup,
+} from "@test/panelTestHelpers";
+import { beforeEach, describe, expect, it } from "vitest";
+import { usePanelLayoutStore } from "./panelLayoutStore";
+
+describe("panelLayoutStore", () => {
+  beforeEach(() => {
+    usePanelLayoutStore.getState().clearAllLayouts();
+    localStorage.clear();
+  });
+
+  describe("initial state", () => {
+    it("returns null for non-existent task", () => {
+      const layout = usePanelLayoutStore.getState().getLayout("task-1");
+      expect(layout).toBeNull();
+    });
+
+    it("creates default layout when task is initialized", () => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      const layout = usePanelLayoutStore.getState().getLayout("task-1");
+
+      expect(layout).not.toBeNull();
+      expect(layout?.panelTree.type).toBe("group");
+    });
+
+    it("creates default layout with correct structure", () => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+
+      withRootGroup("task-1", (root: GroupNode) => {
+        assertGroupStructure(root, {
+          direction: "horizontal",
+          childCount: 2,
+          sizes: [70, 30],
+        });
+
+        assertPanelLayout(root, [
+          {
+            panelId: "main-panel",
+            expectedTabs: ["logs", "shell"],
+            activeTab: "logs",
+          },
+        ]);
+      });
+    });
+  });
+
+  describe("openFile", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+    });
+
+    it("adds file tab to main panel", () => {
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+
+      assertTabCount(getPanelTree("task-1"), "main-panel", 3);
+      assertPanelLayout(getPanelTree("task-1"), [
+        {
+          panelId: "main-panel",
+          expectedTabs: ["logs", "shell", "file-src/App.tsx"],
+        },
+      ]);
+    });
+
+    it("sets newly opened file as active", () => {
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+
+      assertActiveTab(getPanelTree("task-1"), "main-panel", "file-src/App.tsx");
+    });
+
+    it("does not duplicate file if already open", () => {
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+
+      const panel = findPanelById(getPanelTree("task-1"), "main-panel");
+      const fileTabs = panel?.content.tabs.filter((t: { id: string }) =>
+        t.id.startsWith("file-"),
+      );
+      expect(fileTabs).toHaveLength(1);
+    });
+
+    it("sets existing file as active when opened again", () => {
+      openMultipleFiles("task-1", ["src/App.tsx", "src/Other.tsx"]);
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+
+      assertActiveTab(getPanelTree("task-1"), "main-panel", "file-src/App.tsx");
+    });
+
+    it("tracks open files in metadata", () => {
+      openMultipleFiles("task-1", ["src/App.tsx", "src/Other.tsx"]);
+
+      const layout = getLayout("task-1");
+      expect(layout.openFiles).toContain("src/App.tsx");
+      expect(layout.openFiles).toContain("src/Other.tsx");
+      expect(layout.openFiles).toHaveLength(2);
+    });
+  });
+
+  describe("openArtifact", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+    });
+
+    it("adds artifact tab to main panel", () => {
+      usePanelLayoutStore.getState().openArtifact("task-1", "plan.md");
+
+      const panel = findPanelById(getPanelTree("task-1"), "main-panel");
+      const artifactTab = panel?.content.tabs.find((t: { id: string }) =>
+        t.id.startsWith("artifact-"),
+      );
+      expect(artifactTab?.id).toBe("artifact-plan.md");
+    });
+
+    it("tracks open artifacts in metadata", () => {
+      usePanelLayoutStore.getState().openArtifact("task-1", "plan.md");
+      usePanelLayoutStore.getState().openArtifact("task-1", "notes.md");
+
+      const layout = getLayout("task-1");
+      expect(layout.openArtifacts).toContain("plan.md");
+      expect(layout.openArtifacts).toContain("notes.md");
+      expect(layout.openArtifacts).toHaveLength(2);
+    });
+  });
+
+  describe("closeTab", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      openMultipleFiles("task-1", ["src/App.tsx", "src/Other.tsx"]);
+    });
+
+    it("removes tab from panel", () => {
+      usePanelLayoutStore
+        .getState()
+        .closeTab("task-1", "main-panel", "file-src/App.tsx");
+
+      const panel = findPanelById(getPanelTree("task-1"), "main-panel");
+      const fileTab = panel?.content.tabs.find(
+        (t: { id: string }) => t.id === "file-src/App.tsx",
+      );
+      expect(fileTab).toBeUndefined();
+    });
+
+    it("removes file from metadata", () => {
+      usePanelLayoutStore
+        .getState()
+        .closeTab("task-1", "main-panel", "file-src/App.tsx");
+
+      const layout = getLayout("task-1");
+      expect(layout.openFiles).not.toContain("src/App.tsx");
+      expect(layout.openFiles).toContain("src/Other.tsx");
+    });
+
+    it("auto-selects next tab when closing active tab", () => {
+      usePanelLayoutStore
+        .getState()
+        .closeTab("task-1", "main-panel", "file-src/Other.tsx");
+
+      assertActiveTab(getPanelTree("task-1"), "main-panel", "file-src/App.tsx");
+    });
+
+    it("falls back to shell when last file tab closed", () => {
+      closeMultipleTabs("task-1", "main-panel", [
+        "file-src/App.tsx",
+        "file-src/Other.tsx",
+      ]);
+
+      assertActiveTab(getPanelTree("task-1"), "main-panel", "shell");
+    });
+  });
+
+  describe("setActiveTab", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      openMultipleFiles("task-1", ["src/App.tsx", "src/Other.tsx"]);
+    });
+
+    it("changes active tab in panel", () => {
+      usePanelLayoutStore
+        .getState()
+        .setActiveTab("task-1", "main-panel", "file-src/App.tsx");
+
+      assertActiveTab(getPanelTree("task-1"), "main-panel", "file-src/App.tsx");
+    });
+  });
+
+  describe("task isolation", () => {
+    it("keeps tasks isolated from each other", () => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      usePanelLayoutStore.getState().initializeTask("task-2");
+
+      openMultipleFiles("task-1", ["src/App.tsx"]);
+      openMultipleFiles("task-2", ["src/Other.tsx"]);
+
+      const layout1 = getLayout("task-1");
+      const layout2 = getLayout("task-2");
+
+      expect(layout1.openFiles).toContain("src/App.tsx");
+      expect(layout1.openFiles).not.toContain("src/Other.tsx");
+
+      expect(layout2.openFiles).toContain("src/Other.tsx");
+      expect(layout2.openFiles).not.toContain("src/App.tsx");
+    });
+  });
+
+  describe("panel size persistence", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+    });
+
+    it(
+      "preserves custom panel sizes when opening a file",
+      testSizePreservation("opening a file", () => {
+        openMultipleFiles("task-1", ["src/App.tsx"]);
+      }, [50, 50]),
+    );
+
+    it(
+      "preserves custom panel sizes when switching tabs",
+      testSizePreservation("switching tabs", () => {
+        openMultipleFiles("task-1", ["src/App.tsx", "src/Other.tsx"]);
+        usePanelLayoutStore
+          .getState()
+          .setActiveTab("task-1", "main-panel", "file-src/App.tsx");
+      }, [60, 40]),
+    );
+
+    it(
+      "preserves custom panel sizes when closing tabs",
+      testSizePreservation("closing tabs", () => {
+        openMultipleFiles("task-1", ["src/App.tsx", "src/Other.tsx"]);
+        usePanelLayoutStore
+          .getState()
+          .closeTab("task-1", "main-panel", "file-src/Other.tsx");
+      }),
+    );
+
+    it(
+      "preserves custom panel sizes in nested groups when splitting panels",
+      testSizePreservation("splitting panels", () => {
+        openMultipleFiles("task-1", ["src/App.tsx", "src/Other.tsx"]);
+        usePanelLayoutStore
+          .getState()
+          .splitPanel(
+            "task-1",
+            "file-src/Other.tsx",
+            "main-panel",
+            "main-panel",
+            "right",
+          );
+      }, [65, 35]),
+    );
+  });
+
+  describe("persistence", () => {
+    it("persists state to localStorage", () => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+
+      const storedData = localStorage.getItem("panel-layout-store");
+      expect(storedData).not.toBeNull();
+
+      const parsed = JSON.parse(storedData!);
+      expect(parsed.state.taskLayouts["task-1"]).toBeDefined();
+      expect(parsed.state.taskLayouts["task-1"].openFiles).toContain(
+        "src/App.tsx",
+      );
+    });
+
+    it("restores state from localStorage", () => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+
+      const storedData = localStorage.getItem("panel-layout-store");
+
+      usePanelLayoutStore.getState().clearAllLayouts();
+      expect(usePanelLayoutStore.getState().getLayout("task-1")).toBeNull();
+
+      if (storedData) {
+        localStorage.setItem("panel-layout-store", storedData);
+        usePanelLayoutStore.persist.rehydrate();
+      }
+
+      const restoredLayout = getLayout("task-1");
+      expect(restoredLayout.openFiles).toContain("src/App.tsx");
+    });
+  });
+
+  describe("drag state", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+    });
+
+    it("tracks dragging tab state", () => {
+      usePanelLayoutStore
+        .getState()
+        .setDraggingTab("task-1", "file-src/App.tsx", "main-panel");
+
+      const layout = getLayout("task-1");
+      expect(layout.draggingTabId).toBe("file-src/App.tsx");
+      expect(layout.draggingTabPanelId).toBe("main-panel");
+    });
+
+    it("clears dragging tab state", () => {
+      usePanelLayoutStore
+        .getState()
+        .setDraggingTab("task-1", "file-src/App.tsx", "main-panel");
+      usePanelLayoutStore.getState().clearDraggingTab("task-1");
+
+      const layout = getLayout("task-1");
+      expect(layout.draggingTabId).toBeNull();
+      expect(layout.draggingTabPanelId).toBeNull();
+    });
+
+    it("isolates drag state between tasks", () => {
+      usePanelLayoutStore.getState().initializeTask("task-2");
+      usePanelLayoutStore
+        .getState()
+        .setDraggingTab("task-1", "file-src/App.tsx", "main-panel");
+
+      const layout1 = getLayout("task-1");
+      const layout2 = getLayout("task-2");
+
+      expect(layout1.draggingTabId).toBe("file-src/App.tsx");
+      expect(layout2.draggingTabId).toBeNull();
+    });
+  });
+
+  describe("reorderTabs", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      openMultipleFiles("task-1", [
+        "src/App.tsx",
+        "src/Other.tsx",
+        "src/Third.tsx",
+      ]);
+    });
+
+    it("reorders tabs within a panel", () => {
+      usePanelLayoutStore.getState().reorderTabs("task-1", "main-panel", 2, 3);
+
+      const panel = findPanelById(getPanelTree("task-1"), "main-panel");
+      const tabIds = panel?.content.tabs.map((t: { id: string }) => t.id);
+      expect(tabIds?.[2]).toBe("file-src/Other.tsx");
+      expect(tabIds?.[3]).toBe("file-src/App.tsx");
+    });
+
+    it("preserves active tab after reorder", () => {
+      usePanelLayoutStore
+        .getState()
+        .setActiveTab("task-1", "main-panel", "file-src/App.tsx");
+      usePanelLayoutStore.getState().reorderTabs("task-1", "main-panel", 0, 2);
+
+      assertActiveTabInNestedPanel("task-1", "file-src/App.tsx", "left");
+    });
+  });
+
+  describe("moveTab", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+    });
+
+    it("moves tab to different panel", () => {
+      usePanelLayoutStore
+        .getState()
+        .moveTab("task-1", "file-src/App.tsx", "main-panel", "details-panel");
+
+      assertTabInNestedPanel("task-1", "file-src/App.tsx", false, "left");
+      assertTabInNestedPanel(
+        "task-1",
+        "file-src/App.tsx",
+        true,
+        "right",
+        "left",
+      );
+    });
+
+    it("sets moved tab as active in target panel", () => {
+      usePanelLayoutStore
+        .getState()
+        .moveTab("task-1", "file-src/App.tsx", "main-panel", "details-panel");
+
+      assertActiveTabInNestedPanel(
+        "task-1",
+        "file-src/App.tsx",
+        "right",
+        "left",
+      );
+    });
+  });
+
+  describe("splitPanel", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+    });
+
+    it.each([
+      ["right", "horizontal"],
+      ["left", "horizontal"],
+      ["top", "vertical"],
+      ["bottom", "vertical"],
+    ] as const)(
+      "splits panel %s creates %s layout",
+      (direction, expectedDirection) => {
+        splitAndAssert(
+          "task-1",
+          "file-src/App.tsx",
+          direction,
+          expectedDirection,
+        );
+      },
+    );
+
+    it("moves tab to new split panel", () => {
+      usePanelLayoutStore
+        .getState()
+        .splitPanel(
+          "task-1",
+          "file-src/App.tsx",
+          "main-panel",
+          "main-panel",
+          "right",
+        );
+
+      assertTabInNestedPanel(
+        "task-1",
+        "file-src/App.tsx",
+        true,
+        "left",
+        "right",
+      );
+      assertActiveTabInNestedPanel(
+        "task-1",
+        "file-src/App.tsx",
+        "left",
+        "right",
+      );
+    });
+  });
+
+  describe("updateSizes", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+    });
+
+    it("updates panel group sizes", () => {
+      usePanelLayoutStore.getState().updateSizes("task-1", "root", [60, 40]);
+
+      withRootGroup("task-1", (root: GroupNode) => {
+        expect(root.sizes).toEqual([60, 40]);
+      });
+    });
+
+    it("updates nested group sizes", () => {
+      usePanelLayoutStore
+        .getState()
+        .updateSizes("task-1", "right-group", [30, 70]);
+
+      const rightGroup = getNestedPanel("task-1", "right");
+      assertGroupStructure(rightGroup, {
+        direction: "vertical",
+        childCount: 2,
+        sizes: [30, 70],
+      });
+    });
+  });
+
+  describe("tree cleanup", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+      usePanelLayoutStore.getState().openFile("task-1", "src/App.tsx");
+    });
+
+    it("removes empty panels after closing all tabs", () => {
+      usePanelLayoutStore
+        .getState()
+        .splitPanel(
+          "task-1",
+          "file-src/App.tsx",
+          "main-panel",
+          "main-panel",
+          "right",
+        );
+
+      const newPanel = getNestedPanel("task-1", "left", "right");
+      usePanelLayoutStore
+        .getState()
+        .closeTab("task-1", newPanel.id, "file-src/App.tsx");
+
+      const updatedLeftPanel = getNestedPanel("task-1", "left");
+      expect(updatedLeftPanel.type).toBe("leaf");
+    });
+  });
+});

--- a/src/renderer/features/panels/store/panelLayoutStore.ts
+++ b/src/renderer/features/panels/store/panelLayoutStore.ts
@@ -1,0 +1,471 @@
+import { persist } from "zustand/middleware";
+import { createWithEqualityFn } from "zustand/traditional";
+import {
+  DEFAULT_PANEL_IDS,
+  DEFAULT_TAB_IDS,
+  PANEL_SIZES,
+} from "../constants/panelConstants";
+import {
+  addNewTabToPanel,
+  applyCleanupWithFallback,
+  createArtifactTabId,
+  createFileTabId,
+  generatePanelId,
+  getLeafPanel,
+  getSplitConfig,
+  selectNextTabAfterClose,
+  updateMetadataForTab,
+  updateTaskLayout,
+} from "./panelStoreHelpers";
+import {
+  addTabToPanel,
+  cleanupNode,
+  findTabInPanel,
+  findTabInTree,
+  removeTabFromPanel,
+  setActiveTabInPanel,
+  updateTreeNode,
+} from "./panelTree";
+import type { PanelNode } from "./panelTypes";
+
+export interface TaskLayout {
+  panelTree: PanelNode;
+  openFiles: string[];
+  openArtifacts: string[];
+  draggingTabId: string | null;
+  draggingTabPanelId: string | null;
+}
+
+export type SplitDirection = "left" | "right" | "top" | "bottom";
+
+export interface PanelLayoutStore {
+  taskLayouts: Record<string, TaskLayout>;
+
+  getLayout: (taskId: string) => TaskLayout | null;
+  initializeTask: (taskId: string) => void;
+  openFile: (taskId: string, filePath: string) => void;
+  openArtifact: (taskId: string, fileName: string) => void;
+  closeTab: (taskId: string, panelId: string, tabId: string) => void;
+  setActiveTab: (taskId: string, panelId: string, tabId: string) => void;
+  setDraggingTab: (
+    taskId: string,
+    tabId: string | null,
+    panelId: string | null,
+  ) => void;
+  clearDraggingTab: (taskId: string) => void;
+  reorderTabs: (
+    taskId: string,
+    panelId: string,
+    sourceIndex: number,
+    targetIndex: number,
+  ) => void;
+  moveTab: (
+    taskId: string,
+    tabId: string,
+    sourcePanelId: string,
+    targetPanelId: string,
+  ) => void;
+  splitPanel: (
+    taskId: string,
+    tabId: string,
+    sourcePanelId: string,
+    targetPanelId: string,
+    direction: SplitDirection,
+  ) => void;
+  updateSizes: (taskId: string, groupId: string, sizes: number[]) => void;
+  clearAllLayouts: () => void;
+}
+
+function createDefaultPanelTree(): PanelNode {
+  return {
+    type: "group",
+    id: DEFAULT_PANEL_IDS.ROOT,
+    direction: "horizontal",
+    sizes: [...PANEL_SIZES.DEFAULT_SPLIT],
+    children: [
+      {
+        type: "leaf",
+        id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+        content: {
+          id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+          tabs: [
+            {
+              id: DEFAULT_TAB_IDS.LOGS,
+              label: "Logs",
+              component: null,
+              closeable: false,
+              draggable: true,
+            },
+            {
+              id: DEFAULT_TAB_IDS.SHELL,
+              label: "Shell",
+              component: null,
+              closeable: false,
+              draggable: true,
+            },
+          ],
+          activeTabId: DEFAULT_TAB_IDS.LOGS,
+          showTabs: true,
+          droppable: true,
+        },
+      },
+      {
+        type: "group",
+        id: DEFAULT_PANEL_IDS.RIGHT_GROUP,
+        direction: "vertical",
+        sizes: [...PANEL_SIZES.EVEN_SPLIT],
+        children: [
+          {
+            type: "leaf",
+            id: DEFAULT_PANEL_IDS.DETAILS_PANEL,
+            content: {
+              id: DEFAULT_PANEL_IDS.DETAILS_PANEL,
+              tabs: [
+                {
+                  id: DEFAULT_TAB_IDS.DETAILS,
+                  label: "Details",
+                  component: null,
+                  closeable: false,
+                  draggable: false,
+                },
+              ],
+              activeTabId: DEFAULT_TAB_IDS.DETAILS,
+              showTabs: true,
+              droppable: false,
+            },
+          },
+          {
+            type: "leaf",
+            id: DEFAULT_PANEL_IDS.FILES_PANEL,
+            content: {
+              id: DEFAULT_PANEL_IDS.FILES_PANEL,
+              tabs: [
+                {
+                  id: DEFAULT_TAB_IDS.FILES,
+                  label: "Files",
+                  component: null,
+                  closeable: false,
+                  draggable: false,
+                },
+              ],
+              activeTabId: DEFAULT_TAB_IDS.FILES,
+              showTabs: true,
+              droppable: false,
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function openTab(
+  state: { taskLayouts: Record<string, TaskLayout> },
+  taskId: string,
+  tabId: string,
+): { taskLayouts: Record<string, TaskLayout> } {
+  return updateTaskLayout(state, taskId, (layout) => {
+    // Check if tab already exists in tree
+    const existingTab = findTabInTree(layout.panelTree, tabId);
+
+    if (existingTab) {
+      // Tab exists, just activate it
+      const updatedTree = updateTreeNode(
+        layout.panelTree,
+        existingTab.panelId,
+        (panel) => setActiveTabInPanel(panel, tabId),
+      );
+
+      return { panelTree: updatedTree };
+    }
+
+    // Tab doesn't exist, add it to main panel
+    const mainPanel = getLeafPanel(
+      layout.panelTree,
+      DEFAULT_PANEL_IDS.MAIN_PANEL,
+    );
+    if (!mainPanel) return {};
+
+    const updatedTree = updateTreeNode(
+      layout.panelTree,
+      DEFAULT_PANEL_IDS.MAIN_PANEL,
+      (panel) => addNewTabToPanel(panel, tabId, true),
+    );
+
+    const metadata = updateMetadataForTab(layout, tabId, "add");
+
+    return {
+      panelTree: updatedTree,
+      ...metadata,
+    };
+  });
+}
+
+export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
+  persist(
+    (set, get) => ({
+      taskLayouts: {},
+
+      getLayout: (taskId) => {
+        return get().taskLayouts[taskId] || null;
+      },
+
+      initializeTask: (taskId) => {
+        set((state) => ({
+          taskLayouts: {
+            ...state.taskLayouts,
+            [taskId]: {
+              panelTree: createDefaultPanelTree(),
+              openFiles: [],
+              openArtifacts: [],
+              draggingTabId: null,
+              draggingTabPanelId: null,
+            },
+          },
+        }));
+      },
+
+      openFile: (taskId, filePath) => {
+        const tabId = createFileTabId(filePath);
+        set((state) => openTab(state, taskId, tabId));
+      },
+
+      openArtifact: (taskId, fileName) => {
+        const tabId = createArtifactTabId(fileName);
+        set((state) => openTab(state, taskId, tabId));
+      },
+
+      closeTab: (taskId, panelId, tabId) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, (layout) => {
+            const updatedTree = updateTreeNode(
+              layout.panelTree,
+              panelId,
+              (panel) => {
+                if (panel.type !== "leaf") return panel;
+
+                const tabIndex = panel.content.tabs.findIndex(
+                  (t) => t.id === tabId,
+                );
+                const remainingTabs = panel.content.tabs.filter(
+                  (t) => t.id !== tabId,
+                );
+
+                const newActiveTabId = selectNextTabAfterClose(
+                  remainingTabs,
+                  tabIndex,
+                  panel.content.activeTabId,
+                  tabId,
+                );
+
+                return {
+                  ...panel,
+                  content: {
+                    ...panel.content,
+                    tabs: remainingTabs,
+                    activeTabId: newActiveTabId,
+                  },
+                };
+              },
+            );
+
+            const cleanedTree = applyCleanupWithFallback(
+              cleanupNode(updatedTree),
+              layout.panelTree,
+            );
+            const metadata = updateMetadataForTab(layout, tabId, "remove");
+
+            return {
+              panelTree: cleanedTree,
+              ...metadata,
+            };
+          }),
+        );
+      },
+
+      setActiveTab: (taskId, panelId, tabId) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, (layout) => {
+            const updatedTree = updateTreeNode(
+              layout.panelTree,
+              panelId,
+              (panel) => setActiveTabInPanel(panel, tabId),
+            );
+
+            return { panelTree: updatedTree };
+          }),
+        );
+      },
+
+      setDraggingTab: (taskId, tabId, panelId) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, () => ({
+            draggingTabId: tabId,
+            draggingTabPanelId: panelId,
+          })),
+        );
+      },
+
+      clearDraggingTab: (taskId) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, () => ({
+            draggingTabId: null,
+            draggingTabPanelId: null,
+          })),
+        );
+      },
+
+      reorderTabs: (taskId, panelId, sourceIndex, targetIndex) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, (layout) => {
+            const updatedTree = updateTreeNode(
+              layout.panelTree,
+              panelId,
+              (panel) => {
+                if (panel.type !== "leaf") return panel;
+
+                const tabs = [...panel.content.tabs];
+                const [removed] = tabs.splice(sourceIndex, 1);
+                tabs.splice(targetIndex, 0, removed);
+
+                return {
+                  ...panel,
+                  content: {
+                    ...panel.content,
+                    tabs,
+                  },
+                };
+              },
+            );
+
+            return { panelTree: updatedTree };
+          }),
+        );
+      },
+
+      moveTab: (taskId, tabId, sourcePanelId, targetPanelId) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, (layout) => {
+            const sourcePanel = getLeafPanel(layout.panelTree, sourcePanelId);
+            if (!sourcePanel) return {};
+
+            const tab = findTabInPanel(sourcePanel, tabId);
+            if (!tab) return {};
+
+            const treeAfterRemove = updateTreeNode(
+              layout.panelTree,
+              sourcePanelId,
+              (panel) => removeTabFromPanel(panel, tabId),
+            );
+
+            const treeAfterAdd = updateTreeNode(
+              treeAfterRemove,
+              targetPanelId,
+              (panel) => addTabToPanel(panel, tab),
+            );
+
+            const cleanedTree = applyCleanupWithFallback(
+              cleanupNode(treeAfterAdd),
+              layout.panelTree,
+            );
+
+            return { panelTree: cleanedTree };
+          }),
+        );
+      },
+
+      splitPanel: (taskId, tabId, sourcePanelId, targetPanelId, direction) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, (layout) => {
+            const sourcePanel = getLeafPanel(layout.panelTree, sourcePanelId);
+            if (!sourcePanel) return {};
+
+            const targetPanel = getLeafPanel(layout.panelTree, targetPanelId);
+            if (!targetPanel) return {};
+
+            const tab = findTabInPanel(sourcePanel, tabId);
+            if (!tab) return {};
+
+            // For same-panel splits, need > 1 tab in the panel
+            if (
+              sourcePanelId === targetPanelId &&
+              targetPanel.content.tabs.length <= 1
+            ) {
+              return {};
+            }
+
+            const config = getSplitConfig(direction);
+            const newPanelId = generatePanelId();
+            const newPanel: PanelNode = {
+              type: "leaf",
+              id: newPanelId,
+              content: {
+                id: newPanelId,
+                tabs: [tab],
+                activeTabId: tab.id,
+                showTabs: true,
+                droppable: true,
+              },
+            };
+
+            // Remove tab from source panel
+            const treeAfterRemove = updateTreeNode(
+              layout.panelTree,
+              sourcePanelId,
+              (panel) => removeTabFromPanel(panel, tabId),
+            );
+
+            // Split the target panel
+            const updatedTree = updateTreeNode(
+              treeAfterRemove,
+              targetPanelId,
+              (panel) => {
+                const newGroup: PanelNode = {
+                  type: "group",
+                  id: generatePanelId(),
+                  direction: config.splitDirection,
+                  sizes: [50, 50],
+                  children: config.isAfter
+                    ? [panel, newPanel]
+                    : [newPanel, panel],
+                };
+                return newGroup;
+              },
+            );
+
+            const cleanedTree = applyCleanupWithFallback(
+              cleanupNode(updatedTree),
+              layout.panelTree,
+            );
+
+            return { panelTree: cleanedTree };
+          }),
+        );
+      },
+
+      updateSizes: (taskId, groupId, sizes) => {
+        set((state) =>
+          updateTaskLayout(state, taskId, (layout) => {
+            const updatedTree = updateTreeNode(
+              layout.panelTree,
+              groupId,
+              (node) => {
+                if (node.type !== "group") return node;
+                return { ...node, sizes };
+              },
+            );
+
+            return { panelTree: updatedTree };
+          }),
+        );
+      },
+
+      clearAllLayouts: () => {
+        set({ taskLayouts: {} });
+      },
+    }),
+    {
+      name: "panel-layout-store",
+    },
+  ),
+);

--- a/src/renderer/features/panels/store/panelStoreHelpers.ts
+++ b/src/renderer/features/panels/store/panelStoreHelpers.ts
@@ -1,0 +1,207 @@
+import { DEFAULT_TAB_IDS } from "../constants/panelConstants";
+import type { SplitDirection, TaskLayout } from "./panelLayoutStore";
+import type { GroupPanel, LeafPanel, PanelNode, Tab } from "./panelTypes";
+
+// Constants
+export const DEFAULT_FALLBACK_TAB = DEFAULT_TAB_IDS.LOGS;
+
+// Tab ID utilities
+export type TabType = "file" | "artifact" | "system";
+
+export interface ParsedTabId {
+  type: TabType;
+  value: string;
+}
+
+export function createFileTabId(filePath: string): string {
+  return `file-${filePath}`;
+}
+
+export function createArtifactTabId(fileName: string): string {
+  return `artifact-${fileName}`;
+}
+
+export function parseTabId(tabId: string): ParsedTabId {
+  if (tabId.startsWith("file-")) {
+    return { type: "file", value: tabId.slice(5) };
+  }
+  if (tabId.startsWith("artifact-")) {
+    return { type: "artifact", value: tabId.slice(9) };
+  }
+  return { type: "system", value: tabId };
+}
+
+export function createTabLabel(tabId: string): string {
+  const parsed = parseTabId(tabId);
+  if (parsed.type === "file") {
+    return parsed.value.split("/").pop() || parsed.value;
+  }
+  return parsed.value;
+}
+
+// Panel finding utilities
+export function findPanelById(
+  node: PanelNode,
+  panelId: string,
+): PanelNode | null {
+  if (node.id === panelId) {
+    return node;
+  }
+
+  if (node.type === "group") {
+    for (const child of node.children) {
+      const found = findPanelById(child, panelId);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+export function getLeafPanel(
+  tree: PanelNode,
+  panelId: string,
+): LeafPanel | null {
+  const panel = findPanelById(tree, panelId);
+  return panel?.type === "leaf" ? panel : null;
+}
+
+export function getGroupPanel(
+  tree: PanelNode,
+  panelId: string,
+): GroupPanel | null {
+  const panel = findPanelById(tree, panelId);
+  return panel?.type === "group" ? panel : null;
+}
+
+// Panel ID generation
+let nextPanelId = 1;
+
+export function generatePanelId(): string {
+  return `panel-${nextPanelId++}`;
+}
+
+export function resetPanelIdCounter(): void {
+  nextPanelId = 1;
+}
+
+// State update wrapper
+export function updateTaskLayout(
+  state: { taskLayouts: Record<string, TaskLayout> },
+  taskId: string,
+  updater: (layout: TaskLayout) => Partial<TaskLayout>,
+): { taskLayouts: Record<string, TaskLayout> } {
+  const layout = state.taskLayouts[taskId];
+  if (!layout) return state;
+
+  const updates = updater(layout);
+
+  return {
+    taskLayouts: {
+      ...state.taskLayouts,
+      [taskId]: {
+        ...layout,
+        ...updates,
+      },
+    },
+  };
+}
+
+// Tree update helpers
+export function createNewTab(tabId: string, closeable = true): Tab {
+  return {
+    id: tabId,
+    label: createTabLabel(tabId),
+    component: null,
+    closeable,
+    draggable: true,
+  };
+}
+
+export function addNewTabToPanel(
+  panel: PanelNode,
+  tabId: string,
+  closeable = true,
+): PanelNode {
+  if (panel.type !== "leaf") return panel;
+
+  return {
+    ...panel,
+    content: {
+      ...panel.content,
+      tabs: [...panel.content.tabs, createNewTab(tabId, closeable)],
+      activeTabId: tabId,
+    },
+  };
+}
+
+export function selectNextTabAfterClose(
+  tabs: Tab[],
+  closedTabIndex: number,
+  activeTabId: string,
+  closedTabId: string,
+): string {
+  if (activeTabId !== closedTabId) {
+    return activeTabId;
+  }
+
+  if (tabs.length === 0) {
+    return DEFAULT_FALLBACK_TAB;
+  }
+
+  const nextIndex = Math.min(closedTabIndex, tabs.length - 1);
+  return tabs[nextIndex].id;
+}
+
+// Split direction utilities
+export interface SplitConfig {
+  splitDirection: "horizontal" | "vertical";
+  isAfter: boolean;
+}
+
+export function getSplitConfig(direction: SplitDirection): SplitConfig {
+  const horizontalDirections: SplitDirection[] = ["left", "right"];
+  const afterDirections: SplitDirection[] = ["right", "bottom"];
+
+  return {
+    splitDirection: horizontalDirections.includes(direction)
+      ? "horizontal"
+      : "vertical",
+    isAfter: afterDirections.includes(direction),
+  };
+}
+
+// Metadata tracking utilities
+export function updateMetadataForTab(
+  layout: TaskLayout,
+  tabId: string,
+  action: "add" | "remove",
+): Pick<TaskLayout, "openFiles" | "openArtifacts"> {
+  const parsed = parseTabId(tabId);
+
+  if (parsed.type === "file") {
+    const openFiles =
+      action === "add"
+        ? [...layout.openFiles, parsed.value]
+        : layout.openFiles.filter((f) => f !== parsed.value);
+    return { openFiles, openArtifacts: layout.openArtifacts };
+  }
+
+  if (parsed.type === "artifact") {
+    const openArtifacts =
+      action === "add"
+        ? [...layout.openArtifacts, parsed.value]
+        : layout.openArtifacts.filter((f) => f !== parsed.value);
+    return { openFiles: layout.openFiles, openArtifacts };
+  }
+
+  return { openFiles: layout.openFiles, openArtifacts: layout.openArtifacts };
+}
+
+// Cleanup utilities
+export function applyCleanupWithFallback(
+  cleanedTree: PanelNode | null,
+  originalTree: PanelNode,
+): PanelNode {
+  return cleanedTree || originalTree;
+}

--- a/src/renderer/features/panels/store/panelTree.ts
+++ b/src/renderer/features/panels/store/panelTree.ts
@@ -57,6 +57,28 @@ export const findTabInPanel = (
   tabId: string,
 ): Tab | undefined => panel.content.tabs.find((t) => t.id === tabId);
 
+export const findTabInTree = (
+  node: PanelNode,
+  tabId: string,
+): { panelId: string; tab: Tab } | null => {
+  if (node.type === "leaf") {
+    const tab = node.content.tabs.find((t) => t.id === tabId);
+    if (tab) {
+      return { panelId: node.id, tab };
+    }
+    return null;
+  }
+
+  if (node.type === "group") {
+    for (const child of node.children) {
+      const result = findTabInTree(child, tabId);
+      if (result) return result;
+    }
+  }
+
+  return null;
+};
+
 export const updateTreeNode = (
   node: PanelNode,
   targetId: string,
@@ -143,7 +165,9 @@ export const mergeTreeContent = (
 
   if (isLeafNode(existingTree) && isLeafNode(newTree)) {
     // Create a map of new tabs by ID for quick lookup
-    const newTabsMap = new Map(newTree.content.tabs.map((tab) => [tab.id, tab]));
+    const newTabsMap = new Map(
+      newTree.content.tabs.map((tab) => [tab.id, tab]),
+    );
     const existingTabIds = new Set(existingTree.content.tabs.map((t) => t.id));
 
     // Update existing tabs with new components if they exist in new tree
@@ -173,7 +197,9 @@ export const mergeTreeContent = (
     const finalTabs = [...updatedTabs, ...newTabsToAdd];
 
     // Preserve the active tab if it still exists, otherwise use first tab
-    const activeTabId = finalTabs.some ((t) => t.id === existingTree.content.activeTabId)
+    const activeTabId = finalTabs.some(
+      (t) => t.id === existingTree.content.activeTabId,
+    )
       ? existingTree.content.activeTabId
       : finalTabs[0]?.id || "";
 

--- a/src/renderer/features/panels/store/panelTypes.ts
+++ b/src/renderer/features/panels/store/panelTypes.ts
@@ -7,6 +7,7 @@ export type Tab = {
   label: string;
   component?: React.ReactNode;
   closeable?: boolean;
+  draggable?: boolean;
   onClose?: () => void;
   onSelect?: () => void;
   icon?: React.ReactNode;

--- a/src/renderer/features/panels/utils/panelLayoutUtils.ts
+++ b/src/renderer/features/panels/utils/panelLayoutUtils.ts
@@ -1,0 +1,20 @@
+import { PANEL_SIZES } from "../constants/panelConstants";
+import type { GroupPanel } from "../store/panelTypes";
+
+export function calculateDefaultSize(node: GroupPanel, index: number): number {
+  return node.sizes?.[index] ?? 100 / node.children.length;
+}
+
+export function shouldUpdateSizes(
+  currentSizes: number[],
+  storeSizes: number[],
+): boolean {
+  if (currentSizes.length !== storeSizes.length) {
+    return false;
+  }
+
+  return currentSizes.some(
+    (size, i) =>
+      Math.abs(size - storeSizes[i]) > PANEL_SIZES.SIZE_DIFF_THRESHOLD,
+  );
+}

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,0 +1,47 @@
+import type { PanelNode, Tab } from "@features/panels/store/panelTypes";
+
+// Panel fixtures
+export function createMockTab(overrides?: Partial<Tab>): Tab {
+  return {
+    id: "test-tab",
+    label: "Test Tab",
+    component: undefined,
+    closeable: true,
+    ...overrides,
+  };
+}
+
+export function createMockLeafNode(overrides?: Partial<PanelNode>): PanelNode {
+  return {
+    type: "leaf",
+    id: "test-leaf",
+    content: {
+      id: "test-leaf",
+      tabs: [createMockTab()],
+      activeTabId: "test-tab",
+      showTabs: true,
+      droppable: true,
+    },
+    ...overrides,
+  } as PanelNode;
+}
+
+export function createMockGroupNode(overrides?: Partial<PanelNode>): PanelNode {
+  return {
+    type: "group",
+    id: "test-group",
+    direction: "horizontal",
+    children: [createMockLeafNode({ id: "leaf-1" })],
+    sizes: [100],
+    ...overrides,
+  } as PanelNode;
+}
+
+// File fixtures
+export const MOCK_FILES = [
+  { path: "App.tsx", name: "App.tsx" },
+  { path: "helper.ts", name: "helper.ts" },
+  { path: "README.md", name: "README.md" },
+];
+
+export const MOCK_FILE_CONTENT = "// file content";

--- a/src/test/panelTestHelpers.ts
+++ b/src/test/panelTestHelpers.ts
@@ -1,0 +1,386 @@
+import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
+import type { PanelNode } from "@features/panels/store/panelTypes";
+import type { Task } from "@shared/types";
+import { expect, vi } from "vitest";
+
+export function createMockTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "test-task-1",
+    task_number: 1,
+    slug: "test-task",
+    title: "Test Task",
+    description: "",
+    status: "pending",
+    origin_product: "test",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function mockElectronAPI(
+  overrides: Partial<typeof window.electronAPI> = {},
+) {
+  window.electronAPI = {
+    listRepoFiles: vi.fn().mockResolvedValue([
+      { path: "App.tsx", name: "App.tsx" },
+      { path: "helper.ts", name: "helper.ts" },
+      { path: "README.md", name: "README.md" },
+    ]),
+    readRepoFile: vi.fn().mockResolvedValue("// file content"),
+    shellCreate: vi.fn().mockResolvedValue(undefined),
+    shellWrite: vi.fn().mockResolvedValue(undefined),
+    shellResize: vi.fn().mockResolvedValue(undefined),
+    shellDispose: vi.fn().mockResolvedValue(undefined),
+    shellDestroy: vi.fn().mockResolvedValue(undefined),
+    onShellData: vi.fn().mockReturnValue(() => {}),
+    onShellExit: vi.fn().mockReturnValue(() => {}),
+    ...overrides,
+  } as any;
+}
+
+export interface PanelStructure {
+  id: string;
+  type: "group" | "leaf";
+  direction?: "horizontal" | "vertical";
+  tabIds?: string[];
+  activeTabId?: string;
+  children?: PanelStructure[];
+}
+
+export function getPanelStructure(node: PanelNode): PanelStructure {
+  if (node.type === "leaf") {
+    return {
+      id: node.id,
+      type: "leaf",
+      tabIds: node.content.tabs.map((t) => t.id),
+      activeTabId: node.content.activeTabId,
+    };
+  }
+
+  return {
+    id: node.id,
+    type: "group",
+    direction: node.direction,
+    children: node.children.map(getPanelStructure),
+  };
+}
+
+export function findPanelById(
+  node: PanelNode,
+  panelId: string,
+): Extract<PanelNode, { type: "leaf" }> | null {
+  if (node.id === panelId && node.type === "leaf") {
+    return node;
+  }
+
+  if (node.type === "group") {
+    for (const child of node.children) {
+      const found = findPanelById(child, panelId);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+export interface ExpectedPanelLayout {
+  panelId: string;
+  expectedTabs: string[];
+  activeTab?: string;
+}
+
+export function assertPanelLayout(
+  tree: PanelNode,
+  expectations: ExpectedPanelLayout[],
+) {
+  for (const { panelId, expectedTabs, activeTab } of expectations) {
+    const panel = findPanelById(tree, panelId);
+    if (!panel) {
+      throw new Error(`Panel ${panelId} not found in tree`);
+    }
+
+    const actualTabs = panel.content.tabs.map((t) => t.id);
+
+    if (actualTabs.length !== expectedTabs.length) {
+      throw new Error(
+        `Panel ${panelId}: expected ${expectedTabs.length} tabs but got ${actualTabs.length}. Expected: [${expectedTabs.join(", ")}], Got: [${actualTabs.join(", ")}]`,
+      );
+    }
+
+    for (const expectedTab of expectedTabs) {
+      if (!actualTabs.includes(expectedTab)) {
+        throw new Error(
+          `Panel ${panelId}: expected tab "${expectedTab}" but it was not found. Got: [${actualTabs.join(", ")}]`,
+        );
+      }
+    }
+
+    if (activeTab && panel.content.activeTabId !== activeTab) {
+      throw new Error(
+        `Panel ${panelId}: expected active tab "${activeTab}" but got "${panel.content.activeTabId}"`,
+      );
+    }
+  }
+}
+
+export function assertTabInPanel(
+  tree: PanelNode,
+  panelId: string,
+  tabId: string,
+) {
+  const panel = findPanelById(tree, panelId);
+  if (!panel) {
+    throw new Error(`Panel ${panelId} not found in tree`);
+  }
+
+  const hasTab = panel.content.tabs.some((t) => t.id === tabId);
+  if (!hasTab) {
+    const actualTabs = panel.content.tabs.map((t) => t.id).join(", ");
+    throw new Error(
+      `Tab "${tabId}" not found in panel ${panelId}. Actual tabs: [${actualTabs}]`,
+    );
+  }
+}
+
+export function assertActiveTab(
+  tree: PanelNode,
+  panelId: string,
+  expectedTabId: string,
+) {
+  const panel = findPanelById(tree, panelId);
+  if (!panel) {
+    throw new Error(`Panel ${panelId} not found in tree`);
+  }
+
+  if (panel.content.activeTabId !== expectedTabId) {
+    throw new Error(
+      `Panel ${panelId}: expected active tab "${expectedTabId}" but got "${panel.content.activeTabId}"`,
+    );
+  }
+}
+
+export function assertTabCount(
+  tree: PanelNode,
+  panelId: string,
+  expectedCount: number,
+) {
+  const panel = findPanelById(tree, panelId);
+  if (!panel) {
+    throw new Error(`Panel ${panelId} not found in tree`);
+  }
+
+  if (panel.content.tabs.length !== expectedCount) {
+    const actualTabs = panel.content.tabs.map((t) => t.id).join(", ");
+    throw new Error(
+      `Panel ${panelId}: expected ${expectedCount} tabs but got ${panel.content.tabs.length}. Actual: [${actualTabs}]`,
+    );
+  }
+}
+
+export interface ExpectedGroupStructure {
+  direction: "horizontal" | "vertical";
+  childCount: number;
+  sizes?: number[];
+}
+
+export function assertGroupStructure(
+  node: PanelNode,
+  expected: ExpectedGroupStructure,
+) {
+  if (node.type !== "group") {
+    throw new Error(
+      `Expected node to be a group but got ${node.type} (id: ${node.id})`,
+    );
+  }
+
+  if (node.direction !== expected.direction) {
+    throw new Error(
+      `Group ${node.id}: expected direction "${expected.direction}" but got "${node.direction}"`,
+    );
+  }
+
+  if (node.children.length !== expected.childCount) {
+    throw new Error(
+      `Group ${node.id}: expected ${expected.childCount} children but got ${node.children.length}`,
+    );
+  }
+
+  if (
+    expected.sizes &&
+    JSON.stringify(node.sizes) !== JSON.stringify(expected.sizes)
+  ) {
+    throw new Error(
+      `Group ${node.id}: expected sizes [${expected.sizes.join(", ")}] but got [${node.sizes?.join(", ") ?? "undefined"}]`,
+    );
+  }
+}
+
+export function openMultipleFiles(taskId: string, files: string[]) {
+  for (const file of files) {
+    usePanelLayoutStore.getState().openFile(taskId, file);
+  }
+}
+
+export function closeMultipleTabs(
+  taskId: string,
+  panelId: string,
+  tabIds: string[],
+) {
+  for (const tabId of tabIds) {
+    usePanelLayoutStore.getState().closeTab(taskId, panelId, tabId);
+  }
+}
+
+export type GroupNode = Extract<PanelNode, { type: "group" }>;
+
+export function withRootGroup(
+  taskId: string,
+  callback: (root: GroupNode) => void,
+) {
+  const layout = usePanelLayoutStore.getState().getLayout(taskId);
+  const root = layout?.panelTree;
+
+  if (!root) {
+    throw new Error(`No layout found for task ${taskId}`);
+  }
+
+  if (root.type !== "group") {
+    throw new Error(
+      `Expected group node for task ${taskId} but got ${root.type} (id: ${root.id})`,
+    );
+  }
+
+  callback(root);
+}
+
+export function testSizePreservation(
+  _testName: string,
+  operation: () => void,
+  customSizes: number[] = [55, 45],
+) {
+  return () => {
+    usePanelLayoutStore.getState().updateSizes("task-1", "root", customSizes);
+
+    const layoutBefore = usePanelLayoutStore.getState().getLayout("task-1");
+    const rootBefore = layoutBefore?.panelTree;
+    if (rootBefore && rootBefore.type === "group") {
+      expect(rootBefore.sizes).toEqual(customSizes);
+    }
+
+    operation();
+
+    withRootGroup("task-1", (root) => {
+      expect(root.sizes).toEqual(customSizes);
+    });
+  };
+}
+
+export type LeafNode = Extract<PanelNode, { type: "leaf" }>;
+
+export function getNestedPanel(
+  taskId: string,
+  ...path: Array<number | "left" | "right">
+): PanelNode {
+  const layout = usePanelLayoutStore.getState().getLayout(taskId);
+  const root = layout?.panelTree;
+
+  if (!root) {
+    throw new Error(`No layout found for task ${taskId}`);
+  }
+
+  let current: PanelNode = root;
+
+  for (const step of path) {
+    if (current.type !== "group") {
+      throw new Error(`Cannot navigate into leaf node at step ${step}`);
+    }
+
+    const index = step === "left" ? 0 : step === "right" ? 1 : step;
+    const child = current.children[index];
+
+    if (!child) {
+      throw new Error(`No child at index ${index} in group ${current.id}`);
+    }
+
+    current = child;
+  }
+
+  return current;
+}
+
+export function assertTabInNestedPanel(
+  taskId: string,
+  tabId: string,
+  hasTab: boolean,
+  ...path: Array<number | "left" | "right">
+) {
+  const panel = getNestedPanel(taskId, ...path);
+
+  if (panel.type !== "leaf") {
+    throw new Error(
+      `Expected leaf panel but got group at path [${path.join(", ")}]`,
+    );
+  }
+
+  const actualHasTab = panel.content.tabs.some((t) => t.id === tabId);
+
+  if (actualHasTab !== hasTab) {
+    const actualTabs = panel.content.tabs.map((t) => t.id).join(", ");
+    throw new Error(
+      hasTab
+        ? `Expected tab "${tabId}" in panel but it was not found. Actual tabs: [${actualTabs}]`
+        : `Expected tab "${tabId}" NOT to be in panel but it was found. Actual tabs: [${actualTabs}]`,
+    );
+  }
+}
+
+export function assertActiveTabInNestedPanel(
+  taskId: string,
+  expectedTabId: string,
+  ...path: Array<number | "left" | "right">
+) {
+  const panel = getNestedPanel(taskId, ...path);
+
+  if (panel.type !== "leaf") {
+    throw new Error(
+      `Expected leaf panel but got group at path [${path.join(", ")}]`,
+    );
+  }
+
+  if (panel.content.activeTabId !== expectedTabId) {
+    throw new Error(
+      `Panel at path [${path.join(", ")}]: expected active tab "${expectedTabId}" but got "${panel.content.activeTabId}"`,
+    );
+  }
+}
+
+export function getLayout(taskId: string) {
+  const layout = usePanelLayoutStore.getState().getLayout(taskId);
+  if (!layout) {
+    throw new Error(`No layout found for task ${taskId}`);
+  }
+  return layout;
+}
+
+export function getPanelTree(taskId: string) {
+  return getLayout(taskId).panelTree;
+}
+
+export function splitAndAssert(
+  taskId: string,
+  tabId: string,
+  direction: "top" | "bottom" | "left" | "right",
+  expectedDirection: "horizontal" | "vertical",
+) {
+  usePanelLayoutStore
+    .getState()
+    .splitPanel(taskId, tabId, "main-panel", "main-panel", direction);
+
+  const leftPanel = getNestedPanel(taskId, "left");
+  assertGroupStructure(leftPanel, {
+    direction: expectedDirection,
+    childCount: 2,
+    sizes: [50, 50],
+  });
+}


### PR DESCRIPTION
The way we were doing panel management was not great, this detaches all remaining panel logic from the renderer and puts it in a central store instead. This means we won't declare panels through JSX either.