### PR TITLE
fix: discard is broken

### DIFF
--- a/apps/twig/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -181,6 +181,7 @@ function ChangedFileItem({
 
   const handleDiscard = async (e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
 
     const { message, action } = getDiscardInfo(file, fileName);
 

--- a/packages/git/src/sagas/discard.ts
+++ b/packages/git/src/sagas/discard.ts
@@ -122,7 +122,7 @@ export class DiscardFileChangesSaga extends Saga<
       case "untracked":
         await this.step({
           name: "clean-untracked-file",
-          execute: () => git.clean(["f", "--", filePath]),
+          execute: () => git.clean("f", ["--", filePath]),
           rollback: async () => {
             if (this.backupContent) {
               const dir = path.dirname(fullPath);


### PR DESCRIPTION
### TL;DR

Fixed event propagation in the discard file changes functionality and corrected the git clean command parameter format.

closes https://github.com/PostHog/Twig/issues/796

### What changed?

- Added `e.stopPropagation()` to the `handleDiscard` function in `ChangesPanel.tsx` to prevent the click event from bubbling up to parent elements
- Fixed the parameter format in the git clean command in `discard.ts` by separating the flag from the file path arguments

### How to test?

1. Make changes to a file in a task
2. Open the task detail view and locate the changed file in the Changes panel
3. Click the discard button for the file
4. Verify that only the discard action is triggered without any parent element actions

### Why make this change?

The discard button click was propagating to parent elements, potentially triggering unwanted actions. Additionally, the git clean command was using an incorrect parameter format which could cause issues when discarding untracked files. These fixes ensure proper event handling and correct git command execution.