### PR TITLE
feat(code): add git diff head query

### DIFF
--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -120,6 +120,13 @@ export const getFileAtHeadInput = z.object({
 });
 export const getFileAtHeadOutput = z.string().nullable();
 
+// getDiffHead schemas
+export const getDiffHeadInput = z.object({
+  directoryPath: z.string(),
+  ignoreWhitespace: z.boolean().optional(),
+});
+export const getDiffHeadOutput = z.string();
+
 // getDiffStats schemas
 export const getDiffStatsInput = directoryPathInput;
 export const getDiffStatsOutput = diffStatsSchema;

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -9,6 +9,7 @@ import {
   getCurrentBranch,
   getDefaultBranch,
   getDiffAgainstRemote,
+  getDiffHead,
   getDiffStats,
   getFileAtHead,
   getLatestCommit,
@@ -273,6 +274,13 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     filePath: string,
   ): Promise<string | null> {
     return getFileAtHead(directoryPath, filePath);
+  }
+
+  public async getDiffHead(
+    directoryPath: string,
+    ignoreWhitespace?: boolean,
+  ): Promise<string> {
+    return getDiffHead(directoryPath, { ignoreWhitespace });
   }
 
   public async getDiffStats(directoryPath: string): Promise<DiffStats> {

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -29,6 +29,8 @@ import {
   getCommitConventionsOutput,
   getCurrentBranchInput,
   getCurrentBranchOutput,
+  getDiffHeadInput,
+  getDiffHeadOutput,
   getDiffStatsInput,
   getDiffStatsOutput,
   getFileAtHeadInput,
@@ -134,6 +136,13 @@ export const gitRouter = router({
     .output(getFileAtHeadOutput)
     .query(({ input }) =>
       getService().getFileAtHead(input.directoryPath, input.filePath),
+    ),
+
+  getDiffHead: publicProcedure
+    .input(getDiffHeadInput)
+    .output(getDiffHeadOutput)
+    .query(({ input }) =>
+      getService().getDiffHead(input.directoryPath, input.ignoreWhitespace),
     ),
 
   getDiffStats: publicProcedure

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -935,6 +935,18 @@ export async function getUnstagedDiff(
   });
 }
 
+export async function getDiffHead(
+  baseDir: string,
+  options?: CreateGitClientOptions & { ignoreWhitespace?: boolean },
+): Promise<string> {
+  const manager = getGitOperationManager();
+  const args = ["HEAD"];
+  if (options?.ignoreWhitespace) args.push("--ignore-all-space");
+  return manager.executeRead(baseDir, (git) => git.diff(args), {
+    signal: options?.abortSignal,
+  });
+}
+
 export async function getDiffAgainstRemote(
   baseDir: string,
   baseBranch: string,


### PR DESCRIPTION
## Problem

in #1410 i am adding a new diff viewer

it needs to be very fast

we don't have a sufficiently-fast query yet

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds a new query `getDiffHead` to slurp up the whole diff in one query

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->