### PR TITLE
feat: Introduce MCP Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ npm install -g pnpm
 # Install dependencies for all packages
 pnpm install
 
-# Copy environment config
+# Optional: copy environment config
+# Only needed for code signing (APPLE_*) or PostHog analytics (VITE_POSTHOG_*).
+# The app runs fine in dev without it.
 cp .env.example .env
 
 ```

--- a/apps/code/ARCHITECTURE.md
+++ b/apps/code/ARCHITECTURE.md
@@ -27,6 +27,7 @@ Main Process (Node.js)                      Renderer Process (React)
 ```
 
 **Key points:**
+
 - Both processes use InversifyJS for DI
 - Renderer DI holds services + tRPC client; services can coordinate stores
 - Zustand stores own all application state (not in DI)
@@ -36,16 +37,16 @@ Main Process (Node.js)                      Renderer Process (React)
 
 Both processes use [InversifyJS](https://inversify.io/) for dependency injection with singleton scope.
 
-| Process  | Container          | Holds                                |
-|----------|--------------------|------------------------------------- |
-| Main     | `src/main/di/`     | Stateless services (GitService, etc.)|
-| Renderer | `src/renderer/di/` | Services + TRPCClient                |
+| Process  | Container          | Holds                                 |
+| -------- | ------------------ | ------------------------------------- |
+| Main     | `src/main/di/`     | Stateless services (GitService, etc.) |
+| Renderer | `src/renderer/di/` | Services + TRPCClient                 |
 
 ### Defining a Service
 
 ```typescript
 // src/main/services/my-service/service.ts (or src/renderer/services/)
-import { injectable } from "inversify";
+import { injectable } from "inversify"
 
 @injectable()
 export class MyService {
@@ -59,14 +60,14 @@ export class MyService {
 
 ```typescript
 // src/main/di/container.ts (or src/renderer/di/container.ts)
-container.bind<MyService>(TOKENS.MyService).to(MyService);
+container.bind<MyService>(TOKENS.MyService).to(MyService)
 ```
 
 ```typescript
 // src/main/di/tokens.ts (or src/renderer/di/tokens.ts)
 export const MAIN_TOKENS = Object.freeze({
   MyService: Symbol.for("Main.MyService"),
-});
+})
 ```
 
 ### Injecting Dependencies
@@ -74,8 +75,8 @@ export const MAIN_TOKENS = Object.freeze({
 Services should declare dependencies via constructor injection:
 
 ```typescript
-import { inject, injectable } from "inversify";
-import { MAIN_TOKENS } from "../di/tokens";
+import { inject, injectable } from "inversify"
+import { MAIN_TOKENS } from "../di/tokens"
 
 @injectable()
 export class MyService {
@@ -85,7 +86,7 @@ export class MyService {
   ) {}
 
   doSomething() {
-    return this.otherService.getData();
+    return this.otherService.getData()
   }
 }
 ```
@@ -95,14 +96,14 @@ export class MyService {
 tRPC routers resolve services from the container:
 
 ```typescript
-import { container } from "../../di/container";
-import { MAIN_TOKENS } from "../../di/tokens";
+import { container } from "../../di/container"
+import { MAIN_TOKENS } from "../../di/tokens"
 
-const getService = () => container.get<MyService>(MAIN_TOKENS.MyService);
+const getService = () => container.get<MyService>(MAIN_TOKENS.MyService)
 
 export const myRouter = router({
   getData: publicProcedure.query(() => getService().getData()),
-});
+})
 ```
 
 ### Testing with Mocks
@@ -111,14 +112,14 @@ Constructor injection makes testing straightforward:
 
 ```typescript
 // Direct instantiation with mock
-const mockOtherService = { getData: vi.fn().mockReturnValue("test") };
-const service = new MyService(mockOtherService as OtherService);
+const mockOtherService = { getData: vi.fn().mockReturnValue("test") }
+const service = new MyService(mockOtherService as OtherService)
 
 // Or rebind in container for integration tests
-container.snapshot();
-container.rebind(MAIN_TOKENS.OtherService).toConstantValue(mockOtherService);
+container.snapshot()
+container.rebind(MAIN_TOKENS.OtherService).toConstantValue(mockOtherService)
 // ... run tests ...
-container.restore();
+container.restore()
 ```
 
 ## IPC via tRPC
@@ -129,16 +130,16 @@ We use [tRPC](https://trpc.io/) with [trpc-electron](https://github.com/jsonnull
 
 ```typescript
 // src/main/trpc/routers/my-router.ts
-import { container } from "../../di/container";
-import { MAIN_TOKENS } from "../../di/tokens";
+import { container } from "../../di/container"
+import { MAIN_TOKENS } from "../../di/tokens"
 import {
   getDataInput,
   getDataOutput,
   updateDataInput,
-} from "../../services/my-service/schemas";
-import { router, publicProcedure } from "../trpc";
+} from "../../services/my-service/schemas"
+import { router, publicProcedure } from "../trpc"
 
-const getService = () => container.get<MyService>(MAIN_TOKENS.MyService);
+const getService = () => container.get<MyService>(MAIN_TOKENS.MyService)
 
 export const myRouter = router({
   getData: publicProcedure
@@ -149,111 +150,113 @@ export const myRouter = router({
   updateData: publicProcedure
     .input(updateDataInput)
     .mutation(({ input }) => getService().updateData(input.id, input.value)),
-});
+})
 ```
 
 ### Registering the Router
 
 ```typescript
 // src/main/trpc/router.ts
-import { myRouter } from "./routers/my-router";
+import { myRouter } from "./routers/my-router"
 
 export const trpcRouter = router({
   my: myRouter,
   // ...
-});
+})
 ```
 
 ### Using tRPC in Renderer
 
 There are three tRPC exports, each for a different context:
 
-| Export | Where to use | Purpose |
-|--------|-------------|---------|
-| `useTRPC()` | React components/hooks | Options proxy via React context |
-| `trpc` | Outside React (module scope, services, stores) | Options proxy bound to the singleton `queryClient` |
-| `trpcClient` | Anywhere (imperative calls) | Vanilla tRPC client for direct `.query()` / `.mutate()` / `.subscribe()` |
+| Export       | Where to use                                   | Purpose                                                                  |
+| ------------ | ---------------------------------------------- | ------------------------------------------------------------------------ |
+| `useTRPC()`  | React components/hooks                         | Options proxy via React context                                          |
+| `trpc`       | Outside React (module scope, services, stores) | Options proxy bound to the singleton `queryClient`                       |
+| `trpcClient` | Anywhere (imperative calls)                    | Vanilla tRPC client for direct `.query()` / `.mutate()` / `.subscribe()` |
 
 **React components** use `useTRPC()` + TanStack Query hooks:
 
 ```typescript
-import { useTRPC } from "@renderer/trpc/client";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useTRPC } from "@renderer/trpc/client"
+import { useMutation, useQuery } from "@tanstack/react-query"
 
 function MyComponent() {
-  const trpc = useTRPC();
+  const trpc = useTRPC()
 
   // Queries — pass queryOptions() to useQuery
-  const { data } = useQuery(
-    trpc.my.getData.queryOptions({ id: "123" }),
-  );
+  const { data } = useQuery(trpc.my.getData.queryOptions({ id: "123" }))
 
   // Mutations — pass mutationOptions() to useMutation
   const mutation = useMutation(
     trpc.my.updateData.mutationOptions({
-      onSuccess: () => { /* ... */ },
+      onSuccess: () => {
+        /* ... */
+      },
     }),
-  );
-  const handleUpdate = () => mutation.mutate({ id: "123", value: "new" });
+  )
+  const handleUpdate = () => mutation.mutate({ id: "123", value: "new" })
 }
 ```
 
 **Subscriptions** use `useSubscription` from `@trpc/tanstack-react-query`:
 
 ```typescript
-import { useSubscription } from "@trpc/tanstack-react-query";
+import { useSubscription } from "@trpc/tanstack-react-query"
 
 useSubscription(
   trpc.my.onItemCreated.subscriptionOptions(undefined, {
-    onData: (item) => { /* ... */ },
+    onData: (item) => {
+      /* ... */
+    },
   }),
-);
+)
 ```
 
 **Cache invalidation** uses `pathFilter()` or `queryFilter()` with the query client:
 
 ```typescript
-const queryClient = useQueryClient();
+const queryClient = useQueryClient()
 
 // Invalidate all queries under a router path
-queryClient.invalidateQueries(trpc.workspace.getAll.pathFilter());
+queryClient.invalidateQueries(trpc.workspace.getAll.pathFilter())
 
 // Invalidate a specific query by input
 queryClient.invalidateQueries(
   trpc.git.getCurrentBranch.queryFilter({ directoryPath: repoPath }),
-);
+)
 
 // Set cache data directly
 queryClient.setQueryData(
   trpc.git.getLatestCommit.queryKey({ directoryPath: repoPath }),
   commitData,
-);
+)
 ```
 
 **Outside React** (stores, sagas, services, module-scope utilities):
 
 ```typescript
 // Imperative calls — use trpcClient
-import { trpcClient } from "@renderer/trpc/client";
+import { trpcClient } from "@renderer/trpc/client"
 
-const data = await trpcClient.my.getData.query({ id: "123" });
-await trpcClient.my.updateData.mutate({ id: "123", value: "new" });
+const data = await trpcClient.my.getData.query({ id: "123" })
+await trpcClient.my.updateData.mutate({ id: "123", value: "new" })
 
 // Cache operations outside React — use trpc (the module-level options proxy)
-import { trpc } from "@renderer/trpc";
-import { queryClient } from "@utils/queryClient";
+import { trpc } from "@renderer/trpc"
+import { queryClient } from "@utils/queryClient"
 
-queryClient.invalidateQueries(trpc.workspace.getAll.pathFilter());
+queryClient.invalidateQueries(trpc.workspace.getAll.pathFilter())
 ```
 
 ## State Management
 
 **All application state lives in the renderer.** Main process services should be stateless/pure.
 
-| Layer | State | Role |
-|-------|-------|------|
-| **Renderer** | Zustand stores | Owns all application state |
-| **Main** | Stateless | Pure operations (file I/O, git, shell, etc.) |
+| Layer        | State          | Role                                         |
+| ------------ | -------------- | -------------------------------------------- |
+| **Renderer** | Zustand stores | Owns all application state                   |
+| **Main**     | Stateless      | Pure operations (file I/O, git, shell, etc.) |
 
 This keeps state predictable, easy to debug, and naturally supports patterns like undo/rollback.
 
@@ -263,14 +266,18 @@ This keeps state predictable, easy to debug, and naturally supports patterns lik
 // ❌ Bad - main service with state
 @injectable()
 class TaskService {
-  private currentTask: Task | null = null;  // Don't do this
+  private currentTask: Task | null = null // Don't do this
 }
 
 // ✅ Good - main service is pure
 @injectable()
 class TaskService {
-  async readTask(id: string): Promise<Task> { /* ... */ }
-  async writeTask(task: Task): Promise<void> { /* ... */ }
+  async readTask(id: string): Promise<Task> {
+    /* ... */
+  }
+  async writeTask(task: Task): Promise<void> {
+    /* ... */
+  }
 }
 
 // ✅ Good - state lives in renderer
@@ -278,7 +285,7 @@ class TaskService {
 const useTaskStore = create<TaskState>((set) => ({
   currentTask: null,
   setCurrentTask: (task) => set({ currentTask: task }),
-}));
+}))
 ```
 
 ### Learned Hints
@@ -287,16 +294,16 @@ The settings store (`src/renderer/features/settings/stores/settingsStore.ts`) pr
 
 ```typescript
 // In the store: hints is Record<string, { count: number; learned: boolean }>
-const store = useFeatureSettingsStore.getState();
+const store = useFeatureSettingsStore.getState()
 
 // Check if a hint should still be shown (max N times, not yet learned)
 if (store.shouldShowHint("my-hint-key", 3)) {
-  store.recordHintShown("my-hint-key");
-  toast.info("Did you know?", "You can do X with Y.");
+  store.recordHintShown("my-hint-key")
+  toast.info("Did you know?", "You can do X with Y.")
 }
 
 // When the user demonstrates the behavior, mark it learned (stops showing)
-store.markHintLearned("my-hint-key");
+store.markHintLearned("my-hint-key")
 ```
 
 Hint state is persisted via `electronStorage`. Use this pattern instead of ad-hoc boolean flags when introducing new discoverable features.
@@ -333,37 +340,37 @@ All tRPC inputs and outputs use Zod schemas as the single source of truth. Types
 
 ```typescript
 // src/main/services/my-service/schemas.ts
-import { z } from "zod";
+import { z } from "zod"
 
 export const getDataInput = z.object({
   id: z.string(),
-});
+})
 
 export const getDataOutput = z.object({
   id: z.string(),
   name: z.string(),
   createdAt: z.string(),
-});
+})
 
-export type GetDataInput = z.infer<typeof getDataInput>;
-export type GetDataOutput = z.infer<typeof getDataOutput>;
+export type GetDataInput = z.infer<typeof getDataInput>
+export type GetDataOutput = z.infer<typeof getDataOutput>
 ```
 
 ```typescript
 // src/main/trpc/routers/my-router.ts
-import { getDataInput, getDataOutput } from "../../services/my-service/schemas";
+import { getDataInput, getDataOutput } from "../../services/my-service/schemas"
 
 export const myRouter = router({
   getData: publicProcedure
     .input(getDataInput)
     .output(getDataOutput)
     .query(({ input }) => getService().getData(input.id)),
-});
+})
 ```
 
 ```typescript
 // src/main/services/my-service/service.ts
-import type { GetDataInput, GetDataOutput } from "./schemas";
+import type { GetDataInput, GetDataOutput } from "./schemas"
 
 @injectable()
 export class MyService {
@@ -374,6 +381,7 @@ export class MyService {
 ```
 
 This pattern provides:
+
 - Runtime validation of inputs and outputs
 - Single source of truth for types
 - Explicit API contracts between main and renderer
@@ -400,11 +408,11 @@ Use a const object for event names and an interface for payloads:
 export const MyServiceEvent = {
   ItemCreated: "item-created",
   ItemDeleted: "item-deleted",
-} as const;
+} as const
 
 export interface MyServiceEvents {
-  [MyServiceEvent.ItemCreated]: { id: string; name: string };
-  [MyServiceEvent.ItemDeleted]: { id: string };
+  [MyServiceEvent.ItemCreated]: { id: string; name: string }
+  [MyServiceEvent.ItemDeleted]: { id: string }
 }
 ```
 
@@ -412,16 +420,16 @@ export interface MyServiceEvents {
 
 ```typescript
 // src/main/services/my-service/service.ts
-import { TypedEventEmitter } from "../../lib/typed-event-emitter";
-import { MyServiceEvent, type MyServiceEvents } from "./schemas";
+import { TypedEventEmitter } from "../../lib/typed-event-emitter"
+import { MyServiceEvent, type MyServiceEvents } from "./schemas"
 
 @injectable()
 export class MyService extends TypedEventEmitter<MyServiceEvents> {
   async createItem(name: string) {
-    const item = { id: "123", name };
+    const item = { id: "123", name }
     // TypeScript enforces correct event name and payload shape
-    this.emit(MyServiceEvent.ItemCreated, item);
-    return item;
+    this.emit(MyServiceEvent.ItemCreated, item)
+    return item
   }
 }
 ```
@@ -432,23 +440,26 @@ Use `toIterable()` on the service to convert events to an async iterable. For gl
 
 ```typescript
 // src/main/trpc/routers/my-router.ts
-import { MyServiceEvent, type MyServiceEvents } from "../../services/my-service/schemas";
+import {
+  MyServiceEvent,
+  type MyServiceEvents,
+} from "../../services/my-service/schemas"
 
 function subscribe<K extends keyof MyServiceEvents>(event: K) {
   return publicProcedure.subscription(async function* (opts) {
-    const service = getService();
-    const iterable = service.toIterable(event, { signal: opts.signal });
+    const service = getService()
+    const iterable = service.toIterable(event, { signal: opts.signal })
     for await (const data of iterable) {
-      yield data;
+      yield data
     }
-  });
+  })
 }
 
 export const myRouter = router({
   // ... queries and mutations
   onItemCreated: subscribe(MyServiceEvent.ItemCreated),
   onItemDeleted: subscribe(MyServiceEvent.ItemDeleted),
-});
+})
 ```
 
 For per-instance events (e.g., shell sessions), filter by an identifier:
@@ -456,8 +467,8 @@ For per-instance events (e.g., shell sessions), filter by an identifier:
 ```typescript
 // Events include an identifier to filter on
 export interface ShellEvents {
-  [ShellEvent.Data]: { sessionId: string; data: string };
-  [ShellEvent.Exit]: { sessionId: string; exitCode: number };
+  [ShellEvent.Data]: { sessionId: string; data: string }
+  [ShellEvent.Exit]: { sessionId: string; exitCode: number }
 }
 
 // Router filters events to the specific session
@@ -465,30 +476,30 @@ function subscribeFiltered<K extends keyof ShellEvents>(event: K) {
   return publicProcedure
     .input(sessionIdInput)
     .subscription(async function* (opts) {
-      const service = getService();
-      const targetSessionId = opts.input.sessionId;
-      const iterable = service.toIterable(event, { signal: opts.signal });
+      const service = getService()
+      const targetSessionId = opts.input.sessionId
+      const iterable = service.toIterable(event, { signal: opts.signal })
 
       for await (const data of iterable) {
         if (data.sessionId === targetSessionId) {
-          yield data;
+          yield data
         }
       }
-    });
+    })
 }
 
 export const shellRouter = router({
   onData: subscribeFiltered(ShellEvent.Data),
   onExit: subscribeFiltered(ShellEvent.Exit),
-});
+})
 ```
 
 ### 4. Subscribe in Renderer
 
 ```typescript
-import { useSubscription } from "@trpc/tanstack-react-query";
+import { useSubscription } from "@trpc/tanstack-react-query"
 
-const trpc = useTRPC();
+const trpc = useTRPC()
 
 // React component - global events
 useSubscription(
@@ -498,7 +509,7 @@ useSubscription(
       // item is typed as { id: string; name: string }
     },
   }),
-);
+)
 
 // React component - per-session events
 useSubscription(
@@ -508,18 +519,95 @@ useSubscription(
       enabled: !!sessionId,
       onData: (event) => {
         // event is typed as { sessionId: string; data: string }
-        terminal.write(event.data);
+        terminal.write(event.data)
       },
     },
   ),
-);
+)
 ```
+
+## MCP Apps
+
+MCP Apps let MCP servers ship interactive HTML UIs alongside their tools. When a tool has an associated `ui://` resource, we render the app's HTML inside a sandboxed iframe instead of showing the raw tool input/output.
+
+### How It Works
+
+```
+Agent Session                      Main Process                    Renderer
+┌──────────────┐                  ┌─────────────────────┐          ┌───────────────────────────┐
+│ Tool call    │─-session/update─►│ AgentService        │          │ McpToolBlock              │
+│ (mcp__X__Y)  │                  │  ├─notifyToolInput  │──event──►│  ├─ hasUiForTool?         │
+│              │                  │  └─notifyToolResult │──event──►│  ├─ McpAppHost            │
+└──────────────┘                  ├─────────────────────┤          │  │  ├─ iframe (sandbox).  │
+                                  │ McpAppsService      │          │  │  └─ useAppBridge       │
+                                  │  ├─ connections     │◄─proxy───│  └─ McpToolView (fallback)│
+                                  │  ├─ resourceCache   │          └───────────────────────────┘
+                                  │  └─ toolAssociations│
+                                  └─────────────────────┘
+```
+
+On session start, `AgentService` passes the active MCP server configs to `McpAppsService`, which connects to each server over Streamable HTTP and discovers UI resources. It lists the server's resources looking for `ui://` URIs with mime type `text/html;profile=mcp-app`, then maps each resource to its associated tool via the tool's `_meta.ui.resourceUri` field. The HTML content is fetched and cached in memory (capped at 5MB per resource).
+
+### Shared Types
+
+Schemas and event types for MCP Apps live in `src/shared/types/mcp-apps.ts` rather than in the service directory, since both processes need them. This file defines the Zod schemas for tRPC input/output, the `McpUiResource` interface, tool-to-UI association types, and the `McpAppsServiceEvent` constants.
+
+### Main Process
+
+`McpAppsService` (`src/main/services/mcp-apps/service.ts`) manages MCP server connections and acts as a proxy between the renderer and remote MCP servers. It extends `TypedEventEmitter` to push tool input/result/cancellation events to the renderer via tRPC subscriptions.
+
+`AgentService` hooks into the ACP `sessionUpdate` callback to intercept tool call updates for MCP tools (those prefixed with `mcp__`). It forwards tool inputs and results to `McpAppsService`, which re-emits them as typed events.
+
+The tRPC router (`src/main/trpc/routers/mcp-apps.ts`) exposes:
+
+- `getUiResource` / `hasUiForTool` — queries for UI resource lookup
+- `proxyToolCall` / `proxyResourceRead` — mutations that forward calls to the remote MCP server, with visibility checks (tools marked as model-only are rejected)
+- `openLink` — opens URLs via `shell.openExternal`, restricted to http/https
+- `onToolInput` / `onToolResult` / `onToolCancelled` — per-tool filtered subscriptions
+
+### Renderer
+
+The renderer feature lives in `src/renderer/features/mcp-apps/`:
+
+```
+mcp-apps/
+├── components/
+│   ├── McpToolBlock.tsx         # McpToolView + optional McpAppHost below
+│   ├── McpAppHost.tsx           # Iframe host with inline/fullscreen display modes
+│   └── McpToolView.tsx          # Standard MCP tool call rendering (moved from sessions/)
+├── hooks/
+│   └── useAppBridge.ts          # AppBridge lifecycle, message routing, context sync
+└── utils/
+    ├── mcp-app-csp.ts           # CSP generation from server-declared domains
+    ├── mcp-app-sandbox-proxy.ts # Generates the outer sandbox iframe HTML
+    ├── mcp-app-host-utils.ts    # Tool key parsing, container dimension helpers
+    └── mcp-app-theme.ts         # Maps Radix theme tokens to MCP App CSS variables
+```
+
+`McpToolBlock` is the entry point, rendered from `ToolCallBlock` for any `mcp__` tool. It always renders `McpToolView` (the pre-existing MCP tool call display, moved here from `sessions/`). When the tool has a UI resource and the server isn't disabled in settings, it additionally renders `McpAppHost` below the tool view. This keeps the standard tool call display (input preview, status, expandable output) visible regardless of whether an app is present.
+
+### Sandbox Model
+
+Apps run inside a double-iframe sandbox. The outer iframe loads a generated proxy page (`mcp-app-sandbox-proxy.ts`) with `sandbox="allow-scripts allow-same-origin ..."`. The proxy receives the app's HTML from the host via postMessage and injects it into an inner iframe with a server-declared CSP meta tag. This isolates the app's DOM from the host while still allowing structured communication over the bridge.
+
+### App Bridge
+
+`useAppBridge` manages the host side of the `@modelcontextprotocol/ext-apps` `AppBridge`. It handles the full lifecycle: waiting for the sandbox proxy to signal readiness, creating the bridge with a `PostMessageTransport`, sending the HTML resource into the inner iframe, and tearing down on unmount.
+
+The bridge routes app requests to tRPC mutations in the main process — tool calls, resource reads, and link opens all proxy through `McpAppsService`. It also forwards host context changes (theme, display mode, container dimensions) to the app when those values change, and handles app-initiated actions like display mode requests and messages that get routed to the draft store.
+
+`sendWhenReady` buffers bridge calls until the app has finished its initialization handshake, then flushes them. This lets the component forward tool results from tRPC subscriptions without worrying about race conditions with app startup.
+
+### Disabling MCP Apps
+
+Users can disable MCP Apps per server via `settingsStore.mcpAppsDisabledServers`. When a server is disabled, `McpAppsService` skips connecting to it and the renderer falls back to `McpToolView`.
 
 ## Code Style
 
 See [CLAUDE.md](./CLAUDE.md) for linting, formatting, and import conventions.
 
 Key points:
+
 - Use path aliases (`@main/*`, `@renderer/*`, etc.)
 - No barrel files - import directly from source
 - Use `logger` instead of `console.*`

--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -119,6 +119,8 @@
     "@opentelemetry/resources": "^2.5.0",
     "@opentelemetry/sdk-logs": "^0.208.0",
     "@opentelemetry/semantic-conventions": "^1.39.0",
+    "@modelcontextprotocol/ext-apps": "^1.1.2",
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "@parcel/watcher": "^2.5.1",
     "@phosphor-icons/react": "^2.1.10",
     "@posthog/agent": "workspace:*",

--- a/apps/code/src/main/bootstrap.ts
+++ b/apps/code/src/main/bootstrap.ts
@@ -9,7 +9,7 @@
 
 import dns from "node:dns";
 import path from "node:path";
-import { app } from "electron";
+import { app, protocol } from "electron";
 import { fixPath } from "./utils/fixPath";
 
 const isDev = !app.isPackaged;
@@ -29,6 +29,21 @@ dns.setDefaultResultOrder("ipv4first");
 
 // Call fixPath early to ensure PATH is correct for any child processes
 fixPath();
+
+// Register mcp-sandbox: protocol scheme for MCP Apps iframe isolation.
+// Must be called before app.ready — gives the sandbox proxy its own origin
+// so MCP Apps can't access the renderer's DOM, storage, or cookies.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: "mcp-sandbox",
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: false,
+    },
+  },
+]);
 
 // Now dynamically import the rest of the application
 // Dynamic import ensures the path is set BEFORE index.js is evaluated

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -1,8 +1,9 @@
 import "reflect-metadata";
+
 import { Container } from "inversify";
 import { ArchiveRepository } from "../db/repositories/archive-repository";
 import { RepositoryRepository } from "../db/repositories/repository-repository";
-import { SuspensionRepositoryImpl } from "../db/repositories/suspension-repository.js";
+import { SuspensionRepositoryImpl } from "../db/repositories/suspension-repository";
 import { WorkspaceRepository } from "../db/repositories/workspace-repository";
 import { WorktreeRepository } from "../db/repositories/worktree-repository";
 import { DatabaseService } from "../db/service";
@@ -25,6 +26,7 @@ import { GitService } from "../services/git/service";
 import { GitHubIntegrationService } from "../services/github-integration/service";
 import { LinearIntegrationService } from "../services/linear-integration/service";
 import { LlmGatewayService } from "../services/llm-gateway/service";
+import { McpAppsService } from "../services/mcp-apps/service";
 import { McpCallbackService } from "../services/mcp-callback/service";
 import { NotificationService } from "../services/notification/service";
 import { OAuthService } from "../services/oauth/service";
@@ -34,7 +36,7 @@ import { ProvisioningService } from "../services/provisioning/service";
 import { settingsStore } from "../services/settingsStore";
 import { ShellService } from "../services/shell/service";
 import { SleepService } from "../services/sleep/service";
-import { SuspensionService } from "../services/suspension/service.js";
+import { SuspensionService } from "../services/suspension/service";
 import { TaskLinkService } from "../services/task-link/service";
 import { UIService } from "../services/ui/service";
 import { UpdatesService } from "../services/updates/service";
@@ -66,6 +68,7 @@ container.bind(MAIN_TOKENS.ProvisioningService).to(ProvisioningService);
 
 container.bind(MAIN_TOKENS.ExternalAppsService).to(ExternalAppsService);
 container.bind(MAIN_TOKENS.LlmGatewayService).to(LlmGatewayService);
+container.bind(MAIN_TOKENS.McpAppsService).to(McpAppsService);
 container.bind(MAIN_TOKENS.FileWatcherService).to(FileWatcherService);
 container.bind(MAIN_TOKENS.FocusService).to(FocusService);
 container.bind(MAIN_TOKENS.FocusSyncService).to(FocusSyncService);

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -28,6 +28,7 @@ export const MAIN_TOKENS = Object.freeze({
 
   ExternalAppsService: Symbol.for("Main.ExternalAppsService"),
   LlmGatewayService: Symbol.for("Main.LlmGatewayService"),
+  McpAppsService: Symbol.for("Main.McpAppsService"),
   FileWatcherService: Symbol.for("Main.FileWatcherService"),
   FocusService: Symbol.for("Main.FocusService"),
   FocusSyncService: Symbol.for("Main.FocusSyncService"),

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -9,6 +9,7 @@ import type { DatabaseService } from "./db/service";
 import { initializeDeepLinks, registerDeepLinkHandlers } from "./deep-links";
 import { container } from "./di/container";
 import { MAIN_TOKENS } from "./di/tokens";
+import { registerMcpSandboxProtocol } from "./protocols/mcp-sandbox";
 import type { AppLifecycleService } from "./services/app-lifecycle/service";
 import type { ExternalAppsService } from "./services/external-apps/service";
 import type { NotificationService } from "./services/notification/service";
@@ -19,7 +20,7 @@ import {
   trackAppEvent,
 } from "./services/posthog-analytics";
 import type { PosthogPluginService } from "./services/posthog-plugin/service";
-import type { SuspensionService } from "./services/suspension/service.js";
+import type { SuspensionService } from "./services/suspension/service";
 import type { TaskLinkService } from "./services/task-link/service";
 import type { UpdatesService } from "./services/updates/service";
 import type { WorkspaceService } from "./services/workspace/service";
@@ -84,6 +85,7 @@ app.whenReady().then(() => {
     ].join(" | "),
   );
   ensureClaudeConfigDir();
+  registerMcpSandboxProtocol();
   createWindow();
   initializeServices();
   initializeDeepLinks();

--- a/apps/code/src/main/menu.ts
+++ b/apps/code/src/main/menu.ts
@@ -10,6 +10,7 @@ import {
 } from "electron";
 import { container } from "./di/container";
 import { MAIN_TOKENS } from "./di/tokens";
+import type { McpAppsService } from "./services/mcp-apps/service";
 import type { UIService } from "./services/ui/service";
 import type { UpdatesService } from "./services/updates/service";
 import { isDevBuild } from "./utils/env";
@@ -127,6 +128,29 @@ function buildFileMenu(): MenuItemConstructorOptions {
             label: "Invalidate OAuth token",
             click: () => {
               container.get<UIService>(MAIN_TOKENS.UIService).invalidateToken();
+            },
+          },
+          {
+            label: "Refresh MCP Apps discovery",
+            click: () => {
+              container
+                .get<McpAppsService>(MAIN_TOKENS.McpAppsService)
+                .refreshDiscovery()
+                .then(() => {
+                  dialog.showMessageBox({
+                    type: "info",
+                    title: "MCP Apps Refreshed",
+                    message:
+                      "Cleared all cached resources and re-ran discovery.\nCheck logs for details.",
+                  });
+                })
+                .catch((err: Error) => {
+                  dialog.showMessageBox({
+                    type: "error",
+                    title: "MCP Apps Refresh Failed",
+                    message: err.message,
+                  });
+                });
             },
           },
           { type: "separator" },

--- a/apps/code/src/main/protocols/mcp-sandbox.ts
+++ b/apps/code/src/main/protocols/mcp-sandbox.ts
@@ -1,0 +1,42 @@
+/**
+ * MCP Sandbox protocol handler.
+ *
+ * Serves the sandbox proxy HTML on `mcp-sandbox://proxy`, giving it an
+ * isolated origin separate from the Electron renderer. This prevents
+ * MCP Apps (running in the inner iframe) from accessing the host's DOM,
+ * storage, or cookies via `window.parent.parent`.
+ *
+ * The scheme must be registered with `protocol.registerSchemesAsPrivileged`
+ * BEFORE `app.ready` (done in bootstrap.ts). This handler is registered
+ * AFTER `app.ready`.
+ */
+
+import { sandboxProxyHtml } from "@shared/mcp-sandbox-proxy";
+import { session } from "electron";
+
+import { logger } from "../utils/logger";
+
+const log = logger.scope("mcp-sandbox protocol");
+
+/**
+ * Register the mcp-sandbox: protocol handler on the "persist:main" session
+ * (which the BrowserWindow uses). Must be called after app.ready.
+ *
+ * Note: `protocol.registerSchemesAsPrivileged()` is global and must be
+ * called before app.ready — that's done separately in bootstrap.ts.
+ */
+export function registerMcpSandboxProtocol(): void {
+  const mainSession = session.fromPartition("persist:main");
+
+  log.info("Registering protocol handler on persist:main", {
+    htmlLength: sandboxProxyHtml.length,
+  });
+
+  mainSession.protocol.handle("mcp-sandbox", (request) => {
+    log.debug("Serving proxy HTML", { url: request.url });
+
+    return new Response(sandboxProxyHtml, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  });
+}

--- a/apps/code/src/main/services/agent/service.test.ts
+++ b/apps/code/src/main/services/agent/service.test.ts
@@ -192,6 +192,14 @@ describe("AgentService", () => {
       deps.fsService as never,
       deps.posthogPluginService as never,
       deps.authProxy as never,
+      {
+        setServerConfigs: vi.fn(),
+        handleDiscovery: vi.fn().mockResolvedValue(undefined),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+        notifyToolInput: vi.fn(),
+        notifyToolResult: vi.fn(),
+        notifyToolCancelled: vi.fn(),
+      } as never,
     );
   });
 
@@ -358,7 +366,10 @@ describe("AgentService", () => {
 
       vi.advanceTimersByTime(5 * 60 * 1000);
       service.recordActivity("run-1");
-      const secondDeadline = getIdleTimeouts(service).get("run-1")?.deadline;
+      const secondDeadline = getIdleTimeouts(service).get("run-1")
+        ?.deadline as number;
+      if (secondDeadline === undefined)
+        throw new Error("Expected secondDeadline to be defined");
 
       expect(secondDeadline).toBeGreaterThan(firstDeadline);
     });

--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -10,6 +10,7 @@ import {
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionConfigOption,
+  type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { isMcpToolReadOnly } from "@posthog/agent";
 import { hydrateSessionJsonl } from "@posthog/agent/adapters/claude/session/jsonl-hydration";
@@ -31,6 +32,7 @@ import { logger } from "../../utils/logger";
 import { TypedEventEmitter } from "../../utils/typed-event-emitter";
 import type { AuthProxyService } from "../auth-proxy/service";
 import type { FsService } from "../fs/service";
+import type { McpAppsService } from "../mcp-apps/service";
 import type { PosthogPluginService } from "../posthog-plugin/service";
 import type { ProcessTrackingService } from "../process-tracking/service";
 import type { SleepService } from "../sleep/service";
@@ -60,6 +62,11 @@ function getMockNodeDir(): string {
 
 /** Mark all content blocks as hidden so the renderer doesn't show a duplicate user message on retry */
 type MessageCallback = (message: unknown) => void;
+
+/** Shape of the `_meta.claudeCode` extension field on tool call updates. */
+interface ClaudeCodeToolMeta {
+  claudeCode?: { toolName?: string };
+}
 
 class NdJsonTap {
   private decoder = new TextDecoder();
@@ -205,6 +212,8 @@ interface ManagedSession {
   promptPending: boolean;
   pendingContext?: string;
   configOptions?: SessionConfigOption[];
+  /** Tracks in-flight MCP tool calls (toolCallId → toolKey) for cancellation */
+  inFlightMcpToolCalls: Map<string, string>;
 }
 
 /** Get the agent session ID from a managed session, throwing if not set. */
@@ -254,6 +263,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
   private fsService: FsService;
   private posthogPluginService: PosthogPluginService;
   private authProxy: AuthProxyService;
+  private mcpAppsService: McpAppsService;
 
   constructor(
     @inject(MAIN_TOKENS.ProcessTrackingService)
@@ -266,6 +276,8 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     posthogPluginService: PosthogPluginService,
     @inject(MAIN_TOKENS.AuthProxyService)
     authProxy: AuthProxyService,
+    @inject(MAIN_TOKENS.McpAppsService)
+    mcpAppsService: McpAppsService,
   ) {
     super();
     this.processTracking = processTracking;
@@ -273,6 +285,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     this.fsService = fsService;
     this.posthogPluginService = posthogPluginService;
     this.authProxy = authProxy;
+    this.mcpAppsService = mcpAppsService;
 
     powerMonitor.on("resume", () => this.checkIdleDeadlines());
   }
@@ -675,6 +688,13 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
           onProcessExited: (pid) => {
             this.processTracking.unregister(pid, "agent-exited");
           },
+          onMcpServersReady: (serverNames) => {
+            this.mcpAppsService.handleDiscovery(serverNames).catch((err) => {
+              log.warn("MCP Apps discovery failed", {
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+          },
         },
       });
       const { clientStreams } = acpConnection;
@@ -697,6 +717,16 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       });
 
       const mcpServers = await this.buildMcpServers(credentials);
+
+      // Store server configs for lazy MCP connections — actual connections
+      // are created on-demand when UI resources are first requested.
+      this.mcpAppsService.setServerConfigs(
+        mcpServers.map((s) => ({
+          name: s.name,
+          url: s.url,
+          headers: Object.fromEntries(s.headers.map((h) => [h.name, h.value])),
+        })),
+      );
 
       let externalPlugins: Awaited<ReturnType<typeof discoverExternalPlugins>> =
         [];
@@ -820,10 +850,12 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
         config,
         promptPending: false,
         configOptions,
+        inFlightMcpToolCalls: new Map(),
       };
 
       this.sessions.set(taskRunId, session);
       this.recordActivity(taskRunId);
+
       if (isRetry) {
         log.info("Session created after auth retry", { taskRunId });
       }
@@ -949,6 +981,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     if (!session) return false;
 
     try {
+      this.cancelInFlightMcpToolCalls(session);
       await session.clientSideConnection.cancel({
         sessionId: getAgentSessionId(session),
         _meta: reason ? { interruptReason: reason } : undefined,
@@ -1187,9 +1220,18 @@ For git operations while detached:
     return mockNodeDir;
   }
 
+  private cancelInFlightMcpToolCalls(session: ManagedSession): void {
+    for (const [toolCallId, toolKey] of session.inFlightMcpToolCalls) {
+      this.mcpAppsService.notifyToolCancelled(toolKey, toolCallId);
+    }
+
+    session.inFlightMcpToolCalls.clear();
+  }
+
   private async cleanupSession(taskRunId: string): Promise<void> {
     const session = this.sessions.get(taskRunId);
     if (session) {
+      this.cancelInFlightMcpToolCalls(session);
       this.sleepService.release(taskRunId);
       try {
         await session.agent.cleanup();
@@ -1203,6 +1245,13 @@ For git operations while detached:
       if (timeout) {
         clearTimeout(timeout.handle);
         this.idleTimeouts.delete(taskRunId);
+      }
+
+      // When no sessions remain, tear down MCP Apps connections and cached resources
+      if (this.sessions.size === 0) {
+        this.mcpAppsService.cleanup().catch(() => {
+          log.debug("MCP Apps cleanup failed");
+        });
       }
     }
   }
@@ -1232,7 +1281,7 @@ For git operations while detached:
       emitToRenderer(acpMessage);
 
       // Detect PR URLs in bash tool results and attach to task
-      this.detectAndAttachPrUrl(taskRunId, message);
+      this.detectAndAttachPrUrl(taskRunId, message as AcpMessage["message"]);
     };
 
     const tappedReadable = createTappedReadableStream(
@@ -1361,8 +1410,41 @@ For git operations while detached:
         return {};
       },
 
-      async sessionUpdate() {
-        // session/update notifications flow through the tapped stream
+      async sessionUpdate(params: SessionNotification) {
+        // Forward MCP tool events to McpAppsService using the SDK's
+        // typed discriminated union instead of parsing raw JSON.
+        const { update } = params;
+        if (
+          update.sessionUpdate !== "tool_call" &&
+          update.sessionUpdate !== "tool_call_update"
+        ) {
+          return;
+        }
+
+        const toolName = (update._meta as ClaudeCodeToolMeta | undefined)
+          ?.claudeCode?.toolName;
+        if (!toolName?.startsWith("mcp__")) return;
+
+        const session = service.sessions.get(taskRunId);
+        if (update.sessionUpdate === "tool_call") {
+          session?.inFlightMcpToolCalls.set(update.toolCallId, toolName);
+          service.mcpAppsService.notifyToolInput(
+            toolName,
+            update.toolCallId,
+            update.rawInput,
+          );
+        } else if (
+          update.status === "completed" ||
+          update.status === "failed"
+        ) {
+          session?.inFlightMcpToolCalls.delete(update.toolCallId);
+          service.mcpAppsService.notifyToolResult(
+            toolName,
+            update.toolCallId,
+            update.rawOutput,
+            update.status === "failed",
+          );
+        }
       },
 
       extNotification: async (

--- a/apps/code/src/main/services/mcp-apps/service.ts
+++ b/apps/code/src/main/services/mcp-apps/service.ts
@@ -1,0 +1,473 @@
+import { Client } from "@modelcontextprotocol/sdk/client";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import {
+  type McpAppsDiscoveryCompleteEvent,
+  McpAppsServiceEvent,
+  type McpAppsServiceEvents,
+  type McpAppsToolCancelledEvent,
+  type McpAppsToolInputEvent,
+  type McpAppsToolResultEvent,
+  type McpResourceUiMeta,
+  type McpServerConnectionConfig,
+  type McpToolUiAssociation,
+  type McpToolUiMeta,
+  type McpUiResource,
+} from "@shared/types/mcp-apps";
+import { shell } from "electron";
+import { injectable } from "inversify";
+import { logger } from "../../utils/logger";
+import { TypedEventEmitter } from "../../utils/typed-event-emitter";
+
+const log = logger.scope("mcp-apps-service");
+
+const UI_MIME_TYPE = "text/html;profile=mcp-app";
+const MAX_HTML_SIZE = 5 * 1024 * 1024; // 5MB
+
+interface ServerConnection {
+  name: string;
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+}
+
+@injectable()
+export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
+  private connections = new Map<string, ServerConnection>();
+  private resourceCache = new Map<string, McpUiResource>();
+  private toolAssociations = new Map<string, McpToolUiAssociation>();
+  private toolDefinitions = new Map<string, Tool>();
+  private serverConfigs = new Map<string, McpServerConnectionConfig>();
+  private pendingConnections = new Map<string, Promise<ServerConnection>>();
+  private pendingFetches = new Map<string, Promise<McpUiResource | null>>();
+  private resourceMetaCache = new Map<string, McpResourceUiMeta>();
+
+  /**
+   * Store server configs for lazy connections later.
+   * No connections are created at this point.
+   */
+  setServerConfigs(configs: McpServerConnectionConfig[]): void {
+    this.serverConfigs.clear();
+    for (const config of configs) {
+      this.serverConfigs.set(config.name, config);
+    }
+  }
+
+  /**
+   * Called when the agent confirms MCP servers are connected.
+   * Connects to each server, calls listTools() to discover _meta.ui fields
+   * (which the agent SDK strips), then populates tool associations and
+   * emits DiscoveryComplete.
+   */
+  async handleDiscovery(serverNames: string[]): Promise<void> {
+    await Promise.allSettled(
+      serverNames
+        .filter((name) => this.serverConfigs.has(name))
+        .map((name) => this.discoverServerUiTools(name)),
+    );
+
+    const toolKeys = [...this.toolAssociations.keys()];
+    log.info("Discovery complete", {
+      serverNames,
+      toolKeys,
+      associationCount: this.toolAssociations.size,
+    });
+
+    this.emit(McpAppsServiceEvent.DiscoveryComplete, {
+      toolKeys,
+    } satisfies McpAppsDiscoveryCompleteEvent);
+  }
+
+  /**
+   * Connect to a single server and call listTools() to discover which
+   * tools have _meta.ui fields. The connection is kept for later reuse
+   * (proxy calls, resource reads, lazy HTML fetches).
+   */
+  private async discoverServerUiTools(serverName: string): Promise<void> {
+    try {
+      const conn = await this.getOrCreateConnection(serverName);
+
+      const [toolsList, resourcesList] = await Promise.all([
+        conn.client.listTools(),
+        conn.client.listResources().catch((err) => {
+          log.warn("listResources failed during discovery", {
+            serverName,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return null;
+        }),
+      ]);
+
+      for (const tool of toolsList.tools) {
+        const uiMeta = (tool as McpToolUiMeta)._meta?.ui;
+        if (!uiMeta?.resourceUri) continue;
+
+        const toolKey = `mcp__${serverName}__${tool.name}`;
+        this.toolAssociations.set(toolKey, {
+          toolKey,
+          serverName,
+          toolName: tool.name,
+          resourceUri: uiMeta.resourceUri,
+          visibility: uiMeta.visibility,
+        });
+        this.toolDefinitions.set(toolKey, tool);
+      }
+
+      // Cache resource metadata (CSP, permissions) for use in fetchUiResource
+      if (resourcesList) {
+        for (const resource of resourcesList.resources) {
+          const meta = resource as McpResourceUiMeta;
+          if (meta._meta?.ui) {
+            this.resourceMetaCache.set(resource.uri, meta);
+          }
+        }
+      }
+    } catch (err) {
+      log.warn("Failed to discover UI tools for server", {
+        serverName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Get or create a lazy MCP connection for a server.
+   * Deduplicates concurrent connection attempts for the same server.
+   */
+  private async getOrCreateConnection(
+    serverName: string,
+  ): Promise<ServerConnection> {
+    const existing = this.connections.get(serverName);
+    if (existing) {
+      log.debug("Reusing existing MCP connection", { serverName });
+      return existing;
+    }
+
+    // Deduplicate concurrent connection attempts
+    const pending = this.pendingConnections.get(serverName);
+    if (pending) {
+      log.info("Joining pending MCP connection attempt", { serverName });
+      return pending;
+    }
+
+    const config = this.serverConfigs.get(serverName);
+    if (!config) {
+      throw new Error(`No server config for: ${serverName}`);
+    }
+
+    log.info("Creating lazy MCP connection", { serverName, url: config.url });
+    const connectionPromise = this.createConnection(config);
+    this.pendingConnections.set(serverName, connectionPromise);
+
+    try {
+      const conn = await connectionPromise;
+      this.connections.set(serverName, conn);
+      return conn;
+    } finally {
+      this.pendingConnections.delete(serverName);
+    }
+  }
+
+  private async createConnection(
+    config: McpServerConnectionConfig,
+  ): Promise<ServerConnection> {
+    const transport = new StreamableHTTPClientTransport(new URL(config.url), {
+      requestInit: {
+        headers: config.headers,
+      },
+    });
+
+    const client = new Client(
+      { name: "Twig", version: "1.0.0" },
+      {
+        capabilities: {
+          extensions: {
+            "io.modelcontextprotocol/ui": {
+              mimeTypes: [UI_MIME_TYPE],
+            },
+          },
+        } as Record<string, unknown>,
+      },
+    );
+
+    await client.connect(transport);
+
+    log.info("Lazy MCP connection established", {
+      serverName: config.name,
+      serverVersion: client.getServerVersion(),
+    });
+
+    return { name: config.name, client, transport };
+  }
+
+  /**
+   * Get the UI resource for a tool. Fetches lazily on first access:
+   * creates an MCP connection if needed, then reads the resource HTML.
+   * Deduplicates concurrent fetches for the same resource URI.
+   */
+  async getUiResourceForTool(toolKey: string): Promise<McpUiResource | null> {
+    const association = this.toolAssociations.get(toolKey);
+    if (!association) {
+      log.debug("getUiResourceForTool: no association found", { toolKey });
+      return null;
+    }
+
+    // Return cached resource immediately
+    const cached = this.resourceCache.get(association.resourceUri);
+    if (cached) {
+      log.debug("getUiResourceForTool: cache hit", { toolKey });
+      return cached;
+    }
+
+    // Deduplicate concurrent fetches for the same resource URI
+    const pendingFetch = this.pendingFetches.get(association.resourceUri);
+    if (pendingFetch) {
+      log.debug("getUiResourceForTool: joining pending fetch", {
+        toolKey,
+        uri: association.resourceUri,
+      });
+      return pendingFetch;
+    }
+
+    // Start the fetch for this resource URI
+    log.debug("getUiResourceForTool: starting lazy fetch", {
+      toolKey,
+      serverName: association.serverName,
+      uri: association.resourceUri,
+    });
+    const fetchPromise = this.fetchUiResource(association);
+    this.pendingFetches.set(association.resourceUri, fetchPromise);
+
+    try {
+      return await fetchPromise;
+    } finally {
+      this.pendingFetches.delete(association.resourceUri);
+    }
+  }
+
+  private async fetchUiResource(
+    association: McpToolUiAssociation,
+  ): Promise<McpUiResource | null> {
+    try {
+      const conn = await this.getOrCreateConnection(association.serverName);
+      const resourceResult = await conn.client.readResource({
+        uri: association.resourceUri,
+      });
+
+      const textContent = resourceResult.contents.find(
+        (c) => "text" in c && c.mimeType === UI_MIME_TYPE,
+      );
+      if (!textContent || !("text" in textContent)) {
+        log.warn("UI resource had no matching text content", {
+          serverName: association.serverName,
+          uri: association.resourceUri,
+          contentsCount: resourceResult.contents.length,
+        });
+        return null;
+      }
+
+      if (textContent.text.length > MAX_HTML_SIZE) {
+        log.warn("UI resource HTML exceeds size limit", {
+          uri: association.resourceUri,
+          size: textContent.text.length,
+          limit: MAX_HTML_SIZE,
+        });
+        return null;
+      }
+
+      // Use metadata cached during discovery
+      const resourceMeta = this.resourceMetaCache.get(association.resourceUri);
+
+      const resource: McpUiResource = {
+        uri: association.resourceUri,
+        name: resourceMeta?.name,
+        mimeType: UI_MIME_TYPE,
+        csp: resourceMeta?._meta?.ui?.csp,
+        permissions: resourceMeta?._meta?.ui?.permissions,
+        html: textContent.text,
+        serverName: association.serverName,
+      };
+
+      this.resourceCache.set(association.resourceUri, resource);
+      log.info("Lazily fetched and cached UI resource", {
+        serverName: association.serverName,
+        uri: association.resourceUri,
+        htmlLength: textContent.text.length,
+        hasCsp: !!resource.csp,
+      });
+
+      return resource;
+    } catch (err) {
+      log.warn("Failed to lazily fetch UI resource", {
+        serverName: association.serverName,
+        uri: association.resourceUri,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  hasUiForTool(toolKey: string): boolean {
+    const has = this.toolAssociations.has(toolKey);
+    log.debug("hasUiForTool", { toolKey, result: has });
+    return has;
+  }
+
+  getToolDefinition(toolKey: string): Tool | null {
+    return this.toolDefinitions.get(toolKey) ?? null;
+  }
+
+  async proxyToolCall(
+    serverName: string,
+    toolName: string,
+    args?: Record<string, unknown>,
+  ): Promise<unknown> {
+    // Validate visibility: reject if tool is model-only
+    const toolKey = `mcp__${serverName}__${toolName}`;
+    const association = this.toolAssociations.get(toolKey);
+    if (association?.visibility && !association.visibility.includes("app")) {
+      throw new Error(
+        `Tool "${toolName}" is not accessible to apps (visibility: ${association.visibility.join(", ")})`,
+      );
+    }
+
+    const conn = await this.getOrCreateConnection(serverName);
+    const result = await conn.client.callTool({
+      name: toolName,
+      arguments: args,
+    });
+
+    return result;
+  }
+
+  async proxyResourceRead(serverName: string, uri: string): Promise<unknown> {
+    // Only allow ui:// scheme reads
+    if (!uri.startsWith("ui://")) {
+      throw new Error(`Only ui:// URIs are allowed, got: ${uri}`);
+    }
+
+    const conn = await this.getOrCreateConnection(serverName);
+    const result = await conn.client.readResource({ uri });
+    return result;
+  }
+
+  async openLink(url: string): Promise<void> {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(
+        `Only http/https URLs are allowed, got: ${parsed.protocol}`,
+      );
+    }
+    await shell.openExternal(url);
+  }
+
+  notifyToolInput(toolKey: string, toolCallId: string, args: unknown): void {
+    log.info("notifyToolInput", { toolKey, toolCallId });
+    this.emit(McpAppsServiceEvent.ToolInput, {
+      toolKey,
+      toolCallId,
+      args,
+    } satisfies McpAppsToolInputEvent);
+  }
+
+  notifyToolResult(
+    toolKey: string,
+    toolCallId: string,
+    result: unknown,
+    isError?: boolean,
+  ): void {
+    log.info("notifyToolResult", { toolKey, toolCallId, isError });
+    this.emit(McpAppsServiceEvent.ToolResult, {
+      toolKey,
+      toolCallId,
+      result,
+      isError,
+    } satisfies McpAppsToolResultEvent);
+  }
+
+  notifyToolCancelled(toolKey: string, toolCallId: string): void {
+    log.info("notifyToolCancelled", { toolKey, toolCallId });
+    this.emit(McpAppsServiceEvent.ToolCancelled, {
+      toolKey,
+      toolCallId,
+    } satisfies McpAppsToolCancelledEvent);
+  }
+
+  /**
+   * Clear all cached resources and connections, re-run discovery, and
+   * emit DiscoveryComplete so the renderer refetches everything.
+   * Intended for developer debugging via the File > Developer menu.
+   */
+  async refreshDiscovery(): Promise<void> {
+    log.info("refreshDiscovery: clearing caches and re-running discovery");
+
+    // Close existing connections
+    for (const [, conn] of this.connections) {
+      await conn.client.close().catch(() => {});
+    }
+    this.connections.clear();
+    this.resourceCache.clear();
+    this.resourceMetaCache.clear();
+    this.toolAssociations.clear();
+    this.toolDefinitions.clear();
+    this.pendingConnections.clear();
+    this.pendingFetches.clear();
+
+    // Re-discover using stored server configs
+    const serverNames = [...this.serverConfigs.keys()];
+    if (serverNames.length > 0) {
+      await this.handleDiscovery(serverNames);
+    } else {
+      log.warn(
+        "refreshDiscovery: no server configs stored, nothing to discover",
+      );
+    }
+  }
+
+  async disconnectServer(serverName: string): Promise<void> {
+    const conn = this.connections.get(serverName);
+    if (!conn) return;
+
+    try {
+      await conn.client.close();
+    } catch (err) {
+      log.warn("Error closing MCP connection", {
+        serverName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    this.connections.delete(serverName);
+
+    // Clean up associations and cached resources for this server
+    const urisToEvict = new Set<string>();
+    for (const [key, assoc] of this.toolAssociations) {
+      if (assoc.serverName === serverName) {
+        urisToEvict.add(assoc.resourceUri);
+        this.toolAssociations.delete(key);
+      }
+    }
+
+    // Only evict cached resources not referenced by remaining associations
+    const stillReferenced = new Set(
+      [...this.toolAssociations.values()].map((a) => a.resourceUri),
+    );
+    for (const uri of urisToEvict) {
+      if (!stillReferenced.has(uri)) {
+        this.resourceCache.delete(uri);
+      }
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    const serverNames = [...this.connections.keys()];
+    for (const name of serverNames) {
+      await this.disconnectServer(name);
+    }
+    this.resourceCache.clear();
+    this.resourceMetaCache.clear();
+    this.toolAssociations.clear();
+    this.toolDefinitions.clear();
+    this.serverConfigs.clear();
+    this.pendingConnections.clear();
+    this.pendingFetches.clear();
+  }
+}

--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -17,6 +17,7 @@ import { githubIntegrationRouter } from "./routers/github-integration";
 import { linearIntegrationRouter } from "./routers/linear-integration.js";
 import { llmGatewayRouter } from "./routers/llm-gateway";
 import { logsRouter } from "./routers/logs";
+import { mcpAppsRouter } from "./routers/mcp-apps";
 import { mcpCallbackRouter } from "./routers/mcp-callback";
 import { notificationRouter } from "./routers/notification";
 import { oauthRouter } from "./routers/oauth";
@@ -52,6 +53,7 @@ export const trpcRouter = router({
   githubIntegration: githubIntegrationRouter,
   linearIntegration: linearIntegrationRouter,
   llmGateway: llmGatewayRouter,
+  mcpApps: mcpAppsRouter,
   mcpCallback: mcpCallbackRouter,
   notification: notificationRouter,
   oauth: oauthRouter,

--- a/apps/code/src/main/trpc/routers/mcp-apps.ts
+++ b/apps/code/src/main/trpc/routers/mcp-apps.ts
@@ -1,0 +1,104 @@
+import {
+  getToolDefinitionInput,
+  getUiResourceInput,
+  hasUiForToolInput,
+  McpAppsServiceEvent,
+  mcpAppsSubscriptionInput,
+  mcpUiResourceSchema,
+  openLinkInput,
+  proxyResourceReadInput,
+  proxyToolCallInput,
+} from "@shared/types/mcp-apps";
+import { container } from "../../di/container";
+import { MAIN_TOKENS } from "../../di/tokens";
+import type { McpAppsService } from "../../services/mcp-apps/service";
+import { publicProcedure, router } from "../trpc";
+
+const getService = () =>
+  container.get<McpAppsService>(MAIN_TOKENS.McpAppsService);
+
+export const mcpAppsRouter = router({
+  getUiResource: publicProcedure
+    .input(getUiResourceInput)
+    .output(mcpUiResourceSchema.nullable())
+    .query(({ input }) => getService().getUiResourceForTool(input.toolKey)),
+
+  hasUiForTool: publicProcedure
+    .input(hasUiForToolInput)
+    .query(({ input }) => getService().hasUiForTool(input.toolKey)),
+
+  getToolDefinition: publicProcedure
+    .input(getToolDefinitionInput)
+    .query(({ input }) => getService().getToolDefinition(input.toolKey)),
+
+  proxyToolCall: publicProcedure
+    .input(proxyToolCallInput)
+    .mutation(({ input }) =>
+      getService().proxyToolCall(input.serverName, input.toolName, input.args),
+    ),
+
+  proxyResourceRead: publicProcedure
+    .input(proxyResourceReadInput)
+    .mutation(({ input }) =>
+      getService().proxyResourceRead(input.serverName, input.uri),
+    ),
+
+  openLink: publicProcedure
+    .input(openLinkInput)
+    .mutation(({ input }) => getService().openLink(input.url)),
+
+  onToolInput: publicProcedure
+    .input(mcpAppsSubscriptionInput)
+    .subscription(async function* (opts) {
+      const service = getService();
+      const targetToolKey = opts.input.toolKey;
+      for await (const event of service.toIterable(
+        McpAppsServiceEvent.ToolInput,
+        { signal: opts.signal },
+      )) {
+        if (event.toolKey === targetToolKey) {
+          yield event;
+        }
+      }
+    }),
+
+  onToolResult: publicProcedure
+    .input(mcpAppsSubscriptionInput)
+    .subscription(async function* (opts) {
+      const service = getService();
+      const targetToolKey = opts.input.toolKey;
+      for await (const event of service.toIterable(
+        McpAppsServiceEvent.ToolResult,
+        { signal: opts.signal },
+      )) {
+        if (event.toolKey === targetToolKey) {
+          yield event;
+        }
+      }
+    }),
+
+  onToolCancelled: publicProcedure
+    .input(mcpAppsSubscriptionInput)
+    .subscription(async function* (opts) {
+      const service = getService();
+      const targetToolKey = opts.input.toolKey;
+      for await (const event of service.toIterable(
+        McpAppsServiceEvent.ToolCancelled,
+        { signal: opts.signal },
+      )) {
+        if (event.toolKey === targetToolKey) {
+          yield event;
+        }
+      }
+    }),
+
+  onDiscoveryComplete: publicProcedure.subscription(async function* (opts) {
+    const service = getService();
+    for await (const event of service.toIterable(
+      McpAppsServiceEvent.DiscoveryComplete,
+      { signal: opts.signal },
+    )) {
+      yield event;
+    }
+  }),
+});

--- a/apps/code/src/renderer/features/mcp-apps/components/McpAppHost.tsx
+++ b/apps/code/src/renderer/features/mcp-apps/components/McpAppHost.tsx
@@ -1,0 +1,258 @@
+import type { ToolViewProps } from "@features/sessions/components/session-update/toolCallUtils";
+import type { McpUiDisplayMode } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type {
+  CallToolResult,
+  ReadResourceResult,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import { ArrowsIn, ArrowsOut, Plugs, X } from "@phosphor-icons/react";
+import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
+import { useTRPC } from "@renderer/trpc/client";
+import { useThemeStore } from "@stores/themeStore";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { logger } from "@utils/logger";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { type Phase, useAppBridge } from "../hooks/useAppBridge";
+import { toCallToolResult } from "../utils/mcp-app-host-utils";
+
+const log = logger.scope("mcp-app-host");
+
+interface McpAppHostProps extends ToolViewProps {
+  mcpToolName: string;
+  serverName: string;
+  toolName: string;
+}
+
+export function McpAppHost({
+  toolCall,
+  mcpToolName,
+  serverName,
+  toolName,
+}: McpAppHostProps) {
+  const trpcReact = useTRPC();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [_phase, setPhase] = useState<Phase>("loading");
+  const [displayMode, setDisplayMode] = useState<McpUiDisplayMode>("inline");
+  const [iframeHeight, setIframeHeight] = useState(300);
+  const [containerWidth, setContainerWidth] = useState(640);
+  const [iframeEl, setIframeEl] = useState<HTMLIFrameElement | null>(null);
+  const isDarkMode = useThemeStore((s) => s.isDarkMode);
+
+  const { data: uiResource, isLoading: resourceLoading } = useQuery(
+    trpcReact.mcpApps.getUiResource.queryOptions(
+      { toolKey: mcpToolName },
+      { staleTime: Infinity },
+    ),
+  );
+
+  const { data: toolDefinition } = useQuery(
+    trpcReact.mcpApps.getToolDefinition.queryOptions(
+      { toolKey: mcpToolName },
+      { staleTime: Infinity },
+    ),
+  );
+
+  useEffect(() => {
+    log.debug("McpAppHost render", {
+      mcpToolName,
+      resourceLoading,
+      hasResource: !!uiResource,
+      resourceUri: uiResource?.uri,
+    });
+  }, [mcpToolName, resourceLoading, uiResource, uiResource?.uri]);
+
+  const proxyToolCallMut = useMutation(
+    trpcReact.mcpApps.proxyToolCall.mutationOptions(),
+  );
+  const proxyResourceReadMut = useMutation(
+    trpcReact.mcpApps.proxyResourceRead.mutationOptions(),
+  );
+  const openLinkMut = useMutation(trpcReact.mcpApps.openLink.mutationOptions());
+
+  const { sendWhenReady } = useAppBridge({
+    iframeEl,
+    uiResource: uiResource,
+    serverName,
+    toolName,
+    toolDefinition: toolDefinition as Tool | null | undefined,
+    toolCall,
+    isDarkMode,
+    displayMode,
+    containerWidth,
+    onPhaseChange: setPhase,
+    onSizeChange: setIframeHeight,
+    onDisplayModeChange: setDisplayMode,
+    proxyToolCall: proxyToolCallMut.mutateAsync as (args: {
+      serverName: string;
+      toolName: string;
+      args?: Record<string, unknown>;
+    }) => Promise<CallToolResult>,
+    proxyResourceRead: proxyResourceReadMut.mutateAsync as (args: {
+      serverName: string;
+      uri: string;
+    }) => Promise<ReadResourceResult>,
+    openLink: openLinkMut.mutateAsync,
+  });
+
+  // Forward tool results from subscriptions
+  useSubscription(
+    trpcReact.mcpApps.onToolResult.subscriptionOptions(
+      { toolKey: mcpToolName },
+      {
+        onData: (event) => {
+          const toolResult = toCallToolResult(event.result);
+          log.info("Sending tool result to app", {
+            mcpToolName,
+            toolResult,
+          });
+
+          sendWhenReady((bridge) => bridge.sendToolResult(toolResult));
+        },
+      },
+    ),
+  );
+
+  // Forward tool cancellations from subscriptions
+  useSubscription(
+    trpcReact.mcpApps.onToolCancelled.subscriptionOptions(
+      { toolKey: mcpToolName },
+      {
+        onData: () => {
+          log.info("Received tool cancellation from subscription", {
+            mcpToolName,
+          });
+          sendWhenReady((bridge) => bridge.sendToolCancelled({}));
+        },
+      },
+    ),
+  );
+
+  // Track inline container width with ResizeObserver
+  useEffect(() => {
+    if (displayMode !== "inline") return;
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerWidth(Math.round(entry.contentRect.width));
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [displayMode]);
+
+  // Handle escape key for fullscreen
+  useEffect(() => {
+    if (displayMode !== "fullscreen") return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setDisplayMode("inline");
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [displayMode]);
+
+  if (resourceLoading || !uiResource) {
+    return null;
+  }
+
+  const iframeElement = (
+    <iframe
+      ref={setIframeEl}
+      src="mcp-sandbox://proxy"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation"
+      style={{
+        width: "100%",
+        height: displayMode === "fullscreen" ? "100%" : `${iframeHeight}px`,
+        border: "none",
+        borderRadius: "var(--radius-2)",
+      }}
+      title={`MCP App: ${serverName} - ${toolName}`}
+    />
+  );
+
+  const fullscreenToggle = (
+    <Flex justify="end" className="py-0.5">
+      <IconButton
+        size="1"
+        variant="ghost"
+        color="gray"
+        onClick={(e) => {
+          e.stopPropagation();
+          const newMode = displayMode === "inline" ? "fullscreen" : "inline";
+          setDisplayMode(newMode);
+        }}
+        title={
+          displayMode === "inline" ? "Expand to fullscreen" : "Exit fullscreen"
+        }
+      >
+        {displayMode === "inline" ? (
+          <ArrowsOut size={12} />
+        ) : (
+          <ArrowsIn size={12} />
+        )}
+      </IconButton>
+    </Flex>
+  );
+
+  const portalTarget = document.getElementById("mcp-fullscreen-portal");
+
+  if (displayMode === "fullscreen" && portalTarget) {
+    return (
+      <>
+        {fullscreenToggle}
+
+        {createPortal(
+          <Box
+            className="pointer-events-auto absolute inset-0 flex flex-col bg-gray-1"
+            style={{
+              transition: "opacity 150ms ease",
+            }}
+          >
+            <Flex
+              align="center"
+              justify="between"
+              className="border-gray-6 border-b px-4 py-2"
+            >
+              <Flex align="center" gap="2">
+                <Plugs size={14} className="text-gray-11" />
+                <Text size="2" className="text-gray-11">
+                  {serverName} - {toolName}
+                </Text>
+              </Flex>
+              <IconButton
+                size="1"
+                variant="ghost"
+                color="gray"
+                onClick={() => {
+                  setDisplayMode("inline");
+                }}
+                title="Exit fullscreen (Escape)"
+              >
+                <X size={14} />
+              </IconButton>
+            </Flex>
+
+            <Box className="flex-1 overflow-hidden p-4">{iframeElement}</Box>
+          </Box>,
+          portalTarget,
+        )}
+      </>
+    );
+  }
+
+  return (
+    <Box>
+      {fullscreenToggle}
+      <Box
+        ref={containerRef}
+        className="overflow-hidden rounded-lg border border-gray-6"
+      >
+        {iframeElement}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/code/src/renderer/features/mcp-apps/components/McpToolView.tsx
+++ b/apps/code/src/renderer/features/mcp-apps/components/McpToolView.tsx
@@ -1,6 +1,3 @@
-import { Plugs } from "@phosphor-icons/react";
-import { Box, Flex } from "@radix-ui/themes";
-import { useState } from "react";
 import {
   compactInput,
   ExpandableIcon,
@@ -12,18 +9,11 @@ import {
   ToolTitle,
   type ToolViewProps,
   useToolCallStatus,
-} from "./toolCallUtils";
-
-function parseMcpName(mcpToolName: string): {
-  serverName: string;
-  toolName: string;
-} {
-  const parts = mcpToolName.split("__");
-  return {
-    serverName: parts[1] ?? "",
-    toolName: parts.slice(2).join("__"),
-  };
-}
+} from "@features/sessions/components/session-update/toolCallUtils";
+import { Plugs } from "@phosphor-icons/react";
+import { Box, Flex } from "@radix-ui/themes";
+import { useState } from "react";
+import { parseMcpToolKey } from "../utils/mcp-app-host-utils";
 
 interface McpToolViewProps extends ToolViewProps {
   mcpToolName: string;
@@ -44,7 +34,7 @@ export function McpToolView({
     turnComplete,
   );
 
-  const { serverName, toolName } = parseMcpName(mcpToolName);
+  const { serverName, toolName } = parseMcpToolKey(mcpToolName);
   const inputPreview = compactInput(rawInput);
   const fullInput = formatInput(rawInput);
 

--- a/apps/code/src/renderer/features/mcp-apps/hooks/useAppBridge.ts
+++ b/apps/code/src/renderer/features/mcp-apps/hooks/useAppBridge.ts
@@ -1,0 +1,409 @@
+import { useDraftStore } from "@features/message-editor/stores/draftStore";
+import type { ToolCall } from "@features/sessions/types";
+import {
+  AppBridge,
+  type McpUiDisplayMode,
+  type McpUiHostCapabilities,
+  type McpUiHostContext,
+  type McpUiStyles,
+  PostMessageTransport,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import type {
+  CallToolResult,
+  ReadResourceResult,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { McpUiResource } from "@shared/types/mcp-apps";
+import { useNavigationStore } from "@stores/navigationStore";
+import { logger } from "@utils/logger";
+import { useCallback, useEffect, useRef } from "react";
+import {
+  computeContainerDimensions,
+  INLINE_MAX_HEIGHT,
+  toCallToolResult,
+} from "../utils/mcp-app-host-utils";
+import { buildHostStyles } from "../utils/mcp-app-theme";
+
+const log = logger.scope("mcp-app-bridge");
+
+export type Phase =
+  | "loading"
+  | "proxy-ready"
+  | "resource-sent"
+  | "initialized"
+  | "error";
+
+interface UseAppBridgeArgs {
+  iframeEl: HTMLIFrameElement | null;
+  uiResource: McpUiResource | null | undefined;
+  serverName: string;
+  toolName: string;
+  toolDefinition?: Tool | null;
+  toolCall: ToolCall;
+  isDarkMode: boolean;
+  displayMode: McpUiDisplayMode;
+  containerWidth: number;
+  onPhaseChange: (phase: Phase) => void;
+  onSizeChange: (height: number) => void;
+  onDisplayModeChange: (mode: McpUiDisplayMode) => void;
+  proxyToolCall: (args: {
+    serverName: string;
+    toolName: string;
+    args?: Record<string, unknown>;
+  }) => Promise<CallToolResult>;
+  proxyResourceRead: (args: {
+    serverName: string;
+    uri: string;
+  }) => Promise<ReadResourceResult>;
+  openLink: (args: { url: string }) => Promise<void>;
+}
+
+interface UseAppBridgeReturn {
+  sendWhenReady: (fn: (bridge: AppBridge) => void) => void;
+}
+
+const HOST_INFO = { name: "Twig", version: "1.0.0" };
+
+const HOST_CAPABILITIES: McpUiHostCapabilities = {
+  openLinks: {},
+  serverTools: {},
+  serverResources: {},
+  logging: {},
+  message: { text: {} },
+  sandbox: {},
+};
+
+function buildInitialHostContext(
+  isDarkMode: boolean,
+  displayMode: McpUiDisplayMode,
+  containerWidth: number,
+  toolDefinition?: Tool | null,
+): McpUiHostContext {
+  const hostStyles = buildHostStyles(isDarkMode);
+
+  return {
+    theme: isDarkMode ? "dark" : "light",
+    styles: {
+      variables: hostStyles.variables as McpUiStyles,
+      css: hostStyles.css,
+    },
+    availableDisplayModes: ["inline", "fullscreen"],
+    displayMode,
+    containerDimensions: computeContainerDimensions(
+      displayMode,
+      containerWidth,
+    ),
+    locale: navigator.language,
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    userAgent: navigator.userAgent,
+    platform: "desktop",
+    deviceCapabilities: { touch: false, hover: true },
+    safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    ...(toolDefinition ? { toolInfo: { tool: toolDefinition } } : {}),
+  };
+}
+
+/**
+ * Manages the host side of the MCP Apps bridge for a single sandboxed iframe.
+ *
+ * MCP Apps run inside a double-iframe sandbox (proxy → app) and communicate
+ * with the host over JSON-RPC postMessage. Rather than hand-rolling that
+ * protocol, this hook wraps the official `AppBridge` from
+ * `@modelcontextprotocol/ext-apps` which handles the full JSON-RPC transport,
+ * handshake, and message validation.
+ *
+ * The hook owns the entire bridge lifecycle: it waits for the sandbox proxy to
+ * signal readiness, creates and connects the bridge, sends the app's HTML
+ * resource into the inner iframe, and tears everything down on unmount. It also
+ * forwards host context (theme, display mode, container size) to the app
+ * whenever those values change.
+ *
+ * Because the actual MCP server connection lives in the main process (behind
+ * tRPC IPC), the bridge's `client` is `null` — tool calls, resource reads,
+ * and link opens are routed through tRPC mutations passed in as props.
+ *
+ * Returns `sendWhenReady`, which buffers calls until the app has finished
+ * initializing, then flushes them. Use it to forward tool results and
+ * cancellations from tRPC subscriptions without worrying about timing.
+ */
+export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
+  const bridgeRef = useRef<AppBridge | null>(null);
+  const initializedRef = useRef(false);
+  const pendingRef = useRef<Array<(bridge: AppBridge) => void>>([]);
+
+  // Single mutable ref for latest props — handlers read from this
+  const latestRef = useRef(args);
+  latestRef.current = args;
+
+  // Stable references for effect dependencies
+  const { iframeEl, uiResource } = args;
+
+  // Track previous context values to compute deltas
+  const prevContextRef = useRef<{
+    isDarkMode: boolean;
+    displayMode: McpUiDisplayMode;
+    containerWidth: number;
+  } | null>(null);
+
+  // Main lifecycle effect
+  useEffect(() => {
+    if (!iframeEl || !uiResource) {
+      log.debug("useAppBridge effect skipped", {
+        hasIframeEl: !!iframeEl,
+        hasUiResource: !!uiResource,
+        serverName: args.serverName,
+      });
+      return;
+    }
+
+    const iframe = iframeEl;
+    const resource = uiResource;
+    let cleanedUp = false;
+
+    const onProxyReady = async (event: MessageEvent) => {
+      if (event.source !== iframe.contentWindow) return;
+      if (event.data?.method !== "ui/notifications/sandbox-proxy-ready") return;
+      window.removeEventListener("message", onProxyReady);
+
+      if (cleanedUp) return;
+
+      try {
+        const latest = latestRef.current;
+        const hostContext = buildInitialHostContext(
+          latest.isDarkMode,
+          latest.displayMode,
+          latest.containerWidth,
+          latest.toolDefinition,
+        );
+
+        const bridge = new AppBridge(null, HOST_INFO, HOST_CAPABILITIES, {
+          hostContext,
+        });
+
+        // We are NOT listening to every single event coming from the bridge
+        // but this can always very easily be extended to listen to more events if needed
+        bridge.oncalltool = async (params) =>
+          latestRef.current.proxyToolCall({
+            serverName: latestRef.current.serverName,
+            toolName: params.name,
+            args: params.arguments,
+          });
+
+        bridge.onreadresource = async (params) =>
+          latestRef.current.proxyResourceRead({
+            serverName: latestRef.current.serverName,
+            uri: params.uri,
+          });
+
+        bridge.onopenlink = async (params) => {
+          await latestRef.current.openLink({ url: params.url });
+          return {};
+        };
+
+        // When an MCP App sends a ui/message, pre-fill the chat input
+        // for the active task so the user can review before sending.
+        bridge.onmessage = async (params) => {
+          const textParts = params.content
+            .filter(
+              (block): block is { type: "text"; text: string } =>
+                block.type === "text",
+            )
+            .map((block) => block.text);
+
+          const message = textParts.join("\n");
+          if (message) {
+            // Route to the current task's session, or "default" if not on a task
+            const view = useNavigationStore.getState().view;
+            const sessionId =
+              view.type === "task-detail"
+                ? (view.data?.id ?? "default")
+                : "default";
+            const { setPendingContent, requestFocus } =
+              useDraftStore.getState().actions;
+
+            setPendingContent(sessionId, {
+              segments: [{ type: "text", text: message }],
+            });
+            requestFocus(sessionId);
+          }
+          return {};
+        };
+
+        // `pip` is not supported at the moment
+        bridge.onrequestdisplaymode = async (params) => {
+          const requested = params.mode;
+          if (["inline", "fullscreen"].includes(requested)) {
+            latestRef.current.onDisplayModeChange(requested);
+            return { mode: requested };
+          }
+          return { mode: latestRef.current.displayMode };
+        };
+
+        bridge.onsizechange = (params) => {
+          if (params.height && typeof params.height === "number") {
+            const maxHeight =
+              latestRef.current.displayMode === "inline"
+                ? INLINE_MAX_HEIGHT
+                : 10000;
+            latestRef.current.onSizeChange(Math.min(params.height, maxHeight));
+          }
+        };
+
+        bridge.onloggingmessage = (params) => {
+          log.info("Log forwarding", {
+            server: latestRef.current.serverName,
+            level: params.level,
+            data: params.data,
+          });
+        };
+
+        bridge.oninitialized = () => {
+          log.debug("App initialized, phase -> initialized", {
+            serverName: latestRef.current.serverName,
+          });
+          initializedRef.current = true;
+          latestRef.current.onPhaseChange("initialized");
+
+          // Send tool input with complete arguments
+          const tc = latestRef.current.toolCall;
+          if (tc.rawInput) {
+            log.debug("Sending tool input to app", {
+              serverName: latestRef.current.serverName,
+              tc,
+              input: { arguments: tc.rawInput },
+            });
+            bridge.sendToolInput({
+              arguments: tc.rawInput as Record<string, unknown>,
+            });
+          } else {
+            log.warn("No rawInput to send to app", {
+              serverName: latestRef.current.serverName,
+              toolCallId: tc.toolCallId,
+            });
+          }
+
+          // If the tool already completed (e.g. component remounted after
+          // scrolling back into the virtualized list), send the result now
+          // since the subscription event was missed.
+          if (
+            tc.rawOutput &&
+            (tc.status === "completed" || tc.status === "failed")
+          ) {
+            const toolResult = toCallToolResult(tc.rawOutput);
+            log.debug("Sending existing tool result to app (remount)", {
+              serverName: latestRef.current.serverName,
+              toolResult,
+            });
+            bridge.sendToolResult(toolResult);
+          }
+
+          // Flush pending
+          log.debug("Flushing pending messages", {
+            count: pendingRef.current.length,
+          });
+          for (const fn of pendingRef.current) {
+            fn(bridge);
+          }
+          pendingRef.current = [];
+        };
+
+        // Connect bridge via PostMessageTransport
+        const transport = new PostMessageTransport(
+          iframe.contentWindow as Window,
+          iframe.contentWindow as Window,
+        );
+        await bridge.connect(transport);
+        bridgeRef.current = bridge;
+
+        // Send resource to proxy
+        await bridge.sendSandboxResourceReady({
+          html: resource.html,
+          csp: resource.csp,
+          permissions: resource.permissions,
+        });
+
+        if (!cleanedUp) {
+          log.debug("Resource sent to proxy, phase -> resource-sent", {
+            serverName: latestRef.current.serverName,
+          });
+          latestRef.current.onPhaseChange("resource-sent");
+        }
+      } catch (err) {
+        log.error("Failed to initialize AppBridge", err);
+        if (!cleanedUp) {
+          latestRef.current.onPhaseChange("error");
+        }
+      }
+    };
+
+    window.addEventListener("message", onProxyReady);
+
+    return () => {
+      cleanedUp = true;
+      window.removeEventListener("message", onProxyReady);
+
+      if (bridgeRef.current) {
+        const b = bridgeRef.current;
+        b.teardownResource({}).catch(() => {});
+        b.close().catch(() => {});
+      }
+
+      bridgeRef.current = null;
+      initializedRef.current = false;
+      prevContextRef.current = null;
+      pendingRef.current = [];
+    };
+  }, [iframeEl, uiResource, args.serverName]); // Only re-run when iframe element or resource identity changes
+
+  // Host context change effect — sends deltas when theme/displayMode/containerWidth change
+  useEffect(() => {
+    if (!initializedRef.current || !bridgeRef.current) return;
+
+    const prev = prevContextRef.current;
+    prevContextRef.current = {
+      isDarkMode: args.isDarkMode,
+      displayMode: args.displayMode,
+      containerWidth: args.containerWidth,
+    };
+
+    // Skip initial (values already in hostContext from constructor)
+    if (!prev) return;
+
+    const bridge = bridgeRef.current;
+    const delta: Partial<McpUiHostContext> = {};
+
+    if (prev.isDarkMode !== args.isDarkMode) {
+      const hostStyles = buildHostStyles(args.isDarkMode);
+      delta.theme = args.isDarkMode ? "dark" : "light";
+      delta.styles = {
+        variables: hostStyles.variables as McpUiStyles,
+        css: hostStyles.css,
+      };
+    }
+
+    if (
+      prev.displayMode !== args.displayMode ||
+      prev.containerWidth !== args.containerWidth
+    ) {
+      delta.displayMode = args.displayMode;
+      delta.containerDimensions = computeContainerDimensions(
+        args.displayMode,
+        args.containerWidth,
+      );
+    }
+
+    if (Object.keys(delta).length > 0) {
+      bridge.sendHostContextChange(delta as McpUiHostContext);
+    }
+  }, [args.isDarkMode, args.displayMode, args.containerWidth]);
+
+  const sendWhenReady = useCallback((fn: (bridge: AppBridge) => void) => {
+    if (initializedRef.current && bridgeRef.current) {
+      fn(bridgeRef.current);
+    } else {
+      pendingRef.current.push(fn);
+    }
+  }, []);
+
+  return { sendWhenReady };
+}

--- a/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-csp.test.ts
+++ b/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-csp.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCspMetaTag,
+  buildCspString,
+  escapeAttr,
+  sanitizeDomain,
+} from "./mcp-app-csp";
+
+describe("sanitizeDomain", () => {
+  it("passes through valid domains", () => {
+    expect(sanitizeDomain("example.com")).toBe("example.com");
+    expect(sanitizeDomain("*.example.com")).toBe("*.example.com");
+    // CSP domains don't include protocol slashes - slashes are stripped
+    expect(sanitizeDomain("example.com:8080")).toBe("example.com:8080");
+  });
+
+  it("strips injection characters", () => {
+    // Semicolons, quotes, and spaces are stripped; * is allowed (CSP wildcard)
+    expect(sanitizeDomain("' unsafe-eval; script-src *;")).toBe(
+      "unsafe-evalscript-src*",
+    );
+    expect(sanitizeDomain('" onload=alert(1)')).toBe("onloadalert1");
+    expect(sanitizeDomain("example.com; frame-ancestors *")).toBe(
+      "example.comframe-ancestors*",
+    );
+  });
+
+  it("strips whitespace", () => {
+    expect(sanitizeDomain("example .com")).toBe("example.com");
+  });
+});
+
+describe("buildCspString", () => {
+  it("returns default CSP when no metadata provided", () => {
+    const result = buildCspString();
+    expect(result).toContain("default-src 'none'");
+    expect(result).toContain("script-src 'self' 'unsafe-inline'");
+    expect(result).toContain("style-src 'self' 'unsafe-inline'");
+    expect(result).toContain("img-src 'self' data:");
+    expect(result).toContain("media-src 'self' data:");
+    expect(result).toContain("connect-src 'none'");
+    expect(result).toContain("frame-src 'none'");
+    expect(result).toContain("form-action 'none'");
+    expect(result).toContain("base-uri 'none'");
+  });
+
+  it("returns default CSP for empty metadata", () => {
+    const result = buildCspString({});
+    expect(result).toContain("connect-src 'none'");
+    expect(result).toContain("frame-src 'none'");
+    expect(result).toContain("form-action 'none'");
+  });
+
+  it("always includes form-action 'none'", () => {
+    const result = buildCspString({
+      connectDomains: ["api.example.com"],
+    });
+    expect(result).toContain("form-action 'none'");
+  });
+
+  it("maps connectDomains to connect-src", () => {
+    const result = buildCspString({
+      connectDomains: ["api.example.com", "*.cdn.example.com"],
+    });
+    expect(result).toContain("connect-src api.example.com *.cdn.example.com");
+  });
+
+  it("maps resourceDomains to img/media/font/script/style-src", () => {
+    const result = buildCspString({
+      resourceDomains: ["cdn.example.com"],
+    });
+    expect(result).toContain("img-src 'self' data: cdn.example.com");
+    expect(result).toContain("media-src 'self' data: cdn.example.com");
+    expect(result).toContain("font-src cdn.example.com");
+    expect(result).toContain(
+      "script-src 'self' 'unsafe-inline' cdn.example.com",
+    );
+    expect(result).toContain(
+      "style-src 'self' 'unsafe-inline' cdn.example.com",
+    );
+  });
+
+  it("does not include resourceDomains in script/style-src when not declared", () => {
+    const result = buildCspString({});
+    expect(result).toContain("script-src 'self' 'unsafe-inline'");
+    expect(result).toContain("style-src 'self' 'unsafe-inline'");
+    // Should NOT have trailing space after 'unsafe-inline'
+    expect(result).not.toMatch(/script-src 'self' 'unsafe-inline' ;/);
+  });
+
+  it("maps frameDomains to frame-src", () => {
+    const result = buildCspString({
+      frameDomains: ["embed.example.com"],
+    });
+    expect(result).toContain("frame-src embed.example.com");
+  });
+
+  it("maps baseUriDomains to base-uri", () => {
+    const result = buildCspString({
+      baseUriDomains: ["example.com"],
+    });
+    expect(result).toContain("base-uri example.com");
+  });
+
+  it("sanitizes domains with injection attempts", () => {
+    const result = buildCspString({
+      connectDomains: ["example.com; script-src 'unsafe-eval'"],
+    });
+    // After sanitization, the semicolons, quotes, and spaces are stripped
+    // so the domain can't inject new CSP directives
+    expect(result).toContain("connect-src example.comscript-srcunsafe-eval");
+    // The injected directive should not appear as a separate CSP directive
+    expect(result).not.toMatch(/;\s*script-src\s+'unsafe-eval'/);
+  });
+});
+
+describe("escapeAttr", () => {
+  it("escapes double quotes", () => {
+    expect(escapeAttr('hello "world"')).toBe("hello &quot;world&quot;");
+  });
+
+  it("escapes single quotes", () => {
+    expect(escapeAttr("hello 'world'")).toBe("hello &#39;world&#39;");
+  });
+
+  it("escapes ampersands", () => {
+    expect(escapeAttr("a & b")).toBe("a &amp; b");
+  });
+
+  it("escapes angle brackets", () => {
+    expect(escapeAttr("<script>alert(1)</script>")).toBe(
+      "&lt;script&gt;alert(1)&lt;/script&gt;",
+    );
+  });
+
+  it("handles combination", () => {
+    expect(escapeAttr(`"foo" & 'bar' <baz>`)).toBe(
+      "&quot;foo&quot; &amp; &#39;bar&#39; &lt;baz&gt;",
+    );
+  });
+
+  it("passes through safe strings", () => {
+    expect(escapeAttr("default-src none")).toBe("default-src none");
+  });
+});
+
+describe("buildCspMetaTag", () => {
+  it("returns a valid meta tag", () => {
+    const tag = buildCspMetaTag();
+    expect(tag).toMatch(
+      /^<meta http-equiv="Content-Security-Policy" content=".*">$/,
+    );
+    expect(tag).toContain("default-src");
+  });
+
+  it("escapes CSP content in the attribute", () => {
+    const tag = buildCspMetaTag({
+      connectDomains: ["example.com"],
+    });
+    expect(tag).toContain("connect-src example.com");
+    // Verify it's inside a proper attribute
+    expect(tag).toMatch(/content="[^"]+"/);
+  });
+});

--- a/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-csp.ts
+++ b/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-csp.ts
@@ -1,0 +1,85 @@
+/**
+ * Builds Content Security Policy directives for MCP App iframes.
+ *
+ * MCP Apps run inside a sandboxed iframe with a null origin. The CSP restricts
+ * what the app can load (scripts, styles, images, connections, etc.) based on
+ * domains declared in the resource's `ui.csp` metadata. When no CSP metadata
+ * is provided, a restrictive default is used.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-03-26/extensions/mcp-apps
+ */
+
+import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps/app-bridge";
+
+// Per MCP Apps spec, the default CSP includes 'self' in script/style/img/media-src.
+// 'self' is effectively inert in our sandbox model because the inner iframe runs
+// without allow-same-origin (null origin), but we include it for spec compliance.
+const DEFAULT_CSP =
+  "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; media-src 'self' data:; connect-src 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; base-uri 'none'";
+
+export function sanitizeDomain(domain: string): string {
+  return domain.replace(/[^a-zA-Z0-9.*:-]/g, "");
+}
+
+export function buildCspString(csp?: McpUiResourceCsp): string {
+  if (!csp) return DEFAULT_CSP;
+
+  const resourceDomainsSuffix = csp.resourceDomains?.length
+    ? ` ${csp.resourceDomains.map(sanitizeDomain).join(" ")}`
+    : "";
+
+  const directives: string[] = [
+    "default-src 'none'",
+    `script-src 'self' 'unsafe-inline'${resourceDomainsSuffix}`,
+    `style-src 'self' 'unsafe-inline'${resourceDomainsSuffix}`,
+    "object-src 'none'",
+    "form-action 'none'",
+  ];
+
+  if (csp.connectDomains?.length) {
+    const domains = csp.connectDomains.map(sanitizeDomain).join(" ");
+    directives.push(`connect-src ${domains}`);
+  } else {
+    directives.push("connect-src 'none'");
+  }
+
+  if (csp.resourceDomains?.length) {
+    const domains = csp.resourceDomains.map(sanitizeDomain).join(" ");
+    directives.push(`img-src 'self' data: ${domains}`);
+    directives.push(`media-src 'self' data: ${domains}`);
+    directives.push(`font-src ${domains}`);
+  } else {
+    directives.push("img-src 'self' data:");
+    directives.push("media-src 'self' data:");
+  }
+
+  if (csp.frameDomains?.length) {
+    const domains = csp.frameDomains.map(sanitizeDomain).join(" ");
+    directives.push(`frame-src ${domains}`);
+  } else {
+    directives.push("frame-src 'none'");
+  }
+
+  if (csp.baseUriDomains?.length) {
+    const domains = csp.baseUriDomains.map(sanitizeDomain).join(" ");
+    directives.push(`base-uri ${domains}`);
+  } else {
+    directives.push("base-uri 'none'");
+  }
+
+  return directives.join("; ");
+}
+
+export function escapeAttr(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function buildCspMetaTag(csp?: McpUiResourceCsp): string {
+  const cspString = buildCspString(csp);
+  return `<meta http-equiv="Content-Security-Policy" content="${escapeAttr(cspString)}">`;
+}

--- a/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-host-utils.test.ts
+++ b/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-host-utils.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeContainerDimensions,
+  FULLSCREEN_HEADER_HEIGHT,
+  FULLSCREEN_PADDING,
+  INLINE_MAX_HEIGHT,
+  toCallToolResult,
+} from "./mcp-app-host-utils";
+
+describe("computeContainerDimensions", () => {
+  it("returns inline dimensions with maxHeight", () => {
+    const result = computeContainerDimensions("inline", 500);
+    expect(result).toEqual({
+      width: 500,
+      maxHeight: INLINE_MAX_HEIGHT,
+    });
+    expect(result.height).toBeUndefined();
+  });
+
+  it("uses provided inlineWidth for inline mode", () => {
+    expect(computeContainerDimensions("inline", 800).width).toBe(800);
+    expect(computeContainerDimensions("inline", 320).width).toBe(320);
+  });
+
+  it("returns fullscreen dimensions based on viewport", () => {
+    const result = computeContainerDimensions("fullscreen", 500, 1920, 1080);
+    expect(result).toEqual({
+      width: 1920 - FULLSCREEN_PADDING,
+      height: 1080 - FULLSCREEN_HEADER_HEIGHT - FULLSCREEN_PADDING,
+    });
+    expect(result.maxHeight).toBeUndefined();
+  });
+
+  it("clamps fullscreen dimensions to zero for tiny viewports", () => {
+    const result = computeContainerDimensions("fullscreen", 500, 10, 10);
+    expect(result.width).toBe(0);
+    expect(result.height).toBe(0);
+  });
+
+  it("ignores inlineWidth in fullscreen mode", () => {
+    const a = computeContainerDimensions("fullscreen", 100, 1920, 1080);
+    const b = computeContainerDimensions("fullscreen", 999, 1920, 1080);
+    expect(a.width).toBe(b.width);
+    expect(a.height).toBe(b.height);
+  });
+});
+
+describe("toCallToolResult", () => {
+  it("passes through a well-formed CallToolResult", () => {
+    const result = {
+      content: [{ type: "text" as const, text: "hello" }],
+      isError: false,
+    };
+    expect(toCallToolResult(result)).toBe(result);
+  });
+
+  it("passes through a result with structuredContent", () => {
+    const result = {
+      content: [],
+      structuredContent: { key: "value" },
+    };
+    expect(toCallToolResult(result)).toBe(result);
+  });
+
+  it("wraps a bare string into a text content block", () => {
+    expect(toCallToolResult("hello")).toEqual({
+      content: [{ type: "text", text: "hello" }],
+    });
+  });
+
+  it("wraps null into an empty text content block", () => {
+    expect(toCallToolResult(null)).toEqual({
+      content: [{ type: "text", text: "" }],
+    });
+  });
+
+  it("wraps undefined into an empty text content block", () => {
+    expect(toCallToolResult(undefined)).toEqual({
+      content: [{ type: "text", text: "" }],
+    });
+  });
+
+  it("JSON-stringifies non-string objects without content", () => {
+    expect(toCallToolResult({ foo: "bar" })).toEqual({
+      content: [{ type: "text", text: '{"foo":"bar"}' }],
+    });
+  });
+
+  it("normalizes content that is a string instead of an array", () => {
+    const result = toCallToolResult({
+      content: "plain text result",
+      isError: false,
+    });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "plain text result" }],
+      isError: false,
+    });
+  });
+
+  it("normalizes content that is a non-array non-string", () => {
+    const result = toCallToolResult({
+      content: 42,
+      isError: true,
+    });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "42" }],
+      isError: true,
+    });
+  });
+
+  it("preserves structuredContent when normalizing string content", () => {
+    const structured = { type: "chart", data: [1, 2, 3] };
+    const result = toCallToolResult({
+      content: "fallback text",
+      structuredContent: structured,
+      isError: false,
+    });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "fallback text" }],
+      structuredContent: structured,
+      isError: false,
+    });
+  });
+
+  it("preserves _meta when normalizing string content", () => {
+    const result = toCallToolResult({
+      content: "text",
+      _meta: { requestId: "abc" },
+      structuredContent: { key: "val" },
+    });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "text" }],
+      _meta: { requestId: "abc" },
+      structuredContent: { key: "val" },
+    });
+  });
+});

--- a/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-host-utils.ts
+++ b/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-host-utils.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared utilities for McpAppHost: container dimension calculations
+ * for inline/fullscreen display modes.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-03-26/extensions/mcp-apps
+ */
+
+import type { McpUiDisplayMode } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export const INLINE_MAX_HEIGHT = 600;
+export const FULLSCREEN_HEADER_HEIGHT = 48;
+export const FULLSCREEN_PADDING = 32;
+
+export interface ContainerDimensions {
+  width: number;
+  height?: number;
+  maxHeight?: number;
+}
+
+export function parseMcpToolKey(mcpToolName: string): {
+  serverName: string;
+  toolName: string;
+} {
+  const parts = mcpToolName.split("__");
+  return {
+    serverName: parts[1] ?? "",
+    toolName: parts.slice(2).join("__"),
+  };
+}
+
+/**
+ * Safely converts an unknown rawOutput into a well-formed CallToolResult.
+ * The ACP SDK types rawOutput as `unknown`; this normalizes whatever arrives
+ * so the MCP App bridge always receives valid data.
+ *
+ * The Anthropic API can return `mcp_tool_result.content` as either a string
+ * or an array. The Claude Agent SDK builds `tool_use_result` as:
+ *   { content: toolUseResult, ...mcpMeta }
+ * where `mcpMeta` may contain `structuredContent` and `_meta`.
+ *
+ * This function ensures `content` is always an array while preserving all
+ * other fields (structuredContent, _meta, isError) from the raw result.
+ */
+export function toCallToolResult(raw: unknown): CallToolResult {
+  if (raw != null && typeof raw === "object" && "content" in raw) {
+    const obj = raw as { content: unknown };
+    if (Array.isArray(obj.content)) {
+      return raw as CallToolResult;
+    }
+    // content exists but isn't an array — normalize to text block array
+    // while preserving structuredContent, _meta, isError, etc.
+    const text =
+      typeof obj.content === "string"
+        ? obj.content
+        : JSON.stringify(obj.content);
+    return {
+      ...(raw as CallToolResult),
+      content: [{ type: "text", text }],
+    };
+  }
+
+  // Wrap primitives (e.g. a bare string) into the expected shape
+  const text =
+    typeof raw === "string" ? raw : raw != null ? JSON.stringify(raw) : "";
+  return {
+    content: [{ type: "text", text }],
+  };
+}
+
+export function computeContainerDimensions(
+  mode: McpUiDisplayMode,
+  inlineWidth: number,
+  viewportWidth = window.innerWidth,
+  viewportHeight = window.innerHeight,
+): ContainerDimensions {
+  if (mode === "fullscreen") {
+    return {
+      width: Math.max(0, viewportWidth - FULLSCREEN_PADDING),
+      height: Math.max(
+        0,
+        viewportHeight - FULLSCREEN_HEADER_HEIGHT - FULLSCREEN_PADDING,
+      ),
+    };
+  }
+  return {
+    width: inlineWidth,
+    maxHeight: INLINE_MAX_HEIGHT,
+  };
+}

--- a/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-sandbox-proxy.test.ts
+++ b/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-sandbox-proxy.test.ts
@@ -1,0 +1,57 @@
+import { sandboxProxyHtml } from "@shared/mcp-sandbox-proxy";
+import { describe, expect, it } from "vitest";
+
+// The checks here aren't 100% validating what the code is doing, HOWEVER,
+// it does validate we're at least considering the different situations
+describe("sandboxProxyHtml", () => {
+  it("returns valid HTML", () => {
+    expect(sandboxProxyHtml).toContain("<!DOCTYPE html>");
+    expect(sandboxProxyHtml).toContain("<html>");
+    expect(sandboxProxyHtml).toContain("</html>");
+  });
+
+  it("sends sandbox-proxy-ready notification on load", () => {
+    expect(sandboxProxyHtml).toContain("ui/notifications/sandbox-proxy-ready");
+  });
+
+  it("listens for sandbox-resource-ready message", () => {
+    expect(sandboxProxyHtml).toContain(
+      "ui/notifications/sandbox-resource-ready",
+    );
+  });
+
+  it("creates inner iframe with allow-scripts, allow-same-origin, and allow-forms sandbox", () => {
+    expect(sandboxProxyHtml).toContain(
+      "allow-scripts allow-same-origin allow-forms",
+    );
+  });
+
+  it("uses document.write to inject HTML instead of srcdoc", () => {
+    expect(sandboxProxyHtml).toContain("doc.open()");
+    expect(sandboxProxyHtml).toContain("doc.write(params.html)");
+    expect(sandboxProxyHtml).toContain("doc.close()");
+  });
+
+  it("uses location.origin for forwarding messages to inner iframe", () => {
+    expect(sandboxProxyHtml).toContain("postMessage(data, location.origin)");
+  });
+
+  it("builds permission policy allow attribute with cross-origin delegation", () => {
+    expect(sandboxProxyHtml).toContain("buildAllowAttribute");
+    expect(sandboxProxyHtml).toContain("clipboard-write");
+
+    // Features use " *" suffix for cross-origin delegation
+    expect(sandboxProxyHtml).toContain('+ " *"');
+  });
+
+  it("relays inner iframe messages back to host", () => {
+    expect(sandboxProxyHtml).toContain("inner.contentWindow");
+    expect(sandboxProxyHtml).toContain("window.parent.postMessage");
+  });
+
+  it("favors var over let/const", () => {
+    expect(sandboxProxyHtml).toContain("var ");
+    expect(sandboxProxyHtml).not.toContain("let ");
+    expect(sandboxProxyHtml).not.toContain("const ");
+  });
+});

--- a/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-theme.test.ts
+++ b/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-theme.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildHostStyles, buildHostStylesCss } from "./mcp-app-theme";
+
+// Mock getComputedStyle to return predictable values
+const mockStyles = new Map<string, string>([
+  ["--gray-1", "#111"],
+  ["--gray-2", "#222"],
+  ["--gray-3", "#333"],
+  ["--gray-5", "#555"],
+  ["--gray-6", "#666"],
+  ["--gray-10", "#aaa"],
+  ["--gray-11", "#bbb"],
+  ["--gray-12", "#ccc"],
+  ["--accent-3", "#fa3"],
+  ["--accent-6", "#f86"],
+  ["--accent-9", "#f90"],
+  ["--accent-11", "#fb0"],
+  ["--red-3", "#f33"],
+  ["--red-6", "#f44"],
+  ["--red-9", "#f00"],
+  ["--red-11", "#f66"],
+  ["--green-3", "#3f3"],
+  ["--green-6", "#4f4"],
+  ["--green-9", "#0f0"],
+  ["--green-11", "#6f6"],
+  ["--yellow-3", "#ff3"],
+  ["--yellow-6", "#ff4"],
+  ["--yellow-9", "#ff0"],
+  ["--yellow-11", "#ff6"],
+  ["--default-font-family", "Berkeley Mono, monospace"],
+  ["--code-font-family", "JetBrains Mono, monospace"],
+  ["--font-size-1", "12px"],
+  ["--font-size-2", "14px"],
+  ["--font-size-3", "16px"],
+  ["--font-size-4", "18px"],
+  ["--font-size-5", "20px"],
+  ["--font-size-6", "24px"],
+  ["--font-size-7", "28px"],
+  ["--font-size-8", "35px"],
+  ["--font-size-9", "60px"],
+  ["--radius-2", "4px"],
+  ["--radius-3", "8px"],
+  ["--radius-4", "12px"],
+  ["--radius-5", "16px"],
+]);
+
+beforeEach(() => {
+  vi.stubGlobal("getComputedStyle", () => ({
+    getPropertyValue: (name: string) => mockStyles.get(name) ?? "",
+  }));
+
+  vi.stubGlobal("document", {
+    ...document,
+    documentElement: document.documentElement,
+    fonts: { check: () => false },
+  });
+});
+
+describe("buildHostStyles", () => {
+  it("returns variables and css objects", () => {
+    const result = buildHostStyles(true);
+    expect(result).toHaveProperty("variables");
+    expect(result).toHaveProperty("css");
+    expect(result.css).toHaveProperty("fonts");
+  });
+
+  it("includes all required MCP Apps CSS variables", () => {
+    const result = buildHostStyles(true);
+    const vars = result.variables;
+
+    // Background (all spec-defined)
+    expect(vars["--color-background-primary"]).toBeDefined();
+    expect(vars["--color-background-secondary"]).toBeDefined();
+    expect(vars["--color-background-tertiary"]).toBeDefined();
+    expect(vars["--color-background-inverse"]).toBeDefined();
+    expect(vars["--color-background-ghost"]).toBe("transparent");
+    expect(vars["--color-background-info"]).toBeDefined();
+    expect(vars["--color-background-danger"]).toBeDefined();
+    expect(vars["--color-background-success"]).toBeDefined();
+    expect(vars["--color-background-warning"]).toBeDefined();
+    expect(vars["--color-background-disabled"]).toBeDefined();
+
+    // Text (all spec-defined)
+    expect(vars["--color-text-primary"]).toBeDefined();
+    expect(vars["--color-text-secondary"]).toBeDefined();
+    expect(vars["--color-text-tertiary"]).toBeDefined();
+    expect(vars["--color-text-inverse"]).toBeDefined();
+    expect(vars["--color-text-ghost"]).toBeDefined();
+    expect(vars["--color-text-info"]).toBeDefined();
+    expect(vars["--color-text-danger"]).toBeDefined();
+    expect(vars["--color-text-success"]).toBeDefined();
+    expect(vars["--color-text-warning"]).toBeDefined();
+    expect(vars["--color-text-disabled"]).toBeDefined();
+
+    // Border (all spec-defined)
+    expect(vars["--color-border-primary"]).toBeDefined();
+    expect(vars["--color-border-secondary"]).toBeDefined();
+    expect(vars["--color-border-tertiary"]).toBeDefined();
+    expect(vars["--color-border-inverse"]).toBeDefined();
+    expect(vars["--color-border-ghost"]).toBe("transparent");
+    expect(vars["--color-border-info"]).toBeDefined();
+    expect(vars["--color-border-danger"]).toBeDefined();
+    expect(vars["--color-border-success"]).toBeDefined();
+    expect(vars["--color-border-warning"]).toBeDefined();
+    expect(vars["--color-border-disabled"]).toBeDefined();
+
+    // Ring (all spec-defined)
+    expect(vars["--color-ring-primary"]).toBeDefined();
+    expect(vars["--color-ring-secondary"]).toBeDefined();
+    expect(vars["--color-ring-inverse"]).toBeDefined();
+    expect(vars["--color-ring-info"]).toBeDefined();
+    expect(vars["--color-ring-danger"]).toBeDefined();
+    expect(vars["--color-ring-success"]).toBeDefined();
+    expect(vars["--color-ring-warning"]).toBeDefined();
+
+    // Fonts
+    expect(vars["--font-sans"]).toBeDefined();
+    expect(vars["--font-mono"]).toBeDefined();
+
+    // Font weights
+    expect(vars["--font-weight-normal"]).toBe("400");
+    expect(vars["--font-weight-medium"]).toBe("500");
+    expect(vars["--font-weight-semibold"]).toBe("600");
+    expect(vars["--font-weight-bold"]).toBe("700");
+
+    // Font sizes (spec names: xs, sm, md, lg)
+    expect(vars["--font-text-xs-size"]).toBeDefined();
+    expect(vars["--font-text-sm-size"]).toBeDefined();
+    expect(vars["--font-text-md-size"]).toBeDefined();
+    expect(vars["--font-text-lg-size"]).toBeDefined();
+
+    // Heading sizes (spec names: xs through 3xl)
+    expect(vars["--font-heading-xs-size"]).toBeDefined();
+    expect(vars["--font-heading-sm-size"]).toBeDefined();
+    expect(vars["--font-heading-md-size"]).toBeDefined();
+    expect(vars["--font-heading-lg-size"]).toBeDefined();
+    expect(vars["--font-heading-xl-size"]).toBeDefined();
+    expect(vars["--font-heading-2xl-size"]).toBeDefined();
+    expect(vars["--font-heading-3xl-size"]).toBeDefined();
+
+    // Line heights (all spec-defined)
+    expect(vars["--font-text-xs-line-height"]).toBe("1.5");
+    expect(vars["--font-text-sm-line-height"]).toBe("1.5");
+    expect(vars["--font-text-md-line-height"]).toBe("1.5");
+    expect(vars["--font-text-lg-line-height"]).toBe("1.5");
+    expect(vars["--font-heading-xs-line-height"]).toBe("1.3");
+    expect(vars["--font-heading-sm-line-height"]).toBe("1.3");
+    expect(vars["--font-heading-md-line-height"]).toBe("1.25");
+    expect(vars["--font-heading-lg-line-height"]).toBe("1.25");
+    expect(vars["--font-heading-xl-line-height"]).toBe("1.2");
+    expect(vars["--font-heading-2xl-line-height"]).toBe("1.2");
+    expect(vars["--font-heading-3xl-line-height"]).toBe("1.1");
+
+    // Border radius
+    expect(vars["--border-radius-xs"]).toBeDefined();
+    expect(vars["--border-radius-full"]).toBe("9999px");
+
+    // Border width
+    expect(vars["--border-width-regular"]).toBe("1px");
+
+    // Shadows
+    expect(vars["--shadow-hairline"]).toBeDefined();
+    expect(vars["--shadow-sm"]).toBeDefined();
+    expect(vars["--shadow-md"]).toBeDefined();
+    expect(vars["--shadow-lg"]).toBeDefined();
+  });
+
+  it("reads from computed CSS variables", () => {
+    const result = buildHostStyles(true);
+    expect(result.variables["--color-background-primary"]).toBe("#111");
+    expect(result.variables["--color-text-primary"]).toBe("#ccc");
+    expect(result.variables["--color-border-info"]).toBe("#f86");
+    expect(result.variables["--color-ring-danger"]).toBe("#f00");
+  });
+});
+
+describe("buildHostStylesCss", () => {
+  it("converts variables to CSS string", () => {
+    const css = buildHostStylesCss({
+      "--color-background-primary": "#111",
+      "--color-text-primary": "#ccc",
+    });
+    expect(css).toContain("--color-background-primary: #111;");
+    expect(css).toContain("--color-text-primary: #ccc;");
+  });
+});

--- a/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-theme.ts
+++ b/apps/code/src/renderer/features/mcp-apps/utils/mcp-app-theme.ts
@@ -1,0 +1,160 @@
+/**
+ * Maps Twig's Radix UI theme to the MCP Apps host styling spec.
+ *
+ * MCP Apps receive a set of CSS variables from the host so they can render with
+ * a consistent look and feel. This module reads Twig's computed CSS custom
+ * properties (gray scale, accent colors, font sizes, radii, etc.) and maps them
+ * to the spec-defined variable names (e.g. --color-background-primary,
+ * --font-text-sm-size, --border-radius-xs).
+ *
+ * The variables are sent to the app during `ui/initialize` and updated via
+ * `ui/notifications/host-context-changed` on theme changes.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-03-26/extensions/mcp-apps
+ */
+
+interface HostStyles {
+  variables: Record<string, string>;
+  css: { fonts: string };
+}
+
+function getVar(name: string): string {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+}
+
+export function buildHostStyles(_isDarkMode: boolean): HostStyles {
+  const variables: Record<string, string> = {
+    // --- Background colors ---
+    "--color-background-primary": getVar("--gray-1"),
+    "--color-background-secondary": getVar("--gray-2"),
+    "--color-background-tertiary": getVar("--gray-3"),
+    "--color-background-inverse": getVar("--gray-12"),
+    "--color-background-ghost": "transparent",
+    "--color-background-info": getVar("--accent-3"),
+    "--color-background-danger": getVar("--red-3"),
+    "--color-background-success": getVar("--green-3"),
+    "--color-background-warning": getVar("--yellow-3"),
+    "--color-background-disabled": getVar("--gray-3"),
+
+    // --- Text colors ---
+    "--color-text-primary": getVar("--gray-12"),
+    "--color-text-secondary": getVar("--gray-11"),
+    "--color-text-tertiary": getVar("--gray-10"),
+    "--color-text-inverse": getVar("--gray-1"),
+    "--color-text-ghost": getVar("--gray-10"),
+    "--color-text-info": getVar("--accent-11"),
+    "--color-text-danger": getVar("--red-11"),
+    "--color-text-success": getVar("--green-11"),
+    "--color-text-warning": getVar("--yellow-11"),
+    "--color-text-disabled": getVar("--gray-6"),
+
+    // --- Border colors ---
+    "--color-border-primary": getVar("--gray-6"),
+    "--color-border-secondary": getVar("--gray-5"),
+    "--color-border-tertiary": getVar("--gray-3"),
+    "--color-border-inverse": getVar("--gray-12"),
+    "--color-border-ghost": "transparent",
+    "--color-border-info": getVar("--accent-6"),
+    "--color-border-danger": getVar("--red-6"),
+    "--color-border-success": getVar("--green-6"),
+    "--color-border-warning": getVar("--yellow-6"),
+    "--color-border-disabled": getVar("--gray-5"),
+
+    // --- Ring / focus colors ---
+    "--color-ring-primary": getVar("--accent-9"),
+    "--color-ring-secondary": getVar("--gray-6"),
+    "--color-ring-inverse": getVar("--gray-1"),
+    "--color-ring-info": getVar("--accent-9"),
+    "--color-ring-danger": getVar("--red-9"),
+    "--color-ring-success": getVar("--green-9"),
+    "--color-ring-warning": getVar("--yellow-9"),
+
+    // --- Fonts ---
+    "--font-sans": getVar("--default-font-family") || "system-ui, sans-serif",
+    "--font-mono":
+      getVar("--code-font-family") ||
+      "'Berkeley Mono', 'JetBrains Mono', monospace",
+
+    // --- Font weights ---
+    "--font-weight-normal": "400",
+    "--font-weight-medium": "500",
+    "--font-weight-semibold": "600",
+    "--font-weight-bold": "700",
+
+    // --- Font sizes (spec names) ---
+    "--font-text-xs-size": getVar("--font-size-1") || "12px",
+    "--font-text-sm-size": getVar("--font-size-2") || "14px",
+    "--font-text-md-size": getVar("--font-size-3") || "16px",
+    "--font-text-lg-size": getVar("--font-size-4") || "18px",
+    "--font-heading-xs-size": getVar("--font-size-4") || "18px",
+    "--font-heading-sm-size": getVar("--font-size-5") || "20px",
+    "--font-heading-md-size": getVar("--font-size-6") || "24px",
+    "--font-heading-lg-size": getVar("--font-size-7") || "28px",
+    "--font-heading-xl-size": getVar("--font-size-8") || "35px",
+    "--font-heading-2xl-size": getVar("--font-size-9") || "60px",
+    "--font-heading-3xl-size": "72px",
+
+    // --- Line heights ---
+    "--font-text-xs-line-height": "1.5",
+    "--font-text-sm-line-height": "1.5",
+    "--font-text-md-line-height": "1.5",
+    "--font-text-lg-line-height": "1.5",
+    "--font-heading-xs-line-height": "1.3",
+    "--font-heading-sm-line-height": "1.3",
+    "--font-heading-md-line-height": "1.25",
+    "--font-heading-lg-line-height": "1.25",
+    "--font-heading-xl-line-height": "1.2",
+    "--font-heading-2xl-line-height": "1.2",
+    "--font-heading-3xl-line-height": "1.1",
+
+    // --- Border radius ---
+    "--border-radius-xs": "2px",
+    "--border-radius-sm": getVar("--radius-2") || "4px",
+    "--border-radius-md": getVar("--radius-3") || "8px",
+    "--border-radius-lg": getVar("--radius-4") || "12px",
+    "--border-radius-xl": getVar("--radius-5") || "16px",
+    "--border-radius-full": "9999px",
+
+    // --- Border width ---
+    "--border-width-regular": "1px",
+
+    // --- Shadows ---
+    "--shadow-hairline": `0 0 0 1px ${getVar("--gray-6") || "rgba(0,0,0,0.1)"}`,
+    "--shadow-sm": "0 1px 2px rgba(0,0,0,0.05)",
+    "--shadow-md":
+      "0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06)",
+    "--shadow-lg":
+      "0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05)",
+  };
+
+  // Build font CSS (include @font-face if Berkeley Mono is available)
+  const fontCss = buildFontCss();
+
+  return {
+    variables,
+    css: { fonts: fontCss },
+  };
+}
+
+function buildFontCss(): string {
+  // Check if Berkeley Mono is loaded
+  const berkeleyMonoAvailable = document.fonts.check("12px 'Berkeley Mono'");
+
+  if (!berkeleyMonoAvailable) {
+    return "";
+  }
+
+  // Berkeley Mono is available on the host, but the sandboxed iframe
+  // can't access host fonts. We provide the font-family declarations
+  // so the app knows the preferred font, but the actual font rendering
+  // falls back to JetBrains Mono or system monospace in the iframe.
+  return "";
+}
+
+export function buildHostStylesCss(variables: Record<string, string>): string {
+  return Object.entries(variables)
+    .map(([key, value]) => `${key}: ${value};`)
+    .join("\n");
+}

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -98,6 +98,25 @@ export function ConversationView({
     return queuedItems.length > 0 ? [...result, ...queuedItems] : result;
   }, [conversationItems, optimisticItems, queuedItems]);
 
+  // Keep MCP App tool call items mounted so their iframes and bridges
+  // survive scrolling out of the virtualized viewport.
+  const mcpAppIndices = useMemo(() => {
+    const indices: number[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.type !== "session_update") continue;
+      const update = item.update;
+      if (!("_meta" in update)) continue;
+      const meta = update._meta as
+        | { claudeCode?: { toolName?: string } }
+        | undefined;
+      if (meta?.claudeCode?.toolName?.startsWith("mcp__")) {
+        indices.push(i);
+      }
+    }
+    return indices;
+  }, [items]);
+
   const handleScrollStateChange = useCallback((isAtBottom: boolean) => {
     setShowScrollButton(!isAtBottom);
   }, []);
@@ -181,12 +200,18 @@ export function ConversationView({
 
   return (
     <div className="relative flex-1">
+      <div
+        id="mcp-fullscreen-portal"
+        className="pointer-events-none absolute inset-0 z-20"
+      />
+
       <VirtualizedList
         ref={listRef}
         items={items}
         getItemKey={getItemKey}
         renderItem={renderItem}
         onScrollStateChange={handleScrollStateChange}
+        keepMounted={mcpAppIndices}
         className="absolute inset-0 bg-gray-1"
         itemClassName="mx-auto max-w-[750px] px-2 py-1.5"
         footer={

--- a/apps/code/src/renderer/features/sessions/components/VirtualizedList.tsx
+++ b/apps/code/src/renderer/features/sessions/components/VirtualizedList.tsx
@@ -17,6 +17,7 @@ interface VirtualizedListProps<T> {
   itemClassName?: string;
   footer?: ReactNode;
   onScrollStateChange?: (isAtBottom: boolean) => void;
+  keepMounted?: readonly number[];
 }
 
 export interface VirtualizedListHandle {
@@ -34,6 +35,7 @@ function VirtualizedListInner<T>(
     itemClassName,
     footer,
     onScrollStateChange,
+    keepMounted,
   }: VirtualizedListProps<T>,
   ref: React.ForwardedRef<VirtualizedListHandle>,
 ) {
@@ -111,6 +113,7 @@ function VirtualizedListInner<T>(
         shift={false}
         style={{ flex: 1 }}
         onScroll={handleScroll}
+        keepMounted={keepMounted}
       >
         {items.map((item, index) => (
           <div

--- a/apps/code/src/renderer/features/sessions/components/session-update/McpToolBlock.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/McpToolBlock.tsx
@@ -1,0 +1,74 @@
+import { McpAppHost } from "@features/mcp-apps/components/McpAppHost";
+import { McpToolView } from "@features/mcp-apps/components/McpToolView";
+import { parseMcpToolKey } from "@features/mcp-apps/utils/mcp-app-host-utils";
+import { useSettingsStore } from "@features/settings/stores/settingsStore";
+import { useTRPC } from "@renderer/trpc/client";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { logger } from "@utils/logger";
+import { useEffect } from "react";
+import type { ToolViewProps } from "./toolCallUtils";
+
+const log = logger.scope("mcp-tool-block");
+
+interface McpToolBlockProps extends ToolViewProps {
+  mcpToolName: string;
+}
+
+export function McpToolBlock(props: McpToolBlockProps) {
+  const { mcpToolName } = props;
+  const { serverName, toolName } = parseMcpToolKey(mcpToolName);
+
+  const mcpAppsDisabled = useSettingsStore((s) => s.mcpAppsDisabledServers);
+  const isDisabledForServer = mcpAppsDisabled.includes(serverName);
+
+  const trpcReact = useTRPC();
+  const queryClient = useQueryClient();
+
+  const { data: hasUi } = useQuery(
+    trpcReact.mcpApps.hasUiForTool.queryOptions(
+      { toolKey: mcpToolName },
+      {
+        staleTime: Infinity,
+        enabled: !isDisabledForServer,
+      },
+    ),
+  );
+
+  // TODO: Remove this, used for local debugging only
+  useEffect(() => {
+    log.debug("McpToolBlock render", {
+      mcpToolName,
+      hasUi,
+      isDisabledForServer,
+    });
+  }, [mcpToolName, hasUi, isDisabledForServer]);
+
+  // When MCP Apps discovery completes (possibly after this component mounted),
+  // invalidate the hasUiForTool query so we pick up newly-discovered UIs.
+  useSubscription(
+    trpcReact.mcpApps.onDiscoveryComplete.subscriptionOptions(undefined, {
+      onData: (event) => {
+        log.info("Discovery complete, invalidating queries", {
+          mcpToolName,
+          discoveredTools: event.toolKeys,
+        });
+        void queryClient.invalidateQueries(
+          trpcReact.mcpApps.hasUiForTool.pathFilter(),
+        );
+        void queryClient.invalidateQueries(
+          trpcReact.mcpApps.getUiResource.pathFilter(),
+        );
+      },
+    }),
+  );
+
+  return (
+    <>
+      <McpToolView {...props} />
+      {hasUi && !isDisabledForServer && (
+        <McpAppHost {...props} serverName={serverName} toolName={toolName} />
+      )}
+    </>
+  );
+}

--- a/apps/code/src/renderer/features/sessions/components/session-update/ToolCallBlock.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ToolCallBlock.tsx
@@ -8,7 +8,7 @@ import { DeleteToolView } from "./DeleteToolView";
 import { EditToolView } from "./EditToolView";
 import { ExecuteToolView } from "./ExecuteToolView";
 import { FetchToolView } from "./FetchToolView";
-import { McpToolView } from "./McpToolView";
+import { McpToolBlock } from "./McpToolBlock";
 import { MoveToolView } from "./MoveToolView";
 import { PlanApprovalView } from "./PlanApprovalView";
 import { QuestionToolView } from "./QuestionToolView";
@@ -67,7 +67,7 @@ export function ToolCallBlock({
   if (toolName?.startsWith("mcp__")) {
     return (
       <Box className="pl-3">
-        <McpToolView {...props} mcpToolName={toolName} />
+        <McpToolBlock {...props} mcpToolName={toolName} />
       </Box>
     );
   }

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.ts
@@ -38,6 +38,7 @@ interface SettingsStore {
   customInstructions: string;
   diffOpenMode: DiffOpenMode;
   hedgehogMode: boolean;
+  mcpAppsDisabledServers: string[];
   hints: Record<string, HintState>;
 
   shouldShowHint: (key: string, max?: number) => boolean;
@@ -69,6 +70,7 @@ interface SettingsStore {
   setCustomInstructions: (instructions: string) => void;
   setDiffOpenMode: (mode: DiffOpenMode) => void;
   setHedgehogMode: (enabled: boolean) => void;
+  setMcpAppsDisabledServers: (servers: string[]) => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -95,6 +97,7 @@ export const useSettingsStore = create<SettingsStore>()(
       customInstructions: "",
       diffOpenMode: "auto",
       hedgehogMode: false,
+      mcpAppsDisabledServers: [],
       hints: {},
 
       shouldShowHint: (key, max = 3) => {
@@ -162,6 +165,8 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ customInstructions: instructions }),
       setDiffOpenMode: (mode) => set({ diffOpenMode: mode }),
       setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
+      setMcpAppsDisabledServers: (servers) =>
+        set({ mcpAppsDisabledServers: servers }),
     }),
     {
       name: "settings-storage",
@@ -189,6 +194,7 @@ export const useSettingsStore = create<SettingsStore>()(
         diffOpenMode: state.diffOpenMode,
         hedgehogMode: state.hedgehogMode,
         hints: state.hints,
+        mcpAppsDisabledServers: state.mcpAppsDisabledServers,
       }),
       merge: (persisted, current) => {
         const merged = {

--- a/apps/code/src/shared/mcp-sandbox-proxy.html
+++ b/apps/code/src/shared/mcp-sandbox-proxy.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <style>
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    iframe {
+      border: none;
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <script>
+    function log(...args) {
+      console.log("[mcp-sandbox-proxy]", ...args);
+    }
+
+    function init() {
+      "use strict";
+
+      log("Proxy starting", { origin: location.origin, href: location.href });
+
+      var inner = document.createElement("iframe");
+      inner.style.cssText = "width:100%; height:100%; border:none;";
+      inner.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+      document.body.appendChild(inner);
+
+      // Build Permission Policy allow attribute from permissions object.
+      // Maps McpUiResourcePermissions keys to Permission Policy feature names.
+      // Uses "*" suffix for cross-origin permission delegation.
+      function buildAllowAttribute(permissions) {
+        if (!permissions || typeof permissions !== "object") return "";
+
+        var mapping = {
+          camera: "camera",
+          microphone: "microphone",
+          geolocation: "geolocation",
+          clipboardWrite: "clipboard-write"
+        };
+
+        var features = Object.keys(permissions)
+          .filter(function (key) { return mapping[key] && permissions[key] != null; })
+          .map(function (key) { return mapping[key] + " *"; });
+
+        return features.join("; ");
+      }
+
+      // Handle messages from the host (parent)
+      function handleParentMessage(data) {
+        if (data && data.method === "ui/notifications/sandbox-resource-ready") {
+          var params = data.params;
+          sent = true; // Stop retrying sandbox-proxy-ready
+          log("Received sandbox-resource-ready", {
+            hasHtml: !!(params && params.html),
+            htmlLength: params && params.html ? params.html.length : 0,
+            hasPermissions: !!(params && params.permissions),
+            hasCsp: !!(params && params.csp)
+          });
+
+          if (params && typeof params.html === "string") {
+            // Set allow attribute for Permission Policy features
+            var allowValue = buildAllowAttribute(params.permissions);
+            if (allowValue) {
+              inner.setAttribute("allow", allowValue);
+            }
+
+            // Use document.write() instead of srcdoc to preserve origin.
+            // srcdoc creates an opaque origin that breaks WebGL canvas operations
+            // like toDataURL() and cross-origin resource access.
+            var doc = inner.contentDocument;
+            log("Writing HTML to inner iframe", {
+              htmlLength: params.html.length,
+              hasContentDocument: !!doc
+            });
+
+            doc.open();
+            doc.write(params.html);
+            doc.close();
+
+            log("HTML written to inner iframe");
+          }
+        } else {
+          // Forward all other messages to inner iframe
+          log("Forwarding host -> inner", {
+            method: data.method,
+            id: data.id,
+            hasInner: !!(inner && inner.contentWindow),
+            targetOrigin: location.origin
+          });
+
+          if (inner && inner.contentWindow) {
+            inner.contentWindow.postMessage(data, location.origin);
+          }
+        }
+      }
+
+      // Listen for messages from host (parent) and inner iframe
+      window.addEventListener("message", function (event) {
+        var data = event.data;
+        if (!data || typeof data !== "object") return;
+
+        if (event.source === window.parent) {
+          log("Message from host", {
+            method: data.method,
+            id: data.id,
+            origin: event.origin
+          });
+          handleParentMessage(data);
+        } else if (event.source === inner.contentWindow) {
+          log("Relaying inner -> host", {
+            method: data.method,
+            id: data.id,
+            origin: event.origin
+          });
+          // Relay messages from inner iframe back to host
+          window.parent.postMessage(data, "*");
+        } else {
+          log("Message from unknown source", {
+            method: data.method,
+            origin: event.origin,
+            isParent: event.source === window.parent,
+            isInner: event.source === inner.contentWindow
+          });
+        }
+      });
+
+      // Notify host that proxy is ready to receive HTML.
+      // Retry a few times because the host's useEffect listener may not be
+      // registered yet when src= loads faster than React's effect cycle.
+      var readyMsg = {
+        jsonrpc: "2.0",
+        method: "ui/notifications/sandbox-proxy-ready",
+        params: {}
+      };
+      var sent = false;
+      function sendReady() {
+        if (sent) return;
+        log("Sending sandbox-proxy-ready to host");
+        window.parent.postMessage(readyMsg, "*");
+      }
+
+      // The host removes its listener on first receipt, so retries are harmless
+      sendReady();
+      setTimeout(sendReady, 50);
+      setTimeout(sendReady, 150);
+    };
+
+    // Fire and forget, similar to IIFE
+    init();
+  </script>
+</body>
+
+</html>

--- a/apps/code/src/shared/mcp-sandbox-proxy.ts
+++ b/apps/code/src/shared/mcp-sandbox-proxy.ts
@@ -1,0 +1,23 @@
+/**
+ * Sandbox proxy HTML for MCP Apps.
+ *
+ * This is the intermediate layer in the double-iframe architecture:
+ *
+ *   Host (renderer) → Outer iframe (sandbox proxy) → Inner iframe (MCP App)
+ *
+ * The outer iframe is served from the `mcp-sandbox:` custom protocol, giving it
+ * an isolated origin separate from the renderer. The inner iframe uses
+ * allow-same-origin so the proxy can write HTML via document.write() — srcdoc
+ * creates an opaque origin that breaks WebGL canvas operations (toDataURL) and
+ * cross-origin resource access.
+ *
+ * Because the proxy's origin (`mcp-sandbox://proxy`) differs from the
+ * renderer's origin, the app cannot traverse `window.parent.parent` to access
+ * the host's DOM, storage, or cookies.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-03-26/extensions/mcp-apps
+ */
+
+import html from "./mcp-sandbox-proxy.html?raw";
+
+export const sandboxProxyHtml: string = html;

--- a/apps/code/src/shared/types/mcp-apps.ts
+++ b/apps/code/src/shared/types/mcp-apps.ts
@@ -1,0 +1,159 @@
+import type {
+  McpUiResourceCsp,
+  McpUiResourcePermissions,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import { z } from "zod";
+
+// --- UI Resources ---
+
+export const mcpUiResourceSchema = z.object({
+  uri: z.string(),
+  name: z.string().optional(),
+  mimeType: z.string(),
+  csp: z
+    .object({
+      connectDomains: z.array(z.string()).optional(),
+      resourceDomains: z.array(z.string()).optional(),
+      frameDomains: z.array(z.string()).optional(),
+      baseUriDomains: z.array(z.string()).optional(),
+    })
+    .optional(),
+  permissions: z
+    .object({
+      camera: z.object({}).optional(),
+      microphone: z.object({}).optional(),
+      geolocation: z.object({}).optional(),
+      clipboardWrite: z.object({}).optional(),
+    })
+    .optional(),
+  html: z.string(),
+  serverName: z.string(),
+});
+
+export interface McpUiResource {
+  uri: string;
+  name?: string;
+  mimeType: string;
+  csp?: McpUiResourceCsp;
+  permissions?: McpUiResourcePermissions;
+  html: string;
+  serverName: string;
+}
+
+// --- MCP extension metadata shapes ---
+// The MCP SDK types don't expose the `_meta.ui` extension fields, so we define
+// them here for use when casting raw SDK tool/resource objects.
+
+export type McpToolUiVisibility = "model" | "app";
+
+/** Shape of the `_meta.ui` field on MCP tool definitions that have a UI. */
+export interface McpToolUiMeta {
+  _meta?: {
+    ui?: {
+      resourceUri?: string;
+      visibility?: McpToolUiVisibility[];
+    };
+  };
+}
+
+/** Shape of MCP resource definitions that carry `_meta.ui` CSP/permissions. */
+export interface McpResourceUiMeta {
+  uri: string;
+  name?: string;
+  _meta?: {
+    ui?: {
+      csp?: McpUiResource["csp"];
+      permissions?: McpUiResource["permissions"];
+    };
+  };
+}
+
+/** Tool-to-UI associations */
+export const mcpToolUiAssociationSchema = z.object({
+  toolKey: z.string(),
+  serverName: z.string(),
+  toolName: z.string(),
+  resourceUri: z.string(),
+  visibility: z.array(z.enum(["model", "app"])).optional(),
+});
+
+export type McpToolUiAssociation = z.infer<typeof mcpToolUiAssociationSchema>;
+
+// --- tRPC input/output schemas ---
+
+export const getUiResourceInput = z.object({
+  toolKey: z.string(),
+});
+
+export const hasUiForToolInput = z.object({
+  toolKey: z.string(),
+});
+
+export const getToolDefinitionInput = z.object({
+  toolKey: z.string(),
+});
+
+export const proxyToolCallInput = z.object({
+  serverName: z.string(),
+  toolName: z.string(),
+  args: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const proxyResourceReadInput = z.object({
+  serverName: z.string(),
+  uri: z.string(),
+});
+
+export const openLinkInput = z.object({
+  url: z.string(),
+});
+
+export const mcpAppsSubscriptionInput = z.object({
+  toolKey: z.string(),
+});
+
+// --- Service event types ---
+
+export interface McpAppsToolInputEvent {
+  toolKey: string;
+  toolCallId: string;
+  args: unknown;
+}
+
+export interface McpAppsToolResultEvent {
+  toolKey: string;
+  toolCallId: string;
+  result: unknown;
+  isError?: boolean;
+}
+
+export interface McpAppsToolCancelledEvent {
+  toolKey: string;
+  toolCallId: string;
+}
+
+export interface McpAppsDiscoveryCompleteEvent {
+  toolKeys: string[];
+}
+
+export const McpAppsServiceEvent = {
+  ToolInput: "tool-input",
+  ToolResult: "tool-result",
+  ToolCancelled: "tool-cancelled",
+  DiscoveryComplete: "discovery-complete",
+} as const;
+
+export interface McpAppsServiceEvents {
+  [McpAppsServiceEvent.ToolInput]: McpAppsToolInputEvent;
+  [McpAppsServiceEvent.ToolResult]: McpAppsToolResultEvent;
+  [McpAppsServiceEvent.ToolCancelled]: McpAppsToolCancelledEvent;
+  [McpAppsServiceEvent.DiscoveryComplete]: McpAppsDiscoveryCompleteEvent;
+}
+
+// --- MCP server connection config ---
+
+export interface McpServerConnectionConfig {
+  name: string;
+  url: string;
+  headers: Record<string, string>;
+}

--- a/apps/code/src/shared/vite-raw-modules.d.ts
+++ b/apps/code/src/shared/vite-raw-modules.d.ts
@@ -1,0 +1,7 @@
+// Type declarations for Vite-style raw imports (e.g. `import txt from "./file.txt?raw"`).
+// These are not valid module names for classic TS resolution, but Vite supports them.
+
+declare module "*.html?raw" {
+  const content: string;
+  export default content;
+}

--- a/apps/code/src/vite-env.d.ts
+++ b/apps/code/src/vite-env.d.ts
@@ -13,6 +13,9 @@ interface ImportMetaEnv {
   readonly VITE_POSTHOG_UI_HOST?: string;
 }
 
+// This interface is used by TypeScript to type-check `import.meta.env` in Vite.
+// It appears unused in this file, but it is intentionally kept for global augmentation.
+// biome-ignore lint: noUnusedVariables
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,20 +1,22 @@
 procs:
   code:
-    shell: 'pnpm --filter code run start'
+    shell: "pnpm --filter code run start"
+    env:
+      DEBUG: "false"
     depends_on:
       - agent
       - git
 
   agent:
-    shell: 'pnpm --filter agent run dev'
-  
+    shell: "pnpm --filter agent run dev"
+
   git:
-    shell: 'pnpm --filter @posthog/git run dev'
+    shell: "pnpm --filter @posthog/git run dev"
 
   storybook:
-    shell: 'pnpm --filter code run storybook'
+    shell: "pnpm --filter code run storybook"
     autostart: false
 
   mobile-ios:
-    shell: 'pnpm --filter @posthog/mobile run ios'
+    shell: "pnpm --filter @posthog/mobile run ios"
     autostart: false

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -55,7 +55,10 @@ import {
   handleSystemMessage,
   handleUserAssistantMessage,
 } from "./conversion/sdk-to-acp";
-import { fetchMcpToolMetadata } from "./mcp/tool-metadata";
+import {
+  fetchMcpToolMetadata,
+  getConnectedMcpServerNames,
+} from "./mcp/tool-metadata";
 import { canUseTool } from "./permissions/permission-handlers";
 import { getAvailableSlashCommands } from "./session/commands";
 import { parseMcpServers } from "./session/mcp-config";
@@ -101,6 +104,7 @@ function sanitizeTitle(text: string): string {
 export interface ClaudeAcpAgentOptions {
   onProcessSpawned?: (info: ProcessSpawnedInfo) => void;
   onProcessExited?: (pid: number) => void;
+  onMcpServersReady?: (serverNames: string[]) => void;
 }
 
 export class ClaudeAcpAgent extends BaseAcpAgent {
@@ -1020,11 +1024,17 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
    * Both populate caches used later — neither is needed to return configOptions.
    */
   private deferBackgroundFetches(q: Query): void {
+    this.logger.info("Starting background fetches (commands + MCP metadata)");
     Promise.all([
       new Promise<void>((resolve) => setTimeout(resolve, 10)).then(() =>
         this.sendAvailableCommandsUpdate(),
       ),
-      fetchMcpToolMetadata(q, this.logger),
+      fetchMcpToolMetadata(q, this.logger).then(() => {
+        const serverNames = getConnectedMcpServerNames();
+        if (serverNames.length > 0) {
+          this.options?.onMcpServersReady?.(serverNames);
+        }
+      }),
     ]).catch((err) =>
       this.logger.error("Background fetch failed", { error: err }),
     );

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -56,6 +56,8 @@ type ChunkHandlerContext = {
   registerHooks?: boolean;
   supportsTerminalOutput?: boolean;
   cwd?: string;
+  /** Raw MCP tool result from SDKUserMessage.tool_use_result (contains content, structuredContent, _meta) */
+  mcpToolUseResult?: Record<string, unknown>;
 };
 
 export interface MessageHandlerContext {
@@ -348,7 +350,16 @@ function handleToolResultChunk(
     toolCallId: chunk.tool_use_id,
     sessionUpdate: "tool_call_update",
     status: chunk.is_error ? "failed" : "completed",
-    rawOutput: chunk.content,
+    rawOutput: ctx.mcpToolUseResult
+      ? { ...ctx.mcpToolUseResult, isError: chunk.is_error ?? false }
+      : {
+          content: Array.isArray(chunk.content)
+            ? chunk.content
+            : typeof chunk.content === "string"
+              ? [{ type: "text" as const, text: chunk.content }]
+              : [],
+          isError: chunk.is_error ?? false,
+        },
     ...toolUpdate,
   });
 
@@ -435,6 +446,7 @@ function toAcpNotifications(
   registerHooks?: boolean,
   supportsTerminalOutput?: boolean,
   cwd?: string,
+  mcpToolUseResult?: Record<string, unknown>,
 ): SessionNotification[] {
   if (typeof content === "string") {
     const update: SessionUpdate = {
@@ -461,6 +473,7 @@ function toAcpNotifications(
     registerHooks,
     supportsTerminalOutput,
     cwd,
+    mcpToolUseResult,
   };
   const output: SessionNotification[] = [];
 
@@ -829,6 +842,13 @@ export async function handleUserAssistantMessage(
       ? (message.parent_tool_use_id ?? undefined)
       : undefined;
 
+  // Pass the raw MCP tool result (contains content, structuredContent, _meta)
+  // so it can be forwarded as-is to the renderer for MCP Apps
+  const mcpToolUseResult =
+    message.type === "user" && message.tool_use_result != null
+      ? (message.tool_use_result as Record<string, unknown>)
+      : undefined;
+
   for (const notification of toAcpNotifications(
     contentToProcess as typeof content,
     message.message.role,
@@ -841,6 +861,7 @@ export async function handleUserAssistantMessage(
     context.registerHooks,
     context.supportsTerminalOutput,
     session.cwd,
+    mcpToolUseResult,
   )) {
     await client.sessionUpdate(notification);
     session.notificationHistory.push(notification);

--- a/packages/agent/src/adapters/claude/mcp/tool-metadata.ts
+++ b/packages/agent/src/adapters/claude/mcp/tool-metadata.ts
@@ -48,6 +48,7 @@ export async function fetchMcpToolMetadata(
       for (const tool of server.tools) {
         const toolKey = buildToolKey(server.name, tool.name);
         const readOnly = tool.annotations?.readOnly === true;
+
         mcpToolMetadataCache.set(toolKey, {
           readOnly,
           name: tool.name,
@@ -92,6 +93,15 @@ export function getMcpToolMetadata(
 export function isMcpToolReadOnly(toolName: string): boolean {
   const metadata = mcpToolMetadataCache.get(toolName);
   return metadata?.readOnly === true;
+}
+
+export function getConnectedMcpServerNames(): string[] {
+  const names = new Set<string>();
+  for (const key of mcpToolMetadataCache.keys()) {
+    const parts = key.split("__");
+    if (parts.length >= 3) names.add(parts[1]);
+  }
+  return [...names];
 }
 
 export function clearMcpToolMetadataCache(): void {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,1 +1,5 @@
-export { isMcpToolReadOnly } from "./adapters/claude/mcp/tool-metadata";
+export {
+  getMcpToolMetadata,
+  isMcpToolReadOnly,
+  type McpToolMetadata,
+} from "./adapters/claude/mcp/tool-metadata";

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -103,6 +103,7 @@ export interface ProcessSpawnedCallback {
     sessionId?: string;
   }) => void;
   onProcessExited?: (pid: number) => void;
+  onMcpServersReady?: (serverNames: string[]) => void;
 }
 
 export interface TaskExecutionOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,12 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@modelcontextprotocol/ext-apps':
+        specifier: ^1.1.2
+        version: 1.2.2(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.1
+        version: 1.27.1(zod@4.3.6)
       '@opentelemetry/api-logs':
         specifier: ^0.208.0
         version: 0.208.0
@@ -2983,6 +2989,30 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@modelcontextprotocol/ext-apps@1.2.2':
+    resolution: {integrity: sha512-qMnhIKb8tyPesl+kZU76Xz9Bi9putCO+LcgvBJ00fDdIniiLZsnQbAeTKoq+sTiYH1rba2Fvj8NPAFxij+gyxw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.24.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@mswjs/interceptors@0.41.0':
     resolution: {integrity: sha512-edAo9bW53BLYeSK+UPRr2Iz1Fj9DeGMjytvVM0HXRoo750ElWUgPsZPAOTQa12EUiwgDErH2PsFNTLvk1jBxjQ==}
     engines: {node: '>=18'}
@@ -5153,6 +5183,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -5460,6 +5494,10 @@ packages:
   bmp-ts@1.0.9:
     resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -5556,6 +5594,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   call-me-maybe@1.0.2:
@@ -5825,8 +5867,24 @@ packages:
     resolution: {integrity: sha512-dPyZofqggxuvSf7WXvNjuRfnsOk1YazkVP8FdxH4tcH2c37wc79/Yl6Bhr7Lsu00KMgy2ql/qCMuNu8xctZM8g==}
     engines: {node: '> 0.10'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -5844,6 +5902,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -6402,6 +6464,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   exec-async@2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
 
@@ -6647,6 +6717,16 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -6734,6 +6814,10 @@ packages:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
@@ -6787,6 +6871,10 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -6811,6 +6899,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -7137,6 +7229,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -7209,6 +7305,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -7301,6 +7401,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
@@ -7424,6 +7527,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -7915,6 +8021,10 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   mem@4.3.0:
     resolution: {integrity: sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==}
     engines: {node: '>=6'}
@@ -7926,6 +8036,10 @@ packages:
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-options@3.0.4:
     resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
@@ -8095,6 +8209,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -8400,6 +8518,10 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -8629,6 +8751,9 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@2.0.0:
     resolution: {integrity: sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==}
     engines: {node: '>=4'}
@@ -8695,6 +8820,10 @@ packages:
 
   pixi.js@8.16.0:
     resolution: {integrity: sha512-gu2xw3sZGAn3cWBtk0HqTQT+v19YAfiaYXwUGgWoJl5NKz4cEZJUgWrwkmdfDszGyYBAGqOvJNbd2M9+vzLLMg==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -8970,6 +9099,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -8987,6 +9120,10 @@ packages:
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
     hasBin: true
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
@@ -9030,6 +9167,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -9413,6 +9554,10 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -9477,6 +9622,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
@@ -9491,6 +9640,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -9523,6 +9676,22 @@ packages:
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -10162,6 +10331,10 @@ packages:
     resolution: {integrity: sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==}
     engines: {node: '>=20'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typed-openapi@2.2.4:
     resolution: {integrity: sha512-OVSqe63hAvk+aaCIsdmnwjvUruhY6x5yRLiux583iTzDoBKJ247ZVj30oYqvNFD31TzzCPx8P0SNs9KJhXYZnA==}
     hasBin: true
@@ -10777,6 +10950,11 @@ packages:
 
   yoga-wasm-web@0.3.3:
     resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -13664,6 +13842,36 @@ snapshots:
       '@types/react': 19.2.11
       react: 19.1.0
 
+  '@modelcontextprotocol/ext-apps@1.2.2(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      zod: 4.3.6
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.7)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.11.7
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@mswjs/interceptors@0.41.0':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -16005,6 +16213,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-phases@1.0.4(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -16351,6 +16564,20 @@ snapshots:
 
   bmp-ts@1.0.9: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   boolean@3.2.0:
@@ -16487,6 +16714,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   call-me-maybe@1.0.2: {}
 
@@ -16753,7 +16985,15 @@ snapshots:
     dependencies:
       easy-table: 1.1.0
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -16768,6 +17008,11 @@ snapshots:
   core-js@3.48.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   crelt@1.0.6: {}
 
@@ -17268,6 +17513,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   exec-async@2.2.0: {}
 
   execa@1.0.0:
@@ -17565,6 +17816,44 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend@3.0.2: {}
 
   external-editor@3.1.0:
@@ -17661,6 +17950,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@2.1.0:
     dependencies:
       locate-path: 2.0.0
@@ -17718,6 +18018,8 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
 
   framer-motion@12.31.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
@@ -17732,6 +18034,8 @@ snapshots:
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -18112,6 +18416,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -18168,6 +18476,8 @@ snapshots:
       - reflect-metadata
 
   ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -18239,6 +18549,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-property@1.0.2:
     optional: true
@@ -18421,6 +18733,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
+
+  jose@6.2.1: {}
 
   joycon@3.1.1: {}
 
@@ -19036,6 +19350,8 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-typer@1.1.0: {}
+
   mem@4.3.0:
     dependencies:
       map-age-cleaner: 0.1.3
@@ -19060,6 +19376,8 @@ snapshots:
       tslib: 2.8.1
 
   memoize-one@5.2.1: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-options@3.0.4:
     dependencies:
@@ -19448,6 +19766,10 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@1.6.0: {}
 
   mime@3.0.0: {}
@@ -19764,6 +20086,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1:
     optional: true
 
@@ -20001,6 +20325,8 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  path-to-regexp@8.3.0: {}
+
   path-type@2.0.0:
     dependencies:
       pify: 2.3.0
@@ -20053,6 +20379,8 @@ snapshots:
       ismobilejs: 1.1.1
       parse-svg-path: 0.1.2
       tiny-lru: 11.4.7
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -20360,6 +20688,11 @@ snapshots:
       '@types/node': 24.12.0
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   pump@3.0.3:
@@ -20372,6 +20705,10 @@ snapshots:
   punycode@2.3.1: {}
 
   qrcode-terminal@0.11.0: {}
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
 
   query-selector-shadow-dom@1.0.1: {}
 
@@ -20466,6 +20803,13 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -20975,6 +21319,16 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.8.0: {}
 
   rtl-detect@1.1.2: {}
@@ -21035,6 +21389,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@2.1.0: {}
 
   serialize-error@7.0.1:
@@ -21052,6 +21422,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -21076,6 +21455,34 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -21696,6 +22103,12 @@ snapshots:
   type-fest@5.4.3:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-openapi@2.2.4(openapi-types@12.1.3)(react@19.1.0):
     dependencies:
@@ -22339,6 +22752,10 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoga-wasm-web@0.3.3: {}
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - apps/*
   - packages/*
 
+ignoredBuiltDependencies:
+  - msw
+  - protobufjs
+
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
@@ -9,10 +13,11 @@ minimumReleaseAgeExclude:
 
 onlyBuiltDependencies:
   - '@parcel/watcher'
+  - '@posthog/cli'
+  - better-sqlite3
   - core-js
   - electron
   - esbuild
   - fs-xattr
   - macos-alias
   - node-pty
-


### PR DESCRIPTION
This pull request adds comprehensive support for MCP Apps, which allows MCP servers to ship interactive HTML UIs alongside their tools. When a tool has an associated `ui://` resource, the app renders the HTML inside a sandboxed iframe instead of showing raw tool input/output.

## Key Features

- **Double-iframe sandbox architecture** for security isolation using a custom `mcp-sandbox:` protocol
- **Lazy connection management** - MCP server connections are created on-demand when UI resources are first requested
- **Tool-to-UI discovery** via `_meta.ui.resourceUri` fields in MCP tool definitions
- **Real-time communication** between apps and the host using the official `@modelcontextprotocol/ext-apps` AppBridge
- **Theme integration** that maps Radix UI theme tokens to MCP Apps CSS variables
- **Fullscreen and inline display modes** with smooth transitions
- **Content Security Policy** generation from server-declared domains
- **Permission Policy** support for camera, microphone, geolocation, and clipboard access

## Architecture

The implementation spans both main and renderer processes:

**Main Process:**
- `McpAppsService` manages server connections and acts as a proxy between renderer and MCP servers
- Tool input/result/cancellation events are forwarded from `AgentService` to apps via tRPC subscriptions
- Custom protocol handler serves the sandbox proxy HTML on `mcp-sandbox://proxy`

**Renderer Process:**
- `McpAppHost` component manages iframe lifecycle and AppBridge communication
- `useAppBridge` hook handles the complete bridge setup, context synchronization, and message routing
- Apps can send messages to pre-fill the chat input and request display mode changes

## Security Model

Apps run in a double-iframe sandbox where the outer iframe has an isolated origin (`mcp-sandbox://proxy`) preventing access to the host's DOM, storage, or cookies. The inner iframe uses `document.write()` instead of `srcdoc` to preserve origin for WebGL operations while maintaining security boundaries.

## Developer Experience

- Per-server disable toggle in settings
- Debug menu option to refresh MCP Apps discovery and clear caches
- Comprehensive error handling and logging throughout the pipeline
- Standard MCP tool view always remains visible alongside the app UI