### PR TITLE
feat: Create a preview session on task input page

### DIFF
--- a/apps/twig/src/main/services/agent/service.ts
+++ b/apps/twig/src/main/services/agent/service.ts
@@ -442,13 +442,16 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     const mockNodeDir = this.setupMockNodeEnvironment(taskRunId);
     this.setupEnvironment(credentials, mockNodeDir);
 
+    // Preview sessions don't persist logs — no real task exists
+    const isPreview = taskId === "__preview__";
+
     // OTEL log pipeline or legacy S3 writer if FF false
-    const useOtelPipeline = await this.isFeatureFlagEnabled(
-      "twig-agent-logs-pipeline",
-    );
+    const useOtelPipeline = isPreview
+      ? false
+      : await this.isFeatureFlagEnabled("twig-agent-logs-pipeline");
 
     log.info("Agent log transport", {
-      transport: useOtelPipeline ? "otel" : "s3",
+      transport: isPreview ? "none" : useOtelPipeline ? "otel" : "s3",
       taskId,
       taskRunId,
     });
@@ -466,6 +469,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
             logsPath: "/i/v1/agent-logs",
           }
         : undefined,
+      skipLogPersistence: isPreview,
       debug: !app.isPackaged,
       onLog: onAgentLog,
     });

--- a/apps/twig/src/renderer/features/message-editor/components/EditorToolbar.tsx
+++ b/apps/twig/src/renderer/features/message-editor/components/EditorToolbar.tsx
@@ -13,6 +13,8 @@ interface EditorToolbarProps {
   onAttachFiles?: (files: File[]) => void;
   attachTooltip?: string;
   iconSize?: number;
+  /** Hide model and reasoning selectors (when rendered separately) */
+  hideSelectors?: boolean;
 }
 
 export function EditorToolbar({
@@ -23,6 +25,7 @@ export function EditorToolbar({
   onAttachFiles,
   attachTooltip = "Attach file",
   iconSize = 14,
+  hideSelectors = false,
 }: EditorToolbarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -68,8 +71,16 @@ export function EditorToolbar({
           <Paperclip size={iconSize} weight="bold" />
         </IconButton>
       </Tooltip>
-      <ModelSelector taskId={taskId} adapter={adapter} disabled={disabled} />
-      <ReasoningLevelSelector taskId={taskId} disabled={disabled} />
+      {!hideSelectors && (
+        <>
+          <ModelSelector
+            taskId={taskId}
+            adapter={adapter}
+            disabled={disabled}
+          />
+          <ReasoningLevelSelector taskId={taskId} disabled={disabled} />
+        </>
+      )}
     </Flex>
   );
 }

--- a/apps/twig/src/renderer/features/message-editor/components/ModeIndicatorInput.tsx
+++ b/apps/twig/src/renderer/features/message-editor/components/ModeIndicatorInput.tsx
@@ -55,7 +55,8 @@ const DEFAULT_STYLE: ModeStyle = {
 };
 
 interface ModeIndicatorInputProps {
-  modeOption: SessionConfigOption;
+  modeOption: SessionConfigOption | undefined;
+  onCycleMode?: () => void;
 }
 
 function flattenOptions(
@@ -70,7 +71,12 @@ function flattenOptions(
   return options as SessionConfigSelectOption[];
 }
 
-export function ModeIndicatorInput({ modeOption }: ModeIndicatorInputProps) {
+export function ModeIndicatorInput({
+  modeOption,
+  onCycleMode,
+}: ModeIndicatorInputProps) {
+  if (!modeOption) return null;
+
   const id = modeOption.currentValue;
 
   const style = MODE_STYLES[id] ?? DEFAULT_STYLE;
@@ -80,7 +86,13 @@ export function ModeIndicatorInput({ modeOption }: ModeIndicatorInputProps) {
   const label = option?.name ?? id;
 
   return (
-    <Flex align="center" justify="between" py="1">
+    <Flex
+      align="center"
+      justify="between"
+      py="1"
+      style={onCycleMode ? { cursor: "pointer" } : undefined}
+      onClick={onCycleMode}
+    >
       <Flex align="center" gap="1">
         <Text
           size="1"

--- a/apps/twig/src/renderer/features/sessions/service/service.ts
+++ b/apps/twig/src/renderer/features/sessions/service/service.ts
@@ -46,6 +46,8 @@ import { ANALYTICS_EVENTS } from "@/types/analytics";
 
 const log = logger.scope("session-service");
 
+export const PREVIEW_TASK_ID = "__preview__";
+
 interface AuthCredentials {
   apiKey: string;
   apiHost: string;
@@ -60,6 +62,7 @@ interface ConnectParams {
   executionMode?: ExecutionMode;
   adapter?: "claude" | "codex";
   model?: string;
+  reasoningLevel?: string;
 }
 
 // --- Singleton Service Instance ---
@@ -95,6 +98,8 @@ export class SessionService {
       permission?: { unsubscribe: () => void };
     }
   >();
+  /** Version counter to discard stale preview session results */
+  private previewVersion = 0;
 
   /**
    * Connect to a task session.
@@ -136,8 +141,15 @@ export class SessionService {
   }
 
   private async doConnect(params: ConnectParams): Promise<void> {
-    const { task, repoPath, initialPrompt, executionMode, adapter, model } =
-      params;
+    const {
+      task,
+      repoPath,
+      initialPrompt,
+      executionMode,
+      adapter,
+      model,
+      reasoningLevel,
+    } = params;
     const { id: taskId, latest_run: latestRun } = task;
     const taskTitle = task.title || task.description || "Task";
 
@@ -214,6 +226,7 @@ export class SessionService {
           executionMode,
           adapter,
           model,
+          reasoningLevel,
         );
       }
     } catch (error) {
@@ -366,6 +379,7 @@ export class SessionService {
     executionMode?: ExecutionMode,
     adapter?: "claude" | "codex",
     model?: string,
+    reasoningLevel?: string,
   ): Promise<void> {
     if (!auth.client) {
       throw new Error("Unable to reach server. Please check your connection.");
@@ -425,6 +439,15 @@ export class SessionService {
       );
     }
 
+    // Set reasoning level if provided (e.g., from Codex adapter's preview session)
+    if (reasoningLevel) {
+      await this.setSessionConfigOptionByCategory(
+        taskId,
+        "thought_level",
+        reasoningLevel,
+      );
+    }
+
     if (initialPrompt?.length) {
       await this.sendPrompt(taskId, initialPrompt);
     }
@@ -446,6 +469,127 @@ export class SessionService {
     }
     this.unsubscribeFromChannel(session.taskRunId);
     sessionStoreSetters.removeSession(session.taskRunId);
+  }
+
+  // --- Preview Session Management ---
+
+  /**
+   * Start a lightweight preview session for the task input page.
+   * This session is used solely to retrieve adapter-specific config options
+   * (models, modes, reasoning levels) without creating a real PostHog task.
+   *
+   * Uses a version counter to prevent race conditions when rapidly switching
+   * adapters — stale results from a previous start are discarded.
+   */
+  async startPreviewSession(params: {
+    adapter: "claude" | "codex";
+    repoPath?: string;
+  }): Promise<void> {
+    // Increment version to invalidate any in-flight start
+    const version = ++this.previewVersion;
+
+    // Cancel any existing preview session first
+    await this.cancelPreviewSession();
+
+    // Check if a newer start was requested while we were cancelling
+    if (version !== this.previewVersion) {
+      log.info("Preview session start superseded, skipping", { version });
+      return;
+    }
+
+    const auth = this.getAuthCredentials();
+    if (!auth) {
+      log.info("Skipping preview session - not authenticated");
+      return;
+    }
+
+    const taskRunId = `preview-${crypto.randomUUID()}`;
+    const session = this.createBaseSession(
+      taskRunId,
+      PREVIEW_TASK_ID,
+      "Preview",
+    );
+    session.adapter = params.adapter;
+    sessionStoreSetters.setSession(session);
+
+    try {
+      const result = await trpcVanilla.agent.start.mutate({
+        taskId: PREVIEW_TASK_ID,
+        taskRunId,
+        repoPath: params.repoPath || "~",
+        apiKey: auth.apiKey,
+        apiHost: auth.apiHost,
+        projectId: auth.projectId,
+        adapter: params.adapter,
+      });
+
+      // Check again after the async start — a newer call may have superseded us
+      if (version !== this.previewVersion) {
+        log.info(
+          "Preview session start superseded after agent.start, cleaning up stale session",
+          { taskRunId, version },
+        );
+        // Clean up the session we just started but is now stale
+        trpcVanilla.agent.cancel
+          .mutate({ sessionId: taskRunId })
+          .catch((err) => {
+            log.warn("Failed to cancel stale preview session", {
+              taskRunId,
+              error: err,
+            });
+          });
+        sessionStoreSetters.removeSession(taskRunId);
+        return;
+      }
+
+      const configOptions = result.configOptions as
+        | SessionConfigOption[]
+        | undefined;
+
+      sessionStoreSetters.updateSession(taskRunId, {
+        status: "connected",
+        channel: result.channel,
+        configOptions,
+      });
+
+      this.subscribeToChannel(taskRunId);
+
+      log.info("Preview session started", {
+        taskRunId,
+        adapter: params.adapter,
+        configOptionsCount: configOptions?.length ?? 0,
+      });
+    } catch (error) {
+      // Only clean up if we're still the current version
+      if (version === this.previewVersion) {
+        log.error("Failed to start preview session", { error });
+        sessionStoreSetters.removeSession(taskRunId);
+      }
+    }
+  }
+
+  /**
+   * Cancel and clean up the preview session.
+   * Unsubscribes and removes from store first (so nothing writes to the old
+   * session), then awaits the cancel on the main process.
+   */
+  async cancelPreviewSession(): Promise<void> {
+    const session = sessionStoreSetters.getSessionByTaskId(PREVIEW_TASK_ID);
+    if (!session) return;
+
+    const { taskRunId } = session;
+
+    // Unsubscribe and remove from store first so nothing writes to the old session
+    this.unsubscribeFromChannel(taskRunId);
+    sessionStoreSetters.removeSession(taskRunId);
+
+    try {
+      await trpcVanilla.agent.cancel.mutate({ sessionId: taskRunId });
+    } catch (error) {
+      log.warn("Failed to cancel preview session", { taskRunId, error });
+    }
+
+    log.info("Preview session cancelled", { taskRunId });
   }
 
   // --- Subscription Management ---
@@ -517,6 +661,7 @@ export class SessionService {
     }
 
     this.connectingTasks.clear();
+    this.previewVersion = 0;
   }
 
   private handleSessionEvent(taskRunId: string, acpMsg: AcpMessage): void {

--- a/apps/twig/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -1,7 +1,12 @@
 import { TorchGlow } from "@components/TorchGlow";
 import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
 import type { MessageEditorHandle } from "@features/message-editor/components/MessageEditor";
-import { useModelsStore } from "@features/sessions/stores/modelsStore";
+import { ModeIndicatorInput } from "@features/message-editor/components/ModeIndicatorInput";
+import { getSessionService } from "@features/sessions/service/service";
+import {
+  cycleModeOption,
+  getCurrentModeFromConfigOptions,
+} from "@features/sessions/stores/sessionStore";
 import type { AgentAdapter } from "@features/settings/stores/settingsStore";
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { useRepositoryIntegration } from "@hooks/useIntegrations";
@@ -9,11 +14,11 @@ import { Flex } from "@radix-ui/themes";
 import { useRegisteredFoldersStore } from "@renderer/stores/registeredFoldersStore";
 import { useNavigationStore } from "@stores/navigationStore";
 import { useTaskDirectoryStore } from "@stores/taskDirectoryStore";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePreviewSession } from "../hooks/usePreviewSession";
 import { useTaskCreation } from "../hooks/useTaskCreation";
 import { AdapterSelect } from "./AdapterSelect";
 import { TaskInputEditor } from "./TaskInputEditor";
-import { TaskInputModelSelector } from "./TaskInputModelSelector";
 import { type WorkspaceMode, WorkspaceModeSelect } from "./WorkspaceModeSelect";
 
 const DOT_FILL = "var(--gray-6)";
@@ -26,10 +31,8 @@ export function TaskInput() {
     setLastUsedLocalWorkspaceMode,
     lastUsedAdapter,
     setLastUsedAdapter,
-    lastUsedModel,
-    setLastUsedModel,
+    allowBypassPermissions,
   } = useSettingsStore();
-  const { getEffectiveModel } = useModelsStore();
 
   const editorRef = useRef<MessageEditorHandle>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -40,7 +43,6 @@ export function TaskInput() {
   const selectedDirectory = lastUsedDirectory || "";
   const workspaceMode = lastUsedLocalWorkspaceMode || "worktree";
   const adapter = lastUsedAdapter;
-  const selectedModel = lastUsedModel ?? getEffectiveModel();
 
   const setSelectedDirectory = (path: string) =>
     setLastUsedDirectory(path || null);
@@ -48,9 +50,17 @@ export function TaskInput() {
     setLastUsedLocalWorkspaceMode(mode as "worktree" | "local");
   const setAdapter = (newAdapter: AgentAdapter) =>
     setLastUsedAdapter(newAdapter);
-  const setSelectedModel = (model: string) => setLastUsedModel(model);
 
   const { githubIntegration } = useRepositoryIntegration();
+
+  // Preview session provides adapter-specific config options
+  const {
+    modeOption,
+    modelOption,
+    thoughtOption,
+    previewTaskId,
+    isConnecting,
+  } = usePreviewSession(adapter, selectedDirectory || undefined);
 
   useEffect(() => {
     if (view.folderId) {
@@ -62,32 +72,14 @@ export function TaskInput() {
     }
   }, [view.folderId, setLastUsedDirectory]);
 
-  // When adapter changes, validate that selected model is compatible
-  useEffect(() => {
-    const { groupedModels } = useModelsStore.getState();
-    if (groupedModels.length === 0) return;
-
-    // Filter models by current adapter
-    const compatibleModels =
-      adapter === "claude"
-        ? groupedModels.filter((g) => g.provider === "Anthropic")
-        : groupedModels.filter((g) => g.provider !== "Anthropic");
-
-    const allCompatibleModelIds = compatibleModels.flatMap((g) =>
-      g.models.map((m) => m.modelId),
-    );
-
-    // If current model is not compatible with adapter, select first available model
-    if (!selectedModel || !allCompatibleModelIds.includes(selectedModel)) {
-      // Get first available model for this adapter
-      const firstCompatibleModel = compatibleModels[0]?.models[0]?.modelId;
-      if (firstCompatibleModel) {
-        setLastUsedModel(firstCompatibleModel);
-      }
-    }
-  }, [adapter, selectedModel, setLastUsedModel]);
-
   const effectiveWorkspaceMode = workspaceMode;
+
+  // Get current values from preview session config options for task creation
+  const currentModel = modelOption?.currentValue;
+  const currentExecutionMode = getCurrentModeFromConfigOptions(
+    modeOption ? [modeOption] : undefined,
+  );
+  const currentReasoningLevel = thoughtOption?.currentValue;
 
   const { isCreatingTask, canSubmit, handleSubmit } = useTaskCreation({
     editorRef,
@@ -97,8 +89,21 @@ export function TaskInput() {
     branch: null,
     editorIsEmpty,
     adapter,
-    model: selectedModel,
+    executionMode: currentExecutionMode,
+    model: currentModel,
+    reasoningLevel: currentReasoningLevel,
   });
+
+  const handleCycleMode = useCallback(() => {
+    const nextValue = cycleModeOption(modeOption, allowBypassPermissions);
+    if (nextValue && modeOption) {
+      getSessionService().setSessionConfigOption(
+        previewTaskId,
+        modeOption.id,
+        nextValue,
+      );
+    }
+  }, [modeOption, allowBypassPermissions, previewTaskId]);
 
   return (
     <div
@@ -178,12 +183,6 @@ export function TaskInput() {
               size="1"
             />
             <AdapterSelect value={adapter} onChange={setAdapter} size="1" />
-            <TaskInputModelSelector
-              value={selectedModel}
-              onChange={setSelectedModel}
-              adapter={adapter}
-              size="1"
-            />
           </Flex>
 
           <TaskInputEditor
@@ -197,6 +196,14 @@ export function TaskInput() {
             hasDirectory={!!selectedDirectory}
             onEmptyChange={setEditorIsEmpty}
             adapter={adapter}
+            previewTaskId={previewTaskId}
+            onCycleMode={handleCycleMode}
+            isPreviewConnecting={isConnecting}
+          />
+
+          <ModeIndicatorInput
+            modeOption={modeOption}
+            onCycleMode={handleCycleMode}
           />
         </Flex>
       </Flex>

--- a/apps/twig/src/renderer/features/task-detail/components/TaskInputEditor.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/TaskInputEditor.tsx
@@ -2,8 +2,10 @@ import "@features/message-editor/components/message-editor.css";
 import { EditorToolbar } from "@features/message-editor/components/EditorToolbar";
 import type { MessageEditorHandle } from "@features/message-editor/components/MessageEditor";
 import { useTiptapEditor } from "@features/message-editor/tiptap/useTiptapEditor";
+import { ModelSelector } from "@features/sessions/components/ModelSelector";
+import { ReasoningLevelSelector } from "@features/sessions/components/ReasoningLevelSelector";
 import { useConnectivity } from "@hooks/useConnectivity";
-import { ArrowUp } from "@phosphor-icons/react";
+import { ArrowUp, Spinner } from "@phosphor-icons/react";
 import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
 import { EditorContent } from "@tiptap/react";
 import { forwardRef, useImperativeHandle } from "react";
@@ -20,6 +22,9 @@ interface TaskInputEditorProps {
   hasDirectory: boolean;
   onEmptyChange?: (isEmpty: boolean) => void;
   adapter?: "claude" | "codex";
+  previewTaskId?: string;
+  onCycleMode?: () => void;
+  isPreviewConnecting?: boolean;
 }
 
 export const TaskInputEditor = forwardRef<
@@ -36,6 +41,9 @@ export const TaskInputEditor = forwardRef<
       hasDirectory,
       onEmptyChange,
       adapter,
+      previewTaskId,
+      onCycleMode,
+      isPreviewConnecting,
     },
     ref,
   ) => {
@@ -129,6 +137,13 @@ export const TaskInputEditor = forwardRef<
               focus();
             }
           }}
+          onKeyDown={(e) => {
+            if (e.key === "Tab" && e.shiftKey && onCycleMode) {
+              e.preventDefault();
+              e.stopPropagation();
+              onCycleMode();
+            }
+          }}
         >
           <Flex
             align="start"
@@ -181,13 +196,42 @@ export const TaskInputEditor = forwardRef<
         </Flex>
 
         <Flex justify="between" align="center" px="3" pb="3">
-          <EditorToolbar
-            disabled={isCreatingTask}
-            adapter={adapter}
-            onInsertChip={insertChip}
-            attachTooltip="Attach files from anywhere"
-            iconSize={16}
-          />
+          <Flex align="center" gap="1">
+            <EditorToolbar
+              disabled={isCreatingTask}
+              adapter={adapter}
+              onInsertChip={insertChip}
+              attachTooltip="Attach files from anywhere"
+              iconSize={16}
+              hideSelectors
+            />
+            {isPreviewConnecting ? (
+              <Flex align="center" gap="1" px="1">
+                <Spinner size={12} className="animate-spin text-gray-9" />
+                <Text
+                  size="1"
+                  style={{
+                    color: "var(--gray-9)",
+                    fontFamily: "monospace",
+                  }}
+                >
+                  Loading options...
+                </Text>
+              </Flex>
+            ) : (
+              <>
+                <ModelSelector
+                  taskId={previewTaskId}
+                  adapter={adapter}
+                  disabled={isCreatingTask}
+                />
+                <ReasoningLevelSelector
+                  taskId={previewTaskId}
+                  disabled={isCreatingTask}
+                />
+              </>
+            )}
+          </Flex>
 
           <Flex align="center" gap="4">
             <Tooltip content={getSubmitTooltip()}>

--- a/apps/twig/src/renderer/features/task-detail/hooks/usePreviewSession.ts
+++ b/apps/twig/src/renderer/features/task-detail/hooks/usePreviewSession.ts
@@ -1,0 +1,59 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import {
+  getSessionService,
+  PREVIEW_TASK_ID,
+} from "@features/sessions/service/service";
+import {
+  useModeConfigOptionForTask,
+  useModelConfigOptionForTask,
+  useSessionForTask,
+  useThoughtLevelConfigOptionForTask,
+} from "@features/sessions/stores/sessionStore";
+import { useEffect } from "react";
+
+interface PreviewSessionResult {
+  modeOption: SessionConfigOption | undefined;
+  modelOption: SessionConfigOption | undefined;
+  thoughtOption: SessionConfigOption | undefined;
+  previewTaskId: string;
+  /** True while the preview session is connecting (no config options yet) */
+  isConnecting: boolean;
+}
+
+/**
+ * Manages a lightweight preview session that provides adapter-specific
+ * config options (models, modes, reasoning levels) for the task input page.
+ *
+ * Starts a new preview session when adapter or repoPath change,
+ * and cleans up on unmount or when inputs change.
+ */
+export function usePreviewSession(
+  adapter: "claude" | "codex",
+  repoPath: string | undefined,
+): PreviewSessionResult {
+  useEffect(() => {
+    const service = getSessionService();
+    service.startPreviewSession({ adapter, repoPath });
+
+    return () => {
+      service.cancelPreviewSession();
+    };
+  }, [adapter, repoPath]);
+
+  const session = useSessionForTask(PREVIEW_TASK_ID);
+  const modeOption = useModeConfigOptionForTask(PREVIEW_TASK_ID);
+  const modelOption = useModelConfigOptionForTask(PREVIEW_TASK_ID);
+  const thoughtOption = useThoughtLevelConfigOptionForTask(PREVIEW_TASK_ID);
+
+  // Connecting if we have a session but it's not connected yet,
+  // or if we don't have a session at all (start hasn't created one yet)
+  const isConnecting = !session || session.status === "connecting";
+
+  return {
+    modeOption,
+    modelOption,
+    thoughtOption,
+    previewTaskId: PREVIEW_TASK_ID,
+    isConnecting,
+  };
+}

--- a/apps/twig/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/twig/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -25,6 +25,7 @@ interface UseTaskCreationOptions {
   executionMode?: ExecutionMode;
   adapter?: "claude" | "codex";
   model?: string;
+  reasoningLevel?: string;
 }
 
 interface UseTaskCreationReturn {
@@ -81,6 +82,7 @@ function prepareTaskInput(
     executionMode?: ExecutionMode;
     adapter?: "claude" | "codex";
     model?: string;
+    reasoningLevel?: string;
   },
 ): TaskCreationInput {
   return {
@@ -94,6 +96,7 @@ function prepareTaskInput(
     executionMode: options.executionMode,
     adapter: options.adapter,
     model: options.model,
+    reasoningLevel: options.reasoningLevel,
   };
 }
 
@@ -120,6 +123,7 @@ export function useTaskCreation({
   executionMode,
   adapter,
   model,
+  reasoningLevel,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const { navigateToTask } = useNavigationStore();
@@ -157,6 +161,7 @@ export function useTaskCreation({
         executionMode,
         adapter,
         model,
+        reasoningLevel,
       });
 
       const taskService = get<TaskService>(RENDERER_TOKENS.TaskService);
@@ -201,6 +206,7 @@ export function useTaskCreation({
     executionMode,
     adapter,
     model,
+    reasoningLevel,
     invalidateTasks,
     navigateToTask,
   ]);

--- a/apps/twig/src/renderer/sagas/task/task-creation.ts
+++ b/apps/twig/src/renderer/sagas/task/task-creation.ts
@@ -38,6 +38,7 @@ export interface TaskCreationInput {
   executionMode?: ExecutionMode;
   adapter?: "claude" | "codex";
   model?: string;
+  reasoningLevel?: string;
 }
 
 export interface TaskCreationOutput {
@@ -210,6 +211,7 @@ export class TaskCreationSaga extends Saga<
               executionMode: input.executionMode,
               adapter: input.adapter,
               model: input.model,
+              reasoningLevel: input.reasoningLevel,
             });
           }
           return { taskId: task.id };

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -32,22 +32,24 @@ export class Agent {
       this.posthogAPI = new PostHogAPIClient(config.posthog);
     }
 
-    if (config.otelTransport) {
-      // OTEL pipeline: use OtelLogWriter only (no S3 writer)
-      this.sessionLogWriter = new SessionLogWriter({
-        otelConfig: {
-          posthogHost: config.otelTransport.host,
-          apiKey: config.otelTransport.apiKey,
-          logsPath: config.otelTransport.logsPath,
-        },
-        logger: this.logger.child("SessionLogWriter"),
-      });
-    } else if (config.posthog) {
-      // Legacy: use S3 writer via PostHog API
-      this.sessionLogWriter = new SessionLogWriter({
-        posthogAPI: this.posthogAPI,
-        logger: this.logger.child("SessionLogWriter"),
-      });
+    if (!config.skipLogPersistence) {
+      if (config.otelTransport) {
+        // OTEL pipeline: use OtelLogWriter only (no S3 writer)
+        this.sessionLogWriter = new SessionLogWriter({
+          otelConfig: {
+            posthogHost: config.otelTransport.host,
+            apiKey: config.otelTransport.apiKey,
+            logsPath: config.otelTransport.logsPath,
+          },
+          logger: this.logger.child("SessionLogWriter"),
+        });
+      } else if (config.posthog) {
+        // Legacy: use S3 writer via PostHog API
+        this.sessionLogWriter = new SessionLogWriter({
+          posthogAPI: this.posthogAPI,
+          logger: this.logger.child("SessionLogWriter"),
+        });
+      }
     }
   }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -141,6 +141,8 @@ export interface AgentConfig {
   posthog?: PostHogAPIConfig;
   /** OTEL transport config for shipping logs to PostHog Logs */
   otelTransport?: OtelTransportConfig;
+  /** Skip session log persistence (e.g. for preview sessions with no real task) */
+  skipLogPersistence?: boolean;
   debug?: boolean;
   onLog?: OnLogCallback;
 }


### PR DESCRIPTION
### TL;DR

Added a preview session feature for the task input page that loads adapter-specific configuration options without creating a real task.

### What changed?

- Created a preview session system that loads model options, reasoning levels, and execution modes for the selected adapter
- Added a visual mode indicator that shows the current execution mode with an icon and label
- Separated model and reasoning level selectors from the editor toolbar for better organization
- Disabled log persistence for preview sessions since they don't correspond to real tasks
- Added keyboard shortcut (Shift+Tab) to cycle through execution modes
- Implemented version tracking to prevent race conditions when rapidly switching adapters

### How to test?

1. Open the task input page and verify that model options and reasoning levels load correctly
2. Change the adapter and confirm that the available options update accordingly
3. Use Shift+Tab to cycle through execution modes and verify the mode indicator updates
4. Check that no logs are persisted for preview sessions
5. Rapidly switch between adapters to ensure no race conditions occur

### Why make this change?

The task input page needed to display adapter-specific configuration options before task creation, but previously these options were only available after creating a task. This change improves the user experience by showing relevant options upfront, allowing users to configure their task properly before submission. It also prevents unnecessary log persistence for these temporary preview sessions.