### PR TITLE
fix(code): fix timestamp hover

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
@@ -112,7 +112,7 @@ export function UserMessage({
           <span>View Slack thread</span>
         </a>
       )}
-      <Box className="absolute top-1 right-1 flex items-center gap-2 opacity-0 transition-opacity group-hover/msg:opacity-100">
+      <Box className="flex h-0 items-center justify-end gap-2 overflow-hidden opacity-0 transition-all group-hover/msg:mt-1 group-hover/msg:h-5 group-hover/msg:opacity-100">
         {timestamp != null && (
           <span aria-hidden className="text-[11px] text-gray-10">
             {formatTimestamp(timestamp)}


### PR DESCRIPTION
## Problem

on message hover, the timestamp and copy button overlap the message content

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

makes the timestamp + copy button "slide out" on hover so they don't overlap

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->