### PR TITLE
fix: dropdown text color

### DIFF
--- a/apps/twig/src/renderer/styles/globals.css
+++ b/apps/twig/src/renderer/styles/globals.css
@@ -936,6 +936,7 @@ button,
 .rt-SelectItem[data-highlighted],
 .rt-BaseMenuItem[data-highlighted] {
   background-color: var(--gray-4) !important;
+  color: var(--gray-12) !important;
 }
 
 /* Select/Menu dropdown background matches theme */


### PR DESCRIPTION
When using the dropdown, the currently selected option was hard to read as we didn’t modify the text color on highlight, but we were changing the background color