### PR TITLE
chore: node heap macos runner 8GB

### DIFF
--- a/.github/workflows/twig-release.yml
+++ b/.github/workflows/twig-release.yml
@@ -13,6 +13,7 @@ jobs:
   publish:
     runs-on: macos-latest
     env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
       NODE_ENV: production
       VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
       VITE_POSTHOG_API_HOST: ${{ secrets.VITE_POSTHOG_API_HOST }}


### PR DESCRIPTION
The release workflow (v0.25.57) OOM'd during `pnpm --filter twig run publish`.
This tweaks the macos runner with 8GB which should be plenty of headroom for stop failing randomly.