### PR TITLE
feat: onboarding styling - make all steps full height

### DIFF
--- a/apps/code/src/renderer/features/onboarding/components/BillingStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/BillingStep.tsx
@@ -38,55 +38,75 @@ export function BillingStep({ onNext, onBack }: BillingStepProps) {
 
   return (
     <Flex align="center" height="100%" px="8">
-      <Flex direction="column" gap="6" style={{ width: "100%", maxWidth: 520 }}>
-        <Flex direction="column" gap="3">
-          <img
-            src={phWordmark}
-            alt="PostHog"
-            style={{
-              height: "40px",
-              objectFit: "contain",
-              alignSelf: "flex-start",
-            }}
-          />
-          <Text
-            size="6"
-            style={{
-              color: "var(--gray-12)",
-              lineHeight: 1.3,
-            }}
-          >
-            Choose your plan
-          </Text>
+      <Flex
+        direction="column"
+        style={{
+          width: "100%",
+          maxWidth: 520,
+          height: "100%",
+          paddingTop: 80,
+          paddingBottom: 40,
+        }}
+      >
+        <img
+          src={phWordmark}
+          alt="PostHog"
+          style={{
+            height: "40px",
+            objectFit: "contain",
+            alignSelf: "flex-start",
+          }}
+        />
+
+        <Flex
+          direction="column"
+          justify="center"
+          style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+        >
+          <Flex direction="column" gap="6">
+            <Text
+              size="6"
+              style={{
+                color: "var(--gray-12)",
+                lineHeight: 1.3,
+              }}
+            >
+              Choose your plan
+            </Text>
+            <Flex direction="column" gap="3">
+              {/* Free Plan */}
+              <PlanCard
+                name="Free"
+                price="$0"
+                period="/month"
+                features={FREE_FEATURES}
+                isSelected={selectedPlan === "free"}
+                onSelect={() => selectPlan("free")}
+              />
+
+              {/* Pro Plan */}
+              <PlanCard
+                name="Pro"
+                price="$200"
+                period="/month"
+                features={PRO_FEATURES}
+                isSelected={selectedPlan === "pro"}
+                onSelect={() => selectPlan("pro")}
+                recommended
+              />
+            </Flex>
+            <Text
+              size="1"
+              mt="3"
+              style={{ color: "var(--gray-12)", opacity: 0.5 }}
+            >
+              * Usage is limited to "human" level usage, this cannot be used as
+              your api key. If you hit this limit, please contact support.
+            </Text>
+          </Flex>
         </Flex>
 
-        <Flex direction="column" gap="3">
-          {/* Free Plan */}
-          <PlanCard
-            name="Free"
-            price="$0"
-            period="/month"
-            features={FREE_FEATURES}
-            isSelected={selectedPlan === "free"}
-            onSelect={() => selectPlan("free")}
-          />
-
-          {/* Pro Plan */}
-          <PlanCard
-            name="Pro"
-            price="$200"
-            period="/month"
-            features={PRO_FEATURES}
-            isSelected={selectedPlan === "pro"}
-            onSelect={() => selectPlan("pro")}
-            recommended
-          />
-        </Flex>
-        <Text size="1" style={{ color: "var(--gray-12)", opacity: 0.5 }}>
-          * Usage is limited to "human" level usage, this cannot be used as your
-          api key. If you hit this limit, please contact support.
-        </Text>
-        <Flex gap="3" align="center">
+        <Flex gap="3" align="center" flexShrink="0">
           <Button
             size="3"
             variant="ghost"

--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -88,271 +88,298 @@ export function GitIntegrationStep({
 
   return (
     <Flex align="center" height="100%" px="8">
-      <Flex direction="column" gap="6" style={{ width: "100%", maxWidth: 520 }}>
-        <Flex direction="column" gap="3">
-          <img
-            src={phWordmark}
-            alt="PostHog"
-            style={{
-              height: "40px",
-              objectFit: "contain",
-              alignSelf: "flex-start",
-            }}
-          />
-          <Text
-            size="6"
-            style={{
-              color: "var(--gray-12)",
-              lineHeight: 1.3,
-            }}
-          >
-            Connect your git repository
-          </Text>
-          <Text size="2" style={{ color: "var(--gray-12)", opacity: 0.7 }}>
-            PostHog Code needs access to your GitHub repositories to enable
-            cloud runs and PR creation.
-          </Text>
-
-          {selectedProject && (
-            <Flex direction="column" gap="1">
-              <Text size="1" style={{ color: "var(--gray-12)", opacity: 0.5 }}>
-                {selectedProject.organization.name}
-              </Text>
-              <ProjectSelect
-                projectId={selectedProject.id}
-                projectName={selectedProject.name}
-                projects={projects.map((p) => ({ id: p.id, name: p.name }))}
-                onProjectChange={setManuallySelectedProjectId}
-                disabled={isLoading}
-              />
-            </Flex>
-          )}
-        </Flex>
-
-        {/* Consistent status box - same height regardless of connection state */}
-        <Box
-          p="5"
+      <Flex
+        direction="column"
+        style={{
+          width: "100%",
+          maxWidth: 520,
+          height: "100%",
+          paddingTop: 80,
+          paddingBottom: 40,
+        }}
+      >
+        <img
+          src={phWordmark}
+          alt="PostHog"
           style={{
-            backgroundColor: "var(--color-panel-solid)",
-            border: "1px solid var(--gray-4)",
+            height: "40px",
+            objectFit: "contain",
+            alignSelf: "flex-start",
           }}
+        />
+
+        <Flex
+          direction="column"
+          justify="center"
+          style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
         >
-          <Flex direction="column" gap="4" align="center">
-            <AnimatePresence mode="wait">
-              {isLoading ? (
-                <motion.div
-                  key="icon-skeleton"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15 }}
-                >
-                  <Skeleton
-                    style={{
-                      width: "32px",
-                      height: "32px",
-                      borderRadius: "8px",
-                    }}
-                  />
-                </motion.div>
-              ) : hasGitIntegration ? (
-                <motion.div
-                  key="icon-connected"
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.9 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <CheckCircle
-                    size={32}
-                    weight="fill"
-                    style={{ color: "var(--green-9)" }}
-                  />
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="icon-disconnected"
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.9 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <GitBranch size={32} style={{ color: "var(--gray-12)" }} />
-                </motion.div>
-              )}
-            </AnimatePresence>
-            <Flex direction="column" gap="2" align="center">
-              <AnimatePresence mode="wait">
-                {isLoading ? (
-                  <motion.div
-                    key="text-skeleton"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.15 }}
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "8px",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Skeleton style={{ width: "180px", height: "20px" }} />
-                    <Skeleton style={{ width: "260px", height: "16px" }} />
-                  </motion.div>
-                ) : hasGitIntegration ? (
-                  <motion.div
-                    key="text-connected"
-                    initial={{ opacity: 0, y: 4 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -4 }}
-                    transition={{ duration: 0.2, delay: 0.05 }}
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "8px",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Text
-                      size="3"
-                      weight="bold"
-                      style={{ color: "var(--gray-12)" }}
-                    >
-                      GitHub connected
-                    </Text>
-                    <Text
-                      size="2"
-                      align="center"
-                      style={{
-                        color: "var(--gray-12)",
-                        opacity: 0.7,
-                      }}
-                    >
-                      Your GitHub integration is active and ready to use.
-                    </Text>
-                  </motion.div>
-                ) : (
-                  <motion.div
-                    key="text-disconnected"
-                    initial={{ opacity: 0, y: 4 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -4 }}
-                    transition={{ duration: 0.2, delay: 0.05 }}
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "8px",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Text
-                      size="3"
-                      weight="bold"
-                      style={{ color: "var(--gray-12)" }}
-                    >
-                      No git integration found
-                    </Text>
-                    <Text
-                      size="2"
-                      align="center"
-                      style={{
-                        color: "var(--gray-12)",
-                        opacity: 0.7,
-                      }}
-                    >
-                      Connect GitHub.
-                    </Text>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </Flex>
-            <AnimatePresence mode="wait">
-              {isLoading ? (
-                <motion.div
-                  key="action-skeleton"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15 }}
-                >
-                  <Skeleton
-                    style={{
-                      width: "160px",
-                      height: "32px",
-                      borderRadius: "6px",
-                    }}
-                  />
-                </motion.div>
-              ) : !hasGitIntegration ? (
-                <motion.div
-                  key="action-disconnected"
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -4 }}
-                  transition={{ duration: 0.2, delay: 0.1 }}
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "8px",
-                    alignItems: "center",
-                  }}
-                >
-                  <Button
-                    size="2"
-                    onClick={handleConnectGitHub}
-                    loading={isConnecting}
-                  >
-                    Connect GitHub
-                    <ArrowSquareOut size={16} />
-                  </Button>
+          <Flex direction="column" gap="6">
+            <Flex direction="column" gap="3">
+              <Text
+                size="6"
+                style={{
+                  color: "var(--gray-12)",
+                  lineHeight: 1.3,
+                }}
+              >
+                Connect your git repository
+              </Text>
+              <Text size="2" style={{ color: "var(--gray-12)", opacity: 0.7 }}>
+                PostHog Code needs access to your GitHub repositories to enable
+                cloud runs and PR creation.
+              </Text>
+
+              {selectedProject && (
+                <Flex direction="column" gap="1">
                   <Text
                     size="1"
-                    style={{
-                      color: "var(--gray-12)",
-                      opacity: 0.5,
-                    }}
+                    style={{ color: "var(--gray-12)", opacity: 0.5 }}
                   >
-                    Opens GitHub to authorize the PostHog app
+                    {selectedProject.organization.name}
                   </Text>
-                  <Button
-                    size="1"
-                    variant="ghost"
-                    loading={isFetching}
-                    onClick={handleRefresh}
-                    style={{ color: "var(--gray-12)" }}
-                  >
-                    Refresh status
-                  </Button>
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="action-connected"
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -4 }}
-                  transition={{ duration: 0.2, delay: 0.1 }}
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "8px",
-                    alignItems: "center",
-                  }}
-                >
-                  <Button
-                    size="1"
-                    variant="ghost"
-                    loading={isFetching}
-                    onClick={handleRefresh}
-                    style={{ color: "var(--gray-12)" }}
-                  >
-                    Refresh status
-                  </Button>
-                </motion.div>
+                  <ProjectSelect
+                    projectId={selectedProject.id}
+                    projectName={selectedProject.name}
+                    projects={projects.map((p) => ({
+                      id: p.id,
+                      name: p.name,
+                    }))}
+                    onProjectChange={setManuallySelectedProjectId}
+                    disabled={isLoading}
+                  />
+                </Flex>
               )}
-            </AnimatePresence>
+            </Flex>
+
+            {/* Consistent status box - same height regardless of connection state */}
+            <Box
+              p="5"
+              style={{
+                backgroundColor: "var(--color-panel-solid)",
+                border: "1px solid var(--gray-4)",
+              }}
+            >
+              <Flex direction="column" gap="4" align="center">
+                <AnimatePresence mode="wait">
+                  {isLoading ? (
+                    <motion.div
+                      key="icon-skeleton"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.15 }}
+                    >
+                      <Skeleton
+                        style={{
+                          width: "32px",
+                          height: "32px",
+                          borderRadius: "8px",
+                        }}
+                      />
+                    </motion.div>
+                  ) : hasGitIntegration ? (
+                    <motion.div
+                      key="icon-connected"
+                      initial={{ opacity: 0, scale: 0.9 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.9 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <CheckCircle
+                        size={32}
+                        weight="fill"
+                        style={{ color: "var(--green-9)" }}
+                      />
+                    </motion.div>
+                  ) : (
+                    <motion.div
+                      key="icon-disconnected"
+                      initial={{ opacity: 0, scale: 0.9 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.9 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <GitBranch
+                        size={32}
+                        style={{ color: "var(--gray-12)" }}
+                      />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+                <Flex direction="column" gap="2" align="center">
+                  <AnimatePresence mode="wait">
+                    {isLoading ? (
+                      <motion.div
+                        key="text-skeleton"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.15 }}
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "8px",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Skeleton style={{ width: "180px", height: "20px" }} />
+                        <Skeleton style={{ width: "260px", height: "16px" }} />
+                      </motion.div>
+                    ) : hasGitIntegration ? (
+                      <motion.div
+                        key="text-connected"
+                        initial={{ opacity: 0, y: 4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -4 }}
+                        transition={{ duration: 0.2, delay: 0.05 }}
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "8px",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Text
+                          size="3"
+                          weight="bold"
+                          style={{ color: "var(--gray-12)" }}
+                        >
+                          GitHub connected
+                        </Text>
+                        <Text
+                          size="2"
+                          align="center"
+                          style={{
+                            color: "var(--gray-12)",
+                            opacity: 0.7,
+                          }}
+                        >
+                          Your GitHub integration is active and ready to use.
+                        </Text>
+                      </motion.div>
+                    ) : (
+                      <motion.div
+                        key="text-disconnected"
+                        initial={{ opacity: 0, y: 4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -4 }}
+                        transition={{ duration: 0.2, delay: 0.05 }}
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "8px",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Text
+                          size="3"
+                          weight="bold"
+                          style={{ color: "var(--gray-12)" }}
+                        >
+                          No git integration found
+                        </Text>
+                        <Text
+                          size="2"
+                          align="center"
+                          style={{
+                            color: "var(--gray-12)",
+                            opacity: 0.7,
+                          }}
+                        >
+                          Connect GitHub.
+                        </Text>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </Flex>
+                <AnimatePresence mode="wait">
+                  {isLoading ? (
+                    <motion.div
+                      key="action-skeleton"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.15 }}
+                    >
+                      <Skeleton
+                        style={{
+                          width: "160px",
+                          height: "32px",
+                          borderRadius: "6px",
+                        }}
+                      />
+                    </motion.div>
+                  ) : !hasGitIntegration ? (
+                    <motion.div
+                      key="action-disconnected"
+                      initial={{ opacity: 0, y: 4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -4 }}
+                      transition={{ duration: 0.2, delay: 0.1 }}
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "8px",
+                        alignItems: "center",
+                      }}
+                    >
+                      <Button
+                        size="2"
+                        onClick={handleConnectGitHub}
+                        loading={isConnecting}
+                      >
+                        Connect GitHub
+                        <ArrowSquareOut size={16} />
+                      </Button>
+                      <Text
+                        size="1"
+                        style={{
+                          color: "var(--gray-12)",
+                          opacity: 0.5,
+                        }}
+                      >
+                        Opens GitHub to authorize the PostHog app
+                      </Text>
+                      <Button
+                        size="1"
+                        variant="ghost"
+                        loading={isFetching}
+                        onClick={handleRefresh}
+                        style={{ color: "var(--gray-12)" }}
+                      >
+                        Refresh status
+                      </Button>
+                    </motion.div>
+                  ) : (
+                    <motion.div
+                      key="action-connected"
+                      initial={{ opacity: 0, y: 4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -4 }}
+                      transition={{ duration: 0.2, delay: 0.1 }}
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "8px",
+                        alignItems: "center",
+                      }}
+                    >
+                      <Button
+                        size="1"
+                        variant="ghost"
+                        loading={isFetching}
+                        onClick={handleRefresh}
+                        style={{ color: "var(--gray-12)" }}
+                      >
+                        Refresh status
+                      </Button>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </Flex>
+            </Box>
           </Flex>
-        </Box>
+        </Flex>
 
         <AnimatePresence>
           {!isLoading && (
@@ -362,7 +389,7 @@ export function GitIntegrationStep({
               exit={{ opacity: 0, y: 8 }}
               transition={{ duration: 0.25, delay: 0.15 }}
             >
-              <Flex gap="3" align="center">
+              <Flex gap="3" align="center" flexShrink="0">
                 <Button
                   size="3"
                   variant="ghost"

--- a/apps/code/src/renderer/features/onboarding/components/SignalsStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/SignalsStep.tsx
@@ -106,44 +106,62 @@ export function SignalsStep({ onNext, onBack }: SignalsStepProps) {
 
   return (
     <Flex align="center" height="100%" px="8">
-      <Flex direction="column" gap="6" style={{ width: "100%", maxWidth: 520 }}>
-        <Flex direction="column" gap="3">
-          <img
-            src={phWordmark}
-            alt="PostHog"
-            style={{
-              height: "40px",
-              objectFit: "contain",
-              alignSelf: "flex-start",
-            }}
-          />
-          <Text
-            size="6"
-            style={{
-              color: "var(--gray-12)",
-              lineHeight: 1.3,
-            }}
-          >
-            Enable "the inbox"
-          </Text>
-          <Text size="2" style={{ color: "var(--gray-12)", opacity: 0.7 }}>
-            Automatically analyze your product data and surface actionable
-            insights. Choose which sources to enable for this project.
-          </Text>
-        </Flex>
-
-        <SignalSourceToggles
-          value={sources}
-          onChange={setUserSelections}
-          disabled={isSaving}
+      <Flex
+        direction="column"
+        style={{
+          width: "100%",
+          maxWidth: 520,
+          height: "100%",
+          paddingTop: 80,
+          paddingBottom: 40,
+        }}
+      >
+        <img
+          src={phWordmark}
+          alt="PostHog"
+          style={{
+            height: "40px",
+            objectFit: "contain",
+            alignSelf: "flex-start",
+          }}
         />
+
+        <Flex
+          direction="column"
+          justify="center"
+          style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+        >
+          <Flex direction="column" gap="6">
+            <Flex direction="column" gap="3">
+              <Text
+                size="6"
+                style={{
+                  color: "var(--gray-12)",
+                  lineHeight: 1.3,
+                }}
+              >
+                Enable "the inbox"
+              </Text>
+              <Text size="2" style={{ color: "var(--gray-12)", opacity: 0.7 }}>
+                Automatically analyze your product data and surface actionable
+                insights. Choose which sources to enable for this project.
+              </Text>
+            </Flex>
+
+            <SignalSourceToggles
+              value={sources}
+              onChange={setUserSelections}
+              disabled={isSaving}
+            />
+          </Flex>
+        </Flex>
 
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, delay: 0.15 }}
         >
-          <Flex gap="3" align="center">
+          <Flex gap="3" align="center" flexShrink="0">
             <Button
               size="3"
               variant="ghost"

--- a/apps/code/src/renderer/features/onboarding/components/WelcomeStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/WelcomeStep.tsx
@@ -6,7 +6,7 @@ import {
   Robot,
   Stack,
 } from "@phosphor-icons/react";
-import { Box, Button, Flex } from "@radix-ui/themes";
+import { Button, Flex } from "@radix-ui/themes";
 import phWordmark from "@renderer/assets/images/wordmark-alt.png";
 import { FeatureListItem } from "./FeatureListItem";
 
@@ -49,18 +49,15 @@ const FEATURES = [
 
 export function WelcomeStep({ onNext }: WelcomeStepProps) {
   return (
-    <Flex height="100%">
-      {/* Left side - features list */}
+    <Flex align="center" height="100%" px="8">
       <Flex
         direction="column"
-        justify="center"
-        gap="4"
         style={{
           width: "100%",
           maxWidth: 520,
-          paddingLeft: "var(--space-8)",
-          paddingRight: "var(--space-6)",
           height: "100%",
+          paddingTop: 80,
+          paddingBottom: 40,
         }}
       >
         <Flex direction="column" gap="3" mb="4">
@@ -75,23 +72,29 @@ export function WelcomeStep({ onNext }: WelcomeStepProps) {
           />
         </Flex>
 
-        <Flex direction="column" gap="3">
-          {FEATURES.map((feature) => (
-            <FeatureListItem
-              key={feature.title}
-              icon={feature.icon}
-              title={feature.title}
-              description={feature.description}
-            />
-          ))}
+        <Flex
+          direction="column"
+          justify="center"
+          style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+        >
+          <Flex direction="column" gap="3">
+            {FEATURES.map((feature) => (
+              <FeatureListItem
+                key={feature.title}
+                icon={feature.icon}
+                title={feature.title}
+                description={feature.description}
+              />
+            ))}
+          </Flex>
         </Flex>
 
-        <Box mt="2">
+        <Flex gap="3" align="center" flexShrink="0" mt="4">
           <Button size="3" onClick={onNext}>
             Get Started
             <ArrowRight size={16} />
           </Button>
-        </Box>
+        </Flex>
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
### TL;DR

Improved the layout structure of onboarding steps to use proper flexbox layout with fixed header, scrollable content area, and fixed footer.

### What changed?

Restructured the layout of all onboarding step components (BillingStep, GitIntegrationStep, SignalsStep, and WelcomeStep) to use a consistent three-section layout:
- Fixed header with PostHog logo at the top
- Scrollable content area in the middle that takes up remaining space
- Fixed footer with navigation buttons at the bottom

The main container now uses `flex: 1` for the content area with `overflowY: "auto"` to handle content that exceeds the viewport height, while the header and footer use `flexShrink="0"` to maintain their fixed positions.