### PR TITLE
fix: Remove registry-url from setup-node to fix OIDC npm publish

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           node-version: 24
           cache: "pnpm"
-          registry-url: https://registry.npmjs.org
 
       - name: Extract version from tag
         id: version
@@ -61,12 +60,8 @@ jobs:
       - name: Run tests
         run: pnpm --filter agent run test
 
-      - name: Ensure modern npm (OIDC support)
-        run: npm install -g npm@11.6.4
-
       - name: Publish the package to npm registry
         working-directory: packages/agent
         run: pnpm publish --access public --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: true
-          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
Closes https://github.com/PostHog/code/issues/1178

Docs: https://github.com/PostHog/posthog.com/pull/15480

The npm publish step was failing with OIDC auth errors because `setup-node` with `registry-url` creates an `.npmrc` that conflicts with the OIDC flow.

1. Remove registry-url from setup-node so npm uses its built-in OIDC provenance flow
2. Remove manual npm upgrade step (no longer needed)
3. Remove empty NODE_AUTH_TOKEN env var