### PR TITLE
fix: Only send 1M context beta header for supported models

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -66,6 +66,7 @@ import {
   DEFAULT_MODEL,
   getEffortOptions,
   resolveModelPreference,
+  supports1MContext,
   toSdkModelId,
 } from "./session/models";
 import {
@@ -930,6 +931,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const resolvedSdkModel = toSdkModelId(resolvedModelId);
     if (!isResume && resolvedSdkModel !== DEFAULT_MODEL) {
       await this.session.query.setModel(resolvedSdkModel);
+    }
+
+    if (supports1MContext(resolvedModelId)) {
+      options.betas = ["context-1m-2025-08-07"];
     }
 
     const availableModes = getAvailableModes();


### PR DESCRIPTION
## Problem

Related: https://github.com/Kilo-Org/kilocode/issues/6300

## Changes

1. Import supports1MContext from session models
2. Conditionally set betas header only when the resolved model supports 1M context
3. Prevents "extra usage required for long context" errors on standard 200K models

## How did you test this?

Manually