### PR TITLE
fix: Don't auto-install updates when user quits the app

### DIFF
--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -124,21 +124,6 @@ app.on("before-quit", async (event) => {
 
   event.preventDefault();
 
-  // If an update is downloaded, install it instead of doing a normal shutdown.
-  // installUpdate() handles its own lightweight cleanup and quitAndInstall.
-  try {
-    const updatesService = container.get<UpdatesService>(
-      MAIN_TOKENS.UpdatesService,
-    );
-    if (updatesService.hasUpdateReady) {
-      log.info("Update ready, installing on quit");
-      const { installed } = await updatesService.installUpdate();
-      if (installed) return;
-    }
-  } catch {
-    // Updates service not available, fall through to normal shutdown
-  }
-
   await lifecycleService.gracefulExit();
 });
 


### PR DESCRIPTION
when a pending update was downloaded and the user quit, the `before-quit` handler called `quitAndInstall()`, restarting the app instead of closing it

`squirrel` already stages downloaded updates, so the next manual launch applies the update automatically, no restart needed