### PR TITLE
fix: Signal inbox text wrapping in detail panel and card titles

### DIFF
--- a/apps/twig/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/twig/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -334,7 +334,7 @@ export function InboxSignalsTab({ onGoToSetup }: InboxSignalsTabProps) {
               className="scroll-area-constrain-width"
               style={{ height: "calc(100% - 41px)" }}
             >
-              <Flex direction="column" gap="2" p="2">
+              <Flex direction="column" gap="2" p="2" className="min-w-0">
                 <Text
                   size="1"
                   color="gray"

--- a/apps/twig/src/renderer/features/inbox/components/SignalCard.tsx
+++ b/apps/twig/src/renderer/features/inbox/components/SignalCard.tsx
@@ -136,19 +136,19 @@ function GitHubIssueSignalCard({ signal }: SignalCardProps) {
   return (
     <Box className="min-w-0 overflow-hidden rounded-lg border border-gray-6 bg-gray-1">
       <Flex
-        align="center"
+        align="start"
         gap="2"
         px="3"
         py="2"
         className="min-w-0 border-gray-5 border-b bg-gray-2"
       >
-        <GithubLogoIcon size={14} className="shrink-0 text-gray-11" />
+        <GithubLogoIcon size={14} className="mt-0.5 shrink-0 text-gray-11" />
         {issueUrl ? (
           <a
             href={issueUrl}
             target="_blank"
             rel="noreferrer"
-            className="min-w-0 flex-1 truncate font-medium font-mono text-[11px] text-gray-12 hover:text-accent-11"
+            className="min-w-0 flex-1 break-words font-medium font-mono text-[11px] text-gray-12 hover:text-accent-11"
           >
             {titleContent}
           </a>
@@ -156,7 +156,7 @@ function GitHubIssueSignalCard({ signal }: SignalCardProps) {
           <Text
             size="1"
             weight="medium"
-            className="min-w-0 flex-1 truncate font-mono text-[11px]"
+            className="min-w-0 flex-1 break-words font-mono text-[11px]"
           >
             {titleContent}
           </Text>

--- a/apps/twig/src/renderer/styles/globals.css
+++ b/apps/twig/src/renderer/styles/globals.css
@@ -995,3 +995,11 @@ button,
 .rt-SelectTrigger {
   background-color: var(--gray-2) !important;
 }
+
+/* Radix ScrollArea wraps viewport children in a div with display:table,
+   which expands to content width. This class overrides that so content
+   wraps within the viewport width instead of overflowing horizontally. */
+.scroll-area-constrain-width > .rt-ScrollAreaViewport > div {
+  display: block !important;
+  width: 100% !important;
+}


### PR DESCRIPTION
Fixes text overflow issues in the Signals Inbox where text failed to wrap properly within the panel width.

## Changes

- **CSS**: Added `scroll-area-constrain-width` override to force Radix ScrollArea viewport children to use `display: block` instead of `display: table`, enabling proper text wrapping
- **InboxSignalsTab**: Applied the `scroll-area-constrain-width` class to the detail panel's ScrollArea and added `min-w-0` to inner flex container
- **SignalCard**: Changed GitHub issue signal titles from `truncate` to `break-words`, adjusted header alignment to `start`, and added margin to icon for proper multi-line alignment

## Root Cause

Radix UI's ScrollArea component wraps viewport children in a div with `display: table`, which causes content to expand horizontally rather than wrap. This bypasses normal flex/width constraints entirely, so simply adding `overflow-hidden` or `break-words` wasn't sufficient.

## Testing

✅ Verified in local Electron build:
- Text in detail panel now wraps within sidebar width
- Signal card titles break to new lines instead of being truncated
- Resizing the sidebar causes text to reflow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)