### PR TITLE
feat: Invite system

### DIFF
--- a/apps/twig/src/renderer/App.tsx
+++ b/apps/twig/src/renderer/App.tsx
@@ -2,6 +2,7 @@ import { ErrorBoundary } from "@components/ErrorBoundary";
 import { LoginTransition } from "@components/LoginTransition";
 import { MainLayout } from "@components/MainLayout";
 import { AuthScreen } from "@features/auth/components/AuthScreen";
+import { InviteCodeScreen } from "@features/auth/components/InviteCodeScreen";
 import { useAuthStore } from "@features/auth/stores/authStore";
 import { OnboardingFlow } from "@features/onboarding/components/OnboardingFlow";
 import { useWorkspaceStore } from "@features/workspace/stores/workspaceStore";
@@ -19,7 +20,8 @@ import { useEffect, useRef, useState } from "react";
 const log = logger.scope("app");
 
 function App() {
-  const { isAuthenticated, hasCompletedOnboarding } = useAuthStore();
+  const { isAuthenticated, hasCompletedOnboarding, hasTwigAccess } =
+    useAuthStore();
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
   const [isLoading, setIsLoading] = useState(true);
   const [showTransition, setShowTransition] = useState(false);
@@ -164,7 +166,7 @@ function App() {
     );
   }
 
-  // Three-phase rendering: auth → onboarding → main app
+  // Four-phase rendering: auth → access gate → onboarding → main app
   const renderContent = () => {
     if (!isAuthenticated) {
       return (
@@ -175,6 +177,41 @@ function App() {
           transition={{ duration: 0.5 }}
         >
           <AuthScreen />
+        </motion.div>
+      );
+    }
+
+    // Access check loading state
+    if (hasTwigAccess === null) {
+      return (
+        <motion.div
+          key="access-check"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+        >
+          <Flex align="center" justify="center" minHeight="100vh">
+            <Flex align="center" gap="3">
+              <Spinner size="3" />
+              <Text color="gray">Checking access...</Text>
+            </Flex>
+          </Flex>
+        </motion.div>
+      );
+    }
+
+    // Access gate: show invite code screen if flag is not enabled
+    if (!hasTwigAccess) {
+      return (
+        <motion.div
+          key="invite-code"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.5 }}
+        >
+          <InviteCodeScreen />
         </motion.div>
       );
     }

--- a/apps/twig/src/renderer/features/auth/components/InviteCodeScreen.tsx
+++ b/apps/twig/src/renderer/features/auth/components/InviteCodeScreen.tsx
@@ -1,0 +1,190 @@
+import { DraggableTitleBar } from "@components/DraggableTitleBar";
+import { useAuthStore } from "@features/auth/stores/authStore";
+import { Callout, Flex, Spinner, Text } from "@radix-ui/themes";
+import treeBg from "@renderer/assets/images/tree-bg.svg";
+import twigLogo from "@renderer/assets/images/twig-logo.svg";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function InviteCodeScreen() {
+  const [code, setCode] = useState("");
+  const { redeemInviteCode, logout } = useAuthStore();
+
+  const redeemMutation = useMutation({
+    mutationFn: async () => {
+      await redeemInviteCode(code.trim());
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code.trim()) return;
+    redeemMutation.mutate();
+  };
+
+  const errorMessage = redeemMutation.error?.message ?? null;
+
+  return (
+    <Flex height="100vh" style={{ position: "relative", overflow: "hidden" }}>
+      <DraggableTitleBar />
+
+      {/* Background */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundColor: "#FAEEDE",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: "50%",
+          backgroundImage: `url(${treeBg})`,
+          backgroundSize: "cover",
+          backgroundPosition: "left center",
+          backgroundRepeat: "no-repeat",
+        }}
+      />
+
+      {/* Left side with card */}
+      <Flex
+        width="50%"
+        align="center"
+        justify="center"
+        style={{ position: "relative", zIndex: 1 }}
+      >
+        {/* Scrim behind card area */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(247, 237, 223, 0.7) 0%, rgba(247, 237, 223, 0.3) 70%, transparent 100%)",
+            pointerEvents: "none",
+          }}
+        />
+
+        {/* Invite code card */}
+        <Flex
+          direction="column"
+          gap="5"
+          style={{
+            position: "relative",
+            width: "360px",
+            padding: "32px",
+            backgroundColor: "rgba(247, 237, 223, 0.7)",
+            backdropFilter: "blur(20px)",
+            WebkitBackdropFilter: "blur(20px)",
+            borderRadius: "16px",
+            border: "1px solid rgba(255, 255, 255, 0.3)",
+            boxShadow:
+              "0 8px 32px rgba(0, 0, 0, 0.08), 0 2px 8px rgba(0, 0, 0, 0.04)",
+          }}
+        >
+          {/* Logo */}
+          <img
+            src={twigLogo}
+            alt="Twig"
+            style={{
+              height: "48px",
+              objectFit: "contain",
+              alignSelf: "center",
+            }}
+          />
+
+          <Text
+            size="2"
+            align="center"
+            style={{ color: "var(--cave-charcoal)", opacity: 0.7 }}
+          >
+            Enter your invite code to get started
+          </Text>
+
+          {/* Error */}
+          {errorMessage && (
+            <Callout.Root color="red" size="1">
+              <Callout.Text>{errorMessage}</Callout.Text>
+            </Callout.Root>
+          )}
+
+          {/* Form */}
+          <form onSubmit={handleSubmit}>
+            <Flex direction="column" gap="3">
+              <input
+                type="text"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="Invite code"
+                disabled={redeemMutation.isPending}
+                style={{
+                  width: "100%",
+                  height: "44px",
+                  padding: "0 12px",
+                  border: "1px solid rgba(0, 0, 0, 0.15)",
+                  borderRadius: "10px",
+                  fontSize: "15px",
+                  backgroundColor: "rgba(255, 255, 255, 0.5)",
+                  color: "var(--cave-charcoal)",
+                  outline: "none",
+                  boxSizing: "border-box",
+                }}
+              />
+              <button
+                type="submit"
+                disabled={redeemMutation.isPending || !code.trim()}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "8px",
+                  width: "100%",
+                  height: "44px",
+                  border: "none",
+                  borderRadius: "10px",
+                  fontSize: "15px",
+                  fontWeight: 500,
+                  cursor:
+                    redeemMutation.isPending || !code.trim()
+                      ? "not-allowed"
+                      : "pointer",
+                  backgroundColor: "var(--cave-charcoal)",
+                  color: "var(--cave-cream)",
+                  opacity: redeemMutation.isPending || !code.trim() ? 0.5 : 1,
+                  transition: "opacity 150ms ease",
+                }}
+              >
+                {redeemMutation.isPending ? <Spinner size="1" /> : "Redeem"}
+              </button>
+            </Flex>
+          </form>
+
+          {/* Log out link */}
+          <Flex justify="center">
+            <button
+              type="button"
+              onClick={logout}
+              style={{
+                background: "none",
+                border: "none",
+                padding: 0,
+                color: "var(--cave-charcoal)",
+                opacity: 0.5,
+                cursor: "pointer",
+                fontSize: "13px",
+              }}
+            >
+              Log out
+            </button>
+          </Flex>
+        </Flex>
+      </Flex>
+
+      {/* Right side - shows background */}
+      <div style={{ width: "50%" }} />
+    </Flex>
+  );
+}

--- a/apps/twig/src/renderer/features/auth/stores/authStore.test.ts
+++ b/apps/twig/src/renderer/features/auth/stores/authStore.test.ts
@@ -40,6 +40,9 @@ vi.mock("@renderer/lib/analytics", () => ({
   identifyUser: vi.fn(),
   resetUser: vi.fn(),
   track: vi.fn(),
+  isFeatureFlagEnabled: vi.fn().mockReturnValue(false),
+  onFeatureFlagsLoaded: vi.fn(),
+  reloadFeatureFlags: vi.fn(),
 }));
 
 vi.mock("@renderer/lib/logger", () => ({

--- a/apps/twig/src/renderer/features/auth/stores/authStore.ts
+++ b/apps/twig/src/renderer/features/auth/stores/authStore.ts
@@ -1,5 +1,11 @@
 import { PostHogAPIClient } from "@renderer/api/posthogClient";
-import { identifyUser, resetUser, track } from "@renderer/lib/analytics";
+import {
+  identifyUser,
+  isFeatureFlagEnabled,
+  reloadFeatureFlags,
+  resetUser,
+  track,
+} from "@renderer/lib/analytics";
 import { electronStorage } from "@renderer/lib/electronStorage";
 import { logger } from "@renderer/lib/logger";
 import { queryClient } from "@renderer/lib/queryClient";
@@ -70,10 +76,17 @@ interface AuthState {
 
   needsScopeReauth: boolean; // True when stored token scope version is stale
 
+  // Access gate state
+  hasTwigAccess: boolean | null; // null = not yet checked
+
   // Onboarding state
   hasCompletedOnboarding: boolean;
   selectedPlan: "free" | "pro" | null;
   selectedOrgId: string | null;
+
+  // Access gate methods
+  checkTwigAccess: () => void;
+  redeemInviteCode: (code: string) => Promise<void>;
 
   // OAuth methods
   loginWithOAuth: (region: CloudRegion) => Promise<void>;
@@ -122,10 +135,66 @@ export const useAuthStore = create<AuthState>()(
         // Scope re-auth state
         needsScopeReauth: false,
 
+        // Access gate state
+        hasTwigAccess: null,
+
         // Onboarding state
         hasCompletedOnboarding: false,
         selectedPlan: null,
         selectedOrgId: null,
+
+        checkTwigAccess: () => {
+          const state = get();
+          if (!state.cloudRegion || !state.oauthAccessToken) {
+            set({ hasTwigAccess: false });
+            return;
+          }
+
+          set({ hasTwigAccess: null });
+
+          const baseUrl = getCloudUrlFromRegion(state.cloudRegion);
+          fetch(`${baseUrl}/api/code/invites/check-access/`, {
+            headers: {
+              Authorization: `Bearer ${state.oauthAccessToken}`,
+            },
+          })
+            .then((res) => res.json())
+            .then((data) => {
+              set({ hasTwigAccess: data.has_access === true });
+            })
+            .catch((err) => {
+              log.error("Failed to check Twig access", err);
+              // On network error, fall back to feature flag check
+              set({ hasTwigAccess: isFeatureFlagEnabled("tasks") });
+            });
+        },
+
+        redeemInviteCode: async (code: string) => {
+          const state = get();
+          if (!state.cloudRegion || !state.oauthAccessToken) {
+            throw new Error("Not authenticated");
+          }
+
+          const baseUrl = getCloudUrlFromRegion(state.cloudRegion);
+          const response = await fetch(`${baseUrl}/api/code/invites/redeem/`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${state.oauthAccessToken}`,
+            },
+            body: JSON.stringify({ code }),
+          });
+
+          const data = await response.json();
+
+          if (!response.ok || !data.success) {
+            throw new Error(data.error || "Failed to redeem invite code");
+          }
+
+          // Optimistically grant access — the flag will catch up on next launch
+          set({ hasTwigAccess: true });
+          reloadFeatureFlags();
+        },
 
         loginWithOAuth: async (region: CloudRegion) => {
           const result = await trpcVanilla.oauth.startFlow.mutate({ region });
@@ -231,6 +300,8 @@ export const useAuthStore = create<AuthState>()(
                 region,
               },
             });
+
+            get().checkTwigAccess();
           } catch (error) {
             log.error("Failed to authenticate with PostHog", error);
             throw new Error("Failed to authenticate with PostHog");
@@ -560,6 +631,8 @@ export const useAuthStore = create<AuthState>()(
                   },
                 });
 
+                get().checkTwigAccess();
+
                 return true;
               } catch (error) {
                 log.error("Failed to validate OAuth session:", error);
@@ -697,6 +770,8 @@ export const useAuthStore = create<AuthState>()(
                 region,
               },
             });
+
+            get().checkTwigAccess();
           } catch (error) {
             log.error("Failed to authenticate with PostHog", error);
             throw new Error("Failed to authenticate with PostHog");
@@ -824,6 +899,7 @@ export const useAuthStore = create<AuthState>()(
             availableOrgIds: [],
             needsProjectSelection: false,
             needsScopeReauth: false,
+            hasTwigAccess: null,
             hasCompletedOnboarding: false,
             selectedPlan: null,
             selectedOrgId: null,
@@ -841,6 +917,7 @@ export const useAuthStore = create<AuthState>()(
           projectId: state.projectId,
           availableProjectIds: state.availableProjectIds,
           availableOrgIds: state.availableOrgIds,
+          hasTwigAccess: state.hasTwigAccess,
           hasCompletedOnboarding: state.hasCompletedOnboarding,
           selectedPlan: state.selectedPlan,
           selectedOrgId: state.selectedOrgId,

--- a/apps/twig/src/renderer/lib/analytics.ts
+++ b/apps/twig/src/renderer/lib/analytics.ts
@@ -176,3 +176,15 @@ export function onFeatureFlagsLoaded(callback: () => void): () => void {
 
   return posthog.onFeatureFlags(callback);
 }
+
+/**
+ * Reload feature flags from the server.
+ * Useful after a person property change (e.g., invite code redemption).
+ */
+export function reloadFeatureFlags(): void {
+  if (!isInitialized) {
+    return;
+  }
+
+  posthog.reloadFeatureFlags();
+}


### PR DESCRIPTION
### TL;DR

Added an invite code screen that gates access to the main application based on a feature flag.

### What changed?

- Added a new `InviteCodeScreen` component with a form for entering invite codes
- Introduced `hasTwigAccess` state to the auth store that checks the "tasks" feature flag
- Added `checkTwigAccess()` method that evaluates feature flag status with timeout handling
- Added `redeemInviteCode()` method that calls the invite code redemption API endpoint
- Added `reloadFeatureFlags()` function to refresh feature flags after invite code redemption
- Modified the App component to render a four-phase flow: auth → access gate → onboarding → main app
- Added loading state while checking access permissions