### PR TITLE
feat: retain chatbox focus in common scenarios

### DIFF
--- a/apps/array/src/renderer/features/message-editor/components/MessageEditor.tsx
+++ b/apps/array/src/renderer/features/message-editor/components/MessageEditor.tsx
@@ -3,7 +3,7 @@ import type { ExecutionMode } from "@features/sessions/stores/sessionStore";
 import { ArrowUp, Stop } from "@phosphor-icons/react";
 import { Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
 import { EditorContent } from "@tiptap/react";
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useEffect, useImperativeHandle } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useDraftStore } from "../stores/draftStore";
 import { useTiptapEditor } from "../tiptap/useTiptapEditor";
@@ -45,6 +45,8 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
     ref,
   ) => {
     const context = useDraftStore((s) => s.contexts[sessionId]);
+    const focusRequested = useDraftStore((s) => s.focusRequested[sessionId]);
+    const clearFocusRequest = useDraftStore((s) => s.actions.clearFocusRequest);
     const taskId = context?.taskId;
     const disabled = context?.disabled ?? false;
     const isLoading = context?.isLoading ?? false;
@@ -53,6 +55,7 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
 
     const {
       editor,
+      isReady,
       isEmpty,
       isBashMode,
       submit,
@@ -89,6 +92,12 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
       }),
       [focus, blur, clear, isEmpty, getContent, getText, setContent],
     );
+
+    useEffect(() => {
+      if (!focusRequested || !isReady) return;
+      focus();
+      clearFocusRequest(sessionId);
+    }, [focusRequested, focus, clearFocusRequest, sessionId, isReady]);
 
     useHotkeys(
       "escape",

--- a/apps/array/src/renderer/features/message-editor/stores/draftStore.ts
+++ b/apps/array/src/renderer/features/message-editor/stores/draftStore.ts
@@ -19,6 +19,7 @@ interface DraftState {
   drafts: Record<SessionId, EditorContent | string>;
   contexts: Record<SessionId, EditorContext>;
   commands: Record<SessionId, AvailableCommand[]>;
+  focusRequested: Record<SessionId, number>;
   _hasHydrated: boolean;
 }
 
@@ -35,6 +36,8 @@ export interface DraftActions {
   setCommands: (sessionId: SessionId, commands: AvailableCommand[]) => void;
   getCommands: (sessionId: SessionId) => AvailableCommand[];
   clearCommands: (sessionId: SessionId) => void;
+  requestFocus: (sessionId: SessionId) => void;
+  clearFocusRequest: (sessionId: SessionId) => void;
 }
 
 type DraftStore = DraftState & { actions: DraftActions };
@@ -45,6 +48,7 @@ export const useDraftStore = create<DraftStore>()(
       drafts: {},
       contexts: {},
       commands: {},
+      focusRequested: {},
       _hasHydrated: false,
 
       actions: {
@@ -91,6 +95,16 @@ export const useDraftStore = create<DraftStore>()(
         clearCommands: (sessionId) =>
           set((state) => {
             delete state.commands[sessionId];
+          }),
+
+        requestFocus: (sessionId) =>
+          set((state) => {
+            state.focusRequested[sessionId] = Date.now();
+          }),
+
+        clearFocusRequest: (sessionId) =>
+          set((state) => {
+            delete state.focusRequested[sessionId];
           }),
       },
     })),

--- a/apps/array/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/array/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -71,6 +71,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
 
   const historyActions = usePromptHistoryStore.getState();
   const [isEmptyState, setIsEmptyState] = useState(true);
+  const [isReady, setIsReady] = useState(false);
 
   const handleCommandSubmit = useCallback((text: string) => {
     callbackRefs.current.onSubmit?.(text);
@@ -181,6 +182,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
         },
       },
       onCreate: ({ editor: e }) => {
+        setIsReady(true);
         const newIsEmpty = !e.getText().trim();
         setIsEmptyState(newIsEmpty);
         prevIsEmptyRef.current = newIsEmpty;
@@ -238,7 +240,11 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
 
   submitRef.current = submit;
 
-  const focus = useCallback(() => editor?.commands.focus("end"), [editor]);
+  const focus = useCallback(() => {
+    if (editor?.view) {
+      editor.commands.focus("end");
+    }
+  }, [editor]);
   const blur = useCallback(() => editor?.commands.blur(), [editor]);
   const clear = useCallback(() => {
     editor?.commands.clearContent();
@@ -274,6 +280,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
 
   return {
     editor,
+    isReady,
     isEmpty,
     isBashMode,
     submit,

--- a/apps/array/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/array/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -1,4 +1,5 @@
 import { BackgroundWrapper } from "@components/BackgroundWrapper";
+import { useDraftStore } from "@features/message-editor/stores/draftStore";
 import { SessionView } from "@features/sessions/components/SessionView";
 import {
   useSessionActions,
@@ -34,6 +35,7 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
   const { connectToTask, sendPrompt, cancelPrompt } = useSessionActions();
   const markActivity = useTaskViewedStore((state) => state.markActivity);
   const markAsViewed = useTaskViewedStore((state) => state.markAsViewed);
+  const requestFocus = useDraftStore((s) => s.actions.requestFocus);
 
   const isRunning =
     session?.status === "connected" || session?.status === "connecting";
@@ -42,6 +44,11 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
   const isPromptPending = session?.isPromptPending ?? false;
 
   const isConnecting = useRef(false);
+
+  // Focus the message editor when navigating to this task
+  useEffect(() => {
+    requestFocus(taskId);
+  }, [taskId, requestFocus]);
 
   useEffect(() => {
     if (!repoPath) return;
@@ -110,7 +117,8 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
   const handleCancelPrompt = useCallback(async () => {
     const result = await cancelPrompt(taskId);
     log.info("Prompt cancelled", { success: result });
-  }, [taskId, cancelPrompt]);
+    requestFocus(taskId);
+  }, [taskId, cancelPrompt, requestFocus]);
 
   const { appendUserShellExecute } = useSessionActions();
 


### PR DESCRIPTION
We've had some cases where we would not be focussing the chat box when the user probably wants to interact with it:
- Navigating to a task
- Navigating from another tab to the chat tab
- Interrupting the agent

In these scenarios we'll now automatically focus the chatbox

Closes #457 