### PR TITLE
feat(cloud): cloud task service & rendering

### DIFF
--- a/apps/twig/src/api/posthogClient.ts
+++ b/apps/twig/src/api/posthogClient.ts
@@ -354,7 +354,7 @@ export class PostHogAPIClient {
           task_id: taskId,
           id: runId,
         },
-        body: updates,
+        body: updates as Record<string, unknown>,
       },
     );
     return data as unknown as TaskRun;
@@ -380,6 +380,40 @@ export class PostHogAPIClient {
     });
     if (!response.ok) {
       throw new Error(`Failed to append log: ${response.statusText}`);
+    }
+  }
+
+  async getTaskRunSessionLogs(
+    taskId: string,
+    runId: string,
+    options?: { limit?: number; after?: string },
+  ): Promise<StoredLogEntry[]> {
+    try {
+      const teamId = await this.getTeamId();
+      const url = new URL(
+        `${this.api.baseUrl}/api/projects/${teamId}/tasks/${taskId}/runs/${runId}/session_logs/`,
+      );
+      url.searchParams.set("limit", String(options?.limit ?? 5000));
+      if (options?.after) {
+        url.searchParams.set("after", options.after);
+      }
+      const response = await this.api.fetcher.fetch({
+        method: "get",
+        url,
+        path: `/api/projects/${teamId}/tasks/${taskId}/runs/${runId}/session_logs/`,
+      });
+
+      if (!response.ok) {
+        log.warn(
+          `Failed to fetch session logs: ${response.status} ${response.statusText}`,
+        );
+        return [];
+      }
+
+      return (await response.json()) as StoredLogEntry[];
+    } catch (err) {
+      log.warn("Failed to fetch task run session logs", err);
+      return [];
     }
   }
 

--- a/apps/twig/src/main/di/container.ts
+++ b/apps/twig/src/main/di/container.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { Container } from "inversify";
 import { AgentService } from "../services/agent/service.js";
 import { AppLifecycleService } from "../services/app-lifecycle/service.js";
+import { CloudTaskService } from "../services/cloud-task/service.js";
 import { ConnectivityService } from "../services/connectivity/service.js";
 import { ContextMenuService } from "../services/context-menu/service.js";
 import { DeepLinkService } from "../services/deep-link/service.js";
@@ -32,6 +33,7 @@ export const container = new Container({
 
 container.bind(MAIN_TOKENS.AgentService).to(AgentService);
 container.bind(MAIN_TOKENS.AppLifecycleService).to(AppLifecycleService);
+container.bind(MAIN_TOKENS.CloudTaskService).to(CloudTaskService);
 container.bind(MAIN_TOKENS.ConnectivityService).to(ConnectivityService);
 container.bind(MAIN_TOKENS.ContextMenuService).to(ContextMenuService);
 container.bind(MAIN_TOKENS.DeepLinkService).to(DeepLinkService);

--- a/apps/twig/src/main/di/tokens.ts
+++ b/apps/twig/src/main/di/tokens.ts
@@ -8,6 +8,7 @@ export const MAIN_TOKENS = Object.freeze({
   // Services
   AgentService: Symbol.for("Main.AgentService"),
   AppLifecycleService: Symbol.for("Main.AppLifecycleService"),
+  CloudTaskService: Symbol.for("Main.CloudTaskService"),
   ConnectivityService: Symbol.for("Main.ConnectivityService"),
   ContextMenuService: Symbol.for("Main.ContextMenuService"),
 

--- a/apps/twig/src/main/services/cloud-task/schemas.ts
+++ b/apps/twig/src/main/services/cloud-task/schemas.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { CloudTaskUpdatePayload, TaskRun } from "../../../shared/types.js";
+
+export type { CloudTaskUpdatePayload };
+
+// --- Terminal statuses ---
+
+export const TERMINAL_STATUSES = ["completed", "failed", "cancelled"] as const;
+
+// --- Events ---
+
+export const CloudTaskEvent = {
+  Update: "cloud-task-update",
+} as const;
+
+export interface CloudTaskEvents {
+  [CloudTaskEvent.Update]: CloudTaskUpdatePayload;
+}
+
+export type TaskRunStatus = TaskRun["status"];
+
+// --- tRPC Schemas ---
+
+export const watchInput = z.object({
+  taskId: z.string(),
+  runId: z.string(),
+  apiHost: z.string(),
+  teamId: z.number(),
+});
+
+export type WatchInput = z.infer<typeof watchInput>;
+
+export const unwatchInput = z.object({
+  taskId: z.string(),
+  runId: z.string(),
+});
+
+export const updateTokenInput = z.object({
+  token: z.string(),
+});
+
+export const onUpdateInput = z.object({
+  taskId: z.string(),
+  runId: z.string(),
+});

--- a/apps/twig/src/main/services/cloud-task/service.ts
+++ b/apps/twig/src/main/services/cloud-task/service.ts
@@ -1,0 +1,453 @@
+import { net } from "electron";
+import { injectable, preDestroy } from "inversify";
+import type { StoredLogEntry } from "../../../shared/types/session-events.js";
+import { logger } from "../../lib/logger.js";
+import { TypedEventEmitter } from "../../lib/typed-event-emitter.js";
+import {
+  CloudTaskEvent,
+  type CloudTaskEvents,
+  type TaskRunStatus,
+  TERMINAL_STATUSES,
+  type WatchInput,
+} from "./schemas.js";
+
+const log = logger.scope("cloud-task");
+
+const LOG_POLL_INTERVAL_MS = 5_000;
+const STATUS_POLL_INTERVAL_MS = 10_000;
+
+interface TaskRunResponse {
+  id: string;
+  status: TaskRunStatus;
+  stage?: string | null;
+  output?: Record<string, unknown> | null;
+  error_message?: string | null;
+  branch?: string | null;
+}
+
+interface WatcherState {
+  taskId: string;
+  runId: string;
+  apiHost: string;
+  teamId: number;
+  pollTimeoutId: ReturnType<typeof setTimeout> | null;
+  processedLogCount: number;
+  lastLogCursor: string | null;
+  lastCursorSeenCount: number;
+  lastStatus: TaskRunStatus | null;
+  lastStage: string | null;
+  lastOutput: Record<string, unknown> | null;
+  lastErrorMessage: string | null;
+  lastBranch: string | null;
+  lastStatusPollTime: number;
+  subscriberCount: number;
+}
+
+interface PendingWatchState {
+  input: WatchInput;
+  subscriberCount: number;
+}
+
+function watcherKey(taskId: string, runId: string): string {
+  return `${taskId}:${runId}`;
+}
+
+@injectable()
+export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
+  private watchers = new Map<string, WatcherState>();
+  private pendingWatches = new Map<string, PendingWatchState>();
+  private apiKey: string | null = null;
+
+  watch(input: WatchInput): void {
+    const key = watcherKey(input.taskId, input.runId);
+
+    // If watcher already exists, increment subscriber count
+    const existing = this.watchers.get(key);
+    if (existing) {
+      existing.subscriberCount++;
+      log.info("Cloud task watcher subscriber added", {
+        key,
+        subscribers: existing.subscriberCount,
+      });
+      return;
+    }
+
+    // If no token yet, queue (deduplicated by key)
+    if (!this.apiKey) {
+      const pending = this.pendingWatches.get(key);
+      if (pending) {
+        pending.subscriberCount++;
+      } else {
+        this.pendingWatches.set(key, { input, subscriberCount: 1 });
+      }
+      log.info("Cloud task watch queued (no token yet)", { key });
+      return;
+    }
+
+    this.startWatcher(input, 1);
+  }
+
+  unwatch(taskId: string, runId: string): void {
+    const key = watcherKey(taskId, runId);
+    const watcher = this.watchers.get(key);
+    if (!watcher) {
+      const pending = this.pendingWatches.get(key);
+      if (!pending) return;
+
+      pending.subscriberCount--;
+      if (pending.subscriberCount <= 0) {
+        this.pendingWatches.delete(key);
+      }
+      return;
+    }
+
+    watcher.subscriberCount--;
+    if (watcher.subscriberCount <= 0) {
+      this.stopWatcher(key);
+    } else {
+      log.info("Cloud task watcher subscriber removed", {
+        key,
+        subscribers: watcher.subscriberCount,
+      });
+    }
+  }
+
+  updateToken(token: string): void {
+    this.apiKey = token;
+
+    // Drain pending watches
+    if (this.pendingWatches.size > 0) {
+      const pending = [...this.pendingWatches.values()];
+      this.pendingWatches.clear();
+      for (const queued of pending) {
+        this.startWatcher(queued.input, queued.subscriberCount);
+      }
+      log.info("Drained pending cloud task watches", {
+        count: pending.length,
+      });
+    }
+  }
+
+  @preDestroy()
+  unwatchAll(): void {
+    for (const key of [...this.watchers.keys()]) {
+      this.stopWatcher(key);
+    }
+    this.pendingWatches.clear();
+  }
+
+  // --- Private ---
+
+  private startWatcher(input: WatchInput, subscriberCount: number): void {
+    const key = watcherKey(input.taskId, input.runId);
+
+    const watcher: WatcherState = {
+      taskId: input.taskId,
+      runId: input.runId,
+      apiHost: input.apiHost,
+      teamId: input.teamId,
+      pollTimeoutId: null,
+      processedLogCount: 0,
+      lastLogCursor: null,
+      lastCursorSeenCount: 0,
+      lastStatus: null,
+      lastStage: null,
+      lastOutput: null,
+      lastErrorMessage: null,
+      lastBranch: null,
+      lastStatusPollTime: 0,
+      subscriberCount,
+    };
+
+    this.watchers.set(key, watcher);
+    log.info("Cloud task watcher started", { key });
+
+    // Immediate first poll (snapshot)
+    this.poll(key, true);
+  }
+
+  private stopWatcher(key: string): void {
+    const watcher = this.watchers.get(key);
+    if (!watcher) return;
+
+    if (watcher.pollTimeoutId) {
+      clearTimeout(watcher.pollTimeoutId);
+      watcher.pollTimeoutId = null;
+    }
+
+    this.watchers.delete(key);
+    log.info("Cloud task watcher stopped", { key });
+  }
+
+  private schedulePoll(key: string): void {
+    const watcher = this.watchers.get(key);
+    if (!watcher) return;
+
+    watcher.pollTimeoutId = setTimeout(() => {
+      watcher.pollTimeoutId = null;
+      this.poll(key, false);
+    }, LOG_POLL_INTERVAL_MS);
+  }
+
+  private async poll(key: string, isSnapshot: boolean): Promise<void> {
+    const watcher = this.watchers.get(key);
+    if (!watcher || !this.apiKey) return;
+
+    try {
+      // Always fetch logs
+      const logResult = await this.fetchLogs(watcher);
+
+      // Fetch status if snapshot or interval elapsed
+      const now = Date.now();
+      const shouldFetchStatus =
+        isSnapshot ||
+        now - watcher.lastStatusPollTime >= STATUS_POLL_INTERVAL_MS;
+
+      let statusResult: TaskRunResponse | null = null;
+      let statusChanged = false;
+
+      if (shouldFetchStatus) {
+        statusResult = await this.fetchRunStatus(watcher);
+        watcher.lastStatusPollTime = now;
+
+        if (statusResult) {
+          statusChanged =
+            statusResult.status !== watcher.lastStatus ||
+            statusResult.stage !== watcher.lastStage ||
+            JSON.stringify(statusResult.output) !==
+              JSON.stringify(watcher.lastOutput) ||
+            statusResult.error_message !== watcher.lastErrorMessage ||
+            statusResult.branch !== watcher.lastBranch;
+
+          if (statusChanged) {
+            watcher.lastStatus = statusResult.status;
+            watcher.lastStage = statusResult.stage ?? null;
+            watcher.lastOutput = statusResult.output ?? null;
+            watcher.lastErrorMessage = statusResult.error_message ?? null;
+            watcher.lastBranch = statusResult.branch ?? null;
+          }
+        }
+      }
+
+      // Determine kind and whether to emit
+      const hasNewLogs = logResult.newEntries.length > 0;
+      const hasStatusUpdate = statusChanged && statusResult;
+
+      if (isSnapshot) {
+        // Always emit snapshot on first poll, even if empty
+        this.emit(CloudTaskEvent.Update, {
+          taskId: watcher.taskId,
+          runId: watcher.runId,
+          kind: "snapshot",
+          newEntries: logResult.newEntries,
+          totalEntryCount: watcher.processedLogCount,
+          status: statusResult?.status ?? watcher.lastStatus ?? undefined,
+          stage: statusResult?.stage ?? watcher.lastStage,
+          output: statusResult?.output ?? watcher.lastOutput,
+          errorMessage: statusResult?.error_message ?? watcher.lastErrorMessage,
+          branch: statusResult?.branch ?? watcher.lastBranch,
+        });
+      } else {
+        if (hasNewLogs && hasStatusUpdate && statusResult) {
+          // Both changed — emit snapshot
+          this.emit(CloudTaskEvent.Update, {
+            taskId: watcher.taskId,
+            runId: watcher.runId,
+            kind: "snapshot",
+            newEntries: logResult.newEntries,
+            totalEntryCount: watcher.processedLogCount,
+            status: statusResult.status,
+            stage: statusResult.stage ?? null,
+            output: statusResult.output ?? null,
+            errorMessage: statusResult.error_message ?? null,
+            branch: statusResult.branch ?? null,
+          });
+        } else if (hasNewLogs) {
+          this.emit(CloudTaskEvent.Update, {
+            taskId: watcher.taskId,
+            runId: watcher.runId,
+            kind: "logs",
+            newEntries: logResult.newEntries,
+            totalEntryCount: watcher.processedLogCount,
+          });
+        } else if (hasStatusUpdate && statusResult) {
+          this.emit(CloudTaskEvent.Update, {
+            taskId: watcher.taskId,
+            runId: watcher.runId,
+            kind: "status",
+            status: statusResult.status,
+            stage: statusResult.stage ?? null,
+            output: statusResult.output ?? null,
+            errorMessage: statusResult.error_message ?? null,
+            branch: statusResult.branch ?? null,
+          });
+        }
+      }
+
+      // Check for terminal status
+      const currentStatus = watcher.lastStatus;
+      if (
+        currentStatus &&
+        TERMINAL_STATUSES.includes(
+          currentStatus as (typeof TERMINAL_STATUSES)[number],
+        )
+      ) {
+        // The regular poll above already fetched logs and emitted any updates.
+        // Only emit a final status event if we did NOT already emit a status or
+        // snapshot update above, to ensure the renderer knows the run is terminal.
+        if (!hasStatusUpdate && !isSnapshot) {
+          this.emit(CloudTaskEvent.Update, {
+            taskId: watcher.taskId,
+            runId: watcher.runId,
+            kind: "status",
+            status: watcher.lastStatus ?? undefined,
+            stage: watcher.lastStage,
+            output: watcher.lastOutput,
+            errorMessage: watcher.lastErrorMessage,
+            branch: watcher.lastBranch,
+          });
+        }
+
+        log.info("Cloud task reached terminal status", {
+          key,
+          status: currentStatus,
+        });
+        this.stopWatcher(key);
+        return;
+      }
+    } catch (error) {
+      log.warn("Cloud task poll error", { key, error });
+    }
+
+    // Schedule next poll (only if watcher still exists)
+    if (this.watchers.has(key)) {
+      this.schedulePoll(key);
+    }
+  }
+
+  private async fetchLogs(
+    watcher: WatcherState,
+  ): Promise<{ newEntries: StoredLogEntry[] }> {
+    const url = new URL(
+      `${watcher.apiHost}/api/projects/${watcher.teamId}/tasks/${watcher.taskId}/runs/${watcher.runId}/session_logs/`,
+    );
+    url.searchParams.set("limit", "5000");
+    if (watcher.lastLogCursor) {
+      url.searchParams.set("after", watcher.lastLogCursor);
+    }
+
+    try {
+      const response = await net.fetch(url.toString(), {
+        method: "GET",
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      });
+
+      if (!response.ok) {
+        log.warn("Cloud task log fetch failed", {
+          status: response.status,
+          taskId: watcher.taskId,
+        });
+        return { newEntries: [] };
+      }
+
+      const entries = (await response.json()) as StoredLogEntry[];
+
+      if (entries.length === 0) {
+        return { newEntries: [] };
+      }
+
+      // Dedupe: skip entries we've already seen (guard against non-unique cursors)
+      const startIndex = this.findDedupeStartIndex(entries, watcher);
+      const newEntries = entries.slice(startIndex);
+
+      if (newEntries.length > 0) {
+        watcher.processedLogCount += newEntries.length;
+        // Update cursor to last entry's timestamp
+        const lastEntry = newEntries[newEntries.length - 1];
+        const lastTimestamp = lastEntry?.timestamp;
+        if (lastTimestamp) {
+          if (lastTimestamp === watcher.lastLogCursor) {
+            watcher.lastCursorSeenCount += newEntries.filter(
+              (entry) => entry.timestamp === lastTimestamp,
+            ).length;
+          } else {
+            watcher.lastLogCursor = lastTimestamp;
+            watcher.lastCursorSeenCount = newEntries.filter(
+              (entry) => entry.timestamp === lastTimestamp,
+            ).length;
+          }
+        }
+      }
+
+      return { newEntries };
+    } catch (error) {
+      log.warn("Cloud task log fetch error", {
+        taskId: watcher.taskId,
+        error,
+      });
+      return { newEntries: [] };
+    }
+  }
+
+  private findDedupeStartIndex(
+    entries: StoredLogEntry[],
+    watcher: WatcherState,
+  ): number {
+    // If no cursor, all entries are new
+    if (!watcher.lastLogCursor) return 0;
+
+    let seenAtCursor = 0;
+
+    // Skip entries before cursor, then skip already-seen entries at cursor
+    for (let i = 0; i < entries.length; i++) {
+      const ts = entries[i]?.timestamp;
+      if (!ts) {
+        return i;
+      }
+
+      if (ts < watcher.lastLogCursor) {
+        continue;
+      }
+
+      if (ts === watcher.lastLogCursor) {
+        seenAtCursor++;
+        if (seenAtCursor <= watcher.lastCursorSeenCount) {
+          continue;
+        }
+      }
+
+      return i;
+    }
+    // All entries are at or before cursor — nothing new
+    return entries.length;
+  }
+
+  private async fetchRunStatus(
+    watcher: WatcherState,
+  ): Promise<TaskRunResponse | null> {
+    const url = `${watcher.apiHost}/api/projects/${watcher.teamId}/tasks/${watcher.taskId}/runs/${watcher.runId}/`;
+
+    try {
+      const response = await net.fetch(url, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      });
+
+      if (!response.ok) {
+        log.warn("Cloud task status fetch failed", {
+          status: response.status,
+          taskId: watcher.taskId,
+        });
+        return null;
+      }
+
+      return (await response.json()) as TaskRunResponse;
+    } catch (error) {
+      log.warn("Cloud task status fetch error", {
+        taskId: watcher.taskId,
+        error,
+      });
+      return null;
+    }
+  }
+}

--- a/apps/twig/src/main/services/git/schemas.ts
+++ b/apps/twig/src/main/services/git/schemas.ts
@@ -282,6 +282,12 @@ export type GetCommitConventionsOutput = z.infer<
   typeof getCommitConventionsOutput
 >;
 
+// getPrChangedFiles schemas
+export const getPrChangedFilesInput = z.object({
+  prUrl: z.string(),
+});
+export const getPrChangedFilesOutput = z.array(changedFileSchema);
+
 export const generateCommitMessageInput = z.object({
   directoryPath: z.string(),
   credentials: z.object({

--- a/apps/twig/src/main/services/git/schemas.ts
+++ b/apps/twig/src/main/services/git/schemas.ts
@@ -288,6 +288,12 @@ export const getPrChangedFilesInput = z.object({
 });
 export const getPrChangedFilesOutput = z.array(changedFileSchema);
 
+export const getBranchChangedFilesInput = z.object({
+  repo: z.string(),
+  branch: z.string(),
+});
+export const getBranchChangedFilesOutput = z.array(changedFileSchema);
+
 export const generateCommitMessageInput = z.object({
   directoryPath: z.string(),
   credentials: z.object({

--- a/apps/twig/src/main/services/git/service.test.ts
+++ b/apps/twig/src/main/services/git/service.test.ts
@@ -115,13 +115,15 @@ describe("GitService.getPrChangedFiles", () => {
     expect(mockExecGh).not.toHaveBeenCalled();
   });
 
-  it("returns empty array when gh command fails", async () => {
-    mockExecGh.mockResolvedValue({ exitCode: 1, stdout: "" });
+  it("throws when gh command fails", async () => {
+    mockExecGh.mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "auth required",
+    });
 
-    const result = await service.getPrChangedFiles(
-      "https://github.com/posthog/twig/pull/123",
-    );
-
-    expect(result).toEqual([]);
+    await expect(
+      service.getPrChangedFiles("https://github.com/posthog/twig/pull/123"),
+    ).rejects.toThrow("Failed to fetch PR files");
   });
 });

--- a/apps/twig/src/main/services/git/service.test.ts
+++ b/apps/twig/src/main/services/git/service.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecGh = vi.hoisted(() => vi.fn());
+
+vi.mock("@twig/git/gh", () => ({
+  execGh: mockExecGh,
+}));
+
+vi.mock("../../lib/logger.js", () => ({
+  logger: {
+    scope: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+import type { LlmGatewayService } from "../llm-gateway/service.js";
+import { GitService } from "./service.js";
+
+describe("GitService.getPrChangedFiles", () => {
+  let service: GitService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitService({} as LlmGatewayService);
+  });
+
+  it("flattens paginated GH API results and maps file statuses", async () => {
+    mockExecGh.mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify([
+        [
+          {
+            filename: "src/new.ts",
+            status: "added",
+            additions: 10,
+            deletions: 0,
+          },
+          {
+            filename: "src/old.ts",
+            status: "removed",
+            additions: 0,
+            deletions: 3,
+          },
+        ],
+        [
+          {
+            filename: "src/renamed-new.ts",
+            status: "renamed",
+            previous_filename: "src/renamed-old.ts",
+            additions: 1,
+            deletions: 1,
+          },
+          {
+            filename: "src/changed.ts",
+            status: "changed",
+            additions: 4,
+            deletions: 2,
+          },
+        ],
+      ]),
+    });
+
+    const result = await service.getPrChangedFiles(
+      "https://github.com/posthog/twig/pull/123",
+    );
+
+    expect(mockExecGh).toHaveBeenCalledWith([
+      "api",
+      "repos/posthog/twig/pulls/123/files",
+      "--paginate",
+      "--slurp",
+    ]);
+
+    expect(result).toEqual([
+      {
+        path: "src/new.ts",
+        status: "added",
+        originalPath: undefined,
+        linesAdded: 10,
+        linesRemoved: 0,
+      },
+      {
+        path: "src/old.ts",
+        status: "deleted",
+        originalPath: undefined,
+        linesAdded: 0,
+        linesRemoved: 3,
+      },
+      {
+        path: "src/renamed-new.ts",
+        status: "renamed",
+        originalPath: "src/renamed-old.ts",
+        linesAdded: 1,
+        linesRemoved: 1,
+      },
+      {
+        path: "src/changed.ts",
+        status: "modified",
+        originalPath: undefined,
+        linesAdded: 4,
+        linesRemoved: 2,
+      },
+    ]);
+  });
+
+  it("returns empty array for non-GitHub PR URL", async () => {
+    const result = await service.getPrChangedFiles(
+      "https://example.com/pull/1",
+    );
+    expect(result).toEqual([]);
+    expect(mockExecGh).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array when gh command fails", async () => {
+    mockExecGh.mockResolvedValue({ exitCode: 1, stdout: "" });
+
+    const result = await service.getPrChangedFiles(
+      "https://github.com/posthog/twig/pull/123",
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/twig/src/main/trpc/router.ts
+++ b/apps/twig/src/main/trpc/router.ts
@@ -1,5 +1,6 @@
 import { agentRouter } from "./routers/agent.js";
 import { analyticsRouter } from "./routers/analytics.js";
+import { cloudTaskRouter } from "./routers/cloud-task.js";
 import { connectivityRouter } from "./routers/connectivity.js";
 import { contextMenuRouter } from "./routers/context-menu.js";
 import { deepLinkRouter } from "./routers/deep-link.js";
@@ -28,6 +29,7 @@ import { router } from "./trpc.js";
 export const trpcRouter = router({
   agent: agentRouter,
   analytics: analyticsRouter,
+  cloudTask: cloudTaskRouter,
   connectivity: connectivityRouter,
   contextMenu: contextMenuRouter,
 

--- a/apps/twig/src/main/trpc/routers/cloud-task.ts
+++ b/apps/twig/src/main/trpc/routers/cloud-task.ts
@@ -1,0 +1,44 @@
+import { container } from "../../di/container.js";
+import { MAIN_TOKENS } from "../../di/tokens.js";
+import {
+  CloudTaskEvent,
+  onUpdateInput,
+  unwatchInput,
+  updateTokenInput,
+  watchInput,
+} from "../../services/cloud-task/schemas.js";
+import type { CloudTaskService } from "../../services/cloud-task/service.js";
+import { publicProcedure, router } from "../trpc.js";
+
+const getService = () =>
+  container.get<CloudTaskService>(MAIN_TOKENS.CloudTaskService);
+
+export const cloudTaskRouter = router({
+  watch: publicProcedure
+    .input(watchInput)
+    .mutation(({ input }) => getService().watch(input)),
+
+  unwatch: publicProcedure
+    .input(unwatchInput)
+    .mutation(({ input }) => getService().unwatch(input.taskId, input.runId)),
+
+  updateToken: publicProcedure
+    .input(updateTokenInput)
+    .mutation(({ input }) => getService().updateToken(input.token)),
+
+  onUpdate: publicProcedure
+    .input(onUpdateInput)
+    .subscription(async function* (opts) {
+      const service = getService();
+      for await (const data of service.toIterable(CloudTaskEvent.Update, {
+        signal: opts.signal,
+      })) {
+        if (
+          data.taskId === opts.input.taskId &&
+          data.runId === opts.input.runId
+        ) {
+          yield data;
+        }
+      }
+    }),
+});

--- a/apps/twig/src/main/trpc/routers/git.ts
+++ b/apps/twig/src/main/trpc/routers/git.ts
@@ -19,6 +19,8 @@ import {
   generatePrTitleAndBodyOutput,
   getAllBranchesInput,
   getAllBranchesOutput,
+  getBranchChangedFilesInput,
+  getBranchChangedFilesOutput,
   getChangedFilesHeadInput,
   getChangedFilesHeadOutput,
   getCommitConventionsInput,
@@ -260,6 +262,13 @@ export const gitRouter = router({
     .input(getPrChangedFilesInput)
     .output(getPrChangedFilesOutput)
     .query(({ input }) => getService().getPrChangedFiles(input.prUrl)),
+
+  getBranchChangedFiles: publicProcedure
+    .input(getBranchChangedFilesInput)
+    .output(getBranchChangedFilesOutput)
+    .query(({ input }) =>
+      getService().getBranchChangedFiles(input.repo, input.branch),
+    ),
 
   generateCommitMessage: publicProcedure
     .input(generateCommitMessageInput)

--- a/apps/twig/src/main/trpc/routers/git.ts
+++ b/apps/twig/src/main/trpc/routers/git.ts
@@ -36,6 +36,8 @@ import {
   getGitSyncStatusOutput,
   getLatestCommitInput,
   getLatestCommitOutput,
+  getPrChangedFilesInput,
+  getPrChangedFilesOutput,
   getPrTemplateInput,
   getPrTemplateOutput,
   ghStatusOutput,
@@ -253,6 +255,11 @@ export const gitRouter = router({
     .query(({ input }) =>
       getService().getCommitConventions(input.directoryPath, input.sampleSize),
     ),
+
+  getPrChangedFiles: publicProcedure
+    .input(getPrChangedFilesInput)
+    .output(getPrChangedFilesOutput)
+    .query(({ input }) => getService().getPrChangedFiles(input.prUrl)),
 
   generateCommitMessage: publicProcedure
     .input(generateCommitMessageInput)

--- a/apps/twig/src/renderer/components/HeaderRow.tsx
+++ b/apps/twig/src/renderer/components/HeaderRow.tsx
@@ -3,6 +3,7 @@ import { RightSidebarTrigger } from "@features/right-sidebar/components/RightSid
 import { useRightSidebarStore } from "@features/right-sidebar/stores/rightSidebarStore";
 import { SidebarTrigger } from "@features/sidebar/components/SidebarTrigger";
 import { useSidebarStore } from "@features/sidebar/stores/sidebarStore";
+import { useWorkspaceStore } from "@features/workspace/stores/workspaceStore";
 import { Box, Flex } from "@radix-ui/themes";
 import { useHeaderStore } from "@stores/headerStore";
 import { useNavigationStore } from "@stores/navigationStore";
@@ -28,6 +29,11 @@ export function HeaderRow() {
     (state) => state.setIsResizing,
   );
 
+  const activeTaskId = view.type === "task-detail" ? view.data?.id : undefined;
+  const activeWorkspace = useWorkspaceStore((s) =>
+    activeTaskId ? s.workspaces[activeTaskId] : undefined,
+  );
+  const isCloudTask = activeWorkspace?.mode === "cloud";
   const showRightSidebarSection = view.type === "task-detail";
 
   const handleLeftSidebarMouseDown = (e: React.MouseEvent) => {
@@ -119,7 +125,7 @@ export function HeaderRow() {
           }}
         >
           <RightSidebarTrigger />
-          <GitInteractionHeader taskId={view.data.id} />
+          {!isCloudTask && <GitInteractionHeader taskId={view.data.id} />}
           {rightSidebarOpen && (
             <Box
               onMouseDown={handleRightSidebarMouseDown}

--- a/apps/twig/src/renderer/features/auth/stores/authStore.ts
+++ b/apps/twig/src/renderer/features/auth/stores/authStore.ts
@@ -167,6 +167,11 @@ export const useAuthStore = create<AuthState>()(
             trpcVanilla.agent.updateToken
               .mutate({ token: tokenResponse.access_token })
               .catch((err) => log.warn("Failed to update agent token", err));
+            trpcVanilla.cloudTask.updateToken
+              .mutate({ token: tokenResponse.access_token })
+              .catch((err) =>
+                log.warn("Failed to update cloud task token", err),
+              );
 
             // Clear any cached data from previous sessions AFTER setting new auth
             queryClient.clear();
@@ -306,6 +311,11 @@ export const useAuthStore = create<AuthState>()(
                   .mutate({ token: tokenResponse.access_token })
                   .catch((err) =>
                     log.warn("Failed to update agent token", err),
+                  );
+                trpcVanilla.cloudTask.updateToken
+                  .mutate({ token: tokenResponse.access_token })
+                  .catch((err) =>
+                    log.warn("Failed to update cloud task token", err),
                   );
 
                 get().scheduleTokenRefresh();
@@ -472,6 +482,11 @@ export const useAuthStore = create<AuthState>()(
                   .catch((err) =>
                     log.warn("Failed to update agent token", err),
                   );
+                trpcVanilla.cloudTask.updateToken
+                  .mutate({ token: currentTokens.accessToken })
+                  .catch((err) =>
+                    log.warn("Failed to update cloud task token", err),
+                  );
 
                 get().scheduleTokenRefresh();
 
@@ -597,6 +612,11 @@ export const useAuthStore = create<AuthState>()(
             trpcVanilla.agent.updateToken
               .mutate({ token: tokenResponse.access_token })
               .catch((err) => log.warn("Failed to update agent token", err));
+            trpcVanilla.cloudTask.updateToken
+              .mutate({ token: tokenResponse.access_token })
+              .catch((err) =>
+                log.warn("Failed to update cloud task token", err),
+              );
 
             queryClient.clear();
 
@@ -697,6 +717,9 @@ export const useAuthStore = create<AuthState>()(
           trpcVanilla.agent.updateToken
             .mutate({ token: accessToken })
             .catch((err) => log.warn("Failed to update agent token", err));
+          trpcVanilla.cloudTask.updateToken
+            .mutate({ token: accessToken })
+            .catch((err) => log.warn("Failed to update cloud task token", err));
 
           track(ANALYTICS_EVENTS.USER_LOGGED_IN, {
             project_id: projectId.toString(),

--- a/apps/twig/src/renderer/features/git-interaction/hooks/useGitQueries.ts
+++ b/apps/twig/src/renderer/features/git-interaction/hooks/useGitQueries.ts
@@ -1,5 +1,4 @@
 import { trpcVanilla } from "@renderer/trpc";
-import type { ChangedFile } from "@shared/types";
 import { useQuery } from "@tanstack/react-query";
 
 const EMPTY_DIFF_STATS = { filesChanged: 0, linesAdded: 0, linesRemoved: 0 };
@@ -123,8 +122,6 @@ export function useGitQueries(repoPath?: string) {
   };
 }
 
-const EMPTY_FILES: ChangedFile[] = [];
-
 export function useCloudPrChangedFiles(prUrl: string | null) {
   return useQuery({
     queryKey: ["pr-changed-files", prUrl],
@@ -132,6 +129,24 @@ export function useCloudPrChangedFiles(prUrl: string | null) {
       trpcVanilla.git.getPrChangedFiles.query({ prUrl: prUrl as string }),
     enabled: !!prUrl,
     staleTime: 5 * 60_000,
-    placeholderData: EMPTY_FILES,
+    retry: 1,
+  });
+}
+
+export function useCloudBranchChangedFiles(
+  repo: string | null,
+  branch: string | null,
+) {
+  return useQuery({
+    queryKey: ["branch-changed-files", repo, branch],
+    queryFn: () =>
+      trpcVanilla.git.getBranchChangedFiles.query({
+        repo: repo as string,
+        branch: branch as string,
+      }),
+    enabled: !!repo && !!branch,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+    retry: 1,
   });
 }

--- a/apps/twig/src/renderer/features/git-interaction/hooks/useGitQueries.ts
+++ b/apps/twig/src/renderer/features/git-interaction/hooks/useGitQueries.ts
@@ -1,4 +1,5 @@
 import { trpcVanilla } from "@renderer/trpc";
+import type { ChangedFile } from "@shared/types";
 import { useQuery } from "@tanstack/react-query";
 
 const EMPTY_DIFF_STATS = { filesChanged: 0, linesAdded: 0, linesRemoved: 0 };
@@ -120,4 +121,17 @@ export function useGitQueries(repoPath?: string) {
     defaultBranch,
     isLoading: isRepoLoading || changesLoading || syncLoading,
   };
+}
+
+const EMPTY_FILES: ChangedFile[] = [];
+
+export function useCloudPrChangedFiles(prUrl: string | null) {
+  return useQuery({
+    queryKey: ["pr-changed-files", prUrl],
+    queryFn: () =>
+      trpcVanilla.git.getPrChangedFiles.query({ prUrl: prUrl as string }),
+    enabled: !!prUrl,
+    staleTime: 5 * 60_000,
+    placeholderData: EMPTY_FILES,
+  });
 }

--- a/apps/twig/src/renderer/features/panels/components/LeafNodeRenderer.tsx
+++ b/apps/twig/src/renderer/features/panels/components/LeafNodeRenderer.tsx
@@ -1,5 +1,9 @@
+import { Cloud as CloudIcon } from "@phosphor-icons/react";
+import { Flex, Text } from "@radix-ui/themes";
 import type { Task } from "@shared/types";
 import type React from "react";
+import { useMemo } from "react";
+import { useWorkspaceStore } from "@/renderer/features/workspace/stores/workspaceStore";
 import { useTabInjection } from "../hooks/usePanelLayoutHooks";
 import type { SplitDirection } from "../store/panelLayoutStore";
 import type { LeafPanel } from "../store/panelTypes";
@@ -44,6 +48,29 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
     closeTab,
   );
 
+  const workspace = useWorkspaceStore((s) => s.workspaces[taskId]);
+  const isCloud = workspace?.mode === "cloud";
+
+  const cloudEmptyState = useMemo(
+    () =>
+      isCloud ? (
+        <Flex
+          align="center"
+          justify="center"
+          height="100%"
+          style={{ backgroundColor: "var(--gray-2)" }}
+        >
+          <Flex direction="column" align="center" gap="2">
+            <CloudIcon size={24} className="text-gray-10" />
+            <Text size="2" color="gray">
+              Cloud runs are read-only
+            </Text>
+          </Flex>
+        </Flex>
+      ) : undefined,
+    [isCloud],
+  );
+
   const contentWithComponents = {
     ...node.content,
     tabs,
@@ -62,6 +89,7 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
       draggingTabPanelId={draggingTabPanelId}
       onAddTerminal={() => onAddTerminal(node.id)}
       onSplitPanel={(direction) => onSplitPanel(node.id, direction)}
+      emptyState={cloudEmptyState}
     />
   );
 };

--- a/apps/twig/src/renderer/features/panels/components/TabbedPanel.tsx
+++ b/apps/twig/src/renderer/features/panels/components/TabbedPanel.tsx
@@ -61,6 +61,7 @@ interface TabbedPanelProps {
   onAddTerminal?: () => void;
   onSplitPanel?: (direction: SplitDirection) => void;
   rightContent?: React.ReactNode;
+  emptyState?: React.ReactNode;
 }
 
 export const TabbedPanel: React.FC<TabbedPanelProps> = ({
@@ -76,6 +77,7 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
   onAddTerminal,
   onSplitPanel,
   rightContent,
+  emptyState,
 }) => {
   const activeTab = content.tabs.find((tab) => tab.id === content.activeTabId);
 
@@ -246,6 +248,8 @@ export const TabbedPanel: React.FC<TabbedPanelProps> = ({
       >
         {activeTab ? (
           activeTab.component
+        ) : emptyState ? (
+          emptyState
         ) : (
           <Flex
             align="center"

--- a/apps/twig/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/SessionView.tsx
@@ -47,6 +47,7 @@ interface SessionViewProps {
   onRetry?: () => void;
   onDelete?: () => void;
   isInitializing?: boolean;
+  readOnlyMessage?: string;
 }
 
 const DEFAULT_ERROR_MESSAGE =
@@ -67,6 +68,7 @@ export function SessionView({
   onRetry,
   onDelete,
   isInitializing = false,
+  readOnlyMessage,
 }: SessionViewProps) {
   const showRawLogs = useShowRawLogs();
   const { setShowRawLogs } = useSessionViewActions();
@@ -416,6 +418,22 @@ export function SessionView({
                       onSelect={handlePermissionSelect}
                       onCancel={handlePermissionCancel}
                     />
+                  </Box>
+                </Box>
+              ) : readOnlyMessage ? (
+                <Box className="border-gray-4 border-t">
+                  <Box className="mx-auto max-w-[750px] p-2">
+                    <Flex align="center" justify="center" py="3">
+                      <Text
+                        size="2"
+                        style={{
+                          color: "var(--gray-9)",
+                          fontFamily: "var(--font-mono)",
+                        }}
+                      >
+                        {readOnlyMessage}
+                      </Text>
+                    </Flex>
                   </Box>
                 </Box>
               ) : (

--- a/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/twig/src/renderer/features/sessions/stores/sessionStore.ts
@@ -21,6 +21,13 @@ export interface QueuedMessage {
   queuedAt: number;
 }
 
+export type TaskRunStatus =
+  | "started"
+  | "in_progress"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
 export interface AgentSession {
   taskRunId: string;
   taskId: string;
@@ -41,6 +48,16 @@ export interface AgentSession {
   configOptions?: SessionConfigOption[];
   pendingPermissions: Map<string, PermissionRequest>;
   messageQueue: QueuedMessage[];
+  /** Cloud task run status (only set for cloud sessions) */
+  cloudStatus?: TaskRunStatus;
+  /** Cloud task current stage */
+  cloudStage?: string | null;
+  /** Cloud task output (PR URL, commit SHA, etc.) */
+  cloudOutput?: Record<string, unknown> | null;
+  /** Cloud task error message */
+  cloudErrorMessage?: string | null;
+  /** Cloud task branch */
+  cloudBranch?: string | null;
 }
 
 // --- Config Option Helpers ---
@@ -224,6 +241,28 @@ export const sessionStoreSetters = {
           session.processedLineCount = newLineCount;
         }
       }
+    });
+  },
+
+  updateCloudStatus: (
+    taskRunId: string,
+    fields: {
+      status?: TaskRunStatus;
+      stage?: string | null;
+      output?: Record<string, unknown> | null;
+      errorMessage?: string | null;
+      branch?: string | null;
+    },
+  ) => {
+    useSessionStore.setState((state) => {
+      const session = state.sessions[taskRunId];
+      if (!session) return;
+      if (fields.status !== undefined) session.cloudStatus = fields.status;
+      if (fields.stage !== undefined) session.cloudStage = fields.stage;
+      if (fields.output !== undefined) session.cloudOutput = fields.output;
+      if (fields.errorMessage !== undefined)
+        session.cloudErrorMessage = fields.errorMessage;
+      if (fields.branch !== undefined) session.cloudBranch = fields.branch;
     });
   },
 

--- a/apps/twig/src/renderer/features/sidebar/components/SidebarSection.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/SidebarSection.tsx
@@ -77,17 +77,26 @@ export function SidebarSection({
           <span className="flex shrink-0 items-center gap-1 text-gray-10">
             {onNewTask && isHovered && (
               <Tooltip content={newTaskTooltip ?? "Start new task"} side="left">
-                <button
-                  type="button"
+                {/* biome-ignore lint/a11y/useSemanticElements: Cannot use button inside parent button (Collapsible.Trigger) */}
+                <span
+                  role="button"
+                  tabIndex={0}
                   className="flex h-[18px] w-[18px] items-center justify-center rounded-sm border-0 bg-transparent p-0 hover:bg-gray-3"
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
                     onNewTask();
                   }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onNewTask();
+                    }
+                  }}
                 >
                   <Plus size={12} />
-                </button>
+                </span>
               </Tooltip>
             )}
           </span>

--- a/apps/twig/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -99,6 +99,7 @@ function TaskRow({
       isUnread={task.isUnread}
       isPinned={task.isPinned}
       needsPermission={task.needsPermission}
+      taskRunStatus={task.taskRunStatus}
       timestamp={timestamp}
       onClick={onClick}
       onDoubleClick={onDoubleClick}

--- a/apps/twig/src/renderer/features/sidebar/components/items/TaskItem.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/items/TaskItem.tsx
@@ -24,6 +24,12 @@ interface TaskItemProps {
   isUnread?: boolean;
   isPinned?: boolean;
   needsPermission?: boolean;
+  taskRunStatus?:
+    | "started"
+    | "in_progress"
+    | "completed"
+    | "failed"
+    | "cancelled";
   timestamp?: number;
   isEditing?: boolean;
   onClick: () => void;
@@ -119,6 +125,53 @@ function TaskHoverToolbar({
 const ICON_SIZE = 12;
 const INDENT_SIZE = 8;
 
+function CloudStatusIcon({
+  taskRunStatus,
+}: {
+  taskRunStatus?: TaskItemProps["taskRunStatus"];
+}) {
+  if (taskRunStatus === "started" || taskRunStatus === "in_progress") {
+    return (
+      <Tooltip content="Cloud (running)" side="right">
+        <span className="relative flex items-center justify-center">
+          <CloudIcon size={ICON_SIZE} className="text-accent-11" />
+          <DotsCircleSpinner
+            size={8}
+            className="-right-0.5 -bottom-0.5 absolute text-accent-11"
+          />
+        </span>
+      </Tooltip>
+    );
+  }
+  if (taskRunStatus === "completed") {
+    return (
+      <Tooltip content="Cloud (completed)" side="right">
+        <span className="flex items-center justify-center">
+          <CloudIcon size={ICON_SIZE} weight="fill" className="text-green-11" />
+        </span>
+      </Tooltip>
+    );
+  }
+  if (taskRunStatus === "failed" || taskRunStatus === "cancelled") {
+    const label =
+      taskRunStatus === "cancelled" ? "Cloud (cancelled)" : "Cloud (failed)";
+    return (
+      <Tooltip content={label} side="right">
+        <span className="flex items-center justify-center">
+          <CloudIcon size={ICON_SIZE} weight="fill" className="text-red-11" />
+        </span>
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip content="Cloud" side="right">
+      <span className="flex items-center justify-center">
+        <CloudIcon size={ICON_SIZE} />
+      </span>
+    </Tooltip>
+  );
+}
+
 export function TaskItem({
   depth = 0,
   label,
@@ -129,6 +182,7 @@ export function TaskItem({
   isUnread,
   isPinned = false,
   needsPermission = false,
+  taskRunStatus,
   timestamp,
   isEditing = false,
   onClick,
@@ -144,6 +198,7 @@ export function TaskItem({
   );
 
   const isWorktreeTask = workspaceMode === "worktree";
+  const isCloudTask = workspaceMode === "cloud";
 
   const icon = needsPermission ? (
     <BellRinging size={ICON_SIZE} className="text-blue-11" />
@@ -155,6 +210,8 @@ export function TaskItem({
     </span>
   ) : isPinned ? (
     <PushPin size={ICON_SIZE} className="text-accent-11" />
+  ) : isCloudTask ? (
+    <CloudStatusIcon taskRunStatus={taskRunStatus} />
   ) : isWorktreeTask ? (
     isFocused ? (
       <Tooltip content="Worktree (syncing)" side="right">
@@ -173,12 +230,6 @@ export function TaskItem({
         </span>
       </Tooltip>
     )
-  ) : workspaceMode === "cloud" ? (
-    <Tooltip content="Cloud" side="right">
-      <span className="flex items-center justify-center">
-        <CloudIcon size={ICON_SIZE} />
-      </span>
-    </Tooltip>
   ) : (
     <Tooltip content="Local" side="right">
       <span className="flex items-center justify-center">

--- a/apps/twig/src/renderer/features/sidebar/hooks/useSidebarData.ts
+++ b/apps/twig/src/renderer/features/sidebar/hooks/useSidebarData.ts
@@ -26,6 +26,12 @@ export interface TaskData {
   isPinned: boolean;
   needsPermission: boolean;
   repository: TaskRepositoryInfo | null;
+  taskRunStatus?:
+    | "started"
+    | "in_progress"
+    | "completed"
+    | "failed"
+    | "cancelled";
 }
 
 export interface TaskGroup {
@@ -168,6 +174,7 @@ export function useSidebarData({
         isPinned: pinnedTaskIds.has(task.id),
         needsPermission: (session?.pendingPermissions?.size ?? 0) > 0,
         repository: getRepositoryInfo(task),
+        taskRunStatus: task.latest_run?.status,
       };
     });
   }, [allTasks, lastViewedAt, localActivityAt, pinnedTaskIds, sessionByTaskId]);

--- a/apps/twig/src/renderer/features/task-detail/components/TaskDetail.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/TaskDetail.tsx
@@ -28,7 +28,7 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
     return () => selectTask(null);
   }, [taskId, selectTask]);
 
-  useTaskData({ taskId, initialTask });
+  const { task } = useTaskData({ taskId, initialTask });
 
   const workspace = useWorkspaceStore((state) => state.workspaces[taskId]);
   const effectiveRepoPath = useCwd(taskId);
@@ -94,7 +94,7 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
 
   return (
     <Box height="100%">
-      <PanelLayout taskId={taskId} task={initialTask} />
+      <PanelLayout taskId={taskId} task={task} />
       <FilePicker
         open={filePickerOpen}
         onOpenChange={setFilePickerOpen}

--- a/apps/twig/src/shared/types.ts
+++ b/apps/twig/src/shared/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { StoredLogEntry } from "./types/session-events";
 
 // Execution mode schema and type - shared between main and renderer
 export const executionModeSchema = z.enum([
@@ -146,6 +147,23 @@ export interface TaskRun {
   created_at: string;
   updated_at: string;
   completed_at: string | null;
+}
+
+export type CloudTaskUpdateKind = "logs" | "status" | "snapshot";
+
+export interface CloudTaskUpdatePayload {
+  taskId: string;
+  runId: string;
+  kind: CloudTaskUpdateKind;
+  // Log fields (present when kind is "logs" or "snapshot")
+  newEntries?: StoredLogEntry[];
+  totalEntryCount?: number;
+  // Status fields (present when kind is "status" or "snapshot")
+  status?: TaskRun["status"];
+  stage?: string | null;
+  output?: Record<string, unknown> | null;
+  errorMessage?: string | null;
+  branch?: string | null;
 }
 
 // Mention types for editors

--- a/apps/twig/src/shared/types.ts
+++ b/apps/twig/src/shared/types.ts
@@ -138,7 +138,7 @@ export interface TaskRun {
   branch: string | null;
   stage?: string | null; // Current stage (e.g., 'research', 'plan', 'build')
   environment?: "local" | "cloud";
-  status: "started" | "in_progress" | "completed" | "failed";
+  status: "started" | "in_progress" | "completed" | "failed" | "cancelled";
   log_url: string;
   error_message: string | null;
   output: Record<string, unknown> | null; // Structured output (PR URL, commit SHA, etc.)

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -21,10 +21,15 @@ interface SessionState {
 }
 
 export class SessionLogWriter {
+  private static readonly FLUSH_DEBOUNCE_MS = 500;
+  private static readonly FLUSH_MAX_INTERVAL_MS = 5000;
+
   private posthogAPI?: PostHogAPIClient;
   private pendingEntries: Map<string, StoredNotification[]> = new Map();
   private flushTimeouts: Map<string, NodeJS.Timeout> = new Map();
+  private lastFlushAttemptTime: Map<string, number> = new Map();
   private sessions: Map<string, SessionState> = new Map();
+  private messageCounts: Map<string, number> = new Map();
   private logger: Logger;
 
   constructor(options: SessionLogWriterOptions = {}) {
@@ -35,8 +40,19 @@ export class SessionLogWriter {
   }
 
   async flushAll(): Promise<void> {
+    const sessionIds = [...this.sessions.keys()];
+    const pendingCounts = sessionIds.map((id) => ({
+      id,
+      pending: this.pendingEntries.get(id)?.length ?? 0,
+      messages: this.messageCounts.get(id) ?? 0,
+    }));
+    this.logger.info("flushAll called", {
+      sessions: sessionIds.length,
+      pending: pendingCounts,
+    });
+
     const flushPromises: Promise<void>[] = [];
-    for (const sessionId of this.sessions.keys()) {
+    for (const sessionId of sessionIds) {
       flushPromises.push(this.flush(sessionId));
     }
     await Promise.all(flushPromises);
@@ -47,7 +63,12 @@ export class SessionLogWriter {
       return;
     }
 
+    this.logger.info("Session registered", {
+      sessionId,
+      taskId: context.taskId,
+    });
     this.sessions.set(sessionId, { context });
+    this.lastFlushAttemptTime.set(sessionId, Date.now());
   }
 
   isRegistered(sessionId: string): boolean {
@@ -57,7 +78,16 @@ export class SessionLogWriter {
   appendRawLine(sessionId: string, line: string): void {
     const session = this.sessions.get(sessionId);
     if (!session) {
+      this.logger.warn("appendRawLine called for unregistered session", {
+        sessionId,
+      });
       return;
+    }
+
+    const count = (this.messageCounts.get(sessionId) ?? 0) + 1;
+    this.messageCounts.set(sessionId, count);
+    if (count % 10 === 1) {
+      this.logger.info("Messages received", { count, sessionId });
     }
 
     try {
@@ -103,13 +133,23 @@ export class SessionLogWriter {
 
   async flush(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId);
-    if (!session) return;
+    if (!session) {
+      this.logger.warn("flush: no session found", { sessionId });
+      return;
+    }
 
     // Emit any buffered chunks before flushing
     this.emitCoalescedMessage(sessionId, session);
 
     const pending = this.pendingEntries.get(sessionId);
-    if (!this.posthogAPI || !pending?.length) return;
+    if (!this.posthogAPI || !pending?.length) {
+      this.logger.info("flush: nothing to persist", {
+        sessionId,
+        hasPosthogAPI: !!this.posthogAPI,
+        pendingCount: pending?.length ?? 0,
+      });
+      return;
+    }
 
     this.pendingEntries.delete(sessionId);
     const timeout = this.flushTimeouts.get(sessionId);
@@ -118,14 +158,24 @@ export class SessionLogWriter {
       this.flushTimeouts.delete(sessionId);
     }
 
+    this.lastFlushAttemptTime.set(sessionId, Date.now());
+
     try {
       await this.posthogAPI.appendTaskRunLog(
         session.context.taskId,
         session.context.runId,
         pending,
       );
+      this.logger.info("Flushed session logs", {
+        sessionId,
+        entryCount: pending.length,
+      });
     } catch (error) {
       this.logger.error("Failed to persist session logs:", error);
+
+      const currentPending = this.pendingEntries.get(sessionId) ?? [];
+      this.pendingEntries.set(sessionId, [...pending, ...currentPending]);
+      this.scheduleFlush(sessionId);
     }
   }
 
@@ -180,7 +230,16 @@ export class SessionLogWriter {
   private scheduleFlush(sessionId: string): void {
     const existing = this.flushTimeouts.get(sessionId);
     if (existing) clearTimeout(existing);
-    const timeout = setTimeout(() => this.flush(sessionId), 500);
+
+    const lastAttempt = this.lastFlushAttemptTime.get(sessionId) ?? 0;
+    const elapsed = Date.now() - lastAttempt;
+    // If we've been accumulating for longer than the max interval, flush immediately
+    const delay =
+      elapsed >= SessionLogWriter.FLUSH_MAX_INTERVAL_MS
+        ? 0
+        : SessionLogWriter.FLUSH_DEBOUNCE_MS;
+
+    const timeout = setTimeout(() => this.flush(sessionId), delay);
     this.flushTimeouts.set(sessionId, timeout);
   }
 }


### PR DESCRIPTION
## Summary

- Cloud session log rendering, cloud task session logs in Twig UI
- Cloud changes panel, PR file changes for cloud tasks by fetching via `gh` with slurp pagination  GitHub.
- Cloud task status with icons feedback
- SessionLogWriter visibility logging, this should help diagnose things from prod Sandboxes
- Flush before completion, needed this before sandbox gets cleaned-up
- Cloud watcher stack and CloudTask service

**Before**:

https://github.com/user-attachments/assets/f3b613a4-097f-44f3-a138-67ece0d4c16f

**After**:

https://github.com/user-attachments/assets/5a8c8258-8702-4a10-882b-5cc557073947

