### PR TITLE
fix: Fix single-select checkbox state in planning mode

### DIFF
--- a/apps/code/src/renderer/components/action-selector/useActionSelectorState.ts
+++ b/apps/code/src/renderer/components/action-selector/useActionSelectorState.ts
@@ -173,8 +173,12 @@ export function useActionSelectorState({
             next.add(optionId);
           }
         } else {
-          next.clear();
-          next.add(optionId);
+          if (next.has(optionId)) {
+            next.clear();
+          } else {
+            next.clear();
+            next.add(optionId);
+          }
         }
         return next;
       });
@@ -227,6 +231,9 @@ export function useActionSelectorState({
 
     if (showSubmitButton) {
       if (needsCustomInput(selected) && !isEditing) {
+        if (!multiSelect) {
+          setCheckedOptions(new Set());
+        }
         setIsEditing(true);
       } else {
         toggleCheck(selected.id);
@@ -330,6 +337,9 @@ export function useActionSelectorState({
 
       if (showSubmitButton) {
         if (needsCustomInput(selected)) {
+          if (!multiSelect) {
+            setCheckedOptions(new Set());
+          }
           setIsEditing(true);
         } else {
           toggleCheck(selected.id);
@@ -382,6 +392,9 @@ export function useActionSelectorState({
           const next = new Set(prev);
           if (value.trim()) {
             if (!prev.has(selectedOption.id)) {
+              if (!multiSelect) {
+                next.clear();
+              }
               next.add(selectedOption.id);
             }
           } else {
@@ -391,7 +404,7 @@ export function useActionSelectorState({
         });
       }
     },
-    [showSubmitButton, selectedOption],
+    [showSubmitButton, selectedOption, multiSelect],
   );
 
   const ensureChecked = useCallback((optionId: string) => {


### PR DESCRIPTION
## Problem

In single-select mode, clicking the "Other" option enters edit mode without clearing the previous selection, and typing auto-checks "Other" without clearing others so you end up with two items checked. Then you can't uncheck either because single-select toggleCheck always re-selects the clicked item.

![image.png](https://app.graphite.com/user-attachments/assets/463a9513-6a82-4370-8e52-1da252522d63.png)

## Changes

1. Allow unchecking a selected option in single-select mode (toggleCheck)
2. Clear other selections when clicking a custom-input option in single-select mode (handleClick, selectCurrent)
3. Clear other selections when auto-checking custom input on text entry in single-select mode (handleCustomInputChange)

## How did you test this?

Manually