### PR TITLE
fix: Force-kill process on shutdown timeout to prevent hang

### DIFF
--- a/apps/twig/src/main/services/app-lifecycle/service.ts
+++ b/apps/twig/src/main/services/app-lifecycle/service.ts
@@ -11,48 +11,72 @@ const log = logger.scope("app-lifecycle");
 @injectable()
 export class AppLifecycleService {
   private _isQuittingForUpdate = false;
+  private _isShuttingDown = false;
   private static readonly SHUTDOWN_TIMEOUT_MS = 3000;
 
   get isQuittingForUpdate(): boolean {
     return this._isQuittingForUpdate;
   }
 
+  get isShuttingDown(): boolean {
+    return this._isShuttingDown;
+  }
+
   setQuittingForUpdate(): void {
     this._isQuittingForUpdate = true;
   }
 
+  forceExit(): never {
+    log.warn("Force-killing process");
+    process.exit(1);
+  }
+
   async shutdown(): Promise<void> {
-    // Race shutdown against timeout to prevent app from hanging forever
+    if (this._isShuttingDown) {
+      log.warn("Shutdown already in progress, forcing exit");
+      this.forceExit();
+    }
+
+    this._isShuttingDown = true;
+
     const result = await withTimeout(
       this.doShutdown(),
       AppLifecycleService.SHUTDOWN_TIMEOUT_MS,
     );
 
     if (result.result === "timeout") {
-      log.warn("Shutdown timeout reached, proceeding anyway", {
+      log.warn("Shutdown timeout reached, forcing exit", {
         timeoutMs: AppLifecycleService.SHUTDOWN_TIMEOUT_MS,
       });
+      this.forceExit();
     }
   }
 
   private async doShutdown(): Promise<void> {
+    log.info("Shutdown started: unbinding container");
     try {
       await container.unbindAll();
+      log.info("Container unbound successfully");
     } catch (error) {
       log.error("Failed to unbind container", error);
     }
 
     trackAppEvent(ANALYTICS_EVENTS.APP_QUIT);
 
+    log.info("Shutting down PostHog");
     try {
       await shutdownPostHog();
+      log.info("PostHog shutdown complete");
     } catch (error) {
       log.error("Failed to shutdown PostHog", error);
     }
+
+    log.info("Graceful shutdown complete");
   }
 
   async shutdownAndExit(): Promise<void> {
     await this.shutdown();
+    log.info("Calling app.exit(0)");
     app.exit(0);
   }
 }


### PR DESCRIPTION
The problem was that app.exit(0) wasn't enough to kill the process. It tells Electron to close windows and exit, but orphaned child processes (agent subprocesses, shell PTYs) can keep the process group alive.

ProcessService W.I.P.