### PR TITLE
fix: set env vars with token

### DIFF
--- a/apps/array/src/main/services/session-manager.ts
+++ b/apps/array/src/main/services/session-manager.ts
@@ -448,9 +448,12 @@ export class SessionManager {
     credentials: PostHogCredentials,
     mockNodeDir: string,
   ): void {
+    const token = this.getToken(credentials.apiKey);
     const newPath = `${mockNodeDir}:${process.env.PATH || ""}`;
     process.env.PATH = newPath;
-    process.env.POSTHOG_AUTH_HEADER = `Bearer ${credentials.apiKey}`;
+    process.env.POSTHOG_AUTH_HEADER = `Bearer ${token}`;
+    process.env.ANTHROPIC_API_KEY = token;
+    process.env.ANTHROPIC_AUTH_TOKEN = token;
 
     const llmGatewayUrl =
       process.env.LLM_GATEWAY_URL ||
@@ -461,7 +464,7 @@ export class SessionManager {
     process.env.CLAUDE_CODE_EXECUTABLE = getClaudeCliPath();
 
     // Set env vars for SessionStore in agent package
-    process.env.POSTHOG_API_KEY = credentials.apiKey;
+    process.env.POSTHOG_API_KEY = token;
     process.env.POSTHOG_API_URL = credentials.apiHost;
     process.env.POSTHOG_PROJECT_ID = String(credentials.projectId);
   }


### PR DESCRIPTION
after the trpc refactor we accidentally were not passing in some env vars anymore, causing chat to break, this adds them back