### PR TITLE
feat: move from oauth to first party auth support

### DIFF
--- a/apps/twig/src/api/posthogClient.ts
+++ b/apps/twig/src/api/posthogClient.ts
@@ -373,4 +373,62 @@ export class PostHogAPIClient {
     });
     return data.results ?? [];
   }
+
+  /**
+   * Get details for multiple projects by their IDs.
+   * Returns project info including organization details.
+   */
+  async getProjectDetails(projectIds: number[]): Promise<
+    Array<{
+      id: number;
+      name: string;
+      organization: { id: string; name: string };
+    }>
+  > {
+    const results = await Promise.all(
+      projectIds.map(async (projectId) => {
+        try {
+          const project = await this.getProject(projectId);
+          return {
+            id: project.id,
+            name: project.name ?? `Project ${project.id}`,
+            organization: {
+              id: project.organization?.toString() ?? "",
+              name: project.organization?.toString() ?? "Unknown Organization",
+            },
+          };
+        } catch (error) {
+          log.warn(`Failed to fetch project ${projectId}:`, error);
+          return null;
+        }
+      }),
+    );
+    return results.filter((r): r is NonNullable<typeof r> => r !== null);
+  }
+
+  /**
+   * Get all organizations the user belongs to.
+   */
+  async getOrganizations(): Promise<
+    Array<{ id: string; name: string; slug: string }>
+  > {
+    const url = new URL(`${this.api.baseUrl}/api/organizations/`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: "/api/organizations/",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch organizations: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    const orgs = data.results ?? data ?? [];
+    return orgs.map((org: { id: string; name: string; slug?: string }) => ({
+      id: org.id,
+      name: org.name,
+      slug: org.slug ?? org.id,
+    }));
+  }
 }

--- a/apps/twig/src/main/services/oauth/schemas.ts
+++ b/apps/twig/src/main/services/oauth/schemas.ts
@@ -22,7 +22,7 @@ export const oAuthTokenResponse = z.object({
   access_token: z.string(),
   expires_in: z.number(),
   token_type: z.string(),
-  scope: z.string(),
+  scope: z.string().optional().default(""),
   refresh_token: z.string(),
   scoped_teams: z.array(z.number()).optional(),
   scoped_organizations: z.array(z.string()).optional(),
@@ -41,6 +41,9 @@ export const startFlowOutput = z.object({
   errorCode: oAuthErrorCode.optional(),
 });
 export type StartFlowOutput = z.infer<typeof startFlowOutput>;
+
+export const startSignupFlowInput = startFlowInput;
+export type StartSignupFlowInput = z.infer<typeof startSignupFlowInput>;
 
 export const refreshTokenInput = z.object({
   refreshToken: z.string(),
@@ -61,3 +64,8 @@ export const cancelFlowOutput = z.object({
   error: z.string().optional(),
 });
 export type CancelFlowOutput = z.infer<typeof cancelFlowOutput>;
+
+export const openExternalUrlInput = z.object({
+  url: z.string().url(),
+});
+export type OpenExternalUrlInput = z.infer<typeof openExternalUrlInput>;

--- a/apps/twig/src/main/trpc/routers/oauth.ts
+++ b/apps/twig/src/main/trpc/routers/oauth.ts
@@ -2,10 +2,12 @@ import { container } from "../../di/container.js";
 import { MAIN_TOKENS } from "../../di/tokens.js";
 import {
   cancelFlowOutput,
+  openExternalUrlInput,
   refreshTokenInput,
   refreshTokenOutput,
   startFlowInput,
   startFlowOutput,
+  startSignupFlowInput,
 } from "../../services/oauth/schemas.js";
 import type { OAuthService } from "../../services/oauth/service.js";
 import { publicProcedure, router } from "../trpc.js";
@@ -18,6 +20,11 @@ export const oauthRouter = router({
     .output(startFlowOutput)
     .mutation(({ input }) => getService().startFlow(input.region)),
 
+  startSignupFlow: publicProcedure
+    .input(startSignupFlowInput)
+    .output(startFlowOutput)
+    .mutation(({ input }) => getService().startSignupFlow(input.region)),
+
   refreshToken: publicProcedure
     .input(refreshTokenInput)
     .output(refreshTokenOutput)
@@ -28,4 +35,8 @@ export const oauthRouter = router({
   cancelFlow: publicProcedure
     .output(cancelFlowOutput)
     .mutation(() => getService().cancelFlow()),
+
+  openExternalUrl: publicProcedure
+    .input(openExternalUrlInput)
+    .mutation(({ input }) => getService().openExternalUrl(input.url)),
 });

--- a/apps/twig/src/renderer/App.tsx
+++ b/apps/twig/src/renderer/App.tsx
@@ -138,29 +138,36 @@ function App() {
     );
   }
 
+  // Determine which screen to show
+  const renderContent = () => {
+    if (!isAuthenticated) {
+      return (
+        <motion.div
+          key="auth"
+          initial={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.5 }}
+        >
+          <AuthScreen />
+        </motion.div>
+      );
+    }
+
+    return (
+      <motion.div
+        key="main"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: showTransition ? 1.5 : 0 }}
+      >
+        <MainLayout />
+      </motion.div>
+    );
+  };
+
   return (
     <ErrorBoundary name="App">
-      <AnimatePresence mode="wait">
-        {!isAuthenticated ? (
-          <motion.div
-            key="auth"
-            initial={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            <AuthScreen />
-          </motion.div>
-        ) : (
-          <motion.div
-            key="main"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5, delay: showTransition ? 1.5 : 0 }}
-          >
-            <MainLayout />
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <AnimatePresence mode="wait">{renderContent()}</AnimatePresence>
       <LoginTransition
         isAnimating={showTransition}
         onComplete={handleTransitionComplete}

--- a/apps/twig/src/renderer/features/auth/components/AuthScreen.tsx
+++ b/apps/twig/src/renderer/features/auth/components/AuthScreen.tsx
@@ -1,19 +1,27 @@
 import { DraggableTitleBar } from "@components/DraggableTitleBar";
 import { useAuthStore } from "@features/auth/stores/authStore";
-import { Box, Callout, Flex, Select, Spinner, Text } from "@radix-ui/themes";
+import { Box, Button, Flex, Text } from "@radix-ui/themes";
 import caveHero from "@renderer/assets/images/cave-hero.jpg";
 import twigLogo from "@renderer/assets/images/twig-logo.svg";
 import { trpcVanilla } from "@renderer/trpc/client";
 import type { CloudRegion } from "@shared/types/oauth";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
-import { IS_DEV } from "@/constants/environment";
+import { LoginForm } from "./LoginForm";
+import { SignupForm } from "./SignupForm";
 
 export const getErrorMessage = (error: unknown) => {
+  if (!error) {
+    return null;
+  }
   if (!(error instanceof Error)) {
     return "Failed to authenticate";
   }
   const message = error.message;
+
+  if (message === "2FA_REQUIRED") {
+    return null; // 2FA dialog will handle this
+  }
 
   if (message.includes("access_denied")) {
     return "Authorization cancelled.";
@@ -23,33 +31,62 @@ export const getErrorMessage = (error: unknown) => {
     return "Authorization timed out. Please try again.";
   }
 
+  if (message.includes("SSO login required")) {
+    return message;
+  }
+
   return message;
 };
 
+type AuthMode = "login" | "signup";
+
 export function AuthScreen() {
   const [region, setRegion] = useState<CloudRegion>("us");
+  const [authMode, setAuthMode] = useState<AuthMode>("login");
+  const { loginWithOAuth, signupWithOAuth } = useAuthStore();
 
-  const { loginWithOAuth } = useAuthStore();
-
-  const authMutation = useMutation({
-    mutationFn: async (selectedRegion: CloudRegion) => {
-      await loginWithOAuth(selectedRegion);
+  // Login mutation (OAuth authorization code + PKCE)
+  const loginMutation = useMutation({
+    mutationFn: async () => {
+      await loginWithOAuth(region);
     },
   });
 
-  const handleSignIn = async () => {
-    if (authMutation.isPending) {
-      authMutation.reset();
-      await trpcVanilla.oauth.cancelFlow.mutate();
-    } else {
-      authMutation.mutate(region);
+  // Signup mutation
+  const signupMutation = useMutation({
+    mutationFn: async () => {
+      await signupWithOAuth(region);
+    },
+  });
+
+  const handleLogin = async () => {
+    loginMutation.mutate();
+  };
+
+  const handleSignup = async () => {
+    signupMutation.mutate();
+  };
+
+  const handleAuthModeChange = (mode: AuthMode) => {
+    if (mode !== authMode) {
+      setAuthMode(mode);
     }
   };
 
-  const handleRegionChange = (value: string) => {
-    setRegion(value as CloudRegion);
-    authMutation.reset();
+  const handleRegionChange = (value: CloudRegion) => {
+    setRegion(value);
+    loginMutation.reset();
+    signupMutation.reset();
   };
+
+  const handleCancel = async () => {
+    loginMutation.reset();
+    await trpcVanilla.oauth.cancelFlow.mutate();
+  };
+
+  const isLoading = loginMutation.isPending || signupMutation.isPending;
+  const error = loginMutation.error || signupMutation.error;
+  const errorMessage = getErrorMessage(error);
 
   return (
     <Flex height="100vh" style={{ position: "relative" }}>
@@ -98,64 +135,63 @@ export function AuthScreen() {
             </Text>
           </Flex>
 
-          <Flex direction="column" gap="4">
-            <Flex direction="column" gap="2">
-              <Text
-                size="2"
-                weight="medium"
-                style={{ color: "var(--cave-charcoal)", opacity: 0.6 }}
-              >
-                PostHog region
-              </Text>
-              <Select.Root
-                value={region}
-                onValueChange={handleRegionChange}
-                size="3"
-              >
-                <Select.Trigger />
-                <Select.Content>
-                  <Select.Item value="us">US Cloud</Select.Item>
-                  <Select.Item value="eu">EU Cloud</Select.Item>
-                  {IS_DEV && <Select.Item value="dev">Development</Select.Item>}
-                </Select.Content>
-              </Select.Root>
-            </Flex>
-
-            {authMutation.isError && (
-              <Callout.Root color="red">
-                <Callout.Text>
-                  {getErrorMessage(authMutation.error)}
-                </Callout.Text>
-              </Callout.Root>
-            )}
-
-            {authMutation.isPending && (
-              <Callout.Root color="blue">
-                <Callout.Text>
-                  Waiting for authorization in your browser...
-                </Callout.Text>
-              </Callout.Root>
-            )}
-
-            <button
+          <Flex
+            align="center"
+            gap="2"
+            style={{
+              backgroundColor: "rgba(255, 255, 255, 0.6)",
+              borderRadius: "999px",
+              padding: "4px",
+              border: "1px solid rgba(0, 0, 0, 0.08)",
+            }}
+          >
+            <Button
               type="button"
-              onClick={handleSignIn}
-              className="flex items-center justify-center gap-2 px-6 py-3 font-bold text-base transition-opacity hover:opacity-90"
+              size="2"
+              variant={authMode === "login" ? "solid" : "ghost"}
+              onClick={() => handleAuthModeChange("login")}
               style={{
-                backgroundColor: authMutation.isPending
-                  ? "var(--gray-8)"
-                  : "var(--cave-charcoal)",
-                color: authMutation.isPending
-                  ? "var(--gray-11)"
-                  : "var(--cave-cream)",
+                borderRadius: "999px",
+                flex: 1,
               }}
             >
-              {authMutation.isPending && <Spinner />}
-              {authMutation.isPending
-                ? "Cancel authorization"
-                : "Sign in with PostHog"}
-            </button>
+              Sign in
+            </Button>
+            <Button
+              type="button"
+              size="2"
+              variant={authMode === "signup" ? "solid" : "ghost"}
+              onClick={() => handleAuthModeChange("signup")}
+              style={{
+                borderRadius: "999px",
+                flex: 1,
+              }}
+            >
+              Sign up
+            </Button>
           </Flex>
+
+          {authMode === "login" ? (
+            <LoginForm
+              region={region}
+              onRegionChange={handleRegionChange}
+              onLogin={handleLogin}
+              onSwitchToSignup={() => setAuthMode("signup")}
+              isLoading={isLoading}
+              isPending={loginMutation.isPending}
+              error={errorMessage}
+              onCancel={handleCancel}
+            />
+          ) : (
+            <SignupForm
+              region={region}
+              onRegionChange={handleRegionChange}
+              onSignup={handleSignup}
+              onSwitchToLogin={() => setAuthMode("login")}
+              isLoading={isLoading}
+              error={errorMessage}
+            />
+          )}
         </Flex>
       </Flex>
 

--- a/apps/twig/src/renderer/features/auth/components/LoginForm.tsx
+++ b/apps/twig/src/renderer/features/auth/components/LoginForm.tsx
@@ -1,0 +1,111 @@
+import { Button, Callout, Flex, Select, Spinner, Text } from "@radix-ui/themes";
+import type { CloudRegion } from "@shared/types/oauth";
+import { IS_DEV } from "@/constants/environment";
+
+interface LoginFormProps {
+  region: CloudRegion;
+  onRegionChange: (region: CloudRegion) => void;
+  onLogin: () => void;
+  onSwitchToSignup: () => void;
+  isLoading?: boolean;
+  isPending?: boolean;
+  error?: string | null;
+  onCancel?: () => void;
+}
+
+export function LoginForm({
+  region,
+  onRegionChange,
+  onLogin,
+  onSwitchToSignup,
+  isLoading = false,
+  isPending = false,
+  error,
+  onCancel,
+}: LoginFormProps) {
+  const handleButtonClick = () => {
+    if (isPending) {
+      onCancel?.();
+    } else {
+      onLogin();
+    }
+  };
+
+  return (
+    <Flex direction="column" gap="4">
+      <Text size="4" weight="medium" style={{ color: "var(--cave-charcoal)" }}>
+        Sign in to your account
+      </Text>
+
+      {error && (
+        <Callout.Root color="red" size="1">
+          <Callout.Text>{error}</Callout.Text>
+        </Callout.Root>
+      )}
+
+      {isPending && (
+        <Callout.Root color="blue" size="1">
+          <Callout.Text>Waiting for authorization...</Callout.Text>
+        </Callout.Root>
+      )}
+
+      <Button
+        type="button"
+        size="3"
+        onClick={handleButtonClick}
+        disabled={isLoading}
+        style={{
+          backgroundColor: isPending ? "var(--gray-8)" : "var(--cave-charcoal)",
+          color: isPending ? "var(--gray-11)" : "var(--cave-cream)",
+        }}
+      >
+        {isPending && <Spinner />}
+        {isPending ? "Cancel" : "Continue in browser"}
+      </Button>
+
+      <Flex direction="column" gap="2">
+        <Text
+          size="2"
+          weight="medium"
+          style={{ color: "var(--cave-charcoal)", opacity: 0.6 }}
+        >
+          PostHog region
+        </Text>
+        <Select.Root
+          value={region}
+          onValueChange={(value) => onRegionChange(value as CloudRegion)}
+          size="3"
+          disabled={isLoading || isPending}
+        >
+          <Select.Trigger />
+          <Select.Content>
+            <Select.Item value="us">US Cloud</Select.Item>
+            <Select.Item value="eu">EU Cloud</Select.Item>
+            {IS_DEV && <Select.Item value="dev">Development</Select.Item>}
+          </Select.Content>
+        </Select.Root>
+      </Flex>
+
+      <Text
+        size="2"
+        style={{ color: "var(--cave-charcoal)", textAlign: "center" }}
+      >
+        Don&apos;t have an account?{" "}
+        <button
+          type="button"
+          onClick={onSwitchToSignup}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            color: "var(--accent-9)",
+            cursor: "pointer",
+            fontWeight: 500,
+          }}
+        >
+          Create one
+        </button>
+      </Text>
+    </Flex>
+  );
+}

--- a/apps/twig/src/renderer/features/auth/components/SignupForm.tsx
+++ b/apps/twig/src/renderer/features/auth/components/SignupForm.tsx
@@ -1,0 +1,95 @@
+import { Button, Callout, Flex, Select, Spinner, Text } from "@radix-ui/themes";
+import type { CloudRegion } from "@shared/types/oauth";
+import { IS_DEV } from "@/constants/environment";
+
+interface SignupFormProps {
+  region: CloudRegion;
+  onRegionChange: (region: CloudRegion) => void;
+  onSignup: () => Promise<void>;
+  onSwitchToLogin: () => void;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+export function SignupForm({
+  region,
+  onRegionChange,
+  onSignup,
+  onSwitchToLogin,
+  isLoading = false,
+  error,
+}: SignupFormProps) {
+  const displayError = error;
+
+  return (
+    <Flex direction="column" gap="4">
+      <Text size="4" weight="medium" style={{ color: "var(--cave-charcoal)" }}>
+        Create your account
+      </Text>
+
+      {displayError && (
+        <Callout.Root color="red" size="1">
+          <Callout.Text>{displayError}</Callout.Text>
+        </Callout.Root>
+      )}
+
+      <Button
+        type="button"
+        size="3"
+        disabled={isLoading}
+        onClick={() => onSignup()}
+        style={{
+          backgroundColor: "var(--cave-charcoal)",
+          color: "var(--cave-cream)",
+        }}
+      >
+        {isLoading && <Spinner />}
+        Continue in browser
+      </Button>
+
+      <Flex direction="column" gap="2">
+        <Text
+          size="2"
+          weight="medium"
+          style={{ color: "var(--cave-charcoal)", opacity: 0.6 }}
+        >
+          PostHog region
+        </Text>
+        <Select.Root
+          value={region}
+          onValueChange={(value) => onRegionChange(value as CloudRegion)}
+          size="3"
+          disabled={isLoading}
+        >
+          <Select.Trigger />
+          <Select.Content>
+            <Select.Item value="us">US Cloud</Select.Item>
+            <Select.Item value="eu">EU Cloud</Select.Item>
+            {IS_DEV && <Select.Item value="dev">Development</Select.Item>}
+          </Select.Content>
+        </Select.Root>
+      </Flex>
+
+      <Text
+        size="2"
+        style={{ color: "var(--cave-charcoal)", textAlign: "center" }}
+      >
+        Already have an account?{" "}
+        <button
+          type="button"
+          onClick={onSwitchToLogin}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            color: "var(--accent-9)",
+            cursor: "pointer",
+            fontWeight: 500,
+          }}
+        >
+          Sign in
+        </button>
+      </Text>
+    </Flex>
+  );
+}

--- a/apps/twig/src/renderer/features/projects/hooks/useProjects.tsx
+++ b/apps/twig/src/renderer/features/projects/hooks/useProjects.tsx
@@ -1,0 +1,62 @@
+import { useAuthStore } from "@features/auth/stores/authStore";
+import { useQuery } from "@tanstack/react-query";
+
+export interface ProjectInfo {
+  id: number;
+  name: string;
+  organization: { id: string; name: string };
+}
+
+export interface GroupedProjects {
+  orgId: string;
+  orgName: string;
+  projects: ProjectInfo[];
+}
+
+export function groupProjectsByOrg(projects: ProjectInfo[]): GroupedProjects[] {
+  const orgMap = new Map<string, GroupedProjects>();
+
+  for (const project of projects) {
+    const orgId = project.organization.id;
+    if (!orgMap.has(orgId)) {
+      orgMap.set(orgId, {
+        orgId,
+        orgName: project.organization.name,
+        projects: [],
+      });
+    }
+    orgMap.get(orgId)?.projects.push(project);
+  }
+
+  return Array.from(orgMap.values());
+}
+
+export function useProjects() {
+  const availableProjectIds = useAuthStore((s) => s.availableProjectIds);
+  const client = useAuthStore((s) => s.client);
+  const currentProjectId = useAuthStore((s) => s.projectId);
+
+  const query = useQuery({
+    queryKey: ["projects", availableProjectIds],
+    queryFn: async () => {
+      if (!client || availableProjectIds.length === 0) {
+        return [];
+      }
+      return client.getProjectDetails(availableProjectIds);
+    },
+    enabled: !!client && availableProjectIds.length > 0,
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  });
+
+  const currentProject = query.data?.find((p) => p.id === currentProjectId);
+  const groupedProjects = query.data ? groupProjectsByOrg(query.data) : [];
+
+  return {
+    projects: query.data ?? [],
+    groupedProjects,
+    currentProject,
+    currentProjectId,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/apps/twig/src/renderer/features/sidebar/components/ProjectSwitcher.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/ProjectSwitcher.tsx
@@ -1,0 +1,130 @@
+import { useAuthStore } from "@features/auth/stores/authStore";
+import { useProjects } from "@features/projects/hooks/useProjects";
+import { Buildings, CaretUpDown, Check, Plus } from "@phosphor-icons/react";
+import { Box, DropdownMenu, Flex, Spinner, Text } from "@radix-ui/themes";
+import { trpcVanilla } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { getCloudUrlFromRegion } from "@/constants/oauth";
+
+export function ProjectSwitcher() {
+  const cloudRegion = useAuthStore((s) => s.cloudRegion);
+  const selectProject = useAuthStore((s) => s.selectProject);
+  const client = useAuthStore((s) => s.client);
+  const { groupedProjects, currentProject, currentProjectId, isLoading } =
+    useProjects();
+
+  const { data: currentUser } = useQuery({
+    queryKey: ["currentUser"],
+    queryFn: () => client?.getCurrentUser(),
+    enabled: !!client,
+  });
+
+  // Don't show the switcher if there's only one project
+  if (!isLoading && groupedProjects.length === 0) {
+    return null;
+  }
+
+  const handleProjectSelect = (projectId: number) => {
+    if (projectId !== currentProjectId) {
+      selectProject(projectId);
+    }
+  };
+
+  const handleAddProject = async () => {
+    // Open PostHog in browser to add a new project
+    if (cloudRegion) {
+      const cloudUrl = getCloudUrlFromRegion(cloudRegion);
+      await trpcVanilla.oauth.openExternalUrl.mutate({
+        url: `${cloudUrl}/organization/create-project`,
+      });
+    }
+  };
+
+  return (
+    <Box px="2" py="2">
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between rounded-md px-2 py-1.5 transition-colors hover:bg-gray-3"
+            style={{
+              border: "none",
+              background: "transparent",
+              cursor: "pointer",
+            }}
+          >
+            <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+              <Buildings
+                size={16}
+                weight="regular"
+                className="shrink-0 text-gray-11"
+              />
+              {isLoading ? (
+                <Spinner size="1" />
+              ) : (
+                <Flex direction="column" align="start" style={{ minWidth: 0 }}>
+                  <Text
+                    size="2"
+                    weight="medium"
+                    className="truncate"
+                    style={{ maxWidth: "180px" }}
+                  >
+                    {currentProject?.name ?? "Select project"}
+                  </Text>
+                  {currentUser?.email && (
+                    <Text
+                      size="1"
+                      className="truncate text-gray-10"
+                      style={{ maxWidth: "180px" }}
+                    >
+                      {currentUser.email}
+                    </Text>
+                  )}
+                </Flex>
+              )}
+            </Flex>
+            <CaretUpDown size={14} className="shrink-0 text-gray-10" />
+          </button>
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Content
+          align="start"
+          style={{ minWidth: "220px" }}
+          size="2"
+        >
+          {currentUser?.email && (
+            <DropdownMenu.Label>
+              <Text size="1" className="text-gray-10">
+                {currentUser.email}
+              </Text>
+            </DropdownMenu.Label>
+          )}
+          {groupedProjects.flatMap((group) =>
+            group.projects.map((project) => (
+              <DropdownMenu.Item
+                key={project.id}
+                onSelect={() => handleProjectSelect(project.id)}
+              >
+                <Flex align="center" justify="between" gap="2" width="100%">
+                  <Text size="2">{project.name}</Text>
+                  {project.id === currentProjectId && (
+                    <Check size={14} className="text-accent-11" />
+                  )}
+                </Flex>
+              </DropdownMenu.Item>
+            )),
+          )}
+
+          <DropdownMenu.Separator />
+
+          <DropdownMenu.Item onSelect={handleAddProject}>
+            <Flex align="center" gap="2">
+              <Plus size={14} />
+              <Text size="2">Add project</Text>
+            </Flex>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </Box>
+  );
+}

--- a/apps/twig/src/renderer/features/sidebar/components/SidebarContent.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/SidebarContent.tsx
@@ -1,6 +1,13 @@
+import { Flex } from "@radix-ui/themes";
 import type React from "react";
+import { ProjectSwitcher } from "./ProjectSwitcher";
 import { SidebarMenu } from "./SidebarMenu";
 
 export const SidebarContent: React.FC = () => {
-  return <SidebarMenu />;
+  return (
+    <Flex direction="column" height="100%">
+      <ProjectSwitcher />
+      <SidebarMenu />
+    </Flex>
+  );
 };

--- a/apps/twig/tests/e2e/tests/smoke.spec.ts
+++ b/apps/twig/tests/e2e/tests/smoke.spec.ts
@@ -21,7 +21,8 @@ test.describe("Smoke Tests", () => {
       .catch(() => {});
 
     const hasAuthScreen = await window
-      .locator("text=Sign in with PostHog")
+      .locator("text=Sign in")
+      .first()
       .isVisible()
       .catch(() => false);
 


### PR DESCRIPTION
**Problem**
  Twig needs a native‑feeling onboarding flow while using PostHog Cloud’s secure OAuth login (passkeys, MFA, social login) without confusing users.

  **Changes**
  - **Standard OAuth flow:** Twig now uses Authorization Code + PKCE for both login and signup.
  - **Browser‑based auth:** Users are redirected to a Twig‑branded PostHog login/signup page.
  - **Signup via `/signup?next=/oauth/authorize...`** to keep default project creation and return to Twig with tokens.
  - **Simplified in‑app UI:** Login/Signup is a lightweight toggle with a visible region selector.

  **How did you test this code?**
  - Login via browser OAuth (Authorization Code + PKCE)
  - Signup via `/signup?next=/oauth/authorize...`
  - Verified token refresh, project scoping, and normal app usage after auth

  **Publish to changelog?**
  No