### PR TITLE
feat: use fuze for file grep when using @

### DIFF
--- a/apps/array/src/renderer/features/message-editor/suggestions/getSuggestions.ts
+++ b/apps/array/src/renderer/features/message-editor/suggestions/getSuggestions.ts
@@ -6,15 +6,30 @@ import Fuse, { type IFuseOptions } from "fuse.js";
 import { useDraftStore } from "../stores/draftStore";
 import type { CommandSuggestionItem, FileSuggestionItem } from "../types";
 
-const FILE_LIMIT = 5;
+const FILE_DISPLAY_LIMIT = 25;
+const FILE_FETCH_LIMIT = 100;
 const COMMAND_LIMIT = 5;
 
-const FUSE_OPTIONS: IFuseOptions<AvailableCommand> = {
+const COMMAND_FUSE_OPTIONS: IFuseOptions<AvailableCommand> = {
   keys: [
     { name: "name", weight: 0.7 },
     { name: "description", weight: 0.3 },
   ],
   threshold: 0.3,
+  includeScore: true,
+};
+
+interface FileItem {
+  path: string;
+  name: string;
+}
+
+const FILE_FUSE_OPTIONS: IFuseOptions<FileItem> = {
+  keys: [
+    { name: "name", weight: 0.7 },
+    { name: "path", weight: 0.3 },
+  ],
+  threshold: 0.4,
   includeScore: true,
 };
 
@@ -26,7 +41,7 @@ function searchCommands(
     return commands.slice(0, COMMAND_LIMIT);
   }
 
-  const fuse = new Fuse(commands, FUSE_OPTIONS);
+  const fuse = new Fuse(commands, COMMAND_FUSE_OPTIONS);
   const results = fuse.search(query, { limit: COMMAND_LIMIT * 2 });
 
   const lowerQuery = query.toLowerCase();
@@ -42,6 +57,27 @@ function searchCommands(
   return results.slice(0, COMMAND_LIMIT).map((result) => result.item);
 }
 
+function searchFiles(files: FileItem[], query: string): FileItem[] {
+  if (!query.trim()) {
+    return files.slice(0, FILE_DISPLAY_LIMIT);
+  }
+
+  const fuse = new Fuse(files, FILE_FUSE_OPTIONS);
+  const results = fuse.search(query, { limit: FILE_DISPLAY_LIMIT * 2 });
+
+  const lowerQuery = query.toLowerCase();
+  results.sort((a, b) => {
+    const aStartsWithQuery = a.item.name.toLowerCase().startsWith(lowerQuery);
+    const bStartsWithQuery = b.item.name.toLowerCase().startsWith(lowerQuery);
+
+    if (aStartsWithQuery && !bStartsWithQuery) return -1;
+    if (!aStartsWithQuery && bStartsWithQuery) return 1;
+    return (a.score ?? 0) - (b.score ?? 0);
+  });
+
+  return results.slice(0, FILE_DISPLAY_LIMIT).map((result) => result.item);
+}
+
 export async function getFileSuggestions(
   sessionId: string,
   query: string,
@@ -55,19 +91,26 @@ export async function getFileSuggestions(
   const results = await trpcVanilla.fs.listRepoFiles.query({
     repoPath,
     query,
-    limit: FILE_LIMIT,
+    limit: FILE_FETCH_LIMIT,
   });
 
-  return results
+  const files: FileItem[] = results
     .filter(
       (file: MentionItem): file is MentionItem & { path: string } =>
         !!file.path,
     )
     .map((file) => ({
-      id: file.path,
-      label: file.path,
       path: file.path,
+      name: file.path.split("/").pop() ?? file.path,
     }));
+
+  const matched = searchFiles(files, query);
+
+  return matched.map((file) => ({
+    id: file.path,
+    label: file.path,
+    path: file.path,
+  }));
 }
 
 export function getCommandSuggestions(


### PR DESCRIPTION
### TL;DR

Improved file suggestion search with better matching and increased result limits.

closes https://github.com/PostHog/Array/issues/505

### What changed?

- Increased file display limit from 5 to 25 files
- Added a separate file fetch limit of 100 to retrieve more potential matches
- Implemented a dedicated fuzzy search for files using Fuse.js with appropriate weighting
- Added sorting logic to prioritize files that start with the query string
- Renamed `FUSE_OPTIONS` to `COMMAND_FUSE_OPTIONS` for clarity
- Created a new `FileItem` interface to better structure file data

### How to test?

1. Open the message editor
2. Type a file reference (e.g., `@file:`)
3. Enter search terms and verify:
   - Up to 25 results are displayed (instead of 5)
   - Results are properly sorted with exact matches first
   - Fuzzy matching works correctly for partial file names

### Why make this change?

The previous implementation limited file suggestions to only 5 results and lacked sophisticated search capabilities. This change enhances the user experience by providing more relevant file suggestions through improved search algorithms and displaying a more useful number of results.