### PR TITLE
fix: Optimize thought completion marking from O(n²) to O(n)

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
+++ b/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
@@ -98,19 +98,19 @@ function isThoughtItem(
 }
 
 function markThoughtCompletion(items: ConversationItem[]) {
+  const seenContexts = new Set<TurnContext>();
+
   for (let i = items.length - 1; i >= 0; i--) {
     const item = items[i];
-    if (!isThoughtItem(item)) continue;
 
-    const hasSubsequentItem = items
-      .slice(i + 1)
-      .some(
-        (next) =>
-          next.type === "session_update" &&
-          next.turnContext === item.turnContext,
-      );
+    if (isThoughtItem(item)) {
+      item.thoughtComplete =
+        seenContexts.has(item.turnContext) || item.turnContext.turnComplete;
+    }
 
-    item.thoughtComplete = hasSubsequentItem || item.turnContext.turnComplete;
+    if (item.type === "session_update") {
+      seenContexts.add(item.turnContext);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

markThoughtCompletion scanned all subsequent items for every thought item using .slice().some(), making it O(n²) in conversation length.

## Changes

  1. Replace nested scan with a single reverse pass using a Set to track seen turn contexts
  2. Reduce time complexity from O(n²) to O(n) by eliminating repeated .slice().some() calls
  3. Preserve identical completion semantics (checks for subsequent session_update or turnComplete)

## How did you test this?

Manually