### PR TITLE
feat: tell MCP which porject it should use

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -207,6 +207,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       cwd: params.cwd,
       permissionMode: "default",
       mcpServers,
+      systemPrompt: buildSystemPrompt(meta?.systemPrompt),
       userProvidedOptions: meta?.claudeCode?.options,
       sdkSessionId: meta?.sdkSessionId,
       additionalDirectories: meta?.claudeCode?.options?.additionalDirectories,


### PR DESCRIPTION
### TL;DR

Added PostHog project context to the system prompt for agent sessions.

### What changed?

- Created a new `buildPostHogSystemPrompt` method that generates a system prompt with PostHog project context
- Added the PostHog system prompt to both new sessions and resumed sessions
- Added support for a `POSTHOG_MCP_URL` environment variable to override the MCP URL
- Modified the logic for determining the PostHog MCP URL to prioritize the environment variable

### How to test?

1. Set the `POSTHOG_MCP_URL` environment variable to test the override functionality
2. Start a new agent session and verify that the PostHog project context is included in the system prompt
3. Resume an existing session and confirm the context is maintained

### Why make this change?

This change ensures that the agent has proper context about which PostHog project it should operate on. By including the project ID and API host in the system prompt, the agent can make more accurate decisions when using PostHog MCP tools, preventing accidental cross-project operations.