### PR TITLE
feat(twig): add back button to repository not found

### DIFF
--- a/apps/twig/src/renderer/features/settings/components/FolderSettingsView.tsx
+++ b/apps/twig/src/renderer/features/settings/components/FolderSettingsView.tsx
@@ -1,5 +1,5 @@
 import { useSetHeaderContent } from "@hooks/useSetHeaderContent";
-import { Warning } from "@phosphor-icons/react";
+import { ArrowLeft, Warning } from "@phosphor-icons/react";
 import {
   Box,
   Button,
@@ -43,12 +43,23 @@ export function FolderSettingsView() {
     return (
       <Box height="100%" overflowY="auto">
         <Box p="6" style={{ maxWidth: "600px", margin: "0 auto" }}>
-          <Callout.Root color="red">
-            <Callout.Icon>
-              <Warning />
-            </Callout.Icon>
-            <Callout.Text>Repository not found</Callout.Text>
-          </Callout.Root>
+          <Flex direction="column" gap="4">
+            <Callout.Root color="red">
+              <Callout.Icon>
+                <Warning />
+              </Callout.Icon>
+              <Callout.Text>Repository not found</Callout.Text>
+            </Callout.Root>
+            <Button
+              variant="soft"
+              size="2"
+              onClick={() => navigateToTaskInput()}
+              style={{ alignSelf: "flex-start" }}
+            >
+              <ArrowLeft size={16} />
+              Back to home
+            </Button>
+          </Flex>
         </Box>
       </Box>
     );
@@ -128,6 +139,16 @@ export function FolderSettingsView() {
                 </Button>
               </Flex>
             </Card>
+
+            <Button
+              variant="soft"
+              size="2"
+              onClick={() => navigateToTaskInput()}
+              style={{ alignSelf: "flex-start" }}
+            >
+              <ArrowLeft size={16} />
+              Back to home
+            </Button>
           </Flex>
         </Box>
       </Box>


### PR DESCRIPTION
Repository not found screen is not super helpful to users if they want to go back to main welcome screen.

**Before**:

<img width="2051" height="1033" alt="twig_not_found" src="https://github.com/user-attachments/assets/71e74c1f-7525-4ec7-99c6-773b96c5f3a0" />

**After**:

<img width="2051" height="1036" alt="twig_not_found_better" src="https://github.com/user-attachments/assets/4e64ab27-bf95-4571-b9fc-96a8e12c5957" />
