### PR TITLE
feat(mcp): Send project ID header to PostHog MCP server

### DIFF
--- a/apps/twig/src/main/services/agent/service.ts
+++ b/apps/twig/src/main/services/agent/service.ts
@@ -357,7 +357,13 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       name: "posthog",
       type: "http",
       url: mcpUrl,
-      headers: [{ name: "Authorization", value: `Bearer ${token}` }],
+      headers: [
+        { name: "Authorization", value: `Bearer ${token}` },
+        {
+          name: "x-posthog-project-id",
+          value: String(credentials.projectId),
+        },
+      ],
     });
 
     return servers;


### PR DESCRIPTION
## Problem

The PostHog MCP server can now scope all interactions to a specific organization or project, which steered trajectories quite well in my tests.

## Changes

Adds the `x-posthog-project-id` header to the MCP server configuration in the agent service, using the project ID from the user's credentials.

## How did you test this code?

Verified the header is correctly included in the MCP server config by running the agent and confirming the PostHog MCP server receives the project ID.

## Publish to changelog?

no