### PR TITLE
fix: remove scopes of signals

### DIFF
--- a/apps/twig/src/shared/constants/oauth.test.ts
+++ b/apps/twig/src/shared/constants/oauth.test.ts
@@ -13,8 +13,6 @@ describe("OAUTH_SCOPES guard", () => {
           "user:read",
           "project:read",
           "task:write",
-          "signal_report:read",
-          "signal_report:write",
           "llm_gateway:read",
           "integration:read",
           "introspection",

--- a/apps/twig/src/shared/constants/oauth.ts
+++ b/apps/twig/src/shared/constants/oauth.ts
@@ -10,8 +10,6 @@ export const OAUTH_SCOPES = [
   "user:read",
   "project:read",
   "task:write",
-  "signal_report:read",
-  "signal_report:write",
   "llm_gateway:read",
   "integration:read",
   "introspection",


### PR DESCRIPTION
signals scope cannot be merged due to ongoing incident https://github.com/PostHog/posthog/pull/48582, let's remove them for now