### PR TITLE
fix: o(n) requests on project switch + perisstance

### DIFF
--- a/apps/twig/src/renderer/components/action-selector/useActionSelectorState.ts
+++ b/apps/twig/src/renderer/components/action-selector/useActionSelectorState.ts
@@ -245,6 +245,7 @@ export function useActionSelectorState({
     customInput,
     onSelect,
     saveCurrentStepAnswer,
+    setStep,
   ]);
 
   const selectByIndex = useCallback(
@@ -291,6 +292,7 @@ export function useActionSelectorState({
       toggleCheck,
       onSelect,
       saveCurrentStepAnswer,
+      setStep,
     ],
   );
 


### PR DESCRIPTION
### TL;DR

Improved project selection logic and optimized query cache clearing when switching projects.

closes https://github.com/PostHog/Twig/issues/798

### What changed?

- Enhanced project selection logic to maintain the current project when switching accounts if it's available in the new account's scoped teams
- Added `setStep` to the dependency arrays in `useActionSelectorState` to ensure proper reactivity
- Modified query cache clearing behavior when switching projects to only remove project-specific queries while preserving project list and user data
- Added proper handling of available project IDs when authenticating

### How to test?

1. Log in with an account that has access to multiple projects
2. Switch between projects and verify that the current project is maintained if available in both accounts
3. Verify that the project switcher still shows the correct list of available projects after switching
4. Check that navigation to task input works correctly after project selection

### Why make this change?

This change improves the user experience when switching between projects by:
1. Maintaining context when possible (keeping the same project if available)
2. Preserving necessary data in the query cache to avoid unnecessary refetching
3. Ensuring the project switcher has the correct data available immediately