### PR TITLE
fix: Fix preserving the users manual folder selection.

### DIFF
--- a/apps/array/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -32,7 +32,6 @@ export function TaskInput() {
 
   const { view } = useNavigationStore();
   const { lastUsedDirectory } = useTaskDirectoryStore();
-  const { folders } = useRegisteredFoldersStore();
   const { lastUsedLocalWorkspaceMode } = useSettingsStore();
 
   const editorRef = useRef<MessageEditorHandle>(null);
@@ -56,12 +55,14 @@ export function TaskInput() {
 
   useEffect(() => {
     if (view.folderId) {
-      const folder = folders.find((f) => f.id === view.folderId);
+      // Access store directly to avoid folders dependency triggering re-sync
+      const currentFolders = useRegisteredFoldersStore.getState().folders;
+      const folder = currentFolders.find((f) => f.id === view.folderId);
       if (folder) {
         setSelectedDirectory(folder.path);
       }
     }
-  }, [view.folderId, folders]);
+  }, [view.folderId]);
 
   const handleDirectoryChange = (newPath: string) => {
     setSelectedDirectory(newPath);


### PR DESCRIPTION
- Removed folders from the dependency array so the effect only runs when view.folderId changes, not when the folders array updates. This preserves the users manual folder selection.
- Resolves https://github.com/PostHog/Array/issues/438

What's happening in James screenshots:
  1. selectedDirectory was correctly updated to [redacted].com's path
  2. updateLastAccessed() was called, which updated the folders array (changing the last timestamp)
  3. This triggered the useEffect to run again
  4. Since view.folderId was still set to the original folder, it reset selectedDirectory back