### PR TITLE
fix: recreate agent on token refresh

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -189,10 +189,12 @@ export class Agent {
       );
     };
 
-    await sendNotification(POSTHOG_NOTIFICATIONS.RUN_STARTED, {
-      sessionId: taskRunId,
-      runId: taskRunId,
-    });
+    if (!options.isReconnect) {
+      await sendNotification(POSTHOG_NOTIFICATIONS.RUN_STARTED, {
+        sessionId: taskRunId,
+        runId: taskRunId,
+      });
+    }
 
     // Only fetch task when we need the slug for git branch creation
     if (!options.skipGitBranch) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -143,6 +143,7 @@ export interface TaskExecutionOptions {
   skipGitBranch?: boolean; // Skip creating a task-specific git branch
   framework?: "claude" | "codex"; // Agent framework to use (defaults to "claude")
   task?: Task; // Pre-fetched task to avoid redundant API call
+  isReconnect?: boolean; // Session recreation - skip RUN_STARTED notification
 }
 
 export interface ExecutionResult {


### PR DESCRIPTION
Every time the token refreshed, we were only updating the tokens, but not respawning the agent. This means that the agent will be using an outdated token, causing chat to break. 