### PR TITLE
feat: low handing fruit issues

### DIFF
--- a/apps/twig/src/renderer/components/GlobalEventHandlers.tsx
+++ b/apps/twig/src/renderer/components/GlobalEventHandlers.tsx
@@ -151,12 +151,6 @@ export function GlobalEventHandlers({
     preventDefault: true,
   } as const;
 
-  const nonEditorOptions = {
-    enableOnFormTags: false,
-    enableOnContentEditable: false,
-    preventDefault: true,
-  } as const;
-
   useHotkeys(SHORTCUTS.COMMAND_MENU, onToggleCommandMenu, {
     ...globalOptions,
     enabled: !commandMenuOpen,
@@ -165,11 +159,7 @@ export function GlobalEventHandlers({
   useHotkeys(SHORTCUTS.SETTINGS, handleOpenSettings, globalOptions);
   useHotkeys(SHORTCUTS.GO_BACK, goBack, globalOptions);
   useHotkeys(SHORTCUTS.GO_FORWARD, goForward, globalOptions);
-  useHotkeys(
-    SHORTCUTS.TOGGLE_LEFT_SIDEBAR,
-    toggleLeftSidebar,
-    nonEditorOptions,
-  );
+  useHotkeys(SHORTCUTS.TOGGLE_LEFT_SIDEBAR, toggleLeftSidebar, globalOptions);
   useHotkeys(SHORTCUTS.TOGGLE_RIGHT_SIDEBAR, toggleRightSidebar, globalOptions);
   useHotkeys(SHORTCUTS.SHORTCUTS_SHEET, onToggleShortcutsSheet, globalOptions);
 

--- a/apps/twig/src/renderer/components/action-selector/ActionSelector.tsx
+++ b/apps/twig/src/renderer/components/action-selector/ActionSelector.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, Text } from "@radix-ui/themes";
+import { compactHomePath } from "@utils/path";
 import { useCallback, useEffect, useRef } from "react";
 import { isOtherOption } from "./constants";
 import { OptionRow } from "./OptionRow";
@@ -217,8 +218,8 @@ export function ActionSelector({
         )}
 
         {title && (
-          <Text size="1" weight="medium" className="text-blue-11">
-            {title}
+          <Text size="1" weight="medium" className="text-blue-11" title={title}>
+            {compactHomePath(title)}
           </Text>
         )}
 

--- a/apps/twig/src/renderer/components/action-selector/InlineEditableText.tsx
+++ b/apps/twig/src/renderer/components/action-selector/InlineEditableText.tsx
@@ -65,7 +65,7 @@ export function InlineEditableText({
       } else if (e.key === "ArrowDown" || e.key === "Tab") {
         e.preventDefault();
         onNavigateDown();
-      } else if (e.key === "Enter") {
+      } else if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         onSubmit();
       } else if (!value && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
@@ -103,6 +103,8 @@ export function InlineEditableText({
           outline: "none",
           minWidth: "200px",
           display: "inline-block",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
         }}
       />
     </Text>

--- a/apps/twig/src/renderer/components/action-selector/OptionRow.tsx
+++ b/apps/twig/src/renderer/components/action-selector/OptionRow.tsx
@@ -1,4 +1,5 @@
 import { Box, Checkbox, Flex, Text } from "@radix-ui/themes";
+import { compactHomePath } from "@utils/path";
 import { useRef } from "react";
 import { isOtherOption, isSubmitOption } from "./constants";
 import { InlineEditableText } from "./InlineEditableText";
@@ -108,7 +109,7 @@ export function OptionRow({
 
     const displayText = showsCustomInput
       ? customInput || getPlaceholder(option, customInputPlaceholder)
-      : option.label;
+      : compactHomePath(option.label);
 
     const textClass =
       showsCustomInput && !customInput
@@ -169,7 +170,7 @@ export function OptionRow({
             marginTop: "2px",
           }}
         >
-          {option.description}
+          {compactHomePath(option.description)}
         </Text>
       )}
     </Box>

--- a/apps/twig/src/renderer/components/permissions/DeletePermission.tsx
+++ b/apps/twig/src/renderer/components/permissions/DeletePermission.tsx
@@ -1,5 +1,6 @@
 import { ActionSelector } from "@components/ActionSelector";
 import { Code, Text } from "@radix-ui/themes";
+import { compactHomePath } from "@utils/path";
 import { type BasePermissionProps, toSelectorOptions } from "./types";
 
 export function DeletePermission({
@@ -15,7 +16,9 @@ export function DeletePermission({
       title={toolCall.title ?? "Delete file"}
       pendingAction={
         <>
-          <Code size="1">{filePath}</Code>
+          <Code size="1" title={filePath} className="truncate">
+            {compactHomePath(filePath)}
+          </Code>
           <Text size="1" color="red" mt="1" as="p">
             This action cannot be undone.
           </Text>

--- a/apps/twig/src/renderer/components/permissions/ExecutePermission.tsx
+++ b/apps/twig/src/renderer/components/permissions/ExecutePermission.tsx
@@ -1,5 +1,6 @@
 import { ActionSelector } from "@components/ActionSelector";
 import { Code } from "@radix-ui/themes";
+import { compactHomePath } from "@utils/path";
 import {
   type BasePermissionProps,
   findTextContent,
@@ -19,8 +20,8 @@ export function ExecutePermission({
       title={toolCall.title ?? "Execute command"}
       pendingAction={
         command ? (
-          <Code variant="ghost" size="1">
-            {command}
+          <Code variant="ghost" size="1" title={command}>
+            {compactHomePath(command)}
           </Code>
         ) : undefined
       }

--- a/apps/twig/src/renderer/features/panels/components/TabbedPanel.tsx
+++ b/apps/twig/src/renderer/features/panels/components/TabbedPanel.tsx
@@ -1,9 +1,10 @@
+import { Tooltip } from "@components/ui/Tooltip";
 import { useDroppable } from "@dnd-kit/react";
 import { SquareSplitHorizontalIcon, Terminal } from "@phosphor-icons/react";
 import { Box, Flex } from "@radix-ui/themes";
 import { trpcVanilla } from "@renderer/trpc/client";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 import type { SplitDirection } from "../store/panelLayoutStore";
 import type { PanelContent } from "../store/panelStore";
 import { PanelDropZones } from "./PanelDropZones";
@@ -15,33 +16,37 @@ interface TabBarButtonProps {
   children: React.ReactNode;
 }
 
-function TabBarButton({ ariaLabel, onClick, children }: TabBarButtonProps) {
-  const [isHovered, setIsHovered] = useState(false);
+const TabBarButton = forwardRef<HTMLButtonElement, TabBarButtonProps>(
+  function TabBarButton({ ariaLabel, onClick, children, ...props }, ref) {
+    const [isHovered, setIsHovered] = useState(false);
 
-  return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      onClick={onClick}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      style={{
-        height: "32px",
-        width: "32px",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        background: isHovered ? "var(--gray-4)" : "var(--color-background)",
-        border: "none",
-        borderBottom: "1px solid var(--gray-6)",
-        cursor: "pointer",
-        color: "var(--gray-11)",
-      }}
-    >
-      {children}
-    </button>
-  );
-}
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={ariaLabel}
+        onClick={onClick}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        style={{
+          height: "32px",
+          width: "32px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: isHovered ? "var(--gray-4)" : "var(--color-background)",
+          border: "none",
+          borderBottom: "1px solid var(--gray-6)",
+          cursor: "pointer",
+          color: "var(--gray-11)",
+        }}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
 
 interface TabbedPanelProps {
   panelId: string;
@@ -209,17 +214,24 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
             >
               {rightContent}
               {content.droppable && onSplitPanel && (
-                <TabBarButton
-                  ariaLabel="Split panel"
-                  onClick={handleSplitClick}
-                >
-                  <SquareSplitHorizontalIcon width={12} height={12} />
-                </TabBarButton>
+                <Tooltip content="Split panel" side="bottom">
+                  <TabBarButton
+                    ariaLabel="Split panel"
+                    onClick={handleSplitClick}
+                  >
+                    <SquareSplitHorizontalIcon width={12} height={12} />
+                  </TabBarButton>
+                </Tooltip>
               )}
               {content.droppable && onAddTerminal && (
-                <TabBarButton ariaLabel="Add terminal" onClick={onAddTerminal}>
-                  <Terminal size={14} />
-                </TabBarButton>
+                <Tooltip content="New terminal" side="bottom">
+                  <TabBarButton
+                    ariaLabel="Add terminal"
+                    onClick={onAddTerminal}
+                  >
+                    <Terminal size={14} />
+                  </TabBarButton>
+                </Tooltip>
               )}
             </Flex>
           )}

--- a/apps/twig/src/renderer/features/right-sidebar/components/RightSidebarTrigger.tsx
+++ b/apps/twig/src/renderer/features/right-sidebar/components/RightSidebarTrigger.tsx
@@ -1,5 +1,10 @@
+import { Tooltip } from "@components/ui/Tooltip";
 import { SidebarSimpleIcon } from "@phosphor-icons/react";
 import { IconButton } from "@radix-ui/themes";
+import {
+  formatHotkey,
+  SHORTCUTS,
+} from "@renderer/constants/keyboard-shortcuts";
 import type React from "react";
 import { useRightSidebarStore } from "../stores/rightSidebarStore";
 
@@ -7,14 +12,20 @@ export const RightSidebarTrigger: React.FC = () => {
   const toggle = useRightSidebarStore((state) => state.toggle);
 
   return (
-    <IconButton
-      variant="ghost"
-      color="gray"
-      onClick={toggle}
-      className="no-drag"
-      style={{ transform: "scaleX(-1)" }}
+    <Tooltip
+      content="Toggle right sidebar"
+      shortcut={formatHotkey(SHORTCUTS.TOGGLE_RIGHT_SIDEBAR)}
+      side="bottom"
     >
-      <SidebarSimpleIcon size={16} />
-    </IconButton>
+      <IconButton
+        variant="ghost"
+        color="gray"
+        onClick={toggle}
+        className="no-drag"
+        style={{ transform: "scaleX(-1)" }}
+      >
+        <SidebarSimpleIcon size={16} />
+      </IconButton>
+    </Tooltip>
   );
 };

--- a/apps/twig/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -1,6 +1,8 @@
+import { Tooltip } from "@components/ui/Tooltip";
 import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
-import { Box } from "@radix-ui/themes";
-import { memo } from "react";
+import { Check, Copy } from "@phosphor-icons/react";
+import { Box, IconButton } from "@radix-ui/themes";
+import { memo, useCallback, useState } from "react";
 
 interface AgentMessageProps {
   content: string;
@@ -9,9 +11,29 @@ interface AgentMessageProps {
 export const AgentMessage = memo(function AgentMessage({
   content,
 }: AgentMessageProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [content]);
+
   return (
-    <Box className="py-1 pl-3 [&>*:last-child]:mb-0">
+    <Box className="group/msg relative py-1 pl-3 [&>*:last-child]:mb-0">
       <MarkdownRenderer content={content} />
+      <Box className="absolute top-1 right-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color={copied ? "green" : "gray"}
+            onClick={handleCopy}
+          >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+          </IconButton>
+        </Tooltip>
+      </Box>
     </Box>
   );
 });

--- a/apps/twig/src/renderer/features/sessions/components/session-update/CodePreview.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/CodePreview.tsx
@@ -2,6 +2,7 @@ import { unifiedMergeView } from "@codemirror/merge";
 import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { Code } from "@radix-ui/themes";
+import { compactHomePath } from "@utils/path";
 import { useEffect, useRef } from "react";
 import {
   CODE_PREVIEW_CONTAINER_STYLE,
@@ -67,9 +68,9 @@ export function CodePreview({
   return (
     <div style={CODE_PREVIEW_CONTAINER_STYLE}>
       {showPath && filePath && (
-        <div style={CODE_PREVIEW_PATH_STYLE}>
-          <Code variant="ghost" size="1">
-            {filePath}
+        <div style={CODE_PREVIEW_PATH_STYLE} title={filePath}>
+          <Code variant="ghost" size="1" className="truncate">
+            {compactHomePath(filePath)}
           </Code>
         </div>
       )}

--- a/apps/twig/src/renderer/features/sessions/components/session-update/ExecuteToolView.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/ExecuteToolView.tsx
@@ -1,5 +1,6 @@
 import { Terminal } from "@phosphor-icons/react";
 import { Box, Flex } from "@radix-ui/themes";
+import { compactHomePath } from "@utils/path";
 import { useState } from "react";
 import {
   ExpandableIcon,
@@ -64,7 +65,9 @@ export function ExecuteToolView({
           {description && <ToolTitle>{description}</ToolTitle>}
           {command && (
             <ToolTitle>
-              <span className="font-mono text-accent-11">{command}</span>
+              <span className="font-mono text-accent-11" title={command}>
+                {compactHomePath(command)}
+              </span>
             </ToolTitle>
           )}
           <StatusIndicators isFailed={isFailed} wasCancelled={wasCancelled} />

--- a/apps/twig/src/renderer/features/sessions/components/session-update/MoveToolView.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/MoveToolView.tsx
@@ -1,6 +1,10 @@
 import { ArrowsLeftRight } from "@phosphor-icons/react";
 import { ToolRow } from "./ToolRow";
-import { type ToolViewProps, useToolCallStatus } from "./toolCallUtils";
+import {
+  getFilename,
+  type ToolViewProps,
+  useToolCallStatus,
+} from "./toolCallUtils";
 
 export function MoveToolView({
   toolCall,
@@ -26,7 +30,7 @@ export function MoveToolView({
     >
       {title ||
         (sourcePath && destPath
-          ? `Move ${sourcePath} → ${destPath}`
+          ? `Move ${getFilename(sourcePath)} → ${getFilename(destPath)}`
           : "Move file")}
     </ToolRow>
   );

--- a/apps/twig/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
@@ -13,8 +13,13 @@ import {
   Trash,
   Wrench,
 } from "@phosphor-icons/react";
+import { compactHomePath } from "@utils/path";
 import { ToolRow } from "./ToolRow";
-import { type ToolViewProps, useToolCallStatus } from "./toolCallUtils";
+import {
+  getFilename,
+  type ToolViewProps,
+  useToolCallStatus,
+} from "./toolCallUtils";
 
 const kindIcons: Record<TwigToolKind, Icon> = {
   read: FileText,
@@ -44,7 +49,11 @@ export function ToolCallView({
   const KindIcon = (kind && kindIcons[kind]) || Wrench;
 
   const filePath = kind === "read" && locations?.[0]?.path;
-  const displayText = filePath ? `Read ${filePath}` : title;
+  const displayText = filePath
+    ? `Read ${getFilename(filePath)}`
+    : title
+      ? compactHomePath(title)
+      : undefined;
 
   return (
     <ToolRow

--- a/apps/twig/src/renderer/features/sessions/components/session-update/UserMessage.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/session-update/UserMessage.tsx
@@ -1,12 +1,13 @@
+import { Tooltip } from "@components/ui/Tooltip";
 import {
   baseComponents,
   defaultRemarkPlugins,
   MarkdownRenderer,
 } from "@features/editor/components/MarkdownRenderer";
-import { File } from "@phosphor-icons/react";
-import { Box, Code, Text } from "@radix-ui/themes";
+import { Check, Copy, File } from "@phosphor-icons/react";
+import { Box, Code, IconButton, Text } from "@radix-ui/themes";
 import type { ReactNode } from "react";
-import { memo } from "react";
+import { memo, useCallback, useState } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 
@@ -92,10 +93,17 @@ function parseFileMentions(content: string): ReactNode[] {
 
 export function UserMessage({ content }: UserMessageProps) {
   const hasFileMentions = /<file\s+path="[^"]+"\s*\/>/.test(content);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [content]);
 
   return (
     <Box
-      className="border-l-2 bg-gray-2 py-2 pl-3"
+      className="group/msg relative border-l-2 bg-gray-2 py-2 pl-3"
       style={{ borderColor: "var(--accent-9)" }}
     >
       <Box className="font-medium [&>*:last-child]:mb-0">
@@ -104,6 +112,18 @@ export function UserMessage({ content }: UserMessageProps) {
         ) : (
           <MarkdownRenderer content={content} />
         )}
+      </Box>
+      <Box className="absolute top-1 right-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color={copied ? "green" : "gray"}
+            onClick={handleCopy}
+          >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+          </IconButton>
+        </Tooltip>
       </Box>
     </Box>
   );

--- a/apps/twig/src/renderer/features/sidebar/components/SidebarTrigger.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/SidebarTrigger.tsx
@@ -1,5 +1,10 @@
+import { Tooltip } from "@components/ui/Tooltip";
 import { SidebarSimpleIcon } from "@phosphor-icons/react";
 import { IconButton } from "@radix-ui/themes";
+import {
+  formatHotkey,
+  SHORTCUTS,
+} from "@renderer/constants/keyboard-shortcuts";
 import type React from "react";
 import { useSidebarStore } from "../stores/sidebarStore";
 
@@ -7,13 +12,19 @@ export const SidebarTrigger: React.FC = () => {
   const toggle = useSidebarStore((state) => state.toggle);
 
   return (
-    <IconButton
-      variant="ghost"
-      color="gray"
-      onClick={toggle}
-      className="no-drag"
+    <Tooltip
+      content="Toggle left sidebar"
+      shortcut={formatHotkey(SHORTCUTS.TOGGLE_LEFT_SIDEBAR)}
+      side="bottom"
     >
-      <SidebarSimpleIcon size={16} />
-    </IconButton>
+      <IconButton
+        variant="ghost"
+        color="gray"
+        onClick={toggle}
+        className="no-drag"
+      >
+        <SidebarSimpleIcon size={16} />
+      </IconButton>
+    </Tooltip>
   );
 };

--- a/apps/twig/src/renderer/utils/path.ts
+++ b/apps/twig/src/renderer/utils/path.ts
@@ -7,16 +7,9 @@ export function expandTildePath(path: string): string {
   return path;
 }
 
-export function compactHomePath(path: string): string {
-  // Replace common home directory patterns with ~
-  const userPattern = /^\/Users\/[^/]+/;
-  const homePattern = /^\/home\/[^/]+/;
-
-  if (userPattern.test(path)) {
-    return path.replace(userPattern, "~");
-  }
-  if (homePattern.test(path)) {
-    return path.replace(homePattern, "~");
-  }
-  return path;
+export function compactHomePath(text: string): string {
+  // Replace all occurrences of home directory patterns with ~
+  return text
+    .replace(/\/Users\/[^/\s]+/g, "~")
+    .replace(/\/home\/[^/\s]+/g, "~");
 }


### PR DESCRIPTION
## Summary

- Compact home directory paths (/Users/username/... → ~/...) across all permission dialogs, tool call displays, bash command previews, and option labels
- Add tooltips with keyboard shortcuts to sidebar toggle buttons (⌘B / ⌘⇧B) and panel action buttons (split panel, new terminal)
- Add copy-to-clipboard button on hover for agent and user messages
- Support multiline input (Shift+Enter) in the permission "Other" text field
- Fix ⌘B sidebar toggle not working on task pages due to editor bold shortcut conflict

## Test plan

-  Trigger permission prompts with bash commands containing full paths → should show ~/... not /Users/.../...
-  Hover permission option labels → paths should be compacted
-  Hover tool call rows in chat (read, execute, move) → paths compacted, full path on hover
-  Hover left sidebar toggle → tooltip "Toggle left sidebar" + ⌘B
-  Hover right sidebar toggle → tooltip "Toggle right sidebar" + ⌘⇧B
-  Hover split panel / new terminal buttons → tooltips shown
-  Press ⌘B on a task page with editor focused → should toggle sidebar, not bold
-  Hover agent message → copy icon appears, click copies content
-  Hover user message → same copy behavior
-  Select "Other" in permission prompt → Shift+Enter inserts newline, Enter submits

 
 
Closes https://github.com/PostHog/Twig/issues/828
Closes https://github.com/PostHog/Twig/issues/637
Closes https://github.com/PostHog/Twig/issues/563
Closes https://github.com/PostHog/Twig/issues/653