### PR TITLE
feat: temporary tabs

### DIFF
--- a/apps/array/src/renderer/features/panels/components/DraggableTab.tsx
+++ b/apps/array/src/renderer/features/panels/components/DraggableTab.tsx
@@ -14,10 +14,12 @@ interface DraggableTabProps {
   isActive: boolean;
   index: number;
   closeable?: boolean;
+  isPreview?: boolean;
   onSelect: () => void;
   onClose?: () => void;
   onCloseOthers?: () => void;
   onCloseToRight?: () => void;
+  onKeep?: () => void;
   icon?: React.ReactNode;
   badge?: React.ReactNode;
   hasUnsavedChanges?: boolean;
@@ -31,10 +33,12 @@ export const DraggableTab: React.FC<DraggableTabProps> = ({
   isActive,
   index,
   closeable = true,
+  isPreview,
   onSelect,
   onClose,
   onCloseOthers,
   onCloseToRight,
+  onKeep,
   icon,
   badge,
   hasUnsavedChanges,
@@ -49,6 +53,12 @@ export const DraggableTab: React.FC<DraggableTabProps> = ({
     },
     data: { tabId, panelId, type: "tab" },
   });
+
+  const handleDoubleClick = useCallback(() => {
+    if (isPreview) {
+      onKeep?.();
+    }
+  }, [isPreview, onKeep]);
 
   const handleContextMenu = useCallback(
     async (e: React.MouseEvent) => {
@@ -112,6 +122,7 @@ export const DraggableTab: React.FC<DraggableTabProps> = ({
         minWidth: "60px",
       }}
       onClick={onSelect}
+      onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
       onMouseEnter={(e) => {
         if (!isActive) {
@@ -130,6 +141,10 @@ export const DraggableTab: React.FC<DraggableTabProps> = ({
       <Text
         size="1"
         className="max-w-[200px] select-none overflow-hidden text-ellipsis whitespace-nowrap"
+        style={{
+          fontStyle: isPreview ? "italic" : "normal",
+          opacity: isPreview ? 0.7 : 1,
+        }}
       >
         {label}
       </Text>

--- a/apps/array/src/renderer/features/panels/components/LeafNodeRenderer.tsx
+++ b/apps/array/src/renderer/features/panels/components/LeafNodeRenderer.tsx
@@ -12,6 +12,7 @@ interface LeafNodeRendererProps {
   closeTab: (taskId: string, panelId: string, tabId: string) => void;
   closeOtherTabs: (panelId: string, tabId: string) => void;
   closeTabsToRight: (panelId: string, tabId: string) => void;
+  keepTab: (panelId: string, tabId: string) => void;
   draggingTabId: string | null;
   draggingTabPanelId: string | null;
   onActiveTabChange: (panelId: string, tabId: string) => void;
@@ -28,6 +29,7 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
   closeTab,
   closeOtherTabs,
   closeTabsToRight,
+  keepTab,
   draggingTabId,
   draggingTabPanelId,
   onActiveTabChange,
@@ -56,6 +58,7 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
       onActiveTabChange={onActiveTabChange}
       onCloseOtherTabs={closeOtherTabs}
       onCloseTabsToRight={closeTabsToRight}
+      onKeepTab={keepTab}
       onPanelFocus={onPanelFocus}
       draggingTabId={draggingTabId}
       draggingTabPanelId={draggingTabPanelId}

--- a/apps/array/src/renderer/features/panels/components/PanelLayout.tsx
+++ b/apps/array/src/renderer/features/panels/components/PanelLayout.tsx
@@ -52,6 +52,13 @@ const PanelLayoutRenderer: React.FC<{
     [layoutState, taskId],
   );
 
+  const handleKeepTab = useCallback(
+    (panelId: string, tabId: string) => {
+      layoutState.keepTab(taskId, panelId, tabId);
+    },
+    [layoutState, taskId],
+  );
+
   const handlePanelFocus = useCallback(
     (panelId: string) => {
       layoutState.setFocusedPanel(taskId, panelId);
@@ -116,6 +123,7 @@ const PanelLayoutRenderer: React.FC<{
             closeTab={layoutState.closeTab}
             closeOtherTabs={handleCloseOtherTabs}
             closeTabsToRight={handleCloseTabsToRight}
+            keepTab={handleKeepTab}
             draggingTabId={layoutState.draggingTabId}
             draggingTabPanelId={layoutState.draggingTabPanelId}
             onActiveTabChange={handleSetActiveTab}
@@ -147,6 +155,7 @@ const PanelLayoutRenderer: React.FC<{
       handleSetActiveTab,
       handleCloseOtherTabs,
       handleCloseTabsToRight,
+      handleKeepTab,
       handlePanelFocus,
       handleAddTerminal,
       handleSplitPanel,

--- a/apps/array/src/renderer/features/panels/components/PanelTab.tsx
+++ b/apps/array/src/renderer/features/panels/components/PanelTab.tsx
@@ -12,10 +12,12 @@ interface PanelTabProps {
   index: number;
   draggable?: boolean;
   closeable?: boolean;
+  isPreview?: boolean;
   onSelect: () => void;
   onClose?: () => void;
   onCloseOthers?: () => void;
   onCloseToRight?: () => void;
+  onKeep?: () => void;
   icon?: React.ReactNode;
   badge?: React.ReactNode;
   hasUnsavedChanges?: boolean;
@@ -30,10 +32,12 @@ export const PanelTab: React.FC<PanelTabProps> = ({
   index,
   draggable = true,
   closeable = true,
+  isPreview,
   onSelect,
   onClose,
   onCloseOthers,
   onCloseToRight,
+  onKeep,
   icon,
   badge,
   hasUnsavedChanges,
@@ -60,10 +64,12 @@ export const PanelTab: React.FC<PanelTabProps> = ({
       isActive={isActive}
       index={index}
       closeable={closeable}
+      isPreview={isPreview}
       onSelect={onSelect}
       onClose={onClose}
       onCloseOthers={onCloseOthers}
       onCloseToRight={onCloseToRight}
+      onKeep={onKeep}
       icon={icon}
       badge={badge}
       hasUnsavedChanges={hasUnsavedChanges}

--- a/apps/array/src/renderer/features/panels/components/TabbedPanel.tsx
+++ b/apps/array/src/renderer/features/panels/components/TabbedPanel.tsx
@@ -48,6 +48,7 @@ interface TabbedPanelProps {
   onActiveTabChange?: (panelId: string, tabId: string) => void;
   onCloseOtherTabs?: (panelId: string, tabId: string) => void;
   onCloseTabsToRight?: (panelId: string, tabId: string) => void;
+  onKeepTab?: (panelId: string, tabId: string) => void;
   onPanelFocus?: (panelId: string) => void;
   draggingTabId?: string | null;
   draggingTabPanelId?: string | null;
@@ -62,6 +63,7 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
   onActiveTabChange,
   onCloseOtherTabs,
   onCloseTabsToRight,
+  onKeepTab,
   onPanelFocus,
   draggingTabId = null,
   draggingTabPanelId = null,
@@ -163,6 +165,7 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
                 index={index}
                 draggable={tab.draggable}
                 closeable={tab.closeable !== false}
+                isPreview={tab.isPreview}
                 onSelect={() => {
                   onActiveTabChange?.(panelId, tab.id);
                   onPanelFocus?.(panelId);
@@ -175,6 +178,7 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
                 }
                 onCloseOthers={() => onCloseOtherTabs?.(panelId, tab.id)}
                 onCloseToRight={() => onCloseTabsToRight?.(panelId, tab.id)}
+                onKeep={() => onKeepTab?.(panelId, tab.id)}
                 icon={tab.icon}
                 hasUnsavedChanges={tab.hasUnsavedChanges}
                 badge={tab.badge}

--- a/apps/array/src/renderer/features/panels/hooks/usePanelLayoutHooks.tsx
+++ b/apps/array/src/renderer/features/panels/hooks/usePanelLayoutHooks.tsx
@@ -18,6 +18,7 @@ export interface PanelLayoutState {
   closeTab: (taskId: string, panelId: string, tabId: string) => void;
   closeOtherTabs: (taskId: string, panelId: string, tabId: string) => void;
   closeTabsToRight: (taskId: string, panelId: string, tabId: string) => void;
+  keepTab: (taskId: string, panelId: string, tabId: string) => void;
   setFocusedPanel: (taskId: string, panelId: string) => void;
   addTerminalTab: (taskId: string, panelId: string) => void;
   splitPanel: (
@@ -41,6 +42,7 @@ export function usePanelLayoutState(taskId: string): PanelLayoutState {
         closeTab: state.closeTab,
         closeOtherTabs: state.closeOtherTabs,
         closeTabsToRight: state.closeTabsToRight,
+        keepTab: state.keepTab,
         setFocusedPanel: state.setFocusedPanel,
         addTerminalTab: state.addTerminalTab,
         splitPanel: state.splitPanel,

--- a/apps/array/src/renderer/features/panels/store/panelStoreHelpers.ts
+++ b/apps/array/src/renderer/features/panels/store/panelStoreHelpers.ts
@@ -157,7 +157,11 @@ export function updateTaskLayout(
 }
 
 // Tree update helpers
-export function createNewTab(tabId: string, closeable = true): Tab {
+export function createNewTab(
+  tabId: string,
+  closeable = true,
+  isPreview = false,
+): Tab {
   const parsed = parseTabId(tabId);
   let data: Tab["data"];
 
@@ -210,6 +214,7 @@ export function createNewTab(tabId: string, closeable = true): Tab {
     component: null,
     closeable,
     draggable: true,
+    isPreview,
   };
 }
 
@@ -217,14 +222,20 @@ export function addNewTabToPanel(
   panel: PanelNode,
   tabId: string,
   closeable = true,
+  isPreview = false,
 ): PanelNode {
   if (panel.type !== "leaf") return panel;
+
+  // If opening as preview, remove any existing preview tab first
+  const tabs = isPreview
+    ? panel.content.tabs.filter((tab) => !tab.isPreview)
+    : panel.content.tabs;
 
   return {
     ...panel,
     content: {
       ...panel.content,
-      tabs: [...panel.content.tabs, createNewTab(tabId, closeable)],
+      tabs: [...tabs, createNewTab(tabId, closeable, isPreview)],
       activeTabId: tabId,
     },
   };

--- a/apps/array/src/renderer/features/panels/store/panelTypes.ts
+++ b/apps/array/src/renderer/features/panels/store/panelTypes.ts
@@ -57,6 +57,7 @@ export type Tab = {
   icon?: React.ReactNode;
   hasUnsavedChanges?: boolean;
   badge?: React.ReactNode;
+  isPreview?: boolean;
 };
 
 export type PanelContent = {

--- a/apps/array/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -127,6 +127,10 @@ function ChangedFileItem({
     openDiff(taskId, file.path, file.status);
   };
 
+  const handleDoubleClick = () => {
+    openDiff(taskId, file.path, file.status, false);
+  };
+
   const handleContextMenu = async (e: React.MouseEvent) => {
     e.preventDefault();
     const result = await window.electronAPI.showFileContextMenu(fullPath);
@@ -190,6 +194,7 @@ function ChangedFileItem({
       align="center"
       gap="1"
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/apps/array/src/renderer/features/task-detail/components/FileTreePanel.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/FileTreePanel.tsx
@@ -69,6 +69,12 @@ function LazyTreeItem({
     }
   };
 
+  const handleDoubleClick = () => {
+    if (entry.type === "file") {
+      openFile(taskId, relativePath, false);
+    }
+  };
+
   const handleContextMenu = async (e: React.MouseEvent) => {
     e.preventDefault();
     const result = await window.electronAPI.showFileContextMenu(entry.path, {
@@ -104,6 +110,7 @@ function LazyTreeItem({
             : "border-transparent border-y hover:bg-gray-3"
         }
         onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
         onContextMenu={handleContextMenu}
       >
         <Box

--- a/apps/array/src/test/panelTestHelpers.ts
+++ b/apps/array/src/test/panelTestHelpers.ts
@@ -251,7 +251,7 @@ export function assertGroupStructure(
 
 export function openMultipleFiles(taskId: string, files: string[]) {
   for (const file of files) {
-    usePanelLayoutStore.getState().openFile(taskId, file);
+    usePanelLayoutStore.getState().openFile(taskId, file, false);
   }
 }
 


### PR DESCRIPTION
Now when you click a tab in the editor, it'll open as a temporary tab.
Double clicking the file again (either in the changelist, filetree, or the tab itself), makes it a permanent one.
Also fixed an issue where navigating through the ChangesPanel would open a new tab every time.

<img width="416" height="67" alt="image" src="https://github.com/user-attachments/assets/2b9b1d95-530b-4a0e-b62e-f0a0f559474f" />

