### PR TITLE
fix: Stop embedding file content in prompts and fix image preview

### DIFF
--- a/apps/twig/src/main/services/fs/service.ts
+++ b/apps/twig/src/main/services/fs/service.ts
@@ -108,6 +108,39 @@ export class FsService {
     }
   }
 
+  async readFileAsBase64(filePath: string): Promise<string | null> {
+    const resolved = path.resolve(filePath);
+    try {
+      const buffer = await fs.promises.readFile(resolved);
+      return buffer.toString("base64");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        log.error(`Failed to read file as base64 ${filePath}:`, error);
+        return null;
+      }
+      // macOS uses narrow no-break space (U+202F) in screenshot filenames
+      // but paths often lose this during text processing. Find the actual file.
+      const dir = path.dirname(resolved);
+      const basename = path.basename(resolved);
+      try {
+        const files = await fs.promises.readdir(dir);
+        const normalizeSpaces = (s: string) =>
+          s.replace(/[\s\u00A0\u202F]/g, " ");
+        const normalizedTarget = normalizeSpaces(basename);
+        const match = files.find(
+          (f) => normalizeSpaces(f) === normalizedTarget,
+        );
+        if (match) {
+          const buffer = await fs.promises.readFile(path.join(dir, match));
+          return buffer.toString("base64");
+        }
+      } catch {
+        // Directory read failed
+      }
+      return null;
+    }
+  }
+
   async writeRepoFile(
     repoPath: string,
     filePath: string,

--- a/apps/twig/src/main/trpc/routers/fs.ts
+++ b/apps/twig/src/main/trpc/routers/fs.ts
@@ -33,6 +33,11 @@ export const fsRouter = router({
     .output(readRepoFileOutput)
     .query(({ input }) => getService().readAbsoluteFile(input.filePath)),
 
+  readFileAsBase64: publicProcedure
+    .input(readAbsoluteFileInput)
+    .output(readRepoFileOutput)
+    .query(({ input }) => getService().readFileAsBase64(input.filePath)),
+
   writeRepoFile: publicProcedure
     .input(writeRepoFileInput)
     .mutation(({ input }) =>

--- a/apps/twig/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
+++ b/apps/twig/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
@@ -7,6 +7,24 @@ import { Box, Flex } from "@radix-ui/themes";
 import { trpcReact } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
 
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  svg: "image/svg+xml",
+  tiff: "image/tiff",
+  tif: "image/tiff",
+};
+
+function getImageMimeType(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_MIME_TYPES[ext] ?? "image/png";
+}
+
 interface CodeEditorPanelProps {
   taskId: string;
   task: Task;
@@ -33,6 +51,11 @@ export function CodeEditorPanel({
     { enabled: !isInsideRepo && !isImage, staleTime: Infinity },
   );
 
+  const imageQuery = trpcReact.fs.readFileAsBase64.useQuery(
+    { filePath: absolutePath },
+    { enabled: isImage, staleTime: Infinity },
+  );
+
   const {
     data: fileContent,
     isLoading,
@@ -40,6 +63,15 @@ export function CodeEditorPanel({
   } = isInsideRepo ? repoQuery : absoluteQuery;
 
   if (isImage) {
+    if (imageQuery.isLoading) {
+      return <PanelMessage>Loading image...</PanelMessage>;
+    }
+    if (imageQuery.error || !imageQuery.data) {
+      return (
+        <PanelMessage detail={absolutePath}>Failed to load image</PanelMessage>
+      );
+    }
+    const mimeType = getImageMimeType(absolutePath);
     return (
       <Flex
         align="center"
@@ -49,7 +81,7 @@ export function CodeEditorPanel({
         style={{ overflow: "auto" }}
       >
         <img
-          src={`file://${absolutePath}`}
+          src={`data:${mimeType};base64,${imageQuery.data}`}
           alt={filePath}
           style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
         />
@@ -67,7 +99,6 @@ export function CodeEditorPanel({
     );
   }
 
-  // If we ever allow editing in the CodeMirrorEditor, this can be removed
   if (fileContent.length === 0) {
     return <PanelMessage>File is empty</PanelMessage>;
   }

--- a/apps/twig/src/renderer/features/editor/utils/prompt-builder.ts
+++ b/apps/twig/src/renderer/features/editor/utils/prompt-builder.ts
@@ -1,79 +1,37 @@
-import { trpcVanilla } from "@renderer/trpc/client";
-
-function getMimeType(filePath: string): string {
-  const ext = filePath.split(".").pop()?.toLowerCase();
-  const mimeTypes: Record<string, string> = {
-    ts: "text/typescript",
-    tsx: "text/typescript",
-    js: "text/javascript",
-    jsx: "text/javascript",
-    json: "application/json",
-    md: "text/markdown",
-    py: "text/x-python",
-    css: "text/css",
-    html: "text/html",
-    yml: "text/yaml",
-    yaml: "text/yaml",
-  };
-  return mimeTypes[ext ?? ""] ?? "text/plain";
-}
+import type { ContentBlock } from "@agentclientprotocol/sdk";
 
 function isAbsolutePath(filePath: string): boolean {
   return filePath.startsWith("/") || /^[a-zA-Z]:\\/.test(filePath);
 }
 
-async function readFileContent(
-  filePath: string,
-  repoPath: string,
-): Promise<string | null> {
-  if (isAbsolutePath(filePath)) {
-    return trpcVanilla.fs.readAbsoluteFile.query({ filePath });
-  }
-  return trpcVanilla.fs.readRepoFile.query({ repoPath, filePath });
+function pathToFileUri(filePath: string): string {
+  const encoded = filePath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `file://${encoded}`;
 }
 
 export async function buildPromptBlocks(
   textContent: string,
   filePaths: string[],
   repoPath: string,
-): Promise<
-  Array<
-    | { type: "text"; text: string }
-    | {
-        type: "resource";
-        resource: { uri: string; mimeType: string; text: string };
-      }
-  >
-> {
-  const blocks: Array<
-    | { type: "text"; text: string }
-    | {
-        type: "resource";
-        resource: { uri: string; mimeType: string; text: string };
-      }
-  > = [];
+): Promise<ContentBlock[]> {
+  const blocks: ContentBlock[] = [];
 
   blocks.push({ type: "text", text: textContent });
 
   for (const filePath of filePaths) {
-    try {
-      const fileContent = await readFileContent(filePath, repoPath);
-      if (fileContent) {
-        const uri = isAbsolutePath(filePath)
-          ? `file://${filePath}`
-          : `file://${repoPath}/${filePath}`;
-        blocks.push({
-          type: "resource",
-          resource: {
-            uri,
-            mimeType: getMimeType(filePath),
-            text: fileContent,
-          },
-        });
-      }
-    } catch {
-      // Skip files that can't be read
-    }
+    const absolutePath = isAbsolutePath(filePath)
+      ? filePath
+      : `${repoPath}/${filePath}`;
+    const uri = pathToFileUri(absolutePath);
+    const name = filePath.split("/").pop() ?? filePath;
+    blocks.push({
+      type: "resource_link",
+      uri,
+      name,
+    });
   }
 
   return blocks;


### PR DESCRIPTION
1. Replace inline file content embedding with resource_link blocks in prompt builder
2. Add readFileAsBase64 tRPC endpoint for image preview rendering. The renderer can't reference a file path on the users file system, it does not have access.
3. Render images via base64 data URLs instead of broken file:// paths
4. Handle macOS narrow no-break space (U+202F) in screenshot filenames via directory lookup fallback

![Screenshot 2026-03-04 at 1.11.24 PM.png](https://app.graphite.com/user-attachments/assets/70733011-da57-41d7-8b7e-8a7aa8cb6106.png)