### PR TITLE
feat: add checkpoint api to git

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -13,10 +13,12 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist .turbo"
+    "clean": "rm -rf dist .turbo",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/tar": "^6.1.13",
+    "vitest": "^2.1.8",
     "typescript": "^5.5.0"
   },
   "files": [

--- a/packages/git/src/sagas/checkpoint.test.ts
+++ b/packages/git/src/sagas/checkpoint.test.ts
@@ -1,0 +1,573 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createGitClient } from "../client.js";
+import {
+  CaptureCheckpointSaga,
+  DiffCheckpointSaga,
+  deleteCheckpoint,
+  getGitBusyState,
+  listCheckpoints,
+  RevertCheckpointSaga,
+} from "./checkpoint.js";
+
+async function setupRepo(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "twig-checkpoint-"));
+  const git = createGitClient(dir);
+  await git.init();
+  await git.addConfig("user.name", "Twig Test");
+  await git.addConfig("user.email", "twig-test@example.com");
+
+  await writeFile(path.join(dir, "a.txt"), "one\n");
+  await writeFile(path.join(dir, "b.txt"), "base\n");
+  await git.add(["a.txt", "b.txt"]);
+  await git.commit("initial");
+
+  return dir;
+}
+
+async function withRepo<T>(fn: (repoPath: string) => Promise<T>): Promise<T> {
+  const repoPath = await setupRepo();
+  try {
+    return await fn(repoPath);
+  } finally {
+    await rm(repoPath, { recursive: true, force: true });
+  }
+}
+
+async function withRepoAndWorktree<T>(
+  fn: (repoPath: string, worktreePath: string) => Promise<T>,
+): Promise<T> {
+  const repoPath = await setupRepo();
+  const worktreePath = await mkdtemp(path.join(tmpdir(), "twig-worktree-"));
+  try {
+    const git = createGitClient(repoPath);
+    await git.raw(["worktree", "add", worktreePath]);
+    return await fn(repoPath, worktreePath);
+  } finally {
+    await rm(worktreePath, { recursive: true, force: true });
+    await rm(repoPath, { recursive: true, force: true });
+  }
+}
+
+async function getIndexFileContent(
+  repoPath: string,
+  filePath: string,
+): Promise<string> {
+  const git = createGitClient(repoPath);
+  const output = await git.raw(["show", `:${filePath}`]);
+  return output;
+}
+
+async function captureCheckpoint(
+  repoPath: string,
+  checkpointId: string,
+): Promise<void> {
+  const capture = new CaptureCheckpointSaga();
+  const result = await capture.run({ baseDir: repoPath, checkpointId });
+  expect(result.success).toBe(true);
+}
+
+async function revertCheckpoint(
+  repoPath: string,
+  checkpointId: string,
+): Promise<void> {
+  const revert = new RevertCheckpointSaga();
+  const result = await revert.run({ baseDir: repoPath, checkpointId });
+  expect(result.success).toBe(true);
+}
+
+describe("checkpoint sagas", () => {
+  it("captures and reverts worktree + index + untracked", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+
+      // staged change
+      await writeFile(path.join(repoPath, "a.txt"), "staged\n");
+      await git.add(["a.txt"]);
+
+      // unstaged change
+      await writeFile(path.join(repoPath, "b.txt"), "unstaged\n");
+
+      // untracked
+      await writeFile(path.join(repoPath, "c.txt"), "untracked\n");
+
+      await captureCheckpoint(repoPath, "test-checkpoint");
+
+      // mutate after capture
+      await writeFile(path.join(repoPath, "a.txt"), "after\n");
+      await git.add(["a.txt"]);
+      await writeFile(path.join(repoPath, "b.txt"), "after-unstaged\n");
+      await rm(path.join(repoPath, "c.txt"));
+      await writeFile(path.join(repoPath, "d.txt"), "new-untracked\n");
+
+      await revertCheckpoint(repoPath, "test-checkpoint");
+
+      const aWorktree = await readFile(path.join(repoPath, "a.txt"), "utf8");
+      const aIndex = await getIndexFileContent(repoPath, "a.txt");
+      const bWorktree = await readFile(path.join(repoPath, "b.txt"), "utf8");
+      const cWorktree = await readFile(path.join(repoPath, "c.txt"), "utf8");
+
+      expect(aWorktree).toBe("staged\n");
+      expect(aIndex).toBe("staged");
+      expect(bWorktree).toBe("unstaged\n");
+      expect(cWorktree).toBe("untracked\n");
+
+      const status = await git.raw(["status", "--porcelain"]);
+      const lines = status.trim().split("\n").filter(Boolean);
+      expect(lines).toContain("M  a.txt");
+      expect(lines).toContain(" M b.txt");
+      expect(lines).toContain("?? c.txt");
+      expect(lines).not.toContain("?? d.txt");
+    });
+  });
+
+  it("restores renames, deletes, and nested untracked files", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+
+      // staged rename
+      await git.raw(["mv", "a.txt", "renamed.txt"]);
+
+      // unstaged delete
+      await rm(path.join(repoPath, "b.txt"));
+
+      // nested untracked
+      await mkdir(path.join(repoPath, "nested/dir"), { recursive: true });
+      await writeFile(path.join(repoPath, "nested/dir/file.txt"), "nested\n");
+
+      await captureCheckpoint(repoPath, "rename-delete");
+
+      // mutate after capture
+      await git.raw(["mv", "renamed.txt", "a.txt"]);
+      await writeFile(path.join(repoPath, "b.txt"), "recreated\n");
+      await rm(path.join(repoPath, "nested/dir/file.txt"));
+
+      await revertCheckpoint(repoPath, "rename-delete");
+
+      const renamed = await readFile(
+        path.join(repoPath, "renamed.txt"),
+        "utf8",
+      );
+      expect(renamed).toBe("one\n");
+      await expect(
+        readFile(path.join(repoPath, "a.txt"), "utf8"),
+      ).rejects.toBeTruthy();
+      await expect(
+        readFile(path.join(repoPath, "b.txt"), "utf8"),
+      ).rejects.toBeTruthy();
+      const nested = await readFile(
+        path.join(repoPath, "nested/dir/file.txt"),
+        "utf8",
+      );
+      expect(nested).toBe("nested\n");
+    });
+  });
+
+  it("round-trips binary content", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      const binaryPath = path.join(repoPath, "bin.dat");
+      const data = Buffer.from([0, 1, 2, 3, 255, 128, 64]);
+      await writeFile(binaryPath, data);
+      await git.add(["bin.dat"]);
+
+      await captureCheckpoint(repoPath, "binary");
+
+      await writeFile(binaryPath, Buffer.from([9, 9, 9]));
+
+      await revertCheckpoint(repoPath, "binary");
+
+      const restored = await readFile(binaryPath);
+      expect(Buffer.compare(restored, data)).toBe(0);
+    });
+  });
+
+  it("works on a detached HEAD", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      await writeFile(path.join(repoPath, "c.txt"), "second\n");
+      await git.add(["c.txt"]);
+      await git.commit("second");
+
+      const head = (await git.revparse(["HEAD"])).trim();
+      await git.checkout([`${head}^`]);
+      const detachedHead = (await git.revparse(["HEAD"])).trim();
+
+      await writeFile(path.join(repoPath, "a.txt"), "detached\n");
+
+      await captureCheckpoint(repoPath, "detached");
+
+      await writeFile(path.join(repoPath, "a.txt"), "after\n");
+
+      await revertCheckpoint(repoPath, "detached");
+
+      const restored = await readFile(path.join(repoPath, "a.txt"), "utf8");
+      expect(restored).toBe("detached\n");
+      const headAfter = (await git.revparse(["HEAD"])).trim();
+      expect(headAfter).toBe(detachedHead);
+    });
+  });
+
+  it("works in a worktree", async () => {
+    await withRepoAndWorktree(async (_repoPath, worktreePath) => {
+      const worktreeGit = createGitClient(worktreePath);
+      await writeFile(path.join(worktreePath, "a.txt"), "wt-staged\n");
+      await worktreeGit.add(["a.txt"]);
+      await writeFile(path.join(worktreePath, "b.txt"), "wt-unstaged\n");
+      await writeFile(path.join(worktreePath, "c.txt"), "wt-untracked\n");
+
+      await captureCheckpoint(worktreePath, "worktree");
+
+      await writeFile(path.join(worktreePath, "a.txt"), "after\n");
+      await worktreeGit.add(["a.txt"]);
+      await rm(path.join(worktreePath, "c.txt"));
+
+      await revertCheckpoint(worktreePath, "worktree");
+
+      const aWorktree = await readFile(
+        path.join(worktreePath, "a.txt"),
+        "utf8",
+      );
+      const aIndex = await getIndexFileContent(worktreePath, "a.txt");
+      const bWorktree = await readFile(
+        path.join(worktreePath, "b.txt"),
+        "utf8",
+      );
+      const cWorktree = await readFile(
+        path.join(worktreePath, "c.txt"),
+        "utf8",
+      );
+
+      expect(aWorktree).toBe("wt-staged\n");
+      expect(aIndex).toBe("wt-staged");
+      expect(bWorktree).toBe("wt-unstaged\n");
+      expect(cWorktree).toBe("wt-untracked\n");
+    });
+  });
+
+  it("handles submodules without breaking", async () => {
+    const subRepo = await mkdtemp(path.join(tmpdir(), "twig-submodule-"));
+    await withRepo(async (repoPath) => {
+      const subGit = createGitClient(subRepo);
+      await subGit.init();
+      await subGit.addConfig("user.name", "Twig Test");
+      await subGit.addConfig("user.email", "twig-test@example.com");
+      await writeFile(path.join(subRepo, "sub.txt"), "sub\n");
+      await subGit.add(["sub.txt"]);
+      await subGit.commit("sub-init");
+
+      const git = createGitClient(repoPath);
+      await git
+        .env({ ...process.env, GIT_ALLOW_PROTOCOL: "file" })
+        .raw(["submodule", "add", subRepo, "submod"]);
+      await git.commit("add submodule");
+
+      await captureCheckpoint(repoPath, "submodule");
+
+      await writeFile(path.join(repoPath, "a.txt"), "after\n");
+
+      await revertCheckpoint(repoPath, "submodule");
+
+      const subStatus = await git.raw(["submodule", "status"]);
+      expect(subStatus.trim()).not.toBe("");
+      const subExists = await readFile(
+        path.join(repoPath, "submod/sub.txt"),
+        "utf8",
+      );
+      expect(subExists).toBe("sub\n");
+    });
+    await rm(subRepo, { recursive: true, force: true });
+  });
+
+  it("fails capture with a clear error when index has unresolved merges", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      const defaultBranch = (
+        await git.raw(["rev-parse", "--abbrev-ref", "HEAD"])
+      ).trim();
+
+      await git.checkoutLocalBranch("feature");
+      await writeFile(path.join(repoPath, "a.txt"), "feature\n");
+      await git.add(["a.txt"]);
+      await git.commit("feature-change");
+
+      await git.checkout(defaultBranch);
+      await writeFile(path.join(repoPath, "a.txt"), "default\n");
+      await git.add(["a.txt"]);
+      await git.commit("default-change");
+
+      await git.raw(["merge", "feature"]);
+      const status = await git.raw(["status", "--porcelain"]);
+      expect(status.trim().split("\n")).toContain("UU a.txt");
+
+      const capture = new CaptureCheckpointSaga();
+      const result = await capture.run({
+        baseDir: repoPath,
+        checkpointId: "conflicted-index",
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain("git operation is in progress");
+      expect(result.error).toContain("merge");
+      expect(result.failedStep).toBe("check_git_busy");
+    });
+  });
+
+  it("restores checkpoint on unborn HEAD", async () => {
+    const repoPath = await mkdtemp(path.join(tmpdir(), "twig-checkpoint-"));
+    try {
+      const git = createGitClient(repoPath);
+      await git.init();
+      await git.addConfig("user.name", "Twig Test");
+      await git.addConfig("user.email", "twig-test@example.com");
+
+      await writeFile(path.join(repoPath, "x.txt"), "one\n");
+      await captureCheckpoint(repoPath, "unborn-head");
+
+      await writeFile(path.join(repoPath, "x.txt"), "two\n");
+      await writeFile(path.join(repoPath, "y.txt"), "new\n");
+
+      await revertCheckpoint(repoPath, "unborn-head");
+
+      const restoredX = await readFile(path.join(repoPath, "x.txt"), "utf8");
+      expect(restoredX).toBe("one\n");
+
+      const status = await git.raw(["status", "--porcelain"]);
+      expect(status.trim().split("\n").filter(Boolean).sort()).toEqual([
+        "?? x.txt",
+      ]);
+    } finally {
+      await rm(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it("diffs between checkpoints and current", async () => {
+    await withRepo(async (repoPath) => {
+      await writeFile(path.join(repoPath, "a.txt"), "one\n");
+      await captureCheckpoint(repoPath, "diff-1");
+
+      await writeFile(path.join(repoPath, "a.txt"), "two\n");
+      await captureCheckpoint(repoPath, "diff-2");
+
+      const diffSaga = new DiffCheckpointSaga();
+      const diffResult = await diffSaga.run({
+        baseDir: repoPath,
+        from: "diff-1",
+        to: "diff-2",
+      });
+      expect(diffResult.success).toBe(true);
+      if (!diffResult.success) return;
+      expect(diffResult.data.diff).toContain("-one");
+      expect(diffResult.data.diff).toContain("+two");
+    });
+  });
+
+  it("diff against current excludes ignored-file changes", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      await writeFile(path.join(repoPath, ".gitignore"), "ignored.log\n");
+      await git.add([".gitignore"]);
+      await git.commit("add-ignore");
+
+      await captureCheckpoint(repoPath, "ignore-diff");
+
+      await writeFile(path.join(repoPath, "ignored.log"), "ignored-change\n");
+      await writeFile(path.join(repoPath, "a.txt"), "tracked-change\n");
+
+      const diffSaga = new DiffCheckpointSaga();
+      const diffResult = await diffSaga.run({
+        baseDir: repoPath,
+        from: "ignore-diff",
+        to: "current",
+      });
+
+      expect(diffResult.success).toBe(true);
+      if (!diffResult.success) return;
+      expect(diffResult.data.diff).toContain("a.txt");
+      expect(diffResult.data.diff).not.toContain("ignored.log");
+      expect(diffResult.data.diff).toContain("tracked-change");
+    });
+  });
+
+  it("does not leak temp index into normal git operations", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      await writeFile(path.join(repoPath, "a.txt"), "staged\n");
+      await git.add(["a.txt"]);
+
+      await captureCheckpoint(repoPath, "no-leak");
+
+      const status = await git.raw(["status", "--porcelain"]);
+      expect(status.trim().split("\n")).toContain("M  a.txt");
+    });
+  });
+
+  it("fails capture during interactive rebase", async () => {
+    const repoPath = await setupRepo();
+    try {
+      const git = createGitClient(repoPath);
+
+      await writeFile(path.join(repoPath, "a.txt"), "second\n");
+      await git.add(["a.txt"]);
+      await git.commit("second");
+
+      await writeFile(path.join(repoPath, "a.txt"), "third\n");
+      await git.add(["a.txt"]);
+      await git.commit("third");
+
+      const rebaseMergeRelative = (
+        await git.raw(["rev-parse", "--git-path", "rebase-merge"])
+      ).trim();
+      const rebaseMergePath = path.resolve(repoPath, rebaseMergeRelative);
+      await mkdir(rebaseMergePath, { recursive: true });
+
+      const busyState = await getGitBusyState(git);
+      expect(busyState).toEqual({ busy: true, operation: "rebase" });
+
+      const capture = new CaptureCheckpointSaga();
+      const result = await capture.run({
+        baseDir: repoPath,
+        checkpointId: "during-rebase",
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain("git operation is in progress");
+      expect(result.error).toContain("rebase");
+      expect(result.failedStep).toBe("check_git_busy");
+    } finally {
+      await rm(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it("fails capture during cherry-pick", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      const defaultBranch = (
+        await git.raw(["rev-parse", "--abbrev-ref", "HEAD"])
+      ).trim();
+
+      await git.checkoutLocalBranch("feature");
+      await writeFile(path.join(repoPath, "a.txt"), "feature\n");
+      await git.add(["a.txt"]);
+      await git.commit("feature-change");
+      const featureCommit = (await git.revparse(["HEAD"])).trim();
+
+      await git.checkout(defaultBranch);
+      await writeFile(path.join(repoPath, "a.txt"), "conflict\n");
+      await git.add(["a.txt"]);
+      await git.commit("conflict-change");
+
+      try {
+        await git.raw(["cherry-pick", featureCommit]);
+      } catch {
+        // expected to fail with conflict
+      }
+
+      const busyState = await getGitBusyState(git);
+      expect(busyState).toEqual({ busy: true, operation: "cherry-pick" });
+
+      const capture = new CaptureCheckpointSaga();
+      const result = await capture.run({
+        baseDir: repoPath,
+        checkpointId: "during-cherry-pick",
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain("git operation is in progress");
+      expect(result.error).toContain("cherry-pick");
+    });
+  });
+
+  it("fails capture during revert", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+
+      await writeFile(path.join(repoPath, "a.txt"), "second\n");
+      await git.add(["a.txt"]);
+      await git.commit("second");
+
+      await writeFile(path.join(repoPath, "a.txt"), "third\n");
+      await git.add(["a.txt"]);
+      await git.commit("third");
+      const thirdCommit = (await git.revparse(["HEAD"])).trim();
+
+      await writeFile(path.join(repoPath, "a.txt"), "fourth\n");
+      await git.add(["a.txt"]);
+      await git.commit("fourth");
+
+      try {
+        await git.raw(["revert", "--no-commit", thirdCommit]);
+      } catch {
+        // expected to fail with conflict
+      }
+
+      const busyState = await getGitBusyState(git);
+      expect(busyState).toEqual({ busy: true, operation: "revert" });
+
+      const capture = new CaptureCheckpointSaga();
+      const result = await capture.run({
+        baseDir: repoPath,
+        checkpointId: "during-revert",
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain("git operation is in progress");
+      expect(result.error).toContain("revert");
+    });
+  });
+
+  it("returns clean state when no git operation in progress", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      const busyState = await getGitBusyState(git);
+      expect(busyState).toEqual({ busy: false });
+    });
+  });
+
+  it("lists checkpoints sorted by timestamp descending", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+
+      await captureCheckpoint(repoPath, "first");
+      await new Promise((r) => setTimeout(r, 10));
+      await captureCheckpoint(repoPath, "second");
+      await new Promise((r) => setTimeout(r, 10));
+      await captureCheckpoint(repoPath, "third");
+
+      const checkpoints = await listCheckpoints(git);
+      expect(checkpoints).toHaveLength(3);
+      expect(checkpoints[0].checkpointId).toBe("third");
+      expect(checkpoints[1].checkpointId).toBe("second");
+      expect(checkpoints[2].checkpointId).toBe("first");
+    });
+  });
+
+  it("deletes a checkpoint", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+
+      await captureCheckpoint(repoPath, "to-delete");
+      let checkpoints = await listCheckpoints(git);
+      expect(checkpoints).toHaveLength(1);
+
+      await deleteCheckpoint(git, "to-delete");
+      checkpoints = await listCheckpoints(git);
+      expect(checkpoints).toHaveLength(0);
+    });
+  });
+
+  it("throws when deleting non-existent checkpoint", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      await expect(deleteCheckpoint(git, "does-not-exist")).rejects.toThrow(
+        "Checkpoint not found",
+      );
+    });
+  });
+});

--- a/packages/git/src/sagas/checkpoint.ts
+++ b/packages/git/src/sagas/checkpoint.ts
@@ -1,0 +1,730 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createGitClient, type GitClient } from "../client.js";
+import { GitSaga, type GitSagaInput } from "../git-saga.js";
+
+const CHECKPOINT_REF_PREFIX = "refs/twig-checkpoint/";
+const CHECKPOINT_VERSION = "v1";
+const UNMERGED_INDEX_ERROR =
+  "Cannot capture checkpoint with unresolved merge conflicts in the index";
+const GIT_BUSY_ERROR =
+  "Cannot capture checkpoint while git operation is in progress";
+const CHECKPOINT_AUTHOR = {
+  name: "Twig",
+  email: "twig@local",
+};
+
+export interface CheckpointState {
+  checkpointId: string;
+  commit: string;
+  head: string | null;
+  branch: string | null;
+  indexTree: string;
+  worktreeTree: string;
+  timestamp: string;
+}
+
+interface CheckpointMetadata {
+  head: string | null;
+  branch: string | null;
+  indexTree: string | null;
+  worktreeTree: string | null;
+  timestamp: string | null;
+}
+
+export type GitBusyState =
+  | { busy: false }
+  | { busy: true; operation: "rebase" | "merge" | "cherry-pick" | "revert" };
+
+export interface CaptureCheckpointInput extends GitSagaInput {
+  checkpointId?: string;
+}
+
+export interface CaptureCheckpointOutput extends CheckpointState {}
+
+export class CaptureCheckpointSaga extends GitSaga<
+  CaptureCheckpointInput,
+  CaptureCheckpointOutput
+> {
+  protected async executeGitOperations(
+    input: CaptureCheckpointInput,
+  ): Promise<CaptureCheckpointOutput> {
+    const { baseDir } = input;
+
+    const headInfo = await this.readOnlyStep("get_head_info", () =>
+      getHeadInfo(this.git),
+    );
+
+    const busyState = await this.readOnlyStep("check_git_busy", () =>
+      getGitBusyState(this.git),
+    );
+    if (busyState.busy) {
+      throw new Error(`${GIT_BUSY_ERROR}: ${busyState.operation}`);
+    }
+
+    const hasUnmerged = await this.readOnlyStep("check_unmerged_index", () =>
+      hasUnmergedEntries(this.git),
+    );
+    if (hasUnmerged) {
+      throw new Error(UNMERGED_INDEX_ERROR);
+    }
+
+    const indexTree = await this.readOnlyStep("write_index_tree", () =>
+      this.git.raw(["write-tree"]),
+    );
+
+    const worktreeTree = await this.readOnlyStep("write_worktree_tree", () =>
+      createWorktreeTree(this.git, baseDir, headInfo.head),
+    );
+
+    const metaTree = await this.readOnlyStep("write_meta_tree", () =>
+      createMetaTree(this.git, baseDir, indexTree.trim(), worktreeTree.trim()),
+    );
+
+    const timestamp = new Date().toISOString();
+    const message = formatCheckpointMessage({
+      head: headInfo.head,
+      branch: headInfo.branch,
+      indexTree: indexTree.trim(),
+      worktreeTree: worktreeTree.trim(),
+      timestamp,
+    });
+
+    const commitHash = await this.step({
+      name: "create_checkpoint_commit",
+      execute: async () => {
+        const commitGit = this.git.env({
+          ...process.env,
+          GIT_AUTHOR_NAME: CHECKPOINT_AUTHOR.name,
+          GIT_AUTHOR_EMAIL: CHECKPOINT_AUTHOR.email,
+          GIT_COMMITTER_NAME: CHECKPOINT_AUTHOR.name,
+          GIT_COMMITTER_EMAIL: CHECKPOINT_AUTHOR.email,
+        });
+        const rawCommit = await commitGit.raw([
+          "commit-tree",
+          metaTree.trim(),
+          "-m",
+          message,
+        ]);
+        return rawCommit.trim();
+      },
+      rollback: async () => {
+        // Dangling commit objects are cleaned up by git gc
+      },
+    });
+
+    const checkpointId = input.checkpointId ?? randomUUID();
+    const refName = `${CHECKPOINT_REF_PREFIX}${checkpointId}`;
+
+    const existingRef = await this.readOnlyStep(
+      "check_existing_ref",
+      async () => {
+        try {
+          await this.git.revparse(["--verify", refName]);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    );
+
+    if (existingRef) {
+      throw new Error(`Checkpoint ref already exists: ${refName}`);
+    }
+
+    await this.step({
+      name: "update_checkpoint_ref",
+      execute: () => this.git.raw(["update-ref", refName, commitHash]),
+      rollback: async () => {
+        await this.git.raw(["update-ref", "-d", refName]).catch(() => {});
+      },
+    });
+
+    return {
+      checkpointId,
+      commit: commitHash,
+      head: headInfo.head,
+      branch: headInfo.branch,
+      indexTree: indexTree.trim(),
+      worktreeTree: worktreeTree.trim(),
+      timestamp,
+    };
+  }
+}
+
+export interface RevertCheckpointInput extends GitSagaInput {
+  checkpointId: string;
+}
+
+export interface RevertCheckpointOutput {
+  checkpointId: string;
+  commit: string;
+  head: string | null;
+  branch: string | null;
+}
+
+export class RevertCheckpointSaga extends GitSaga<
+  RevertCheckpointInput,
+  RevertCheckpointOutput
+> {
+  protected async executeGitOperations(
+    input: RevertCheckpointInput,
+  ): Promise<RevertCheckpointOutput> {
+    const { baseDir, checkpointId } = input;
+
+    const checkpoint = await this.readOnlyStep("resolve_checkpoint", () =>
+      resolveCheckpoint(this.git, checkpointId),
+    );
+
+    const { head, branch, indexTree, worktreeTree, commit } = checkpoint;
+
+    if (!worktreeTree || !indexTree) {
+      throw new Error("Checkpoint is missing tree data");
+    }
+
+    const originalState = await this.readOnlyStep(
+      "capture_original_state",
+      async () => {
+        const origHead = await getHeadInfo(this.git);
+        const origIndexTree = (await this.git.raw(["write-tree"])).trim();
+        const origWorktreeTree = await createWorktreeTree(
+          this.git,
+          baseDir,
+          origHead.head,
+        );
+        return {
+          head: origHead.head,
+          branch: origHead.branch,
+          indexTree: origIndexTree,
+          worktreeTree: origWorktreeTree,
+        };
+      },
+    );
+
+    await this.step({
+      name: "checkout_head",
+      execute: async () => {
+        if (!head) return;
+        if (branch) {
+          const branchExists = await refExists(
+            this.git,
+            `refs/heads/${branch}`,
+          );
+          if (branchExists) {
+            await this.git.checkout(branch);
+          } else {
+            await this.git.checkout(head);
+          }
+        } else {
+          await this.git.checkout(head);
+        }
+      },
+      rollback: async () => {
+        if (originalState.branch) {
+          const branchExists = await refExists(
+            this.git,
+            `refs/heads/${originalState.branch}`,
+          );
+          if (branchExists) {
+            await this.git.checkout(originalState.branch);
+            return;
+          }
+        }
+        if (originalState.head) {
+          await this.git.checkout(originalState.head);
+        }
+      },
+    });
+
+    if (head) {
+      await this.step({
+        name: "reset_head",
+        execute: () => this.git.reset(["--hard", head]),
+        rollback: async () => {
+          if (originalState.head) {
+            await this.git.reset(["--hard", originalState.head]);
+          }
+        },
+      });
+    }
+
+    await this.step({
+      name: "clean_worktree",
+      execute: () => this.git.clean(["f", "d"]),
+      rollback: async () => {
+        await this.git.raw([
+          "read-tree",
+          "--reset",
+          "-u",
+          originalState.worktreeTree,
+        ]);
+      },
+    });
+
+    await this.step({
+      name: "restore_worktree_tree",
+      execute: () => this.git.raw(["read-tree", "--reset", "-u", worktreeTree]),
+      rollback: async () => {
+        await this.git.raw([
+          "read-tree",
+          "--reset",
+          "-u",
+          originalState.worktreeTree,
+        ]);
+      },
+    });
+
+    await this.step({
+      name: "restore_index_tree",
+      execute: () => this.git.raw(["read-tree", indexTree]),
+      rollback: async () => {
+        await this.git.raw(["read-tree", originalState.indexTree]);
+      },
+    });
+
+    return {
+      checkpointId,
+      commit,
+      head: head ?? null,
+      branch: branch ?? null,
+    };
+  }
+}
+
+export interface DiffCheckpointInput extends GitSagaInput {
+  from: string;
+  to: string | "current";
+}
+
+export interface DiffCheckpointOutput {
+  diff: string;
+  fromTree: string;
+  toTree: string;
+}
+
+export class DiffCheckpointSaga extends GitSaga<
+  DiffCheckpointInput,
+  DiffCheckpointOutput
+> {
+  protected async executeGitOperations(
+    input: DiffCheckpointInput,
+  ): Promise<DiffCheckpointOutput> {
+    const { baseDir, from, to } = input;
+
+    const fromTree = await this.readOnlyStep("resolve_from_tree", async () => {
+      const checkpoint = await resolveCheckpoint(this.git, from);
+      if (!checkpoint.worktreeTree) {
+        throw new Error("Checkpoint is missing worktree tree");
+      }
+      return checkpoint.worktreeTree;
+    });
+
+    const toTree = await this.readOnlyStep("resolve_to_tree", async () => {
+      if (to === "current") {
+        const head = await getHeadShaOrNull(this.git);
+        return createWorktreeTree(this.git, baseDir, head);
+      }
+
+      const checkpoint = await resolveCheckpoint(this.git, to);
+      if (!checkpoint.worktreeTree) {
+        throw new Error("Checkpoint is missing worktree tree");
+      }
+      return checkpoint.worktreeTree;
+    });
+
+    const diff = await this.readOnlyStep("diff_trees", () =>
+      this.git.raw(["--no-pager", "diff", "--no-color", fromTree, toTree]),
+    );
+
+    return {
+      diff,
+      fromTree,
+      toTree,
+    };
+  }
+}
+
+async function getHeadInfo(git: GitClient): Promise<{
+  head: string | null;
+  branch: string | null;
+}> {
+  let head: string | null = null;
+  let branch: string | null = null;
+
+  try {
+    head = (await git.revparse(["HEAD"]))?.trim() || null;
+  } catch {
+    head = null;
+  }
+
+  try {
+    const rawBranch = await git.raw(["symbolic-ref", "--short", "HEAD"]);
+    branch = rawBranch.trim() || null;
+  } catch {
+    branch = null;
+  }
+
+  return { head, branch };
+}
+
+async function getHeadShaOrNull(git: GitClient): Promise<string | null> {
+  try {
+    const head = await git.revparse(["HEAD"]);
+    return head.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function hasUnmergedEntries(git: GitClient): Promise<boolean> {
+  const output = await git.raw(["ls-files", "--unmerged"]);
+  return output.trim().length > 0;
+}
+
+export async function getGitBusyState(git: GitClient): Promise<GitBusyState> {
+  const toplevel = (await git.raw(["rev-parse", "--show-toplevel"])).trim();
+
+  const resolveGitPath = async (gitPath: string): Promise<string> => {
+    const relative = (
+      await git.raw(["rev-parse", "--git-path", gitPath])
+    ).trim();
+    return path.isAbsolute(relative)
+      ? relative
+      : path.resolve(toplevel, relative);
+  };
+
+  const pathExists = async (gitPath: string): Promise<boolean> => {
+    const resolved = await resolveGitPath(gitPath);
+    try {
+      await fs.access(resolved);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const dirExists = async (gitPath: string): Promise<boolean> => {
+    const resolved = await resolveGitPath(gitPath);
+    try {
+      const stat = await fs.stat(resolved);
+      return stat.isDirectory();
+    } catch {
+      return false;
+    }
+  };
+
+  if ((await dirExists("rebase-merge")) || (await dirExists("rebase-apply"))) {
+    return { busy: true, operation: "rebase" };
+  }
+
+  if (await pathExists("MERGE_HEAD")) {
+    return { busy: true, operation: "merge" };
+  }
+
+  if (await pathExists("CHERRY_PICK_HEAD")) {
+    return { busy: true, operation: "cherry-pick" };
+  }
+
+  if (await pathExists("REVERT_HEAD")) {
+    return { busy: true, operation: "revert" };
+  }
+
+  return { busy: false };
+}
+
+async function createWorktreeTree(
+  git: GitClient,
+  baseDir: string,
+  head: string | null,
+): Promise<string> {
+  const { tempGit, tempIndexPath } = await createTempIndexGit(
+    git,
+    baseDir,
+    "checkpoint-worktree",
+  );
+
+  try {
+    if (head) {
+      await tempGit.raw(["read-tree", head]);
+    } else {
+      await tempGit.raw(["read-tree", "--empty"]);
+    }
+
+    await tempGit.raw(["add", "-A", "--", "."]);
+    const treeHash = await tempGit.raw(["write-tree"]);
+    return treeHash.trim();
+  } finally {
+    await fs.rm(tempIndexPath, { force: true }).catch(() => {});
+  }
+}
+
+async function createMetaTree(
+  git: GitClient,
+  baseDir: string,
+  indexTree: string,
+  worktreeTree: string,
+): Promise<string> {
+  const { tempGit, tempIndexPath } = await createTempIndexGit(
+    git,
+    baseDir,
+    "checkpoint-meta",
+  );
+
+  try {
+    await tempGit.raw(["read-tree", "--empty"]);
+    await tempGit.raw([
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "040000",
+      indexTree,
+      "index",
+    ]);
+    await tempGit.raw([
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "040000",
+      worktreeTree,
+      "worktree",
+    ]);
+    const metaTree = await tempGit.raw(["write-tree"]);
+    return metaTree.trim();
+  } finally {
+    await fs.rm(tempIndexPath, { force: true }).catch(() => {});
+  }
+}
+
+function formatCheckpointMessage(meta: {
+  head: string | null;
+  branch: string | null;
+  indexTree: string;
+  worktreeTree: string;
+  timestamp: string;
+}): string {
+  return [
+    `TWIG-CHECKPOINT ${CHECKPOINT_VERSION}`,
+    `head=${meta.head ?? "null"}`,
+    `branch=${meta.branch ?? "null"}`,
+    `index=${meta.indexTree}`,
+    `worktree=${meta.worktreeTree}`,
+    `timestamp=${meta.timestamp}`,
+  ].join("\n");
+}
+
+async function getGitCommonDir(
+  git: GitClient,
+  baseDir: string,
+): Promise<string> {
+  const raw = await git.raw(["rev-parse", "--git-common-dir"]);
+  const dir = raw.trim() || ".git";
+  return path.isAbsolute(dir) ? dir : path.resolve(baseDir, dir);
+}
+
+async function createTempIndexGit(
+  git: GitClient,
+  baseDir: string,
+  label: string,
+): Promise<{ tempGit: GitClient; tempIndexPath: string }> {
+  const tmpDir = path.join(await getGitCommonDir(git, baseDir), "twig-tmp");
+  await fs.mkdir(tmpDir, { recursive: true });
+
+  const tempIndexPath = path.join(
+    tmpDir,
+    `${label}-${Date.now()}-${randomUUID()}`,
+  );
+  const tempGit = createGitClient(baseDir).env({
+    ...process.env,
+    GIT_INDEX_FILE: tempIndexPath,
+  });
+
+  return { tempGit, tempIndexPath };
+}
+
+function parseCheckpointMessage(message: string): CheckpointMetadata {
+  const meta: CheckpointMetadata = {
+    head: null,
+    branch: null,
+    indexTree: null,
+    worktreeTree: null,
+    timestamp: null,
+  };
+
+  const lines = message
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (!lines[0]?.startsWith("TWIG-CHECKPOINT")) {
+    throw new Error("Not a twig checkpoint commit");
+  }
+
+  for (const line of lines.slice(1)) {
+    const [key, ...rest] = line.split("=");
+    if (!key || rest.length === 0) continue;
+    const value = rest.join("=").trim();
+
+    switch (key) {
+      case "head":
+        meta.head = value === "null" ? null : value;
+        break;
+      case "branch":
+        meta.branch = value === "null" ? null : value;
+        break;
+      case "index":
+        meta.indexTree = value || null;
+        break;
+      case "worktree":
+        meta.worktreeTree = value || null;
+        break;
+      case "timestamp":
+        meta.timestamp = value || null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return meta;
+}
+
+async function resolveCheckpoint(
+  git: GitClient,
+  checkpointId: string,
+): Promise<{
+  commit: string;
+  head: string | null;
+  branch: string | null;
+  indexTree: string | null;
+  worktreeTree: string | null;
+  timestamp: string | null;
+}> {
+  const refName = `${CHECKPOINT_REF_PREFIX}${checkpointId}`;
+  const commit = await resolveCheckpointCommit(git, checkpointId, refName);
+
+  const message = await git.raw(["show", "-s", "--format=%B", commit]);
+  const meta = parseCheckpointMessage(message);
+
+  const treeHash = await getCommitTree(git, commit);
+  const treeEntries = treeHash ? await readMetaTree(git, treeHash) : null;
+
+  const indexTree = meta.indexTree ?? treeEntries?.indexTree ?? null;
+  const worktreeTree = meta.worktreeTree ?? treeEntries?.worktreeTree ?? null;
+
+  return {
+    commit,
+    head: meta.head,
+    branch: meta.branch,
+    indexTree,
+    worktreeTree,
+    timestamp: meta.timestamp,
+  };
+}
+
+async function resolveCheckpointCommit(
+  git: GitClient,
+  checkpointId: string,
+  refName: string,
+): Promise<string> {
+  try {
+    const commit = await git.revparse([refName]);
+    return commit.trim();
+  } catch {
+    try {
+      const commit = await git.revparse([checkpointId]);
+      return commit.trim();
+    } catch {
+      throw new Error(`Checkpoint not found: ${checkpointId}`);
+    }
+  }
+}
+
+async function getCommitTree(
+  git: GitClient,
+  commit: string,
+): Promise<string | null> {
+  const raw = await git.raw(["cat-file", "-p", commit]);
+  const line = raw.split("\n").find((l) => l.startsWith("tree "));
+  return line ? line.split(" ")[1]?.trim() || null : null;
+}
+
+async function readMetaTree(
+  git: GitClient,
+  treeHash: string,
+): Promise<{ indexTree: string | null; worktreeTree: string | null }> {
+  const raw = await git.raw(["ls-tree", treeHash]);
+  let indexTree: string | null = null;
+  let worktreeTree: string | null = null;
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const [meta, name] = line.split("\t");
+    const parts = meta.split(" ");
+    const hash = parts[2];
+    if (name === "index") indexTree = hash;
+    if (name === "worktree") worktreeTree = hash;
+  }
+
+  return { indexTree, worktreeTree };
+}
+
+async function refExists(git: GitClient, refName: string): Promise<boolean> {
+  try {
+    await git.revparse(["--verify", refName]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface CheckpointInfo {
+  checkpointId: string;
+  commit: string;
+  head: string | null;
+  branch: string | null;
+  timestamp: string | null;
+}
+
+export async function listCheckpoints(
+  git: GitClient,
+): Promise<CheckpointInfo[]> {
+  const output = await git.raw([
+    "for-each-ref",
+    "--format=%(refname)",
+    CHECKPOINT_REF_PREFIX,
+  ]);
+  const refs = output.trim().split("\n").filter(Boolean);
+
+  const checkpoints: CheckpointInfo[] = [];
+  for (const ref of refs) {
+    const checkpointId = ref.replace(CHECKPOINT_REF_PREFIX, "");
+    try {
+      const resolved = await resolveCheckpoint(git, checkpointId);
+      checkpoints.push({
+        checkpointId,
+        commit: resolved.commit,
+        head: resolved.head,
+        branch: resolved.branch,
+        timestamp: resolved.timestamp,
+      });
+    } catch {}
+  }
+
+  return checkpoints.sort((a, b) => {
+    if (!a.timestamp || !b.timestamp) return 0;
+    return b.timestamp.localeCompare(a.timestamp);
+  });
+}
+
+export async function deleteCheckpoint(
+  git: GitClient,
+  checkpointId: string,
+): Promise<void> {
+  const refName = `${CHECKPOINT_REF_PREFIX}${checkpointId}`;
+  const exists = await refExists(git, refName);
+  if (!exists) {
+    throw new Error(`Checkpoint not found: ${checkpointId}`);
+  }
+  await git.raw(["update-ref", "-d", refName]);
+}

--- a/packages/git/vitest.config.ts
+++ b/packages/git/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/.git/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -672,6 +672,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@25.2.0)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(terser@5.46.0)
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
This adds a checkpoint API to the git package. 

Three available operations:
- Checkpoint
- Restore from checkpoint
- Diff, two compare to checkpoint states

They’re stored as Git refs under: `refs/twig-checkpoint/<checkpointId>`

Checkpoint ids are either user provided or randomly generated.

We will use this for:
- Rolling back agent state
- Archiving chats
- Handing off to local repository from worktrees and cloud