### PR TITLE
feat: allow users to cancel oauth

### DIFF
--- a/apps/array/src/main/preload.ts
+++ b/apps/array/src/main/preload.ts
@@ -57,6 +57,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     region: CloudRegion,
   ): Promise<{ success: boolean; data?: OAuthTokenResponse; error?: string }> =>
     ipcRenderer.invoke("oauth:refresh-token", refreshToken, region),
+  oauthCancelFlow: (): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke("oauth:cancel-flow"),
   selectDirectory: (): Promise<string | null> =>
     ipcRenderer.invoke("select-directory"),
   searchDirectories: (query: string, searchRoot?: string): Promise<string[]> =>

--- a/apps/array/src/main/services/oauth.ts
+++ b/apps/array/src/main/services/oauth.ts
@@ -396,4 +396,19 @@ export function registerOAuthHandlers(): void {
       }
     },
   );
+
+  ipcMain.handle("oauth:cancel-flow", async () => {
+    try {
+      if (activeCloseServer) {
+        activeCloseServer();
+        activeCloseServer = null;
+      }
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  });
 }

--- a/apps/array/src/renderer/features/auth/components/AuthScreen.tsx
+++ b/apps/array/src/renderer/features/auth/components/AuthScreen.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   Heading,
   Select,
+  Spinner,
   Text,
 } from "@radix-ui/themes";
 import type { CloudRegion } from "@shared/types/oauth";
@@ -84,9 +85,14 @@ export function AuthScreen() {
     },
   });
 
-  const handleSignIn = () => {
-    setWorkspaceError(null);
-    authMutation.mutate({ selectedRegion: region, workspace });
+  const handleSignIn = async () => {
+    if (authMutation.isPending) {
+      authMutation.reset();
+      await window.electronAPI.oauthCancelFlow();
+    } else {
+      setWorkspaceError(null);
+      authMutation.mutate({ selectedRegion: region, workspace });
+    }
   };
 
   const handleRegionChange = (value: string) => {
@@ -175,14 +181,16 @@ export function AuthScreen() {
 
                   <Button
                     onClick={handleSignIn}
-                    disabled={authMutation.isPending || !workspace}
-                    variant="classic"
+                    disabled={!workspace}
+                    variant={"classic"}
                     size="3"
                     mt="2"
-                    loading={authMutation.isPending}
+                    color={authMutation.isPending ? "gray" : undefined}
                   >
+                    {authMutation.isPending && <Spinner />}
+
                     {authMutation.isPending
-                      ? "Waiting for authorization..."
+                      ? "Cancel authorization"
                       : "Sign in with PostHog"}
                   </Button>
                 </Flex>

--- a/apps/array/src/renderer/features/settings/components/SettingsView.tsx
+++ b/apps/array/src/renderer/features/settings/components/SettingsView.tsx
@@ -14,6 +14,7 @@ import {
   Flex,
   Heading,
   Select,
+  Spinner,
   Switch,
   Text,
 } from "@radix-ui/themes";
@@ -62,8 +63,11 @@ export function SettingsView() {
     },
   });
 
-  const handleReauthenticate = () => {
-    if (cloudRegion) {
+  const handleReauthenticate = async () => {
+    if (reauthMutation.isPending) {
+      reauthMutation.reset();
+      await window.electronAPI.oauthCancelFlow();
+    } else if (cloudRegion) {
       reauthMutation.mutate(cloudRegion);
     }
   };
@@ -263,11 +267,11 @@ export function SettingsView() {
                       variant="classic"
                       size="1"
                       onClick={handleReauthenticate}
-                      disabled={reauthMutation.isPending}
-                      loading={reauthMutation.isPending}
+                      color={reauthMutation.isPending ? "gray" : undefined}
                     >
+                      {reauthMutation.isPending && <Spinner />}
                       {reauthMutation.isPending
-                        ? "Authenticating..."
+                        ? "Cancel authorization"
                         : "Re-authenticate"}
                     </Button>
                     <Button

--- a/apps/array/src/renderer/types/electron.d.ts
+++ b/apps/array/src/renderer/types/electron.d.ts
@@ -35,6 +35,7 @@ declare global {
       data?: OAuthTokenResponse;
       error?: string;
     }>;
+    oauthCancelFlow: () => Promise<{ success: boolean; error?: string }>;
     selectDirectory: () => Promise<string | null>;
     searchDirectories: (
       query: string,


### PR DESCRIPTION
previously, users could not cancel the oauth flow when a browser window was opened, meaning they had to either restart or reload the application if something went wrong with the oauth provider. this PR makes it possible to cancel the sign in.

<img width="486" height="500" alt="image" src="https://github.com/user-attachments/assets/c28a6fac-141c-453e-8499-9aec9af15b8e" />
