### PR TITLE
fix: Restore skill suggestions in new task view

### DIFF
--- a/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
+++ b/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
@@ -65,8 +65,12 @@ export function getCommandSuggestions(
   sessionId: string,
   query: string,
 ): CommandSuggestionItem[] {
-  const taskId = useDraftStore.getState().contexts[sessionId]?.taskId;
-  const merged = [...CODE_COMMANDS, ...getAvailableCommandsForTask(taskId)];
+  const store = useDraftStore.getState();
+  const taskId = store.contexts[sessionId]?.taskId;
+  const agentCommands = taskId
+    ? getAvailableCommandsForTask(taskId)
+    : (store.commands[sessionId] ?? []);
+  const merged = [...CODE_COMMANDS, ...agentCommands];
   const commands = [...new Map(merged.map((cmd) => [cmd.name, cmd])).values()];
   const filtered = searchCommands(commands, query);
 

--- a/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
@@ -4,6 +4,7 @@ import { TourHighlight } from "@components/TourHighlight";
 import { AttachmentsBar } from "@features/message-editor/components/AttachmentsBar";
 import { EditorToolbar } from "@features/message-editor/components/EditorToolbar";
 import type { MessageEditorHandle } from "@features/message-editor/components/MessageEditor";
+import { useDraftStore } from "@features/message-editor/stores/draftStore";
 import { useTaskInputHistoryStore } from "@features/message-editor/stores/taskInputHistoryStore";
 import { useTiptapEditor } from "@features/message-editor/tiptap/useTiptapEditor";
 import { ReasoningLevelSelector } from "@features/sessions/components/ReasoningLevelSelector";
@@ -12,8 +13,9 @@ import type { AgentAdapter } from "@features/settings/stores/settingsStore";
 import { useConnectivity } from "@hooks/useConnectivity";
 import { ArrowUp } from "@phosphor-icons/react";
 import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
+import { trpcClient } from "@renderer/trpc/client";
 import { EditorContent } from "@tiptap/react";
-import { forwardRef, useCallback, useImperativeHandle } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle } from "react";
 import "./TaskInput.css";
 
 interface TaskInputEditorProps {
@@ -100,6 +102,21 @@ export const TaskInputEditor = forwardRef<
       },
       onEmptyChange,
     });
+
+    useEffect(() => {
+      let cancelled = false;
+      trpcClient.skills.list.query().then((skills) => {
+        if (cancelled) return;
+        useDraftStore.getState().actions.setCommands(
+          sessionId,
+          skills.map((s) => ({ name: s.name, description: s.description })),
+        );
+      });
+      return () => {
+        cancelled = true;
+        useDraftStore.getState().actions.clearCommands(sessionId);
+      };
+    }, [sessionId]);
 
     useImperativeHandle(
       ref,


### PR DESCRIPTION
## Problem

Removing the preview session in #1438 broke slash command suggestions in the new task view -- only the 3 built-in feedback commands appear when typing /.

## Changes

  1. Fetch skills from skills.list on TaskInputEditor mount and store in draftStore.commands
  2. Fall back to draftStore.commands in getCommandSuggestions when no active session exists
  3. Clean up stored commands on unmount

## How did you test this?

Manually