### PR TITLE
fix: Disable spell checking on task creation and chat box

### DIFF
--- a/apps/twig/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/twig/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -98,7 +98,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
       editable: !disabled,
       autofocus: autoFocus ? "end" : false,
       editorProps: {
-        attributes: { class: EDITOR_CLASS },
+        attributes: { class: EDITOR_CLASS, spellcheck: "false" },
         handleKeyDown: (view, event) => {
           if (event.key === "Enter") {
             const sendMessagesWith =


### PR DESCRIPTION
Disables spell checking on task creation input and chat box by adding `spellcheck="false"` to the shared Tiptap editor configuration


Closes #607