### PR TITLE
fix: extract sdkSessionId when reading from logs

### DIFF
--- a/apps/array/src/main/preload.ts
+++ b/apps/array/src/main/preload.ts
@@ -183,6 +183,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     apiHost: string;
     projectId: number;
     logUrl?: string;
+    sdkSessionId?: string;
   }): Promise<{ sessionId: string; channel: string } | null> =>
     ipcRenderer.invoke("agent-reconnect", params),
   onAgentEvent: (

--- a/apps/array/src/main/services/session-manager.ts
+++ b/apps/array/src/main/services/session-manager.ts
@@ -122,6 +122,7 @@ export interface SessionConfig {
   repoPath: string;
   credentials: PostHogCredentials;
   logUrl?: string; // For reconnection from S3
+  sdkSessionId?: string; // SDK session ID for resuming Claude Code context
 }
 
 export interface ManagedSession {
@@ -171,7 +172,8 @@ export class SessionManager {
     config: SessionConfig,
     isReconnect: boolean,
   ): Promise<ManagedSession | null> {
-    const { taskId, taskRunId, repoPath, credentials, logUrl } = config;
+    const { taskId, taskRunId, repoPath, credentials, logUrl, sdkSessionId } =
+      config;
 
     const existing = this.sessions.get(taskRunId);
     if (existing) {
@@ -214,9 +216,12 @@ export class SessionManager {
           sessionId: taskRunId,
           cwd: repoPath,
           mcpServers: [],
-          _meta: logUrl
-            ? { persistence: { taskId, runId: taskRunId, logUrl } }
-            : undefined,
+          _meta: {
+            ...(logUrl && {
+              persistence: { taskId, runId: taskRunId, logUrl },
+            }),
+            ...(sdkSessionId && { sdkSessionId }),
+          },
         });
       } else {
         await connection.newSession({
@@ -439,6 +444,7 @@ interface AgentSessionParams {
   apiHost: string;
   projectId: number;
   logUrl?: string;
+  sdkSessionId?: string;
 }
 
 type SessionResponse = { sessionId: string; channel: string };
@@ -467,6 +473,7 @@ function toSessionConfig(params: AgentSessionParams): SessionConfig {
       projectId: params.projectId,
     },
     logUrl: params.logUrl,
+    sdkSessionId: params.sdkSessionId,
   };
 }
 

--- a/apps/array/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/array/src/renderer/features/sessions/stores/sessionStore.ts
@@ -124,11 +124,12 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           latestRunId,
           logUrl: latestRunLogUrl,
         });
-        const { notifications, rawEntries } =
+        const { notifications, rawEntries, sdkSessionId } =
           await fetchSessionLogs(latestRunLogUrl);
         log.info("Loaded historical logs", {
           notifications: notifications.length,
           rawEntries: rawEntries.length,
+          sdkSessionId,
         });
 
         // 2. Convert to SessionEvent format - interleave raw and parsed by order
@@ -189,6 +190,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           apiHost,
           projectId,
           logUrl: latestRunLogUrl,
+          sdkSessionId,
         });
 
         if (result) {

--- a/apps/array/src/renderer/types/electron.d.ts
+++ b/apps/array/src/renderer/types/electron.d.ts
@@ -136,6 +136,7 @@ declare global {
       apiHost: string;
       projectId: number;
       logUrl?: string;
+      sdkSessionId?: string;
     }) => Promise<{ sessionId: string; channel: string } | null>;
     onAgentEvent: (
       channel: string,

--- a/packages/agent/src/adapters/claude/claude.ts
+++ b/packages/agent/src/adapters/claude/claude.ts
@@ -171,7 +171,7 @@ export class ClaudeAcpAgent implements Agent {
   fileContentCache: { [key: string]: string };
   backgroundTerminals: { [key: string]: BackgroundTerminal } = {};
   clientCapabilities?: ClientCapabilities;
-  logger: Logger = new Logger({ debug: false, prefix: "[ClaudeAcpAgent]" });
+  logger: Logger = new Logger({ debug: true, prefix: "[ClaudeAcpAgent]" });
   sessionStore?: SessionStore;
 
   constructor(client: AgentSideConnection, sessionStore?: SessionStore) {
@@ -934,6 +934,7 @@ export class ClaudeAcpAgent implements Agent {
   async resumeSession(
     params: LoadSessionRequest,
   ): Promise<LoadSessionResponse> {
+    this.logger.info("[RESUME] Resuming session", { params });
     const { sessionId } = params;
 
     // Extract persistence config and SDK session ID from _meta
@@ -980,6 +981,11 @@ export class ClaudeAcpAgent implements Agent {
 
       const permissionMode = "default";
 
+      this.logger.info("Resuming session", {
+        cwd: params.cwd,
+        sdkSessionId,
+        persistence,
+      });
       const options: Options = {
         cwd: params.cwd,
         includePartialMessages: true,


### PR DESCRIPTION
we werent reading sdkSessionId from the logs anymore, which caused claude to lose context on session restore. this makes sure we extract it from the logs