### PR TITLE
feat(arr): sequential merge and track pr linking

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,7 +10,6 @@
     "build": "bun build ./src/index.ts --outdir ./dist --target bun",
     "dev": "bun run ./bin/arr.ts",
     "typecheck": "tsc --noEmit",
-    "test": "bun test --concurrent tests/unit tests/e2e/cli.test.ts",
     "test:pty": "vitest run tests/e2e/pty.test.ts"
   },
   "devDependencies": {

--- a/apps/cli/src/commands/track.ts
+++ b/apps/cli/src/commands/track.ts
@@ -16,4 +16,7 @@ export async function track(
 
   message(formatSuccess(`Now tracking ${cyan(result.bookmark)}`));
   indent(`${dim("Parent:")} ${result.parent}`);
+  if (result.linkedPr) {
+    indent(`${dim("Linked:")} PR #${result.linkedPr}`);
+  }
 }

--- a/packages/core/src/commands/merge.ts
+++ b/packages/core/src/commands/merge.ts
@@ -7,8 +7,8 @@ import type { Command } from "./types";
 interface MergeOptions {
   method?: "merge" | "squash" | "rebase";
   engine: Engine;
-  onMerging?: (pr: PRToMerge, nextPr?: PRToMerge) => void;
-  onWaiting?: () => void;
+  onWaitingForCI?: (pr: PRToMerge) => void;
+  onMerging?: (pr: PRToMerge) => void;
   onMerged?: (pr: PRToMerge) => void;
 }
 
@@ -20,7 +20,8 @@ export async function getMergeablePrs(): Promise<Result<PRToMerge[]>> {
 }
 
 /**
- * Merge the stack of PRs.
+ * Merge the stack of PRs sequentially.
+ * Waits for CI to pass on each PR before merging, then updates the next PR's base.
  * Untracks merged bookmarks from the engine.
  */
 export async function merge(
@@ -31,8 +32,8 @@ export async function merge(
     prs,
     { method: options.method ?? "squash", engine: options.engine },
     {
+      onWaitingForCI: options.onWaitingForCI,
       onMerging: options.onMerging,
-      onWaiting: options.onWaiting,
       onMerged: options.onMerged,
     },
   );

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -33,6 +33,7 @@ export type JJErrorCode =
   | "ALREADY_MERGED"
   | "NOT_FOUND"
   | "EMPTY_CHANGE"
+  | "CI_FAILED"
   | "UNKNOWN";
 
 export function createError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,9 @@ importers:
       electron:
         specifier: ^35.2.1
         version: 35.7.5
+      superjson:
+        specifier: ^2.2.2
+        version: 2.2.6
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -507,6 +510,9 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.25)(jsdom@26.1.0)(msw@2.12.4(@types/node@20.19.25)(typescript@5.9.3))(terser@5.44.1)
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
 
 packages:
 
@@ -1999,10 +2005,6 @@ packages:
   '@octokit/types@6.41.0':
     resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
 
-  '@openai/codex-sdk@0.60.1':
-    resolution: {integrity: sha512-w7FhUXfqpzw9igTZFfKS7cUNW1FK+tT426ZkClG2X8vufW0jyGqfgPd6Uq8+gJgSTLxayF9I802FDW2KjYcfYQ==}
-    engines: {node: '>=18'}
-
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -2011,6 +2013,10 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@openai/codex-sdk@0.60.1':
+    resolution: {integrity: sha512-w7FhUXfqpzw9igTZFfKS7cUNW1FK+tT426ZkClG2X8vufW0jyGqfgPd6Uq8+gJgSTLxayF9I802FDW2KjYcfYQ==}
+    engines: {node: '>=18'}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -4184,6 +4190,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
+
   core-js@3.47.0:
     resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
 
@@ -5127,6 +5137,10 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -6791,6 +6805,10 @@ packages:
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -9569,8 +9587,6 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 12.11.0
 
-  '@openai/codex-sdk@0.60.1': {}
-
   '@open-draft/deferred-promise@2.2.0':
     optional: true
 
@@ -9582,6 +9598,8 @@ snapshots:
 
   '@open-draft/until@2.1.0':
     optional: true
+
+  '@openai/codex-sdk@0.60.1': {}
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -11784,6 +11802,10 @@ snapshots:
   cookie@1.1.1:
     optional: true
 
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
+
   core-js@3.47.0: {}
 
   cors@2.8.5:
@@ -12830,6 +12852,8 @@ snapshots:
       better-path-resolve: 1.0.0
 
   is-unicode-supported@0.1.0: {}
+
+  is-what@5.5.0: {}
 
   is-windows@1.0.2: {}
 
@@ -14918,6 +14942,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
 
   supports-color@7.2.0:
     dependencies:


### PR DESCRIPTION
**TL;DR**

  Rewrote `arr merge` to merge PRs sequentially (one at a time), waiting for CI on each before proceeding. Also improved `arr track` to automatically detect and link existing PRs.

  **What changed?**

  _Sequential merge flow_
  - PRs now merge one at a time instead of rebasing all to main upfront
  - Waits for CI checks to complete before each merge (`gh pr checks --watch`)
  - Only updates next PR's base to main after current PR successfully merges
  - Falls back to auto-merge + polling if blocked by branch protection
  - 30 minute timeout for CI wait

  _Auto-link PRs on track_
  - arr track now checks GitHub for an existing PR on the bookmark
  - Shows "Linked: PR #X" when found, making it easier to recover state


  **How to test?**

  1. Create a stack of 2+ PRs with arr submit
  2. Run arr merge and verify it:
    - Waits for CI on first PR
    - Merges first PR
    - Updates second PR's base to main
    - Waits for CI on second PR
    - Merges second PR
  3. Test Ctrl+C during merge - verify stack stays intact (only completed merges affected)
  4. Run `arr untrack <branch>` then `arr track <branch>` on a branch with an existing PR - verify it shows `Linked: PR #X`

  **Why make this change?**

  The previous merge flow rebased all PRs to main upfront, which caused issues:
  - If interrupted, the stack was broken (all PRs pointing at main)
  - Hard to recover from failures mid-merge
  - Lost the visual stack on GitHub
