### PR TITLE
feat: Add grid icons to layout picker

### DIFF
--- a/apps/code/src/renderer/features/command-center/components/CommandCenterToolbar.tsx
+++ b/apps/code/src/renderer/features/command-center/components/CommandCenterToolbar.tsx
@@ -15,13 +15,55 @@ import {
   useCommandCenterStore,
 } from "../stores/commandCenterStore";
 
-const LAYOUT_OPTIONS: { value: LayoutPreset; label: string }[] = [
-  { value: "1x1", label: "1x1" },
-  { value: "2x1", label: "2x1" },
-  { value: "1x2", label: "1x2" },
-  { value: "2x2", label: "2x2" },
-  { value: "3x2", label: "3x2" },
-  { value: "3x3", label: "3x3" },
+function LayoutIcon({ cols, rows }: { cols: number; rows: number }) {
+  const size = 14;
+  const gap = 1.5;
+  const cellW = (size - gap * (cols - 1)) / cols;
+  const cellH = (size - gap * (rows - 1)) / rows;
+
+  const rects: React.ReactElement[] = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      rects.push(
+        <rect
+          key={`${r}-${c}`}
+          x={c * (cellW + gap)}
+          y={r * (cellH + gap)}
+          width={cellW}
+          height={cellH}
+          rx={1}
+          fill="currentColor"
+          opacity={0.5}
+        />,
+      );
+    }
+  }
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={`${cols} by ${rows} grid`}
+    >
+      {rects}
+    </svg>
+  );
+}
+
+const LAYOUT_OPTIONS: {
+  value: LayoutPreset;
+  label: string;
+  cols: number;
+  rows: number;
+}[] = [
+  { value: "1x1", label: "1x1", cols: 1, rows: 1 },
+  { value: "2x1", label: "2x1", cols: 2, rows: 1 },
+  { value: "1x2", label: "1x2", cols: 1, rows: 2 },
+  { value: "2x2", label: "2x2", cols: 2, rows: 2 },
+  { value: "3x2", label: "3x2", cols: 3, rows: 2 },
+  { value: "3x3", label: "3x3", cols: 3, rows: 3 },
 ];
 
 interface CommandCenterToolbarProps {
@@ -86,7 +128,10 @@ export function CommandCenterToolbar({
         <Select.Content>
           {LAYOUT_OPTIONS.map((opt) => (
             <Select.Item key={opt.value} value={opt.value}>
-              {opt.label}
+              <Flex align="center" gap="2">
+                <LayoutIcon cols={opt.cols} rows={opt.rows} />
+                {opt.label}
+              </Flex>
             </Select.Item>
           ))}
         </Select.Content>


### PR DESCRIPTION
## Problem

Paul has been squinting at the layout dropdown like it's an eye exam and picking the wrong grid every single time.

![CleanShot 2026-04-02 at 06.40.17@2x.png](https://app.graphite.com/user-attachments/assets/ccef1ac9-0cf1-474d-8e1e-b86719629702.png)

## Changes

  1. Add LayoutIcon SVG component that renders a mini grid preview matching each layout preset
  2. Show the icon inline next to each label in the layout picker dropdown
  3. Extend LAYOUT_OPTIONS with explicit cols/rows for icon generation

## How did you test this?

Manually
