### PR TITLE
feat(code): remove cloud status bar, add pr view button

### DIFF
--- a/apps/code/src/renderer/components/HeaderRow.tsx
+++ b/apps/code/src/renderer/components/HeaderRow.tsx
@@ -1,3 +1,4 @@
+import { CloudGitInteractionHeader } from "@features/git-interaction/components/CloudGitInteractionHeader";
 import { GitInteractionHeader } from "@features/git-interaction/components/GitInteractionHeader";
 import { RightSidebarTrigger } from "@features/right-sidebar/components/RightSidebarTrigger";
 import { useRightSidebarStore } from "@features/right-sidebar/stores/rightSidebarStore";
@@ -124,9 +125,12 @@ export function HeaderRow() {
           }}
         >
           <RightSidebarTrigger />
-          {!isCloudTask && rightSidebarOpen && (
-            <GitInteractionHeader taskId={view.data.id} />
-          )}
+          {rightSidebarOpen &&
+            (isCloudTask ? (
+              <CloudGitInteractionHeader taskId={view.data.id} />
+            ) : (
+              <GitInteractionHeader taskId={view.data.id} />
+            ))}
           {rightSidebarOpen && (
             <Box
               onMouseDown={handleRightSidebarMouseDown}

--- a/apps/code/src/renderer/features/git-interaction/components/CloudGitInteractionHeader.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/CloudGitInteractionHeader.tsx
@@ -1,0 +1,29 @@
+import { useSessionForTask } from "@features/sessions/hooks/useSession";
+import { Eye } from "@phosphor-icons/react";
+import { Button, Flex, Text } from "@radix-ui/themes";
+
+interface CloudGitInteractionHeaderProps {
+  taskId: string;
+}
+
+export function CloudGitInteractionHeader({
+  taskId,
+}: CloudGitInteractionHeaderProps) {
+  const session = useSessionForTask(taskId);
+  const prUrl = (session?.cloudOutput?.pr_url as string) ?? null;
+
+  if (!prUrl) return null;
+
+  return (
+    <div className="no-drag">
+      <Button size="1" variant="solid" asChild>
+        <a href={prUrl} target="_blank" rel="noopener noreferrer">
+          <Flex align="center" gap="2">
+            <Eye size={12} weight="bold" />
+            <Text size="1">View PR</Text>
+          </Flex>
+        </a>
+      </Button>
+    </div>
+  );
+}

--- a/apps/code/src/renderer/features/inbox/components/ReportTaskLogs.tsx
+++ b/apps/code/src/renderer/features/inbox/components/ReportTaskLogs.tsx
@@ -222,7 +222,6 @@ export function ReportTaskLogs({
             taskId={task.id}
             task={task}
             hideInput={reportStatus !== "ready"}
-            hideCloudStatus
           />
         </div>
       </div>

--- a/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -20,7 +20,7 @@ import {
   useCreateWorkspace,
   useWorkspaceLoaded,
 } from "@features/workspace/hooks/useWorkspace";
-import { Box, Button, Flex, Spinner, Text } from "@radix-ui/themes";
+import { Box, Flex } from "@radix-ui/themes";
 import type { Task } from "@shared/types";
 import { getTaskRepository } from "@utils/repository";
 import { useCallback, useEffect, useMemo } from "react";
@@ -30,16 +30,9 @@ interface TaskLogsPanelProps {
   task: Task;
   /** Hide the message input — log-only view. */
   hideInput?: boolean;
-  /** Hide the cloud status footer bar. */
-  hideCloudStatus?: boolean;
 }
 
-export function TaskLogsPanel({
-  taskId,
-  task,
-  hideInput,
-  hideCloudStatus,
-}: TaskLogsPanelProps) {
+export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
   const isWorkspaceLoaded = useWorkspaceLoaded();
   const { isPending: isCreatingWorkspace } = useCreateWorkspace();
   const repoKey = getTaskRepository(task);
@@ -60,8 +53,6 @@ export function TaskLogsPanel({
     session,
     repoPath,
     isCloud,
-    isCloudRunNotTerminal,
-    cloudStatus,
     isRunning,
     hasError,
     events,
@@ -90,9 +81,7 @@ export function TaskLogsPanel({
     handleBashCommand,
   } = useSessionCallbacks({ taskId, task, session, repoPath });
 
-  const cloudStage = session?.cloudStage ?? null;
   const cloudOutput = session?.cloudOutput ?? null;
-  const cloudErrorMessage = session?.cloudErrorMessage ?? null;
   const prUrl =
     isCloud && cloudOutput?.pr_url ? (cloudOutput.pr_url as string) : null;
   const slackThreadUrl =
@@ -175,50 +164,6 @@ export function TaskLogsPanel({
             />
           </ErrorBoundary>
         </Box>
-        {isCloud && !hideCloudStatus && (
-          <Flex
-            align="center"
-            justify="center"
-            gap="2"
-            py="2"
-            className="border-gray-4 border-t"
-          >
-            {prUrl ? (
-              <>
-                <Text size="2" color="gray">
-                  Task completed
-                </Text>
-                <Button size="2" variant="soft" asChild>
-                  <a href={prUrl} target="_blank" rel="noopener noreferrer">
-                    View Pull Request
-                  </a>
-                </Button>
-              </>
-            ) : isCloudRunNotTerminal ? (
-              <>
-                <Spinner size="2" />
-                <Text size="2" color="gray">
-                  Running in cloud
-                  {cloudStage ? ` \u2014 ${cloudStage}` : ""}
-                  ...
-                </Text>
-              </>
-            ) : cloudStatus === "failed" ? (
-              <Text size="2" color="red">
-                Task failed
-                {cloudErrorMessage ? `: ${cloudErrorMessage}` : ""}
-              </Text>
-            ) : cloudStatus === "cancelled" ? (
-              <Text size="2" color="red">
-                Task cancelled
-              </Text>
-            ) : cloudStatus ? (
-              <Text size="2" color="gray">
-                Cloud task completed
-              </Text>
-            ) : null}
-          </Flex>
-        )}
       </Flex>
     </BackgroundWrapper>
   );


### PR DESCRIPTION
## Problem

cloud is a bit inconsistent with local

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

- removes the bottom status bar from the cloud page
    - we might want to re-add the cancelled/failed states, but...
    - in progress, stopped, completed states can all just be inferred from the agent output
- moves the "view PR" button to the top-right like local tasks

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->