### PR TITLE
fix: pass custom instructions to agent when rejecting tool permissions

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -252,7 +252,10 @@ export function SessionView({
       }
 
       if (customInput) {
-        if (isOtherOption(optionId)) {
+        if (
+          isOtherOption(optionId) ||
+          selectedOption?._meta?.customInput === true
+        ) {
           await getSessionService().respondToPermission(
             taskId,
             firstPendingPermission.toolCallId,

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -388,12 +388,14 @@ async function handleDefaultPermissionFlow(
       updatedInput: toolInput as Record<string, unknown>,
     };
   } else {
-    const message = "User refused permission to run tool";
+    const feedback = (
+      response._meta?.customInput as string | undefined
+    )?.trim();
+    const message = feedback
+      ? `User refused permission to run tool with feedback: ${feedback}`
+      : "User refused permission to run tool";
     await emitToolDenial(context, message);
-    return {
-      behavior: "deny",
-      message,
-    };
+    return { behavior: "deny", message, interrupt: !feedback };
   }
 }
 


### PR DESCRIPTION
## Problem

- When rejecting tool permission with custom instructions, the agent was not receiving the custom input. Because of this, it completely ignored any instructions passed and sent them later as a queued message.

Closes #1368

## Changes

- Route reject-with-instruction custom input through the permission response instead of sending it as a separate prompt
- Extract and include user feedback in the tool denial message so the agent can act on it

## How did you test this?

- Manually

<img width="1349" height="505" alt="image" src="https://github.com/user-attachments/assets/6769230d-3983-443f-a3ea-e5e2dc8a3446" />


<img width="1267" height="425" alt="image" src="https://github.com/user-attachments/assets/85e9dcf2-0e1e-4ccd-a6fd-7be97cb9bb4d" />
