### PR TITLE
feat: worktree qol, update worktree path

### DIFF
--- a/apps/twig/src/main/services/settingsStore.ts
+++ b/apps/twig/src/main/services/settingsStore.ts
@@ -1,7 +1,7 @@
 import { existsSync, renameSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { LEGACY_DATA_DIRS, WORKSPACES_DIR } from "@shared/constants";
+import { LEGACY_DATA_DIRS, WORKTREES_DIR } from "@shared/constants";
 import { app } from "electron";
 import Store from "electron-store";
 
@@ -12,12 +12,20 @@ interface SettingsSchema {
 
 function getDefaultWorktreeLocation(): string {
   const isDev = !app.isPackaged;
-  const dir = isDev ? `${WORKSPACES_DIR}-dev` : WORKSPACES_DIR;
+  const dir = isDev ? `${WORKTREES_DIR}-dev` : WORKTREES_DIR;
   return path.join(os.homedir(), dir);
 }
 
 function getLegacyWorktreeLocations(): string[] {
-  return LEGACY_DATA_DIRS.map((dir) => path.join(os.homedir(), dir));
+  const isDev = !app.isPackaged;
+  const locations: string[] = [];
+  for (const dir of LEGACY_DATA_DIRS) {
+    if (isDev) {
+      locations.push(path.join(os.homedir(), `${dir}-dev`));
+    }
+    locations.push(path.join(os.homedir(), dir));
+  }
+  return locations;
 }
 
 /**
@@ -76,17 +84,6 @@ function migrateWorktreeSetting(): void {
   const stored = settingsStore.get("worktreeLocation");
   const newDefault = getDefaultWorktreeLocation();
 
-  // If dev still points to the shared prod workspaces path, update to dev-specific path
-  const isDev = !app.isPackaged;
-  if (isDev) {
-    const sharedPath = path.join(os.homedir(), WORKSPACES_DIR);
-    if (stored === sharedPath) {
-      settingsStore.set("worktreeLocation", newDefault);
-      return;
-    }
-  }
-
-  // If user had a legacy default, update to new default
   for (const legacyPath of getLegacyWorktreeLocations()) {
     if (stored === legacyPath && existsSync(newDefault)) {
       settingsStore.set("worktreeLocation", newDefault);

--- a/apps/twig/src/main/services/shell/service.ts
+++ b/apps/twig/src/main/services/shell/service.ts
@@ -303,7 +303,10 @@ export class ShellService extends TypedEventEmitter<ShellEvents> {
     if (association.mode === "worktree") {
       worktreeName = association.worktree;
       const worktreeBasePath = getWorktreeLocation();
-      worktreePath = path.join(worktreeBasePath, folder.name, worktreeName);
+      const isLegacy = !/^\d+$/.test(worktreeName);
+      worktreePath = isLegacy
+        ? path.join(worktreeBasePath, folder.name, worktreeName)
+        : path.join(worktreeBasePath, worktreeName, folder.name);
     }
 
     return buildWorkspaceEnv({

--- a/apps/twig/src/main/services/workspace/service.ts
+++ b/apps/twig/src/main/services/workspace/service.ts
@@ -53,10 +53,17 @@ function getFolderPath(folderId: string): string | null {
   return folder?.path ?? null;
 }
 
+function isLegacyWorktreeName(name: string): boolean {
+  return !/^\d+$/.test(name);
+}
+
 function deriveWorktreePath(folderPath: string, worktreeName: string): string {
   const worktreeBasePath = getWorktreeLocation();
   const repoName = path.basename(folderPath);
-  return path.join(worktreeBasePath, repoName, worktreeName);
+  if (isLegacyWorktreeName(worktreeName)) {
+    return path.join(worktreeBasePath, repoName, worktreeName);
+  }
+  return path.join(worktreeBasePath, worktreeName, repoName);
 }
 
 async function hasAnyFiles(repoPath: string): Promise<boolean> {

--- a/apps/twig/src/renderer/features/task-detail/components/TaskDetail.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/TaskDetail.tsx
@@ -55,8 +55,6 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
   useBlurOnEscape();
   useWorkspaceEvents(taskId);
 
-  const worktreePath = workspace?.worktreePath;
-
   const headerContent = useMemo(
     () => (
       <Flex align="center" justify="between" gap="2" width="100%">
@@ -84,10 +82,12 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
             </Tooltip>
           )}
         </Flex>
-        {worktreePath && <ExternalAppsOpener targetPath={worktreePath} />}
+        {effectiveRepoPath && (
+          <ExternalAppsOpener targetPath={effectiveRepoPath} />
+        )}
       </Flex>
     ),
-    [task.title, taskId, workspace?.branchName, worktreePath],
+    [task.title, taskId, workspace?.branchName, effectiveRepoPath],
   );
 
   useSetHeaderContent(headerContent);

--- a/apps/twig/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -25,7 +25,7 @@ const MODE_CONFIG: Record<
   },
   worktree: {
     label: "Worktree",
-    description: "Edits a copy so your work stays isolated",
+    description: "Create a copy of your local project to work in parallel",
     icon: <GitBranch size={16} weight="regular" />,
   },
   cloud: {

--- a/apps/twig/src/shared/constants.ts
+++ b/apps/twig/src/shared/constants.ts
@@ -13,11 +13,6 @@ export function isTwigBranch(branchName: string): boolean {
   );
 }
 
-/**
- * Data directory conventions.
- * - Worktrees stored in WORKSPACES_DIR (~/.twig/workspaces)
- * - LEGACY_DATA_DIRS are old locations that need migration (only .array)
- */
 export const DATA_DIR = ".twig";
-export const WORKSPACES_DIR = ".twig/workspaces";
-export const LEGACY_DATA_DIRS = [".array"];
+export const WORKTREES_DIR = ".twig/worktrees";
+export const LEGACY_DATA_DIRS = [".twig/workspaces", ".array"];

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -23,58 +23,6 @@ export interface WorktreeConfig {
   worktreeBasePath?: string;
 }
 
-const COLORS = [
-  "red",
-  "orange",
-  "yellow",
-  "green",
-  "blue",
-  "purple",
-  "pink",
-  "brown",
-  "cyan",
-  "magenta",
-  "teal",
-  "navy",
-  "maroon",
-  "olive",
-  "coral",
-  "turquoise",
-  "indigo",
-  "violet",
-  "lavender",
-  "crimson",
-  "gold",
-  "silver",
-  "bronze",
-  "ivory",
-  "charcoal",
-  "slate",
-  "jade",
-  "ruby",
-  "amber",
-  "emerald",
-  "sapphire",
-  "pearl",
-  "onyx",
-  "copper",
-  "mint",
-  "peach",
-  "plum",
-  "lime",
-  "aqua",
-  "rose",
-  "sky",
-  "moss",
-  "sand",
-  "rust",
-  "burgundy",
-  "cobalt",
-  "ochre",
-  "lilac",
-  "cedar",
-];
-
 const WORKTREE_FOLDER_NAME = ".twig";
 
 export class WorktreeManager {
@@ -92,28 +40,23 @@ export class WorktreeManager {
     return this.worktreeBasePath !== null;
   }
 
-  private randomElement<T>(array: T[]): T {
-    return array[crypto.randomInt(array.length)];
-  }
-
   generateWorktreeName(): string {
-    const color = this.randomElement(COLORS);
-    return `workspace-${color}`;
+    return crypto.randomInt(1000, 10000).toString();
   }
 
-  private getWorktreeFolderPath(): string {
+  private getWorktreeBaseFolderPath(): string {
     if (this.worktreeBasePath) {
-      return path.join(this.worktreeBasePath, this.repoName);
+      return this.worktreeBasePath;
     }
     return path.join(this.mainRepoPath, WORKTREE_FOLDER_NAME);
   }
 
   private getWorktreePath(name: string): string {
-    return path.join(this.getWorktreeFolderPath(), name);
+    return path.join(this.getWorktreeBaseFolderPath(), name, this.repoName);
   }
 
   getLocalWorktreePath(): string {
-    return path.join(this.getWorktreeFolderPath(), "local");
+    return path.join(this.getWorktreeBaseFolderPath(), "local", this.repoName);
   }
 
   async localWorktreeExists(): Promise<boolean> {
@@ -170,7 +113,7 @@ export class WorktreeManager {
     }
 
     if (attempts >= maxAttempts) {
-      name = `${this.generateWorktreeName()}-${Date.now()}`;
+      name = `${this.generateWorktreeName()}${Date.now()}`;
     }
 
     return name;
@@ -185,9 +128,6 @@ export class WorktreeManager {
 
     if (!this.usesExternalPath()) {
       setupPromises.push(this.ensureArrayDirIgnored());
-    } else {
-      const folderPath = this.getWorktreeFolderPath();
-      setupPromises.push(fs.mkdir(folderPath, { recursive: true }));
     }
 
     const worktreeNamePromise = this.generateUniqueWorktreeName();
@@ -204,6 +144,9 @@ export class WorktreeManager {
     const baseBranch = await baseBranchPromise;
     const worktreePath = this.getWorktreePath(worktreeName);
 
+    const parentDir = path.dirname(worktreePath);
+    await fs.mkdir(parentDir, { recursive: true });
+
     await manager.executeWrite(this.mainRepoPath, async (git) => {
       if (this.usesExternalPath()) {
         await git.raw([
@@ -215,7 +158,7 @@ export class WorktreeManager {
           baseBranch,
         ]);
       } else {
-        const relativePath = `./${WORKTREE_FOLDER_NAME}/${worktreeName}`;
+        const relativePath = `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
         await git.raw([
           "worktree",
           "add",
@@ -246,27 +189,26 @@ export class WorktreeManager {
       throw new Error(`Branch '${branch}' does not exist`);
     }
 
-    const sanitizedBranchName = branch.replace(/\//g, "-");
-    let worktreeName = sanitizedBranchName;
+    let worktreeName = this.generateWorktreeName();
 
     if (await this.worktreeExists(worktreeName)) {
-      worktreeName = `${sanitizedBranchName}-${Date.now()}`;
+      worktreeName = `${this.generateWorktreeName()}${Date.now()}`;
     }
 
     if (!this.usesExternalPath()) {
       await this.ensureArrayDirIgnored();
-    } else {
-      const folderPath = this.getWorktreeFolderPath();
-      await fs.mkdir(folderPath, { recursive: true });
     }
 
     const worktreePath = this.getWorktreePath(worktreeName);
+
+    const parentDir = path.dirname(worktreePath);
+    await fs.mkdir(parentDir, { recursive: true });
 
     await manager.executeWrite(this.mainRepoPath, async (git) => {
       if (this.usesExternalPath()) {
         await git.raw(["worktree", "add", "--quiet", worktreePath, branch]);
       } else {
-        const relativePath = `./${WORKTREE_FOLDER_NAME}/${worktreeName}`;
+        const relativePath = `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
         await git.raw(["worktree", "add", "--quiet", relativePath, branch]);
       }
     });
@@ -339,18 +281,18 @@ export class WorktreeManager {
   async listWorktrees(): Promise<WorktreeInfo[]> {
     try {
       const rawWorktrees = await listWorktreesRaw(this.mainRepoPath);
-      const worktreeFolderPath = this.getWorktreeFolderPath();
+      const baseFolderPath = this.getWorktreeBaseFolderPath();
 
       return rawWorktrees
         .filter((wt) => {
           const isMainRepo =
             path.resolve(wt.path) === path.resolve(this.mainRepoPath);
-          const isInWorktreeFolder = wt.path.startsWith(worktreeFolderPath);
-          return wt.branch && !isMainRepo && isInWorktreeFolder;
+          const isUnderBase = wt.path.startsWith(baseFolderPath);
+          return wt.branch && !isMainRepo && isUnderBase;
         })
         .map((wt) => ({
           worktreePath: wt.path,
-          worktreeName: path.basename(wt.path),
+          worktreeName: path.basename(path.dirname(wt.path)),
           branchName: wt.branch as string,
           baseBranch: "",
           createdAt: "",


### PR DESCRIPTION
- Worktrees are now located in `.twig/worktrees/{4-number-id}/{repo-name}`, this is clearer than something like `workspace-orange` as the folder name
- Updated worktree hint to `Create a copy of your local project to work in parallel
- Also display `Open in external editor` button in local tasks, not just worktree tasks