### PR TITLE
refactor: hook up renderer auth logic to service

### DIFF
--- a/apps/code/src/main/services/auth/service.test.ts
+++ b/apps/code/src/main/services/auth/service.test.ts
@@ -171,4 +171,70 @@ describe("AuthService", () => {
       "rotated-refresh-token",
     );
   });
+
+  it("preserves the selected project across logout and re-login for the same account", async () => {
+    vi.mocked(oauthService.startFlow)
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          access_token: "initial-access-token",
+          refresh_token: "initial-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "",
+          scoped_teams: [42, 84],
+          scoped_organizations: ["org-1"],
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          access_token: "second-access-token",
+          refresh_token: "second-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "",
+          scoped_teams: [42, 84],
+          scoped_organizations: ["org-1"],
+        },
+      });
+    vi.mocked(oauthService.refreshToken).mockResolvedValue({
+      success: true,
+      data: {
+        access_token: "refreshed-access-token",
+        refresh_token: "refreshed-refresh-token",
+        expires_in: 3600,
+        token_type: "Bearer",
+        scope: "",
+        scoped_teams: [42, 84],
+        scoped_organizations: ["org-1"],
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue({ has_access: true }),
+      }) as unknown as typeof fetch,
+    );
+
+    await service.login("us");
+    await service.selectProject(84);
+    await service.logout();
+
+    expect(service.getState()).toMatchObject({
+      status: "anonymous",
+      cloudRegion: "us",
+      projectId: 84,
+    });
+
+    await service.login("us");
+
+    expect(service.getState()).toMatchObject({
+      status: "authenticated",
+      cloudRegion: "us",
+      projectId: 84,
+      availableProjectIds: [42, 84],
+    });
+  });
 });

--- a/apps/code/src/main/services/auth/service.ts
+++ b/apps/code/src/main/services/auth/service.ts
@@ -219,9 +219,11 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   }
 
   async logout(): Promise<AuthState> {
+    const { cloudRegion, projectId } = this.state;
+
     this.authSessionRepository.clearCurrent();
     this.session = null;
-    this.setAnonymousState();
+    this.setAnonymousState({ cloudRegion, projectId });
     return this.getState();
   }
 

--- a/apps/code/src/renderer/App.tsx
+++ b/apps/code/src/renderer/App.tsx
@@ -5,8 +5,10 @@ import { ScopeReauthPrompt } from "@components/ScopeReauthPrompt";
 import { UpdatePrompt } from "@components/UpdatePrompt";
 import { AuthScreen } from "@features/auth/components/AuthScreen";
 import { InviteCodeScreen } from "@features/auth/components/InviteCodeScreen";
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
+import { useAuthSession } from "@features/auth/hooks/useAuthSession";
 import { OnboardingFlow } from "@features/onboarding/components/OnboardingFlow";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { Flex, Spinner, Text } from "@radix-ui/themes";
 import { initializeConnectivityStore } from "@renderer/stores/connectivityStore";
 import { useFocusStore } from "@renderer/stores/focusStore";
@@ -25,10 +27,14 @@ const log = logger.scope("app");
 
 function App() {
   const trpcReact = useTRPC();
-  const { isAuthenticated, hasCompletedOnboarding, hasCodeAccess } =
-    useAuthStore();
+  const { isBootstrapped } = useAuthSession();
+  const authState = useAuthStateValue((state) => state);
+  const hasCompletedOnboarding = useOnboardingStore(
+    (state) => state.hasCompletedOnboarding,
+  );
+  const isAuthenticated = authState.status === "authenticated";
+  const hasCodeAccess = authState.hasCodeAccess;
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
-  const [isLoading, setIsLoading] = useState(true);
   const [showTransition, setShowTransition] = useState(false);
   const wasInMainApp = useRef(isAuthenticated && hasCompletedOnboarding);
 
@@ -114,15 +120,6 @@ function App() {
     }),
   );
 
-  // Initialize auth state from main process
-  useEffect(() => {
-    const initialize = async () => {
-      await useAuthStore.getState().initializeOAuth();
-      setIsLoading(false);
-    };
-    void initialize();
-  }, []);
-
   // Handle transition into main app — only show the dark overlay if dark mode is active
   useEffect(() => {
     const isInMainApp = isAuthenticated && hasCompletedOnboarding;
@@ -136,7 +133,7 @@ function App() {
     setShowTransition(false);
   };
 
-  if (isLoading) {
+  if (!isBootstrapped) {
     return (
       <Flex align="center" justify="center" minHeight="100vh">
         <Flex align="center" gap="3">

--- a/apps/code/src/renderer/components/ScopeReauthPrompt.test.tsx
+++ b/apps/code/src/renderer/components/ScopeReauthPrompt.test.tsx
@@ -1,65 +1,40 @@
+import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ScopeReauthPrompt } from "./ScopeReauthPrompt";
 
-vi.mock("@renderer/trpc/client", () => ({
-  trpcClient: {
-    auth: {
-      getState: { query: vi.fn() },
-      onStateChanged: { subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })) },
-      getValidAccessToken: {
-        query: vi.fn().mockResolvedValue({
-          accessToken: "token",
-          apiHost: "https://us.posthog.com",
-        }),
-      },
-      refreshAccessToken: {
-        mutate: vi.fn().mockResolvedValue({
-          accessToken: "token",
-          apiHost: "https://us.posthog.com",
-        }),
-      },
-      login: {
-        mutate: vi.fn().mockResolvedValue({
-          state: {
-            status: "authenticated",
-            bootstrapComplete: true,
-            cloudRegion: "us",
-            projectId: 1,
-            availableProjectIds: [1],
-            availableOrgIds: [],
-            hasCodeAccess: true,
-            needsScopeReauth: false,
-          },
-        }),
-      },
-      signup: { mutate: vi.fn() },
-      selectProject: { mutate: vi.fn() },
-      redeemInviteCode: { mutate: vi.fn() },
-      logout: {
-        mutate: vi.fn().mockResolvedValue({
-          status: "anonymous",
-          bootstrapComplete: true,
-          cloudRegion: null,
-          projectId: null,
-          availableProjectIds: [],
-          availableOrgIds: [],
-          hasCodeAccess: null,
-          needsScopeReauth: false,
-        }),
-      },
-    },
-    analytics: {
-      setUserId: { mutate: vi.fn().mockResolvedValue(undefined) },
-      resetUser: { mutate: vi.fn().mockResolvedValue(undefined) },
-    },
-  },
+const authState = {
+  status: "anonymous" as const,
+  bootstrapComplete: true,
+  cloudRegion: null as "us" | "eu" | "dev" | null,
+  projectId: null,
+  availableProjectIds: [],
+  availableOrgIds: [],
+  hasCodeAccess: null,
+  needsScopeReauth: false,
+};
+
+const mockLoginMutateAsync = vi.fn();
+const mockLogoutMutate = vi.fn(() => {
+  authState.needsScopeReauth = false;
+  authState.cloudRegion = null;
+});
+
+vi.mock("@features/auth/hooks/authQueries", () => ({
+  useAuthStateValue: (selector: (state: typeof authState) => unknown) =>
+    selector(authState),
 }));
 
-vi.mock("@utils/analytics", () => ({
-  identifyUser: vi.fn(),
-  resetUser: vi.fn(),
-  track: vi.fn(),
+vi.mock("@features/auth/hooks/authMutations", () => ({
+  useLoginMutation: () => ({
+    mutateAsync: mockLoginMutateAsync,
+    isPending: false,
+  }),
+  useLogoutMutation: () => ({
+    mutate: mockLogoutMutate,
+  }),
 }));
 
 vi.mock("@utils/logger", () => ({
@@ -73,40 +48,18 @@ vi.mock("@utils/logger", () => ({
   },
 }));
 
-vi.mock("@utils/queryClient", () => ({
-  queryClient: {
-    clear: vi.fn(),
-    setQueryData: vi.fn(),
-    removeQueries: vi.fn(),
-  },
-}));
-
-vi.mock("@stores/navigationStore", () => ({
-  useNavigationStore: {
-    getState: () => ({ navigateToTaskInput: vi.fn() }),
-  },
-}));
-
-import {
-  resetAuthStoreModuleStateForTest,
-  useAuthStore,
-} from "@features/auth/stores/authStore";
-import { Theme } from "@radix-ui/themes";
-import type { ReactElement } from "react";
-import { ScopeReauthPrompt } from "./ScopeReauthPrompt";
-
 function renderWithTheme(ui: ReactElement) {
   return render(<Theme>{ui}</Theme>);
 }
 
 describe("ScopeReauthPrompt", () => {
   beforeEach(() => {
-    localStorage.clear();
-    resetAuthStoreModuleStateForTest();
-    useAuthStore.setState({
-      needsScopeReauth: false,
-      cloudRegion: null,
-    });
+    vi.clearAllMocks();
+    authState.status = "anonymous";
+    authState.cloudRegion = null;
+    authState.projectId = null;
+    authState.hasCodeAccess = null;
+    authState.needsScopeReauth = false;
   });
 
   it("does not render dialog when needsScopeReauth is false", () => {
@@ -117,25 +70,34 @@ describe("ScopeReauthPrompt", () => {
   });
 
   it("renders dialog when needsScopeReauth is true", () => {
-    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: "us" });
+    authState.needsScopeReauth = true;
+    authState.cloudRegion = "us";
+
     renderWithTheme(<ScopeReauthPrompt />);
+
     expect(screen.getByText("Re-authentication required")).toBeInTheDocument();
   });
 
   it("disables Sign in button when cloudRegion is null", () => {
-    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: null });
+    authState.needsScopeReauth = true;
+
     renderWithTheme(<ScopeReauthPrompt />);
+
     expect(screen.getByRole("button", { name: "Sign in" })).toBeDisabled();
   });
 
   it("enables Sign in button when cloudRegion is set", () => {
-    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: "us" });
+    authState.needsScopeReauth = true;
+    authState.cloudRegion = "us";
+
     renderWithTheme(<ScopeReauthPrompt />);
+
     expect(screen.getByRole("button", { name: "Sign in" })).not.toBeDisabled();
   });
 
   it("shows Log out button as an escape hatch when cloudRegion is null", () => {
-    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: null });
+    authState.needsScopeReauth = true;
+
     renderWithTheme(<ScopeReauthPrompt />);
 
     const logoutButton = screen.getByRole("button", { name: "Log out" });
@@ -145,14 +107,14 @@ describe("ScopeReauthPrompt", () => {
 
   it("calls logout when Log out button is clicked", async () => {
     const user = userEvent.setup();
-    useAuthStore.setState({ needsScopeReauth: true, cloudRegion: null });
+    authState.needsScopeReauth = true;
+
     renderWithTheme(<ScopeReauthPrompt />);
 
     await user.click(screen.getByRole("button", { name: "Log out" }));
 
-    const state = useAuthStore.getState();
-    expect(state.needsScopeReauth).toBe(false);
-    expect(state.isAuthenticated).toBe(false);
-    expect(state.cloudRegion).toBeNull();
+    expect(mockLogoutMutate).toHaveBeenCalledTimes(1);
+    expect(authState.needsScopeReauth).toBe(false);
+    expect(authState.cloudRegion).toBeNull();
   });
 });

--- a/apps/code/src/renderer/components/ScopeReauthPrompt.tsx
+++ b/apps/code/src/renderer/components/ScopeReauthPrompt.tsx
@@ -1,17 +1,19 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import {
+  useLoginMutation,
+  useLogoutMutation,
+} from "@features/auth/hooks/authMutations";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { ShieldWarning } from "@phosphor-icons/react";
 import { Button, Dialog, Flex, Text } from "@radix-ui/themes";
 import { logger } from "@utils/logger";
-import { useState } from "react";
 
 const log = logger.scope("scope-reauth-prompt");
 
 export function ScopeReauthPrompt() {
-  const needsScopeReauth = useAuthStore((s) => s.needsScopeReauth);
-  const cloudRegion = useAuthStore((s) => s.cloudRegion);
-  const loginWithOAuth = useAuthStore((s) => s.loginWithOAuth);
-  const logout = useAuthStore((s) => s.logout);
-  const [isLoading, setIsLoading] = useState(false);
+  const needsScopeReauth = useAuthStateValue((state) => state.needsScopeReauth);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const loginMutation = useLoginMutation();
+  const logoutMutation = useLogoutMutation();
 
   const handleSignIn = async () => {
     if (!cloudRegion) {
@@ -19,13 +21,10 @@ export function ScopeReauthPrompt() {
       return;
     }
 
-    setIsLoading(true);
     try {
-      await loginWithOAuth(cloudRegion);
+      await loginMutation.mutateAsync(cloudRegion);
     } catch (error) {
       log.error("Re-authentication failed", error);
-    } finally {
-      setIsLoading(false);
     }
   };
 
@@ -50,13 +49,18 @@ export function ScopeReauthPrompt() {
             </Text>
           </Dialog.Description>
           <Flex justify="between" mt="2">
-            <Button type="button" variant="soft" color="gray" onClick={logout}>
+            <Button
+              type="button"
+              variant="soft"
+              color="gray"
+              onClick={() => logoutMutation.mutate()}
+            >
               Log out
             </Button>
             <Button
               type="button"
               onClick={handleSignIn}
-              loading={isLoading}
+              loading={loginMutation.isPending}
               disabled={!cloudRegion}
             >
               Sign in

--- a/apps/code/src/renderer/features/auth/components/AuthScreen.tsx
+++ b/apps/code/src/renderer/features/auth/components/AuthScreen.tsx
@@ -1,14 +1,16 @@
 import { DraggableTitleBar } from "@components/DraggableTitleBar";
 import { ZenHedgehog } from "@components/ZenHedgehog";
-import { useAuthStore } from "@features/auth/stores/authStore";
+import {
+  useLoginMutation,
+  useSignupMutation,
+} from "@features/auth/hooks/authMutations";
+import { useAuthUiStateStore } from "@features/auth/stores/authUiStateStore";
 import { Callout, Flex, Spinner, Text, Theme } from "@radix-ui/themes";
 import codeLogo from "@renderer/assets/images/code.svg";
 import logomark from "@renderer/assets/images/logomark.svg";
 import { trpcClient } from "@renderer/trpc/client";
 import { REGION_LABELS } from "@shared/constants/oauth";
 import type { CloudRegion } from "@shared/types/oauth";
-import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
 import { RegionSelect } from "./RegionSelect";
 
 export const getErrorMessage = (error: unknown) => {
@@ -39,36 +41,28 @@ export const getErrorMessage = (error: unknown) => {
   return message;
 };
 
-type AuthMode = "login" | "signup";
-
 export function AuthScreen() {
-  const staleRegion = useAuthStore((s) => s.staleCloudRegion);
-  const [region, setRegion] = useState<CloudRegion>(staleRegion ?? "us");
-  const [authMode, setAuthMode] = useState<AuthMode>("login");
-  const { loginWithOAuth, signupWithOAuth } = useAuthStore();
-
-  const loginMutation = useMutation({
-    mutationFn: async () => {
-      await loginWithOAuth(region);
-    },
-  });
-
-  const signupMutation = useMutation({
-    mutationFn: async () => {
-      await signupWithOAuth(region);
-    },
-  });
+  const staleRegion = useAuthUiStateStore((state) => state.staleRegion);
+  const selectedRegion = useAuthUiStateStore((state) => state.selectedRegion);
+  const setSelectedRegion = useAuthUiStateStore(
+    (state) => state.setSelectedRegion,
+  );
+  const authMode = useAuthUiStateStore((state) => state.authMode);
+  const setAuthMode = useAuthUiStateStore((state) => state.setAuthMode);
+  const loginMutation = useLoginMutation();
+  const signupMutation = useSignupMutation();
+  const region: CloudRegion = selectedRegion ?? staleRegion ?? "us";
 
   const handleAuth = () => {
     if (authMode === "login") {
-      loginMutation.mutate();
+      loginMutation.mutate(region);
     } else {
-      signupMutation.mutate();
+      signupMutation.mutate(region);
     }
   };
 
   const handleRegionChange = (value: CloudRegion) => {
-    setRegion(value);
+    setSelectedRegion(value);
     loginMutation.reset();
     signupMutation.reset();
   };

--- a/apps/code/src/renderer/features/auth/components/InviteCodeScreen.tsx
+++ b/apps/code/src/renderer/features/auth/components/InviteCodeScreen.tsx
@@ -1,25 +1,26 @@
 import { DraggableTitleBar } from "@components/DraggableTitleBar";
-import { useAuthStore } from "@features/auth/stores/authStore";
+import {
+  useLogoutMutation,
+  useRedeemInviteCodeMutation,
+} from "@features/auth/hooks/authMutations";
+import { useAuthUiStateStore } from "@features/auth/stores/authUiStateStore";
 import { Callout, Flex, Spinner, Text, Theme } from "@radix-ui/themes";
 import phWordmark from "@renderer/assets/images/wordmark.svg";
 import zenHedgehog from "@renderer/assets/images/zen.png";
-import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
 
 export function InviteCodeScreen() {
-  const [code, setCode] = useState("");
-  const { redeemInviteCode, logout } = useAuthStore();
-
-  const redeemMutation = useMutation({
-    mutationFn: async () => {
-      await redeemInviteCode(code.trim());
-    },
-  });
+  const code = useAuthUiStateStore((state) => state.inviteCode);
+  const setInviteCode = useAuthUiStateStore((state) => state.setInviteCode);
+  const resetInviteCode = useAuthUiStateStore((state) => state.resetInviteCode);
+  const redeemMutation = useRedeemInviteCodeMutation();
+  const logoutMutation = useLogoutMutation();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!code.trim()) return;
-    redeemMutation.mutate();
+    redeemMutation.mutate(code.trim(), {
+      onSuccess: () => resetInviteCode(),
+    });
   };
 
   const errorMessage = redeemMutation.error?.message ?? null;
@@ -113,7 +114,7 @@ export function InviteCodeScreen() {
                 <input
                   type="text"
                   value={code}
-                  onChange={(e) => setCode(e.target.value)}
+                  onChange={(e) => setInviteCode(e.target.value)}
                   placeholder="Invite code"
                   disabled={redeemMutation.isPending}
                   style={{
@@ -163,7 +164,7 @@ export function InviteCodeScreen() {
             <Flex justify="center">
               <button
                 type="button"
-                onClick={logout}
+                onClick={() => logoutMutation.mutate()}
                 style={{
                   background: "none",
                   border: "none",

--- a/apps/code/src/renderer/features/auth/hooks/authClient.ts
+++ b/apps/code/src/renderer/features/auth/hooks/authClient.ts
@@ -1,0 +1,63 @@
+import { PostHogAPIClient } from "@renderer/api/posthogClient";
+import { trpcClient } from "@renderer/trpc/client";
+import { getCloudUrlFromRegion } from "@shared/constants/oauth";
+import { useMemo } from "react";
+import {
+  type AuthState,
+  fetchAuthState,
+  useAuthStateValue,
+} from "./authQueries";
+
+async function getValidAccessToken(): Promise<string> {
+  const { accessToken } = await trpcClient.auth.getValidAccessToken.query();
+  return accessToken;
+}
+
+async function refreshAccessToken(): Promise<string> {
+  const { accessToken } = await trpcClient.auth.refreshAccessToken.mutate();
+  return accessToken;
+}
+
+export function createAuthenticatedClient(
+  authState: AuthState | null | undefined,
+): PostHogAPIClient | null {
+  if (authState?.status !== "authenticated" || !authState.cloudRegion) {
+    return null;
+  }
+
+  const client = new PostHogAPIClient(
+    getCloudUrlFromRegion(authState.cloudRegion),
+    getValidAccessToken,
+    refreshAccessToken,
+    authState.projectId ?? undefined,
+  );
+
+  if (authState.projectId) {
+    client.setTeamId(authState.projectId);
+  }
+
+  return client;
+}
+
+export async function getAuthenticatedClient(): Promise<PostHogAPIClient | null> {
+  return createAuthenticatedClient(await fetchAuthState());
+}
+
+export function useOptionalAuthenticatedClient(): PostHogAPIClient | null {
+  const authState = useAuthStateValue((state) => state);
+
+  return useMemo(
+    () => createAuthenticatedClient(authState),
+    [authState.cloudRegion, authState.projectId, authState.status, authState],
+  );
+}
+
+export function useAuthenticatedClient(): PostHogAPIClient {
+  const client = useOptionalAuthenticatedClient();
+
+  if (!client) {
+    throw new Error("Not authenticated");
+  }
+
+  return client;
+}

--- a/apps/code/src/renderer/features/auth/hooks/authMutations.ts
+++ b/apps/code/src/renderer/features/auth/hooks/authMutations.ts
@@ -1,0 +1,91 @@
+import {
+  clearAuthScopedQueries,
+  fetchAuthState,
+  refreshAuthStateQuery,
+} from "@features/auth/hooks/authQueries";
+import { useAuthUiStateStore } from "@features/auth/stores/authUiStateStore";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
+import { resetSessionService } from "@features/sessions/service/service";
+import { trpcClient } from "@renderer/trpc/client";
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
+import type { CloudRegion } from "@shared/types/oauth";
+import { useNavigationStore } from "@stores/navigationStore";
+import { useMutation } from "@tanstack/react-query";
+import { track } from "@utils/analytics";
+
+function useAuthFlowMutation(
+  mutateAuth: (region: CloudRegion) => Promise<{
+    state: Awaited<ReturnType<typeof trpcClient.auth.getState.query>>;
+  }>,
+) {
+  return useMutation({
+    mutationFn: async (region: CloudRegion) => {
+      return await mutateAuth(region);
+    },
+    onSuccess: async ({ state }, region) => {
+      await refreshAuthStateQuery();
+      useAuthUiStateStore.getState().clearStaleRegion();
+      track(ANALYTICS_EVENTS.USER_LOGGED_IN, {
+        project_id: state.projectId?.toString() ?? "",
+        region,
+      });
+    },
+  });
+}
+
+export function useLoginMutation() {
+  return useAuthFlowMutation(async (region) => {
+    return await trpcClient.auth.login.mutate({ region });
+  });
+}
+
+export function useSignupMutation() {
+  return useAuthFlowMutation(async (region) => {
+    return await trpcClient.auth.signup.mutate({ region });
+  });
+}
+
+export function useSelectProjectMutation() {
+  return useMutation({
+    mutationFn: async (projectId: number) => {
+      resetSessionService();
+      return await trpcClient.auth.selectProject.mutate({ projectId });
+    },
+    onSuccess: async () => {
+      clearAuthScopedQueries();
+      await refreshAuthStateQuery();
+      useNavigationStore.getState().navigateToTaskInput();
+    },
+  });
+}
+
+export function useRedeemInviteCodeMutation() {
+  return useMutation({
+    mutationFn: async (code: string) =>
+      await trpcClient.auth.redeemInviteCode.mutate({ code }),
+    onSuccess: async () => {
+      await refreshAuthStateQuery();
+    },
+  });
+}
+
+export function useLogoutMutation() {
+  return useMutation({
+    mutationFn: async () => {
+      const previousState = await fetchAuthState();
+
+      track(ANALYTICS_EVENTS.USER_LOGGED_OUT);
+      resetSessionService();
+      clearAuthScopedQueries();
+
+      const state = await trpcClient.auth.logout.mutate();
+      return { state, previousState };
+    },
+    onSuccess: async ({ previousState }) => {
+      await refreshAuthStateQuery();
+      useAuthUiStateStore.getState().setStaleRegion(previousState.cloudRegion);
+      useNavigationStore.getState().navigateToTaskInput();
+      useOnboardingStore.getState().resetSelections();
+    },
+  });
+}

--- a/apps/code/src/renderer/features/auth/hooks/authQueries.ts
+++ b/apps/code/src/renderer/features/auth/hooks/authQueries.ts
@@ -1,0 +1,90 @@
+import type { PostHogAPIClient } from "@renderer/api/posthogClient";
+import { trpc, trpcClient } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { queryClient } from "@utils/queryClient";
+
+export type AuthState = Awaited<
+  ReturnType<typeof trpcClient.auth.getState.query>
+>;
+
+export const AUTH_SCOPED_QUERY_META = {
+  authScoped: true,
+} as const;
+
+export const ANONYMOUS_AUTH_STATE: AuthState = {
+  status: "anonymous",
+  bootstrapComplete: false,
+  cloudRegion: null,
+  projectId: null,
+  availableProjectIds: [],
+  availableOrgIds: [],
+  hasCodeAccess: null,
+  needsScopeReauth: false,
+};
+
+export const authKeys = {
+  currentUsers: () => ["auth", "current-user"] as const,
+  currentUser: (identity: string | null) =>
+    [...authKeys.currentUsers(), identity ?? "anonymous"] as const,
+};
+
+function getAuthStateQueryOptions() {
+  return trpc.auth.getState.queryOptions();
+}
+
+export async function fetchAuthState(): Promise<AuthState> {
+  return await trpcClient.auth.getState.query();
+}
+
+export async function refreshAuthStateQuery(): Promise<void> {
+  await queryClient.invalidateQueries(trpc.auth.getState.pathFilter());
+}
+
+export function clearAuthScopedQueries(): void {
+  queryClient.removeQueries({
+    predicate: (query) => query.meta?.authScoped === true,
+  });
+}
+
+export function getAuthIdentity(authState: AuthState): string | null {
+  if (authState.status !== "authenticated" || !authState.cloudRegion) {
+    return null;
+  }
+
+  return `${authState.cloudRegion}:${authState.projectId ?? "none"}`;
+}
+
+export function useAuthState() {
+  return useQuery({
+    ...getAuthStateQueryOptions(),
+    placeholderData: ANONYMOUS_AUTH_STATE,
+  });
+}
+
+export function useAuthStateValue<T>(selector: (state: AuthState) => T): T {
+  const { data } = useAuthState();
+  return selector(data ?? ANONYMOUS_AUTH_STATE);
+}
+
+export function useCurrentUser(options?: {
+  enabled?: boolean;
+  client?: PostHogAPIClient | null;
+}) {
+  const authState = useAuthStateValue((state) => state);
+  const client = options?.client ?? null;
+  const authIdentity = getAuthIdentity(authState);
+
+  return useQuery({
+    queryKey: authKeys.currentUser(authIdentity),
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("Not authenticated");
+      }
+
+      return await client.getCurrentUser();
+    },
+    enabled: !!client && !!authIdentity && (options?.enabled ?? true),
+    staleTime: 5 * 60 * 1000,
+    meta: AUTH_SCOPED_QUERY_META,
+  });
+}

--- a/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
+++ b/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
@@ -1,0 +1,97 @@
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
+import {
+  type AuthState,
+  clearAuthScopedQueries,
+  getAuthIdentity,
+  refreshAuthStateQuery,
+  useAuthStateValue,
+  useCurrentUser,
+} from "@features/auth/hooks/authQueries";
+import { useAuthUiStateStore } from "@features/auth/stores/authUiStateStore";
+import { trpcClient } from "@renderer/trpc/client";
+import { identifyUser, resetUser } from "@utils/analytics";
+import { logger } from "@utils/logger";
+import { useEffect } from "react";
+
+const log = logger.scope("auth-session");
+
+function useAuthSubscriptionSync(): void {
+  useEffect(() => {
+    const subscription = trpcClient.auth.onStateChanged.subscribe(undefined, {
+      onData: () => {
+        void refreshAuthStateQuery();
+      },
+      onError: (error) => {
+        log.error("Auth state subscription error", { error });
+      },
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+}
+
+function useAuthIdentitySync(
+  authIdentity: string | null,
+  cloudRegion: "us" | "eu" | "dev" | null,
+): void {
+  useEffect(() => {
+    if (!authIdentity) {
+      resetUser();
+      void trpcClient.analytics.resetUser.mutate();
+      clearAuthScopedQueries();
+      if (cloudRegion) {
+        useAuthUiStateStore.getState().setStaleRegion(cloudRegion);
+      }
+      return;
+    }
+
+    useAuthUiStateStore.getState().clearStaleRegion();
+  }, [authIdentity, cloudRegion]);
+}
+
+function useAuthAnalyticsIdentity(
+  authIdentity: string | null,
+  authState: AuthState,
+  currentUser: ReturnType<typeof useCurrentUser>["data"],
+): void {
+  useEffect(() => {
+    if (!authIdentity || !currentUser) {
+      return;
+    }
+
+    const distinctId = currentUser.distinct_id || currentUser.email;
+
+    identifyUser(distinctId, {
+      email: currentUser.email,
+      uuid: currentUser.uuid,
+      project_id: authState.projectId?.toString() ?? "",
+      region: authState.cloudRegion ?? "",
+    });
+
+    void trpcClient.analytics.setUserId.mutate({
+      userId: distinctId,
+      properties: {
+        email: currentUser.email,
+        uuid: currentUser.uuid,
+        project_id: authState.projectId?.toString() ?? "",
+        region: authState.cloudRegion ?? "",
+      },
+    });
+  }, [authIdentity, authState.cloudRegion, authState.projectId, currentUser]);
+}
+
+export function useAuthSession() {
+  const authState = useAuthStateValue((state) => state);
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
+  const authIdentity = getAuthIdentity(authState);
+
+  useAuthSubscriptionSync();
+  useAuthIdentitySync(authIdentity, authState.cloudRegion);
+  useAuthAnalyticsIdentity(authIdentity, authState, currentUser);
+
+  return {
+    authState,
+    isBootstrapped: authState.bootstrapComplete,
+  };
+}

--- a/apps/code/src/renderer/features/auth/stores/authUiStateStore.ts
+++ b/apps/code/src/renderer/features/auth/stores/authUiStateStore.ts
@@ -1,0 +1,34 @@
+import type { CloudRegion } from "@shared/types/oauth";
+import { create } from "zustand";
+
+interface AuthUiStateStoreState {
+  authMode: "login" | "signup";
+  inviteCode: string;
+  selectedRegion: CloudRegion | null;
+  staleRegion: CloudRegion | null;
+}
+
+interface AuthUiStateStoreActions {
+  setAuthMode: (mode: "login" | "signup") => void;
+  setInviteCode: (inviteCode: string) => void;
+  resetInviteCode: () => void;
+  setSelectedRegion: (region: CloudRegion | null) => void;
+  setStaleRegion: (region: CloudRegion | null) => void;
+  clearStaleRegion: () => void;
+}
+
+type AuthUiStateStore = AuthUiStateStoreState & AuthUiStateStoreActions;
+
+export const useAuthUiStateStore = create<AuthUiStateStore>((set) => ({
+  authMode: "login",
+  inviteCode: "",
+  selectedRegion: null,
+  staleRegion: null,
+
+  setAuthMode: (authMode) => set({ authMode }),
+  setInviteCode: (inviteCode) => set({ inviteCode }),
+  resetInviteCode: () => set({ inviteCode: "" }),
+  setSelectedRegion: (selectedRegion) => set({ selectedRegion }),
+  setStaleRegion: (region) => set({ staleRegion: region }),
+  clearStaleRegion: () => set({ staleRegion: null }),
+}));

--- a/apps/code/src/renderer/features/inbox/components/DataSourceSetup.tsx
+++ b/apps/code/src/renderer/features/inbox/components/DataSourceSetup.tsx
@@ -1,4 +1,5 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { GitHubRepoPicker } from "@features/folder-picker/components/GitHubRepoPicker";
 import { useRepositoryIntegration } from "@hooks/useIntegrations";
 import { Box, Button, Flex, Text, TextField } from "@radix-ui/themes";
@@ -52,8 +53,8 @@ interface SetupFormProps {
 }
 
 function GitHubSetup({ onComplete, onCancel }: SetupFormProps) {
-  const projectId = useAuthStore((s) => s.projectId);
-  const client = useAuthStore((s) => s.client);
+  const projectId = useAuthStateValue((state) => state.projectId);
+  const client = useAuthenticatedClient();
   const { githubIntegration, repositories, isLoadingRepos } =
     useRepositoryIntegration();
   const [repo, setRepo] = useState<string | null>(null);
@@ -133,9 +134,9 @@ const POLL_INTERVAL_MS = 3_000;
 const POLL_TIMEOUT_MS = 300_000; // 5 minutes
 
 function LinearSetup({ onComplete }: SetupFormProps) {
-  const cloudRegion = useAuthStore((s) => s.cloudRegion);
-  const projectId = useAuthStore((s) => s.projectId);
-  const client = useAuthStore((s) => s.client);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const projectId = useAuthStateValue((state) => state.projectId);
+  const client = useAuthenticatedClient();
   const [loading, setLoading] = useState(false);
   const [oauthConnected, setOauthConnected] = useState(false);
   const [pollError, setPollError] = useState<string | null>(null);
@@ -256,8 +257,8 @@ function LinearSetup({ onComplete }: SetupFormProps) {
 }
 
 function ZendeskSetup({ onComplete, onCancel }: SetupFormProps) {
-  const projectId = useAuthStore((s) => s.projectId);
-  const client = useAuthStore((s) => s.client);
+  const projectId = useAuthStateValue((state) => state.projectId);
+  const client = useAuthenticatedClient();
   const [subdomain, setSubdomain] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [email, setEmail] = useState("");

--- a/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -1,5 +1,5 @@
 import { ResizableSidebar } from "@components/ResizableSidebar";
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { InboxLiveRail } from "@features/inbox/components/InboxLiveRail";
 import {
   useInboxReportArtefacts,
@@ -217,8 +217,8 @@ export function InboxSignalsTab() {
 
   const canActOnReport = !!selectedReport && selectedReport.status === "ready";
 
-  const cloudRegion = useAuthStore((state) => state.cloudRegion);
-  const projectId = useAuthStore((state) => state.projectId);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const projectId = useAuthStateValue((state) => state.projectId);
   const replayBaseUrl =
     cloudRegion && projectId
       ? `${getCloudUrlFromRegion(cloudRegion)}/project/${projectId}/replay`

--- a/apps/code/src/renderer/features/inbox/hooks/useExternalDataSources.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useExternalDataSources.ts
@@ -1,9 +1,9 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { useAuthenticatedQuery } from "@hooks/useAuthenticatedQuery";
 import type { ExternalDataSource } from "@renderer/api/posthogClient";
 
 export function useExternalDataSources() {
-  const projectId = useAuthStore((s) => s.projectId);
+  const projectId = useAuthStateValue((state) => state.projectId);
   return useAuthenticatedQuery<ExternalDataSource[]>(
     ["external-data-sources", projectId],
     (client) =>

--- a/apps/code/src/renderer/features/inbox/hooks/useSignalSourceConfigs.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSignalSourceConfigs.ts
@@ -1,9 +1,9 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { useAuthenticatedQuery } from "@hooks/useAuthenticatedQuery";
 import type { SignalSourceConfig } from "@renderer/api/posthogClient";
 
 export function useSignalSourceConfigs() {
-  const projectId = useAuthStore((s) => s.projectId);
+  const projectId = useAuthStateValue((state) => state.projectId);
   return useAuthenticatedQuery<SignalSourceConfig[]>(
     ["signals", "source-configs", projectId],
     (client) =>

--- a/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
@@ -1,4 +1,5 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import type { SignalSourceValues } from "@features/inbox/components/SignalSourceToggles";
 import { useAuthenticatedMutation } from "@hooks/useAuthenticatedMutation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -45,8 +46,8 @@ const ALL_SOURCE_PRODUCTS: SourceProduct[] = [
 ];
 
 export function useSignalSourceManager() {
-  const projectId = useAuthStore((s) => s.projectId);
-  const client = useAuthStore((s) => s.client);
+  const projectId = useAuthStateValue((state) => state.projectId);
+  const client = useAuthenticatedClient();
   const queryClient = useQueryClient();
   const { data: configs, isLoading: configsLoading } = useSignalSourceConfigs();
   const { data: externalSources, isLoading: sourcesLoading } =

--- a/apps/code/src/renderer/features/onboarding/components/BillingStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/BillingStep.tsx
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { ArrowLeft, ArrowRight, Check } from "@phosphor-icons/react";
 import { Badge, Button, Flex, Text } from "@radix-ui/themes";
 import codeLogo from "@renderer/assets/images/code.svg";
@@ -24,7 +24,8 @@ const PRO_FEATURES: PlanFeature[] = [
 ];
 
 export function BillingStep({ onNext, onBack }: BillingStepProps) {
-  const { selectedPlan, selectPlan } = useAuthStore();
+  const selectedPlan = useOnboardingStore((state) => state.selectedPlan);
+  const selectPlan = useOnboardingStore((state) => state.selectPlan);
 
   useEffect(() => {
     if (!selectedPlan) {

--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -1,4 +1,7 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { useSelectProjectMutation } from "@features/auth/hooks/authMutations";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import {
   ArrowLeft,
   ArrowRight,
@@ -11,7 +14,7 @@ import codeLogo from "@renderer/assets/images/code.svg";
 import { trpcClient } from "@renderer/trpc/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useProjectsWithIntegrations } from "../hooks/useProjectsWithIntegrations";
 import { ProjectSelect } from "./ProjectSelect";
 
@@ -27,22 +30,26 @@ export function GitIntegrationStep({
   onNext,
   onBack,
 }: GitIntegrationStepProps) {
-  const cloudRegion = useAuthStore((s) => s.cloudRegion);
-  const currentProjectId = useAuthStore((s) => s.projectId);
-  const selectProject = useAuthStore((s) => s.selectProject);
-  const client = useAuthStore((s) => s.client);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const currentProjectId = useAuthStateValue((state) => state.projectId);
+  const client = useAuthenticatedClient();
+  const selectProjectMutation = useSelectProjectMutation();
 
   const queryClient = useQueryClient();
   const { projects, isLoading, isFetching } = useProjectsWithIntegrations();
 
-  const [isConnecting, setIsConnecting] = useState(false);
+  const isConnecting = useOnboardingStore((state) => state.isConnectingGithub);
+  const setConnectingGithub = useOnboardingStore(
+    (state) => state.setConnectingGithub,
+  );
+  const manuallySelectedProjectId = useOnboardingStore(
+    (state) => state.selectedProjectId,
+  );
+  const setSelectedProjectId = useOnboardingStore(
+    (state) => state.selectProjectId,
+  );
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // User can manually select a different project
-  const [manuallySelectedProjectId, setManuallySelectedProjectId] = useState<
-    number | null
-  >(null);
 
   // Determine which project to show:
   // 1. If user manually selected one, use that
@@ -77,16 +84,16 @@ export function GitIntegrationStep({
   useEffect(() => {
     if (hasGitIntegration && isConnecting) {
       stopPolling();
-      setIsConnecting(false);
+      setConnectingGithub(false);
     }
-  }, [hasGitIntegration, isConnecting, stopPolling]);
+  }, [hasGitIntegration, isConnecting, setConnectingGithub, stopPolling]);
 
   // Cleanup on unmount
   useEffect(() => stopPolling, [stopPolling]);
 
   const handleConnectGitHub = async () => {
     if (!cloudRegion || !selectedProjectId || !client) return;
-    setIsConnecting(true);
+    setConnectingGithub(true);
     try {
       await trpcClient.githubIntegration.startFlow.mutate({
         region: cloudRegion,
@@ -101,10 +108,10 @@ export function GitIntegrationStep({
       // Timeout after 5 minutes
       pollTimeoutRef.current = setTimeout(() => {
         stopPolling();
-        setIsConnecting(false);
+        setConnectingGithub(false);
       }, POLL_TIMEOUT_MS);
     } catch {
-      setIsConnecting(false);
+      setConnectingGithub(false);
     }
   };
 
@@ -115,7 +122,7 @@ export function GitIntegrationStep({
   const handleContinue = () => {
     // Persist the selected project if it's different from current
     if (selectedProjectId && selectedProjectId !== currentProjectId) {
-      selectProject(selectedProjectId);
+      selectProjectMutation.mutate(selectedProjectId);
     }
     onNext();
   };
@@ -179,7 +186,7 @@ export function GitIntegrationStep({
                       id: p.id,
                       name: p.name,
                     }))}
-                    onProjectChange={setManuallySelectedProjectId}
+                    onProjectChange={setSelectedProjectId}
                     disabled={isLoading}
                   />
                 </Flex>

--- a/apps/code/src/renderer/features/onboarding/components/OnboardingFlow.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/OnboardingFlow.tsx
@@ -1,6 +1,7 @@
 import { DraggableTitleBar } from "@components/DraggableTitleBar";
 import { ZenHedgehog } from "@components/ZenHedgehog";
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useLogoutMutation } from "@features/auth/hooks/authMutations";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { SignOut } from "@phosphor-icons/react";
 import { Button, Flex, Theme } from "@radix-ui/themes";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
@@ -16,7 +17,10 @@ import { WelcomeStep } from "./WelcomeStep";
 
 export function OnboardingFlow() {
   const { currentStep, activeSteps, next, back } = useOnboardingFlow();
-  const { completeOnboarding, logout } = useAuthStore();
+  const completeOnboarding = useOnboardingStore(
+    (state) => state.completeOnboarding,
+  );
+  const logoutMutation = useLogoutMutation();
 
   const handleComplete = () => {
     completeOnboarding();
@@ -166,7 +170,7 @@ export function OnboardingFlow() {
                     size="1"
                     variant="ghost"
                     color="gray"
-                    onClick={logout}
+                    onClick={() => logoutMutation.mutate()}
                     style={{ opacity: 0.5 }}
                   >
                     <SignOut size={14} />

--- a/apps/code/src/renderer/features/onboarding/components/OrgBillingStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/OrgBillingStep.tsx
@@ -1,4 +1,6 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { authKeys, useCurrentUser } from "@features/auth/hooks/authQueries";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { useOrganizations } from "@hooks/useOrganizations";
 import { ArrowLeft, ArrowRight, CheckCircle } from "@phosphor-icons/react";
 import {
@@ -11,10 +13,9 @@ import {
   Text,
 } from "@radix-ui/themes";
 import codeLogo from "@renderer/assets/images/code.svg";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { logger } from "@utils/logger";
 import { AnimatePresence, motion } from "framer-motion";
-import { useState } from "react";
 
 const log = logger.scope("org-billing-step");
 
@@ -24,18 +25,27 @@ interface OrgBillingStepProps {
 }
 
 export function OrgBillingStep({ onNext, onBack }: OrgBillingStepProps) {
-  const selectedOrgId = useAuthStore((s) => s.selectedOrgId);
-  const selectOrg = useAuthStore((s) => s.selectOrg);
-  const client = useAuthStore((s) => s.client);
+  const selectedOrgId = useOnboardingStore((state) => state.selectedOrgId);
+  const selectOrg = useOnboardingStore((state) => state.selectOrg);
+  const client = useAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
   const queryClient = useQueryClient();
-  const [isSwitching, setIsSwitching] = useState(false);
+  const switchOrganizationMutation = useMutation({
+    mutationFn: async (orgId: string) => {
+      await client.switchOrganization(orgId);
+      await queryClient.invalidateQueries({
+        queryKey: authKeys.currentUsers(),
+      });
+    },
+    onError: (err) => {
+      log.error("Failed to switch organization", err);
+    },
+  });
 
   const { orgsWithBilling, effectiveSelectedOrgId, isLoading, error } =
     useOrganizations();
 
-  const currentUserOrgId = queryClient.getQueryData<{
-    organization?: { id: string };
-  }>(["currentUser"])?.organization?.id;
+  const currentUserOrgId = currentUser?.organization?.id;
 
   const handleContinue = async () => {
     if (!effectiveSelectedOrgId) return;
@@ -45,15 +55,9 @@ export function OrgBillingStep({ onNext, onBack }: OrgBillingStepProps) {
     }
 
     if (client && effectiveSelectedOrgId !== currentUserOrgId) {
-      setIsSwitching(true);
       try {
-        await client.switchOrganization(effectiveSelectedOrgId);
-        await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
-      } catch (err) {
-        log.error("Failed to switch organization", err);
-      } finally {
-        setIsSwitching(false);
-      }
+        await switchOrganizationMutation.mutateAsync(effectiveSelectedOrgId);
+      } catch {}
     }
 
     onNext();
@@ -188,10 +192,14 @@ export function OrgBillingStep({ onNext, onBack }: OrgBillingStepProps) {
           <Button
             size="2"
             onClick={handleContinue}
-            disabled={!effectiveSelectedOrgId || isLoading || isSwitching}
+            disabled={
+              !effectiveSelectedOrgId ||
+              isLoading ||
+              switchOrganizationMutation.isPending
+            }
           >
-            {isSwitching ? "Switching..." : "Continue"}
-            {!isSwitching && <ArrowRight size={16} />}
+            {switchOrganizationMutation.isPending ? "Switching..." : "Continue"}
+            {!switchOrganizationMutation.isPending && <ArrowRight size={16} />}
           </Button>
         </Flex>
       </Flex>

--- a/apps/code/src/renderer/features/onboarding/components/TutorialStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/TutorialStep.tsx
@@ -1,11 +1,11 @@
 import { TourHighlight } from "@components/TourHighlight";
-import { useAuthStore } from "@features/auth/stores/authStore";
 import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
 import { GitHubRepoPicker } from "@features/folder-picker/components/GitHubRepoPicker";
 import { BranchSelector } from "@features/git-interaction/components/BranchSelector";
 import type { MessageEditorHandle } from "@features/message-editor/components/MessageEditor";
 import { ModeIndicatorInput } from "@features/message-editor/components/ModeIndicatorInput";
 import { useDraftStore } from "@features/message-editor/stores/draftStore";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { getSessionService } from "@features/sessions/service/service";
 import {
   cycleModeOption,
@@ -61,7 +61,9 @@ interface TutorialStepProps {
 
 export function TutorialStep({ onComplete, onBack }: TutorialStepProps) {
   const { allowBypassPermissions } = useSettingsStore();
-  const { completeOnboarding } = useAuthStore();
+  const completeOnboarding = useOnboardingStore(
+    (state) => state.completeOnboarding,
+  );
 
   // Tour state machine
   const {

--- a/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
@@ -1,9 +1,11 @@
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { ONBOARDING_STEPS, type OnboardingStep } from "../types";
 
 export function useOnboardingFlow() {
-  const [currentStep, setCurrentStep] = useState<OnboardingStep>("welcome");
+  const currentStep = useOnboardingStore((state) => state.currentStep);
+  const setCurrentStep = useOnboardingStore((state) => state.setCurrentStep);
   const billingEnabled = useFeatureFlag("twig-billing", false);
 
   // Show billing onboarding steps only when billing is enabled
@@ -21,7 +23,7 @@ export function useOnboardingFlow() {
     if (!activeSteps.includes(currentStep)) {
       setCurrentStep(activeSteps[0]);
     }
-  }, [activeSteps, currentStep]);
+  }, [activeSteps, currentStep, setCurrentStep]);
 
   const currentIndex = activeSteps.indexOf(currentStep);
   const isFirstStep = currentIndex === 0;

--- a/apps/code/src/renderer/features/onboarding/hooks/useProjectsWithIntegrations.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useProjectsWithIntegrations.ts
@@ -1,4 +1,5 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { AUTH_SCOPED_QUERY_META } from "@features/auth/hooks/authQueries";
 import type { Integration } from "@features/integrations/stores/integrationStore";
 import { useProjects } from "@features/projects/hooks/useProjects";
 import { useQueries } from "@tanstack/react-query";
@@ -14,7 +15,7 @@ export interface ProjectWithIntegrations {
 
 export function useProjectsWithIntegrations() {
   const { projects, isLoading: projectsLoading } = useProjects();
-  const client = useAuthStore((s) => s.client);
+  const client = useAuthenticatedClient();
 
   // Fetch integrations for each project in parallel
   const integrationQueries = useQueries({
@@ -26,6 +27,7 @@ export function useProjectsWithIntegrations() {
       },
       enabled: !!client && projects.length > 0,
       staleTime: 60 * 1000, // 1 minute
+      meta: AUTH_SCOPED_QUERY_META,
     })),
   });
 

--- a/apps/code/src/renderer/features/onboarding/stores/onboardingStore.ts
+++ b/apps/code/src/renderer/features/onboarding/stores/onboardingStore.ts
@@ -1,0 +1,68 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { OnboardingStep } from "../types";
+
+interface OnboardingStoreState {
+  currentStep: OnboardingStep;
+  hasCompletedOnboarding: boolean;
+  isConnectingGithub: boolean;
+  selectedPlan: "free" | "pro" | null;
+  selectedOrgId: string | null;
+  selectedProjectId: number | null;
+}
+
+interface OnboardingStoreActions {
+  setCurrentStep: (step: OnboardingStep) => void;
+  completeOnboarding: () => void;
+  resetOnboarding: () => void;
+  resetSelections: () => void;
+  setConnectingGithub: (isConnecting: boolean) => void;
+  selectPlan: (plan: "free" | "pro") => void;
+  selectOrg: (orgId: string) => void;
+  selectProjectId: (projectId: number | null) => void;
+}
+
+type OnboardingStore = OnboardingStoreState & OnboardingStoreActions;
+
+const initialState: OnboardingStoreState = {
+  currentStep: "welcome",
+  hasCompletedOnboarding: false,
+  isConnectingGithub: false,
+  selectedPlan: null,
+  selectedOrgId: null,
+  selectedProjectId: null,
+};
+
+export const useOnboardingStore = create<OnboardingStore>()(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      setCurrentStep: (step) => set({ currentStep: step }),
+      completeOnboarding: () => set({ hasCompletedOnboarding: true }),
+      resetOnboarding: () => set({ ...initialState }),
+      resetSelections: () =>
+        set({
+          currentStep: "welcome",
+          isConnectingGithub: false,
+          selectedPlan: null,
+          selectedOrgId: null,
+          selectedProjectId: null,
+        }),
+      setConnectingGithub: (isConnectingGithub) => set({ isConnectingGithub }),
+      selectPlan: (plan) => set({ selectedPlan: plan }),
+      selectOrg: (orgId) => set({ selectedOrgId: orgId }),
+      selectProjectId: (selectedProjectId) => set({ selectedProjectId }),
+    }),
+    {
+      name: "onboarding-store",
+      partialize: (state) => ({
+        currentStep: state.currentStep,
+        hasCompletedOnboarding: state.hasCompletedOnboarding,
+        selectedPlan: state.selectedPlan,
+        selectedOrgId: state.selectedOrgId,
+        selectedProjectId: state.selectedProjectId,
+      }),
+    },
+  ),
+);

--- a/apps/code/src/renderer/features/projects/hooks/useProjects.tsx
+++ b/apps/code/src/renderer/features/projects/hooks/useProjects.tsx
@@ -1,5 +1,9 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
-import { useQuery } from "@tanstack/react-query";
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { useSelectProjectMutation } from "@features/auth/hooks/authMutations";
+import {
+  useAuthStateValue,
+  useCurrentUser,
+} from "@features/auth/hooks/authQueries";
 import { logger } from "@utils/logger";
 import { useEffect, useMemo } from "react";
 
@@ -36,20 +40,12 @@ export function groupProjectsByOrg(projects: ProjectInfo[]): GroupedProjects[] {
 }
 
 export function useProjects() {
-  const availableProjectIds = useAuthStore((s) => s.availableProjectIds);
-  const client = useAuthStore((s) => s.client);
-  const currentProjectId = useAuthStore((s) => s.projectId);
-
-  const {
-    data: currentUser,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["currentUser"],
-    queryFn: () => client?.getCurrentUser(),
-    enabled: !!client,
-    staleTime: 5 * 60 * 1000,
-  });
+  const availableProjectIds = useAuthStateValue(
+    (state) => state.availableProjectIds,
+  );
+  const currentProjectId = useAuthStateValue((state) => state.projectId);
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser, isLoading, error } = useCurrentUser({ client });
 
   const projects = useMemo(() => {
     if (!currentUser?.organization) return [];
@@ -84,7 +80,7 @@ export function useProjects() {
       .filter((p): p is ProjectInfo => p !== null);
   }, [currentUser, availableProjectIds]);
 
-  const selectProject = useAuthStore((s) => s.selectProject);
+  const selectProjectMutation = useSelectProjectMutation();
   const currentProject = projects.find((p) => p.id === currentProjectId);
   const groupedProjects = groupProjectsByOrg(projects);
 
@@ -97,9 +93,9 @@ export function useProjects() {
             ? "no project selected"
             : "current project not found in list",
       });
-      selectProject(projects[0].id);
+      selectProjectMutation.mutate(projects[0].id);
     }
-  }, [projects, currentProject, currentProjectId, selectProject]);
+  }, [currentProject, currentProjectId, projects, selectProjectMutation]);
 
   return {
     projects,

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { getAuthenticatedClient } from "@features/auth/hooks/authClient";
 import { getSessionService } from "@features/sessions/service/service";
 import { useSessionStore } from "@features/sessions/stores/sessionStore";
 import type { Task } from "@shared/types";
@@ -71,7 +71,7 @@ export function useChatTitleGenerator(taskId: string): void {
 
         const title = await generateTitle(content);
         if (title) {
-          const client = useAuthStore.getState().client;
+          const client = await getAuthenticatedClient();
           if (client) {
             await client.updateTask(taskId, { title });
             queryClient.setQueriesData<Task[]>(

--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -61,21 +61,49 @@ vi.mock("@features/sessions/stores/sessionStore", () => ({
   mergeConfigOptions: vi.fn((live: unknown[], _persisted: unknown[]) => live),
 }));
 
-const mockAuthStore = vi.hoisted(() => ({
-  useAuthStore: {
-    getState: vi.fn(() => ({
-      cloudRegion: "us",
-      projectId: 123,
-      client: {
-        createTaskRun: vi.fn(),
-        appendTaskRunLog: vi.fn(),
-      },
-    })),
-  },
-  setSessionResetCallback: vi.fn(),
+const mockBuildAuthenticatedClient = vi.hoisted(() =>
+  vi.fn<
+    () => {
+      createTaskRun: ReturnType<typeof vi.fn>;
+      appendTaskRunLog: ReturnType<typeof vi.fn>;
+    } | null
+  >(() => ({
+    createTaskRun: vi.fn(),
+    appendTaskRunLog: vi.fn(),
+  })),
+);
+
+const mockAuth = vi.hoisted(() => ({
+  fetchAuthState: vi.fn<() => Promise<Record<string, unknown>>>(async () => ({
+    status: "authenticated",
+    bootstrapComplete: true,
+    cloudRegion: "us",
+    projectId: 123,
+    availableProjectIds: [123],
+    availableOrgIds: [],
+    hasCodeAccess: true,
+    needsScopeReauth: false,
+  })),
+  getAuthenticatedClient: vi.fn<() => Promise<Record<string, unknown> | null>>(
+    async () => mockBuildAuthenticatedClient(),
+  ),
+  createAuthenticatedClient: vi.fn((authState: Record<string, unknown>) => {
+    return authState.status === "authenticated"
+      ? mockBuildAuthenticatedClient()
+      : null;
+  }),
 }));
 
-vi.mock("@features/auth/stores/authStore", () => mockAuthStore);
+vi.mock("@features/auth/hooks/authQueries", () => ({
+  AUTH_SCOPED_QUERY_META: { authScoped: true },
+  clearAuthScopedQueries: vi.fn(),
+  getAuthIdentity: vi.fn(),
+  fetchAuthState: mockAuth.fetchAuthState,
+}));
+vi.mock("@features/auth/hooks/authClient", () => ({
+  getAuthenticatedClient: mockAuth.getAuthenticatedClient,
+  createAuthenticatedClient: mockAuth.createAuthenticatedClient,
+}));
 
 vi.mock("@features/sessions/stores/modelsStore", () => ({
   useModelsStore: {
@@ -280,13 +308,19 @@ describe("SessionService", () => {
 
       // Track how many times createTaskRun is called
       const createTaskRunMock = vi.fn().mockResolvedValue({ id: "run-123" });
-      mockAuthStore.useAuthStore.getState.mockReturnValue({
+      mockAuth.fetchAuthState.mockResolvedValue({
+        status: "authenticated",
+        bootstrapComplete: true,
         cloudRegion: "us",
         projectId: 123,
-        client: {
-          createTaskRun: createTaskRunMock,
-          appendTaskRunLog: vi.fn(),
-        },
+        availableProjectIds: [123],
+        availableOrgIds: [],
+        hasCodeAccess: true,
+        needsScopeReauth: false,
+      });
+      mockBuildAuthenticatedClient.mockReturnValue({
+        createTaskRun: createTaskRunMock,
+        appendTaskRunLog: vi.fn(),
       });
 
       mockTrpcAgent.start.mutate.mockResolvedValue({
@@ -333,11 +367,17 @@ describe("SessionService", () => {
     it("creates error session when auth is missing", async () => {
       const service = getSessionService();
 
-      mockAuthStore.useAuthStore.getState.mockReturnValue({
+      mockAuth.fetchAuthState.mockResolvedValue({
+        status: "anonymous",
+        bootstrapComplete: true,
         cloudRegion: null,
         projectId: null,
-        client: null,
-      } as unknown as ReturnType<typeof mockAuthStore.useAuthStore.getState>);
+        availableProjectIds: [],
+        availableOrgIds: [],
+        hasCodeAccess: null,
+        needsScopeReauth: false,
+      });
+      mockBuildAuthenticatedClient.mockReturnValue(null);
 
       await service.connectToTask({
         task: createMockTask(),
@@ -414,13 +454,19 @@ describe("SessionService", () => {
 
       // Setup: create a task run to trigger subscription creation
       const createTaskRunMock = vi.fn().mockResolvedValue({ id: "run-456" });
-      mockAuthStore.useAuthStore.getState.mockReturnValue({
+      mockAuth.fetchAuthState.mockResolvedValue({
+        status: "authenticated",
+        bootstrapComplete: true,
         cloudRegion: "us",
         projectId: 123,
-        client: {
-          createTaskRun: createTaskRunMock,
-          appendTaskRunLog: vi.fn(),
-        },
+        availableProjectIds: [123],
+        availableOrgIds: [],
+        hasCodeAccess: true,
+        needsScopeReauth: false,
+      });
+      mockBuildAuthenticatedClient.mockReturnValue({
+        createTaskRun: createTaskRunMock,
+        appendTaskRunLog: vi.fn(),
       });
       mockTrpcAgent.start.mutate.mockResolvedValue({
         channel: "test-channel",

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -4,9 +4,10 @@ import type {
   SessionConfigOption,
 } from "@agentclientprotocol/sdk";
 import {
-  setSessionResetCallback,
-  useAuthStore,
-} from "@features/auth/stores/authStore";
+  createAuthenticatedClient,
+  getAuthenticatedClient,
+} from "@features/auth/hooks/authClient";
+import { fetchAuthState } from "@features/auth/hooks/authQueries";
 import { useSessionAdapterStore } from "@features/sessions/stores/sessionAdapterStore";
 import {
   getPersistedConfigOptions,
@@ -65,7 +66,7 @@ export const PREVIEW_TASK_ID = "__preview__";
 interface AuthCredentials {
   apiHost: string;
   projectId: number;
-  client: ReturnType<typeof useAuthStore.getState>["client"];
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>;
 }
 
 export interface ConnectParams {
@@ -101,8 +102,6 @@ export function resetSessionService(): void {
     log.error("Failed to reset all sessions on main process", err);
   });
 }
-
-setSessionResetCallback(resetSessionService);
 
 export class SessionService {
   private connectingTasks = new Map<string, Promise<void>>();
@@ -193,7 +192,7 @@ export class SessionService {
     const taskTitle = task.title || task.description || "Task";
 
     try {
-      const auth = this.getAuthCredentials();
+      const auth = await this.getAuthCredentials();
       if (!auth) {
         log.error("Missing auth credentials");
         const taskRunId = latestRun?.id ?? `error-${taskId}`;
@@ -656,7 +655,7 @@ export class SessionService {
     await this.cleanupPreviewSession();
     if (abort.signal.aborted) return;
 
-    const auth = this.getAuthCredentials();
+    const auth = await this.getAuthCredentials();
     if (!auth) {
       log.info("Skipping preview session - not authenticated");
       return;
@@ -1253,7 +1252,7 @@ export class SessionService {
       return { stopReason: "queued" };
     }
 
-    const auth = this.getCloudCommandAuth();
+    const auth = await this.getCloudCommandAuth();
     if (!auth) {
       throw new Error("Authentication required for cloud commands");
     }
@@ -1384,7 +1383,7 @@ export class SessionService {
     session: AgentSession,
     promptText: string,
   ): Promise<{ stopReason: string }> {
-    const client = useAuthStore.getState().client;
+    const client = await getAuthenticatedClient();
     if (!client) {
       throw new Error("Authentication required for cloud commands");
     }
@@ -1461,7 +1460,7 @@ export class SessionService {
       return false;
     }
 
-    const auth = this.getCloudCommandAuth();
+    const auth = await this.getCloudCommandAuth();
     if (!auth) {
       log.error("No auth for cloud cancel");
       return false;
@@ -1501,11 +1500,11 @@ export class SessionService {
     }
   }
 
-  private getCloudCommandAuth(): {
+  private async getCloudCommandAuth(): Promise<{
     apiHost: string;
     teamId: number;
-  } | null {
-    const authState = useAuthStore.getState();
+  } | null> {
+    const authState = await fetchAuthState();
     if (!authState.cloudRegion || !authState.projectId) return null;
     return {
       apiHost: getCloudUrlFromRegion(authState.cloudRegion),
@@ -1809,7 +1808,7 @@ export class SessionService {
     if (session?.initialPrompt?.length) {
       const { taskTitle, initialPrompt } = session;
       await this.teardownSession(session.taskRunId);
-      const auth = this.getAuthCredentials();
+      const auth = await this.getAuthCredentials();
       if (!auth) {
         throw new Error(
           "Unable to reach server. Please check your connection.",
@@ -1865,7 +1864,7 @@ export class SessionService {
     }
     this.unsubscribeFromChannel(taskRunId);
 
-    const auth = this.getAuthCredentials();
+    const auth = await this.getAuthCredentials();
     if (!auth) {
       throw new Error("Unable to reach server. Please check your connection.");
     }
@@ -1942,21 +1941,20 @@ export class SessionService {
       });
     }
 
-    // Get auth for host info
-    const auth = useAuthStore.getState();
-    if (!auth.projectId || !auth.cloudRegion) {
-      log.warn("No auth for cloud task watcher", { taskId });
-      return () => {};
-    }
+    void fetchAuthState()
+      .then((authState) => {
+        if (!authState.projectId || !authState.cloudRegion) {
+          log.warn("No auth for cloud task watcher", { taskId });
+          return;
+        }
 
-    // Start main-process watcher
-    trpcClient.cloudTask.watch
-      .mutate({
-        taskId,
-        runId,
-        apiHost: getCloudUrlFromRegion(auth.cloudRegion),
-        teamId: auth.projectId,
-        viewing,
+        return trpcClient.cloudTask.watch.mutate({
+          taskId,
+          runId,
+          apiHost: getCloudUrlFromRegion(authState.cloudRegion),
+          teamId: authState.projectId,
+          viewing,
+        });
       })
       .catch((err: unknown) =>
         log.warn("Failed to start cloud task watcher", { taskId, err }),
@@ -2163,13 +2161,13 @@ export class SessionService {
 
   // --- Helper Methods ---
 
-  private getAuthCredentials(): AuthCredentials | null {
-    const authState = useAuthStore.getState();
+  private async getAuthCredentials(): Promise<AuthCredentials | null> {
+    const authState = await fetchAuthState();
     const apiHost = authState.cloudRegion
       ? getCloudUrlFromRegion(authState.cloudRegion)
       : null;
     const projectId = authState.projectId;
-    const client = authState.client;
+    const client = createAuthenticatedClient(authState);
 
     if (!apiHost || !projectId || !client) return null;
     return { apiHost, projectId, client };
@@ -2288,23 +2286,13 @@ export class SessionService {
     // Don't update processedLineCount - it tracks S3 log lines, not local events
     sessionStoreSetters.appendEvents(session.taskRunId, [event]);
 
-    const auth = useAuthStore.getState();
-    if (auth.client) {
+    const client = await getAuthenticatedClient();
+    if (client) {
       try {
-        await auth.client.appendTaskRunLog(taskId, session.taskRunId, [
-          storedEntry,
-        ]);
+        await client.appendTaskRunLog(taskId, session.taskRunId, [storedEntry]);
       } catch (error) {
         log.warn("Failed to persist event to logs", { error });
       }
     }
   }
-}
-
-// Register callback when module loads (not during tests)
-if (typeof window !== "undefined" && !import.meta.env?.VITEST) {
-  setSessionResetCallback(() => {
-    log.info("Auth triggered session reset");
-    resetSessionService();
-  });
 }

--- a/apps/code/src/renderer/features/settings/components/sections/AccountSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/AccountSettings.tsx
@@ -1,26 +1,30 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { useLogoutMutation } from "@features/auth/hooks/authMutations";
+import {
+  useAuthStateValue,
+  useCurrentUser,
+} from "@features/auth/hooks/authQueries";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { SettingRow } from "@features/settings/components/SettingRow";
 import { SignOut } from "@phosphor-icons/react";
 import { Avatar, Badge, Button, Flex, Spinner, Text } from "@radix-ui/themes";
 import { REGION_LABELS } from "@shared/constants/oauth";
-import { useQuery } from "@tanstack/react-query";
 
 export function AccountSettings() {
-  const { client, isAuthenticated, selectedPlan, logout, cloudRegion } =
-    useAuthStore();
-
-  // Fetch current user from PostHog
-  const { data: user, isLoading } = useQuery({
-    queryKey: ["currentUser"],
-    queryFn: async () => {
-      if (!client) return null;
-      return await client.getCurrentUser();
-    },
-    enabled: !!client && isAuthenticated,
+  const isAuthenticated = useAuthStateValue(
+    (state) => state.status === "authenticated",
+  );
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const selectedPlan = useOnboardingStore((state) => state.selectedPlan);
+  const logoutMutation = useLogoutMutation();
+  const client = useOptionalAuthenticatedClient();
+  const { data: user, isLoading } = useCurrentUser({
+    client,
+    enabled: isAuthenticated,
   });
 
   const handleLogout = () => {
-    logout();
+    logoutMutation.mutate();
   };
 
   if (!isAuthenticated) {

--- a/apps/code/src/renderer/features/settings/components/sections/AdvancedSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/AdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { SettingRow } from "@features/settings/components/SettingRow";
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
@@ -22,9 +22,7 @@ export function AdvancedSettings() {
         <Button
           variant="soft"
           size="1"
-          onClick={() =>
-            useAuthStore.setState({ hasCompletedOnboarding: false })
-          }
+          onClick={() => useOnboardingStore.getState().resetOnboarding()}
         >
           Reset
         </Button>

--- a/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { SettingRow } from "@features/settings/components/SettingRow";
 import {
   type AutoConvertLongText,
@@ -479,8 +479,8 @@ export function GeneralSettings() {
 }
 
 function HedgehogDescription() {
-  const cloudRegion = useAuthStore((s) => s.cloudRegion);
-  const projectId = useAuthStore((s) => s.projectId);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const projectId = useAuthStateValue((state) => state.projectId);
 
   const customizeUrl =
     cloudRegion && projectId

--- a/apps/code/src/renderer/features/sidebar/components/ProjectSwitcher.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/ProjectSwitcher.tsx
@@ -1,4 +1,8 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import {
+  useLogoutMutation,
+  useSelectProjectMutation,
+} from "@features/auth/hooks/authMutations";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { Command } from "@features/command/components/Command";
 import { useProjects } from "@features/projects/hooks/useProjects";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
@@ -52,9 +56,9 @@ export function ProjectSwitcher() {
       setLearnMoreOpen(false);
     }
   }, [popoverOpen]);
-  const cloudRegion = useAuthStore((s) => s.cloudRegion);
-  const selectProject = useAuthStore((s) => s.selectProject);
-  const logout = useAuthStore((s) => s.logout);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const selectProjectMutation = useSelectProjectMutation();
+  const logoutMutation = useLogoutMutation();
   const {
     groupedProjects,
     currentProject,
@@ -65,7 +69,7 @@ export function ProjectSwitcher() {
 
   const handleProjectSelect = (projectId: number) => {
     if (projectId !== currentProjectId) {
-      selectProject(projectId);
+      selectProjectMutation.mutate(projectId);
     }
     setPopoverOpen(false);
     setDialogOpen(false);
@@ -112,7 +116,7 @@ export function ProjectSwitcher() {
 
   const handleLogout = () => {
     setPopoverOpen(false);
-    logout();
+    logoutMutation.mutate();
   };
 
   return (

--- a/apps/code/src/renderer/features/task-detail/hooks/usePreviewSession.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/usePreviewSession.ts
@@ -1,5 +1,5 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import {
   getSessionService,
   PREVIEW_TASK_ID,
@@ -31,7 +31,7 @@ interface PreviewSessionResult {
 export function usePreviewSession(
   adapter: "claude" | "codex",
 ): PreviewSessionResult {
-  const projectId = useAuthStore((s) => s.projectId);
+  const projectId = useAuthStateValue((state) => state.projectId);
 
   useEffect(() => {
     if (!projectId) return;

--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import type { MessageEditorHandle } from "@features/message-editor/components/MessageEditor";
 import { useTaskInputHistoryStore } from "@features/message-editor/stores/taskInputHistoryStore";
 import {
@@ -105,7 +105,9 @@ export function useTaskCreation({
 }: UseTaskCreationOptions): UseTaskCreationReturn {
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const { navigateToTask } = useNavigationStore();
-  const { isAuthenticated } = useAuthStore();
+  const isAuthenticated = useAuthStateValue(
+    (state) => state.status === "authenticated",
+  );
   const { invalidateTasks } = useCreateTask();
   const { isOnline } = useConnectivity();
 

--- a/apps/code/src/renderer/features/task-detail/service/service.ts
+++ b/apps/code/src/renderer/features/task-detail/service/service.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { getAuthenticatedClient } from "@features/auth/hooks/authClient";
 import { useDraftStore } from "@features/message-editor/stores/draftStore";
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { workspaceApi } from "@features/workspace/hooks/useWorkspace";
@@ -48,7 +48,7 @@ export class TaskService {
       };
     }
 
-    const posthogClient = useAuthStore.getState().client;
+    const posthogClient = await getAuthenticatedClient();
     if (!posthogClient) {
       return {
         success: false,
@@ -95,7 +95,7 @@ export class TaskService {
   ): Promise<CreateTaskResult> {
     log.info("Opening existing task", { taskId, taskRunId });
 
-    const posthogClient = useAuthStore.getState().client;
+    const posthogClient = await getAuthenticatedClient();
     if (!posthogClient) {
       return {
         success: false,

--- a/apps/code/src/renderer/hooks/useAuthenticatedClient.ts
+++ b/apps/code/src/renderer/hooks/useAuthenticatedClient.ts
@@ -1,11 +1,5 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthenticatedClient as useClient } from "@features/auth/hooks/authClient";
 
 export function useAuthenticatedClient() {
-  const client = useAuthStore((state) => state.client);
-
-  if (!client) {
-    throw new Error("Not authenticated");
-  }
-
-  return client;
+  return useClient();
 }

--- a/apps/code/src/renderer/hooks/useAuthenticatedInfiniteQuery.ts
+++ b/apps/code/src/renderer/hooks/useAuthenticatedInfiniteQuery.ts
@@ -1,4 +1,5 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { AUTH_SCOPED_QUERY_META } from "@features/auth/hooks/authQueries";
 import type { PostHogAPIClient } from "@renderer/api/posthogClient";
 import type { QueryKey } from "@tanstack/react-query";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -33,7 +34,7 @@ export function useAuthenticatedInfiniteQuery<
   queryFn: AuthenticatedInfiniteQueryFn<TData, TPageParam>,
   options: UseAuthenticatedInfiniteQueryOptions<TData, TPageParam>,
 ) {
-  const client = useAuthStore((state) => state.client);
+  const client = useOptionalAuthenticatedClient();
 
   return useInfiniteQuery({
     queryKey,
@@ -47,5 +48,6 @@ export function useAuthenticatedInfiniteQuery<
     refetchInterval: options.refetchInterval,
     refetchIntervalInBackground: options.refetchIntervalInBackground,
     staleTime: options.staleTime,
+    meta: AUTH_SCOPED_QUERY_META,
   });
 }

--- a/apps/code/src/renderer/hooks/useAuthenticatedMutation.ts
+++ b/apps/code/src/renderer/hooks/useAuthenticatedMutation.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
 import type { PostHogAPIClient } from "@renderer/api/posthogClient";
 import type {
   UseMutationOptions,
@@ -19,7 +19,7 @@ export function useAuthenticatedMutation<
   mutationFn: AuthenticatedMutationFn<TVariables, TData>,
   options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationFn">,
 ): UseMutationResult<TData, TError, TVariables> {
-  const client = useAuthStore((state) => state.client);
+  const client = useOptionalAuthenticatedClient();
 
   return useMutation({
     mutationFn: async (variables: TVariables) => {

--- a/apps/code/src/renderer/hooks/useAuthenticatedQuery.ts
+++ b/apps/code/src/renderer/hooks/useAuthenticatedQuery.ts
@@ -1,4 +1,5 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { AUTH_SCOPED_QUERY_META } from "@features/auth/hooks/authQueries";
 import type { PostHogAPIClient } from "@renderer/api/posthogClient";
 import type {
   QueryKey,
@@ -21,7 +22,8 @@ export function useAuthenticatedQuery<
     "queryKey" | "queryFn"
   >,
 ): UseQueryResult<TData, TError> {
-  const client = useAuthStore((state) => state.client);
+  const client = useOptionalAuthenticatedClient();
+  const { meta, ...restOptions } = options ?? {};
 
   return useQuery({
     queryKey,
@@ -30,7 +32,12 @@ export function useAuthenticatedQuery<
       return await queryFn(client);
     },
     enabled:
-      !!client && (options?.enabled !== undefined ? options.enabled : true),
-    ...options,
+      !!client &&
+      (restOptions.enabled !== undefined ? restOptions.enabled : true),
+    meta: {
+      ...AUTH_SCOPED_QUERY_META,
+      ...meta,
+    },
+    ...restOptions,
   });
 }

--- a/apps/code/src/renderer/hooks/useOrganizations.ts
+++ b/apps/code/src/renderer/hooks/useOrganizations.ts
@@ -1,7 +1,8 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { useCurrentUser } from "@features/auth/hooks/authQueries";
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { useAuthenticatedQuery } from "@hooks/useAuthenticatedQuery";
 import type { PostHogAPIClient } from "@renderer/api/posthogClient";
-import { useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 export interface OrgWithBilling {
@@ -52,8 +53,9 @@ async function fetchOrgsWithBilling(
 }
 
 export function useOrganizations() {
-  const selectedOrgId = useAuthStore((s) => s.selectedOrgId);
-  const queryClient = useQueryClient();
+  const selectedOrgId = useOnboardingStore((state) => state.selectedOrgId);
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
 
   const {
     data: orgsWithBilling,
@@ -70,9 +72,6 @@ export function useOrganizations() {
     if (!orgsWithBilling?.length) return null;
 
     // Default to the user's currently active org in PostHog
-    const currentUser = queryClient.getQueryData<{
-      organization?: { id: string };
-    }>(["currentUser"]);
     const userCurrentOrgId = currentUser?.organization?.id;
     if (
       userCurrentOrgId &&
@@ -85,7 +84,7 @@ export function useOrganizations() {
       (org) => org.has_active_subscription,
     );
     return (withBilling ?? orgsWithBilling[0]).id;
-  }, [selectedOrgId, orgsWithBilling, queryClient]);
+  }, [currentUser?.organization?.id, orgsWithBilling, selectedOrgId]);
 
   const sortedOrgs = useMemo(() => {
     return [...(orgsWithBilling ?? [])].sort((a, b) =>

--- a/apps/code/src/renderer/hooks/useProjectQuery.ts
+++ b/apps/code/src/renderer/hooks/useProjectQuery.ts
@@ -1,8 +1,8 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { useAuthenticatedQuery } from "./useAuthenticatedQuery";
 
 export function useProjectQuery() {
-  const projectId = useAuthStore((state) => state.projectId);
+  const projectId = useAuthStateValue((state) => state.projectId);
 
   return useAuthenticatedQuery(
     ["project", projectId],

--- a/apps/code/src/renderer/hooks/useTaskDeepLink.ts
+++ b/apps/code/src/renderer/hooks/useTaskDeepLink.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { useTaskViewed } from "@features/sidebar/hooks/useTaskViewed";
 import type { TaskService } from "@features/task-detail/service/service";
 import { get } from "@renderer/di/container";
@@ -30,7 +30,9 @@ export function useTaskDeepLink() {
   const navigateToTask = useNavigationStore((state) => state.navigateToTask);
   const { markAsViewed } = useTaskViewed();
   const queryClient = useQueryClient();
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const isAuthenticated = useAuthStateValue(
+    (state) => state.status === "authenticated",
+  );
   const hasFetchedPending = useRef(false);
 
   const handleOpenTask = useCallback(

--- a/apps/code/src/renderer/utils/generateTitle.ts
+++ b/apps/code/src/renderer/utils/generateTitle.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { fetchAuthState } from "@features/auth/hooks/authQueries";
 import { trpcClient } from "@renderer/trpc";
 import { logger } from "@utils/logger";
 
@@ -41,8 +41,8 @@ Never wrap the title in quotes.`;
 
 export async function generateTitle(content: string): Promise<string | null> {
   try {
-    const authState = useAuthStore.getState();
-    if (!authState.isAuthenticated) return null;
+    const authState = await fetchAuthState();
+    if (authState.status !== "authenticated") return null;
 
     const result = await trpcClient.llmGateway.prompt.mutate({
       system: SYSTEM_PROMPT,


### PR DESCRIPTION
## Problem

We've now hooked up our main services to the auth service, but the auth store is just a thin unreliable wrapper around the main service. We want to rely on trpc queries with tanstack query instead.
<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

- Gets rid of the auth store
- Moves onboarding logic into its own store
- Moves auth ui state into its own store
- Add a bunch of hooks for querying and mutating the auth state via the main auth service

-------

one test fails here (preferred org persistence), we can just forge merge with CI bypass this one since it's fixed in the [next PR](https://github.com/PostHog/code/pull/1366) in the stack 
