### PR TITLE
feat: New history based side nav

### DIFF
--- a/apps/array/src/renderer/features/sidebar/components/HistoryView.tsx
+++ b/apps/array/src/renderer/features/sidebar/components/HistoryView.tsx
@@ -1,0 +1,136 @@
+import { useTaskExecutionStore } from "@features/task-detail/stores/taskExecutionStore";
+import { Button, Flex } from "@radix-ui/themes";
+import { useWorkspaceStore } from "@/renderer/features/workspace/stores/workspaceStore";
+import type { HistoryData, HistoryTaskData } from "../hooks/useSidebarData";
+import { useSidebarStore } from "../stores/sidebarStore";
+import { TaskItem } from "./items/TaskItem";
+
+interface HistoryViewProps {
+  historyData: HistoryData;
+  activeTaskId: string | null;
+  onTaskClick: (taskId: string) => void;
+  onTaskContextMenu: (taskId: string, e: React.MouseEvent) => void;
+  onTaskDelete: (taskId: string) => void;
+  onTaskTogglePin: (taskId: string) => void;
+}
+
+function HistorySectionLabel({ label }: { label: string }) {
+  return (
+    <div className="px-2 py-1 font-medium font-mono text-[10px] text-gray-10 uppercase tracking-wide">
+      {label}
+    </div>
+  );
+}
+
+interface HistoryTaskItemProps {
+  task: HistoryTaskData;
+  isActive: boolean;
+  onClick: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onDelete: () => void;
+  onTogglePin: () => void;
+}
+
+function HistoryTaskItem({
+  task,
+  isActive,
+  onClick,
+  onContextMenu,
+  onDelete,
+  onTogglePin,
+}: HistoryTaskItemProps) {
+  const workspaces = useWorkspaceStore.use.workspaces();
+  const taskStates = useTaskExecutionStore((state) => state.taskStates);
+
+  const workspace = workspaces[task.id];
+  const taskState = taskStates[task.id];
+
+  return (
+    <TaskItem
+      id={task.id}
+      label={task.title}
+      isActive={isActive}
+      worktreeName={workspace?.worktreeName ?? undefined}
+      worktreePath={workspace?.worktreePath ?? workspace?.folderPath}
+      workspaceMode={taskState?.workspaceMode}
+      lastActivityAt={task.lastActivityAt}
+      isGenerating={task.isGenerating}
+      isUnread={task.isUnread}
+      isPinned={task.isPinned}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      onDelete={onDelete}
+      onTogglePin={onTogglePin}
+    />
+  );
+}
+
+export function HistoryView({
+  historyData,
+  activeTaskId,
+  onTaskClick,
+  onTaskContextMenu,
+  onTaskDelete,
+  onTaskTogglePin,
+}: HistoryViewProps) {
+  const loadMoreHistory = useSidebarStore((state) => state.loadMoreHistory);
+  const { activeTasks, recentTasks, hasMore } = historyData;
+
+  const hasActiveTasks = activeTasks.length > 0;
+  const hasRecentTasks = recentTasks.length > 0;
+
+  return (
+    <Flex direction="column">
+      {hasActiveTasks && (
+        <>
+          <HistorySectionLabel label="Active" />
+          {activeTasks.map((task) => (
+            <HistoryTaskItem
+              key={task.id}
+              task={task}
+              isActive={activeTaskId === task.id}
+              onClick={() => onTaskClick(task.id)}
+              onContextMenu={(e) => onTaskContextMenu(task.id, e)}
+              onDelete={() => onTaskDelete(task.id)}
+              onTogglePin={() => onTaskTogglePin(task.id)}
+            />
+          ))}
+          {hasRecentTasks && (
+            <div className="mx-2 my-2 border-gray-6 border-t" />
+          )}
+        </>
+      )}
+
+      {hasRecentTasks && (
+        <>
+          <HistorySectionLabel label="Recent" />
+          {recentTasks.map((task) => (
+            <HistoryTaskItem
+              key={task.id}
+              task={task}
+              isActive={activeTaskId === task.id}
+              onClick={() => onTaskClick(task.id)}
+              onContextMenu={(e) => onTaskContextMenu(task.id, e)}
+              onDelete={() => onTaskDelete(task.id)}
+              onTogglePin={() => onTaskTogglePin(task.id)}
+            />
+          ))}
+        </>
+      )}
+
+      {hasMore && (
+        <div className="px-2 py-2">
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={loadMoreHistory}
+            style={{ width: "100%" }}
+          >
+            Show more
+          </Button>
+        </div>
+      )}
+    </Flex>
+  );
+}

--- a/apps/array/src/renderer/features/sidebar/components/SidebarFooter.tsx
+++ b/apps/array/src/renderer/features/sidebar/components/SidebarFooter.tsx
@@ -5,10 +5,12 @@ import { useRegisteredFoldersStore } from "@renderer/stores/registeredFoldersSto
 import { trpcVanilla } from "@renderer/trpc";
 import { useNavigationStore } from "@stores/navigationStore";
 import { useCallback } from "react";
+import { useSidebarStore } from "../stores/sidebarStore";
 
 export function SidebarFooter() {
   const addFolder = useRegisteredFoldersStore((state) => state.addFolder);
-  const { toggleSettings } = useNavigationStore();
+  const { toggleSettings, navigateToTaskInput } = useNavigationStore();
+  const viewMode = useSidebarStore((state) => state.viewMode);
 
   const handleAddRepository = useCallback(async () => {
     const selectedPath = await trpcVanilla.os.selectDirectory.query();
@@ -16,6 +18,12 @@ export function SidebarFooter() {
       await addFolder(selectedPath);
     }
   }, [addFolder]);
+
+  const handleNewTask = useCallback(() => {
+    navigateToTaskInput();
+  }, [navigateToTaskInput]);
+
+  const isHistoryView = viewMode === "history";
 
   return (
     <Box
@@ -30,15 +38,22 @@ export function SidebarFooter() {
       }}
     >
       <Flex align="center" gap="2" justify="between">
-        <Button
-          size="1"
-          variant="ghost"
-          color="gray"
-          onClick={handleAddRepository}
-        >
-          <Plus size={14} weight="bold" />
-          Add repository
-        </Button>
+        {isHistoryView ? (
+          <Button size="1" variant="ghost" color="gray" onClick={handleNewTask}>
+            <Plus size={14} weight="bold" />
+            New task
+          </Button>
+        ) : (
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={handleAddRepository}
+          >
+            <Plus size={14} weight="bold" />
+            Add repository
+          </Button>
+        )}
 
         <IconButton
           size="1"

--- a/apps/array/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/array/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -18,11 +18,13 @@ import { useSidebarData } from "../hooks/useSidebarData";
 import { usePinnedTasksStore } from "../stores/pinnedTasksStore";
 import { useSidebarStore } from "../stores/sidebarStore";
 import { useTaskViewedStore } from "../stores/taskViewedStore";
+import { HistoryView } from "./HistoryView";
 import { HomeItem } from "./items/HomeItem";
 import { NewTaskItem } from "./items/NewTaskItem";
 import { TaskItem } from "./items/TaskItem";
 import { SidebarFooter } from "./SidebarFooter";
 import { SortableFolderSection } from "./SortableFolderSection";
+import { ViewModeSelector } from "./ViewModeSelector";
 
 function SidebarMenuComponent() {
   const {
@@ -41,6 +43,7 @@ function SidebarMenuComponent() {
   const toggleSection = useSidebarStore((state) => state.toggleSection);
   const folderOrder = useSidebarStore((state) => state.folderOrder);
   const reorderFolders = useSidebarStore((state) => state.reorderFolders);
+  const viewMode = useSidebarStore((state) => state.viewMode);
   const workspaces = useWorkspaceStore.use.workspaces();
   const taskStates = useTaskExecutionStore((state) => state.taskStates);
   const markAsViewed = useTaskViewedStore((state) => state.markAsViewed);
@@ -196,87 +199,104 @@ function SidebarMenuComponent() {
               onClick={handleHomeClick}
             />
 
+            <div className="px-2 py-1">
+              <ViewModeSelector />
+            </div>
+
             <div className="mx-2 my-2 border-gray-6 border-t" />
 
-            <DragDropProvider
-              onDragOver={handleDragOver}
-              sensors={[
-                PointerSensor.configure({
-                  activationConstraints: {
-                    distance: { value: 5 },
-                  },
-                }),
-              ]}
-            >
-              {sidebarData.folders.map((folder, index) => {
-                const isExpanded = !collapsedSections.has(folder.id);
-                return (
-                  <div key={folder.id}>
-                    {index > 0 && (
-                      <div className="mx-2 my-2 border-gray-6 border-t" />
-                    )}
-                    <SortableFolderSection
-                      id={folder.id}
-                      index={index}
-                      label={folder.name}
-                      icon={
-                        isExpanded ? (
-                          <FolderOpenIcon size={14} weight="regular" />
-                        ) : (
-                          <FolderIcon size={14} weight="regular" />
-                        )
-                      }
-                      isExpanded={isExpanded}
-                      onToggle={() => toggleSection(folder.id)}
-                      onSettingsClick={() => handleFolderSettings(folder.id)}
-                      onContextMenu={(e) =>
-                        handleFolderContextMenu(folder.id, e)
-                      }
-                    >
-                      <NewTaskItem
-                        onClick={() => handleFolderNewTask(folder.id)}
-                      />
-                      {folder.tasks.map((task) => (
-                        <TaskItem
-                          key={task.id}
-                          id={task.id}
-                          label={task.title}
-                          isActive={sidebarData.activeTaskId === task.id}
-                          worktreeName={
-                            workspaces[task.id]?.worktreeName ?? undefined
-                          }
-                          worktreePath={
-                            workspaces[task.id]?.worktreePath ??
-                            workspaces[task.id]?.folderPath
-                          }
-                          workspaceMode={taskStates[task.id]?.workspaceMode}
-                          lastActivityAt={task.lastActivityAt}
-                          isGenerating={task.isGenerating}
-                          isUnread={task.isUnread}
-                          isPinned={task.isPinned}
-                          onClick={() => handleTaskClick(task.id)}
-                          onContextMenu={(e) =>
-                            handleTaskContextMenu(task.id, e)
-                          }
-                          onDelete={() => handleTaskDelete(task.id)}
-                          onTogglePin={() => handleTaskTogglePin(task.id)}
+            {viewMode === "history" ? (
+              <HistoryView
+                historyData={sidebarData.historyData}
+                activeTaskId={sidebarData.activeTaskId}
+                onTaskClick={handleTaskClick}
+                onTaskContextMenu={handleTaskContextMenu}
+                onTaskDelete={handleTaskDelete}
+                onTaskTogglePin={handleTaskTogglePin}
+              />
+            ) : (
+              <DragDropProvider
+                onDragOver={handleDragOver}
+                sensors={[
+                  PointerSensor.configure({
+                    activationConstraints: {
+                      distance: { value: 5 },
+                    },
+                  }),
+                ]}
+              >
+                {sidebarData.folders.map((folder, index) => {
+                  const isExpanded = !collapsedSections.has(folder.id);
+                  return (
+                    <div key={folder.id}>
+                      {index > 0 && (
+                        <div className="mx-2 my-2 border-gray-6 border-t" />
+                      )}
+                      <SortableFolderSection
+                        id={folder.id}
+                        index={index}
+                        label={folder.name}
+                        icon={
+                          isExpanded ? (
+                            <FolderOpenIcon size={14} weight="regular" />
+                          ) : (
+                            <FolderIcon size={14} weight="regular" />
+                          )
+                        }
+                        isExpanded={isExpanded}
+                        onToggle={() => toggleSection(folder.id)}
+                        onSettingsClick={() => handleFolderSettings(folder.id)}
+                        onContextMenu={(e) =>
+                          handleFolderContextMenu(folder.id, e)
+                        }
+                      >
+                        <NewTaskItem
+                          onClick={() => handleFolderNewTask(folder.id)}
                         />
-                      ))}
-                    </SortableFolderSection>
-                  </div>
-                );
-              })}
-              <DragOverlay>
-                {(source) =>
-                  source?.type === "folder" ? (
-                    <div className="flex w-full items-center gap-1 rounded bg-gray-2 px-2 py-1 font-mono text-[12px] text-gray-11 shadow-lg">
-                      <FolderIcon size={14} weight="regular" />
-                      <span className="font-medium">{source.data?.label}</span>
+                        {folder.tasks.map((task) => (
+                          <TaskItem
+                            key={task.id}
+                            id={task.id}
+                            label={task.title}
+                            isActive={sidebarData.activeTaskId === task.id}
+                            worktreeName={
+                              workspaces[task.id]?.worktreeName ?? undefined
+                            }
+                            worktreePath={
+                              workspaces[task.id]?.worktreePath ??
+                              workspaces[task.id]?.folderPath
+                            }
+                            workspaceMode={taskStates[task.id]?.workspaceMode}
+                            lastActivityAt={task.lastActivityAt}
+                            isGenerating={task.isGenerating}
+                            isUnread={task.isUnread}
+                            isPinned={task.isPinned}
+                            onClick={() => handleTaskClick(task.id)}
+                            onContextMenu={(e) =>
+                              handleTaskContextMenu(task.id, e)
+                            }
+                            onDelete={() => handleTaskDelete(task.id)}
+                            onTogglePin={() => handleTaskTogglePin(task.id)}
+                          />
+                        ))}
+                      </SortableFolderSection>
                     </div>
-                  ) : null
-                }
-              </DragOverlay>
-            </DragDropProvider>
+                  );
+                })}
+                <DragOverlay>
+                  {(source) =>
+                    source?.type === "folder" ? (
+                      <div className="flex w-full items-center gap-1 rounded bg-gray-2 px-2 py-1 font-mono text-[12px] text-gray-11 shadow-lg">
+                        <FolderIcon size={14} weight="regular" />
+                        <span className="font-medium">
+                          {source.data?.label}
+                        </span>
+                      </div>
+                    ) : null
+                  }
+                </DragOverlay>
+              </DragDropProvider>
+            )}
           </Flex>
         </Box>
         <SidebarFooter />

--- a/apps/array/src/renderer/features/sidebar/components/ViewModeSelector.tsx
+++ b/apps/array/src/renderer/features/sidebar/components/ViewModeSelector.tsx
@@ -1,0 +1,62 @@
+import { ClockCounterClockwise, Folder } from "@phosphor-icons/react";
+import { Select, Text } from "@radix-ui/themes";
+import { type SidebarViewMode, useSidebarStore } from "../stores/sidebarStore";
+
+const VIEW_OPTIONS = [
+  { value: "folders" as const, label: "Repositories", Icon: Folder },
+  { value: "history" as const, label: "History", Icon: ClockCounterClockwise },
+];
+
+export function ViewModeSelector() {
+  const viewMode = useSidebarStore((state) => state.viewMode);
+  const setViewMode = useSidebarStore((state) => state.setViewMode);
+  const resetHistoryVisibleCount = useSidebarStore(
+    (state) => state.resetHistoryVisibleCount,
+  );
+
+  const handleChange = (value: SidebarViewMode) => {
+    if (value === "history") {
+      resetHistoryVisibleCount();
+    }
+    setViewMode(value);
+  };
+
+  const currentOption = VIEW_OPTIONS.find((o) => o.value === viewMode);
+  const CurrentIcon = currentOption?.Icon ?? Folder;
+
+  return (
+    <Select.Root value={viewMode} onValueChange={handleChange} size="1">
+      <Select.Trigger
+        variant="ghost"
+        style={{
+          fontSize: "var(--font-size-1)",
+          color: "var(--gray-11)",
+          padding: "4px 8px",
+          height: "auto",
+          minHeight: "unset",
+          width: "100%",
+        }}
+      >
+        <span className="flex items-center gap-1.5">
+          <CurrentIcon size={12} />
+          <Text size="1" style={{ fontFamily: "var(--font-mono)" }}>
+            {currentOption?.label}
+          </Text>
+        </span>
+      </Select.Trigger>
+      <Select.Content position="popper" sideOffset={4}>
+        {VIEW_OPTIONS.map((option) => {
+          const OptionIcon = option.Icon;
+          return (
+            <Select.Item key={option.value} value={option.value}>
+              <span className="flex items-center gap-1.5">
+                <OptionIcon size={12} />
+                {option.label}
+              </span>
+            </Select.Item>
+          );
+        })}
+      </Select.Content>
+    </Select.Root>
+  );
+}

--- a/apps/array/src/renderer/features/sidebar/stores/sidebarStore.ts
+++ b/apps/array/src/renderer/features/sidebar/stores/sidebarStore.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+export type SidebarViewMode = "folders" | "history";
+
 interface SidebarStoreState {
   open: boolean;
   hasUserSetOpen: boolean;
@@ -8,6 +10,8 @@ interface SidebarStoreState {
   isResizing: boolean;
   collapsedSections: Set<string>;
   folderOrder: string[];
+  viewMode: SidebarViewMode;
+  historyVisibleCount: number;
 }
 
 interface SidebarStoreActions {
@@ -20,6 +24,9 @@ interface SidebarStoreActions {
   reorderFolders: (fromIndex: number, toIndex: number) => void;
   setFolderOrder: (order: string[]) => void;
   syncFolderOrder: (folderIds: string[]) => void;
+  setViewMode: (mode: SidebarViewMode) => void;
+  loadMoreHistory: () => void;
+  resetHistoryVisibleCount: () => void;
 }
 
 type SidebarStore = SidebarStoreState & SidebarStoreActions;
@@ -33,6 +40,8 @@ export const useSidebarStore = create<SidebarStore>()(
       isResizing: false,
       collapsedSections: new Set<string>(),
       folderOrder: [],
+      viewMode: "history" as SidebarViewMode,
+      historyVisibleCount: 25,
       setOpen: (open) => set({ open, hasUserSetOpen: true }),
       setOpenAuto: (open) =>
         set((state) => (state.hasUserSetOpen ? state : { open })),
@@ -74,6 +83,12 @@ export const useSidebarStore = create<SidebarStore>()(
           }
           return state;
         }),
+      setViewMode: (mode) => set({ viewMode: mode }),
+      loadMoreHistory: () =>
+        set((state) => ({
+          historyVisibleCount: state.historyVisibleCount + 25,
+        })),
+      resetHistoryVisibleCount: () => set({ historyVisibleCount: 25 }),
     }),
     {
       name: "sidebar-storage",
@@ -83,6 +98,8 @@ export const useSidebarStore = create<SidebarStore>()(
         width: state.width,
         collapsedSections: Array.from(state.collapsedSections),
         folderOrder: state.folderOrder,
+        viewMode: state.viewMode,
+        historyVisibleCount: state.historyVisibleCount,
       }),
       merge: (persisted, current) => {
         const persistedState = persisted as {
@@ -91,6 +108,8 @@ export const useSidebarStore = create<SidebarStore>()(
           width?: number;
           collapsedSections?: string[];
           folderOrder?: string[];
+          viewMode?: SidebarViewMode;
+          historyVisibleCount?: number;
         };
         return {
           ...current,
@@ -100,6 +119,9 @@ export const useSidebarStore = create<SidebarStore>()(
           width: persistedState.width ?? current.width,
           collapsedSections: new Set(persistedState.collapsedSections ?? []),
           folderOrder: persistedState.folderOrder ?? [],
+          viewMode: persistedState.viewMode ?? current.viewMode,
+          historyVisibleCount:
+            persistedState.historyVisibleCount ?? current.historyVisibleCount,
         };
       },
     },


### PR DESCRIPTION
### TL;DR

Added a new History view to the sidebar that shows active and recent tasks, with the ability to toggle between repository and history views.

### What changed?

- Created a new `HistoryView` component that displays tasks in "Active" and "Recent" sections
- Added a `ViewModeSelector` component to switch between "Repositories" and "History" views
- Enhanced the `SidebarFooter` to show different actions based on the current view mode
- Extended the `useSidebarData` hook to build and provide history data
- Updated the `sidebarStore` to track view mode, history pagination, and related actions
- Implemented "Show more" functionality to load additional history items

### How to test?

1. Open the application and check the sidebar
2. Use the new view selector dropdown to switch between "Repositories" and "History" views
3. In History view, verify that tasks are properly categorized as "Active" or "Recent"
4. Test the "Show more" button to load additional history items
5. Verify that task actions (clicking, context menu, delete, pin/unpin) work in History view
6. Check that the "New task" button appears in the footer when in History view

### Why make this change?

This change improves task management by providing a dedicated history view that makes it easier to find and resume recent work. The separation of active and recent tasks helps users quickly identify tasks that need attention versus those that are completed or inactive. The ability to toggle between repository-based and history-based views gives users flexibility in how they organize and access their tasks.