### PR TITLE
ci: always release on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,74 +4,28 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Version tag (e.g. v0.1.0). Leave empty to reuse package.json."
-        required: false
-        type: string
+    paths:
+      - "apps/array/**"
+      - "packages/agent/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - "turbo.json"
+      - ".github/workflows/release.yml"
 
 permissions:
   contents: write
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+
 jobs:
-  determine-version:
-    runs-on: ubuntu-latest
-    outputs:
-      should_publish: ${{ steps.detect.outputs.should_publish || steps.manual.outputs.should_publish }}
-      version: ${{ steps.detect.outputs.version || steps.manual.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Manual version input
-        if: github.event_name == 'workflow_dispatch'
-        id: manual
-        run: |
-          VERSION="${{ inputs.tag }}"
-          if [ -z "$VERSION" ]; then
-            VERSION=$(jq -r .version apps/array/package.json)
-          fi
-          VERSION="${VERSION#v}"
-          if [ -z "$VERSION" ]; then
-            echo "Failed to determine version for manual publish."
-            exit 1
-          fi
-          echo "Using manual version $VERSION"
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Detect version change on main
-        if: github.event_name != 'workflow_dispatch'
-        id: detect
-        run: |
-          if ! git rev-parse HEAD~1 >/dev/null 2>&1; then
-            echo "Initial commit detected, skipping publish."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          CURRENT_VERSION=$(jq -r .version apps/array/package.json)
-          PREVIOUS_VERSION=$(git show HEAD~1:apps/array/package.json | jq -r .version)
-          if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
-            echo "Version unchanged ($CURRENT_VERSION), skipping publish."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Detected version bump from $PREVIOUS_VERSION to $CURRENT_VERSION"
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-
   publish:
-    needs: determine-version
-    if: needs.determine-version.outputs.should_publish == 'true'
     runs-on: macos-latest
     env:
       GH_TOKEN: ${{ secrets.POSTHOG_BOT_PAT }}
       GITHUB_TOKEN: ${{ secrets.POSTHOG_BOT_PAT }}
       NODE_ENV: production
-      APP_VERSION: ${{ needs.determine-version.outputs.version }}
       APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
@@ -84,17 +38,42 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "pnpm"
+
+      - name: Bump minor version
+        id: version
+        run: |
+          CURRENT_VERSION=$(jq -r .version apps/array/package.json)
+          MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+          NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+          echo "Bumping version from $CURRENT_VERSION to $NEW_VERSION"
+
+          jq --arg v "$NEW_VERSION" '.version = $v' apps/array/package.json > tmp.json && mv tmp.json apps/array/package.json
+
+          git config user.name "posthog-bot"
+          git config user.email "infra@posthog.com"
+          git add apps/array/package.json
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          git push
+
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
       - name: Build agent package
         run: pnpm --filter @posthog/agent run build
+
       - name: Import code signing certificate
         if: env.APPLE_CODESIGN_IDENTITY != ''
         env:
@@ -115,26 +94,19 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           rm "$RUNNER_TEMP/certificate.p12"
-      - name: Verify package version
-        run: |
-          PACKAGE_VERSION=$(jq -r .version apps/array/package.json)
-          if [ "$PACKAGE_VERSION" != "$APP_VERSION" ]; then
-            echo "Package version $PACKAGE_VERSION does not match expected $APP_VERSION"
-            exit 1
-          fi
-      - name: Create or reuse tag
+
+      - name: Create tag
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version }}
         run: |
           TAG="v$APP_VERSION"
-          git fetch --tags
-          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, reusing it."
-          else
-            git config user.name "posthog-bot"
-            git config user.email "infra@posthog.com"
-            git tag -a "$TAG" -m "Release $TAG"
-            git push https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }} "$TAG"
-          fi
+          git tag -a "$TAG" -m "Release $TAG"
+          git push https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }} "$TAG"
+
       - name: Build native modules
         run: pnpm --filter array run build-native
+
       - name: Publish with Electron Forge
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version }}
         run: pnpm --filter array run publish


### PR DESCRIPTION
Closes #342 

This PR adjusts  to always release on push to main, with a minor version bump.

It'll only release the most recently pushed one, so we don't have multiple releases going on if we merge a stack of PRs for example