### PR TITLE
feat: fix build + posthog integration

### DIFF
--- a/.github/workflows/array-release.yml
+++ b/.github/workflows/array-release.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: macos-latest
     env:
       NODE_ENV: production
+      VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
+      VITE_POSTHOG_API_HOST: ${{ secrets.VITE_POSTHOG_API_HOST }}
       APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "build": "bun build ./src/cli.ts --outdir ./dist --target bun",
     "dev": "bun run ./bin/arr.ts",
     "typecheck": "tsc --noEmit",
     "test:pty": "vitest run tests/e2e/pty.test.ts"


### PR DESCRIPTION
### TL;DR

Added PostHog environment variables to the Array release workflow and build configuration.

### What changed?

- Added PostHog API key and host environment variables to the GitHub workflow for Array releases
- Modified the Vite main config to load environment variables and inject PostHog configuration at build time
- Updated the CLI package.json build script to use `cli.ts` instead of `index.ts` as the entry point

### How to test?

1. Verify that PostHog analytics work correctly in production builds
2. Ensure the CLI builds successfully with the new entry point
3. Check that the GitHub workflow can access the PostHog environment variables during the release process

### Why make this change?

This change ensures that PostHog analytics configuration is properly included in production builds, allowing for tracking usage metrics in the released application. The environment variables are now properly passed through the build process, making analytics available in the packaged application where `process.env` would not normally be accessible.