### PR TITLE
feat: add file path to read tool

### DIFF
--- a/apps/array/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
+++ b/apps/array/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
@@ -36,12 +36,16 @@ interface ToolCallViewProps {
 }
 
 export function ToolCallView({ toolCall, turnCancelled }: ToolCallViewProps) {
-  const { title, kind, status } = toolCall;
+  const { title, kind, status, locations } = toolCall;
   const isIncomplete = status === "pending" || status === "in_progress";
   const isLoading = isIncomplete && !turnCancelled;
   const isFailed = status === "failed";
   const wasCancelled = isIncomplete && turnCancelled;
   const KindIcon = kind ? kindIcons[kind] : Wrench;
+
+  // For read tool, show file path from locations if available
+  const filePath = kind === "read" && locations?.[0]?.path;
+  const displayText = filePath ? `Read ${filePath}` : title;
 
   return (
     <Flex align="center" gap="2" className="py-0.5 pl-3">
@@ -51,7 +55,7 @@ export function ToolCallView({ toolCall, turnCancelled }: ToolCallViewProps) {
         <KindIcon size={12} className="text-gray-9" />
       )}
       <Code size="1" color="gray">
-        {title}
+        {displayText}
       </Code>
       {isFailed && (
         <Text size="1" color="gray">


### PR DESCRIPTION
### TL;DR

Enhance tool call display by showing file paths for read operations

### What changed?

- Added support for displaying file paths in the `ToolCallView` component when the tool kind is "read"
- Extracted the file path from the first location in the `locations` array
- Created a `displayText` variable that shows "Read {filePath}" for read operations or falls back to the original title
- Updated the component to render the new `displayText` instead of just the title

### How to test?

1. Trigger a tool call with kind "read" that includes location data
2. Verify that the tool call displays "Read {filePath}" instead of the generic title
3. Confirm that other tool kinds still display their original titles
4. Check that the UI properly handles cases where location data is missing

### Why make this change?

This change improves the user experience by providing more specific and contextual information about read operations. By displaying the actual file path being read, users can more easily understand what files the system is accessing during tool calls, making the interface more informative and transparent.