### PR TITLE
chore(cloud): bundle private packages in agent package

### DIFF
--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -76,8 +76,6 @@ export default defineConfig({
     ...builtinModules.map((m) => `node:${m}`),
     "@agentclientprotocol/sdk",
     "@anthropic-ai/claude-agent-sdk",
-    "@posthog/shared",
-    "@twig/git",
     "dotenv",
     "openai",
     "tar",


### PR DESCRIPTION
These aren’t published, lets bundle them into agent so we can use them in the docker image for cloud