### PR TITLE
feat(code): add live context window usage indicator 

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/ContextUsageIndicator.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ContextUsageIndicator.tsx
@@ -1,0 +1,82 @@
+import { Tooltip } from "@components/ui/Tooltip";
+import type { ContextUsage } from "@features/sessions/hooks/useContextUsage";
+import { Flex, Text } from "@radix-ui/themes";
+
+function formatTokensCompact(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    return `${(tokens / 1_000_000).toFixed(1)}M`;
+  }
+  return `${Math.round(tokens / 1000)}K`;
+}
+
+function formatTokensFull(tokens: number): string {
+  return tokens.toLocaleString();
+}
+
+function getUsageColor(percentage: number): string {
+  if (percentage >= 90) return "var(--red-9)";
+  if (percentage >= 75) return "var(--orange-9)";
+  if (percentage >= 50) return "var(--amber-9)";
+  return "var(--green-9)";
+}
+
+const CIRCLE_SIZE = 20;
+const STROKE_WIDTH = 2.5;
+const RADIUS = (CIRCLE_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+interface ContextUsageIndicatorProps {
+  usage: ContextUsage | null;
+}
+
+export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
+  if (!usage) return null;
+
+  const { used, size, percentage, cost } = usage;
+  const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;
+  const color = getUsageColor(percentage);
+
+  const tooltipLines = [
+    `Context: ${formatTokensFull(used)} / ${formatTokensFull(size)} tokens (${percentage}%)`,
+  ];
+  if (cost) {
+    tooltipLines.push(`Cost: $${cost.amount.toFixed(2)}`);
+  }
+
+  return (
+    <Tooltip content={tooltipLines.join(" | ")} side="top">
+      <Flex align="center" gap="1" className="cursor-default select-none">
+        <svg
+          width={CIRCLE_SIZE}
+          height={CIRCLE_SIZE}
+          className="-rotate-90 shrink-0"
+          role="img"
+          aria-label={`Context usage: ${percentage}%`}
+        >
+          <circle
+            cx={CIRCLE_SIZE / 2}
+            cy={CIRCLE_SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            stroke="var(--gray-5)"
+            strokeWidth={STROKE_WIDTH}
+          />
+          <circle
+            cx={CIRCLE_SIZE / 2}
+            cy={CIRCLE_SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            stroke={color}
+            strokeWidth={STROKE_WIDTH}
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={strokeDashoffset}
+            strokeLinecap="round"
+          />
+        </svg>
+        <Text size="1" className="text-gray-10 tabular-nums">
+          {formatTokensCompact(used)}/{formatTokensCompact(size)}
+        </Text>
+      </Flex>
+    </Tooltip>
+  );
+}

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -1,3 +1,4 @@
+import { useContextUsage } from "@features/sessions/hooks/useContextUsage";
 import {
   sessionStoreSetters,
   useOptimisticItemsForTask,
@@ -52,6 +53,7 @@ export function ConversationView({
   const agentLogsEnabled = useFeatureFlag("posthog-code-background-agent-logs");
   const debugLogsCloudRuns = useSettingsStore((s) => s.debugLogsCloudRuns);
   const showDebugLogs = agentLogsEnabled && debugLogsCloudRuns;
+  const contextUsage = useContextUsage(events);
 
   const { items: conversationItems, lastTurnInfo } = useMemo(
     () =>
@@ -199,6 +201,7 @@ export function ConversationView({
               queuedCount={queuedMessages.length}
               hasPendingPermission={pendingPermissionsCount > 0}
               pausedDurationMs={pausedDurationMs}
+              usage={contextUsage}
             />
           </div>
         }

--- a/apps/code/src/renderer/features/sessions/components/SessionFooter.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionFooter.tsx
@@ -1,6 +1,8 @@
+import type { ContextUsage } from "@features/sessions/hooks/useContextUsage";
 import { Pause } from "@phosphor-icons/react";
 import { Box, Flex, Text } from "@radix-ui/themes";
 
+import { ContextUsageIndicator } from "./ContextUsageIndicator";
 import { formatDuration, GeneratingIndicator } from "./GeneratingIndicator";
 
 interface SessionFooterProps {
@@ -11,6 +13,7 @@ interface SessionFooterProps {
   queuedCount?: number;
   hasPendingPermission?: boolean;
   pausedDurationMs?: number;
+  usage?: ContextUsage | null;
 }
 
 export function SessionFooter({
@@ -21,20 +24,24 @@ export function SessionFooter({
   queuedCount = 0,
   hasPendingPermission = false,
   pausedDurationMs,
+  usage,
 }: SessionFooterProps) {
   if (isPromptPending) {
     // Show static "waiting" state when permission is pending
     if (hasPendingPermission) {
       return (
         <Box className="pt-3 pb-1">
-          <Flex
-            align="center"
-            gap="2"
-            className="select-none text-gray-10"
-            style={{ userSelect: "none", WebkitUserSelect: "none" }}
-          >
-            <Pause size={14} weight="fill" />
-            <Text size="1">Awaiting permission...</Text>
+          <Flex align="center" justify="between" gap="2">
+            <Flex
+              align="center"
+              gap="2"
+              className="select-none text-gray-10"
+              style={{ userSelect: "none", WebkitUserSelect: "none" }}
+            >
+              <Pause size={14} weight="fill" />
+              <Text size="1">Awaiting permission...</Text>
+            </Flex>
+            <ContextUsageIndicator usage={usage ?? null} />
           </Flex>
         </Box>
       );
@@ -42,16 +49,19 @@ export function SessionFooter({
 
     return (
       <Box className="pt-3 pb-1">
-        <Flex align="center" gap="2">
-          <GeneratingIndicator
-            startedAt={promptStartedAt}
-            pausedDurationMs={pausedDurationMs}
-          />
-          {queuedCount > 0 && (
-            <Text size="1" color="gray">
-              ({queuedCount} queued)
-            </Text>
-          )}
+        <Flex align="center" justify="between" gap="2">
+          <Flex align="center" gap="2">
+            <GeneratingIndicator
+              startedAt={promptStartedAt}
+              pausedDurationMs={pausedDurationMs}
+            />
+            {queuedCount > 0 && (
+              <Text size="1" color="gray">
+                ({queuedCount} queued)
+              </Text>
+            )}
+          </Flex>
+          <ContextUsageIndicator usage={usage ?? null} />
         </Flex>
       </Box>
     );
@@ -67,13 +77,26 @@ export function SessionFooter({
   ) {
     return (
       <Box className="pb-1">
-        <Text
-          size="1"
-          color="gray"
-          style={{ fontVariantNumeric: "tabular-nums" }}
-        >
-          Generated in {formatDuration(lastGenerationDuration)}
-        </Text>
+        <Flex align="center" justify="between" gap="2">
+          <Text
+            size="1"
+            color="gray"
+            style={{ fontVariantNumeric: "tabular-nums" }}
+          >
+            Generated in {formatDuration(lastGenerationDuration)}
+          </Text>
+          <ContextUsageIndicator usage={usage ?? null} />
+        </Flex>
+      </Box>
+    );
+  }
+
+  if (usage) {
+    return (
+      <Box className="pb-1">
+        <Flex justify="end">
+          <ContextUsageIndicator usage={usage} />
+        </Flex>
       </Box>
     );
   }

--- a/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
+++ b/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
@@ -560,6 +560,7 @@ function processSessionUpdate(b: ItemBuilder, update: SessionUpdate) {
     case "plan":
     case "available_commands_update":
     case "config_option_update":
+    case "usage_update":
       break;
 
     default: {

--- a/apps/code/src/renderer/features/sessions/hooks/useContextUsage.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useContextUsage.ts
@@ -1,0 +1,59 @@
+import type { AcpMessage } from "@shared/types/session-events";
+import { useMemo } from "react";
+
+export interface ContextUsage {
+  used: number;
+  size: number;
+  percentage: number;
+  cost: { amount: number; currency: string } | null;
+}
+
+/**
+ * Extract the latest context window usage from session events.
+ * Scans backwards to find the most recent usage_update notification.
+ * Re-derives on each new event, giving live updates during streaming.
+ */
+export function useContextUsage(events: AcpMessage[]): ContextUsage | null {
+  return useMemo(() => extractContextUsage(events), [events]);
+}
+
+export function extractContextUsage(events: AcpMessage[]): ContextUsage | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const msg = events[i].message;
+    if (
+      "method" in msg &&
+      msg.method === "session/update" &&
+      !("id" in msg) &&
+      "params" in msg
+    ) {
+      const params = msg.params as
+        | {
+            update?: {
+              sessionUpdate?: string;
+              used?: number;
+              size?: number;
+              cost?: { amount: number; currency: string } | null;
+            };
+          }
+        | undefined;
+      const update = params?.update;
+      if (
+        update?.sessionUpdate === "usage_update" &&
+        typeof update.used === "number" &&
+        typeof update.size === "number"
+      ) {
+        const percentage =
+          update.size > 0
+            ? Math.min(100, Math.round((update.used / update.size) * 100))
+            : 0;
+        return {
+          used: update.used,
+          size: update.size,
+          percentage,
+          cost: update.cost ?? null,
+        };
+      }
+    }
+  }
+  return null;
+}

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -59,7 +59,11 @@ import { fetchMcpToolMetadata } from "./mcp/tool-metadata";
 import { canUseTool } from "./permissions/permission-handlers";
 import { getAvailableSlashCommands } from "./session/commands";
 import { parseMcpServers } from "./session/mcp-config";
-import { DEFAULT_MODEL, toSdkModelId } from "./session/models";
+import {
+  DEFAULT_MODEL,
+  getDefaultContextWindow,
+  toSdkModelId,
+} from "./session/models";
 import {
   buildSessionOptions,
   buildSystemPrompt,
@@ -275,6 +279,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     this.session.promptRunning = true;
     let handedOff = false;
     let lastAssistantTotalUsage: number | null = null;
+    // Context window size: use model-aware default, refined by SDK result messages.
+    if (this.session.lastContextWindowSize == null) {
+      this.session.lastContextWindowSize = getDefaultContextWindow(
+        this.session.modelId ?? "",
+      );
+    }
+    let lastContextWindowSize = this.session.lastContextWindowSize;
 
     const supportsTerminalOutput =
       (
@@ -336,8 +347,12 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
             const contextWindows = Object.values(message.modelUsage).map(
               (m) => m.contextWindow,
             );
-            const contextWindowSize =
-              contextWindows.length > 0 ? Math.min(...contextWindows) : 200000;
+            lastContextWindowSize =
+              contextWindows.length > 0
+                ? Math.min(...contextWindows)
+                : getDefaultContextWindow(this.session.modelId ?? "");
+            // Persist SDK-reported value so it survives across prompt() calls
+            this.session.lastContextWindowSize = lastContextWindowSize;
 
             // Send usage_update notification
             if (lastAssistantTotalUsage !== null) {
@@ -346,7 +361,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                 update: {
                   sessionUpdate: "usage_update",
                   used: lastAssistantTotalUsage,
-                  size: contextWindowSize,
+                  size: lastContextWindowSize,
                   cost: {
                     amount: message.total_cost_usd,
                     currency: "USD",
@@ -436,6 +451,17 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                 usage.output_tokens +
                 usage.cache_read_input_tokens +
                 usage.cache_creation_input_tokens;
+
+              // Broadcast live usage update during streaming
+              await this.client.sessionUpdate({
+                sessionId: params.sessionId,
+                update: {
+                  sessionUpdate: "usage_update",
+                  used: lastAssistantTotalUsage,
+                  size: lastContextWindowSize,
+                  cost: null,
+                },
+              });
             }
 
             const result = await handleUserAssistantMessage(message, context);
@@ -509,6 +535,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const sdkModelId = toSdkModelId(params.modelId);
     await this.session.query.setModel(sdkModelId);
     this.session.modelId = params.modelId;
+    // Reset context window to new model's default
+    this.session.lastContextWindowSize = getDefaultContextWindow(
+      params.modelId,
+    );
     await this.updateConfigOption("model", params.modelId);
     return {};
   }
@@ -559,6 +589,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       const sdkModelId = toSdkModelId(params.value);
       await this.session.query.setModel(sdkModelId);
       this.session.modelId = params.value;
+      // Reset context window to new model's default
+      this.session.lastContextWindowSize = getDefaultContextWindow(
+        params.value,
+      );
     } else if (params.configId === "effort") {
       const newEffort = params.value as EffortLevel;
       this.session.effort = newEffort;
@@ -770,6 +804,9 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const modelOptions = await this.getModelConfigOptions();
     const resolvedModelId = settingsModel || modelOptions.currentModelId;
     session.modelId = resolvedModelId;
+
+    // Seed context window size from model-aware default
+    session.lastContextWindowSize = getDefaultContextWindow(resolvedModelId);
 
     if (!isResume) {
       const resolvedSdkModel = toSdkModelId(resolvedModelId);

--- a/packages/agent/src/adapters/claude/session/models.ts
+++ b/packages/agent/src/adapters/claude/session/models.ts
@@ -11,3 +11,16 @@ const GATEWAY_TO_SDK_MODEL: Record<string, string> = {
 export function toSdkModelId(modelId: string): string {
   return GATEWAY_TO_SDK_MODEL[modelId] ?? modelId;
 }
+
+const MODELS_WITH_1M_CONTEXT = new Set([
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+]);
+
+export function supports1MContext(modelId: string): boolean {
+  return MODELS_WITH_1M_CONTEXT.has(modelId);
+}
+
+export function getDefaultContextWindow(modelId: string): number {
+  return supports1MContext(modelId) ? 1_000_000 : 200_000;
+}

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -53,6 +53,8 @@ export type Session = BaseSession & {
   effort?: EffortLevel;
   configOptions: SessionConfigOption[];
   accumulatedUsage: AccumulatedUsage;
+  /** Persists across prompt() calls so SDK-reported values survive turn boundaries */
+  lastContextWindowSize?: number;
   promptRunning: boolean;
   pendingMessages: Map<string, PendingMessage>;
   nextPendingOrder: number;


### PR DESCRIPTION
<img width="1312" height="974" alt="Screenshot 2026-03-15 at 04 29 38" src="https://github.com/user-attachments/assets/ad278005-e262-4231-99ed-f822600465cf" />

  ## Summary

  Adds a live context window usage indicator to the session footer — a
  color-coded ring with compact token count (e.g. `120K/1.0M`) that updates
   during streaming.

  ### How it works

  **Agent-side** — broadcasts `usage_update` via `session/update` at two
  points:

  1. **On SDK result messages** — ground-truth context window from
  `modelUsage.contextWindow`
  2. **During streaming** — live token accumulation so the UI updates in
  real-time

  ```ts
  // Broadcast live usage update during streaming
  await this.client.sessionUpdate({
    sessionId: params.sessionId,
    update: {
      sessionUpdate: "usage_update",
      used: lastAssistantTotalUsage,
      size: lastContextWindowSize,
      cost: null,
    },
  });
  ```

  **Model-aware defaults** replace the previous gateway API fetch.
  `getDefaultContextWindow()` returns 1M for 4.6 models, 200K otherwise —
  the UI shows the correct value immediately without waiting for the first
  SDK response:

  ```ts
  const MODELS_WITH_1M_CONTEXT = new Set(["claude-opus-4-6",
  "claude-sonnet-4-6"]);

  export function getDefaultContextWindow(modelId: string): number {
    return supports1MContext(modelId) ? 1_000_000 : 200_000;
  }
  ```

  **Context window persists** across prompt turns via
  `session.lastContextWindowSize` — SDK-reported values survive turn
  boundaries. Resets to the new model's default when the user switches
  models mid-session.

  **Renderer-side** — `useContextUsage` hook scans events backwards (pure
  `useMemo`, no `useEffect`) and `ContextUsageIndicator` renders a
  color-coded SVG ring: green (<50%), amber (50-74%), orange (75-89%), red
  (90%+).

  ### Changes

  | File | What |
  |------|------|
  | `session/models.ts` | `supports1MContext()`, `getDefaultContextWindow()` |
  | `types.ts` | Add `lastContextWindowSize` to `Session` |
  | `claude-agent.ts` | Broadcast `usage_update` during streaming + on result, seed/persist/reset context window size |
  | `useContextUsage.ts` | New hook — extracts latest usage from events array |
  | `ContextUsageIndicator.tsx` | New component — SVG ring + compact token label |
  | `ConversationView.tsx` | Wire `useContextUsage` → `SessionFooter` |
  | `SessionFooter.tsx` | Render indicator in all footer states |
  | `buildConversationItems.ts` | Handle `usage_update` as no-op (consumed by hook instead) |

  ### Note on PR #1245                                                     
   
  The indicator displays the context window size reported by the           
  SDK/gateway — currently 200K for all models. `getDefaultContextWindow()`
  seeds the initial value before the first SDK response, but the
  ground-truth from `modelUsage.contextWindow` takes over once available.

  When #1245 merges and the gateway starts serving 1M context for
  opus-4.6/sonnet-4.6, the indicator will automatically show `X/1.0M` with
  no changes needed here. `supports1MContext()` and
  `getDefaultContextWindow()` in `models.ts` are identical to #1245 — both
  PRs can merge independently.

  ## Test plan

  - [x] Start session with `claude-opus-4-6` → shows `X/1.0M`(post1245 merge)
  - [x] Start session with 200K model → shows `X/200K`
  - [x] Switch models mid-session → indicator updates immediately
  - [x] Usage ring updates live during streaming
  - [x] Hover tooltip shows exact token count and cost
  - [x] Ring color transitions: green → amber → orange → red as usage
  increases