### PR TITLE
fix: use default modal

### DIFF
--- a/apps/twig/src/renderer/features/sessions/service/service.ts
+++ b/apps/twig/src/renderer/features/sessions/service/service.ts
@@ -136,7 +136,8 @@ export class SessionService {
   }
 
   private async doConnect(params: ConnectParams): Promise<void> {
-    const { task, repoPath, initialPrompt, executionMode, adapter } = params;
+    const { task, repoPath, initialPrompt, executionMode, adapter, model } =
+      params;
     const { id: taskId, latest_run: latestRun } = task;
     const taskTitle = task.title || task.description || "Task";
 
@@ -212,6 +213,7 @@ export class SessionService {
           initialPrompt,
           executionMode,
           adapter,
+          model,
         );
       }
     } catch (error) {
@@ -357,6 +359,7 @@ export class SessionService {
     initialPrompt?: ContentBlock[],
     executionMode?: ExecutionMode,
     adapter?: "claude" | "codex",
+    model?: string,
   ): Promise<void> {
     if (!auth.client) {
       throw new Error("Unable to reach server. Please check your connection.");
@@ -405,8 +408,9 @@ export class SessionService {
       execution_type: "local",
     });
 
-    // Set the user's preferred model if available
-    const preferredModel = useModelsStore.getState().getEffectiveModel();
+    // Set the model - use passed model if provided, otherwise use store's effective model
+    const preferredModel =
+      model ?? useModelsStore.getState().getEffectiveModel();
     if (preferredModel) {
       await this.setSessionConfigOptionByCategory(
         taskId,

--- a/packages/agent/src/adapters/claude/session/models.ts
+++ b/packages/agent/src/adapters/claude/session/models.ts
@@ -2,6 +2,7 @@ export const DEFAULT_MODEL = "opus";
 
 const GATEWAY_TO_SDK_MODEL: Record<string, string> = {
   "claude-opus-4-5": "opus",
+  "claude-opus-4-6": "opus",
   "claude-sonnet-4-5": "sonnet",
   "claude-haiku-4-5": "haiku",
 };


### PR DESCRIPTION
### TL;DR

Added support for the Claude Opus 4.6 model and improved model selection in session connections.

### What changed?

- Added `claude-opus-4-6` to the model mapping in the Claude adapter, mapping it to `opus`
- Modified the `SessionService.doConnect` method to accept and pass through a `model` parameter
- Updated the `connectToSession` method to accept a model parameter and use it when available instead of the store's effective model

### How to test?

1. Connect to a session using the Claude adapter with the new Opus 4.6 model
2. Verify that the model is correctly passed through the connection flow
3. Check that both explicitly specified models and the default model from the store work correctly

### Why make this change?

This change enables support for the newer Claude Opus 4.6 model while maintaining backward compatibility with existing models. It also improves the session connection flow by allowing explicit model specification, which provides more flexibility when initiating sessions.