### PR TITLE
feat(code): add commit and pr attribution to system prompt

### DIFF
--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -418,11 +418,40 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
 
   private buildSystemPrompt(
     credentials: Credentials,
+    taskId: string,
     customInstructions?: string,
   ): {
     append: string;
   } {
     let prompt = `PostHog context: use project ${credentials.projectId} on ${credentials.apiHost}. When using PostHog MCP tools, operate only on this project.`;
+
+    prompt += `
+
+## Attribution
+Do NOT use Claude Code's default attribution (no "Co-Authored-By" trailers, no "Generated with [Claude Code]" lines).
+
+Instead, add the following trailers to EVERY commit message (after a blank line at the end):
+  Generated-By: PostHog Code
+  Task-Id: ${taskId}
+
+Example:
+\`\`\`
+git commit -m "$(cat <<'EOF'
+fix: resolve login redirect loop
+
+Generated-By: PostHog Code
+Task-Id: ${taskId}
+EOF
+)"
+\`\`\`
+
+When creating new branches, prefix them with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`).
+
+When creating pull requests, add the following footer at the end of the PR description:
+\`\`\`
+---
+*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
+\`\`\``;
 
     if (customInstructions) {
       prompt += `\n\nUser custom instructions:\n${customInstructions}`;
@@ -632,6 +661,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
 
         const systemPrompt = this.buildSystemPrompt(
           credentials,
+          taskId,
           customInstructions,
         );
         const resumeResponse = await connection.unstable_resumeSession({
@@ -669,6 +699,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
         }
         const systemPrompt = this.buildSystemPrompt(
           credentials,
+          taskId,
           customInstructions,
         );
         const newSessionResponse = await connection.newSession({

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -365,14 +365,19 @@ describe("AgentServer HTTP Mode", () => {
       expect(prompt).toContain("https://github.com/org/repo/pull/1");
       expect(prompt).toContain("gh pr checkout");
       expect(prompt).not.toContain("Create a draft pull request");
+      expect(prompt).toContain("Generated-By: PostHog Code");
+      expect(prompt).toContain("Task-Id: test-task-id");
     });
 
     it("returns default prompt when no prUrl", () => {
       const s = createServer();
       const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt();
-      expect(prompt).toContain("Create a new branch");
+      expect(prompt).toContain("posthog-code/");
       expect(prompt).toContain("Create a draft pull request");
       expect(prompt).toContain("gh pr create --draft");
+      expect(prompt).toContain("Generated-By: PostHog Code");
+      expect(prompt).toContain("Task-Id: test-task-id");
+      expect(prompt).toContain("Created with [PostHog Code]");
     });
 
     it("returns default prompt when prUrl is null", () => {
@@ -380,7 +385,7 @@ describe("AgentServer HTTP Mode", () => {
       const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt(
         null,
       );
-      expect(prompt).toContain("Create a new branch");
+      expect(prompt).toContain("posthog-code/");
       expect(prompt).toContain("Create a draft pull request");
       expect(prompt).toContain("gh pr create --draft");
     });

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1062,6 +1062,26 @@ export class AgentServer {
   }
 
   private buildCloudSystemPrompt(prUrl?: string | null): string {
+    const taskId = this.config.taskId;
+    const attributionInstructions = `
+## Attribution
+Do NOT use Claude Code's default attribution (no "Co-Authored-By" trailers, no "Generated with [Claude Code]" lines).
+
+Instead, add the following trailers to EVERY commit message (after a blank line at the end):
+  Generated-By: PostHog Code
+  Task-Id: ${taskId}
+
+Example:
+\`\`\`
+git commit -m "$(cat <<'EOF'
+fix: resolve login redirect loop
+
+Generated-By: PostHog Code
+Task-Id: ${taskId}
+EOF
+)"
+\`\`\``;
+
     if (prUrl) {
       return `
 # Cloud Task Execution
@@ -1075,8 +1095,7 @@ After completing the requested changes:
 
 Important:
 - Do NOT create a new branch or a new pull request.
-- Do NOT add "Co-Authored-By" trailers to commit messages.
-- Do NOT add "Generated with [Claude Code]" or similar attribution lines to PR descriptions.
+${attributionInstructions}
 `;
     }
 
@@ -1105,15 +1124,18 @@ Important:
 # Cloud Task Execution
 
 After completing the requested changes:
-1. Create a new branch with a descriptive name based on the work done
+1. Create a new branch prefixed with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`) based on the work done
 2. Stage and commit all changes with a clear commit message
 3. Push the branch to origin
-4. Create a draft pull request using \`gh pr create --draft${this.config.baseBranch ? ` --base ${this.config.baseBranch}` : ""}\` with a descriptive title and body
+4. Create a draft pull request using \`gh pr create --draft${this.config.baseBranch ? ` --base ${this.config.baseBranch}` : ""}\` with a descriptive title and body. Add the following footer at the end of the PR description:
+\`\`\`
+---
+*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
+\`\`\`
 
 Important:
 - Always create the PR as a draft. Do not ask for confirmation.
-- Do NOT add "Co-Authored-By" trailers to commit messages.
-- Do NOT add "Generated with [Claude Code]" or similar attribution lines to PR descriptions.
+${attributionInstructions}
 `;
   }
 


### PR DESCRIPTION
## Problem

we explicitly instruct the (cloud) agent to not include any attribution lines -- presumably to avoid the default claude code stuff

however, this means there's also no attribution back to posthog code

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

- cloud: replaces the "no attribution" prompting with instructions to add commit trailers (see #1431 ) and PR body footers
- local: adds new commit+PR attribution instructions, which hopefully will override whatever is injected by claude code

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

i haven't yet :see_no_evil:

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->