### PR TITLE
feat(agent-server): optional repository config

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -140,7 +140,7 @@ interface ActiveSession {
   acpSessionId: string;
   acpConnection: InProcessAcpConnection;
   clientConnection: ClientSideConnection;
-  treeTracker: TreeTracker;
+  treeTracker: TreeTracker | null;
   sseController: SseController | null;
   deviceInfo: DeviceInfo;
   logWriter: SessionLogWriter;
@@ -510,12 +510,14 @@ export class AgentServer {
 
     this.configureEnvironment();
 
-    const treeTracker = new TreeTracker({
-      repositoryPath: this.config.repositoryPath,
-      taskId: payload.task_id,
-      runId: payload.run_id,
-      logger: new Logger({ debug: true, prefix: "[TreeTracker]" }),
-    });
+    const treeTracker = this.config.repositoryPath
+      ? new TreeTracker({
+          repositoryPath: this.config.repositoryPath,
+          taskId: payload.task_id,
+          runId: payload.run_id,
+          logger: new Logger({ debug: true, prefix: "[TreeTracker]" }),
+        })
+      : null;
 
     const posthogAPI = new PostHogAPIClient({
       apiUrl: this.config.apiUrl,
@@ -594,7 +596,7 @@ export class AgentServer {
     }
 
     const sessionResponse = await clientConnection.newSession({
-      cwd: this.config.repositoryPath,
+      cwd: this.config.repositoryPath ?? "/tmp/workspace",
       mcpServers: this.config.mcpServers ?? [],
       _meta: {
         sessionId: payload.run_id,

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -43,7 +43,7 @@ program
     "Execution mode: interactive or background",
     "interactive",
   )
-  .requiredOption("--repositoryPath <path>", "Path to the repository")
+  .option("--repositoryPath <path>", "Path to the repository")
   .requiredOption("--taskId <id>", "Task ID")
   .requiredOption("--runId <id>", "Task run ID")
   .option(

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -3,7 +3,7 @@ import type { RemoteMcpServer } from "./schemas.js";
 
 export interface AgentServerConfig {
   port: number;
-  repositoryPath: string;
+  repositoryPath?: string;
   apiUrl: string;
   apiKey: string;
   projectId: number;


### PR DESCRIPTION
### TL;DR

Made `repositoryPath` optional in the agent server configuration, allowing the agent to run without a repository.

### What changed?

- Changed `repositoryPath` from a required to optional parameter in the CLI and configuration interface
- Updated `TreeTracker` initialization to only create an instance when `repositoryPath` is provided, otherwise set to `null`
- Modified session creation to use `/tmp/workspace` as fallback when no repository path is specified
- Updated `ActiveSession` interface to reflect that `treeTracker` can be `null`

### How to test?

1. Run the agent server without the `--repositoryPath` flag to verify it starts successfully
2. Test that sessions are created with `/tmp/workspace` as the working directory when no repository path is provided
3. Verify existing functionality still works when `repositoryPath` is provided

### Why make this change?

This change enables the agent to operate in scenarios where a repository is not available or required, making it more flexible for different use cases while maintaining backward compatibility.