### PR TITLE
fix(code): remove mcp tools from haiku (primary sessions)

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -67,6 +67,7 @@ import {
   getEffortOptions,
   resolveModelPreference,
   supports1MContext,
+  supportsMcpInjection,
   toSdkModelId,
 } from "./session/models";
 import {
@@ -797,7 +798,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const settingsManager = new SettingsManager(cwd);
     await settingsManager.initialize();
 
-    const mcpServers = parseMcpServers(params);
+    const earlyModelId =
+      settingsManager.getSettings().model || meta?.model || "";
+    const mcpServers = supportsMcpInjection(earlyModelId)
+      ? parseMcpServers(params)
+      : {};
     const systemPrompt = buildSystemPrompt(meta?.systemPrompt);
 
     this.logger.info(isResume ? "Resuming session" : "Creating new session", {

--- a/packages/agent/src/adapters/claude/session/models.ts
+++ b/packages/agent/src/adapters/claude/session/models.ts
@@ -37,6 +37,12 @@ export function supportsMaxEffort(modelId: string): boolean {
   return MODELS_WITH_MAX_EFFORT.has(modelId);
 }
 
+const MODELS_TO_EXCLUDE_MCP_TOOLS = new Set(["claude-haiku-4-5"]);
+
+export function supportsMcpInjection(modelId: string): boolean {
+  return !MODELS_TO_EXCLUDE_MCP_TOOLS.has(modelId);
+}
+
 interface EffortOption {
   value: string;
   name: string;


### PR DESCRIPTION
## Problem

- posthog mcp is >200k tokens
- haiku doesn't support tool search
- all 200k+ tokens are inlined into the haiku initial prompt
- ...so haiku sessions do not work at all right now

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

does not inject mcp definitiions into new sessions with haiku

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->