### PR TITLE
feat: Symlink CLAUDE.local.md to workspaces

### DIFF
--- a/packages/agent/src/worktree-manager.ts
+++ b/packages/agent/src/worktree-manager.ts
@@ -504,28 +504,50 @@ export class WorktreeManager {
   }
 
   private async symlinkClaudeConfig(worktreePath: string): Promise<void> {
+    // Symlink .claude directory
     const sourceClaudeDir = path.join(this.mainRepoPath, ".claude");
     const targetClaudeDir = path.join(worktreePath, ".claude");
 
     try {
       await fs.access(sourceClaudeDir);
+      try {
+        await fs.symlink(sourceClaudeDir, targetClaudeDir, "dir");
+        this.logger.info("Symlinked .claude config to worktree", {
+          source: sourceClaudeDir,
+          target: targetClaudeDir,
+        });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          this.logger.debug(".claude symlink already exists in worktree");
+        } else {
+          this.logger.warn("Failed to symlink .claude config", { error });
+        }
+      }
     } catch {
       this.logger.debug("No .claude directory in main repo to symlink");
-      return;
     }
 
+    // Symlink CLAUDE.local.md
+    const sourceClaudeLocalMd = path.join(this.mainRepoPath, "CLAUDE.local.md");
+    const targetClaudeLocalMd = path.join(worktreePath, "CLAUDE.local.md");
+
     try {
-      await fs.symlink(sourceClaudeDir, targetClaudeDir, "dir");
-      this.logger.info("Symlinked .claude config to worktree", {
-        source: sourceClaudeDir,
-        target: targetClaudeDir,
-      });
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-        this.logger.debug(".claude symlink already exists in worktree");
-      } else {
-        this.logger.warn("Failed to symlink .claude config", { error });
+      await fs.access(sourceClaudeLocalMd);
+      try {
+        await fs.symlink(sourceClaudeLocalMd, targetClaudeLocalMd, "file");
+        this.logger.info("Symlinked CLAUDE.local.md to worktree", {
+          source: sourceClaudeLocalMd,
+          target: targetClaudeLocalMd,
+        });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          this.logger.debug("CLAUDE.local.md symlink already exists in worktree");
+        } else {
+          this.logger.warn("Failed to symlink CLAUDE.local.md", { error });
+        }
       }
+    } catch {
+      this.logger.debug("No CLAUDE.local.md in main repo to symlink");
     }
   }
 


### PR DESCRIPTION
## Summary

When creating a new workspace/worktree, we already symlink the `.claude` directory from the main repo. This change also symlinks `CLAUDE.local.md` if it exists, ensuring local Claude configurations are available in workspaces.

## Changes

- Updated `symlinkClaudeConfig` method in `worktree-manager.ts` to also symlink `CLAUDE.local.md`
- Both `.claude` and `CLAUDE.local.md` symlinks are now created independently with proper error handling
- Added debug logging for when files don't exist or already have symlinks

## Test plan

- [ ] Create a new workspace and verify `CLAUDE.local.md` is symlinked if it exists in the main repo
- [ ] Verify existing `.claude` directory symlink still works
- [ ] Test behavior when `CLAUDE.local.md` doesn't exist (should gracefully skip)
- [ ] Test behavior when symlink already exists (should skip with debug log)