### PR TITLE
feat(code): add attribution to PR body from UI

### DIFF
--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -767,10 +767,13 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     body?: string,
     draft?: boolean,
   ): Promise<{ success: boolean; message: string; prUrl: string | null }> {
+    const prFooter =
+      "\n\n---\n*Created with [PostHog Code](https://posthog.com/code?ref=pr)*";
+
     const args = ["pr", "create"];
     if (title) {
       args.push("--title", title);
-      args.push("--body", body || "");
+      args.push("--body", (body || "") + prFooter);
     } else {
       args.push("--fill");
     }


### PR DESCRIPTION
## Problem

#1431 adds commit trailers when committing via UI, #1432 adds trailers + PR body instructions for agent

now we need to add PR body footer when creating a PR via UI

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

appends "created by posthog code" to PR body when creating from UI

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

https://github.com/PostHog/posthog/pull/53123