### PR TITLE
feat: Implement cloud follow-up resume for agent sessions

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -402,11 +402,19 @@ export class PostHogAPIClient {
     }
   }
 
-  async runTaskInCloud(taskId: string, branch?: string | null): Promise<Task> {
+  async runTaskInCloud(
+    taskId: string,
+    branch?: string | null,
+    resumeOptions?: { resumeFromRunId: string; pendingUserMessage: string },
+  ): Promise<Task> {
     const teamId = await this.getTeamId();
-    const body: Record<string, unknown> = {};
+    const body: Record<string, unknown> = { mode: "interactive" };
     if (branch) {
       body.branch = branch;
+    }
+    if (resumeOptions) {
+      body.resume_from_run_id = resumeOptions.resumeFromRunId;
+      body.pending_user_message = resumeOptions.pendingUserMessage;
     }
 
     const data = await this.api.post(

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -55,7 +55,6 @@ interface SessionViewProps {
   onRetry?: () => void;
   onNewSession?: () => void;
   isInitializing?: boolean;
-  readOnlyMessage?: string;
   slackThreadUrl?: string;
 }
 
@@ -80,7 +79,6 @@ export function SessionView({
   onRetry,
   onNewSession,
   isInitializing = false,
-  readOnlyMessage,
   slackThreadUrl,
 }: SessionViewProps) {
   const showRawLogs = useShowRawLogs();
@@ -437,22 +435,6 @@ export function SessionView({
                       onSelect={handlePermissionSelect}
                       onCancel={handlePermissionCancel}
                     />
-                  </Box>
-                </Box>
-              ) : readOnlyMessage ? (
-                <Box className="border-gray-4 border-t">
-                  <Box className="mx-auto max-w-[750px] p-2">
-                    <Flex align="center" justify="center" py="3">
-                      <Text
-                        size="2"
-                        style={{
-                          color: "var(--gray-9)",
-                          fontFamily: "var(--font-mono)",
-                        }}
-                      >
-                        {readOnlyMessage}
-                      </Text>
-                    </Flex>
                   </Box>
                 </Box>
               ) : (

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -44,8 +44,10 @@ import {
   notifyPermissionRequest,
   notifyPromptComplete,
 } from "@utils/notifications";
+import { queryClient } from "@utils/queryClient";
 import {
   convertStoredEntriesToEvents,
+  createUserMessageEvent,
   createUserShellExecuteEvent,
   extractPromptText,
   getUserShellExecutesSinceLastPrompt,
@@ -1134,6 +1136,7 @@ export class SessionService {
   private async sendCloudPrompt(
     session: AgentSession,
     prompt: string | ContentBlock[],
+    options?: { skipQueueGuard?: boolean },
   ): Promise<{ stopReason: string }> {
     const promptText = extractPromptText(prompt);
     if (!promptText.trim()) {
@@ -1142,10 +1145,10 @@ export class SessionService {
 
     const terminalStatuses = new Set(["completed", "failed", "cancelled"]);
     if (session.cloudStatus && terminalStatuses.has(session.cloudStatus)) {
-      throw new Error("This cloud run has already finished");
+      return this.resumeCloudRun(session, promptText);
     }
 
-    if (session.isPromptPending) {
+    if (!options?.skipQueueGuard && session.isPromptPending) {
       sessionStoreSetters.enqueueMessage(session.taskId, promptText);
       log.info("Cloud message queued", {
         taskId: session.taskId,
@@ -1216,24 +1219,140 @@ export class SessionService {
 
   private async sendQueuedCloudMessages(
     taskId: string,
+    attempt = 0,
+    pendingText?: string,
   ): Promise<{ stopReason: string }> {
-    const combinedText = sessionStoreSetters.dequeueMessagesAsText(taskId);
-    if (!combinedText) {
-      return { stopReason: "skipped" };
-    }
+    // First attempt: atomically dequeue. Retries reuse the already-dequeued text.
+    const combinedText =
+      pendingText ?? sessionStoreSetters.dequeueMessagesAsText(taskId);
+    if (!combinedText) return { stopReason: "skipped" };
 
     const session = sessionStoreSetters.getSessionByTaskId(taskId);
     if (!session) {
-      log.warn("No session found for queued cloud messages", { taskId });
+      log.warn("No session found for queued cloud messages, message lost", {
+        taskId,
+      });
       return { stopReason: "no_session" };
     }
 
     log.info("Sending queued cloud messages", {
       taskId,
       promptLength: combinedText.length,
+      attempt,
     });
 
-    return this.sendCloudPrompt(session, combinedText);
+    try {
+      return await this.sendCloudPrompt(session, combinedText, {
+        skipQueueGuard: true,
+      });
+    } catch (error) {
+      const maxRetries = 5;
+      if (attempt < maxRetries) {
+        const delayMs = Math.min(1000 * 2 ** attempt, 10_000);
+        log.warn("Cloud message send failed, scheduling retry", {
+          taskId,
+          attempt,
+          delayMs,
+          error: String(error),
+        });
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(
+              this.sendQueuedCloudMessages(
+                taskId,
+                attempt + 1,
+                combinedText,
+              ).catch((err) => {
+                log.error("Queued cloud message retry failed", {
+                  taskId,
+                  attempt: attempt + 1,
+                  error: err,
+                });
+                return { stopReason: "error" };
+              }),
+            );
+          }, delayMs);
+        });
+      }
+
+      log.error("Queued cloud message send failed after max retries", {
+        taskId,
+        attempts: attempt + 1,
+      });
+      toast.error("Failed to send follow-up message. Please try again.");
+      return { stopReason: "error" };
+    }
+  }
+
+  private async resumeCloudRun(
+    session: AgentSession,
+    promptText: string,
+  ): Promise<{ stopReason: string }> {
+    const client = useAuthStore.getState().client;
+    if (!client) {
+      throw new Error("Authentication required for cloud commands");
+    }
+
+    log.info("Creating resume run for terminal cloud task", {
+      taskId: session.taskId,
+      previousRunId: session.taskRunId,
+      previousStatus: session.cloudStatus,
+    });
+
+    // Create a new run WITH resume context — backend validates the previous run,
+    // derives snapshot_external_id server-side, and passes everything as extra_state.
+    // The agent will load conversation history and restore the sandbox snapshot.
+    const updatedTask = await client.runTaskInCloud(
+      session.taskId,
+      session.cloudBranch,
+      {
+        resumeFromRunId: session.taskRunId,
+        pendingUserMessage: promptText,
+      },
+    );
+    const newRun = updatedTask.latest_run;
+    if (!newRun?.id) {
+      throw new Error("Failed to create resume run");
+    }
+
+    // Replace session with one for the new run, preserving conversation history.
+    // setSession handles old session cleanup via taskIdIndex.
+    const newSession = this.createBaseSession(
+      newRun.id,
+      session.taskId,
+      session.taskTitle,
+    );
+    newSession.status = "disconnected";
+    newSession.isCloud = true;
+    // Carry over existing events and add optimistic user bubble for the follow-up.
+    // Reset processedLineCount to 0 because the new run's log stream starts fresh.
+    newSession.events = [
+      ...session.events,
+      createUserMessageEvent(promptText, Date.now()),
+    ];
+    newSession.processedLineCount = 0;
+    // Skip the first session/prompt from polled logs — we already have the
+    // optimistic user event, so showing the polled one would duplicate it.
+    newSession.skipPolledPromptCount = 1;
+    sessionStoreSetters.setSession(newSession);
+
+    // No enqueueMessage / isPromptPending needed — the follow-up is passed
+    // in run state (pending_user_message), NOT via user_message command.
+
+    // Start the watcher immediately so we don't miss status updates.
+    this.watchCloudTask(session.taskId, newRun.id);
+
+    // Invalidate task queries so the UI picks up the new run metadata
+    queryClient.invalidateQueries({ queryKey: ["tasks"] });
+
+    track(ANALYTICS_EVENTS.PROMPT_SENT, {
+      task_id: session.taskId,
+      is_initial: false,
+      execution_type: "cloud",
+      prompt_length_chars: promptText.length,
+    });
+
+    return { stopReason: "queued" };
   }
 
   private async cancelCloudPrompt(session: AgentSession): Promise<boolean> {
@@ -1772,7 +1891,12 @@ export class SessionService {
       } else if (delta <= update.newEntries.length) {
         // Normal case: append only the tail (last `delta` entries)
         const entriesToAppend = update.newEntries.slice(-delta);
-        const newEvents = convertStoredEntriesToEvents(entriesToAppend);
+        let newEvents = convertStoredEntriesToEvents(entriesToAppend);
+        newEvents = this.filterSkippedPromptEvents(
+          taskRunId,
+          session,
+          newEvents,
+        );
         sessionStoreSetters.appendEvents(taskRunId, newEvents, expectedCount);
         this.updatePromptStateFromEvents(taskRunId, newEvents);
       } else {
@@ -1783,7 +1907,12 @@ export class SessionService {
           expectedCount,
           entriesReceived: update.newEntries.length,
         });
-        const newEvents = convertStoredEntriesToEvents(update.newEntries);
+        let newEvents = convertStoredEntriesToEvents(update.newEntries);
+        newEvents = this.filterSkippedPromptEvents(
+          taskRunId,
+          session,
+          newEvents,
+        );
         sessionStoreSetters.appendEvents(
           taskRunId,
           newEvents,
@@ -1792,6 +1921,22 @@ export class SessionService {
         this.updatePromptStateFromEvents(taskRunId, newEvents);
       }
     }
+
+    // Flush queued messages when a cloud turn completes (detected via log polling)
+    const sessionAfterLogs = sessionStoreSetters.getSessions()[taskRunId];
+    if (
+      sessionAfterLogs &&
+      !sessionAfterLogs.isPromptPending &&
+      sessionAfterLogs.messageQueue.length > 0
+    ) {
+      this.sendQueuedCloudMessages(sessionAfterLogs.taskId).catch((err) => {
+        log.error("Failed to send queued cloud messages after turn complete", {
+          taskId: sessionAfterLogs.taskId,
+          error: err,
+        });
+      });
+    }
+
     // Update cloud status fields if present
     if (update.kind === "status" || update.kind === "snapshot") {
       sessionStoreSetters.updateCloudStatus(taskRunId, {
@@ -1802,11 +1947,72 @@ export class SessionService {
         branch: update.branch,
       });
 
+      // Auto-send queued messages when a resumed run becomes active
+      if (update.status === "in_progress") {
+        const session = sessionStoreSetters.getSessions()[taskRunId];
+        if (session && session.messageQueue.length > 0) {
+          // Clear the pending flag first — resumeCloudRun sets it as a guard
+          // while waiting for the run to start. Now that the run is active,
+          // sendCloudPrompt needs the flag clear to actually send.
+          sessionStoreSetters.updateSession(taskRunId, {
+            isPromptPending: false,
+          });
+          this.sendQueuedCloudMessages(session.taskId).catch(() => {
+            // Retries exhausted — message was re-enqueued by
+            // sendQueuedCloudMessages, poll-based flush will keep trying
+          });
+        }
+      }
+
       const terminalStatuses = new Set(["completed", "failed", "cancelled"]);
       if (update.status && terminalStatuses.has(update.status)) {
+        // Clean up any pending resume messages that couldn't be sent
+        const session = sessionStoreSetters.getSessions()[taskRunId];
+        if (
+          session &&
+          (session.messageQueue.length > 0 || session.isPromptPending)
+        ) {
+          sessionStoreSetters.clearMessageQueue(session.taskId);
+          sessionStoreSetters.updateSession(taskRunId, {
+            isPromptPending: false,
+          });
+        }
         this.stopCloudTaskWatch(update.taskId);
       }
     }
+  }
+
+  /**
+   * Filter out session/prompt events that should be skipped during resume.
+   * When resuming a cloud run, the initial session/prompt from the new run's
+   * logs would duplicate the optimistic user bubble we already added.
+   */
+  // Note: `session` is a snapshot from the start of handleCloudTaskUpdate.
+  // The updateSession call below makes it stale, but this is safe because
+  // skipPolledPromptCount is only ever 1, so this method runs at most once.
+  private filterSkippedPromptEvents(
+    taskRunId: string,
+    session: AgentSession | undefined,
+    events: AcpMessage[],
+  ): AcpMessage[] {
+    if (!session?.skipPolledPromptCount || session.skipPolledPromptCount <= 0) {
+      return events;
+    }
+
+    const promptIdx = events.findIndex(
+      (e) =>
+        isJsonRpcRequest(e.message) && e.message.method === "session/prompt",
+    );
+    if (promptIdx !== -1) {
+      const filtered = [...events];
+      filtered.splice(promptIdx, 1);
+      sessionStoreSetters.updateSession(taskRunId, {
+        skipPolledPromptCount: (session.skipPolledPromptCount ?? 0) - 1,
+      });
+      return filtered;
+    }
+
+    return events;
   }
 
   // --- Helper Methods ---

--- a/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
@@ -61,6 +61,8 @@ export interface AgentSession {
   cloudErrorMessage?: string | null;
   /** Cloud task branch */
   cloudBranch?: string | null;
+  /** Number of session/prompt events to skip from polled logs (set during resume) */
+  skipPolledPromptCount?: number;
 }
 
 // --- Config Option Helpers ---

--- a/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -73,7 +73,6 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
     (!cloudStatus ||
       cloudStatus === "started" ||
       cloudStatus === "in_progress");
-  const isCloudRunTerminal = isCloud && !isCloudRunNotTerminal;
   const prUrl =
     isCloud && cloudOutput?.pr_url ? (cloudOutput.pr_url as string) : null;
   const slackThreadUrl =
@@ -102,9 +101,7 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
     };
   }, [isCloud, prUrl, prFiles, branchFiles]);
 
-  const isRunning = isCloud
-    ? isCloudRunNotTerminal
-    : session?.status === "connected";
+  const isRunning = isCloud ? true : session?.status === "connected";
   const hasError = isCloud ? false : session?.status === "error";
   const errorTitle = isCloud ? undefined : session?.errorTitle;
   const errorMessage = isCloud ? undefined : session?.errorMessage;
@@ -367,9 +364,6 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
               onRetry={isCloud ? undefined : handleRetry}
               onNewSession={isCloud ? undefined : handleNewSession}
               isInitializing={isInitializing}
-              readOnlyMessage={
-                isCloudRunTerminal ? "This cloud run has finished" : undefined
-              }
               slackThreadUrl={slackThreadUrl}
             />
           </ErrorBoundary>

--- a/apps/code/src/renderer/utils/session.ts
+++ b/apps/code/src/renderer/utils/session.ts
@@ -10,6 +10,7 @@ import type {
 import type {
   AcpMessage,
   JsonRpcMessage,
+  JsonRpcRequest,
   StoredLogEntry,
   UserShellExecuteParams,
 } from "@shared/types/session-events";
@@ -32,19 +33,18 @@ function storedEntryToAcpMessage(entry: StoredLogEntry): AcpMessage {
 /**
  * Create a user message event for display.
  */
-function createUserMessageEvent(text: string, ts: number): AcpMessage {
+export function createUserMessageEvent(text: string, ts: number): AcpMessage {
   return {
     type: "acp_message",
     ts,
     message: {
-      method: "session/update",
+      jsonrpc: "2.0",
+      id: ts,
+      method: "session/prompt",
       params: {
-        update: {
-          sessionUpdate: "user_message_chunk",
-          content: { type: "text", text },
-        },
-      } as SessionNotification,
-    },
+        prompt: [{ type: "text", text }],
+      },
+    } as JsonRpcRequest,
   };
 }
 

--- a/packages/agent/src/acp-extensions.ts
+++ b/packages/agent/src/acp-extensions.ts
@@ -26,6 +26,9 @@ export const POSTHOG_NOTIFICATIONS = {
   /** Task has completed (success or failure) */
   TASK_COMPLETE: "_posthog/task_complete",
 
+  /** Agent finished processing a turn (prompt returned, waiting for next input) */
+  TURN_COMPLETE: "_posthog/turn_complete",
+
   /** Error occurred during task execution */
   ERROR: "_posthog/error",
 

--- a/packages/agent/src/resume.ts
+++ b/packages/agent/src/resume.ts
@@ -47,7 +47,7 @@ export interface ToolCallInfo {
 export interface ResumeConfig {
   taskId: string;
   runId: string;
-  repositoryPath: string;
+  repositoryPath?: string;
   apiClient: PostHogAPIClient;
   logger?: Logger;
 }

--- a/packages/agent/src/sagas/resume-saga.ts
+++ b/packages/agent/src/sagas/resume-saga.ts
@@ -26,7 +26,7 @@ export interface ToolCallInfo {
 export interface ResumeInput {
   taskId: string;
   runId: string;
-  repositoryPath: string;
+  repositoryPath?: string;
   apiClient: PostHogAPIClient;
   logger?: Logger;
 }
@@ -78,7 +78,7 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
     // Step 4: Apply snapshot if present (wrapped in step for consistent logging)
     // Note: We use a try/catch inside the step because snapshot failure should NOT fail the saga
     let snapshotApplied = false;
-    if (latestSnapshot?.archiveUrl) {
+    if (latestSnapshot?.archiveUrl && repositoryPath) {
       this.log.info("Found tree snapshot", {
         treeHash: latestSnapshot.treeHash,
         hasArchiveUrl: true,
@@ -120,6 +120,14 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
           // Inner ApplySnapshotSaga handles its own rollback
         },
       });
+    } else if (latestSnapshot?.archiveUrl && !repositoryPath) {
+      this.log.warn(
+        "Snapshot found but no repositoryPath configured - files cannot be restored",
+        {
+          treeHash: latestSnapshot.treeHash,
+          changes: latestSnapshot.changes?.length ?? 0,
+        },
+      );
     } else if (latestSnapshot) {
       this.log.warn(
         "Snapshot found but has no archive URL - files cannot be restored",

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -11,7 +11,13 @@ import {
   createAcpConnection,
   type InProcessAcpConnection,
 } from "../adapters/acp-connection.js";
+import { selectRecentTurns } from "../adapters/claude/session/jsonl-hydration.js";
 import { PostHogAPIClient } from "../posthog-api.js";
+import {
+  type ConversationTurn,
+  type ResumeState,
+  resumeFromLog,
+} from "../resume.js";
 import { SessionLogWriter } from "../session-log-writer.js";
 import { TreeTracker } from "../tree-tracker.js";
 import type {
@@ -155,6 +161,7 @@ export class AgentServer {
   private posthogAPI: PostHogAPIClient;
   private questionRelayedToSlack = false;
   private detectedPrUrl: string | null = null;
+  private resumeState: ResumeState | null = null;
 
   private emitConsoleLog = (
     level: LogLevel,
@@ -380,6 +387,34 @@ export class AgentServer {
 
     this.logger.info("Auto-initializing session", { taskId, runId, mode });
 
+    // Check if this is a resume from a previous run
+    const resumeRunId = process.env.POSTHOG_RESUME_RUN_ID;
+    if (resumeRunId) {
+      this.logger.info("Resuming from previous run", {
+        resumeRunId,
+        currentRunId: runId,
+      });
+      try {
+        this.resumeState = await resumeFromLog({
+          taskId,
+          runId: resumeRunId,
+          repositoryPath: this.config.repositoryPath,
+          apiClient: this.posthogAPI,
+          logger: new Logger({ debug: true, prefix: "[Resume]" }),
+        });
+        this.logger.info("Resume state loaded", {
+          conversationTurns: this.resumeState.conversation.length,
+          snapshotApplied: this.resumeState.snapshotApplied,
+          logEntries: this.resumeState.logEntryCount,
+        });
+      } catch (error) {
+        this.logger.warn("Failed to load resume state, starting fresh", {
+          error,
+        });
+        this.resumeState = null;
+      }
+    }
+
     // Create a synthetic payload from config (no JWT needed for auto-init)
     const payload: JwtPayload = {
       task_id: taskId,
@@ -464,6 +499,8 @@ export class AgentServer {
           }),
         });
 
+        this.broadcastTurnComplete(result.stopReason);
+
         return { stopReason: result.stopReason };
       }
 
@@ -510,21 +547,22 @@ export class AgentServer {
 
     this.configureEnvironment();
 
-    const treeTracker = this.config.repositoryPath
-      ? new TreeTracker({
-          repositoryPath: this.config.repositoryPath,
-          taskId: payload.task_id,
-          runId: payload.run_id,
-          logger: new Logger({ debug: true, prefix: "[TreeTracker]" }),
-        })
-      : null;
-
     const posthogAPI = new PostHogAPIClient({
       apiUrl: this.config.apiUrl,
       projectId: this.config.projectId,
       getApiKey: () => this.config.apiKey,
       userAgent: `posthog/cloud.hog.dev; version: ${this.config.version ?? packageJson.version}`,
     });
+
+    const treeTracker = this.config.repositoryPath
+      ? new TreeTracker({
+          repositoryPath: this.config.repositoryPath,
+          taskId: payload.task_id,
+          runId: payload.run_id,
+          apiClient: posthogAPI,
+          logger: new Logger({ debug: true, prefix: "[TreeTracker]" }),
+        })
+      : null;
 
     const logWriter = new SessionLogWriter({
       posthogAPI,
@@ -653,27 +691,61 @@ export class AgentServer {
   ): Promise<void> {
     if (!this.session) return;
 
-    try {
-      const task = await this.posthogAPI.getTask(payload.task_id);
+    // Fetch TaskRun early — needed for both resume detection and initial prompt
+    let taskRun = prefetchedRun ?? null;
+    if (!taskRun) {
+      try {
+        taskRun = await this.posthogAPI.getTaskRun(
+          payload.task_id,
+          payload.run_id,
+        );
+      } catch (error) {
+        this.logger.warn("Failed to fetch task run", {
+          taskId: payload.task_id,
+          runId: payload.run_id,
+          error,
+        });
+      }
+    }
 
-      let taskRun = prefetchedRun ?? null;
-      if (!taskRun) {
+    // Check for resume if not already loaded from env var in autoInitializeSession
+    if (!this.resumeState) {
+      const resumeRunId = this.getResumeRunId(taskRun);
+      if (resumeRunId) {
+        this.logger.info("Resuming from previous run (via TaskRun state)", {
+          resumeRunId,
+          currentRunId: payload.run_id,
+        });
         try {
-          taskRun = await this.posthogAPI.getTaskRun(
-            payload.task_id,
-            payload.run_id,
-          );
+          this.resumeState = await resumeFromLog({
+            taskId: payload.task_id,
+            runId: resumeRunId,
+            repositoryPath: this.config.repositoryPath,
+            apiClient: this.posthogAPI,
+            logger: new Logger({ debug: true, prefix: "[Resume]" }),
+          });
+          this.logger.info("Resume state loaded (via TaskRun state)", {
+            conversationTurns: this.resumeState.conversation.length,
+            snapshotApplied: this.resumeState.snapshotApplied,
+            logEntries: this.resumeState.logEntryCount,
+          });
         } catch (error) {
-          this.logger.warn(
-            "Failed to fetch task run for initial prompt override",
-            {
-              taskId: payload.task_id,
-              runId: payload.run_id,
-              error,
-            },
-          );
+          this.logger.warn("Failed to load resume state, starting fresh", {
+            error,
+          });
+          this.resumeState = null;
         }
       }
+    }
+
+    // Resume flow: if we have resume state, format conversation history as context
+    if (this.resumeState && this.resumeState.conversation.length > 0) {
+      await this.sendResumeMessage(payload, taskRun);
+      return;
+    }
+
+    try {
+      const task = await this.posthogAPI.getTask(payload.task_id);
 
       const initialPromptOverride = taskRun
         ? this.getInitialPromptOverride(taskRun)
@@ -700,6 +772,8 @@ export class AgentServer {
         stopReason: result.stopReason,
       });
 
+      this.broadcastTurnComplete(result.stopReason);
+
       if (result.stopReason === "end_turn") {
         await this.relayAgentResponse(payload);
       }
@@ -712,6 +786,127 @@ export class AgentServer {
     }
   }
 
+  private async sendResumeMessage(
+    payload: JwtPayload,
+    taskRun: TaskRun | null,
+  ): Promise<void> {
+    if (!this.session || !this.resumeState) return;
+
+    try {
+      const conversationSummary = this.formatConversationForResume(
+        this.resumeState.conversation,
+      );
+
+      // Read the pending user message from TaskRun state (set by the workflow
+      // when the user sends a follow-up message that triggers a resume).
+      const pendingUserMessage = this.getPendingUserMessage(taskRun);
+
+      const sandboxContext = this.resumeState.snapshotApplied
+        ? `The sandbox environment (all files, packages, and code changes) has been fully restored from a snapshot.`
+        : `The sandbox could not be restored from a snapshot (it may have expired). You are starting with a fresh environment but have the full conversation history below.`;
+
+      let resumePrompt: string;
+      if (pendingUserMessage) {
+        // Include the pending message as the user's new question so the agent
+        // responds to it directly instead of the generic resume context.
+        resumePrompt =
+          `You are resuming a previous conversation. ${sandboxContext}\n\n` +
+          `Here is the conversation history from the previous session:\n\n` +
+          `${conversationSummary}\n\n` +
+          `The user has sent a new message:\n\n` +
+          `${pendingUserMessage}\n\n` +
+          `Respond to the user's new message above. You have full context from the previous session.`;
+      } else {
+        resumePrompt =
+          `You are resuming a previous conversation. ${sandboxContext}\n\n` +
+          `Here is the conversation history from the previous session:\n\n` +
+          `${conversationSummary}\n\n` +
+          `Continue from where you left off. The user is waiting for your response.`;
+      }
+
+      this.logger.info("Sending resume message", {
+        taskId: payload.task_id,
+        conversationTurns: this.resumeState.conversation.length,
+        promptLength: resumePrompt.length,
+        hasPendingUserMessage: !!pendingUserMessage,
+        snapshotApplied: this.resumeState.snapshotApplied,
+      });
+
+      // Clear resume state so it's not reused
+      this.resumeState = null;
+
+      const result = await this.session.clientConnection.prompt({
+        sessionId: this.session.acpSessionId,
+        prompt: [{ type: "text", text: resumePrompt }],
+      });
+
+      this.logger.info("Resume message completed", {
+        stopReason: result.stopReason,
+      });
+
+      this.broadcastTurnComplete(result.stopReason);
+    } catch (error) {
+      this.logger.error("Failed to send resume message", error);
+      if (this.session) {
+        await this.session.logWriter.flushAll();
+      }
+      await this.signalTaskComplete(payload, "error");
+    }
+  }
+
+  private static RESUME_HISTORY_TOKEN_BUDGET = 50_000;
+  private static TOOL_RESULT_MAX_CHARS = 2000;
+
+  private formatConversationForResume(
+    conversation: ConversationTurn[],
+  ): string {
+    const selected = selectRecentTurns(
+      conversation,
+      AgentServer.RESUME_HISTORY_TOKEN_BUDGET,
+    );
+    const parts: string[] = [];
+
+    if (selected.length < conversation.length) {
+      parts.push(
+        `*(${conversation.length - selected.length} earlier turns omitted)*`,
+      );
+    }
+
+    for (const turn of selected) {
+      const role = turn.role === "user" ? "User" : "Assistant";
+
+      const textParts = turn.content
+        .filter((block) => block.type === "text")
+        .map((block) => (block as { type: "text"; text: string }).text);
+
+      if (textParts.length > 0) {
+        parts.push(`**${role}**: ${textParts.join("\n")}`);
+      }
+
+      if (turn.toolCalls?.length) {
+        const toolSummary = turn.toolCalls
+          .map((tc) => {
+            let resultStr = "";
+            if (tc.result !== undefined) {
+              const raw =
+                typeof tc.result === "string"
+                  ? tc.result
+                  : JSON.stringify(tc.result);
+              resultStr =
+                raw.length > AgentServer.TOOL_RESULT_MAX_CHARS
+                  ? ` → ${raw.substring(0, AgentServer.TOOL_RESULT_MAX_CHARS)}...(truncated)`
+                  : ` → ${raw}`;
+            }
+            return `  - ${tc.toolName}${resultStr}`;
+          })
+          .join("\n");
+        parts.push(`**${role} (tools)**:\n${toolSummary}`);
+      }
+    }
+
+    return parts.join("\n\n");
+  }
+
   private getInitialPromptOverride(taskRun: TaskRun): string | null {
     const state = taskRun.state as Record<string, unknown> | undefined;
     const override = state?.initial_prompt_override;
@@ -721,6 +916,32 @@ export class AgentServer {
 
     const trimmed = override.trim();
     return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private getPendingUserMessage(taskRun: TaskRun | null): string | null {
+    if (!taskRun) return null;
+    const state = taskRun.state as Record<string, unknown> | undefined;
+    const message = state?.pending_user_message;
+    if (typeof message !== "string") {
+      return null;
+    }
+
+    const trimmed = message.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private getResumeRunId(taskRun: TaskRun | null): string | null {
+    // Env var takes precedence (set by backend infra)
+    const envRunId = process.env.POSTHOG_RESUME_RUN_ID;
+    if (envRunId) return envRunId;
+
+    // Fallback: read from TaskRun state (set by API when creating the run)
+    if (!taskRun) return null;
+    const state = taskRun.state as Record<string, unknown> | undefined;
+    const stateRunId = state?.resume_from_run_id;
+    return typeof stateRunId === "string" && stateRunId.trim().length > 0
+      ? stateRunId.trim()
+      : null;
   }
 
   private buildCloudSystemPrompt(prUrl?: string | null): string {
@@ -1161,20 +1382,34 @@ Important:
           notification,
         });
 
-        // Persist to log writer so cloud runs have tree snapshots
-        const { archiveUrl: _, ...paramsWithoutArchive } = snapshotWithDevice;
-        const logNotification = {
-          ...notification,
-          params: paramsWithoutArchive,
-        };
+        // Persist full snapshot (including archiveUrl) so resume can restore files.
+        // archiveUrl is a pre-signed S3 URL that expires — if the user resumes
+        // after expiry, ApplySnapshotSaga fails gracefully and the agent continues
+        // with conversation context but a fresh sandbox (snapshotApplied=false).
         this.session.logWriter.appendRawLine(
           this.session.payload.run_id,
-          JSON.stringify(logNotification),
+          JSON.stringify(notification),
         );
       }
     } catch (error) {
       this.logger.error("Failed to capture tree state", error);
     }
+  }
+
+  private broadcastTurnComplete(stopReason: string): void {
+    if (!this.session) return;
+    this.broadcastEvent({
+      type: "notification",
+      timestamp: new Date().toISOString(),
+      notification: {
+        jsonrpc: "2.0",
+        method: POSTHOG_NOTIFICATIONS.TURN_COMPLETE,
+        params: {
+          sessionId: this.session.acpSessionId,
+          stopReason,
+        },
+      },
+    });
   }
 
   private broadcastEvent(event: Record<string, unknown>): void {


### PR DESCRIPTION
agent server broadcasts a notification when a turn finishes, needed for follow ups messages to cloud runs.
added support for cloud resume flow and snapshot-aware state management.

Edited UI to allow user to add messages while cloud run is executing and/or snapshot created ready to be resumed.



https://github.com/user-attachments/assets/a2702838-eabe-4bc3-a1b2-f8d00e955bc4



