### PR TITLE
feat: Track diff view mode changes

### DIFF
--- a/apps/code/src/renderer/features/code-editor/stores/diffViewerStore.ts
+++ b/apps/code/src/renderer/features/code-editor/stores/diffViewerStore.ts
@@ -1,3 +1,5 @@
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
+import { track } from "@utils/analytics";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -30,11 +32,32 @@ export const useDiffViewerStore = create<DiffViewerStore>()(
       loadFullFiles: false,
       wordDiffs: true,
       hideWhitespaceChanges: false,
-      setViewMode: (mode) => set({ viewMode: mode }),
+      setViewMode: (mode) =>
+        set((state) => {
+          if (state.viewMode === mode) {
+            return state;
+          }
+
+          track(ANALYTICS_EVENTS.DIFF_VIEW_MODE_CHANGED, {
+            from_mode: state.viewMode,
+            to_mode: mode,
+          });
+
+          return { viewMode: mode };
+        }),
       toggleViewMode: () =>
-        set((s) => ({
-          viewMode: s.viewMode === "split" ? "unified" : "split",
-        })),
+        set((state) => {
+          const nextMode = state.viewMode === "split" ? "unified" : "split";
+
+          track(ANALYTICS_EVENTS.DIFF_VIEW_MODE_CHANGED, {
+            from_mode: state.viewMode,
+            to_mode: nextMode,
+          });
+
+          return {
+            viewMode: nextMode,
+          };
+        }),
       toggleWordWrap: () => set((s) => ({ wordWrap: !s.wordWrap })),
       toggleLoadFullFiles: () =>
         set((s) => ({ loadFullFiles: !s.loadFullFiles })),

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -120,6 +120,11 @@ export interface ReviewPanelViewedProperties {
   task_id: string;
 }
 
+export interface DiffViewModeChangedProperties {
+  from_mode: "split" | "unified";
+  to_mode: "split" | "unified";
+}
+
 // Workspace events
 export interface WorkspaceCreatedProperties {
   task_id: string;
@@ -221,6 +226,7 @@ export const ANALYTICS_EVENTS = {
   FILE_OPENED: "File opened",
   FILE_DIFF_VIEWED: "File diff viewed",
   REVIEW_PANEL_VIEWED: "Review panel viewed",
+  DIFF_VIEW_MODE_CHANGED: "Diff view mode changed",
 
   // Workspace events
   WORKSPACE_CREATED: "Workspace created",
@@ -275,6 +281,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.FILE_OPENED]: FileOpenedProperties;
   [ANALYTICS_EVENTS.FILE_DIFF_VIEWED]: FileDiffViewedProperties;
   [ANALYTICS_EVENTS.REVIEW_PANEL_VIEWED]: ReviewPanelViewedProperties;
+  [ANALYTICS_EVENTS.DIFF_VIEW_MODE_CHANGED]: DiffViewModeChangedProperties;
 
   // Workspace events
   [ANALYTICS_EVENTS.WORKSPACE_CREATED]: WorkspaceCreatedProperties;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Add PostHog tracking when users change their diff view mode.

## Changes
- Added a new analytics event `Diff view mode changed` with `from_mode` / `to_mode` properties.
- Emitted the event from `useDiffViewerStore` whenever `viewMode` is updated via `setViewMode` / `toggleViewMode`.

## How did you test this?
- Ran `biome check` on the touched files.
- (`pnpm --filter code typecheck` in this environment fails due to missing workspace type modules unrelated to this change.)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c81a39da-3a98-472f-bce5-747188b8247b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c81a39da-3a98-472f-bce5-747188b8247b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

