### PR TITLE
feat: add Twig attribution to agent-generated PR descriptions

### DIFF
--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -41,13 +41,20 @@ const BRANCH_NAMING_INSTRUCTIONS = `
 When working in a detached HEAD state, create a descriptive branch name based on the work being done before committing. Do this automatically without asking the user.
 `;
 
+const PR_ATTRIBUTION = `
+# PR Attribution
+
+When creating pull requests, replace the default "Generated with Claude Code" line with:
+🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Twig](https://twig.com) 🌱
+`;
+
 export function buildSystemPrompt(
   customPrompt?: unknown,
 ): Options["systemPrompt"] {
   const defaultPrompt: Options["systemPrompt"] = {
     type: "preset",
     preset: "claude_code",
-    append: BRANCH_NAMING_INSTRUCTIONS,
+    append: BRANCH_NAMING_INSTRUCTIONS + PR_ATTRIBUTION,
   };
 
   if (!customPrompt) {
@@ -55,7 +62,7 @@ export function buildSystemPrompt(
   }
 
   if (typeof customPrompt === "string") {
-    return customPrompt + BRANCH_NAMING_INSTRUCTIONS;
+    return customPrompt + BRANCH_NAMING_INSTRUCTIONS + PR_ATTRIBUTION;
   }
 
   if (
@@ -66,7 +73,7 @@ export function buildSystemPrompt(
   ) {
     return {
       ...defaultPrompt,
-      append: customPrompt.append + BRANCH_NAMING_INSTRUCTIONS,
+      append: customPrompt.append + BRANCH_NAMING_INSTRUCTIONS + PR_ATTRIBUTION,
     };
   }
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -610,7 +610,7 @@ After completing the requested changes:
 Important:
 - Always create the PR. Do not ask for confirmation.
 - Do NOT add "Co-Authored-By" trailers to commit messages.
-- Do NOT add "Generated with [Claude Code]" or similar attribution lines to PR descriptions.
+- Instead of the default "Generated with Claude Code" attribution, add this line to PR descriptions: 🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Twig](https://twig.com) 🌱
 `;
   }
 


### PR DESCRIPTION
## Summary
- Replace the default "Generated with Claude Code" line with Twig-branded attribution in PRs created by the agent
- Changes applied to both system prompt options and agent server instructions

## Changes
- Updated `packages/agent/src/adapters/claude/session/options.ts` to append Twig PR attribution to system prompt
- Updated `packages/agent/src/server/agent-server.ts` to instruct agent to use Twig attribution instead of default

## Test plan
- [ ] Create a PR using the agent and verify it contains: 🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Twig](https://twig.com) 🌱

🤖 Generated with [Claude Code](https://claude.com/claude-code)