### PR TITLE
feat: Add inline code review comments

### DIFF
--- a/apps/array/src/renderer/features/code-editor/components/CodeMirrorDiffEditor.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/CodeMirrorDiffEditor.tsx
@@ -9,6 +9,7 @@ interface CodeMirrorDiffEditorProps {
   originalContent: string;
   modifiedContent: string;
   filePath?: string;
+  fileId?: string; // Unique identifier for comments (e.g., relative path)
   onContentChange?: (content: string) => void;
 }
 
@@ -16,10 +17,14 @@ export function CodeMirrorDiffEditor({
   originalContent,
   modifiedContent,
   filePath,
+  fileId,
   onContentChange,
 }: CodeMirrorDiffEditorProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("split");
-  const extensions = useEditorExtensions(filePath, true);
+  const extensions = useEditorExtensions(filePath, true, {
+    enableComments: true,
+    fileId: fileId || filePath, // Fall back to filePath if no fileId provided
+  });
   const options = useMemo(
     () => ({
       original: originalContent,

--- a/apps/array/src/renderer/features/code-editor/components/CodeMirrorEditor.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/CodeMirrorEditor.tsx
@@ -5,15 +5,22 @@ import { useEditorExtensions } from "../hooks/useEditorExtensions";
 interface CodeMirrorEditorProps {
   content: string;
   filePath?: string;
+  fileId?: string; // Unique identifier for comments (e.g., relative path)
   readOnly?: boolean;
+  enableComments?: boolean;
 }
 
 export function CodeMirrorEditor({
   content,
   filePath,
+  fileId,
   readOnly = false,
+  enableComments = false,
 }: CodeMirrorEditorProps) {
-  const extensions = useEditorExtensions(filePath, readOnly);
+  const extensions = useEditorExtensions(filePath, readOnly, {
+    enableComments,
+    fileId: fileId || filePath,
+  });
   const options = useMemo(
     () => ({ doc: content, extensions, filePath }),
     [content, extensions, filePath],

--- a/apps/array/src/renderer/features/code-editor/components/DiffEditorPanel.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/DiffEditorPanel.tsx
@@ -96,13 +96,16 @@ export function DiffEditorPanel({
           originalContent={originalContent ?? ""}
           modifiedContent={modifiedContent ?? ""}
           filePath={absolutePath}
+          fileId={filePath} // Use relative path as fileId for comments
           onContentChange={handleContentChange}
         />
       ) : (
         <CodeMirrorEditor
           content={content ?? ""}
           filePath={absolutePath}
+          fileId={filePath}
           readOnly
+          enableComments
         />
       )}
     </Box>

--- a/apps/array/src/renderer/features/code-editor/hooks/useEditorExtensions.ts
+++ b/apps/array/src/renderer/features/code-editor/hooks/useEditorExtensions.ts
@@ -4,19 +4,61 @@ import {
   highlightActiveLineGutter,
   lineNumbers,
 } from "@codemirror/view";
+import { commentComposerExtension } from "@features/comments/extensions/commentComposerExtension";
+import { commentGutterExtension } from "@features/comments/extensions/commentGutterExtension";
+import { commentWidgetExtension } from "@features/comments/extensions/commentWidgetExtension";
+import { useCommentStore } from "@features/comments/store/commentStore";
 import { useThemeStore } from "@stores/themeStore";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { mergeViewTheme, oneDark, oneLight } from "../theme/editorTheme";
 import { getLanguageExtension } from "../utils/languages";
 
-export function useEditorExtensions(filePath?: string, readOnly = false) {
+export function useEditorExtensions(
+  filePath?: string,
+  readOnly = false,
+  options?: { enableComments?: boolean; fileId?: string },
+) {
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
+  const showComments = useCommentStore((state) => state.showComments);
+  const getCommentsForFile = useCommentStore(
+    (state) => state.getCommentsForFile,
+  );
+  const openComposer = useCommentStore((state) => state.openComposer);
+  const closeComposer = useCommentStore((state) => state.closeComposer);
+  const createComment = useCommentStore((state) => state.createComment);
+  const composerState = useCommentStore((state) => state.composerState);
+
+  const { enableComments = false, fileId } = options || {};
+
+  // Handler for when user clicks "+" to add a comment
+  const handleOpenComposer = useCallback(
+    (clickedFileId: string, line: number) => {
+      openComposer(clickedFileId, line);
+    },
+    [openComposer],
+  );
+
+  // Handler for submitting a new comment
+  const handleSubmitComment = useCallback(
+    async (line: number, content: string) => {
+      if (!fileId) return;
+
+      await createComment({
+        fileId,
+        line,
+        side: "right",
+        content,
+      });
+      closeComposer();
+    },
+    [fileId, createComment, closeComposer],
+  );
 
   return useMemo(() => {
     const languageExtension = filePath ? getLanguageExtension(filePath) : null;
     const theme = isDarkMode ? oneDark : oneLight;
 
-    return [
+    const extensions = [
       lineNumbers(),
       highlightActiveLineGutter(),
       theme,
@@ -25,5 +67,38 @@ export function useEditorExtensions(filePath?: string, readOnly = false) {
       ...(readOnly ? [EditorState.readOnly.of(true)] : []),
       ...(languageExtension ? [languageExtension] : []),
     ];
-  }, [filePath, isDarkMode, readOnly]);
+
+    // Add comment extensions if enabled and we have a fileId
+    if (enableComments && fileId) {
+      // Gutter with "+" button for adding comments
+      extensions.push(commentGutterExtension(fileId, handleOpenComposer));
+      // Inline comment composer
+      extensions.push(
+        commentComposerExtension(
+          fileId,
+          () => composerState,
+          handleSubmitComment,
+          closeComposer,
+        ),
+      );
+      // Inline comment display
+      extensions.push(
+        commentWidgetExtension(() => getCommentsForFile(fileId), showComments),
+      );
+    }
+
+    return extensions;
+  }, [
+    filePath,
+    isDarkMode,
+    readOnly,
+    enableComments,
+    fileId,
+    showComments,
+    getCommentsForFile,
+    handleOpenComposer,
+    handleSubmitComment,
+    closeComposer,
+    composerState,
+  ]);
 }

--- a/apps/array/src/renderer/features/comments/api/commentApi.ts
+++ b/apps/array/src/renderer/features/comments/api/commentApi.ts
@@ -1,0 +1,172 @@
+/**
+ * ============================================
+ * COMMENT API ADAPTER
+ * ============================================
+ *
+ * TODO FOR API INTEGRATION:
+ *
+ * 1. Create a new file `githubCommentApi.ts` that implements `CommentApi`
+ * 2. Replace `mockCommentApi` with your implementation below
+ *
+ * Example:
+ *   import { githubCommentApi } from "./githubCommentApi";
+ *   export const commentApi: CommentApi = githubCommentApi;
+ *
+ * The store calls these functions automatically - you just need to
+ * implement them to hit your GitHub API endpoints.
+ * ============================================
+ */
+
+import type { Comment } from "@shared/types";
+import { getCurrentUser } from "../utils/currentUser";
+
+// ============================================
+// INPUT TYPES
+// ============================================
+
+export interface CreateCommentInput {
+  fileId: string;
+  line: number;
+  side: "left" | "right";
+  content: string;
+}
+
+export interface CreateReplyInput extends CreateCommentInput {
+  parentId: string;
+}
+
+// ============================================
+// API INTERFACE
+// ============================================
+
+export interface CommentApi {
+  /**
+   * Fetch all comments for a file
+   * GET /api/comments?fileId=...
+   */
+  fetchComments(fileId: string): Promise<Comment[]>;
+
+  /**
+   * Create a new comment on a line
+   * POST /api/comments
+   * Body: { fileId, line, side, content }
+   * Returns: Created comment with server-generated ID
+   */
+  createComment(input: CreateCommentInput): Promise<Comment>;
+
+  /**
+   * Create a reply to an existing comment
+   * POST /api/comments/:parentId/replies
+   * Body: { content }
+   * Returns: Created reply with server-generated ID
+   */
+  createReply(input: CreateReplyInput): Promise<Comment>;
+
+  /**
+   * Update a comment's content
+   * PATCH /api/comments/:commentId
+   * Body: { content }
+   * Returns: Updated comment
+   */
+  updateComment(commentId: string, content: string): Promise<Comment>;
+
+  /**
+   * Delete a comment
+   * DELETE /api/comments/:commentId
+   */
+  deleteComment(commentId: string): Promise<void>;
+
+  /**
+   * Mark a comment as resolved or unresolved
+   * PATCH /api/comments/:commentId/resolve
+   * Body: { resolved: boolean }
+   * Returns: Updated comment
+   */
+  resolveComment(commentId: string, resolved: boolean): Promise<Comment>;
+}
+
+// ============================================
+// MOCK IMPLEMENTATION (local-only, no persistence)
+// ============================================
+
+/**
+ * Mock API that works with local state only.
+ * Replace this with `githubCommentApi` when ready.
+ */
+export const mockCommentApi: CommentApi = {
+  async fetchComments(_fileId) {
+    // Mock: Return empty array (store manages local state)
+    // Real: GET /api/comments?fileId=...
+    return [];
+  },
+
+  async createComment(input) {
+    // Mock: Create comment object with generated ID
+    // Real: POST /api/comments, return server response
+    const user = getCurrentUser();
+    return {
+      id: crypto.randomUUID(),
+      fileId: input.fileId,
+      line: input.line,
+      side: input.side,
+      content: input.content,
+      author: user.name,
+      timestamp: new Date(),
+      resolved: false,
+      replies: [],
+    };
+  },
+
+  async createReply(input) {
+    // Mock: Create reply object with generated ID
+    // Real: POST /api/comments/:parentId/replies
+    const user = getCurrentUser();
+    return {
+      id: crypto.randomUUID(),
+      fileId: input.fileId,
+      line: input.line,
+      side: input.side,
+      content: input.content,
+      author: user.name,
+      timestamp: new Date(),
+      resolved: false,
+      replies: [],
+    };
+  },
+
+  async updateComment(commentId, content) {
+    // Mock: Return updated comment (store handles state update)
+    // Real: PATCH /api/comments/:commentId
+    return {
+      id: commentId,
+      content,
+    } as Comment;
+  },
+
+  async deleteComment(_commentId) {
+    // Mock: No-op (store handles state removal)
+    // Real: DELETE /api/comments/:commentId
+  },
+
+  async resolveComment(commentId, resolved) {
+    // Mock: Return updated comment (store handles state update)
+    // Real: PATCH /api/comments/:commentId/resolve
+    return {
+      id: commentId,
+      resolved,
+    } as Comment;
+  },
+};
+
+// ============================================
+// ACTIVE API IMPLEMENTATION
+// ============================================
+
+/**
+ * Change this to switch between mock and real API.
+ *
+ * When ready for GitHub integration:
+ *   import { githubCommentApi } from "./githubCommentApi";
+ *   export const commentApi: CommentApi = githubCommentApi;
+ */
+export const commentApi: CommentApi = mockCommentApi;

--- a/apps/array/src/renderer/features/comments/components/CommentBubble.tsx
+++ b/apps/array/src/renderer/features/comments/components/CommentBubble.tsx
@@ -1,0 +1,203 @@
+import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
+import { Pencil, Trash } from "@phosphor-icons/react";
+import {
+  Avatar,
+  Box,
+  Button,
+  Flex,
+  IconButton,
+  Text,
+  TextArea,
+} from "@radix-ui/themes";
+import type { Comment } from "@shared/types";
+import { useCallback, useState } from "react";
+import { useCommentStore } from "../store/commentStore";
+import { isCurrentUser } from "../utils/currentUser";
+
+interface CommentBubbleProps {
+  comment: Comment;
+  isReply?: boolean;
+}
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export function CommentBubble({
+  comment,
+  isReply = false,
+}: CommentBubbleProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(comment.content);
+
+  const updateComment = useCommentStore((state) => state.updateComment);
+  const deleteComment = useCommentStore((state) => state.deleteComment);
+
+  const isOwnComment = isCurrentUser(comment.author);
+
+  const handleStartEdit = useCallback(() => {
+    setEditContent(comment.content);
+    setIsEditing(true);
+  }, [comment.content]);
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setEditContent(comment.content);
+  }, [comment.content]);
+
+  const handleSaveEdit = useCallback(async () => {
+    const trimmed = editContent.trim();
+    if (!trimmed) return;
+
+    await updateComment(comment.id, trimmed);
+    setIsEditing(false);
+  }, [editContent, comment.id, updateComment]);
+
+  const handleDelete = useCallback(async () => {
+    if (window.confirm("Delete this comment? This action cannot be undone.")) {
+      await deleteComment(comment.id);
+    }
+  }, [comment.id, deleteComment]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSaveEdit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        handleCancelEdit();
+      }
+    },
+    [handleSaveEdit, handleCancelEdit],
+  );
+
+  return (
+    <Box
+      style={{
+        backgroundColor: "var(--gray-2)",
+        border: "1px solid var(--gray-5)",
+        borderRadius: "var(--radius-2)",
+        padding: "var(--space-2) var(--space-3)",
+        marginLeft: isReply ? "var(--space-4)" : 0,
+        borderLeftColor: isReply ? "var(--accent-8)" : "var(--gray-5)",
+        borderLeftWidth: isReply ? "2px" : "1px",
+      }}
+    >
+      <Flex gap="2" align="start">
+        <Avatar
+          size="1"
+          fallback={getInitials(comment.author)}
+          radius="full"
+          color="gray"
+        />
+        <Box style={{ flex: 1, minWidth: 0 }}>
+          <Flex gap="2" align="center" justify="between" mb="1">
+            <Flex gap="2" align="center">
+              <Text size="1" weight="medium" color="gray" highContrast>
+                {comment.author}
+              </Text>
+              <Text size="1" color="gray">
+                {formatRelativeTime(comment.timestamp)}
+              </Text>
+              {comment.resolved && (
+                <Text size="1" color="green">
+                  ✓ Resolved
+                </Text>
+              )}
+              {comment.isOutdated && (
+                <Text size="1" color="orange">
+                  ⚠ Outdated
+                </Text>
+              )}
+            </Flex>
+
+            {/* Action menu - only show for own comments */}
+            {isOwnComment && !isEditing && (
+              <Flex gap="1">
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  color="gray"
+                  onClick={handleStartEdit}
+                  title="Edit"
+                >
+                  <Pencil size={12} />
+                </IconButton>
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  color="red"
+                  onClick={handleDelete}
+                  title="Delete"
+                >
+                  <Trash size={12} />
+                </IconButton>
+              </Flex>
+            )}
+          </Flex>
+
+          {/* Content - either editing or displaying */}
+          {isEditing ? (
+            <Box>
+              <TextArea
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                onKeyDown={handleKeyDown}
+                size="1"
+                autoFocus
+                style={{ minHeight: "60px", resize: "vertical" }}
+              />
+              <Flex gap="2" mt="2" justify="between">
+                <Box style={{ fontSize: "11px", color: "var(--gray-9)" }}>
+                  ⌘+Enter to save · Esc to cancel
+                </Box>
+                <Flex gap="2">
+                  <Button
+                    size="1"
+                    variant="soft"
+                    color="gray"
+                    onClick={handleCancelEdit}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="1"
+                    variant="solid"
+                    onClick={handleSaveEdit}
+                    disabled={!editContent.trim()}
+                  >
+                    Save
+                  </Button>
+                </Flex>
+              </Flex>
+            </Box>
+          ) : (
+            <Box>
+              <MarkdownRenderer content={comment.content} />
+            </Box>
+          )}
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/array/src/renderer/features/comments/components/CommentComposer.tsx
+++ b/apps/array/src/renderer/features/comments/components/CommentComposer.tsx
@@ -1,0 +1,131 @@
+import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
+import { Box, Button, Flex, Tabs, TextArea } from "@radix-ui/themes";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface CommentComposerProps {
+  onSubmit: (content: string) => void;
+  onCancel: () => void;
+  placeholder?: string;
+  submitLabel?: string;
+  autoFocus?: boolean;
+}
+
+export function CommentComposer({
+  onSubmit,
+  onCancel,
+  placeholder = "Write a comment... (Markdown supported)",
+  submitLabel = "Comment",
+  autoFocus = true,
+}: CommentComposerProps) {
+  const [content, setContent] = useState("");
+  const [activeTab, setActiveTab] = useState<"write" | "preview">("write");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (autoFocus && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [autoFocus]);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setContent("");
+  }, [content, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSubmit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [handleSubmit, onCancel],
+  );
+
+  return (
+    <Box
+      style={{
+        backgroundColor: "var(--gray-2)",
+        border: "1px solid var(--gray-6)",
+        borderRadius: "var(--radius-2)",
+        overflow: "hidden",
+      }}
+    >
+      <Tabs.Root
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as "write" | "preview")}
+      >
+        <Tabs.List size="1">
+          <Tabs.Trigger value="write">Write</Tabs.Trigger>
+          <Tabs.Trigger value="preview">Preview</Tabs.Trigger>
+        </Tabs.List>
+
+        <Box p="2">
+          <Tabs.Content value="write" style={{ outline: "none" }}>
+            <TextArea
+              ref={textareaRef}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              size="2"
+              style={{
+                minHeight: "80px",
+                resize: "vertical",
+              }}
+            />
+          </Tabs.Content>
+
+          <Tabs.Content value="preview" style={{ outline: "none" }}>
+            <Box
+              style={{
+                minHeight: "80px",
+                padding: "var(--space-2)",
+                backgroundColor: "var(--gray-1)",
+                borderRadius: "var(--radius-1)",
+                border: "1px solid var(--gray-4)",
+              }}
+            >
+              {content.trim() ? (
+                <MarkdownRenderer content={content} />
+              ) : (
+                <Box style={{ color: "var(--gray-9)", fontStyle: "italic" }}>
+                  Nothing to preview
+                </Box>
+              )}
+            </Box>
+          </Tabs.Content>
+        </Box>
+      </Tabs.Root>
+
+      <Flex
+        gap="2"
+        justify="between"
+        p="2"
+        style={{ borderTop: "1px solid var(--gray-4)" }}
+      >
+        <Box style={{ fontSize: "11px", color: "var(--gray-9)" }}>
+          ⌘+Enter to submit · Esc to cancel
+        </Box>
+        <Flex gap="2">
+          <Button size="1" variant="soft" color="gray" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            size="1"
+            variant="solid"
+            onClick={handleSubmit}
+            disabled={!content.trim()}
+          >
+            {submitLabel}
+          </Button>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/array/src/renderer/features/comments/components/CommentThread.tsx
+++ b/apps/array/src/renderer/features/comments/components/CommentThread.tsx
@@ -1,0 +1,196 @@
+import { Check, CheckCircle } from "@phosphor-icons/react";
+import { Box, Button, Flex, TextArea } from "@radix-ui/themes";
+import type { Comment } from "@shared/types";
+import { useCallback, useState } from "react";
+import type { CreateReplyInput } from "../api/commentApi";
+import { useCommentStore } from "../store/commentStore";
+import { CommentBubble } from "./CommentBubble";
+
+interface CommentThreadProps {
+  comment: Comment;
+}
+
+export function CommentThread({ comment: initialComment }: CommentThreadProps) {
+  const [isReplying, setIsReplying] = useState(false);
+  const [replyContent, setReplyContent] = useState("");
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const createReply = useCommentStore((state) => state.createReply);
+  const resolveComment = useCommentStore((state) => state.resolveComment);
+
+  // Subscribe to the store to get live updates for this comment
+  // Returns null if comment was deleted
+  const comment = useCommentStore((state) => {
+    const fileComments = state.comments[initialComment.fileId] || [];
+    return fileComments.find((c) => c.id === initialComment.id) || null;
+  });
+
+  const handleStartReply = useCallback(() => {
+    setIsReplying(true);
+  }, []);
+
+  const handleCancelReply = useCallback(() => {
+    setIsReplying(false);
+    setReplyContent("");
+  }, []);
+
+  const handleSubmitReply = useCallback(async () => {
+    const trimmed = replyContent.trim();
+    if (!trimmed || !comment) return;
+
+    const input: CreateReplyInput = {
+      parentId: comment.id,
+      fileId: comment.fileId,
+      line: comment.line,
+      side: comment.side,
+      content: trimmed,
+    };
+
+    await createReply(input);
+    setReplyContent("");
+    setIsReplying(false);
+  }, [replyContent, comment, createReply]);
+
+  const handleToggleResolved = useCallback(async () => {
+    if (!comment) return;
+    await resolveComment(comment.id, !comment.resolved);
+    // Auto-collapse when resolving
+    if (!comment.resolved) {
+      setIsCollapsed(true);
+    }
+  }, [comment, resolveComment]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSubmitReply();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        handleCancelReply();
+      }
+    },
+    [handleSubmitReply, handleCancelReply],
+  );
+
+  // If comment was deleted, don't render anything
+  if (!comment) {
+    return null;
+  }
+
+  // Collapsed view for resolved comments
+  if (comment.resolved && isCollapsed) {
+    return (
+      <Box
+        style={{
+          padding: "var(--space-2)",
+          backgroundColor: "var(--gray-1)",
+          borderRadius: "var(--radius-2)",
+          border: "1px solid var(--green-6)",
+          cursor: "pointer",
+        }}
+        onClick={() => setIsCollapsed(false)}
+      >
+        <Flex align="center" gap="2">
+          <CheckCircle size={14} weight="fill" color="var(--green-9)" />
+          <Box style={{ fontSize: "12px", color: "var(--gray-11)" }}>
+            Resolved thread by {comment.author}
+            {comment.replies.length > 0 &&
+              ` · ${comment.replies.length} replies`}
+          </Box>
+          <Box
+            style={{
+              fontSize: "11px",
+              color: "var(--gray-9)",
+              marginLeft: "auto",
+            }}
+          >
+            Click to expand
+          </Box>
+        </Flex>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      style={{
+        padding: "var(--space-2)",
+        backgroundColor: comment.resolved ? "var(--green-2)" : "var(--gray-1)",
+        borderRadius: "var(--radius-2)",
+        border: `1px solid ${comment.resolved ? "var(--green-6)" : "var(--gray-4)"}`,
+      }}
+    >
+      <Flex direction="column" gap="2">
+        <CommentBubble comment={comment} />
+
+        {/* Replies */}
+        {comment.replies.map((reply) => (
+          <CommentBubble key={reply.id} comment={reply} isReply />
+        ))}
+
+        {/* Reply composer */}
+        {isReplying ? (
+          <Box style={{ marginLeft: "var(--space-4)" }}>
+            <TextArea
+              value={replyContent}
+              onChange={(e) => setReplyContent(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Write a reply..."
+              size="1"
+              autoFocus
+              style={{ minHeight: "60px", resize: "vertical" }}
+            />
+            <Flex gap="2" mt="2" justify="between">
+              <Box style={{ fontSize: "11px", color: "var(--gray-9)" }}>
+                ⌘+Enter to submit · Esc to cancel
+              </Box>
+              <Flex gap="2">
+                <Button
+                  size="1"
+                  variant="soft"
+                  color="gray"
+                  onClick={handleCancelReply}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="1"
+                  variant="solid"
+                  onClick={handleSubmitReply}
+                  disabled={!replyContent.trim()}
+                >
+                  Reply
+                </Button>
+              </Flex>
+            </Flex>
+          </Box>
+        ) : (
+          <Flex
+            gap="2"
+            align="center"
+            justify="between"
+            style={{ marginLeft: "var(--space-4)" }}
+          >
+            <Button
+              size="1"
+              variant="ghost"
+              color="gray"
+              onClick={handleStartReply}
+            >
+              Reply
+            </Button>
+            <Button
+              size="1"
+              variant={comment.resolved ? "soft" : "ghost"}
+              color={comment.resolved ? "green" : "gray"}
+              onClick={handleToggleResolved}
+            >
+              <Check size={12} weight="bold" />
+              {comment.resolved ? "Resolved" : "Resolve"}
+            </Button>
+          </Flex>
+        )}
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/array/src/renderer/features/comments/extensions/commentComposerExtension.ts
+++ b/apps/array/src/renderer/features/comments/extensions/commentComposerExtension.ts
@@ -1,0 +1,140 @@
+import { type Extension, StateField } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  WidgetType,
+} from "@codemirror/view";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CommentComposer } from "../components/CommentComposer";
+
+interface ComposerState {
+  fileId: string;
+  line: number;
+}
+
+/**
+ * A CodeMirror widget that renders the CommentComposer component
+ */
+class ComposerWidget extends WidgetType {
+  private root: Root | null = null;
+
+  constructor(
+    private readonly line: number,
+    private readonly onSubmit: (content: string) => void,
+    private readonly onCancel: () => void,
+  ) {
+    super();
+  }
+
+  eq(other: ComposerWidget) {
+    return other.line === this.line;
+  }
+
+  toDOM() {
+    const container = document.createElement("div");
+    container.className = "cm-comment-composer-widget";
+    container.style.padding = "8px 16px 8px 48px";
+    container.style.backgroundColor = "var(--accent-2)";
+    container.style.borderBottom = "1px solid var(--accent-6)";
+    container.style.borderTop = "1px solid var(--accent-6)";
+
+    this.root = createRoot(container);
+    this.root.render(
+      createElement(CommentComposer, {
+        onSubmit: this.onSubmit,
+        onCancel: this.onCancel,
+        autoFocus: true,
+      }),
+    );
+
+    return container;
+  }
+
+  destroy() {
+    if (this.root) {
+      const root = this.root;
+      setTimeout(() => root.unmount(), 0);
+    }
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
+/**
+ * Creates decorations for the composer widget
+ */
+function createComposerDecorations(
+  composerState: ComposerState | null,
+  fileId: string,
+  doc: { lines: number; line: (n: number) => { to: number } },
+  onSubmit: (content: string) => void,
+  onCancel: () => void,
+): DecorationSet {
+  // Only show composer if it's for this file
+  if (!composerState || composerState.fileId !== fileId) {
+    return Decoration.none;
+  }
+
+  const lineNum = composerState.line;
+  if (lineNum < 1 || lineNum > doc.lines) {
+    return Decoration.none;
+  }
+
+  const line = doc.line(lineNum);
+  const widget = new ComposerWidget(lineNum, onSubmit, onCancel);
+
+  return Decoration.set([
+    Decoration.widget({
+      widget,
+      block: true,
+      side: 1,
+    }).range(line.to),
+  ]);
+}
+
+/**
+ * Creates a CodeMirror extension that displays the comment composer inline
+ */
+export function commentComposerExtension(
+  fileId: string,
+  getComposerState: () => ComposerState | null,
+  onSubmit: (line: number, content: string) => void,
+  onCancel: () => void,
+): Extension {
+  const composerField = StateField.define<DecorationSet>({
+    create(state) {
+      const composerState = getComposerState();
+      return createComposerDecorations(
+        composerState,
+        fileId,
+        state.doc,
+        (content) => {
+          const cs = getComposerState();
+          if (cs) onSubmit(cs.line, content);
+        },
+        onCancel,
+      );
+    },
+    update(_decorations, tr) {
+      // Always rebuild - composer state might have changed
+      const composerState = getComposerState();
+      return createComposerDecorations(
+        composerState,
+        fileId,
+        tr.state.doc,
+        (content) => {
+          const cs = getComposerState();
+          if (cs) onSubmit(cs.line, content);
+        },
+        onCancel,
+      );
+    },
+    provide: (field) => EditorView.decorations.from(field),
+  });
+
+  return composerField;
+}

--- a/apps/array/src/renderer/features/comments/extensions/commentGutterExtension.ts
+++ b/apps/array/src/renderer/features/comments/extensions/commentGutterExtension.ts
@@ -1,0 +1,108 @@
+import type { Extension } from "@codemirror/state";
+import { EditorView, GutterMarker, gutter } from "@codemirror/view";
+
+/**
+ * Spacer marker to reserve space in the gutter
+ */
+class SpacerMarker extends GutterMarker {
+  toDOM() {
+    const spacer = document.createElement("span");
+    spacer.className = "cm-comment-add-button cm-comment-add-spacer";
+    spacer.textContent = "+";
+    return spacer;
+  }
+}
+
+/**
+ * Gutter marker that shows a "+" button for adding comments
+ */
+class AddCommentMarker extends GutterMarker {
+  constructor(
+    private readonly fileId: string,
+    private readonly line: number,
+    private readonly onAddComment: (fileId: string, line: number) => void,
+  ) {
+    super();
+  }
+
+  toDOM() {
+    const button = document.createElement("button");
+    button.className = "cm-comment-add-button";
+    button.textContent = "+";
+    button.title = "Add comment";
+    button.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.onAddComment(this.fileId, this.line);
+    });
+    return button;
+  }
+}
+
+/**
+ * Creates the comment gutter extension that shows "+" buttons on hover
+ */
+export function commentGutterExtension(
+  fileId: string,
+  onAddComment: (fileId: string, line: number) => void,
+): Extension {
+  // Create a gutter that shows "+" on every line
+  const commentGutter = gutter({
+    class: "cm-comment-gutter",
+    lineMarker: (view, line) => {
+      const lineNumber = view.state.doc.lineAt(line.from).number;
+      return new AddCommentMarker(fileId, lineNumber, onAddComment);
+    },
+    initialSpacer: () => new SpacerMarker(),
+  });
+
+  // Styles for the comment gutter
+  const commentGutterStyles = EditorView.baseTheme({
+    ".cm-comment-gutter": {
+      width: "20px",
+      cursor: "pointer",
+    },
+    ".cm-comment-add-button": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      width: "16px",
+      height: "16px",
+      margin: "0 2px",
+      padding: "0",
+      border: "none",
+      borderRadius: "3px",
+      background: "transparent",
+      color: "var(--accent-9)",
+      fontSize: "14px",
+      fontWeight: "bold",
+      lineHeight: "1",
+      cursor: "pointer",
+      opacity: "0",
+      transition: "opacity 0.15s ease, background-color 0.15s ease",
+    },
+    ".cm-comment-add-spacer": {
+      visibility: "hidden",
+    },
+    // Show button on line hover
+    ".cm-line:hover + .cm-comment-gutter .cm-comment-add-button, .cm-gutters:hover .cm-comment-add-button":
+      {
+        opacity: "0",
+      },
+    // Show on gutter hover for that specific line
+    ".cm-gutter.cm-comment-gutter .cm-gutterElement:hover .cm-comment-add-button":
+      {
+        opacity: "1",
+        background: "var(--accent-3)",
+      },
+    ".cm-comment-add-button:hover": {
+      opacity: "1 !important",
+      background: "var(--accent-4) !important",
+    },
+    ".cm-comment-add-button:active": {
+      background: "var(--accent-5) !important",
+    },
+  });
+
+  return [commentGutter, commentGutterStyles];
+}

--- a/apps/array/src/renderer/features/comments/extensions/commentWidgetExtension.ts
+++ b/apps/array/src/renderer/features/comments/extensions/commentWidgetExtension.ts
@@ -1,0 +1,134 @@
+import { type Extension, StateField } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  WidgetType,
+} from "@codemirror/view";
+import type { Comment } from "@shared/types";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CommentThread } from "../components/CommentThread";
+
+/**
+ * A CodeMirror widget that renders a React CommentThread component
+ */
+class CommentWidget extends WidgetType {
+  private root: Root | null = null;
+
+  constructor(readonly comment: Comment) {
+    super();
+  }
+
+  eq(other: CommentWidget) {
+    return (
+      other.comment.id === this.comment.id &&
+      other.comment.content === this.comment.content &&
+      other.comment.resolved === this.comment.resolved &&
+      other.comment.replies.length === this.comment.replies.length
+    );
+  }
+
+  toDOM() {
+    const container = document.createElement("div");
+    container.className = "cm-comment-widget";
+    container.style.padding = "8px 16px 8px 48px"; // Left padding to align with code
+    container.style.backgroundColor = "var(--gray-1)";
+    container.style.borderBottom = "1px solid var(--gray-4)";
+
+    // Use React to render the CommentThread
+    this.root = createRoot(container);
+    this.root.render(createElement(CommentThread, { comment: this.comment }));
+
+    return container;
+  }
+
+  destroy() {
+    // Schedule unmount for next tick to avoid React warnings
+    if (this.root) {
+      const root = this.root;
+      setTimeout(() => root.unmount(), 0);
+    }
+  }
+
+  ignoreEvent() {
+    return true; // Let React handle events
+  }
+}
+
+/**
+ * Creates decorations for all comments in the document
+ */
+function createCommentDecorations(
+  comments: Comment[],
+  doc: { lines: number; line: (n: number) => { to: number } },
+): DecorationSet {
+  const decorations: Array<{ pos: number; widget: CommentWidget }> = [];
+
+  for (const comment of comments) {
+    // Get the line in the document (1-indexed in our data, need to find correct line)
+    const lineNum = comment.line;
+    if (lineNum < 1 || lineNum > doc.lines) continue;
+
+    const line = doc.line(lineNum);
+    const widget = new CommentWidget(comment);
+
+    decorations.push({
+      pos: line.to,
+      widget,
+    });
+  }
+
+  // Sort by position and create decoration set
+  decorations.sort((a, b) => a.pos - b.pos);
+
+  return Decoration.set(
+    decorations.map(({ pos, widget }) =>
+      Decoration.widget({
+        widget,
+        block: true,
+        side: 1, // After the line
+      }).range(pos),
+    ),
+  );
+}
+
+/**
+ * Comment type for the comments facet
+ */
+export type CommentsFacetValue = Comment[];
+
+/**
+ * Creates a CodeMirror extension that displays comment widgets inline
+ * Uses StateField instead of ViewPlugin because block decorations
+ * cannot be provided via plugins.
+ *
+ * @param getComments - Function to get comments for the current file
+ * @param showComments - Whether to show comments
+ */
+export function commentWidgetExtension(
+  getComments: () => Comment[],
+  showComments: boolean,
+): Extension {
+  // If comments are disabled, return an empty extension
+  if (!showComments) {
+    return [];
+  }
+
+  const commentField = StateField.define<DecorationSet>({
+    create(state) {
+      const comments = getComments();
+      return createCommentDecorations(comments, state.doc);
+    },
+    update(decorations, tr) {
+      if (tr.docChanged) {
+        const comments = getComments();
+        return createCommentDecorations(comments, tr.state.doc);
+      }
+      return decorations;
+    },
+    provide: (field) => EditorView.decorations.from(field),
+  });
+
+  return commentField;
+}

--- a/apps/array/src/renderer/features/comments/index.ts
+++ b/apps/array/src/renderer/features/comments/index.ts
@@ -1,0 +1,21 @@
+// Store
+
+export type {
+  CommentApi,
+  CreateCommentInput,
+  CreateReplyInput,
+} from "./api/commentApi";
+
+// API (adapter pattern - see commentApi.ts for integration instructions)
+export { commentApi } from "./api/commentApi";
+// Components
+export { CommentBubble } from "./components/CommentBubble";
+export { CommentThread } from "./components/CommentThread";
+export { commentComposerExtension } from "./extensions/commentComposerExtension";
+export { commentGutterExtension } from "./extensions/commentGutterExtension";
+// Extensions
+export { commentWidgetExtension } from "./extensions/commentWidgetExtension";
+export { useCommentStore } from "./store/commentStore";
+export type { CommentAuthor } from "./utils/currentUser";
+// Utilities
+export { getCurrentUser, isCurrentUser } from "./utils/currentUser";

--- a/apps/array/src/renderer/features/comments/store/commentStore.ts
+++ b/apps/array/src/renderer/features/comments/store/commentStore.ts
@@ -1,0 +1,276 @@
+/**
+ * ============================================
+ * COMMENT STORE
+ * ============================================
+ *
+ * Local state management for comments.
+ * Uses the API adapter for server communication.
+ *
+ * TODO FOR API INTEGRATION:
+ * The store actions call `commentApi` methods. When you implement
+ * the real API, the store will automatically use it.
+ *
+ * See: api/commentApi.ts for the API interface.
+ * ============================================
+ */
+
+import type { Comment } from "@shared/types";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import {
+  type CreateCommentInput,
+  type CreateReplyInput,
+  commentApi,
+} from "../api/commentApi";
+
+// ============================================
+// STORE INTERFACE
+// ============================================
+
+interface CommentStore {
+  // State
+  comments: Record<string, Comment[]>; // fileId -> comments
+  showComments: boolean;
+  composerState: { fileId: string; line: number } | null;
+
+  // Queries (sync, read from local state)
+  getCommentsForFile: (fileId: string) => Comment[];
+  getCommentsForLine: (fileId: string, line: number) => Comment[];
+
+  // Commands (async, call API then update local state)
+  createComment: (input: CreateCommentInput) => Promise<Comment>;
+  createReply: (input: CreateReplyInput) => Promise<Comment>;
+  updateComment: (commentId: string, content: string) => Promise<void>;
+  deleteComment: (commentId: string) => Promise<void>;
+  resolveComment: (commentId: string, resolved: boolean) => Promise<void>;
+
+  // Local-only actions (no API call)
+  toggleShowComments: () => void;
+  openComposer: (fileId: string, line: number) => void;
+  closeComposer: () => void;
+
+  // Internal: Update local state (used after API calls)
+  _setComments: (fileId: string, comments: Comment[]) => void;
+  _addCommentToState: (comment: Comment) => void;
+  _addReplyToState: (parentId: string, reply: Comment) => void;
+  _updateCommentInState: (commentId: string, updates: Partial<Comment>) => void;
+  _removeCommentFromState: (commentId: string) => void;
+}
+
+// ============================================
+// STORE IMPLEMENTATION
+// ============================================
+
+export const useCommentStore = create<CommentStore>()(
+  persist(
+    (set, get) => ({
+      // Initial state
+      comments: {},
+      showComments: true,
+      composerState: null,
+
+      // ----------------------------------------
+      // QUERIES (sync, local state only)
+      // ----------------------------------------
+
+      getCommentsForFile: (fileId: string) => {
+        return get().comments[fileId] || [];
+      },
+
+      getCommentsForLine: (fileId: string, line: number) => {
+        const comments = get().getCommentsForFile(fileId);
+        return comments.filter((c) => c.line === line);
+      },
+
+      // ----------------------------------------
+      // COMMANDS (async, call API + update state)
+      // ----------------------------------------
+
+      createComment: async (input: CreateCommentInput) => {
+        // Call API to create comment
+        const comment = await commentApi.createComment(input);
+
+        // Update local state
+        get()._addCommentToState(comment);
+
+        return comment;
+      },
+
+      createReply: async (input: CreateReplyInput) => {
+        // Call API to create reply
+        const reply = await commentApi.createReply(input);
+
+        // Update local state
+        get()._addReplyToState(input.parentId, reply);
+
+        return reply;
+      },
+
+      updateComment: async (commentId: string, content: string) => {
+        // Call API to update
+        await commentApi.updateComment(commentId, content);
+
+        // Update local state
+        get()._updateCommentInState(commentId, { content });
+      },
+
+      deleteComment: async (commentId: string) => {
+        // Call API to delete
+        await commentApi.deleteComment(commentId);
+
+        // Update local state
+        get()._removeCommentFromState(commentId);
+      },
+
+      resolveComment: async (commentId: string, resolved: boolean) => {
+        // Call API to update resolve status
+        await commentApi.resolveComment(commentId, resolved);
+
+        // Update local state
+        get()._updateCommentInState(commentId, { resolved });
+      },
+
+      // ----------------------------------------
+      // LOCAL-ONLY ACTIONS (no API call)
+      // ----------------------------------------
+
+      toggleShowComments: () => {
+        set((state) => ({ showComments: !state.showComments }));
+      },
+
+      openComposer: (fileId: string, line: number) => {
+        set({ composerState: { fileId, line } });
+      },
+
+      closeComposer: () => {
+        set({ composerState: null });
+      },
+
+      // ----------------------------------------
+      // INTERNAL STATE UPDATES
+      // ----------------------------------------
+
+      _setComments: (fileId: string, comments: Comment[]) => {
+        set((state) => ({
+          comments: {
+            ...state.comments,
+            [fileId]: comments,
+          },
+        }));
+      },
+
+      _addCommentToState: (comment: Comment) => {
+        set((state) => ({
+          comments: {
+            ...state.comments,
+            [comment.fileId]: [
+              ...(state.comments[comment.fileId] || []),
+              comment,
+            ],
+          },
+        }));
+      },
+
+      _addReplyToState: (parentId: string, reply: Comment) => {
+        set((state) => {
+          const newComments = { ...state.comments };
+          for (const fileId of Object.keys(newComments)) {
+            newComments[fileId] = newComments[fileId].map((comment) =>
+              comment.id === parentId
+                ? { ...comment, replies: [...comment.replies, reply] }
+                : comment,
+            );
+          }
+          return { comments: newComments };
+        });
+      },
+
+      _updateCommentInState: (commentId: string, updates: Partial<Comment>) => {
+        set((state) => {
+          const newComments = { ...state.comments };
+          for (const fileId of Object.keys(newComments)) {
+            newComments[fileId] = newComments[fileId].map((comment) => {
+              // Check if this is the comment to update
+              if (comment.id === commentId) {
+                return { ...comment, ...updates };
+              }
+              // Check replies
+              if (comment.replies.some((r) => r.id === commentId)) {
+                return {
+                  ...comment,
+                  replies: comment.replies.map((reply) =>
+                    reply.id === commentId ? { ...reply, ...updates } : reply,
+                  ),
+                };
+              }
+              return comment;
+            });
+          }
+          return { comments: newComments };
+        });
+      },
+
+      _removeCommentFromState: (commentId: string) => {
+        set((state) => {
+          const newComments = { ...state.comments };
+          for (const fileId of Object.keys(newComments)) {
+            // First try to filter out top-level comments
+            const filtered = newComments[fileId].filter(
+              (comment) => comment.id !== commentId,
+            );
+            // If nothing was removed, check if it's a reply
+            if (filtered.length === newComments[fileId].length) {
+              newComments[fileId] = newComments[fileId].map((comment) => ({
+                ...comment,
+                replies: comment.replies.filter((r) => r.id !== commentId),
+              }));
+            } else {
+              newComments[fileId] = filtered;
+            }
+          }
+          return { comments: newComments };
+        });
+      },
+    }),
+    {
+      name: "comments-storage",
+      // Custom serialization to handle Date objects
+      storage: {
+        getItem: (name) => {
+          const str = localStorage.getItem(name);
+          if (!str) return null;
+          const parsed = JSON.parse(str);
+          // Convert timestamp strings back to Date objects
+          if (parsed.state?.comments) {
+            for (const fileId of Object.keys(parsed.state.comments)) {
+              parsed.state.comments[fileId] = parsed.state.comments[fileId].map(
+                (c: Comment) => ({
+                  ...c,
+                  timestamp: new Date(c.timestamp),
+                  replies: c.replies.map((r: Comment) => ({
+                    ...r,
+                    timestamp: new Date(r.timestamp),
+                  })),
+                }),
+              );
+            }
+          }
+          return parsed;
+        },
+        setItem: (name, value) => {
+          localStorage.setItem(name, JSON.stringify(value));
+        },
+        removeItem: (name) => {
+          localStorage.removeItem(name);
+        },
+      },
+    },
+  ),
+);
+
+// Expose store for dev testing - access via window.__commentStore in console
+if (import.meta.env.DEV) {
+  (
+    window as unknown as { __commentStore: typeof useCommentStore }
+  ).__commentStore = useCommentStore;
+}

--- a/apps/array/src/renderer/features/comments/utils/currentUser.ts
+++ b/apps/array/src/renderer/features/comments/utils/currentUser.ts
@@ -1,0 +1,45 @@
+/**
+ * ============================================
+ * CURRENT USER UTILITY
+ * ============================================
+ *
+ * TODO FOR API INTEGRATION:
+ * Replace the mock implementation below with real user from auth.
+ *
+ * Example:
+ *   import { useAuthStore } from "@features/auth";
+ *
+ *   export function getCurrentUser(): CommentAuthor {
+ *     const user = useAuthStore.getState().user;
+ *     return {
+ *       id: user.id,
+ *       name: user.name || user.email,
+ *     };
+ *   }
+ * ============================================
+ */
+
+export interface CommentAuthor {
+  id: string;
+  name: string;
+}
+
+/**
+ * Get the current user for comment authorship.
+ * Replace this mock with real auth integration.
+ */
+export function getCurrentUser(): CommentAuthor {
+  // MOCK - Replace with real auth
+  return {
+    id: "current-user",
+    name: "You",
+  };
+}
+
+/**
+ * Check if a comment author matches the current user.
+ * Used to determine if edit/delete actions should be shown.
+ */
+export function isCurrentUser(authorName: string): boolean {
+  return authorName === getCurrentUser().name;
+}

--- a/apps/array/src/shared/types.ts
+++ b/apps/array/src/shared/types.ts
@@ -203,3 +203,17 @@ export interface DetectedApplication {
 export interface ExternalAppsPreferences {
   lastUsedApp?: string;
 }
+
+// Comment types for code review
+export interface Comment {
+  id: string;
+  fileId: string;
+  line: number;
+  side: "left" | "right";
+  content: string; // Markdown
+  author: string;
+  timestamp: Date;
+  resolved: boolean;
+  replies: Comment[];
+  isOutdated?: boolean;
+}


### PR DESCRIPTION
## Summary
- Implements inline commenting system for code review with threaded replies
- Comments display below code lines with edit, delete, and resolve actions
- Add comments via "+" gutter button that appears on hover
- Resolved threads auto-collapse and can be expanded
- Persisted to localStorage with mock API ready for GitHub integration

## API Integration (for teammate)
The architecture is designed for easy GitHub API replacement:

1. **`utils/currentUser.ts`** - Replace mock with real auth:
   ```typescript
   export function getCurrentUser(): CommentAuthor {
     const user = useAuthStore.getState().user;
     return { id: user.id, name: user.name };
   }
   ```

2. **`api/commentApi.ts`** - Implement `CommentApi` interface, then swap:
   ```typescript
   import { githubCommentApi } from "./githubCommentApi";
   export const commentApi: CommentApi = githubCommentApi;
   ```

## Test plan
- [ ] Open a task with file changes
- [ ] Hover over line numbers to see "+" button appear
- [ ] Click "+" to open comment composer, submit a comment
- [ ] Verify comment appears inline below the line
- [ ] Test reply functionality
- [ ] Test edit/delete on own comments
- [ ] Test resolve/unresolve and auto-collapse behavior
- [ ] Refresh page and verify comments persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)