### PR TITLE
feat(code): remove auto-submit from slash commands, fix search

### DIFF
--- a/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
+++ b/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
@@ -66,7 +66,8 @@ export function getCommandSuggestions(
   query: string,
 ): CommandSuggestionItem[] {
   const taskId = useDraftStore.getState().contexts[sessionId]?.taskId;
-  const commands = [...CODE_COMMANDS, ...getAvailableCommandsForTask(taskId)];
+  const merged = [...CODE_COMMANDS, ...getAvailableCommandsForTask(taskId)];
+  const commands = [...new Map(merged.map((cmd) => [cmd.name, cmd])).values()];
   const filtered = searchCommands(commands, query);
 
   return filtered.map((cmd) => ({

--- a/apps/code/src/renderer/features/message-editor/tiptap/CommandMention.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/CommandMention.ts
@@ -9,8 +9,6 @@ import { SuggestionList, type SuggestionListRef } from "./SuggestionList";
 
 function createSuggestion(
   sessionId: string,
-  onSubmit?: (text: string) => void,
-  onClearDraft?: () => void,
 ): Partial<SuggestionOptions<SuggestionItem>> {
   return {
     char: "/",
@@ -85,15 +83,7 @@ function createSuggestion(
     command: ({ editor, range, props }) => {
       const item = props as CommandSuggestionItem;
 
-      // Commands without input hints execute immediately
-      if (!item.command.input?.hint) {
-        editor.commands.clearContent();
-        onClearDraft?.();
-        onSubmit?.(`/${item.command.name}`);
-        return;
-      }
-
-      // Commands with input insert a chip
+      // Insert command as a chip, let user add context and submit when ready
       editor
         .chain()
         .focus()
@@ -116,12 +106,10 @@ function createSuggestion(
 
 export interface CommandMentionOptions {
   sessionId: string;
-  onSubmit?: (text: string) => void;
-  onClearDraft?: () => void;
 }
 
 export function createCommandMention(options: CommandMentionOptions) {
-  const { sessionId, onSubmit, onClearDraft } = options;
+  const { sessionId } = options;
 
   return Mention.extend<CommandMentionOptions>({
     name: "commandMention",
@@ -130,9 +118,7 @@ export function createCommandMention(options: CommandMentionOptions) {
       return {
         ...this.parent?.(),
         sessionId,
-        onSubmit,
-        onClearDraft,
-        suggestion: createSuggestion(sessionId, onSubmit, onClearDraft),
+        suggestion: createSuggestion(sessionId),
       };
     },
   });

--- a/apps/code/src/renderer/features/message-editor/tiptap/SuggestionList.tsx
+++ b/apps/code/src/renderer/features/message-editor/tiptap/SuggestionList.tsx
@@ -41,9 +41,10 @@ export const SuggestionList = forwardRef<
     setHasMouseMoved(false);
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-scroll when items change
   useEffect(() => {
     itemRefs.current[selectedIndex]?.scrollIntoView({ block: "nearest" });
-  }, [selectedIndex]);
+  }, [selectedIndex, items]);
 
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }) => {

--- a/apps/code/src/renderer/features/message-editor/tiptap/extensions.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/extensions.ts
@@ -9,8 +9,6 @@ export interface EditorExtensionsOptions {
   placeholder?: string;
   fileMentions?: boolean;
   commands?: boolean;
-  onCommandSubmit?: (text: string) => void;
-  onClearDraft?: () => void;
 }
 
 export function getEditorExtensions(options: EditorExtensionsOptions) {
@@ -19,8 +17,6 @@ export function getEditorExtensions(options: EditorExtensionsOptions) {
     placeholder = "",
     fileMentions = true,
     commands = true,
-    onCommandSubmit,
-    onClearDraft,
   } = options;
 
   const extensions = [
@@ -46,13 +42,7 @@ export function getEditorExtensions(options: EditorExtensionsOptions) {
   }
 
   if (commands) {
-    extensions.push(
-      createCommandMention({
-        sessionId,
-        onSubmit: onCommandSubmit,
-        onClearDraft,
-      }),
-    );
+    extensions.push(createCommandMention({ sessionId }));
   }
 
   return extensions;

--- a/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -95,14 +95,6 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
   const [attachments, setAttachments] = useState<FileAttachment[]>([]);
   const attachmentsRef = useRef<FileAttachment[]>([]);
 
-  const handleCommandSubmit = useCallback((text: string) => {
-    callbackRefs.current.onSubmit?.(text);
-  }, []);
-
-  const handleClearDraft = useCallback(() => {
-    draftRef.current?.clearDraft();
-  }, []);
-
   const editor = useEditor(
     {
       extensions: getEditorExtensions({
@@ -110,8 +102,6 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
         placeholder,
         fileMentions,
         commands,
-        onCommandSubmit: handleCommandSubmit,
-        onClearDraft: handleClearDraft,
       }),
       editable: !disabled,
       autofocus: autoFocus ? "end" : false,

--- a/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
@@ -79,8 +79,8 @@ export const TaskInputEditor = forwardRef<
       submitDisabled: !isOnline,
       isLoading: isCreatingTask,
       autoFocus,
-      context: { repoPath },
-      capabilities: { commands: false, bashMode: false },
+      context: { repoPath, taskId: previewTaskId },
+      capabilities: { commands: true, bashMode: false },
       clearOnSubmit: false,
       onSubmit: (text) => {
         if (text && canSubmit) {


### PR DESCRIPTION
## problem

1. when typing to search for a command/skill, the scrolling/filtering does not work
2. commands are not available in the new task view
3. commands always nuke and auto-submit your prompt
4. duplicate skills show up in the list (e.g. one `(project)`and one `(repo-skills-xyz)` , they are keyed on `name`, so multiple skills end up getting highlighted at the same time when searching/filtering and breaking things

## changes

1. fixes scroll/filter when typing to search
2. adds commands to the new task view
3. changes to _not_ auto-submit prompts on command selection
4. deduplicates commands/skills by name
    1. **no, this is not a very good solution, but it needs more thinking on how we actually want to handle duplicate commands/skills or their names**