### PR TITLE
fix(code): preserve initial prompt across session error transitions

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -202,6 +202,9 @@ export class SessionService {
         session.status = "error";
         session.errorMessage =
           "Authentication required. Please sign in to continue.";
+        if (initialPrompt?.length) {
+          session.initialPrompt = initialPrompt;
+        }
         sessionStoreSetters.setSession(session);
         return;
       }
@@ -296,6 +299,9 @@ export class SessionService {
       session.status = "error";
       session.errorTitle = "Failed to connect";
       session.errorMessage = message;
+      if (initialPrompt?.length) {
+        session.initialPrompt = initialPrompt;
+      }
 
       if (latestRun?.log_url) {
         try {
@@ -504,6 +510,9 @@ export class SessionService {
     if (existing?.logUrl) {
       session.logUrl = existing.logUrl;
     }
+    if (existing?.initialPrompt?.length) {
+      session.initialPrompt = existing.initialPrompt;
+    }
     sessionStoreSetters.setSession(session);
   }
 
@@ -562,6 +571,13 @@ export class SessionService {
     // Persist the adapter
     if (adapter) {
       useSessionAdapterStore.getState().setAdapter(taskRun.id, adapter);
+    }
+
+    // Store the initial prompt on the session so retry/reset flows can
+    // re-send it if the session errors after this point (e.g. subscription
+    // error, agent crash, or prompt failure).
+    if (initialPrompt?.length) {
+      session.initialPrompt = initialPrompt;
     }
 
     sessionStoreSetters.setSession(session);
@@ -1786,8 +1802,32 @@ export class SessionService {
    * Retry connecting to the existing session (resume attempt using
    * the sessionId from logs). Does NOT tear down — avoids the connect
    * effect loop.
+   *
+   * If the session failed before any conversation started (has an
+   * initialPrompt saved from the original creation attempt), creates
+   * a fresh session and re-sends the prompt instead of reconnecting
+   * to an empty session.
    */
   async clearSessionError(taskId: string, repoPath: string): Promise<void> {
+    const session = sessionStoreSetters.getSessionByTaskId(taskId);
+    if (session?.initialPrompt?.length) {
+      const { taskTitle, initialPrompt } = session;
+      await this.teardownSession(session.taskRunId);
+      const auth = this.getAuthCredentials();
+      if (!auth) {
+        throw new Error(
+          "Unable to reach server. Please check your connection.",
+        );
+      }
+      await this.createNewLocalSession(
+        taskId,
+        taskTitle,
+        repoPath,
+        auth,
+        initialPrompt,
+      );
+      return;
+    }
     await this.reconnectInPlace(taskId, repoPath);
   }
 

--- a/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
@@ -1,4 +1,5 @@
 import type {
+  ContentBlock,
   SessionConfigOption,
   SessionConfigSelectGroup,
   SessionConfigSelectOption,
@@ -68,6 +69,8 @@ export interface AgentSession {
   cloudOutput?: Record<string, unknown> | null;
   /** Cloud task error message */
   cloudErrorMessage?: string | null;
+  /** Initial prompt to re-send on retry if the first connection attempt failed */
+  initialPrompt?: ContentBlock[];
   /** Cloud task branch */
   cloudBranch?: string | null;
   /** Number of session/prompt events to skip from polled logs (set during resume) */


### PR DESCRIPTION
## Problem

When creating a new task with a prompt and the session errors (e.g. "Failed to connect / Internal error"), clicking Retry doesn't re-send the original prompt. The user has to type their prompt again.

This happens because:
1. `createNewLocalSession` sends the initial prompt but never stores it on the session object
2. When the session later transitions to error state (via subscription error, agent crash, or fatal prompt failure), the prompt is lost
3. `setErrorSession` carries forward `events` and `logUrl` from the existing session but not `initialPrompt`

## Changes

- Store `initialPrompt` on the session in `createNewLocalSession` so it survives error transitions via `updateSession`
- Preserve `initialPrompt` in `setErrorSession` when carrying forward session state to a new error session
- Add the `initialPrompt` field and `ContentBlock` import to the `AgentSession` interface in the store

## How did you test this?

- Ran full test suite: 536 tests passing
- Type check passes