### PR TITLE
fix: cancel on oauth doesnt work

### DIFF
--- a/apps/twig/src/renderer/features/auth/components/LoginForm.tsx
+++ b/apps/twig/src/renderer/features/auth/components/LoginForm.tsx
@@ -53,7 +53,7 @@ export function LoginForm({
         type="button"
         size="3"
         onClick={handleButtonClick}
-        disabled={isLoading}
+        disabled={isLoading && !isPending}
         style={{
           backgroundColor: isPending ? "var(--gray-8)" : "var(--cave-charcoal)",
           color: isPending ? "var(--gray-11)" : "var(--cave-cream)",


### PR DESCRIPTION
### TL;DR

Updated the disabled state logic for the login button to handle pending states correctly.

closes: https://github.com/PostHog/Twig/issues/791

### What changed?

Modified the `disabled` prop in the LoginForm component to only disable the button when both `isLoading` is true and `isPending` is false. Previously, the button was disabled whenever `isLoading` was true, regardless of the pending state.

### How to test?

1. Navigate to the login screen
2. Attempt to log in and observe the button behavior
3. Verify that the button remains enabled when in a pending state, even if `isLoading` is true
4. Confirm that the button is properly disabled during non-pending loading states

### Why make this change?

This change improves the user experience by ensuring the login button remains interactive during pending states, allowing users to cancel or retry actions while preventing unintended interactions during actual loading operations.