### PR TITLE
fix: onboarding orgs list scrollable

### DIFF
--- a/apps/twig/src/renderer/features/onboarding/components/OnboardingFlow.tsx
+++ b/apps/twig/src/renderer/features/onboarding/components/OnboardingFlow.tsx
@@ -55,7 +55,12 @@ export function OnboardingFlow() {
         flexGrow="1"
         style={{ position: "relative", zIndex: 1, minHeight: 0 }}
       >
-        <Flex direction="column" flexGrow="1" overflow="hidden" style={{ minHeight: 0 }}>
+        <Flex
+          direction="column"
+          flexGrow="1"
+          overflow="hidden"
+          style={{ minHeight: 0 }}
+        >
           <AnimatePresence mode="wait">
             {currentStep === "welcome" && (
               <motion.div

--- a/apps/twig/src/renderer/features/onboarding/components/OrgBillingStep.tsx
+++ b/apps/twig/src/renderer/features/onboarding/components/OrgBillingStep.tsx
@@ -86,7 +86,15 @@ export function OrgBillingStep({ onNext, onBack }: OrgBillingStepProps) {
           </Callout.Root>
         )}
 
-        <Box className="scrollbar-hide" style={{ flex: 1, minHeight: 0, overflowY: "auto", marginBottom: "var(--space-6)" }}>
+        <Box
+          className="scrollbar-hide"
+          style={{
+            flex: 1,
+            minHeight: 0,
+            overflowY: "auto",
+            marginBottom: "var(--space-6)",
+          }}
+        >
           <AnimatePresence mode="wait">
             {isLoading ? (
               <motion.div


### PR DESCRIPTION
I couldn’t complete onboarding as i have a lot of orgs, this makes the list scrollable

<img width="1100" height="1063" alt="Screenshot 2026-02-24 at 11 30 30" src="https://github.com/user-attachments/assets/d9cfe3da-67e5-4272-a8a0-d43aae416d7d" />