### PR TITLE
chore: change name of recommended mcp servers

### DIFF
--- a/apps/twig/src/renderer/features/settings/components/sections/McpServersSettings.tsx
+++ b/apps/twig/src/renderer/features/settings/components/sections/McpServersSettings.tsx
@@ -510,7 +510,7 @@ export function McpServersSettings() {
         <Flex direction="column" gap="3">
           <Flex align="center" justify="between">
             <Text size="2" weight="medium">
-              Recommended servers
+              Pre-configured servers
             </Text>
           </Flex>
 


### PR DESCRIPTION
Small change from "Recommended servers" to "Pre-configured servers" to avoid implying we endorse those MCPs