### PR TITLE
Centralized branch/directory constants and migration fix

### DIFF
--- a/apps/twig/src/main/index.ts
+++ b/apps/twig/src/main/index.ts
@@ -43,6 +43,7 @@ import {
 } from "./services/posthog-analytics.js";
 import type { TaskLinkService } from "./services/task-link/service";
 import type { UpdatesService } from "./services/updates/service.js";
+import { migrateStoredWorktreePaths } from "./utils/store.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -320,6 +321,9 @@ function createWindow(): void {
 }
 
 app.whenReady().then(() => {
+  // Migrate stored worktree paths from legacy directories (e.g., ~/.array -> ~/.twig)
+  migrateStoredWorktreePaths();
+
   createWindow();
   ensureClaudeConfigDir();
 

--- a/apps/twig/src/main/services/git/service.ts
+++ b/apps/twig/src/main/services/git/service.ts
@@ -2,6 +2,7 @@ import { exec, execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
+import { isTwigBranch } from "@shared/constants";
 import { injectable } from "inversify";
 import { TypedEventEmitter } from "../../lib/typed-event-emitter.js";
 import type {
@@ -190,7 +191,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
         .split("\n")
         .filter(Boolean)
         .map((branch) => branch.trim())
-        .filter((branch) => !branch.startsWith("array/"));
+        .filter((branch) => !isTwigBranch(branch));
     } catch {
       return [];
     }

--- a/apps/twig/src/renderer/components/StatusBarMenu.tsx
+++ b/apps/twig/src/renderer/components/StatusBarMenu.tsx
@@ -4,7 +4,7 @@ export function StatusBarMenu() {
   return (
     <Button size="1" variant="ghost">
       <Code size="1" color="gray" variant="ghost">
-        ARRAY
+        TWIG
       </Code>
     </Button>
   );

--- a/apps/twig/src/renderer/features/sidebar/components/items/TaskItem.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/items/TaskItem.tsx
@@ -10,6 +10,7 @@ import {
 import { Tooltip } from "@radix-ui/themes";
 import { trpcVanilla } from "@renderer/trpc";
 import { formatRelativeTime } from "@renderer/utils/time";
+import { isTwigBranch } from "@shared/constants";
 import type { WorkspaceMode } from "@shared/types";
 import { selectFocusedBranch, useFocusStore } from "@stores/focusStore";
 import { useQuery } from "@tanstack/react-query";
@@ -156,15 +157,12 @@ export function TaskItem({
   const focusedBranch = useFocusStore(selectFocusedBranch(mainRepoPath ?? ""));
 
   const isCloudTask = workspaceMode === "cloud";
-  const isTwigBranch =
-    branchName?.startsWith("twig/") ||
-    branchName?.startsWith("array/") ||
-    branchName?.startsWith("posthog/");
+  const hasTwigBranch = branchName ? isTwigBranch(branchName) : false;
   // Only show "Watching" indicator for twig-created branches, not borrowed ones
   const isWatching = !!(
     branchName &&
     focusedBranch === branchName &&
-    isTwigBranch
+    hasTwigBranch
   );
 
   const activityText = isGenerating

--- a/apps/twig/src/renderer/features/workspace/components/FocusWorkspaceButton.tsx
+++ b/apps/twig/src/renderer/features/workspace/components/FocusWorkspaceButton.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, ArrowsClockwise, GitBranch } from "@phosphor-icons/react";
 import { Button, Spinner, Text, Tooltip } from "@radix-ui/themes";
+import { isTwigBranch } from "@shared/constants";
 import {
   selectIsFocusedOnWorktree,
   selectIsLoading,
@@ -9,15 +10,6 @@ import { showFocusSuccessToast } from "@utils/focusToast";
 import { toast } from "@utils/toast";
 import { useCallback } from "react";
 import { selectWorkspace, useWorkspaceStore } from "../stores/workspaceStore";
-
-/** Check if branch is a twig-created branch (not borrowed) */
-function isTwigBranch(branchName: string): boolean {
-  return (
-    branchName.startsWith("twig/") ||
-    branchName.startsWith("array/") ||
-    branchName.startsWith("posthog/")
-  );
-}
 
 interface FocusWorkspaceButtonProps {
   taskId: string;

--- a/apps/twig/src/shared/constants.ts
+++ b/apps/twig/src/shared/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Branch naming conventions.
+ * - Reading: Accept all prefixes for backwards compatibility
+ * - Writing: Always use BRANCH_PREFIX (twig/)
+ */
+export const BRANCH_PREFIX = "twig/";
+export const LEGACY_BRANCH_PREFIXES = ["array/", "posthog/"];
+
+export function isTwigBranch(branchName: string): boolean {
+  return (
+    branchName.startsWith(BRANCH_PREFIX) ||
+    LEGACY_BRANCH_PREFIXES.some((p) => branchName.startsWith(p))
+  );
+}
+
+/**
+ * Data directory conventions.
+ * - Reading: Accept all directories for backwards compatibility
+ * - Writing: Always use DATA_DIR (.twig)
+ */
+export const DATA_DIR = ".twig";
+export const LEGACY_DATA_DIRS = [".array"];

--- a/packages/agent/src/constants.ts
+++ b/packages/agent/src/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Branch naming conventions.
+ * - Reading: Accept all prefixes for backwards compatibility
+ * - Writing: Always use BRANCH_PREFIX (twig/)
+ */
+export const BRANCH_PREFIX = "twig/";
+export const LEGACY_BRANCH_PREFIXES = ["array/", "posthog/"];
+
+export function isTwigBranch(branchName: string): boolean {
+  return (
+    branchName.startsWith(BRANCH_PREFIX) ||
+    LEGACY_BRANCH_PREFIXES.some((p) => branchName.startsWith(p))
+  );
+}
+
+export function makeBranchName(name: string): string {
+  return `${BRANCH_PREFIX}${name}`;
+}


### PR DESCRIPTION


### What changed?

- Added constants for branch prefixes and data directories, supporting both current (`twig/`) and legacy (`array/`, `posthog/`) prefixes
- Created utility functions to handle branch name detection and creation
- Implemented migration logic for stored worktree paths from legacy directories (e.g., `~/.array`) to current (`~/.twig`)
- Updated UI elements to use "TWIG" instead of "ARRAY" in the status bar
- Added support for checking multiple worktree locations for backward compatibility
- Extracted branch naming logic into shared constants for consistency
