### PR TITLE
feat(twig): use base branch for changes panel diff comparison

### DIFF
--- a/apps/twig/src/main/services/git/schemas.ts
+++ b/apps/twig/src/main/services/git/schemas.ts
@@ -301,6 +301,7 @@ export const getPrChangedFilesOutput = z.array(changedFileSchema);
 export const getBranchChangedFilesInput = z.object({
   repo: z.string(),
   branch: z.string(),
+  baseBranch: z.string().optional(),
 });
 export const getBranchChangedFilesOutput = z.array(changedFileSchema);
 

--- a/apps/twig/src/main/services/git/service.ts
+++ b/apps/twig/src/main/services/git/service.ts
@@ -751,6 +751,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
   public async getBranchChangedFiles(
     repo: string,
     branch: string,
+    baseBranch?: string,
   ): Promise<ChangedFile[]> {
     const parts = repo.split("/");
     if (parts.length !== 2) return [];
@@ -758,21 +759,24 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     const [owner, repoName] = parts;
 
     try {
-      const repoResult = await execGh([
-        "api",
-        `repos/${owner}/${repoName}`,
-        "--jq",
-        ".default_branch",
-      ]);
+      let compareBase = baseBranch;
+      if (!compareBase) {
+        const repoResult = await execGh([
+          "api",
+          `repos/${owner}/${repoName}`,
+          "--jq",
+          ".default_branch",
+        ]);
 
-      const defaultBranch =
-        repoResult.exitCode === 0 && repoResult.stdout.trim()
-          ? repoResult.stdout.trim()
-          : "main";
+        compareBase =
+          repoResult.exitCode === 0 && repoResult.stdout.trim()
+            ? repoResult.stdout.trim()
+            : "main";
+      }
 
       const result = await execGh([
         "api",
-        `repos/${owner}/${repoName}/compare/${defaultBranch}...${branch}`,
+        `repos/${owner}/${repoName}/compare/${compareBase}...${branch}`,
         "--jq",
         ".files",
       ]);

--- a/apps/twig/src/main/trpc/routers/git.ts
+++ b/apps/twig/src/main/trpc/routers/git.ts
@@ -276,7 +276,11 @@ export const gitRouter = router({
     .input(getBranchChangedFilesInput)
     .output(getBranchChangedFilesOutput)
     .query(({ input }) =>
-      getService().getBranchChangedFiles(input.repo, input.branch),
+      getService().getBranchChangedFiles(
+        input.repo,
+        input.branch,
+        input.baseBranch,
+      ),
     ),
 
   generateCommitMessage: publicProcedure

--- a/apps/twig/src/renderer/features/git-interaction/hooks/useGitQueries.ts
+++ b/apps/twig/src/renderer/features/git-interaction/hooks/useGitQueries.ts
@@ -152,13 +152,15 @@ export function useCloudPrChangedFiles(prUrl: string | null) {
 export function useCloudBranchChangedFiles(
   repo: string | null,
   branch: string | null,
+  baseBranch?: string | null,
 ) {
   return useQuery({
-    queryKey: ["branch-changed-files", repo, branch],
+    queryKey: ["branch-changed-files", repo, branch, baseBranch],
     queryFn: () =>
       trpcVanilla.git.getBranchChangedFiles.query({
         repo: repo as string,
         branch: branch as string,
+        baseBranch: baseBranch ?? undefined,
       }),
     enabled: !!repo && !!branch,
     staleTime: 30_000,

--- a/apps/twig/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/twig/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -503,8 +503,14 @@ function CloudChangedFileItem({
 }
 
 function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
-  const { prUrl, effectiveBranch, repo, isRunActive, fallbackFiles } =
-    useCloudRunState(taskId, task);
+  const {
+    prUrl,
+    effectiveBranch,
+    baseBranch,
+    repo,
+    isRunActive,
+    fallbackFiles,
+  } = useCloudRunState(taskId, task);
 
   const layout = usePanelLayoutStore((state) => state.getLayout(taskId));
 
@@ -528,6 +534,7 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
   } = useCloudBranchChangedFiles(
     !prUrl ? repo : null,
     !prUrl ? effectiveBranch : null,
+    baseBranch,
   );
 
   const changedFiles = prUrl ? (prFiles ?? []) : (branchFiles ?? []);

--- a/apps/twig/src/renderer/features/task-detail/hooks/useCloudRunState.ts
+++ b/apps/twig/src/renderer/features/task-detail/hooks/useCloudRunState.ts
@@ -23,6 +23,11 @@ export function useCloudRunState(taskId: string, task: Task) {
   const effectiveBranch = branch ?? cloudBranch;
   const repo = freshTask.repository ?? null;
 
+  const rawBaseBranch = (
+    freshTask.latest_run?.state as Record<string, unknown> | undefined
+  )?.branch;
+  const baseBranch = typeof rawBaseBranch === "string" ? rawBaseBranch : null;
+
   const cloudStatus =
     session?.cloudStatus ?? freshTask.latest_run?.status ?? null;
   const isRunActive =
@@ -46,6 +51,7 @@ export function useCloudRunState(taskId: string, task: Task) {
     session,
     prUrl,
     effectiveBranch,
+    baseBranch,
     repo,
     cloudStatus,
     isRunActive,


### PR DESCRIPTION
added `baseBranch` from task run state through to the gh compare API so the Changes panel diffs against the user-selected branch instead of always comparing against the repo default branch.