### PR TITLE
chore: Sync claude-agent-acp upstream v0.20.2 → v0.21.0

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -87,8 +87,8 @@
     "vitest": "^2.1.8"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.14.0",
-    "@anthropic-ai/claude-agent-sdk": "0.2.68",
+    "@agentclientprotocol/sdk": "0.15.0",
+    "@anthropic-ai/claude-agent-sdk": "0.2.71",
     "@anthropic-ai/sdk": "^0.78.0",
     "@hono/node-server": "^1.19.9",
     "@opentelemetry/api-logs": "^0.208.0",

--- a/packages/agent/src/adapters/claude/UPSTREAM.md
+++ b/packages/agent/src/adapters/claude/UPSTREAM.md
@@ -5,8 +5,8 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 ## Fork Point
 
 - **Forked**: v0.10.9, commit `5411e0f4`, Dec 2 2025
-- **Last sync**: v0.20.2, commit `dd9fe3a98ea494ba1982516f8aa0464b48fdd5e1`, March 6 2026
-- **SDK**: `@anthropic-ai/claude-agent-sdk` 0.2.68, `@agentclientprotocol/sdk` ^0.14.0
+- **Last sync**: v0.21.0, commit `c13edf3b02ddaf49f8e8b9e11b02cbf17869b57d`, March 9 2026
+- **SDK**: `@anthropic-ai/claude-agent-sdk` 0.2.71, `@agentclientprotocol/sdk` 0.15.0
 
 ## File Mapping
 
@@ -55,7 +55,7 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 
 ## Next Sync
 
-1. Check upstream changelog since v0.20.2
+1. Check upstream changelog since v0.21.0
 2. Diff upstream source against PostHog Code using the file mapping above
 3. Port in phases: bug fixes first, then features
 4. After each phase: `pnpm --filter agent typecheck && pnpm --filter agent build && pnpm lint`

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -344,8 +344,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                 sessionId: params.sessionId,
                 update: {
                   sessionUpdate: "usage_update",
-                  used: lastAssistantTotalUsage as unknown as bigint,
-                  size: contextWindowSize as unknown as bigint,
+                  used: lastAssistantTotalUsage,
+                  size: contextWindowSize,
                   cost: {
                     amount: message.total_cost_usd,
                     currency: "USD",
@@ -365,11 +365,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
               cost: message.total_cost_usd,
             });
 
-            // Build usage for PromptResponse
-            // ACP SDK types declare these as bigint but JSON.stringify can't
-            // serialize BigInt. Token counts never exceed MAX_SAFE_INTEGER so
-            // we pass plain numbers and cast to satisfy the type system.
-            const usage = {
+            const usage: Usage = {
               inputTokens: this.session.accumulatedUsage.inputTokens,
               outputTokens: this.session.accumulatedUsage.outputTokens,
               cachedReadTokens: this.session.accumulatedUsage.cachedReadTokens,
@@ -380,7 +376,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                 this.session.accumulatedUsage.outputTokens +
                 this.session.accumulatedUsage.cachedReadTokens +
                 this.session.accumulatedUsage.cachedWriteTokens,
-            } as unknown as Usage;
+            };
 
             const result = handleResultMessage(message);
             if (result.error) throw result.error;

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -55,6 +55,7 @@ type ChunkHandlerContext = {
   parentToolCallId?: string;
   registerHooks?: boolean;
   supportsTerminalOutput?: boolean;
+  cwd?: string;
 };
 
 export interface MessageHandlerContext {
@@ -193,6 +194,7 @@ function handleToolUseChunk(
     supportsTerminalOutput: ctx.supportsTerminalOutput,
     toolUseId: chunk.id,
     cachedFileContent: ctx.fileContentCache,
+    cwd: ctx.cwd,
   });
 
   const meta: Record<string, unknown> = {
@@ -432,6 +434,7 @@ function toAcpNotifications(
   parentToolCallId?: string,
   registerHooks?: boolean,
   supportsTerminalOutput?: boolean,
+  cwd?: string,
 ): SessionNotification[] {
   if (typeof content === "string") {
     const update: SessionUpdate = {
@@ -457,6 +460,7 @@ function toAcpNotifications(
     parentToolCallId,
     registerHooks,
     supportsTerminalOutput,
+    cwd,
   };
   const output: SessionNotification[] = [];
 
@@ -479,6 +483,7 @@ function streamEventToAcpNotifications(
   parentToolCallId?: string,
   registerHooks?: boolean,
   supportsTerminalOutput?: boolean,
+  cwd?: string,
 ): SessionNotification[] {
   const event = message.event;
   switch (event.type) {
@@ -494,6 +499,7 @@ function streamEventToAcpNotifications(
         parentToolCallId,
         registerHooks,
         supportsTerminalOutput,
+        cwd,
       );
     case "content_block_delta":
       return toAcpNotifications(
@@ -507,6 +513,7 @@ function streamEventToAcpNotifications(
         parentToolCallId,
         registerHooks,
         supportsTerminalOutput,
+        cwd,
       );
     case "message_start":
     case "message_delta":
@@ -694,6 +701,7 @@ export async function handleStreamEvent(
     parentToolCallId,
     context.registerHooks,
     context.supportsTerminalOutput,
+    context.session.cwd,
   )) {
     await client.sessionUpdate(notification);
     context.session.notificationHistory.push(notification);
@@ -832,6 +840,7 @@ export async function handleUserAssistantMessage(
     parentToolCallId,
     context.registerHooks,
     context.supportsTerminalOutput,
+    session.cwd,
   )) {
     await client.sessionUpdate(notification);
     session.notificationHistory.push(notification);

--- a/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type {
   PlanEntry,
   ToolCall,
@@ -32,12 +33,30 @@ import { getMcpToolMetadata } from "../mcp/tool-metadata.js";
 
 type ToolInfo = Pick<ToolCall, "title" | "kind" | "content" | "locations">;
 
+/**
+ * Convert an absolute file path to a project-relative path for display.
+ * Returns the original path if it's outside the project directory or if no cwd is provided.
+ */
+export function toDisplayPath(filePath: string, cwd?: string): string {
+  if (!cwd) return filePath;
+  const resolvedCwd = path.resolve(cwd);
+  const resolvedFile = path.resolve(filePath);
+  if (
+    resolvedFile.startsWith(resolvedCwd + path.sep) ||
+    resolvedFile === resolvedCwd
+  ) {
+    return path.relative(resolvedCwd, resolvedFile);
+  }
+  return filePath;
+}
+
 export function toolInfoFromToolUse(
   toolUse: Pick<ToolUseBlock, "name" | "input">,
   options?: {
     supportsTerminalOutput?: boolean;
     toolUseId?: string;
     cachedFileContent?: Record<string, string>;
+    cwd?: string;
   },
 ): ToolInfo {
   const name = toolUse.name;
@@ -123,8 +142,11 @@ export function toolInfoFromToolUse(
       } else if (inputOffset > 1) {
         limit = ` (from line ${inputOffset})`;
       }
+      const displayPath = input?.file_path
+        ? toDisplayPath(String(input.file_path), options?.cwd)
+        : "File";
       return {
-        title: `Read ${input?.file_path ? String(input.file_path) : "File"}${limit}`,
+        title: `Read ${displayPath}${limit}`,
         kind: "read",
         locations: input?.file_path
           ? [
@@ -147,7 +169,10 @@ export function toolInfoFromToolUse(
       };
 
     case "Edit": {
-      const path = input?.file_path ? String(input.file_path) : undefined;
+      const filePath = input?.file_path ? String(input.file_path) : undefined;
+      const displayPath = filePath
+        ? toDisplayPath(filePath, options?.cwd)
+        : undefined;
       let oldText: string | null = input?.old_string
         ? String(input.old_string)
         : null;
@@ -155,11 +180,11 @@ export function toolInfoFromToolUse(
 
       // If we have cached file content, show a full-file diff
       if (
-        path &&
+        filePath &&
         options?.cachedFileContent &&
-        path in options.cachedFileContent
+        filePath in options.cachedFileContent
       ) {
-        const oldContent = options.cachedFileContent[path];
+        const oldContent = options.cachedFileContent[filePath];
         const newContent = input?.replace_all
           ? oldContent.replaceAll(oldText ?? "", newText)
           : oldContent.replace(oldText ?? "", newText);
@@ -168,43 +193,49 @@ export function toolInfoFromToolUse(
       }
 
       return {
-        title: path ? `Edit \`${path}\`` : "Edit",
+        title: displayPath ? `Edit \`${displayPath}\`` : "Edit",
         kind: "edit",
         content:
-          input && path
+          input && filePath
             ? [
                 {
                   type: "diff",
-                  path,
+                  path: filePath,
                   oldText,
                   newText,
                 },
               ]
             : [],
-        locations: path ? [{ path }] : [],
+        locations: filePath ? [{ path: filePath }] : [],
       };
     }
 
     case "Write": {
       let contentResult: ToolCallContent[] = [];
-      const filePath = input?.file_path ? String(input.file_path) : undefined;
+      const writeFilePath = input?.file_path
+        ? String(input.file_path)
+        : undefined;
+      const writeDisplayPath = writeFilePath
+        ? toDisplayPath(writeFilePath, options?.cwd)
+        : undefined;
       const contentStr = input?.content ? String(input.content) : undefined;
-      if (filePath) {
+      if (writeFilePath) {
         const oldContent =
-          options?.cachedFileContent && filePath in options.cachedFileContent
-            ? options.cachedFileContent[filePath]
+          options?.cachedFileContent &&
+          writeFilePath in options.cachedFileContent
+            ? options.cachedFileContent[writeFilePath]
             : null;
         contentResult = toolContent()
-          .diff(filePath, oldContent, contentStr ?? "")
+          .diff(writeFilePath, oldContent, contentStr ?? "")
           .build();
       } else if (contentStr) {
         contentResult = toolContent().text(contentStr).build();
       }
       return {
-        title: filePath ? `Write ${filePath}` : "Write",
+        title: writeDisplayPath ? `Write ${writeDisplayPath}` : "Write",
         kind: "edit",
         content: contentResult,
-        locations: filePath ? [{ path: filePath }] : [],
+        locations: writeFilePath ? [{ path: writeFilePath }] : [],
       };
     }
 

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -229,6 +229,16 @@ function ensureLocalSettings(cwd: string): void {
 export function buildSessionOptions(params: BuildOptionsParams): Options {
   ensureLocalSettings(params.cwd);
 
+  // Resolve which built-in tools to expose.
+  // Explicit tools array from userProvidedOptions takes precedence.
+  // disableBuiltInTools is a legacy shorthand for tools: [] — kept for
+  // backward compatibility but callers should prefer the tools array.
+  const tools: Options["tools"] =
+    params.userProvidedOptions?.tools ??
+    (params.disableBuiltInTools
+      ? []
+      : { type: "preset", preset: "claude_code" });
+
   const options: Options = {
     ...params.userProvidedOptions,
     systemPrompt: params.systemPrompt ?? buildSystemPrompt(),
@@ -240,7 +250,7 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     permissionMode: params.permissionMode,
     canUseTool: params.canUseTool,
     executable: "node",
-    tools: { type: "preset", preset: "claude_code" },
+    tools,
     extraArgs: {
       ...params.userProvidedOptions?.extraArgs,
       "replay-user-messages": "",
@@ -283,29 +293,6 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
 
   if (params.additionalDirectories) {
     options.additionalDirectories = params.additionalDirectories;
-  }
-
-  if (params.disableBuiltInTools) {
-    const builtInTools = [
-      "Read",
-      "Write",
-      "Edit",
-      "Bash",
-      "Glob",
-      "Grep",
-      "Task",
-      "TodoWrite",
-      "ExitPlanMode",
-      "WebSearch",
-      "WebFetch",
-      "SlashCommand",
-      "Skill",
-      "NotebookEdit",
-    ];
-    options.disallowedTools = [
-      ...(options.disallowedTools ?? []),
-      ...builtInTools,
-    ];
   }
 
   clearStatsigCache();

--- a/packages/agent/src/utils/acp-content.ts
+++ b/packages/agent/src/utils/acp-content.ts
@@ -19,7 +19,7 @@ export function resourceLink(
     mimeType?: string;
     title?: string;
     description?: string;
-    size?: bigint;
+    size?: number | null;
   },
 ): ContentBlock {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,11 +557,11 @@ importers:
   packages/agent:
     dependencies:
       '@agentclientprotocol/sdk':
-        specifier: ^0.14.0
-        version: 0.14.0(zod@3.25.76)
+        specifier: 0.15.0
+        version: 0.15.0(zod@3.25.76)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.68
-        version: 0.2.68(zod@3.25.76)
+        specifier: 0.2.71
+        version: 0.2.71(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.78.0
         version: 0.78.0(zod@3.25.76)
@@ -716,8 +716,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@agentclientprotocol/sdk@0.14.0':
-    resolution: {integrity: sha512-PNaDAiFIRzthaBjPljioHoadzYD2mRovA00ksCeCaerAU9qyqUQJdRBiJwlOxJ3SucY/nyJg8+0sh1sZrPhgmA==}
+  '@agentclientprotocol/sdk@0.15.0':
+    resolution: {integrity: sha512-TH4utu23Ix8ec34srBHmDD4p3HI0cYleS1jN9lghRczPfhFlMBNrQgZWeBBe12DWy27L11eIrtciY2MXFSEiDg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -729,8 +729,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.68':
-    resolution: {integrity: sha512-y4n6hTTgAqmiV/pqy1G4OgIdg6gDiAKPJaEgO1NOh7/rdsrXyc/HQoUmUy0ty4HkBq1hasm7hB92wtX3W1UMEw==}
+  '@anthropic-ai/claude-agent-sdk@0.2.71':
+    resolution: {integrity: sha512-pIsQJnM7Y+cJHL7aFY6SCCW3FIni218gVEpPqG8XGowfYxboFNBbNssWiUNRwthT8bp9jypcX7q5kx0Xsw14xg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -10787,7 +10787,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@agentclientprotocol/sdk@0.14.0(zod@3.25.76)':
+  '@agentclientprotocol/sdk@0.15.0(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
 
@@ -10798,7 +10798,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.2.68(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.71(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
1. Bump @anthropic-ai/claude-agent-sdk 0.2.68 → 0.2.71 and @agentclientprotocol/sdk ^0.14.0 → 0.15.0
2. Add toDisplayPath helper to show project-relative paths in tool call titles
3. Thread cwd through conversion pipeline for relative path display in Read/Edit/Write
4. Remove bigint workaround casts in usage tracking (SDK now uses number)
5. Replace disableBuiltInTools blocklist approach with tools: [] preset override
6. Update [UPSTREAM.md](http://UPSTREAM.md) fork point to v0.21.0