### PR TITLE
feat(twig): add cloud diff viewing with file change tracking

### DIFF
--- a/apps/twig/src/renderer/features/code-editor/components/CloudDiffEditorPanel.tsx
+++ b/apps/twig/src/renderer/features/code-editor/components/CloudDiffEditorPanel.tsx
@@ -1,0 +1,59 @@
+import { PanelMessage } from "@components/ui/PanelMessage";
+import { CodeMirrorDiffEditor } from "@features/code-editor/components/CodeMirrorDiffEditor";
+import { useSessionForTask } from "@features/sessions/hooks/useSession";
+import {
+  buildCloudEventSummary,
+  extractCloudFileDiff,
+} from "@features/task-detail/utils/cloudToolChanges";
+import { Box } from "@radix-ui/themes";
+import type { AcpMessage } from "@shared/types/session-events";
+import { useMemo } from "react";
+
+const EMPTY_EVENTS: AcpMessage[] = [];
+
+interface CloudDiffEditorPanelProps {
+  taskId: string;
+  relativePath: string;
+}
+
+export function CloudDiffEditorPanel({
+  taskId,
+  relativePath,
+}: CloudDiffEditorPanelProps) {
+  const session = useSessionForTask(taskId);
+  const events = session?.events ?? EMPTY_EVENTS;
+
+  const { toolCalls } = useMemo(() => buildCloudEventSummary(events), [events]);
+  const diff = useMemo(
+    () => extractCloudFileDiff(toolCalls, relativePath),
+    [toolCalls, relativePath],
+  );
+
+  if (!diff) {
+    return (
+      <PanelMessage>
+        File was modified outside of tracked tool calls
+      </PanelMessage>
+    );
+  }
+
+  const { oldText, newText } = diff;
+
+  // File was created then deleted — nothing to show
+  if (oldText === null && newText === null) {
+    return <PanelMessage>No diff data available for this file</PanelMessage>;
+  }
+
+  // Always show the diff editor — treat null as empty string so additions
+  // appear green and deletions red (Write tools don't capture oldText, so
+  // null oldText just means "show everything as added").
+  return (
+    <Box height="100%" style={{ overflow: "hidden" }}>
+      <CodeMirrorDiffEditor
+        originalContent={oldText ?? ""}
+        modifiedContent={newText ?? ""}
+        relativePath={relativePath}
+      />
+    </Box>
+  );
+}

--- a/apps/twig/src/renderer/features/panels/store/panelLayoutStore.ts
+++ b/apps/twig/src/renderer/features/panels/store/panelLayoutStore.ts
@@ -10,9 +10,11 @@ import {
 import {
   addNewTabToPanel,
   applyCleanupWithFallback,
+  createCloudDiffTabId,
   createDiffTabId,
   createFileTabId,
   generatePanelId,
+  getCloudDiffTabIdsForFile,
   getDiffTabIdsForFile,
   getLeafPanel,
   getSplitConfig,
@@ -34,6 +36,24 @@ import type { PanelNode, Tab } from "./panelTypes";
 function getFileExtension(filePath: string): string {
   const parts = filePath.split(".");
   return parts.length > 1 ? parts[parts.length - 1] : "";
+}
+
+function trackDiffViewed(
+  taskId: string,
+  filePath: string,
+  status?: string,
+): void {
+  const changeType =
+    status === "added"
+      ? "added"
+      : status === "deleted"
+        ? "deleted"
+        : "modified";
+  track(ANALYTICS_EVENTS.FILE_DIFF_VIEWED, {
+    file_extension: getFileExtension(filePath),
+    change_type: changeType,
+    task_id: taskId,
+  });
 }
 
 const MAX_RECENT_FILES = 10;
@@ -61,6 +81,12 @@ export interface PanelLayoutStore {
     asPreview?: boolean,
   ) => void;
   openDiffByMode: (
+    taskId: string,
+    filePath: string,
+    status?: string,
+    asPreview?: boolean,
+  ) => void;
+  openCloudDiffByMode: (
     taskId: string,
     filePath: string,
     status?: string,
@@ -226,6 +252,39 @@ function findNonMainLeafPanel(node: PanelNode): PanelNode | null {
     }
   }
   return null;
+}
+
+function openTabByDiffMode(
+  state: { taskLayouts: Record<string, TaskLayout> },
+  taskId: string,
+  tabId: string,
+  asPreview: boolean,
+): { taskLayouts: Record<string, TaskLayout> } {
+  const mode = useSettingsStore.getState().diffOpenMode;
+  switch (mode) {
+    case "split":
+      return openTabInSplit(state, taskId, tabId, asPreview);
+    case "same-pane":
+      return openTab(
+        state,
+        taskId,
+        tabId,
+        asPreview,
+        DEFAULT_PANEL_IDS.MAIN_PANEL,
+      );
+    case "last-active-pane":
+      return openTab(state, taskId, tabId, asPreview);
+    default:
+      return window.outerWidth >= 1440
+        ? openTabInSplit(state, taskId, tabId, asPreview)
+        : openTab(
+            state,
+            taskId,
+            tabId,
+            asPreview,
+            DEFAULT_PANEL_IDS.MAIN_PANEL,
+          );
+  }
 }
 
 function openTabInSplit(
@@ -397,47 +456,15 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
       },
 
       openDiffByMode: (taskId, filePath, status, asPreview = true) => {
-        const mode = useSettingsStore.getState().diffOpenMode;
         const tabId = createDiffTabId(filePath, status);
+        set((state) => openTabByDiffMode(state, taskId, tabId, asPreview));
+        trackDiffViewed(taskId, filePath, status);
+      },
 
-        set((state) => {
-          switch (mode) {
-            case "split":
-              return openTabInSplit(state, taskId, tabId, asPreview);
-            case "same-pane":
-              return openTab(
-                state,
-                taskId,
-                tabId,
-                asPreview,
-                DEFAULT_PANEL_IDS.MAIN_PANEL,
-              );
-            case "last-active-pane":
-              return openTab(state, taskId, tabId, asPreview);
-            default:
-              return window.outerWidth >= 1440
-                ? openTabInSplit(state, taskId, tabId, asPreview)
-                : openTab(
-                    state,
-                    taskId,
-                    tabId,
-                    asPreview,
-                    DEFAULT_PANEL_IDS.MAIN_PANEL,
-                  );
-          }
-        });
-
-        const changeType =
-          status === "added"
-            ? "added"
-            : status === "deleted"
-              ? "deleted"
-              : "modified";
-        track(ANALYTICS_EVENTS.FILE_DIFF_VIEWED, {
-          file_extension: getFileExtension(filePath),
-          change_type: changeType,
-          task_id: taskId,
-        });
+      openCloudDiffByMode: (taskId, filePath, status, asPreview = true) => {
+        const tabId = createCloudDiffTabId(filePath, status);
+        set((state) => openTabByDiffMode(state, taskId, tabId, asPreview));
+        trackDiffViewed(taskId, filePath, status);
       },
 
       keepTab: (taskId, panelId, tabId) => {
@@ -582,6 +609,7 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
         const tabIds = [
           createFileTabId(filePath),
           ...getDiffTabIdsForFile(filePath),
+          ...getCloudDiffTabIdsForFile(filePath),
         ];
 
         for (const tabId of tabIds) {
@@ -596,7 +624,10 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
         const layout = get().taskLayouts[taskId];
         if (!layout) return;
 
-        const tabIds = getDiffTabIdsForFile(filePath);
+        const tabIds = [
+          ...getDiffTabIdsForFile(filePath),
+          ...getCloudDiffTabIdsForFile(filePath),
+        ];
 
         for (const tabId of tabIds) {
           const tabLocation = findTabInTree(layout.panelTree, tabId);

--- a/apps/twig/src/renderer/features/panels/store/panelStoreHelpers.ts
+++ b/apps/twig/src/renderer/features/panels/store/panelStoreHelpers.ts
@@ -7,7 +7,15 @@ import type { GroupPanel, LeafPanel, PanelNode, Tab } from "./panelTypes";
 export const DEFAULT_FALLBACK_TAB = DEFAULT_TAB_IDS.LOGS;
 
 // Tab ID utilities
-export type TabType = "file" | "diff" | "system";
+export type TabType = "file" | "diff" | "cloud-diff" | "system";
+
+const DIFF_STATUSES = [
+  "modified",
+  "deleted",
+  "added",
+  "untracked",
+  "renamed",
+] as const;
 
 export interface ParsedTabId {
   type: TabType;
@@ -26,19 +34,30 @@ export function createDiffTabId(filePath: string, status?: string): string {
 }
 
 export function getDiffTabIdsForFile(filePath: string): string[] {
-  return [
-    createDiffTabId(filePath),
-    createDiffTabId(filePath, "modified"),
-    createDiffTabId(filePath, "deleted"),
-    createDiffTabId(filePath, "added"),
-    createDiffTabId(filePath, "untracked"),
-    createDiffTabId(filePath, "renamed"),
-  ];
+  return DIFF_STATUSES.map((s) => createDiffTabId(filePath, s));
+}
+
+export function getCloudDiffTabIdsForFile(filePath: string): string[] {
+  return DIFF_STATUSES.map((s) => createCloudDiffTabId(filePath, s));
+}
+
+export function createCloudDiffTabId(
+  filePath: string,
+  status?: string,
+): string {
+  return `cloud-diff-${status ?? "modified"}:${filePath}`;
 }
 
 export function parseTabId(tabId: string): ParsedTabId & { status?: string } {
   if (tabId.startsWith("file-")) {
     return { type: "file", value: tabId.slice(5) };
+  }
+  if (tabId.startsWith("cloud-diff-")) {
+    const rest = tabId.slice(11);
+    const colonIndex = rest.indexOf(":");
+    const status = colonIndex !== -1 ? rest.slice(0, colonIndex) : "modified";
+    const value = colonIndex !== -1 ? rest.slice(colonIndex + 1) : rest;
+    return { type: "cloud-diff", value, status };
   }
   if (tabId.startsWith("diff-")) {
     const rest = tabId.slice(5);
@@ -73,7 +92,7 @@ export function createTabLabel(tabId: string): string {
   if (parsed.type === "file") {
     return parsed.value.split("/").pop() || parsed.value;
   }
-  if (parsed.type === "diff") {
+  if (parsed.type === "diff" || parsed.type === "cloud-diff") {
     const fileName = parsed.value.split("/").pop() || parsed.value;
     const label = getStatusLabel(parsed.status);
     return `${fileName} (${label})`;
@@ -174,6 +193,13 @@ export function createNewTab(
         relativePath: parsed.value,
         absolutePath: "", // Will be populated by tab injection
         repoPath: "", // Will be populated by tab injection
+        status: (parsed.status || "modified") as GitFileStatus,
+      };
+      break;
+    case "cloud-diff":
+      data = {
+        type: "cloud-diff",
+        relativePath: parsed.value,
         status: (parsed.status || "modified") as GitFileStatus,
       };
       break;
@@ -305,6 +331,15 @@ export function isDiffTabActiveInTree(
   status?: string,
 ): boolean {
   const tabId = createDiffTabId(filePath, status);
+  return isTabActiveInTree(tree, tabId);
+}
+
+export function isCloudDiffTabActiveInTree(
+  tree: PanelNode,
+  filePath: string,
+  status?: string,
+): boolean {
+  const tabId = createCloudDiffTabId(filePath, status);
   return isTabActiveInTree(tree, tabId);
 }
 

--- a/apps/twig/src/renderer/features/panels/store/panelTypes.ts
+++ b/apps/twig/src/renderer/features/panels/store/panelTypes.ts
@@ -34,6 +34,11 @@ export type TabData =
       scriptType: "init" | "start";
     }
   | {
+      type: "cloud-diff";
+      relativePath: string;
+      status: GitFileStatus;
+    }
+  | {
       type: "logs";
     }
   | {

--- a/apps/twig/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -7,10 +7,14 @@ import {
   useGitQueries,
 } from "@features/git-interaction/hooks/useGitQueries";
 import { updateGitCacheFromSnapshot } from "@features/git-interaction/utils/updateGitCache";
-import { isDiffTabActiveInTree, usePanelLayoutStore } from "@features/panels";
+import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
+import {
+  isCloudDiffTabActiveInTree,
+  isDiffTabActiveInTree,
+} from "@features/panels/store/panelStoreHelpers";
 import { usePendingPermissionsForTask } from "@features/sessions/stores/sessionStore";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { useTasks } from "@features/tasks/hooks/useTasks";
+import { useCloudRunState } from "@features/task-detail/hooks/useCloudRunState";
 import { useFocusWorkspace } from "@features/workspace/hooks/useFocusWorkspace";
 import {
   ArrowCounterClockwiseIcon,
@@ -38,7 +42,7 @@ import { useExternalAppsStore } from "@stores/externalAppsStore";
 import { useQueryClient } from "@tanstack/react-query";
 import { showMessageBox } from "@utils/dialog";
 import { handleExternalAppAction } from "@utils/handleExternalAppAction";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 interface ChangesPanelProps {
@@ -388,18 +392,27 @@ function ChangedFileItem({
 
 function CloudChangedFileItem({
   file,
-  prUrl,
+  taskId,
+  isActive,
 }: {
   file: ChangedFile;
-  prUrl: string;
+  taskId: string;
+  isActive: boolean;
 }) {
+  const openCloudDiffByMode = usePanelLayoutStore(
+    (state) => state.openCloudDiffByMode,
+  );
   const fileName = file.path.split("/").pop() || file.path;
   const indicator = getStatusIndicator(file.status);
   const hasLineStats =
     file.linesAdded !== undefined || file.linesRemoved !== undefined;
 
   const handleClick = () => {
-    trpcVanilla.os.openExternal.mutate({ url: `${prUrl}/files` });
+    openCloudDiffByMode(taskId, file.path, file.status);
+  };
+
+  const handleDoubleClick = () => {
+    openCloudDiffByMode(taskId, file.path, file.status, false);
   };
 
   return (
@@ -412,7 +425,12 @@ function CloudChangedFileItem({
         align="center"
         gap="1"
         onClick={handleClick}
-        className="border-transparent border-y hover:bg-gray-3"
+        onDoubleClick={handleDoubleClick}
+        className={
+          isActive
+            ? "border-accent-8 border-y bg-accent-4"
+            : "border-transparent border-y hover:bg-gray-3"
+        }
         style={{
           cursor: "pointer",
           whiteSpace: "nowrap",
@@ -485,17 +503,15 @@ function CloudChangedFileItem({
 }
 
 function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
-  // Resolve freshest task data — the prop may be stale (e.g. right sidebar
-  // receives the initial navigation snapshot before output.pr_url is set).
-  const { data: tasks = [] } = useTasks();
-  const freshTask = useMemo(
-    () => tasks.find((t) => t.id === taskId) ?? task,
-    [tasks, taskId, task],
-  );
+  const { prUrl, effectiveBranch, repo, isRunActive, fallbackFiles } =
+    useCloudRunState(taskId, task);
 
-  const prUrl = (freshTask.latest_run?.output?.pr_url as string) ?? null;
-  const branch = freshTask.latest_run?.branch ?? null;
-  const repo = freshTask.repository ?? null;
+  const layout = usePanelLayoutStore((state) => state.getLayout(taskId));
+
+  const isFileActive = (file: ChangedFile): boolean => {
+    if (!layout) return false;
+    return isCloudDiffTabActiveInTree(layout.panelTree, file.path, file.status);
+  };
 
   // PR-based files (preferred when PR exists, to avoid possible state weirdness)
   const {
@@ -504,26 +520,42 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
     isError: prError,
   } = useCloudPrChangedFiles(prUrl);
 
-  // Branch-based files (no PR)
+  // Branch-based files — use effectiveBranch (includes live cloudBranch)
   const {
     data: branchFiles,
     isPending: branchPending,
     isError: branchError,
-  } = useCloudBranchChangedFiles(!prUrl ? repo : null, !prUrl ? branch : null);
+  } = useCloudBranchChangedFiles(
+    !prUrl ? repo : null,
+    !prUrl ? effectiveBranch : null,
+  );
 
   const changedFiles = prUrl ? (prFiles ?? []) : (branchFiles ?? []);
-  const isLoading = prUrl ? prPending : branchPending;
-  const hasError = prUrl ? prError : branchError;
+  const isLoading = prUrl ? prPending : effectiveBranch ? branchPending : false;
+  const hasError = prUrl ? prError : effectiveBranch ? branchError : false;
 
-  if (!prUrl && !branch) {
+  const effectiveFiles = changedFiles.length > 0 ? changedFiles : fallbackFiles;
+
+  // No branch/PR yet and run is active — show waiting state
+  if (!prUrl && !effectiveBranch && effectiveFiles.length === 0) {
+    if (isRunActive) {
+      return (
+        <PanelMessage detail="Changes will appear once the agent starts writing code">
+          <Flex align="center" gap="2">
+            <Spinner size="1" />
+            <Text size="2">Waiting for changes...</Text>
+          </Flex>
+        </PanelMessage>
+      );
+    }
     return <PanelMessage>No file changes yet</PanelMessage>;
   }
 
-  if (isLoading) {
+  if (isLoading && effectiveFiles.length === 0) {
     return <PanelMessage>Loading changes...</PanelMessage>;
   }
 
-  if (changedFiles.length === 0) {
+  if (effectiveFiles.length === 0) {
     if (hasError && prUrl) {
       return (
         <PanelMessage>
@@ -541,19 +573,38 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
     if (prUrl) {
       return <PanelMessage>No file changes in pull request</PanelMessage>;
     }
+    if (isRunActive) {
+      return (
+        <PanelMessage detail="Changes will appear as the agent modifies files">
+          <Flex align="center" gap="2">
+            <Spinner size="1" />
+            <Text size="2">Waiting for changes...</Text>
+          </Flex>
+        </PanelMessage>
+      );
+    }
     return <PanelMessage>No file changes yet</PanelMessage>;
   }
 
   return (
     <Box height="100%" overflowY="auto" py="2">
       <Flex direction="column">
-        {changedFiles.map((file) => (
+        {effectiveFiles.map((file) => (
           <CloudChangedFileItem
             key={file.path}
             file={file}
-            prUrl={prUrl ?? `https://github.com/${repo}/tree/${branch}`}
+            taskId={taskId}
+            isActive={isFileActive(file)}
           />
         ))}
+        {isRunActive && (
+          <Flex align="center" gap="2" px="3" py="2">
+            <Spinner size="1" />
+            <Text size="1" color="gray">
+              Agent is still running...
+            </Text>
+          </Flex>
+        )}
       </Flex>
     </Box>
   );
@@ -561,8 +612,10 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
 
 export function ChangesPanel({ taskId, task }: ChangesPanelProps) {
   const workspace = useWorkspaceStore((s) => s.workspaces[taskId]);
+  const isCloud =
+    workspace?.mode === "cloud" || task.latest_run?.environment === "cloud";
 
-  if (workspace?.mode === "cloud") {
+  if (isCloud) {
     return <CloudChangesPanel taskId={taskId} task={task} />;
   }
 

--- a/apps/twig/src/renderer/features/task-detail/components/FileTreePanel.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/FileTreePanel.tsx
@@ -1,13 +1,20 @@
 import { FileIcon } from "@components/ui/FileIcon";
 import { PanelMessage } from "@components/ui/PanelMessage";
-import { isFileTabActiveInTree, usePanelLayoutStore } from "@features/panels";
+import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
+import { isFileTabActiveInTree } from "@features/panels/store/panelStoreHelpers";
 import {
   selectIsPathExpanded,
   useFileTreeStore,
 } from "@features/right-sidebar/stores/fileTreeStore";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { CaretRight, FolderIcon, FolderOpenIcon } from "@phosphor-icons/react";
-import { Box, Flex } from "@radix-ui/themes";
+import { useCloudRunState } from "@features/task-detail/hooks/useCloudRunState";
+import {
+  CaretRight,
+  Cloud,
+  FolderIcon,
+  FolderOpenIcon,
+} from "@phosphor-icons/react";
+import { Box, Button, Flex, Spinner, Text } from "@radix-ui/themes";
 import { useWorkspaceStore } from "@renderer/features/workspace/stores/workspaceStore";
 import { trpcReact, trpcVanilla } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
@@ -179,7 +186,69 @@ function LazyTreeItem({
   );
 }
 
-export function FileTreePanel({ taskId, task: _task }: FileTreePanelProps) {
+function CloudFileTreePanel({ taskId, task }: FileTreePanelProps) {
+  const { prUrl, effectiveBranch, repo, isRunActive, fallbackFiles } =
+    useCloudRunState(taskId, task);
+
+  const hasFallbackChanges = fallbackFiles.length > 0;
+
+  if (isRunActive && !hasFallbackChanges) {
+    return (
+      <PanelMessage detail="Files are in the cloud sandbox">
+        <Flex align="center" gap="2">
+          <Spinner size="1" />
+          <Text size="2">Running in cloud...</Text>
+        </Flex>
+      </PanelMessage>
+    );
+  }
+
+  const githubUrl = prUrl
+    ? `${prUrl}/files`
+    : repo && effectiveBranch
+      ? `https://github.com/${repo}/tree/${effectiveBranch}`
+      : null;
+
+  return (
+    <PanelMessage detail="Files are in the cloud sandbox">
+      <Flex direction="column" align="center" gap="2">
+        <Flex align="center" gap="2">
+          <Cloud size={16} weight="regular" />
+          <Text size="2">
+            {hasFallbackChanges
+              ? `${fallbackFiles.length} file${fallbackFiles.length === 1 ? "" : "s"} changed in cloud sandbox`
+              : "Files are in the cloud sandbox"}
+          </Text>
+        </Flex>
+        {githubUrl && (
+          <Button
+            size="1"
+            variant="soft"
+            onClick={() =>
+              trpcVanilla.os.openExternal.mutate({ url: githubUrl })
+            }
+          >
+            View on GitHub
+          </Button>
+        )}
+      </Flex>
+    </PanelMessage>
+  );
+}
+
+export function FileTreePanel({ taskId, task }: FileTreePanelProps) {
+  const workspace = useWorkspaceStore((s) => s.workspaces[taskId]);
+  const isCloud =
+    workspace?.mode === "cloud" || task.latest_run?.environment === "cloud";
+
+  if (isCloud) {
+    return <CloudFileTreePanel taskId={taskId} task={task} />;
+  }
+
+  return <LocalFileTreePanel taskId={taskId} task={task} />;
+}
+
+function LocalFileTreePanel({ taskId, task: _task }: FileTreePanelProps) {
   const workspace = useWorkspaceStore((s) => s.workspaces[taskId]);
   const repoPath = useCwd(taskId);
   const mainRepoPath = workspace?.folderPath;

--- a/apps/twig/src/renderer/features/task-detail/components/TabContentRenderer.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/TabContentRenderer.tsx
@@ -1,3 +1,4 @@
+import { CloudDiffEditorPanel } from "@features/code-editor/components/CloudDiffEditorPanel";
 import { CodeEditorPanel } from "@features/code-editor/components/CodeEditorPanel";
 import { DiffEditorPanel } from "@features/code-editor/components/DiffEditorPanel";
 import type { Tab } from "@features/panels/store/panelTypes";
@@ -54,6 +55,14 @@ export function TabContentRenderer({
           taskId={taskId}
           task={task}
           absolutePath={data.absolutePath}
+        />
+      );
+
+    case "cloud-diff":
+      return (
+        <CloudDiffEditorPanel
+          taskId={taskId}
+          relativePath={data.relativePath}
         />
       );
 

--- a/apps/twig/src/renderer/features/task-detail/hooks/useCloudRunState.ts
+++ b/apps/twig/src/renderer/features/task-detail/hooks/useCloudRunState.ts
@@ -1,0 +1,54 @@
+import { useSessionForTask } from "@features/sessions/hooks/useSession";
+import {
+  buildCloudEventSummary,
+  extractCloudToolChangedFiles,
+} from "@features/task-detail/utils/cloudToolChanges";
+import { useTasks } from "@features/tasks/hooks/useTasks";
+import type { ChangedFile, Task } from "@shared/types";
+import { useMemo } from "react";
+
+export function useCloudRunState(taskId: string, task: Task) {
+  const { data: tasks = [] } = useTasks();
+  const freshTask = useMemo(
+    () => tasks.find((t) => t.id === taskId) ?? task,
+    [tasks, taskId, task],
+  );
+
+  const session = useSessionForTask(taskId);
+
+  const rawPrUrl = freshTask.latest_run?.output?.pr_url;
+  const prUrl = typeof rawPrUrl === "string" ? rawPrUrl : null;
+  const branch = freshTask.latest_run?.branch ?? null;
+  const cloudBranch = session?.cloudBranch ?? null;
+  const effectiveBranch = branch ?? cloudBranch;
+  const repo = freshTask.repository ?? null;
+
+  const cloudStatus =
+    session?.cloudStatus ?? freshTask.latest_run?.status ?? null;
+  const isRunActive =
+    cloudStatus === "started" ||
+    cloudStatus === "in_progress" ||
+    (cloudStatus === null && session != null);
+
+  const events = session?.events;
+  const summary = useMemo(() => buildCloudEventSummary(events ?? []), [events]);
+  const toolCallFiles = useMemo(
+    () => extractCloudToolChangedFiles(summary.toolCalls),
+    [summary],
+  );
+  const fallbackFiles: ChangedFile[] =
+    summary.treeSnapshotFiles.length > 0
+      ? summary.treeSnapshotFiles
+      : toolCallFiles;
+
+  return {
+    freshTask,
+    session,
+    prUrl,
+    effectiveBranch,
+    repo,
+    cloudStatus,
+    isRunActive,
+    fallbackFiles,
+  };
+}

--- a/apps/twig/src/renderer/features/task-detail/utils/cloudToolChanges.ts
+++ b/apps/twig/src/renderer/features/task-detail/utils/cloudToolChanges.ts
@@ -1,0 +1,286 @@
+import type {
+  ToolCallContent,
+  ToolCallLocation,
+} from "@features/sessions/types";
+import type { ChangedFile, GitFileStatus } from "@shared/types";
+import {
+  type AcpMessage,
+  isJsonRpcNotification,
+} from "@shared/types/session-events";
+
+interface ParsedToolCall {
+  toolCallId: string;
+  kind?: string | null;
+  title?: string;
+  status?: string | null;
+  locations?: ToolCallLocation[];
+  content?: ToolCallContent[];
+}
+
+// Match file paths that may differ in format (absolute vs relative)
+function pathsMatch(a: string | undefined, b: string): boolean {
+  if (!a) return false;
+  if (a === b) return true;
+  return a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+}
+
+function inferKind(kind?: string | null, title?: string): string | null {
+  if (kind) return kind;
+  if (!title) return null;
+
+  const normalized = title.toLowerCase();
+  if (normalized.startsWith("write")) return "write";
+  if (normalized.startsWith("edit")) return "edit";
+  if (normalized.startsWith("delete")) return "delete";
+  if (normalized.startsWith("move") || normalized.startsWith("rename")) {
+    return "move";
+  }
+
+  return null;
+}
+
+function mergeToolCall(
+  existing: ParsedToolCall | undefined,
+  patch: Partial<ParsedToolCall>,
+): ParsedToolCall {
+  return {
+    toolCallId: patch.toolCallId ?? existing?.toolCallId ?? "",
+    kind: patch.kind ?? existing?.kind,
+    title: patch.title ?? existing?.title,
+    status: patch.status ?? existing?.status,
+    locations:
+      patch.locations && patch.locations.length > 0
+        ? patch.locations
+        : existing?.locations,
+    content:
+      patch.content && patch.content.length > 0
+        ? patch.content
+        : existing?.content,
+  };
+}
+
+function getDiffContent(
+  content: ToolCallContent[] | undefined,
+): Extract<ToolCallContent, { type: "diff" }> | undefined {
+  return content?.find(
+    (item): item is Extract<ToolCallContent, { type: "diff" }> =>
+      item.type === "diff",
+  );
+}
+
+/**
+ * diff stats with bag of lines, these are computed for every changed file whenever the session events update
+ * so we want this to be fast
+ */
+function getDiffStats(
+  oldText: string | null | undefined,
+  newText: string | null | undefined,
+): { added?: number; removed?: number } {
+  if (!oldText && !newText) return {};
+
+  const oldLines = oldText ? oldText.split("\n") : [];
+  const newLines = newText ? newText.split("\n") : [];
+
+  if (!oldText) {
+    return { added: newLines.length, removed: 0 };
+  }
+
+  const oldCounts = new Map<string, number>();
+  for (const line of oldLines) {
+    oldCounts.set(line, (oldCounts.get(line) ?? 0) + 1);
+  }
+
+  const newCounts = new Map<string, number>();
+  for (const line of newLines) {
+    newCounts.set(line, (newCounts.get(line) ?? 0) + 1);
+  }
+
+  let added = 0;
+  let removed = 0;
+
+  for (const [line, count] of newCounts) {
+    const oldCount = oldCounts.get(line) ?? 0;
+    if (count > oldCount) added += count - oldCount;
+  }
+
+  for (const [line, count] of oldCounts) {
+    const newCount = newCounts.get(line) ?? 0;
+    if (count > newCount) removed += count - newCount;
+  }
+
+  return { added, removed };
+}
+
+export interface CloudEventSummary {
+  toolCalls: Map<string, ParsedToolCall>;
+  treeSnapshotFiles: ChangedFile[];
+}
+
+const TREE_SNAPSHOT_STATUS_MAP: Record<string, GitFileStatus> = {
+  A: "added",
+  M: "modified",
+  D: "deleted",
+};
+
+/**
+ * Single-pass extraction of tool calls and the last tree snapshot from events.
+ */
+export function buildCloudEventSummary(
+  events: AcpMessage[],
+): CloudEventSummary {
+  const toolCalls = new Map<string, ParsedToolCall>();
+  let treeSnapshotFiles: ChangedFile[] = [];
+
+  for (const event of events) {
+    const message = event.message;
+    if (!isJsonRpcNotification(message)) continue;
+
+    if (message.method === "session/update") {
+      const params = message.params as
+        | { update?: Record<string, unknown> }
+        | undefined;
+      const update = params?.update;
+      if (!update || typeof update !== "object") continue;
+
+      const sessionUpdate = update.sessionUpdate;
+      if (
+        sessionUpdate !== "tool_call" &&
+        sessionUpdate !== "tool_call_update"
+      ) {
+        continue;
+      }
+
+      const toolCallId =
+        typeof update.toolCallId === "string" ? update.toolCallId : undefined;
+      if (!toolCallId) continue;
+
+      const patch: Partial<ParsedToolCall> = {
+        toolCallId,
+        kind: typeof update.kind === "string" ? update.kind : null,
+        title: typeof update.title === "string" ? update.title : undefined,
+        status: typeof update.status === "string" ? update.status : null,
+        locations: Array.isArray(update.locations)
+          ? (update.locations as ToolCallLocation[])
+          : undefined,
+        content: Array.isArray(update.content)
+          ? (update.content as ToolCallContent[])
+          : undefined,
+      };
+
+      const merged = mergeToolCall(toolCalls.get(toolCallId), patch);
+      toolCalls.set(toolCallId, merged);
+    } else if (isPosthogMethod(message.method, "tree_snapshot")) {
+      const params = message.params as
+        | {
+            changes?: Array<{ path: string; status: "A" | "M" | "D" }>;
+          }
+        | undefined;
+      const changes = params?.changes;
+      if (!Array.isArray(changes) || changes.length === 0) continue;
+
+      // Overwrite — we only care about the last snapshot
+      treeSnapshotFiles = changes
+        .filter((c) => c.path && c.status in TREE_SNAPSHOT_STATUS_MAP)
+        .map((c) => ({
+          path: c.path,
+          status: TREE_SNAPSHOT_STATUS_MAP[c.status],
+        }));
+    }
+  }
+
+  return { toolCalls, treeSnapshotFiles };
+}
+
+export function extractCloudFileDiff(
+  toolCalls: Map<string, ParsedToolCall>,
+  filePath: string,
+): { oldText: string | null; newText: string | null } | null {
+  // Iterate forward to compute cumulative diff:
+  // oldText from the *first* tool call, newText from the *last*.
+  let firstOldText: string | null | undefined;
+  let lastNewText: string | null | undefined;
+  let found = false;
+
+  for (const toolCall of toolCalls.values()) {
+    if (toolCall.status === "failed") continue;
+
+    const kind = inferKind(toolCall.kind, toolCall.title);
+    if (!kind || !["write", "edit", "delete", "move"].includes(kind)) continue;
+
+    const diff = getDiffContent(toolCall.content);
+    const locationPath = toolCall.locations?.[0]?.path;
+    const destinationPath = toolCall.locations?.[1]?.path;
+    const path =
+      diff?.path ?? (kind === "move" ? destinationPath : locationPath);
+    if (!pathsMatch(path, filePath)) continue;
+
+    if (!found) {
+      firstOldText = diff?.oldText ?? null;
+      found = true;
+    }
+    lastNewText = diff?.newText ?? null;
+  }
+
+  if (!found) return null;
+
+  return {
+    oldText: firstOldText ?? null,
+    newText: lastNewText ?? null,
+  };
+}
+
+function isPosthogMethod(method: string, name: string): boolean {
+  return method === `_posthog/${name}` || method === `__posthog/${name}`;
+}
+
+export function extractCloudToolChangedFiles(
+  toolCalls: Map<string, ParsedToolCall>,
+): ChangedFile[] {
+  const filesByPath = new Map<string, ChangedFile>();
+
+  for (const toolCall of toolCalls.values()) {
+    if (toolCall.status === "failed") continue;
+
+    const kind = inferKind(toolCall.kind, toolCall.title);
+    if (!kind || !["write", "edit", "delete", "move"].includes(kind)) {
+      continue;
+    }
+
+    const diff = getDiffContent(toolCall.content);
+    const locationPath = toolCall.locations?.[0]?.path;
+    const destinationPath = toolCall.locations?.[1]?.path;
+    const path =
+      diff?.path ?? (kind === "move" ? destinationPath : locationPath);
+    if (!path) continue;
+
+    let file: ChangedFile;
+    if (kind === "move") {
+      file = {
+        path,
+        originalPath: locationPath,
+        status: "renamed",
+      };
+    } else if (kind === "delete") {
+      file = {
+        path,
+        status: "deleted",
+      };
+    } else {
+      const diffStats = getDiffStats(diff?.oldText, diff?.newText);
+      file = {
+        path,
+        status: kind === "write" && !diff?.oldText ? "added" : "modified",
+        linesAdded: diffStats.added,
+        linesRemoved: diffStats.removed,
+      };
+    }
+
+    // Delete and re-insert so the last tool call for a path appears at the end of iteration order
+    if (filesByPath.has(path)) {
+      filesByPath.delete(path);
+    }
+    filesByPath.set(path, file);
+  }
+
+  return [...filesByPath.values()];
+}


### PR DESCRIPTION
Add cloud-diff tab type and infrastructure for viewing file changes from background cloud runs. Includes utilities to extract diffs from session events, rendering before/after diffs.