### PR TITLE
fix: only navigate to settings, dont toggle

### DIFF
--- a/apps/twig/src/renderer/components/GlobalEventHandlers.tsx
+++ b/apps/twig/src/renderer/components/GlobalEventHandlers.tsx
@@ -24,7 +24,7 @@ export function GlobalEventHandlers({
   onToggleShortcutsSheet,
   commandMenuOpen,
 }: GlobalEventHandlersProps) {
-  const toggleSettings = useNavigationStore((state) => state.toggleSettings);
+  const openSettings = useNavigationStore((state) => state.openSettings);
   const navigateToTaskInput = useNavigationStore(
     (state) => state.navigateToTaskInput,
   );
@@ -76,8 +76,8 @@ export function GlobalEventHandlers({
   );
 
   const handleOpenSettings = useCallback(() => {
-    toggleSettings();
-  }, [toggleSettings]);
+    openSettings();
+  }, [openSettings]);
 
   const handleFocusTaskMode = useCallback(
     (data?: unknown) => {

--- a/apps/twig/src/renderer/components/SettingsToggle.tsx
+++ b/apps/twig/src/renderer/components/SettingsToggle.tsx
@@ -4,7 +4,7 @@ import { useNavigationStore } from "@stores/navigationStore";
 
 export function SettingsToggle() {
   const view = useNavigationStore((s) => s.view);
-  const toggleSettings = useNavigationStore((s) => s.toggleSettings);
+  const openSettings = useNavigationStore((s) => s.openSettings);
   const isSettingsOpen = view.type === "settings";
 
   return (
@@ -12,7 +12,7 @@ export function SettingsToggle() {
       <IconButton
         size="1"
         variant="ghost"
-        onClick={toggleSettings}
+        onClick={openSettings}
         style={{
           color: isSettingsOpen ? "var(--blue-9)" : "var(--gray-9)",
         }}

--- a/apps/twig/src/renderer/stores/navigationStore.test.ts
+++ b/apps/twig/src/renderer/stores/navigationStore.test.ts
@@ -65,12 +65,9 @@ describe("navigationStore", () => {
       });
     });
 
-    it("navigates to settings and back via toggle", () => {
-      getStore().toggleSettings();
+    it("navigates to settings", () => {
+      getStore().openSettings();
       expect(getView().type).toBe("settings");
-
-      getStore().toggleSettings();
-      expect(getView().type).toBe("task-input");
     });
 
     it("navigates to task input with folderId", () => {

--- a/apps/twig/src/renderer/stores/navigationStore.ts
+++ b/apps/twig/src/renderer/stores/navigationStore.ts
@@ -29,7 +29,7 @@ interface NavigationStore {
   navigateToTaskInput: (folderId?: string) => void;
   navigateToSettings: () => void;
   navigateToFolderSettings: (folderId: string) => void;
-  toggleSettings: () => void;
+  openSettings: () => void;
   goBack: () => void;
   goForward: () => void;
   canGoBack: () => boolean;
@@ -145,13 +145,8 @@ export const useNavigationStore = create<NavigationStore>()(
           navigate({ type: "folder-settings", folderId });
         },
 
-        toggleSettings: () => {
-          const current = get().view;
-          if (current.type === "settings") {
-            get().navigateToTaskInput();
-          } else {
-            get().navigateToSettings();
-          }
+        openSettings: () => {
+          get().navigateToSettings();
         },
 
         goBack: () => {


### PR DESCRIPTION
We had a weird condition which was caused by a toggle. 
People can just click the a nav item sidebar to leave the settings page