### PR TITLE
get full list of changed files

### DIFF
--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -143,7 +143,7 @@ export async function getStatus(
   return manager.executeRead(
     baseDir,
     async (git) => {
-      const status = await git.status(["--untracked-files=normal"]);
+      const status = await git.status(["--untracked-files=all"]);
       return {
         isClean: status.isClean(),
         staged: status.staged,
@@ -339,7 +339,7 @@ export async function getChangedFiles(
           } catch {}
         }
 
-        const status = await git.status(["--untracked-files=normal"]);
+        const status = await git.status(["--untracked-files=all"]);
         for (const file of [
           ...status.modified,
           ...status.created,
@@ -430,7 +430,7 @@ export async function getChangedFilesDetailed(
       try {
         const [diffSummary, status] = await Promise.all([
           git.diffSummary(["-M", "HEAD"]),
-          git.status(["--untracked-files=normal"]),
+          git.status(["--untracked-files=all"]),
         ]);
 
         const seenPaths = new Set<string>();


### PR DESCRIPTION
## Problem

the "changed files" list does not include untracked files in a directory, e.g. if i create `/path/to/[a,b].tsx` then the list will show only `/path/to/` and clicking it does nothing

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

swaps `--untracked-files=normal` to `--untracked-files=all` for relevant diff queries

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->