### PR TITLE
feat: fix model nits

### DIFF
--- a/packages/agent/src/adapters/acp-connection.ts
+++ b/packages/agent/src/adapters/acp-connection.ts
@@ -1,5 +1,6 @@
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
 import { POSTHOG_NOTIFICATIONS } from "../acp-extensions";
+import { formatModelId } from "../gateway-models";
 import type { SessionLogWriter } from "../session-log-writer";
 import type { ProcessSpawnedCallback } from "../types";
 import { Logger } from "../utils/logger";
@@ -36,19 +37,25 @@ export type AcpConnection = {
 
 export type InProcessAcpConnection = AcpConnection;
 
+type ModelOption = { value?: string; name?: string };
+type ModelGroup = { group?: string; name?: string; options?: ModelOption[] };
+
 type ConfigOption = {
   id?: string;
   category?: string | null;
   currentValue?: string;
-  options?: Array<
-    { value?: string } | { group?: string; options?: Array<{ value?: string }> }
-  >;
+  options?: Array<ModelOption | ModelGroup>;
 };
 
 function isGroupedOptions(
   options: NonNullable<ConfigOption["options"]>,
-): options is Array<{ group?: string; options?: Array<{ value?: string }> }> {
+): options is ModelGroup[] {
   return options.length > 0 && "group" in options[0];
+}
+
+function formatOption(o: ModelOption): ModelOption {
+  if (!o.value) return o;
+  return { ...o, name: formatModelId(o.value) };
 }
 
 function filterModelConfigOptions(
@@ -74,9 +81,9 @@ function filterModelConfigOptions(
     if (isGroupedOptions(options)) {
       const filteredOptions = options.map((group) => ({
         ...group,
-        options: (group.options ?? []).filter(
-          (o) => o?.value && allowedModelIds.has(o.value),
-        ),
+        options: (group.options ?? [])
+          .filter((o) => o?.value && allowedModelIds.has(o.value))
+          .map(formatOption),
       }));
       const flat = filteredOptions.flatMap((g) => g.options ?? []);
       const currentAllowed =
@@ -91,10 +98,10 @@ function filterModelConfigOptions(
       };
     }
 
-    const valueOptions = options as Array<{ value?: string }>;
-    const filteredOptions = valueOptions.filter(
-      (o) => o?.value && allowedModelIds.has(o.value),
-    );
+    const valueOptions = options as ModelOption[];
+    const filteredOptions = valueOptions
+      .filter((o) => o?.value && allowedModelIds.has(o.value))
+      .map(formatOption);
     const currentAllowed =
       opt.currentValue && allowedModelIds.has(opt.currentValue);
     const nextCurrent =

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -143,7 +143,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           list: {},
           fork: {},
           resume: {},
-          close: {},
         },
         _meta: {
           posthog: {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -107,7 +107,7 @@ export class Agent {
         sanitizedModel = codexModelIds[0];
       }
     }
-    if (!sanitizedModel) {
+    if (!sanitizedModel && options.adapter !== "codex") {
       sanitizedModel = DEFAULT_GATEWAY_MODEL;
     }
 

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -146,7 +146,11 @@ export function getProviderName(ownedBy: string): string {
 const PROVIDER_PREFIXES = ["anthropic/", "openai/", "google-vertex/"];
 
 export function formatGatewayModelName(model: GatewayModel): string {
-  let cleanId = model.id;
+  return formatModelId(model.id);
+}
+
+export function formatModelId(modelId: string): string {
+  let cleanId = modelId;
   for (const prefix of PROVIDER_PREFIXES) {
     if (cleanId.startsWith(prefix)) {
       cleanId = cleanId.slice(prefix.length);


### PR DESCRIPTION
## Problem

Model IDs in the ACP connection configuration options display with provider prefixes (e.g., "anthropic/claude-3-sonnet") instead of user-friendly names, making them harder to read in the UI.

## Changes

- Added `formatModelId` function to strip provider prefixes from model IDs for display purposes
- Updated ACP connection adapter to format model option names using the new function while preserving original values
- Improved type definitions for model options and groups with proper TypeScript interfaces
- Fixed model sanitization logic to only apply default gateway model when not using codex adapter
- Removed unused `close` capability from Claude agent initialization

## How did you test this?

Manual testing of model selection UI to verify that model names display without provider prefixes while maintaining correct functionality for model selection and filtering.  
  
closes: https://github.com/PostHog/code/issues/1320