### PR TITLE
feat: Add initial task mode setting

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -660,8 +660,15 @@ export class SessionService {
     sessionStoreSetters.setSession(session);
 
     try {
-      const { customInstructions: previewCustomInstructions } =
-        useSettingsStore.getState();
+      const {
+        customInstructions: previewCustomInstructions,
+        defaultInitialTaskMode,
+        lastUsedInitialTaskMode,
+      } = useSettingsStore.getState();
+      const initialMode =
+        defaultInitialTaskMode === "last_used"
+          ? lastUsedInitialTaskMode
+          : "plan";
       const result = await trpcClient.agent.start.mutate({
         taskId: PREVIEW_TASK_ID,
         taskRunId,
@@ -670,7 +677,7 @@ export class SessionService {
         apiHost: auth.apiHost,
         projectId: auth.projectId,
         adapter: params.adapter,
-        permissionMode: "plan",
+        permissionMode: initialMode,
         customInstructions: previewCustomInstructions || undefined,
       });
 

--- a/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
@@ -3,6 +3,7 @@ import { SettingRow } from "@features/settings/components/SettingRow";
 import {
   type AutoConvertLongText,
   type CompletionSound,
+  type DefaultInitialTaskMode,
   type DiffOpenMode,
   type SendMessagesWith,
   useSettingsStore,
@@ -101,6 +102,7 @@ export function GeneralSettings() {
     completionSound,
     completionVolume,
     autoConvertLongText,
+    defaultInitialTaskMode,
     diffOpenMode,
     sendMessagesWith,
     hedgehogMode,
@@ -110,6 +112,7 @@ export function GeneralSettings() {
     setCompletionSound,
     setCompletionVolume,
     setAutoConvertLongText,
+    setDefaultInitialTaskMode,
     setDiffOpenMode,
     setSendMessagesWith,
     setHedgehogMode,
@@ -313,6 +316,18 @@ export function GeneralSettings() {
       setDiffOpenMode(value);
     },
     [diffOpenMode, setDiffOpenMode],
+  );
+
+  const handleDefaultInitialTaskModeChange = useCallback(
+    (value: DefaultInitialTaskMode) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "default_initial_task_mode",
+        new_value: value,
+        old_value: defaultInitialTaskMode,
+      });
+      setDefaultInitialTaskMode(value);
+    },
+    [defaultInitialTaskMode, setDefaultInitialTaskMode],
   );
 
   const handleSendMessagesWithChange = useCallback(
@@ -521,6 +536,25 @@ export function GeneralSettings() {
       >
         Input
       </Text>
+
+      <SettingRow
+        label="Initial task mode"
+        description="Choose whether new tasks always start in Plan mode or remember your last-used mode"
+      >
+        <Select.Root
+          value={defaultInitialTaskMode}
+          onValueChange={(value) =>
+            handleDefaultInitialTaskModeChange(value as DefaultInitialTaskMode)
+          }
+          size="1"
+        >
+          <Select.Trigger style={{ minWidth: "100px" }} />
+          <Select.Content>
+            <Select.Item value="plan">Plan</Select.Item>
+            <Select.Item value="last_used">Last used</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </SettingRow>
 
       <SettingRow
         label="Send messages with"

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceMode } from "@main/services/workspace/schemas";
+import type { ExecutionMode } from "@shared/types";
 import { electronStorage } from "@utils/electronStorage";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -9,6 +10,7 @@ export type SendMessagesWith = "enter" | "cmd+enter";
 export type CompletionSound = "none" | "guitar" | "danilo" | "revi" | "meep";
 export type AgentAdapter = "claude" | "codex";
 export type AutoConvertLongText = "off" | "1000" | "2500" | "5000" | "10000";
+export type DefaultInitialTaskMode = "plan" | "last_used";
 
 export interface HintState {
   count: number;
@@ -36,6 +38,8 @@ interface SettingsStore {
   preventSleepWhileRunning: boolean;
   debugLogsCloudRuns: boolean;
   customInstructions: string;
+  defaultInitialTaskMode: DefaultInitialTaskMode;
+  lastUsedInitialTaskMode: ExecutionMode;
   diffOpenMode: DiffOpenMode;
   hedgehogMode: boolean;
   mcpAppsDisabledServers: string[];
@@ -68,6 +72,8 @@ interface SettingsStore {
   setPreventSleepWhileRunning: (enabled: boolean) => void;
   setDebugLogsCloudRuns: (enabled: boolean) => void;
   setCustomInstructions: (instructions: string) => void;
+  setDefaultInitialTaskMode: (mode: DefaultInitialTaskMode) => void;
+  setLastUsedInitialTaskMode: (mode: ExecutionMode) => void;
   setDiffOpenMode: (mode: DiffOpenMode) => void;
   setHedgehogMode: (enabled: boolean) => void;
   setMcpAppsDisabledServers: (servers: string[]) => void;
@@ -95,6 +101,8 @@ export const useSettingsStore = create<SettingsStore>()(
       preventSleepWhileRunning: false,
       debugLogsCloudRuns: false,
       customInstructions: "",
+      defaultInitialTaskMode: "plan",
+      lastUsedInitialTaskMode: "plan",
       diffOpenMode: "auto",
       hedgehogMode: false,
       mcpAppsDisabledServers: [],
@@ -163,6 +171,10 @@ export const useSettingsStore = create<SettingsStore>()(
       setDebugLogsCloudRuns: (enabled) => set({ debugLogsCloudRuns: enabled }),
       setCustomInstructions: (instructions) =>
         set({ customInstructions: instructions }),
+      setDefaultInitialTaskMode: (mode) =>
+        set({ defaultInitialTaskMode: mode }),
+      setLastUsedInitialTaskMode: (mode) =>
+        set({ lastUsedInitialTaskMode: mode }),
       setDiffOpenMode: (mode) => set({ diffOpenMode: mode }),
       setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
       setMcpAppsDisabledServers: (servers) =>
@@ -191,6 +203,8 @@ export const useSettingsStore = create<SettingsStore>()(
         preventSleepWhileRunning: state.preventSleepWhileRunning,
         debugLogsCloudRuns: state.debugLogsCloudRuns,
         customInstructions: state.customInstructions,
+        defaultInitialTaskMode: state.defaultInitialTaskMode,
+        lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,
         diffOpenMode: state.diffOpenMode,
         hedgehogMode: state.hedgehogMode,
         hints: state.hints,

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -47,6 +47,8 @@ export function TaskInput() {
     allowBypassPermissions,
     setLastUsedEnvironment,
     getLastUsedEnvironment,
+    defaultInitialTaskMode,
+    lastUsedInitialTaskMode,
   } = useSettingsStore();
 
   const editorRef = useRef<MessageEditorHandle>(null);
@@ -137,9 +139,11 @@ export function TaskInput() {
   // Get current values from preview session config options for task creation.
   // Defaults ensure values are always passed even before the preview session loads.
   const currentModel = modelOption?.currentValue;
+  const modeFallback =
+    defaultInitialTaskMode === "last_used" ? lastUsedInitialTaskMode : "plan";
   const currentExecutionMode =
     getCurrentModeFromConfigOptions(modeOption ? [modeOption] : undefined) ??
-    "plan";
+    modeFallback;
   const currentReasoningLevel = thoughtOption?.currentValue;
 
   const branchForTaskCreation =

--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -4,6 +4,7 @@ import {
   contentToXml,
   extractFilePaths,
 } from "@features/message-editor/utils/content";
+import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { useCreateTask } from "@features/tasks/hooks/useTasks";
 import { useConnectivity } from "@hooks/useConnectivity";
 import type { WorkspaceMode } from "@main/services/workspace/schemas";
@@ -134,6 +135,10 @@ export function useTaskCreation({
         reasoningLevel,
         environmentId,
       });
+
+      if (executionMode) {
+        useSettingsStore.getState().setLastUsedInitialTaskMode(executionMode);
+      }
 
       const taskService = get<TaskService>(RENDERER_TOKENS.TaskService);
       const result = await taskService.createTask(input, (output) => {


### PR DESCRIPTION
## Problem

New tasks always revert to Plan mode, forcing users who prefer other modes to switch every time.

## Changes

  1. Add defaultInitialTaskMode setting with "Plan" (default) and "Last used" options
  2. Track last-used execution mode when creating tasks via lastUsedInitialTaskMode
  3. Use persisted mode for preview session initialization and TaskInput fallback

## How did you test this?

Manually