### PR TITLE
fix(code): increase diff scan limit

### DIFF
--- a/apps/code/src/renderer/features/code-editor/hooks/useCodeMirror.ts
+++ b/apps/code/src/renderer/features/code-editor/hooks/useCodeMirror.ts
@@ -86,9 +86,10 @@ const getBaseDiffConfig = (
   highlightChanges: false,
   gutter: true,
   mergeControls: createMergeControls(onReject),
-  diffConfig: hideWhitespaceChanges
-    ? { override: whitespaceIgnoringDiff }
-    : undefined,
+  diffConfig: {
+    scanLimit: 50000,
+    ...(hideWhitespaceChanges && { override: whitespaceIgnoringDiff }),
+  },
 });
 
 export function useCodeMirror(options: SingleDocOptions | DiffOptions) {


### PR DESCRIPTION
## Problem

for large files, diffs sometimes render poorly (showing entire file changes) because the default codemirror diff scan limit is low

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

increases codemirror's default diff scan limit to avoid wonky diff rendering

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->