### PR TITLE
feat: give codex system prompt via personality

### DIFF
--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -601,11 +601,18 @@ When creating pull requests, add the following footer at the end of the PR descr
     });
 
     try {
+      const systemPrompt = this.buildSystemPrompt(
+        credentials,
+        taskId,
+        customInstructions,
+      );
+
       const acpConnection = await agent.run(taskId, taskRunId, {
         adapter,
         gatewayUrl: proxyUrl,
         codexBinaryPath: adapter === "codex" ? getCodexBinaryPath() : undefined,
         model,
+        instructions: adapter === "codex" ? systemPrompt.append : undefined,
         processCallbacks: {
           onProcessSpawned: (info) => {
             this.processTracking.register(
@@ -711,12 +718,6 @@ When creating pull requests, add the following footer at the end of the PR descr
           }
         }
 
-        const systemPrompt = this.buildSystemPrompt(
-          credentials,
-          taskId,
-          customInstructions,
-        );
-
         // Both adapters implement unstable_resumeSession:
         // - Claude: delegates to SDK's resumeSession with JSONL hydration
         // - Codex: delegates to codex-acp's loadSession internally
@@ -747,11 +748,6 @@ When creating pull requests, add the following footer at the end of the PR descr
             taskRunId,
           });
         }
-        const systemPrompt = this.buildSystemPrompt(
-          credentials,
-          taskId,
-          customInstructions,
-        );
         const newSessionResponse = await connection.newSession({
           cwd: repoPath,
           mcpServers,

--- a/packages/agent/src/adapters/codex/codex-agent.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.ts
@@ -282,18 +282,49 @@ export class CodexAcpAgent extends BaseAcpAgent {
 
     const response = await this.codexConnection.prompt(params);
 
-    // Emit PostHog usage notification
-    if (this.sessionState?.taskRunId && response.usage) {
-      await this.client.extNotification("_posthog/usage_update", {
+    if (this.sessionState && response.usage) {
+      // Accumulate token usage from the prompt response
+      this.sessionState.accumulatedUsage.inputTokens +=
+        response.usage.inputTokens ?? 0;
+      this.sessionState.accumulatedUsage.outputTokens +=
+        response.usage.outputTokens ?? 0;
+      this.sessionState.accumulatedUsage.cachedReadTokens +=
+        response.usage.cachedReadTokens ?? 0;
+      this.sessionState.accumulatedUsage.cachedWriteTokens +=
+        response.usage.cachedWriteTokens ?? 0;
+    }
+
+    if (this.sessionState?.taskRunId) {
+      const { accumulatedUsage } = this.sessionState;
+
+      await this.client.extNotification(POSTHOG_NOTIFICATIONS.TURN_COMPLETE, {
         sessionId: params.sessionId,
-        used: {
-          inputTokens: response.usage.inputTokens ?? 0,
-          outputTokens: response.usage.outputTokens ?? 0,
-          cachedReadTokens: response.usage.cachedReadTokens ?? 0,
-          cachedWriteTokens: response.usage.cachedWriteTokens ?? 0,
+        stopReason: response.stopReason ?? "end_turn",
+        usage: {
+          inputTokens: accumulatedUsage.inputTokens,
+          outputTokens: accumulatedUsage.outputTokens,
+          cachedReadTokens: accumulatedUsage.cachedReadTokens,
+          cachedWriteTokens: accumulatedUsage.cachedWriteTokens,
+          totalTokens:
+            accumulatedUsage.inputTokens +
+            accumulatedUsage.outputTokens +
+            accumulatedUsage.cachedReadTokens +
+            accumulatedUsage.cachedWriteTokens,
         },
-        cost: null,
       });
+
+      if (response.usage) {
+        await this.client.extNotification("_posthog/usage_update", {
+          sessionId: params.sessionId,
+          used: {
+            inputTokens: response.usage.inputTokens ?? 0,
+            outputTokens: response.usage.outputTokens ?? 0,
+            cachedReadTokens: response.usage.cachedReadTokens ?? 0,
+            cachedWriteTokens: response.usage.cachedWriteTokens ?? 0,
+          },
+          cost: null,
+        });
+      }
     }
 
     return response;

--- a/packages/agent/src/adapters/codex/codex-client.ts
+++ b/packages/agent/src/adapters/codex/codex-client.ts
@@ -60,17 +60,34 @@ export function createCodexClient(
     },
 
     async sessionUpdate(params: SessionNotification): Promise<void> {
-      // Parse usage data from session updates
       const update = params.update as Record<string, unknown> | undefined;
       if (update?.sessionUpdate === "usage_update") {
         const used = update.used as number | undefined;
         const size = update.size as number | undefined;
         if (used !== undefined) sessionState.contextUsed = used;
         if (size !== undefined) sessionState.contextSize = size;
+
+        // Accumulate per-message token usage when available
+        const inputTokens = update.inputTokens as number | undefined;
+        const outputTokens = update.outputTokens as number | undefined;
+        if (inputTokens !== undefined) {
+          sessionState.accumulatedUsage.inputTokens += inputTokens;
+        }
+        if (outputTokens !== undefined) {
+          sessionState.accumulatedUsage.outputTokens += outputTokens;
+        }
+        const cachedRead = update.cachedReadTokens as number | undefined;
+        const cachedWrite = update.cachedWriteTokens as number | undefined;
+        if (cachedRead !== undefined) {
+          sessionState.accumulatedUsage.cachedReadTokens += cachedRead;
+        }
+        if (cachedWrite !== undefined) {
+          sessionState.accumulatedUsage.cachedWriteTokens += cachedWrite;
+        }
+
         callbacks?.onUsageUpdate?.(update);
       }
 
-      // Forward to upstream client
       await upstreamClient.sessionUpdate(params);
     },
 

--- a/packages/agent/src/adapters/codex/spawn.ts
+++ b/packages/agent/src/adapters/codex/spawn.ts
@@ -10,6 +10,7 @@ export interface CodexProcessOptions {
   apiBaseUrl?: string;
   apiKey?: string;
   model?: string;
+  instructions?: string;
   binaryPath?: string;
   logger?: Logger;
   processCallbacks?: ProcessSpawnedCallback;
@@ -40,6 +41,13 @@ function buildConfigArgs(options: CodexProcessOptions): string[] {
 
   if (options.model) {
     args.push("-c", `model="${options.model}"`);
+  }
+
+  if (options.instructions) {
+    const escaped = options.instructions
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"');
+    args.push("-c", `instructions="${escaped}"`);
   }
 
   return args;

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -131,6 +131,7 @@ export class Agent {
               apiKey: gatewayConfig.apiKey,
               binaryPath: options.codexBinaryPath,
               model: sanitizedModel,
+              instructions: options.instructions,
             }
           : undefined,
     });

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -112,6 +112,7 @@ export interface TaskExecutionOptions {
   model?: string;
   gatewayUrl?: string;
   codexBinaryPath?: string;
+  instructions?: string;
   processCallbacks?: ProcessSpawnedCallback;
 }
 


### PR DESCRIPTION
## Problem

The Codex adapter was not receiving custom instructions/system prompts, and token usage tracking was incomplete, limiting its ability to follow user-specific guidance and provide accurate usage metrics during task execution.

## Changes

- Added `instructions` parameter to `TaskExecutionOptions` and `CodexProcessOptions` interfaces
- Modified the Codex spawn logic to pass instructions as a configuration parameter with proper escaping for backslashes and quotes
- Moved system prompt building earlier in the agent service to make it available during initial connection setup
- Enhanced token usage tracking in the Codex adapter to accumulate usage across prompts and emit turn completion notifications
- Updated the Codex client to track per-message token usage including cached read/write tokens
- Added proper usage accumulation in session state for comprehensive token tracking

## How did you test this?

I wont lie, i didnt test this more than a quick test prompt. trust the agents bro