### PR TITLE
feat: add spinner for tasks loading

### DIFF
--- a/apps/twig/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -1,3 +1,4 @@
+import { DotsCircleSpinner } from "@components/DotsCircleSpinner";
 import { RenameTaskDialog } from "@components/RenameTaskDialog";
 import { useDeleteTask, useTasks } from "@features/tasks/hooks/useTasks";
 import { useTaskStore } from "@features/tasks/stores/taskStore";
@@ -13,6 +14,7 @@ import { usePinnedTasksStore } from "../stores/pinnedTasksStore";
 import { useTaskViewedStore } from "../stores/taskViewedStore";
 import { HistoryView } from "./HistoryView";
 import { NewTaskItem } from "./items/HomeItem";
+import { SidebarItem } from "./SidebarItem";
 
 function SidebarMenuComponent() {
   const { view, navigateToTask, navigateToTaskInput } = useNavigationStore();
@@ -118,15 +120,23 @@ function SidebarMenuComponent() {
               />
             </Box>
 
-            <HistoryView
-              historyData={sidebarData.historyData}
-              pinnedData={sidebarData.pinnedData}
-              activeTaskId={sidebarData.activeTaskId}
-              onTaskClick={handleTaskClick}
-              onTaskContextMenu={handleTaskContextMenu}
-              onTaskDelete={handleTaskDelete}
-              onTaskTogglePin={handleTaskTogglePin}
-            />
+            {sidebarData.isLoading ? (
+              <SidebarItem
+                depth={0}
+                icon={<DotsCircleSpinner size={12} className="text-gray-10" />}
+                label="Loading tasks..."
+              />
+            ) : (
+              <HistoryView
+                historyData={sidebarData.historyData}
+                pinnedData={sidebarData.pinnedData}
+                activeTaskId={sidebarData.activeTaskId}
+                onTaskClick={handleTaskClick}
+                onTaskContextMenu={handleTaskContextMenu}
+                onTaskDelete={handleTaskDelete}
+                onTaskTogglePin={handleTaskTogglePin}
+              />
+            )}
           </Flex>
         </Box>
       </Box>


### PR DESCRIPTION
### TL;DR

Added a loading state to the sidebar task list.

### What changed?

- Imported the `DotsCircleSpinner` component and `SidebarItem` component
- Added a conditional rendering in the sidebar menu that shows a loading spinner with "Loading tasks..." text when `sidebarData.isLoading` is true
- When not loading, the regular `HistoryView` component is displayed as before

### How to test?

1. Open the application and observe the sidebar behavior during task loading
2. Verify that the loading spinner appears when tasks are being fetched
3. Confirm that the regular task list appears once loading is complete

### Why make this change?

This change improves the user experience by providing visual feedback when tasks are being loaded, rather than showing an empty sidebar which might confuse users into thinking there are no tasks. The loading indicator helps users understand that the application is working and content will appear shortly.