### PR TITLE
fix: try some fixes for laggy chatbox

### DIFF
--- a/apps/twig/src/renderer/features/editor/components/MarkdownRenderer.tsx
+++ b/apps/twig/src/renderer/features/editor/components/MarkdownRenderer.tsx
@@ -10,6 +10,7 @@ import {
   Link,
   Text,
 } from "@radix-ui/themes";
+import { memo, useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -150,10 +151,18 @@ const components: Components = {
   ),
 };
 
-export function MarkdownRenderer({ content }: MarkdownRendererProps) {
+const remarkPlugins = [remarkGfm];
+
+export const MarkdownRenderer = memo(function MarkdownRenderer({
+  content,
+}: MarkdownRendererProps) {
+  const processedContent = useMemo(
+    () => preprocessMarkdown(content),
+    [content],
+  );
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-      {preprocessMarkdown(content)}
+    <ReactMarkdown remarkPlugins={remarkPlugins} components={components}>
+      {processedContent}
     </ReactMarkdown>
   );
-}
+});

--- a/apps/twig/src/renderer/features/message-editor/stores/draftStore.ts
+++ b/apps/twig/src/renderer/features/message-editor/stores/draftStore.ts
@@ -73,18 +73,30 @@ export const useDraftStore = create<DraftStore>()(
 
         getDraft: (sessionId) => get().drafts[sessionId] ?? null,
 
-        setContext: (sessionId, context) =>
+        setContext: (sessionId, context) => {
+          const existing = get().contexts[sessionId];
+          const newContext: EditorContext = {
+            sessionId,
+            taskId: context.taskId ?? existing?.taskId,
+            repoPath: context.repoPath ?? existing?.repoPath,
+            disabled: context.disabled ?? existing?.disabled ?? false,
+            isLoading: context.isLoading ?? existing?.isLoading ?? false,
+            isCloud: context.isCloud ?? existing?.isCloud ?? false,
+          };
+          if (
+            existing?.sessionId === newContext.sessionId &&
+            existing?.taskId === newContext.taskId &&
+            existing?.repoPath === newContext.repoPath &&
+            existing?.disabled === newContext.disabled &&
+            existing?.isLoading === newContext.isLoading &&
+            existing?.isCloud === newContext.isCloud
+          ) {
+            return;
+          }
           set((state) => {
-            const existing = state.contexts[sessionId];
-            state.contexts[sessionId] = {
-              sessionId,
-              taskId: context.taskId ?? existing?.taskId,
-              repoPath: context.repoPath ?? existing?.repoPath,
-              disabled: context.disabled ?? existing?.disabled ?? false,
-              isLoading: context.isLoading ?? existing?.isLoading ?? false,
-              isCloud: context.isCloud ?? existing?.isCloud ?? false,
-            };
-          }),
+            state.contexts[sessionId] = newContext;
+          });
+        },
 
         getContext: (sessionId) => get().contexts[sessionId] ?? null,
 

--- a/apps/twig/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -1,14 +1,17 @@
 import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
 import { Box } from "@radix-ui/themes";
+import { memo } from "react";
 
 interface AgentMessageProps {
   content: string;
 }
 
-export function AgentMessage({ content }: AgentMessageProps) {
+export const AgentMessage = memo(function AgentMessage({
+  content,
+}: AgentMessageProps) {
   return (
     <Box className="py-1 pl-3 [&>*:last-child]:mb-0">
       <MarkdownRenderer content={content} />
     </Box>
   );
-}
+});

--- a/apps/twig/src/renderer/features/sessions/components/session-update/SessionUpdateView.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/SessionUpdateView.tsx
@@ -1,4 +1,5 @@
 import type { SessionUpdate, ToolCall } from "@features/sessions/types";
+import { memo } from "react";
 
 import { AgentMessage } from "./AgentMessage";
 import { CompactBoundaryView } from "./CompactBoundaryView";
@@ -46,14 +47,14 @@ interface SessionUpdateViewProps {
   turnCancelled?: boolean;
 }
 
-export function SessionUpdateView({
+export const SessionUpdateView = memo(function SessionUpdateView({
   item,
   toolCalls,
   turnCancelled,
 }: SessionUpdateViewProps) {
   switch (item.sessionUpdate) {
     case "user_message_chunk":
-      return null; // User messages rendered separately
+      return null;
     case "agent_message_chunk":
       return item.content.type === "text" ? (
         <AgentMessage content={item.content.text} />
@@ -70,9 +71,9 @@ export function SessionUpdateView({
         />
       );
     case "tool_call_update":
-      return null; // Updates are merged into the original tool_call
+      return null;
     case "plan":
-      return null; // Plan shown in PlanStatusBar above message input
+      return null;
     case "available_commands_update":
       return null;
     case "current_mode_update":
@@ -113,4 +114,4 @@ export function SessionUpdateView({
     default:
       return null;
   }
-}
+});

--- a/apps/twig/src/renderer/features/sessions/components/session-update/ThoughtView.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/ThoughtView.tsx
@@ -1,10 +1,13 @@
 import { Box, Text } from "@radix-ui/themes";
+import { memo } from "react";
 
 interface ThoughtViewProps {
   content: string;
 }
 
-export function ThoughtView({ content }: ThoughtViewProps) {
+export const ThoughtView = memo(function ThoughtView({
+  content,
+}: ThoughtViewProps) {
   return (
     <Box
       className="border-l-2 py-1 pl-3"
@@ -18,4 +21,4 @@ export function ThoughtView({ content }: ThoughtViewProps) {
       </Text>
     </Box>
   );
-}
+});


### PR DESCRIPTION
The laggy chatbox in #697 and #564 are highly likely caused by the session subscription in the draftStore, which causes rerenders in the chatbox, causing input lag. This is a bit of a guess. Couldn't reproduce lag when streaming agent responses anymore with this fix.

Closes #697, #564, feel free to reopen either if this keeps occurring.