### PR TITLE
fix(ci): failing Electron Forge publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,4 +117,5 @@ jobs:
       - name: Publish with Electron Forge
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm --filter array run publish


### PR DESCRIPTION
Follow up to https://github.com/PostHog/Array/pull/370.

Log from failed publish: https://github.com/PostHog/Array/actions/runs/20420269519/job/58670507454