### PR TITLE
feat: increase base permissions for agents

### DIFF
--- a/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
@@ -276,31 +276,6 @@ function subscribeToChannel(taskRunId: string) {
                 draft.sessions[taskRunId].pendingPermissions = newPermissions;
               }
             });
-
-            const auth = useAuthStore.getState();
-            if (auth.client && session.taskId) {
-              const storedEntry: StoredLogEntry = {
-                type: "notification",
-                timestamp: new Date().toISOString(),
-                notification: {
-                  method: "_array/permission_request",
-                  params: payload,
-                },
-              };
-              try {
-                await auth.client.appendTaskRunLog(session.taskId, taskRunId, [
-                  storedEntry,
-                ]);
-                log.info("Permission request persisted to logs", {
-                  taskRunId,
-                  toolCallId: payload.toolCall.toolCallId,
-                });
-              } catch (error) {
-                log.warn("Failed to persist permission request to logs", {
-                  error,
-                });
-              }
-            }
           } else {
             log.warn("Session not found for permission request", {
               taskRunId,
@@ -1291,36 +1266,6 @@ const useStore = create<SessionStore>()(
               optionId,
               hasCustomInput: !!customInput,
             });
-
-            // Persist permission response to logs for recovery tracking
-            const auth = useAuthStore.getState();
-            if (auth.client) {
-              const storedEntry: StoredLogEntry = {
-                type: "notification",
-                timestamp: new Date().toISOString(),
-                notification: {
-                  method: "_array/permission_response",
-                  params: {
-                    toolCallId,
-                    optionId,
-                    ...(customInput && { customInput }),
-                  },
-                },
-              };
-              try {
-                await auth.client.appendTaskRunLog(taskId, session.taskRunId, [
-                  storedEntry,
-                ]);
-                log.info("Permission response persisted to logs", {
-                  taskId,
-                  toolCallId,
-                });
-              } catch (persistError) {
-                log.warn("Failed to persist permission response to logs", {
-                  error: persistError,
-                });
-              }
-            }
           } catch (error) {
             log.error("Failed to respond to permission", {
               taskId,
@@ -1362,36 +1307,6 @@ const useStore = create<SessionStore>()(
             });
 
             log.info("Permission cancelled", { taskId, toolCallId });
-
-            // Persist permission cancellation to logs for recovery tracking
-            const auth = useAuthStore.getState();
-            if (auth.client) {
-              const storedEntry: StoredLogEntry = {
-                type: "notification",
-                timestamp: new Date().toISOString(),
-                notification: {
-                  // TODO: Migrate to twig
-                  method: "_array/permission_response",
-                  params: {
-                    toolCallId,
-                    optionId: "_cancelled",
-                  },
-                },
-              };
-              try {
-                await auth.client.appendTaskRunLog(taskId, session.taskRunId, [
-                  storedEntry,
-                ]);
-                log.info("Permission cancellation persisted to logs", {
-                  taskId,
-                  toolCallId,
-                });
-              } catch (persistError) {
-                log.warn("Failed to persist permission cancellation to logs", {
-                  error: persistError,
-                });
-              }
-            }
           } catch (error) {
             log.error("Failed to cancel permission", {
               taskId,

--- a/packages/agent/src/adapters/base-acp-agent.ts
+++ b/packages/agent/src/adapters/base-acp-agent.ts
@@ -35,8 +35,8 @@ export abstract class BaseAcpAgent implements Agent {
   protected session!: BaseSession;
   protected sessionId!: string;
   client: AgentSideConnection;
-  protected logger: Logger;
-  protected fileContentCache: { [key: string]: string } = {};
+  logger: Logger;
+  fileContentCache: { [key: string]: string } = {};
 
   constructor(client: AgentSideConnection) {
     this.client = client;

--- a/packages/agent/src/adapters/claude/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permission-handlers.ts
@@ -4,6 +4,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import type { PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
 import type { Logger } from "@/utils/logger.js";
+import { isToolAllowedForMode } from "./permission-mode-config.js";
 import { buildPermissionOptions, isWriteTool } from "./permission-options.js";
 import {
   getClaudePlansDir,
@@ -421,7 +422,14 @@ function handlePlanFileException(
 export async function evaluateToolPermission(
   context: ToolHandlerContext,
 ): Promise<ToolPermissionResult> {
-  const { toolName } = context;
+  const { toolName, toolInput, session } = context;
+
+  if (isToolAllowedForMode(toolName, session.permissionMode)) {
+    return {
+      behavior: "allow",
+      updatedInput: toolInput as Record<string, unknown>,
+    };
+  }
 
   if (toolName === "ExitPlanMode") {
     return handleExitPlanModeTool(context);

--- a/packages/agent/src/adapters/claude/permission-mode-config.ts
+++ b/packages/agent/src/adapters/claude/permission-mode-config.ts
@@ -1,0 +1,36 @@
+import type { PermissionMode } from "@anthropic-ai/claude-agent-sdk";
+
+// TODO: Use TwigToolKind here instead.
+const BASE_ALLOWED_TOOLS = new Set([
+  "TodoWrite",
+  "Glob",
+  "Grep",
+  "Read",
+  "LS",
+  "WebSearch",
+  "WebFetch",
+  "Task",
+]);
+
+// TODO: Key this with our own TwigMode type instead of reusing an agents PermissionMode
+const MODE_ALLOWED_TOOLS: Record<PermissionMode, Set<string>> = {
+  default: new Set(),
+  acceptEdits: new Set(["Edit", "Write", "NotebookEdit"]),
+  plan: new Set(),
+  bypassPermissions: new Set(),
+  delegate: new Set(),
+  dontAsk: new Set(),
+};
+
+export function isToolAllowedForMode(
+  toolName: string,
+  mode: PermissionMode,
+): boolean {
+  if (BASE_ALLOWED_TOOLS.has(toolName)) {
+    return true;
+  }
+  if (mode === "bypassPermissions") {
+    return true;
+  }
+  return MODE_ALLOWED_TOOLS[mode]?.has(toolName) ?? false;
+}


### PR DESCRIPTION

- Defined a set of base tools that are always allowed (`TodoWrite`, `Glob`, `Grep`, etc.)
- Implemented mode-specific tool permissions (e.g., `acceptEdits` mode allows `Edit`, `Write`, and `NotebookEdit` tools)
- Also make the MCP tools check for these permissions

This needs a bigger refactor so the flow of data for toolcalls/MCP tools is more clear, but this gets the basic concepts in