### PR TITLE
feat: agent chunks coalescing

### DIFF
--- a/packages/agent/src/sagas/resume-saga.ts
+++ b/packages/agent/src/sagas/resume-saga.ts
@@ -244,7 +244,30 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
             break;
           }
 
+          case "agent_message": {
+            const content = update.content as ContentBlock | undefined;
+            if (content) {
+              if (
+                content.type === "text" &&
+                currentAssistantContent.length > 0 &&
+                currentAssistantContent[currentAssistantContent.length - 1]
+                  .type === "text"
+              ) {
+                const lastBlock = currentAssistantContent[
+                  currentAssistantContent.length - 1
+                ] as { type: "text"; text: string };
+                lastBlock.text += (
+                  content as { type: "text"; text: string }
+                ).text;
+              } else {
+                currentAssistantContent.push(content);
+              }
+            }
+            break;
+          }
+
           case "agent_message_chunk": {
+            // Backward compatibility with older logs that have individual chunks
             const content = update.content as ContentBlock | undefined;
             if (content) {
               if (

--- a/packages/agent/src/sagas/test-fixtures.ts
+++ b/packages/agent/src/sagas/test-fixtures.ts
@@ -205,6 +205,15 @@ export function createAgentChunk(text: string): StoredNotification {
   });
 }
 
+export function createAgentMessage(text: string): StoredNotification {
+  return createNotification("session/update", {
+    update: {
+      sessionUpdate: "agent_message",
+      content: { type: "text", text },
+    },
+  });
+}
+
 export function createToolCall(
   toolCallId: string,
   toolName: string,


### PR DESCRIPTION
We are currently storing every `agent_message_chunk` delta to S3, this doesn't spark joy.
Let's buffer'em and emit a single `agent_message` event per turn segment.

Keeping the buffer since resume saga works on top of this mechanism for now.