### PR TITLE
Rename logs to chat

### DIFF
--- a/apps/array/src/renderer/features/panels/store/panelLayoutStore.ts
+++ b/apps/array/src/renderer/features/panels/store/panelLayoutStore.ts
@@ -111,7 +111,7 @@ function createDefaultPanelTree(
       tabs: [
         {
           id: DEFAULT_TAB_IDS.LOGS,
-          label: "Logs",
+          label: "Chat",
           data: { type: "logs" },
           component: null,
           closeable: false,
@@ -166,7 +166,7 @@ function createDefaultPanelTree(
             tabs: [
               {
                 id: DEFAULT_TAB_IDS.LOGS,
-                label: "Logs",
+                label: "Chat",
                 data: { type: "logs" },
                 component: null,
                 closeable: false,


### PR DESCRIPTION
Rename "Logs" to "Chat" in the Array app's UI tab labels.

---
[Slack Thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1765296201364879?thread_ts=1765296201.364879&cid=C09G8Q32R6F)

<a href="https://cursor.com/background-agent?bcId=bc-cc5171b0-c317-4bfc-8cc3-92ecd225b7ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc5171b0-c317-4bfc-8cc3-92ecd225b7ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

