### PR TITLE
Add emoji icons to README section headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 
 Found a bug or have feedback? [Open an issue](https://github.com/PostHog/code/issues/new) on GitHub.
 
-# PostHog Code
+# 🦔 PostHog Code
 
 This is the monorepo for PostHog Code apps and the agent framework that powers them.
 
-## Development
+## 🛠️ Development
 
-### Prerequisites
+### 📋 Prerequisites
 
 - Node.js 22+
 - pnpm 10.23.0
 
-### Setup
+### ⚙️ Setup
 
 ```bash
 # Install pnpm if you haven't already
@@ -32,7 +32,7 @@ cp .env.example .env
 
 ```
 
-### Running in Development
+### 🚀 Running in Development
 
 By default, `pnpm dev` uses [mprocs](https://github.com/pvolok/mprocs) to run the agent and code app in parallel.
 
@@ -45,7 +45,7 @@ pnpm dev:agent  # Run agent in watch mode
 pnpm dev:code   # Run code app
 ```
 
-### phrocs (alpha)
+### 🧪 phrocs (alpha)
 
 phrocs is our custom process runner built as a replacement for mprocs. It's currently in alpha and can be used as an alternative dev runner. phrocs does not auto-update — you must manually run the update command to pull the latest version.
 
@@ -61,7 +61,7 @@ phrocs reads the same `mprocs.yaml` config file. The binary is downloaded to `bi
 
 > **Want to connect to a local PostHog instance?** See [docs/LOCAL-DEVELOPMENT.md](./docs/LOCAL-DEVELOPMENT.md) for OAuth setup and connecting to localhost:8010.
 
-### Utility Scripts
+### 🔧 Utility Scripts
 
 Scripts in `scripts/` for development and debugging:
 
@@ -70,7 +70,7 @@ Scripts in `scripts/` for development and debugging:
 | `scripts/clean-posthog-code-macos.sh` | Remove all PostHog Code app data from macOS (caches, preferences, logs, saved state). Use `--app` flag to also delete PostHog Code.app from /Applications. |
 | `scripts/test-access-token.js` | Validate a PostHog OAuth access token by testing API endpoints. Usage: `node scripts/test-access-token.js <token> <project_id> [region]` |
 
-## Project Structure
+## 📁 Project Structure
 
 ```
 posthog-code/
@@ -85,7 +85,7 @@ posthog-code/
 │   └── shared/          # Shared utilities (Saga pattern, etc.)
 ```
 
-## Documentation
+## 📚 Documentation
 
 | File | Description |
 |------|-------------|
@@ -99,10 +99,10 @@ posthog-code/
 | [docs/UPDATES.md](./docs/UPDATES.md) | Release versioning and git tagging |
 | [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) | Common issues and fixes |
 
-## Contributing
+## 🤝 Contributing
 
 We love contributions big and small. See [CONTRIBUTING.md](./CONTRIBUTING.md) to get started.
 
-## Troubleshooting
+## 🔍 Troubleshooting
 
 See [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) for common issues (black screen, Electron install failures, native module crashes, etc.).


### PR DESCRIPTION
## TL;DR
Added emoji icons to all major section headers in the README to improve visual organization and make the document more visually appealing.

## Problem
The README section headers were plain text, making the document less visually engaging and harder to scan quickly.

## Changes
- Added emoji icons to 11 section headers throughout README.md:
  - 🦔 PostHog Code (main title)
  - 🛠️ Development
  - 📋 Prerequisites
  - ⚙️ Setup
  - 🚀 Running in Development
  - 🧪 phrocs (alpha)
  - 🔧 Utility Scripts
  - 📁 Project Structure
  - 📚 Documentation
  - 🤝 Contributing
  - 🔍 Troubleshooting

## How did you test this?
Visually verified that all emoji icons render correctly in the README and that the markdown formatting remains intact.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*