### PR TITLE
feat: Add release notification workflow

### DIFF
--- a/.github/workflows/code-discord-release.yml
+++ b/.github/workflows/code-discord-release.yml
@@ -10,8 +10,6 @@ permissions: {}
 jobs:
   notify:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: SethCohen/github-releases-to-discord@37afa88c8c9302a9307244b5a0d4e782d528a4b5 # v1.15.1
         with:


### PR DESCRIPTION
## Problem

No automated way to notify the Discord community when a new app release is published.

This will play nicely when we have proper release changelogs as well.

## Changes

1. Add code-discord-release.yml workflow triggered on GitHub release publish
2. Use SethCohen/github-releases-to-discord action to post release notes
3. Requires DISCORD_RELEASE_WEBHOOK_URL repo secret

## How did you test this?

I tested the webhook and set the secret, but not this action.