### PR TITLE
swap some fonts back to mono

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/DeleteToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/DeleteToolView.tsx
@@ -37,7 +37,7 @@ export function DeleteToolView({
         <LoadingIcon icon={Trash} isLoading={isLoading} />
         {filePath && <FileMentionChip filePath={filePath} />}
         {deletedLines !== null && (
-          <Text size="1">
+          <Text size="1" className="font-mono">
             <span className="text-red-11">-{deletedLines}</span>
           </Text>
         )}

--- a/apps/code/src/renderer/features/sessions/components/session-update/EditToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/EditToolView.tsx
@@ -92,7 +92,7 @@ export function EditToolView({
           <LoadingIcon icon={PencilSimple} isLoading={isLoading} />
           {filePath && <FileMentionChip filePath={filePath} />}
           {diffStats && (
-            <Text size="1">
+            <Text size="1" className="font-mono">
               <span className="text-green-11">+{diffStats.added}</span>{" "}
               <span className="text-red-11">-{diffStats.removed}</span>
             </Text>

--- a/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
@@ -87,7 +87,7 @@ export const FileMentionChip = memo(function FileMentionChip({
     >
       <Text size="1">
         <FileIcon filename={filename} size={12} />
-        {filename}
+        <span className="font-mono">{filename}</span>
       </Text>
     </Flex>
   );

--- a/apps/code/src/renderer/features/sessions/components/session-update/MoveToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/MoveToolView.tsx
@@ -29,9 +29,14 @@ export function MoveToolView({
       wasCancelled={wasCancelled}
     >
       {title ||
-        (sourcePath && destPath
-          ? `Move ${getFilename(sourcePath)} → ${getFilename(destPath)}`
-          : "Move file")}
+        (sourcePath && destPath ? (
+          <>
+            Move <span className="font-mono">{getFilename(sourcePath)}</span> →{" "}
+            <span className="font-mono">{getFilename(destPath)}</span>
+          </>
+        ) : (
+          "Move file"
+        ))}
     </ToolRow>
   );
 }

--- a/apps/code/src/renderer/features/sessions/components/session-update/SearchToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/SearchToolView.tsx
@@ -63,7 +63,9 @@ export function SearchToolView({
           isExpandable
           isExpanded={isExpanded}
         />
-        <ToolTitle>{title || "Search"}</ToolTitle>
+        <ToolTitle className="truncate">
+          <span className="font-mono">{title || "Search"}</span>
+        </ToolTitle>
         <ToolTitle className="shrink-0 whitespace-nowrap">
           {resultCount} {resultCount === 1 ? "result" : "results"}
         </ToolTitle>

--- a/apps/code/src/renderer/features/sessions/components/session-update/ThinkToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ThinkToolView.tsx
@@ -81,7 +81,7 @@ export function ThinkToolView({
 
       <Box className="border-gray-6 border-t px-3 py-2">
         <Text asChild size="1" className="text-gray-11">
-          <pre className="m-0 whitespace-pre-wrap break-all">
+          <pre className="m-0 whitespace-pre-wrap break-all font-mono">
             {displayedContent}
           </pre>
         </Text>

--- a/apps/code/src/renderer/features/sessions/components/session-update/ThoughtView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ThoughtView.tsx
@@ -46,7 +46,7 @@ export const ThoughtView = memo(function ThoughtView({
         <Box className="mt-1 ml-5 max-w-4xl overflow-hidden rounded-lg border border-gray-6">
           <Box className="max-h-64 overflow-auto px-3 py-2">
             <Text asChild size="1" className="text-gray-11">
-              <pre className="m-0 whitespace-pre-wrap break-all">
+              <pre className="m-0 whitespace-pre-wrap break-all font-mono">
                 {displayedContent}
               </pre>
             </Text>

--- a/apps/code/src/renderer/features/sessions/components/session-update/toolCallUtils.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/toolCallUtils.tsx
@@ -234,7 +234,9 @@ export function ContentPre({ children }: { children: React.ReactNode }) {
   return (
     <Box className="max-h-64 overflow-auto px-3 py-2">
       <Text asChild size="1" className="text-gray-11">
-        <pre className="m-0 whitespace-pre-wrap break-all">{children}</pre>
+        <pre className="m-0 whitespace-pre-wrap break-all font-mono">
+          {children}
+        </pre>
       </Text>
     </Box>
   );

--- a/packages/git/src/operation-manager.ts
+++ b/packages/git/src/operation-manager.ts
@@ -2,6 +2,29 @@ import { createGitClient, type GitClient } from "./client";
 import { removeLock, waitForUnlock } from "./lock-detector";
 import { AsyncReaderWriterLock } from "./rw-lock";
 
+/**
+ * Returns process.env with Electron/Chromium variables cleaned so that
+ * child processes spawned by git hooks (e.g. biome via lint-staged) don't
+ * crash trying to initialise GPU subsystems.
+ *
+ * The agent service symlinks `node → Electron binary` and prepends it to
+ * PATH. If ELECTRON_RUN_AS_NODE is missing, that binary starts as a full
+ * Chromium browser (GPU init → SIGTRAP crash). We strip most ELECTRON_/
+ * CHROME_ vars but explicitly keep ELECTRON_RUN_AS_NODE=1 so any such
+ * shim still behaves as plain Node.js.
+ */
+function getCleanEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (key === "ELECTRON_RUN_AS_NODE") continue;
+    if (key.startsWith("ELECTRON_") || key.startsWith("CHROME_")) continue;
+    env[key] = value;
+  }
+  env.ELECTRON_RUN_AS_NODE = "1";
+  return env;
+}
+
 interface RepoState {
   lock: AsyncReaderWriterLock;
   client: GitClient;
@@ -62,11 +85,11 @@ class GitOperationManagerImpl {
         abortSignal: options.signal,
       });
       return operation(
-        scopedGit.env({ ...process.env, GIT_OPTIONAL_LOCKS: "0" }),
+        scopedGit.env({ ...getCleanEnv(), GIT_OPTIONAL_LOCKS: "0" }),
       );
     }
 
-    const git = state.client.env({ ...process.env, GIT_OPTIONAL_LOCKS: "0" });
+    const git = state.client.env({ ...getCleanEnv(), GIT_OPTIONAL_LOCKS: "0" });
     return operation(git);
   }
 
@@ -93,10 +116,10 @@ class GitOperationManagerImpl {
         const scopedGit = createGitClient(repoPath, {
           abortSignal: options.signal,
         });
-        return await operation(scopedGit.env(process.env));
+        return await operation(scopedGit.env(getCleanEnv()));
       }
 
-      return await operation(state.client.env(process.env));
+      return await operation(state.client.env(getCleanEnv()));
     } catch (error) {
       if (options?.signal?.aborted) {
         await removeLock(repoPath).catch(() => {});


### PR DESCRIPTION
## Problem

- redesign made a few fonts sans-serif that probably need to be mono
- also commit is broken

<!-- Closes #ISSUE_ID -->

## Changes

SORRY FOR COMBINING PRS lol i wanted to dogfood the commit workflow with this small change

- reverts some fonts back to mono
- updates git commands to strip `ELECTRON_` and `CHROME_` env keys, and add `ELECTRON_RUN_AS_NODE = 1`, so the git commands work

<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually tested

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->

## git commit error

was getting this on every attempted commit in the `code` repo:

```
[STARTED] Backing up original state...
[COMPLETED] Backed up original state in git stash (baec94254b9e03334d3af12ea6f04800defae1a0)
[STARTED] Running tasks for staged files...
[STARTED] package.json — 8 files
[STARTED] *.{ts,tsx,js,jsx} — 8 files
[STARTED] biome check --write --unsafe --files-ignore-unknown=true --no-errors-on-unmatched
[FAILED] biome check --write --unsafe --files-ignore-unknown=true --no-errors-on-unmatched [SIGTRAP]
[FAILED] biome check --write --unsafe --files-ignore-unknown=true --no-errors-on-unmatched [SIGTRAP]
[COMPLETED] Running tasks for staged files...
[STARTED] Applying modifications from tasks...
[SKIPPED] Skipped because of errors from tasks.
[STARTED] Reverting to original state because of errors...
[COMPLETED] Reverting to original state because of errors...
[STARTED] Cleaning up temporary files...
[COMPLETED] Cleaning up temporary files...

✖ biome check --write --unsafe --files-ignore-unknown=true --no-errors-on-unmatched:
[56263:0330/084708.929267:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56263:0330/084708.929824:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56263:0330/084708.951469:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56263:0330/084708.951729:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56263:0330/084708.972725:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56263:0330/084708.973232:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56263:0330/084708.994342:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56263:0330/084708.994411:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56263:0330/084709.016458:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56263:0330/084709.016530:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56263:0330/084709.040407:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56263:0330/084709.040617:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56263:0330/084709.040627:FATAL:content/browser/gpu/gpu_data_manager_impl_private.cc:417] GPU process isn't usable. Goodbye.
Checked 8 files in 28ms. Fixed 4 files.
[56209:0330/084709.155487:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56209:0330/084709.155584:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56209:0330/084709.177300:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56209:0330/084709.177374:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56209:0330/084709.198649:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56209:0330/084709.198930:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56209:0330/084709.220288:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56209:0330/084709.220360:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56209:0330/084709.241435:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56209:0330/084709.241684:ERROR:content/browser/network_service_instance_impl.cc:608] Network service crashed or was terminated, restarting service.
[56209:0330/084709.262629:ERROR:content/browser/gpu/gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=5
[56209:0330/084709.262648:FATAL:content/browser/gpu/gpu_data_manager_impl_private.cc:417] GPU process isn't usable. Goodbye.
undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command was killed with SIGTRAP (Debugger breakpoint): lint-staged
husky - pre-commit script failed (code 1)   
```
