### PR TITLE
fix: Detect non-standard default branch names

### DIFF
--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -766,10 +766,10 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
         ".default_branch",
       ]);
 
-      const defaultBranch =
-        repoResult.exitCode === 0 && repoResult.stdout.trim()
-          ? repoResult.stdout.trim()
-          : "main";
+      if (repoResult.exitCode !== 0 || !repoResult.stdout.trim()) {
+        return [];
+      }
+      const defaultBranch = repoResult.stdout.trim();
 
       const result = await execGh([
         "api",

--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -446,8 +446,8 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     let worktree: WorktreeInfo;
 
     try {
-      const defaultBranch = await getDefaultBranch(mainRepoPath).catch(
-        () => "main",
+      const defaultBranch = await getDefaultBranch(mainRepoPath).catch(() =>
+        getCurrentBranch(mainRepoPath).then((b) => b ?? "main"),
       );
       const selectedBranch = branch ?? defaultBranch;
       const isTrunkSelected = selectedBranch === defaultBranch;

--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createGitClient } from "./client";
+import { detectDefaultBranch } from "./queries";
+
+async function setupRepo(defaultBranch = "main"): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "posthog-code-queries-"));
+  const git = createGitClient(dir);
+  await git.init(["--initial-branch", defaultBranch]);
+  await git.addConfig("user.name", "Test");
+  await git.addConfig("user.email", "test@example.com");
+  await writeFile(path.join(dir, "file.txt"), "content\n");
+  await git.add(["file.txt"]);
+  await git.commit("initial");
+  return dir;
+}
+
+describe("detectDefaultBranch", () => {
+  let repoDir: string;
+
+  afterEach(async () => {
+    if (repoDir) {
+      await rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects 'main' as default branch", async () => {
+    repoDir = await setupRepo("main");
+    const git = createGitClient(repoDir);
+    const result = await detectDefaultBranch(git);
+    expect(result).toBe("main");
+  });
+
+  it("detects 'master' as default branch", async () => {
+    repoDir = await setupRepo("master");
+    const git = createGitClient(repoDir);
+    const result = await detectDefaultBranch(git);
+    expect(result).toBe("master");
+  });
+
+  it("detects non-standard default branch via init.defaultBranch config", async () => {
+    repoDir = await setupRepo("develop");
+    const git = createGitClient(repoDir);
+
+    // Set init.defaultBranch in the repo's local config
+    await git.addConfig("init.defaultBranch", "develop");
+
+    const result = await detectDefaultBranch(git);
+    expect(result).toBe("develop");
+  });
+
+  it("falls back to current branch when no standard branch exists", async () => {
+    repoDir = await setupRepo("trunk");
+    const git = createGitClient(repoDir);
+    const result = await detectDefaultBranch(git);
+    expect(result).toBe("trunk");
+  });
+
+  it("prefers 'main' over other detection methods", async () => {
+    repoDir = await setupRepo("main");
+    const git = createGitClient(repoDir);
+
+    // Create additional branches
+    await git.checkoutLocalBranch("develop");
+    await git.checkout("main");
+
+    const result = await detectDefaultBranch(git);
+    expect(result).toBe("main");
+  });
+
+  it("prefers remote HEAD over local detection", async () => {
+    repoDir = await setupRepo("main");
+    const git = createGitClient(repoDir);
+
+    // Set up a bare remote with a non-standard default branch
+    const remoteDir = await mkdtemp(
+      path.join(tmpdir(), "posthog-code-remote-"),
+    );
+    const remoteGit = createGitClient(remoteDir);
+    await remoteGit.init(["--bare", "--initial-branch", "production"]);
+    await git.addRemote("origin", remoteDir);
+
+    // Push main as production on remote and set HEAD
+    await git.push(["origin", "main:production"]);
+    await remoteGit.raw(["symbolic-ref", "HEAD", "refs/heads/production"]);
+    await git.fetch(["origin"]);
+
+    const result = await detectDefaultBranch(git);
+    expect(result).toBe("production");
+
+    await rm(remoteDir, { recursive: true, force: true });
+  });
+});

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -35,17 +35,36 @@ export async function detectDefaultBranch(git: GitLike): Promise<string> {
     ]);
     return remoteBranch.trim().replace("refs/remotes/origin/", "");
   } catch {
-    try {
-      await git.revparse(["--verify", "main"]);
-      return "main";
-    } catch {
+    // Check common default branch names
+    for (const candidate of ["main", "master"]) {
       try {
-        await git.revparse(["--verify", "master"]);
-        return "master";
-      } catch {
-        throw new Error("Cannot determine default branch");
-      }
+        await git.revparse(["--verify", candidate]);
+        return candidate;
+      } catch {}
     }
+
+    // Check git config init.defaultBranch (user's configured default)
+    try {
+      const configured = await git.raw(["config", "init.defaultBranch"]);
+      const branch = configured.trim();
+      if (branch) {
+        try {
+          await git.revparse(["--verify", branch]);
+          return branch;
+        } catch {}
+      }
+    } catch {}
+
+    // Fall back to current branch (HEAD)
+    try {
+      const head = await git.raw(["rev-parse", "--abbrev-ref", "HEAD"]);
+      const branch = head.trim();
+      if (branch && branch !== "HEAD") {
+        return branch;
+      }
+    } catch {}
+
+    throw new Error("Cannot determine default branch");
   }
 }
 
@@ -53,6 +72,14 @@ async function detectDefaultBranchWithFallback(git: GitLike): Promise<string> {
   try {
     return await detectDefaultBranch(git);
   } catch {
+    // Last resort: use current branch or "main"
+    try {
+      const head = await git.raw(["rev-parse", "--abbrev-ref", "HEAD"]);
+      const branch = head.trim();
+      if (branch && branch !== "HEAD") {
+        return branch;
+      }
+    } catch {}
     return "main";
   }
 }


### PR DESCRIPTION
## Problem

Git setup fails with fatal: invalid reference main when a repo's default branch isn't main or master, because detection only checked those two names and callers silently fell back to hardcoded "main".

## Changes

  1. Add init.defaultBranch config and current HEAD as fallbacks in detectDefaultBranch()
  2. Fix detectDefaultBranchWithFallback() to try HEAD before hardcoding "main"
  3. Fix workspace service .catch(() => "main") to use current branch
  4. Fix git service GitHub API fallback to return empty instead of guessing "main"
  5. Add unit tests for all default branch detection strategies

## How did you test this?

Manually + added unit tests
