### PR TITLE
feat: Scope oauth tokens by org, replace flat project list with org-keyed map

### DIFF
--- a/apps/code/src/main/services/agent/service.test.ts
+++ b/apps/code/src/main/services/agent/service.test.ts
@@ -343,13 +343,14 @@ describe("AgentService", () => {
     it("recordActivity resets the timeout on subsequent calls", () => {
       injectSession(service, "run-1");
       service.recordActivity("run-1");
-      const firstDeadline = getIdleTimeouts(service).get("run-1")?.deadline;
+      const firstDeadline =
+        getIdleTimeouts(service).get("run-1")?.deadline ?? 0;
 
       vi.advanceTimersByTime(5 * 60 * 1000);
       service.recordActivity("run-1");
       const secondDeadline = getIdleTimeouts(service).get("run-1")?.deadline;
 
-      expect(secondDeadline).toBeGreaterThan(firstDeadline!);
+      expect(secondDeadline).toBeGreaterThan(firstDeadline);
     });
 
     it("kills idle session after timeout expires", () => {

--- a/apps/code/src/main/services/oauth/schemas.ts
+++ b/apps/code/src/main/services/oauth/schemas.ts
@@ -24,7 +24,6 @@ export const oAuthTokenResponse = z.object({
   token_type: z.string(),
   scope: z.string().optional().default(""),
   refresh_token: z.string(),
-  scoped_teams: z.array(z.number()).optional(),
   scoped_organizations: z.array(z.string()).optional(),
 });
 export type OAuthTokenResponse = z.infer<typeof oAuthTokenResponse>;

--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -132,8 +132,8 @@ export class PostHogAPIClient {
     }
   }
 
-  setTeamId(teamId: number): void {
-    this._teamId = teamId;
+  setTeamId(teamId: number | null | undefined): void {
+    this._teamId = teamId ?? null;
   }
 
   private async getTeamId(): Promise<number> {
@@ -165,6 +165,32 @@ export class PostHogAPIClient {
       path: { uuid: "@me" },
       body: { set_current_organization: orgId } as Record<string, unknown>,
     });
+  }
+
+  async listOrgProjects(
+    orgId: string,
+  ): Promise<{ id: number; name: string }[]> {
+    const url = new URL(
+      `${this.api.baseUrl}/api/organizations/${orgId}/projects/`,
+    );
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: `/api/organizations/${orgId}/projects/`,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch projects for org ${orgId}: ${response.statusText}`,
+      );
+    }
+
+    const data = await response.json();
+    const results = data.results ?? data ?? [];
+    return results.map((p: { id: number; name?: string }) => ({
+      id: p.id,
+      name: p.name ?? `Project ${p.id}`,
+    }));
   }
 
   async getProject(projectId: number) {

--- a/apps/code/src/renderer/features/auth/stores/authStore.test.ts
+++ b/apps/code/src/renderer/features/auth/stores/authStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetCurrentUser = vi.fn();
+const mockListOrgProjects = vi.fn();
 
 const { getItem, setItem } = vi.hoisted(() => ({
   getItem: vi.fn(),
@@ -69,6 +70,7 @@ vi.mock("@renderer/api/posthogClient", () => ({
     this: Record<string, unknown>,
   ) {
     this.getCurrentUser = mockGetCurrentUser;
+    this.listOrgProjects = mockListOrgProjects;
     this.setTeamId = vi.fn();
   }),
 }));
@@ -88,7 +90,6 @@ function makeStoredTokens(overrides: Record<string, unknown> = {}) {
     refreshToken: "test-refresh-token",
     expiresAt: Date.now() + 3600 * 1000,
     cloudRegion: "us" as const,
-    scopedTeams: [1],
     scopeVersion: OAUTH_SCOPE_VERSION,
     ...overrides,
   };
@@ -107,6 +108,7 @@ describe("authStore - scope version", () => {
     getItem.mockResolvedValue(null);
     setItem.mockResolvedValue(undefined);
     mockGetCurrentUser.mockResolvedValue(mockUser);
+    mockListOrgProjects.mockResolvedValue([]);
 
     useAuthStore.setState({
       oauthAccessToken: null,
@@ -118,8 +120,7 @@ describe("authStore - scope version", () => {
       isAuthenticated: false,
       client: null,
       projectId: null,
-      availableProjectIds: [],
-      availableOrgIds: [],
+      orgProjectsMap: {},
       needsProjectSelection: false,
       needsScopeReauth: false,
     });
@@ -186,7 +187,6 @@ describe("authStore - scope version", () => {
           access_token: "new-access-token",
           refresh_token: "new-refresh-token",
           expires_in: 3600,
-          scoped_teams: [1],
           scoped_organizations: ["org-1"],
         },
       });
@@ -215,7 +215,7 @@ describe("authStore - scope version", () => {
           access_token: "new-access-token",
           refresh_token: "new-refresh-token",
           expires_in: 3600,
-          scoped_teams: [1],
+          scoped_organizations: ["org-1"],
         },
       });
 
@@ -242,7 +242,7 @@ describe("authStore - scope version", () => {
           access_token: "new-access-token",
           refresh_token: "new-refresh-token",
           expires_in: 3600,
-          scoped_teams: [1],
+          scoped_organizations: ["org-1"],
         },
       });
 

--- a/apps/code/src/renderer/features/auth/stores/authStore.ts
+++ b/apps/code/src/renderer/features/auth/stores/authStore.ts
@@ -187,41 +187,6 @@ async function attemptRefreshWithActivityCheck(
   }
 }
 
-function buildOrgProjectsMapFromUser(
-  user: Record<string, unknown>,
-): Record<string, OrgProjects> {
-  const org = user?.organization as
-    | {
-        id?: string;
-        name?: string;
-        teams?: { id: number | string; name?: string }[];
-      }
-    | undefined;
-
-  if (!org?.id) return {};
-
-  const orgId = String(org.id);
-  const teams = Array.isArray(org.teams) ? org.teams : [];
-
-  return {
-    [orgId]: {
-      orgName: org.name ?? "Unknown Organization",
-      projects: teams
-        .filter(
-          (t): t is { id: number | string; name?: string } =>
-            t != null &&
-            typeof t === "object" &&
-            (typeof t.id === "number" || typeof t.id === "string"),
-        )
-        .map((t) => ({
-          id: Number(t.id),
-          name: t.name ?? `Project ${t.id}`,
-        }))
-        .filter((t) => !Number.isNaN(t.id)),
-    },
-  };
-}
-
 async function buildOrgProjectsMap(
   user: Record<string, unknown>,
   client: PostHogAPIClient,
@@ -231,35 +196,88 @@ async function buildOrgProjectsMap(
     name?: string;
   }[];
 
-  const entries = await Promise.all(
-    orgs.map(async (org) => {
-      const projects = await client.listOrgProjects(org.id).catch((err) => {
-        log.warn("Failed to fetch projects for org", { orgId: org.id, err });
-        return null;
-      });
-      return { orgId: org.id, orgName: org.name, projects };
-    }),
-  );
-
-  const allFailed =
-    entries.length > 0 && entries.every((e) => e.projects === null);
-
-  if (allFailed) {
-    log.warn(
-      "All org project calls failed, falling back to user organization teams",
-    );
-    return buildOrgProjectsMapFromUser(user);
+  const map: Record<string, OrgProjects> = {};
+  for (const org of orgs) {
+    map[org.id] = {
+      orgName: org.name ?? "Unknown Organization",
+      projects: [],
+    };
   }
 
-  return Object.fromEntries(
-    entries.map((e) => [
-      e.orgId,
-      {
-        orgName: e.orgName ?? "Unknown Organization",
-        projects: e.projects ?? [],
-      },
-    ]),
-  );
+  // Try the first org to check if org-level endpoints are accessible.
+  // If not (e.g. project-scoped token), skip the rest and fall back to
+  // the project-scoped endpoint.
+  if (orgs.length > 0) {
+    try {
+      map[orgs[0].id].projects = await client.listOrgProjects(orgs[0].id);
+
+      // First org worked, fetch the rest in parallel
+      if (orgs.length > 1) {
+        const rest = await Promise.all(
+          orgs.slice(1).map(async (org) => {
+            const projects = await client
+              .listOrgProjects(org.id)
+              .catch((err) => {
+                log.warn("Failed to fetch projects for org", {
+                  orgId: org.id,
+                  err,
+                });
+                return [];
+              });
+            return [org.id, projects] as const;
+          }),
+        );
+        for (const [orgId, projects] of rest) {
+          map[orgId].projects = projects;
+        }
+      }
+
+      return map;
+    } catch (err) {
+      log.warn(
+        "Org-level project listing unavailable, falling back to project endpoint",
+        { err },
+      );
+    }
+  }
+
+  // Fallback: switch into each org and read team from /me.
+  // Both switchOrganization and getCurrentUser are user-level endpoints
+  // that work regardless of token scoping.
+  const currentOrgId = (user?.organization as { id?: string } | undefined)?.id;
+
+  for (const org of orgs) {
+    try {
+      let orgUser: Record<string, unknown>;
+      if (org.id === currentOrgId) {
+        orgUser = user;
+      } else {
+        await client.switchOrganization(org.id);
+        orgUser = await client.getCurrentUser();
+      }
+
+      const team = orgUser?.team as { id?: number; name?: string } | undefined;
+      if (team?.id && map[org.id]) {
+        map[org.id].projects = [
+          { id: team.id, name: team.name ?? `Project ${team.id}` },
+        ];
+      }
+    } catch (err) {
+      log.warn("Failed to fetch project via org switch", {
+        orgId: org.id,
+        err,
+      });
+    }
+  }
+
+  // Switch back to the original org
+  if (currentOrgId && orgs.length > 1) {
+    await client.switchOrganization(currentOrgId).catch((err) => {
+      log.warn("Failed to switch back to original org", { err });
+    });
+  }
+
+  return map;
 }
 
 export const useAuthStore = create<AuthState>()(

--- a/apps/code/src/renderer/features/auth/stores/authStore.ts
+++ b/apps/code/src/renderer/features/auth/stores/authStore.ts
@@ -52,8 +52,12 @@ interface StoredTokens {
   refreshToken: string;
   expiresAt: number;
   cloudRegion: CloudRegion;
-  scopedTeams?: number[];
   scopeVersion?: number;
+}
+
+export interface OrgProjects {
+  orgName: string;
+  projects: { id: number; name: string }[];
 }
 
 interface AuthState {
@@ -70,9 +74,8 @@ interface AuthState {
   client: PostHogAPIClient | null;
   projectId: number | null; // Current team/project ID
 
-  // Multi-project state
-  availableProjectIds: number[]; // All projects from scoped_teams
-  availableOrgIds: string[]; // All orgs from scoped_organizations
+  // Multi-project state — keyed by org ID
+  orgProjectsMap: Record<string, OrgProjects>;
   needsProjectSelection: boolean; // True when multiple projects and no selection stored
 
   needsScopeReauth: boolean; // True when stored token scope version is stale
@@ -100,6 +103,9 @@ interface AuthState {
 
   // Project selection
   selectProject: (projectId: number) => void;
+
+  // Organization switching
+  switchOrg: (orgId: string) => Promise<void>;
 
   // Onboarding methods
   completeOnboarding: () => void;
@@ -181,6 +187,81 @@ async function attemptRefreshWithActivityCheck(
   }
 }
 
+function buildOrgProjectsMapFromUser(
+  user: Record<string, unknown>,
+): Record<string, OrgProjects> {
+  const org = user?.organization as
+    | {
+        id?: string;
+        name?: string;
+        teams?: { id: number | string; name?: string }[];
+      }
+    | undefined;
+
+  if (!org?.id) return {};
+
+  const orgId = String(org.id);
+  const teams = Array.isArray(org.teams) ? org.teams : [];
+
+  return {
+    [orgId]: {
+      orgName: org.name ?? "Unknown Organization",
+      projects: teams
+        .filter(
+          (t): t is { id: number | string; name?: string } =>
+            t != null &&
+            typeof t === "object" &&
+            (typeof t.id === "number" || typeof t.id === "string"),
+        )
+        .map((t) => ({
+          id: Number(t.id),
+          name: t.name ?? `Project ${t.id}`,
+        }))
+        .filter((t) => !Number.isNaN(t.id)),
+    },
+  };
+}
+
+async function buildOrgProjectsMap(
+  user: Record<string, unknown>,
+  client: PostHogAPIClient,
+): Promise<Record<string, OrgProjects>> {
+  const orgs = (user?.organizations ?? []) as {
+    id: string;
+    name?: string;
+  }[];
+
+  const entries = await Promise.all(
+    orgs.map(async (org) => {
+      const projects = await client.listOrgProjects(org.id).catch((err) => {
+        log.warn("Failed to fetch projects for org", { orgId: org.id, err });
+        return null;
+      });
+      return { orgId: org.id, orgName: org.name, projects };
+    }),
+  );
+
+  const allFailed =
+    entries.length > 0 && entries.every((e) => e.projects === null);
+
+  if (allFailed) {
+    log.warn(
+      "All org project calls failed, falling back to user organization teams",
+    );
+    return buildOrgProjectsMapFromUser(user);
+  }
+
+  return Object.fromEntries(
+    entries.map((e) => [
+      e.orgId,
+      {
+        orgName: e.orgName ?? "Unknown Organization",
+        projects: e.projects ?? [],
+      },
+    ]),
+  );
+}
+
 export const useAuthStore = create<AuthState>()(
   subscribeWithSelector(
     persist(
@@ -199,8 +280,7 @@ export const useAuthStore = create<AuthState>()(
         projectId: null,
 
         // Multi-project state
-        availableProjectIds: [],
-        availableOrgIds: [],
+        orgProjectsMap: {},
         needsProjectSelection: false,
         // Scope re-auth state
         needsScopeReauth: false,
@@ -275,20 +355,11 @@ export const useAuthStore = create<AuthState>()(
 
           const tokenResponse = result.data;
           const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
-
-          const scopedTeams = tokenResponse.scoped_teams ?? [];
-          const scopedOrgs = tokenResponse.scoped_organizations ?? [];
-
-          if (scopedTeams.length === 0) {
-            throw new Error("No team found in OAuth scopes");
-          }
-
           const storedTokens: StoredTokens = {
             accessToken: tokenResponse.access_token,
             refreshToken: tokenResponse.refresh_token,
             expiresAt,
             cloudRegion: region,
-            scopedTeams,
             scopeVersion: OAUTH_SCOPE_VERSION,
           };
 
@@ -305,24 +376,16 @@ export const useAuthStore = create<AuthState>()(
               }
               return token;
             },
-            scopedTeams[0],
           );
 
           try {
             const user = await client.getCurrentUser();
+            const orgProjectsMap = await buildOrgProjectsMap(user, client);
 
-            // Determine project: prefer user's current PostHog project, then previously stored, then first available
             const userCurrentTeam = user?.team?.id;
             const storedProjectId = get().projectId;
-            const selectedProjectId =
-              userCurrentTeam != null && scopedTeams.includes(userCurrentTeam)
-                ? userCurrentTeam
-                : storedProjectId !== null &&
-                    scopedTeams.includes(storedProjectId)
-                  ? storedProjectId
-                  : scopedTeams[0];
+            const selectedProjectId = userCurrentTeam ?? storedProjectId;
 
-            // Update client's teamId to match selected project
             client.setTeamId(selectedProjectId);
 
             set({
@@ -334,8 +397,7 @@ export const useAuthStore = create<AuthState>()(
               isAuthenticated: true,
               client,
               projectId: selectedProjectId,
-              availableProjectIds: scopedTeams,
-              availableOrgIds: scopedOrgs,
+              orgProjectsMap,
               needsProjectSelection: false,
               needsScopeReauth: false,
             });
@@ -353,11 +415,11 @@ export const useAuthStore = create<AuthState>()(
             identifyUser(distinctId, {
               email: user.email,
               uuid: user.uuid,
-              project_id: selectedProjectId.toString(),
+              project_id: selectedProjectId?.toString(),
               region,
             });
             track(ANALYTICS_EVENTS.USER_LOGGED_IN, {
-              project_id: selectedProjectId.toString(),
+              project_id: selectedProjectId?.toString(),
               region,
             });
 
@@ -366,7 +428,7 @@ export const useAuthStore = create<AuthState>()(
               properties: {
                 email: user.email,
                 uuid: user.uuid,
-                project_id: selectedProjectId.toString(),
+                project_id: selectedProjectId?.toString(),
                 region,
               },
             });
@@ -445,17 +507,11 @@ export const useAuthStore = create<AuthState>()(
                   refreshToken: tokenResponse.refresh_token,
                   expiresAt,
                   cloudRegion: state.cloudRegion,
-                  scopedTeams: tokenResponse.scoped_teams,
                   scopeVersion: state.storedTokens?.scopeVersion ?? 0,
                 };
 
                 const apiHost = getCloudUrlFromRegion(state.cloudRegion);
-                const scopedTeams = tokenResponse.scoped_teams ?? [];
-                const storedProjectId = state.projectId;
-                const projectId =
-                  storedProjectId && scopedTeams.includes(storedProjectId)
-                    ? storedProjectId
-                    : (scopedTeams[0] ?? storedProjectId ?? undefined);
+                const projectId = state.projectId ?? undefined;
 
                 const client = new PostHogAPIClient(
                   tokenResponse.access_token,
@@ -478,10 +534,6 @@ export const useAuthStore = create<AuthState>()(
                   storedTokens,
                   client,
                   ...(projectId && { projectId }),
-                  availableProjectIds:
-                    scopedTeams.length > 0
-                      ? scopedTeams
-                      : state.availableProjectIds,
                 });
 
                 updateServiceTokens(tokenResponse.access_token);
@@ -618,22 +670,7 @@ export const useAuthStore = create<AuthState>()(
               }
 
               const apiHost = getCloudUrlFromRegion(currentTokens.cloudRegion);
-              const scopedTeams = currentTokens.scopedTeams ?? [];
-
-              if (scopedTeams.length === 0) {
-                log.error("No projects found in stored tokens");
-                get().logout();
-                return false;
-              }
-
               const storedProjectId = get().projectId;
-              const availableProjects =
-                get().availableProjectIds.length > 0
-                  ? get().availableProjectIds
-                  : scopedTeams;
-              const hasValidStoredProject =
-                storedProjectId !== null &&
-                availableProjects.includes(storedProjectId);
 
               const client = new PostHogAPIClient(
                 currentTokens.accessToken,
@@ -646,29 +683,23 @@ export const useAuthStore = create<AuthState>()(
                   }
                   return token;
                 },
-                hasValidStoredProject ? storedProjectId : scopedTeams[0],
+                storedProjectId ?? undefined,
               );
 
               try {
                 const user = await client.getCurrentUser();
+                const orgProjectsMap = await buildOrgProjectsMap(user, client);
 
-                // Prefer stored project, then user's current PostHog project, then first available
                 const userCurrentTeam = user?.team?.id;
-                const selectedProjectId = hasValidStoredProject
-                  ? storedProjectId
-                  : userCurrentTeam != null &&
-                      scopedTeams.includes(userCurrentTeam)
-                    ? userCurrentTeam
-                    : scopedTeams[0];
+                const selectedProjectId = storedProjectId ?? userCurrentTeam;
 
-                // Update client's teamId to match selected project
                 client.setTeamId(selectedProjectId);
 
                 set({
                   isAuthenticated: true,
                   client,
                   projectId: selectedProjectId,
-                  availableProjectIds: scopedTeams,
+                  orgProjectsMap,
                   needsProjectSelection: false,
                 });
 
@@ -683,7 +714,7 @@ export const useAuthStore = create<AuthState>()(
                 identifyUser(distinctId, {
                   email: user.email,
                   uuid: user.uuid,
-                  project_id: selectedProjectId.toString(),
+                  project_id: selectedProjectId?.toString(),
                   region: tokens.cloudRegion,
                 });
 
@@ -692,7 +723,7 @@ export const useAuthStore = create<AuthState>()(
                   properties: {
                     email: user.email,
                     uuid: user.uuid,
-                    project_id: selectedProjectId.toString(),
+                    project_id: selectedProjectId?.toString(),
                     region: tokens.cloudRegion,
                   },
                 });
@@ -711,14 +742,10 @@ export const useAuthStore = create<AuthState>()(
                   log.warn(
                     "Network error during session validation - keeping session active",
                   );
-                  const fallbackProjectId = hasValidStoredProject
-                    ? storedProjectId
-                    : scopedTeams[0];
                   set({
                     isAuthenticated: true,
                     client,
-                    projectId: fallbackProjectId,
-                    availableProjectIds: scopedTeams,
+                    projectId: storedProjectId,
                     needsProjectSelection: false,
                   });
                   get().scheduleTokenRefresh();
@@ -756,25 +783,15 @@ export const useAuthStore = create<AuthState>()(
 
           const tokenResponse = result.data;
           const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
-
-          const scopedTeams = tokenResponse.scoped_teams ?? [];
-          const scopedOrgs = tokenResponse.scoped_organizations ?? [];
-
-          if (scopedTeams.length === 0) {
-            throw new Error("No team found in OAuth scopes");
-          }
-
           const storedTokens: StoredTokens = {
             accessToken: tokenResponse.access_token,
             refreshToken: tokenResponse.refresh_token,
             expiresAt,
             cloudRegion: region,
-            scopedTeams,
             scopeVersion: OAUTH_SCOPE_VERSION,
           };
 
           const apiHost = getCloudUrlFromRegion(region);
-          const selectedProjectId = scopedTeams[0];
 
           const client = new PostHogAPIClient(
             tokenResponse.access_token,
@@ -787,11 +804,15 @@ export const useAuthStore = create<AuthState>()(
               }
               return token;
             },
-            selectedProjectId,
           );
 
           try {
             const user = await client.getCurrentUser();
+            const orgProjectsMap = await buildOrgProjectsMap(user, client);
+
+            const selectedProjectId = user?.team?.id;
+
+            client.setTeamId(selectedProjectId);
 
             set({
               oauthAccessToken: tokenResponse.access_token,
@@ -802,8 +823,7 @@ export const useAuthStore = create<AuthState>()(
               isAuthenticated: true,
               client,
               projectId: selectedProjectId,
-              availableProjectIds: scopedTeams,
-              availableOrgIds: scopedOrgs,
+              orgProjectsMap,
               needsProjectSelection: false,
               needsScopeReauth: false,
             });
@@ -819,11 +839,11 @@ export const useAuthStore = create<AuthState>()(
             identifyUser(distinctId, {
               email: user.email,
               uuid: user.uuid,
-              project_id: selectedProjectId.toString(),
+              project_id: selectedProjectId?.toString(),
               region,
             });
             track(ANALYTICS_EVENTS.USER_LOGGED_IN, {
-              project_id: selectedProjectId.toString(),
+              project_id: selectedProjectId?.toString(),
               region,
             });
 
@@ -832,7 +852,7 @@ export const useAuthStore = create<AuthState>()(
               properties: {
                 email: user.email,
                 uuid: user.uuid,
-                project_id: selectedProjectId.toString(),
+                project_id: selectedProjectId?.toString(),
                 region,
               },
             });
@@ -847,8 +867,10 @@ export const useAuthStore = create<AuthState>()(
         selectProject: (projectId: number) => {
           const state = get();
 
-          // Validate that the project is in the available list
-          if (!state.availableProjectIds.includes(projectId)) {
+          const allProjectIds = Object.values(state.orgProjectsMap).flatMap(
+            (o) => o.projects.map((p) => p.id),
+          );
+          if (!allProjectIds.includes(projectId)) {
             log.error("Attempted to select invalid project", { projectId });
             throw new Error("Invalid project selection");
           }
@@ -883,16 +905,10 @@ export const useAuthStore = create<AuthState>()(
             projectId,
           );
 
-          // Update stored tokens with the selected project
-          const updatedTokens = state.storedTokens
-            ? { ...state.storedTokens, scopedTeams: state.availableProjectIds }
-            : null;
-
           set({
             projectId,
             client,
             needsProjectSelection: false,
-            storedTokens: updatedTokens,
           });
 
           // Clear project-scoped queries, but keep project list/user for the switcher
@@ -917,6 +933,20 @@ export const useAuthStore = create<AuthState>()(
           });
 
           log.info("Project selected", { projectId });
+        },
+
+        switchOrg: async (orgId: string) => {
+          const state = get();
+          if (!state.client) {
+            throw new Error("No client available");
+          }
+
+          await state.client.switchOrganization(orgId);
+          const user = await state.client.getCurrentUser();
+          const orgProjectsMap = await buildOrgProjectsMap(user, state.client);
+
+          set({ orgProjectsMap });
+          queryClient.setQueryData(["currentUser"], user);
         },
 
         completeOnboarding: () => {
@@ -961,8 +991,7 @@ export const useAuthStore = create<AuthState>()(
             isAuthenticated: false,
             client: null,
             projectId: null,
-            availableProjectIds: [],
-            availableOrgIds: [],
+            orgProjectsMap: {},
             needsProjectSelection: false,
             needsScopeReauth: false,
             hasCodeAccess: null,
@@ -981,8 +1010,7 @@ export const useAuthStore = create<AuthState>()(
           storedTokens: state.storedTokens,
           staleTokens: state.staleTokens,
           projectId: state.projectId,
-          availableProjectIds: state.availableProjectIds,
-          availableOrgIds: state.availableOrgIds,
+          orgProjectsMap: state.orgProjectsMap,
           hasCodeAccess: state.hasCodeAccess,
           hasCompletedOnboarding: state.hasCompletedOnboarding,
           selectedPlan: state.selectedPlan,

--- a/apps/code/src/renderer/features/onboarding/components/OrgBillingStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/OrgBillingStep.tsx
@@ -26,7 +26,7 @@ interface OrgBillingStepProps {
 export function OrgBillingStep({ onNext, onBack }: OrgBillingStepProps) {
   const selectedOrgId = useAuthStore((s) => s.selectedOrgId);
   const selectOrg = useAuthStore((s) => s.selectOrg);
-  const client = useAuthStore((s) => s.client);
+  const switchOrg = useAuthStore((s) => s.switchOrg);
   const queryClient = useQueryClient();
   const [isSwitching, setIsSwitching] = useState(false);
 
@@ -44,11 +44,10 @@ export function OrgBillingStep({ onNext, onBack }: OrgBillingStepProps) {
       selectOrg(effectiveSelectedOrgId);
     }
 
-    if (client && effectiveSelectedOrgId !== currentUserOrgId) {
+    if (effectiveSelectedOrgId !== currentUserOrgId) {
       setIsSwitching(true);
       try {
-        await client.switchOrganization(effectiveSelectedOrgId);
-        await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+        await switchOrg(effectiveSelectedOrgId);
       } catch (err) {
         log.error("Failed to switch organization", err);
       } finally {

--- a/apps/code/src/renderer/features/onboarding/hooks/useProjectsWithIntegrations.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useProjectsWithIntegrations.ts
@@ -13,7 +13,7 @@ export interface ProjectWithIntegrations {
 }
 
 export function useProjectsWithIntegrations() {
-  const { projects, isLoading: projectsLoading } = useProjects();
+  const { projects } = useProjects();
   const client = useAuthStore((s) => s.client);
 
   // Fetch integrations for each project in parallel
@@ -29,8 +29,7 @@ export function useProjectsWithIntegrations() {
     })),
   });
 
-  const isLoading =
-    projectsLoading || integrationQueries.some((q) => q.isLoading);
+  const isLoading = integrationQueries.some((q) => q.isLoading);
   const isFetching = integrationQueries.some((q) => q.isFetching);
 
   const projectsWithIntegrations: ProjectWithIntegrations[] = useMemo(() => {

--- a/apps/code/src/renderer/features/projects/hooks/useProjects.tsx
+++ b/apps/code/src/renderer/features/projects/hooks/useProjects.tsx
@@ -36,7 +36,9 @@ export function groupProjectsByOrg(
 export function useProjects() {
   const orgProjectsMap = useAuthStore((s) => s.orgProjectsMap);
   const currentProjectId = useAuthStore((s) => s.projectId);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const selectProject = useAuthStore((s) => s.selectProject);
+  const logout = useAuthStore((s) => s.logout);
 
   const groupedProjects = useMemo(
     () => groupProjectsByOrg(orgProjectsMap),
@@ -51,6 +53,12 @@ export function useProjects() {
   const currentProject = projects.find((p) => p.id === currentProjectId);
 
   useEffect(() => {
+    const hasOrgData = Object.keys(orgProjectsMap).length > 0;
+    if (isAuthenticated && hasOrgData && projects.length === 0) {
+      log.info("No projects available, logging out");
+      logout();
+      return;
+    }
     if (projects.length > 0 && !currentProject) {
       log.info("Auto-selecting first available project", {
         projectId: projects[0].id,
@@ -61,7 +69,15 @@ export function useProjects() {
       });
       selectProject(projects[0].id);
     }
-  }, [projects, currentProject, currentProjectId, selectProject]);
+  }, [
+    isAuthenticated,
+    projects,
+    currentProject,
+    currentProjectId,
+    selectProject,
+    logout,
+    orgProjectsMap,
+  ]);
 
   return {
     projects,

--- a/apps/code/src/renderer/features/projects/hooks/useProjects.tsx
+++ b/apps/code/src/renderer/features/projects/hooks/useProjects.tsx
@@ -1,5 +1,7 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
-import { useQuery } from "@tanstack/react-query";
+import {
+  type OrgProjects,
+  useAuthStore,
+} from "@features/auth/stores/authStore";
 import { logger } from "@utils/logger";
 import { useEffect, useMemo } from "react";
 
@@ -17,76 +19,36 @@ export interface GroupedProjects {
   projects: ProjectInfo[];
 }
 
-export function groupProjectsByOrg(projects: ProjectInfo[]): GroupedProjects[] {
-  const orgMap = new Map<string, GroupedProjects>();
-
-  for (const project of projects) {
-    const orgId = project.organization.id;
-    if (!orgMap.has(orgId)) {
-      orgMap.set(orgId, {
-        orgId,
-        orgName: project.organization.name,
-        projects: [],
-      });
-    }
-    orgMap.get(orgId)?.projects.push(project);
-  }
-
-  return Array.from(orgMap.values());
+export function groupProjectsByOrg(
+  orgProjectsMap: Record<string, OrgProjects>,
+): GroupedProjects[] {
+  return Object.entries(orgProjectsMap).map(([orgId, org]) => ({
+    orgId,
+    orgName: org.orgName,
+    projects: org.projects.map((p) => ({
+      id: p.id,
+      name: p.name,
+      organization: { id: orgId, name: org.orgName },
+    })),
+  }));
 }
 
 export function useProjects() {
-  const availableProjectIds = useAuthStore((s) => s.availableProjectIds);
-  const client = useAuthStore((s) => s.client);
+  const orgProjectsMap = useAuthStore((s) => s.orgProjectsMap);
   const currentProjectId = useAuthStore((s) => s.projectId);
-
-  const {
-    data: currentUser,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["currentUser"],
-    queryFn: () => client?.getCurrentUser(),
-    enabled: !!client,
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const projects = useMemo(() => {
-    if (!currentUser?.organization) return [];
-
-    const rawTeams = Array.isArray(currentUser.organization.teams)
-      ? currentUser.organization.teams
-      : [];
-    const teams = rawTeams
-      .filter(
-        (t): t is { id: number | string; name?: string } =>
-          t != null &&
-          typeof t === "object" &&
-          (typeof t.id === "number" || typeof t.id === "string"),
-      )
-      .map((t) => ({ ...t, id: Number(t.id) }))
-      .filter((t) => !Number.isNaN(t.id));
-    const orgName = currentUser.organization.name ?? "Unknown Organization";
-    const orgId = currentUser.organization.id ?? "";
-
-    const teamMap = new Map(teams.map((t) => [t.id, t]));
-
-    return availableProjectIds
-      .map((id) => {
-        const team = teamMap.get(id);
-        if (!team) return null;
-        return {
-          id,
-          name: team.name ?? `Project ${id}`,
-          organization: { id: orgId, name: orgName },
-        };
-      })
-      .filter((p): p is ProjectInfo => p !== null);
-  }, [currentUser, availableProjectIds]);
-
   const selectProject = useAuthStore((s) => s.selectProject);
+
+  const groupedProjects = useMemo(
+    () => groupProjectsByOrg(orgProjectsMap),
+    [orgProjectsMap],
+  );
+
+  const projects = useMemo(
+    () => groupedProjects.flatMap((g) => g.projects),
+    [groupedProjects],
+  );
+
   const currentProject = projects.find((p) => p.id === currentProjectId);
-  const groupedProjects = groupProjectsByOrg(projects);
 
   useEffect(() => {
     if (projects.length > 0 && !currentProject) {
@@ -106,8 +68,5 @@ export function useProjects() {
     groupedProjects,
     currentProject,
     currentProjectId,
-    currentUser: currentUser ?? null,
-    isLoading,
-    error,
   };
 }

--- a/apps/code/src/renderer/features/sidebar/components/ProjectSwitcher.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/ProjectSwitcher.tsx
@@ -2,6 +2,7 @@ import { useAuthStore } from "@features/auth/stores/authStore";
 import { Command } from "@features/command/components/Command";
 import { useProjects } from "@features/projects/hooks/useProjects";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
+import { useMeQuery } from "@hooks/useMeQuery";
 import {
   ArrowSquareOut,
   CaretDown,
@@ -55,13 +56,8 @@ export function ProjectSwitcher() {
   const cloudRegion = useAuthStore((s) => s.cloudRegion);
   const selectProject = useAuthStore((s) => s.selectProject);
   const logout = useAuthStore((s) => s.logout);
-  const {
-    groupedProjects,
-    currentProject,
-    currentProjectId,
-    currentUser,
-    isLoading,
-  } = useProjects();
+  const { groupedProjects, currentProject, currentProjectId } = useProjects();
+  const { data: currentUser } = useMeQuery();
 
   const handleProjectSelect = (projectId: number) => {
     if (projectId !== currentProjectId) {
@@ -135,7 +131,7 @@ export function ProjectSwitcher() {
               gap="1"
               style={{ minWidth: 0, flex: 1, maxWidth: "calc(100% - 24px)" }}
             >
-              {isLoading ? (
+              {!currentProject && !currentUser ? (
                 <>
                   <Box className="h-4 w-24 animate-pulse rounded bg-gray-6" />
                   <Box className="h-3.5 w-32 animate-pulse rounded bg-gray-5" />

--- a/apps/mobile/src/features/auth/stores/authStore.ts
+++ b/apps/mobile/src/features/auth/stores/authStore.ts
@@ -67,18 +67,12 @@ export const useAuthStore = create<AuthState>()(
 
         const tokenResponse = result.data;
         const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
-        const projectId = tokenResponse.scoped_teams?.[0];
-
-        if (!projectId) {
-          throw new Error("No team found in OAuth scopes");
-        }
 
         const storedTokens: StoredTokens = {
           accessToken: tokenResponse.access_token,
           refreshToken: tokenResponse.refresh_token,
           expiresAt,
           cloudRegion: region,
-          scopedTeams: tokenResponse.scoped_teams,
         };
 
         // Save tokens securely
@@ -89,7 +83,6 @@ export const useAuthStore = create<AuthState>()(
           oauthRefreshToken: tokenResponse.refresh_token,
           tokenExpiry: expiresAt,
           cloudRegion: region,
-          projectId,
           isAuthenticated: true,
         });
 
@@ -109,14 +102,12 @@ export const useAuthStore = create<AuthState>()(
         );
 
         const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
-        const projectId = tokenResponse.scoped_teams?.[0] || state.projectId;
 
         const storedTokens: StoredTokens = {
           accessToken: tokenResponse.access_token,
           refreshToken: tokenResponse.refresh_token,
           expiresAt,
           cloudRegion: state.cloudRegion,
-          scopedTeams: tokenResponse.scoped_teams,
         };
 
         // Save tokens securely
@@ -126,7 +117,6 @@ export const useAuthStore = create<AuthState>()(
           oauthAccessToken: tokenResponse.access_token,
           oauthRefreshToken: tokenResponse.refresh_token,
           tokenExpiry: expiresAt,
-          projectId,
         });
 
         get().scheduleTokenRefresh();
@@ -183,7 +173,6 @@ export const useAuthStore = create<AuthState>()(
             oauthRefreshToken: tokens.refreshToken,
             tokenExpiry: tokens.expiresAt,
             cloudRegion: tokens.cloudRegion,
-            projectId: tokens.scopedTeams?.[0] || null,
           });
 
           if (isExpired) {

--- a/apps/mobile/src/features/auth/types.ts
+++ b/apps/mobile/src/features/auth/types.ts
@@ -20,5 +20,4 @@ export interface StoredTokens {
   refreshToken: string;
   expiresAt: number;
   cloudRegion: CloudRegion;
-  scopedTeams?: number[];
 }


### PR DESCRIPTION
Issue: https://github.com/PostHog/code/issues/1101
PostHog/posthog PR: https://github.com/PostHog/posthog/pull/50725

  1. Replace flat availableProjectIds/availableOrgIds arrays with org-keyed orgProjectsMap in auth store
  2. Add listOrgProjects API method and buildOrgProjectsMap helper to fetch projects per organization
  3. Remove scoped_teams from OAuth token response schema and stored tokens
  4. Simplify useProjects hook to derive project list from org map instead of fetching user data
  5. Move currentUser query out of useProjects into ProjectSwitcher where it's actually used
  6. Update mobile auth store to drop scoped_teams dependency