### PR TITLE
fix: handle parcel shutdown race condition

### DIFF
--- a/apps/twig/src/main/services/focus/service.ts
+++ b/apps/twig/src/main/services/focus/service.ts
@@ -15,10 +15,12 @@ import {
   StashPopSaga,
   StashPushSaga,
 } from "@twig/git/sagas/stash";
-import { injectable, preDestroy } from "inversify";
+import { inject, injectable, preDestroy } from "inversify";
+import { MAIN_TOKENS } from "../../di/tokens.js";
 import { logger } from "../../lib/logger";
 import { TypedEventEmitter } from "../../lib/typed-event-emitter";
 import { type FocusSession, focusStore } from "../../utils/store.js";
+import type { ProcessTrackingService } from "../process-tracking/service.js";
 import { getWorktreeLocation } from "../settingsStore";
 import type { FocusResult, StashResult } from "./schemas.js";
 
@@ -49,6 +51,13 @@ export class FocusService extends TypedEventEmitter<FocusServiceEvents> {
   private mainRepoWatcher: watcher.AsyncSubscription | null = null;
   private watchedMainRepo: string | null = null;
 
+  constructor(
+    @inject(MAIN_TOKENS.ProcessTrackingService)
+    private processTracking: ProcessTrackingService,
+  ) {
+    super();
+  }
+
   async startWatchingMainRepo(mainRepoPath: string): Promise<void> {
     if (this.watchedMainRepo === mainRepoPath && this.mainRepoWatcher) {
       return;
@@ -61,6 +70,10 @@ export class FocusService extends TypedEventEmitter<FocusServiceEvents> {
 
     this.watchedMainRepo = mainRepoPath;
     this.mainRepoWatcher = await watcher.subscribe(gitDir, (err, events) => {
+      if (this.processTracking.isShuttingDown) {
+        return;
+      }
+
       if (err) {
         log.error("Main repo watcher error:", err);
         return;

--- a/apps/twig/src/main/services/process-tracking/service.ts
+++ b/apps/twig/src/main/services/process-tracking/service.ts
@@ -34,6 +34,12 @@ export interface ProcessSnapshot {
 
 @injectable()
 export class ProcessTrackingService {
+  private _isShuttingDown = false;
+
+  get isShuttingDown(): boolean {
+    return this._isShuttingDown;
+  }
+
   private processes = new Map<number, TrackedProcess>();
   private taskProcesses = new Map<string, Set<number>>();
 
@@ -235,6 +241,8 @@ export class ProcessTrackingService {
 
   @preDestroy()
   killAll(): void {
+    this._isShuttingDown = true;
+
     const count = this.processes.size;
     if (count > 0) {
       log.info(`Killing all tracked processes (${count} active)`);


### PR DESCRIPTION
If a task was focused, on shutdown, we'd try to call something that's nonexistent, causing a crash