### PR TITLE
fix: run dev and prod at the same time

### DIFF
--- a/apps/array/forge.config.ts
+++ b/apps/array/forge.config.ts
@@ -230,7 +230,7 @@ const config: ForgeConfig = {
     new VitePlugin({
       build: [
         {
-          entry: "src/main/index.ts",
+          entry: "src/main/bootstrap.ts",
           config: "vite.main.config.mts",
           target: "main",
         },

--- a/apps/array/package.json
+++ b/apps/array/package.json
@@ -2,7 +2,7 @@
   "name": "@posthog/array",
   "version": "0.0.0-dev",
   "description": "Array - PostHog desktop task manager",
-  "main": ".vite/build/index.js",
+  "main": ".vite/build/bootstrap.js",
   "versionHash": "dynamic",
   "engines": {
     "node": ">=22.0.0",
@@ -22,7 +22,7 @@
     "typecheck": "tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.web.json --noEmit",
     "generate-client": "tsx scripts/update-openapi-client.ts",
     "test": "vitest run",
-    "postinstall": "cd ../.. && npx @electron/rebuild -f -m node_modules/node-pty || true"
+    "postinstall": "cd ../.. && npx @electron/rebuild -f -m node_modules/node-pty || true && bash apps/array/scripts/patch-electron-name.sh"
   },
   "keywords": [
     "posthog",

--- a/apps/array/scripts/patch-electron-name.sh
+++ b/apps/array/scripts/patch-electron-name.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Patches the Electron binary's Info.plist to show "Array (Development)" in the macOS menu bar
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PLIST_FILE="$REPO_ROOT/node_modules/electron/dist/Electron.app/Contents/Info.plist"
+
+if [ ! -f "$PLIST_FILE" ]; then
+  exit 0
+fi
+
+if /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$PLIST_FILE" | grep -q "Array (Development)"; then
+  exit 0
+fi
+
+/usr/libexec/PlistBuddy -c "Set :CFBundleName 'Array (Development)'" "$PLIST_FILE"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName 'Array (Development)'" "$PLIST_FILE"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier 'com.posthog.array.dev'" "$PLIST_FILE"

--- a/apps/array/src/main/bootstrap.ts
+++ b/apps/array/src/main/bootstrap.ts
@@ -1,0 +1,24 @@
+/**
+ * Bootstrap entry point - sets userData path before any service initialization.
+ *
+ * This MUST be the entry point for both dev and prod builds. It ensures the
+ * userData path is set BEFORE any imports that might trigger electron-store
+ * instantiation (which calls app.getPath('userData') in their constructors).
+ *
+ */
+import path from "node:path";
+import { app } from "electron";
+
+const isDev = !app.isPackaged;
+
+// Set different app names for separate single-instance locks
+const appName = isDev ? "array-dev" : "Array";
+app.setName(isDev ? "Array (Development)" : "Array");
+
+const userDataPath = path.join(app.getPath("appData"), "@posthog", appName);
+app.setPath("userData", userDataPath);
+
+// Now dynamically import the rest of the application
+// Dynamic import ensures the path is set BEFORE index.js is evaluated
+// Static imports are hoisted and would run before our setPath() call
+import("./index.js");

--- a/apps/array/src/main/index.ts
+++ b/apps/array/src/main/index.ts
@@ -52,9 +52,6 @@ let mainWindow: BrowserWindow | null = null;
 // instead of ::1. This matches how the renderer already reaches the PostHog API.
 dns.setDefaultResultOrder("ipv4first");
 
-// Set app name to ensure consistent userData path across platforms
-app.setName("Array");
-
 // Single instance lock must be acquired FIRST before any other app setup
 // This ensures deep links go to the existing instance, not a new one
 // In development, we need to pass the same args that setAsDefaultProtocolClient uses

--- a/apps/array/src/main/services/external-apps/service.ts
+++ b/apps/array/src/main/services/external-apps/service.ts
@@ -1,6 +1,5 @@
 import { exec } from "node:child_process";
 import fs from "node:fs/promises";
-import path from "node:path";
 import { promisify } from "node:util";
 import { app, clipboard } from "electron";
 import Store from "electron-store";
@@ -63,19 +62,11 @@ export class ExternalAppsService {
   constructor() {
     this.prefsStore = new Store<ExternalAppsSchema>({
       name: "external-apps",
-      cwd: this.getStorePath(),
+      cwd: app.getPath("userData"),
       defaults: {
         externalAppsPrefs: {},
       },
     });
-  }
-
-  private getStorePath(): string {
-    const userDataPath = app.getPath("userData");
-    if (userDataPath.includes("@posthog")) {
-      return path.join(path.dirname(userDataPath), "Array");
-    }
-    return userDataPath;
   }
 
   private async getFileIcon() {

--- a/apps/array/src/main/services/settingsStore.ts
+++ b/apps/array/src/main/services/settingsStore.ts
@@ -7,14 +7,6 @@ interface SettingsSchema {
   worktreeLocation: string;
 }
 
-function getStorePath(): string {
-  const userDataPath = app.getPath("userData");
-  if (userDataPath.includes("@posthog")) {
-    return path.join(path.dirname(userDataPath), "Array");
-  }
-  return userDataPath;
-}
-
 function getDefaultWorktreeLocation(): string {
   return path.join(os.homedir(), ".array");
 }
@@ -29,7 +21,7 @@ const schema = {
 export const settingsStore = new Store<SettingsSchema>({
   name: "settings",
   schema,
-  cwd: getStorePath(),
+  cwd: app.getPath("userData"),
   defaults: {
     worktreeLocation: getDefaultWorktreeLocation(),
   },

--- a/apps/array/src/main/utils/store.ts
+++ b/apps/array/src/main/utils/store.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { WorktreeManager } from "@posthog/agent";
 import { app } from "electron";
 import Store from "electron-store";
@@ -59,23 +58,15 @@ const schema = {
   },
 };
 
-function getStorePath(): string {
-  const userDataPath = app.getPath("userData");
-  if (userDataPath.includes("@posthog")) {
-    return path.join(path.dirname(userDataPath), "Array");
-  }
-  return userDataPath;
-}
-
 export const rendererStore = new Store<RendererStoreSchema>({
   name: "renderer-storage",
-  cwd: getStorePath(),
+  cwd: app.getPath("userData"),
 });
 
 export const foldersStore = new Store<FoldersSchema>({
   name: "folders",
   schema,
-  cwd: getStorePath(),
+  cwd: app.getPath("userData"),
   defaults: {
     folders: [],
     taskAssociations: [],

--- a/apps/array/src/renderer/main.tsx
+++ b/apps/array/src/renderer/main.tsx
@@ -6,6 +6,8 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./styles/globals.css";
 
+document.title = import.meta.env.DEV ? "Array (Development)" : "Array";
+
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");
 


### PR DESCRIPTION
I had some issues trying to run our production app and development app at the same time.
To fix this, we need to separate our application support folders for array and array-dev. 
I also made it that we patch the local electrons plist to render as "Array (Development)" , and it'll use `com.posthog.array.dev` as its bundle identifier.
Also properly sets the window title in development.

<img width="205" height="62" alt="image" src="https://github.com/user-attachments/assets/84d519d5-043a-4c84-bb91-fa941e6333aa" />

<img width="233" height="134" alt="image" src="https://github.com/user-attachments/assets/f6b9de3a-ebae-478e-99a0-c5561ed01aa2" />