### PR TITLE
fix: agent package build race

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -60,7 +60,7 @@
   "author": "PostHog",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
-    "build": "tsup",
+    "build": "rm -rf dist && tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -84,7 +84,7 @@ export default defineConfig([
     ],
     format: ["esm"],
     dts: true,
-    clean: true,
+    clean: false,
     ...sharedOptions,
     onSuccess: async () => {
       copyAssets();


### PR DESCRIPTION
Having clean: true here would wipe the agent server build if that completed before the other build.