### PR TITLE
fix(code): add 1m context window beta header

### DIFF
--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -238,6 +238,7 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
 
   const options: Options = {
     ...params.userProvidedOptions,
+    betas: ["context-1m-2025-08-07"],
     systemPrompt: params.systemPrompt ?? buildSystemPrompt(),
     settingSources: ["user", "project", "local"],
     stderr: (err) => params.logger.error(err),


### PR DESCRIPTION
## Problem

two problems:
1. every session starts with ~150k tokens eaten
2. we support 1M context now, but the agent still compacts at 200k (which means code is unusable lol)

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

does not solve the first problem!!!

but adds the `context-1m-2025-08-07` beta header to claude session options so we can actually use 1m context

docs: https://platform.claude.com/docs/en/build-with-claude/context-windows

related issue: https://github.com/Kilo-Org/kilocode/issues/6300

<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

![Screenshot 2026-03-25 at 8.21.50 PM.png](https://app.graphite.com/user-attachments/assets/2df977a8-3dc2-4054-91a2-230afd740195.png)

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->
