### PR TITLE
fix: show all slash commands in suggestion dropdown

### DIFF
--- a/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
+++ b/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
@@ -6,8 +6,6 @@ import Fuse, { type IFuseOptions } from "fuse.js";
 import { useDraftStore } from "../stores/draftStore";
 import type { CommandSuggestionItem, FileSuggestionItem } from "../types";
 
-const COMMAND_LIMIT = 5;
-
 const COMMAND_FUSE_OPTIONS: IFuseOptions<AvailableCommand> = {
   keys: [
     { name: "name", weight: 0.7 },
@@ -22,11 +20,11 @@ function searchCommands(
   query: string,
 ): AvailableCommand[] {
   if (!query.trim()) {
-    return commands.slice(0, COMMAND_LIMIT);
+    return commands;
   }
 
   const fuse = new Fuse(commands, COMMAND_FUSE_OPTIONS);
-  const results = fuse.search(query, { limit: COMMAND_LIMIT * 2 });
+  const results = fuse.search(query);
 
   const lowerQuery = query.toLowerCase();
   results.sort((a, b) => {
@@ -38,7 +36,7 @@ function searchCommands(
     return (a.score ?? 0) - (b.score ?? 0);
   });
 
-  return results.slice(0, COMMAND_LIMIT).map((result) => result.item);
+  return results.map((result) => result.item);
 }
 
 export async function getFileSuggestions(


### PR DESCRIPTION
## Summary
- Removes the hardcoded `COMMAND_LIMIT = 5` cap so all available slash commands appear when typing `/`
- Previously, only the first 5 commands were shown (3 built-ins + 2 agent commands), hiding skills like `/mcp`
- The dropdown already supports scrolling (`max-h-60 overflow-y-auto`) so this works without UI changes

## Test plan
- [x] Type `/` in the message editor and verify all commands appear (including skills like `/instrument-feature-flags`, `/mcp:*`, etc.)
- [x] Type `/inst` and verify fuzzy search still works and returns all matching results

🤖 Generated with [Claude Code](https://claude.com/claude-code)