### PR TITLE
chore(agent): make PRs drafts by default

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -364,14 +364,15 @@ describe("AgentServer HTTP Mode", () => {
       expect(prompt).toContain("Do NOT create a new branch");
       expect(prompt).toContain("https://github.com/org/repo/pull/1");
       expect(prompt).toContain("gh pr checkout");
-      expect(prompt).not.toContain("Create a pull request");
+      expect(prompt).not.toContain("Create a draft pull request");
     });
 
     it("returns default prompt when no prUrl", () => {
       const s = createServer();
       const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt();
       expect(prompt).toContain("Create a new branch");
-      expect(prompt).toContain("Create a pull request");
+      expect(prompt).toContain("Create a draft pull request");
+      expect(prompt).toContain("gh pr create --draft");
     });
 
     it("returns default prompt when prUrl is null", () => {
@@ -380,7 +381,8 @@ describe("AgentServer HTTP Mode", () => {
         null,
       );
       expect(prompt).toContain("Create a new branch");
-      expect(prompt).toContain("Create a pull request");
+      expect(prompt).toContain("Create a draft pull request");
+      expect(prompt).toContain("gh pr create --draft");
     });
   });
 });

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -706,10 +706,10 @@ After completing the requested changes:
 1. Create a new branch with a descriptive name based on the work done
 2. Stage and commit all changes with a clear commit message
 3. Push the branch to origin
-4. Create a pull request using \`gh pr create\` with a descriptive title and body
+4. Create a draft pull request using \`gh pr create --draft\` with a descriptive title and body
 
 Important:
-- Always create the PR. Do not ask for confirmation.
+- Always create the PR as a draft. Do not ask for confirmation.
 - Do NOT add "Co-Authored-By" trailers to commit messages.
 - Do NOT add "Generated with [Claude Code]" or similar attribution lines to PR descriptions.
 `;


### PR DESCRIPTION
When the cloud agent opens a PR, we aren't yet confident this change is actionable or the fix is correct, we should default to it creating draft PRs here.