### PR TITLE
feat: context menus for opening external editor

### DIFF
--- a/apps/array/src/main/preload.ts
+++ b/apps/array/src/main/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, type IpcRendererEvent, ipcRenderer } from "electron";
 import type { CloudRegion, OAuthTokenResponse } from "../shared/types/oauth";
 import type {
+  ExternalAppContextMenuResult,
   FolderContextMenuResult,
   SplitContextMenuResult,
   TabContextMenuResult,
@@ -319,17 +320,36 @@ contextBridge.exposeInMainWorld("electronAPI", {
   showTaskContextMenu: (
     taskId: string,
     taskTitle: string,
+    worktreePath?: string,
   ): Promise<TaskContextMenuResult> =>
-    ipcRenderer.invoke("show-task-context-menu", taskId, taskTitle),
+    ipcRenderer.invoke(
+      "show-task-context-menu",
+      taskId,
+      taskTitle,
+      worktreePath,
+    ),
   showFolderContextMenu: (
     folderId: string,
     folderName: string,
+    folderPath?: string,
   ): Promise<FolderContextMenuResult> =>
-    ipcRenderer.invoke("show-folder-context-menu", folderId, folderName),
-  showTabContextMenu: (canClose: boolean): Promise<TabContextMenuResult> =>
-    ipcRenderer.invoke("show-tab-context-menu", canClose),
+    ipcRenderer.invoke(
+      "show-folder-context-menu",
+      folderId,
+      folderName,
+      folderPath,
+    ),
+  showTabContextMenu: (
+    canClose: boolean,
+    filePath?: string,
+  ): Promise<TabContextMenuResult> =>
+    ipcRenderer.invoke("show-tab-context-menu", canClose, filePath),
   showSplitContextMenu: (): Promise<SplitContextMenuResult> =>
     ipcRenderer.invoke("show-split-context-menu"),
+  showFileContextMenu: (
+    filePath: string,
+  ): Promise<ExternalAppContextMenuResult> =>
+    ipcRenderer.invoke("show-file-context-menu", filePath),
   folders: {
     getFolders: (): Promise<
       Array<{

--- a/apps/array/src/main/services/contextMenu.types.ts
+++ b/apps/array/src/main/services/contextMenu.types.ts
@@ -1,12 +1,26 @@
-export type TaskContextMenuAction = "rename" | "duplicate" | "delete" | null;
+// External app actions (discriminated union for type safety)
+export type ExternalAppAction =
+  | { type: "open-in-app"; appId: string }
+  | { type: "copy-path" }
+  | null;
 
-export type FolderContextMenuAction = "remove" | null;
+export interface ExternalAppContextMenuResult {
+  action: ExternalAppAction;
+}
+
+export type TaskContextMenuAction =
+  | "rename"
+  | "duplicate"
+  | "delete"
+  | ExternalAppAction;
+
+export type FolderContextMenuAction = "remove" | ExternalAppAction;
 
 export type TabContextMenuAction =
   | "close"
   | "close-others"
   | "close-right"
-  | null;
+  | ExternalAppAction;
 
 export type SplitDirection = "left" | "right" | "up" | "down" | null;
 
@@ -31,6 +45,7 @@ declare global {
     showTaskContextMenu: (
       taskId: string,
       taskTitle: string,
+      worktreePath?: string,
     ) => Promise<TaskContextMenuResult>;
   }
 }

--- a/apps/array/src/main/services/index.ts
+++ b/apps/array/src/main/services/index.ts
@@ -20,3 +20,4 @@ import "./store.js";
 import "./transcription-prompts.js";
 import "./updates.js";
 import "./worktree.js";
+import "./worktreeUtils.js";

--- a/apps/array/src/main/services/store.ts
+++ b/apps/array/src/main/services/store.ts
@@ -5,6 +5,7 @@ import type {
   RegisteredFolder,
   TaskFolderAssociation,
 } from "../../shared/types";
+import { deleteWorktreeIfExists } from "./worktreeUtils";
 
 interface FoldersSchema {
   folders: RegisteredFolder[];
@@ -70,6 +71,17 @@ export const foldersStore = new Store<FoldersSchema>({
   },
 });
 
-export function clearAllStoreData(): void {
+export async function clearAllStoreData(): Promise<void> {
+  // Delete all worktrees before clearing store
+  const associations = foldersStore.get("taskAssociations", []);
+  for (const assoc of associations) {
+    if (assoc.worktree) {
+      await deleteWorktreeIfExists(
+        assoc.folderPath,
+        assoc.worktree.worktreePath,
+      );
+    }
+  }
+
   foldersStore.clear();
 }

--- a/apps/array/src/main/services/worktreeUtils.ts
+++ b/apps/array/src/main/services/worktreeUtils.ts
@@ -1,0 +1,17 @@
+import { WorktreeManager } from "@posthog/agent";
+import { logger } from "../lib/logger";
+
+const log = logger.scope("worktree-utils");
+
+export async function deleteWorktreeIfExists(
+  mainRepoPath: string,
+  worktreePath: string,
+): Promise<void> {
+  try {
+    const manager = new WorktreeManager({ mainRepoPath });
+    await manager.deleteWorktree(worktreePath);
+    log.debug(`Deleted worktree: ${worktreePath}`);
+  } catch (error) {
+    log.error(`Failed to delete worktree ${worktreePath}:`, error);
+  }
+}

--- a/apps/array/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
@@ -1,23 +1,29 @@
 import { PanelMessage } from "@components/ui/PanelMessage";
 import { CodeMirrorEditor } from "@features/code-editor/components/CodeMirrorEditor";
+import { getRelativePath } from "@features/code-editor/utils/pathUtils";
 import { useTaskData } from "@features/task-detail/hooks/useTaskData";
 import { Box } from "@radix-ui/themes";
 import type { Task } from "@shared/types";
+import { useWorktreeStore } from "@stores/worktreeStore";
 import { useQuery } from "@tanstack/react-query";
 
 interface CodeEditorPanelProps {
   taskId: string;
   task: Task;
-  filePath: string;
+  absolutePath: string;
 }
 
 export function CodeEditorPanel({
   taskId,
   task,
-  filePath,
+  absolutePath,
 }: CodeEditorPanelProps) {
   const taskData = useTaskData({ taskId, initialTask: task });
-  const repoPath = taskData.repoPath;
+  const worktreePath = useWorktreeStore(
+    (state) => state.taskWorktrees[taskId]?.worktreePath,
+  );
+  const repoPath = worktreePath ?? taskData.repoPath;
+  const filePath = getRelativePath(absolutePath, repoPath);
 
   const {
     data: fileContent,
@@ -49,7 +55,11 @@ export function CodeEditorPanel({
 
   return (
     <Box height="100%" style={{ overflow: "hidden" }}>
-      <CodeMirrorEditor content={fileContent} filePath={filePath} readOnly />
+      <CodeMirrorEditor
+        content={fileContent}
+        filePath={absolutePath}
+        readOnly
+      />
     </Box>
   );
 }

--- a/apps/array/src/renderer/features/code-editor/components/CodeMirrorDiffEditor.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/CodeMirrorDiffEditor.tsx
@@ -24,8 +24,9 @@ export function CodeMirrorDiffEditor({
       modified: modifiedContent,
       extensions,
       mode: viewMode,
+      filePath,
     }),
-    [originalContent, modifiedContent, extensions, viewMode],
+    [originalContent, modifiedContent, extensions, viewMode, filePath],
   );
   const containerRef = useCodeMirror(options);
 

--- a/apps/array/src/renderer/features/code-editor/components/CodeMirrorEditor.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/CodeMirrorEditor.tsx
@@ -15,8 +15,8 @@ export function CodeMirrorEditor({
 }: CodeMirrorEditorProps) {
   const extensions = useEditorExtensions(filePath, readOnly);
   const options = useMemo(
-    () => ({ doc: content, extensions }),
-    [content, extensions],
+    () => ({ doc: content, extensions, filePath }),
+    [content, extensions, filePath],
   );
   const containerRef = useCodeMirror(options);
 

--- a/apps/array/src/renderer/features/code-editor/components/DiffEditorPanel.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/DiffEditorPanel.tsx
@@ -1,6 +1,7 @@
 import { PanelMessage } from "@components/ui/PanelMessage";
 import { CodeMirrorDiffEditor } from "@features/code-editor/components/CodeMirrorDiffEditor";
 import { CodeMirrorEditor } from "@features/code-editor/components/CodeMirrorEditor";
+import { getRelativePath } from "@features/code-editor/utils/pathUtils";
 import { useTaskData } from "@features/task-detail/hooks/useTaskData";
 import { Box } from "@radix-ui/themes";
 import type { Task } from "@shared/types";
@@ -10,19 +11,20 @@ import { useQuery } from "@tanstack/react-query";
 interface DiffEditorPanelProps {
   taskId: string;
   task: Task;
-  filePath: string;
+  absolutePath: string;
 }
 
 export function DiffEditorPanel({
   taskId,
   task,
-  filePath,
+  absolutePath,
 }: DiffEditorPanelProps) {
   const taskData = useTaskData({ taskId, initialTask: task });
   const worktreePath = useWorktreeStore(
     (state) => state.taskWorktrees[taskId]?.worktreePath,
   );
   const repoPath = worktreePath ?? taskData.repoPath;
+  const filePath = getRelativePath(absolutePath, repoPath);
 
   const { data: changedFiles = [] } = useQuery({
     queryKey: ["changed-files-head", repoPath],
@@ -72,12 +74,12 @@ export function DiffEditorPanel({
         <CodeMirrorDiffEditor
           originalContent={originalContent ?? ""}
           modifiedContent={modifiedContent ?? ""}
-          filePath={filePath}
+          filePath={absolutePath}
         />
       ) : (
         <CodeMirrorEditor
           content={content ?? ""}
-          filePath={filePath}
+          filePath={absolutePath}
           readOnly
         />
       )}

--- a/apps/array/src/renderer/features/code-editor/utils/pathUtils.ts
+++ b/apps/array/src/renderer/features/code-editor/utils/pathUtils.ts
@@ -1,0 +1,9 @@
+export function getRelativePath(
+  absolutePath: string,
+  repoPath: string | null | undefined,
+): string {
+  if (!repoPath || !absolutePath.startsWith(repoPath)) {
+    return absolutePath;
+  }
+  return absolutePath.slice(repoPath.length + 1);
+}

--- a/apps/array/src/renderer/features/logs/components/LogEventRenderer.tsx
+++ b/apps/array/src/renderer/features/logs/components/LogEventRenderer.tsx
@@ -15,6 +15,7 @@ import { IS_DEV } from "@/constants/environment";
 
 const EVENT_COMPONENT_MAP: Record<
   string,
+  // biome-ignore lint/suspicious/noExplicitAny: Components handle type narrowing from AgentEvent union
   React.ComponentType<{ event: any }>
 > = {
   token: TokenView,

--- a/apps/array/src/renderer/features/logs/components/ToolExecutionView.tsx
+++ b/apps/array/src/renderer/features/logs/components/ToolExecutionView.tsx
@@ -34,9 +34,9 @@ interface ToolExecutionViewProps {
 }
 
 // Map tool names to their view components
-// biome-ignore lint/suspicious/noExplicitAny: Tool args have varying shapes, components handle type narrowing
 const TOOL_VIEW_MAP: Record<
   string,
+  // biome-ignore lint/suspicious/noExplicitAny: Tool args vary by type, components handle narrowing
   React.ComponentType<{ args: any; result?: any }>
 > = {
   Read: ReadToolView,
@@ -65,9 +65,9 @@ function getToolDisplayName(toolName: string): string {
   }
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: Args have varying shapes depending on tool
 function getToolSummary(
   toolName: string,
+  // biome-ignore lint/suspicious/noExplicitAny: Args accessed dynamically based on tool type
   args: Record<string, any>,
 ): ReactNode {
   switch (toolName) {
@@ -210,10 +210,11 @@ function getToolSummary(
   }
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: Args and results have varying shapes depending on tool
 function renderToolContent(
   toolName: string,
+  // biome-ignore lint/suspicious/noExplicitAny: Args accessed dynamically based on tool type
   args: Record<string, any>,
+  // biome-ignore lint/suspicious/noExplicitAny: Result type varies by tool
   result?: any,
 ) {
   // Extract args and result if structured

--- a/apps/array/src/renderer/features/panels/components/PanelTab.tsx
+++ b/apps/array/src/renderer/features/panels/components/PanelTab.tsx
@@ -1,3 +1,4 @@
+import type { TabData } from "@features/panels/store/panelTypes";
 import type React from "react";
 import { DraggableTab } from "./DraggableTab";
 import { StaticTab } from "./StaticTab";
@@ -6,6 +7,7 @@ interface PanelTabProps {
   tabId: string;
   panelId: string;
   label: string;
+  tabData: TabData;
   isActive: boolean;
   index: number;
   draggable?: boolean;
@@ -23,6 +25,7 @@ export const PanelTab: React.FC<PanelTabProps> = ({
   tabId,
   panelId,
   label,
+  tabData,
   isActive,
   index,
   draggable = true,
@@ -53,6 +56,7 @@ export const PanelTab: React.FC<PanelTabProps> = ({
       tabId={tabId}
       panelId={panelId}
       label={label}
+      tabData={tabData}
       isActive={isActive}
       index={index}
       closeable={closeable}

--- a/apps/array/src/renderer/features/panels/components/PanelTree.tsx
+++ b/apps/array/src/renderer/features/panels/components/PanelTree.tsx
@@ -113,6 +113,7 @@ function compileNode(element: React.ReactElement, path: string): PanelNode {
         tabs.push({
           id: tabId,
           label: label || tabId,
+          data: { type: "other" },
           component,
           closeable,
           onClose,
@@ -126,6 +127,7 @@ function compileNode(element: React.ReactElement, path: string): PanelNode {
         tabs.push({
           id: tabId,
           label: tabId,
+          data: { type: "other" },
           component: child,
         });
       }

--- a/apps/array/src/renderer/features/panels/components/TabbedPanel.tsx
+++ b/apps/array/src/renderer/features/panels/components/TabbedPanel.tsx
@@ -158,6 +158,7 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
                 tabId={tab.id}
                 panelId={panelId}
                 label={tab.label}
+                tabData={tab.data}
                 isActive={tab.id === content.activeTabId}
                 index={index}
                 draggable={tab.draggable}

--- a/apps/array/src/renderer/features/panels/store/panelLayoutStore.ts
+++ b/apps/array/src/renderer/features/panels/store/panelLayoutStore.ts
@@ -106,6 +106,7 @@ function createDefaultPanelTree(): PanelNode {
             {
               id: DEFAULT_TAB_IDS.LOGS,
               label: "Logs",
+              data: { type: "logs" },
               component: null,
               closeable: false,
               draggable: true,
@@ -113,6 +114,11 @@ function createDefaultPanelTree(): PanelNode {
             {
               id: DEFAULT_TAB_IDS.SHELL,
               label: "Terminal",
+              data: {
+                type: "terminal",
+                terminalId: DEFAULT_TAB_IDS.SHELL,
+                cwd: "",
+              },
               component: null,
               closeable: true,
               draggable: true,
@@ -138,6 +144,7 @@ function createDefaultPanelTree(): PanelNode {
                 {
                   id: DEFAULT_TAB_IDS.FILES,
                   label: "Files",
+                  data: { type: "other" },
                   component: null,
                   closeable: false,
                   draggable: false,
@@ -145,6 +152,7 @@ function createDefaultPanelTree(): PanelNode {
                 {
                   id: DEFAULT_TAB_IDS.CHANGES,
                   label: "Changes",
+                  data: { type: "other" },
                   component: null,
                   closeable: false,
                   draggable: false,
@@ -164,6 +172,7 @@ function createDefaultPanelTree(): PanelNode {
                 {
                   id: DEFAULT_TAB_IDS.TODO_LIST,
                   label: "Todo list",
+                  data: { type: "other" },
                   component: null,
                   closeable: false,
                   draggable: false,
@@ -171,6 +180,7 @@ function createDefaultPanelTree(): PanelNode {
                 {
                   id: DEFAULT_TAB_IDS.ARTIFACTS,
                   label: "Artifacts",
+                  data: { type: "other" },
                   component: null,
                   closeable: false,
                   draggable: false,
@@ -178,6 +188,7 @@ function createDefaultPanelTree(): PanelNode {
                 {
                   id: DEFAULT_TAB_IDS.DETAILS,
                   label: "Details",
+                  data: { type: "other" },
                   component: null,
                   closeable: false,
                   draggable: false,
@@ -668,6 +679,7 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
                 return addTabToPanel(panel, {
                   id: tabId,
                   label: "Terminal",
+                  data: { type: "terminal", terminalId: tabId, cwd: "" },
                   component: null,
                   draggable: true,
                   closeable: true,
@@ -687,7 +699,7 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
     {
       name: "panel-layout-store",
       // Bump this version when the default panel structure changes to reset all layouts
-      version: 3,
+      version: 4,
       migrate: () => ({ taskLayouts: {} }),
     },
   ),

--- a/apps/array/src/renderer/features/panels/store/panelTypes.ts
+++ b/apps/array/src/renderer/features/panels/store/panelTypes.ts
@@ -1,10 +1,48 @@
+import type { GitFileStatus } from "@shared/types";
+
 export type PanelId = string;
 export type TabId = string;
 export type GroupId = string;
 
+/**
+ * Discriminated union for tab-specific data
+ * Each tab type can carry its own typed data
+ */
+export type TabData =
+  | {
+      type: "file";
+      relativePath: string;
+      absolutePath: string;
+      repoPath: string;
+    }
+  | {
+      type: "diff";
+      relativePath: string;
+      absolutePath: string;
+      repoPath: string;
+      status: GitFileStatus;
+    }
+  | {
+      type: "terminal";
+      terminalId: string;
+      cwd: string;
+    }
+  | {
+      type: "artifact";
+      artifactId: string;
+    }
+  | {
+      type: "logs";
+    }
+  | {
+      type: "other";
+      // Generic tab without specific data
+    };
+
 export type Tab = {
   id: TabId;
   label: string;
+  data: TabData;
   component?: React.ReactNode;
   closeable?: boolean;
   draggable?: boolean;

--- a/apps/array/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/array/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -73,7 +73,8 @@ function SidebarMenuComponent() {
   const handleTaskContextMenu = (taskId: string, e: React.MouseEvent) => {
     const task = taskMap.get(taskId);
     if (task) {
-      showContextMenu(task, e);
+      const worktreePath = taskWorktrees[taskId]?.worktreePath;
+      showContextMenu(task, e, worktreePath);
     }
   };
 
@@ -102,10 +103,17 @@ function SidebarMenuComponent() {
     const result = await window.electronAPI.showFolderContextMenu(
       folderId,
       folder.name,
+      folder.path,
     );
 
     if (result.action === "remove") {
       await removeFolder(folderId);
+    } else if (result.action && typeof result.action === "object") {
+      // Handle external app actions
+      const { handleExternalAppAction } = await import(
+        "@utils/handleExternalAppAction"
+      );
+      await handleExternalAppAction(result.action, folder.path, folder.name);
     }
   };
 

--- a/apps/array/src/renderer/features/sidebar/components/items/TaskItem.tsx
+++ b/apps/array/src/renderer/features/sidebar/components/items/TaskItem.tsx
@@ -80,12 +80,7 @@ function DiffStatsDisplay({ worktreePath }: DiffStatsDisplayProps) {
       className="ml-auto flex shrink-0 bg-transparent text-[10px] text-gray-10"
       style={{ gap: "4px" }}
     >
-      {parts.reduce<React.ReactNode[]>((acc, part, i) => {
-        // biome-ignore lint/suspicious/noArrayIndexKey: Separator keys are stable and order-dependent
-        if (i > 0) acc.push(<span key={`sep-${i}`}>, </span>);
-        acc.push(part);
-        return acc;
-      }, [])}
+      {parts}
     </span>
   );
 }

--- a/apps/array/src/renderer/features/task-detail/components/FileTreePanel.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/FileTreePanel.tsx
@@ -5,6 +5,7 @@ import { FileIcon, FolderIcon, FolderOpenIcon } from "@phosphor-icons/react";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import type { Task } from "@shared/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { handleExternalAppAction } from "@utils/handleExternalAppAction";
 import { useEffect, useState } from "react";
 
 interface FileTreePanelProps {
@@ -44,6 +45,15 @@ function LazyTreeItem({ entry, depth, taskId, repoPath }: LazyTreeItemProps) {
     }
   };
 
+  const handleContextMenu = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    const result = await window.electronAPI.showFileContextMenu(entry.path);
+
+    if (!result.action) return;
+
+    await handleExternalAppAction(result.action, entry.path, entry.name);
+  };
+
   return (
     <Box>
       <Flex
@@ -54,6 +64,7 @@ function LazyTreeItem({ entry, depth, taskId, repoPath }: LazyTreeItemProps) {
         style={{ paddingLeft: `${depth * 16 + 8}px`, cursor: "pointer" }}
         className="rounded hover:bg-gray-2"
         onClick={handleClick}
+        onContextMenu={handleContextMenu}
       >
         {entry.type === "directory" ? (
           isExpanded ? (

--- a/apps/array/src/renderer/stores/externalAppsStore.ts
+++ b/apps/array/src/renderer/stores/externalAppsStore.ts
@@ -1,0 +1,40 @@
+import type { DetectedApplication } from "@shared/types";
+import { create } from "zustand";
+
+interface ExternalAppsState {
+  detectedApps: DetectedApplication[];
+  lastUsedAppId: string | undefined;
+  isLoading: boolean;
+
+  // Actions
+  initialize: () => Promise<void>;
+  setLastUsedApp: (appId: string) => Promise<void>;
+}
+
+export const useExternalAppsStore = create<ExternalAppsState>((set) => ({
+  detectedApps: [],
+  lastUsedAppId: undefined,
+  isLoading: true,
+
+  initialize: async () => {
+    try {
+      const [apps, lastUsed] = await Promise.all([
+        window.electronAPI.externalApps.getDetectedApps(),
+        window.electronAPI.externalApps.getLastUsed(),
+      ]);
+
+      set({
+        detectedApps: apps,
+        lastUsedAppId: lastUsed.lastUsedApp,
+        isLoading: false,
+      });
+    } catch (_error) {
+      set({ isLoading: false });
+    }
+  },
+
+  setLastUsedApp: async (appId: string) => {
+    await window.electronAPI.externalApps.setLastUsed(appId);
+    set({ lastUsedAppId: appId });
+  },
+}));

--- a/apps/array/src/renderer/types/electron.d.ts
+++ b/apps/array/src/renderer/types/electron.d.ts
@@ -1,8 +1,10 @@
 import type { AgentEvent } from "@posthog/agent";
 import type {
+  ExternalAppContextMenuResult,
   FolderContextMenuResult,
   SplitContextMenuResult,
   TabContextMenuResult,
+  TaskContextMenuResult,
 } from "@main/services/contextMenu.types";
 import type {
   ChangedFile,
@@ -194,12 +196,24 @@ declare global {
       listener: (data: string) => void,
     ) => () => void;
     onShellExit: (sessionId: string, listener: () => void) => () => void;
+    showTaskContextMenu: (
+      taskId: string,
+      taskTitle: string,
+      worktreePath?: string,
+    ) => Promise<TaskContextMenuResult>;
     showFolderContextMenu: (
       folderId: string,
       folderName: string,
+      folderPath?: string,
     ) => Promise<FolderContextMenuResult>;
-    showTabContextMenu: (canClose: boolean) => Promise<TabContextMenuResult>;
+    showTabContextMenu: (
+      canClose: boolean,
+      filePath?: string,
+    ) => Promise<TabContextMenuResult>;
     showSplitContextMenu: () => Promise<SplitContextMenuResult>;
+    showFileContextMenu: (
+      filePath: string,
+    ) => Promise<ExternalAppContextMenuResult>;
     folders: {
       getFolders: () => Promise<RegisteredFolder[]>;
       addFolder: (folderPath: string) => Promise<RegisteredFolder>;

--- a/apps/array/src/renderer/utils/handleExternalAppAction.ts
+++ b/apps/array/src/renderer/utils/handleExternalAppAction.ts
@@ -1,0 +1,44 @@
+import type { ExternalAppAction } from "@main/services/contextMenu.types";
+import { logger } from "@renderer/lib/logger";
+import { useExternalAppsStore } from "@stores/externalAppsStore";
+import { toast } from "@utils/toast";
+
+const log = logger.scope("external-app-action");
+
+export async function handleExternalAppAction(
+  action: ExternalAppAction,
+  filePath: string,
+  displayName: string,
+): Promise<void> {
+  if (!action) return;
+
+  if (action.type === "open-in-app") {
+    log.info("Opening file in app", {
+      appId: action.appId,
+      filePath,
+      displayName,
+    });
+    const openResult = await window.electronAPI.externalApps.openInApp(
+      action.appId,
+      filePath,
+    );
+    if (openResult.success) {
+      await useExternalAppsStore.getState().setLastUsedApp(action.appId);
+
+      const apps = await window.electronAPI.externalApps.getDetectedApps();
+      const app = apps.find((a) => a.id === action.appId);
+      toast.success(`Opening in ${app?.name || "external app"}`, {
+        description: displayName,
+      });
+    } else {
+      toast.error("Failed to open in external app", {
+        description: openResult.error || "Unknown error",
+      });
+    }
+  } else if (action.type === "copy-path") {
+    await window.electronAPI.externalApps.copyPath(filePath);
+    toast.success("Path copied to clipboard", {
+      description: filePath,
+    });
+  }
+}

--- a/apps/array/src/test/fixtures.ts
+++ b/apps/array/src/test/fixtures.ts
@@ -5,6 +5,7 @@ export function createMockTab(overrides?: Partial<Tab>): Tab {
   return {
     id: "test-tab",
     label: "Test Tab",
+    data: { type: "other" },
     component: undefined,
     closeable: true,
     ...overrides,

--- a/apps/array/src/test/panelTestHelpers.ts
+++ b/apps/array/src/test/panelTestHelpers.ts
@@ -36,7 +36,7 @@ export function mockElectronAPI(
     onShellData: vi.fn().mockReturnValue(() => {}),
     onShellExit: vi.fn().mockReturnValue(() => {}),
     ...overrides,
-  } as any;
+  } as unknown as typeof window.electronAPI;
 }
 
 export interface PanelStructure {

--- a/apps/array/src/test/vitest.d.ts
+++ b/apps/array/src/test/vitest.d.ts
@@ -2,7 +2,7 @@ import "vitest";
 import type { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
 
 declare module "vitest" {
-  interface Assertion<T = any> extends TestingLibraryMatchers<T, void> {}
+  interface Assertion<T = unknown> extends TestingLibraryMatchers<T, void> {}
   interface AsymmetricMatchersContaining
-    extends TestingLibraryMatchers<any, void> {}
+    extends TestingLibraryMatchers<unknown, void> {}
 }

--- a/packages/agent/src/adapters/types.ts
+++ b/packages/agent/src/adapters/types.ts
@@ -21,13 +21,13 @@ export interface ProviderAdapter {
    * Create a standardized status event.
    * Used for task phase transitions and other status updates.
    */
-  createStatusEvent(phase: string, additionalData?: any): StatusEvent;
+  createStatusEvent(phase: string, additionalData?: unknown): StatusEvent;
 
   /**
    * Create an artifact event for custom task artifacts (todos, etc).
    * Used to emit structured artifacts for UI consumption.
    */
-  createArtifactEvent(kind: string, content: any): ArtifactEvent;
+  createArtifactEvent(kind: string, content: unknown): ArtifactEvent;
 
   /**
    * Create a raw SDK event for debugging purposes.


### PR DESCRIPTION
Besides being able to open your worktree in the context menu, you can now also open any file/folder via several spots (file tree, diff viewer, right click on tabs, etc.)

Also refactored some stuff and fixed some typing

<img width="401" height="317" alt="image" src="https://github.com/user-attachments/assets/be298b6b-b4fd-49f3-bfa1-6c909413da14" />
