### PR TITLE
test: Fix test repos using git commit signing if global commit signing is enabled

### DIFF
--- a/apps/code/src/main/services/archive/service.integration.test.ts
+++ b/apps/code/src/main/services/archive/service.integration.test.ts
@@ -46,6 +46,7 @@ async function createTempGitRepo(): Promise<string> {
     stdio: "pipe",
   });
   execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
+  execSync("git config commit.gpgsign false", { cwd: dir, stdio: "pipe" });
   await fs.writeFile(path.join(dir, "README.md"), "# Test Repo");
   execSync("git add . && git commit -m 'Initial commit'", {
     cwd: dir,

--- a/packages/agent/src/sagas/test-fixtures.ts
+++ b/packages/agent/src/sagas/test-fixtures.ts
@@ -38,6 +38,7 @@ export async function createTestRepo(prefix = "test-repo"): Promise<TestRepo> {
   await git(["init"]);
   await git(["config", "user.email", "test@test.com"]);
   await git(["config", "user.name", "Test"]);
+  await git(["config", "commit.gpgsign", "false"]);
 
   await writeFile(join(repoPath, ".gitignore"), ".posthog/\n");
   await writeFile(join(repoPath, "README.md"), "# Test Repo");

--- a/packages/agent/src/test/fixtures/api.ts
+++ b/packages/agent/src/test/fixtures/api.ts
@@ -35,6 +35,7 @@ export async function createTestRepo(prefix = "test-repo"): Promise<TestRepo> {
   await git(["init"]);
   await git(["config", "user.email", "test@test.com"]);
   await git(["config", "user.name", "Test"]);
+  await git(["config", "commit.gpgsign", "false"]);
 
   await writeFile(join(repoPath, ".gitignore"), ".posthog/\n");
   await writeFile(join(repoPath, "README.md"), "# Test Repo");

--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -11,6 +11,7 @@ async function setupRepo(defaultBranch = "main"): Promise<string> {
   await git.init(["--initial-branch", defaultBranch]);
   await git.addConfig("user.name", "Test");
   await git.addConfig("user.email", "test@example.com");
+  await git.addConfig("commit.gpgsign", "false");
   await writeFile(path.join(dir, "file.txt"), "content\n");
   await git.add(["file.txt"]);
   await git.commit("initial");

--- a/packages/git/src/sagas/checkpoint.test.ts
+++ b/packages/git/src/sagas/checkpoint.test.ts
@@ -18,6 +18,7 @@ async function setupRepo(): Promise<string> {
   await git.init();
   await git.addConfig("user.name", "PostHog Code Test");
   await git.addConfig("user.email", "posthog-code-test@example.com");
+  await git.addConfig("commit.gpgsign", "false");
 
   await writeFile(path.join(dir, "a.txt"), "one\n");
   await writeFile(path.join(dir, "b.txt"), "base\n");
@@ -258,6 +259,7 @@ describe("checkpoint sagas", () => {
       await subGit.init();
       await subGit.addConfig("user.name", "PostHog Code Test");
       await subGit.addConfig("user.email", "posthog-code-test@example.com");
+      await subGit.addConfig("commit.gpgsign", "false");
       await writeFile(path.join(subRepo, "sub.txt"), "sub\n");
       await subGit.add(["sub.txt"]);
       await subGit.commit("sub-init");


### PR DESCRIPTION
## Problem
Currently, if global commit signing is enabled for git, the tests require authorizing many commits manually, usually through a UI pop up with a fingerprint authorization.
<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes
Disables the commitsign git configuration option when creating the test repository. 
<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?
Run tests locally with commit signing enabled globally and verify that no commit signing requests occur.
<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->
