### PR TITLE
feat: add worktree provisioning view

### DIFF
--- a/.posthog-code/environments/twig.toml
+++ b/.posthog-code/environments/twig.toml
@@ -1,0 +1,7 @@
+id = "a5fe304a-8007-4435-951f-fcc982247457" # DO NOT EDIT MANUALLY
+version = 1
+
+name = "twig"
+
+[setup]
+script = "pnpm install"

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -30,6 +30,7 @@ import { NotificationService } from "../services/notification/service";
 import { OAuthService } from "../services/oauth/service";
 import { PosthogPluginService } from "../services/posthog-plugin/service";
 import { ProcessTrackingService } from "../services/process-tracking/service";
+import { ProvisioningService } from "../services/provisioning/service";
 import { settingsStore } from "../services/settingsStore";
 import { ShellService } from "../services/shell/service";
 import { SleepService } from "../services/sleep/service";
@@ -61,6 +62,7 @@ container.bind(MAIN_TOKENS.ConnectivityService).to(ConnectivityService);
 container.bind(MAIN_TOKENS.ContextMenuService).to(ContextMenuService);
 container.bind(MAIN_TOKENS.DeepLinkService).to(DeepLinkService);
 container.bind(MAIN_TOKENS.EnvironmentService).to(EnvironmentService);
+container.bind(MAIN_TOKENS.ProvisioningService).to(ProvisioningService);
 
 container.bind(MAIN_TOKENS.ExternalAppsService).to(ExternalAppsService);
 container.bind(MAIN_TOKENS.LlmGatewayService).to(LlmGatewayService);

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -49,5 +49,6 @@ export const MAIN_TOKENS = Object.freeze({
   TaskLinkService: Symbol.for("Main.TaskLinkService"),
   WatcherRegistryService: Symbol.for("Main.WatcherRegistryService"),
   EnvironmentService: Symbol.for("Main.EnvironmentService"),
+  ProvisioningService: Symbol.for("Main.ProvisioningService"),
   WorkspaceService: Symbol.for("Main.WorkspaceService"),
 });

--- a/apps/code/src/main/services/provisioning/service.ts
+++ b/apps/code/src/main/services/provisioning/service.ts
@@ -1,0 +1,22 @@
+import { injectable } from "inversify";
+import { TypedEventEmitter } from "../../utils/typed-event-emitter";
+
+export const ProvisioningEvent = {
+  Output: "output",
+} as const;
+
+export interface ProvisioningOutputPayload {
+  taskId: string;
+  data: string;
+}
+
+export interface ProvisioningServiceEvents {
+  [ProvisioningEvent.Output]: ProvisioningOutputPayload;
+}
+
+@injectable()
+export class ProvisioningService extends TypedEventEmitter<ProvisioningServiceEvents> {
+  emitOutput(taskId: string, data: string): void {
+    this.emit(ProvisioningEvent.Output, { taskId, data });
+  }
+}

--- a/apps/code/src/main/services/workspace/schemas.ts
+++ b/apps/code/src/main/services/workspace/schemas.ts
@@ -11,6 +11,7 @@ export const worktreeInfoSchema = z.object({
   branchName: z.string().nullable(),
   baseBranch: z.string(),
   createdAt: z.string(),
+  output: z.string().optional(),
 });
 
 export const workspaceInfoSchema = z.object({

--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -28,6 +28,7 @@ import type { FileWatcherService } from "../file-watcher/service";
 import type { FocusService } from "../focus/service";
 import { FocusServiceEvent } from "../focus/service";
 import type { ProcessTrackingService } from "../process-tracking/service";
+import type { ProvisioningService } from "../provisioning/service";
 import { getWorktreeLocation } from "../settingsStore";
 import type { SuspensionService } from "../suspension/service.js";
 import type {
@@ -127,6 +128,9 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
 
   @inject(MAIN_TOKENS.SuspensionService)
   private suspensionService!: SuspensionService;
+
+  @inject(MAIN_TOKENS.ProvisioningService)
+  private provisioningService!: ProvisioningService;
 
   private creatingWorkspaces = new Map<string, Promise<WorkspaceInfo>>();
   private branchWatcherInitialized = false;
@@ -448,12 +452,17 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       const selectedBranch = branch ?? defaultBranch;
       const isTrunkSelected = selectedBranch === defaultBranch;
 
+      const onOutput = (data: string) => {
+        this.provisioningService.emitOutput(taskId, data);
+      };
+
       if (isTrunkSelected) {
         log.info(
           `Trunk branch selected (${defaultBranch}), creating detached worktree`,
         );
         worktree = await worktreeManager.createWorktree({
           baseBranch: defaultBranch,
+          onOutput,
         });
         log.info(
           `Created detached worktree from trunk: ${worktree.worktreeName} at ${worktree.worktreePath}`,
@@ -463,10 +472,11 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
           `Non-trunk branch selected (${selectedBranch}), attempting checkout`,
         );
         try {
-          worktree =
-            await worktreeManager.createWorktreeForExistingBranch(
-              selectedBranch,
-            );
+          worktree = await worktreeManager.createWorktreeForExistingBranch(
+            selectedBranch,
+            undefined,
+            { onOutput },
+          );
           log.info(
             `Created worktree with branch checkout: ${worktree.worktreeName} at ${worktree.worktreePath} (branch: ${selectedBranch})`,
           );
@@ -481,6 +491,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
             );
             worktree = await worktreeManager.createWorktree({
               baseBranch: selectedBranch,
+              onOutput,
             });
             log.info(
               `Created detached worktree from occupied branch: ${worktree.worktreeName} at ${worktree.worktreePath}`,

--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -22,6 +22,7 @@ import { notificationRouter } from "./routers/notification";
 import { oauthRouter } from "./routers/oauth";
 import { osRouter } from "./routers/os";
 import { processTrackingRouter } from "./routers/process-tracking";
+import { provisioningRouter } from "./routers/provisioning";
 import { secureStoreRouter } from "./routers/secure-store";
 import { shellRouter } from "./routers/shell";
 import { skillsRouter } from "./routers/skills";
@@ -57,6 +58,7 @@ export const trpcRouter = router({
   logs: logsRouter,
   os: osRouter,
   processTracking: processTrackingRouter,
+  provisioning: provisioningRouter,
   sleep: sleepRouter,
   suspension: suspensionRouter,
   secureStore: secureStoreRouter,

--- a/apps/code/src/main/trpc/routers/provisioning.ts
+++ b/apps/code/src/main/trpc/routers/provisioning.ts
@@ -1,0 +1,21 @@
+import { container } from "../../di/container";
+import { MAIN_TOKENS } from "../../di/tokens";
+import {
+  ProvisioningEvent,
+  type ProvisioningService,
+} from "../../services/provisioning/service";
+import { publicProcedure, router } from "../trpc";
+
+const getService = () =>
+  container.get<ProvisioningService>(MAIN_TOKENS.ProvisioningService);
+
+export const provisioningRouter = router({
+  onOutput: publicProcedure.subscription(async function* (opts) {
+    const service = getService();
+    for await (const data of service.toIterable(ProvisioningEvent.Output, {
+      signal: opts.signal,
+    })) {
+      yield data;
+    }
+  }),
+});

--- a/apps/code/src/renderer/features/environments/components/EnvironmentSelector.tsx
+++ b/apps/code/src/renderer/features/environments/components/EnvironmentSelector.tsx
@@ -32,8 +32,10 @@ export function EnvironmentSelector({
   const selectedEnvironment = environments.find((env) => env.id === value);
   const displayText = selectedEnvironment?.name ?? "No environment";
 
+  const NONE_VALUE = "__none__";
+
   const handleChange = (newValue: string) => {
-    onChange(newValue || null);
+    onChange(newValue === NONE_VALUE ? null : newValue || null);
     setOpen(false);
   };
 
@@ -70,6 +72,9 @@ export function EnvironmentSelector({
           <Combobox.Empty>No environments found.</Combobox.Empty>
 
           <Combobox.Group heading="Environments">
+            <Combobox.Item key={NONE_VALUE} value={NONE_VALUE}>
+              No environment
+            </Combobox.Item>
             {environments.map((env) => (
               <Combobox.Item
                 key={env.id}

--- a/apps/code/src/renderer/features/provisioning/components/ProvisioningView.tsx
+++ b/apps/code/src/renderer/features/provisioning/components/ProvisioningView.tsx
@@ -1,0 +1,101 @@
+import { BackgroundWrapper } from "@components/BackgroundWrapper";
+import { Box, Flex, Spinner, Text } from "@radix-ui/themes";
+import { useTRPC } from "@renderer/trpc/client";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { useEffect, useRef, useState } from "react";
+
+interface ProvisioningViewProps {
+  taskId: string;
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ESC is required to strip ANSI sequences
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+function processOutput(lines: string[], chunk: string): string[] {
+  const next = [...lines];
+  const parts = chunk.split("\n");
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const crSegments = part.split("\r");
+    const lastSegment = crSegments[crSegments.length - 1];
+
+    if (i === 0 && next.length > 0) {
+      if (crSegments.length > 1) {
+        next[next.length - 1] = lastSegment;
+      } else {
+        next[next.length - 1] += lastSegment;
+      }
+    } else {
+      next.push(lastSegment);
+    }
+  }
+
+  return next;
+}
+
+export function ProvisioningView({ taskId }: ProvisioningViewProps) {
+  const trpc = useTRPC();
+  const [lines, setLines] = useState<string[]>([]);
+  const scrollRef = useRef<HTMLPreElement>(null);
+
+  useSubscription(
+    trpc.provisioning.onOutput.subscriptionOptions(undefined, {
+      onData: (data) => {
+        if (data.taskId !== taskId) return;
+        setLines((prev) => processOutput(prev, stripAnsi(data.data)));
+      },
+    }),
+  );
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, []);
+
+  return (
+    <BackgroundWrapper>
+      <Flex direction="column" height="100%" p="3" gap="2">
+        <Flex align="center" gap="2">
+          <Spinner size="1" />
+          <Text size="1" weight="medium">
+            Setting up worktree...
+          </Text>
+        </Flex>
+        <Box
+          style={{
+            flex: 1,
+            minHeight: 0,
+            borderRadius: "var(--radius-2)",
+            background: "var(--color-surface)",
+            border: "1px solid var(--gray-a5)",
+          }}
+        >
+          <pre
+            ref={scrollRef}
+            style={{
+              margin: 0,
+              padding: "var(--space-2)",
+              height: "100%",
+              overflow: "auto",
+              fontSize: "var(--font-size-1)",
+              lineHeight: "var(--line-height-2)",
+              fontFamily: "var(--code-font-family)",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+              color: "var(--gray-12)",
+            }}
+          >
+            {lines.join("\n")}
+          </pre>
+        </Box>
+      </Flex>
+    </BackgroundWrapper>
+  );
+}

--- a/apps/code/src/renderer/features/provisioning/stores/provisioningStore.ts
+++ b/apps/code/src/renderer/features/provisioning/stores/provisioningStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+interface ProvisioningStoreState {
+  activeTasks: Set<string>;
+}
+
+interface ProvisioningStoreActions {
+  setActive: (taskId: string) => void;
+  clear: (taskId: string) => void;
+  isActive: (taskId: string) => boolean;
+}
+
+type ProvisioningStore = ProvisioningStoreState & ProvisioningStoreActions;
+
+export const useProvisioningStore = create<ProvisioningStore>()((set, get) => ({
+  activeTasks: new Set(),
+
+  setActive: (taskId) =>
+    set((state) => {
+      const next = new Set(state.activeTasks);
+      next.add(taskId);
+      return { activeTasks: next };
+    }),
+
+  clear: (taskId) =>
+    set((state) => {
+      const next = new Set(state.activeTasks);
+      next.delete(taskId);
+      return { activeTasks: next };
+    }),
+
+  isActive: (taskId) => get().activeTasks.has(taskId),
+}));

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.ts
@@ -23,6 +23,7 @@ interface SettingsStore {
   lastUsedWorkspaceMode: WorkspaceMode;
   lastUsedAdapter: AgentAdapter;
   lastUsedModel: string | null;
+  lastUsedEnvironments: Record<string, string>;
   desktopNotifications: boolean;
   dockBadgeNotifications: boolean;
   dockBounceNotifications: boolean;
@@ -51,6 +52,11 @@ interface SettingsStore {
   setLastUsedWorkspaceMode: (mode: WorkspaceMode) => void;
   setLastUsedAdapter: (adapter: AgentAdapter) => void;
   setLastUsedModel: (model: string) => void;
+  setLastUsedEnvironment: (
+    repoPath: string,
+    environmentId: string | null,
+  ) => void;
+  getLastUsedEnvironment: (repoPath: string) => string | null;
   setDesktopNotifications: (enabled: boolean) => void;
   setDockBadgeNotifications: (enabled: boolean) => void;
   setDockBounceNotifications: (enabled: boolean) => void;
@@ -74,6 +80,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedWorkspaceMode: "local",
       lastUsedAdapter: "claude",
       lastUsedModel: null,
+      lastUsedEnvironments: {},
       desktopNotifications: true,
       dockBadgeNotifications: true,
       dockBounceNotifications: false,
@@ -125,6 +132,18 @@ export const useSettingsStore = create<SettingsStore>()(
       setLastUsedWorkspaceMode: (mode) => set({ lastUsedWorkspaceMode: mode }),
       setLastUsedAdapter: (adapter) => set({ lastUsedAdapter: adapter }),
       setLastUsedModel: (model) => set({ lastUsedModel: model }),
+      setLastUsedEnvironment: (repoPath, environmentId) =>
+        set((state) => {
+          const next = { ...state.lastUsedEnvironments };
+          if (environmentId) {
+            next[repoPath] = environmentId;
+          } else {
+            delete next[repoPath];
+          }
+          return { lastUsedEnvironments: next };
+        }),
+      getLastUsedEnvironment: (repoPath) =>
+        get().lastUsedEnvironments[repoPath] ?? null,
       setDesktopNotifications: (enabled) =>
         set({ desktopNotifications: enabled }),
       setDockBadgeNotifications: (enabled) =>
@@ -154,6 +173,7 @@ export const useSettingsStore = create<SettingsStore>()(
         lastUsedWorkspaceMode: state.lastUsedWorkspaceMode,
         lastUsedAdapter: state.lastUsedAdapter,
         lastUsedModel: state.lastUsedModel,
+        lastUsedEnvironments: state.lastUsedEnvironments,
         desktopNotifications: state.desktopNotifications,
         dockBadgeNotifications: state.dockBadgeNotifications,
         dockBounceNotifications: state.dockBounceNotifications,

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -45,6 +45,8 @@ export function TaskInput() {
     lastUsedAdapter,
     setLastUsedAdapter,
     allowBypassPermissions,
+    setLastUsedEnvironment,
+    getLastUsedEnvironment,
   } = useSettingsStore();
 
   const editorRef = useRef<MessageEditorHandle>(null);
@@ -54,9 +56,9 @@ export function TaskInput() {
   const [editorIsEmpty, setEditorIsEmpty] = useState(true);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
-  const [selectedEnvironment, setSelectedEnvironment] = useState<string | null>(
-    null,
-  );
+  const [selectedEnvironment, setSelectedEnvironmentRaw] = useState<
+    string | null
+  >(null);
 
   const [selectedDirectory, setSelectedDirectory] = useState("");
   const workspaceMode = lastUsedWorkspaceMode || "local";
@@ -111,9 +113,24 @@ export function TaskInput() {
   const effectiveRepoPath =
     workspaceMode === "cloud" ? selectedRepository : selectedDirectory;
 
+  const setSelectedEnvironment = useCallback(
+    (envId: string | null) => {
+      setSelectedEnvironmentRaw(envId);
+      if (effectiveRepoPath) {
+        setLastUsedEnvironment(effectiveRepoPath, envId);
+      }
+    },
+    [effectiveRepoPath, setLastUsedEnvironment],
+  );
+
   useEffect(() => {
-    setSelectedEnvironment(null);
-  }, []);
+    setSelectedBranch(null);
+    if (effectiveRepoPath) {
+      setSelectedEnvironmentRaw(getLastUsedEnvironment(effectiveRepoPath));
+    } else {
+      setSelectedEnvironmentRaw(null);
+    }
+  }, [effectiveRepoPath, getLastUsedEnvironment]);
 
   const effectiveWorkspaceMode = workspaceMode;
 
@@ -142,6 +159,7 @@ export function TaskInput() {
     executionMode: currentExecutionMode,
     model: currentModel,
     reasoningLevel: currentReasoningLevel,
+    environmentId: selectedEnvironment,
   });
 
   const handleCycleMode = useCallback(() => {
@@ -332,12 +350,14 @@ export function TaskInput() {
               cloudBranches={cloudBranches}
               cloudBranchesLoading={cloudBranchesLoading}
             />
-            <EnvironmentSelector
-              repoPath={effectiveRepoPath ?? null}
-              value={selectedEnvironment}
-              onChange={setSelectedEnvironment}
-              disabled={isCreatingTask}
-            />
+            {workspaceMode === "worktree" && (
+              <EnvironmentSelector
+                repoPath={effectiveRepoPath ?? null}
+                value={selectedEnvironment}
+                onChange={setSelectedEnvironment}
+                disabled={isCreatingTask}
+              />
+            )}
           </Flex>
 
           <TaskInputEditor

--- a/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -6,6 +6,8 @@ import {
   useCloudPrChangedFiles,
 } from "@features/git-interaction/hooks/useGitQueries";
 import { useDraftStore } from "@features/message-editor/stores/draftStore";
+import { ProvisioningView } from "@features/provisioning/components/ProvisioningView";
+import { useProvisioningStore } from "@features/provisioning/stores/provisioningStore";
 import { SessionView } from "@features/sessions/components/SessionView";
 import { useSessionCallbacks } from "@features/sessions/hooks/useSessionCallbacks";
 import { useSessionConnection } from "@features/sessions/hooks/useSessionConnection";
@@ -39,6 +41,8 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
   const suspendedTaskIds = useSuspendedTaskIds();
   const isSuspended = suspendedTaskIds.has(taskId);
   const { restoreTask, isRestoring } = useRestoreTask();
+
+  const isProvisioning = useProvisioningStore((s) => s.activeTasks.has(taskId));
 
   const { requestFocus } = useDraftStore((s) => s.actions);
 
@@ -110,6 +114,10 @@ export function TaskLogsPanel({ taskId, task }: TaskLogsPanelProps) {
   const handleRestoreWorktree = useCallback(async () => {
     await restoreTask(taskId);
   }, [taskId, restoreTask]);
+
+  if (isProvisioning) {
+    return <ProvisioningView taskId={taskId} />;
+  }
 
   if (
     !repoPath &&

--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -9,11 +9,11 @@ import { useConnectivity } from "@hooks/useConnectivity";
 import type { WorkspaceMode } from "@main/services/workspace/schemas";
 import { get } from "@renderer/di/container";
 import { RENDERER_TOKENS } from "@renderer/di/tokens";
+import { toast } from "@renderer/utils/toast";
 import type { ExecutionMode } from "@shared/types";
 import { useNavigationStore } from "@stores/navigationStore";
 import { logger } from "@utils/logger";
 import { useCallback, useState } from "react";
-import { toast } from "sonner";
 import type { TaskCreationInput, TaskService } from "../service/service";
 
 const log = logger.scope("task-creation");
@@ -30,6 +30,7 @@ interface UseTaskCreationOptions {
   adapter?: "claude" | "codex";
   model?: string;
   reasoningLevel?: string;
+  environmentId?: string | null;
 }
 
 interface UseTaskCreationReturn {
@@ -50,6 +51,7 @@ function prepareTaskInput(
     adapter?: "claude" | "codex";
     model?: string;
     reasoningLevel?: string;
+    environmentId?: string | null;
   },
 ): TaskCreationInput {
   return {
@@ -64,19 +66,19 @@ function prepareTaskInput(
     adapter: options.adapter,
     model: options.model,
     reasoningLevel: options.reasoningLevel,
+    environmentId: options.environmentId ?? undefined,
   };
 }
 
-function getErrorMessage(failedStep: string, error: string): string {
-  const messages: Record<string, string> = {
-    validation: error,
+function getErrorTitle(failedStep: string): string {
+  const titles: Record<string, string> = {
     repo_detection: "Failed to detect repository",
     task_creation: "Failed to create task",
     workspace_creation: "Failed to create workspace",
     cloud_run: "Failed to start cloud execution",
     agent_session: "Failed to start agent session",
   };
-  return messages[failedStep] ?? error;
+  return titles[failedStep] ?? "Task creation failed";
 }
 
 export function useTaskCreation({
@@ -91,6 +93,7 @@ export function useTaskCreation({
   adapter,
   model,
   reasoningLevel,
+  environmentId,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const { navigateToTask } = useNavigationStore();
@@ -129,35 +132,29 @@ export function useTaskCreation({
         adapter,
         model,
         reasoningLevel,
+        environmentId,
       });
 
       const taskService = get<TaskService>(RENDERER_TOKENS.TaskService);
-      const result = await taskService.createTask(input);
-
-      if (result.success) {
-        const { task } = result.data;
-
-        // Invalidate tasks query
-        invalidateTasks(task);
-
-        // Navigate to the new task
-        navigateToTask(task);
-
-        // Clear editor
+      const result = await taskService.createTask(input, (output) => {
+        invalidateTasks(output.task);
+        navigateToTask(output.task);
         editor.clear();
+        log.info("Task ready, navigated early", { taskId: output.task.id });
+      });
 
-        log.info("Task created successfully", { taskId: task.id });
-      } else {
-        const message = getErrorMessage(result.failedStep, result.error);
-        toast.error(message);
+      if (!result.success) {
+        const title = getErrorTitle(result.failedStep);
+        toast.error(title, { description: result.error });
         log.error("Task creation failed", {
           failedStep: result.failedStep,
           error: result.error,
         });
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown error";
-      toast.error(`Failed to create task: ${message}`);
+      const description =
+        error instanceof Error ? error.message : "Unknown error";
+      toast.error("Failed to create task", { description });
       log.error("Unexpected error during task creation", { error });
     } finally {
       setIsCreatingTask(false);
@@ -174,6 +171,7 @@ export function useTaskCreation({
     adapter,
     model,
     reasoningLevel,
+    environmentId,
     invalidateTasks,
     navigateToTask,
   ]);

--- a/apps/code/src/renderer/features/task-detail/service/service.ts
+++ b/apps/code/src/renderer/features/task-detail/service/service.ts
@@ -30,7 +30,10 @@ export class TaskService {
    * 3. Updates renderer stores on success
    * 4. Returns a typed result for the hook to handle UI effects
    */
-  public async createTask(input: TaskCreationInput): Promise<CreateTaskResult> {
+  public async createTask(
+    input: TaskCreationInput,
+    onTaskReady?: (output: TaskCreationOutput) => void,
+  ): Promise<CreateTaskResult> {
     log.info("Creating task", {
       workspaceMode: input.workspaceMode,
       hasContent: !!input.content,
@@ -45,7 +48,6 @@ export class TaskService {
       };
     }
 
-    // Get posthogClient from auth store (created dynamically on login)
     const posthogClient = useAuthStore.getState().client;
     if (!posthogClient) {
       return {
@@ -57,13 +59,25 @@ export class TaskService {
 
     const saga = new TaskCreationSaga({
       posthogClient,
+      onTaskReady: onTaskReady
+        ? (output) => {
+            this.optimisticallyUpdateWorkspaceCache(output);
+            this.updateStoresOnSuccess(output, input);
+            void queryClient.invalidateQueries(
+              trpc.workspace.getAll.pathFilter(),
+            );
+            onTaskReady(output);
+          }
+        : undefined,
     });
 
     const result = await saga.run(input);
 
     if (result.success) {
       this.optimisticallyUpdateWorkspaceCache(result.data);
-      this.updateStoresOnSuccess(result.data, input);
+      if (!onTaskReady) {
+        this.updateStoresOnSuccess(result.data, input);
+      }
       void queryClient.invalidateQueries(trpc.workspace.getAll.pathFilter());
     }
 

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -1,4 +1,5 @@
 import { buildPromptBlocks } from "@features/editor/utils/prompt-builder";
+import { useProvisioningStore } from "@features/provisioning/stores/provisioningStore";
 import {
   type ConnectParams,
   getSessionService,
@@ -67,6 +68,7 @@ export interface TaskCreationInput {
   adapter?: "claude" | "codex";
   model?: string;
   reasoningLevel?: string;
+  environmentId?: string;
 }
 
 export interface TaskCreationOutput {
@@ -76,6 +78,7 @@ export interface TaskCreationOutput {
 
 export interface TaskCreationDeps {
   posthogClient: PostHogAPIClient;
+  onTaskReady?: (output: TaskCreationOutput) => void;
 }
 
 export class TaskCreationSaga extends Saga<
@@ -136,9 +139,17 @@ export class TaskCreationSaga extends Saga<
     // Step 4: Create workspace if we have a directory
     let workspace: Workspace | null = null;
     const branch = input.branch ?? task.latest_run?.branch ?? null;
+    const hasProvisioning =
+      workspaceMode === "worktree" && !!repoPath && !input.taskId;
+
+    if (hasProvisioning) {
+      useProvisioningStore.getState().setActive(task.id);
+      if (this.deps.onTaskReady) {
+        this.deps.onTaskReady({ task, workspace });
+      }
+    }
 
     if (repoPath) {
-      // Use the pre-fetched folder if we started it in parallel, otherwise fetch now
       const folder = folderPromise
         ? await this.readOnlyStep("folder_registration", () => folderPromise)
         : await this.readOnlyStep("folder_registration", () =>
@@ -215,6 +226,14 @@ export class TaskCreationSaga extends Saga<
       };
     }
 
+    if (!hasProvisioning && this.deps.onTaskReady) {
+      this.deps.onTaskReady({ task, workspace });
+    }
+
+    if (hasProvisioning) {
+      useProvisioningStore.getState().clear(task.id);
+    }
+
     // Step 5: Start cloud run (only for new cloud tasks)
     if (workspaceMode === "cloud" && !task.latest_run) {
       await this.step({
@@ -226,7 +245,7 @@ export class TaskCreationSaga extends Saga<
       });
     }
 
-    // Step 6: Connect to session
+    // Step 7: Connect to session
     // Cloud create: skip local session — the sandbox handles execution
     const agentCwd =
       workspace?.worktreePath ?? workspace?.folderPath ?? repoPath;

--- a/packages/git/src/sagas/worktree.ts
+++ b/packages/git/src/sagas/worktree.ts
@@ -35,15 +35,7 @@ export class CreateWorktreeSaga extends GitSaga<
     await this.step({
       name: "create-worktree",
       execute: () =>
-        this.git.raw([
-          "worktree",
-          "add",
-          "--quiet",
-          "-b",
-          branchName,
-          worktreePath,
-          base,
-        ]),
+        this.git.raw(["worktree", "add", "-b", branchName, worktreePath, base]),
       rollback: async () => {
         try {
           await this.git.raw(["worktree", "remove", worktreePath, "--force"]);
@@ -131,7 +123,7 @@ export class CreateWorktreeForBranchSaga extends GitSaga<
     await this.step({
       name: "create-worktree",
       execute: () =>
-        this.git.raw(["worktree", "add", "--quiet", worktreePath, branchName]),
+        this.git.raw(["worktree", "add", worktreePath, branchName]),
       rollback: async () => {
         try {
           await this.git.raw(["worktree", "remove", worktreePath, "--force"]);

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -16,6 +17,7 @@ export interface WorktreeInfo {
   branchName: string;
   baseBranch: string;
   createdAt: string;
+  output?: string;
 }
 
 export interface WorktreeConfig {
@@ -121,6 +123,7 @@ export class WorktreeManager {
 
   async createWorktree(options?: {
     baseBranch?: string;
+    onOutput?: (data: string) => void;
   }): Promise<WorktreeInfo> {
     const manager = getGitOperationManager();
 
@@ -147,27 +150,14 @@ export class WorktreeManager {
     const parentDir = path.dirname(worktreePath);
     await fs.mkdir(parentDir, { recursive: true });
 
-    await manager.executeWrite(this.mainRepoPath, async (git) => {
-      if (this.usesExternalPath()) {
-        await git.raw([
-          "worktree",
-          "add",
-          "--quiet",
-          "--detach",
-          worktreePath,
-          baseBranch,
-        ]);
-      } else {
-        const relativePath = `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
-        await git.raw([
-          "worktree",
-          "add",
-          "--quiet",
-          "--detach",
-          relativePath,
-          baseBranch,
-        ]);
-      }
+    const targetPath = this.usesExternalPath()
+      ? worktreePath
+      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+
+    const output = await manager.executeWrite(this.mainRepoPath, async () => {
+      return this.spawnWorktreeAdd(["--detach", targetPath, baseBranch], {
+        onOutput: options?.onOutput,
+      });
     });
 
     await this.symlinkClaudeConfig(worktreePath);
@@ -178,12 +168,14 @@ export class WorktreeManager {
       branchName: "",
       baseBranch,
       createdAt: new Date().toISOString(),
+      output: output.trim() || undefined,
     };
   }
 
   async createWorktreeForExistingBranch(
     branch: string,
     preferredName?: string,
+    options?: { onOutput?: (data: string) => void },
   ): Promise<WorktreeInfo> {
     const manager = getGitOperationManager();
 
@@ -218,13 +210,14 @@ export class WorktreeManager {
     const parentDir = path.dirname(worktreePath);
     await fs.mkdir(parentDir, { recursive: true });
 
-    await manager.executeWrite(this.mainRepoPath, async (git) => {
-      if (this.usesExternalPath()) {
-        await git.raw(["worktree", "add", "--quiet", worktreePath, branch]);
-      } else {
-        const relativePath = `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
-        await git.raw(["worktree", "add", "--quiet", relativePath, branch]);
-      }
+    const targetPath = this.usesExternalPath()
+      ? worktreePath
+      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+
+    const output = await manager.executeWrite(this.mainRepoPath, async () => {
+      return this.spawnWorktreeAdd([targetPath, branch], {
+        onOutput: options?.onOutput,
+      });
     });
 
     await this.symlinkClaudeConfig(worktreePath);
@@ -235,12 +228,14 @@ export class WorktreeManager {
       branchName: branch,
       baseBranch: branch,
       createdAt: new Date().toISOString(),
+      output: output.trim() || undefined,
     };
   }
 
   async createDetachedWorktreeAtCommit(
     commit: string,
     preferredName?: string,
+    options?: { onOutput?: (data: string) => void },
   ): Promise<WorktreeInfo> {
     const manager = getGitOperationManager();
 
@@ -269,27 +264,14 @@ export class WorktreeManager {
     const parentDir = path.dirname(worktreePath);
     await fs.mkdir(parentDir, { recursive: true });
 
-    await manager.executeWrite(this.mainRepoPath, async (git) => {
-      if (this.usesExternalPath()) {
-        await git.raw([
-          "worktree",
-          "add",
-          "--quiet",
-          "--detach",
-          worktreePath,
-          commit,
-        ]);
-      } else {
-        const relativePath = `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
-        await git.raw([
-          "worktree",
-          "add",
-          "--quiet",
-          "--detach",
-          relativePath,
-          commit,
-        ]);
-      }
+    const targetPath = this.usesExternalPath()
+      ? worktreePath
+      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+
+    const output = await manager.executeWrite(this.mainRepoPath, async () => {
+      return this.spawnWorktreeAdd(["--detach", targetPath, commit], {
+        onOutput: options?.onOutput,
+      });
     });
 
     await this.symlinkClaudeConfig(worktreePath);
@@ -300,7 +282,43 @@ export class WorktreeManager {
       branchName: "",
       baseBranch: commit,
       createdAt: new Date().toISOString(),
+      output: output.trim() || undefined,
     };
+  }
+
+  private spawnWorktreeAdd(
+    args: string[],
+    options?: { onOutput?: (data: string) => void },
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const chunks: string[] = [];
+      const proc = spawn("git", ["worktree", "add", ...args], {
+        cwd: this.mainRepoPath,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      const handleData = (data: Buffer) => {
+        const text = data.toString("utf-8");
+        chunks.push(text);
+        options?.onOutput?.(text);
+      };
+
+      proc.stdout.on("data", handleData);
+      proc.stderr.on("data", handleData);
+
+      proc.on("error", (err) => reject(err));
+      proc.on("close", (code) => {
+        if (code !== 0) {
+          reject(
+            new Error(
+              `git worktree add exited with code ${code}: ${chunks.join("")}`,
+            ),
+          );
+          return;
+        }
+        resolve(chunks.join(""));
+      });
+    });
   }
 
   async deleteWorktree(worktreePath: string): Promise<void> {


### PR DESCRIPTION
replace the long loading times for worktree creation with a view which displays the git stream of setting up a worktree, including any hooks that get triggered by that command