### PR TITLE
fix: Keep prompt visible during task creation

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
@@ -182,30 +182,18 @@ export const TaskInputEditor = forwardRef<
             >
               &gt;
             </Text>
-            {isCreatingTask ? (
-              <Text
-                size="2"
-                color="gray"
-                style={{
-                  fontFamily: "monospace",
-                  fontSize: "var(--font-size-1)",
-                }}
-              >
-                Creating task...
-              </Text>
-            ) : (
-              <Box
-                style={{
-                  flex: 1,
-                  position: "relative",
-                  minWidth: 0,
-                  maxHeight: "200px",
-                  overflowY: "auto",
-                }}
-              >
-                <EditorContent editor={editor} />
-              </Box>
-            )}
+            <Box
+              style={{
+                flex: 1,
+                position: "relative",
+                minWidth: 0,
+                maxHeight: "200px",
+                overflowY: "auto",
+                opacity: isCreatingTask ? 0.5 : 1,
+              }}
+            >
+              <EditorContent editor={editor} />
+            </Box>
           </Flex>
         </Flex>
 


### PR DESCRIPTION
## Problem

Clicking "Create task" instantly replaces the prompt with "Creating task..." text, causing anxiety that the input was lost.

## Changes

  1. Keep the editor visible during task creation instead of swapping it for static text
  2. Dim the editor to 50% opacity to signal the disabled state
  3. Rely on existing disabled prop and submit button spinner for loading feedback

## How did you test this?

Manually