### PR TITLE
feat: add AskUserQuestion tool call and UI

### DIFF
--- a/apps/array/src/main/services/agent/schemas.ts
+++ b/apps/array/src/main/services/agent/schemas.ts
@@ -14,7 +14,7 @@ export const agentFrameworkSchema = z.enum(["claude", "codex"]);
 export type AgentFramework = z.infer<typeof agentFrameworkSchema>;
 
 // Execution mode schema
-export const executionModeSchema = z.enum(["plan", "acceptEdits"]);
+export const executionModeSchema = z.enum(["plan", "acceptEdits", "default"]);
 export type ExecutionMode = z.infer<typeof executionModeSchema>;
 
 // Session config schema
@@ -45,7 +45,7 @@ export const startSessionInput = z.object({
   autoProgress: z.boolean().optional(),
   model: z.string().optional(),
   framework: agentFrameworkSchema.optional().default("claude"),
-  executionMode: z.enum(["plan", "acceptEdits"]).optional(),
+  executionMode: z.enum(["plan", "acceptEdits", "default"]).optional(),
   runMode: z.enum(["local", "cloud"]).optional(),
   createPR: z.boolean().optional(),
 });
@@ -164,6 +164,10 @@ export const respondToPermissionInput = z.object({
   sessionId: z.string(),
   toolCallId: z.string(),
   optionId: z.string(),
+  // For multi-select mode: array of selected option IDs
+  selectedOptionIds: z.array(z.string()).optional(),
+  // For "Other" option: custom text input from user
+  customInput: z.string().optional(),
 });
 
 export type RespondToPermissionInput = z.infer<typeof respondToPermissionInput>;

--- a/apps/array/src/main/services/agent/service.ts
+++ b/apps/array/src/main/services/agent/service.ts
@@ -130,7 +130,7 @@ interface SessionConfig {
   sdkSessionId?: string;
   model?: string;
   framework?: "claude" | "codex";
-  executionMode?: "plan" | "acceptEdits";
+  executionMode?: "plan" | "acceptEdits" | "default";
 }
 
 interface ManagedSession {
@@ -179,6 +179,8 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     sessionId: string,
     toolCallId: string,
     optionId: string,
+    selectedOptionIds?: string[],
+    customInput?: string,
   ): void {
     const key = `${sessionId}:${toolCallId}`;
     const pending = this.pendingPermissions.get(key);
@@ -192,12 +194,17 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       sessionId,
       toolCallId,
       optionId,
+      selectedOptionIds,
+      hasCustomInput: !!customInput,
     });
 
     pending.resolve({
       outcome: {
         outcome: "selected",
         optionId,
+        // Include multi-select and custom input in the response
+        ...(selectedOptionIds && { selectedOptionIds }),
+        ...(customInput && { customInput }),
       },
     });
 

--- a/apps/array/src/main/trpc/routers/agent.ts
+++ b/apps/array/src/main/trpc/routers/agent.ts
@@ -107,6 +107,8 @@ export const agentRouter = router({
         input.sessionId,
         input.toolCallId,
         input.optionId,
+        input.selectedOptionIds,
+        input.customInput,
       ),
     ),
 

--- a/apps/array/src/renderer/features/message-editor/components/MessageEditor.tsx
+++ b/apps/array/src/renderer/features/message-editor/components/MessageEditor.tsx
@@ -105,20 +105,6 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
       [isLoading, onCancel],
     );
 
-    useHotkeys(
-      "shift+tab",
-      (e) => {
-        e.preventDefault();
-        onModeChange?.();
-      },
-      {
-        enableOnFormTags: true,
-        enableOnContentEditable: true,
-        enabled: !disabled && !!onModeChange,
-      },
-      [onModeChange, disabled],
-    );
-
     const handleContainerClick = (e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
       if (!target.closest("button") && !target.closest(".ProseMirror")) {

--- a/apps/array/src/renderer/features/sessions/components/InlinePermissionSelector.tsx
+++ b/apps/array/src/renderer/features/sessions/components/InlinePermissionSelector.tsx
@@ -39,14 +39,25 @@ export function InlinePermissionSelector({
 
   // Filter to only show: allow_always (Accept All), allow_once (Accept), and custom input
   // The custom input uses reject_once under the hood to send feedback
+  // Only add "Other" if there's a reject_once option available for custom feedback
   const allOptions = useMemo(() => {
     const filteredOptions = options.filter(
       (o) => o.kind === "allow_always" || o.kind === "allow_once",
     );
-    return [
-      ...filteredOptions,
-      { optionId: "_custom", name: "Other", description: "", kind: "custom" },
-    ];
+    // Check if there's already an "Other" option or if we have reject_once for custom input
+    const hasOtherOption = filteredOptions.some(
+      (o) => o.name.toLowerCase() === "other",
+    );
+    const hasRejectOnce = options.some((o) => o.kind === "reject_once");
+
+    // Only add custom "Other" if there isn't one already AND we have reject_once available
+    if (!hasOtherOption && hasRejectOnce) {
+      return [
+        ...filteredOptions,
+        { optionId: "_custom", name: "Other", description: "", kind: "custom" },
+      ];
+    }
+    return filteredOptions;
   }, [options]);
 
   const numOptions = allOptions.length;
@@ -66,14 +77,19 @@ export function InlinePermissionSelector({
     setSelectedIndex((prev) => (prev < numOptions - 1 ? prev + 1 : 0));
   }, [numOptions]);
 
+  // Check if an option is a custom input option (either "_custom" or "other")
+  const isCustomOption = useCallback((optionId: string) => {
+    return optionId === "_custom" || optionId === "other";
+  }, []);
+
   const selectCurrent = useCallback(() => {
     const selected = allOptions[selectedIndex];
-    if (selected.optionId === "_custom") {
+    if (isCustomOption(selected.optionId)) {
       setIsCustomInputMode(true);
     } else {
       onSelect(selected.optionId);
     }
-  }, [allOptions, selectedIndex, onSelect]);
+  }, [allOptions, selectedIndex, onSelect, isCustomOption]);
 
   const handleCancel = useCallback(() => {
     onCancel?.();
@@ -168,6 +184,13 @@ export function InlinePermissionSelector({
         setCustomInput("");
       } else if (e.key === "Enter" && customInput.trim()) {
         e.preventDefault();
+        // First try to find the "other" option (for AskUserQuestion)
+        const otherOption = options.find((o) => o.optionId === "other");
+        if (otherOption) {
+          onSelect(otherOption.optionId, customInput.trim());
+          return;
+        }
+        // Fallback to reject_once for plan mode feedback
         const keepPlanningOption = options.find(
           (o) => o.kind === "reject_once",
         );
@@ -182,7 +205,7 @@ export function InlinePermissionSelector({
   const handleOptionClick = (index: number) => {
     if (disabled) return;
     const opt = allOptions[index];
-    if (opt.optionId === "_custom") {
+    if (isCustomOption(opt.optionId)) {
       setSelectedIndex(index);
       setIsCustomInputMode(true);
     } else {
@@ -194,10 +217,10 @@ export function InlinePermissionSelector({
     <Box
       ref={containerRef}
       tabIndex={0}
-      className="border-gray-6 border-t bg-gray-2 px-4 py-3 outline-none"
+      className="border-gray-6 border-t bg-gray-2 px-3 py-2 outline-none"
     >
       {/* Question/Title */}
-      <Text size="1" weight="medium" className="mb-2 block text-amber-11">
+      <Text size="1" weight="medium" className="mb-1 block text-amber-11">
         {title}
       </Text>
 
@@ -205,14 +228,14 @@ export function InlinePermissionSelector({
       <Flex direction="column" gap="1">
         {allOptions.map((option, index) => {
           const isSelected = selectedIndex === index;
-          const isCustom = option.optionId === "_custom";
+          const isCustom = isCustomOption(option.optionId);
 
           if (isCustom && isCustomInputMode) {
             return (
               <Flex
                 key={option.optionId}
                 align="center"
-                gap="2"
+                gap="1"
                 className="py-0.5"
               >
                 <span className="inline-block w-3 text-green-9 text-xs">›</span>
@@ -222,8 +245,8 @@ export function InlinePermissionSelector({
                   value={customInput}
                   onChange={(e) => setCustomInput(e.target.value)}
                   onKeyDown={handleCustomInputKeyDown}
-                  placeholder="Type your feedback and press Enter..."
-                  className="flex-1 border-none bg-transparent text-gray-12 text-xs outline-none placeholder:text-gray-9"
+                  placeholder="Type your response and press Enter..."
+                  className="h-5 flex-1 border-none bg-transparent text-[12px] text-gray-12 leading-tight outline-none placeholder:text-gray-9"
                   disabled={disabled}
                 />
               </Flex>
@@ -234,12 +257,16 @@ export function InlinePermissionSelector({
             <Flex
               key={option.optionId}
               align="center"
-              gap="2"
-              className={`cursor-pointer py-0.5 ${isSelected ? "text-gray-12" : "text-gray-10"}`}
+              gap="1"
+              className={`cursor-pointer py-0.5 ${
+                isSelected ? "text-gray-12" : "text-gray-10"
+              }`}
               onClick={() => handleOptionClick(index)}
             >
               <span
-                className={`inline-block w-3 text-xs ${isSelected ? "text-green-9" : "text-transparent"}`}
+                className={`inline-block w-3 text-xs ${
+                  isSelected ? "text-green-9" : "text-transparent"
+                }`}
               >
                 ›
               </span>

--- a/apps/array/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/array/src/renderer/features/sessions/components/SessionView.tsx
@@ -159,15 +159,26 @@ export function SessionView({
     async (optionId: string, customInput?: string) => {
       if (!firstPendingPermission || !taskId) return;
 
-      // If custom input provided, send it as a prompt after selecting "keep planning"
       if (customInput) {
-        await respondToPermission(
-          taskId,
-          firstPendingPermission.toolCallId,
-          optionId,
-        );
-        // Send the custom input as a follow-up prompt
-        onSendPrompt(customInput);
+        // Check if this is an "other" option (AskUserQuestion) or plan feedback
+        if (optionId === "other") {
+          // For AskUserQuestion "Other" - pass customInput to the permission response
+          await respondToPermission(
+            taskId,
+            firstPendingPermission.toolCallId,
+            optionId,
+            undefined,
+            customInput,
+          );
+        } else {
+          // For plan mode feedback - respond and send as follow-up prompt
+          await respondToPermission(
+            taskId,
+            firstPendingPermission.toolCallId,
+            optionId,
+          );
+          onSendPrompt(customInput);
+        }
       } else {
         await respondToPermission(
           taskId,

--- a/apps/array/src/renderer/features/sessions/components/session-update/InlineQuestionView.tsx
+++ b/apps/array/src/renderer/features/sessions/components/session-update/InlineQuestionView.tsx
@@ -4,9 +4,14 @@ import {
   useSessionActions,
 } from "@features/sessions/stores/sessionStore";
 import type { ToolCall } from "@features/sessions/types";
-import { ChatCircle, CheckCircle } from "@phosphor-icons/react";
-import { Box, Button, Flex, Text } from "@radix-ui/themes";
-import { useState } from "react";
+import {
+  CaretRight,
+  ChatCircle,
+  CheckCircle,
+  Circle,
+} from "@phosphor-icons/react";
+import { Box, Button, Checkbox, Flex, Text, TextField } from "@radix-ui/themes";
+import { useCallback, useState } from "react";
 
 interface InlineQuestionViewProps {
   toolCall: ToolCall;
@@ -14,17 +19,22 @@ interface InlineQuestionViewProps {
   turnCancelled?: boolean;
 }
 
-interface QuestionInput {
-  questions?: Array<{
-    question: string;
-    header?: string;
-    options: Array<{
-      label: string;
-      description?: string;
-    }>;
-    multiSelect?: boolean;
+interface Question {
+  question: string;
+  header?: string;
+  options: Array<{
+    label: string;
+    description?: string;
   }>;
-  answers?: Record<string, string>;
+  multiSelect?: boolean;
+}
+
+interface QuestionInput {
+  questions?: Question[];
+  currentQuestion?: Question;
+  questionIndex?: number;
+  totalQuestions?: number;
+  answers?: Record<string, string | string[]>;
 }
 
 export function InlineQuestionView({
@@ -38,18 +48,71 @@ export function InlineQuestionView({
   const { respondToPermission } = useSessionActions();
   const [isResponding, setIsResponding] = useState(false);
 
+  // Multi-select state
+  const [selectedOptions, setSelectedOptions] = useState<Set<string>>(
+    new Set(),
+  );
+  // "Other" text input state
+  const [otherText, setOtherText] = useState("");
+  const [isOtherSelected, setIsOtherSelected] = useState(false);
+
   const pendingPermission = pendingPermissions.get(toolCallId);
   const isComplete = status === "completed";
   const isPending = !!pendingPermission && !isComplete;
   const wasCancelled =
     (status === "pending" || status === "in_progress") && turnCancelled;
 
-  const firstQuestion = input?.questions?.[0];
-  const questionText = firstQuestion?.question ?? "Question";
-  const selectedAnswer = input?.answers?.[questionText];
+  // Get all questions - from questions array or build from currentQuestion
+  const allQuestions: Question[] =
+    input?.questions || (input?.currentQuestion ? [input.currentQuestion] : []);
+  const totalQuestions = input?.totalQuestions ?? allQuestions.length;
+  const questionIndex = input?.questionIndex ?? 0;
+  const hasMultipleQuestions = totalQuestions > 1;
 
-  const handleOptionClick = async (optionId: string) => {
+  // Current question being asked
+  const currentQuestion = input?.currentQuestion || allQuestions[questionIndex];
+  const questionText = currentQuestion?.question ?? "Question";
+  const headerText = currentQuestion?.header;
+  const isMultiSelect = currentQuestion?.multiSelect ?? false;
+
+  // Get all answers
+  const answers = input?.answers ?? {};
+
+  // Check if we only have the "Other" option (no predefined options from Claude)
+  const hasOnlyOtherOption =
+    pendingPermission?.options.length === 1 &&
+    pendingPermission.options[0]?.optionId === "other";
+
+  const toggleOption = useCallback(
+    (optionId: string) => {
+      if (optionId === "other") {
+        setIsOtherSelected((prev) => !prev);
+        if (isOtherSelected) {
+          setOtherText("");
+        }
+      } else {
+        setSelectedOptions((prev) => {
+          const newSet = new Set(prev);
+          if (newSet.has(optionId)) {
+            newSet.delete(optionId);
+          } else {
+            newSet.add(optionId);
+          }
+          return newSet;
+        });
+      }
+    },
+    [isOtherSelected],
+  );
+
+  const handleSingleSelect = async (optionId: string) => {
     if (!pendingPermission || isResponding) return;
+
+    if (optionId === "other") {
+      setIsOtherSelected(true);
+      return;
+    }
+
     setIsResponding(true);
     try {
       await respondToPermission(taskId, toolCallId, optionId);
@@ -57,6 +120,70 @@ export function InlineQuestionView({
       setIsResponding(false);
     }
   };
+
+  const handleMultiSelectSubmit = async () => {
+    if (!pendingPermission || isResponding) return;
+    if (selectedOptions.size === 0 && !isOtherSelected) return;
+
+    setIsResponding(true);
+    try {
+      const selectedIds = Array.from(selectedOptions);
+      const primaryOptionId = selectedIds.length > 0 ? selectedIds[0] : "other";
+
+      await respondToPermission(
+        taskId,
+        toolCallId,
+        primaryOptionId,
+        selectedIds.length > 0 ? selectedIds : undefined,
+        isOtherSelected ? otherText : undefined,
+      );
+    } finally {
+      setIsResponding(false);
+    }
+  };
+
+  const handleOtherSubmit = async () => {
+    if (!pendingPermission || isResponding || !otherText.trim()) return;
+    setIsResponding(true);
+    try {
+      await respondToPermission(
+        taskId,
+        toolCallId,
+        "other",
+        undefined,
+        otherText.trim(),
+      );
+    } finally {
+      setIsResponding(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleOtherSubmit();
+    }
+  };
+
+  // Format answer for display
+  const formatAnswer = (answer: string | string[] | undefined): string => {
+    if (!answer) return "";
+    if (Array.isArray(answer)) return answer.join(", ");
+    return answer;
+  };
+
+  // Build questions list for multi-question display
+  const questionsList = hasMultipleQuestions
+    ? Array.from({ length: totalQuestions }, (_, idx) => {
+        const q = allQuestions[idx];
+        const qText = q?.question || `Question ${idx + 1}`;
+        const qHeader = q?.header || `Question ${idx + 1}`;
+        const answer = answers[qText];
+        const isAnswered = answer !== undefined;
+        const isCurrent = idx === questionIndex && isPending;
+        return { idx, qHeader, answer, isAnswered, isCurrent };
+      })
+    : [];
 
   return (
     <Box className="my-2 max-w-xl overflow-hidden rounded-lg border border-accent-6 bg-accent-2">
@@ -73,56 +200,248 @@ export function InlineQuestionView({
         ) : (
           <DotsCircleSpinner size={14} className="text-accent-9" />
         )}
-        <Text size="2" weight="medium" className="text-accent-11">
-          {firstQuestion?.header ?? "Question"}
+        <Text size="1" weight="medium" className="text-accent-11">
+          {headerText || "Question"}
         </Text>
+        {hasMultipleQuestions && (
+          <Text size="1" className="ml-auto text-gray-10">
+            {questionIndex + 1} of {totalQuestions}
+          </Text>
+        )}
       </Flex>
 
-      {/* Question text */}
-      <Box className="px-3 py-3">
-        <Text size="2" className="text-gray-12">
-          {questionText}
-        </Text>
-      </Box>
-
-      {/* Options or Answer */}
-      {isPending && pendingPermission.options.length > 0 ? (
-        <Flex
-          gap="2"
-          wrap="wrap"
-          className="border-accent-6 border-t px-3 py-3"
-        >
-          {pendingPermission.options.map((option) => (
-            <Button
-              key={option.optionId}
-              size="1"
-              variant="soft"
-              color="gray"
-              disabled={isResponding || wasCancelled}
-              onClick={() => handleOptionClick(option.optionId)}
-            >
-              {option.name}
-            </Button>
-          ))}
-        </Flex>
-      ) : selectedAnswer ? (
-        <Box className="border-accent-6 border-t px-3 py-2">
-          <Flex align="center" gap="2">
-            <Text size="1" className="text-gray-10">
-              Answer:
-            </Text>
-            <Text size="2" weight="medium" className="text-accent-11">
-              {selectedAnswer}
-            </Text>
+      {/* Multi-question progress list */}
+      {hasMultipleQuestions && (
+        <Box className="border-accent-6 border-b px-3 py-2">
+          <Flex direction="column" gap="1">
+            {questionsList.map(
+              ({ idx, qHeader, isAnswered, isCurrent, answer }) => (
+                <Flex key={idx} align="center" gap="2">
+                  {isAnswered ? (
+                    <CheckCircle
+                      size={12}
+                      weight="fill"
+                      className="flex-shrink-0 text-green-9"
+                    />
+                  ) : isCurrent ? (
+                    <CaretRight
+                      size={12}
+                      weight="bold"
+                      className="flex-shrink-0 text-accent-9"
+                    />
+                  ) : (
+                    <Circle
+                      size={12}
+                      weight="regular"
+                      className="flex-shrink-0 text-gray-8"
+                    />
+                  )}
+                  <Text
+                    size="1"
+                    className={
+                      isCurrent
+                        ? "text-accent-11"
+                        : isAnswered
+                          ? "text-gray-11"
+                          : "text-gray-9"
+                    }
+                  >
+                    {qHeader}
+                  </Text>
+                  {isAnswered && (
+                    <>
+                      <Text size="1" className="flex-shrink-0 text-gray-8">
+                        —
+                      </Text>
+                      <Text
+                        size="1"
+                        className="min-w-0 flex-1 truncate text-gray-11"
+                      >
+                        {formatAnswer(answer)}
+                      </Text>
+                    </>
+                  )}
+                </Flex>
+              ),
+            )}
           </Flex>
         </Box>
-      ) : wasCancelled ? (
-        <Box className="border-accent-6 border-t px-3 py-2">
+      )}
+
+      {/* Current question content (when pending) */}
+      {isPending && pendingPermission.options.length > 0 && (
+        <Box className="px-3 py-2">
+          {/* Full question text */}
+          <Text size="1" className="mb-2 block text-gray-12">
+            {questionText}
+          </Text>
+
+          {/* Options */}
+          {hasOnlyOtherOption ? (
+            <Flex direction="column" gap="2">
+              <TextField.Root
+                size="1"
+                placeholder="Type your answer..."
+                value={otherText}
+                onChange={(e) => setOtherText(e.target.value)}
+                onKeyDown={handleKeyDown}
+                disabled={isResponding}
+                autoFocus
+                className="[&_input]:text-[12px]"
+              />
+              <Button
+                size="1"
+                variant="soft"
+                disabled={isResponding || wasCancelled || !otherText.trim()}
+                onClick={handleOtherSubmit}
+                className="self-start"
+              >
+                Submit
+              </Button>
+            </Flex>
+          ) : isMultiSelect ? (
+            <Flex direction="column" gap="2">
+              {pendingPermission.options.map((option) => (
+                <Flex key={option.optionId} align="start" gap="2">
+                  <Checkbox
+                    checked={
+                      option.optionId === "other"
+                        ? isOtherSelected
+                        : selectedOptions.has(option.optionId)
+                    }
+                    onCheckedChange={() => toggleOption(option.optionId)}
+                    disabled={isResponding || wasCancelled}
+                    className="mt-0.5"
+                  />
+                  <Flex direction="column" gap="0">
+                    <Text size="1">{option.name}</Text>
+                    {option.description && (
+                      <Text size="1" className="text-gray-10">
+                        {option.description}
+                      </Text>
+                    )}
+                  </Flex>
+                </Flex>
+              ))}
+              {isOtherSelected && (
+                <TextField.Root
+                  size="1"
+                  placeholder="Enter your response..."
+                  value={otherText}
+                  onChange={(e) => setOtherText(e.target.value)}
+                  disabled={isResponding}
+                  className="ml-6 [&_input]:text-[12px]"
+                />
+              )}
+              <Button
+                size="1"
+                variant="soft"
+                disabled={
+                  isResponding ||
+                  wasCancelled ||
+                  (selectedOptions.size === 0 && !isOtherSelected)
+                }
+                onClick={handleMultiSelectSubmit}
+                className="mt-1 self-start"
+              >
+                Submit
+              </Button>
+            </Flex>
+          ) : isOtherSelected ? (
+            <Flex direction="column" gap="2">
+              <TextField.Root
+                size="1"
+                placeholder="Enter your response..."
+                value={otherText}
+                onChange={(e) => setOtherText(e.target.value)}
+                onKeyDown={handleKeyDown}
+                disabled={isResponding}
+                autoFocus
+                className="[&_input]:text-[12px]"
+              />
+              <Flex gap="2">
+                <Button
+                  size="1"
+                  variant="soft"
+                  disabled={isResponding || !otherText.trim()}
+                  onClick={handleOtherSubmit}
+                >
+                  Submit
+                </Button>
+                <Button
+                  size="1"
+                  variant="ghost"
+                  color="gray"
+                  disabled={isResponding}
+                  onClick={() => {
+                    setIsOtherSelected(false);
+                    setOtherText("");
+                  }}
+                >
+                  Back
+                </Button>
+              </Flex>
+            </Flex>
+          ) : (
+            <Flex direction="column" gap="2">
+              {pendingPermission.options.map((option) => (
+                <Flex key={option.optionId} direction="column" gap="0">
+                  <Button
+                    size="1"
+                    variant="soft"
+                    color="gray"
+                    disabled={isResponding || wasCancelled}
+                    onClick={() => handleSingleSelect(option.optionId)}
+                    className="justify-start"
+                  >
+                    {option.name}
+                  </Button>
+                  {option.description && (
+                    <Text size="1" className="mt-0.5 ml-2 text-gray-10">
+                      {option.description}
+                    </Text>
+                  )}
+                </Flex>
+              ))}
+            </Flex>
+          )}
+        </Box>
+      )}
+
+      {/* Completed state - show answer(s) */}
+      {isComplete && (
+        <Box className="px-3 py-2">
+          {Object.keys(answers).length > 0 ? (
+            <Flex direction="column" gap="1">
+              {Object.entries(answers).map(([question, answer]) => (
+                <Flex key={question} align="start" gap="2">
+                  <CheckCircle
+                    size={12}
+                    weight="fill"
+                    className="mt-0.5 flex-shrink-0 text-green-9"
+                  />
+                  <Text size="1" className="text-gray-11">
+                    {formatAnswer(answer)}
+                  </Text>
+                </Flex>
+              ))}
+            </Flex>
+          ) : (
+            <Text size="1" className="text-gray-10">
+              Completed
+            </Text>
+          )}
+        </Box>
+      )}
+
+      {/* Cancelled state */}
+      {wasCancelled && (
+        <Box className="px-3 py-2">
           <Text size="1" className="text-gray-9">
             (Cancelled)
           </Text>
         </Box>
-      ) : null}
+      )}
     </Box>
   );
 }

--- a/apps/array/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/array/src/renderer/features/sessions/stores/sessionStore.ts
@@ -86,6 +86,8 @@ interface SessionActions {
     taskId: string,
     toolCallId: string,
     optionId: string,
+    selectedOptionIds?: string[],
+    customInput?: string,
   ) => Promise<void>;
   cancelPermission: (taskId: string, toolCallId: string) => Promise<void>;
 }
@@ -928,7 +930,13 @@ const useStore = create<SessionStore>()(
           await appendAndPersist(taskId, session, event, storedEntry);
         },
 
-        respondToPermission: async (taskId, toolCallId, optionId) => {
+        respondToPermission: async (
+          taskId,
+          toolCallId,
+          optionId,
+          selectedOptionIds,
+          customInput,
+        ) => {
           const session = getSessionByTaskId(taskId);
           if (!session) {
             log.error("No session found for permission response", { taskId });
@@ -940,6 +948,8 @@ const useStore = create<SessionStore>()(
               sessionId: session.taskRunId,
               toolCallId,
               optionId,
+              selectedOptionIds,
+              customInput,
             });
 
             // Create new Map outside of Immer (Maps don't work well with Immer proxies)
@@ -960,6 +970,8 @@ const useStore = create<SessionStore>()(
               taskId,
               toolCallId,
               optionId,
+              selectedOptionIds,
+              hasCustomInput: !!customInput,
             });
 
             // Persist permission response to logs for recovery tracking
@@ -973,6 +985,8 @@ const useStore = create<SessionStore>()(
                   params: {
                     toolCallId,
                     optionId,
+                    ...(selectedOptionIds && { selectedOptionIds }),
+                    ...(customInput && { customInput }),
                   },
                 },
               };


### PR DESCRIPTION
### TL;DR

Enhanced the permission system to support multi-select options and custom text input for user questions.

### What changed?

- Added support for multi-select options in permission requests
- Added support for custom text input via the "Other" option
- Enhanced the `AskUserQuestion` tool to handle multiple questions in sequence
- Improved the UI for question display with better formatting and multi-question progress tracking
- Added automatic scrolling when new permission requests appear
- Enabled the `AskUserQuestion` tool by default in the Claude adapter

### How to test?

1. Run a task that uses the `AskUserQuestion` tool (most plan mode tasks)
2. Verify that multi-select options work correctly when available
3. Test the "Other" option by entering custom text
4. Test a sequence of multiple questions and verify the progress tracking
5. Verify that the conversation automatically scrolls when new questions appear

### Why make this change?

This change significantly improves the user experience when Claude needs to gather information from users. The multi-select capability allows for more complex data collection, while the custom text input provides flexibility when predefined options don't cover the user's needs. The enhanced UI makes it clearer when multiple questions are being asked in sequence, improving the overall interaction flow.