### PR TITLE
feat: default layout

### DIFF
--- a/apps/array/src/main/preload.ts
+++ b/apps/array/src/main/preload.ts
@@ -472,5 +472,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("settings:get-worktree-location"),
     setWorktreeLocation: (location: string): Promise<void> =>
       ipcRenderer.invoke("settings:set-worktree-location", location),
+    getTerminalLayout: (): Promise<"split" | "tabbed"> =>
+      ipcRenderer.invoke("settings:get-terminal-layout"),
+    setTerminalLayout: (mode: "split" | "tabbed"): Promise<void> =>
+      ipcRenderer.invoke("settings:set-terminal-layout", mode),
   },
 });

--- a/apps/array/src/main/services/store.ts
+++ b/apps/array/src/main/services/store.ts
@@ -165,3 +165,16 @@ ipcMain.handle(
 ipcMain.handle("renderer-store:remove", (_event, key: string): void => {
   rendererStore.delete(key);
 });
+
+ipcMain.handle("settings:get-terminal-layout", (): string => {
+  const encrypted = rendererStore.get("terminal-layout-mode");
+  if (!encrypted) {
+    return "split";
+  }
+  const decrypted = decrypt(encrypted as string);
+  return decrypted || "split";
+});
+
+ipcMain.handle("settings:set-terminal-layout", (_event, mode: string): void => {
+  rendererStore.set("terminal-layout-mode", encrypt(mode));
+});

--- a/apps/array/src/renderer/components/StatusBar.tsx
+++ b/apps/array/src/renderer/components/StatusBar.tsx
@@ -1,5 +1,7 @@
 import { StatusBarMenu } from "@components/StatusBarMenu";
-import { Badge, Box, Code, Flex, Kbd } from "@radix-ui/themes";
+import { GearIcon } from "@radix-ui/react-icons";
+import { Badge, Box, Code, Flex, IconButton, Kbd } from "@radix-ui/themes";
+import { useNavigationStore } from "@stores/navigationStore";
 import { useStatusBarStore } from "@stores/statusBarStore";
 
 import { IS_DEV } from "@/constants/environment";
@@ -10,6 +12,7 @@ interface StatusBarProps {
 
 export function StatusBar({ showKeyHints = true }: StatusBarProps) {
   const { statusText, keyHints } = useStatusBarStore();
+  const { toggleSettings } = useNavigationStore();
 
   return (
     <Box className="flex flex-row items-center justify-between border-gray-6 border-t bg-gray-2 px-4 py-2">
@@ -42,15 +45,24 @@ export function StatusBar({ showKeyHints = true }: StatusBarProps) {
         </Flex>
       )}
 
-      {IS_DEV && (
-        <Flex align="center" gap="2">
+      <Flex align="center" gap="2">
+        <IconButton
+          size="1"
+          variant="ghost"
+          color="gray"
+          onClick={toggleSettings}
+          title="Settings"
+        >
+          <GearIcon />
+        </IconButton>
+        {IS_DEV && (
           <Badge size="1">
             <Code size="1" variant="ghost">
               DEV
             </Code>
           </Badge>
-        </Flex>
-      )}
+        )}
+      </Flex>
     </Box>
   );
 }

--- a/apps/array/src/renderer/features/panels/components/PanelLayout.tsx
+++ b/apps/array/src/renderer/features/panels/components/PanelLayout.tsx
@@ -1,5 +1,6 @@
 import { DragDropProvider } from "@dnd-kit/react";
 import type { Task } from "@shared/types";
+import { useSettingsStore } from "@stores/settingsStore";
 import type React from "react";
 import { useCallback, useEffect } from "react";
 import { useDragDropHandlers } from "../hooks/useDragDropHandlers";
@@ -161,14 +162,25 @@ export const PanelLayout: React.FC<PanelLayoutProps> = ({ taskId, task }) => {
   const layout = usePanelLayoutStore((state) => state.getLayout(taskId));
   const initializeTask = usePanelLayoutStore((state) => state.initializeTask);
   const dragDropHandlers = useDragDropHandlers(taskId);
+  const terminalLayoutMode = useSettingsStore(
+    (state) => state.terminalLayoutMode,
+  );
+  const loadTerminalLayout = useSettingsStore(
+    (state) => state.loadTerminalLayout,
+  );
+  const isLoading = useSettingsStore((state) => state.isLoading);
 
   usePanelKeyboardShortcuts(taskId);
 
   useEffect(() => {
-    if (!layout) {
-      initializeTask(taskId);
+    loadTerminalLayout();
+  }, [loadTerminalLayout]);
+
+  useEffect(() => {
+    if (!layout && !isLoading) {
+      initializeTask(taskId, terminalLayoutMode);
     }
-  }, [taskId, layout, initializeTask]);
+  }, [taskId, layout, initializeTask, terminalLayoutMode, isLoading]);
 
   if (!layout) {
     return null;

--- a/apps/array/src/renderer/features/panels/store/panelLayoutStore.ts
+++ b/apps/array/src/renderer/features/panels/store/panelLayoutStore.ts
@@ -44,7 +44,10 @@ export interface PanelLayoutStore {
   taskLayouts: Record<string, TaskLayout>;
 
   getLayout: (taskId: string) => TaskLayout | null;
-  initializeTask: (taskId: string) => void;
+  initializeTask: (
+    taskId: string,
+    terminalLayoutMode?: "split" | "tabbed",
+  ) => void;
   openFile: (taskId: string, filePath: string) => void;
   openArtifact: (taskId: string, fileName: string) => void;
   openDiff: (taskId: string, filePath: string, status?: string) => void;
@@ -96,108 +99,131 @@ export interface PanelLayoutStore {
   clearAllLayouts: () => void;
 }
 
-function createDefaultPanelTree(): PanelNode {
+function createDefaultPanelTree(
+  terminalLayoutMode: "split" | "tabbed" = "split",
+): PanelNode {
+  const logsPanel: PanelNode = {
+    type: "leaf",
+    id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+    content: {
+      id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+      tabs: [
+        {
+          id: DEFAULT_TAB_IDS.LOGS,
+          label: "Logs",
+          data: { type: "logs" },
+          component: null,
+          closeable: false,
+          draggable: true,
+        },
+      ],
+      activeTabId: DEFAULT_TAB_IDS.LOGS,
+      showTabs: true,
+      droppable: true,
+    },
+  };
+
+  const terminalPanel: PanelNode = {
+    type: "leaf",
+    id: "terminal-panel",
+    content: {
+      id: "terminal-panel",
+      tabs: [
+        {
+          id: DEFAULT_TAB_IDS.SHELL,
+          label: "Terminal",
+          data: {
+            type: "terminal",
+            terminalId: DEFAULT_TAB_IDS.SHELL,
+            cwd: "",
+          },
+          component: null,
+          closeable: true,
+          draggable: true,
+        },
+      ],
+      activeTabId: DEFAULT_TAB_IDS.SHELL,
+      showTabs: true,
+      droppable: true,
+    },
+  };
+
+  const leftPanel: PanelNode =
+    terminalLayoutMode === "split"
+      ? {
+          type: "group",
+          id: "left-group",
+          direction: "vertical",
+          sizes: [70, 30],
+          children: [logsPanel, terminalPanel],
+        }
+      : {
+          type: "leaf",
+          id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+          content: {
+            id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+            tabs: [
+              {
+                id: DEFAULT_TAB_IDS.LOGS,
+                label: "Logs",
+                data: { type: "logs" },
+                component: null,
+                closeable: false,
+                draggable: true,
+              },
+              {
+                id: DEFAULT_TAB_IDS.SHELL,
+                label: "Terminal",
+                data: {
+                  type: "terminal",
+                  terminalId: DEFAULT_TAB_IDS.SHELL,
+                  cwd: "",
+                },
+                component: null,
+                closeable: true,
+                draggable: true,
+              },
+            ],
+            activeTabId: DEFAULT_TAB_IDS.LOGS,
+            showTabs: true,
+            droppable: true,
+          },
+        };
+
   return {
     type: "group",
     id: DEFAULT_PANEL_IDS.ROOT,
     direction: "horizontal",
     sizes: [...PANEL_SIZES.DEFAULT_SPLIT],
     children: [
+      leftPanel,
       {
         type: "leaf",
-        id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+        id: DEFAULT_PANEL_IDS.TOP_RIGHT,
         content: {
-          id: DEFAULT_PANEL_IDS.MAIN_PANEL,
+          id: DEFAULT_PANEL_IDS.TOP_RIGHT,
           tabs: [
             {
-              id: DEFAULT_TAB_IDS.LOGS,
-              label: "Logs",
-              data: { type: "logs" },
+              id: DEFAULT_TAB_IDS.CHANGES,
+              label: "Changes",
+              data: { type: "other" },
               component: null,
               closeable: false,
-              draggable: true,
+              draggable: false,
             },
             {
-              id: DEFAULT_TAB_IDS.SHELL,
-              label: "Terminal",
-              data: {
-                type: "terminal",
-                terminalId: DEFAULT_TAB_IDS.SHELL,
-                cwd: "",
-              },
+              id: DEFAULT_TAB_IDS.FILES,
+              label: "Files",
+              data: { type: "other" },
               component: null,
-              closeable: true,
-              draggable: true,
+              closeable: false,
+              draggable: false,
             },
           ],
-          activeTabId: DEFAULT_TAB_IDS.LOGS,
+          activeTabId: DEFAULT_TAB_IDS.CHANGES,
           showTabs: true,
-          droppable: true,
+          droppable: false,
         },
-      },
-      {
-        type: "group",
-        id: DEFAULT_PANEL_IDS.RIGHT_GROUP,
-        direction: "vertical",
-        sizes: [...PANEL_SIZES.EVEN_SPLIT],
-        children: [
-          {
-            type: "leaf",
-            id: DEFAULT_PANEL_IDS.TOP_RIGHT,
-            content: {
-              id: DEFAULT_PANEL_IDS.TOP_RIGHT,
-              tabs: [
-                {
-                  id: DEFAULT_TAB_IDS.FILES,
-                  label: "Files",
-                  data: { type: "other" },
-                  component: null,
-                  closeable: false,
-                  draggable: false,
-                },
-                {
-                  id: DEFAULT_TAB_IDS.CHANGES,
-                  label: "Changes",
-                  data: { type: "other" },
-                  component: null,
-                  closeable: false,
-                  draggable: false,
-                },
-              ],
-              activeTabId: DEFAULT_TAB_IDS.FILES,
-              showTabs: true,
-              droppable: false,
-            },
-          },
-          {
-            type: "leaf",
-            id: DEFAULT_PANEL_IDS.BOTTOM_RIGHT,
-            content: {
-              id: DEFAULT_PANEL_IDS.BOTTOM_RIGHT,
-              tabs: [
-                {
-                  id: DEFAULT_TAB_IDS.TODO_LIST,
-                  label: "Todo list",
-                  data: { type: "other" },
-                  component: null,
-                  closeable: false,
-                  draggable: false,
-                },
-                {
-                  id: DEFAULT_TAB_IDS.ARTIFACTS,
-                  label: "Artifacts",
-                  data: { type: "other" },
-                  component: null,
-                  closeable: false,
-                  draggable: false,
-                },
-              ],
-              activeTabId: DEFAULT_TAB_IDS.TODO_LIST,
-              showTabs: true,
-              droppable: false,
-            },
-          },
-        ],
       },
     ],
   };
@@ -254,12 +280,12 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
         return get().taskLayouts[taskId] || null;
       },
 
-      initializeTask: (taskId) => {
+      initializeTask: (taskId, terminalLayoutMode = "split") => {
         set((state) => ({
           taskLayouts: {
             ...state.taskLayouts,
             [taskId]: {
-              panelTree: createDefaultPanelTree(),
+              panelTree: createDefaultPanelTree(terminalLayoutMode),
               openFiles: [],
               openArtifacts: [],
               draggingTabId: null,
@@ -740,7 +766,7 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
     {
       name: "panel-layout-store",
       // Bump this version when the default panel structure changes to reset all layouts
-      version: 5,
+      version: 7,
       migrate: () => ({ taskLayouts: {} }),
     },
   ),

--- a/apps/array/src/renderer/features/settings/components/SettingsView.tsx
+++ b/apps/array/src/renderer/features/settings/components/SettingsView.tsx
@@ -21,6 +21,7 @@ import {
 } from "@radix-ui/themes";
 import { logger } from "@renderer/lib/logger";
 import type { CloudRegion } from "@shared/types/oauth";
+import { useSettingsStore as useTerminalLayoutStore } from "@stores/settingsStore";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useThemeStore } from "../../../stores/themeStore";
@@ -60,6 +61,12 @@ export function SettingsView() {
     setDefaultRunMode,
     setCreatePR,
   } = useSettingsStore();
+  const terminalLayoutMode = useTerminalLayoutStore(
+    (state) => state.terminalLayoutMode,
+  );
+  const setTerminalLayout = useTerminalLayoutStore(
+    (state) => state.setTerminalLayout,
+  );
 
   const { data: currentUser } = useMeQuery();
   const { data: project } = useProjectQuery();
@@ -121,15 +128,40 @@ export function SettingsView() {
           <Flex direction="column" gap="3">
             <Heading size="3">Appearance</Heading>
             <Card>
-              <Flex align="center" justify="between">
-                <Text size="1" weight="medium">
-                  Dark mode
-                </Text>
-                <Switch
-                  checked={isDarkMode}
-                  onCheckedChange={toggleDarkMode}
-                  size="1"
-                />
+              <Flex direction="column" gap="4">
+                <Flex align="center" justify="between">
+                  <Text size="1" weight="medium">
+                    Dark mode
+                  </Text>
+                  <Switch
+                    checked={isDarkMode}
+                    onCheckedChange={toggleDarkMode}
+                    size="1"
+                  />
+                </Flex>
+
+                <Flex direction="column" gap="2">
+                  <Text size="1" weight="medium">
+                    Terminal layout
+                  </Text>
+                  <Select.Root
+                    value={terminalLayoutMode}
+                    onValueChange={(value) =>
+                      setTerminalLayout(value as "split" | "tabbed")
+                    }
+                    size="1"
+                  >
+                    <Select.Trigger />
+                    <Select.Content>
+                      <Select.Item value="split">Split pane</Select.Item>
+                      <Select.Item value="tabbed">Tabbed</Select.Item>
+                    </Select.Content>
+                  </Select.Root>
+                  <Text size="1" color="gray">
+                    Split pane shows the terminal in a separate pane beneath the
+                    logs. Tabbed shows the terminal as a tab alongside logs.
+                  </Text>
+                </Flex>
               </Flex>
             </Card>
           </Flex>

--- a/apps/array/src/renderer/stores/settingsStore.ts
+++ b/apps/array/src/renderer/stores/settingsStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+export type TerminalLayoutMode = "split" | "tabbed";
+
+interface SettingsState {
+  terminalLayoutMode: TerminalLayoutMode;
+  isLoading: boolean;
+  loadTerminalLayout: () => Promise<void>;
+  setTerminalLayout: (mode: TerminalLayoutMode) => Promise<void>;
+}
+
+export const useSettingsStore = create<SettingsState>()((set) => ({
+  terminalLayoutMode: "split",
+  isLoading: true,
+
+  loadTerminalLayout: async () => {
+    try {
+      const mode = await window.electronAPI.settings.getTerminalLayout();
+      set({ terminalLayoutMode: mode, isLoading: false });
+    } catch (_error) {
+      set({ terminalLayoutMode: "split", isLoading: false });
+    }
+  },
+
+  setTerminalLayout: async (mode: TerminalLayoutMode) => {
+    try {
+      await window.electronAPI.settings.setTerminalLayout(mode);
+      set({ terminalLayoutMode: mode });
+    } catch (_error) {}
+  },
+}));

--- a/apps/array/src/renderer/types/electron.d.ts
+++ b/apps/array/src/renderer/types/electron.d.ts
@@ -306,6 +306,8 @@ declare global {
     settings: {
       getWorktreeLocation: () => Promise<string>;
       setWorktreeLocation: (location: string) => Promise<void>;
+      getTerminalLayout: () => Promise<"split" | "tabbed">;
+      setTerminalLayout: (mode: "split" | "tabbed") => Promise<void>;
     };
   }
 


### PR DESCRIPTION
You can now toggle between placing the terminal in a separate pane by default, or as a tab in the main panel.

Also got rid of the artifacts and todo panel, doesn't show here bc the screenshot is outdated, but trust me its gone

<img width="1260" height="912" alt="image" src="https://github.com/user-attachments/assets/d28cd6b6-5283-410a-a620-005a79a4f802" />


---

<img width="549" height="320" alt="image" src="https://github.com/user-attachments/assets/20144d70-4bdd-41cb-93e7-14cc4d3a4ccf" />

