### PR TITLE
feat(agent): add --baseBranch flag for PR target branch

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -722,6 +722,8 @@ export class AgentServer {
   }
 
   private buildCloudSystemPrompt(prUrl?: string | null): string {
+    const baseBranch = this.config.baseBranch;
+
     if (prUrl) {
       return `
 # Cloud Task Execution
@@ -740,6 +742,8 @@ Important:
 `;
     }
 
+    const baseFlag = baseBranch ? ` --base ${baseBranch}` : "";
+
     return `
 # Cloud Task Execution
 
@@ -747,7 +751,7 @@ After completing the requested changes:
 1. Create a new branch with a descriptive name based on the work done
 2. Stage and commit all changes with a clear commit message
 3. Push the branch to origin
-4. Create a draft pull request using \`gh pr create --draft\` with a descriptive title and body
+4. Create a draft pull request using \`gh pr create --draft${baseFlag}\` with a descriptive title and body
 
 Important:
 - Always create the PR as a draft. Do not ask for confirmation.

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -45,6 +45,7 @@ program
   .requiredOption("--repositoryPath <path>", "Path to the repository")
   .requiredOption("--taskId <id>", "Task ID")
   .requiredOption("--runId <id>", "Task run ID")
+  .option("--baseBranch <branch>", "Base branch for pull requests")
   .action(async (options) => {
     const envResult = envSchema.safeParse(process.env);
 
@@ -70,6 +71,7 @@ program
       mode,
       taskId: options.taskId,
       runId: options.runId,
+      baseBranch: options.baseBranch,
     });
 
     process.on("SIGINT", async () => {

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -10,5 +10,6 @@ export interface AgentServerConfig {
   mode: AgentMode;
   taskId: string;
   runId: string;
+  baseBranch?: string;
   version?: string;
 }


### PR DESCRIPTION
adds `--baseBranch` CLI option to agent-server. When set, includes `--base <branch>` in `gh pr create` so PRs target the correct branch. No change when omitted so safe.