### PR TITLE
feat: Add hotkeys to switch between files in the changes panel

### DIFF
--- a/apps/array/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -24,9 +24,8 @@ import { useExternalAppsStore } from "@stores/externalAppsStore";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { showMessageBox } from "@utils/dialog";
 import { handleExternalAppAction } from "@utils/handleExternalAppAction";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { useState } from "react";
 import {
   selectWorktreePath,
   useWorkspaceStore,


### PR DESCRIPTION
https://www.loom.com/share/075b8640ccc64c489144f7b3e4a3416b

- Uses react hotkeys @k11kirky, re: your comment from the earlier PR, I am guessing this is the convention we want to standardize around.
- Adds up/down hotkeys to switch between files in the changes panel, decided to not wrap it around and hard stop.
- Adds a little tip at the bottom of the changes panel for feature discovery.