### PR TITLE
fix: remove gpt models for now

### DIFF
--- a/apps/twig/src/main/services/agent/service.ts
+++ b/apps/twig/src/main/services/agent/service.ts
@@ -1248,7 +1248,12 @@ For git operations while detached:
       return MODEL_TIER_ORDER.length;
     };
 
-    const mapped = models.map((model) => ({
+    // TODO: Re-enable OpenAI models once the upstream gateway issue is fixed.
+    const filteredModels = models.filter(
+      (model) => model.owned_by !== "openai" && !model.id.startsWith("openai/"),
+    );
+
+    const mapped = filteredModels.map((model) => ({
       modelId: model.id,
       name: formatGatewayModelName(model),
       description: `Context: ${model.context_window.toLocaleString()} tokens`,


### PR DESCRIPTION
### TL;DR

Temporarily filter out OpenAI models from the available model list due to a gateway issue. ref: https://github.com/PostHog/Twig/issues/783

### What changed?

Added a filter to exclude models owned by OpenAI or with IDs that start with "openai/" from the list of available models. This is a temporary measure as indicated by the TODO comment, which mentions re-enabling these models once the upstream gateway issue is fixed.

### How to test?

1. Launch the application and navigate to where models are listed
2. Verify that no OpenAI models appear in the model selection dropdown
3. Confirm that all other non-OpenAI models are still available and functioning correctly

### Why make this change?

There's an ongoing issue with the upstream gateway for OpenAI models. Rather than allowing users to select models that won't work properly, this change temporarily removes them from the selection options until the issue is resolved.