### PR TITLE
chore: update docs for git tag updates

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -6,13 +6,15 @@ The version in `apps/array/package.json` is set to `0.0.0-dev` - this is intenti
 
 ## Version Format: `major.minor.patch`
 
-- **major.minor**: Controlled by git tags (e.g., `v0.15`, `v1.0`)
+- **major.minor**: Controlled by git tags (e.g., `v0.15.0`, `v1.0.0`)
 - **patch**: Auto-calculated as number of commits since the minor tag
+
+**Important:** Releases must use proper three-part semver versions (e.g., `v0.22.1`, not `v0.22`). The Electron auto-updater uses update.electronjs.org, which requires valid semver for version comparison. Two-part versions will break auto-updates.
 
 ## How It Works
 
-1. A base tag like `v0.15` marks the start of a minor version
-2. Each push to `main` triggers a release with version `0.15.N` where N = commits since `v0.15`
+1. A base tag like `v0.15.0` marks the start of a minor version
+2. Each push to `main` triggers a release with version `0.15.N` where N = commits since `v0.15.0`
 3. No manual `package.json` updates needed for patch releases
 
 ## Releasing a Patch (Automatic)
@@ -20,7 +22,7 @@ The version in `apps/array/package.json` is set to `0.0.0-dev` - this is intenti
 Just push to `main`. The workflow computes the version automatically:
 
 ```
-v0.15 tag exists
+v0.15.0 tag exists
 Push commit #1 → releases 0.15.1
 Push commit #2 → releases 0.15.2
 Push commit #3 → releases 0.15.3
@@ -31,8 +33,8 @@ Push commit #3 → releases 0.15.3
 Create a new base tag when you want to bump the minor version:
 
 ```bash
-git tag v0.16
-git push origin v0.16
+git tag v0.16.0
+git push origin v0.16.0
 ```
 
 The next push to `main` will release `0.16.1`.
@@ -42,8 +44,8 @@ The next push to `main` will release `0.16.1`.
 Same process, just increment the major:
 
 ```bash
-git tag v1.0
-git push origin v1.0
+git tag v1.0.0
+git push origin v1.0.0
 ```
 
 ## Checking Current Version
@@ -52,15 +54,15 @@ See what version would be released:
 
 ```bash
 # Find the current base tag
-git tag --list 'v[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+$' | head -1
+git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.0$' | head -1
 
 # Count commits since base tag (this is the patch number)
-git rev-list v0.15..HEAD --count
+git rev-list v0.15.0..HEAD --count
 ```
 
 ## Tag Naming Convention
 
-- **Base tags** (manual): `vX.Y` - e.g., `v0.15`, `v1.0`
+- **Base tags** (manual): `vX.Y.0` - e.g., `v0.15.0`, `v1.0.0`
 - **Release tags** (auto): `vX.Y.Z` - e.g., `v0.15.3`, created by CI
 
-Only base tags (`vX.Y`) are used for version calculation. Release tags (`vX.Y.Z`) are created for GitHub releases but ignored when computing the next version.
+Only base tags (`vX.Y.0`) are used for version calculation. Release tags (`vX.Y.Z`) are created for GitHub releases but ignored when computing the next version.


### PR DESCRIPTION
### TL;DR

Updated version tagging format docs to use proper three-part semver versions to ensure Electron auto-updates work correctly.

### What changed?

- Changed all base tag examples from two-part format (`vX.Y`) to three-part format (`vX.Y.0`)
- Updated all references and examples throughout the document to use the three-part semver format
- Added an important note explaining that Electron auto-updater requires valid semver for version comparison
- Updated the git tag search command to look for three-part version tags

### How to test?

1. Verify the updated documentation accurately reflects the new tagging format
2. Test the updated git commands to ensure they correctly identify the latest version tag
3. Confirm that creating a new tag with the format `vX.Y.0` works as expected for version calculation

### Why make this change?

The Electron auto-updater uses update.electronjs.org, which requires valid semver for version comparison. Two-part versions were breaking the auto-update functionality. This change ensures that all version tags follow proper semver format, maintaining compatibility with the Electron update system.