### PR TITLE
Set explicit gcTime on QueryClient

### DIFF
--- a/apps/code/src/renderer/utils/queryClient.ts
+++ b/apps/code/src/renderer/utils/queryClient.ts
@@ -4,6 +4,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5,
+      gcTime: 1000 * 60 * 30,
       refetchOnWindowFocus: true,
     },
   },


### PR DESCRIPTION
## Problem

We set `staleTime` globally but never set `gcTime`. TanStack Query's default gcTime is 5 min which sounds fine, but queries that override with `staleTime: Infinity` (we have a bunch) stay "fresh" forever, meaning the GC never kicks in for them even when they go inactive.

## Changes

Set an explicit `gcTime: 30min` at the client level so inactive query data always gets cleaned up regardless of staleTime. 30 min is generous enough for a long-running desktop app where you're switching between tasks/files, but prevents multi-hour sessions from hoarding stale data indefinitely.