### PR TITLE
fix(code): fix skills default highlight

### DIFF
--- a/apps/code/src/renderer/features/skills/components/SkillsView.tsx
+++ b/apps/code/src/renderer/features/skills/components/SkillsView.tsx
@@ -113,7 +113,7 @@ export function SkillsView() {
                         key={source}
                         title={config.sectionTitle}
                         skills={items}
-                        selectedPath={selectedPath}
+                        selectedPath={selectedSkill?.path ?? null}
                         onSelect={handleSelect}
                       />
                     );


### PR DESCRIPTION
## Problem

skills view auto-selects a skill when you open it, but it doesn't highlight that skill

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

fixes it

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->