### PR TITLE
fix(agent): add missing claude-sonnet-4-6 model mapping

### DIFF
--- a/packages/agent/src/adapters/claude/session/models.ts
+++ b/packages/agent/src/adapters/claude/session/models.ts
@@ -4,6 +4,7 @@ const GATEWAY_TO_SDK_MODEL: Record<string, string> = {
   "claude-opus-4-5": "opus",
   "claude-opus-4-6": "opus",
   "claude-sonnet-4-5": "sonnet",
+  "claude-sonnet-4-6": "sonnet",
   "claude-haiku-4-5": "haiku",
 };
 


### PR DESCRIPTION
## Problem

The `claude-sonnet-4-6` model ID was missing from the gateway-to-SDK model mapping, causing sessions using Sonnet 4.6 to fail model resolution.

## Changes

Added `claude-sonnet-4-6` → `sonnet` entry to the `GATEWAY_TO_SDK_MODEL` mapping in `packages/agent/src/adapters/claude/session/models.ts`.

## How did you test this code?

Typecheck passes (`pnpm typecheck`). Verified the mapping table is consistent with other model entries.

## Publish to changelog?

no