### PR TITLE
chore: avoid race condition

### DIFF
--- a/apps/twig/src/renderer/features/auth/stores/authStore.test.ts
+++ b/apps/twig/src/renderer/features/auth/stores/authStore.test.ts
@@ -137,7 +137,12 @@ describe("authStore - scope version", () => {
       expect(result).toBe(true);
       expect(useAuthStore.getState().needsScopeReauth).toBe(true);
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useAuthStore.getState().cloudRegion).toBe("us");
       expect(useAuthStore.getState().storedTokens).not.toBeNull();
+      // Should NOT create a client or call getCurrentUser — early return avoids
+      // racing with loginWithOAuth when the user clicks Sign In.
+      expect(mockGetCurrentUser).not.toHaveBeenCalled();
+      expect(useAuthStore.getState().client).toBeNull();
     });
 
     it("sets needsScopeReauth when scopeVersion is less than OAUTH_SCOPE_VERSION", async () => {
@@ -148,7 +153,10 @@ describe("authStore - scope version", () => {
       expect(result).toBe(true);
       expect(useAuthStore.getState().needsScopeReauth).toBe(true);
       expect(useAuthStore.getState().isAuthenticated).toBe(true);
+      expect(useAuthStore.getState().cloudRegion).toBe("us");
       expect(useAuthStore.getState().storedTokens).not.toBeNull();
+      expect(mockGetCurrentUser).not.toHaveBeenCalled();
+      expect(useAuthStore.getState().client).toBeNull();
     });
 
     it("does not set needsScopeReauth when scopeVersion matches", async () => {

--- a/apps/twig/src/renderer/features/auth/stores/authStore.ts
+++ b/apps/twig/src/renderer/features/auth/stores/authStore.ts
@@ -413,17 +413,24 @@ export const useAuthStore = create<AuthState>()(
             const state = get();
 
             if (state.storedTokens) {
-              const tokenScopeVersion = state.storedTokens.scopeVersion ?? 0;
+              const tokens = state.storedTokens;
+              const tokenScopeVersion = tokens.scopeVersion ?? 0;
               if (tokenScopeVersion < OAUTH_SCOPE_VERSION) {
                 log.info("OAuth scopes updated, re-authentication required", {
                   tokenVersion: tokenScopeVersion,
                   requiredVersion: OAUTH_SCOPE_VERSION,
                   requiredScopes: OAUTH_SCOPES,
                 });
-                set({ needsScopeReauth: true });
+                set({
+                  needsScopeReauth: true,
+                  oauthAccessToken: tokens.accessToken,
+                  oauthRefreshToken: tokens.refreshToken,
+                  tokenExpiry: tokens.expiresAt,
+                  cloudRegion: tokens.cloudRegion,
+                  isAuthenticated: true,
+                });
+                return true;
               }
-
-              const tokens = state.storedTokens;
               const now = Date.now();
               const isExpired = tokens.expiresAt <= now;
 


### PR DESCRIPTION
initializeOAuth now returns early when scope reauth is needed, setting only the minimal state for the re-auth dialog.
Tentativi fix since we never bumped the scope version...