### PR TITLE
fix: Configure the git identity in the new tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -72,5 +72,7 @@ jobs:
           TAG="v$NEW_VERSION"
           echo "Creating tag: $TAG (from base tag $LATEST_TAG + $PATCH commits)"
 
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           git tag -a "$TAG" -m "Release $TAG"
           git push "https://x-access-token:${GH_TOKEN}@github.com/$REPOSITORY" "$TAG"


### PR DESCRIPTION
previous workflow used macOS runners which have a default git identity configured

the last commit moved the tag creation to a new tag.yml workflow that runs on ubuntu-latest, which does not have git identity configured by default