### PR TITLE
feat: Add /good and /bad feedback commands

### DIFF
--- a/apps/twig/src/renderer/features/message-editor/suggestions/getSuggestions.test.ts
+++ b/apps/twig/src/renderer/features/message-editor/suggestions/getSuggestions.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetAvailableCommandsForTask = vi.hoisted(() => vi.fn());
+const mockGetState = vi.hoisted(() => vi.fn());
+
+vi.mock("@features/sessions/stores/sessionStore", () => ({
+  getAvailableCommandsForTask: mockGetAvailableCommandsForTask,
+}));
+
+vi.mock("../stores/draftStore", () => ({
+  useDraftStore: {
+    getState: mockGetState,
+  },
+}));
+
+vi.mock("@hooks/useRepoFiles", () => ({
+  fetchRepoFiles: vi.fn(),
+  searchFiles: vi.fn(),
+}));
+
+import { getCommandSuggestions } from "./getSuggestions";
+
+describe("getCommandSuggestions", () => {
+  beforeEach(() => {
+    mockGetAvailableCommandsForTask.mockReset();
+    mockGetState.mockReset();
+    mockGetState.mockReturnValue({
+      contexts: {
+        "session-123": { taskId: "task-456" },
+      },
+    });
+  });
+
+  it("includes client commands (good, bad) in suggestions", () => {
+    mockGetAvailableCommandsForTask.mockReturnValue([]);
+
+    const suggestions = getCommandSuggestions("session-123", "");
+
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0]).toMatchObject({
+      id: "good",
+      label: "good",
+      description: "Send positive feedback for this session",
+    });
+    expect(suggestions[1]).toMatchObject({
+      id: "bad",
+      label: "bad",
+      description: "Send negative feedback for this session",
+    });
+  });
+
+  it("client commands appear before AI commands", () => {
+    mockGetAvailableCommandsForTask.mockReturnValue([
+      { name: "commit", description: "Commit changes" },
+      { name: "help", description: "Show help" },
+    ]);
+
+    const suggestions = getCommandSuggestions("session-123", "");
+
+    // With COMMAND_LIMIT=5, we should get: good, bad, commit, help
+    expect(suggestions.length).toBeLessThanOrEqual(5);
+    expect(suggestions[0].id).toBe("good");
+    expect(suggestions[1].id).toBe("bad");
+  });
+
+  it("filters commands by query", () => {
+    mockGetAvailableCommandsForTask.mockReturnValue([
+      { name: "commit", description: "Commit changes" },
+    ]);
+
+    const suggestions = getCommandSuggestions("session-123", "go");
+
+    // Should match "good" based on "go" prefix
+    expect(suggestions.some((s) => s.id === "good")).toBe(true);
+    // Should not match "bad" or "commit"
+    expect(suggestions.some((s) => s.id === "commit")).toBe(false);
+  });
+
+  it("filters to show bad command", () => {
+    mockGetAvailableCommandsForTask.mockReturnValue([]);
+
+    const suggestions = getCommandSuggestions("session-123", "bad");
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].id).toBe("bad");
+  });
+
+  it("returns empty array when no session context", () => {
+    mockGetState.mockReturnValue({ contexts: {} });
+    mockGetAvailableCommandsForTask.mockReturnValue([]);
+
+    const suggestions = getCommandSuggestions("unknown-session", "");
+
+    // Should still return client commands since they don't require session context for display
+    expect(suggestions.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes command object in suggestion item", () => {
+    mockGetAvailableCommandsForTask.mockReturnValue([]);
+
+    const suggestions = getCommandSuggestions("session-123", "good");
+
+    expect(suggestions[0].command).toEqual({
+      name: "good",
+      description: "Send positive feedback for this session",
+    });
+  });
+});

--- a/apps/twig/src/renderer/features/message-editor/suggestions/getSuggestions.ts
+++ b/apps/twig/src/renderer/features/message-editor/suggestions/getSuggestions.ts
@@ -7,6 +7,12 @@ import type { CommandSuggestionItem, FileSuggestionItem } from "../types";
 
 const COMMAND_LIMIT = 5;
 
+// Client-side commands that don't go to the agent
+const CLIENT_COMMANDS: AvailableCommand[] = [
+  { name: "good", description: "Send positive feedback for this session" },
+  { name: "bad", description: "Send negative feedback for this session" },
+];
+
 const COMMAND_FUSE_OPTIONS: IFuseOptions<AvailableCommand> = {
   keys: [
     { name: "name", weight: 0.7 },
@@ -67,8 +73,9 @@ export function getCommandSuggestions(
   query: string,
 ): CommandSuggestionItem[] {
   const taskId = useDraftStore.getState().contexts[sessionId]?.taskId;
-  const commands = getAvailableCommandsForTask(taskId);
-  const filtered = searchCommands(commands, query);
+  const aiCommands = getAvailableCommandsForTask(taskId);
+  const allCommands = [...CLIENT_COMMANDS, ...aiCommands];
+  const filtered = searchCommands(allCommands, query);
 
   return filtered.map((cmd) => ({
     id: cmd.name,

--- a/apps/twig/src/renderer/features/message-editor/tiptap/CommandMention.ts
+++ b/apps/twig/src/renderer/features/message-editor/tiptap/CommandMention.ts
@@ -5,6 +5,7 @@ import type { SuggestionOptions } from "@tiptap/suggestion";
 import tippy, { type Instance as TippyInstance } from "tippy.js";
 import { getCommandSuggestions } from "../suggestions/getSuggestions";
 import type { CommandSuggestionItem, SuggestionItem } from "../types";
+import { executeClientCommand, isClientCommand } from "../utils/clientCommands";
 import { SuggestionList, type SuggestionListRef } from "./SuggestionList";
 
 function createSuggestion(
@@ -82,6 +83,13 @@ function createSuggestion(
 
     command: ({ editor, range, props }) => {
       const item = props as CommandSuggestionItem;
+
+      // Client-side commands execute locally without going to agent
+      if (isClientCommand(item.command.name)) {
+        executeClientCommand(item.command.name, sessionId);
+        editor.chain().focus().deleteRange(range).run();
+        return;
+      }
 
       // Commands without input hints execute immediately
       if (!item.command.input?.hint) {

--- a/apps/twig/src/renderer/features/message-editor/utils/clientCommands.test.ts
+++ b/apps/twig/src/renderer/features/message-editor/utils/clientCommands.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockTrack = vi.hoisted(() => vi.fn());
+const mockGetSessionForTask = vi.hoisted(() => vi.fn());
+const mockGetState = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/lib/analytics", () => ({
+  track: mockTrack,
+}));
+
+vi.mock("@features/sessions/stores/sessionStore", () => ({
+  getSessionForTask: mockGetSessionForTask,
+}));
+
+vi.mock("../stores/draftStore", () => ({
+  useDraftStore: {
+    getState: mockGetState,
+  },
+}));
+
+import { ANALYTICS_EVENTS } from "@/types/analytics";
+import { executeClientCommand, isClientCommand } from "./clientCommands";
+
+describe("clientCommands", () => {
+  beforeEach(() => {
+    mockTrack.mockReset();
+    mockGetSessionForTask.mockReset();
+    mockGetState.mockReset();
+  });
+
+  describe("isClientCommand", () => {
+    it("returns true for 'good' command", () => {
+      expect(isClientCommand("good")).toBe(true);
+    });
+
+    it("returns true for 'bad' command", () => {
+      expect(isClientCommand("bad")).toBe(true);
+    });
+
+    it("returns false for unknown commands", () => {
+      expect(isClientCommand("commit")).toBe(false);
+      expect(isClientCommand("help")).toBe(false);
+      expect(isClientCommand("unknown")).toBe(false);
+    });
+  });
+
+  describe("executeClientCommand", () => {
+    it("tracks feedback for 'good' command with local session", () => {
+      mockGetState.mockReturnValue({
+        contexts: {
+          "session-123": { taskId: "task-456" },
+        },
+      });
+      mockGetSessionForTask.mockReturnValue({
+        taskId: "task-456",
+        taskRunId: "run-789",
+        isCloud: false,
+        model: "claude-sonnet-4-20250514",
+      });
+
+      executeClientCommand("good", "session-123");
+
+      expect(mockTrack).toHaveBeenCalledWith(ANALYTICS_EVENTS.SESSION_FEEDBACK, {
+        task_id: "task-456",
+        session_id: "run-789",
+        execution_type: "local",
+        model: "claude-sonnet-4-20250514",
+        feedback_type: "good",
+      });
+    });
+
+    it("tracks feedback for 'bad' command with cloud session", () => {
+      mockGetState.mockReturnValue({
+        contexts: {
+          "session-123": { taskId: "task-456" },
+        },
+      });
+      mockGetSessionForTask.mockReturnValue({
+        taskId: "task-456",
+        taskRunId: "run-789",
+        isCloud: true,
+        model: "claude-opus-4-20250514",
+      });
+
+      executeClientCommand("bad", "session-123");
+
+      expect(mockTrack).toHaveBeenCalledWith(ANALYTICS_EVENTS.SESSION_FEEDBACK, {
+        task_id: "task-456",
+        session_id: "run-789",
+        execution_type: "cloud",
+        model: "claude-opus-4-20250514",
+        feedback_type: "bad",
+      });
+    });
+
+    it("does not track when session is not found", () => {
+      mockGetState.mockReturnValue({
+        contexts: {
+          "session-123": { taskId: "task-456" },
+        },
+      });
+      mockGetSessionForTask.mockReturnValue(undefined);
+
+      executeClientCommand("good", "session-123");
+
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+
+    it("does not track when context is not found", () => {
+      mockGetState.mockReturnValue({
+        contexts: {},
+      });
+
+      executeClientCommand("good", "session-123");
+
+      expect(mockGetSessionForTask).toHaveBeenCalledWith(undefined);
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+
+    it("handles session without model", () => {
+      mockGetState.mockReturnValue({
+        contexts: {
+          "session-123": { taskId: "task-456" },
+        },
+      });
+      mockGetSessionForTask.mockReturnValue({
+        taskId: "task-456",
+        taskRunId: "run-789",
+        isCloud: false,
+        model: undefined,
+      });
+
+      executeClientCommand("good", "session-123");
+
+      expect(mockTrack).toHaveBeenCalledWith(ANALYTICS_EVENTS.SESSION_FEEDBACK, {
+        task_id: "task-456",
+        session_id: "run-789",
+        execution_type: "local",
+        model: undefined,
+        feedback_type: "good",
+      });
+    });
+
+    it("does nothing for unknown commands", () => {
+      executeClientCommand("unknown", "session-123");
+
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/twig/src/renderer/features/message-editor/utils/clientCommands.ts
+++ b/apps/twig/src/renderer/features/message-editor/utils/clientCommands.ts
@@ -1,0 +1,38 @@
+import { getSessionForTask } from "@features/sessions/stores/sessionStore";
+import { track } from "@renderer/lib/analytics";
+import { ANALYTICS_EVENTS } from "@/types/analytics";
+import { useDraftStore } from "../stores/draftStore";
+
+const CLIENT_COMMAND_NAMES = ["good", "bad"] as const;
+type ClientCommandName = (typeof CLIENT_COMMAND_NAMES)[number];
+
+export function isClientCommand(name: string): name is ClientCommandName {
+  return CLIENT_COMMAND_NAMES.includes(name as ClientCommandName);
+}
+
+export function executeClientCommand(
+  commandName: string,
+  sessionId: string,
+): void {
+  if (commandName === "good" || commandName === "bad") {
+    trackSessionFeedback(sessionId, commandName);
+  }
+}
+
+function trackSessionFeedback(
+  sessionId: string,
+  feedbackType: "good" | "bad",
+): void {
+  const taskId = useDraftStore.getState().contexts[sessionId]?.taskId;
+  const session = getSessionForTask(taskId);
+
+  if (!session) return;
+
+  track(ANALYTICS_EVENTS.SESSION_FEEDBACK, {
+    task_id: session.taskId,
+    session_id: session.taskRunId,
+    execution_type: session.isCloud ? "cloud" : "local",
+    model: session.model,
+    feedback_type: feedbackType,
+  });
+}

--- a/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
@@ -1417,6 +1417,12 @@ export const useSessionForTask = (taskId: string | undefined) =>
   );
 export const getSessionActions = () => useStore.getState().actions;
 
+export function getSessionForTask(taskId: string | undefined) {
+  if (!taskId) return undefined;
+  const sessions = useStore.getState().sessions;
+  return Object.values(sessions).find((s) => s.taskId === taskId);
+}
+
 function extractAvailableCommandsFromEvents(
   events: AcpMessage[],
 ): AvailableCommand[] {

--- a/apps/twig/src/types/analytics.ts
+++ b/apps/twig/src/types/analytics.ts
@@ -147,6 +147,14 @@ export interface AgentSessionErrorProperties {
   error_type: string;
 }
 
+export interface SessionFeedbackProperties {
+  task_id: string;
+  session_id: string;
+  execution_type: ExecutionType;
+  model?: string;
+  feedback_type: "good" | "bad";
+}
+
 // Activation events
 export interface FirstTaskCreatedProperties {
   task_id: string;
@@ -204,6 +212,9 @@ export const ANALYTICS_EVENTS = {
   // Error events
   TASK_CREATION_FAILED: "Task creation failed",
   AGENT_SESSION_ERROR: "Agent session error",
+
+  // Feedback events
+  SESSION_FEEDBACK: "Session feedback",
 } as const;
 
 export type AnalyticsEvent =
@@ -249,4 +260,7 @@ export type EventPropertyMap = {
   // Error events
   [ANALYTICS_EVENTS.TASK_CREATION_FAILED]: TaskCreationFailedProperties;
   [ANALYTICS_EVENTS.AGENT_SESSION_ERROR]: AgentSessionErrorProperties;
+
+  // Feedback events
+  [ANALYTICS_EVENTS.SESSION_FEEDBACK]: SessionFeedbackProperties;
 };


### PR DESCRIPTION
## Summary
- Add client-side `/good` and `/bad` slash commands for session feedback
- Commands execute locally without being sent to the agent
- Sends "Session feedback" event to PostHog with session context

## Changes
- `types/analytics.ts`: Add `SessionFeedbackProperties` interface and `SESSION_FEEDBACK` event
- `sessionStore.ts`: Add `getSessionForTask()` sync getter
- `getSuggestions.ts`: Include client commands in command suggestions
- `CommandMention.ts`: Intercept client commands and execute locally
- `clientCommands.ts`: New utility for client command handling and feedback tracking

## Event payload
- `task_id`: Task identifier
- `session_id`: Task run identifier
- `execution_type`: "cloud" or "local"
- `model`: Model being used (if set)
- `feedback_type`: "good" or "bad"

## Test plan
- [x] Unit tests for `isClientCommand` and `executeClientCommand`
- [x] Unit tests for command suggestions including client commands
- [ ] Manual: Type `/` in message editor, verify "good" and "bad" appear
- [ ] Manual: Select `/good`, verify editor clears and no message sent to agent
- [ ] Manual: Check PostHog for "Session feedback" event with correct properties