### PR TITLE
fix: Only show "Cancelled" for explicitly cancelled turns

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/toolCallUtils.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/toolCallUtils.tsx
@@ -51,7 +51,7 @@ export function useToolCallStatus(
   const isIncomplete = status === "pending" || status === "in_progress";
   const isLoading = isIncomplete && !turnCancelled && !turnComplete;
   const isFailed = status === "failed";
-  const wasCancelled = isIncomplete && (turnCancelled || turnComplete);
+  const wasCancelled = isIncomplete && turnCancelled;
   const isComplete = status === "completed";
 
   return { isIncomplete, isLoading, isFailed, wasCancelled, isComplete };


### PR DESCRIPTION
## Problem

Tool calls pending permission incorrectly flash "(Cancelled)" because wasCancelled triggers on turnComplete, not just turnCancelled.

Closes https://github.com/PostHog/code/issues/1267

## Changes

  1. Remove turnComplete from wasCancelled check in useToolCallStatus
  2. Only show "(Cancelled)" when stopReason is actually "cancelled"

## How did you test this?

Manually
