### PR TITLE
fix/cmd-shift-p-for-action-palette

### DIFF
--- a/apps/array/src/renderer/constants/keyboard-shortcuts.ts
+++ b/apps/array/src/renderer/constants/keyboard-shortcuts.ts
@@ -1,5 +1,5 @@
 export const SHORTCUTS = {
-  COMMAND_MENU: "mod+k",
+  COMMAND_MENU: "mod+shift+p",
   NEW_TASK: "mod+n",
   SETTINGS: "mod+,",
   SHORTCUTS_SHEET: "mod+/",


### PR DESCRIPTION
Because both terminal clearing and command palette use `CMD+K`, we should probably just move palette to `CMD+SHIFT+P` only and get rid of CMD+K for command palette


Closes #450 