### PR TITLE
refactor(agent): remove OTEL write path from SessionLogWriter

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -32,24 +32,11 @@ export class Agent {
       this.posthogAPI = new PostHogAPIClient(config.posthog);
     }
 
-    if (!config.skipLogPersistence) {
-      if (config.otelTransport) {
-        // OTEL pipeline: use OtelLogWriter only (no S3 writer)
-        this.sessionLogWriter = new SessionLogWriter({
-          otelConfig: {
-            posthogHost: config.otelTransport.host,
-            apiKey: config.otelTransport.apiKey,
-            logsPath: config.otelTransport.logsPath,
-          },
-          logger: this.logger.child("SessionLogWriter"),
-        });
-      } else if (config.posthog) {
-        // Legacy: use S3 writer via PostHog API
-        this.sessionLogWriter = new SessionLogWriter({
-          posthogAPI: this.posthogAPI,
-          logger: this.logger.child("SessionLogWriter"),
-        });
-      }
+    if (config.posthog && !config.skipLogPersistence) {
+      this.sessionLogWriter = new SessionLogWriter({
+        posthogAPI: this.posthogAPI,
+        logger: this.logger.child("SessionLogWriter"),
+      });
     }
   }
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -464,18 +464,14 @@ export class AgentServer {
       logger: new Logger({ debug: true, prefix: "[TreeTracker]" }),
     });
 
-    const _posthogAPI = new PostHogAPIClient({
+    const posthogAPI = new PostHogAPIClient({
       apiUrl: this.config.apiUrl,
       projectId: this.config.projectId,
       getApiKey: () => this.config.apiKey,
     });
 
     const logWriter = new SessionLogWriter({
-      otelConfig: {
-        posthogHost: this.config.apiUrl,
-        apiKey: this.config.apiKey,
-        logsPath: "/i/v1/agent-logs",
-      },
+      posthogAPI,
       logger: new Logger({ debug: true, prefix: "[SessionLogWriter]" }),
     });
 


### PR DESCRIPTION
Remove the OTEL transport path from `SessionLogWriter`, keeping only the S3 write path