### PR TITLE
feat: remove codex

### DIFF
--- a/apps/array/vite.main.config.mts
+++ b/apps/array/vite.main.config.mts
@@ -50,28 +50,6 @@ function fixFilenameCircularRef(): Plugin {
 }
 
 /**
- * Copy agent templates to the build directory
- */
-function copyAgentTemplates(): Plugin {
-  return {
-    name: "copy-agent-templates",
-    writeBundle() {
-      const templateSrc = join(
-        __dirname,
-        "node_modules/@posthog/agent/dist/templates/plan-template.md",
-      );
-      const templateDest = join(
-        __dirname,
-        ".vite/build/templates/plan-template.md",
-      );
-
-      mkdirSync(join(__dirname, ".vite/build/templates"), { recursive: true });
-      copyFileSync(templateSrc, templateDest);
-    },
-  };
-}
-
-/**
  * Copy Claude executable to the build directory
  */
 function copyClaudeExecutable(): Plugin {
@@ -163,7 +141,6 @@ export default defineConfig(({ mode }) => {
       tsconfigPaths(),
       autoServicesPlugin(join(__dirname, "src/main/services")),
       fixFilenameCircularRef(),
-      copyAgentTemplates(),
       copyClaudeExecutable(),
     ],
     define: {


### PR DESCRIPTION
IGNORE - I hijacked this pr to fix a build error  - the below changes were already merged





### TL;DR

Remove Codex agent framework support, standardizing on Claude as the sole agent framework.

### What changed?

- Removed the `framework` option from agent configuration and session parameters
- Deleted the entire Codex adapter implementation (`packages/agent/src/adapters/codex/codex.ts`)
- Removed the `@openai/codex-sdk` dependency
- Removed the `FrameworkSelector` component from the UI
- Updated the connection factory to only create Claude agents
- Simplified type definitions to only reference Claude as the agent framework

### How to test?

1. Verify that the application starts and runs normally
2. Create a new task and confirm that it executes properly with Claude
3. Ensure no framework selection UI appears in the task input editor
4. Check that existing sessions can be resumed without issues

### Why make this change?

This change simplifies the codebase by standardizing on Claude as the sole agent framework. The Codex implementation was likely not being actively used or maintained, and removing it reduces complexity, maintenance burden, and potential points of failure. This allows the team to focus development efforts on improving the Claude integration rather than maintaining multiple agent frameworks.