### PR TITLE
fix: Replace plan mode "keep planning" with feedback option

### DIFF
--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -190,10 +190,15 @@ async function applyPlanApproval(
     };
   }
 
-  const message =
-    "User wants to continue planning. Please refine your plan based on any feedback provided, or ask clarifying questions if needed.";
+  const customInput = (response._meta as Record<string, unknown> | undefined)
+    ?.customInput as string | undefined;
+  const feedback = customInput?.trim();
+
+  const message = feedback
+    ? `User rejected the plan with feedback: ${feedback}`
+    : "User rejected the plan. Wait for the user to provide direction.";
   await emitToolDenial(context, message);
-  return { behavior: "deny", message, interrupt: false };
+  return { behavior: "deny", message, interrupt: !feedback };
 }
 
 async function handleEnterPlanModeTool(

--- a/packages/agent/src/adapters/claude/permissions/permission-options.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-options.ts
@@ -105,8 +105,9 @@ export function buildExitPlanModePermissionOptions(): PermissionOption[] {
     },
     {
       kind: "reject_once",
-      name: "No, keep planning",
-      optionId: "plan",
+      name: "No, and tell the agent what to do differently",
+      optionId: "reject_with_feedback",
+      _meta: { customInput: true },
     },
   ];
 }


### PR DESCRIPTION
Closes https://github.com/PostHog/code/issues/1078

1. Replace "No, keep planning" button with "Type here to tell the agent what to do differently" with custom input
2. Use user feedback to deny the plan with context instead of a generic "continue planning" message
3. Interrupt the agent (wait for user input) when no feedback is provided

![Screenshot 2026-03-10 at 11.01.02 AM.png](https://app.graphite.com/user-attachments/assets/25622276-e726-4b75-8a8d-9ace5f9499ac.png)