### PR TITLE
fix(agent): Enable MCP servers for Codex adapter

### DIFF
--- a/apps/twig/src/main/services/agent/service.ts
+++ b/apps/twig/src/main/services/agent/service.ts
@@ -536,8 +536,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
         },
       });
 
-      const mcpServers =
-        adapter === "codex" ? [] : this.buildMcpServers(credentials);
+      const mcpServers = this.buildMcpServers(credentials);
 
       let configOptions: SessionConfigOption[] | undefined;
       let agentSessionId: string;


### PR DESCRIPTION
## Problem

MCP servers were explicitly disabled for the Codex adapter (`adapter === "codex" ? [] : ...`), which meant Codex sessions couldn't use MCPs like PostHog. This was likely an early workaround that's no longer needed.

## Changes

- Removed the Codex-specific exclusion so `buildMcpServers()` is called for all adapters equally.

## How did you test this code?

- Verified Codex sessions now receive MCP server configurations.

## Publish to changelog?

no