### PR TITLE
Non-threatening inbox badge

### DIFF
--- a/apps/twig/src/renderer/features/sidebar/components/items/HomeItem.tsx
+++ b/apps/twig/src/renderer/features/sidebar/components/items/HomeItem.tsx
@@ -40,7 +40,7 @@ export function InboxItem({ isActive, onClick, signalCount }: InboxItemProps) {
       endContent={
         signalCount && signalCount > 0 ? (
           <span
-            className="inline-flex min-w-[16px] items-center justify-center rounded-full bg-red-9 px-1 text-[10px] text-white leading-none"
+            className="inline-flex min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] text-gray-11 leading-none"
             style={{ height: "16px" }}
             title={`${signalCount} signals`}
           >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Change the Inbox badge from a red filled pill to plain muted text to make it non-threatening.

---
[Slack Thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1772653099896919?thread_ts=1772653099.896919&cid=C09SK2PAGKF)

<p><a href="https://cursor.com/agents/bc-d6d28027-5213-5bd8-99c7-743dd8d772a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6d28027-5213-5bd8-99c7-743dd8d772a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->