### PR TITLE
fix: Fix github integration callback port conflict and permission deny handling

### DIFF
--- a/apps/code/src/main/services/github-integration/service.ts
+++ b/apps/code/src/main/services/github-integration/service.ts
@@ -16,7 +16,7 @@ const log = logger.scope("github-integration-service");
 
 const PROTOCOL = "posthog-code";
 const TIMEOUT_MS = 300_000; // 5 minutes
-const DEV_CALLBACK_PORT = 8238; // Different from OAuth's 8237
+const DEV_CALLBACK_PORT = 8239; // Different from OAuth's 8237 and MCP's 8238
 
 // Use HTTP callback in development, deep link in production
 const IS_DEV = process.defaultApp || false;

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -1,3 +1,4 @@
+import { isOtherOption } from "@components/action-selector/constants";
 import { PermissionSelector } from "@components/permissions/PermissionSelector";
 import {
   MessageEditor,
@@ -236,7 +237,7 @@ export function SessionView({
       }
 
       if (customInput) {
-        if (optionId === "other") {
+        if (isOtherOption(optionId)) {
           await getSessionService().respondToPermission(
             taskId,
             firstPendingPermission.toolCallId,
@@ -275,6 +276,7 @@ export function SessionView({
       taskId,
       firstPendingPermission.toolCallId,
     );
+    await getSessionService().cancelPrompt(taskId);
     requestFocus(sessionId);
   }, [firstPendingPermission, taskId, requestFocus, sessionId]);
 


### PR DESCRIPTION
Closes https://github.com/PostHog/code/issues/1157
Closes https://github.com/PostHog/code/issues/1161
Closes https://github.com/PostHog/code/issues/1162

1. Change github integration callback port from 8238 to 8239 to avoid conflict with MCP server
2. Use isOtherOption() helper instead of raw string check for "other" option
3. Cancel pending prompt when user denies a permission request