### PR TITLE
Add Linear integration service

### DIFF
--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -21,6 +21,7 @@ import { FoldersService } from "../services/folders/service";
 import { FsService } from "../services/fs/service";
 import { GitService } from "../services/git/service";
 import { GitHubIntegrationService } from "../services/github-integration/service";
+import { LinearIntegrationService } from "../services/linear-integration/service";
 import { LlmGatewayService } from "../services/llm-gateway/service";
 import { McpCallbackService } from "../services/mcp-callback/service";
 import { NotificationService } from "../services/notification/service";
@@ -68,6 +69,9 @@ container
   .bind(MAIN_TOKENS.GitHubIntegrationService)
   .to(GitHubIntegrationService);
 container.bind(MAIN_TOKENS.GitService).to(GitService);
+container
+  .bind(MAIN_TOKENS.LinearIntegrationService)
+  .to(LinearIntegrationService);
 container.bind(MAIN_TOKENS.McpCallbackService).to(McpCallbackService);
 container.bind(MAIN_TOKENS.NotificationService).to(NotificationService);
 container.bind(MAIN_TOKENS.OAuthService).to(OAuthService);

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -34,6 +34,7 @@ export const MAIN_TOKENS = Object.freeze({
   FsService: Symbol.for("Main.FsService"),
   GitService: Symbol.for("Main.GitService"),
   GitHubIntegrationService: Symbol.for("Main.GitHubIntegrationService"),
+  LinearIntegrationService: Symbol.for("Main.LinearIntegrationService"),
   DeepLinkService: Symbol.for("Main.DeepLinkService"),
   NotificationService: Symbol.for("Main.NotificationService"),
   McpCallbackService: Symbol.for("Main.McpCallbackService"),

--- a/apps/code/src/main/services/linear-integration/schemas.ts
+++ b/apps/code/src/main/services/linear-integration/schemas.ts
@@ -1,0 +1,8 @@
+export {
+  type CloudRegion,
+  cloudRegion,
+  type StartIntegrationFlowInput as StartLinearFlowInput,
+  type StartIntegrationFlowOutput as StartLinearFlowOutput,
+  startIntegrationFlowInput as startLinearFlowInput,
+  startIntegrationFlowOutput as startLinearFlowOutput,
+} from "../integration-flow-schemas";

--- a/apps/code/src/main/services/linear-integration/service.ts
+++ b/apps/code/src/main/services/linear-integration/service.ts
@@ -1,0 +1,31 @@
+import { getCloudUrlFromRegion } from "@shared/constants/oauth.js";
+import { shell } from "electron";
+import { injectable } from "inversify";
+import { logger } from "../../utils/logger.js";
+import type { CloudRegion, StartLinearFlowOutput } from "./schemas.js";
+
+const log = logger.scope("linear-integration-service");
+
+@injectable()
+export class LinearIntegrationService {
+  public async startFlow(
+    region: CloudRegion,
+    projectId: number,
+  ): Promise<StartLinearFlowOutput> {
+    try {
+      const cloudUrl = getCloudUrlFromRegion(region);
+      const next = `${cloudUrl}/projects/${projectId}`;
+      const authorizeUrl = `${cloudUrl}/api/environments/${projectId}/integrations/authorize/?kind=linear&next=${encodeURIComponent(next)}`;
+
+      log.info("Opening Linear authorization URL in browser");
+      await shell.openExternal(authorizeUrl);
+
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  }
+}

--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -14,6 +14,7 @@ import { foldersRouter } from "./routers/folders";
 import { fsRouter } from "./routers/fs";
 import { gitRouter } from "./routers/git";
 import { githubIntegrationRouter } from "./routers/github-integration";
+import { linearIntegrationRouter } from "./routers/linear-integration.js";
 import { llmGatewayRouter } from "./routers/llm-gateway";
 import { logsRouter } from "./routers/logs";
 import { mcpCallbackRouter } from "./routers/mcp-callback";
@@ -46,6 +47,7 @@ export const trpcRouter = router({
   fs: fsRouter,
   git: gitRouter,
   githubIntegration: githubIntegrationRouter,
+  linearIntegration: linearIntegrationRouter,
   llmGateway: llmGatewayRouter,
   mcpCallback: mcpCallbackRouter,
   notification: notificationRouter,

--- a/apps/code/src/main/trpc/routers/linear-integration.ts
+++ b/apps/code/src/main/trpc/routers/linear-integration.ts
@@ -1,0 +1,20 @@
+import { container } from "../../di/container.js";
+import { MAIN_TOKENS } from "../../di/tokens.js";
+import {
+  startLinearFlowInput,
+  startLinearFlowOutput,
+} from "../../services/linear-integration/schemas.js";
+import type { LinearIntegrationService } from "../../services/linear-integration/service.js";
+import { publicProcedure, router } from "../trpc.js";
+
+const getService = () =>
+  container.get<LinearIntegrationService>(MAIN_TOKENS.LinearIntegrationService);
+
+export const linearIntegrationRouter = router({
+  startFlow: publicProcedure
+    .input(startLinearFlowInput)
+    .output(startLinearFlowOutput)
+    .mutation(({ input }) =>
+      getService().startFlow(input.region, input.projectId),
+    ),
+});


### PR DESCRIPTION
## Problem

We want to support Linear as a signal source, but there's no backend service to kick off the Linear OAuth flow.

## Changes

Add `LinearIntegrationService` with a `startFlow` method that opens the Linear authorize URL in the browser (same pattern as the simplified GitHub service)