### PR TITLE
fix: Bypass CORS for S3 log fetching in renderer

### DIFF
--- a/apps/array/src/main/preload.ts
+++ b/apps/array/src/main/preload.ts
@@ -1,5 +1,4 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
-import type { AgentEvent } from "@posthog/agent";
 import { contextBridge, type IpcRendererEvent, ipcRenderer } from "electron";
 import type {
   CreateWorkspaceOptions,
@@ -69,7 +68,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("store-api-key", apiKey),
   retrieveApiKey: (encryptedKey: string): Promise<string | null> =>
     ipcRenderer.invoke("retrieve-api-key", encryptedKey),
-  fetchS3Logs: (logUrl: string): Promise<AgentEvent[]> =>
+  fetchS3Logs: (logUrl: string): Promise<string | null> =>
     ipcRenderer.invoke("fetch-s3-logs", logUrl),
   rendererStore: {
     getItem: (key: string): Promise<string | null> =>

--- a/apps/array/src/renderer/types/electron.d.ts
+++ b/apps/array/src/renderer/types/electron.d.ts
@@ -5,7 +5,6 @@ import type {
   TabContextMenuResult,
   TaskContextMenuResult,
 } from "@main/services/contextMenu.types";
-import type { AgentEvent } from "@posthog/agent";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import type {
   ChangedFile,
@@ -25,7 +24,7 @@ declare global {
   interface IElectronAPI {
     storeApiKey: (apiKey: string) => Promise<string>;
     retrieveApiKey: (encryptedKey: string) => Promise<string | null>;
-    fetchS3Logs: (logUrl: string) => Promise<AgentEvent[]>;
+    fetchS3Logs: (logUrl: string) => Promise<string | null>;
     rendererStore: {
       getItem: (key: string) => Promise<string | null>;
       setItem: (key: string, value: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- Moves S3 log fetching from the renderer process to the main process via IPC
- Fixes CORS errors when fetching presigned S3 URLs from localhost in development mode
- The main process (Node.js) is not subject to CORS restrictions

## Problem
When running the app in development mode (localhost:5173), the renderer process was blocked by CORS when trying to fetch session logs from S3 presigned URLs. This caused session history to fail to load for both local and cloud runs.

## Solution
Return raw text from the main process `fetch-s3-logs` IPC handler instead of parsed events, letting the renderer parse the ndjson. This bypasses CORS since Node.js fetch in the main process is not subject to browser CORS restrictions.

## Test plan
- [ ] Start the app in development mode
- [ ] Connect to a US or EU PostHog instance
- [ ] Select a task with existing runs
- [ ] Verify session logs load and display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)