### PR TITLE
fix: add electron-trpc build to dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b",
   "scripts": {
     "setup": "bash apps/array/bin/setup",
-    "dev": "mprocs",
+    "dev": "pnpm --filter @posthog/electron-trpc build && mprocs",
     "dev:agent": "pnpm --filter agent dev",
     "dev:array": "pnpm --filter array dev",
     "start": "pnpm --filter array start",


### PR DESCRIPTION
### TL;DR

Updated the `dev` script to build the electron-trpc package before starting the development environment.

### What changed?
-

### How to test?
-

### Why make this change?

The electron-trpc package needs to be built before starting the development environment.