### PR TITLE
fix: make custom permission prompt option support multiline text

### DIFF
--- a/apps/twig/src/renderer/components/action-selector/InlineEditableText.tsx
+++ b/apps/twig/src/renderer/components/action-selector/InlineEditableText.tsx
@@ -10,6 +10,11 @@ interface InlineEditableTextProps {
   onSubmit: () => void;
 }
 
+function autoGrow(el: HTMLTextAreaElement) {
+  el.style.height = "auto";
+  el.style.height = `${el.scrollHeight}px`;
+}
+
 export function InlineEditableText({
   value,
   placeholder,
@@ -19,21 +24,37 @@ export function InlineEditableText({
   onEscape,
   onSubmit,
 }: InlineEditableTextProps) {
-  const nativeInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    nativeInputRef.current?.focus();
+    const el = textareaRef.current;
+    if (el) {
+      el.focus();
+      autoGrow(el);
+    }
   }, []);
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Escape") {
         e.preventDefault();
         onEscape();
       } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        onNavigateUp();
-      } else if (e.key === "ArrowDown" || e.key === "Tab") {
+        const el = e.currentTarget;
+        if (el.selectionStart === 0 && el.selectionEnd === 0) {
+          e.preventDefault();
+          onNavigateUp();
+        }
+      } else if (e.key === "ArrowDown") {
+        const el = e.currentTarget;
+        if (
+          el.selectionStart === el.value.length &&
+          el.selectionEnd === el.value.length
+        ) {
+          e.preventDefault();
+          onNavigateDown();
+        }
+      } else if (e.key === "Tab") {
         e.preventDefault();
         onNavigateDown();
       } else if (e.key === "Enter" && !e.shiftKey) {
@@ -45,22 +66,27 @@ export function InlineEditableText({
   );
 
   return (
-    <input
-      ref={nativeInputRef}
-      type="text"
+    <textarea
+      ref={textareaRef}
       value={value}
       placeholder={placeholder}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => {
+        onChange(e.target.value);
+        autoGrow(e.target);
+      }}
       onKeyDown={handleKeyDown}
       onClick={(e) => e.stopPropagation()}
+      rows={1}
       className="text-gray-12 placeholder:text-gray-10"
       style={{
         all: "unset",
         fontSize: "var(--font-size-1)",
         lineHeight: "var(--line-height-1)",
         fontWeight: 500,
-        minWidth: "200px",
-        display: "inline-block",
+        width: "100%",
+        display: "block",
+        resize: "none",
+        overflow: "hidden",
       }}
     />
   );

--- a/apps/twig/src/renderer/components/action-selector/OptionRow.tsx
+++ b/apps/twig/src/renderer/components/action-selector/OptionRow.tsx
@@ -127,11 +127,11 @@ export function OptionRow({
       onMouseEnter={onMouseEnter}
       style={{ cursor: "pointer" }}
     >
-      <Flex align="center" gap="2">
+      <Flex align="start" gap="2">
         <Text
           size="1"
           className={isSelected ? "text-blue-11" : "text-gray-11"}
-          style={{ width: "1ch" }}
+          style={{ width: "1ch", flexShrink: 0 }}
         >
           {isSelected ? "›" : ""}
         </Text>
@@ -142,6 +142,7 @@ export function OptionRow({
             minWidth: "16px",
             textAlign: "right",
             whiteSpace: "nowrap",
+            flexShrink: 0,
           }}
         >
           {index + 1}.
@@ -154,7 +155,7 @@ export function OptionRow({
             style={{ pointerEvents: "none" }}
           />
         )}
-        {renderLabel()}
+        <Box style={{ flex: 1, minWidth: 0 }}>{renderLabel()}</Box>
       </Flex>
       {option.description && !isCurrentlyEditing && (
         <Text


### PR DESCRIPTION
it’d get cut off if you typed something more than a few words, this allows multiline text there

<img width="742" height="262" alt="Screenshot 2026-02-24 at 17 55 26" src="https://github.com/user-attachments/assets/6220da04-410b-4d7d-82f0-b9b9edbc1e4b" />