### PR TITLE
fix(code): fix truncated diff preview

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/EditToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/EditToolView.tsx
@@ -69,6 +69,7 @@ export function EditToolView({
   const oldText = diff?.oldText;
   const newText = diff?.newText;
   const isNewFile = diff && !oldText;
+  const hasDiff = diff && (oldText || newText);
   const diffStats = diff ? getDiffStats(oldText, newText) : null;
 
   const isPlanFile = filePath.includes("claude/plans/");
@@ -98,7 +99,7 @@ export function EditToolView({
           )}
           <StatusIndicators isFailed={isFailed} wasCancelled={wasCancelled} />
         </Flex>
-        {newText && (
+        {hasDiff && (
           <IconButton asChild size="1" variant="ghost" color="gray">
             <span>
               {isExpanded ? (
@@ -111,9 +112,9 @@ export function EditToolView({
         )}
       </button>
 
-      {isExpanded && newText && (
+      {isExpanded && hasDiff && (
         <CodePreview
-          content={newText}
+          content={newText ?? ""}
           filePath={filePath}
           oldContent={isNewFile ? null : oldText}
           maxHeight="700px"

--- a/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type {
   PlanEntry,
@@ -179,18 +180,22 @@ export function toolInfoFromToolUse(
         : null;
       let newText: string = input?.new_string ? String(input.new_string) : "";
 
-      // If we have cached file content, show a full-file diff
-      if (
-        filePath &&
-        options?.cachedFileContent &&
-        filePath in options.cachedFileContent
-      ) {
-        const oldContent = options.cachedFileContent[filePath];
-        const newContent = input?.replace_all
-          ? oldContent.replaceAll(oldText ?? "", newText)
-          : oldContent.replace(oldText ?? "", newText);
-        oldText = oldContent;
-        newText = newContent;
+      // try to display a rich diff by first checking if file content is cached
+      // and valid (old_text exists in the content), then fall back to reading
+      // file from disk, then fall back to fragemented snippet diff
+      if (filePath && oldText !== null) {
+        const fileContent = resolveFileContent(
+          filePath,
+          oldText,
+          options?.cachedFileContent,
+        );
+        if (fileContent) {
+          const newContent = input?.replace_all
+            ? fileContent.replaceAll(oldText, newText)
+            : fileContent.replace(oldText, newText);
+          oldText = fileContent;
+          newText = newContent;
+        }
       }
 
       return {
@@ -757,6 +762,37 @@ export function planEntries(input: { todos: ClaudePlanEntry[] }): PlanEntry[] {
     status: input.status,
     priority: "medium",
   }));
+}
+
+/**
+ * attempt to resolve full file contents for diff generation
+ *
+ * 1) check file content cache exists, and is valid (old_text in content)
+ * 2) if missing or invalid, read file from disk
+ * 3) if both fail, return null, we'll fall back to fragmented snippet diff
+ */
+function resolveFileContent(
+  filePath: string,
+  oldText: string,
+  cachedFileContent?: Record<string, string>,
+): string | null {
+  if (cachedFileContent && filePath in cachedFileContent) {
+    const cached = cachedFileContent[filePath];
+    if (cached.includes(oldText)) {
+      return cached;
+    }
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    if (content.includes(oldText)) {
+      return content;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 function markdownEscape(text: string): string {


### PR DESCRIPTION
## problem

diff viewer is a little broken - mostly because sometimes the tool output is too large, causing the "diff preview content" to be something like this:

```
<persisted-output>
Output too large (110.7KB). Full output saved to: /Users/adambowker/Library/Application Support/@posthog/posthog-code-dev/claude/projects/-Users-adambowker-posthog/019ce8a1-8438-7365-af52-3e0d8a594eb2/tool-results/toolu_019XVYxMKKxpPvfecMUzFEwj.txt  
Preview (first 2KB):  
import './EditSurvey.scss'  
import { DndContext } from '@dnd-kit/core'  
import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'  
import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'  
...
</persisted-output>
```

when this happens, 1) it looks bad, 2) the stats are computed incorrectly as `+0 -0` , and 3) just means you can’t actually view the diff

also, the diff sometimes doesn't work if it's a delete-only, because we only check `newText` when rendering the diff

## changes

1. updates `EditToolView` to check `oldText || newText` to determine if there is a diff, instead of only `newText`
2. updates `toolInfoFromToolUse` to build the diff by:
    1. first, check file content cache exists and is valid (old text exists in the content)
    2. if missing or not valid, attempt to read the file contents from disk
    3. if both of those fail, fall back to rendering fragment diff only, no context lines