### PR TITLE
fix: electron debug off

### DIFF
--- a/apps/array/src/renderer/lib/analytics.ts
+++ b/apps/array/src/renderer/lib/analytics.ts
@@ -1,8 +1,8 @@
 import posthog from "posthog-js/dist/module.full.no-external";
 // Import the recorder to set up __PosthogExtensions__.initSessionRecording
 // The module.full.no-external bundle includes rrweb but not the initSessionRecording function
-// This import adds the missing piece needed for session replay in Electron
-import "posthog-js/dist/lazy-recorder";
+// posthog-recorder (vs lazy-recorder) ensures recording is ready immediately
+import "posthog-js/dist/posthog-recorder";
 import type {
   EventPropertyMap,
   UserIdentifyProperties,
@@ -27,16 +27,13 @@ export function initializePostHog() {
   posthog.init(apiKey, {
     api_host: apiHost,
     ui_host: uiHost,
-    capture_pageview: false,
-    capture_pageleave: false,
     disable_session_recording: false,
-    debug: true, // Enable debug mode for now (TODO: turn this off before launch)
     loaded: () => {
       log.info("PostHog loaded");
-      // Log session recording status after remote config loads
-      setTimeout(() => {
-        logSessionRecordingStatus();
-      }, 3000);
+      // Start session recording immediately after load
+      // In Electron, we need to explicitly start since there's no page navigation trigger
+      posthog.startSessionRecording();
+      log.info("Session recording started");
     },
   });
 


### PR DESCRIPTION
### TL;DR

Improved PostHog session recording in Electron by switching to a more reliable recorder implementation and explicitly starting recording after initialization.

### What changed?

- Replaced `posthog-js/dist/lazy-recorder` with `posthog-js/dist/posthog-recorder` to ensure recording is ready immediately
- Removed unnecessary configuration options (`capture_pageview`, `capture_pageleave`, and `debug: true`)
- Added explicit call to `posthog.startSessionRecording()` after PostHog loads
- Removed the delayed `logSessionRecordingStatus()` call that was using setTimeout

### How to test?

1. Run the application in development mode
2. Check the logs for "PostHog loaded" and "Session recording started" messages
3. Verify in PostHog dashboard that session recordings are being captured correctly

### Why make this change?

The previous implementation had reliability issues with session recording in Electron. Since Electron doesn't have the same page navigation events as a browser, we need to explicitly start session recording. Using the full recorder implementation instead of the lazy-loader ensures the recording functionality is available immediately after initialization.