### PR TITLE
refactor: remove agent chat header and move raw logs toggle to context menu

### DIFF
--- a/apps/array/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -26,9 +26,6 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
   // Get session state from store
   const session = useSessionStore((state) => state.getSessionForTask(taskId));
   const connectToTask = useSessionStore((state) => state.connectToTask);
-  const disconnectFromTask = useSessionStore(
-    (state) => state.disconnectFromTask,
-  );
   const sendPrompt = useSessionStore((state) => state.sendPrompt);
 
   const isRunning =
@@ -78,11 +75,6 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
     [taskId, sendPrompt],
   );
 
-  const handleCancelSession = useCallback(async () => {
-    await disconnectFromTask(taskId);
-    log.info("Agent session cancelled");
-  }, [taskId, disconnectFromTask]);
-
   return (
     <BackgroundWrapper>
       <Box height="100%" width="100%">
@@ -92,7 +84,6 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
           isRunning={isRunning}
           isPromptPending={session?.isPromptPending}
           onSendPrompt={handleSendPrompt}
-          onCancelSession={handleCancelSession}
           onStartSession={handleStartSession}
         />
       </Box>


### PR DESCRIPTION
## Summary

- Removed the deprecated agent chat header that contained run status indicators and various buttons
- Moved the raw ACP logs toggle to a right-click context menu for a cleaner, more minimal UI
- Cleaned up unused props and handlers

## Changes

- **Removed from LogView component:**
  - "Agent Chat" heading
  - Run status indicators (Running/Idle with animated dots)
  - Copy logs button
  - Cancel session button
  - Entire header section

- **Added:**
  - Radix UI context menu wrapper around the logs display area
  - Checkbox item in context menu to toggle raw ACP logs view

- **Cleaned up:**
  - Removed unused imports (CodeIcon, CopyIcon, StopIcon, Heading)
  - Removed `onCancelSession` prop from LogViewProps
  - Removed `handleCopyLogs` function
  - Updated TaskLogsPanel to remove `onCancelSession` handler and `disconnectFromTask` usage

## Test plan

- [x] Run the application
- [x] Right-click on the logs area
- [x] Verify context menu appears with "Show raw ACP logs" checkbox
- [x] Toggle the checkbox and verify it switches between pretty view and raw ACP logs
- [x] Verify the input area and chat functionality still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)