### PR TITLE
feat: add notification id to each acp log

### DIFF
--- a/packages/agent/src/adapters/acp-connection.ts
+++ b/packages/agent/src/adapters/acp-connection.ts
@@ -5,6 +5,7 @@ import type { ProcessSpawnedCallback } from "../types.js";
 import { Logger } from "../utils/logger.js";
 import {
   createBidirectionalStreams,
+  createNotificationIdInjectorStream,
   createTappedWritableStream,
   nodeReadableToWebReadable,
   nodeWritableToWebWritable,
@@ -158,7 +159,8 @@ function createClaudeConnection(config: AcpConnectionConfig): AcpConnection {
 
   const { logWriter } = config;
 
-  let agentWritable = streams.agent.writable;
+  let agentWritable: globalThis.WritableStream<Uint8Array> =
+    streams.agent.writable;
   let clientWritable = streams.client.writable;
 
   if (config.taskRunId && logWriter) {
@@ -190,6 +192,8 @@ function createClaudeConnection(config: AcpConnectionConfig): AcpConnection {
       hasLogWriter: !!logWriter,
     });
   }
+
+  agentWritable = createNotificationIdInjectorStream(agentWritable, { logger });
 
   const agentStream = ndJsonStream(agentWritable, streams.agent.readable);
 

--- a/packages/agent/src/utils/streams.ts
+++ b/packages/agent/src/utils/streams.ts
@@ -1,5 +1,6 @@
 import type { Readable, Writable } from "node:stream";
 import { ReadableStream, WritableStream } from "node:stream/web";
+import { v7 as uuidv7 } from "uuid";
 import type { Logger } from "./logger.js";
 
 export class Pushable<T> implements AsyncIterable<T> {
@@ -217,4 +218,111 @@ export function nodeWritableToWebWritable(
       );
     },
   }) as globalThis.WritableStream<Uint8Array>;
+}
+
+type SessionUpdateMessage = {
+  method?: string;
+  params?: {
+    _meta?: Record<string, unknown> | null;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+function injectNotificationId(msg: SessionUpdateMessage): SessionUpdateMessage {
+  if (msg.method !== "session/update" || !msg.params) {
+    return msg;
+  }
+
+  const existingMeta = msg.params._meta ?? {};
+  return {
+    ...msg,
+    params: {
+      ...msg.params,
+      _meta: {
+        ...existingMeta,
+        notificationId: uuidv7(),
+      },
+    },
+  };
+}
+
+export function createNotificationIdInjectorStream(
+  underlying: globalThis.WritableStream<Uint8Array>,
+  options?: { logger?: Logger },
+): globalThis.WritableStream<Uint8Array> {
+  const { logger } = options ?? {};
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+
+  return new WritableStream({
+    async write(chunk: Uint8Array) {
+      buffer += decoder.decode(chunk, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      const outputLines: string[] = [];
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          outputLines.push(line);
+          continue;
+        }
+
+        try {
+          const msg = JSON.parse(trimmed) as SessionUpdateMessage;
+          const transformed = injectNotificationId(msg);
+          outputLines.push(JSON.stringify(transformed));
+        } catch {
+          outputLines.push(line);
+        }
+      }
+
+      if (outputLines.length > 0) {
+        const output = `${outputLines.join("\n")}\n`;
+        try {
+          const writer = underlying.getWriter();
+          await writer.write(encoder.encode(output));
+          writer.releaseLock();
+        } catch (err) {
+          logger?.error("Notification ID injector write error", err);
+        }
+      }
+    },
+    async close() {
+      if (buffer.trim()) {
+        try {
+          const msg = JSON.parse(buffer.trim()) as SessionUpdateMessage;
+          const transformed = injectNotificationId(msg);
+          const writer = underlying.getWriter();
+          await writer.write(
+            encoder.encode(`${JSON.stringify(transformed)}\n`),
+          );
+          writer.releaseLock();
+        } catch {
+          const writer = underlying.getWriter();
+          await writer.write(encoder.encode(buffer));
+          writer.releaseLock();
+        }
+      }
+      try {
+        const writer = underlying.getWriter();
+        await writer.close();
+        writer.releaseLock();
+      } catch {
+        // Stream may already be closed
+      }
+    },
+    async abort(reason: unknown) {
+      logger?.warn("Notification ID injector stream aborted", { reason });
+      try {
+        const writer = underlying.getWriter();
+        await writer.abort(reason);
+        writer.releaseLock();
+      } catch {
+        // Stream may already be closed
+      }
+    },
+  });
 }


### PR DESCRIPTION

Added unique notification IDs to session update messages, we'll need this for rolling back to a certain checkpoint.

