### PR TITLE
Add staged file tracking and selective commit support

### DIFF
--- a/apps/code/src/main/services/git/create-pr-saga.ts
+++ b/apps/code/src/main/services/git/create-pr-saga.ts
@@ -17,6 +17,7 @@ export interface CreatePrSagaInput {
   prTitle?: string;
   prBody?: string;
   draft?: boolean;
+  stagedOnly?: boolean;
 }
 
 export interface CreatePrSagaOutput {
@@ -32,7 +33,11 @@ export interface CreatePrDeps {
   ): Promise<{ previousBranch: string; currentBranch: string }>;
   getChangedFilesHead(dir: string): Promise<ChangedFile[]>;
   generateCommitMessage(dir: string): Promise<{ message: string }>;
-  commit(dir: string, message: string): Promise<CommitOutput>;
+  commit(
+    dir: string,
+    message: string,
+    stagedOnly?: boolean,
+  ): Promise<CommitOutput>;
   getSyncStatus(dir: string): Promise<GitSyncStatus>;
   push(dir: string): Promise<PushOutput>;
   publish(dir: string): Promise<PublishOutput>;
@@ -123,7 +128,11 @@ export class CreatePrSaga extends Saga<CreatePrSagaInput, CreatePrSagaOutput> {
       await this.step({
         name: "committing",
         execute: async () => {
-          const result = await this.deps.commit(directoryPath, commitMessage!);
+          const result = await this.deps.commit(
+            directoryPath,
+            commitMessage!,
+            input.stagedOnly,
+          );
           if (!result.success) throw new Error(result.message);
           return result;
         },

--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -21,6 +21,7 @@ export const changedFileSchema = z.object({
   originalPath: z.string().optional(),
   linesAdded: z.number().optional(),
   linesRemoved: z.number().optional(),
+  staged: z.boolean().optional(),
 });
 
 export type ChangedFile = z.infer<typeof changedFileSchema>;
@@ -120,16 +121,22 @@ export const getFileAtHeadInput = z.object({
 });
 export const getFileAtHeadOutput = z.string().nullable();
 
-// getDiffHead schemas
-export const getDiffHeadInput = z.object({
+// Shared diff schemas (getDiffHead, getDiffCached, getDiffUnstaged)
+export const diffInput = z.object({
   directoryPath: z.string(),
   ignoreWhitespace: z.boolean().optional(),
 });
-export const getDiffHeadOutput = z.string();
+export const diffOutput = z.string();
 
 // getDiffStats schemas
 export const getDiffStatsInput = directoryPathInput;
 export const getDiffStatsOutput = diffStatsSchema;
+
+// stageFiles / unstageFiles shared schema
+export const stageFilesInput = z.object({
+  directoryPath: z.string(),
+  paths: z.array(z.string()),
+});
 
 // getCurrentBranch schemas
 export const getCurrentBranchInput = directoryPathInput;
@@ -198,6 +205,7 @@ export const commitInput = z.object({
   message: z.string(),
   paths: z.array(z.string()).optional(),
   allowEmpty: z.boolean().optional(),
+  stagedOnly: z.boolean().optional(),
 });
 
 export type CommitInput = z.infer<typeof commitInput>;
@@ -241,6 +249,7 @@ export const createPrInput = z.object({
   prTitle: z.string().optional(),
   prBody: z.string().optional(),
   draft: z.boolean().optional(),
+  stagedOnly: z.boolean().optional(),
 });
 
 export type CreatePrInput = z.infer<typeof createPrInput>;

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -19,6 +19,8 @@ import {
   getUnstagedDiff,
   fetch as gitFetch,
   isGitRepository,
+  stageFiles,
+  unstageFiles,
 } from "@posthog/git/queries";
 import { CreateBranchSaga, SwitchBranchSaga } from "@posthog/git/sagas/branch";
 import { CloneSaga } from "@posthog/git/sagas/clone";
@@ -266,6 +268,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
       originalPath: f.originalPath,
       linesAdded: f.linesAdded,
       linesRemoved: f.linesRemoved,
+      staged: f.staged,
     }));
   }
 
@@ -281,6 +284,36 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     ignoreWhitespace?: boolean,
   ): Promise<string> {
     return getDiffHead(directoryPath, { ignoreWhitespace });
+  }
+
+  public async getDiffCached(
+    directoryPath: string,
+    ignoreWhitespace?: boolean,
+  ): Promise<string> {
+    return getStagedDiff(directoryPath, { ignoreWhitespace });
+  }
+
+  public async getDiffUnstaged(
+    directoryPath: string,
+    ignoreWhitespace?: boolean,
+  ): Promise<string> {
+    return getUnstagedDiff(directoryPath, { ignoreWhitespace });
+  }
+
+  public async stageFiles(
+    directoryPath: string,
+    paths: string[],
+  ): Promise<GitStateSnapshot> {
+    await stageFiles(directoryPath, paths);
+    return this.getStateSnapshot(directoryPath);
+  }
+
+  public async unstageFiles(
+    directoryPath: string,
+    paths: string[],
+  ): Promise<GitStateSnapshot> {
+    await unstageFiles(directoryPath, paths);
+    return this.getStateSnapshot(directoryPath);
   }
 
   public async getDiffStats(directoryPath: string): Promise<DiffStats> {
@@ -479,6 +512,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     prTitle?: string;
     prBody?: string;
     draft?: boolean;
+    stagedOnly?: boolean;
   }): Promise<CreatePrOutput> {
     const { directoryPath, flowId } = input;
 
@@ -502,7 +536,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
         checkoutBranch: (dir, name) => this.checkoutBranch(dir, name),
         getChangedFilesHead: (dir) => this.getChangedFilesHead(dir),
         generateCommitMessage: (dir) => this.generateCommitMessage(dir),
-        commit: (dir, msg) => this.commit(dir, msg),
+        commit: (dir, msg, stagedOnly) => this.commit(dir, msg, { stagedOnly }),
         getSyncStatus: (dir) => this.getGitSyncStatus(dir),
         push: (dir) => this.push(dir),
         publish: (dir) => this.publish(dir),
@@ -521,6 +555,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
       prTitle: input.prTitle,
       prBody: input.prBody,
       draft: input.draft,
+      stagedOnly: input.stagedOnly,
     });
 
     if (!result.success) {
@@ -584,8 +619,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
   public async commit(
     directoryPath: string,
     message: string,
-    paths?: string[],
-    allowEmpty?: boolean,
+    options?: { paths?: string[]; allowEmpty?: boolean; stagedOnly?: boolean },
   ): Promise<CommitOutput> {
     const fail = (msg: string): CommitOutput => ({
       success: false,
@@ -600,8 +634,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     const result = await saga.run({
       baseDir: directoryPath,
       message: message.trim(),
-      paths,
-      allowEmpty,
+      ...options,
     });
 
     if (!result.success) return fail(result.error);

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -13,6 +13,8 @@ import {
   createPrOutput,
   detectRepoInput,
   detectRepoOutput,
+  diffInput,
+  diffOutput,
   discardFileChangesInput,
   discardFileChangesOutput,
   generateCommitMessageInput,
@@ -29,8 +31,6 @@ import {
   getCommitConventionsOutput,
   getCurrentBranchInput,
   getCurrentBranchOutput,
-  getDiffHeadInput,
-  getDiffHeadOutput,
   getDiffStatsInput,
   getDiffStatsOutput,
   getFileAtHeadInput,
@@ -45,6 +45,7 @@ import {
   getPrTemplateInput,
   getPrTemplateOutput,
   ghStatusOutput,
+  gitStateSnapshotSchema,
   openPrInput,
   openPrOutput,
   prStatusInput,
@@ -57,6 +58,7 @@ import {
   pushOutput,
   searchGithubIssuesInput,
   searchGithubIssuesOutput,
+  stageFilesInput,
   syncInput,
   syncOutput,
   validateRepoInput,
@@ -139,16 +141,44 @@ export const gitRouter = router({
     ),
 
   getDiffHead: publicProcedure
-    .input(getDiffHeadInput)
-    .output(getDiffHeadOutput)
+    .input(diffInput)
+    .output(diffOutput)
     .query(({ input }) =>
       getService().getDiffHead(input.directoryPath, input.ignoreWhitespace),
+    ),
+
+  getDiffCached: publicProcedure
+    .input(diffInput)
+    .output(diffOutput)
+    .query(({ input }) =>
+      getService().getDiffCached(input.directoryPath, input.ignoreWhitespace),
+    ),
+
+  getDiffUnstaged: publicProcedure
+    .input(diffInput)
+    .output(diffOutput)
+    .query(({ input }) =>
+      getService().getDiffUnstaged(input.directoryPath, input.ignoreWhitespace),
     ),
 
   getDiffStats: publicProcedure
     .input(getDiffStatsInput)
     .output(getDiffStatsOutput)
     .query(({ input }) => getService().getDiffStats(input.directoryPath)),
+
+  stageFiles: publicProcedure
+    .input(stageFilesInput)
+    .output(gitStateSnapshotSchema)
+    .mutation(({ input }) =>
+      getService().stageFiles(input.directoryPath, input.paths),
+    ),
+
+  unstageFiles: publicProcedure
+    .input(stageFilesInput)
+    .output(gitStateSnapshotSchema)
+    .mutation(({ input }) =>
+      getService().unstageFiles(input.directoryPath, input.paths),
+    ),
 
   discardFileChanges: publicProcedure
     .input(discardFileChangesInput)
@@ -189,12 +219,11 @@ export const gitRouter = router({
     .input(commitInput)
     .output(commitOutput)
     .mutation(({ input }) =>
-      getService().commit(
-        input.directoryPath,
-        input.message,
-        input.paths,
-        input.allowEmpty,
-      ),
+      getService().commit(input.directoryPath, input.message, {
+        paths: input.paths,
+        allowEmpty: input.allowEmpty,
+        stagedOnly: input.stagedOnly,
+      }),
     ),
 
   push: publicProcedure

--- a/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
@@ -1,18 +1,19 @@
-import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
-import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
+import { makeFileKey } from "@features/git-interaction/utils/fileKey";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { parsePatchFiles } from "@pierre/diffs";
+import type { parsePatchFiles } from "@pierre/diffs";
 import { Flex, Text } from "@radix-ui/themes";
 import { useTRPC } from "@renderer/trpc/client";
 import type { ChangedFile } from "@shared/types";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useReviewComment } from "../hooks/useReviewComment";
+import { useReviewDiffs } from "../hooks/useReviewDiffs";
 import type { DiffOptions, OnCommentCallback } from "../types";
 import { InteractiveFileDiff } from "./InteractiveFileDiff";
 import {
   DeferredDiffPlaceholder,
+  type DeferredReason,
   DiffFileHeader,
   ReviewShell,
   sumHunkStats,
@@ -24,40 +25,22 @@ interface ReviewPageProps {
 }
 
 export function ReviewPage({ taskId }: ReviewPageProps) {
-  const trpc = useTRPC();
   const repoPath = useCwd(taskId);
-  const { changedFiles, changesLoading } = useGitQueries(repoPath);
-  const hideWhitespace = useDiffViewerStore((s) => s.hideWhitespaceChanges);
   const openFile = usePanelLayoutStore((s) => s.openFile);
   const onComment = useReviewComment(taskId);
 
-  const { data: rawDiff, isLoading: diffLoading } = useQuery(
-    trpc.git.getDiffHead.queryOptions(
-      { directoryPath: repoPath as string, ignoreWhitespace: hideWhitespace },
-      { enabled: !!repoPath, staleTime: 30_000, refetchOnMount: "always" },
-    ),
-  );
-
-  const parsedFiles = useMemo(() => {
-    if (!rawDiff) return [];
-    const patches = parsePatchFiles(rawDiff);
-    return patches.flatMap((p) => p.files);
-  }, [rawDiff]);
-
-  const untrackedFiles = useMemo(
-    () => changedFiles.filter((f) => f.status === "untracked"),
-    [changedFiles],
-  );
-
-  const totalFileCount = parsedFiles.length + untrackedFiles.length;
-
-  const allPaths = useMemo(
-    () => [
-      ...parsedFiles.map((f) => f.name ?? f.prevName ?? ""),
-      ...untrackedFiles.map((f) => f.path),
-    ],
-    [parsedFiles, untrackedFiles],
-  );
+  const {
+    changedFiles,
+    changesLoading,
+    hasStagedFiles,
+    stagedParsedFiles,
+    unstagedParsedFiles,
+    untrackedFiles,
+    totalFileCount,
+    allPaths,
+    diffLoading,
+    refetch,
+  } = useReviewDiffs(repoPath);
 
   const {
     diffOptions,
@@ -82,6 +65,18 @@ export function ReviewPage({ taskId }: ReviewPageProps) {
     );
   }
 
+  const sharedDiffProps = {
+    repoPath,
+    taskId,
+    diffOptions,
+    collapsedFiles,
+    toggleFile,
+    revealFile,
+    getDeferredReason,
+    openFile,
+    onComment,
+  };
+
   return (
     <ReviewShell
       taskId={taskId}
@@ -94,60 +89,30 @@ export function ReviewPage({ taskId }: ReviewPageProps) {
       onExpandAll={expandAll}
       onCollapseAll={collapseAll}
       onUncollapseFile={uncollapseFile}
+      onRefresh={refetch}
     >
-      {parsedFiles.map((fileDiff) => {
-        const key = fileDiff.name ?? fileDiff.prevName ?? "";
+      {hasStagedFiles && stagedParsedFiles.length > 0 && (
+        <>
+          <SectionLabel label="Staged Changes" />
+          <FileDiffList files={stagedParsedFiles} staged {...sharedDiffProps} />
+        </>
+      )}
+      {hasStagedFiles &&
+        (unstagedParsedFiles.length > 0 || untrackedFiles.length > 0) && (
+          <SectionLabel label="Changes" />
+        )}
+      <FileDiffList files={unstagedParsedFiles} {...sharedDiffProps} />
+      {untrackedFiles.map((file) => {
+        const key = makeFileKey(file.staged, file.path);
         const isCollapsed = collapsedFiles.has(key);
-        const deferredReason = getDeferredReason(key);
-
-        if (deferredReason) {
-          const { additions, deletions } = sumHunkStats(fileDiff.hunks);
-          return (
-            <div key={key} data-file-path={key}>
-              <DeferredDiffPlaceholder
-                filePath={key}
-                linesAdded={additions}
-                linesRemoved={deletions}
-                reason={deferredReason}
-                collapsed={isCollapsed}
-                onToggle={() => toggleFile(key)}
-                onShow={() => revealFile(key)}
-              />
-            </div>
-          );
-        }
-
         return (
           <div key={key} data-file-path={key}>
-            <InteractiveFileDiff
-              fileDiff={fileDiff}
-              repoPath={repoPath}
-              options={{ ...diffOptions, collapsed: isCollapsed }}
-              onComment={onComment}
-              renderCustomHeader={(fd) => (
-                <DiffFileHeader
-                  fileDiff={fd}
-                  collapsed={isCollapsed}
-                  onToggle={() => toggleFile(key)}
-                  onOpenFile={() =>
-                    openFile(taskId, `${repoPath}/${key}`, false)
-                  }
-                />
-              )}
-            />
-          </div>
-        );
-      })}
-      {untrackedFiles.map((file) => {
-        const isCollapsed = collapsedFiles.has(file.path);
-        return (
-          <div key={file.path} data-file-path={file.path}>
             <UntrackedFileDiff
               file={file}
               repoPath={repoPath}
               options={diffOptions}
               collapsed={isCollapsed}
-              onToggle={() => toggleFile(file.path)}
+              onToggle={() => toggleFile(key)}
               onComment={onComment}
             />
           </div>
@@ -155,6 +120,89 @@ export function ReviewPage({ taskId }: ReviewPageProps) {
       })}
     </ReviewShell>
   );
+}
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <Flex px="3" py="2">
+      <Text size="1" color="gray" weight="medium">
+        {label}
+      </Text>
+    </Flex>
+  );
+}
+
+interface FileDiffListProps {
+  files: ReturnType<typeof parsePatchFiles>[number]["files"];
+  staged?: boolean;
+  repoPath: string;
+  taskId: string;
+  diffOptions: DiffOptions;
+  collapsedFiles: Set<string>;
+  toggleFile: (key: string) => void;
+  revealFile: (key: string) => void;
+  getDeferredReason: (key: string) => DeferredReason | null;
+  openFile: (taskId: string, path: string, preview: boolean) => void;
+  onComment: OnCommentCallback;
+}
+
+function FileDiffList({
+  files,
+  staged = false,
+  repoPath,
+  taskId,
+  diffOptions,
+  collapsedFiles,
+  toggleFile,
+  revealFile,
+  getDeferredReason,
+  openFile,
+  onComment,
+}: FileDiffListProps) {
+  return files.map((fileDiff) => {
+    const filePath = fileDiff.name ?? fileDiff.prevName ?? "";
+    const key = makeFileKey(staged, filePath);
+    const isCollapsed = collapsedFiles.has(key);
+    const deferredReason = getDeferredReason(key);
+
+    if (deferredReason) {
+      const { additions, deletions } = sumHunkStats(fileDiff.hunks);
+      return (
+        <div key={key} data-file-path={key}>
+          <DeferredDiffPlaceholder
+            filePath={filePath}
+            linesAdded={additions}
+            linesRemoved={deletions}
+            reason={deferredReason}
+            collapsed={isCollapsed}
+            onToggle={() => toggleFile(key)}
+            onShow={() => revealFile(key)}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div key={key} data-file-path={key}>
+        <InteractiveFileDiff
+          fileDiff={fileDiff}
+          repoPath={repoPath}
+          options={{ ...diffOptions, collapsed: isCollapsed }}
+          onComment={onComment}
+          renderCustomHeader={(fd) => (
+            <DiffFileHeader
+              fileDiff={fd}
+              collapsed={isCollapsed}
+              onToggle={() => toggleFile(key)}
+              onOpenFile={() =>
+                openFile(taskId, `${repoPath}/${filePath}`, false)
+              }
+            />
+          )}
+        />
+      </div>
+    );
+  });
 }
 
 function UntrackedFileDiff({

--- a/apps/code/src/renderer/features/code-review/components/ReviewShell.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewShell.tsx
@@ -220,6 +220,7 @@ export interface ReviewShellProps {
   allExpanded: boolean;
   onExpandAll: () => void;
   onCollapseAll: () => void;
+  onRefresh?: () => void;
 }
 
 export function ReviewShell({
@@ -234,6 +235,7 @@ export function ReviewShell({
   allExpanded,
   onExpandAll,
   onCollapseAll,
+  onRefresh,
 }: ReviewShellProps) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -349,6 +351,7 @@ export function ReviewShell({
           allExpanded={allExpanded}
           onExpandAll={onExpandAll}
           onCollapseAll={onCollapseAll}
+          onRefresh={onRefresh}
         />
         <div
           ref={scrollContainerRef}

--- a/apps/code/src/renderer/features/code-review/components/ReviewToolbar.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewToolbar.tsx
@@ -1,5 +1,12 @@
+import { Tooltip } from "@components/ui/Tooltip";
 import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
-import { ArrowsIn, ArrowsOut, Columns, Rows } from "@phosphor-icons/react";
+import {
+  ArrowsClockwise,
+  ArrowsIn,
+  ArrowsOut,
+  Columns,
+  Rows,
+} from "@phosphor-icons/react";
 import { Flex, IconButton, Text } from "@radix-ui/themes";
 import { DiffSettingsMenu } from "@renderer/features/code-review/components/DiffSettingsMenu";
 import { memo } from "react";
@@ -11,6 +18,7 @@ interface ReviewToolbarProps {
   allExpanded: boolean;
   onExpandAll: () => void;
   onCollapseAll: () => void;
+  onRefresh?: () => void;
 }
 
 export const ReviewToolbar = memo(function ReviewToolbar({
@@ -20,6 +28,7 @@ export const ReviewToolbar = memo(function ReviewToolbar({
   allExpanded,
   onExpandAll,
   onCollapseAll,
+  onRefresh,
 }: ReviewToolbarProps) {
   const viewMode = useDiffViewerStore((s) => s.viewMode);
   const toggleViewMode = useDiffViewerStore((s) => s.toggleViewMode);
@@ -56,6 +65,19 @@ export const ReviewToolbar = memo(function ReviewToolbar({
       </Flex>
 
       <Flex align="center" gap="2" ml="auto">
+        {onRefresh && (
+          <Tooltip content="Refresh diff">
+            <IconButton
+              size="1"
+              variant="ghost"
+              color="gray"
+              onClick={onRefresh}
+              style={{ cursor: "pointer" }}
+            >
+              <ArrowsClockwise size={14} />
+            </IconButton>
+          </Tooltip>
+        )}
         <IconButton
           size="1"
           variant="ghost"

--- a/apps/code/src/renderer/features/code-review/hooks/useReviewDiffs.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/useReviewDiffs.ts
@@ -1,0 +1,110 @@
+import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
+import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
+import { makeFileKey } from "@features/git-interaction/utils/fileKey";
+import { invalidateGitWorkingTreeQueries } from "@features/git-interaction/utils/gitCacheKeys";
+import { parsePatchFiles } from "@pierre/diffs";
+import { useTRPC } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+
+export function useReviewDiffs(repoPath: string | undefined) {
+  const trpc = useTRPC();
+  const { changedFiles, changesLoading } = useGitQueries(repoPath);
+  const hideWhitespace = useDiffViewerStore((s) => s.hideWhitespaceChanges);
+
+  const hasStagedFiles = useMemo(
+    () => changedFiles.some((f) => f.staged),
+    [changedFiles],
+  );
+
+  const {
+    data: rawDiffCached,
+    isLoading: diffCachedLoading,
+    refetch: refetchDiffCached,
+  } = useQuery(
+    trpc.git.getDiffCached.queryOptions(
+      { directoryPath: repoPath as string, ignoreWhitespace: hideWhitespace },
+      {
+        enabled: !!repoPath && hasStagedFiles,
+        staleTime: 30_000,
+        refetchOnMount: "always",
+      },
+    ),
+  );
+
+  const {
+    data: rawDiffUnstaged,
+    isLoading: diffUnstagedLoading,
+    refetch: refetchDiffUnstaged,
+  } = useQuery(
+    trpc.git.getDiffUnstaged.queryOptions(
+      { directoryPath: repoPath as string, ignoreWhitespace: hideWhitespace },
+      {
+        enabled: !!repoPath,
+        staleTime: 30_000,
+        refetchOnMount: "always",
+      },
+    ),
+  );
+
+  const diffLoading =
+    diffUnstagedLoading || (hasStagedFiles && diffCachedLoading);
+
+  const stagedParsedFiles = useMemo(
+    () =>
+      rawDiffCached
+        ? parsePatchFiles(rawDiffCached).flatMap((p) => p.files)
+        : [],
+    [rawDiffCached],
+  );
+
+  const unstagedParsedFiles = useMemo(
+    () =>
+      rawDiffUnstaged
+        ? parsePatchFiles(rawDiffUnstaged).flatMap((p) => p.files)
+        : [],
+    [rawDiffUnstaged],
+  );
+
+  const untrackedFiles = useMemo(
+    () => changedFiles.filter((f) => f.status === "untracked"),
+    [changedFiles],
+  );
+
+  const totalFileCount =
+    stagedParsedFiles.length +
+    unstagedParsedFiles.length +
+    untrackedFiles.length;
+
+  const allPaths = useMemo(
+    () => [
+      ...stagedParsedFiles.map((f) =>
+        makeFileKey(true, f.name ?? f.prevName ?? ""),
+      ),
+      ...unstagedParsedFiles.map((f) =>
+        makeFileKey(false, f.name ?? f.prevName ?? ""),
+      ),
+      ...untrackedFiles.map((f) => makeFileKey(f.staged, f.path)),
+    ],
+    [stagedParsedFiles, unstagedParsedFiles, untrackedFiles],
+  );
+
+  const refetch = useCallback(() => {
+    if (repoPath) invalidateGitWorkingTreeQueries(repoPath);
+    refetchDiffUnstaged();
+    if (hasStagedFiles) refetchDiffCached();
+  }, [repoPath, hasStagedFiles, refetchDiffCached, refetchDiffUnstaged]);
+
+  return {
+    changedFiles,
+    changesLoading,
+    hasStagedFiles,
+    stagedParsedFiles,
+    unstagedParsedFiles,
+    untrackedFiles,
+    totalFileCount,
+    allPaths,
+    diffLoading,
+    refetch,
+  };
+}

--- a/apps/code/src/renderer/features/git-interaction/components/CreatePrDialog.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/CreatePrDialog.tsx
@@ -1,11 +1,15 @@
 import {
+  CommitAllToggle,
   ErrorContainer,
   GenerateButton,
 } from "@features/git-interaction/components/GitInteractionDialogs";
 import { useFixWithAgent } from "@features/git-interaction/hooks/useFixWithAgent";
 import { useGitInteractionStore } from "@features/git-interaction/state/gitInteractionStore";
 import type { CreatePrStep } from "@features/git-interaction/types";
-import type { DiffStats } from "@features/git-interaction/utils/diffStats";
+import {
+  type DiffStats,
+  formatFileCountLabel,
+} from "@features/git-interaction/utils/diffStats";
 import { buildCreatePrFlowErrorPrompt } from "@features/git-interaction/utils/errorPrompts";
 import {
   CheckCircle,
@@ -121,6 +125,10 @@ export interface CreatePrDialogProps {
   onSubmit: () => void;
   onGenerateCommitMessage: () => void;
   onGeneratePr: () => void;
+  showCommitAllToggle?: boolean;
+  commitAll?: boolean;
+  onCommitAllChange?: (value: boolean) => void;
+  stagedFileCount?: number;
 }
 
 export function CreatePrDialog({
@@ -132,6 +140,10 @@ export function CreatePrDialog({
   onSubmit,
   onGenerateCommitMessage,
   onGeneratePr,
+  showCommitAllToggle,
+  commitAll,
+  onCommitAllChange,
+  stagedFileCount,
 }: CreatePrDialogProps) {
   const store = useGitInteractionStore();
   const { actions } = store;
@@ -197,8 +209,11 @@ export function CreatePrDialog({
                     </Text>
                     <Flex align="center" gap="2">
                       <Text size="1" color="gray">
-                        {diffStats.filesChanged} file
-                        {diffStats.filesChanged === 1 ? "" : "s"}
+                        {formatFileCountLabel(
+                          !!(showCommitAllToggle && !commitAll),
+                          stagedFileCount ?? 0,
+                          diffStats.filesChanged,
+                        )}
                       </Text>
                       <Text size="1" color="green">
                         +{diffStats.linesAdded}
@@ -221,6 +236,12 @@ export function CreatePrDialog({
                     disabled={store.isGeneratingCommitMessage}
                     autoFocus={!store.createPrNeedsBranch}
                   />
+                  {showCommitAllToggle && onCommitAllChange && (
+                    <CommitAllToggle
+                      checked={commitAll}
+                      onChange={onCommitAllChange}
+                    />
+                  )}
                 </Flex>
               )}
 

--- a/apps/code/src/renderer/features/git-interaction/components/GitInteractionDialogs.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/GitInteractionDialogs.tsx
@@ -1,5 +1,8 @@
 import { Tooltip } from "@components/ui/Tooltip";
-import type { DiffStats } from "@features/git-interaction/utils/diffStats";
+import {
+  type DiffStats,
+  formatFileCountLabel,
+} from "@features/git-interaction/utils/diffStats";
 import {
   CheckCircle,
   CloudArrowUp,
@@ -13,6 +16,7 @@ import { CheckIcon } from "@radix-ui/react-icons";
 import {
   Box,
   Button,
+  Checkbox,
   Dialog,
   Flex,
   IconButton,
@@ -118,6 +122,34 @@ export function GenerateButton({
         {isGenerating ? <Spinner size="1" /> : <Sparkle size={14} />}
       </IconButton>
     </Tooltip>
+  );
+}
+
+export function CommitAllToggle({
+  checked,
+  onChange,
+}: {
+  checked?: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <Flex
+      align="center"
+      gap="2"
+      py="1"
+      style={{ cursor: "pointer" }}
+      onClick={() => onChange(!checked)}
+    >
+      <Checkbox
+        size="1"
+        checked={checked}
+        onCheckedChange={(c) => onChange(c === true)}
+        onClick={(e) => e.stopPropagation()}
+      />
+      <Text size="1" color="gray">
+        Commit all changes
+      </Text>
+    </Flex>
   );
 }
 
@@ -275,6 +307,10 @@ interface GitCommitDialogProps {
   error: string | null;
   onGenerateMessage: () => void;
   isGeneratingMessage: boolean;
+  showCommitAllToggle?: boolean;
+  commitAll?: boolean;
+  onCommitAllChange?: (value: boolean) => void;
+  stagedFileCount?: number;
 }
 
 export function GitCommitDialog({
@@ -292,6 +328,10 @@ export function GitCommitDialog({
   error,
   onGenerateMessage,
   isGeneratingMessage,
+  showCommitAllToggle,
+  commitAll,
+  onCommitAllChange,
+  stagedFileCount,
 }: GitCommitDialogProps) {
   const options = [
     {
@@ -326,8 +366,11 @@ export function GitCommitDialog({
         <InfoRow label="Changes">
           <Flex align="center" gap="2">
             <Text size="1" color="gray">
-              {diffStats.filesChanged} file
-              {diffStats.filesChanged === 1 ? "" : "s"}
+              {formatFileCountLabel(
+                !!(showCommitAllToggle && !commitAll),
+                stagedFileCount ?? 0,
+                diffStats.filesChanged,
+              )}
             </Text>
             <Text size="1" color="green">
               +{diffStats.linesAdded}
@@ -337,6 +380,9 @@ export function GitCommitDialog({
             </Text>
           </Flex>
         </InfoRow>
+        {showCommitAllToggle && onCommitAllChange && (
+          <CommitAllToggle checked={commitAll} onChange={onCommitAllChange} />
+        )}
       </Flex>
 
       <Flex direction="column" gap="1">

--- a/apps/code/src/renderer/features/git-interaction/components/GitInteractionHeader.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/GitInteractionHeader.tsx
@@ -52,6 +52,12 @@ export function GitInteractionHeader({ taskId }: GitInteractionHeaderProps) {
         error={modals.commitError}
         onGenerateMessage={actions.generateCommitMessage}
         isGeneratingMessage={modals.isGeneratingCommitMessage}
+        showCommitAllToggle={
+          state.stagedFiles.length > 0 && state.unstagedFiles.length > 0
+        }
+        commitAll={modals.commitAll}
+        onCommitAllChange={actions.setCommitAll}
+        stagedFileCount={state.stagedFiles.length}
       />
 
       <GitPushDialog
@@ -79,6 +85,12 @@ export function GitInteractionHeader({ taskId }: GitInteractionHeaderProps) {
         onSubmit={actions.runCreatePr}
         onGenerateCommitMessage={actions.generateCommitMessage}
         onGeneratePr={actions.generatePrTitleAndBody}
+        showCommitAllToggle={
+          state.stagedFiles.length > 0 && state.unstagedFiles.length > 0
+        }
+        commitAll={modals.commitAll}
+        onCommitAllChange={actions.setCommitAll}
+        stagedFileCount={state.stagedFiles.length}
       />
 
       <GitBranchDialog

--- a/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
@@ -17,8 +17,10 @@ import { sanitizeBranchName } from "@features/git-interaction/utils/branchNameVa
 import type { DiffStats } from "@features/git-interaction/utils/diffStats";
 import { getSuggestedBranchName } from "@features/git-interaction/utils/getSuggestedBranchName";
 import { invalidateGitBranchQueries } from "@features/git-interaction/utils/gitCacheKeys";
+import { partitionByStaged } from "@features/git-interaction/utils/partitionByStaged";
 import { updateGitCacheFromSnapshot } from "@features/git-interaction/utils/updateGitCache";
 import { trpc, trpcClient } from "@renderer/trpc";
+import type { ChangedFile } from "@shared/types";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { useQueryClient } from "@tanstack/react-query";
 import { track } from "@utils/analytics";
@@ -43,6 +45,8 @@ interface GitInteractionState {
   prUrl: string | null;
   pushDisabledReason: string | null;
   isLoading: boolean;
+  stagedFiles: ChangedFile[];
+  unstagedFiles: ChangedFile[];
 }
 
 interface GitInteractionActions {
@@ -52,6 +56,7 @@ interface GitInteractionActions {
   closeBranch: () => void;
   setCommitMessage: (value: string) => void;
   setCommitNextStep: (value: CommitNextStep) => void;
+  setCommitAll: (value: boolean) => void;
   setPrTitle: (value: string) => void;
   setPrBody: (value: string) => void;
   setBranchName: (value: string) => void;
@@ -66,7 +71,35 @@ interface GitInteractionActions {
   setCreatePrDraft: (value: boolean) => void;
 }
 
-function trackGitAction(taskId: string, actionType: string, success: boolean) {
+function buildStagingContext(
+  stagedFiles: ChangedFile[],
+  unstagedFiles: ChangedFile[],
+  commitAll: boolean,
+) {
+  const stagedOnly =
+    stagedFiles.length > 0 && unstagedFiles.length > 0 && !commitAll;
+  return {
+    stagedOnly,
+    analytics: {
+      staged_file_count: stagedFiles.length,
+      unstaged_file_count: unstagedFiles.length,
+      commit_all: commitAll,
+      staged_only: stagedOnly,
+    },
+  };
+}
+
+function trackGitAction(
+  taskId: string,
+  actionType: string,
+  success: boolean,
+  stagingContext?: {
+    staged_file_count: number;
+    unstaged_file_count: number;
+    commit_all: boolean;
+    staged_only: boolean;
+  },
+) {
   track(ANALYTICS_EVENTS.GIT_ACTION_EXECUTED, {
     action_type: actionType as
       | "commit"
@@ -78,6 +111,7 @@ function trackGitAction(taskId: string, actionType: string, success: boolean) {
       | "update-pr",
     success,
     task_id: taskId,
+    ...stagingContext,
   });
 }
 
@@ -131,10 +165,16 @@ export function useGitInteraction(
     ],
   );
 
+  const { stagedFiles, unstagedFiles } = useMemo(
+    () => partitionByStaged(git.changedFiles),
+    [git.changedFiles],
+  );
+
   const openCreatePr = () => {
     const prExists = git.prStatus?.prExists ?? false;
     const needsBranch = !git.isFeatureBranch || prExists;
     const needsCommit = git.hasChanges;
+    modal.setCommitAll(!(stagedFiles.length > 0 && unstagedFiles.length > 0));
     modal.openCreatePr({
       needsBranch,
       needsCommit,
@@ -173,6 +213,12 @@ export function useGitInteraction(
     );
 
     try {
+      const { stagedOnly, analytics: prStagingContext } = buildStagingContext(
+        stagedFiles,
+        unstagedFiles,
+        store.commitAll,
+      );
+
       const result = await trpcClient.git.createPr.mutate({
         directoryPath: repoPath,
         flowId,
@@ -183,10 +229,11 @@ export function useGitInteraction(
         prTitle: store.prTitle.trim() || undefined,
         prBody: store.prBody.trim() || undefined,
         draft: store.createPrDraft || undefined,
+        stagedOnly: stagedOnly || undefined,
       });
 
       if (!result.success) {
-        trackGitAction(taskId, "create-pr", false);
+        trackGitAction(taskId, "create-pr", false, prStagingContext);
         useGitInteractionStore.setState({
           createPrError: result.message,
           createPrFailedStep: result.failedStep ?? null,
@@ -195,7 +242,7 @@ export function useGitInteraction(
         return;
       }
 
-      trackGitAction(taskId, "create-pr", true);
+      trackGitAction(taskId, "create-pr", true, prStagingContext);
       track(ANALYTICS_EVENTS.PR_CREATED, { task_id: taskId, success: true });
 
       if (result.state) {
@@ -226,7 +273,12 @@ export function useGitInteraction(
 
   const openAction = (id: GitMenuActionId) => {
     const actionMap: Record<GitMenuActionId, () => void> = {
-      commit: () => modal.openCommit("commit"),
+      commit: () => {
+        modal.setCommitAll(
+          !(stagedFiles.length > 0 && unstagedFiles.length > 0),
+        );
+        modal.openCommit("commit");
+      },
       push: () => modal.openPush("push"),
       sync: () => modal.openPush("sync"),
       publish: () => modal.openPush("publish"),
@@ -290,18 +342,22 @@ export function useGitInteraction(
     }
 
     try {
+      const { stagedOnly, analytics: commitStagingContext } =
+        buildStagingContext(stagedFiles, unstagedFiles, store.commitAll);
+
       const result = await trpcClient.git.commit.mutate({
         directoryPath: repoPath,
         message,
+        stagedOnly: stagedOnly || undefined,
       });
 
       if (!result.success) {
-        trackGitAction(taskId, "commit", false);
+        trackGitAction(taskId, "commit", false, commitStagingContext);
         modal.setCommitError(result.message || "Commit failed.");
         return;
       }
 
-      trackGitAction(taskId, "commit", true);
+      trackGitAction(taskId, "commit", true, commitStagingContext);
 
       if (result.state) {
         updateGitCacheFromSnapshot(queryClient, repoPath, result.state);
@@ -469,6 +525,8 @@ export function useGitInteraction(
       prUrl: computed.prUrl,
       pushDisabledReason: computed.pushDisabledReason,
       isLoading: git.isLoading,
+      stagedFiles,
+      unstagedFiles,
     },
     modals: store,
     actions: {
@@ -478,6 +536,7 @@ export function useGitInteraction(
       closeBranch: modal.closeBranch,
       setCommitMessage: modal.setCommitMessage,
       setCommitNextStep: modal.setCommitNextStep,
+      setCommitAll: modal.setCommitAll,
       setPrTitle: modal.setPrTitle,
       setPrBody: modal.setPrBody,
       setBranchName: (value: string) => {

--- a/apps/code/src/renderer/features/git-interaction/state/gitInteractionStore.ts
+++ b/apps/code/src/renderer/features/git-interaction/state/gitInteractionStore.ts
@@ -34,6 +34,7 @@ interface GitInteractionState {
   isSubmitting: boolean;
   isGeneratingCommitMessage: boolean;
   isGeneratingPr: boolean;
+  commitAll: boolean;
 }
 
 interface GitInteractionActions {
@@ -53,6 +54,7 @@ interface GitInteractionActions {
   setIsSubmitting: (value: boolean) => void;
   setIsGeneratingCommitMessage: (value: boolean) => void;
   setIsGeneratingPr: (value: boolean) => void;
+  setCommitAll: (value: boolean) => void;
 
   openCommit: (nextStep: CommitNextStep) => void;
   openPush: (mode: PushMode) => void;
@@ -102,6 +104,7 @@ const initialState: GitInteractionState = {
   isSubmitting: false,
   isGeneratingCommitMessage: false,
   isGeneratingPr: false,
+  commitAll: true,
 };
 
 export const useGitInteractionStore = create<GitInteractionStore>((set) => ({
@@ -124,6 +127,7 @@ export const useGitInteractionStore = create<GitInteractionStore>((set) => ({
     setIsGeneratingCommitMessage: (value) =>
       set({ isGeneratingCommitMessage: value }),
     setIsGeneratingPr: (value) => set({ isGeneratingPr: value }),
+    setCommitAll: (value) => set({ commitAll: value }),
 
     openCommit: (nextStep) =>
       set({ commitNextStep: nextStep, commitError: null, commitOpen: true }),

--- a/apps/code/src/renderer/features/git-interaction/utils/diffStats.ts
+++ b/apps/code/src/renderer/features/git-interaction/utils/diffStats.ts
@@ -9,9 +9,22 @@ export interface DiffStats {
 export function computeDiffStats(files: ChangedFile[]): DiffStats {
   let linesAdded = 0;
   let linesRemoved = 0;
+  const uniquePaths = new Set<string>();
   for (const file of files) {
     linesAdded += file.linesAdded ?? 0;
     linesRemoved += file.linesRemoved ?? 0;
+    uniquePaths.add(file.path);
   }
-  return { filesChanged: files.length, linesAdded, linesRemoved };
+  return { filesChanged: uniquePaths.size, linesAdded, linesRemoved };
+}
+
+export function formatFileCountLabel(
+  stagedOnly: boolean,
+  stagedFileCount: number,
+  totalFileCount: number,
+): string {
+  if (stagedOnly) {
+    return `${stagedFileCount} staged file${stagedFileCount === 1 ? "" : "s"}`;
+  }
+  return `${totalFileCount} file${totalFileCount === 1 ? "" : "s"}`;
 }

--- a/apps/code/src/renderer/features/git-interaction/utils/fileKey.ts
+++ b/apps/code/src/renderer/features/git-interaction/utils/fileKey.ts
@@ -1,0 +1,3 @@
+export function makeFileKey(staged: boolean | undefined, path: string): string {
+  return `${staged ? "staged:" : "unstaged:"}${path}`;
+}

--- a/apps/code/src/renderer/features/git-interaction/utils/gitCacheKeys.ts
+++ b/apps/code/src/renderer/features/git-interaction/utils/gitCacheKeys.ts
@@ -7,6 +7,8 @@ export function invalidateGitWorkingTreeQueries(repoPath: string) {
     trpc.git.getChangedFilesHead.queryFilter(input),
   );
   queryClient.invalidateQueries(trpc.git.getDiffStats.queryFilter(input));
+  queryClient.invalidateQueries(trpc.git.getDiffCached.pathFilter());
+  queryClient.invalidateQueries(trpc.git.getDiffUnstaged.pathFilter());
 }
 
 export function invalidateGitBranchQueries(repoPath: string) {

--- a/apps/code/src/renderer/features/git-interaction/utils/partitionByStaged.ts
+++ b/apps/code/src/renderer/features/git-interaction/utils/partitionByStaged.ts
@@ -1,0 +1,14 @@
+import type { ChangedFile } from "@shared/types";
+
+export function partitionByStaged(files: ChangedFile[]): {
+  stagedFiles: ChangedFile[];
+  unstagedFiles: ChangedFile[];
+} {
+  const stagedFiles: ChangedFile[] = [];
+  const unstagedFiles: ChangedFile[] = [];
+  for (const f of files) {
+    if (f.staged) stagedFiles.push(f);
+    else unstagedFiles.push(f);
+  }
+  return { stagedFiles, unstagedFiles };
+}

--- a/apps/code/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -3,6 +3,9 @@ import { PanelMessage } from "@components/ui/PanelMessage";
 import { Tooltip } from "@components/ui/Tooltip";
 import { useExternalApps } from "@features/external-apps/hooks/useExternalApps";
 import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
+import { makeFileKey } from "@features/git-interaction/utils/fileKey";
+import { invalidateGitWorkingTreeQueries } from "@features/git-interaction/utils/gitCacheKeys";
+import { partitionByStaged } from "@features/git-interaction/utils/partitionByStaged";
 import { updateGitCacheFromSnapshot } from "@features/git-interaction/utils/updateGitCache";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
@@ -12,6 +15,8 @@ import {
   CodeIcon,
   CopyIcon,
   FilePlus,
+  MinusIcon,
+  PlusIcon,
 } from "@phosphor-icons/react";
 import {
   Badge,
@@ -34,7 +39,10 @@ import { ANALYTICS_EVENTS, type FileChangeType } from "@shared/types/analytics";
 import { useQueryClient } from "@tanstack/react-query";
 import { showMessageBox } from "@utils/dialog";
 import { handleExternalAppAction } from "@utils/handleExternalAppAction";
-import { useState } from "react";
+import { logger } from "@utils/logger";
+import { Fragment, useMemo, useState } from "react";
+
+const log = logger.scope("changes-panel");
 
 interface ChangesPanelProps {
   taskId: string;
@@ -48,6 +56,7 @@ interface ChangedFileItemProps {
   /** When provided, enables the hover toolbar (discard, open-with, context menu) */
   repoPath?: string;
   mainRepoPath?: string;
+  onStageToggle?: (file: ChangedFile) => void;
 }
 
 function getDiscardInfo(
@@ -88,12 +97,37 @@ function getDiscardInfo(
   }
 }
 
+function CompactIconButton({
+  tooltip,
+  onClick,
+  children,
+}: {
+  tooltip: string;
+  onClick: (e: React.MouseEvent) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip content={tooltip}>
+      <IconButton
+        size="1"
+        variant="ghost"
+        color="gray"
+        onClick={onClick}
+        className="mx-0.5 size-[18px] shrink-0 p-0"
+      >
+        {children}
+      </IconButton>
+    </Tooltip>
+  );
+}
+
 function ChangedFileItem({
   file,
   taskId,
   isActive,
   repoPath,
   mainRepoPath,
+  onStageToggle,
 }: ChangedFileItemProps) {
   const openReview = usePanelLayoutStore((state) => state.openReview);
   const requestScrollToFile = useReviewNavigationStore(
@@ -113,13 +147,15 @@ function ChangedFileItem({
   const fullPath = repoPath ? `${repoPath}/${file.path}` : file.path;
   const indicator = getStatusIndicator(file.status);
 
+  const fileKey = makeFileKey(file.staged, file.path);
+
   const handleClick = () => {
     track(ANALYTICS_EVENTS.FILE_DIFF_VIEWED, {
       change_type: file.status as FileChangeType,
       file_extension: getFileExtension(file.path),
       task_id: taskId,
     });
-    requestScrollToFile(taskId, file.path);
+    requestScrollToFile(taskId, fileKey);
     openReview(taskId);
   };
 
@@ -279,26 +315,28 @@ function ChangedFileItem({
           </Flex>
         )}
 
-        {isToolbarVisible && handleDiscard && (
+        {isToolbarVisible && (handleDiscard || onStageToggle) && (
           <Flex align="center" gap="1" style={{ flexShrink: 0 }}>
-            <Tooltip content="Discard changes">
-              <IconButton
-                size="1"
-                variant="ghost"
-                color="gray"
-                onClick={handleDiscard}
-                style={{
-                  flexShrink: 0,
-                  width: "18px",
-                  height: "18px",
-                  padding: 0,
-                  marginLeft: "2px",
-                  marginRight: "2px",
+            {onStageToggle && (
+              <CompactIconButton
+                tooltip={file.staged ? "Unstage" : "Stage"}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onStageToggle(file);
                 }}
               >
+                {file.staged ? <MinusIcon size={12} /> : <PlusIcon size={12} />}
+              </CompactIconButton>
+            )}
+            {handleDiscard && (
+              <CompactIconButton
+                tooltip="Discard changes"
+                onClick={handleDiscard}
+              >
                 <ArrowCounterClockwiseIcon size={12} />
-              </IconButton>
-            </Tooltip>
+              </CompactIconButton>
+            )}
 
             <DropdownMenu.Root
               open={isDropdownOpen}
@@ -475,10 +513,33 @@ export function ChangesPanel({ taskId, task }: ChangesPanelProps) {
 function LocalChangesPanel({ taskId, task: _task }: ChangesPanelProps) {
   const workspace = useWorkspace(taskId);
   const repoPath = useCwd(taskId);
+  const queryClient = useQueryClient();
   const activeFilePath = useReviewNavigationStore(
     (s) => s.activeFilePaths[taskId] ?? null,
   );
   const { changedFiles, changesLoading: isLoading } = useGitQueries(repoPath);
+
+  const { stagedFiles, unstagedFiles } = useMemo(
+    () => partitionByStaged(changedFiles),
+    [changedFiles],
+  );
+
+  const hasStagedFiles = stagedFiles.length > 0;
+
+  const handleStageToggle = async (file: ChangedFile) => {
+    if (!repoPath) return;
+    const paths = [file.originalPath ?? file.path];
+    const endpoint = file.staged
+      ? trpcClient.git.unstageFiles
+      : trpcClient.git.stageFiles;
+    try {
+      const result = await endpoint.mutate({ directoryPath: repoPath, paths });
+      updateGitCacheFromSnapshot(queryClient, repoPath, result);
+      invalidateGitWorkingTreeQueries(repoPath);
+    } catch (error) {
+      log.error("Failed to toggle staging", { file: file.path, error });
+    }
+  };
 
   if (!repoPath) {
     return <PanelMessage>No repository path available</PanelMessage>;
@@ -500,18 +561,40 @@ function LocalChangesPanel({ taskId, task: _task }: ChangesPanelProps) {
     );
   }
 
+  const fileGroups: { files: ChangedFile[]; header?: string }[] = hasStagedFiles
+    ? [
+        { files: stagedFiles, header: "Staged Changes" },
+        { files: unstagedFiles, header: "Changes" },
+      ]
+    : [{ files: changedFiles }];
+
   return (
     <Box height="100%" overflowY="auto" py="2">
       <Flex direction="column">
-        {changedFiles.map((file) => (
-          <ChangedFileItem
-            key={file.path}
-            file={file}
-            taskId={taskId}
-            repoPath={repoPath}
-            isActive={activeFilePath === file.path}
-            mainRepoPath={workspace?.folderPath}
-          />
+        {fileGroups.map(({ files, header }) => (
+          <Fragment key={header ?? "all"}>
+            {header && (
+              <Flex px="2" py="1" className="select-none">
+                <Text size="1" color="gray" weight="medium">
+                  {header} ({files.length})
+                </Text>
+              </Flex>
+            )}
+            {files.map((file) => {
+              const key = makeFileKey(file.staged, file.path);
+              return (
+                <ChangedFileItem
+                  key={key}
+                  file={file}
+                  taskId={taskId}
+                  repoPath={repoPath}
+                  isActive={activeFilePath === key}
+                  mainRepoPath={workspace?.folderPath}
+                  onStageToggle={handleStageToggle}
+                />
+              );
+            })}
+          </Fragment>
         ))}
       </Flex>
     </Box>

--- a/apps/code/src/shared/types.ts
+++ b/apps/code/src/shared/types.ts
@@ -138,6 +138,7 @@ export interface ChangedFile {
   originalPath?: string; // For renames: the old path
   linesAdded?: number;
   linesRemoved?: number;
+  staged?: boolean;
 }
 
 // External apps detection types

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -96,6 +96,14 @@ export interface GitActionExecutedProperties {
   action_type: GitActionType;
   success: boolean;
   task_id?: string;
+  /** Number of staged files at time of action */
+  staged_file_count?: number;
+  /** Number of unstaged files at time of action */
+  unstaged_file_count?: number;
+  /** Whether user chose to commit all changes (vs staged only) */
+  commit_all?: boolean;
+  /** Whether stagedOnly mode was used for the commit */
+  staged_only?: boolean;
 }
 
 export interface PrCreatedProperties {

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -389,6 +389,7 @@ export interface ChangedFileInfo {
   originalPath?: string;
   linesAdded?: number;
   linesRemoved?: number;
+  staged?: boolean;
 }
 
 export interface GetChangedFilesDetailedOptions extends CreateGitClientOptions {
@@ -428,23 +429,27 @@ export async function getChangedFilesDetailed(
     baseDir,
     async (git) => {
       try {
-        const [diffSummary, status] = await Promise.all([
-          git.diffSummary(["-M", "HEAD"]),
+        const [stagedSummary, unstagedSummary, status] = await Promise.all([
+          git.diffSummary(["--cached", "-M", "HEAD"]),
+          git.diffSummary(["-M"]),
           git.status(["--untracked-files=all"]),
         ]);
 
-        const seenPaths = new Set<string>();
+        const diffSeenPaths = new Set<string>();
+        const excludedPaths = new Set<string>();
         const files: ChangedFileInfo[] = [];
 
-        for (const file of diffSummary.files) {
+        const pushDiffFile = (
+          file: (typeof stagedSummary.files)[number],
+          staged: boolean,
+        ) => {
           if (
             excludePatterns &&
             matchesExcludePattern(file.file, excludePatterns)
           ) {
-            seenPaths.add(file.file);
-            continue;
+            excludedPaths.add(file.file);
+            return;
           }
-
           const hasFrom = "from" in file && file.from;
           const isBinary = file.binary;
           files.push({
@@ -463,80 +468,35 @@ export async function getChangedFilesDetailed(
             linesRemoved: isBinary
               ? undefined
               : (file as { deletions: number }).deletions,
+            staged,
           });
-          seenPaths.add(file.file);
-          if (hasFrom) seenPaths.add(file.from as string);
+          diffSeenPaths.add(file.file);
+          if (hasFrom) diffSeenPaths.add(file.from as string);
+        };
+
+        for (const file of stagedSummary.files) {
+          pushDiffFile(file, true);
+        }
+        for (const file of unstagedSummary.files) {
+          pushDiffFile(file, false);
         }
 
         const MAX_UNTRACKED_FILES = 10_000;
         let untrackedProcessed = 0;
         for (const file of status.not_added) {
           if (untrackedProcessed >= MAX_UNTRACKED_FILES) break;
-          if (!seenPaths.has(file)) {
-            if (
-              excludePatterns &&
-              matchesExcludePattern(file, excludePatterns)
-            ) {
-              continue;
-            }
-            const lineCount = await countFileLines(path.join(baseDir, file));
-            files.push({
-              path: file,
-              status: "untracked",
-              linesAdded: lineCount,
-              linesRemoved: 0,
-            });
-            untrackedProcessed++;
+          if (diffSeenPaths.has(file) || excludedPaths.has(file)) continue;
+          if (excludePatterns && matchesExcludePattern(file, excludePatterns)) {
+            continue;
           }
-        }
-
-        for (const file of status.modified) {
-          if (!seenPaths.has(file)) {
-            if (
-              excludePatterns &&
-              matchesExcludePattern(file, excludePatterns)
-            ) {
-              continue;
-            }
-            try {
-              const headDiff = await git.diff(["HEAD", "--", file]);
-              if (!headDiff.trim()) continue;
-              const lines = headDiff.split("\n");
-              const linesAdded = lines.filter(
-                (l) => l.startsWith("+") && !l.startsWith("+++"),
-              ).length;
-              const linesRemoved = lines.filter(
-                (l) => l.startsWith("-") && !l.startsWith("---"),
-              ).length;
-              files.push({
-                path: file,
-                status: "modified",
-                linesAdded,
-                linesRemoved,
-              });
-            } catch {}
-          }
-        }
-
-        for (const file of status.deleted) {
-          if (!seenPaths.has(file)) {
-            if (
-              excludePatterns &&
-              matchesExcludePattern(file, excludePatterns)
-            ) {
-              continue;
-            }
-            try {
-              const headDiff = await git.diff(["HEAD", "--", file]);
-              if (!headDiff.trim()) continue;
-            } catch {}
-            files.push({
-              path: file,
-              status: "deleted",
-              linesAdded: 0,
-              linesRemoved: 0,
-            });
-          }
+          const lineCount = await countFileLines(path.join(baseDir, file));
+          files.push({
+            path: file,
+            status: "untracked",
+            linesAdded: lineCount,
+            linesRemoved: 0,
+          });
+          untrackedProcessed++;
         }
 
         return files;
@@ -634,14 +594,16 @@ export interface GetDiffStatsOptions extends CreateGitClientOptions {
 export function computeDiffStatsFromFiles(files: ChangedFileInfo[]): DiffStats {
   let linesAdded = 0;
   let linesRemoved = 0;
+  const uniquePaths = new Set<string>();
 
   for (const file of files) {
     linesAdded += file.linesAdded ?? 0;
     linesRemoved += file.linesRemoved ?? 0;
+    uniquePaths.add(file.path);
   }
 
   return {
-    filesChanged: files.length,
+    filesChanged: uniquePaths.size,
     linesAdded,
     linesRemoved,
   };
@@ -922,20 +884,24 @@ export async function hasTrackedFiles(
 
 export async function getStagedDiff(
   baseDir: string,
-  options?: CreateGitClientOptions,
+  options?: CreateGitClientOptions & { ignoreWhitespace?: boolean },
 ): Promise<string> {
   const manager = getGitOperationManager();
-  return manager.executeRead(baseDir, (git) => git.diff(["--cached", "HEAD"]), {
+  const args = ["--cached", "HEAD"];
+  if (options?.ignoreWhitespace) args.push("-w");
+  return manager.executeRead(baseDir, (git) => git.diff(args), {
     signal: options?.abortSignal,
   });
 }
 
 export async function getUnstagedDiff(
   baseDir: string,
-  options?: CreateGitClientOptions,
+  options?: CreateGitClientOptions & { ignoreWhitespace?: boolean },
 ): Promise<string> {
   const manager = getGitOperationManager();
-  return manager.executeRead(baseDir, (git) => git.diff(), {
+  const args: string[] = [];
+  if (options?.ignoreWhitespace) args.push("-w");
+  return manager.executeRead(baseDir, (git) => git.diff(args), {
     signal: options?.abortSignal,
   });
 }
@@ -950,6 +916,30 @@ export async function getDiffHead(
   return manager.executeRead(baseDir, (git) => git.diff(args), {
     signal: options?.abortSignal,
   });
+}
+
+export async function stageFiles(
+  baseDir: string,
+  paths: string[],
+  options?: CreateGitClientOptions,
+): Promise<void> {
+  const manager = getGitOperationManager();
+  await manager.executeWrite(baseDir, (git) => git.add(paths), {
+    signal: options?.abortSignal,
+  });
+}
+
+export async function unstageFiles(
+  baseDir: string,
+  paths: string[],
+  options?: CreateGitClientOptions,
+): Promise<void> {
+  const manager = getGitOperationManager();
+  await manager.executeWrite(
+    baseDir,
+    (git) => git.reset(["HEAD", "--", ...paths]),
+    { signal: options?.abortSignal },
+  );
 }
 
 export async function getDiffAgainstRemote(

--- a/packages/git/src/sagas/commit.ts
+++ b/packages/git/src/sagas/commit.ts
@@ -4,6 +4,7 @@ export interface CommitInput extends GitSagaInput {
   message: string;
   paths?: string[];
   allowEmpty?: boolean;
+  stagedOnly?: boolean;
 }
 
 export interface CommitOutput {
@@ -18,7 +19,7 @@ export class CommitSaga extends GitSaga<CommitInput, CommitOutput> {
   protected async executeGitOperations(
     input: CommitInput,
   ): Promise<CommitOutput> {
-    const { message, paths, allowEmpty } = input;
+    const { message, paths, allowEmpty, stagedOnly } = input;
 
     const originalHead = await this.readOnlyStep("get-original-head", () =>
       this.git.revparse(["HEAD"]),
@@ -28,25 +29,38 @@ export class CommitSaga extends GitSaga<CommitInput, CommitOutput> {
       this.git.revparse(["--abbrev-ref", "HEAD"]),
     );
 
-    this.previouslyStagedFiles = await this.readOnlyStep(
-      "get-staged-files",
-      async () => {
-        const status = await this.git.status();
-        return status.staged;
-      },
-    );
+    if (stagedOnly) {
+      const stagedCheck = await this.readOnlyStep(
+        "verify-staged-files",
+        async () => {
+          const status = await this.git.status();
+          return status.staged;
+        },
+      );
+      if (stagedCheck.length === 0) {
+        throw new Error("No staged changes to commit.");
+      }
+    } else {
+      this.previouslyStagedFiles = await this.readOnlyStep(
+        "get-staged-files",
+        async () => {
+          const status = await this.git.status();
+          return status.staged;
+        },
+      );
 
-    await this.step({
-      name: "stage-files",
-      execute: () =>
-        paths && paths.length > 0 ? this.git.add(paths) : this.git.add("-A"),
-      rollback: async () => {
-        await this.git.reset();
-        if (this.previouslyStagedFiles.length > 0) {
-          await this.git.add(this.previouslyStagedFiles);
-        }
-      },
-    });
+      await this.step({
+        name: "stage-files",
+        execute: () =>
+          paths && paths.length > 0 ? this.git.add(paths) : this.git.add("-A"),
+        rollback: async () => {
+          await this.git.reset();
+          if (this.previouslyStagedFiles.length > 0) {
+            await this.git.add(this.previouslyStagedFiles);
+          }
+        },
+      });
+    }
 
     const commitResult = await this.step({
       name: "commit",


### PR DESCRIPTION
## TL;DR
Add support for staged file tracking and selective commits, enable diff viewing for staged/unstaged changes separately, and improve the PR creation workflow to support committing only staged files.

## What changed?

### Core functionality
- Added `staged` field to `ChangedFile` schema to track which files are staged
- Added `stagedOnly` parameter to `CreatePrSagaInput` to support selective PR creation
- Modified `commit()` method signature to accept an options object with `paths`, `allowEmpty`, and `stagedOnly` parameters
- Added new methods to `GitService`:
  - `getDiffCached()` - get diff of staged changes
  - `getDiffUnstaged()` - get diff of unstaged changes
  - `stageFiles()` - stage specific files
  - `unstageFiles()` - unstage specific files

### Schema updates
- Renamed generic diff schema from `getDiffHead` to `diffInput`/`diffOutput` for reusability across multiple diff operations
- Added `staged` field to `changedFileSchema`
- Added `stagedOnly` field to `commitInput` and `createPrInput` schemas
- Added new `stageFilesInput` schema for file staging operations

### PR creation workflow
- Updated `CreatePrSaga` to pass `stagedOnly` parameter through to the commit step
- Updated git router to expose new diff and file staging endpoints
- Modified `commit()` call in service to pass `stagedOnly` option

## How did you test this?
Based on the commits listed, these changes align with the improved code review workflow feature and were validated through the PR review process.