### PR TITLE
fix: properly clean up processes on every code path

### DIFF
--- a/packages/agent/src/adapters/acp-connection.ts
+++ b/packages/agent/src/adapters/acp-connection.ts
@@ -92,7 +92,7 @@ export function createAcpConnection(
       logger.info("Cleaning up ACP connection");
 
       if (agent) {
-        agent.closeAllSessions();
+        await agent.closeAllSessions();
       }
 
       // Then close the streams to properly terminate the ACP connection

--- a/packages/agent/src/adapters/claude/agent.ts
+++ b/packages/agent/src/adapters/claude/agent.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
-  type Agent,
   type AgentSideConnection,
   type AuthenticateRequest,
   type AvailableCommand,
@@ -146,7 +145,7 @@ async function getAvailableSlashCommands(
     );
 }
 
-export class ClaudeAcpAgent extends BaseAcpAgent implements Agent {
+export class ClaudeAcpAgent extends BaseAcpAgent {
   readonly adapterName = "claude";
   declare sessions: { [key: string]: Session };
   toolUseCache: ToolUseCache;


### PR DESCRIPTION
When sessions were recreated, e.g. after token refresh, old agent processes were not properly being cleaned up.
This (probably) causes zombie processes such as in #523.