### PR TITLE
feat(inbox): Allow filtering reports by product

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -953,6 +953,9 @@ export class PostHogAPIClient {
     if (params?.ordering) {
       url.searchParams.set("ordering", params.ordering);
     }
+    if (params?.source_product) {
+      url.searchParams.set("source_product", params.source_product);
+    }
 
     const response = await this.api.fetcher.fetch({
       method: "get",

--- a/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -1,5 +1,4 @@
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
-import { InboxLiveRail } from "@features/inbox/components/InboxLiveRail";
 import {
   useInboxReportArtefacts,
   useInboxReportSignals,
@@ -9,6 +8,7 @@ import { useSignalSourceConfigs } from "@features/inbox/hooks/useSignalSourceCon
 import { useInboxCloudTaskStore } from "@features/inbox/stores/inboxCloudTaskStore";
 import { useInboxSignalsFilterStore } from "@features/inbox/stores/inboxSignalsFilterStore";
 import { useInboxSignalsSidebarStore } from "@features/inbox/stores/inboxSignalsSidebarStore";
+import { useInboxSourcesDialogStore } from "@features/inbox/stores/inboxSourcesDialogStore";
 import { buildSignalTaskPrompt } from "@features/inbox/utils/buildSignalTaskPrompt";
 import {
   buildSignalReportListOrdering,
@@ -25,10 +25,17 @@ import {
   ArrowDownIcon,
   ArrowSquareOutIcon,
   ArrowsClockwiseIcon,
+  BrainIcon,
+  BugIcon,
+  CaretRightIcon,
+  CheckIcon,
   CircleNotchIcon,
   ClockIcon,
   Cloud as CloudIcon,
   GithubLogoIcon,
+  KanbanIcon,
+  TicketIcon,
+  VideoIcon,
   WarningIcon,
   XIcon,
 } from "@phosphor-icons/react";
@@ -50,7 +57,6 @@ import mailHog from "@renderer/assets/images/mail-hog.png";
 import { getCloudUrlFromRegion } from "@shared/constants/oauth";
 import type {
   SignalReportArtefact,
-  SignalReportArtefactsResponse,
   SignalReportsQueryParams,
   SuggestedReviewersArtefact,
 } from "@shared/types";
@@ -62,24 +68,132 @@ import { ReportCard } from "./ReportCard";
 import { ReportTaskLogs } from "./ReportTaskLogs";
 import { SignalCard } from "./SignalCard";
 import { SignalReportPriorityBadge } from "./SignalReportPriorityBadge";
+import { SignalReportStatusBadge } from "./SignalReportStatusBadge";
 import { SignalReportSummaryMarkdown } from "./SignalReportSummaryMarkdown";
 import { SignalsToolbar } from "./SignalsToolbar";
 
-function getArtefactsUnavailableMessage(
-  reason: SignalReportArtefactsResponse["unavailableReason"],
-): string {
-  switch (reason) {
-    case "forbidden":
-      return "Evidence could not be loaded with the current API permissions.";
-    case "not_found":
-      return "Evidence endpoint is unavailable for this signal in this environment.";
-    case "invalid_payload":
-      return "Evidence format was unexpected, so no artefacts could be shown.";
-    case "request_failed":
-      return "Evidence is temporarily unavailable. You can still create a task from this report.";
-    default:
-      return "Evidence is currently unavailable for this signal.";
-  }
+function JudgmentBadges({
+  safetyContent,
+  actionabilityContent,
+}: {
+  safetyContent: Record<string, unknown> | null;
+  actionabilityContent: Record<string, unknown> | null;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const isSafe =
+    safetyContent?.safe === true || safetyContent?.judgment === "safe";
+  const actionabilityJudgment =
+    (actionabilityContent?.judgment as string) ?? "";
+
+  const actionabilityLabel =
+    actionabilityJudgment === "immediately_actionable"
+      ? "Immediately actionable"
+      : actionabilityJudgment === "requires_human_input"
+        ? "Requires human input"
+        : "Not actionable";
+
+  const actionabilityColor =
+    actionabilityJudgment === "immediately_actionable"
+      ? "green"
+      : actionabilityJudgment === "requires_human_input"
+        ? "amber"
+        : "gray";
+
+  return (
+    <Box className="rounded border border-gray-6 bg-gray-1">
+      <button
+        type="button"
+        className="flex w-full cursor-pointer items-center gap-2 rounded border-0 bg-transparent px-3 py-2 text-left hover:bg-gray-2"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <Text
+          size="1"
+          weight="medium"
+          className="shrink-0 text-[11px]"
+          style={{ color: "var(--gray-10)" }}
+        >
+          LLM judgment:
+        </Text>
+        <Flex align="center" gap="1" wrap="wrap" className="flex-1">
+          {safetyContent && (
+            <Badge
+              variant="soft"
+              color={isSafe ? "green" : "red"}
+              size="1"
+              className="text-[11px]"
+            >
+              {isSafe ? <CheckIcon size={10} /> : <WarningIcon size={10} />}
+              <span className="ml-0.5">{isSafe ? "Safe" : "Unsafe"}</span>
+            </Badge>
+          )}
+          {actionabilityContent && (
+            <Badge
+              variant="soft"
+              color={actionabilityColor as "green" | "amber" | "gray"}
+              size="1"
+              className="text-[11px]"
+            >
+              {actionabilityJudgment === "immediately_actionable" ? (
+                <CheckIcon size={10} />
+              ) : actionabilityJudgment === "requires_human_input" ? (
+                <WarningIcon size={10} />
+              ) : (
+                <XIcon size={10} />
+              )}
+              <span className="ml-0.5">{actionabilityLabel}</span>
+            </Badge>
+          )}
+        </Flex>
+        <CaretRightIcon
+          size={14}
+          className="shrink-0 text-gray-9 transition-transform"
+          style={{ transform: expanded ? "rotate(90deg)" : undefined }}
+        />
+      </button>
+      {expanded && (
+        <Flex
+          direction="column"
+          gap="2"
+          px="3"
+          pb="3"
+          className="text-[12px]"
+          style={{ color: "var(--gray-11)" }}
+        >
+          {safetyContent?.explanation ? (
+            <Box>
+              <Text
+                size="1"
+                weight="medium"
+                className="text-[11px]"
+                style={{ color: "var(--gray-10)" }}
+              >
+                Safety
+              </Text>
+              <Text size="1" className="mt-0.5 block text-[12px]">
+                {String(safetyContent.explanation)}
+              </Text>
+            </Box>
+          ) : null}
+          {actionabilityContent?.explanation ? (
+            <Box>
+              <Text
+                size="1"
+                weight="medium"
+                className="text-[11px]"
+                style={{ color: "var(--gray-10)" }}
+              >
+                Actionability
+              </Text>
+              <Text size="1" className="mt-0.5 block text-[12px]">
+                {String(actionabilityContent.explanation)}
+              </Text>
+            </Box>
+          ) : null}
+        </Flex>
+      )}
+    </Box>
+  );
 }
 
 function LoadMoreTrigger({
@@ -203,10 +317,48 @@ function WelcomePane({ onEnableInbox }: { onEnableInbox: () => void }) {
   );
 }
 
+const SOURCE_ICON_MAP: Record<
+  string,
+  { icon: React.ReactNode; color: string; label: string }
+> = {
+  session_replay: {
+    icon: <VideoIcon size={16} />,
+    color: "var(--amber-9)",
+    label: "Session replay",
+  },
+  error_tracking: {
+    icon: <BugIcon size={16} />,
+    color: "var(--red-9)",
+    label: "Error tracking",
+  },
+  llm_analytics: {
+    icon: <BrainIcon size={16} />,
+    color: "var(--purple-9)",
+    label: "LLM analytics",
+  },
+  github: {
+    icon: <GithubLogoIcon size={16} />,
+    color: "var(--gray-11)",
+    label: "GitHub",
+  },
+  linear: {
+    icon: <KanbanIcon size={16} />,
+    color: "var(--blue-9)",
+    label: "Linear",
+  },
+  zendesk: {
+    icon: <TicketIcon size={16} />,
+    color: "var(--green-9)",
+    label: "Zendesk",
+  },
+};
+
 function WarmingUpPane({
   onConfigureSources,
+  enabledProducts,
 }: {
   onConfigureSources: () => void;
+  enabledProducts: string[];
 }) {
   return (
     <Flex
@@ -227,7 +379,6 @@ function WarmingUpPane({
           size="4"
           weight="bold"
           align="center"
-          as="div"
           style={{ color: "var(--gray-12)" }}
         >
           Inbox is warming up
@@ -243,15 +394,24 @@ function WarmingUpPane({
           Reports will appear here as soon as signals come in.
         </Text>
 
-        <Button
-          size="2"
-          variant="soft"
-          color="gray"
-          style={{ marginTop: 16 }}
-          onClick={onConfigureSources}
-        >
-          Configure sources
-        </Button>
+        <Flex align="center" gap="3" style={{ marginTop: 16 }}>
+          {enabledProducts.map((sp) => {
+            const info = SOURCE_ICON_MAP[sp];
+            return info ? (
+              <Tooltip key={sp} content={info.label}>
+                <span style={{ color: info.color }}>{info.icon}</span>
+              </Tooltip>
+            ) : null;
+          })}
+          <Button
+            size="2"
+            variant="soft"
+            color="gray"
+            onClick={onConfigureSources}
+          >
+            Configure sources
+          </Button>
+        </Flex>
       </Flex>
     </Flex>
   );
@@ -300,9 +460,24 @@ export function InboxSignalsTab() {
   const sortDirection = useInboxSignalsFilterStore((s) => s.sortDirection);
   const searchQuery = useInboxSignalsFilterStore((s) => s.searchQuery);
   const statusFilter = useInboxSignalsFilterStore((s) => s.statusFilter);
+  const sourceProductFilter = useInboxSignalsFilterStore(
+    (s) => s.sourceProductFilter,
+  );
   const { data: signalSourceConfigs } = useSignalSourceConfigs();
   const hasSignalSources = signalSourceConfigs?.some((c) => c.enabled) ?? false;
-  const [sourcesDialogOpen, setSourcesDialogOpen] = useState(false);
+  const enabledProducts = useMemo(() => {
+    const seen = new Set<string>();
+    return (signalSourceConfigs ?? [])
+      .filter(
+        (c) =>
+          c.enabled &&
+          !seen.has(c.source_product) &&
+          seen.add(c.source_product),
+      )
+      .map((c) => c.source_product);
+  }, [signalSourceConfigs]);
+  const sourcesDialogOpen = useInboxSourcesDialogStore((s) => s.open);
+  const setSourcesDialogOpen = useInboxSourcesDialogStore((s) => s.setOpen);
 
   const windowFocused = useRendererWindowFocusStore((s) => s.focused);
   const isInboxView = useNavigationStore((s) => s.view.type === "inbox");
@@ -312,8 +487,12 @@ export function InboxSignalsTab() {
     (): SignalReportsQueryParams => ({
       status: buildStatusFilterParam(statusFilter),
       ordering: buildSignalReportListOrdering(sortField, sortDirection),
+      source_product:
+        sourceProductFilter.length > 0
+          ? sourceProductFilter.join(",")
+          : undefined,
     }),
-    [statusFilter, sortField, sortDirection],
+    [statusFilter, sortField, sortDirection, sourceProductFilter],
   );
 
   const {
@@ -381,8 +560,8 @@ export function InboxSignalsTab() {
     enabled: !!selectedReport,
   });
   const allArtefacts = artefactsQuery.data?.results ?? [];
-  const visibleArtefacts = allArtefacts.filter(
-    (a): a is SignalReportArtefact => a.type !== "suggested_reviewers",
+  const videoSegments = allArtefacts.filter(
+    (a): a is SignalReportArtefact => a.type === "video_segment",
   );
   const suggestedReviewers = useMemo(() => {
     const reviewerArtefact = allArtefacts.find(
@@ -390,13 +569,21 @@ export function InboxSignalsTab() {
     );
     return reviewerArtefact?.content ?? [];
   }, [allArtefacts]);
-  const artefactsUnavailableReason = artefactsQuery.data?.unavailableReason;
-  const showArtefactsUnavailable =
-    !artefactsQuery.isLoading &&
-    (!!artefactsQuery.error || !!artefactsUnavailableReason);
-  const artefactsUnavailableMessage = artefactsQuery.error
-    ? "Evidence could not be loaded right now. You can still create a task from this report."
-    : getArtefactsUnavailableMessage(artefactsUnavailableReason);
+  const judgments = useMemo(() => {
+    const safety = allArtefacts.find((a) => a.type === "safety_judgment");
+    const actionability = allArtefacts.find(
+      (a) => a.type === "actionability_judgment",
+    );
+    const safetyContent =
+      safety && !Array.isArray(safety.content)
+        ? (safety.content as unknown as Record<string, unknown>)
+        : null;
+    const actionabilityContent =
+      actionability && !Array.isArray(actionability.content)
+        ? (actionability.content as unknown as Record<string, unknown>)
+        : null;
+    return { safetyContent, actionabilityContent };
+  }, [allArtefacts]);
 
   const signalsQuery = useInboxReportSignals(selectedReport?.id ?? "", {
     enabled: !!selectedReport,
@@ -430,11 +617,11 @@ export function InboxSignalsTab() {
     if (!selectedReport) return null;
     return buildSignalTaskPrompt({
       report: selectedReport,
-      artefacts: visibleArtefacts,
+      artefacts: videoSegments,
       signals,
       replayBaseUrl,
     });
-  }, [selectedReport, visibleArtefacts, signals, replayBaseUrl]);
+  }, [selectedReport, videoSegments, signals, replayBaseUrl]);
 
   const handleCreateTask = () => {
     if (!selectedReport || selectedReport.status !== "ready") {
@@ -527,7 +714,10 @@ export function InboxSignalsTab() {
   // ── Layout mode: full-width empty state vs two-pane ─────────────────────
 
   const hasReports = allReports.length > 0;
-  const showTwoPaneLayout = hasReports || !!searchQuery.trim();
+  const hasActiveFilters =
+    sourceProductFilter.length > 0 || statusFilter.length < 5;
+  const showTwoPaneLayout =
+    hasReports || !!searchQuery.trim() || hasActiveFilters;
 
   // ── Determine right pane content (only used in two-pane mode) ──────────
 
@@ -560,40 +750,38 @@ export function InboxSignalsTab() {
               <XIcon size={14} />
             </button>
           </Flex>
-          <Flex align="center" gap="1" wrap="wrap">
-            <Button
-              size="1"
-              variant="soft"
-              onClick={handleCreateTask}
-              disabled={!canActOnReport}
-              className="text-[12px]"
-            >
-              Create task
-            </Button>
-            {cloudModeEnabled && (
+          <Flex align="center" justify="between" gap="2">
+            <Flex align="center" gap="1">
               <Button
                 size="1"
-                variant="solid"
-                onClick={handleOpenCloudConfirm}
-                disabled={
-                  !canActOnReport ||
-                  isRunningCloudTask ||
-                  repositories.length === 0
-                }
+                variant="soft"
+                onClick={handleCreateTask}
+                disabled={!canActOnReport}
                 className="text-[12px]"
               >
-                <CloudIcon size={12} />
-                {isRunningCloudTask ? "Running..." : "Run cloud"}
+                Pick up task
               </Button>
+              {cloudModeEnabled && (
+                <Button
+                  size="1"
+                  variant="solid"
+                  onClick={handleOpenCloudConfirm}
+                  disabled={
+                    !canActOnReport ||
+                    isRunningCloudTask ||
+                    repositories.length === 0
+                  }
+                  className="text-[12px]"
+                >
+                  <CloudIcon size={12} />
+                  {isRunningCloudTask ? "Running..." : "Run cloud"}
+                </Button>
+              )}
+            </Flex>
+            {selectedReport && (
+              <SignalReportStatusBadge status={selectedReport.status} />
             )}
           </Flex>
-          {!canActOnReport && selectedReport ? (
-            <Text size="1" color="gray" className="text-[11px] leading-snug">
-              {selectedReport.status === "pending_input"
-                ? "This report needs input in PostHog before an agent can act on it."
-                : "Research is still running — you can read context below, then create a task when status is Ready."}
-            </Text>
-          ) : null}
         </Flex>
         <ScrollArea
           type="auto"
@@ -603,20 +791,25 @@ export function InboxSignalsTab() {
         >
           <Flex direction="column" gap="2" p="2" className="min-w-0">
             {/* ── Description ─────────────────────────────────────── */}
-            <SignalReportSummaryMarkdown
-              content={selectedReport.summary}
-              fallback="No summary available."
-              variant="detail"
-            />
-            <Flex align="center" gap="2" wrap="wrap">
-              <SignalReportPriorityBadge priority={selectedReport.priority} />
-              <Badge variant="soft" color="gray" size="1">
-                {selectedReport.signal_count} occurrences
-              </Badge>
-              <Badge variant="soft" color="gray" size="1">
-                {selectedReport.relevant_user_count ?? 0} affected users
-              </Badge>
-            </Flex>
+            {selectedReport.status !== "ready" ? (
+              <Tooltip content="This is a preliminary description. A full researched summary will replace it when the research agent completes its work.">
+                <div className="cursor-help">
+                  <SignalReportSummaryMarkdown
+                    content={selectedReport.summary}
+                    fallback="No summary available."
+                    variant="detail"
+                    pending
+                  />
+                </div>
+              </Tooltip>
+            ) : (
+              <SignalReportSummaryMarkdown
+                content={selectedReport.summary}
+                fallback="No summary available."
+                variant="detail"
+              />
+            )}
+            <SignalReportPriorityBadge priority={selectedReport.priority} />
 
             {suggestedReviewers.length > 0 && (
               <Box>
@@ -630,7 +823,12 @@ export function InboxSignalsTab() {
                 </Text>
                 <Flex direction="column" gap="1">
                   {suggestedReviewers.map((reviewer) => (
-                    <Flex key={reviewer.github_login} align="center" gap="2">
+                    <Flex
+                      key={reviewer.github_login}
+                      align="center"
+                      gap="2"
+                      wrap="wrap"
+                    >
                       <GithubLogoIcon
                         size={14}
                         className="shrink-0 text-gray-10"
@@ -644,10 +842,30 @@ export function InboxSignalsTab() {
                         href={`https://github.com/${reviewer.github_login}`}
                         target="_blank"
                         rel="noreferrer"
-                        className="text-[11px] text-gray-9 hover:text-gray-11"
+                        className="inline-flex items-center gap-0.5 text-[11px] text-gray-9 hover:text-gray-11"
                       >
                         @{reviewer.github_login}
+                        <ArrowSquareOutIcon size={10} />
                       </a>
+                      {reviewer.relevant_commits.length > 0 && (
+                        <span className="text-[11px] text-gray-9">
+                          {reviewer.relevant_commits.map((commit, i) => (
+                            <span key={commit.sha}>
+                              {i > 0 && ", "}
+                              <Tooltip content={commit.reason || undefined}>
+                                <a
+                                  href={commit.url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="font-mono text-gray-9 hover:text-gray-11"
+                                >
+                                  {commit.sha.slice(0, 7)}
+                                </a>
+                              </Tooltip>
+                            </span>
+                          ))}
+                        </span>
+                      )}
                     </Flex>
                   ))}
                 </Flex>
@@ -678,73 +896,65 @@ export function InboxSignalsTab() {
               </Text>
             )}
 
-            {/* ── Evidence ────────────────────────────────────────── */}
-            <Box>
-              <Text
-                size="1"
-                weight="medium"
-                className="block text-[13px]"
-                mb="2"
-              >
-                Evidence
-              </Text>
-              {artefactsQuery.isLoading && (
-                <Text size="1" color="gray" className="block text-[12px]">
-                  Loading evidence...
-                </Text>
-              )}
-              {showArtefactsUnavailable && (
-                <Text size="1" color="gray" className="block text-[12px]">
-                  {artefactsUnavailableMessage}
-                </Text>
-              )}
-              {!artefactsQuery.isLoading &&
-                !showArtefactsUnavailable &&
-                visibleArtefacts.length === 0 && (
-                  <Text size="1" color="gray" className="block text-[12px]">
-                    No artefacts were returned for this signal.
-                  </Text>
-                )}
+            {/* ── LLM judgments ──────────────────────────────────── */}
+            {(judgments.safetyContent || judgments.actionabilityContent) && (
+              <JudgmentBadges
+                safetyContent={judgments.safetyContent}
+                actionabilityContent={judgments.actionabilityContent}
+              />
+            )}
 
-              <Flex direction="column" gap="1">
-                {visibleArtefacts.map((artefact) => (
-                  <Box
-                    key={artefact.id}
-                    className="rounded border border-gray-6 bg-gray-1 p-2"
-                  >
-                    <Text
-                      size="1"
-                      className="whitespace-pre-wrap text-pretty break-words text-[12px]"
+            {/* ── Session segments (video artefacts) ──────────────── */}
+            {videoSegments.length > 0 && (
+              <Box>
+                <Text
+                  size="1"
+                  weight="medium"
+                  className="block text-[13px]"
+                  mb="2"
+                >
+                  Session segments
+                </Text>
+                <Flex direction="column" gap="1">
+                  {videoSegments.map((artefact) => (
+                    <Box
+                      key={artefact.id}
+                      className="rounded border border-gray-6 bg-gray-1 p-2"
                     >
-                      {artefact.content.content}
-                    </Text>
-                    <Flex align="center" justify="between" mt="1" gap="2">
-                      <Flex align="center" gap="1">
-                        <ClockIcon size={12} className="text-gray-9" />
-                        <Text size="1" color="gray" className="text-[12px]">
-                          {artefact.content.start_time
-                            ? new Date(
-                                artefact.content.start_time,
-                              ).toLocaleString()
-                            : "Unknown time"}
-                        </Text>
+                      <Text
+                        size="1"
+                        className="whitespace-pre-wrap text-pretty break-words text-[12px]"
+                      >
+                        {artefact.content.content}
+                      </Text>
+                      <Flex align="center" justify="between" mt="1" gap="2">
+                        <Flex align="center" gap="1">
+                          <ClockIcon size={12} className="text-gray-9" />
+                          <Text size="1" color="gray" className="text-[12px]">
+                            {artefact.content.start_time
+                              ? new Date(
+                                  artefact.content.start_time,
+                                ).toLocaleString()
+                              : "Unknown time"}
+                          </Text>
+                        </Flex>
+                        {replayBaseUrl && artefact.content.session_id && (
+                          <a
+                            href={`${replayBaseUrl}/${artefact.content.session_id}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 text-[12px] text-gray-11 hover:text-gray-12"
+                          >
+                            View replay
+                            <ArrowSquareOutIcon size={12} />
+                          </a>
+                        )}
                       </Flex>
-                      {replayBaseUrl && artefact.content.session_id && (
-                        <a
-                          href={`${replayBaseUrl}/${artefact.content.session_id}`}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center gap-1 text-[12px] text-gray-11 hover:text-gray-12"
-                        >
-                          View replay
-                          <ArrowSquareOutIcon size={12} />
-                        </a>
-                      )}
-                    </Flex>
-                  </Box>
-                ))}
-              </Flex>
-            </Box>
+                    </Box>
+                  ))}
+                </Flex>
+              </Box>
+            )}
           </Flex>
         </ScrollArea>
         {/* ── Research task logs (bottom preview + overlay) ─────── */}
@@ -810,7 +1020,15 @@ export function InboxSignalsTab() {
     leftPaneList = (
       <Flex direction="column" align="center" justify="center" gap="2" py="6">
         <Text size="1" color="gray" className="text-[12px]">
-          No matching signals
+          No matching reports
+        </Text>
+      </Flex>
+    );
+  } else if (reports.length === 0 && hasActiveFilters) {
+    leftPaneList = (
+      <Flex direction="column" align="center" justify="center" gap="2" py="6">
+        <Text size="1" color="gray" className="text-[12px]">
+          No reports match current filters
         </Text>
       </Flex>
     );
@@ -883,7 +1101,6 @@ export function InboxSignalsTab() {
               style={{ height: "100%" }}
             >
               <Flex direction="column">
-                <InboxLiveRail active={inboxPollingActive} />
                 <SignalsToolbar
                   totalCount={totalCount}
                   filteredCount={reports.length}
@@ -935,6 +1152,7 @@ export function InboxSignalsTab() {
               filteredCount={0}
               isSearchActive={false}
               searchDisabledReason={searchDisabledReason}
+              hideFilters
             />
             {skeletonBackdrop}
           </Flex>
@@ -954,6 +1172,7 @@ export function InboxSignalsTab() {
             ) : (
               <WarmingUpPane
                 onConfigureSources={() => setSourcesDialogOpen(true)}
+                enabledProducts={enabledProducts}
               />
             )}
           </Box>

--- a/apps/code/src/renderer/features/inbox/components/InboxView.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxView.tsx
@@ -1,4 +1,4 @@
-import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
+import { useInboxSourcesDialogStore } from "@features/inbox/stores/inboxSourcesDialogStore";
 import { useSetHeaderContent } from "@hooks/useSetHeaderContent";
 import { EnvelopeSimpleIcon, GearSixIcon } from "@phosphor-icons/react";
 import { Box, Flex, Text } from "@radix-ui/themes";
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { InboxSignalsTab } from "./InboxSignalsTab";
 
 export function InboxView() {
-  const openSettings = useSettingsDialogStore((s) => s.open);
+  const openSourcesDialog = useInboxSourcesDialogStore((s) => s.setOpen);
 
   const headerContent = useMemo(
     () => (
@@ -22,15 +22,15 @@ export function InboxView() {
         </Text>
         <button
           type="button"
-          onClick={() => openSettings("signals")}
+          onClick={() => openSourcesDialog(true)}
           className="no-drag ml-auto flex cursor-pointer items-center gap-1 border-0 bg-transparent p-0 text-[12px] text-gray-10 transition-colors hover:text-gray-12"
         >
           <GearSixIcon size={12} />
-          <span>Configure signals</span>
+          <span>Configure sources</span>
         </button>
       </Flex>
     ),
-    [openSettings],
+    [openSourcesDialog],
   );
 
   useSetHeaderContent(headerContent);

--- a/apps/code/src/renderer/features/inbox/components/ReportCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/ReportCard.tsx
@@ -1,14 +1,32 @@
 import { SignalReportPriorityBadge } from "@features/inbox/components/SignalReportPriorityBadge";
+import { SignalReportStatusBadge } from "@features/inbox/components/SignalReportStatusBadge";
 import { SignalReportSummaryMarkdown } from "@features/inbox/components/SignalReportSummaryMarkdown";
+import { inboxStatusAccentCss } from "@features/inbox/utils/inboxSort";
 import {
-  inboxStatusAccentCss,
-  inboxStatusLabel,
-} from "@features/inbox/utils/inboxSort";
-import { UserIcon } from "@phosphor-icons/react";
+  BrainIcon,
+  BugIcon,
+  EyeIcon,
+  GithubLogoIcon,
+  KanbanIcon,
+  TicketIcon,
+  VideoIcon,
+} from "@phosphor-icons/react";
 import { Flex, Text, Tooltip } from "@radix-ui/themes";
 import type { SignalReport } from "@shared/types";
 import { motion } from "framer-motion";
 import type { KeyboardEvent, MouseEvent } from "react";
+
+const SOURCE_PRODUCT_ICONS: Record<
+  string,
+  { icon: React.ReactNode; color: string }
+> = {
+  session_replay: { icon: <VideoIcon size={12} />, color: "var(--amber-9)" },
+  error_tracking: { icon: <BugIcon size={12} />, color: "var(--red-9)" },
+  llm_analytics: { icon: <BrainIcon size={12} />, color: "var(--purple-9)" },
+  github: { icon: <GithubLogoIcon size={12} />, color: "var(--gray-11)" },
+  linear: { icon: <KanbanIcon size={12} />, color: "var(--blue-9)" },
+  zendesk: { icon: <TicketIcon size={12} />, color: "var(--green-9)" },
+};
 
 interface ReportCardProps {
   report: SignalReport;
@@ -45,7 +63,6 @@ export function ReportCard({
       : "light";
 
   const accent = inboxStatusAccentCss(report.status);
-  const statusLabel = inboxStatusLabel(report.status);
   const isReady = report.status === "ready";
 
   const handleActivate = (e: MouseEvent | KeyboardEvent): void => {
@@ -75,26 +92,43 @@ export function ReportCard({
       }}
       className="w-full cursor-pointer overflow-hidden border-gray-5 border-b py-2 pr-3 pl-2 text-left transition-colors hover:bg-gray-2"
       style={{
-        backgroundColor: isSelected ? "var(--gray-3)" : "transparent",
+        backgroundColor: isSelected
+          ? "var(--gray-3)"
+          : report.is_suggested_reviewer
+            ? "var(--blue-2)"
+            : "transparent",
         boxShadow: `inset 3px 0 0 0 ${accent}`,
       }}
     >
       <Flex align="start" justify="between" gap="3">
         <Flex direction="column" gap="1" style={{ minWidth: 0, flex: 1 }}>
-          {/* Bullet stays in its own column so title + badges wrap under each other, not under the dot */}
-          <Flex align="center" gapX="2" className="min-w-0">
-            <span
-              title={`Signal strength: ${strengthLabel}`}
-              aria-hidden
-              className="shrink-0"
-              style={{
-                width: "6px",
-                height: "6px",
-                borderRadius: "9999px",
-                backgroundColor: strengthColor,
-                display: "inline-block",
-              }}
-            />
+          <Flex align="start" gapX="2" className="min-w-0">
+            {/* Source product icons — pt-1 (4px) centers 12px icons
+               with the title's 13px/~20px effective line height */}
+            <Flex
+              direction="column"
+              align="center"
+              gap="0.5"
+              className="shrink-0 pt-1"
+            >
+              {(report.source_products ?? []).length > 0 ? (
+                (report.source_products ?? []).map((sp) => {
+                  const info = SOURCE_PRODUCT_ICONS[sp];
+                  return info ? (
+                    <span key={sp} style={{ color: info.color }}>
+                      {info.icon}
+                    </span>
+                  ) : null;
+                })
+              ) : (
+                <span
+                  title={`Signal strength: ${strengthLabel}`}
+                  aria-hidden
+                  className="mt-1 inline-block h-1.5 w-1.5 rounded-full"
+                  style={{ backgroundColor: strengthColor }}
+                />
+              )}
+            </Flex>
             <Flex
               align="center"
               gapX="2"
@@ -108,16 +142,7 @@ export function ReportCard({
               >
                 {report.title ?? "Untitled signal"}
               </Text>
-              <span
-                className="shrink-0 rounded-sm px-1 py-px text-[9px] uppercase tracking-wider"
-                style={{
-                  color: accent,
-                  backgroundColor: isReady ? "var(--green-3)" : "var(--gray-3)",
-                  border: `1px solid ${isReady ? "var(--green-6)" : "var(--gray-6)"}`,
-                }}
-              >
-                {statusLabel}
-              </span>
+              <SignalReportStatusBadge status={report.status} />
               <SignalReportPriorityBadge priority={report.priority} />
               {report.is_suggested_reviewer && (
                 <Tooltip content="You are a suggested reviewer">
@@ -129,21 +154,19 @@ export function ReportCard({
                       border: "1px solid var(--blue-6)",
                     }}
                   >
-                    <UserIcon size={10} weight="bold" />
+                    <EyeIcon size={10} weight="bold" />
                   </span>
                 </Tooltip>
               )}
             </Flex>
           </Flex>
           {/* Summary is outside the title row so wrapped lines align with title text (bullet + gap), not the card edge */}
-          <div
-            className="min-w-0 pl-[calc(6px+var(--space-2))]"
-            style={{ opacity: isReady ? 1 : 0.82 }}
-          >
+          <div className="min-w-0 pl-4" style={{ opacity: isReady ? 1 : 0.82 }}>
             <SignalReportSummaryMarkdown
               content={report.summary}
               fallback="No summary yet — still collecting context."
               variant="list"
+              pending={!isReady}
             />
           </div>
         </Flex>

--- a/apps/code/src/renderer/features/inbox/components/ReportTaskLogs.tsx
+++ b/apps/code/src/renderer/features/inbox/components/ReportTaskLogs.tsx
@@ -6,7 +6,7 @@ import {
   CircleNotchIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
-import { Flex, Spinner, Text } from "@radix-ui/themes";
+import { Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
 import type { SignalReportStatus, Task } from "@shared/types";
 import { useState } from "react";
 
@@ -86,6 +86,7 @@ export function ReportTaskLogs({
   const showBar =
     isLoading ||
     !!task ||
+    reportStatus === "candidate" ||
     reportStatus === "in_progress" ||
     reportStatus === "ready";
 
@@ -95,8 +96,27 @@ export function ReportTaskLogs({
 
   const hasTask = !isLoading && !!task;
 
-  // No task — simple in-flow status bar
+  // No task yet — show pipeline status with tooltip explaining what's happening
   if (!hasTask) {
+    let statusText: string;
+    let tooltipText: string;
+    if (isLoading) {
+      statusText = "Loading task…";
+      tooltipText = "Checking if a research task exists for this report.";
+    } else if (reportStatus === "candidate") {
+      statusText = "Queued for research";
+      tooltipText =
+        "This report has been queued. A repository will be selected and then an AI agent will research it.";
+    } else if (reportStatus === "in_progress") {
+      statusText = "Research is starting…";
+      tooltipText =
+        "An AI research agent is being set up. Logs will appear here once the agent starts running.";
+    } else {
+      statusText = "Waiting for research task";
+      tooltipText =
+        "No research task has been created yet. One will appear when the report is picked up for investigation.";
+    }
+
     return (
       <Flex
         align="center"
@@ -106,14 +126,14 @@ export function ReportTaskLogs({
         className="shrink-0 border-gray-5 border-t"
         style={{ height: BAR_HEIGHT }}
       >
-        <Spinner size="1" />
-        <Text size="1" color="gray" className="text-[12px]">
-          {isLoading
-            ? "Loading task…"
-            : reportStatus === "in_progress"
-              ? "Research is running…"
-              : "No research task yet."}
-        </Text>
+        <Tooltip content={tooltipText}>
+          <Flex align="center" gap="2" className="cursor-help">
+            <Spinner size="1" />
+            <Text size="1" color="gray" className="text-[12px]">
+              {statusText}
+            </Text>
+          </Flex>
+        </Tooltip>
       </Flex>
     );
   }

--- a/apps/code/src/renderer/features/inbox/components/SignalCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalCard.tsx
@@ -1,3 +1,4 @@
+import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
 import {
   ArrowSquareOutIcon,
   BrainIcon,
@@ -143,7 +144,20 @@ function truncateBody(body: string, maxLength = COLLAPSE_THRESHOLD): string {
   const truncated = body.slice(0, maxLength);
   const lastNewline = truncated.lastIndexOf("\n");
   const cutPoint = lastNewline > maxLength * 0.5 ? lastNewline : maxLength;
-  return `${truncated.slice(0, cutPoint)}…`;
+  let result = truncated.slice(0, cutPoint);
+  // Close any open code fences so markdown renders cleanly
+  const fenceCount = (result.match(/^```/gm) || []).length;
+  if (fenceCount % 2 !== 0) {
+    // Trim trailing partial fence line (e.g. just "```" with no content after)
+    const lastFence = result.lastIndexOf("```");
+    const afterFence = result.slice(lastFence + 3).trim();
+    if (!afterFence) {
+      result = result.slice(0, lastFence).trimEnd();
+    } else {
+      result += "\n```";
+    }
+  }
+  return `${result}\n\n…`;
 }
 
 function parseExtra(raw: Record<string, unknown>): Record<string, unknown> {
@@ -225,16 +239,16 @@ function SignalCardHeader({ signal }: { signal: Signal }) {
 function CollapsibleBody({ body }: { body: string }) {
   const [expanded, setExpanded] = useState(false);
   const isLong = body.length > COLLAPSE_THRESHOLD;
+  const displayBody = isLong && !expanded ? truncateBody(body) : body;
 
   return (
     <Box>
-      <Text
-        size="1"
-        color="gray"
-        className="whitespace-pre-wrap text-pretty break-words text-[11px] leading-relaxed"
+      <Box
+        className="text-pretty break-words text-[11px] leading-relaxed [&_code]:text-[10px] [&_p:last-child]:mb-0 [&_p]:mb-1 [&_pre]:text-[10px]"
+        style={{ color: "var(--gray-11)" }}
       >
-        {isLong && !expanded ? truncateBody(body) : body}
-      </Text>
+        <MarkdownRenderer content={displayBody} />
+      </Box>
       {isLong && (
         <button
           type="button"
@@ -429,8 +443,6 @@ function ErrorTrackingSignalCard({
   extra: ErrorTrackingExtra;
 }) {
   const fingerprint = extra.fingerprint ?? "";
-  const fingerprintShort =
-    fingerprint.length > 14 ? `${fingerprint.slice(0, 14)}…` : fingerprint;
 
   return (
     <Box className="min-w-0 overflow-hidden rounded-lg border border-gray-6 bg-gray-1 p-3">
@@ -454,11 +466,10 @@ function ErrorTrackingSignalCard({
           <span>
             Fingerprint{" "}
             <span
-              className="font-mono"
+              className="break-all font-mono"
               style={{ color: "var(--gray-12)" }}
-              title={fingerprint}
             >
-              {fingerprintShort}
+              {fingerprint}
             </span>
           </span>
         </Flex>

--- a/apps/code/src/renderer/features/inbox/components/SignalReportStatusBadge.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalReportStatusBadge.tsx
@@ -1,0 +1,51 @@
+import {
+  inboxStatusBgCss,
+  inboxStatusBorderCss,
+  inboxStatusLabel,
+  inboxStatusTextCss,
+} from "@features/inbox/utils/inboxSort";
+import { Tooltip } from "@radix-ui/themes";
+import type { SignalReportStatus } from "@shared/types";
+
+const STATUS_TOOLTIPS: Record<string, string> = {
+  ready: "Research is complete. You can create a task from this report.",
+  pending_input:
+    "This report needs human input in PostHog before it can proceed.",
+  in_progress: "An AI agent is actively researching this report's signals.",
+  candidate: "Queued for research. An agent will pick this up shortly.",
+  potential:
+    "Gathering signals. The report will be queued once enough signals accumulate.",
+  failed: "Research failed. The report may be retried automatically.",
+  suppressed: "This report has been dismissed.",
+  deleted: "This report has been deleted.",
+};
+
+interface SignalReportStatusBadgeProps {
+  status: SignalReportStatus;
+}
+
+export function SignalReportStatusBadge({
+  status,
+}: SignalReportStatusBadgeProps) {
+  const label = inboxStatusLabel(status);
+  const textColor = inboxStatusTextCss(status);
+  const tooltip = STATUS_TOOLTIPS[status] ?? status;
+
+  const bgColor = inboxStatusBgCss(status);
+  const borderColor = inboxStatusBorderCss(status);
+
+  return (
+    <Tooltip content={tooltip}>
+      <span
+        className="shrink-0 cursor-help rounded-sm px-1 py-px text-[9px] uppercase tracking-wider"
+        style={{
+          color: textColor,
+          backgroundColor: bgColor,
+          border: `1px solid ${borderColor}`,
+        }}
+      >
+        {label}
+      </span>
+    </Tooltip>
+  );
+}

--- a/apps/code/src/renderer/features/inbox/components/SignalReportSummaryMarkdown.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalReportSummaryMarkdown.tsx
@@ -7,6 +7,8 @@ interface SignalReportSummaryMarkdownProps {
   fallback: string;
   /** List rows: clamp lines and tighter spacing. Detail: full block markdown. */
   variant: "list" | "detail";
+  /** Render in italic to indicate the summary is still being written. */
+  pending?: boolean;
 }
 
 /**
@@ -16,14 +18,17 @@ export function SignalReportSummaryMarkdown({
   content,
   fallback,
   variant,
+  pending,
 }: SignalReportSummaryMarkdownProps) {
   const raw = content?.trim() ? content : fallback;
+
+  const italicStyle = pending ? { fontStyle: "italic" as const } : undefined;
 
   if (variant === "list") {
     return (
       <Box
         className="[&_.rt-Text]:!mb-0 [&_p]:!mb-0 [&_ul]:!mb-0 min-w-0 text-left [&_li]:mb-0"
-        style={{ color: "var(--gray-11)" }}
+        style={{ color: "var(--gray-11)", ...italicStyle }}
       >
         <div className="line-clamp-2 overflow-hidden text-[12px] leading-snug [&_a]:pointer-events-auto">
           <MarkdownRenderer content={raw} />
@@ -35,7 +40,7 @@ export function SignalReportSummaryMarkdown({
   return (
     <Box
       className="min-w-0 text-pretty break-words [&_.rt-Text]:mb-2 [&_li]:mb-1 [&_p:last-child]:mb-0"
-      style={{ color: "var(--gray-11)" }}
+      style={{ color: "var(--gray-11)", ...italicStyle }}
     >
       <div className="text-[12px] leading-relaxed [&_a]:pointer-events-auto">
         <MarkdownRenderer content={raw} />

--- a/apps/code/src/renderer/features/inbox/components/SignalsToolbar.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalsToolbar.tsx
@@ -1,16 +1,25 @@
-import { useInboxSignalsFilterStore } from "@features/inbox/stores/inboxSignalsFilterStore";
+import {
+  type SourceProduct,
+  useInboxSignalsFilterStore,
+} from "@features/inbox/stores/inboxSignalsFilterStore";
 import {
   inboxStatusAccentCss,
   inboxStatusLabel,
 } from "@features/inbox/utils/inboxSort";
 import {
+  BrainIcon,
+  BugIcon,
   CalendarPlus,
   Check,
   Clock,
   FunnelSimple as FunnelSimpleIcon,
+  GithubLogoIcon,
+  KanbanIcon,
   ListNumbers,
   MagnifyingGlass,
+  TicketIcon,
   TrendUp,
+  VideoIcon,
 } from "@phosphor-icons/react";
 import { Box, Flex, Popover, Text, TextField, Tooltip } from "@radix-ui/themes";
 import type {
@@ -26,6 +35,7 @@ interface SignalsToolbarProps {
   readyCount?: number;
   processingCount?: number;
   searchDisabledReason?: string | null;
+  hideFilters?: boolean;
 }
 
 type SortOption = {
@@ -81,6 +91,7 @@ export function SignalsToolbar({
   readyCount,
   processingCount = 0,
   searchDisabledReason,
+  hideFilters,
 }: SignalsToolbarProps) {
   const searchQuery = useInboxSignalsFilterStore((s) => s.searchQuery);
   const setSearchQuery = useInboxSignalsFilterStore((s) => s.setSearchQuery);
@@ -89,6 +100,12 @@ export function SignalsToolbar({
   const setSort = useInboxSignalsFilterStore((s) => s.setSort);
   const statusFilter = useInboxSignalsFilterStore((s) => s.statusFilter);
   const toggleStatus = useInboxSignalsFilterStore((s) => s.toggleStatus);
+  const sourceProductFilter = useInboxSignalsFilterStore(
+    (s) => s.sourceProductFilter,
+  );
+  const toggleSourceProduct = useInboxSignalsFilterStore(
+    (s) => s.toggleSourceProduct,
+  );
 
   const countLabel = isSearchActive
     ? `${filteredCount} of ${totalCount}`
@@ -108,37 +125,41 @@ export function SignalsToolbar({
       style={{ borderBottom: "1px solid var(--gray-5)" }}
     >
       <Flex align="center" justify="between" gap="2">
-        <Flex align="center" gap="2" className="min-w-0">
-          {livePolling ? (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full"
-              style={{
-                backgroundColor: "var(--amber-9)",
-                boxShadow: "0 0 10px var(--amber-9)",
-                animation: "inboxToolbarPulse 1.4s ease-in-out infinite",
-              }}
-              title="Watching for new and updated reports"
-              aria-hidden
-            />
-          ) : null}
-          <Flex direction="column" gap="0" className="min-w-0">
+        <Flex direction="column" gap="0" className="min-w-0">
+          <Flex align="center" gap="2">
             <Text size="1" color="gray" className="shrink-0 text-[12px]">
-              Signals ({countLabel})
+              Reports ({countLabel})
             </Text>
-            {pipelineHint && !isSearchActive ? (
-              <Text size="1" color="gray" className="text-[11px] opacity-80">
-                {pipelineHint}
-              </Text>
+            {livePolling ? (
+              <span
+                className="h-1.5 w-1.5 shrink-0 rounded-full"
+                style={{
+                  backgroundColor: "var(--red-9)",
+                  boxShadow: "0 0 8px var(--red-9)",
+                  animation: "inboxToolbarPulse 1.4s ease-in-out infinite",
+                }}
+                title="Watching for new and updated reports"
+                aria-hidden
+              />
             ) : null}
           </Flex>
+          {pipelineHint && !isSearchActive ? (
+            <Text size="1" color="gray" className="text-[11px] opacity-80">
+              {pipelineHint}
+            </Text>
+          ) : null}
         </Flex>
-        <FilterSortMenu
-          sortField={sortField}
-          sortDirection={sortDirection}
-          onSort={setSort}
-          statusFilter={statusFilter}
-          onToggleStatus={toggleStatus}
-        />
+        {!hideFilters && (
+          <FilterSortMenu
+            sortField={sortField}
+            sortDirection={sortDirection}
+            onSort={setSort}
+            statusFilter={statusFilter}
+            onToggleStatus={toggleStatus}
+            sourceProductFilter={sourceProductFilter}
+            onToggleSourceProduct={toggleSourceProduct}
+          />
+        )}
       </Flex>
       <Tooltip content={searchDisabledReason} hidden={!searchDisabledReason}>
         <TextField.Root
@@ -158,12 +179,39 @@ export function SignalsToolbar({
   );
 }
 
+const SOURCE_PRODUCT_OPTIONS: {
+  value: SourceProduct;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    value: "session_replay",
+    label: "Session replay",
+    icon: <VideoIcon size={14} />,
+  },
+  {
+    value: "error_tracking",
+    label: "Error tracking",
+    icon: <BugIcon size={14} />,
+  },
+  {
+    value: "llm_analytics",
+    label: "LLM analytics",
+    icon: <BrainIcon size={14} />,
+  },
+  { value: "github", label: "GitHub", icon: <GithubLogoIcon size={14} /> },
+  { value: "linear", label: "Linear", icon: <KanbanIcon size={14} /> },
+  { value: "zendesk", label: "Zendesk", icon: <TicketIcon size={14} /> },
+];
+
 function FilterSortMenu({
   sortField,
   sortDirection,
   onSort,
   statusFilter,
   onToggleStatus,
+  sourceProductFilter,
+  onToggleSourceProduct,
 }: {
   sortField: string;
   sortDirection: string;
@@ -173,6 +221,8 @@ function FilterSortMenu({
   ) => void;
   statusFilter: SignalReportStatus[];
   onToggleStatus: (status: SignalReportStatus) => void;
+  sourceProductFilter: SourceProduct[];
+  onToggleSourceProduct: (source: SourceProduct) => void;
 }) {
   const itemClassName =
     "flex w-full items-center justify-between rounded-sm px-1 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-gray-3";
@@ -255,6 +305,36 @@ function FilterSortMenu({
                       <span className="text-gray-12">
                         {inboxStatusLabel(status)}
                       </span>
+                    </span>
+                    {isActive && <Check size={12} className="text-gray-12" />}
+                  </button>
+                );
+              })}
+            </Box>
+          </Box>
+
+          <Box>
+            <Text
+              size="1"
+              className="text-gray-10"
+              weight="medium"
+              style={{ paddingLeft: "1px" }}
+            >
+              Source
+            </Text>
+            <Box mt="1">
+              {SOURCE_PRODUCT_OPTIONS.map((option) => {
+                const isActive = sourceProductFilter.includes(option.value);
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={itemClassName}
+                    onClick={() => onToggleSourceProduct(option.value)}
+                  >
+                    <span className="flex items-center gap-1 text-gray-12">
+                      {option.icon}
+                      <span>{option.label}</span>
                     </span>
                     {isActive && <Check size={12} className="text-gray-12" />}
                   </button>

--- a/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -12,6 +12,14 @@ type SignalSortField = Extract<
 
 type SignalSortDirection = "asc" | "desc";
 
+export type SourceProduct =
+  | "session_replay"
+  | "error_tracking"
+  | "llm_analytics"
+  | "github"
+  | "linear"
+  | "zendesk";
+
 const DEFAULT_STATUS_FILTER: SignalReportStatus[] = [
   "ready",
   "pending_input",
@@ -25,6 +33,8 @@ interface InboxSignalsFilterState {
   sortDirection: SignalSortDirection;
   searchQuery: string;
   statusFilter: SignalReportStatus[];
+  /** Empty array means "all sources" (no filter). */
+  sourceProductFilter: SourceProduct[];
 }
 
 interface InboxSignalsFilterActions {
@@ -32,6 +42,7 @@ interface InboxSignalsFilterActions {
   setSearchQuery: (query: string) => void;
   setStatusFilter: (statuses: SignalReportStatus[]) => void;
   toggleStatus: (status: SignalReportStatus) => void;
+  toggleSourceProduct: (source: SourceProduct) => void;
 }
 
 type InboxSignalsFilterStore = InboxSignalsFilterState &
@@ -44,6 +55,7 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
       sortDirection: "asc",
       searchQuery: "",
       statusFilter: DEFAULT_STATUS_FILTER,
+      sourceProductFilter: [],
       setSort: (sortField, sortDirection) => set({ sortField, sortDirection }),
       setSearchQuery: (searchQuery) => set({ searchQuery }),
       setStatusFilter: (statusFilter) => set({ statusFilter }),
@@ -55,6 +67,14 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
             : [...current, status];
           return { statusFilter: next.length > 0 ? next : current };
         }),
+      toggleSourceProduct: (source) =>
+        set((state) => {
+          const current = state.sourceProductFilter;
+          const next = current.includes(source)
+            ? current.filter((s) => s !== source)
+            : [...current, source];
+          return { sourceProductFilter: next };
+        }),
     }),
     {
       name: "inbox-signals-filter-storage",
@@ -62,6 +82,7 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
         sortField: state.sortField,
         sortDirection: state.sortDirection,
         statusFilter: state.statusFilter,
+        sourceProductFilter: state.sourceProductFilter,
       }),
     },
   ),

--- a/apps/code/src/renderer/features/inbox/stores/inboxSourcesDialogStore.ts
+++ b/apps/code/src/renderer/features/inbox/stores/inboxSourcesDialogStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface InboxSourcesDialogStore {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export const useInboxSourcesDialogStore = create<InboxSourcesDialogStore>()(
+  (set) => ({
+    open: false,
+    setOpen: (open) => set({ open }),
+  }),
+);

--- a/apps/code/src/renderer/features/inbox/utils/inboxSort.ts
+++ b/apps/code/src/renderer/features/inbox/utils/inboxSort.ts
@@ -41,3 +41,57 @@ export function inboxStatusAccentCss(status: SignalReportStatus): string {
       return "var(--gray-8)";
   }
 }
+
+/** Higher-contrast text color for status badges (step 11 instead of 9). */
+export function inboxStatusTextCss(status: SignalReportStatus): string {
+  switch (status) {
+    case "ready":
+      return "var(--green-11)";
+    case "pending_input":
+      return "var(--violet-11)";
+    case "in_progress":
+      return "var(--amber-11)";
+    case "candidate":
+      return "var(--cyan-11)";
+    case "potential":
+      return "var(--gray-11)";
+    case "failed":
+      return "var(--red-11)";
+    default:
+      return "var(--gray-11)";
+  }
+}
+
+export function inboxStatusBgCss(status: SignalReportStatus): string {
+  switch (status) {
+    case "ready":
+      return "var(--green-3)";
+    case "pending_input":
+      return "var(--violet-3)";
+    case "in_progress":
+      return "var(--amber-3)";
+    case "candidate":
+      return "var(--cyan-3)";
+    case "failed":
+      return "var(--red-3)";
+    default:
+      return "var(--gray-3)";
+  }
+}
+
+export function inboxStatusBorderCss(status: SignalReportStatus): string {
+  switch (status) {
+    case "ready":
+      return "var(--green-6)";
+    case "pending_input":
+      return "var(--violet-6)";
+    case "in_progress":
+      return "var(--amber-6)";
+    case "candidate":
+      return "var(--cyan-6)";
+    case "failed":
+      return "var(--red-6)";
+    default:
+      return "var(--gray-6)";
+  }
+}

--- a/apps/code/src/shared/types.ts
+++ b/apps/code/src/shared/types.ts
@@ -192,6 +192,8 @@ export interface SignalReport {
   priority?: SignalReportPriority | null;
   /** Whether the current user is a suggested reviewer for this report (server-annotated). */
   is_suggested_reviewer?: boolean;
+  /** Distinct source products contributing signals to this report (e.g. "session_replay", "error_tracking"). */
+  source_products?: string[];
 }
 
 export interface SignalReportArtefactContent {
@@ -300,4 +302,6 @@ export interface SignalReportsQueryParams {
    * `created_at`, `updated_at`, `id`. Example: `status,-total_weight`.
    */
   ordering?: string;
+  /** Comma-separated source products — only returns reports with signals from these sources. */
+  source_product?: string;
 }


### PR DESCRIPTION
## Problem

No way to filter inbox reports by signal source - you see all reports regardless of whether they came from session replay, error tracking, GitHub issues, etc.

## Changes

Adding "Source" multi-select in the toolbar filter popover (session replay, error tracking, LLM analytics, GitHub, Linear, Zendesk).

Backend support (in posthog/ `sig/add-signal-report-task` branch) queries ClickHouse `document_embeddings` for report IDs that have signals from the requested source products, then filters the PostgreSQL queryset by those IDs.