### PR TITLE
fix(code): Default to action button in discard changes dialog

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -199,7 +199,7 @@ function ChangedFileItem({
       title: "Discard changes",
       message,
       buttons: ["Cancel", action],
-      defaultId: 0,
+      defaultId: 1,
       cancelId: 0,
     });
 


### PR DESCRIPTION
## Problem
When discarding changes, you have to click the action button every time.

## Changes
Default to the action button instead so that I can quickly hit Enter, same as VS Code does it.

## How did you test this code?
|Before|After|
|----|----|
|<img width="266" height="250" alt="image" src="https://github.com/user-attachments/assets/22f41bdd-5188-4588-9f55-a1f6ec18e817" />|<img width="267" height="251" alt="image" src="https://github.com/user-attachments/assets/557afe8f-d289-4d57-afcb-f8fc941e7852" />|