### PR TITLE
Revert "feat(code): add /clear command to reset conversation history"

### DIFF
--- a/apps/code/src/renderer/features/message-editor/commands.ts
+++ b/apps/code/src/renderer/features/message-editor/commands.ts
@@ -1,5 +1,4 @@
 import type { AvailableCommand } from "@agentclientprotocol/sdk";
-import { getSessionService } from "@features/sessions/service/service";
 import { ANALYTICS_EVENTS, type FeedbackType } from "@shared/types/analytics";
 import { track } from "@utils/analytics";
 import { toast } from "@utils/toast";
@@ -52,18 +51,6 @@ const commands: CodeCommand[] = [
   makeFeedbackCommand("good", "good", "Positive"),
   makeFeedbackCommand("bad", "bad", "Negative"),
   makeFeedbackCommand("feedback", "general", "General"),
-  {
-    name: "clear",
-    description: "Clear conversation history and start fresh",
-    async execute(_args, ctx) {
-      if (!ctx.repoPath || !ctx.taskId) {
-        toast.error("Cannot clear: no active session");
-        return;
-      }
-      await getSessionService().resetSession(ctx.taskId, ctx.repoPath);
-      toast.success("Conversation cleared");
-    },
-  },
 ];
 
 export const CODE_COMMANDS: AvailableCommand[] = commands.map((cmd) => ({

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -1793,23 +1793,11 @@ export class SessionService {
 
   /**
    * Start a fresh session for a task, abandoning the old conversation.
-   * Tears down the current session and creates a new task run so that
-   * S3 logs start clean — old messages won't reappear on restart.
+   * Clears the backend sessionId so the next reconnect creates a new
+   * session instead of attempting to resume the stale one.
    */
   async resetSession(taskId: string, repoPath: string): Promise<void> {
-    const session = sessionStoreSetters.getSessionByTaskId(taskId);
-    if (!session) return;
-
-    const { taskTitle } = session;
-
-    await this.teardownSession(session.taskRunId);
-
-    const auth = this.getAuthCredentials();
-    if (!auth) {
-      throw new Error("Unable to reach server. Please check your connection.");
-    }
-
-    await this.createNewLocalSession(taskId, taskTitle, repoPath, auth);
+    await this.reconnectInPlace(taskId, repoPath, null);
   }
 
   /**

--- a/packages/agent/src/adapters/claude/session/commands.ts
+++ b/packages/agent/src/adapters/claude/session/commands.ts
@@ -2,7 +2,6 @@ import type { AvailableCommand } from "@agentclientprotocol/sdk";
 import type { SlashCommand } from "@anthropic-ai/claude-agent-sdk";
 
 const UNSUPPORTED_COMMANDS = [
-  "clear",
   "context",
   "cost",
   "keybindings-help",


### PR DESCRIPTION
Reverts PostHog/code#1248

`resetSession` behavior was changed which we depend on in the `New Session` UI if a session errors out. Now it fully clears and resets the chat, which is not supposed to be the behavior of that button, it should reconnect in place (e.g. reconnect to the same task run)