### PR TITLE
chore(agent): use trusted publishing

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -59,5 +59,3 @@ jobs:
       - name: Publish the package to npm registry
         working-directory: packages/agent
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We don’t use auth tokens anymore, lets not provide one