### PR TITLE
feat(twig): add branch name validation/sanitization

### DIFF
--- a/apps/twig/src/renderer/features/git-interaction/components/GitInteractionDialogs.tsx
+++ b/apps/twig/src/renderer/features/git-interaction/components/GitInteractionDialogs.tsx
@@ -555,9 +555,9 @@ export function GitBranchDialog({
       onOpenChange={onOpenChange}
       icon={<GitFork size={ICON_SIZE} />}
       title="New branch"
-      error={error}
+      error={null}
       buttonLabel="Create"
-      buttonDisabled={!branchName.trim()}
+      buttonDisabled={!branchName.trim() || !!error}
       isSubmitting={isSubmitting}
       onSubmit={onConfirm}
     >
@@ -573,7 +573,12 @@ export function GitBranchDialog({
           value={branchName}
           onChange={(e) => onBranchNameChange(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && branchName.trim() && !isSubmitting) {
+            if (
+              e.key === "Enter" &&
+              branchName.trim() &&
+              !error &&
+              !isSubmitting
+            ) {
               e.preventDefault();
               onConfirm();
             }
@@ -582,6 +587,11 @@ export function GitBranchDialog({
           size="1"
           autoFocus
         />
+        {error && (
+          <Text size="1" color="red">
+            {error}
+          </Text>
+        )}
       </Flex>
     </GitDialog>
   );

--- a/apps/twig/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
+++ b/apps/twig/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
@@ -10,6 +10,10 @@ import type {
   GitMenuAction,
   GitMenuActionId,
 } from "@features/git-interaction/types";
+import {
+  sanitizeBranchName,
+  validateBranchName,
+} from "@features/git-interaction/utils/branchNameValidation";
 import { updateGitCacheFromSnapshot } from "@features/git-interaction/utils/updateGitCache";
 import { useWorkspaceStore } from "@features/workspace/stores/workspaceStore";
 import { trpcVanilla } from "@renderer/trpc";
@@ -482,6 +486,12 @@ export function useGitInteraction(
       return;
     }
 
+    const validationError = validateBranchName(branchName);
+    if (validationError) {
+      modal.setBranchError(validationError);
+      return;
+    }
+
     modal.setIsSubmitting(true);
     modal.setBranchError(null);
 
@@ -545,7 +555,11 @@ export function useGitInteraction(
       setCommitNextStep: modal.setCommitNextStep,
       setPrTitle: modal.setPrTitle,
       setPrBody: modal.setPrBody,
-      setBranchName: modal.setBranchName,
+      setBranchName: (value: string) => {
+        const sanitized = sanitizeBranchName(value);
+        modal.setBranchName(sanitized);
+        modal.setBranchError(validateBranchName(sanitized));
+      },
       runCommit,
       runPush,
       runPr,

--- a/apps/twig/src/renderer/features/git-interaction/utils/branchNameValidation.test.ts
+++ b/apps/twig/src/renderer/features/git-interaction/utils/branchNameValidation.test.ts
@@ -1,0 +1,90 @@
+import {
+  sanitizeBranchName,
+  validateBranchName,
+} from "@features/git-interaction/utils/branchNameValidation";
+import { describe, expect, it } from "vitest";
+
+describe("sanitizeBranchName", () => {
+  it("replaces spaces with dashes", () => {
+    expect(sanitizeBranchName("my new branch")).toBe("my-new-branch");
+  });
+
+  it("replaces multiple consecutive spaces", () => {
+    expect(sanitizeBranchName("a  b   c")).toBe("a--b---c");
+  });
+
+  it("returns the same string when there are no spaces", () => {
+    expect(sanitizeBranchName("feature/foo-bar")).toBe("feature/foo-bar");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeBranchName("")).toBe("");
+  });
+});
+
+describe("validateBranchName", () => {
+  it("returns null for valid branch names", () => {
+    expect(validateBranchName("feature/my-branch")).toBeNull();
+    expect(validateBranchName("fix-123")).toBeNull();
+    expect(validateBranchName("release/v1.0.0")).toBeNull();
+    expect(validateBranchName("user/feature")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(validateBranchName("")).toBeNull();
+  });
+
+  it("rejects control characters", () => {
+    expect(validateBranchName("branch\x00name")).not.toBeNull();
+    expect(validateBranchName("branch\x1fname")).not.toBeNull();
+    expect(validateBranchName("branch\x7fname")).not.toBeNull();
+  });
+
+  it('rejects ".."', () => {
+    expect(validateBranchName("branch..name")).not.toBeNull();
+  });
+
+  it("rejects forbidden characters", () => {
+    for (const char of ["~", "^", ":", "?", "*", "[", "]", "\\"]) {
+      expect(validateBranchName(`branch${char}name`)).not.toBeNull();
+    }
+  });
+
+  it("rejects spaces", () => {
+    expect(validateBranchName("branch name")).not.toBeNull();
+  });
+
+  it("rejects names starting or ending with a dot", () => {
+    expect(validateBranchName(".branch")).not.toBeNull();
+    expect(validateBranchName("branch.")).not.toBeNull();
+  });
+
+  it('rejects names ending with ".lock"', () => {
+    expect(validateBranchName("branch.lock")).not.toBeNull();
+  });
+
+  it('rejects "@{"', () => {
+    expect(validateBranchName("branch@{0}")).not.toBeNull();
+  });
+
+  it('rejects bare "@"', () => {
+    expect(validateBranchName("@")).not.toBeNull();
+  });
+
+  it('allows "@" as part of a longer name', () => {
+    expect(validateBranchName("user@feature")).toBeNull();
+  });
+
+  it('rejects "//"', () => {
+    expect(validateBranchName("branch//name")).not.toBeNull();
+  });
+
+  it("rejects path components starting or ending with a dot", () => {
+    expect(validateBranchName("feature/.hidden")).not.toBeNull();
+    expect(validateBranchName("feature/name.")).not.toBeNull();
+  });
+
+  it("returns a descriptive error message", () => {
+    expect(validateBranchName("a..b")).toBe('Branch name cannot contain "..".');
+  });
+});

--- a/apps/twig/src/renderer/features/git-interaction/utils/branchNameValidation.ts
+++ b/apps/twig/src/renderer/features/git-interaction/utils/branchNameValidation.ts
@@ -1,0 +1,63 @@
+/**
+ * Replaces spaces with dashes so users can type natural words and get a
+ * valid branch name without thinking about it.
+ */
+export function sanitizeBranchName(input: string): string {
+  return input.replace(/ /g, "-");
+}
+
+/**
+ * Validates a branch name against the rules in `git check-ref-format`.
+ * Returns the first error message found, or `null` when the name is valid.
+ * Returns `null` for an empty string — the caller handles the empty case
+ * by disabling the submit button.
+ */
+export function validateBranchName(name: string): string | null {
+  if (name === "") return null;
+
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matching ASCII control characters forbidden by git
+  if (/[\x00-\x1f\x7f]/.test(name)) {
+    return "Branch name cannot contain control characters.";
+  }
+
+  if (name.includes("..")) {
+    return 'Branch name cannot contain "..".';
+  }
+
+  if (/[~^:?*[\]\\]/.test(name)) {
+    return "Branch name cannot contain ~, ^, :, ?, *, [, ], or \\.";
+  }
+
+  if (name.includes(" ")) {
+    return "Branch name cannot contain spaces.";
+  }
+
+  if (name.startsWith(".") || name.endsWith(".")) {
+    return "Branch name cannot start or end with a dot.";
+  }
+
+  if (name.endsWith(".lock")) {
+    return 'Branch name cannot end with ".lock".';
+  }
+
+  if (name.includes("@{")) {
+    return 'Branch name cannot contain "@{".';
+  }
+
+  if (name === "@") {
+    return 'Branch name cannot be "@".';
+  }
+
+  if (name.includes("//")) {
+    return 'Branch name cannot contain "//".';
+  }
+
+  const components = name.split("/");
+  for (const component of components) {
+    if (component.startsWith(".") || component.endsWith(".")) {
+      return "Path components cannot start or end with a dot.";
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Problem

There are certain git rules/requirements on the branch name. Currently the create branch input accepting anything and then it fails on the actual git checkout branch. 

## Changes

- Adding validation and sanitization function for branch name
- Behaviour
    - when user is typing with spaces characters are imidiatelly sanitized to dashes, so user flow not broken. (that's how to fork app works actually)
    - when incorrect char spotted, button disabled and error message shown

## Recording

https://github.com/user-attachments/assets/2b05ad0b-e5bd-4143-b521-bb4e956ab74c

