### PR TITLE
feat: clean up session reloadin

### DIFF
--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -692,29 +692,23 @@ When creating pull requests, add the following footer at the end of the PR descr
       let configOptions: SessionConfigOption[] | undefined;
       let agentSessionId: string;
 
-      if (isReconnect && adapter === "codex" && config.sessionId) {
-        const existingSessionId = config.sessionId;
-        const loadResponse = await connection.loadSession({
-          sessionId: existingSessionId,
-          cwd: repoPath,
-          mcpServers,
-        });
-        configOptions = loadResponse.configOptions ?? undefined;
-        agentSessionId = existingSessionId;
-      } else if (isReconnect && adapter === "claude" && config.sessionId) {
+      if (isReconnect && config.sessionId) {
         const existingSessionId = config.sessionId;
 
-        const posthogAPI = agent.getPosthogAPI();
-        if (posthogAPI) {
-          await hydrateSessionJsonl({
-            sessionId: existingSessionId,
-            cwd: repoPath,
-            taskId,
-            runId: taskRunId,
-            permissionMode: config.permissionMode,
-            posthogAPI,
-            log,
-          });
+        // Claude-specific: hydrate session JSONL from PostHog before resuming
+        if (adapter !== "codex") {
+          const posthogAPI = agent.getPosthogAPI();
+          if (posthogAPI) {
+            await hydrateSessionJsonl({
+              sessionId: existingSessionId,
+              cwd: repoPath,
+              taskId,
+              runId: taskRunId,
+              permissionMode: config.permissionMode,
+              posthogAPI,
+              log,
+            });
+          }
         }
 
         const systemPrompt = this.buildSystemPrompt(
@@ -722,6 +716,10 @@ When creating pull requests, add the following footer at the end of the PR descr
           taskId,
           customInstructions,
         );
+
+        // Both adapters implement unstable_resumeSession:
+        // - Claude: delegates to SDK's resumeSession with JSONL hydration
+        // - Codex: delegates to codex-acp's loadSession internally
         const resumeResponse = await connection.unstable_resumeSession({
           sessionId: existingSessionId,
           cwd: repoPath,


### PR DESCRIPTION
simplify agent reconnection

## Problem

The agent service had separate code paths for handling session reconnection between Codex and Claude adapters, leading to code duplication and inconsistent handling.

## Changes

- Consolidated the reconnection logic for both Codex and Claude adapters into a single code path
- Moved PostHog JSONL hydration to be Claude-specific (non-Codex adapters) while keeping it within the unified flow
- Both adapters now use `unstable_resumeSession` method, with Claude delegating to SDK's resumeSession and Codex delegating to codex-acp's loadSession internally
- Added clarifying comments explaining the different internal implementations for each adapter