### PR TITLE
feat: codex 5.4 default and pass to model

### DIFF
--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -18,6 +18,7 @@ import { getEffortOptions } from "@posthog/agent/adapters/claude/session/models"
 import { Agent } from "@posthog/agent/agent";
 import { getAvailableModes } from "@posthog/agent/execution-mode";
 import {
+  DEFAULT_CODEX_MODEL,
   DEFAULT_GATEWAY_MODEL,
   fetchGatewayModels,
   formatGatewayModelName,
@@ -604,6 +605,7 @@ When creating pull requests, add the following footer at the end of the PR descr
         adapter,
         gatewayUrl: proxyUrl,
         codexBinaryPath: adapter === "codex" ? getCodexBinaryPath() : undefined,
+        model,
         processCallbacks: {
           onProcessSpawned: (info) => {
             this.processTracking.register(
@@ -1667,7 +1669,9 @@ For git operations while detached:
 
     const defaultModel =
       adapter === "codex"
-        ? (modelOptions[0]?.value ?? "")
+        ? (modelOptions.find((o) => o.value === DEFAULT_CODEX_MODEL)?.value ??
+          modelOptions[0]?.value ??
+          "")
         : DEFAULT_GATEWAY_MODEL;
 
     const resolvedModelId = modelOptions.some((o) => o.value === defaultModel)

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -4,6 +4,7 @@ import {
 } from "./adapters/acp-connection";
 import {
   BLOCKED_MODELS,
+  DEFAULT_CODEX_MODEL,
   DEFAULT_GATEWAY_MODEL,
   fetchModelsList,
 } from "./gateway-models";
@@ -104,7 +105,9 @@ export class Agent {
       }
 
       if (!sanitizedModel || !allowedModelIds?.has(sanitizedModel)) {
-        sanitizedModel = codexModelIds[0];
+        sanitizedModel = codexModelIds.includes(DEFAULT_CODEX_MODEL)
+          ? DEFAULT_CODEX_MODEL
+          : codexModelIds[0];
       }
     }
     if (!sanitizedModel && options.adapter !== "codex") {

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -17,6 +17,8 @@ export interface FetchGatewayModelsOptions {
 
 export const DEFAULT_GATEWAY_MODEL = "claude-opus-4-6";
 
+export const DEFAULT_CODEX_MODEL = "gpt-5.4";
+
 export const BLOCKED_MODELS = new Set(["gpt-5-mini", "openai/gpt-5-mini"]);
 
 type ModelsListResponse =


### PR DESCRIPTION
## Problem

Codex was not respecting model choice
Default changed to 5.4

## Changes

- Added `DEFAULT_CODEX_MODEL` constant set to "gpt-5.4" in gateway-models.ts
- Updated model selection logic to prefer the default Codex model when available, falling back to the first model only if the default is not in the available options
- Passed the resolved model parameter to the Agent constructor to ensure consistent model usage

## How did you test this?

Manual