### PR TITLE
ci: speed up integration tests with caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,14 +55,31 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Cache Electron binary
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            electron-${{ runner.os }}-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build electron-trpc
-        run: pnpm --filter @posthog/electron-trpc build
-
-      - name: Build agent
-        run: pnpm --filter agent build
+      - name: Build packages
+        run: |
+          pnpm --filter @posthog/electron-trpc build &
+          pnpm --filter agent build &
+          wait
 
       - name: Build native modules
         run: pnpm --filter twig run build-native
@@ -71,6 +88,7 @@ jobs:
         run: pnpm --filter twig run package
 
       - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter twig exec playwright install --with-deps chromium
 
       - name: Run E2E smoke tests


### PR DESCRIPTION
- Add Playwright browser caching to skip re-downloading Chromium on each run
- Add Electron binary caching to speed up installs
- Parallelize electron-trpc and agent package builds
