### PR TITLE
feat: big imporvement to github flow with dep link and direct redirect

### DIFF
--- a/apps/twig/src/main/di/container.ts
+++ b/apps/twig/src/main/di/container.ts
@@ -14,6 +14,7 @@ import { FocusSyncService } from "../services/focus/sync-service.js";
 import { FoldersService } from "../services/folders/service.js";
 import { FsService } from "../services/fs/service.js";
 import { GitService } from "../services/git/service.js";
+import { GitHubIntegrationService } from "../services/github-integration/service.js";
 import { LlmGatewayService } from "../services/llm-gateway/service.js";
 import { NotificationService } from "../services/notification/service.js";
 import { OAuthService } from "../services/oauth/service.js";
@@ -49,6 +50,9 @@ container.bind(MAIN_TOKENS.FocusService).to(FocusService);
 container.bind(MAIN_TOKENS.FocusSyncService).to(FocusSyncService);
 container.bind(MAIN_TOKENS.FoldersService).to(FoldersService);
 container.bind(MAIN_TOKENS.FsService).to(FsService);
+container
+  .bind(MAIN_TOKENS.GitHubIntegrationService)
+  .to(GitHubIntegrationService);
 container.bind(MAIN_TOKENS.GitService).to(GitService);
 container.bind(MAIN_TOKENS.NotificationService).to(NotificationService);
 container.bind(MAIN_TOKENS.OAuthService).to(OAuthService);

--- a/apps/twig/src/main/di/tokens.ts
+++ b/apps/twig/src/main/di/tokens.ts
@@ -26,6 +26,7 @@ export const MAIN_TOKENS = Object.freeze({
   FoldersService: Symbol.for("Main.FoldersService"),
   FsService: Symbol.for("Main.FsService"),
   GitService: Symbol.for("Main.GitService"),
+  GitHubIntegrationService: Symbol.for("Main.GitHubIntegrationService"),
   DeepLinkService: Symbol.for("Main.DeepLinkService"),
   NotificationService: Symbol.for("Main.NotificationService"),
   OAuthService: Symbol.for("Main.OAuthService"),

--- a/apps/twig/src/main/services/github-integration/schemas.ts
+++ b/apps/twig/src/main/services/github-integration/schemas.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const cloudRegion = z.enum(["us", "eu", "dev"]);
+export type CloudRegion = z.infer<typeof cloudRegion>;
+
+export const startGitHubFlowInput = z.object({
+  region: cloudRegion,
+  projectId: z.number(),
+});
+export type StartGitHubFlowInput = z.infer<typeof startGitHubFlowInput>;
+
+export const startGitHubFlowOutput = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+});
+export type StartGitHubFlowOutput = z.infer<typeof startGitHubFlowOutput>;
+
+export const cancelGitHubFlowOutput = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+});
+export type CancelGitHubFlowOutput = z.infer<typeof cancelGitHubFlowOutput>;

--- a/apps/twig/src/main/services/github-integration/service.ts
+++ b/apps/twig/src/main/services/github-integration/service.ts
@@ -1,0 +1,219 @@
+import * as http from "node:http";
+import type { Socket } from "node:net";
+import { getCloudUrlFromRegion } from "@shared/constants/oauth.js";
+import { shell } from "electron";
+import { inject, injectable } from "inversify";
+import { MAIN_TOKENS } from "../../di/tokens.js";
+import { logger } from "../../utils/logger.js";
+import type { DeepLinkService } from "../deep-link/service.js";
+import type {
+  CancelGitHubFlowOutput,
+  CloudRegion,
+  StartGitHubFlowOutput,
+} from "./schemas.js";
+
+const log = logger.scope("github-integration-service");
+
+const PROTOCOL = "twig";
+const TIMEOUT_MS = 300_000; // 5 minutes
+const DEV_CALLBACK_PORT = 8238; // Different from OAuth's 8237
+
+// Use HTTP callback in development, deep link in production
+const IS_DEV = process.defaultApp || false;
+
+interface PendingFlow {
+  resolve: (success: boolean) => void;
+  reject: (error: Error) => void;
+  timeoutId: NodeJS.Timeout;
+  server?: http.Server;
+  connections?: Set<Socket>;
+}
+
+@injectable()
+export class GitHubIntegrationService {
+  private pendingFlow: PendingFlow | null = null;
+
+  constructor(
+    @inject(MAIN_TOKENS.DeepLinkService)
+    private readonly deepLinkService: DeepLinkService,
+  ) {
+    this.deepLinkService.registerHandler("github-connected", () =>
+      this.handleCallback(),
+    );
+    log.info("Registered github-connected handler for deep links");
+  }
+
+  private handleCallback(): boolean {
+    if (!this.pendingFlow) {
+      log.warn("Received GitHub callback but no pending flow");
+      return false;
+    }
+    const { resolve, timeoutId } = this.pendingFlow;
+    clearTimeout(timeoutId);
+    this.pendingFlow = null;
+    resolve(true);
+    return true;
+  }
+
+  private getCallbackUrl(): string {
+    return IS_DEV
+      ? `http://localhost:${DEV_CALLBACK_PORT}/github-callback`
+      : `${PROTOCOL}://github-connected`;
+  }
+
+  public async startFlow(
+    region: CloudRegion,
+    projectId: number,
+  ): Promise<StartGitHubFlowOutput> {
+    try {
+      this.cancelFlow();
+
+      const cloudUrl = getCloudUrlFromRegion(region);
+      const callbackUrl = this.getCallbackUrl();
+      const authorizeUrl = `${cloudUrl}/api/environments/${projectId}/integrations/authorize/?kind=github&next=${encodeURIComponent(callbackUrl)}`;
+
+      const success = IS_DEV
+        ? await this.waitForHttpCallback(authorizeUrl)
+        : await this.waitForDeepLinkCallback(authorizeUrl);
+
+      return { success };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  }
+
+  public cancelFlow(): CancelGitHubFlowOutput {
+    try {
+      if (this.pendingFlow) {
+        if (this.pendingFlow.server) {
+          this.cleanupHttpServer();
+        } else {
+          clearTimeout(this.pendingFlow.timeoutId);
+          this.pendingFlow.reject(new Error("GitHub flow cancelled"));
+          this.pendingFlow = null;
+        }
+      }
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  }
+
+  private async waitForDeepLinkCallback(
+    authorizeUrl: string,
+  ): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pendingFlow = null;
+        reject(new Error("Authorization timed out"));
+      }, TIMEOUT_MS);
+
+      this.pendingFlow = { resolve, reject, timeoutId };
+
+      shell.openExternal(authorizeUrl).catch((error) => {
+        clearTimeout(timeoutId);
+        this.pendingFlow = null;
+        reject(new Error(`Failed to open browser: ${error.message}`));
+      });
+    });
+  }
+
+  private async waitForHttpCallback(authorizeUrl: string): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      const connections = new Set<Socket>();
+
+      const server = http.createServer((req, res) => {
+        if (!req.url) {
+          res.writeHead(400);
+          res.end();
+          return;
+        }
+
+        const url = new URL(req.url, `http://localhost:${DEV_CALLBACK_PORT}`);
+
+        if (url.pathname === "/github-callback") {
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(this.getCallbackHtml());
+          this.cleanupHttpServer();
+          resolve(true);
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      server.on("connection", (conn) => {
+        connections.add(conn);
+        conn.on("close", () => connections.delete(conn));
+      });
+
+      const timeoutId = setTimeout(() => {
+        this.cleanupHttpServer();
+        reject(new Error("Authorization timed out"));
+      }, TIMEOUT_MS);
+
+      this.pendingFlow = { resolve, reject, timeoutId, server, connections };
+
+      server.listen(DEV_CALLBACK_PORT, () => {
+        log.info(
+          `Dev GitHub callback server listening on port ${DEV_CALLBACK_PORT}`,
+        );
+        shell.openExternal(authorizeUrl).catch((error) => {
+          this.cleanupHttpServer();
+          reject(new Error(`Failed to open browser: ${error.message}`));
+        });
+      });
+
+      server.on("error", (error) => {
+        this.cleanupHttpServer();
+        reject(new Error(`Failed to start callback server: ${error.message}`));
+      });
+    });
+  }
+
+  private getCallbackHtml(): string {
+    return `<!DOCTYPE html>
+<html class="radix-themes" data-is-root-theme="true" data-accent-color="orange" data-gray-color="slate" data-has-background="true" data-panel-background="translucent" data-radius="none" data-scaling="100%">
+  <head>
+    <meta charset="utf-8">
+    <title>GitHub connected</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@radix-ui/themes@3.1.6/styles.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      @layer utilities {
+        .text-gray-12 { color: var(--gray-12); }
+        .text-gray-11 { color: var(--gray-11); }
+        .bg-gray-1 { background-color: var(--gray-1); }
+      }
+    </style>
+  </head>
+  <body class="dark bg-gray-1 h-screen overflow-hidden flex flex-col items-center justify-center m-0 gap-2">
+    <h1 class="text-gray-12 text-xl font-semibold">GitHub connected!</h1>
+    <p class="text-gray-11 text-sm">You can close this window and return to PostHog Code.</p>
+    <script>setTimeout(() => window.close(), 500);</script>
+  </body>
+</html>`;
+  }
+
+  private cleanupHttpServer(): void {
+    if (this.pendingFlow?.server) {
+      if (this.pendingFlow.connections) {
+        for (const conn of this.pendingFlow.connections) {
+          conn.destroy();
+        }
+        this.pendingFlow.connections.clear();
+      }
+      this.pendingFlow.server.close();
+    }
+    if (this.pendingFlow?.timeoutId) {
+      clearTimeout(this.pendingFlow.timeoutId);
+    }
+    this.pendingFlow = null;
+  }
+}

--- a/apps/twig/src/main/trpc/router.ts
+++ b/apps/twig/src/main/trpc/router.ts
@@ -13,6 +13,7 @@ import { focusRouter } from "./routers/focus.js";
 import { foldersRouter } from "./routers/folders.js";
 import { fsRouter } from "./routers/fs.js";
 import { gitRouter } from "./routers/git.js";
+import { githubIntegrationRouter } from "./routers/github-integration.js";
 import { llmGatewayRouter } from "./routers/llm-gateway.js";
 import { logsRouter } from "./routers/logs.js";
 import { notificationRouter } from "./routers/notification.js";
@@ -42,6 +43,7 @@ export const trpcRouter = router({
   folders: foldersRouter,
   fs: fsRouter,
   git: gitRouter,
+  githubIntegration: githubIntegrationRouter,
   llmGateway: llmGatewayRouter,
   notification: notificationRouter,
   oauth: oauthRouter,

--- a/apps/twig/src/main/trpc/routers/github-integration.ts
+++ b/apps/twig/src/main/trpc/routers/github-integration.ts
@@ -1,0 +1,25 @@
+import { container } from "../../di/container.js";
+import { MAIN_TOKENS } from "../../di/tokens.js";
+import {
+  cancelGitHubFlowOutput,
+  startGitHubFlowInput,
+  startGitHubFlowOutput,
+} from "../../services/github-integration/schemas.js";
+import type { GitHubIntegrationService } from "../../services/github-integration/service.js";
+import { publicProcedure, router } from "../trpc.js";
+
+const getService = () =>
+  container.get<GitHubIntegrationService>(MAIN_TOKENS.GitHubIntegrationService);
+
+export const githubIntegrationRouter = router({
+  startFlow: publicProcedure
+    .input(startGitHubFlowInput)
+    .output(startGitHubFlowOutput)
+    .mutation(({ input }) =>
+      getService().startFlow(input.region, input.projectId),
+    ),
+
+  cancelFlow: publicProcedure
+    .output(cancelGitHubFlowOutput)
+    .mutation(() => getService().cancelFlow()),
+});

--- a/apps/twig/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/twig/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -8,7 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import { Box, Button, Flex, Skeleton, Text } from "@radix-ui/themes";
 import phWordmark from "@renderer/assets/images/wordmark-alt.png";
-import { getCloudUrlFromRegion } from "@shared/constants/oauth";
+import { trpcVanilla } from "@renderer/trpc/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMemo, useState } from "react";
@@ -30,6 +30,8 @@ export function GitIntegrationStep({
 
   const queryClient = useQueryClient();
   const { projects, isLoading, isFetching } = useProjectsWithIntegrations();
+
+  const [isConnecting, setIsConnecting] = useState(false);
 
   // User can manually select a different project
   const [manuallySelectedProjectId, setManuallySelectedProjectId] = useState<
@@ -54,15 +56,25 @@ export function GitIntegrationStep({
 
   const hasGitIntegration = selectedProject?.hasGithubIntegration ?? false;
 
-  const handleConnectGitHub = () => {
+  const handleConnectGitHub = async () => {
     if (!cloudRegion || !selectedProjectId) return;
-    const cloudUrl = getCloudUrlFromRegion(cloudRegion);
-    const integrationUrl = `${cloudUrl}/project/${selectedProjectId}/settings/project-integrations`;
-    window.open(integrationUrl, "_blank");
+    setIsConnecting(true);
+    try {
+      const result = await trpcVanilla.githubIntegration.startFlow.mutate({
+        region: cloudRegion,
+        projectId: selectedProjectId,
+      });
+      if (result.success) {
+        queryClient.invalidateQueries({ queryKey: ["integrations"] });
+      }
+    } catch {
+      // Flow was cancelled or timed out — user can retry
+    } finally {
+      setIsConnecting(false);
+    }
   };
 
   const handleRefresh = () => {
-    // Re-fetch integrations for the selected project
     queryClient.invalidateQueries({ queryKey: ["integrations"] });
   };
 
@@ -90,14 +102,13 @@ export function GitIntegrationStep({
           <Text
             size="6"
             style={{
-              fontFamily: "Halfre, serif",
               color: "var(--gray-12)",
               lineHeight: 1.3,
             }}
           >
             Connect your git repository
           </Text>
-          <Text size="1" style={{ color: "var(--gray-12)", opacity: 0.7 }}>
+          <Text size="2" style={{ color: "var(--gray-12)", opacity: 0.7 }}>
             PostHog Code needs access to your GitHub repositories to create
             branches, commits, and pull requests.
           </Text>
@@ -211,7 +222,7 @@ export function GitIntegrationStep({
                       GitHub connected
                     </Text>
                     <Text
-                      size="1"
+                      size="2"
                       align="center"
                       style={{
                         color: "var(--gray-12)",
@@ -243,7 +254,7 @@ export function GitIntegrationStep({
                       No git integration found
                     </Text>
                     <Text
-                      size="1"
+                      size="2"
                       align="center"
                       style={{
                         color: "var(--gray-12)",
@@ -288,7 +299,11 @@ export function GitIntegrationStep({
                     alignItems: "center",
                   }}
                 >
-                  <Button size="2" onClick={handleConnectGitHub}>
+                  <Button
+                    size="2"
+                    onClick={handleConnectGitHub}
+                    loading={isConnecting}
+                  >
                     Connect GitHub
                     <ArrowSquareOut size={16} />
                   </Button>
@@ -299,7 +314,7 @@ export function GitIntegrationStep({
                       opacity: 0.5,
                     }}
                   >
-                    Opens your PostHog project settings
+                    Opens GitHub to authorize the PostHog app
                   </Text>
                   <Button
                     size="1"

--- a/apps/twig/src/renderer/features/onboarding/components/OrgBillingStep.tsx
+++ b/apps/twig/src/renderer/features/onboarding/components/OrgBillingStep.tsx
@@ -88,7 +88,6 @@ export function OrgBillingStep({ onNext, onBack }: OrgBillingStepProps) {
           <Text
             size="6"
             style={{
-              fontFamily: "Halfre, serif",
               color: "var(--gray-12)",
               lineHeight: 1.3,
             }}


### PR DESCRIPTION
### TL;DR

Added GitHub integration service to handle OAuth flow for connecting GitHub repositories directly within the application instead of opening external browser tabs.

### What changed?

- Created `GitHubIntegrationService` with OAuth flow handling using deep links in production and HTTP callbacks in development
- Added Zod schemas for input/output validation with cloud region and project ID parameters
- Registered the service in the dependency injection container with appropriate tokens
- Created tRPC router with `startFlow` and `cancelFlow` endpoints
- Updated the onboarding Git integration step to use the new service instead of opening external URLs
- Added loading state and error handling for the GitHub connection process
