### PR TITLE
fix: bring back model selection

### DIFF
--- a/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
@@ -149,6 +149,7 @@ interface SessionActions {
     initialPrompt?: ContentBlock[];
     executionMode?: string;
     adapter?: "claude" | "codex";
+    model?: string;
   }) => Promise<void>;
   disconnectFromTask: (taskId: string) => Promise<void>;
   sendPrompt: (
@@ -819,6 +820,7 @@ const useStore = create<SessionStore>()(
       initialPrompt?: ContentBlock[],
       executionMode?: string,
       adapter?: "claude" | "codex",
+      model?: string,
     ) => {
       if (!auth.client) {
         throw new Error(
@@ -871,12 +873,12 @@ const useStore = create<SessionStore>()(
         );
       }
 
-      const preferredModel = useModelsStore.getState().getEffectiveModel();
-      if (preferredModel) {
+      const modelToUse = model ?? useModelsStore.getState().getEffectiveModel();
+      if (modelToUse) {
         await get().actions.setSessionConfigOptionByCategory(
           taskId,
           "model",
-          preferredModel,
+          modelToUse,
         );
       }
 
@@ -986,6 +988,7 @@ const useStore = create<SessionStore>()(
           initialPrompt,
           executionMode,
           adapter,
+          model,
         }) => {
           log.info("Connecting to task", { taskId: task.id });
 
@@ -1110,6 +1113,7 @@ const useStore = create<SessionStore>()(
                 initialPrompt,
                 executionMode,
                 adapter,
+                model,
               );
             }
           } catch (error) {

--- a/apps/twig/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/twig/src/renderer/features/settings/stores/settingsStore.ts
@@ -15,6 +15,7 @@ interface SettingsStore {
   lastUsedLocalWorkspaceMode: LocalWorkspaceMode;
   lastUsedWorkspaceMode: WorkspaceMode;
   lastUsedAdapter: AgentAdapter;
+  lastUsedModel: string | null;
   desktopNotifications: boolean;
   dockBadgeNotifications: boolean;
   cursorGlow: boolean;
@@ -32,6 +33,7 @@ interface SettingsStore {
   setLastUsedLocalWorkspaceMode: (mode: LocalWorkspaceMode) => void;
   setLastUsedWorkspaceMode: (mode: WorkspaceMode) => void;
   setLastUsedAdapter: (adapter: AgentAdapter) => void;
+  setLastUsedModel: (model: string) => void;
   setDesktopNotifications: (enabled: boolean) => void;
   setDockBadgeNotifications: (enabled: boolean) => void;
   setCursorGlow: (enabled: boolean) => void;
@@ -49,6 +51,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedLocalWorkspaceMode: "worktree",
       lastUsedWorkspaceMode: "worktree",
       lastUsedAdapter: "claude",
+      lastUsedModel: null,
       desktopNotifications: true,
       dockBadgeNotifications: true,
       completionSound: "none",
@@ -67,6 +70,7 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ lastUsedLocalWorkspaceMode: mode }),
       setLastUsedWorkspaceMode: (mode) => set({ lastUsedWorkspaceMode: mode }),
       setLastUsedAdapter: (adapter) => set({ lastUsedAdapter: adapter }),
+      setLastUsedModel: (model) => set({ lastUsedModel: model }),
       setDesktopNotifications: (enabled) =>
         set({ desktopNotifications: enabled }),
       setDockBadgeNotifications: (enabled) =>
@@ -89,6 +93,7 @@ export const useSettingsStore = create<SettingsStore>()(
         lastUsedLocalWorkspaceMode: state.lastUsedLocalWorkspaceMode,
         lastUsedWorkspaceMode: state.lastUsedWorkspaceMode,
         lastUsedAdapter: state.lastUsedAdapter,
+        lastUsedModel: state.lastUsedModel,
         desktopNotifications: state.desktopNotifications,
         dockBadgeNotifications: state.dockBadgeNotifications,
         cursorGlow: state.cursorGlow,

--- a/apps/twig/src/renderer/features/task-detail/components/TaskInputModelSelector.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/TaskInputModelSelector.tsx
@@ -1,0 +1,89 @@
+import { useModelsStore } from "@features/sessions/stores/modelsStore";
+import type { AgentAdapter } from "@features/settings/stores/settingsStore";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+import { Button, DropdownMenu, Flex, Text } from "@radix-ui/themes";
+import type { Responsive } from "@radix-ui/themes/dist/esm/props/prop-def.js";
+import { Fragment, useMemo } from "react";
+
+interface TaskInputModelSelectorProps {
+  value: string;
+  onChange: (modelId: string) => void;
+  adapter: AgentAdapter;
+  size?: Responsive<"1" | "2">;
+}
+
+function filterModelsByAdapter(
+  groupedModels: Array<{
+    provider: string;
+    models: Array<{ modelId: string; name: string }>;
+  }>,
+  adapter: AgentAdapter,
+) {
+  if (adapter === "claude") {
+    // Claude adapter: show only Anthropic models
+    return groupedModels.filter((group) => group.provider === "Anthropic");
+  }
+  // Codex adapter: show OpenAI and other non-Anthropic models
+  return groupedModels.filter((group) => group.provider !== "Anthropic");
+}
+
+export function TaskInputModelSelector({
+  value,
+  onChange,
+  adapter,
+  size = "1",
+}: TaskInputModelSelectorProps) {
+  const { groupedModels } = useModelsStore();
+
+  const filteredGroupedModels = useMemo(
+    () => filterModelsByAdapter(groupedModels, adapter),
+    [groupedModels, adapter],
+  );
+
+  const filteredModels = useMemo(
+    () => filteredGroupedModels.flatMap((group) => group.models),
+    [filteredGroupedModels],
+  );
+
+  if (filteredModels.length === 0) {
+    return null;
+  }
+
+  const currentModel = filteredModels.find((m) => m.modelId === value);
+  const displayName = currentModel?.name ?? value;
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <Button color="gray" variant="outline" size={size}>
+          <Flex justify="between" align="center" gap="2">
+            <Text
+              size={size}
+              style={{ fontFamily: "var(--font-mono)", minWidth: 0 }}
+            >
+              {displayName}
+            </Text>
+            <ChevronDownIcon style={{ flexShrink: 0 }} />
+          </Flex>
+        </Button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Content align="start" size="1">
+        {filteredGroupedModels.map((group, groupIndex) => (
+          <Fragment key={group.provider}>
+            {groupIndex > 0 && <DropdownMenu.Separator />}
+            <DropdownMenu.Label>{group.provider}</DropdownMenu.Label>
+            {group.models.map((model) => (
+              <DropdownMenu.Item
+                key={model.modelId}
+                onSelect={() => onChange(model.modelId)}
+              >
+                <Text size="1">{model.name}</Text>
+              </DropdownMenu.Item>
+            ))}
+          </Fragment>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+}

--- a/apps/twig/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/twig/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -27,6 +27,7 @@ interface UseTaskCreationOptions {
   editorIsEmpty: boolean;
   executionMode?: string;
   adapter?: "claude" | "codex";
+  model?: string;
 }
 
 interface UseTaskCreationReturn {
@@ -82,6 +83,7 @@ function prepareTaskInput(
     branch?: string | null;
     executionMode?: string;
     adapter?: "claude" | "codex";
+    model?: string;
   },
 ): TaskCreationInput {
   return {
@@ -94,6 +96,7 @@ function prepareTaskInput(
     branch: options.branch,
     executionMode: options.executionMode,
     adapter: options.adapter,
+    model: options.model,
   };
 }
 
@@ -119,6 +122,7 @@ export function useTaskCreation({
   editorIsEmpty,
   executionMode,
   adapter,
+  model,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const { navigateToTask } = useNavigationStore();
@@ -158,6 +162,7 @@ export function useTaskCreation({
         branch,
         executionMode,
         adapter,
+        model,
       });
 
       const taskService = get<TaskService>(RENDERER_TOKENS.TaskService);
@@ -201,6 +206,7 @@ export function useTaskCreation({
     branch,
     executionMode,
     adapter,
+    model,
     invalidateTasks,
     navigateToTask,
   ]);

--- a/apps/twig/src/renderer/sagas/task/task-creation.ts
+++ b/apps/twig/src/renderer/sagas/task/task-creation.ts
@@ -32,6 +32,7 @@ export interface TaskCreationInput {
   githubIntegrationId?: number;
   executionMode?: string;
   adapter?: "claude" | "codex";
+  model?: string;
 }
 
 export interface TaskCreationOutput {
@@ -202,6 +203,7 @@ export class TaskCreationSaga extends Saga<
               initialPrompt,
               executionMode: input.executionMode,
               adapter: input.adapter,
+              model: input.model,
             });
           }
           return { taskId: task.id };

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -15,7 +15,7 @@ export interface FetchGatewayModelsOptions {
   gatewayUrl: string;
 }
 
-export const DEFAULT_GATEWAY_MODEL = "claude-opus-4-5";
+export const DEFAULT_GATEWAY_MODEL = "claude-opus-4-6";
 
 export const BLOCKED_MODELS = new Set(["gpt-5-mini", "openai/gpt-5-mini"]);
 


### PR DESCRIPTION
### TL;DR

Added model selection capability to the task creation interface, allowing users to choose specific AI models when creating new tasks.

### What changed?

- Added a model selector dropdown in the task input interface
- Implemented persistence of the last used model in settings
- Added model parameter to task creation flow
- Created filtering logic to show only models compatible with the selected adapter
- Updated the default gateway model from `claude-opus-4-5` to `claude-opus-4-6`
- Added automatic model selection when switching adapters to ensure compatibility

### How to test?

1. Open the task creation interface
2. Verify that a model selector dropdown appears next to the adapter selector
3. Select different adapters (Claude/Codex) and confirm that the model options update accordingly
4. Create tasks with different model selections and verify the selected model is used
5. Restart the application and verify that your last selected model is remembered

### Why make this change?

This change gives users more control over their AI interactions by allowing them to explicitly select which model to use for each task. Previously, the system would automatically select a model based on the adapter, but now users can choose specific models with different capabilities or performance characteristics based on their needs.