### PR TITLE
feat(code): add skills view

### DIFF
--- a/apps/code/src/main/services/agent/discover-plugins.ts
+++ b/apps/code/src/main/services/agent/discover-plugins.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { SdkPluginConfig } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../../utils/logger";
+import { parseSkillFrontmatter } from "./parse-skill-frontmatter";
+import type { SkillInfo, SkillSource } from "./skill-schemas";
 
 const log = logger.scope("discover-plugins");
 
@@ -49,6 +51,11 @@ async function discoverUserSkills(
 }
 
 async function discoverMarketplacePlugins(): Promise<SdkPluginConfig[]> {
+  const paths = await getMarketplaceInstallPaths();
+  return paths.map((p) => ({ type: "local" as const, path: p }));
+}
+
+export async function getMarketplaceInstallPaths(): Promise<string[]> {
   const installedPath = path.join(
     os.homedir(),
     ".claude",
@@ -64,16 +71,16 @@ async function discoverMarketplacePlugins(): Promise<SdkPluginConfig[]> {
       return [];
     }
 
-    const configs: SdkPluginConfig[] = [];
+    const paths: string[] = [];
     for (const entries of Object.values(data.plugins)) {
       if (!Array.isArray(entries)) continue;
       for (const entry of entries) {
         if (entry.installPath && fs.existsSync(entry.installPath)) {
-          configs.push({ type: "local", path: entry.installPath });
+          paths.push(entry.installPath);
         }
       }
     }
-    return configs;
+    return paths;
   } catch {
     return [];
   }
@@ -98,6 +105,24 @@ async function discoverRepoSkills(
   );
 }
 
+async function findSkillDirs(sourceSkillsDir: string): Promise<string[]> {
+  if (!fs.existsSync(sourceSkillsDir)) {
+    return [];
+  }
+
+  const entries = await fs.promises.readdir(sourceSkillsDir, {
+    withFileTypes: true,
+  });
+
+  return entries
+    .filter(
+      (e) =>
+        (e.isDirectory() || e.isSymbolicLink()) &&
+        fs.existsSync(path.join(sourceSkillsDir, e.name, "SKILL.md")),
+    )
+    .map((e) => e.name);
+}
+
 async function buildSyntheticPlugin(
   sourceSkillsDir: string,
   pluginDir: string,
@@ -105,22 +130,7 @@ async function buildSyntheticPlugin(
   description: string,
 ): Promise<SdkPluginConfig[]> {
   try {
-    if (!fs.existsSync(sourceSkillsDir)) {
-      return [];
-    }
-
-    const entries = await fs.promises.readdir(sourceSkillsDir, {
-      withFileTypes: true,
-    });
-
-    const skillDirs = entries
-      .filter(
-        (e) =>
-          (e.isDirectory() || e.isSymbolicLink()) &&
-          fs.existsSync(path.join(sourceSkillsDir, e.name, "SKILL.md")),
-      )
-      .map((e) => e.name);
-
+    const skillDirs = await findSkillDirs(sourceSkillsDir);
     if (skillDirs.length === 0) {
       return [];
     }
@@ -171,4 +181,36 @@ async function buildSyntheticPlugin(
     });
     return [];
   }
+}
+
+export async function readSkillMetadataFromDir(
+  skillsDir: string,
+  source: SkillSource,
+  repoName?: string,
+): Promise<SkillInfo[]> {
+  const skillNames = await findSkillDirs(skillsDir);
+  if (skillNames.length === 0) return [];
+
+  const results = await Promise.all(
+    skillNames.map(async (skillName) => {
+      const skillPath = path.join(skillsDir, skillName);
+      try {
+        const content = await fs.promises.readFile(
+          path.join(skillPath, "SKILL.md"),
+          "utf-8",
+        );
+        const frontmatter = parseSkillFrontmatter(content);
+        return {
+          name: frontmatter?.name ?? skillName,
+          description: frontmatter?.description ?? "",
+          source,
+          path: skillPath,
+          ...(repoName ? { repoName } : {}),
+        } satisfies SkillInfo;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return results.filter((r): r is SkillInfo => r !== null);
 }

--- a/apps/code/src/main/services/agent/parse-skill-frontmatter.ts
+++ b/apps/code/src/main/services/agent/parse-skill-frontmatter.ts
@@ -1,0 +1,72 @@
+/**
+ * Parses YAML frontmatter from a SKILL.md file.
+ * Extracts `name` and `description` fields.
+ *
+ * Handles:
+ * - Simple values: `name: my-skill`
+ * - Quoted strings: `description: 'Some text'` or `description: "Some text"`
+ * - Multi-line folded: `description: >-\n  line1\n  line2`
+ */
+export function parseSkillFrontmatter(
+  content: string,
+): { name: string; description: string } | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const yaml = match[1];
+  const name = extractYamlValue(yaml, "name");
+  if (!name) return null;
+
+  const description = extractYamlValue(yaml, "description") ?? "";
+  return { name, description };
+}
+
+function extractYamlValue(yaml: string, key: string): string | null {
+  const lines = yaml.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const keyPattern = new RegExp(`^${key}:\\s*(.*)$`);
+    const match = line.match(keyPattern);
+    if (!match) continue;
+
+    const rawValue = match[1].trim();
+
+    // Multi-line folded scalar (>- or >)
+    if (rawValue === ">-" || rawValue === ">") {
+      return collectIndentedLines(lines, i + 1).join(" ");
+    }
+
+    // Multi-line literal scalar (|- or |)
+    if (rawValue === "|-" || rawValue === "|") {
+      return collectIndentedLines(lines, i + 1).join("\n");
+    }
+
+    // Quoted string (single or double)
+    if (
+      (rawValue.startsWith("'") && rawValue.endsWith("'")) ||
+      (rawValue.startsWith('"') && rawValue.endsWith('"'))
+    ) {
+      return rawValue.slice(1, -1);
+    }
+
+    // Plain scalar
+    return rawValue;
+  }
+
+  return null;
+}
+
+function collectIndentedLines(lines: string[], startIndex: number): string[] {
+  const result: string[] = [];
+  for (let i = startIndex; i < lines.length; i++) {
+    const line = lines[i];
+    // Continuation lines must be indented
+    if (line.match(/^\s+\S/)) {
+      result.push(line.trim());
+    } else {
+      break;
+    }
+  }
+  return result;
+}

--- a/apps/code/src/main/services/agent/skill-schemas.ts
+++ b/apps/code/src/main/services/agent/skill-schemas.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export type { SkillInfo, SkillSource } from "@shared/types/skills";
+
+export const skillSource = z.enum(["bundled", "user", "repo", "marketplace"]);
+
+export const skillInfo = z.object({
+  name: z.string(),
+  description: z.string(),
+  source: skillSource,
+  path: z.string(),
+  repoName: z.string().optional(),
+});
+
+export const listSkillsOutput = z.array(skillInfo);

--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -24,6 +24,7 @@ import { osRouter } from "./routers/os";
 import { processTrackingRouter } from "./routers/process-tracking";
 import { secureStoreRouter } from "./routers/secure-store";
 import { shellRouter } from "./routers/shell";
+import { skillsRouter } from "./routers/skills";
 import { sleepRouter } from "./routers/sleep";
 import { suspensionRouter } from "./routers/suspension.js";
 import { uiRouter } from "./routers/ui";
@@ -59,6 +60,7 @@ export const trpcRouter = router({
   suspension: suspensionRouter,
   secureStore: secureStoreRouter,
   shell: shellRouter,
+  skills: skillsRouter,
   ui: uiRouter,
   updates: updatesRouter,
   deepLink: deepLinkRouter,

--- a/apps/code/src/main/trpc/routers/skills.ts
+++ b/apps/code/src/main/trpc/routers/skills.ts
@@ -1,0 +1,46 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { container } from "../../di/container";
+import { MAIN_TOKENS } from "../../di/tokens";
+import {
+  getMarketplaceInstallPaths,
+  readSkillMetadataFromDir,
+} from "../../services/agent/discover-plugins";
+import { listSkillsOutput } from "../../services/agent/skill-schemas";
+import type { FoldersService } from "../../services/folders/service";
+import type { PosthogPluginService } from "../../services/posthog-plugin/service";
+import { publicProcedure, router } from "../trpc";
+
+const getPluginService = () =>
+  container.get<PosthogPluginService>(MAIN_TOKENS.PosthogPluginService);
+
+const getFoldersService = () =>
+  container.get<FoldersService>(MAIN_TOKENS.FoldersService);
+
+export const skillsRouter = router({
+  list: publicProcedure.output(listSkillsOutput).query(async () => {
+    const pluginPath = getPluginService().getPluginPath();
+    const folders = await getFoldersService().getFolders();
+    const marketplacePaths = await getMarketplaceInstallPaths();
+
+    const results = await Promise.all([
+      readSkillMetadataFromDir(path.join(pluginPath, "skills"), "bundled"),
+      readSkillMetadataFromDir(
+        path.join(os.homedir(), ".claude", "skills"),
+        "user",
+      ),
+      ...folders.map((f) =>
+        readSkillMetadataFromDir(
+          path.join(f.path, ".claude", "skills"),
+          "repo",
+          f.name,
+        ),
+      ),
+      ...marketplacePaths.map((p) =>
+        readSkillMetadataFromDir(path.join(p, "skills"), "marketplace"),
+      ),
+    ]);
+
+    return results.flat();
+  }),
+});

--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -11,6 +11,7 @@ import { RightSidebar, RightSidebarContent } from "@features/right-sidebar";
 import { FolderSettingsView } from "@features/settings/components/FolderSettingsView";
 import { SettingsDialog } from "@features/settings/components/SettingsDialog";
 import { MainSidebar } from "@features/sidebar/components/MainSidebar";
+import { SkillsView } from "@features/skills/components/SkillsView";
 import { TaskDetail } from "@features/task-detail/components/TaskDetail";
 import { TaskInput } from "@features/task-detail/components/TaskInput";
 import { useTasks } from "@features/tasks/hooks/useTasks";
@@ -78,6 +79,8 @@ export function MainLayout() {
           {view.type === "archived" && <ArchivedTasksView />}
 
           {view.type === "command-center" && <CommandCenterView />}
+
+          {view.type === "skills" && <SkillsView />}
         </Box>
 
         {view.type === "task-detail" && view.data && (

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -17,6 +17,7 @@ import { useSidebarData } from "../hooks/useSidebarData";
 import { useTaskViewed } from "../hooks/useTaskViewed";
 import { CommandCenterItem } from "./items/CommandCenterItem";
 import { InboxItem, NewTaskItem } from "./items/HomeItem";
+import { SkillsItem } from "./items/SkillsItem";
 import { SidebarItem } from "./SidebarItem";
 import { TaskListView } from "./TaskListView";
 
@@ -27,6 +28,7 @@ function SidebarMenuComponent() {
     navigateToTaskInput,
     navigateToInbox,
     navigateToCommandCenter,
+    navigateToSkills,
   } = useNavigationStore();
 
   const { data: allTasks = [] } = useTasks();
@@ -86,6 +88,10 @@ function SidebarMenuComponent() {
 
   const handleCommandCenterClick = () => {
     navigateToCommandCenter();
+  };
+
+  const handleSkillsClick = () => {
+    navigateToSkills();
   };
 
   const handleTaskClick = (taskId: string) => {
@@ -188,11 +194,18 @@ function SidebarMenuComponent() {
             />
           </Box>
 
-          <Box mb="2">
+          <Box mb="1">
             <CommandCenterItem
               isActive={sidebarData.isCommandCenterActive}
               onClick={handleCommandCenterClick}
               activeCount={commandCenterActiveCount}
+            />
+          </Box>
+
+          <Box mb="2">
+            <SkillsItem
+              isActive={sidebarData.isSkillsActive}
+              onClick={handleSkillsClick}
             />
           </Box>
 

--- a/apps/code/src/renderer/features/sidebar/components/items/SkillsItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/SkillsItem.tsx
@@ -1,0 +1,19 @@
+import { Lightning } from "@phosphor-icons/react";
+import { SidebarItem } from "../SidebarItem";
+
+interface SkillsItemProps {
+  isActive: boolean;
+  onClick: () => void;
+}
+
+export function SkillsItem({ isActive, onClick }: SkillsItemProps) {
+  return (
+    <SidebarItem
+      depth={0}
+      icon={<Lightning size={16} weight={isActive ? "fill" : "regular"} />}
+      label="Skills"
+      isActive={isActive}
+      onClick={onClick}
+    />
+  );
+}

--- a/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
+++ b/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
@@ -47,6 +47,7 @@ export interface SidebarData {
   isHomeActive: boolean;
   isInboxActive: boolean;
   isCommandCenterActive: boolean;
+  isSkillsActive: boolean;
   isLoading: boolean;
   activeTaskId: string | null;
   pinnedTasks: TaskData[];
@@ -64,7 +65,8 @@ interface ViewState {
     | "folder-settings"
     | "inbox"
     | "archived"
-    | "command-center";
+    | "command-center"
+    | "skills";
   data?: Task;
 }
 
@@ -168,6 +170,7 @@ export function useSidebarData({
   const isHomeActive = activeView.type === "task-input";
   const isInboxActive = activeView.type === "inbox";
   const isCommandCenterActive = activeView.type === "command-center";
+  const isSkillsActive = activeView.type === "skills";
 
   const activeTaskId =
     activeView.type === "task-detail" && activeView.data
@@ -276,6 +279,7 @@ export function useSidebarData({
     isHomeActive,
     isInboxActive,
     isCommandCenterActive,
+    isSkillsActive,
     isLoading,
     activeTaskId,
     pinnedTasks,

--- a/apps/code/src/renderer/features/skills/components/SkillCard.tsx
+++ b/apps/code/src/renderer/features/skills/components/SkillCard.tsx
@@ -1,0 +1,111 @@
+import { Folder, Package, Storefront, User } from "@phosphor-icons/react";
+import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+import type { SkillInfo, SkillSource } from "@shared/types/skills";
+
+export const SOURCE_CONFIG: Record<
+  SkillSource,
+  { icon: typeof Package; label: string; sectionTitle: string }
+> = {
+  user: { icon: User, label: "User", sectionTitle: "Your skills" },
+  bundled: {
+    icon: Package,
+    label: "PostHog Code",
+    sectionTitle: "PostHog Code",
+  },
+  repo: { icon: Folder, label: "Repo", sectionTitle: "Repository" },
+  marketplace: {
+    icon: Storefront,
+    label: "Marketplace",
+    sectionTitle: "Marketplace",
+  },
+};
+
+interface SkillCardProps {
+  skill: SkillInfo;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+export function SkillCard({ skill, isSelected, onClick }: SkillCardProps) {
+  const config = SOURCE_CONFIG[skill.source];
+  const Icon = config?.icon ?? Package;
+
+  return (
+    <Flex
+      align="center"
+      gap="2"
+      px="3"
+      py="2"
+      className={`cursor-pointer rounded-lg border transition-colors ${
+        isSelected
+          ? "border-accent-8 bg-accent-3"
+          : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
+      }`}
+      onClick={onClick}
+    >
+      <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
+        <Icon size={14} weight="duotone" className="text-gray-11" />
+      </Box>
+
+      <Flex direction="column" gap="0" className="min-w-0 flex-1">
+        <Text
+          size="2"
+          weight="medium"
+          className="truncate font-mono text-[12px] text-gray-12"
+        >
+          {skill.name}
+        </Text>
+        {skill.description && (
+          <Text
+            size="1"
+            className="truncate font-mono text-[11px] text-gray-10"
+          >
+            {skill.description}
+          </Text>
+        )}
+      </Flex>
+
+      {skill.repoName && (
+        <Badge size="1" variant="soft" color="gray" className="shrink-0">
+          {skill.repoName}
+        </Badge>
+      )}
+    </Flex>
+  );
+}
+
+interface SkillSectionProps {
+  title: string;
+  skills: SkillInfo[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+}
+
+export function SkillSection({
+  title,
+  skills,
+  selectedPath,
+  onSelect,
+}: SkillSectionProps) {
+  return (
+    <Flex direction="column" gap="1">
+      <Text
+        size="1"
+        weight="medium"
+        className="mb-1 font-mono text-[11px] text-gray-9 uppercase tracking-wider"
+      >
+        {title}
+      </Text>
+      <Flex direction="column" gap="1">
+        {skills.map((skill) => (
+          <SkillCard
+            key={skill.path}
+            skill={skill}
+            isSelected={selectedPath === skill.path}
+            onClick={() => onSelect(skill.path)}
+          />
+        ))}
+      </Flex>
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/skills/components/SkillDetailPanel.tsx
+++ b/apps/code/src/renderer/features/skills/components/SkillDetailPanel.tsx
@@ -1,0 +1,107 @@
+import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
+import { ExternalAppsOpener } from "@features/task-detail/components/ExternalAppsOpener";
+import { Folder, X } from "@phosphor-icons/react";
+import { Badge, Box, Flex, ScrollArea, Text } from "@radix-ui/themes";
+import { useTRPC } from "@renderer/trpc";
+import type { SkillInfo } from "@shared/types/skills";
+import { useQuery } from "@tanstack/react-query";
+import { SOURCE_CONFIG } from "./SkillCard";
+
+function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n/);
+  return match ? content.slice(match[0].length).trimStart() : content;
+}
+
+interface SkillDetailPanelProps {
+  skill: SkillInfo;
+  onClose: () => void;
+}
+
+export function SkillDetailPanel({ skill, onClose }: SkillDetailPanelProps) {
+  const trpcReact = useTRPC();
+  const config = SOURCE_CONFIG[skill.source];
+
+  const skillMdPath = `${skill.path}/SKILL.md`;
+  const { data: fileContent, isLoading } = useQuery(
+    trpcReact.fs.readAbsoluteFile.queryOptions(
+      { filePath: skillMdPath },
+      { staleTime: 30_000 },
+    ),
+  );
+
+  const body = fileContent ? stripFrontmatter(fileContent) : null;
+
+  return (
+    <>
+      <Flex
+        direction="column"
+        gap="2"
+        px="3"
+        py="2"
+        className="shrink-0"
+        style={{ borderBottom: "1px solid var(--gray-5)" }}
+      >
+        <Flex align="start" justify="between" gap="2">
+          <Text
+            size="1"
+            weight="medium"
+            className="block min-w-0 break-words font-mono text-[12px]"
+          >
+            {skill.name}
+          </Text>
+          <button
+            type="button"
+            onClick={onClose}
+            className="shrink-0 rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+          >
+            <X size={14} />
+          </button>
+        </Flex>
+
+        <Flex align="center" gap="2" wrap="wrap">
+          <Badge size="1" variant="soft" color="gray">
+            {config?.label ?? skill.source}
+          </Badge>
+          {skill.repoName && (
+            <Badge size="1" variant="soft" color="gray">
+              <Folder size={10} className="text-gray-9" />
+              {skill.repoName}
+            </Badge>
+          )}
+          {skill.source !== "bundled" && (
+            <ExternalAppsOpener targetPath={skill.path} label="Open" />
+          )}
+        </Flex>
+      </Flex>
+
+      <ScrollArea
+        type="auto"
+        scrollbars="vertical"
+        className="scroll-area-constrain-width"
+        style={{ height: "100%" }}
+      >
+        <Flex direction="column" gap="3" p="3">
+          {skill.description && (
+            <Text size="1" className="font-mono text-[11px] text-gray-10">
+              {skill.description}
+            </Text>
+          )}
+
+          {isLoading ? (
+            <Text size="1" className="font-mono text-[11px] text-gray-9">
+              Loading...
+            </Text>
+          ) : body ? (
+            <Box className="rounded border border-gray-5 bg-gray-1 px-4 py-3">
+              <MarkdownRenderer content={body} />
+            </Box>
+          ) : (
+            <Text size="1" className="font-mono text-[11px] text-gray-9">
+              No content in SKILL.md
+            </Text>
+          )}
+        </Flex>
+      </ScrollArea>
+    </>
+  );
+}

--- a/apps/code/src/renderer/features/skills/components/SkillsView.tsx
+++ b/apps/code/src/renderer/features/skills/components/SkillsView.tsx
@@ -1,0 +1,145 @@
+import { ResizableSidebar } from "@components/ResizableSidebar";
+import { useSetHeaderContent } from "@hooks/useSetHeaderContent";
+import { Lightning } from "@phosphor-icons/react";
+import { Box, Flex, ScrollArea, Text } from "@radix-ui/themes";
+import { useTRPC } from "@renderer/trpc";
+import type { SkillInfo, SkillSource } from "@shared/types/skills";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+import { useSkillsSidebarStore } from "../stores/skillsSidebarStore";
+import { SkillSection, SOURCE_CONFIG } from "./SkillCard";
+import { SkillDetailPanel } from "./SkillDetailPanel";
+
+const SOURCE_ORDER: SkillSource[] = ["user", "marketplace", "repo", "bundled"];
+
+export function SkillsView() {
+  const trpcReact = useTRPC();
+  const { data: skills = [], isLoading } = useQuery(
+    trpcReact.skills.list.queryOptions(undefined, { staleTime: 30_000 }),
+  );
+
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  const {
+    width: sidebarWidth,
+    setWidth: setSidebarWidth,
+    isResizing,
+    setIsResizing,
+  } = useSkillsSidebarStore();
+
+  const selectedSkill = useMemo(() => {
+    if (skills.length === 0) return null;
+    if (selectedPath !== null) {
+      return skills.find((s) => s.path === selectedPath) ?? skills[0];
+    }
+    return skills[0];
+  }, [skills, selectedPath]);
+
+  const handleSelect = useCallback((path: string) => {
+    setSelectedPath((prev) => (prev === path ? null : path));
+  }, []);
+
+  const handleCloseSidebar = useCallback(() => {
+    setSelectedPath(null);
+  }, []);
+
+  const grouped = useMemo(() => {
+    const map = new Map<SkillSource, SkillInfo[]>();
+    for (const source of SOURCE_ORDER) {
+      map.set(source, []);
+    }
+    for (const skill of skills) {
+      const list = map.get(skill.source);
+      if (list) {
+        list.push(skill);
+      }
+    }
+    return map;
+  }, [skills]);
+
+  const headerContent = useMemo(
+    () => (
+      <Flex align="center" gap="2" className="w-full min-w-0">
+        <Lightning size={12} className="shrink-0 text-gray-10" />
+        <Text
+          size="1"
+          weight="medium"
+          className="truncate whitespace-nowrap font-mono text-[12px]"
+          title="Skills"
+        >
+          Skills
+        </Text>
+      </Flex>
+    ),
+    [],
+  );
+
+  useSetHeaderContent(headerContent);
+
+  return (
+    <Flex direction="column" height="100%" className="overflow-hidden">
+      <Flex style={{ minHeight: 0 }} className="flex-1">
+        <Box flexGrow="1" style={{ minWidth: 0 }}>
+          <ScrollArea
+            type="auto"
+            className="scroll-area-constrain-width"
+            style={{ height: "100%" }}
+          >
+            <Box px="4" py="3">
+              {skills.length === 0 && !isLoading ? (
+                <Flex
+                  align="center"
+                  justify="center"
+                  direction="column"
+                  gap="3"
+                  className="py-12"
+                >
+                  <Box className="rounded-lg border border-gray-6 border-dashed p-4">
+                    <Lightning size={24} className="text-gray-8" />
+                  </Box>
+                  <Text size="2" className="font-mono text-[12px] text-gray-10">
+                    No skills found
+                  </Text>
+                </Flex>
+              ) : (
+                <Flex direction="column" gap="5">
+                  {SOURCE_ORDER.map((source) => {
+                    const items = grouped.get(source);
+                    if (!items || items.length === 0) return null;
+                    const config = SOURCE_CONFIG[source];
+
+                    return (
+                      <SkillSection
+                        key={source}
+                        title={config.sectionTitle}
+                        skills={items}
+                        selectedPath={selectedPath}
+                        onSelect={handleSelect}
+                      />
+                    );
+                  })}
+                </Flex>
+              )}
+            </Box>
+          </ScrollArea>
+        </Box>
+
+        <ResizableSidebar
+          open={!!selectedSkill}
+          width={sidebarWidth}
+          setWidth={setSidebarWidth}
+          isResizing={isResizing}
+          setIsResizing={setIsResizing}
+          side="right"
+        >
+          {selectedSkill && (
+            <SkillDetailPanel
+              skill={selectedSkill}
+              onClose={handleCloseSidebar}
+            />
+          )}
+        </ResizableSidebar>
+      </Flex>
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/skills/stores/skillsSidebarStore.ts
+++ b/apps/code/src/renderer/features/skills/stores/skillsSidebarStore.ts
@@ -1,0 +1,6 @@
+import { createSidebarStore } from "@stores/createSidebarStore";
+
+export const useSkillsSidebarStore = createSidebarStore({
+  name: "skills-sidebar",
+  defaultWidth: 380,
+});

--- a/apps/code/src/renderer/stores/navigationStore.ts
+++ b/apps/code/src/renderer/stores/navigationStore.ts
@@ -18,7 +18,8 @@ type ViewType =
   | "folder-settings"
   | "inbox"
   | "archived"
-  | "command-center";
+  | "command-center"
+  | "skills";
 
 interface ViewState {
   type: ViewType;
@@ -37,6 +38,7 @@ interface NavigationStore {
   navigateToInbox: () => void;
   navigateToArchived: () => void;
   navigateToCommandCenter: () => void;
+  navigateToSkills: () => void;
   goBack: () => void;
   goForward: () => void;
   canGoBack: () => boolean;
@@ -62,6 +64,9 @@ const isSameView = (view1: ViewState, view2: ViewState): boolean => {
     return true;
   }
   if (view1.type === "command-center" && view2.type === "command-center") {
+    return true;
+  }
+  if (view1.type === "skills" && view2.type === "skills") {
     return true;
   }
   return false;
@@ -172,6 +177,10 @@ export const useNavigationStore = create<NavigationStore>()(
         navigateToCommandCenter: () => {
           navigate({ type: "command-center" });
           track(ANALYTICS_EVENTS.COMMAND_CENTER_VIEWED);
+        },
+
+        navigateToSkills: () => {
+          navigate({ type: "skills" });
         },
 
         goBack: () => {

--- a/apps/code/src/shared/types/skills.ts
+++ b/apps/code/src/shared/types/skills.ts
@@ -1,0 +1,9 @@
+export type SkillSource = "bundled" | "user" | "repo" | "marketplace";
+
+export interface SkillInfo {
+  name: string;
+  description: string;
+  source: SkillSource;
+  path: string;
+  repoName?: string;
+}


### PR DESCRIPTION
adds a view to display available skills, from these four places:

- user
- marketplace
- repo
- bundled ("posthog code")

even if the user has none, this list should never be empty since we bundle all the posthog stuff - and might even serve as a discovery tool ("oh cool, error tracking, lemme use that")

in the future i'd like these to be "first-class" pieces of posthog code; like maybe the ability to manually edit them, create new ones via AI prompt, click a button to use a skill, etc

![Screenshot 2026-03-18 at 6.51.47 PM.png](https://app.graphite.com/user-attachments/assets/b2465f94-0450-4bb4-8e53-5fe60f42b26b.png)

