### PR TITLE
fix: Open active file in external app instead of repo directory

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/ExternalAppsOpener.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/ExternalAppsOpener.tsx
@@ -20,6 +20,7 @@ export function ExternalAppsOpener({
   label = "Open",
 }: ExternalAppsOpenerProps) {
   const { detectedApps, defaultApp, isLoading } = useExternalApps();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const handleOpenDefault = useCallback(async () => {
     if (!defaultApp || !targetPath) return;
@@ -73,8 +74,6 @@ export function ExternalAppsOpener({
     { enableOnFormTags: ["INPUT", "TEXTAREA", "SELECT"] },
     [handleCopyPath],
   );
-
-  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   if (!targetPath) {
     return null;

--- a/apps/code/src/renderer/features/task-detail/components/TaskDetail.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskDetail.tsx
@@ -46,7 +46,7 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
     if (!panel) return null;
 
     const parsed = parseTabId(panel.content.activeTabId);
-    if (parsed.type === "file" || parsed.type === "diff") {
+    if (parsed.type === "file") {
       return parsed.value;
     }
     return null;
@@ -54,7 +54,7 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
 
   const openTargetPath =
     activeRelativePath && effectiveRepoPath
-      ? `${effectiveRepoPath}/${activeRelativePath}`
+      ? [effectiveRepoPath, activeRelativePath].join("/").replace(/\/+/g, "/")
       : effectiveRepoPath;
 
   const [filePickerOpen, setFilePickerOpen] = useState(false);


### PR DESCRIPTION
## Problem

Clicking "Open in [app]" always opened the repo root directory, even when a specific file was active in the editor.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Derive active file path from panel layout store in TaskDetail
2. Join relative path with repo path as the external app target, fall back to repo directory
3. Add fixed overlay to prevent drag-through when dropdown menu is open
4. Fix dead diff type check and normalize path joining

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->