### PR TITLE
feat(inbox): Priority sorting, status filter, suggested reviewers

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/ReportCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/ReportCard.tsx
@@ -4,7 +4,8 @@ import {
   inboxStatusAccentCss,
   inboxStatusLabel,
 } from "@features/inbox/utils/inboxSort";
-import { Flex, Text } from "@radix-ui/themes";
+import { UserIcon } from "@phosphor-icons/react";
+import { Flex, Text, Tooltip } from "@radix-ui/themes";
 import type { SignalReport } from "@shared/types";
 import { motion } from "framer-motion";
 import type { KeyboardEvent, MouseEvent } from "react";
@@ -118,6 +119,20 @@ export function ReportCard({
                 {statusLabel}
               </span>
               <SignalReportPriorityBadge priority={report.priority} />
+              {report.is_suggested_reviewer && (
+                <Tooltip content="You are a suggested reviewer">
+                  <span
+                    className="inline-flex shrink-0 items-center rounded-sm px-1 py-px"
+                    style={{
+                      color: "var(--blue-11)",
+                      backgroundColor: "var(--blue-3)",
+                      border: "1px solid var(--blue-6)",
+                    }}
+                  >
+                    <UserIcon size={10} weight="bold" />
+                  </span>
+                </Tooltip>
+              )}
             </Flex>
           </Flex>
           {/* Summary is outside the title row so wrapped lines align with title text (bullet + gap), not the card edge */}

--- a/apps/code/src/renderer/features/inbox/components/SignalsToolbar.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalsToolbar.tsx
@@ -1,14 +1,22 @@
 import { useInboxSignalsFilterStore } from "@features/inbox/stores/inboxSignalsFilterStore";
 import {
+  inboxStatusAccentCss,
+  inboxStatusLabel,
+} from "@features/inbox/utils/inboxSort";
+import {
   CalendarPlus,
   Check,
   Clock,
   FunnelSimple as FunnelSimpleIcon,
+  ListNumbers,
   MagnifyingGlass,
   TrendUp,
 } from "@phosphor-icons/react";
-import { Box, Flex, Popover, Text, TextField } from "@radix-ui/themes";
-import type { SignalReportOrderingField } from "@shared/types";
+import { Box, Flex, Popover, Text, TextField, Tooltip } from "@radix-ui/themes";
+import type {
+  SignalReportOrderingField,
+  SignalReportStatus,
+} from "@shared/types";
 
 interface SignalsToolbarProps {
   totalCount: number;
@@ -17,16 +25,26 @@ interface SignalsToolbarProps {
   livePolling?: boolean;
   readyCount?: number;
   processingCount?: number;
+  searchDisabledReason?: string | null;
 }
 
 type SortOption = {
   label: string;
-  field: Extract<SignalReportOrderingField, "created_at" | "total_weight">;
+  field: Extract<
+    SignalReportOrderingField,
+    "priority" | "created_at" | "total_weight"
+  >;
   direction: "asc" | "desc";
   icon: React.ReactNode;
 };
 
 const sortOptions: SortOption[] = [
+  {
+    label: "Priority",
+    field: "priority",
+    direction: "asc",
+    icon: <ListNumbers size={14} />,
+  },
   {
     label: "Strongest signal",
     field: "total_weight",
@@ -47,6 +65,14 @@ const sortOptions: SortOption[] = [
   },
 ];
 
+const FILTERABLE_STATUSES: SignalReportStatus[] = [
+  "ready",
+  "pending_input",
+  "in_progress",
+  "candidate",
+  "potential",
+];
+
 export function SignalsToolbar({
   totalCount,
   filteredCount,
@@ -54,12 +80,15 @@ export function SignalsToolbar({
   livePolling = false,
   readyCount,
   processingCount = 0,
+  searchDisabledReason,
 }: SignalsToolbarProps) {
   const searchQuery = useInboxSignalsFilterStore((s) => s.searchQuery);
   const setSearchQuery = useInboxSignalsFilterStore((s) => s.setSearchQuery);
   const sortField = useInboxSignalsFilterStore((s) => s.sortField);
   const sortDirection = useInboxSignalsFilterStore((s) => s.sortDirection);
   const setSort = useInboxSignalsFilterStore((s) => s.setSort);
+  const statusFilter = useInboxSignalsFilterStore((s) => s.statusFilter);
+  const toggleStatus = useInboxSignalsFilterStore((s) => s.toggleStatus);
 
   const countLabel = isSearchActive
     ? `${filteredCount} of ${totalCount}`
@@ -103,31 +132,38 @@ export function SignalsToolbar({
             ) : null}
           </Flex>
         </Flex>
-        <SortMenu
+        <FilterSortMenu
           sortField={sortField}
           sortDirection={sortDirection}
           onSort={setSort}
+          statusFilter={statusFilter}
+          onToggleStatus={toggleStatus}
         />
       </Flex>
-      <TextField.Root
-        size="1"
-        placeholder="Search signals..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-        className="text-[12px]"
-      >
-        <TextField.Slot>
-          <MagnifyingGlass size={12} />
-        </TextField.Slot>
-      </TextField.Root>
+      <Tooltip content={searchDisabledReason} hidden={!searchDisabledReason}>
+        <TextField.Root
+          size="1"
+          placeholder="Search reports..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="text-[12px]"
+          disabled={!!searchDisabledReason}
+        >
+          <TextField.Slot>
+            <MagnifyingGlass size={12} />
+          </TextField.Slot>
+        </TextField.Root>
+      </Tooltip>
     </Flex>
   );
 }
 
-function SortMenu({
+function FilterSortMenu({
   sortField,
   sortDirection,
   onSort,
+  statusFilter,
+  onToggleStatus,
 }: {
   sortField: string;
   sortDirection: string;
@@ -135,6 +171,8 @@ function SortMenu({
     field: SortOption["field"],
     direction: SortOption["direction"],
   ) => void;
+  statusFilter: SignalReportStatus[];
+  onToggleStatus: (status: SignalReportStatus) => void;
 }) {
   const itemClassName =
     "flex w-full items-center justify-between rounded-sm px-1 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-gray-3";
@@ -144,7 +182,7 @@ function SortMenu({
       <Popover.Trigger>
         <button
           type="button"
-          aria-label="Sort signals"
+          aria-label="Filter and sort signals"
           className="flex h-6 w-6 items-center justify-center rounded-sm text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
         >
           <FunnelSimpleIcon size={14} />
@@ -156,7 +194,7 @@ function SortMenu({
         sideOffset={6}
         style={{ padding: 8, minWidth: 220 }}
       >
-        <Flex direction="column" gap="1">
+        <Flex direction="column" gap="3">
           <Box>
             <Text
               size="1"
@@ -181,6 +219,42 @@ function SortMenu({
                     <span className="flex items-center gap-1 text-gray-12">
                       {option.icon}
                       <span>{option.label}</span>
+                    </span>
+                    {isActive && <Check size={12} className="text-gray-12" />}
+                  </button>
+                );
+              })}
+            </Box>
+          </Box>
+
+          <Box>
+            <Text
+              size="1"
+              className="text-gray-10"
+              weight="medium"
+              style={{ paddingLeft: "1px" }}
+            >
+              Status
+            </Text>
+            <Box mt="1">
+              {FILTERABLE_STATUSES.map((status) => {
+                const isActive = statusFilter.includes(status);
+                const accent = inboxStatusAccentCss(status);
+                return (
+                  <button
+                    key={status}
+                    type="button"
+                    className={itemClassName}
+                    onClick={() => onToggleStatus(status)}
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <span
+                        className="inline-block h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: accent }}
+                      />
+                      <span className="text-gray-12">
+                        {inboxStatusLabel(status)}
+                      </span>
                     </span>
                     {isActive && <Check size={12} className="text-gray-12" />}
                   </button>

--- a/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -1,23 +1,37 @@
-import type { SignalReportOrderingField } from "@shared/types";
+import type {
+  SignalReportOrderingField,
+  SignalReportStatus,
+} from "@shared/types";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 type SignalSortField = Extract<
   SignalReportOrderingField,
-  "created_at" | "total_weight"
+  "priority" | "created_at" | "total_weight"
 >;
 
 type SignalSortDirection = "asc" | "desc";
+
+const DEFAULT_STATUS_FILTER: SignalReportStatus[] = [
+  "ready",
+  "pending_input",
+  "in_progress",
+  "candidate",
+  "potential",
+];
 
 interface InboxSignalsFilterState {
   sortField: SignalSortField;
   sortDirection: SignalSortDirection;
   searchQuery: string;
+  statusFilter: SignalReportStatus[];
 }
 
 interface InboxSignalsFilterActions {
   setSort: (field: SignalSortField, direction: SignalSortDirection) => void;
   setSearchQuery: (query: string) => void;
+  setStatusFilter: (statuses: SignalReportStatus[]) => void;
+  toggleStatus: (status: SignalReportStatus) => void;
 }
 
 type InboxSignalsFilterStore = InboxSignalsFilterState &
@@ -26,17 +40,28 @@ type InboxSignalsFilterStore = InboxSignalsFilterState &
 export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
   persist(
     (set) => ({
-      sortField: "total_weight",
-      sortDirection: "desc",
+      sortField: "priority",
+      sortDirection: "asc",
       searchQuery: "",
+      statusFilter: DEFAULT_STATUS_FILTER,
       setSort: (sortField, sortDirection) => set({ sortField, sortDirection }),
       setSearchQuery: (searchQuery) => set({ searchQuery }),
+      setStatusFilter: (statusFilter) => set({ statusFilter }),
+      toggleStatus: (status) =>
+        set((state) => {
+          const current = state.statusFilter;
+          const next = current.includes(status)
+            ? current.filter((s) => s !== status)
+            : [...current, status];
+          return { statusFilter: next.length > 0 ? next : current };
+        }),
     }),
     {
       name: "inbox-signals-filter-storage",
       partialize: (state) => ({
         sortField: state.sortField,
         sortDirection: state.sortDirection,
+        statusFilter: state.statusFilter,
       }),
     },
   ),

--- a/apps/code/src/renderer/features/inbox/utils/filterReports.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/filterReports.test.ts
@@ -97,21 +97,21 @@ describe("filterReportsBySearch", () => {
 });
 
 describe("buildSignalReportListOrdering", () => {
-  it("puts status rank first then descending field", () => {
+  it("puts status then suggested reviewer then descending field", () => {
     expect(buildSignalReportListOrdering("total_weight", "desc")).toBe(
-      "status,-total_weight",
+      "status,-is_suggested_reviewer,-total_weight",
     );
   });
 
-  it("puts status rank first then ascending field", () => {
+  it("puts status then suggested reviewer then ascending field", () => {
     expect(buildSignalReportListOrdering("created_at", "asc")).toBe(
-      "status,created_at",
+      "status,-is_suggested_reviewer,created_at",
     );
   });
 
   it("works for signal_count", () => {
     expect(buildSignalReportListOrdering("signal_count", "desc")).toBe(
-      "status,-signal_count",
+      "status,-is_suggested_reviewer,-signal_count",
     );
   });
 });

--- a/apps/code/src/renderer/features/inbox/utils/filterReports.ts
+++ b/apps/code/src/renderer/features/inbox/utils/filterReports.ts
@@ -1,4 +1,8 @@
-import type { SignalReport, SignalReportOrderingField } from "@shared/types";
+import type {
+  SignalReport,
+  SignalReportOrderingField,
+  SignalReportStatus,
+} from "@shared/types";
 
 export function filterReportsBySearch(
   reports: SignalReport[],
@@ -16,13 +20,22 @@ export function filterReportsBySearch(
 }
 
 /**
- * Comma-separated `ordering` for the signal report list API: semantic `status` rank
- * then the toolbar field (matches default inbox UX).
+ * Build a comma-separated status filter string for the API from an array of statuses.
+ */
+export function buildStatusFilterParam(statuses: SignalReportStatus[]): string {
+  return statuses.join(",");
+}
+
+/**
+ * Comma-separated `ordering` for the signal report list API:
+ * 1. Status rank (ready first — semantic server-side rank, always applied)
+ * 2. Suggested reviewer (current user's reports first)
+ * 3. Toolbar-selected field (priority, total_weight, created_at, etc.)
  */
 export function buildSignalReportListOrdering(
   field: SignalReportOrderingField,
   direction: "asc" | "desc",
 ): string {
-  const secondary = direction === "desc" ? `-${field}` : field;
-  return `status,${secondary}`;
+  const fieldKey = direction === "desc" ? `-${field}` : field;
+  return `status,-is_suggested_reviewer,${fieldKey}`;
 }


### PR DESCRIPTION
## Problem

Inbox sorts by `total_weight` with no way to filter by status. Cloud sorts by status → suggested reviewer → priority, has a status multi-select, and shows a reviewer indicator on cards. That's the experience Code needs too.

## Changes

- Default ordering: `status,-is_suggested_reviewer,priority` then toolbar-selected field
- Add `priority` as default sort option alongside Strongest signal / Newest / Oldest
- Replace hardcoded `INBOX_PIPELINE_STATUS_FILTER` with a persisted status multi-select in the toolbar popover
- Blue `UserIcon` badge on report cards when `is_suggested_reviewer` is true
- Rename search placeholder to "Search reports..."
- Add `searchDisabledReason` prop for disabled state with tooltip