### PR TITLE
fix: Use draft releases to support GitHub immutable releases

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -123,3 +123,8 @@ jobs:
           APP_VERSION: ${{ steps.version.outputs.version }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm --filter code run publish
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh release edit "v${{ steps.version.outputs.version }}" --repo PostHog/code --draft=false

--- a/apps/code/forge.config.ts
+++ b/apps/code/forge.config.ts
@@ -243,7 +243,7 @@ const config: ForgeConfig = {
         owner: "PostHog",
         name: "code",
       },
-      draft: false,
+      draft: true,
       prerelease: false,
     }),
   ],


### PR DESCRIPTION
Follows https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases#best-practices-for-publishing-immutable-releases

  1. Set Electron Forge GitHub publisher to create draft releases
  2. Add post-publish step to promote draft to published release after assets upload
  3. Fix "Cannot upload assets to an immutable release" CI failures