### PR TITLE
feat: create a git checkpoint on every user message

### DIFF
--- a/apps/twig/src/main/services/agent/schemas.ts
+++ b/apps/twig/src/main/services/agent/schemas.ts
@@ -264,3 +264,26 @@ export const getGatewayModelsInput = z.object({
 });
 
 export const getGatewayModelsOutput = z.array(modelOptionSchema);
+
+export const checkpointInput = z.object({
+  taskRunId: z.string(),
+  checkpointId: z.string(),
+});
+
+export const checkpointDiffOutput = z
+  .object({
+    linesAdded: z.number(),
+    linesRemoved: z.number(),
+    filesChanged: z.array(z.string()),
+  })
+  .nullable();
+
+export const checkpointRestoreResultSchema = z.object({
+  cwd: z.string(),
+  success: z.boolean(),
+  error: z.string().optional(),
+});
+
+export const checkpointRestoreOutput = z
+  .array(checkpointRestoreResultSchema)
+  .nullable();

--- a/apps/twig/src/main/services/agent/service.ts
+++ b/apps/twig/src/main/services/agent/service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs, { mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -521,6 +522,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
             this.processTracking.unregister(pid, "agent-exited");
           },
         },
+        cwds: [repoPath, ...(additionalDirectories ?? [])],
       });
       const { clientStreams } = acpConnection;
 
@@ -1064,14 +1066,34 @@ For git operations while detached:
     };
 
     const onAcpMessage = (message: unknown) => {
-      const acpMessage: AcpMessage = {
+      const msg = message as Record<string, unknown>;
+      const notificationId = randomUUID();
+
+      const injectMeta = (
+        obj: Record<string, unknown>,
+        key: "params" | "result",
+      ) => {
+        const target = obj[key] as Record<string, unknown>;
+        const existingMeta = (target._meta as Record<string, unknown>) ?? {};
+        return {
+          ...obj,
+          [key]: { ...target, _meta: { ...existingMeta, notificationId } },
+        };
+      };
+
+      const enrichedMessage =
+        msg.params !== undefined
+          ? injectMeta(msg, "params")
+          : msg.result !== undefined
+            ? injectMeta(msg, "result")
+            : msg;
+
+      emitToRenderer({
         type: "acp_message",
         ts: Date.now(),
-        message: message as AcpMessage["message"],
-      };
-      emitToRenderer(acpMessage);
+        message: enrichedMessage as unknown as AcpMessage["message"],
+      });
 
-      // Detect PR URLs in bash tool results and attach to task
       this.detectAndAttachPrUrl(taskRunId, message);
     };
 
@@ -1457,5 +1479,27 @@ For git operations while detached:
       }
       return getModelTier(a.modelId) - getModelTier(b.modelId);
     });
+  }
+
+  async checkpointDiff(
+    taskRunId: string,
+    checkpointId: string,
+  ): Promise<{
+    linesAdded: number;
+    linesRemoved: number;
+    filesChanged: string[];
+  } | null> {
+    const session = this.sessions.get(taskRunId);
+    if (!session) return null;
+    return session.agent.checkpointDiff(checkpointId);
+  }
+
+  async checkpointRestore(
+    taskRunId: string,
+    checkpointId: string,
+  ): Promise<Array<{ cwd: string; success: boolean; error?: string }> | null> {
+    const session = this.sessions.get(taskRunId);
+    if (!session) return null;
+    return session.agent.checkpointRestore(checkpointId);
   }
 }

--- a/apps/twig/src/main/trpc/routers/agent.ts
+++ b/apps/twig/src/main/trpc/routers/agent.ts
@@ -7,6 +7,9 @@ import {
   cancelPermissionInput,
   cancelPromptInput,
   cancelSessionInput,
+  checkpointDiffOutput,
+  checkpointInput,
+  checkpointRestoreOutput,
   getGatewayModelsInput,
   getGatewayModelsOutput,
   listSessionsInput,
@@ -175,5 +178,19 @@ export const agentRouter = router({
     .output(getGatewayModelsOutput)
     .query(({ input }) =>
       getService().getGatewayModels(input.apiHost, input.apiKey),
+    ),
+
+  checkpointDiff: publicProcedure
+    .input(checkpointInput)
+    .output(checkpointDiffOutput)
+    .query(({ input }) =>
+      getService().checkpointDiff(input.taskRunId, input.checkpointId),
+    ),
+
+  checkpointRestore: publicProcedure
+    .input(checkpointInput)
+    .output(checkpointRestoreOutput)
+    .mutation(({ input }) =>
+      getService().checkpointRestore(input.taskRunId, input.checkpointId),
     ),
 });

--- a/apps/twig/src/renderer/features/sessions/service/service.ts
+++ b/apps/twig/src/renderer/features/sessions/service/service.ts
@@ -503,6 +503,11 @@ export class SessionService {
       throw new Error("Failed to create task run. Please try again.");
     }
 
+    const session = this.createBaseSession(taskRun.id, taskId, taskTitle);
+    session.adapter = adapter;
+    sessionStoreSetters.setSession(session);
+    this.subscribeToChannel(taskRun.id);
+
     const { customInstructions: startCustomInstructions } =
       useSettingsStore.getState();
     const result = await trpcVanilla.agent.start.mutate({
@@ -517,27 +522,23 @@ export class SessionService {
       customInstructions: startCustomInstructions || undefined,
     });
 
-    const session = this.createBaseSession(taskRun.id, taskId, taskTitle);
-    session.channel = result.channel;
-    session.status = "connected";
-    session.adapter = adapter;
     const configOptions = result.configOptions as
       | SessionConfigOption[]
       | undefined;
-    session.configOptions = configOptions;
 
-    // Persist the config options
+    sessionStoreSetters.updateSession(taskRun.id, {
+      channel: result.channel,
+      status: "connected",
+      configOptions,
+    });
+
     if (configOptions) {
       setPersistedConfigOptions(taskRun.id, configOptions);
     }
 
-    // Persist the adapter
     if (adapter) {
       useSessionAdapterStore.getState().setAdapter(taskRun.id, adapter);
     }
-
-    sessionStoreSetters.setSession(session);
-    this.subscribeToChannel(taskRun.id);
 
     track(ANALYTICS_EVENTS.TASK_RUN_STARTED, {
       task_id: taskId,
@@ -610,6 +611,7 @@ export class SessionService {
     );
     session.adapter = params.adapter;
     sessionStoreSetters.setSession(session);
+    this.subscribeToChannel(taskRunId);
 
     try {
       const { customInstructions: previewCustomInstructions } =
@@ -648,8 +650,6 @@ export class SessionService {
         channel: result.channel,
         configOptions,
       });
-
-      this.subscribeToChannel(taskRunId);
 
       log.info("Preview session started", {
         taskRunId,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -73,7 +73,6 @@
   },
   "devDependencies": {
     "@posthog/shared": "workspace:*",
-    "@twig/git": "workspace:*",
     "@types/bun": "latest",
     "@types/tar": "^6.1.13",
     "minimatch": "^10.0.3",
@@ -85,6 +84,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.0",
+    "@twig/git": "workspace:*",
     "@anthropic-ai/claude-agent-sdk": "0.2.42",
     "@anthropic-ai/sdk": "^0.71.0",
     "@hono/node-server": "^1.19.9",

--- a/packages/agent/src/adapters/acp-connection.ts
+++ b/packages/agent/src/adapters/acp-connection.ts
@@ -1,11 +1,12 @@
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
 import { POSTHOG_NOTIFICATIONS } from "../acp-extensions.js";
+import { CheckpointManager } from "../checkpoint-manager.js";
 import type { SessionLogWriter } from "../session-log-writer.js";
 import type { ProcessSpawnedCallback } from "../types.js";
 import { Logger } from "../utils/logger.js";
 import {
   createBidirectionalStreams,
-  createNotificationIdInjectorStream,
+  createSessionPromptDetectorStream,
   createTappedWritableStream,
   nodeReadableToWebReadable,
   nodeWritableToWebWritable,
@@ -27,12 +28,15 @@ export type AcpConnectionConfig = {
   processCallbacks?: ProcessSpawnedCallback;
   codexOptions?: CodexProcessOptions;
   allowedModelIds?: Set<string>;
+  /** Working directories to snapshot on each user message */
+  cwds?: string[];
 };
 
 export type AcpConnection = {
   agentConnection?: AgentSideConnection;
   clientStreams: StreamPair;
   cleanup: () => Promise<void>;
+  checkpointManager: CheckpointManager | null;
 };
 
 export type InProcessAcpConnection = AcpConnection;
@@ -193,7 +197,17 @@ function createClaudeConnection(config: AcpConnectionConfig): AcpConnection {
     });
   }
 
-  agentWritable = createNotificationIdInjectorStream(agentWritable, { logger });
+  const cwds = config.cwds ?? [];
+  const checkpointManager =
+    cwds.length > 0 ? new CheckpointManager(cwds, logger) : null;
+
+  if (checkpointManager) {
+    clientWritable = createSessionPromptDetectorStream(clientWritable, {
+      logger,
+      onSessionPrompt: (notificationId) =>
+        checkpointManager.capture(notificationId),
+    });
+  }
 
   const agentStream = ndJsonStream(agentWritable, streams.agent.readable);
 
@@ -228,6 +242,7 @@ function createClaudeConnection(config: AcpConnectionConfig): AcpConnection {
         // Stream may already be closed
       }
     },
+    checkpointManager,
   };
 }
 
@@ -495,5 +510,6 @@ function createCodexConnection(config: AcpConnectionConfig): AcpConnection {
         // Stream may already be closed
       }
     },
+    checkpointManager: null,
   };
 }

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -51,6 +51,7 @@ type ChunkHandlerContext = {
   client: AgentSideConnection;
   logger: Logger;
   parentToolCallId?: string;
+  sdkMessageId?: string;
 };
 
 export interface MessageHandlerContext {
@@ -278,6 +279,7 @@ function toAcpNotifications(
   client: AgentSideConnection,
   logger: Logger,
   parentToolCallId?: string,
+  sdkMessageId?: string,
 ): SessionNotification[] {
   if (typeof content === "string") {
     const update: SessionNotification["update"] = {
@@ -291,7 +293,8 @@ function toAcpNotifications(
         parentToolCallId,
       );
     }
-    return [{ sessionId, update }];
+    return [{ sessionId,
+      _meta: sdkMessageId ? { sdkMessageId } : undefined, update }];
   }
 
   const ctx: ChunkHandlerContext = {
@@ -301,13 +304,18 @@ function toAcpNotifications(
     client,
     logger,
     parentToolCallId,
+    sdkMessageId,
   };
   const output: SessionNotification[] = [];
 
   for (const chunk of content) {
     const update = processContentChunk(chunk, role, ctx);
     if (update) {
-      output.push({ sessionId, update });
+      output.push({
+        sessionId,
+        _meta: sdkMessageId ? { sdkMessageId } : undefined,
+        update,
+      });
     }
   }
 
@@ -324,6 +332,7 @@ function streamEventToAcpNotifications(
   parentToolCallId?: string,
 ): SessionNotification[] {
   const event = message.event;
+  const sdkMessageId = message.uuid;
   switch (event.type) {
     case "content_block_start":
       return toAcpNotifications(
@@ -335,6 +344,7 @@ function streamEventToAcpNotifications(
         client,
         logger,
         parentToolCallId,
+        sdkMessageId,
       );
     case "content_block_delta":
       return toAcpNotifications(
@@ -346,6 +356,7 @@ function streamEventToAcpNotifications(
         client,
         logger,
         parentToolCallId,
+        sdkMessageId,
       );
     case "message_start":
     case "message_delta":
@@ -584,6 +595,7 @@ export async function handleUserAssistantMessage(
     "parent_tool_use_id" in message
       ? (message.parent_tool_use_id ?? undefined)
       : undefined;
+  const sdkMessageId = message.uuid;
 
   for (const notification of toAcpNotifications(
     contentToProcess as typeof content,
@@ -594,10 +606,11 @@ export async function handleUserAssistantMessage(
     client,
     logger,
     parentToolCallId,
+    sdkMessageId,
   )) {
-    await client.sessionUpdate(notification);
-    session.notificationHistory.push(notification);
-  }
+  await client.sessionUpdate(notification);
+  session.notificationHistory.push(notification);
+}
 
   return {};
 }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -112,6 +112,7 @@ export class Agent {
       logger: this.logger,
       processCallbacks: options.processCallbacks,
       allowedModelIds,
+      cwds: options.cwds,
       codexOptions:
         options.adapter === "codex" && gatewayConfig
           ? {
@@ -166,5 +167,17 @@ export class Agent {
       await this.sessionLogWriter.flush(this.taskRunId);
     }
     await this.acpConnection?.cleanup();
+  }
+
+  async checkpointDiff(checkpointId: string) {
+    const manager = this.acpConnection?.checkpointManager;
+    if (!manager) return null;
+    return manager.diff(checkpointId);
+  }
+
+  async checkpointRestore(checkpointId: string) {
+    const manager = this.acpConnection?.checkpointManager;
+    if (!manager) return null;
+    return manager.restore(checkpointId);
   }
 }

--- a/packages/agent/src/checkpoint-manager.ts
+++ b/packages/agent/src/checkpoint-manager.ts
@@ -1,0 +1,144 @@
+import {
+  CaptureCheckpointSaga,
+  DiffCheckpointSaga,
+  RevertCheckpointSaga,
+} from "@twig/git/sagas/checkpoint";
+import type { Logger } from "./utils/logger.js";
+
+export interface RestoreResult {
+  cwd: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface DiffStats {
+  linesAdded: number;
+  linesRemoved: number;
+  filesChanged: string[];
+}
+
+export class CheckpointManager {
+  private cwds: string[];
+  private logger: Logger;
+
+  constructor(cwds: string[], logger: Logger) {
+    this.cwds = cwds;
+    this.logger = logger;
+  }
+
+  capture(checkpointId: string): void {
+    for (const cwd of this.cwds) {
+      const saga = new CaptureCheckpointSaga();
+      saga
+        .run({ baseDir: cwd, checkpointId })
+        .then((result) => {
+          if (result.success) {
+            this.logger.info("Checkpoint captured", {
+              checkpointId,
+              cwd,
+              commit: result.data.commit,
+            });
+          } else {
+            this.logger.warn("Checkpoint capture failed", {
+              checkpointId,
+              cwd,
+              error: result.error,
+              failedStep: result.failedStep,
+            });
+          }
+        })
+        .catch((err) => {
+          this.logger.warn("Failed to capture checkpoint", {
+            checkpointId,
+            cwd,
+            error: err,
+          });
+        });
+    }
+  }
+
+  async restore(checkpointId: string): Promise<RestoreResult[]> {
+    const results: RestoreResult[] = [];
+
+    for (const cwd of this.cwds) {
+      const saga = new RevertCheckpointSaga();
+      const result = await saga.run({ baseDir: cwd, checkpointId });
+
+      if (result.success) {
+        this.logger.info("Checkpoint restored", { checkpointId, cwd });
+        results.push({ cwd, success: true });
+      } else {
+        this.logger.warn("Checkpoint restore failed", {
+          checkpointId,
+          cwd,
+          error: result.error,
+          failedStep: result.failedStep,
+        });
+        results.push({ cwd, success: false, error: result.error });
+      }
+    }
+
+    return results;
+  }
+
+  async diff(checkpointId: string): Promise<DiffStats> {
+    let totalAdded = 0;
+    let totalRemoved = 0;
+    const allFiles = new Set<string>();
+
+    for (const cwd of this.cwds) {
+      const saga = new DiffCheckpointSaga();
+      const result = await saga.run({
+        baseDir: cwd,
+        from: checkpointId,
+        to: "current",
+      });
+
+      if (result.success) {
+        const stats = parseDiffStats(result.data.diff);
+        totalAdded += stats.linesAdded;
+        totalRemoved += stats.linesRemoved;
+        for (const file of stats.filesChanged) {
+          allFiles.add(file);
+        }
+      } else {
+        this.logger.warn("Checkpoint diff failed", {
+          checkpointId,
+          cwd,
+          error: result.error,
+        });
+      }
+    }
+
+    return {
+      linesAdded: totalAdded,
+      linesRemoved: totalRemoved,
+      filesChanged: Array.from(allFiles),
+    };
+  }
+}
+
+function parseDiffStats(diff: string): DiffStats {
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  const filesChanged = new Set<string>();
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) {
+      const match = line.match(/^[+-]{3} [ab]\/(.+)$/);
+      if (match && match[1] !== "/dev/null") {
+        filesChanged.add(match[1]);
+      }
+    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+      linesAdded++;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      linesRemoved++;
+    }
+  }
+
+  return {
+    linesAdded,
+    linesRemoved,
+    filesChanged: Array.from(filesChanged),
+  };
+}

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -111,6 +111,7 @@ export interface TaskExecutionOptions {
   model?: string;
   codexBinaryPath?: string;
   processCallbacks?: ProcessSpawnedCallback;
+  cwds?: string[];
 }
 
 export type LogLevel = "debug" | "info" | "warn" | "error";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.28.0
         version: 1.39.0
+      '@twig/git':
+        specifier: workspace:*
+        version: link:../git
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
@@ -593,9 +596,6 @@ importers:
       '@posthog/shared':
         specifier: workspace:*
         version: link:../shared
-      '@twig/git':
-        specifier: workspace:*
-        version: link:../git
       '@types/bun':
         specifier: latest
         version: 1.3.9


### PR DESCRIPTION
Several changes
- Generate a git checkpoint on every user message
- Attach the Claude SDK message UUID to `params._meta` (we'll need this to use in combination with `resumeAt`)
- Subscribe to the ACP stream earlier so we get all messages in the renderer (previously we were too late to subscribe to the first few protocol initialization messages)