### PR TITLE
feat: add task mode to agent server

### DIFF
--- a/packages/agent/src/posthog-api.ts
+++ b/packages/agent/src/posthog-api.ts
@@ -2,6 +2,7 @@ import type {
   ArtifactType,
   PostHogAPIConfig,
   StoredEntry,
+  Task,
   TaskRun,
   TaskRunArtifact,
 } from "./types.js";
@@ -88,6 +89,11 @@ export class PostHogAPIClient {
 
   getLlmGatewayUrl(): string {
     return getLlmGatewayUrl(this.baseUrl);
+  }
+
+  async getTask(taskId: string): Promise<Task> {
+    const teamId = this.getTeamId();
+    return this.apiRequest<Task>(`/api/projects/${teamId}/tasks/${taskId}/`);
   }
 
   async getTaskRun(taskId: string, runId: string): Promise<TaskRun> {

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -119,14 +119,14 @@ describe("AgentServer HTTP Mode", () => {
   };
 
   describe("GET /health", () => {
-    it("returns ok status", async () => {
+    it("returns ok status with active session", async () => {
       await createServer().start();
 
       const response = await fetch(`http://localhost:${port}/health`);
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toEqual({ status: "ok", hasSession: false });
+      expect(body).toEqual({ status: "ok", hasSession: true });
     });
   });
 
@@ -183,9 +183,9 @@ describe("AgentServer HTTP Mode", () => {
       expect(response.status).toBe(401);
     });
 
-    it("returns 400 when no session exists", async () => {
+    it("returns 400 when run_id does not match active session", async () => {
       await createServer().start();
-      const token = createToken();
+      const token = createToken({ run_id: "different-run-id" });
 
       const response = await fetch(`http://localhost:${port}/command`, {
         method: "POST",

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -96,6 +96,9 @@ describe("AgentServer HTTP Mode", () => {
       apiUrl: "http://localhost:8000",
       apiKey: "test-api-key",
       projectId: 1,
+      mode: "interactive",
+      taskId: "test-task-id",
+      runId: "test-run-id",
     });
     return server;
   };
@@ -108,6 +111,7 @@ describe("AgentServer HTTP Mode", () => {
         team_id: 1,
         user_id: 1,
         distinct_id: "test-distinct-id",
+        mode: "interactive",
         ...overrides,
       },
       TEST_PRIVATE_KEY,

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -332,7 +332,6 @@ export class AgentServer {
       );
     });
 
-    // Auto-initialize session and start working on the task
     await this.autoInitializeSession();
   }
 

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -37,7 +37,10 @@ program
   .name("agent-server")
   .description("PostHog cloud agent server - runs in sandbox environments")
   .option("--port <port>", "HTTP server port", "3001")
+  .option("--mode <mode>", "Execution mode: interactive or background", "interactive")
   .requiredOption("--repositoryPath <path>", "Path to the repository")
+  .requiredOption("--taskId <id>", "Task ID")
+  .requiredOption("--runId <id>", "Task run ID")
   .action(async (options) => {
     const envResult = envSchema.safeParse(process.env);
 
@@ -51,6 +54,8 @@ program
 
     const env = envResult.data;
 
+    const mode = options.mode === "background" ? "background" : "interactive";
+
     const server = new AgentServer({
       port: parseInt(options.port, 10),
       jwtPublicKey: env.JWT_PUBLIC_KEY,
@@ -58,6 +63,9 @@ program
       apiUrl: env.POSTHOG_API_URL,
       apiKey: env.POSTHOG_PERSONAL_API_KEY,
       projectId: env.POSTHOG_PROJECT_ID,
+      mode,
+      taskId: options.taskId,
+      runId: options.runId,
     });
 
     process.on("SIGINT", async () => {

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -37,7 +37,11 @@ program
   .name("agent-server")
   .description("PostHog cloud agent server - runs in sandbox environments")
   .option("--port <port>", "HTTP server port", "3001")
-  .option("--mode <mode>", "Execution mode: interactive or background", "interactive")
+  .option(
+    "--mode <mode>",
+    "Execution mode: interactive or background",
+    "interactive",
+  )
   .requiredOption("--repositoryPath <path>", "Path to the repository")
   .requiredOption("--taskId <id>", "Task ID")
   .requiredOption("--runId <id>", "Task run ID")

--- a/packages/agent/src/server/jwt.ts
+++ b/packages/agent/src/server/jwt.ts
@@ -9,6 +9,7 @@ export const userDataSchema = z.object({
   team_id: z.number(),
   user_id: z.number(),
   distinct_id: z.string(),
+  mode: z.enum(["interactive", "background"]).optional().default("interactive"),
 });
 
 const jwtPayloadSchema = userDataSchema.extend({

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -1,3 +1,5 @@
+import type { AgentMode } from "../types.js";
+
 export interface AgentServerConfig {
   port: number;
   repositoryPath: string;
@@ -5,4 +7,7 @@ export interface AgentServerConfig {
   apiKey: string;
   projectId: number;
   jwtPublicKey: string; // RS256 public key for JWT verification
+  mode: AgentMode;
+  taskId: string;
+  runId: string;
 }

--- a/packages/agent/src/test/fixtures/config.ts
+++ b/packages/agent/src/test/fixtures/config.ts
@@ -25,6 +25,9 @@ export function createAgentServerConfig(
     apiKey: "test-api-key",
     projectId: 1,
     jwtPublicKey: TEST_PUBLIC_KEY,
+    mode: "interactive",
+    taskId: "test-task-id",
+    runId: "test-run-id",
     ...overrides,
   };
 }


### PR DESCRIPTION
We use this to distinguish interactive vs backgrounded task runs.

This is stored in `state` on a task run, so that it can change throughout the lifecycle of a run, a run that started as a background run might end as an interactive one, or vica verca.