### PR TITLE
feat(workflows): output schema MCP

### DIFF
--- a/apps/code/src/main/services/agent/service.test.ts
+++ b/apps/code/src/main/services/agent/service.test.ts
@@ -349,7 +349,7 @@ describe("AgentService", () => {
       service.recordActivity("run-1");
       const secondDeadline = getIdleTimeouts(service).get("run-1")?.deadline;
 
-      expect(secondDeadline).toBeGreaterThan(firstDeadline!);
+      expect(secondDeadline).toBeGreaterThan(firstDeadline as number);
     });
 
     it("kills idle session after timeout expires", () => {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -31,6 +31,7 @@ import { AsyncMutex } from "../utils/async-mutex";
 import { getLlmGatewayUrl } from "../utils/gateway";
 import { Logger } from "../utils/logger";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
+import { ResultMcpServer } from "./result-mcp-server.js";
 import { jsonRpcRequestSchema, validateCommandParams } from "./schemas";
 import type { AgentServerConfig } from "./types";
 
@@ -162,6 +163,7 @@ export class AgentServer {
   private questionRelayedToSlack = false;
   private detectedPrUrl: string | null = null;
   private resumeState: ResumeState | null = null;
+  private resultMcpServer: ResultMcpServer | null = null;
 
   private emitConsoleLog = (
     level: LogLevel,
@@ -379,6 +381,17 @@ export class AgentServer {
       );
     });
 
+    if (this.config.outputSchema) {
+      this.resultMcpServer = new ResultMcpServer({
+        port: this.config.port + 1,
+        outputSchema: this.config.outputSchema,
+        taskId: this.config.taskId,
+        runId: this.config.runId,
+        posthogAPI: this.posthogAPI,
+      });
+      await this.resultMcpServer.start();
+    }
+
     await this.autoInitializeSession();
   }
 
@@ -433,6 +446,11 @@ export class AgentServer {
 
     if (this.session) {
       await this.cleanupSession();
+    }
+
+    if (this.resultMcpServer) {
+      await this.resultMcpServer.stop();
+      this.resultMcpServer = null;
     }
 
     if (this.server) {
@@ -633,9 +651,19 @@ export class AgentServer {
       this.detectedPrUrl = prUrl;
     }
 
+    const mcpServers = [...(this.config.mcpServers ?? [])];
+    if (this.resultMcpServer) {
+      mcpServers.push({
+        type: "http",
+        name: "posthog-result",
+        url: this.resultMcpServer.url,
+        headers: [],
+      });
+    }
+
     const sessionResponse = await clientConnection.newSession({
       cwd: this.config.repositoryPath ?? "/tmp/workspace",
-      mcpServers: this.config.mcpServers ?? [],
+      mcpServers,
       _meta: {
         sessionId: payload.run_id,
         taskRunId: payload.run_id,
@@ -776,6 +804,17 @@ export class AgentServer {
 
       if (result.stopReason === "end_turn") {
         await this.relayAgentResponse(payload);
+      }
+
+      // If structured output was submitted, flush logs first then mark completed
+      if (this.resultMcpServer?.isResultSubmitted) {
+        if (this.session) {
+          await this.session.logWriter.flushAll();
+        }
+        await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
+          status: "completed",
+        });
+        this.logger.info("Task marked completed after submit_result");
       }
     } catch (error) {
       this.logger.error("Failed to send initial task message", error);
@@ -945,6 +984,27 @@ export class AgentServer {
   }
 
   private buildCloudSystemPrompt(prUrl?: string | null): string {
+    // When outputSchema is provided, the agent's job is to gather information
+    // and submit structured results — not create PRs or branches.
+    if (this.config.outputSchema) {
+      return `
+# Structured Output Task
+
+You have access to a tool called \`submit_result\` (from the "posthog-result" MCP server).
+Your job is to complete the task described in the user message, then call \`submit_result\` with the result data.
+
+The output schema is:
+\`\`\`json
+${JSON.stringify(this.config.outputSchema, null, 2)}
+\`\`\`
+
+Instructions:
+1. Read the task carefully and gather all the information needed.
+2. Once you have the answer, call the \`submit_result\` tool with a \`data\` argument that conforms to the schema above.
+3. You MUST call \`submit_result\` exactly once before finishing.
+`;
+    }
+
     if (prUrl) {
       return `
 # Cloud Task Execution

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -51,6 +51,10 @@ program
     "MCP servers config as JSON array (ACP McpServer[] format)",
   )
   .option("--baseBranch <branch>", "Base branch for PR creation")
+  .option(
+    "--outputSchema <json>",
+    "JSON Schema for structured output (enables submit_result MCP tool)",
+  )
   .action(async (options) => {
     const envResult = envSchema.safeParse(process.env);
 
@@ -89,6 +93,16 @@ program
       mcpServers = result.data;
     }
 
+    let outputSchema: Record<string, unknown> | undefined;
+    if (options.outputSchema) {
+      try {
+        outputSchema = JSON.parse(options.outputSchema);
+      } catch {
+        program.error("--outputSchema must be valid JSON");
+        return;
+      }
+    }
+
     const server = new AgentServer({
       port: parseInt(options.port, 10),
       jwtPublicKey: env.JWT_PUBLIC_KEY,
@@ -101,6 +115,7 @@ program
       runId: options.runId,
       mcpServers,
       baseBranch: options.baseBranch,
+      outputSchema,
     });
 
     process.on("SIGINT", async () => {

--- a/packages/agent/src/server/result-mcp-server.ts
+++ b/packages/agent/src/server/result-mcp-server.ts
@@ -1,0 +1,268 @@
+import { type ServerType, serve } from "@hono/node-server";
+import { Hono } from "hono";
+import type { PostHogAPIClient } from "../posthog-api.js";
+import { Logger } from "../utils/logger.js";
+
+export interface ResultMcpServerConfig {
+  port: number;
+  outputSchema: Record<string, unknown>;
+  taskId: string;
+  runId: string;
+  posthogAPI: PostHogAPIClient;
+}
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+  id?: string | number;
+}
+
+/**
+ * Minimal MCP Streamable HTTP server that exposes a single `submit_result` tool.
+ *
+ * The Claude Agent SDK connects to this as a regular MCP server. When the agent
+ * calls `submit_result`, the handler validates the data and writes it to
+ * `TaskRun.output` via the PostHog API.
+ */
+export class ResultMcpServer {
+  private config: ResultMcpServerConfig;
+  private logger: Logger;
+  private server: ServerType | null = null;
+  private app: Hono;
+  private _resultSubmitted = false;
+
+  get isResultSubmitted(): boolean {
+    return this._resultSubmitted;
+  }
+
+  constructor(config: ResultMcpServerConfig) {
+    this.config = config;
+    this.logger = new Logger({
+      debug: true,
+      prefix: "[ResultMcpServer]",
+    });
+    this.app = this.createApp();
+  }
+
+  get url(): string {
+    return `http://localhost:${this.config.port}/mcp`;
+  }
+
+  private createApp(): Hono {
+    const app = new Hono();
+
+    app.post("/mcp", async (c) => {
+      let body: JsonRpcRequest;
+      try {
+        body = await c.req.json();
+      } catch {
+        this.logger.error("Failed to parse JSON-RPC request body");
+        return c.json(
+          { jsonrpc: "2.0", error: { code: -32700, message: "Parse error" } },
+          200,
+        );
+      }
+
+      this.logger.info(`Received JSON-RPC: ${body.method}`, {
+        id: body.id,
+        hasParams: !!body.params,
+      });
+
+      const response = this.handleJsonRpc(body);
+      if (response === null) {
+        // Notification (no id) — return 202 Accepted
+        return c.body(null, 202);
+      }
+      return c.json(response);
+    });
+
+    return app;
+  }
+
+  private handleJsonRpc(
+    request: JsonRpcRequest,
+  ): Record<string, unknown> | null {
+    const { method, id, params } = request;
+
+    switch (method) {
+      case "initialize":
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            protocolVersion: "2025-03-26",
+            capabilities: { tools: {} },
+            serverInfo: {
+              name: "posthog-result",
+              version: "1.0.0",
+            },
+          },
+        };
+
+      case "notifications/initialized":
+        // No-op acknowledgement — notification has no id
+        return null;
+
+      case "tools/list":
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            tools: [this.getToolDefinition()],
+          },
+        };
+
+      case "tools/call":
+        return this.handleToolCall(id, params);
+
+      default:
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: {
+            code: -32601,
+            message: `Method not found: ${method}`,
+          },
+        };
+    }
+  }
+
+  private getToolDefinition(): Record<string, unknown> {
+    return {
+      name: "submit_result",
+      description:
+        "Submit the final structured result for this task. Call this exactly once when you have gathered all the information needed. The data must conform to the output schema.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          data: this.config.outputSchema,
+        },
+        required: ["data"],
+      },
+    };
+  }
+
+  private handleToolCall(
+    id: string | number | undefined,
+    params: Record<string, unknown> | undefined,
+  ): Record<string, unknown> {
+    const toolName = params?.name as string | undefined;
+
+    this.logger.info(`tools/call received: ${toolName}`, {
+      hasArguments: !!params?.arguments,
+    });
+
+    if (toolName !== "submit_result") {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: `Unknown tool: ${toolName}. Only 'submit_result' is available.`,
+            },
+          ],
+          isError: true,
+        },
+      };
+    }
+
+    if (this._resultSubmitted) {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: "Result already submitted. submit_result can only be called once.",
+            },
+          ],
+          isError: true,
+        },
+      };
+    }
+
+    const args = params?.arguments as Record<string, unknown> | undefined;
+    const data = args?.data;
+
+    if (data === undefined || data === null) {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: "Missing required field 'data'. Please provide the result data.",
+            },
+          ],
+          isError: true,
+        },
+      };
+    }
+
+    // Fire-and-forget the API call, but track submission state synchronously
+    this._resultSubmitted = true;
+    this.submitResult(data);
+
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        content: [
+          {
+            type: "text",
+            text: "Result submitted successfully.",
+          },
+        ],
+      },
+    };
+  }
+
+  private submitResult(data: unknown): void {
+    this.config.posthogAPI
+      .updateTaskRun(this.config.taskId, this.config.runId, {
+        output: data as Record<string, unknown>,
+      })
+      .then(() => {
+        this.logger.info("Result submitted to PostHog API", {
+          taskId: this.config.taskId,
+          runId: this.config.runId,
+        });
+      })
+      .catch((error) => {
+        this.logger.error("Failed to submit result to PostHog API", {
+          taskId: this.config.taskId,
+          runId: this.config.runId,
+          error,
+        });
+        // Allow retry on API failure
+        this._resultSubmitted = false;
+      });
+  }
+
+  async start(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.server = serve(
+        { fetch: this.app.fetch, port: this.config.port },
+        () => {
+          this.logger.info(
+            `Result MCP server listening on port ${this.config.port}`,
+          );
+          resolve();
+        },
+      );
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+      this.logger.info("Result MCP server stopped");
+    }
+  }
+}

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -14,4 +14,5 @@ export interface AgentServerConfig {
   version?: string;
   mcpServers?: RemoteMcpServer[];
   baseBranch?: string;
+  outputSchema?: Record<string, unknown>;
 }


### PR DESCRIPTION
### TL;DR

Added structured output support to the agent server through a new MCP server that provides a `submit_result` tool for agents to return JSON Schema-validated results. This is used by workflows agents that need to return a structured output defined by the user.

### What changed?

- Added `ResultMcpServer` class that runs an HTTP MCP server exposing a `submit_result` tool
- Added `--outputSchema` CLI option to accept JSON Schema for structured output validation
- Modified agent initialization to conditionally start the result MCP server and include it in the MCP servers list
- Updated system prompt generation to provide structured output instructions when output schema is configured
- Added automatic task completion marking when structured results are submitted
- Added proper cleanup of the result MCP server during agent shutdown

### How to test?

1. Start the agent server with `--outputSchema '{"type": "object", "properties": {"answer": {"type": "string"}}}'`
2. Send a task to the agent that requires structured output
3. Verify the agent uses the `submit_result` tool to return data conforming to the schema
4. Check that the task run is marked as completed and the output is saved to the PostHog API


### Why make this change?

This enables agents to return structured, validated results instead of only creating PRs or branches.