### PR TITLE
feat(code): disable editing in diff viewer

### DIFF
--- a/apps/code/src/renderer/features/code-editor/components/CodeMirrorDiffEditor.tsx
+++ b/apps/code/src/renderer/features/code-editor/components/CodeMirrorDiffEditor.tsx
@@ -38,7 +38,7 @@ export function CodeMirrorDiffEditor({
   const toggleHideWhitespaceChanges = useDiffViewerStore(
     (s) => s.toggleHideWhitespaceChanges,
   );
-  const extensions = useEditorExtensions(filePath, !onContentChange, true);
+  const extensions = useEditorExtensions(filePath, true, true);
   const options = useMemo(
     () => ({
       original: originalContent,

--- a/apps/code/src/renderer/features/code-editor/hooks/useEditorExtensions.ts
+++ b/apps/code/src/renderer/features/code-editor/hooks/useEditorExtensions.ts
@@ -39,7 +39,7 @@ export function useEditorExtensions(
       theme,
       mergeViewTheme,
       EditorView.editable.of(!readOnly),
-      ...(readOnly ? [EditorState.readOnly.of(true)] : []),
+      ...(readOnly && !isDiff ? [EditorState.readOnly.of(true)] : []),
       ...(languageExtension ? [languageExtension] : []),
     ];
   }, [filePath, isDarkMode, readOnly, isDiff, wordWrap]);


### PR DESCRIPTION
## Problem

files can be "edited" in the diff viewer (b side or unified view). the changes are not persisted, but users shouldn't be able to manually edit these in the first place

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## [phc-editing-bug.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2eb83dcd-d847-4fb6-bbb2-c576e84f2847.mp4" />](https://app.graphite.com/user-attachments/video/2eb83dcd-d847-4fb6-bbb2-c576e84f2847.mp4)

## Changes

updates diff viewer to disable editing, keeps 'revert' functionality working but removes ability to click/type

## notes

i think we probably _should_ allow editing, but since nothing persists right now, it's just confusing so i'm disabling it for now

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->