### PR TITLE
feat: Add repository mismatch warning on folder select

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/WorkspaceSetupPrompt.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/WorkspaceSetupPrompt.tsx
@@ -1,8 +1,9 @@
 import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
 import { foldersApi } from "@features/folders/hooks/useFolders";
 import { useEnsureWorkspace } from "@features/workspace/hooks/useWorkspace";
-import { Folder } from "@phosphor-icons/react";
-import { Box, Code, Flex, Spinner, Text } from "@radix-ui/themes";
+import { Folder, Warning } from "@phosphor-icons/react";
+import { Box, Button, Code, Flex, Spinner, Text } from "@radix-ui/themes";
+import { trpcVanilla } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
 import { logger } from "@utils/logger";
 import { getTaskRepository } from "@utils/repository";
@@ -22,19 +23,21 @@ export function WorkspaceSetupPrompt({
 }: WorkspaceSetupPromptProps) {
   const [isSettingUp, setIsSettingUp] = useState(false);
   const [selectedPath, setSelectedPath] = useState("");
+  const [pendingPath, setPendingPath] = useState<string | null>(null);
+  const [detectedRepo, setDetectedRepo] = useState<string | null>(null);
   const repository = getTaskRepository(task);
   const { ensureWorkspace } = useEnsureWorkspace();
 
-  const handleFolderSelect = useCallback(
+  const proceedWithSetup = useCallback(
     async (path: string) => {
+      setPendingPath(null);
+      setDetectedRepo(null);
       setSelectedPath(path);
       setIsSettingUp(true);
 
       try {
         await foldersApi.addFolder(path);
-
         await ensureWorkspace(taskId, path, "worktree");
-
         log.info("Workspace setup complete", { taskId, path });
       } catch (error) {
         log.error("Failed to set up workspace", { error });
@@ -46,6 +49,47 @@ export function WorkspaceSetupPrompt({
     },
     [taskId, ensureWorkspace],
   );
+
+  const handleFolderSelect = useCallback(
+    async (path: string) => {
+      if (repository) {
+        let detected = null;
+        try {
+          detected = await trpcVanilla.git.detectRepo.query({
+            directoryPath: path,
+          });
+        } catch (error) {
+          log.warn("Failed to detect repo for mismatch check", {
+            error,
+            path,
+          });
+        }
+
+        if (detected) {
+          const detectedFullName = `${detected.organization}/${detected.repository}`;
+          if (detectedFullName !== repository) {
+            setPendingPath(path);
+            setDetectedRepo(detectedFullName);
+            return;
+          }
+        }
+      }
+
+      await proceedWithSetup(path);
+    },
+    [repository, proceedWithSetup],
+  );
+
+  const handleConfirm = useCallback(async () => {
+    if (pendingPath) {
+      await proceedWithSetup(pendingPath);
+    }
+  }, [pendingPath, proceedWithSetup]);
+
+  const handleBack = useCallback(() => {
+    setPendingPath(null);
+    setDetectedRepo(null);
+  }, []);
 
   return (
     <Flex
@@ -61,6 +105,25 @@ export function WorkspaceSetupPrompt({
           <Text size="2" className="text-gray-11">
             Setting up workspace...
           </Text>
+        </>
+      ) : pendingPath ? (
+        <>
+          <Warning size={32} weight="duotone" className="text-amber-9" />
+          <Text size="3" weight="medium" className="text-gray-12">
+            Repository mismatch
+          </Text>
+          <Text size="2" align="center" className="max-w-xs text-gray-11">
+            This task is linked to <Code>{repository}</Code> but the selected
+            folder belongs to <Code>{detectedRepo}</Code>.
+          </Text>
+          <Flex gap="2" mt="1">
+            <Button variant="soft" color="gray" onClick={handleBack}>
+              Go back
+            </Button>
+            <Button variant="solid" onClick={handleConfirm}>
+              Continue anyway
+            </Button>
+          </Flex>
         </>
       ) : (
         <>


### PR DESCRIPTION
1. Detect repo from selected folder path via git.detectRepo tRPC query
2. Show warning UI when selected folder's repo doesn't match the task's linked repository
3. Allow user to go back or continue anyway with mismatched repo
4. Extract folder setup logic into proceedWithSetup callback for reuse