### PR TITLE
feat(code): unified PR creation workflow

### DIFF
--- a/apps/code/src/main/services/git/create-pr-saga.ts
+++ b/apps/code/src/main/services/git/create-pr-saga.ts
@@ -1,0 +1,191 @@
+import { getGitOperationManager } from "@posthog/git/operation-manager";
+import { getHeadSha } from "@posthog/git/queries";
+import { Saga, type SagaLogger } from "@posthog/shared";
+import type {
+  ChangedFile,
+  CommitOutput,
+  CreatePrProgressPayload,
+  GitSyncStatus,
+  PublishOutput,
+  PushOutput,
+} from "./schemas";
+
+export interface CreatePrSagaInput {
+  directoryPath: string;
+  branchName?: string;
+  commitMessage?: string;
+  prTitle?: string;
+  prBody?: string;
+  draft?: boolean;
+}
+
+export interface CreatePrSagaOutput {
+  prUrl: string | null;
+}
+
+export interface CreatePrDeps {
+  getCurrentBranch(dir: string): Promise<string | null>;
+  createBranch(dir: string, name: string): Promise<void>;
+  checkoutBranch(
+    dir: string,
+    name: string,
+  ): Promise<{ previousBranch: string; currentBranch: string }>;
+  getChangedFilesHead(dir: string): Promise<ChangedFile[]>;
+  generateCommitMessage(dir: string): Promise<{ message: string }>;
+  commit(dir: string, message: string): Promise<CommitOutput>;
+  getSyncStatus(dir: string): Promise<GitSyncStatus>;
+  push(dir: string): Promise<PushOutput>;
+  publish(dir: string): Promise<PublishOutput>;
+  generatePrTitleAndBody(dir: string): Promise<{ title: string; body: string }>;
+  createPr(
+    dir: string,
+    title?: string,
+    body?: string,
+    draft?: boolean,
+  ): Promise<{ success: boolean; message: string; prUrl: string | null }>;
+  onProgress(
+    step: CreatePrProgressPayload["step"],
+    message: string,
+    prUrl?: string,
+  ): void;
+}
+
+export class CreatePrSaga extends Saga<CreatePrSagaInput, CreatePrSagaOutput> {
+  readonly sagaName = "CreatePrSaga";
+  private deps: CreatePrDeps;
+
+  constructor(deps: CreatePrDeps, logger?: SagaLogger) {
+    super(logger);
+    this.deps = deps;
+  }
+
+  protected async execute(
+    input: CreatePrSagaInput,
+  ): Promise<CreatePrSagaOutput> {
+    const { directoryPath, draft } = input;
+    let { commitMessage, prTitle, prBody } = input;
+
+    if (input.branchName) {
+      this.deps.onProgress(
+        "creating-branch",
+        `Creating branch ${input.branchName}...`,
+      );
+
+      const originalBranch = await this.readOnlyStep(
+        "get-original-branch",
+        () => this.deps.getCurrentBranch(directoryPath),
+      );
+
+      await this.step({
+        name: "creating-branch",
+        execute: () => this.deps.createBranch(directoryPath, input.branchName!),
+        rollback: async () => {
+          if (originalBranch) {
+            await this.deps.checkoutBranch(directoryPath, originalBranch);
+          }
+        },
+      });
+    }
+
+    const changedFiles = await this.readOnlyStep("check-changes", () =>
+      this.deps.getChangedFilesHead(directoryPath),
+    );
+
+    if (changedFiles.length > 0) {
+      if (!commitMessage) {
+        this.deps.onProgress("committing", "Generating commit message...");
+        const generated = await this.readOnlyStep(
+          "generate-commit-message",
+          async () => {
+            try {
+              return await this.deps.generateCommitMessage(directoryPath);
+            } catch {
+              return null;
+            }
+          },
+        );
+        if (generated) commitMessage = generated.message;
+      }
+
+      if (!commitMessage) {
+        throw new Error("Commit message is required.");
+      }
+
+      this.deps.onProgress("committing", "Committing changes...");
+
+      const preCommitSha = await this.readOnlyStep("get-pre-commit-sha", () =>
+        getHeadSha(directoryPath),
+      );
+
+      await this.step({
+        name: "committing",
+        execute: async () => {
+          const result = await this.deps.commit(directoryPath, commitMessage!);
+          if (!result.success) throw new Error(result.message);
+          return result;
+        },
+        rollback: async () => {
+          const manager = getGitOperationManager();
+          await manager.executeWrite(directoryPath, (git) =>
+            git.reset(["--soft", preCommitSha]),
+          );
+        },
+      });
+    }
+
+    this.deps.onProgress("pushing", "Pushing to remote...");
+
+    const syncStatus = await this.readOnlyStep("check-sync-status", () =>
+      this.deps.getSyncStatus(directoryPath),
+    );
+
+    await this.step({
+      name: "pushing",
+      execute: async () => {
+        const result = syncStatus.hasRemote
+          ? await this.deps.push(directoryPath)
+          : await this.deps.publish(directoryPath);
+        if (!result.success) throw new Error(result.message);
+        return result;
+      },
+      rollback: async () => {}, // no meaningful rollback can happen here w/o force push
+    });
+
+    if (!prTitle || !prBody) {
+      this.deps.onProgress("creating-pr", "Generating PR description...");
+      const generated = await this.readOnlyStep(
+        "generate-pr-description",
+        async () => {
+          try {
+            return await this.deps.generatePrTitleAndBody(directoryPath);
+          } catch {
+            return null;
+          }
+        },
+      );
+      if (generated) {
+        if (!prTitle) prTitle = generated.title;
+        if (!prBody) prBody = generated.body;
+      }
+    }
+
+    this.deps.onProgress("creating-pr", "Creating pull request...");
+
+    const prResult = await this.step({
+      name: "creating-pr",
+      execute: async () => {
+        const result = await this.deps.createPr(
+          directoryPath,
+          prTitle || undefined,
+          prBody || undefined,
+          draft,
+        );
+        if (!result.success) throw new Error(result.message);
+        return result;
+      },
+      rollback: async () => {},
+    });
+
+    return { prUrl: prResult.prUrl };
+  }
+}

--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -228,8 +228,11 @@ export type PrStatusOutput = z.infer<typeof prStatusOutput>;
 // Create PR operation
 export const createPrInput = z.object({
   directoryPath: z.string(),
-  title: z.string().optional(),
-  body: z.string().optional(),
+  flowId: z.string(),
+  branchName: z.string().optional(),
+  commitMessage: z.string().optional(),
+  prTitle: z.string().optional(),
+  prBody: z.string().optional(),
   draft: z.boolean().optional(),
 });
 
@@ -372,10 +375,22 @@ export const syncOutput = z.object({
 
 export type SyncOutput = z.infer<typeof syncOutput>;
 
+export const createPrStep = z.enum([
+  "creating-branch",
+  "committing",
+  "pushing",
+  "creating-pr",
+  "complete",
+  "error",
+]);
+
+export type CreatePrStep = z.infer<typeof createPrStep>;
+
 export const createPrOutput = z.object({
   success: z.boolean(),
   message: z.string(),
   prUrl: z.string().nullable(),
+  failedStep: createPrStep.nullable(),
   state: gitStateSnapshotSchema.optional(),
 });
 
@@ -406,3 +421,12 @@ export const searchGithubIssuesInput = z.object({
 });
 
 export const searchGithubIssuesOutput = z.array(githubIssueSchema);
+
+export const createPrProgressPayload = z.object({
+  flowId: z.string(),
+  step: createPrStep,
+  message: z.string(),
+  prUrl: z.string().optional(),
+});
+
+export type CreatePrProgressPayload = z.infer<typeof createPrProgressPayload>;

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -31,11 +31,13 @@ import { MAIN_TOKENS } from "../../di/tokens";
 import { logger } from "../../utils/logger";
 import { TypedEventEmitter } from "../../utils/typed-event-emitter";
 import type { LlmGatewayService } from "../llm-gateway/service";
+import { CreatePrSaga } from "./create-pr-saga";
 import type {
   ChangedFile,
   CloneProgressPayload,
   CommitOutput,
   CreatePrOutput,
+  CreatePrProgressPayload,
   DetectRepoResult,
   DiffStats,
   DiscardFileChangesOutput,
@@ -60,10 +62,12 @@ const fsPromises = fs.promises;
 
 export const GitServiceEvent = {
   CloneProgress: "cloneProgress",
+  CreatePrProgress: "createPrProgress",
 } as const;
 
 export interface GitServiceEvents {
   [GitServiceEvent.CloneProgress]: CloneProgressPayload;
+  [GitServiceEvent.CreatePrProgress]: CreatePrProgressPayload;
 }
 
 const log = logger.scope("git-service");
@@ -459,6 +463,87 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     };
   }
 
+  public async createPr(input: {
+    directoryPath: string;
+    flowId: string;
+    branchName?: string;
+    commitMessage?: string;
+    prTitle?: string;
+    prBody?: string;
+    draft?: boolean;
+  }): Promise<CreatePrOutput> {
+    const { directoryPath, flowId } = input;
+
+    const emitProgress = (
+      step: CreatePrProgressPayload["step"],
+      message: string,
+      prUrl?: string,
+    ) => {
+      this.emit(GitServiceEvent.CreatePrProgress, {
+        flowId,
+        step,
+        message,
+        prUrl,
+      });
+    };
+
+    const saga = new CreatePrSaga(
+      {
+        getCurrentBranch: (dir) => getCurrentBranch(dir),
+        createBranch: (dir, name) => this.createBranch(dir, name),
+        checkoutBranch: (dir, name) => this.checkoutBranch(dir, name),
+        getChangedFilesHead: (dir) => this.getChangedFilesHead(dir),
+        generateCommitMessage: (dir) => this.generateCommitMessage(dir),
+        commit: (dir, msg) => this.commit(dir, msg),
+        getSyncStatus: (dir) => this.getGitSyncStatus(dir),
+        push: (dir) => this.push(dir),
+        publish: (dir) => this.publish(dir),
+        generatePrTitleAndBody: (dir) => this.generatePrTitleAndBody(dir),
+        createPr: (dir, title, body, draft) =>
+          this.createPrViaGh(dir, title, body, draft),
+        onProgress: emitProgress,
+      },
+      log,
+    );
+
+    const result = await saga.run({
+      directoryPath,
+      branchName: input.branchName,
+      commitMessage: input.commitMessage,
+      prTitle: input.prTitle,
+      prBody: input.prBody,
+      draft: input.draft,
+    });
+
+    if (!result.success) {
+      emitProgress("error", result.error);
+      return {
+        success: false,
+        message: result.error,
+        prUrl: null,
+        failedStep: result.failedStep as CreatePrOutput["failedStep"],
+      };
+    }
+
+    const state = await this.getStateSnapshot(directoryPath, {
+      includePrStatus: true,
+    });
+
+    emitProgress(
+      "complete",
+      "Pull request created",
+      result.data.prUrl ?? undefined,
+    );
+
+    return {
+      success: true,
+      message: "Pull request created",
+      prUrl: result.data.prUrl,
+      failedStep: null,
+      state,
+    };
+  }
+
   public async getPrTemplate(
     directoryPath: string,
   ): Promise<GetPrTemplateOutput> {
@@ -628,12 +713,12 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     }
   }
 
-  public async createPr(
+  private async createPrViaGh(
     directoryPath: string,
     title?: string,
     body?: string,
     draft?: boolean,
-  ): Promise<CreatePrOutput> {
+  ): Promise<{ success: boolean; message: string; prUrl: string | null }> {
     const args = ["pr", "create"];
     if (title) {
       args.push("--title", title);
@@ -655,18 +740,10 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     const prUrlMatch = result.stdout.match(/https:\/\/github\.com\/[^\s]+/);
     const prUrl = prUrlMatch?.[0] ?? null;
 
-    const state = await this.getStateSnapshot(directoryPath, {
-      includeChangedFiles: false,
-      includeDiffStats: false,
-      includeLatestCommit: false,
-      includePrStatus: true,
-    });
-
     return {
       success: true,
       message: "Pull request created",
       prUrl,
-      state,
     };
   }
 

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -233,14 +233,7 @@ export const gitRouter = router({
   createPr: publicProcedure
     .input(createPrInput)
     .output(createPrOutput)
-    .mutation(({ input }) =>
-      getService().createPr(
-        input.directoryPath,
-        input.title,
-        input.body,
-        input.draft,
-      ),
-    ),
+    .mutation(({ input }) => getService().createPr(input)),
 
   openPr: publicProcedure
     .input(openPrInput)
@@ -295,4 +288,14 @@ export const gitRouter = router({
         input.limit,
       ),
     ),
+
+  onCreatePrProgress: publicProcedure.subscription(async function* (opts) {
+    const service = getService();
+    const iterable = service.toIterable(GitServiceEvent.CreatePrProgress, {
+      signal: opts.signal,
+    });
+    for await (const data of iterable) {
+      yield data;
+    }
+  }),
 });

--- a/apps/code/src/renderer/features/git-interaction/components/CreatePrDialog.stories.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/CreatePrDialog.stories.tsx
@@ -1,0 +1,347 @@
+import { useGitInteractionStore } from "@features/git-interaction/state/gitInteractionStore";
+import type { CreatePrStep } from "@features/git-interaction/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CreatePrDialog } from "./CreatePrDialog";
+
+function setStoreState(overrides: {
+  branchName?: string;
+  commitMessage?: string;
+  prTitle?: string;
+  prBody?: string;
+  createPrOpen?: boolean;
+  createPrStep?: CreatePrStep;
+  createPrError?: string | null;
+  createPrNeedsBranch?: boolean;
+  createPrNeedsCommit?: boolean;
+  createPrBaseBranch?: string | null;
+  createPrDraft?: boolean;
+  createPrFailedStep?: CreatePrStep | null;
+  isGeneratingCommitMessage?: boolean;
+  isGeneratingPr?: boolean;
+  isSubmitting?: boolean;
+}) {
+  useGitInteractionStore.setState({
+    branchName: "",
+    commitMessage: "",
+    prTitle: "",
+    prBody: "",
+    createPrOpen: true,
+    createPrStep: "idle",
+    createPrError: null,
+    createPrNeedsBranch: false,
+    createPrNeedsCommit: false,
+    createPrBaseBranch: null,
+    createPrDraft: false,
+    createPrFailedStep: null,
+    isGeneratingCommitMessage: false,
+    isGeneratingPr: false,
+    isSubmitting: false,
+    ...overrides,
+  });
+}
+
+const noop = () => {};
+
+const meta: Meta<typeof CreatePrDialog> = {
+  title: "Git/CreatePrDialog",
+  component: CreatePrDialog,
+  parameters: { layout: "centered" },
+};
+
+export default meta;
+
+export const SetupFull: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsBranch: true,
+        createPrNeedsCommit: true,
+        createPrBaseBranch: "main",
+        branchName: "feature/add-auth",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="main"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const SetupCommitOnly: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsCommit: true,
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="feature/add-auth"
+      diffStats={{ filesChanged: 1, linesAdded: 10, linesRemoved: 2 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const SetupPushOnly: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({});
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="feature/add-auth"
+      diffStats={{ filesChanged: 0, linesAdded: 0, linesRemoved: 0 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const SetupWithDraft: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsCommit: true,
+        createPrDraft: true,
+        prTitle: "Add user authentication",
+        prBody: "Closes #123",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="feature/add-auth"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const SetupWithError: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsBranch: true,
+        createPrError: "Branch name is required.",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="main"
+      diffStats={{ filesChanged: 1, linesAdded: 5, linesRemoved: 0 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const SetupGeneratingCommitMessage: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsCommit: true,
+        isGeneratingCommitMessage: true,
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="feature/add-auth"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const SetupGeneratingPr: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsCommit: true,
+        isGeneratingPr: true,
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="feature/add-auth"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const ExecutingCreatingBranch: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsBranch: true,
+        createPrNeedsCommit: true,
+        createPrStep: "creating-branch",
+        branchName: "feature/add-auth",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="main"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={true}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const ExecutingCommitting: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsBranch: true,
+        createPrNeedsCommit: true,
+        createPrStep: "committing",
+        branchName: "feature/add-auth",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="main"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={true}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const ExecutingPushing: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsCommit: true,
+        createPrStep: "pushing",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="feature/add-auth"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={true}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const ExecutingCreatingPr: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsCommit: true,
+        createPrStep: "creating-pr",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="feature/add-auth"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={true}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};
+
+export const ExecutingError: StoryObj<typeof CreatePrDialog> = {
+  decorators: [
+    (Story) => {
+      setStoreState({
+        createPrNeedsBranch: true,
+        createPrNeedsCommit: true,
+        createPrStep: "error",
+        createPrError: "Failed to push: remote rejected (permission denied)",
+        createPrFailedStep: "pushing",
+        branchName: "feature/add-auth",
+      });
+      return <Story />;
+    },
+  ],
+  render: () => (
+    <CreatePrDialog
+      open={true}
+      onOpenChange={noop}
+      currentBranch="main"
+      diffStats={{ filesChanged: 3, linesAdded: 42, linesRemoved: 12 }}
+      isSubmitting={false}
+      onSubmit={noop}
+      onGenerateCommitMessage={noop}
+      onGeneratePr={noop}
+    />
+  ),
+};

--- a/apps/code/src/renderer/features/git-interaction/components/CreatePrDialog.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/CreatePrDialog.tsx
@@ -1,0 +1,322 @@
+import {
+  ErrorContainer,
+  GenerateButton,
+} from "@features/git-interaction/components/GitInteractionDialogs";
+import { useGitInteractionStore } from "@features/git-interaction/state/gitInteractionStore";
+import type { CreatePrStep } from "@features/git-interaction/types";
+import {
+  CheckCircle,
+  Circle,
+  GitPullRequest,
+  XCircle,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  Flex,
+  Spinner,
+  Text,
+  TextArea,
+  TextField,
+} from "@radix-ui/themes";
+
+const ICON_SIZE = 14;
+
+interface StepDef {
+  id: CreatePrStep;
+  label: string;
+}
+
+function StepIndicator({
+  steps,
+  currentStep,
+  failedStep,
+}: {
+  steps: StepDef[];
+  currentStep: CreatePrStep;
+  failedStep?: CreatePrStep | null;
+}) {
+  const stepOrder: CreatePrStep[] = [
+    "creating-branch",
+    "committing",
+    "pushing",
+    "creating-pr",
+    "complete",
+  ];
+
+  const currentIndex = stepOrder.indexOf(currentStep);
+  const isError = currentStep === "error";
+
+  return (
+    <Flex direction="column" gap="3">
+      {steps.map((step) => {
+        const stepIndex = stepOrder.indexOf(step.id);
+        const isComplete =
+          currentStep === "complete" || stepIndex < currentIndex;
+        const isActive = step.id === currentStep;
+        const isFailed = isError && step.id === failedStep;
+
+        let icon: React.ReactNode;
+        if (isFailed) {
+          icon = <XCircle size={16} weight="fill" color="var(--red-9)" />;
+        } else if (isComplete) {
+          icon = <CheckCircle size={16} weight="fill" color="var(--green-9)" />;
+        } else if (isActive) {
+          icon = <Spinner size="1" />;
+        } else {
+          icon = <Circle size={16} color="var(--gray-6)" />;
+        }
+
+        return (
+          <Flex
+            key={step.id}
+            align="center"
+            gap="2"
+            style={{
+              transition: "opacity 150ms ease",
+              opacity: isComplete ? 0.6 : 1,
+            }}
+          >
+            <Flex
+              style={{
+                transition: "transform 200ms ease",
+                transform: isActive ? "scale(1.15)" : "scale(1)",
+              }}
+            >
+              {icon}
+            </Flex>
+            <Text
+              size="2"
+              weight={isActive ? "medium" : "regular"}
+              style={{
+                transition: "color 150ms ease",
+                color: isFailed
+                  ? "var(--red-11)"
+                  : isComplete
+                    ? "var(--green-11)"
+                    : isActive
+                      ? "var(--gray-12)"
+                      : "var(--gray-9)",
+              }}
+            >
+              {step.label}
+            </Text>
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
+}
+
+export interface CreatePrDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentBranch: string | null;
+  diffStats: { filesChanged: number; linesAdded: number; linesRemoved: number };
+  isSubmitting: boolean;
+  onSubmit: () => void;
+  onGenerateCommitMessage: () => void;
+  onGeneratePr: () => void;
+}
+
+export function CreatePrDialog({
+  open,
+  onOpenChange,
+  currentBranch,
+  diffStats,
+  isSubmitting,
+  onSubmit,
+  onGenerateCommitMessage,
+  onGeneratePr,
+}: CreatePrDialogProps) {
+  const store = useGitInteractionStore();
+  const { actions } = store;
+
+  const { createPrStep: step } = store;
+  const isExecuting = step !== "idle" && step !== "complete";
+
+  // Build the step list based on what's needed
+  const steps: StepDef[] = [];
+  if (store.createPrNeedsBranch) {
+    steps.push({
+      id: "creating-branch",
+      label: `Create branch ${store.branchName || ""}`.trim(),
+    });
+  }
+  if (store.createPrNeedsCommit) {
+    steps.push({ id: "committing", label: "Commit changes" });
+  }
+  steps.push({ id: "pushing", label: "Push to remote" });
+  steps.push({ id: "creating-pr", label: "Create pull request" });
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="500px" size="1">
+        <Flex direction="column" gap="3">
+          <Flex align="center" gap="2">
+            <GitPullRequest size={ICON_SIZE} />
+            <Text size="2" weight="medium">
+              {isExecuting ? "Creating PR..." : "Create PR"}
+            </Text>
+          </Flex>
+
+          {!isExecuting && (
+            <>
+              {store.createPrNeedsBranch && (
+                <Flex direction="column" gap="1">
+                  <Text size="1" color="gray">
+                    Branch
+                  </Text>
+                  <TextField.Root
+                    value={store.branchName}
+                    onChange={(e) => actions.setBranchName(e.target.value)}
+                    placeholder="branch-name"
+                    size="1"
+                    autoFocus
+                  />
+                  {currentBranch && (
+                    <Text size="1" color="gray">
+                      from {currentBranch}
+                    </Text>
+                  )}
+                </Flex>
+              )}
+
+              {store.createPrNeedsCommit && (
+                <Flex direction="column" gap="1">
+                  <Flex align="center" justify="between">
+                    <Text size="1" color="gray">
+                      Commit message
+                    </Text>
+                    <Flex align="center" gap="2">
+                      <Text size="1" color="gray">
+                        {diffStats.filesChanged} file
+                        {diffStats.filesChanged === 1 ? "" : "s"}
+                      </Text>
+                      <Text size="1" color="green">
+                        +{diffStats.linesAdded}
+                      </Text>
+                      <Text size="1" color="red">
+                        -{diffStats.linesRemoved}
+                      </Text>
+                      <GenerateButton
+                        onClick={onGenerateCommitMessage}
+                        isGenerating={store.isGeneratingCommitMessage}
+                      />
+                    </Flex>
+                  </Flex>
+                  <TextArea
+                    value={store.commitMessage}
+                    onChange={(e) => actions.setCommitMessage(e.target.value)}
+                    placeholder="Leave empty to generate"
+                    size="1"
+                    rows={1}
+                    disabled={store.isGeneratingCommitMessage}
+                    autoFocus={!store.createPrNeedsBranch}
+                  />
+                </Flex>
+              )}
+
+              <Flex direction="column" gap="1">
+                <Flex align="center" justify="between">
+                  <Text size="1" color="gray">
+                    PR title
+                  </Text>
+                  <GenerateButton
+                    onClick={onGeneratePr}
+                    isGenerating={store.isGeneratingPr}
+                  />
+                </Flex>
+                <TextField.Root
+                  value={store.prTitle}
+                  onChange={(e) => actions.setPrTitle(e.target.value)}
+                  placeholder="Leave empty to generate"
+                  size="1"
+                  disabled={store.isGeneratingPr}
+                  autoFocus={
+                    !store.createPrNeedsBranch && !store.createPrNeedsCommit
+                  }
+                />
+              </Flex>
+
+              <Flex direction="column" gap="1">
+                <Text size="1" color="gray">
+                  Description
+                </Text>
+                <TextArea
+                  value={store.prBody}
+                  onChange={(e) => actions.setPrBody(e.target.value)}
+                  placeholder="Leave empty to generate"
+                  size="1"
+                  rows={4}
+                  disabled={store.isGeneratingPr}
+                />
+              </Flex>
+
+              <Text as="label" size="1" color="gray">
+                <Flex gap="2" align="center">
+                  <Checkbox
+                    size="1"
+                    checked={store.createPrDraft}
+                    onCheckedChange={(checked) =>
+                      actions.setCreatePrDraft(checked === true)
+                    }
+                  />
+                  Create as draft
+                </Flex>
+              </Text>
+
+              {store.createPrError && (
+                <ErrorContainer error={store.createPrError} />
+              )}
+
+              <Flex gap="2" justify="end">
+                <Dialog.Close>
+                  <Button size="1" variant="soft" color="gray">
+                    Cancel
+                  </Button>
+                </Dialog.Close>
+                <Button
+                  size="1"
+                  disabled={isSubmitting}
+                  loading={isSubmitting}
+                  onClick={onSubmit}
+                >
+                  Create PR
+                </Button>
+              </Flex>
+            </>
+          )}
+
+          {isExecuting && (
+            <>
+              <StepIndicator
+                steps={steps}
+                currentStep={step}
+                failedStep={store.createPrFailedStep}
+              />
+
+              {step === "error" && store.createPrError && (
+                <ErrorContainer error={store.createPrError} />
+              )}
+
+              <Flex gap="2" justify="end">
+                <Dialog.Close>
+                  <Button size="1" variant="soft" color="gray">
+                    {step === "error" ? "Close" : "Cancel"}
+                  </Button>
+                </Dialog.Close>
+                {step === "error" && (
+                  <Button size="1" onClick={onSubmit}>
+                    Retry
+                  </Button>
+                )}
+              </Flex>
+            </>
+          )}
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/apps/code/src/renderer/features/git-interaction/components/GitInteractionDialogs.stories.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/GitInteractionDialogs.stories.tsx
@@ -1,10 +1,6 @@
 import { Flex } from "@radix-ui/themes";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import {
-  GitCommitDialog,
-  GitPrDialog,
-  GitPushDialog,
-} from "./GitInteractionDialogs";
+import { GitCommitDialog, GitPushDialog } from "./GitInteractionDialogs";
 
 function DialogShowcase() {
   return <Flex direction="column" gap="4" />;
@@ -29,7 +25,6 @@ export const CommitDefault: StoryObj<typeof GitCommitDialog> = {
       onCommitMessageChange={() => {}}
       nextStep="commit"
       onNextStepChange={() => {}}
-      prDisabledReason={null}
       pushDisabledReason={null}
       onContinue={() => {}}
       isSubmitting={false}
@@ -51,29 +46,6 @@ export const CommitWithMessage: StoryObj<typeof GitCommitDialog> = {
       onCommitMessageChange={() => {}}
       nextStep="commit-push"
       onNextStepChange={() => {}}
-      prDisabledReason={null}
-      pushDisabledReason={null}
-      onContinue={() => {}}
-      isSubmitting={false}
-      error={null}
-      onGenerateMessage={() => {}}
-      isGeneratingMessage={false}
-    />
-  ),
-};
-
-export const CommitPrDisabled: StoryObj<typeof GitCommitDialog> = {
-  render: () => (
-    <GitCommitDialog
-      open={true}
-      onOpenChange={() => {}}
-      branchName="main"
-      diffStats={{ filesChanged: 1, linesAdded: 10, linesRemoved: 2 }}
-      commitMessage="Fix typo"
-      onCommitMessageChange={() => {}}
-      nextStep="commit"
-      onNextStepChange={() => {}}
-      prDisabledReason="Checkout a feature branch to create PRs."
       pushDisabledReason={null}
       onContinue={() => {}}
       isSubmitting={false}
@@ -95,7 +67,6 @@ export const CommitSubmitting: StoryObj<typeof GitCommitDialog> = {
       onCommitMessageChange={() => {}}
       nextStep="commit"
       onNextStepChange={() => {}}
-      prDisabledReason={null}
       pushDisabledReason={null}
       onContinue={() => {}}
       isSubmitting={true}
@@ -117,7 +88,6 @@ export const CommitWithError: StoryObj<typeof GitCommitDialog> = {
       onCommitMessageChange={() => {}}
       nextStep="commit"
       onNextStepChange={() => {}}
-      prDisabledReason={null}
       pushDisabledReason={null}
       onContinue={() => {}}
       isSubmitting={false}
@@ -139,7 +109,6 @@ export const CommitWithLongPreCommitError: StoryObj<typeof GitCommitDialog> = {
       onCommitMessageChange={() => {}}
       nextStep="commit"
       onNextStepChange={() => {}}
-      prDisabledReason={null}
       pushDisabledReason={null}
       onContinue={() => {}}
       isSubmitting={false}
@@ -172,7 +141,6 @@ export const CommitGenerating: StoryObj<typeof GitCommitDialog> = {
       onCommitMessageChange={() => {}}
       nextStep="commit"
       onNextStepChange={() => {}}
-      prDisabledReason={null}
       pushDisabledReason={null}
       onContinue={() => {}}
       isSubmitting={false}
@@ -307,106 +275,6 @@ export const PublishSuccess: StoryObj<typeof GitPushDialog> = {
       onConfirm={() => {}}
       onClose={() => {}}
       isSubmitting={false}
-    />
-  ),
-};
-
-export const PrCreate: StoryObj<typeof GitPrDialog> = {
-  render: () => (
-    <GitPrDialog
-      open={true}
-      onOpenChange={() => {}}
-      baseBranch="main"
-      headBranch="feature/add-auth"
-      title="Add user authentication"
-      onTitleChange={() => {}}
-      body="Closes #123\n\nAdded login and signup flows."
-      onBodyChange={() => {}}
-      onConfirm={() => {}}
-      isSubmitting={false}
-      error={null}
-      onGenerate={() => {}}
-      isGenerating={false}
-    />
-  ),
-};
-
-export const PrCreateEmpty: StoryObj<typeof GitPrDialog> = {
-  render: () => (
-    <GitPrDialog
-      open={true}
-      onOpenChange={() => {}}
-      baseBranch="main"
-      headBranch="feature/add-auth"
-      title=""
-      onTitleChange={() => {}}
-      body=""
-      onBodyChange={() => {}}
-      onConfirm={() => {}}
-      isSubmitting={false}
-      error={null}
-      onGenerate={() => {}}
-      isGenerating={false}
-    />
-  ),
-};
-
-export const PrGenerating: StoryObj<typeof GitPrDialog> = {
-  render: () => (
-    <GitPrDialog
-      open={true}
-      onOpenChange={() => {}}
-      baseBranch="main"
-      headBranch="feature/add-auth"
-      title=""
-      onTitleChange={() => {}}
-      body=""
-      onBodyChange={() => {}}
-      onConfirm={() => {}}
-      isSubmitting={false}
-      error={null}
-      onGenerate={() => {}}
-      isGenerating={true}
-    />
-  ),
-};
-
-export const PrSubmitting: StoryObj<typeof GitPrDialog> = {
-  render: () => (
-    <GitPrDialog
-      open={true}
-      onOpenChange={() => {}}
-      baseBranch="main"
-      headBranch="feature/add-auth"
-      title="Add user authentication"
-      onTitleChange={() => {}}
-      body="Added login flow"
-      onBodyChange={() => {}}
-      onConfirm={() => {}}
-      isSubmitting={true}
-      error={null}
-      onGenerate={() => {}}
-      isGenerating={false}
-    />
-  ),
-};
-
-export const PrWithError: StoryObj<typeof GitPrDialog> = {
-  render: () => (
-    <GitPrDialog
-      open={true}
-      onOpenChange={() => {}}
-      baseBranch="main"
-      headBranch="feature/add-auth"
-      title="Add user authentication"
-      onTitleChange={() => {}}
-      body="Added login flow"
-      onBodyChange={() => {}}
-      onConfirm={() => {}}
-      isSubmitting={false}
-      error="Failed to create PR: no commits between main and feature/add-auth"
-      onGenerate={() => {}}
-      isGenerating={false}
     />
   ),
 };

--- a/apps/code/src/renderer/features/git-interaction/components/GitInteractionDialogs.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/GitInteractionDialogs.tsx
@@ -6,7 +6,6 @@ import {
   GitBranch,
   GitCommit,
   GitFork,
-  GitPullRequest,
   Sparkle,
 } from "@phosphor-icons/react";
 import { CheckIcon } from "@radix-ui/react-icons";
@@ -26,7 +25,7 @@ import { useState } from "react";
 
 const ICON_SIZE = 14;
 
-function ErrorContainer({ error }: { error: string }) {
+export function ErrorContainer({ error }: { error: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -72,6 +71,32 @@ function ErrorContainer({ error }: { error: string }) {
         </Flex>
       </Flex>
     </Box>
+  );
+}
+
+export function GenerateButton({
+  onClick,
+  isGenerating,
+  disabled = false,
+  tooltip = "Generate with AI",
+}: {
+  onClick: () => void;
+  isGenerating: boolean;
+  disabled?: boolean;
+  tooltip?: string;
+}) {
+  return (
+    <Tooltip content={tooltip}>
+      <IconButton
+        size="1"
+        variant="ghost"
+        color="gray"
+        onClick={onClick}
+        disabled={isGenerating || disabled}
+      >
+        {isGenerating ? <Spinner size="1" /> : <Sparkle size={14} />}
+      </IconButton>
+    </Tooltip>
   );
 }
 
@@ -221,9 +246,8 @@ interface GitCommitDialogProps {
   diffStats: { filesChanged: number; linesAdded: number; linesRemoved: number };
   commitMessage: string;
   onCommitMessageChange: (value: string) => void;
-  nextStep: "commit" | "commit-push" | "commit-pr";
-  onNextStepChange: (value: "commit" | "commit-push" | "commit-pr") => void;
-  prDisabledReason: string | null;
+  nextStep: "commit" | "commit-push";
+  onNextStepChange: (value: "commit" | "commit-push") => void;
   pushDisabledReason: string | null;
   onContinue: () => void;
   isSubmitting: boolean;
@@ -241,7 +265,6 @@ export function GitCommitDialog({
   onCommitMessageChange,
   nextStep,
   onNextStepChange,
-  prDisabledReason,
   pushDisabledReason,
   onContinue,
   isSubmitting,
@@ -260,12 +283,6 @@ export function GitCommitDialog({
       label: "Commit and push",
       icon: <CloudArrowUp size={ICON_SIZE} />,
       disabledReason: pushDisabledReason,
-    },
-    {
-      id: "commit-pr" as const,
-      label: "Commit and create PR",
-      icon: <GitPullRequest size={ICON_SIZE} />,
-      disabledReason: prDisabledReason,
     },
   ];
 
@@ -306,21 +323,12 @@ export function GitCommitDialog({
           <Text size="1" color="gray">
             Message
           </Text>
-          <Tooltip content="Generate commit message with AI">
-            <IconButton
-              size="1"
-              variant="ghost"
-              color="gray"
-              onClick={onGenerateMessage}
-              disabled={isGeneratingMessage || isSubmitting}
-            >
-              {isGeneratingMessage ? (
-                <Spinner size="1" />
-              ) : (
-                <Sparkle size={14} />
-              )}
-            </IconButton>
-          </Tooltip>
+          <GenerateButton
+            onClick={onGenerateMessage}
+            isGenerating={isGeneratingMessage}
+            disabled={isSubmitting}
+            tooltip="Generate commit message with AI"
+          />
         </Flex>
         <TextArea
           value={commitMessage}
@@ -429,103 +437,6 @@ export function GitPushDialog({
           {config.desc}
         </Text>
       )}
-    </GitDialog>
-  );
-}
-
-interface GitPrDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  baseBranch: string | null;
-  headBranch: string | null;
-  title: string;
-  onTitleChange: (value: string) => void;
-  body: string;
-  onBodyChange: (value: string) => void;
-  onConfirm: () => void;
-  isSubmitting: boolean;
-  error: string | null;
-  onGenerate: () => void;
-  isGenerating: boolean;
-}
-
-export function GitPrDialog({
-  open,
-  onOpenChange,
-  baseBranch,
-  headBranch,
-  title,
-  onTitleChange,
-  body,
-  onBodyChange,
-  onConfirm,
-  isSubmitting,
-  error,
-  onGenerate,
-  isGenerating,
-}: GitPrDialogProps) {
-  return (
-    <GitDialog
-      open={open}
-      onOpenChange={onOpenChange}
-      icon={<GitPullRequest size={ICON_SIZE} />}
-      title="Create PR"
-      error={error}
-      buttonLabel="Create PR"
-      buttonDisabled={!title.trim() || isGenerating}
-      isSubmitting={isSubmitting}
-      onSubmit={onConfirm}
-      maxWidth="500px"
-    >
-      <Flex direction="column" gap="1">
-        <InfoRow label="Base">
-          <BranchBadge branch={baseBranch} />
-        </InfoRow>
-        <InfoRow label="Head">
-          <BranchBadge branch={headBranch} />
-        </InfoRow>
-      </Flex>
-
-      <Flex direction="column" gap="1">
-        <Flex align="center" justify="between">
-          <Text size="1" color="gray">
-            Title
-          </Text>
-          <Tooltip content="Generate title and description with AI">
-            <IconButton
-              size="1"
-              variant="ghost"
-              color="gray"
-              onClick={onGenerate}
-              disabled={isGenerating || isSubmitting}
-            >
-              {isGenerating ? <Spinner size="1" /> : <Sparkle size={14} />}
-            </IconButton>
-          </Tooltip>
-        </Flex>
-        <TextField.Root
-          value={title}
-          onChange={(e) => onTitleChange(e.target.value)}
-          placeholder={isGenerating ? "Generating..." : "PR title"}
-          size="1"
-          autoFocus
-          disabled={isGenerating}
-        />
-      </Flex>
-
-      <Flex direction="column" gap="1">
-        <Text size="1" color="gray">
-          Description
-        </Text>
-        <TextArea
-          value={body}
-          onChange={(e) => onBodyChange(e.target.value)}
-          placeholder={isGenerating ? "Generating..." : "Describe your changes"}
-          size="1"
-          rows={6}
-          disabled={isGenerating}
-        />
-      </Flex>
     </GitDialog>
   );
 }

--- a/apps/code/src/renderer/features/git-interaction/components/GitInteractionHeader.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/GitInteractionHeader.tsx
@@ -1,7 +1,7 @@
+import { CreatePrDialog } from "@features/git-interaction/components/CreatePrDialog";
 import {
   GitBranchDialog,
   GitCommitDialog,
-  GitPrDialog,
   GitPushDialog,
 } from "@features/git-interaction/components/GitInteractionDialogs";
 import { GitInteractionMenu } from "@features/git-interaction/components/GitInteractionMenu";
@@ -46,7 +46,6 @@ export function GitInteractionHeader({ taskId }: GitInteractionHeaderProps) {
         onCommitMessageChange={actions.setCommitMessage}
         nextStep={modals.commitNextStep}
         onNextStepChange={actions.setCommitNextStep}
-        prDisabledReason={state.prDisabledReason}
         pushDisabledReason={state.pushDisabledReason}
         onContinue={actions.runCommit}
         isSubmitting={modals.isSubmitting}
@@ -69,22 +68,17 @@ export function GitInteractionHeader({ taskId }: GitInteractionHeaderProps) {
         isSubmitting={modals.isSubmitting}
       />
 
-      <GitPrDialog
-        open={modals.prOpen}
+      <CreatePrDialog
+        open={modals.createPrOpen}
         onOpenChange={(open) => {
-          if (!open) actions.closePr();
+          if (!open) actions.closeCreatePr();
         }}
-        baseBranch={state.prBaseBranch}
-        headBranch={state.prHeadBranch}
-        title={modals.prTitle}
-        onTitleChange={actions.setPrTitle}
-        body={modals.prBody}
-        onBodyChange={actions.setPrBody}
-        onConfirm={actions.runPr}
+        currentBranch={modals.createPrBaseBranch}
+        diffStats={state.diffStats}
         isSubmitting={modals.isSubmitting}
-        error={modals.prError}
-        onGenerate={actions.generatePrTitleAndBody}
-        isGenerating={modals.isGeneratingPr}
+        onSubmit={actions.runCreatePr}
+        onGenerateCommitMessage={actions.generateCommitMessage}
+        onGeneratePr={actions.generatePrTitleAndBody}
       />
 
       <GitBranchDialog

--- a/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
@@ -13,6 +13,7 @@ import {
   createBranch,
   getBranchNameInputState,
 } from "@features/git-interaction/utils/branchCreation";
+import { invalidateGitBranchQueries } from "@features/git-interaction/utils/gitCacheKeys";
 import { updateGitCacheFromSnapshot } from "@features/git-interaction/utils/updateGitCache";
 import { trpc, trpcClient } from "@renderer/trpc";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
@@ -20,6 +21,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { track } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { useMemo } from "react";
+import { sanitizeBranchName } from "../utils/branchNameValidation";
 import { getSuggestedBranchName } from "../utils/getSuggestedBranchName";
 
 const log = logger.scope("git-interaction");
@@ -39,7 +41,6 @@ interface GitInteractionState {
   diffStats: { filesChanged: number; linesAdded: number; linesRemoved: number };
   prUrl: string | null;
   pushDisabledReason: string | null;
-  prDisabledReason: string | null;
   isLoading: boolean;
 }
 
@@ -47,7 +48,6 @@ interface GitInteractionActions {
   openAction: (actionId: GitMenuActionId) => void;
   closeCommit: () => void;
   closePush: () => void;
-  closePr: () => void;
   closeBranch: () => void;
   setCommitMessage: (value: string) => void;
   setCommitNextStep: (value: CommitNextStep) => void;
@@ -56,10 +56,13 @@ interface GitInteractionActions {
   setBranchName: (value: string) => void;
   runCommit: () => Promise<void>;
   runPush: () => Promise<void>;
-  runPr: () => Promise<void>;
   runBranch: () => Promise<void>;
+  runCreatePr: () => Promise<void>;
   generateCommitMessage: () => Promise<void>;
   generatePrTitleAndBody: () => Promise<void>;
+  closeCreatePr: () => void;
+  setCreatePrBranchName: (value: string) => void;
+  setCreatePrDraft: (value: boolean) => void;
 }
 
 function trackGitAction(taskId: string, actionType: string, success: boolean) {
@@ -127,23 +130,96 @@ export function useGitInteraction(
     ],
   );
 
-  const openCreatePr = async () => {
-    modal.openPr("", "");
+  const openCreatePr = () => {
+    const prExists = git.prStatus?.prExists ?? false;
+    const needsBranch = !git.isFeatureBranch || prExists;
+    const needsCommit = git.hasChanges;
+    modal.openCreatePr({
+      needsBranch,
+      needsCommit,
+      baseBranch: git.currentBranch,
+      suggestedBranchName: needsBranch
+        ? getSuggestedBranchName(taskId, repoPath)
+        : undefined,
+    });
+  };
+
+  const runCreatePr = async () => {
     if (!repoPath) return;
 
-    modal.setIsGeneratingPr(true);
+    if (store.createPrNeedsBranch && !store.branchName.trim()) {
+      modal.setCreatePrError("Branch name is required.");
+      return;
+    }
+
+    modal.setIsSubmitting(true);
+    modal.setCreatePrError(null);
+    modal.setCreatePrStep("idle");
+    modal.setCreatePrFailedStep(null);
+
+    const flowId = crypto.randomUUID();
+
+    const subscription = trpcClient.git.onCreatePrProgress.subscribe(
+      undefined,
+      {
+        onData: (data) => {
+          if (data.flowId !== flowId) return;
+          if (useGitInteractionStore.getState().createPrStep === data.step)
+            return;
+          modal.setCreatePrStep(data.step);
+        },
+      },
+    );
+
     try {
-      const result = await trpcClient.git.generatePrTitleAndBody.mutate({
+      const result = await trpcClient.git.createPr.mutate({
         directoryPath: repoPath,
+        flowId,
+        branchName: store.createPrNeedsBranch
+          ? store.branchName.trim()
+          : undefined,
+        commitMessage: store.commitMessage.trim() || undefined,
+        prTitle: store.prTitle.trim() || undefined,
+        prBody: store.prBody.trim() || undefined,
+        draft: store.createPrDraft || undefined,
       });
-      if (result.title || result.body) {
-        modal.setPrTitle(result.title);
-        modal.setPrBody(result.body);
+
+      if (!result.success) {
+        trackGitAction(taskId, "create-pr", false);
+        useGitInteractionStore.setState({
+          createPrError: result.message,
+          createPrFailedStep: result.failedStep ?? null,
+          createPrStep: "error",
+        });
+        return;
       }
+
+      trackGitAction(taskId, "create-pr", true);
+      track(ANALYTICS_EVENTS.PR_CREATED, { task_id: taskId, success: true });
+
+      if (result.state) {
+        updateGitCacheFromSnapshot(queryClient, repoPath, result.state);
+      }
+      if (store.createPrNeedsBranch) {
+        invalidateGitBranchQueries(repoPath);
+      }
+
+      if (result.prUrl) {
+        await trpcClient.os.openExternal.mutate({ url: result.prUrl });
+      }
+
+      modal.closeCreatePr();
     } catch (error) {
-      log.error("Failed to auto-generate PR title and body", error);
+      log.error("Create PR flow failed", error);
+      useGitInteractionStore.setState({
+        createPrFailedStep: useGitInteractionStore.getState().createPrStep,
+        createPrError:
+          error instanceof Error ? error.message : "Create PR flow failed.",
+        createPrStep: "error",
+      });
     } finally {
-      modal.setIsGeneratingPr(false);
+      subscription.unsubscribe();
+      modal.setIsSubmitting(false);
     }
   };
 
@@ -173,11 +249,6 @@ export function useGitInteraction(
 
   const runCommit = async () => {
     if (!repoPath) return;
-
-    if (store.commitNextStep === "commit-pr" && computed.prDisabledReason) {
-      modal.setCommitError(computed.prDisabledReason);
-      return;
-    }
 
     if (store.commitNextStep === "commit-push" && computed.pushDisabledReason) {
       modal.setCommitError(computed.pushDisabledReason);
@@ -238,13 +309,7 @@ export function useGitInteraction(
       modal.setCommitMessage("");
       modal.closeCommit();
 
-      const shouldPush =
-        store.commitNextStep === "commit-push" ||
-        store.commitNextStep === "commit-pr";
-      if (shouldPush) {
-        if (store.commitNextStep === "commit-pr" && !git.prStatus?.prExists) {
-          modal.setOpenPrAfterPush(true);
-        }
+      if (store.commitNextStep === "commit-push") {
         modal.openPush(git.hasRemote ? "push" : "publish");
       }
     } finally {
@@ -286,72 +351,6 @@ export function useGitInteraction(
       }
 
       modal.setPushState("success");
-
-      if (store.openPrAfterPush) {
-        modal.closePush();
-        modal.setOpenPrAfterPush(false);
-        openCreatePr();
-      }
-    } finally {
-      modal.setIsSubmitting(false);
-    }
-  };
-
-  const runPr = async () => {
-    if (!repoPath) return;
-
-    const title = store.prTitle.trim();
-    const body = store.prBody.trim();
-
-    if (!title) {
-      modal.setPrError("PR title is required.");
-      return;
-    }
-
-    modal.setIsSubmitting(true);
-    modal.setPrError(null);
-
-    try {
-      if (!git.hasRemote || git.aheadOfRemote > 0) {
-        const pushFn = git.hasRemote
-          ? trpcClient.git.push
-          : trpcClient.git.publish;
-        const pushResult = await pushFn.mutate({ directoryPath: repoPath });
-
-        if (!pushResult.success) {
-          trackGitAction(taskId, "create-pr", false);
-          modal.setPrError(
-            pushResult.message || "Failed to push before creating PR.",
-          );
-          return;
-        }
-
-        if (pushResult.state) {
-          updateGitCacheFromSnapshot(queryClient, repoPath, pushResult.state);
-        }
-      }
-
-      const result = await trpcClient.git.createPr.mutate({
-        directoryPath: repoPath,
-        title,
-        body,
-      });
-
-      if (!result.success || !result.prUrl) {
-        trackGitAction(taskId, "create-pr", false);
-        modal.setPrError(result.message || "Unable to create PR.");
-        return;
-      }
-
-      trackGitAction(taskId, "create-pr", true);
-      track(ANALYTICS_EVENTS.PR_CREATED, { task_id: taskId, success: true });
-
-      if (result.state) {
-        updateGitCacheFromSnapshot(queryClient, repoPath, result.state);
-      }
-
-      await trpcClient.os.openExternal.mutate({ url: result.prUrl });
-      modal.closePr();
     } finally {
       modal.setIsSubmitting(false);
     }
@@ -391,7 +390,7 @@ export function useGitInteraction(
     if (!repoPath) return;
 
     modal.setIsGeneratingPr(true);
-    modal.setPrError(null);
+    modal.setCreatePrError(null);
 
     try {
       const result = await trpcClient.git.generatePrTitleAndBody.mutate({
@@ -402,11 +401,13 @@ export function useGitInteraction(
         modal.setPrTitle(result.title);
         modal.setPrBody(result.body);
       } else {
-        modal.setPrError("No changes detected to generate PR description.");
+        modal.setCreatePrError(
+          "No changes detected to generate PR description.",
+        );
       }
     } catch (error) {
       log.error("Failed to generate PR title and body", error);
-      modal.setPrError(
+      modal.setCreatePrError(
         error instanceof Error
           ? error.message
           : "Failed to generate PR description.",
@@ -466,7 +467,6 @@ export function useGitInteraction(
       diffStats: git.diffStats,
       prUrl: computed.prUrl,
       pushDisabledReason: computed.pushDisabledReason,
-      prDisabledReason: computed.prDisabledReason,
       isLoading: git.isLoading,
     },
     modals: store,
@@ -474,7 +474,6 @@ export function useGitInteraction(
       openAction,
       closeCommit: modal.closeCommit,
       closePush: modal.closePush,
-      closePr: modal.closePr,
       closeBranch: modal.closeBranch,
       setCommitMessage: modal.setCommitMessage,
       setCommitNextStep: modal.setCommitNextStep,
@@ -487,10 +486,16 @@ export function useGitInteraction(
       },
       runCommit,
       runPush,
-      runPr,
       runBranch,
+      runCreatePr,
       generateCommitMessage,
       generatePrTitleAndBody,
+      closeCreatePr: modal.closeCreatePr,
+      setCreatePrBranchName: (value: string) => {
+        const sanitized = sanitizeBranchName(value);
+        modal.setBranchName(sanitized);
+      },
+      setCreatePrDraft: modal.setCreatePrDraft,
     },
   };
 }

--- a/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.test.ts
+++ b/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.test.ts
@@ -29,7 +29,7 @@ function actionIds(result: ReturnType<typeof computeGitInteractionState>) {
 
 describe("computeGitInteractionState", () => {
   describe("on default branch with changes", () => {
-    it("returns branch-here as primary action", () => {
+    it("returns create-pr as primary action", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "main",
@@ -37,10 +37,10 @@ describe("computeGitInteractionState", () => {
           hasChanges: true,
         }),
       );
-      expect(result.primaryAction.id).toBe("branch-here");
+      expect(result.primaryAction.id).toBe("create-pr");
     });
 
-    it("works without a GitHub remote (defaultBranch null)", () => {
+    it("falls back to branch-here without GitHub remote", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "main",
@@ -53,7 +53,7 @@ describe("computeGitInteractionState", () => {
       expect(result.primaryAction.id).toBe("branch-here");
     });
 
-    it("includes commit in actions as escape hatch", () => {
+    it("includes create-pr, branch, and commit in actions", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "main",
@@ -61,7 +61,7 @@ describe("computeGitInteractionState", () => {
           hasChanges: true,
         }),
       );
-      expect(actionIds(result)).toEqual(["branch-here", "commit"]);
+      expect(actionIds(result)).toEqual(["create-pr", "branch-here", "commit"]);
     });
 
     it("disables push and pr with feature branch message", () => {
@@ -73,7 +73,6 @@ describe("computeGitInteractionState", () => {
         }),
       );
       expect(result.pushDisabledReason).toBe("Create a feature branch first.");
-      expect(result.prDisabledReason).toBe("Create a feature branch first.");
     });
 
     it("is not detected as detached head", () => {
@@ -89,7 +88,7 @@ describe("computeGitInteractionState", () => {
   });
 
   describe("on default branch without changes", () => {
-    it("uses normal flow with commit as primary", () => {
+    it("returns branch-here as primary when nothing to ship", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "main",
@@ -97,11 +96,10 @@ describe("computeGitInteractionState", () => {
           hasChanges: false,
         }),
       );
-      expect(result.primaryAction.id).toBe("commit");
-      expect(result.primaryAction.enabled).toBe(false);
+      expect(result.primaryAction.id).toBe("branch-here");
     });
 
-    it("returns standard three actions", () => {
+    it("returns only branch-here action", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "main",
@@ -109,12 +107,12 @@ describe("computeGitInteractionState", () => {
           hasChanges: false,
         }),
       );
-      expect(actionIds(result)).toEqual(["commit", "push", "create-pr"]);
+      expect(actionIds(result)).toEqual(["branch-here"]);
     });
   });
 
   describe("on default branch with ahead commits but no changes", () => {
-    it("returns push as primary action", () => {
+    it("returns branch-here as primary", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "main",
@@ -123,23 +121,43 @@ describe("computeGitInteractionState", () => {
           aheadOfRemote: 2,
         }),
       );
-      expect(result.primaryAction.id).toBe("push");
+      // On default branch without changes, only branch-here is shown
+      expect(result.primaryAction.id).toBe("branch-here");
     });
   });
 
   describe("on feature branch with changes", () => {
-    it("returns commit as primary action", () => {
+    it("returns create-pr as primary action", () => {
       const result = computeGitInteractionState(
         makeState({ currentBranch: "feature/test", hasChanges: true }),
       );
-      expect(result.primaryAction.id).toBe("commit");
+      expect(result.primaryAction.id).toBe("create-pr");
     });
 
-    it("returns standard three actions", () => {
+    it("returns create-pr plus granular actions", () => {
       const result = computeGitInteractionState(
         makeState({ currentBranch: "feature/test", hasChanges: true }),
       );
-      expect(actionIds(result)).toEqual(["commit", "push", "create-pr"]);
+      expect(actionIds(result)).toEqual(["create-pr", "commit", "push"]);
+    });
+  });
+
+  describe("on feature branch with existing PR", () => {
+    it("still offers create-pr for stacking", () => {
+      const result = computeGitInteractionState(
+        makeState({
+          currentBranch: "feature/test",
+          hasChanges: true,
+          prStatus: {
+            prExists: true,
+            baseBranch: "main",
+            headBranch: "feature/test",
+            prUrl: "https://github.com/test/test/pull/1",
+          },
+        }),
+      );
+      // create-pr still enabled — creates a new stacked branch
+      expect(result.primaryAction.id).toBe("create-pr");
     });
   });
 
@@ -161,7 +179,7 @@ describe("computeGitInteractionState", () => {
   });
 
   describe("isFeatureBranch true even on main", () => {
-    it("falls through to normal commit flow", () => {
+    it("returns create-pr as primary", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "main",
@@ -169,7 +187,7 @@ describe("computeGitInteractionState", () => {
           hasChanges: true,
         }),
       );
-      expect(result.primaryAction.id).toBe("commit");
+      expect(result.primaryAction.id).toBe("create-pr");
     });
   });
 

--- a/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.ts
+++ b/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.ts
@@ -29,7 +29,6 @@ interface GitComputed {
   actions: GitMenuAction[];
   primaryAction: GitMenuAction;
   pushDisabledReason: string | null;
-  prDisabledReason: string | null;
   prBaseBranch: string | null;
   prHeadBranch: string | null;
   prUrl: string | null;
@@ -95,10 +94,9 @@ function getPushDisabledReason(
   return null;
 }
 
-function getPrDisabledReason(
+function getCreatePrDisabledReason(
   s: GitState,
   repoReason: string | null,
-  opts?: { assumeWillHaveCommits?: boolean },
 ): string | null {
   if (repoReason) return repoReason;
 
@@ -108,17 +106,14 @@ function getPrDisabledReason(
     return "Authenticate GitHub CLI with `gh auth login`";
   if (!s.repoInfo) return "No GitHub remote detected.";
 
-  const isOnDefaultBranch =
-    s.defaultBranch && s.currentBranch === s.defaultBranch;
-  if (isOnDefaultBranch) return "Checkout a feature branch to create PRs.";
-
-  if (s.behind > 0) return "Sync branch with remote first.";
-
-  if (s.prStatus?.prExists) return "PR already exists. Use commit and push.";
-
-  if (!opts?.assumeWillHaveCommits && s.aheadOfDefault === 0) {
-    return "No commits to create PR.";
+  if (s.prStatus?.prExists) {
+    if (!s.hasChanges) return "PR already exists.";
   }
+
+  // Something must be shippable: uncommitted changes or unpushed commits
+  const hasShippableWork =
+    s.hasChanges || s.aheadOfRemote > 0 || s.aheadOfDefault > 0 || !s.hasRemote;
+  if (!hasShippableWork) return "No changes to ship.";
 
   return null;
 }
@@ -144,26 +139,31 @@ function getPushAction(
   return makeAction("push", "Push", pushDisabledReason);
 }
 
-function getPrAction(
-  s: GitState,
-  prDisabledReason: string | null,
-): GitMenuAction {
+function getViewPrAction(s: GitState): GitMenuAction | null {
   if (s.prStatus?.prExists) return makeAction("view-pr", "View PR", null);
-  return makeAction("create-pr", "Create PR", prDisabledReason);
+  return null;
+}
+
+function getCreatePrAction(
+  createPrDisabledReason: string | null,
+): GitMenuAction {
+  return makeAction("create-pr", "Create PR", createPrDisabledReason);
 }
 
 function getPrimaryAction(
-  s: GitState,
+  createPrAction: GitMenuAction,
   commitAction: GitMenuAction,
   pushAction: GitMenuAction,
-  prAction: GitMenuAction,
+  viewPrAction: GitMenuAction | null,
 ): GitMenuAction {
-  const allDisabled =
-    !commitAction.enabled && !pushAction.enabled && !prAction.enabled;
-  if (allDisabled) return commitAction;
-  if (s.hasChanges) return commitAction;
-  if (s.aheadOfRemote > 0 || !s.hasRemote || s.behind > 0) return pushAction;
-  return prAction;
+  // createPr handles most cases for getting to a PR (branch creation,
+  // commit, push, etc), so it's always primary when available
+  if (createPrAction.enabled) return createPrAction;
+
+  if (commitAction.enabled) return commitAction;
+  if (pushAction.enabled) return pushAction;
+  if (viewPrAction) return viewPrAction;
+  return commitAction;
 }
 
 export function computeGitInteractionState(input: GitState): GitComputed {
@@ -176,7 +176,6 @@ export function computeGitInteractionState(input: GitState): GitComputed {
       actions: [branchAction],
       primaryAction: branchAction,
       pushDisabledReason: "Create a branch first.",
-      prDisabledReason: "Create a branch first.",
       prBaseBranch: input.defaultBranch,
       prHeadBranch: null,
       prUrl: null,
@@ -186,15 +185,25 @@ export function computeGitInteractionState(input: GitState): GitComputed {
   }
 
   const onDefaultBranch = isOnDefaultBranch(input);
+  const createPrDisabledReason = getCreatePrDisabledReason(input, repoReason);
+  const createPrAction = getCreatePrAction(createPrDisabledReason);
 
-  if (onDefaultBranch && input.hasChanges) {
+  if (onDefaultBranch) {
     const branchAction = makeAction("branch-here", "New branch", repoReason);
     const commitAction = getCommitAction(input, repoReason);
+
+    const actions = input.hasChanges
+      ? [createPrAction, branchAction, commitAction]
+      : [branchAction];
+    const primaryAction =
+      input.hasChanges && createPrAction.enabled
+        ? createPrAction
+        : branchAction;
+
     return {
-      actions: [branchAction, commitAction],
-      primaryAction: branchAction,
+      actions,
+      primaryAction,
       pushDisabledReason: "Create a feature branch first.",
-      prDisabledReason: "Create a feature branch first.",
       prBaseBranch: input.defaultBranch,
       prHeadBranch: input.currentBranch,
       prUrl: input.prStatus?.prUrl ?? null,
@@ -204,25 +213,26 @@ export function computeGitInteractionState(input: GitState): GitComputed {
   }
 
   const pushDisabledReason = getPushDisabledReason(input, repoReason);
-  const prDisabledReason = getPrDisabledReason(input, repoReason);
 
   const commitAction = getCommitAction(input, repoReason);
   const pushAction = getPushAction(input, pushDisabledReason);
-  const prAction = getPrAction(input, prDisabledReason);
+  const viewPrAction = getViewPrAction(input);
   const primaryAction = getPrimaryAction(
-    input,
+    createPrAction,
     commitAction,
     pushAction,
-    prAction,
+    viewPrAction,
   );
 
+  const actions: GitMenuAction[] = [];
+  if (createPrAction.enabled) actions.push(createPrAction);
+  actions.push(commitAction, pushAction);
+  if (viewPrAction) actions.push(viewPrAction);
+
   return {
-    actions: [commitAction, pushAction, prAction],
+    actions,
     primaryAction,
     pushDisabledReason: getPushDisabledReason(input, repoReason, {
-      assumeWillHaveCommits: true,
-    }),
-    prDisabledReason: getPrDisabledReason(input, repoReason, {
       assumeWillHaveCommits: true,
     }),
     prBaseBranch: input.prStatus?.baseBranch ?? input.defaultBranch,

--- a/apps/code/src/renderer/features/git-interaction/state/gitInteractionStore.ts
+++ b/apps/code/src/renderer/features/git-interaction/state/gitInteractionStore.ts
@@ -1,5 +1,6 @@
 import type {
   CommitNextStep,
+  CreatePrStep,
   GitMenuActionId,
   PushMode,
   PushState,
@@ -11,7 +12,7 @@ export type { CommitNextStep, PushMode, PushState };
 interface GitInteractionState {
   commitOpen: boolean;
   pushOpen: boolean;
-  prOpen: boolean;
+  createPrOpen: boolean;
   branchOpen: boolean;
   commitMessage: string;
   commitNextStep: CommitNextStep;
@@ -20,12 +21,17 @@ interface GitInteractionState {
   pushError: string | null;
   prTitle: string;
   prBody: string;
-  prError: string | null;
+  createPrStep: CreatePrStep;
+  createPrError: string | null;
+  createPrNeedsBranch: boolean;
+  createPrNeedsCommit: boolean;
+  createPrBaseBranch: string | null;
+  createPrDraft: boolean;
+  createPrFailedStep: CreatePrStep | null;
   commitError: string | null;
   branchName: string;
   branchError: string | null;
   isSubmitting: boolean;
-  openPrAfterPush: boolean;
   isGeneratingCommitMessage: boolean;
   isGeneratingPr: boolean;
 }
@@ -33,7 +39,6 @@ interface GitInteractionState {
 interface GitInteractionActions {
   setCommitOpen: (open: boolean) => void;
   setPushOpen: (open: boolean) => void;
-  setPrOpen: (open: boolean) => void;
   setBranchOpen: (open: boolean) => void;
   setCommitMessage: (value: string) => void;
   setCommitNextStep: (value: CommitNextStep) => void;
@@ -42,22 +47,29 @@ interface GitInteractionActions {
   setPushError: (value: string | null) => void;
   setPrTitle: (value: string) => void;
   setPrBody: (value: string) => void;
-  setPrError: (value: string | null) => void;
   setCommitError: (value: string | null) => void;
   setBranchName: (value: string) => void;
   setBranchError: (value: string | null) => void;
   setIsSubmitting: (value: boolean) => void;
-  setOpenPrAfterPush: (value: boolean) => void;
   setIsGeneratingCommitMessage: (value: boolean) => void;
   setIsGeneratingPr: (value: boolean) => void;
 
   openCommit: (nextStep: CommitNextStep) => void;
   openPush: (mode: PushMode) => void;
-  openPr: (defaultTitle?: string, defaultBody?: string) => void;
+  openCreatePr: (opts: {
+    needsBranch: boolean;
+    needsCommit: boolean;
+    baseBranch: string | null;
+    suggestedBranchName?: string;
+  }) => void;
+  closeCreatePr: () => void;
+  setCreatePrStep: (step: CreatePrStep) => void;
+  setCreatePrError: (error: string | null) => void;
+  setCreatePrDraft: (value: boolean) => void;
+  setCreatePrFailedStep: (step: CreatePrStep | null) => void;
   openBranch: (suggestedName?: string) => void;
   closeCommit: () => void;
   closePush: () => void;
-  closePr: () => void;
   closeBranch: () => void;
 }
 
@@ -68,7 +80,7 @@ export interface GitInteractionStore extends GitInteractionState {
 const initialState: GitInteractionState = {
   commitOpen: false,
   pushOpen: false,
-  prOpen: false,
+  createPrOpen: false,
   branchOpen: false,
   commitMessage: "",
   commitNextStep: "commit",
@@ -77,12 +89,17 @@ const initialState: GitInteractionState = {
   pushError: null,
   prTitle: "",
   prBody: "",
-  prError: null,
+  createPrStep: "idle",
+  createPrError: null,
+  createPrNeedsBranch: false,
+  createPrNeedsCommit: false,
+  createPrBaseBranch: null,
+  createPrDraft: false,
+  createPrFailedStep: null,
   commitError: null,
   branchName: "",
   branchError: null,
   isSubmitting: false,
-  openPrAfterPush: false,
   isGeneratingCommitMessage: false,
   isGeneratingPr: false,
 };
@@ -92,7 +109,6 @@ export const useGitInteractionStore = create<GitInteractionStore>((set) => ({
   actions: {
     setCommitOpen: (open) => set({ commitOpen: open }),
     setPushOpen: (open) => set({ pushOpen: open }),
-    setPrOpen: (open) => set({ prOpen: open }),
     setBranchOpen: (open) => set({ branchOpen: open }),
     setCommitMessage: (value) => set({ commitMessage: value }),
     setCommitNextStep: (value) => set({ commitNextStep: value }),
@@ -101,12 +117,10 @@ export const useGitInteractionStore = create<GitInteractionStore>((set) => ({
     setPushError: (value) => set({ pushError: value }),
     setPrTitle: (value) => set({ prTitle: value }),
     setPrBody: (value) => set({ prBody: value }),
-    setPrError: (value) => set({ prError: value }),
     setCommitError: (value) => set({ commitError: value }),
     setBranchName: (value) => set({ branchName: value }),
     setBranchError: (value) => set({ branchError: value }),
     setIsSubmitting: (value) => set({ isSubmitting: value }),
-    setOpenPrAfterPush: (value) => set({ openPrAfterPush: value }),
     setIsGeneratingCommitMessage: (value) =>
       set({ isGeneratingCommitMessage: value }),
     setIsGeneratingPr: (value) => set({ isGeneratingPr: value }),
@@ -120,13 +134,36 @@ export const useGitInteractionStore = create<GitInteractionStore>((set) => ({
         pushError: null,
         pushOpen: true,
       }),
-    openPr: (defaultTitle, defaultBody) =>
+    openCreatePr: ({
+      needsBranch,
+      needsCommit,
+      baseBranch,
+      suggestedBranchName,
+    }) =>
       set({
-        prTitle: defaultTitle ?? "",
-        prBody: defaultBody ?? "",
-        prError: null,
-        prOpen: true,
+        createPrOpen: true,
+        createPrStep: "idle",
+        createPrError: null,
+        createPrNeedsBranch: needsBranch,
+        createPrNeedsCommit: needsCommit,
+        createPrBaseBranch: baseBranch,
+        createPrDraft: false,
+        createPrFailedStep: null,
+        branchName: suggestedBranchName ?? "",
+        commitMessage: "",
+        prTitle: "",
+        prBody: "",
+        isGeneratingCommitMessage: false,
+        isGeneratingPr: false,
       }),
+    closeCreatePr: () =>
+      set({
+        createPrOpen: false,
+      }),
+    setCreatePrStep: (step) => set({ createPrStep: step }),
+    setCreatePrError: (error) => set({ createPrError: error }),
+    setCreatePrDraft: (value) => set({ createPrDraft: value }),
+    setCreatePrFailedStep: (step) => set({ createPrFailedStep: step }),
     openBranch: (suggestedName) =>
       set({
         branchName: suggestedName ?? "",
@@ -139,10 +176,7 @@ export const useGitInteractionStore = create<GitInteractionStore>((set) => ({
         pushOpen: false,
         pushState: "idle",
         pushError: null,
-        openPrAfterPush: false,
       }),
-    closePr: () =>
-      set({ prOpen: false, prError: null, prTitle: "", prBody: "" }),
     closeBranch: () =>
       set({ branchOpen: false, branchError: null, branchName: "" }),
   },

--- a/apps/code/src/renderer/features/git-interaction/types.ts
+++ b/apps/code/src/renderer/features/git-interaction/types.ts
@@ -14,6 +14,15 @@ export interface GitMenuAction {
   disabledReason: string | null;
 }
 
-export type CommitNextStep = "commit" | "commit-push" | "commit-pr";
+export type CommitNextStep = "commit" | "commit-push";
 export type PushMode = "push" | "sync" | "publish";
 export type PushState = "idle" | "success" | "error";
+
+export type CreatePrStep =
+  | "idle"
+  | "creating-branch"
+  | "committing"
+  | "pushing"
+  | "creating-pr"
+  | "complete"
+  | "error";


### PR DESCRIPTION
## Problem

the current method for getting changes shipped takes _a lot_ of clicks, and at least 3 separate modals -- create branch, commit, create PR.

for what i expect to be the more general case ("agent did work, i wanna ship it"), we can simplify this

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## removed

- existing "commit and create PR" flow from the commit dialog
- existing standalone "create pr" action / dialog

## added

introduces a new unified "create PR" workflow that does these steps, as needed:

1. create & checkout new branch
2. commit
3. push
4. create PR

| full input - on default branch, changes to be committed | loading states | error state |
| --- | --- | --- |
| ![Screenshot 2026-03-31 at 9.27.33 AM.png](https://app.graphite.com/user-attachments/assets/fc1351a6-826a-44ae-999c-468e89d89e95.png)<br> | ![Screenshot 2026-03-31 at 9.27.47 AM.png](https://app.graphite.com/user-attachments/assets/a8efcc02-5dcb-4237-b9ad-056ca6eb913d.png)<br> | ![Screenshot 2026-03-31 at 9.27.52 AM.png](https://app.graphite.com/user-attachments/assets/684d9fb3-1168-41c0-a680-b0cba6de0a9a.png)<br> |

### create pr flow notes:

- if the user is already on a non-default branch, the first step is optional
- if the user has no uncommitted changes, the flow starts on step 3
- if a PR already exists on the current branch and there are new uncommited changes, the flow creates a new branch (stack time baby)
- AI generation is delayed til the user clicks "create" - happens if the commit msg and/or pr details are left empty
- primary CTA swaps to "view PR" when a PR exists, until new changes appear, then it swaps back to "create PR"
- all existing individual actions are still available in the dropdown

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

_i have not yet tested this in cloud or worktrees_

manually tested, i know it's a big PR, so would appreciate others manually testing a bit too :muscle:

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->