### PR TITLE
feat: new mode selected with shift + tab

### DIFF
--- a/apps/array/src/main/services/agent/schemas.ts
+++ b/apps/array/src/main/services/agent/schemas.ts
@@ -14,7 +14,7 @@ export const agentFrameworkSchema = z.enum(["claude", "codex"]);
 export type AgentFramework = z.infer<typeof agentFrameworkSchema>;
 
 // Execution mode schema
-export const executionModeSchema = z.enum(["plan"]);
+export const executionModeSchema = z.enum(["plan", "acceptEdits"]);
 export type ExecutionMode = z.infer<typeof executionModeSchema>;
 
 // Session config schema
@@ -45,7 +45,7 @@ export const startSessionInput = z.object({
   autoProgress: z.boolean().optional(),
   model: z.string().optional(),
   framework: agentFrameworkSchema.optional().default("claude"),
-  executionMode: z.enum(["plan"]).optional(),
+  executionMode: z.enum(["plan", "acceptEdits"]).optional(),
   runMode: z.enum(["local", "cloud"]).optional(),
   createPR: z.boolean().optional(),
 });
@@ -115,6 +115,12 @@ export const tokenRefreshInput = z.object({
 export const setModelInput = z.object({
   sessionId: z.string(),
   modelId: z.string(),
+});
+
+// Set mode input
+export const setModeInput = z.object({
+  sessionId: z.string(),
+  modeId: z.enum(["plan", "default", "acceptEdits"]),
 });
 
 // Subscribe to session events input

--- a/apps/array/src/main/services/agent/service.ts
+++ b/apps/array/src/main/services/agent/service.ts
@@ -130,7 +130,7 @@ interface SessionConfig {
   sdkSessionId?: string;
   model?: string;
   framework?: "claude" | "codex";
-  executionMode?: "plan";
+  executionMode?: "plan" | "acceptEdits";
 }
 
 interface ManagedSession {
@@ -498,6 +498,24 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       log.info("Session model updated", { sessionId, modelId });
     } catch (err) {
       log.error("Failed to set session model", { sessionId, modelId, err });
+      throw err;
+    }
+  }
+
+  async setSessionMode(sessionId: string, modeId: string): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    try {
+      await session.connection.extMethod("session/setMode", {
+        sessionId,
+        modeId,
+      });
+      log.info("Session mode updated", { sessionId, modeId });
+    } catch (err) {
+      log.error("Failed to set session mode", { sessionId, modeId, err });
       throw err;
     }
   }

--- a/apps/array/src/main/trpc/routers/agent.ts
+++ b/apps/array/src/main/trpc/routers/agent.ts
@@ -11,6 +11,7 @@ import {
   reconnectSessionInput,
   respondToPermissionInput,
   sessionResponseSchema,
+  setModeInput,
   setModelInput,
   startSessionInput,
   subscribeSessionInput,
@@ -57,6 +58,12 @@ export const agentRouter = router({
     .input(setModelInput)
     .mutation(({ input }) =>
       getService().setSessionModel(input.sessionId, input.modelId),
+    ),
+
+  setMode: publicProcedure
+    .input(setModeInput)
+    .mutation(({ input }) =>
+      getService().setSessionMode(input.sessionId, input.modeId),
     ),
 
   onSessionEvent: publicProcedure

--- a/apps/array/src/renderer/features/message-editor/components/MessageEditor.tsx
+++ b/apps/array/src/renderer/features/message-editor/components/MessageEditor.tsx
@@ -1,4 +1,5 @@
 import "./message-editor.css";
+import type { ExecutionMode } from "@features/sessions/stores/sessionStore";
 import { ArrowUp, Stop } from "@phosphor-icons/react";
 import { Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
 import { EditorContent } from "@tiptap/react";
@@ -9,6 +10,7 @@ import { useTiptapEditor } from "../tiptap/useTiptapEditor";
 import type { EditorHandle } from "../types";
 import type { EditorContent as EditorContentType } from "../utils/content";
 import { EditorToolbar } from "./EditorToolbar";
+import { ModeIndicatorInput } from "./ModeIndicatorInput";
 
 export type { EditorHandle as MessageEditorHandle };
 export type { EditorContentType as EditorContent };
@@ -22,6 +24,8 @@ interface MessageEditorProps {
   onCancel?: () => void;
   onAttachFiles?: (files: File[]) => void;
   autoFocus?: boolean;
+  currentMode?: ExecutionMode;
+  onModeChange?: () => void;
 }
 
 export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
@@ -35,6 +39,8 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
       onCancel,
       onAttachFiles,
       autoFocus = false,
+      currentMode,
+      onModeChange,
     },
     ref,
   ) => {
@@ -97,6 +103,20 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
         enableOnContentEditable: true,
       },
       [isLoading, onCancel],
+    );
+
+    useHotkeys(
+      "shift+tab",
+      (e) => {
+        e.preventDefault();
+        onModeChange?.();
+      },
+      {
+        enableOnFormTags: true,
+        enableOnContentEditable: true,
+        enabled: !disabled && !!onModeChange,
+      },
+      [onModeChange, disabled],
     );
 
     const handleContainerClick = (e: React.MouseEvent) => {
@@ -171,6 +191,9 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
             )}
           </Flex>
         </Flex>
+        {onModeChange && currentMode && (
+          <ModeIndicatorInput mode={currentMode} />
+        )}
       </Flex>
     );
   },

--- a/apps/array/src/renderer/features/message-editor/components/ModeIndicatorInput.tsx
+++ b/apps/array/src/renderer/features/message-editor/components/ModeIndicatorInput.tsx
@@ -1,0 +1,63 @@
+import type { ExecutionMode } from "@features/sessions/stores/sessionStore";
+import { Pause, Pencil, ShieldCheck } from "@phosphor-icons/react";
+import { Flex, Text } from "@radix-ui/themes";
+
+interface ModeIndicatorInputProps {
+  mode: ExecutionMode;
+}
+
+const modeConfig: Record<
+  ExecutionMode,
+  {
+    label: string;
+    icon: React.ReactNode;
+    colorVar: string;
+  }
+> = {
+  plan: {
+    label: "plan mode on",
+    icon: <Pause size={12} weight="bold" />,
+    colorVar: "var(--amber-11)",
+  },
+  default: {
+    label: "default mode",
+    icon: <Pencil size={12} />,
+    colorVar: "var(--gray-11)",
+  },
+  acceptEdits: {
+    label: "auto-accept edits",
+    icon: <ShieldCheck size={12} weight="fill" />,
+    colorVar: "var(--green-11)",
+  },
+};
+
+export function ModeIndicatorInput({ mode }: ModeIndicatorInputProps) {
+  const config = modeConfig[mode];
+
+  return (
+    <Flex align="center" gap="1" py="1">
+      <Text
+        size="1"
+        style={{
+          color: config.colorVar,
+          fontFamily: "monospace",
+          display: "flex",
+          alignItems: "center",
+          gap: "4px",
+        }}
+      >
+        {config.icon}
+        {config.label}
+      </Text>
+      <Text
+        size="1"
+        style={{
+          color: "var(--gray-9)",
+          fontFamily: "monospace",
+        }}
+      >
+        (shift+tab to cycle)
+      </Text>
+    </Flex>
+  );
+}

--- a/apps/array/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -5,8 +5,6 @@ import { GitActionsBar } from "@features/task-detail/components/GitActionsBar";
 import { useTaskData } from "@features/task-detail/hooks/useTaskData";
 import {
   ArrowCounterClockwiseIcon,
-  CaretDownIcon,
-  CaretUpIcon,
   CodeIcon,
   CopyIcon,
   FilePlus,
@@ -26,8 +24,7 @@ import { useExternalAppsStore } from "@stores/externalAppsStore";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { showMessageBox } from "@utils/dialog";
 import { handleExternalAppAction } from "@utils/handleExternalAppAction";
-import { useCallback, useState } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
+import { useState } from "react";
 import {
   selectWorktreePath,
   useWorkspaceStore,
@@ -353,7 +350,6 @@ export function ChangesPanel({ taskId, task }: ChangesPanelProps) {
   const worktreePath = useWorkspaceStore(selectWorktreePath(taskId));
   const repoPath = worktreePath ?? taskData.repoPath;
   const layout = usePanelLayoutStore((state) => state.getLayout(taskId));
-  const openDiff = usePanelLayoutStore((state) => state.openDiff);
 
   const { data: changedFiles = [], isLoading } = useQuery({
     queryKey: ["changed-files-head", repoPath],
@@ -365,40 +361,6 @@ export function ChangesPanel({ taskId, task }: ChangesPanelProps) {
     refetchOnMount: "always",
     refetchOnWindowFocus: true,
   });
-
-  const getActiveIndex = useCallback((): number => {
-    if (!layout) return -1;
-    return changedFiles.findIndex((file) =>
-      isDiffTabActiveInTree(layout.panelTree, file.path, file.status),
-    );
-  }, [layout, changedFiles]);
-
-  const handleKeyNavigation = useCallback(
-    (direction: "up" | "down") => {
-      if (changedFiles.length === 0) return;
-
-      const currentIndex = getActiveIndex();
-      const startIndex =
-        currentIndex === -1
-          ? direction === "down"
-            ? -1
-            : changedFiles.length
-          : currentIndex;
-      const newIndex =
-        direction === "up"
-          ? Math.max(0, startIndex - 1)
-          : Math.min(changedFiles.length - 1, startIndex + 1);
-
-      const file = changedFiles[newIndex];
-      if (file) {
-        openDiff(taskId, file.path, file.status);
-      }
-    },
-    [changedFiles, getActiveIndex, openDiff, taskId],
-  );
-
-  useHotkeys("up", () => handleKeyNavigation("up"), [handleKeyNavigation]);
-  useHotkeys("down", () => handleKeyNavigation("down"), [handleKeyNavigation]);
 
   const isFileActive = (file: ChangedFile): boolean => {
     if (!layout) return false;
@@ -442,16 +404,6 @@ export function ChangesPanel({ taskId, task }: ChangesPanelProps) {
               isActive={isFileActive(file)}
             />
           ))}
-          <Flex align="center" justify="center" gap="1" py="2">
-            <CaretUpIcon size={12} color="var(--gray-10)" />
-            <Text size="1" className="text-gray-10">
-              /
-            </Text>
-            <CaretDownIcon size={12} color="var(--gray-10)" />
-            <Text size="1" className="text-gray-10" ml="1">
-              to switch files
-            </Text>
-          </Flex>
         </Flex>
       </Box>
       <GitActionsBar taskId={taskId} repoPath={repoPath} hasChanges={true} />

--- a/apps/array/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/array/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -25,7 +25,7 @@ interface UseTaskCreationOptions {
   workspaceMode: WorkspaceMode;
   branch?: string | null;
   editorIsEmpty: boolean;
-  executionMode?: "plan";
+  executionMode?: "plan" | "acceptEdits";
 }
 
 interface UseTaskCreationReturn {
@@ -80,7 +80,7 @@ function prepareTaskInput(
     workspaceMode: WorkspaceMode;
     branch?: string | null;
     autoRun: boolean;
-    executionMode?: "plan";
+    executionMode?: "plan" | "acceptEdits";
   },
 ): TaskCreationInput {
   return {

--- a/apps/array/src/renderer/sagas/task/task-creation.ts
+++ b/apps/array/src/renderer/sagas/task/task-creation.ts
@@ -31,8 +31,8 @@ export interface TaskCreationInput {
   branch?: string | null;
   githubIntegrationId?: number;
   autoRun?: boolean;
-  // Execution mode: "plan" starts in plan mode (read-only), undefined starts in default mode
-  executionMode?: "plan";
+  // Execution mode: "plan" starts in plan mode (read-only), "acceptEdits" auto-approves edits, undefined starts in default mode
+  executionMode?: "plan" | "acceptEdits";
 }
 
 export interface TaskCreationOutput {


### PR DESCRIPTION
### TL;DR

Added a new "acceptEdits" execution mode that allows the agent to automatically accept file edits without requiring user approval.

### What changed?

- Added a new "acceptEdits" execution mode alongside the existing "plan" mode
- Implemented a mode indicator in the message editor to show the current mode
- Added ability to cycle between modes (plan, default, acceptEdits) using Shift+Tab
- Added a new TRPC endpoint for changing session mode
- Updated schemas and types throughout the codebase to support the new mode
- Added visual indicators in the UI to show the current mode and how to change it

### How to test?

1. Start a new task and notice the mode indicator at the bottom of the input
2. Press Shift+Tab to cycle between modes (plan, default, acceptEdits)
3. Start a task in "acceptEdits" mode and verify that file edits are automatically accepted
4. During an active session, press Shift+Tab to change modes and verify the mode indicator updates
5. Verify that the mode indicator shows the correct keyboard shortcut (shift+tab)

### Why make this change?

This change improves workflow efficiency by allowing users to choose how they want to interact with the agent:
- "plan" mode for cautious review before changes
- "default" mode for standard interaction
- "acceptEdits" mode for faster workflows where users trust the agent to make changes without explicit approval

The mode cycling feature makes it easy to switch between these modes based on the current task requirements.