### PR TITLE
fix: Prevent Escape from canceling agent while overlays are open

### DIFF
--- a/apps/twig/src/renderer/components/KeyboardShortcutsSheet.tsx
+++ b/apps/twig/src/renderer/components/KeyboardShortcutsSheet.tsx
@@ -7,6 +7,7 @@ import {
 } from "@renderer/constants/keyboard-shortcuts";
 import { isMac } from "@utils/platform";
 import { useMemo } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 interface KeyboardShortcutsSheetProps {
   open: boolean;
@@ -17,11 +18,19 @@ export function KeyboardShortcutsSheet({
   open,
   onOpenChange,
 }: KeyboardShortcutsSheetProps) {
+  useHotkeys("escape", () => onOpenChange(false), {
+    enabled: open,
+    enableOnContentEditable: true,
+    enableOnFormTags: true,
+    preventDefault: true,
+  });
+
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Content
         maxWidth="600px"
         style={{ maxHeight: "80vh", overflow: "hidden" }}
+        onEscapeKeyDown={(e) => e.preventDefault()}
       >
         <Dialog.Title size="4" mb="4">
           Keyboard Shortcuts

--- a/apps/twig/src/renderer/features/message-editor/components/MessageEditor.tsx
+++ b/apps/twig/src/renderer/features/message-editor/components/MessageEditor.tsx
@@ -2,9 +2,12 @@ import "./message-editor.css";
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { BranchSelector } from "@features/git-interaction/components/BranchSelector";
 import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
+import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
 import { useConnectivity } from "@hooks/useConnectivity";
 import { ArrowUp, Circle, Stop } from "@phosphor-icons/react";
 import { Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
+import { useCommandMenuStore } from "@stores/commandMenuStore";
+import { useShortcutsSheetStore } from "@stores/shortcutsSheetStore";
 import { EditorContent } from "@tiptap/react";
 import { forwardRef, useEffect, useImperativeHandle } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -145,6 +148,11 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
     const cloudBranch = context?.cloudBranch;
     const cloudDiffStats = context?.cloudDiffStats;
     const isSubmitDisabled = disabled || !isOnline;
+    const isSettingsOpen = useSettingsDialogStore((s) => s.isOpen);
+    const isCommandMenuOpen = useCommandMenuStore((s) => s.isOpen);
+    const isShortcutsSheetOpen = useShortcutsSheetStore((s) => s.isOpen);
+    const hasOverlay =
+      isSettingsOpen || isCommandMenuOpen || isShortcutsSheetOpen;
 
     const {
       editor,
@@ -223,8 +231,9 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
       {
         enableOnFormTags: true,
         enableOnContentEditable: true,
+        enabled: isLoading && !!onCancel && !hasOverlay,
       },
-      [isLoading, onCancel],
+      [isLoading, onCancel, hasOverlay],
     );
 
     const handleContainerClick = (e: React.MouseEvent) => {

--- a/apps/twig/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/twig/src/renderer/features/sessions/components/SessionView.tsx
@@ -11,7 +11,6 @@ import {
   usePendingPermissionsForTask,
 } from "@features/sessions/stores/sessionStore";
 import type { Plan } from "@features/sessions/types";
-import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { useAutoFocusOnTyping } from "@hooks/useAutoFocusOnTyping";
 import { Spinner, Warning } from "@phosphor-icons/react";
@@ -21,8 +20,6 @@ import {
   isJsonRpcNotification,
   isJsonRpcResponse,
 } from "@shared/types/session-events";
-import { useCommandMenuStore } from "@stores/commandMenuStore";
-import { useShortcutsSheetStore } from "@stores/shortcutsSheetStore";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { getSessionService } from "../service/service";
@@ -139,19 +136,6 @@ export function SessionView({
     disabled: !isRunning,
     isLoading: !!isPromptPending,
   });
-
-  const isSettingsOpen = useSettingsDialogStore((s) => s.isOpen);
-  const isCommandMenuOpen = useCommandMenuStore((s) => s.isOpen);
-  const isShortcutsSheetOpen = useShortcutsSheetStore((s) => s.isOpen);
-  const hasOverlay =
-    isSettingsOpen || isCommandMenuOpen || isShortcutsSheetOpen;
-
-  useHotkeys(
-    "escape",
-    onCancelPrompt,
-    { enabled: !!isPromptPending && !hasOverlay },
-    [onCancelPrompt],
-  );
 
   useHotkeys(
     "shift+tab",


### PR DESCRIPTION
  1. Move Escape cancel handler from SessionView into MessageEditor where overlay state is accessible
  2. Disable Escape cancel when settings, command menu or shortcuts sheet are open
  3. Add dedicated Escape handler to KeyboardShortcutsSheet to close itself without bubbling
  4. Clean up unused overlay imports from SessionView