### PR TITLE
feat(cloud-agent): user-authored-prs

### DIFF
--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -223,6 +223,14 @@ export const ghStatusOutput = z.object({
 
 export type GhStatusOutput = z.infer<typeof ghStatusOutput>;
 
+export const ghAuthTokenOutput = z.object({
+  success: z.boolean(),
+  token: z.string().nullable(),
+  error: z.string().nullable(),
+});
+
+export type GhAuthTokenOutput = z.infer<typeof ghAuthTokenOutput>;
+
 // Pull request status
 export const prStatusInput = directoryPathInput;
 export const prStatusOutput = z.object({

--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -127,3 +127,61 @@ describe("GitService.getPrChangedFiles", () => {
     ).rejects.toThrow("Failed to fetch PR files");
   });
 });
+
+describe("GitService.getGhAuthToken", () => {
+  let service: GitService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitService({} as LlmGatewayService);
+  });
+
+  it("returns the authenticated GitHub CLI token", async () => {
+    mockExecGh.mockResolvedValue({
+      exitCode: 0,
+      stdout: "ghu_test_token\n",
+      stderr: "",
+    });
+
+    const result = await service.getGhAuthToken();
+
+    expect(mockExecGh).toHaveBeenCalledWith(["auth", "token"]);
+    expect(result).toEqual({
+      success: true,
+      token: "ghu_test_token",
+      error: null,
+    });
+  });
+
+  it("returns the gh error when auth token lookup fails", async () => {
+    mockExecGh.mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "authentication required",
+    });
+
+    const result = await service.getGhAuthToken();
+
+    expect(result).toEqual({
+      success: false,
+      token: null,
+      error: "authentication required",
+    });
+  });
+
+  it("returns error when stdout is empty", async () => {
+    mockExecGh.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+
+    const result = await service.getGhAuthToken();
+
+    expect(result).toEqual({
+      success: false,
+      token: null,
+      error: "GitHub auth token is empty",
+    });
+  });
+});

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -46,6 +46,7 @@ import type {
   DiscardFileChangesOutput,
   GetCommitConventionsOutput,
   GetPrTemplateOutput,
+  GhAuthTokenOutput,
   GhStatusOutput,
   GitCommitInfo,
   GitFileStatus,
@@ -703,6 +704,33 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
       error: authenticated
         ? null
         : authResult.stderr || authResult.error || null,
+    };
+  }
+
+  public async getGhAuthToken(): Promise<GhAuthTokenOutput> {
+    const result = await execGh(["auth", "token"]);
+    if (result.exitCode !== 0) {
+      return {
+        success: false,
+        token: null,
+        error:
+          result.stderr || result.error || "Failed to read GitHub auth token",
+      };
+    }
+
+    const token = result.stdout.trim();
+    if (!token) {
+      return {
+        success: false,
+        token: null,
+        error: "GitHub auth token is empty",
+      };
+    }
+
+    return {
+      success: true,
+      token,
+      error: null,
     };
   }
 

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -44,6 +44,7 @@ import {
   getPrChangedFilesOutput,
   getPrTemplateInput,
   getPrTemplateOutput,
+  ghAuthTokenOutput,
   ghStatusOutput,
   gitStateSnapshotSchema,
   openPrInput,
@@ -263,6 +264,10 @@ export const gitRouter = router({
   getGhStatus: publicProcedure
     .output(ghStatusOutput)
     .query(() => getService().getGhStatus()),
+
+  getGhAuthToken: publicProcedure
+    .output(ghAuthTokenOutput)
+    .query(() => getService().getGhAuthToken()),
 
   getPrStatus: publicProcedure
     .input(prStatusInput)

--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -18,6 +18,7 @@ import type {
   Task,
   TaskRun,
 } from "@shared/types";
+import type { CloudRunSource, PrAuthorshipMode } from "@shared/types/cloud";
 import type { StoredLogEntry } from "@shared/types/session-events";
 import { logger } from "@utils/logger";
 import { buildApiFetcher } from "./fetcher";
@@ -732,6 +733,10 @@ export class PostHogAPIClient {
       resumeFromRunId?: string;
       pendingUserMessage?: string;
       sandboxEnvironmentId?: string;
+      prAuthorshipMode?: PrAuthorshipMode;
+      runSource?: CloudRunSource;
+      signalReportId?: string;
+      githubUserToken?: string;
     },
   ): Promise<Task> {
     const teamId = await this.getTeamId();
@@ -747,6 +752,18 @@ export class PostHogAPIClient {
     }
     if (options?.sandboxEnvironmentId) {
       body.sandbox_environment_id = options.sandboxEnvironmentId;
+    }
+    if (options?.prAuthorshipMode) {
+      body.pr_authorship_mode = options.prAuthorshipMode;
+    }
+    if (options?.runSource) {
+      body.run_source = options.runSource;
+    }
+    if (options?.signalReportId) {
+      body.signal_report_id = options.signalReportId;
+    }
+    if (options?.githubUserToken) {
+      body.github_user_token = options.githubUserToken;
     }
 
     const data = await this.api.post(

--- a/apps/code/src/renderer/features/inbox/stores/inboxCloudTaskStore.ts
+++ b/apps/code/src/renderer/features/inbox/stores/inboxCloudTaskStore.ts
@@ -61,6 +61,9 @@ export const useInboxCloudTaskStore = create<InboxCloudTaskStore>()(
           workspaceMode: "cloud",
           githubIntegrationId: params.githubIntegrationId,
           repository: selectedRepo,
+          cloudPrAuthorshipMode: "user",
+          cloudRunSource: "signal_report",
+          signalReportId: params.reportId,
         });
 
         if (result.success) {

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -35,6 +35,7 @@ import { isNotification, POSTHOG_NOTIFICATIONS } from "@posthog/agent";
 import { DEFAULT_GATEWAY_MODEL } from "@posthog/agent/gateway-models";
 import { getIsOnline } from "@renderer/stores/connectivityStore";
 import { trpcClient } from "@renderer/trpc/client";
+import { getGhUserTokenOrThrow } from "@renderer/utils/github";
 import { toast } from "@renderer/utils/toast";
 import { getCloudUrlFromRegion } from "@shared/constants/oauth";
 import {
@@ -45,6 +46,7 @@ import {
   type Task,
 } from "@shared/types";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
+import type { CloudRunSource, PrAuthorshipMode } from "@shared/types/cloud";
 import type { AcpMessage, StoredLogEntry } from "@shared/types/session-events";
 import { isJsonRpcRequest } from "@shared/types/session-events";
 import { buildPermissionToolMetadata, track } from "@utils/analytics";
@@ -1342,6 +1344,35 @@ export class SessionService {
 
     const { blocks, promptText } = await this.prepareCloudPrompt(prompt);
 
+    const [previousRun, task] = await Promise.all([
+      client.getTaskRun(session.taskId, session.taskRunId),
+      client.getTask(session.taskId),
+    ]);
+    const hasGitHubRepo = !!task.repository && !!task.github_integration;
+    const previousState = previousRun.state as Record<string, unknown>;
+    const previousOutput = (previousRun.output ?? {}) as Record<
+      string,
+      unknown
+    >;
+    // Prefer the actual working branch the agent last pushed to (synced by
+    // agent-server after each turn), then the run-level branch field, then
+    // the original base branch from state. This preserves unmerged work when
+    // the snapshot has expired and the sandbox is rebuilt from scratch.
+    const previousBaseBranch =
+      (typeof previousOutput.head_branch === "string"
+        ? previousOutput.head_branch
+        : null) ??
+      previousRun.branch ??
+      (typeof previousState.pr_base_branch === "string"
+        ? previousState.pr_base_branch
+        : null) ??
+      session.cloudBranch;
+    const prAuthorshipMode = this.getCloudPrAuthorshipMode(previousState);
+    const githubUserToken =
+      prAuthorshipMode === "user" && hasGitHubRepo
+        ? await getGhUserTokenOrThrow()
+        : undefined;
+
     log.info("Creating resume run for terminal cloud task", {
       taskId: session.taskId,
       previousRunId: session.taskRunId,
@@ -1353,10 +1384,17 @@ export class SessionService {
     // The agent will load conversation history and restore the sandbox snapshot.
     const updatedTask = await client.runTaskInCloud(
       session.taskId,
-      session.cloudBranch,
+      previousBaseBranch,
       {
         resumeFromRunId: session.taskRunId,
         pendingUserMessage: serializeCloudPrompt(blocks),
+        prAuthorshipMode,
+        runSource: this.getCloudRunSource(previousState),
+        signalReportId:
+          typeof previousState.signal_report_id === "string"
+            ? previousState.signal_report_id
+            : undefined,
+        githubUserToken,
       },
     );
     const newRun = updatedTask.latest_run;
@@ -2079,6 +2117,20 @@ export class SessionService {
         this.stopCloudTaskWatch(update.taskId);
       }
     }
+  }
+
+  private getCloudPrAuthorshipMode(
+    state: Record<string, unknown>,
+  ): PrAuthorshipMode {
+    const explicitMode = state.pr_authorship_mode;
+    if (explicitMode === "user" || explicitMode === "bot") {
+      return explicitMode;
+    }
+    return state.run_source === "signal_report" ? "bot" : "user";
+  }
+
+  private getCloudRunSource(state: Record<string, unknown>): CloudRunSource {
+    return state.run_source === "signal_report" ? "signal_report" : "manual";
   }
 
   /**

--- a/apps/code/src/renderer/sagas/task/task-creation.test.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.test.ts
@@ -153,6 +153,10 @@ describe("TaskCreationSaga", () => {
       {
         pendingUserMessage: "Ship the fix",
         sandboxEnvironmentId: undefined,
+        prAuthorshipMode: "bot",
+        runSource: "manual",
+        signalReportId: undefined,
+        githubUserToken: undefined,
       },
     );
     expect(sendRunCommandMock).not.toHaveBeenCalled();
@@ -212,12 +216,14 @@ describe("TaskCreationSaga", () => {
     expect(runTaskInCloudMock).toHaveBeenCalledWith(
       "task-123",
       "release/remembered-branch",
-      {
+      expect.objectContaining({
         pendingUserMessage: expect.stringContaining(
           "__twig_cloud_prompt_v1__:",
         ),
         sandboxEnvironmentId: undefined,
-      },
+        prAuthorshipMode: "bot",
+        runSource: "manual",
+      }),
     );
     expect(sendRunCommandMock).not.toHaveBeenCalled();
     expect(runTaskInCloudMock.mock.invocationCallOrder[0]).toBeLessThan(

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -21,6 +21,8 @@ import { trpcClient } from "@renderer/trpc";
 import { generateTitleAndSummary } from "@renderer/utils/generateTitle";
 import { getTaskRepository } from "@renderer/utils/repository";
 import type { ExecutionMode, Task } from "@shared/types";
+import type { CloudRunSource, PrAuthorshipMode } from "@shared/types/cloud";
+import { getGhUserTokenOrThrow } from "@utils/github";
 import { logger } from "@utils/logger";
 import { queryClient } from "@utils/queryClient";
 
@@ -78,6 +80,8 @@ export interface TaskCreationInput {
   reasoningLevel?: string;
   environmentId?: string;
   sandboxEnvironmentId?: string;
+  cloudPrAuthorshipMode?: PrAuthorshipMode;
+  cloudRunSource?: CloudRunSource;
   signalReportId?: string;
 }
 
@@ -275,13 +279,27 @@ export class TaskCreationSaga extends Saga<
     if (shouldStartCloudRun) {
       task = await this.step({
         name: "cloud_run",
-        execute: () =>
-          this.deps.posthogClient.runTaskInCloud(task.id, branch, {
+        execute: async () => {
+          const hasGitHubRepo = !!task.repository && !!task.github_integration;
+          const prAuthorshipMode =
+            input.cloudPrAuthorshipMode ?? (hasGitHubRepo ? "user" : "bot");
+          let githubUserToken: string | undefined;
+
+          if (prAuthorshipMode === "user" && hasGitHubRepo) {
+            githubUserToken = await getGhUserTokenOrThrow();
+          }
+
+          return this.deps.posthogClient.runTaskInCloud(task.id, branch, {
             pendingUserMessage: initialCloudPrompt
               ? serializeCloudPrompt(initialCloudPrompt)
               : undefined,
             sandboxEnvironmentId: input.sandboxEnvironmentId,
-          }),
+            prAuthorshipMode,
+            runSource: input.cloudRunSource ?? "manual",
+            signalReportId: input.signalReportId,
+            githubUserToken,
+          });
+        },
         rollback: async () => {
           log.info("Rolling back: cloud run (no-op)", { taskId: task.id });
         },

--- a/apps/code/src/renderer/utils/github.ts
+++ b/apps/code/src/renderer/utils/github.ts
@@ -1,0 +1,12 @@
+import { trpcClient } from "@renderer/trpc";
+
+export async function getGhUserTokenOrThrow(): Promise<string> {
+  const tokenResult = await trpcClient.git.getGhAuthToken.query();
+  if (!tokenResult.success || !tokenResult.token) {
+    throw new Error(
+      tokenResult.error ||
+        "Authenticate GitHub CLI with `gh auth login` before starting a cloud task.",
+    );
+  }
+  return tokenResult.token;
+}

--- a/apps/code/src/shared/types/cloud.ts
+++ b/apps/code/src/shared/types/cloud.ts
@@ -1,0 +1,2 @@
+export type PrAuthorshipMode = "user" | "bot";
+export type CloudRunSource = "manual" | "signal_report";

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -5,6 +5,7 @@ import {
   PROTOCOL_VERSION,
 } from "@agentclientprotocol/sdk";
 import { type ServerType, serve } from "@hono/node-server";
+import { getCurrentBranch } from "@posthog/git/queries";
 import { Hono } from "hono";
 import packageJson from "../../package.json" with { type: "json" };
 import { POSTHOG_NOTIFICATIONS } from "../acp-extensions";
@@ -167,6 +168,7 @@ export class AgentServer {
   private posthogAPI: PostHogAPIClient;
   private questionRelayedToSlack = false;
   private detectedPrUrl: string | null = null;
+  private lastReportedBranch: string | null = null;
   private resumeState: ResumeState | null = null;
   // Guards against concurrent session initialization. autoInitializeSession() and
   // the GET /events SSE handler can both call initializeSession() — the SSE connection
@@ -524,6 +526,10 @@ export class AgentServer {
           stopReason: result.stopReason,
         });
 
+        if (result.stopReason === "end_turn") {
+          void this.syncCloudBranchMetadata(this.session.payload);
+        }
+
         this.broadcastTurnComplete(result.stopReason);
 
         if (result.stopReason === "end_turn") {
@@ -879,6 +885,10 @@ export class AgentServer {
         stopReason: result.stopReason,
       });
 
+      if (result.stopReason === "end_turn") {
+        void this.syncCloudBranchMetadata(payload);
+      }
+
       this.broadcastTurnComplete(result.stopReason);
 
       if (result.stopReason === "end_turn") {
@@ -963,6 +973,10 @@ export class AgentServer {
       this.logger.info("Resume message completed", {
         stopReason: result.stopReason,
       });
+
+      if (result.stopReason === "end_turn") {
+        void this.syncCloudBranchMetadata(payload);
+      }
 
       this.broadcastTurnComplete(result.stopReason);
 
@@ -1166,6 +1180,44 @@ Important:
 - Always create the PR as a draft. Do not ask for confirmation.
 ${attributionInstructions}
 `;
+  }
+
+  private async getCurrentGitBranch(): Promise<string | null> {
+    if (!this.config.repositoryPath) {
+      return null;
+    }
+
+    try {
+      return await getCurrentBranch(this.config.repositoryPath);
+    } catch (error) {
+      this.logger.warn("Failed to determine current git branch", {
+        repositoryPath: this.config.repositoryPath,
+        error,
+      });
+      return null;
+    }
+  }
+
+  private async syncCloudBranchMetadata(payload: JwtPayload): Promise<void> {
+    const branchName = await this.getCurrentGitBranch();
+    if (!branchName || branchName === this.lastReportedBranch) {
+      return;
+    }
+
+    try {
+      await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
+        branch: branchName,
+        output: { head_branch: branchName },
+      });
+      this.lastReportedBranch = branchName;
+    } catch (error) {
+      this.logger.warn("Failed to attach current branch to task run", {
+        taskId: payload.task_id,
+        runId: payload.run_id,
+        branchName,
+        error,
+      });
+    }
   }
 
   private async signalTaskComplete(
@@ -1556,6 +1608,7 @@ ${attributionInstructions}
     }
 
     this.pendingEvents = [];
+    this.lastReportedBranch = null;
     this.session = null;
   }
 


### PR DESCRIPTION
## Problem

<img width="917" height="450" alt="CleanShot 2026-04-02 at 3  10 19" src="https://github.com/user-attachments/assets/71af3504-8d32-4e9a-ae42-70791e94c451" />

Cloud runs PRs are always opened by the GH app bot. Users who manually start cloud runs from `code` expect commits and PRs to appear under their own GH identity.

Companion PR: PostHog/posthog#53215
