### PR TITLE
feat: add /good, /bad, and /feedback slash commands

### DIFF
--- a/apps/twig/src/renderer/features/message-editor/suggestions/getSuggestions.ts
+++ b/apps/twig/src/renderer/features/message-editor/suggestions/getSuggestions.ts
@@ -5,6 +5,24 @@ import Fuse, { type IFuseOptions } from "fuse.js";
 import { useDraftStore } from "../stores/draftStore";
 import type { CommandSuggestionItem, FileSuggestionItem } from "../types";
 
+const TWIG_COMMANDS: AvailableCommand[] = [
+  {
+    name: "good",
+    description: "Capture positive feedback",
+    input: { hint: "optional comment" },
+  },
+  {
+    name: "bad",
+    description: "Capture negative feedback",
+    input: { hint: "optional comment" },
+  },
+  {
+    name: "feedback",
+    description: "Capture general feedback",
+    input: { hint: "optional comment" },
+  },
+];
+
 const COMMAND_LIMIT = 5;
 
 const COMMAND_FUSE_OPTIONS: IFuseOptions<AvailableCommand> = {
@@ -67,7 +85,7 @@ export function getCommandSuggestions(
   query: string,
 ): CommandSuggestionItem[] {
   const taskId = useDraftStore.getState().contexts[sessionId]?.taskId;
-  const commands = getAvailableCommandsForTask(taskId);
+  const commands = [...TWIG_COMMANDS, ...getAvailableCommandsForTask(taskId)];
   const filtered = searchCommands(commands, query);
 
   return filtered.map((cmd) => ({

--- a/apps/twig/src/types/analytics.ts
+++ b/apps/twig/src/types/analytics.ts
@@ -11,6 +11,7 @@ export type GitActionType =
   | "publish"
   | "commit-push"
   | "create-pr";
+export type FeedbackType = "good" | "bad" | "general";
 export type FileOpenSource = "sidebar" | "agent-suggestion" | "search" | "diff";
 export type FileChangeType = "added" | "modified" | "deleted";
 export type StopReason = "user_cancelled" | "completed" | "error" | "timeout";
@@ -157,6 +158,16 @@ export interface FirstTaskCompletedProperties {
   duration_seconds: number;
 }
 
+// Feedback events
+export interface TaskFeedbackProperties {
+  task_id: string;
+  task_run_id?: string;
+  log_url?: string;
+  event_count: number;
+  feedback_type: FeedbackType;
+  feedback_comment?: string;
+}
+
 // Event names as constants
 export const ANALYTICS_EVENTS = {
   // App lifecycle
@@ -200,6 +211,9 @@ export const ANALYTICS_EVENTS = {
 
   // Settings events
   SETTING_CHANGED: "Setting changed",
+
+  // Feedback events
+  TASK_FEEDBACK: "Task feedback",
 
   // Error events
   TASK_CREATION_FAILED: "Task creation failed",
@@ -245,6 +259,9 @@ export type EventPropertyMap = {
 
   // Settings events
   [ANALYTICS_EVENTS.SETTING_CHANGED]: SettingChangedProperties;
+
+  // Feedback events
+  [ANALYTICS_EVENTS.TASK_FEEDBACK]: TaskFeedbackProperties;
 
   // Error events
   [ANALYTICS_EVENTS.TASK_CREATION_FAILED]: TaskCreationFailedProperties;


### PR DESCRIPTION
## Summary

- Adds `/good`, `/bad`, and `/feedback` slash commands to the chat input for capturing user feedback as PostHog analytics events
- Commands are intercepted client-side before reaching the agent, fire a "Task feedback" event, and show a toast confirmation
- Each event includes `task_id`, `task_run_id`, `log_url`, and `event_count` to link feedback to the specific conversation turn
- Commands appear in the suggestion dropdown with optional comment support (e.g., `/good clean refactor`)

## Changes

- `apps/twig/src/types/analytics.ts` -- new `FeedbackType`, `TaskFeedbackProperties`, and `TASK_FEEDBACK` event
- `apps/twig/src/renderer/features/message-editor/suggestions/getSuggestions.ts` -- add custom Twig commands to suggestion dropdown
- `apps/twig/src/renderer/features/task-detail/components/TaskLogsPanel.tsx` -- intercept feedback commands in `handleSendPrompt`

## Test plan

- [ ] Type `/` in chat input and verify `good`, `bad`, `feedback` appear in suggestions
- [ ] Select `/good`, optionally type a comment, press Enter -- toast shows "Positive feedback captured"
- [ ] Type `/bad` and press Enter -- toast shows "Negative feedback captured"
- [ ] Type `/feedback` and press Enter -- toast shows "General feedback captured"
- [ ] Verify PostHog event contains `task_id`, `task_run_id`, `log_url`, `event_count`, `feedback_type`, and `feedback_comment`