### PR TITLE
fix: File watcher not picking up local file changes

### DIFF
--- a/apps/array/src/main/services/fileWatcher.ts
+++ b/apps/array/src/main/services/fileWatcher.ts
@@ -124,7 +124,11 @@ class FileService {
 
         for (const event of events) {
           state.pendingDirs.add(path.dirname(event.path));
-          if (event.type === "update") {
+
+          // Handle both "update" and "create" events as file changes
+          // Atomic writes (like the claude code Write tool) produce "create"
+          // events because they write to a temp file then rename/move it
+          if (event.type === "update" || event.type === "create") {
             state.pendingFiles.add(event.path);
           } else if (event.type === "delete") {
             state.pendingDeletes.add(event.path);


### PR DESCRIPTION
I've had this annoying bug for the last two days where if I make changes to the worktree files manually, they were instantly propagated to Array and I could see them in the diff and file viewer. However, if the agent made changes they would never be updated within Array and I would always see the stale version of the file.

I have an explanation on why this happens in the comments, had to do a bit of deep dive to figure it out. I asked Array for help and it kept thinking the problem was the `stableTime` being set to `Infinity` on the tanstack query in each of the editor panels 😢