### PR TITLE
fix(code): disable diff computing when review tab is not active

### DIFF
--- a/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
@@ -1,5 +1,6 @@
 import { makeFileKey } from "@features/git-interaction/utils/fileKey";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
+import { isTabActiveInTree } from "@features/panels/store/panelStoreHelpers";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
 import type { parsePatchFiles } from "@pierre/diffs";
 import { Flex, Text } from "@radix-ui/themes";
@@ -27,6 +28,11 @@ interface ReviewPageProps {
 export function ReviewPage({ taskId }: ReviewPageProps) {
   const repoPath = useCwd(taskId);
   const openFile = usePanelLayoutStore((s) => s.openFile);
+  const isReviewTabActive = usePanelLayoutStore((s) => {
+    const layout = s.getLayout(taskId);
+    if (!layout) return false;
+    return isTabActiveInTree(layout.panelTree, "review");
+  });
   const onComment = useReviewComment(taskId);
 
   const {
@@ -40,7 +46,7 @@ export function ReviewPage({ taskId }: ReviewPageProps) {
     allPaths,
     diffLoading,
     refetch,
-  } = useReviewDiffs(repoPath);
+  } = useReviewDiffs(repoPath, isReviewTabActive);
 
   const {
     diffOptions,

--- a/apps/code/src/renderer/features/code-review/hooks/useReviewDiffs.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/useReviewDiffs.ts
@@ -7,7 +7,10 @@ import { useTRPC } from "@renderer/trpc/client";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 
-export function useReviewDiffs(repoPath: string | undefined) {
+export function useReviewDiffs(
+  repoPath: string | undefined,
+  isActive: boolean,
+) {
   const trpc = useTRPC();
   const { changedFiles, changesLoading } = useGitQueries(repoPath);
   const hideWhitespace = useDiffViewerStore((s) => s.hideWhitespaceChanges);
@@ -25,7 +28,7 @@ export function useReviewDiffs(repoPath: string | undefined) {
     trpc.git.getDiffCached.queryOptions(
       { directoryPath: repoPath as string, ignoreWhitespace: hideWhitespace },
       {
-        enabled: !!repoPath && hasStagedFiles,
+        enabled: isActive && !!repoPath && hasStagedFiles,
         staleTime: 30_000,
         refetchOnMount: "always",
       },
@@ -40,7 +43,7 @@ export function useReviewDiffs(repoPath: string | undefined) {
     trpc.git.getDiffUnstaged.queryOptions(
       { directoryPath: repoPath as string, ignoreWhitespace: hideWhitespace },
       {
-        enabled: !!repoPath,
+        enabled: isActive && !!repoPath,
         staleTime: 30_000,
         refetchOnMount: "always",
       },

--- a/apps/code/src/renderer/features/panels/store/panelStoreHelpers.ts
+++ b/apps/code/src/renderer/features/panels/store/panelStoreHelpers.ts
@@ -237,7 +237,7 @@ export function applyCleanupWithFallback(
 }
 
 // Tab active state utilities
-function isTabActiveInTree(tree: PanelNode, tabId: string): boolean {
+export function isTabActiveInTree(tree: PanelNode, tabId: string): boolean {
   if (tree.type === "leaf") {
     return tree.content.activeTabId === tabId;
   }


### PR DESCRIPTION
## Problem

random black screen / freezing / OOM issues:

- me
- https://posthog.slack.com/archives/C09G8Q32R6F/p1775212277963019
- https://github.com/PostHog/code/issues/1485

i suspect it's related to the diff rendering...

1. file changes
2. file watcher sees it, emits an events
3. git queries are invalidated (getDiffCached, getDiffUnstaged)
4. review diffs have always-active observers on those queries, so they get refetched
5. refetch returns a full repo diff, which is then parsed and diff components re-render

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

disables the diff queries when the review tab is not active

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->