### PR TITLE
Reduce running agent timer precision

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/GeneratingIndicator.test.ts
+++ b/apps/code/src/renderer/features/sessions/components/GeneratingIndicator.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDuration } from "./GeneratingIndicator";
+
+describe("formatDuration", () => {
+  it("formats sub-minute durations with configurable precision", () => {
+    expect(formatDuration(12_340)).toBe("12.34s");
+    expect(formatDuration(12_340, 1)).toBe("12.3s");
+  });
+
+  it("preserves minute formatting", () => {
+    expect(formatDuration(62_340)).toBe("1m 02s");
+    expect(formatDuration(62_340, 1)).toBe("1m 02s");
+  });
+});

--- a/apps/code/src/renderer/features/sessions/components/GeneratingIndicator.tsx
+++ b/apps/code/src/renderer/features/sessions/components/GeneratingIndicator.tsx
@@ -95,16 +95,23 @@ function getRandomThinkingMessage(): string {
   ];
 }
 
-export function formatDuration(ms: number): string {
+export function formatDuration(ms: number, fractionDigits = 2): string {
   const totalSeconds = Math.floor(ms / 1000);
   const mins = Math.floor(totalSeconds / 60);
   const secs = totalSeconds % 60;
-  const centiseconds = Math.floor((ms % 1000) / 10);
 
   if (mins > 0) {
     return `${mins}m ${secs.toString().padStart(2, "0")}s`;
   }
-  return `${secs}.${centiseconds.toString().padStart(2, "0")}s`;
+
+  if (fractionDigits <= 0) {
+    return `${secs}s`;
+  }
+
+  const fractionalUnit = 10 ** (3 - fractionDigits);
+  const fractionalValue = Math.floor((ms % 1000) / fractionalUnit);
+
+  return `${secs}.${fractionalValue.toString().padStart(fractionDigits, "0")}s`;
 }
 
 interface GeneratingIndicatorProps {
@@ -164,7 +171,7 @@ export function GeneratingIndicator({
         color="gray"
         style={{ fontVariantNumeric: "tabular-nums" }}
       >
-        {formatDuration(elapsed)})
+        {formatDuration(elapsed, 1)})
       </Text>
     </Flex>
   );


### PR DESCRIPTION
## Summary
- Update the live running-agent timer to show 1 decimal place instead of 2
- Make `formatDuration` support configurable fractional precision while preserving minute-based formatting
- Add coverage for sub-minute precision and unchanged minute formatting

## Testing
- `pnpm --filter code test -- --run apps/code/src/renderer/features/sessions/components/GeneratingIndicator.test.ts`