### PR TITLE
When in development mode, display the development badge on initial prompt

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -19,7 +19,7 @@ import {
   useGithubBranches,
   useRepositoryIntegration,
 } from "@hooks/useIntegrations";
-import { Badge, Flex } from "@radix-ui/themes";
+import { Flex, Text } from "@radix-ui/themes";
 import { useAuthStore } from "@renderer/features/auth/stores/authStore";
 import { useTRPC } from "@renderer/trpc/client";
 import { useNavigationStore } from "@stores/navigationStore";
@@ -378,13 +378,18 @@ export function TaskInput() {
                 disabled={isCreatingTask}
               />
             )}
+            {cloudRegion === "dev" && (
+              <Flex align="center" gap="1" className="shrink-0">
+                <span
+                  className="inline-block h-2 w-2 rounded-full bg-orange-9"
+                  aria-hidden
+                />
+                <Text size="1" color="orange" weight="medium">
+                  Dev
+                </Text>
+              </Flex>
+            )}
           </Flex>
-
-          {cloudRegion === "dev" && (
-            <Badge color="orange" variant="solid" size="2">
-              Development
-            </Badge>
-          )}
 
           <TaskInputEditor
             ref={editorRef}

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -143,7 +143,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           list: {},
           fork: {},
           resume: {},
-          close: {},
         },
         _meta: {
           posthog: {


### PR DESCRIPTION
## Problem

<!-- Who is this for and what problem does it solve? -->
When in development mode, there is not an obvious indicator that the prompt will be ran against the development environment rather than the production environment
<!-- Closes #ISSUE_ID -->
Closes #1192
## Changes

<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->
Adds a new badge to the input box that displays "Development" whenever the `cloudRegion == "dev"`
<img width="2566" height="1384" alt="image" src="https://github.com/user-attachments/assets/f3d307b2-8f29-42a2-9a5d-f73aabdc3cd5" />

## How did you test this?
Log in the developement environment and verify that the badge appears on initial prompt, log out and log in with any other environment and verify that the badge does not appear on initial prompt.
<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->
