### PR TITLE
Fix git diff to compare against HEAD instead of working directory

### DIFF
--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -499,8 +499,9 @@ export async function getChangedFilesDetailed(
               continue;
             }
             try {
-              const unstaged = await git.diff([file]);
-              const lines = unstaged.split("\n");
+              const headDiff = await git.diff(["HEAD", "--", file]);
+              if (!headDiff.trim()) continue;
+              const lines = headDiff.split("\n");
               const linesAdded = lines.filter(
                 (l) => l.startsWith("+") && !l.startsWith("+++"),
               ).length;
@@ -525,6 +526,10 @@ export async function getChangedFilesDetailed(
             ) {
               continue;
             }
+            try {
+              const headDiff = await git.diff(["HEAD", "--", file]);
+              if (!headDiff.trim()) continue;
+            } catch {}
             files.push({
               path: file,
               status: "deleted",


### PR DESCRIPTION
## TL;DR

Changed git diff operations to compare against HEAD instead of the working directory, ensuring we correctly identify staged vs unstaged file changes.

## What changed?

- Modified `getChangedFilesDetailed` function in `packages/git/src/queries.ts` to use `git.diff(["HEAD", "--", file])` instead of `git.diff([file])`
- Added checks to skip files when the diff against HEAD is empty (indicating no changes relative to HEAD)
- Applied this change to both the unstaged changes section and deleted files section of the diff logic
- Wrapped the HEAD diff check in a try-catch block for the deleted files case to handle potential errors gracefully

## How did you test this?

Unable to verify testing details from the provided information.