### PR TITLE
fix: properly shutdown all services using preDestroy and unbindAll

### DIFF
--- a/apps/twig/src/main/services/agent/service.ts
+++ b/apps/twig/src/main/services/agent/service.ts
@@ -12,7 +12,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import { Agent, getLlmGatewayUrl, type OnLogCallback } from "@posthog/agent";
 import { app } from "electron";
-import { injectable } from "inversify";
+import { injectable, preDestroy } from "inversify";
 import type { AcpMessage } from "../../../shared/types/session-events.js";
 import { logger } from "../../lib/logger.js";
 import { TypedEventEmitter } from "../../lib/typed-event-emitter.js";
@@ -748,6 +748,7 @@ For git operations while detached:
     return `Your worktree is back on branch \`${context.branchName}\`. Normal git commands work again.`;
   }
 
+  @preDestroy()
   async cleanupAll(): Promise<void> {
     log.info("Cleaning up all agent sessions", {
       sessionCount: this.sessions.size,

--- a/apps/twig/src/main/services/connectivity/service.ts
+++ b/apps/twig/src/main/services/connectivity/service.ts
@@ -1,5 +1,5 @@
 import { net } from "electron";
-import { injectable, postConstruct } from "inversify";
+import { injectable, postConstruct, preDestroy } from "inversify";
 import { getBackoffDelay } from "../../../shared/utils/backoff.js";
 import { logger } from "../../lib/logger.js";
 import { TypedEventEmitter } from "../../lib/typed-event-emitter.js";
@@ -101,5 +101,13 @@ export class ConnectivityService extends TypedEventEmitter<ConnectivityEvents> {
 
       this.schedulePoll();
     }, interval);
+  }
+
+  @preDestroy()
+  stopPolling(): void {
+    if (this.pollTimeoutId) {
+      clearTimeout(this.pollTimeoutId);
+      this.pollTimeoutId = null;
+    }
   }
 }

--- a/apps/twig/src/main/services/focus/service.ts
+++ b/apps/twig/src/main/services/focus/service.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import * as watcher from "@parcel/watcher";
-import { injectable } from "inversify";
+import { injectable, preDestroy } from "inversify";
 import { logger } from "../../lib/logger";
 import { TypedEventEmitter } from "../../lib/typed-event-emitter";
 import { type FocusSession, focusStore } from "../../utils/store.js";
@@ -108,6 +108,7 @@ export class FocusService extends TypedEventEmitter<FocusServiceEvents> {
     });
   }
 
+  @preDestroy()
   async stopWatchingMainRepo(): Promise<void> {
     if (this.mainRepoWatcher) {
       await this.mainRepoWatcher.unsubscribe();

--- a/apps/twig/src/main/services/focus/sync-service.ts
+++ b/apps/twig/src/main/services/focus/sync-service.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as watcher from "@parcel/watcher";
 import ignore, { type Ignore } from "ignore";
-import { injectable } from "inversify";
+import { injectable, preDestroy } from "inversify";
 import { logger } from "../../lib/logger.js";
 import { git, withGitLock } from "./service.js";
 
@@ -149,6 +149,7 @@ export class FocusSyncService {
     }
   }
 
+  @preDestroy()
   async stopSync(): Promise<void> {
     if (this.pending.timer) {
       clearTimeout(this.pending.timer);

--- a/apps/twig/src/main/services/shell/service.ts
+++ b/apps/twig/src/main/services/shell/service.ts
@@ -2,7 +2,7 @@ import { exec, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import path from "node:path";
-import { injectable } from "inversify";
+import { injectable, preDestroy } from "inversify";
 import * as pty from "node-pty";
 import { logger } from "../../lib/logger.js";
 import { TypedEventEmitter } from "../../lib/typed-event-emitter.js";
@@ -215,6 +215,7 @@ export class ShellService extends TypedEventEmitter<ShellEvents> {
    * Destroy all active shell sessions.
    * Used during application shutdown to ensure all child processes are cleaned up.
    */
+  @preDestroy()
   destroyAll(): void {
     log.info(`Destroying all shell sessions (${this.sessions.size} active)`);
     for (const sessionId of this.sessions.keys()) {


### PR DESCRIPTION
We were not properly cleaning up all services on `lifecycleService.shutdown`

This caused auto updates, CMD-Q, etc to break, because we'd have lingering services such as file watchers etc.
I've made it so that each stateful service has a `@preDestroy` now.
`LifecycleService` now calls `unbindAll` instead of destroying individual services. This in turn triggers `@preDestroy`



