### PR TITLE
feat(phai): Add --claudeCodeConfig to agent server

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -639,7 +639,14 @@ export class AgentServer {
       _meta: {
         sessionId: payload.run_id,
         taskRunId: payload.run_id,
-        systemPrompt: { append: this.buildCloudSystemPrompt(prUrl) },
+        systemPrompt: this.buildSessionSystemPrompt(prUrl),
+        ...(this.config.claudeCode?.plugins?.length && {
+          claudeCode: {
+            options: {
+              plugins: this.config.claudeCode.plugins,
+            },
+          },
+        }),
       },
     });
 
@@ -942,6 +949,28 @@ export class AgentServer {
     return typeof stateRunId === "string" && stateRunId.trim().length > 0
       ? stateRunId.trim()
       : null;
+  }
+
+  private buildSessionSystemPrompt(
+    prUrl?: string | null,
+  ): string | { append: string } {
+    const cloudAppend = this.buildCloudSystemPrompt(prUrl);
+    const userPrompt = this.config.claudeCode?.systemPrompt;
+
+    // String override: combine user prompt with cloud instructions
+    if (typeof userPrompt === "string") {
+      return [userPrompt, cloudAppend].join("\n\n");
+    }
+
+    // Preset with append: merge user append with cloud instructions
+    if (typeof userPrompt === "object") {
+      return {
+        append: [userPrompt.append, cloudAppend].filter(Boolean).join("\n\n"),
+      };
+    }
+
+    // Default: just cloud instructions
+    return { append: cloudAppend };
   }
 
   private buildCloudSystemPrompt(prUrl?: string | null): string {

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -2,7 +2,7 @@
 import { Command } from "commander";
 import { z } from "zod";
 import { AgentServer } from "./agent-server";
-import { mcpServersSchema } from "./schemas";
+import { claudeCodeConfigSchema, mcpServersSchema } from "./schemas";
 
 const envSchema = z.object({
   JWT_PUBLIC_KEY: z
@@ -34,6 +34,30 @@ const envSchema = z.object({
 
 const program = new Command();
 
+function parseJsonOption<S extends z.ZodTypeAny>(
+  raw: string | undefined,
+  schema: S,
+  flag: string,
+): z.output<S> | undefined {
+  if (!raw) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    program.error(`${flag} must be valid JSON`);
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    const errors = result.error.issues
+      .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
+      .join("\n");
+    program.error(`${flag} validation failed:\n${errors}`);
+  }
+  return result.data;
+}
+
 program
   .name("agent-server")
   .description("PostHog cloud agent server - runs in sandbox environments")
@@ -51,6 +75,10 @@ program
     "MCP servers config as JSON array (ACP McpServer[] format)",
   )
   .option("--baseBranch <branch>", "Base branch for PR creation")
+  .option(
+    "--claudeCodeConfig <json>",
+    "Claude Code config as JSON (systemPrompt, systemPromptAppend, plugins)",
+  )
   .action(async (options) => {
     const envResult = envSchema.safeParse(process.env);
 
@@ -66,28 +94,16 @@ program
 
     const mode = options.mode === "background" ? "background" : "interactive";
 
-    let mcpServers: z.infer<typeof mcpServersSchema> | undefined;
-    if (options.mcpServers) {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(options.mcpServers);
-      } catch {
-        program.error("--mcpServers must be valid JSON");
-        return;
-      }
-
-      const result = mcpServersSchema.safeParse(parsed);
-      if (!result.success) {
-        const errors = result.error.issues
-          .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
-          .join("\n");
-        program.error(
-          `--mcpServers validation failed (only remote http/sse servers are supported):\n${errors}`,
-        );
-        return;
-      }
-      mcpServers = result.data;
-    }
+    const mcpServers = parseJsonOption(
+      options.mcpServers,
+      mcpServersSchema,
+      "--mcpServers",
+    );
+    const claudeCode = parseJsonOption(
+      options.claudeCodeConfig,
+      claudeCodeConfigSchema,
+      "--claudeCodeConfig",
+    );
 
     const server = new AgentServer({
       port: parseInt(options.port, 10),
@@ -101,6 +117,7 @@ program
       runId: options.runId,
       mcpServers,
       baseBranch: options.baseBranch,
+      claudeCode,
     });
 
     process.on("SIGINT", async () => {

--- a/packages/agent/src/server/schemas.ts
+++ b/packages/agent/src/server/schemas.ts
@@ -16,6 +16,22 @@ export const mcpServersSchema = z.array(remoteMcpServerSchema);
 
 export type RemoteMcpServer = z.infer<typeof remoteMcpServerSchema>;
 
+export const claudeCodeConfigSchema = z.object({
+  systemPrompt: z
+    .union([
+      z.string(),
+      z.object({
+        type: z.literal("preset"),
+        preset: z.literal("claude_code"),
+        append: z.string().optional(),
+      }),
+    ])
+    .optional(),
+  plugins: z
+    .array(z.object({ type: z.literal("local"), path: z.string() }))
+    .optional(),
+});
+
 export const jsonRpcRequestSchema = z.object({
   jsonrpc: z.literal("2.0"),
   method: z.string(),

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -1,6 +1,13 @@
 import type { AgentMode } from "../types";
 import type { RemoteMcpServer } from "./schemas";
 
+export interface ClaudeCodeConfig {
+  systemPrompt?:
+    | string
+    | { type: "preset"; preset: "claude_code"; append?: string };
+  plugins?: { type: "local"; path: string }[];
+}
+
 export interface AgentServerConfig {
   port: number;
   repositoryPath?: string;
@@ -14,4 +21,5 @@ export interface AgentServerConfig {
   version?: string;
   mcpServers?: RemoteMcpServer[];
   baseBranch?: string;
+  claudeCode?: ClaudeCodeConfig;
 }


### PR DESCRIPTION
## Problem

The agent server had no way to pass Claude Code-specific configuration (system prompt, plugins). These options were either hardcoded or missing entirely. As we add support for other agent backends (e.g. Codex), we need provider-specific config scoped separately from agent-agnostic config.

## Changes

- Add `--claudeCodeConfig <json>` CLI flag accepting a JSON object with `systemPrompt` and `plugins` fields, matching the Claude Code SDK schema
- Add `ClaudeCodeConfig` type and `claudeCodeConfigSchema` Zod validator
- Add `buildSessionSystemPrompt()` that merges user-provided system prompt with cloud task instructions
- Pass configured plugins through to Claude Code sessions via `_meta.claudeCode.options.plugins`
- Extract reusable `parseJsonOption` helper, deduplicating the JSON parse + Zod validate pattern previously inlined for `--mcpServers`

## How did you test this code?

Verified no new typecheck errors introduced (all failures are pre-existing bigint/missing module issues on main).

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code.