### PR TITLE
feat(agent): add OTEL log transport with resource attributes

### DIFF
--- a/apps/twig/src/main/services/agent/service.ts
+++ b/apps/twig/src/main/services/agent/service.ts
@@ -430,11 +430,22 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     const mockNodeDir = this.setupMockNodeEnvironment(taskRunId);
     this.setupEnvironment(credentials, mockNodeDir);
 
+    // Route agent logs to dedicated agent_logs Kafka topic via capture-logs-agent service
+    // In local dev, use Caddy proxy (port 8010) which routes /i/v1/agent-logs to capture-logs-agent
+    // In prod, use the main API host which proxies /i/v1/agent-logs to capture-logs-agent
+    const otelHost = credentials.apiHost;
+    const otelPath = "/i/v1/agent-logs";
+
     const agent = new Agent({
       posthog: {
         apiUrl: credentials.apiHost,
         getApiKey: () => this.getToken(credentials.apiKey),
         projectId: credentials.projectId,
+      },
+      otelTransport: {
+        host: otelHost,
+        apiKey: this.getToken(credentials.apiKey),
+        logsPath: otelPath,
       },
       debug: !app.isPackaged,
       onLog: onAgentLog,
@@ -577,7 +588,9 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
         return this.getOrCreateSession(config, isReconnect, true);
       }
       log.error(
-        `Failed to ${isReconnect ? "reconnect" : "create"} session${isRetry ? " after retry" : ""}`,
+        `Failed to ${isReconnect ? "reconnect" : "create"} session${
+          isRetry ? " after retry" : ""
+        }`,
         err,
       );
       if (isReconnect) return null;

--- a/apps/twig/src/main/services/git/service.ts
+++ b/apps/twig/src/main/services/git/service.ts
@@ -64,7 +64,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     const remoteUrl = await getRemoteUrl(directoryPath);
     if (!remoteUrl) return null;
 
-    const repo = await parseGitHubUrl(remoteUrl);
+    const repo = parseGitHubUrl(remoteUrl);
     if (!repo) return null;
 
     const branch = await getCurrentBranch(directoryPath);

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -82,6 +82,11 @@
     "vitest": "^2.1.8"
   },
   "dependencies": {
+    "@opentelemetry/api-logs": "^0.208.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+    "@opentelemetry/resources": "^2.0.0",
+    "@opentelemetry/sdk-logs": "^0.208.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@agentclientprotocol/sdk": "^0.13.1",
     "@anthropic-ai/claude-agent-sdk": "0.2.12",
     "@anthropic-ai/sdk": "^0.71.0",

--- a/packages/agent/src/adapters/acp-connection.ts
+++ b/packages/agent/src/adapters/acp-connection.ts
@@ -18,6 +18,8 @@ export type AcpConnectionConfig = {
   logWriter?: SessionLogWriter;
   sessionId?: string;
   taskId?: string;
+  /** Deployment environment - "local" for desktop, "cloud" for cloud sandbox */
+  deviceType?: "local" | "cloud";
   logger?: Logger;
   processCallbacks?: ClaudeAcpAgentOptions;
 };
@@ -52,6 +54,7 @@ export function createAcpConnection(
       logWriter.register(config.sessionId, {
         taskId: config.taskId ?? config.sessionId,
         runId: config.sessionId,
+        deviceType: config.deviceType,
       });
     }
 

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -28,10 +28,8 @@ import {
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { v7 as uuidv7 } from "uuid";
-import type {
-  SessionLogConfig,
-  SessionLogWriter,
-} from "@/session-log-writer.js";
+import type { SessionContext } from "@/otel-log-writer.js";
+import type { SessionLogWriter } from "@/session-log-writer.js";
 import { unreachable } from "@/utils/common.js";
 import { Logger } from "@/utils/logger.js";
 import { Pushable } from "@/utils/streams.js";
@@ -388,7 +386,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     sessionId: string,
     meta: Record<string, unknown> | undefined,
   ) {
-    const persistence = meta?.persistence as SessionLogConfig | undefined;
+    const persistence = meta?.persistence as SessionContext | undefined;
     if (persistence && this.logWriter) {
       this.logWriter.register(sessionId, persistence);
     }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -25,10 +25,17 @@ export class Agent {
 
     if (config.posthog) {
       this.posthogAPI = new PostHogAPIClient(config.posthog);
-      this.sessionLogWriter = new SessionLogWriter(
-        this.posthogAPI,
-        this.logger.child("SessionLogWriter"),
-      );
+    }
+
+    if (config.otelTransport) {
+      this.sessionLogWriter = new SessionLogWriter({
+        otelConfig: {
+          posthogHost: config.otelTransport.host,
+          apiKey: config.otelTransport.apiKey,
+          logsPath: config.otelTransport.logsPath,
+        },
+        logger: this.logger.child("SessionLogWriter"),
+      });
     }
   }
 
@@ -62,6 +69,7 @@ export class Agent {
       logWriter: this.sessionLogWriter,
       sessionId: taskRunId,
       taskId,
+      deviceType: "local",
       logger: this.logger,
       processCallbacks: options.processCallbacks,
     });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,6 +22,8 @@ export type {
 } from "./adapters/acp-connection.js";
 export { createAcpConnection } from "./adapters/acp-connection.js";
 export { Agent } from "./agent.js";
+export type { OtelLogConfig, SessionContext } from "./otel-log-writer.js";
+export { OtelLogWriter } from "./otel-log-writer.js";
 export { PostHogAPIClient } from "./posthog-api.js";
 export type {
   ConversationTurn,
@@ -30,6 +32,8 @@ export type {
   ToolCallInfo,
 } from "./resume.js";
 export { conversationToPromptHistory, resumeFromLog } from "./resume.js";
+export type { SessionLogWriterOptions } from "./session-log-writer.js";
+export { SessionLogWriter } from "./session-log-writer.js";
 export type { TreeSnapshot, TreeTrackerConfig } from "./tree-tracker.js";
 export {
   isCommitOnRemote,
@@ -44,6 +48,7 @@ export type {
   FileStatus,
   LogLevel,
   OnLogCallback,
+  OtelTransportConfig,
   StoredEntry,
   StoredNotification,
   Task,

--- a/packages/agent/src/otel-log-writer.test.ts
+++ b/packages/agent/src/otel-log-writer.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OtelLogWriter } from "./otel-log-writer.js";
+import type { StoredNotification } from "./types.js";
+
+// Mock the OTEL exporter
+const mockExport = vi.fn((_logs, callback) => {
+  callback({ code: 0 }); // Success
+});
+
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+  OTLPLogExporter: vi.fn().mockImplementation(() => ({
+    export: mockExport,
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe("OtelLogWriter", () => {
+  let writer: OtelLogWriter;
+
+  beforeEach(() => {
+    mockExport.mockClear();
+    // Session context (taskId, runId) is now passed in constructor as resource attributes
+    writer = new OtelLogWriter(
+      {
+        posthogHost: "https://us.i.posthog.com",
+        apiKey: "phc_test_key",
+        flushIntervalMs: 100,
+      },
+      {
+        taskId: "task-123",
+        runId: "run-456",
+      },
+    );
+  });
+
+  afterEach(async () => {
+    await writer.shutdown();
+  });
+
+  it("should emit a log entry with event_type as regular attribute", async () => {
+    const notification: StoredNotification = {
+      type: "notification",
+      timestamp: new Date().toISOString(),
+      notification: {
+        jsonrpc: "2.0",
+        method: "_posthog/test_event",
+        params: { foo: "bar" },
+      },
+    };
+
+    // taskId and runId are now resource attributes set in constructor,
+    // only notification is passed per-emit
+    writer.emit({ notification });
+
+    // Force flush to trigger export
+    await writer.flush();
+
+    // Verify export was called
+    expect(mockExport).toHaveBeenCalled();
+
+    // Get the logs that were exported
+    const exportedLogs = mockExport.mock.calls[0][0];
+    expect(exportedLogs.length).toBe(1);
+
+    const log = exportedLogs[0];
+    // task_id and run_id are now resource attributes, not regular attributes
+    expect(log.attributes.task_id).toBeUndefined();
+    expect(log.attributes.run_id).toBeUndefined();
+    // event_type is still a regular attribute (varies per log entry)
+    expect(log.attributes.event_type).toBe("_posthog/test_event");
+    expect(log.body).toBe(JSON.stringify(notification));
+
+    // Verify resource attributes contain task_id and run_id
+    expect(log.resource.attributes.task_id).toBe("task-123");
+    expect(log.resource.attributes.run_id).toBe("run-456");
+    expect(log.resource.attributes["service.name"]).toBe("twig-agent");
+  });
+
+  it("should batch multiple log entries", async () => {
+    const makeNotification = (method: string): StoredNotification => ({
+      type: "notification",
+      timestamp: new Date().toISOString(),
+      notification: {
+        jsonrpc: "2.0",
+        method,
+      },
+    });
+
+    writer.emit({ notification: makeNotification("event_1") });
+    writer.emit({ notification: makeNotification("event_2") });
+    writer.emit({ notification: makeNotification("event_3") });
+
+    await writer.flush();
+
+    expect(mockExport).toHaveBeenCalled();
+    const exportedLogs = mockExport.mock.calls[0][0];
+    expect(exportedLogs.length).toBe(3);
+
+    // All logs should share the same resource attributes
+    for (const log of exportedLogs) {
+      expect(log.resource.attributes.task_id).toBe("task-123");
+      expect(log.resource.attributes.run_id).toBe("run-456");
+    }
+  });
+});

--- a/packages/agent/src/otel-log-writer.ts
+++ b/packages/agent/src/otel-log-writer.ts
@@ -1,0 +1,106 @@
+import { SeverityNumber } from "@opentelemetry/api-logs";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  BatchLogRecordProcessor,
+  LoggerProvider,
+} from "@opentelemetry/sdk-logs";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import type { StoredNotification } from "./types.js";
+import { Logger } from "./utils/logger.js";
+
+export interface OtelLogConfig {
+  /** PostHog ingest host, e.g., "https://us.i.posthog.com" */
+  posthogHost: string;
+  /** Project API key, e.g., "phc_xxx" */
+  apiKey: string;
+  /** Batch flush interval in ms (default: 500) */
+  flushIntervalMs?: number;
+  /** Override the logs endpoint path (default: /i/v1/agent-logs) */
+  logsPath?: string;
+}
+
+/**
+ * Session context for resource attributes.
+ * These are set once per OTEL logger instance and indexed via resource_fingerprint
+ */
+export interface SessionContext {
+  /** Parent task grouping - all runs for a task share this */
+  taskId: string;
+  /** Primary conversation identifier - all events in a run share this */
+  runId: string;
+  /** Deployment environment - "local" for desktop, "cloud" for cloud sandbox */
+  deviceType?: "local" | "cloud";
+}
+
+export class OtelLogWriter {
+  private loggerProvider: LoggerProvider;
+  private logger: ReturnType<LoggerProvider["getLogger"]>;
+  private debugLogger: Logger;
+  private sessionContext: SessionContext;
+
+  constructor(
+    config: OtelLogConfig,
+    sessionContext: SessionContext,
+    debugLogger?: Logger,
+  ) {
+    this.debugLogger =
+      debugLogger ?? new Logger({ debug: false, prefix: "[OtelLogWriter]" });
+    this.sessionContext = sessionContext;
+
+    const logsPath = config.logsPath ?? "/i/v1/agent-logs";
+    const exporter = new OTLPLogExporter({
+      url: `${config.posthogHost}${logsPath}`,
+      headers: { Authorization: `Bearer ${config.apiKey}` },
+    });
+
+    const processor = new BatchLogRecordProcessor(exporter, {
+      scheduledDelayMillis: config.flushIntervalMs ?? 500,
+    });
+
+    // Resource attributes are set ONCE per session and indexed via resource_fingerprint
+    // So we have fast queries by run_id/task_id in PostHog Logs UI
+    this.loggerProvider = new LoggerProvider({
+      resource: resourceFromAttributes({
+        [ATTR_SERVICE_NAME]: "twig-agent",
+        run_id: sessionContext.runId,
+        task_id: sessionContext.taskId,
+        device_type: sessionContext.deviceType ?? "local",
+      }),
+      processors: [processor],
+    });
+
+    this.logger = this.loggerProvider.getLogger("agent-session");
+  }
+
+  /**
+   * Emit an agent event to PostHog Logs via OTEL.
+   */
+  emit(entry: { notification: StoredNotification }): void {
+    const { notification } = entry;
+    const eventType = notification.notification.method;
+
+    this.logger.emit({
+      severityNumber: SeverityNumber.INFO,
+      severityText: "INFO",
+      body: JSON.stringify(notification),
+      attributes: {
+        event_type: eventType,
+      },
+    });
+
+    this.debugLogger.debug("Emitted OTEL log", {
+      taskId: this.sessionContext.taskId,
+      runId: this.sessionContext.runId,
+      eventType,
+    });
+  }
+
+  async flush(): Promise<void> {
+    await this.loggerProvider.forceFlush();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.loggerProvider.shutdown();
+  }
+}

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -434,20 +434,25 @@ export class AgentServer {
       logger: new Logger({ debug: true, prefix: "[TreeTracker]" }),
     });
 
-    const posthogAPI = new PostHogAPIClient({
+    const _posthogAPI = new PostHogAPIClient({
       apiUrl: this.config.apiUrl,
       projectId: this.config.projectId,
       getApiKey: () => this.config.apiKey,
     });
 
-    const logWriter = new SessionLogWriter(
-      posthogAPI,
-      new Logger({ debug: true, prefix: "[SessionLogWriter]" }),
-    );
+    const logWriter = new SessionLogWriter({
+      otelConfig: {
+        posthogHost: this.config.apiUrl,
+        apiKey: this.config.apiKey,
+        logsPath: "/i/v1/agent-logs",
+      },
+      logger: new Logger({ debug: true, prefix: "[SessionLogWriter]" }),
+    });
 
     const acpConnection = createAcpConnection({
       sessionId: payload.run_id,
       taskId: payload.task_id,
+      deviceType: deviceInfo.type,
       logWriter,
     });
 

--- a/packages/agent/src/session-log-writer.test.ts
+++ b/packages/agent/src/session-log-writer.test.ts
@@ -1,40 +1,47 @@
-import { type SetupServerApi, setupServer } from "msw/node";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { PostHogAPIClient } from "./posthog-api.js";
+import { OtelLogWriter } from "./otel-log-writer.js";
 import { SessionLogWriter } from "./session-log-writer.js";
-import { createPostHogHandlers } from "./test/mocks/msw-handlers.js";
+
+// Mock the OtelLogWriter
+vi.mock("./otel-log-writer.js", () => ({
+  OtelLogWriter: vi.fn(),
+}));
 
 describe("SessionLogWriter", () => {
-  let mswServer: SetupServerApi;
-  let appendLogCalls: unknown[][];
-  let apiClient: PostHogAPIClient;
   let logWriter: SessionLogWriter;
+  let mockEmit: ReturnType<typeof vi.fn>;
+  let mockFlush: ReturnType<typeof vi.fn>;
+  let mockShutdown: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    appendLogCalls = [];
-    mswServer = setupServer(
-      ...createPostHogHandlers({
-        baseUrl: "http://localhost:8000",
-        onAppendLog: (entries) => appendLogCalls.push(entries),
-      }),
-    );
-    mswServer.listen({ onUnhandledRequest: "bypass" });
+    mockEmit = vi.fn();
+    mockFlush = vi.fn().mockResolvedValue(undefined);
+    mockShutdown = vi.fn().mockResolvedValue(undefined);
 
-    apiClient = new PostHogAPIClient({
-      apiUrl: "http://localhost:8000",
-      projectId: 1,
-      getApiKey: () => "test-api-key",
+    vi.mocked(OtelLogWriter).mockImplementation(
+      () =>
+        ({
+          emit: mockEmit,
+          flush: mockFlush,
+          shutdown: mockShutdown,
+        }) as unknown as OtelLogWriter,
+    );
+
+    logWriter = new SessionLogWriter({
+      otelConfig: {
+        posthogHost: "http://localhost:8000",
+        apiKey: "test-api-key",
+        logsPath: "/i/v1/agent-logs",
+      },
     });
-    logWriter = new SessionLogWriter(apiClient);
   });
 
   afterEach(() => {
-    mswServer.close();
     vi.restoreAllMocks();
   });
 
   describe("appendRawLine", () => {
-    it("buffers entries until flush", async () => {
+    it("emits entries immediately via OtelLogWriter", () => {
       const sessionId = "test-session";
       logWriter.register(sessionId, { taskId: "task-1", runId: sessionId });
 
@@ -47,15 +54,10 @@ describe("SessionLogWriter", () => {
         JSON.stringify({ method: "test2", params: {} }),
       );
 
-      expect(appendLogCalls).toHaveLength(0);
-
-      await logWriter.flush(sessionId);
-
-      expect(appendLogCalls).toHaveLength(1);
-      expect(appendLogCalls[0]).toHaveLength(2);
+      expect(mockEmit).toHaveBeenCalledTimes(2);
     });
 
-    it("wraps raw messages in StoredNotification format", async () => {
+    it("wraps raw messages in StoredNotification format", () => {
       const sessionId = "test-session";
       logWriter.register(sessionId, { taskId: "task-1", runId: sessionId });
 
@@ -66,80 +68,73 @@ describe("SessionLogWriter", () => {
       };
       logWriter.appendRawLine(sessionId, JSON.stringify(message));
 
-      await logWriter.flush(sessionId);
-
-      expect(appendLogCalls).toHaveLength(1);
-      const entry = appendLogCalls[0][0] as {
-        type: string;
-        timestamp: string;
-        notification: unknown;
-      };
-      expect(entry.type).toBe("notification");
-      expect(entry.timestamp).toBeDefined();
-      expect(entry.notification).toEqual(message);
+      expect(mockEmit).toHaveBeenCalledTimes(1);
+      const emitArg = mockEmit.mock.calls[0][0];
+      expect(emitArg.notification.type).toBe("notification");
+      expect(emitArg.notification.timestamp).toBeDefined();
+      expect(emitArg.notification.notification).toEqual(message);
     });
 
-    it("ignores unregistered sessions", async () => {
+    it("ignores unregistered sessions", () => {
       logWriter.appendRawLine(
         "unknown-session",
         JSON.stringify({ method: "test" }),
       );
-      await logWriter.flush("unknown-session");
-      expect(appendLogCalls).toHaveLength(0);
+
+      expect(mockEmit).not.toHaveBeenCalled();
     });
 
-    it("ignores invalid JSON", async () => {
+    it("ignores invalid JSON", () => {
       const sessionId = "test-session";
       logWriter.register(sessionId, { taskId: "task-1", runId: sessionId });
 
       logWriter.appendRawLine(sessionId, "not valid json {{{");
 
-      await logWriter.flush(sessionId);
-
-      expect(appendLogCalls).toHaveLength(0);
+      expect(mockEmit).not.toHaveBeenCalled();
     });
   });
 
   describe("flush", () => {
-    it("clears pending entries after flush", async () => {
+    it("calls flush on OtelLogWriter", async () => {
       const sessionId = "test-session";
       logWriter.register(sessionId, { taskId: "task-1", runId: sessionId });
 
       logWriter.appendRawLine(sessionId, JSON.stringify({ method: "test" }));
       await logWriter.flush(sessionId);
 
-      expect(appendLogCalls).toHaveLength(1);
-
-      await logWriter.flush(sessionId);
-
-      expect(appendLogCalls).toHaveLength(1);
+      expect(mockFlush).toHaveBeenCalledTimes(1);
     });
 
-    it("does nothing when no pending entries", async () => {
-      const sessionId = "test-session";
-      logWriter.register(sessionId, { taskId: "task-1", runId: sessionId });
+    it("does nothing for unregistered sessions", async () => {
+      await logWriter.flush("unknown-session");
 
-      await logWriter.flush(sessionId);
-
-      expect(appendLogCalls).toHaveLength(0);
+      expect(mockFlush).not.toHaveBeenCalled();
     });
   });
 
-  describe("auto-flush scheduling", () => {
-    it("schedules flush after delay", async () => {
-      vi.useFakeTimers();
+  describe("register", () => {
+    it("creates OtelLogWriter with session context", () => {
+      const sessionId = "test-session";
+      const context = { taskId: "task-1", runId: sessionId };
+
+      logWriter.register(sessionId, context);
+
+      expect(OtelLogWriter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          posthogHost: "http://localhost:8000",
+          apiKey: "test-api-key",
+        }),
+        context,
+        expect.anything(),
+      );
+    });
+
+    it("does not re-register existing sessions", () => {
       const sessionId = "test-session";
       logWriter.register(sessionId, { taskId: "task-1", runId: sessionId });
+      logWriter.register(sessionId, { taskId: "task-2", runId: sessionId });
 
-      logWriter.appendRawLine(sessionId, JSON.stringify({ method: "test" }));
-
-      expect(appendLogCalls).toHaveLength(0);
-
-      await vi.advanceTimersByTimeAsync(600);
-
-      expect(appendLogCalls).toHaveLength(1);
-
-      vi.useRealTimers();
+      expect(OtelLogWriter).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -1,44 +1,91 @@
-import type { PostHogAPIClient } from "./posthog-api.js";
+import {
+  type OtelLogConfig,
+  OtelLogWriter,
+  type SessionContext,
+} from "./otel-log-writer.js";
 import type { StoredNotification } from "./types.js";
 import { Logger } from "./utils/logger.js";
 
-export interface SessionLogConfig {
-  taskId: string;
-  runId: string;
+export interface SessionLogWriterOptions {
+  /** OTEL config for creating writers per session */
+  otelConfig?: OtelLogConfig;
+  /** Logger instance */
+  logger?: Logger;
+}
+
+interface SessionState {
+  context: SessionContext;
+  otelWriter?: OtelLogWriter;
 }
 
 export class SessionLogWriter {
-  private posthogAPI?: PostHogAPIClient;
-  private pendingEntries: Map<string, StoredNotification[]> = new Map();
-  private flushTimeouts: Map<string, NodeJS.Timeout> = new Map();
-  private configs: Map<string, SessionLogConfig> = new Map();
+  private otelConfig?: OtelLogConfig;
+  private sessions: Map<string, SessionState> = new Map();
   private logger: Logger;
 
-  constructor(posthogAPI?: PostHogAPIClient, logger?: Logger) {
-    this.posthogAPI = posthogAPI;
+  constructor(options: SessionLogWriterOptions = {}) {
+    this.otelConfig = options.otelConfig;
     this.logger =
-      logger ?? new Logger({ debug: false, prefix: "[SessionLogWriter]" });
+      options.logger ??
+      new Logger({ debug: false, prefix: "[SessionLogWriter]" });
+
+    const flushAllAndExit = async () => {
+      const shutdownPromises = Array.from(this.sessions.values())
+        .filter((session) => session.otelWriter)
+        .map((session) => session.otelWriter?.shutdown());
+      await Promise.all(shutdownPromises);
+      process.exit(0);
+    };
+
+    process.on("beforeExit", () => {
+      flushAllAndExit().catch((e) => this.logger.error("Flush failed:", e));
+    });
+    process.on("SIGINT", () => {
+      flushAllAndExit().catch((e) => this.logger.error("Flush failed:", e));
+    });
+    process.on("SIGTERM", () => {
+      flushAllAndExit().catch((e) => this.logger.error("Flush failed:", e));
+    });
   }
 
   async flushAll(): Promise<void> {
     const flushPromises: Promise<void>[] = [];
-    for (const sessionId of this.configs.keys()) {
+    for (const sessionId of this.sessions.keys()) {
       flushPromises.push(this.flush(sessionId));
     }
     await Promise.all(flushPromises);
   }
 
-  register(sessionId: string, config: SessionLogConfig): void {
-    this.configs.set(sessionId, config);
+  register(sessionId: string, context: SessionContext): void {
+    if (this.sessions.has(sessionId)) {
+      return;
+    }
+
+    let otelWriter: OtelLogWriter | undefined;
+    if (this.otelConfig) {
+      // Create a dedicated OtelLogWriter for this session with resource attributes
+      otelWriter = new OtelLogWriter(
+        this.otelConfig,
+        context,
+        this.logger.child(`OtelWriter:${sessionId}`),
+      );
+    }
+
+    this.sessions.set(sessionId, { context, otelWriter });
   }
 
   isRegistered(sessionId: string): boolean {
-    return this.configs.has(sessionId);
+    return this.sessions.has(sessionId);
   }
 
   appendRawLine(sessionId: string, line: string): void {
-    const config = this.configs.get(sessionId);
-    if (!config) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+
+    if (!session.otelWriter) {
+      this.logger.debug("No OTEL writer configured for session, skipping log");
       return;
     }
 
@@ -50,11 +97,7 @@ export class SessionLogWriter {
         notification: message,
       };
 
-      const pending = this.pendingEntries.get(sessionId) ?? [];
-      pending.push(entry);
-      this.pendingEntries.set(sessionId, pending);
-
-      this.scheduleFlush(sessionId);
+      session.otelWriter.emit({ notification: entry });
     } catch {
       this.logger.warn("Failed to parse raw line for persistence", {
         sessionId,
@@ -64,38 +107,9 @@ export class SessionLogWriter {
   }
 
   async flush(sessionId: string): Promise<void> {
-    const config = this.configs.get(sessionId);
-    const pending = this.pendingEntries.get(sessionId);
-
-    if (!config || !pending?.length) return;
-
-    this.pendingEntries.delete(sessionId);
-    const timeout = this.flushTimeouts.get(sessionId);
-    if (timeout) {
-      clearTimeout(timeout);
-      this.flushTimeouts.delete(sessionId);
+    const session = this.sessions.get(sessionId);
+    if (session?.otelWriter) {
+      await session.otelWriter.flush();
     }
-
-    if (!this.posthogAPI) {
-      this.logger.debug("No PostHog API configured, skipping flush");
-      return;
-    }
-
-    try {
-      await this.posthogAPI.appendTaskRunLog(
-        config.taskId,
-        config.runId,
-        pending,
-      );
-    } catch (error) {
-      this.logger.error("Failed to persist session logs:", error);
-    }
-  }
-
-  private scheduleFlush(sessionId: string): void {
-    const existing = this.flushTimeouts.get(sessionId);
-    if (existing) clearTimeout(existing);
-    const timeout = setTimeout(() => this.flush(sessionId), 500);
-    this.flushTimeouts.set(sessionId, timeout);
   }
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -126,8 +126,19 @@ export interface PostHogAPIConfig {
   projectId: number;
 }
 
+export interface OtelTransportConfig {
+  /** PostHog ingest host, e.g., "https://us.i.posthog.com" */
+  host: string;
+  /** Project API key */
+  apiKey: string;
+  /** Override the logs endpoint path (default: /i/v1/logs) */
+  logsPath?: string;
+}
+
 export interface AgentConfig {
   posthog?: PostHogAPIConfig;
+  /** OTEL transport config for shipping logs to PostHog Logs */
+  otelTransport?: OtelTransportConfig;
   debug?: boolean;
   onLog?: OnLogCallback;
 }

--- a/packages/git/src/utils.ts
+++ b/packages/git/src/utils.ts
@@ -4,9 +4,12 @@ export interface GitHubRepo {
 }
 
 export function parseGitHubUrl(url: string): GitHubRepo | null {
+  // Trim whitespace/newlines that git commands may include
+  const trimmedUrl = url.trim();
+
   const match =
-    url.match(/github\.com[:/](.+?)\/(.+?)(\.git)?$/) ||
-    url.match(/git@github\.com:(.+?)\/(.+?)(\.git)?$/);
+    trimmedUrl.match(/github\.com[:/](.+?)\/(.+?)(\.git)?$/) ||
+    trimmedUrl.match(/git@github\.com:(.+?)\/(.+?)(\.git)?$/);
 
   if (!match) return null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/mobile:
     dependencies:
@@ -469,10 +469,10 @@ importers:
         version: 10.2.0(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@storybook/addon-docs':
         specifier: 10.2.0
-        version: 10.2.0(@types/react@19.2.8)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
+        version: 10.2.0(@types/react@19.2.8)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
       '@storybook/react-vite':
         specifier: 10.2.0
-        version: 10.2.0(esbuild@0.27.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
+        version: 10.2.0(esbuild@0.27.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -496,7 +496,7 @@ importers:
         version: 9.0.8
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.7.0(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/ui':
         specifier: ^4.0.10
         version: 4.0.17(vitest@4.0.17)
@@ -541,13 +541,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.7
-        version: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.10
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(@vitest/ui@4.0.17)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       yaml:
         specifier: ^2.8.1
         version: 2.8.2
@@ -569,6 +569,21 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.3
         version: 1.25.3(hono@4.11.7)(zod@3.25.76)
+      '@opentelemetry/api-logs':
+        specifier: ^0.208.0
+        version: 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: ^0.208.0
+        version: 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^2.0.0
+        version: 2.4.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.208.0
+        version: 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.38.0
       '@posthog/shared':
         specifier: workspace:*
         version: link:../shared
@@ -620,7 +635,7 @@ importers:
         version: 10.1.1
       msw:
         specifier: ^2.12.7
-        version: 2.12.7(@types/node@25.0.8)(typescript@5.9.3)
+        version: 2.12.8(@types/node@25.0.8)(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -632,7 +647,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@25.0.8)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)
+        version: 2.1.9(@types/node@25.0.8)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)
 
   packages/core:
     dependencies:
@@ -672,7 +687,7 @@ importers:
         version: 20.19.29
       '@vitest/coverage-v8':
         specifier: ^0.34.0
-        version: 0.34.6(vitest@2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0))
+        version: 0.34.6(vitest@2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0))
       builtin-modules:
         specifier: ^3.3.0
         version: 3.3.0
@@ -696,7 +711,7 @@ importers:
         version: 0.1.4(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)
+        version: 2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -2815,8 +2830,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@mswjs/interceptors@0.40.0':
-    resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
+  '@mswjs/interceptors@0.41.0':
+    resolution: {integrity: sha512-edAo9bW53BLYeSK+UPRr2Iz1Fj9DeGMjytvVM0HXRoo750ElWUgPsZPAOTQa12EUiwgDErH2PsFNTLvk1jBxjQ==}
     engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -6809,6 +6824,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
@@ -6827,7 +6843,7 @@ packages:
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -8115,8 +8131,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.12.7:
-    resolution: {integrity: sha512-retd5i3xCZDVWMYjHEVuKTmhqY8lSsxujjVrZiGbbdoxxIBg5S7rCuYy/YQpfrTYIxpd/o0Kyb/3H+1udBMoYg==}
+  msw@2.12.8:
+    resolution: {integrity: sha512-KOriJUhjefCO+liF7Ie1KlSXcBAQEzuLhPZ4EKuEUSEmAR4YhuuzT9YuGxTipjqDrg6eWQ6oMoGVhvEnqukFGg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -9287,8 +9303,8 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
-  rettime@0.7.0:
-    resolution: {integrity: sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==}
+  rettime@0.10.1:
+    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -9766,12 +9782,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.6:
     resolution: {integrity: sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -9870,15 +9886,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts-core@7.0.21:
-    resolution: {integrity: sha512-oVOMdHvgjqyzUZH1rOESgJP1uNe2bVrfK0jUHHmiM2rpEiRbf3j4BrsIc6JigJRbHGanQwuZv/R+LTcHsw+bLA==}
+  tldts-core@7.0.22:
+    resolution: {integrity: sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==}
 
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tldts@7.0.21:
-    resolution: {integrity: sha512-Plu6V8fF/XU6d2k8jPtlQf5F4Xx2hAin4r2C2ca7wR8NK5MbRTo9huLUWRe28f3Uk8bYZfg74tit/dSjc18xnw==}
+  tldts@7.0.22:
+    resolution: {integrity: sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==}
     hasBin: true
 
   tmp@0.0.33:
@@ -13361,11 +13377,11 @@ snapshots:
       '@jimp/types': 1.6.0
       tinycolor2: 1.6.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.3(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.3(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       glob: 11.1.0
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -13551,7 +13567,7 @@ snapshots:
       - hono
       - supports-color
 
-  '@mswjs/interceptors@0.40.0':
+  '@mswjs/interceptors@0.41.0':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -15090,10 +15106,10 @@ snapshots:
       axe-core: 4.11.1
       storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@storybook/addon-docs@10.2.0(@types/react@19.2.8)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/addon-docs@10.2.0(@types/react@19.2.8)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.1.0)
-      '@storybook/csf-plugin': 10.2.0(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
+      '@storybook/csf-plugin': 10.2.0(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
       '@storybook/icons': 2.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@storybook/react-dom-shim': 10.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       react: 19.1.0
@@ -15107,27 +15123,27 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.2.0(esbuild@0.27.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/builder-vite@10.2.0(esbuild@0.27.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.0(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.0(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
+      '@vitest/mocker': 3.2.4(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       ts-dedent: 2.2.0
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - msw
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.0(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/csf-plugin@10.2.0(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
       storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.55.1
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(esbuild@0.27.2)
 
   '@storybook/global@5.0.0': {}
@@ -15143,11 +15159,11 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@storybook/react-vite@10.2.0(esbuild@0.27.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/react-vite@10.2.0(esbuild@0.27.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
-      '@storybook/builder-vite': 10.2.0(esbuild@0.27.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
+      '@storybook/builder-vite': 10.2.0(esbuild@0.27.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(rollup@4.55.1)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.2))
       '@storybook/react': 10.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -15157,7 +15173,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tsconfig-paths: 4.2.0
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - msw
@@ -15652,7 +15668,7 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -15660,11 +15676,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@0.34.6(vitest@2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0))':
+  '@vitest/coverage-v8@0.34.6(vitest@2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -15677,7 +15693,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.3.0
-      vitest: 2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)
+      vitest: 2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15705,49 +15721,49 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@2.1.9(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(vite@5.4.21(@types/node@20.19.29)(lightningcss@1.30.2)(terser@5.45.0))':
+  '@vitest/mocker@2.1.9(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(vite@5.4.21(@types/node@20.19.29)(lightningcss@1.30.2)(terser@5.45.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.7(@types/node@20.19.29)(typescript@5.9.3)
+      msw: 2.12.8(@types/node@20.19.29)(typescript@5.9.3)
       vite: 5.4.21(@types/node@20.19.29)(lightningcss@1.30.2)(terser@5.45.0)
 
-  '@vitest/mocker@2.1.9(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(vite@5.4.21(@types/node@25.0.8)(lightningcss@1.30.2)(terser@5.45.0))':
+  '@vitest/mocker@2.1.9(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(vite@5.4.21(@types/node@25.0.8)(lightningcss@1.30.2)(terser@5.45.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.7(@types/node@25.0.8)(typescript@5.9.3)
+      msw: 2.12.8(@types/node@25.0.8)(typescript@5.9.3)
       vite: 5.4.21(@types/node@25.0.8)(lightningcss@1.30.2)(terser@5.45.0)
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.7(@types/node@20.19.29)(typescript@5.9.3)
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      msw: 2.12.8(@types/node@20.19.29)(typescript@5.9.3)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.17(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.17(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.7(@types/node@20.19.29)(typescript@5.9.3)
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      msw: 2.12.8(@types/node@20.19.29)(typescript@5.9.3)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.17(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(vite@6.4.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.17(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(vite@6.4.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.7(@types/node@25.0.8)(typescript@5.9.3)
+      msw: 2.12.8(@types/node@25.0.8)(typescript@5.9.3)
       vite: 6.4.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@2.1.9':
@@ -15803,7 +15819,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -19574,10 +19590,10 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3):
+  msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@20.19.29)
-      '@mswjs/interceptors': 0.40.0
+      '@mswjs/interceptors': 0.41.0
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
@@ -19587,7 +19603,7 @@ snapshots:
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.7.0
+      rettime: 0.10.1
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
       tough-cookie: 6.0.0
@@ -19600,10 +19616,10 @@ snapshots:
       - '@types/node'
     optional: true
 
-  msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3):
+  msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@25.0.8)
-      '@mswjs/interceptors': 0.40.0
+      '@mswjs/interceptors': 0.41.0
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
@@ -19613,7 +19629,7 @@ snapshots:
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.7.0
+      rettime: 0.10.1
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
       tough-cookie: 6.0.0
@@ -20927,7 +20943,7 @@ snapshots:
 
   retry@0.12.0: {}
 
-  rettime@0.7.0: {}
+  rettime@0.10.1: {}
 
   reusify@1.1.0: {}
 
@@ -21569,15 +21585,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
-  tldts-core@7.0.21: {}
+  tldts-core@7.0.22: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
 
-  tldts@7.0.21:
+  tldts@7.0.22:
     dependencies:
-      tldts-core: 7.0.21
+      tldts-core: 7.0.22
 
   tmp@0.0.33:
     dependencies:
@@ -21612,7 +21628,7 @@ snapshots:
 
   tough-cookie@6.0.0:
     dependencies:
-      tldts: 7.0.21
+      tldts: 7.0.22
 
   tr46@0.0.3: {}
 
@@ -21983,13 +21999,13 @@ snapshots:
       magic-string: 0.30.21
       vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22015,23 +22031,6 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.2
       terser: 5.45.0
-
-  vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.29
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      lightningcss: 1.30.2
-      terser: 5.45.0
-      tsx: 4.21.0
-      yaml: 2.8.2
 
   vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -22067,10 +22066,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0):
+  vitest@2.1.9(@types/node@20.19.29)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(vite@5.4.21(@types/node@20.19.29)(lightningcss@1.30.2)(terser@5.45.0))
+      '@vitest/mocker': 2.1.9(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(vite@5.4.21(@types/node@20.19.29)(lightningcss@1.30.2)(terser@5.45.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -22103,10 +22102,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@25.0.8)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0):
+  vitest@2.1.9(@types/node@25.0.8)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(vite@5.4.21(@types/node@25.0.8)(lightningcss@1.30.2)(terser@5.45.0))
+      '@vitest/mocker': 2.1.9(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(vite@5.4.21(@types/node@25.0.8)(lightningcss@1.30.2)(terser@5.45.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -22139,10 +22138,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(@vitest/ui@4.0.17)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@20.19.29)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(msw@2.12.7(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.17(msw@2.12.8(@types/node@20.19.29)(typescript@5.9.3))(vite@6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -22159,7 +22158,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@20.19.29)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.19.29)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -22179,10 +22178,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.8)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(msw@2.12.7(@types/node@25.0.8)(typescript@5.9.3))(vite@6.4.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.17(msw@2.12.8(@types/node@25.0.8)(typescript@5.9.3))(vite@6.4.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17


### PR DESCRIPTION
Adds OTEL-based logging for agent sessions

  - setting resource attributes for `task_id` and `run_id` (enables fast queries via resource_fingerprint in CH)
  - event_type as regular attribute (varies per log entry)
  - updated `AgentServer` to use new OTEL-based logging
  - some quick tests rewritten to mock OtelLogWriter 

![twig_logs_local_sandbox.png](https://app.graphite.com/user-attachments/assets/f3c9192a-1581-424a-88a1-bdeef8640415.png)

![twig_logs_ph_logs.png](https://app.graphite.com/user-attachments/assets/2fb44800-598b-431b-a9ad-a92df811fe7e.png)

