### PR TITLE
feat: cloud pr flow

### DIFF
--- a/apps/twig/src/renderer/features/sidebar/components/items/TaskItem.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/items/TaskItem.tsx
@@ -3,6 +3,7 @@ import { Tooltip } from "@components/ui/Tooltip";
 import {
   ArrowsClockwise,
   BellRinging,
+  Cloud as CloudIcon,
   GitBranch as GitBranchIcon,
   Laptop as LaptopIcon,
   PushPin,
@@ -139,6 +140,12 @@ export function TaskItem({
         </span>
       </Tooltip>
     )
+  ) : workspaceMode === "cloud" ? (
+    <Tooltip content="Cloud" side="right">
+      <span className="flex items-center justify-center">
+        <CloudIcon size={ICON_SIZE} />
+      </span>
+    </Tooltip>
   ) : (
     <Tooltip content="Local" side="right">
       <span className="flex items-center justify-center">

--- a/apps/twig/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -72,6 +72,9 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
     if (isConnecting.current) return;
     if (!isOnline) return;
 
+    // Cloud tasks are handled by the sandbox
+    if (workspace?.mode === "cloud") return;
+
     if (
       session?.status === "connected" ||
       session?.status === "connecting" ||
@@ -106,7 +109,7 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
       .finally(() => {
         isConnecting.current = false;
       });
-  }, [task, repoPath, session, markActivity, isOnline]);
+  }, [task, repoPath, session, markActivity, isOnline, workspace?.mode]);
 
   const handleSendPrompt = useCallback(
     async (text: string) => {
@@ -201,7 +204,9 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
     async (command: string) => {
       if (!repoPath) return;
 
-      const execId = `user-shell-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const execId = `user-shell-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 9)}`;
       await getSessionService().startUserShellExecute(
         taskId,
         execId,

--- a/apps/twig/src/renderer/sagas/task/task-creation.ts
+++ b/apps/twig/src/renderer/sagas/task/task-creation.ts
@@ -173,12 +173,14 @@ export class TaskCreationSaga extends Saga<
     }
 
     // Step 6: Connect to session
+    // Cloud create: skip local session — the sandbox handles execution
     const agentCwd =
       workspace?.worktreePath ?? workspace?.folderPath ?? repoPath;
+    const isCloudCreate = !input.taskId && workspaceMode === "cloud";
     const shouldConnect =
-      !!input.taskId || // Open: always connect to load chat history
-      workspaceMode === "cloud" || // Cloud create: always connect
-      !!agentCwd; // Local create: always connect if we have a cwd
+      !isCloudCreate &&
+      (!!input.taskId || // Open: always connect to load chat history
+        !!agentCwd); // Local create: always connect if we have a cwd
 
     if (shouldConnect) {
       const initialPrompt =


### PR DESCRIPTION
Cloud task commits, pushes, and creates a PR after completing work.
  - Detects PR URLs from Bash tool output and attaches them to the task run (picked up by Slack notifications automatically)
  - Sets task run to in_progress on session init so the PostHog UI polls for updates
  - Fixes duplicate run creation that caused cloud tasks to show "Not started" forever
  - Adds cloud icon in the sidebar for cloud-mode tasks

  Bug fix: duplicate task run creation for cloud tasks

Bonus: fixed race condition of two code paths that resulted in two task runs per cloud task:
  1. cloud run (correct), executed in the sandbox, completed successfully with a PR URL
  2. local run (orphan), no bueno

https://github.com/user-attachments/assets/410bc2bb-0269-40d9-9cec-fd44f5929932


**Note**: tested this via Docker sandbox locally since will need to pin new sandbox base image once this gets in.