### PR TITLE
feat(twig): oauth versioning

### DIFF
--- a/apps/twig/src/renderer/components/MainLayout.tsx
+++ b/apps/twig/src/renderer/components/MainLayout.tsx
@@ -1,6 +1,7 @@
 import { ConnectivityPrompt } from "@components/ConnectivityPrompt";
 import { HeaderRow } from "@components/HeaderRow";
 import { KeyboardShortcutsSheet } from "@components/KeyboardShortcutsSheet";
+import { ScopeReauthPrompt } from "@components/ScopeReauthPrompt";
 import { UpdatePrompt } from "@components/UpdatePrompt";
 import { useAutonomy } from "@features/autonomy/hooks/useAutonomy";
 import { CommandMenu } from "@features/command/components/CommandMenu";
@@ -86,6 +87,7 @@ export function MainLayout() {
         onOpenChange={(open) => (open ? null : closeShortcutsSheet())}
       />
       <UpdatePrompt />
+      <ScopeReauthPrompt />
       <ConnectivityPrompt
         open={showPrompt}
         isChecking={isChecking}

--- a/apps/twig/src/renderer/components/ScopeReauthPrompt.test.tsx
+++ b/apps/twig/src/renderer/components/ScopeReauthPrompt.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@renderer/trpc/client", () => ({
+  trpcVanilla: {
+    secureStore: {
+      getItem: { query: vi.fn() },
+      setItem: { query: vi.fn() },
+      removeItem: { query: vi.fn() },
+    },
+    oauth: {
+      refreshToken: { mutate: vi.fn() },
+      startFlow: { mutate: vi.fn() },
+      startSignupFlow: { mutate: vi.fn() },
+    },
+    agent: {
+      updateToken: { mutate: vi.fn().mockResolvedValue(undefined) },
+    },
+    cloudTask: {
+      updateToken: { mutate: vi.fn().mockResolvedValue(undefined) },
+    },
+    analytics: {
+      setUserId: { mutate: vi.fn().mockResolvedValue(undefined) },
+      resetUser: { mutate: vi.fn().mockResolvedValue(undefined) },
+    },
+  },
+}));
+
+vi.mock("@renderer/lib/analytics", () => ({
+  identifyUser: vi.fn(),
+  resetUser: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("@renderer/lib/logger", () => ({
+  logger: {
+    scope: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@renderer/lib/queryClient", () => ({
+  queryClient: {
+    clear: vi.fn(),
+    setQueryData: vi.fn(),
+    removeQueries: vi.fn(),
+  },
+}));
+
+vi.mock("@stores/navigationStore", () => ({
+  useNavigationStore: {
+    getState: () => ({ navigateToTaskInput: vi.fn() }),
+  },
+}));
+
+import { useAuthStore } from "@features/auth/stores/authStore";
+import { Theme } from "@radix-ui/themes";
+import type { ReactElement } from "react";
+import { ScopeReauthPrompt } from "./ScopeReauthPrompt";
+
+function renderWithTheme(ui: ReactElement) {
+  return render(<Theme>{ui}</Theme>);
+}
+
+describe("ScopeReauthPrompt", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthStore.setState({
+      needsScopeReauth: false,
+      cloudRegion: null,
+    });
+  });
+
+  it("does not render dialog when needsScopeReauth is false", () => {
+    renderWithTheme(<ScopeReauthPrompt />);
+    expect(
+      screen.queryByText("Re-authentication required"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders dialog when needsScopeReauth is true", () => {
+    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: "us" });
+    renderWithTheme(<ScopeReauthPrompt />);
+    expect(screen.getByText("Re-authentication required")).toBeInTheDocument();
+  });
+
+  it("disables Sign in button when cloudRegion is null", () => {
+    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: null });
+    renderWithTheme(<ScopeReauthPrompt />);
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeDisabled();
+  });
+
+  it("enables Sign in button when cloudRegion is set", () => {
+    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: "us" });
+    renderWithTheme(<ScopeReauthPrompt />);
+    expect(screen.getByRole("button", { name: "Sign in" })).not.toBeDisabled();
+  });
+
+  it("shows Log out button as an escape hatch when cloudRegion is null", () => {
+    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: null });
+    renderWithTheme(<ScopeReauthPrompt />);
+
+    const logoutButton = screen.getByRole("button", { name: "Log out" });
+    expect(logoutButton).toBeInTheDocument();
+    expect(logoutButton).not.toBeDisabled();
+  });
+
+  it("calls logout when Log out button is clicked", async () => {
+    const user = userEvent.setup();
+    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: null });
+    renderWithTheme(<ScopeReauthPrompt />);
+
+    await user.click(screen.getByRole("button", { name: "Log out" }));
+
+    const state = useAuthStore.getState();
+    expect(state.needsScopeReauth).toBe(false);
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.cloudRegion).toBeNull();
+  });
+});

--- a/apps/twig/src/renderer/components/ScopeReauthPrompt.tsx
+++ b/apps/twig/src/renderer/components/ScopeReauthPrompt.tsx
@@ -1,0 +1,69 @@
+import { useAuthStore } from "@features/auth/stores/authStore";
+import { ShieldWarning } from "@phosphor-icons/react";
+import { Button, Dialog, Flex, Text } from "@radix-ui/themes";
+import { logger } from "@renderer/lib/logger";
+import { useState } from "react";
+
+const log = logger.scope("scope-reauth-prompt");
+
+export function ScopeReauthPrompt() {
+  const needsScopeReauth = useAuthStore((s) => s.needsScopeReauth);
+  const cloudRegion = useAuthStore((s) => s.cloudRegion);
+  const loginWithOAuth = useAuthStore((s) => s.loginWithOAuth);
+  const logout = useAuthStore((s) => s.logout);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSignIn = async () => {
+    if (!cloudRegion) {
+      log.warn("Cannot re-authenticate: no cloud region available");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await loginWithOAuth(cloudRegion);
+    } catch (error) {
+      log.error("Re-authentication failed", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog.Root open={needsScopeReauth}>
+      <Dialog.Content
+        maxWidth="360px"
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <Flex direction="column" gap="3">
+          <Flex align="center" gap="2">
+            <ShieldWarning size={20} weight="bold" color="var(--gray-11)" />
+            <Dialog.Title className="mb-0">
+              Re-authentication required
+            </Dialog.Title>
+          </Flex>
+          <Dialog.Description>
+            <Text size="2" color="gray">
+              Twig has been updated with new features that require additional
+              permissions. Please sign in again to continue.
+            </Text>
+          </Dialog.Description>
+          <Flex justify="between" mt="2">
+            <Button type="button" variant="soft" color="gray" onClick={logout}>
+              Log out
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSignIn}
+              loading={isLoading}
+              disabled={!cloudRegion}
+            >
+              Sign in
+            </Button>
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/apps/twig/src/renderer/features/auth/stores/authStore.test.ts
+++ b/apps/twig/src/renderer/features/auth/stores/authStore.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUser = vi.fn();
+
+const { getItem, setItem } = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+}));
+
+const mockRefreshToken = vi.hoisted(() => ({ mutate: vi.fn() }));
+const mockStartFlow = vi.hoisted(() => ({ mutate: vi.fn() }));
+const mockStartSignupFlow = vi.hoisted(() => ({ mutate: vi.fn() }));
+
+vi.mock("@renderer/trpc/client", () => ({
+  trpcVanilla: {
+    secureStore: {
+      getItem: { query: getItem },
+      setItem: { query: setItem },
+      removeItem: { query: vi.fn() },
+    },
+    oauth: {
+      refreshToken: mockRefreshToken,
+      startFlow: mockStartFlow,
+      startSignupFlow: mockStartSignupFlow,
+    },
+    agent: {
+      updateToken: { mutate: vi.fn().mockResolvedValue(undefined) },
+    },
+    cloudTask: {
+      updateToken: { mutate: vi.fn().mockResolvedValue(undefined) },
+    },
+    analytics: {
+      setUserId: { mutate: vi.fn().mockResolvedValue(undefined) },
+      resetUser: { mutate: vi.fn().mockResolvedValue(undefined) },
+    },
+  },
+}));
+
+vi.mock("@renderer/lib/analytics", () => ({
+  identifyUser: vi.fn(),
+  resetUser: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("@renderer/lib/logger", () => ({
+  logger: {
+    scope: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@renderer/lib/queryClient", () => ({
+  queryClient: {
+    clear: vi.fn(),
+    setQueryData: vi.fn(),
+    removeQueries: vi.fn(),
+  },
+}));
+
+vi.mock("@renderer/api/posthogClient", () => ({
+  PostHogAPIClient: vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+  ) {
+    this.getCurrentUser = mockGetCurrentUser;
+  }),
+}));
+
+vi.mock("@stores/navigationStore", () => ({
+  useNavigationStore: {
+    getState: () => ({ navigateToTaskInput: vi.fn() }),
+  },
+}));
+
+import { OAUTH_SCOPE_VERSION } from "@shared/constants/oauth";
+import { useAuthStore } from "./authStore";
+
+function makeStoredTokens(overrides: Record<string, unknown> = {}) {
+  return {
+    accessToken: "test-access-token",
+    refreshToken: "test-refresh-token",
+    expiresAt: Date.now() + 3600 * 1000,
+    cloudRegion: "us" as const,
+    scopedTeams: [1],
+    scopeVersion: OAUTH_SCOPE_VERSION,
+    ...overrides,
+  };
+}
+
+const mockUser = {
+  distinct_id: "user-123",
+  email: "test@example.com",
+  uuid: "uuid-123",
+};
+
+describe("authStore - scope version", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getItem.mockResolvedValue(null);
+    setItem.mockResolvedValue(undefined);
+    mockGetCurrentUser.mockResolvedValue(mockUser);
+
+    useAuthStore.setState({
+      oauthAccessToken: null,
+      oauthRefreshToken: null,
+      tokenExpiry: null,
+      cloudRegion: null,
+      storedTokens: null,
+      staleTokens: null,
+      isAuthenticated: false,
+      client: null,
+      projectId: null,
+      availableProjectIds: [],
+      availableOrgIds: [],
+      needsProjectSelection: false,
+      needsScopeReauth: false,
+    });
+  });
+
+  describe("initializeOAuth", () => {
+    async function initializeWithTokens(
+      tokenOverrides: Record<string, unknown>,
+    ) {
+      const tokens = makeStoredTokens(tokenOverrides);
+      useAuthStore.setState({ storedTokens: tokens });
+      // Ensure hasHydrated returns true
+      await useAuthStore.persist.rehydrate();
+      return useAuthStore.getState().initializeOAuth();
+    }
+
+    it("sets needsScopeReauth when scopeVersion is missing (treated as 0)", async () => {
+      const result = await initializeWithTokens({ scopeVersion: undefined });
+
+      expect(result).toBe(true);
+      expect(useAuthStore.getState().needsScopeReauth).toBe(true);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useAuthStore.getState().storedTokens).not.toBeNull();
+    });
+
+    it("sets needsScopeReauth when scopeVersion is less than OAUTH_SCOPE_VERSION", async () => {
+      const result = await initializeWithTokens({
+        scopeVersion: OAUTH_SCOPE_VERSION - 1,
+      });
+
+      expect(result).toBe(true);
+      expect(useAuthStore.getState().needsScopeReauth).toBe(true);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useAuthStore.getState().storedTokens).not.toBeNull();
+    });
+
+    it("does not set needsScopeReauth when scopeVersion matches", async () => {
+      const result = await initializeWithTokens({
+        scopeVersion: OAUTH_SCOPE_VERSION,
+      });
+
+      expect(result).toBe(true);
+      expect(useAuthStore.getState().needsScopeReauth).toBe(false);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useAuthStore.getState().storedTokens).not.toBeNull();
+    });
+  });
+
+  describe("loginWithOAuth", () => {
+    it("clears needsScopeReauth after successful login", async () => {
+      useAuthStore.setState({ needsScopeReauth: true });
+
+      mockStartFlow.mutate.mockResolvedValue({
+        success: true,
+        data: {
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 3600,
+          scoped_teams: [1],
+          scoped_organizations: ["org-1"],
+        },
+      });
+
+      await useAuthStore.getState().loginWithOAuth("us");
+
+      expect(useAuthStore.getState().needsScopeReauth).toBe(false);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    });
+  });
+
+  describe("refreshAccessToken", () => {
+    it("preserves existing scopeVersion on refreshed tokens", async () => {
+      const staleVersion = OAUTH_SCOPE_VERSION - 1;
+      useAuthStore.setState({
+        oauthAccessToken: "old-token",
+        oauthRefreshToken: "old-refresh-token",
+        cloudRegion: "us",
+        storedTokens: makeStoredTokens({ scopeVersion: staleVersion }),
+        isAuthenticated: true,
+      });
+
+      mockRefreshToken.mutate.mockResolvedValue({
+        success: true,
+        data: {
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 3600,
+          scoped_teams: [1],
+        },
+      });
+
+      await useAuthStore.getState().refreshAccessToken();
+
+      const tokens = useAuthStore.getState().storedTokens;
+      expect(tokens).not.toBeNull();
+      expect(tokens?.scopeVersion).toBe(staleVersion);
+      expect(tokens?.accessToken).toBe("new-access-token");
+    });
+
+    it("defaults scopeVersion to 0 when storedTokens is null", async () => {
+      useAuthStore.setState({
+        oauthAccessToken: "old-token",
+        oauthRefreshToken: "old-refresh-token",
+        cloudRegion: "us",
+        storedTokens: null,
+        isAuthenticated: true,
+      });
+
+      mockRefreshToken.mutate.mockResolvedValue({
+        success: true,
+        data: {
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 3600,
+          scoped_teams: [1],
+        },
+      });
+
+      await useAuthStore.getState().refreshAccessToken();
+
+      const tokens = useAuthStore.getState().storedTokens;
+      expect(tokens).not.toBeNull();
+      expect(tokens?.scopeVersion).toBe(0);
+    });
+  });
+});

--- a/apps/twig/src/shared/constants/oauth.test.ts
+++ b/apps/twig/src/shared/constants/oauth.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { OAUTH_SCOPE_VERSION, OAUTH_SCOPES } from "./oauth";
+
+describe("OAUTH_SCOPES guard", () => {
+  it("snapshot breaks when scopes change — bump OAUTH_SCOPE_VERSION if this fails", () => {
+    expect({
+      scopeVersion: OAUTH_SCOPE_VERSION,
+      scopes: OAUTH_SCOPES,
+    }).toMatchInlineSnapshot(`
+      {
+        "scopeVersion": 1,
+        "scopes": [
+          "user:read",
+          "project:read",
+          "task:write",
+          "signal_report:read",
+          "signal_report:write",
+          "llm_gateway:read",
+          "integration:read",
+          "introspection",
+          "action:read",
+          "action:write",
+          "dashboard:read",
+          "dashboard:write",
+          "error_tracking:read",
+          "error_tracking:write",
+          "event_definition:read",
+          "event_definition:write",
+          "experiment:read",
+          "experiment:write",
+          "feature_flag:read",
+          "feature_flag:write",
+          "insight:read",
+          "insight:write",
+          "logs:read",
+          "organization:read",
+          "property_definition:read",
+          "query:read",
+          "survey:read",
+          "survey:write",
+          "warehouse_table:read",
+          "warehouse_view:read",
+        ],
+      }
+    `);
+  });
+});

--- a/apps/twig/src/shared/constants/oauth.ts
+++ b/apps/twig/src/shared/constants/oauth.ts
@@ -4,6 +4,7 @@ export const POSTHOG_US_CLIENT_ID = "HCWoE0aRFMYxIxFNTTwkOORn5LBjOt2GVDzwSw5W";
 export const POSTHOG_EU_CLIENT_ID = "AIvijgMS0dxKEmr5z6odvRd8Pkh5vts3nPTzgzU9";
 export const POSTHOG_DEV_CLIENT_ID = "DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ";
 
+// Bump OAUTH_SCOPE_VERSION below whenever OAUTH_SCOPES changes to force re-authentication
 export const OAUTH_SCOPES = [
   // Twig app needs
   "user:read",
@@ -38,6 +39,8 @@ export const OAUTH_SCOPES = [
   "warehouse_table:read",
   "warehouse_view:read",
 ];
+
+export const OAUTH_SCOPE_VERSION = 1;
 
 // Token refresh settings
 export const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes before expiry


### PR DESCRIPTION
This adds OAuth scope versioning with an in-session re-authentication flow and also a quick guard to prevent scope/version drift.
When OAuth scopes change, existing users may keep tokens tied to old grants. Instead of forcing an immediate logout (bad UX) we now detect stale scope versions and prompt users to re-authenticate from within Twig

- Users with stale OAuth grants are guided to re-auth
- If re-auth cannot proceed, users can safely log out via the prompt
<img width="3028" height="1886" alt="twig_reoauth" src="https://github.com/user-attachments/assets/8d57ac70-1681-4756-b019-96f7116f6f88" />
