### PR TITLE
fix: scroll chatbox to cursor on newline insertion

### DIFF
--- a/apps/twig/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/twig/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -292,6 +292,8 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
         }
 
         draftRef.current?.saveDraft(e);
+
+        e.commands.scrollIntoView();
       },
     },
     [sessionId, disabled, fileMentions, commands, placeholder],


### PR DESCRIPTION
## Summary

- Fixes the chatbox not scrolling when new lines are inserted via `shift+enter`
- Adds `scrollIntoView()` call in the editor's `onUpdate` handler to keep the cursor visible

Closes #499

## Test Plan

- [ ] Fill the chatbox with content until it requires scrolling
- [ ] Press `shift+enter` to create a new line
- [ ] Verify the view automatically scrolls to show the cursor