### PR TITLE
fix: prevent diff tab from closing on load

### DIFF
--- a/apps/array/src/renderer/features/code-editor/components/DiffEditorPanel.tsx
+++ b/apps/array/src/renderer/features/code-editor/components/DiffEditorPanel.tsx
@@ -34,7 +34,7 @@ export function DiffEditorPanel({
     (s) => s.closeDiffTabsForFile,
   );
 
-  const { data: changedFiles = [] } = useQuery({
+  const { data: changedFiles = [], isLoading: loadingChangelist } = useQuery({
     queryKey: ["changed-files-head", repoPath],
     queryFn: () =>
       trpcVanilla.git.getChangedFilesHead.query({
@@ -96,7 +96,9 @@ export function DiffEditorPanel({
   );
 
   const isLoading =
-    (!isDeleted && loadingModified) || (!isNew && loadingOriginal);
+    loadingChangelist ||
+    (!isDeleted && loadingModified) ||
+    (!isNew && loadingOriginal);
 
   const hasNoChanges =
     !!repoPath &&


### PR DESCRIPTION
Closes #350 

We would prematurely close the diff editor panel, since we did not finish loading, so the panel would assume no changes were made.