### PR TITLE
chore: otel agent logs gated

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -32,16 +32,20 @@ export class Agent {
       this.posthogAPI = new PostHogAPIClient(config.posthog);
     }
 
-    if (config.posthog || config.otelTransport) {
+    if (config.otelTransport) {
+      // OTEL pipeline: use OtelLogWriter only (no S3 writer)
+      this.sessionLogWriter = new SessionLogWriter({
+        otelConfig: {
+          posthogHost: config.otelTransport.host,
+          apiKey: config.otelTransport.apiKey,
+          logsPath: config.otelTransport.logsPath,
+        },
+        logger: this.logger.child("SessionLogWriter"),
+      });
+    } else if (config.posthog) {
+      // Legacy: use S3 writer via PostHog API
       this.sessionLogWriter = new SessionLogWriter({
         posthogAPI: this.posthogAPI,
-        otelConfig: config.otelTransport
-          ? {
-              posthogHost: config.otelTransport.host,
-              apiKey: config.otelTransport.apiKey,
-              logsPath: config.otelTransport.logsPath,
-            }
-          : undefined,
         logger: this.logger.child("SessionLogWriter"),
       });
     }


### PR DESCRIPTION
S3 log writer was added back in https://github.com/PostHog/Twig/pull/811/changes because otherwise prod would be broken, this gates the kafka pipeline route behind [twig-agent-logs-pipeline FF](https://us.posthog.com/project/2/feature_flags/552288) so easier to test when ready