### PR TITLE
feat(code): add commit trailers for attribution

### DIFF
--- a/apps/code/src/main/services/git/create-pr-saga.ts
+++ b/apps/code/src/main/services/git/create-pr-saga.ts
@@ -18,6 +18,7 @@ export interface CreatePrSagaInput {
   prBody?: string;
   draft?: boolean;
   stagedOnly?: boolean;
+  taskId?: string;
 }
 
 export interface CreatePrSagaOutput {
@@ -36,7 +37,7 @@ export interface CreatePrDeps {
   commit(
     dir: string,
     message: string,
-    stagedOnly?: boolean,
+    options?: { stagedOnly?: boolean; taskId?: string },
   ): Promise<CommitOutput>;
   getSyncStatus(dir: string): Promise<GitSyncStatus>;
   push(dir: string): Promise<PushOutput>;
@@ -128,11 +129,10 @@ export class CreatePrSaga extends Saga<CreatePrSagaInput, CreatePrSagaOutput> {
       await this.step({
         name: "committing",
         execute: async () => {
-          const result = await this.deps.commit(
-            directoryPath,
-            commitMessage!,
-            input.stagedOnly,
-          );
+          const result = await this.deps.commit(directoryPath, commitMessage!, {
+            stagedOnly: input.stagedOnly,
+            taskId: input.taskId,
+          });
           if (!result.success) throw new Error(result.message);
           return result;
         },

--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -206,6 +206,7 @@ export const commitInput = z.object({
   paths: z.array(z.string()).optional(),
   allowEmpty: z.boolean().optional(),
   stagedOnly: z.boolean().optional(),
+  taskId: z.string().optional(),
 });
 
 export type CommitInput = z.infer<typeof commitInput>;
@@ -250,6 +251,7 @@ export const createPrInput = z.object({
   prBody: z.string().optional(),
   draft: z.boolean().optional(),
   stagedOnly: z.boolean().optional(),
+  taskId: z.string().optional(),
 });
 
 export type CreatePrInput = z.infer<typeof createPrInput>;

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -513,6 +513,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     prBody?: string;
     draft?: boolean;
     stagedOnly?: boolean;
+    taskId?: string;
   }): Promise<CreatePrOutput> {
     const { directoryPath, flowId } = input;
 
@@ -536,7 +537,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
         checkoutBranch: (dir, name) => this.checkoutBranch(dir, name),
         getChangedFilesHead: (dir) => this.getChangedFilesHead(dir),
         generateCommitMessage: (dir) => this.generateCommitMessage(dir),
-        commit: (dir, msg, stagedOnly) => this.commit(dir, msg, { stagedOnly }),
+        commit: (dir, msg, opts) => this.commit(dir, msg, opts),
         getSyncStatus: (dir) => this.getGitSyncStatus(dir),
         push: (dir) => this.push(dir),
         publish: (dir) => this.publish(dir),
@@ -556,6 +557,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
       prBody: input.prBody,
       draft: input.draft,
       stagedOnly: input.stagedOnly,
+      taskId: input.taskId,
     });
 
     if (!result.success) {
@@ -619,7 +621,12 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
   public async commit(
     directoryPath: string,
     message: string,
-    options?: { paths?: string[]; allowEmpty?: boolean; stagedOnly?: boolean },
+    options?: {
+      paths?: string[];
+      allowEmpty?: boolean;
+      stagedOnly?: boolean;
+      taskId?: string;
+    },
   ): Promise<CommitOutput> {
     const fail = (msg: string): CommitOutput => ({
       success: false,

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -223,6 +223,7 @@ export const gitRouter = router({
         paths: input.paths,
         allowEmpty: input.allowEmpty,
         stagedOnly: input.stagedOnly,
+        taskId: input.taskId,
       }),
     ),
 

--- a/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
@@ -230,6 +230,7 @@ export function useGitInteraction(
         prBody: store.prBody.trim() || undefined,
         draft: store.createPrDraft || undefined,
         stagedOnly: stagedOnly || undefined,
+        taskId,
       });
 
       if (!result.success) {
@@ -349,6 +350,7 @@ export function useGitInteraction(
         directoryPath: repoPath,
         message,
         stagedOnly: stagedOnly || undefined,
+        taskId,
       });
 
       if (!result.success) {

--- a/packages/git/src/sagas/commit.ts
+++ b/packages/git/src/sagas/commit.ts
@@ -1,10 +1,17 @@
 import { GitSaga, type GitSagaInput } from "../git-saga";
 
+function buildPostHogTrailers(taskId?: string): string[] {
+  const trailers = ["Generated-By: PostHog Code"];
+  if (taskId) trailers.push(`Task-Id: ${taskId}`);
+  return trailers;
+}
+
 export interface CommitInput extends GitSagaInput {
   message: string;
   paths?: string[];
   allowEmpty?: boolean;
   stagedOnly?: boolean;
+  taskId?: string;
 }
 
 export interface CommitOutput {
@@ -19,7 +26,7 @@ export class CommitSaga extends GitSaga<CommitInput, CommitOutput> {
   protected async executeGitOperations(
     input: CommitInput,
   ): Promise<CommitOutput> {
-    const { message, paths, allowEmpty, stagedOnly } = input;
+    const { message, paths, allowEmpty, stagedOnly, taskId } = input;
 
     const originalHead = await this.readOnlyStep("get-original-head", () =>
       this.git.revparse(["HEAD"]),
@@ -62,11 +69,19 @@ export class CommitSaga extends GitSaga<CommitInput, CommitOutput> {
       });
     }
 
+    const trailers = buildPostHogTrailers(taskId);
+
+    const commitOptions: Record<string, null | string[]> = {};
+    if (allowEmpty) commitOptions["--allow-empty"] = null;
+    if (trailers.length > 0) commitOptions["--trailer"] = trailers;
+
+    const hasOptions = Object.keys(commitOptions).length > 0;
+
     const commitResult = await this.step({
       name: "commit",
       execute: () =>
-        allowEmpty
-          ? this.git.commit(message, undefined, { "--allow-empty": null })
+        hasOptions
+          ? this.git.commit(message, undefined, commitOptions)
           : this.git.commit(message),
       rollback: async () => {
         await this.git.reset(["--soft", originalHead]);


### PR DESCRIPTION
## Problem

we don't (yet) do a great job of attributing work done by posthog code back to posthog code.

one small step in that direction is adding commit trailers to all commits made in our UI

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds commit trailers to all commits from the UI, with a reference to posthog code and the task ID

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

tested manually, sample `git log`:

```
commit 2c95d4396cc3fed3f138b4f0e63e8f771632c007 (HEAD -> posthog-code/test-change)
Author: Adam Bowker <adam.b@posthog.com>
Date:   Wed Apr 1 14:19:10 2026 -0700

    fix(actions): remove test comment from ActionsModelProps interface

    Generated-By: PostHog Code
    Task-Id: e6f79d08-9b9d-42fe-8648-14fe1aad8bcb
```