### PR TITLE
feat: signal to task

### DIFF
--- a/apps/twig/src/renderer/features/inbox/utils/buildSignalTaskPrompt.ts
+++ b/apps/twig/src/renderer/features/inbox/utils/buildSignalTaskPrompt.ts
@@ -1,0 +1,42 @@
+import type { SignalReport, SignalReportArtefact } from "@shared/types";
+
+export interface SignalPromptInput {
+  report: SignalReport;
+  artefacts: SignalReportArtefact[];
+  replayBaseUrl: string | null;
+}
+
+export function buildSignalTaskPrompt({
+  report,
+  artefacts,
+  replayBaseUrl,
+}: SignalPromptInput): string {
+  const title = report.title ?? "Untitled signal";
+  const summary = report.summary ?? "No summary available.";
+
+  const lines: string[] = [
+    `# Investigate: ${title}`,
+    "",
+    "## Summary",
+    "",
+    summary,
+    "",
+    `**Signal strength:** ${report.signal_count} occurrences, ${report.relevant_user_count ?? 0} affected users`,
+  ];
+
+  if (artefacts.length > 0) {
+    lines.push("", "## Evidence");
+
+    for (const artefact of artefacts) {
+      const timestamp = new Date(artefact.content.start_time).toLocaleString();
+      lines.push("", `### Session ${timestamp}`, "", artefact.content.content);
+      if (replayBaseUrl) {
+        lines.push(
+          `[View replay](${replayBaseUrl}/${artefact.content.session_id})`,
+        );
+      }
+    }
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
### TL;DR

Replace "Run signal" functionality with "Create task" that generates a structured prompt from signal data.

### What changed?

- Replaced the "Run" and "Run with context" buttons with a single "Create task" button
- Added a new utility function `buildSignalTaskPrompt` that formats signal data into a structured markdown prompt
- When clicking "Create task", the app now:
  - Generates a formatted prompt with signal information, evidence, and replay links
  - Sets this content in the task input draft
  - Navigates the user to the task input screen
- Removed all code related to the manual context input and dropdown menu