### PR TITLE
feat: write always allow permissions to local settings, not just session

### DIFF
--- a/packages/agent/src/adapters/claude/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permission-handlers.ts
@@ -207,7 +207,7 @@ async function applyPlanApproval(
         {
           type: "setMode",
           mode: response.outcome.optionId,
-          destination: "session",
+          destination: "localSettings",
         },
       ],
     };
@@ -373,7 +373,7 @@ async function handleDefaultPermissionFlow(
             type: "addRules",
             rules: [{ toolName }],
             behavior: "allow",
-            destination: "session",
+            destination: "localSettings",
           },
         ],
       };


### PR DESCRIPTION
Now we write away to the users `.claude/settings.local.json`. We were already reading from it, so it should work both ways