### PR TITLE
feat(code): tree view for changed files list

### DIFF
--- a/apps/code/src/renderer/components/TreeDirectoryRow.tsx
+++ b/apps/code/src/renderer/components/TreeDirectoryRow.tsx
@@ -1,0 +1,143 @@
+import { FileIcon } from "@components/ui/FileIcon";
+import { CaretRight, FolderIcon, FolderOpenIcon } from "@phosphor-icons/react";
+import { Box, Flex } from "@radix-ui/themes";
+import type { ReactNode } from "react";
+
+const TREE_ROW_ACTIVE_CLASS = "border-accent-8 border-y bg-accent-4";
+const TREE_ROW_INACTIVE_CLASS = "border-transparent border-y hover:bg-gray-3";
+const TREE_INDENT_PX = 12;
+const CARET_COL_SIZE = 16;
+
+interface TreeDirectoryRowProps {
+  name: string;
+  depth: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+  isActive?: boolean;
+}
+
+export function TreeDirectoryRow({
+  name,
+  depth,
+  isExpanded,
+  onToggle,
+  isActive = false,
+}: TreeDirectoryRowProps) {
+  return (
+    <Flex
+      align="center"
+      gap="1"
+      onClick={onToggle}
+      className={isActive ? TREE_ROW_ACTIVE_CLASS : TREE_ROW_INACTIVE_CLASS}
+      style={{
+        paddingLeft: `${depth * TREE_INDENT_PX + 4}px`,
+        paddingRight: "8px",
+        height: "22px",
+        cursor: "pointer",
+        userSelect: "none",
+      }}
+    >
+      <Box
+        style={{
+          width: `${CARET_COL_SIZE}px`,
+          height: `${CARET_COL_SIZE}px`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <CaretRight
+          size={10}
+          weight="bold"
+          color="var(--gray-10)"
+          style={{
+            transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
+            transition: "transform 0.1s ease",
+          }}
+        />
+      </Box>
+      {isExpanded ? (
+        <FolderOpenIcon
+          size={14}
+          weight="fill"
+          color="var(--accent-9)"
+          style={{ flexShrink: 0 }}
+        />
+      ) : (
+        <FolderIcon
+          size={14}
+          color="var(--accent-9)"
+          style={{ flexShrink: 0 }}
+        />
+      )}
+      <span
+        className="select-none overflow-hidden text-ellipsis whitespace-nowrap text-[13px]"
+        style={{ marginLeft: "4px" }}
+      >
+        {name}
+      </span>
+    </Flex>
+  );
+}
+
+interface TreeFileRowProps {
+  fileName: string;
+  depth: number;
+  isActive?: boolean;
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  /** Extra content rendered after the filename (badges, buttons, etc.) */
+  trailing?: ReactNode;
+}
+
+export function TreeFileRow({
+  fileName,
+  depth,
+  isActive = false,
+  onClick,
+  onDoubleClick,
+  onContextMenu,
+  onMouseEnter,
+  onMouseLeave,
+  trailing,
+}: TreeFileRowProps) {
+  return (
+    <Flex
+      align="center"
+      gap="1"
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      onContextMenu={onContextMenu}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className={isActive ? TREE_ROW_ACTIVE_CLASS : TREE_ROW_INACTIVE_CLASS}
+      style={{
+        paddingLeft: `${depth * TREE_INDENT_PX + 4}px`,
+        paddingRight: "8px",
+        height: "22px",
+        cursor: "pointer",
+      }}
+    >
+      {/* Spacer to align with folder caret column */}
+      <Box
+        style={{
+          width: `${CARET_COL_SIZE}px`,
+          height: `${CARET_COL_SIZE}px`,
+          flexShrink: 0,
+        }}
+      />
+      <FileIcon filename={fileName} size={14} />
+      <span
+        className="select-none overflow-hidden text-ellipsis whitespace-nowrap text-[13px]"
+        style={{ marginLeft: "4px", minWidth: 0, flex: 1 }}
+      >
+        {fileName}
+      </span>
+      {trailing}
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/task-detail/components/ChangesPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/ChangesPanel.tsx
@@ -1,4 +1,4 @@
-import { FileIcon } from "@components/ui/FileIcon";
+import { TreeFileRow } from "@components/TreeDirectoryRow";
 import { PanelMessage } from "@components/ui/PanelMessage";
 import { Tooltip } from "@components/ui/Tooltip";
 import { useExternalApps } from "@features/external-apps/hooks/useExternalApps";
@@ -40,7 +40,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { showMessageBox } from "@utils/dialog";
 import { handleExternalAppAction } from "@utils/handleExternalAppAction";
 import { logger } from "@utils/logger";
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useCallback, useMemo, useState } from "react";
+import { ChangesTreeView } from "./ChangesTreeView";
 
 const log = logger.scope("changes-panel");
 
@@ -57,6 +58,8 @@ interface ChangedFileItemProps {
   repoPath?: string;
   mainRepoPath?: string;
   onStageToggle?: (file: ChangedFile) => void;
+  /** Tree indentation depth (0 = flat list) */
+  depth?: number;
 }
 
 function getDiscardInfo(
@@ -128,6 +131,7 @@ function ChangedFileItem({
   repoPath,
   mainRepoPath,
   onStageToggle,
+  depth = 0,
 }: ChangedFileItemProps) {
   const openReview = usePanelLayoutStore((state) => state.openReview);
   const requestScrollToFile = useReviewNavigationStore(
@@ -240,170 +244,127 @@ function ChangedFileItem({
 
   const tooltipContent = `${file.path} - ${indicator.fullLabel}`;
 
+  const trailing = (
+    <>
+      {hasLineStats && !isToolbarVisible && (
+        <Flex
+          align="center"
+          gap="1"
+          style={{ flexShrink: 0, fontSize: "10px", fontFamily: "monospace" }}
+        >
+          {(file.linesAdded ?? 0) > 0 && (
+            <Text style={{ color: "var(--green-9)" }}>+{file.linesAdded}</Text>
+          )}
+          {(file.linesRemoved ?? 0) > 0 && (
+            <Text style={{ color: "var(--red-9)" }}>-{file.linesRemoved}</Text>
+          )}
+        </Flex>
+      )}
+
+      {isToolbarVisible && (handleDiscard || onStageToggle) && (
+        <Flex align="center" gap="1" style={{ flexShrink: 0 }}>
+          {onStageToggle && (
+            <CompactIconButton
+              tooltip={file.staged ? "Unstage" : "Stage"}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onStageToggle(file);
+              }}
+            >
+              {file.staged ? <MinusIcon size={12} /> : <PlusIcon size={12} />}
+            </CompactIconButton>
+          )}
+          {handleDiscard && (
+            <CompactIconButton
+              tooltip="Discard changes"
+              onClick={handleDiscard}
+            >
+              <ArrowCounterClockwiseIcon size={12} />
+            </CompactIconButton>
+          )}
+
+          <DropdownMenu.Root
+            open={isDropdownOpen}
+            onOpenChange={setIsDropdownOpen}
+          >
+            <Tooltip content="Open file">
+              <DropdownMenu.Trigger>
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  color="gray"
+                  onClick={(e) => e.stopPropagation()}
+                  style={{
+                    flexShrink: 0,
+                    width: "18px",
+                    height: "18px",
+                    padding: 0,
+                  }}
+                >
+                  <FilePlus size={12} weight="regular" />
+                </IconButton>
+              </DropdownMenu.Trigger>
+            </Tooltip>
+            <DropdownMenu.Content size="1" align="end">
+              {detectedApps
+                .filter((app) => app.type !== "terminal")
+                .map((app) => (
+                  <DropdownMenu.Item
+                    key={app.id}
+                    onSelect={() => handleOpenWith(app.id)}
+                  >
+                    <Flex align="center" gap="2">
+                      {app.icon ? (
+                        <img
+                          src={app.icon}
+                          width={16}
+                          height={16}
+                          alt=""
+                          style={{ borderRadius: "2px" }}
+                        />
+                      ) : (
+                        <CodeIcon size={16} weight="regular" />
+                      )}
+                      <Text size="1">{app.name}</Text>
+                    </Flex>
+                  </DropdownMenu.Item>
+                ))}
+              <DropdownMenu.Separator />
+              <DropdownMenu.Item onSelect={handleCopyPath}>
+                <Flex align="center" gap="2">
+                  <CopyIcon size={16} weight="regular" />
+                  <Text size="1">Copy Path</Text>
+                </Flex>
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </Flex>
+      )}
+
+      <Badge
+        size="1"
+        color={indicator.color}
+        style={{ flexShrink: 0, fontSize: "10px", padding: "0 4px" }}
+      >
+        {indicator.label}
+      </Badge>
+    </>
+  );
+
   return (
     <Tooltip content={tooltipContent} side="top" delayDuration={500}>
-      <Flex
-        align="center"
-        gap="1"
+      <TreeFileRow
+        fileName={fileName}
+        depth={depth}
+        isActive={isActive}
         onClick={handleClick}
         onDoubleClick={handleClick}
         onContextMenu={handleContextMenu}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
-        className={
-          isActive
-            ? "border-accent-8 border-y bg-accent-4"
-            : "border-transparent border-y hover:bg-gray-3"
-        }
-        style={{
-          cursor: "pointer",
-          whiteSpace: "nowrap",
-          overflow: "hidden",
-          height: "26px",
-          paddingLeft: "8px",
-          paddingRight: "8px",
-        }}
-      >
-        <FileIcon filename={fileName} size={14} />
-        <Text
-          size="1"
-          style={{
-            fontSize: "12px",
-            userSelect: "none",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            marginLeft: "2px",
-            flexShrink: 1,
-            minWidth: 0,
-          }}
-        >
-          {fileName}
-        </Text>
-        <Text
-          size="1"
-          color="gray"
-          style={{
-            userSelect: "none",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            flex: 1,
-            marginLeft: "4px",
-            minWidth: 0,
-          }}
-        >
-          {file.originalPath
-            ? `${file.originalPath} → ${file.path}`
-            : file.path}
-        </Text>
-
-        {hasLineStats && !isToolbarVisible && (
-          <Flex
-            align="center"
-            gap="1"
-            style={{ flexShrink: 0, fontSize: "10px", fontFamily: "monospace" }}
-          >
-            {(file.linesAdded ?? 0) > 0 && (
-              <Text style={{ color: "var(--green-9)" }}>
-                +{file.linesAdded}
-              </Text>
-            )}
-            {(file.linesRemoved ?? 0) > 0 && (
-              <Text style={{ color: "var(--red-9)" }}>
-                -{file.linesRemoved}
-              </Text>
-            )}
-          </Flex>
-        )}
-
-        {isToolbarVisible && (handleDiscard || onStageToggle) && (
-          <Flex align="center" gap="1" style={{ flexShrink: 0 }}>
-            {onStageToggle && (
-              <CompactIconButton
-                tooltip={file.staged ? "Unstage" : "Stage"}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onStageToggle(file);
-                }}
-              >
-                {file.staged ? <MinusIcon size={12} /> : <PlusIcon size={12} />}
-              </CompactIconButton>
-            )}
-            {handleDiscard && (
-              <CompactIconButton
-                tooltip="Discard changes"
-                onClick={handleDiscard}
-              >
-                <ArrowCounterClockwiseIcon size={12} />
-              </CompactIconButton>
-            )}
-
-            <DropdownMenu.Root
-              open={isDropdownOpen}
-              onOpenChange={setIsDropdownOpen}
-            >
-              <Tooltip content="Open file">
-                <DropdownMenu.Trigger>
-                  <IconButton
-                    size="1"
-                    variant="ghost"
-                    color="gray"
-                    onClick={(e) => e.stopPropagation()}
-                    style={{
-                      flexShrink: 0,
-                      width: "18px",
-                      height: "18px",
-                      padding: 0,
-                    }}
-                  >
-                    <FilePlus size={12} weight="regular" />
-                  </IconButton>
-                </DropdownMenu.Trigger>
-              </Tooltip>
-              <DropdownMenu.Content size="1" align="end">
-                {detectedApps
-                  .filter((app) => app.type !== "terminal")
-                  .map((app) => (
-                    <DropdownMenu.Item
-                      key={app.id}
-                      onSelect={() => handleOpenWith(app.id)}
-                    >
-                      <Flex align="center" gap="2">
-                        {app.icon ? (
-                          <img
-                            src={app.icon}
-                            width={16}
-                            height={16}
-                            alt=""
-                            style={{ borderRadius: "2px" }}
-                          />
-                        ) : (
-                          <CodeIcon size={16} weight="regular" />
-                        )}
-                        <Text size="1">{app.name}</Text>
-                      </Flex>
-                    </DropdownMenu.Item>
-                  ))}
-                <DropdownMenu.Separator />
-                <DropdownMenu.Item onSelect={handleCopyPath}>
-                  <Flex align="center" gap="2">
-                    <CopyIcon size={16} weight="regular" />
-                    <Text size="1">Copy Path</Text>
-                  </Flex>
-                </DropdownMenu.Item>
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
-          </Flex>
-        )}
-
-        <Badge
-          size="1"
-          color={indicator.color}
-          style={{ flexShrink: 0, fontSize: "10px", padding: "0 4px" }}
-        >
-          {indicator.label}
-        </Badge>
-      </Flex>
+        trailing={trailing}
+      />
     </Tooltip>
   );
 }
@@ -423,6 +384,19 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
   );
 
   const effectiveFiles = changedFiles;
+
+  const renderFile = useCallback(
+    (file: ChangedFile, depth: number) => (
+      <ChangedFileItem
+        key={file.path}
+        file={file}
+        taskId={taskId}
+        isActive={activeFilePath === file.path}
+        depth={depth}
+      />
+    ),
+    [taskId, activeFilePath],
+  );
 
   // No branch/PR yet and run is active — show waiting state
   if (!prUrl && !effectiveBranch && effectiveFiles.length === 0) {
@@ -477,14 +451,7 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
   return (
     <Box height="100%" overflowY="auto" py="2">
       <Flex direction="column">
-        {effectiveFiles.map((file) => (
-          <ChangedFileItem
-            key={file.path}
-            file={file}
-            taskId={taskId}
-            isActive={activeFilePath === file.path}
-          />
-        ))}
+        <ChangesTreeView files={effectiveFiles} renderFile={renderFile} />
         {isRunActive && (
           <Flex align="center" gap="2" px="3" py="2">
             <Spinner size="1" />
@@ -526,20 +493,51 @@ function LocalChangesPanel({ taskId, task: _task }: ChangesPanelProps) {
 
   const hasStagedFiles = stagedFiles.length > 0;
 
-  const handleStageToggle = async (file: ChangedFile) => {
-    if (!repoPath) return;
-    const paths = [file.originalPath ?? file.path];
-    const endpoint = file.staged
-      ? trpcClient.git.unstageFiles
-      : trpcClient.git.stageFiles;
-    try {
-      const result = await endpoint.mutate({ directoryPath: repoPath, paths });
-      updateGitCacheFromSnapshot(queryClient, repoPath, result);
-      invalidateGitWorkingTreeQueries(repoPath);
-    } catch (error) {
-      log.error("Failed to toggle staging", { file: file.path, error });
-    }
-  };
+  const handleStageToggle = useCallback(
+    async (file: ChangedFile) => {
+      if (!repoPath) return;
+      const paths = [file.originalPath ?? file.path];
+      const endpoint = file.staged
+        ? trpcClient.git.unstageFiles
+        : trpcClient.git.stageFiles;
+      try {
+        const result = await endpoint.mutate({
+          directoryPath: repoPath,
+          paths,
+        });
+        updateGitCacheFromSnapshot(queryClient, repoPath, result);
+        invalidateGitWorkingTreeQueries(repoPath);
+      } catch (error) {
+        log.error("Failed to toggle staging", { file: file.path, error });
+      }
+    },
+    [repoPath, queryClient],
+  );
+
+  const renderLocalFile = useCallback(
+    (file: ChangedFile, depth: number) => {
+      const key = makeFileKey(file.staged, file.path);
+      return (
+        <ChangedFileItem
+          key={key}
+          file={file}
+          taskId={taskId}
+          repoPath={repoPath}
+          isActive={activeFilePath === key}
+          mainRepoPath={workspace?.folderPath}
+          onStageToggle={handleStageToggle}
+          depth={depth}
+        />
+      );
+    },
+    [
+      taskId,
+      repoPath,
+      activeFilePath,
+      workspace?.folderPath,
+      handleStageToggle,
+    ],
+  );
 
   if (!repoPath) {
     return <PanelMessage>No repository path available</PanelMessage>;
@@ -580,20 +578,7 @@ function LocalChangesPanel({ taskId, task: _task }: ChangesPanelProps) {
                 </Text>
               </Flex>
             )}
-            {files.map((file) => {
-              const key = makeFileKey(file.staged, file.path);
-              return (
-                <ChangedFileItem
-                  key={key}
-                  file={file}
-                  taskId={taskId}
-                  repoPath={repoPath}
-                  isActive={activeFilePath === key}
-                  mainRepoPath={workspace?.folderPath}
-                  onStageToggle={handleStageToggle}
-                />
-              );
-            })}
+            <ChangesTreeView files={files} renderFile={renderLocalFile} />
           </Fragment>
         ))}
       </Flex>

--- a/apps/code/src/renderer/features/task-detail/components/ChangesTreeView.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/ChangesTreeView.tsx
@@ -1,0 +1,146 @@
+import { TreeDirectoryRow } from "@components/TreeDirectoryRow";
+import type { ChangedFile } from "@shared/types";
+import { useCallback, useMemo, useState } from "react";
+
+export interface TreeNode {
+  name: string;
+  path: string;
+  children: Map<string, TreeNode>;
+  files: ChangedFile[];
+}
+
+export function buildChangesTree(files: ChangedFile[]): TreeNode {
+  const root: TreeNode = { name: "", path: "", children: new Map(), files: [] };
+  for (const file of files) {
+    const parts = file.path.split("/");
+    let node = root;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (!node.children.has(part)) {
+        node.children.set(part, {
+          name: part,
+          path: parts.slice(0, i + 1).join("/"),
+          children: new Map(),
+          files: [],
+        });
+      }
+      const child = node.children.get(part);
+      if (!child) break;
+      node = child;
+    }
+    node.files.push(file);
+  }
+  return root;
+}
+
+/** Collapse single-child directory chains into one node (e.g. "src/utils") */
+export function compactTree(node: TreeNode): TreeNode {
+  const compacted = new Map<string, TreeNode>();
+  for (const [key, child] of node.children) {
+    let current = child;
+    let label = current.name;
+    while (current.children.size === 1 && current.files.length === 0) {
+      const [, only] = [...current.children.entries()][0];
+      label = `${label}/${only.name}`;
+      current = only;
+    }
+    const result = compactTree(current);
+    result.name = label;
+    compacted.set(key, result);
+  }
+  return { ...node, children: compacted };
+}
+
+interface ChangesTreeNodeProps {
+  node: TreeNode;
+  depth: number;
+  collapsedDirs: Set<string>;
+  onToggleDir: (path: string) => void;
+  renderFile: (file: ChangedFile, depth: number) => React.ReactNode;
+}
+
+function ChangesTreeNode({
+  node,
+  depth,
+  collapsedDirs,
+  onToggleDir,
+  renderFile,
+}: ChangesTreeNodeProps) {
+  const isCollapsed = collapsedDirs.has(node.path);
+  const sortedDirs = useMemo(
+    () =>
+      [...node.children.values()].sort((a, b) => a.name.localeCompare(b.name)),
+    [node.children],
+  );
+  const sortedFiles = useMemo(
+    () =>
+      [...node.files].sort((a, b) => {
+        const aName = a.path.split("/").pop() || "";
+        const bName = b.path.split("/").pop() || "";
+        return aName.localeCompare(bName);
+      }),
+    [node.files],
+  );
+
+  return (
+    <>
+      {node.path && (
+        <TreeDirectoryRow
+          name={node.name}
+          depth={depth}
+          isExpanded={!isCollapsed}
+          onToggle={() => onToggleDir(node.path)}
+        />
+      )}
+      {!isCollapsed && (
+        <>
+          {sortedDirs.map((child) => (
+            <ChangesTreeNode
+              key={child.path}
+              node={child}
+              depth={node.path ? depth + 1 : depth}
+              collapsedDirs={collapsedDirs}
+              onToggleDir={onToggleDir}
+              renderFile={renderFile}
+            />
+          ))}
+          {sortedFiles.map((file) =>
+            renderFile(file, node.path ? depth + 1 : depth),
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
+interface ChangesTreeViewProps {
+  files: ChangedFile[];
+  renderFile: (file: ChangedFile, depth: number) => React.ReactNode;
+}
+
+export function ChangesTreeView({ files, renderFile }: ChangesTreeViewProps) {
+  const tree = useMemo(() => compactTree(buildChangesTree(files)), [files]);
+  const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(new Set());
+
+  const handleToggleDir = useCallback((path: string) => {
+    setCollapsedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <ChangesTreeNode
+      node={tree}
+      depth={0}
+      collapsedDirs={collapsedDirs}
+      onToggleDir={handleToggleDir}
+      renderFile={renderFile}
+    />
+  );
+}

--- a/apps/code/src/renderer/features/task-detail/components/FileTreePanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/FileTreePanel.tsx
@@ -1,4 +1,4 @@
-import { FileIcon } from "@components/ui/FileIcon";
+import { TreeDirectoryRow, TreeFileRow } from "@components/TreeDirectoryRow";
 import { PanelMessage } from "@components/ui/PanelMessage";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
 import { isFileTabActiveInTree } from "@features/panels/store/panelStoreHelpers";
@@ -8,12 +8,7 @@ import {
 } from "@features/right-sidebar/stores/fileTreeStore";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
 import { useCloudRunState } from "@features/task-detail/hooks/useCloudRunState";
-import {
-  CaretRight,
-  Cloud,
-  FolderIcon,
-  FolderOpenIcon,
-} from "@phosphor-icons/react";
+import { Cloud } from "@phosphor-icons/react";
 import { Box, Button, Flex, Spinner, Text } from "@radix-ui/themes";
 import { useWorkspace } from "@renderer/features/workspace/hooks/useWorkspace";
 import { trpcClient, useTRPC } from "@renderer/trpc/client";
@@ -110,71 +105,28 @@ function LazyTreeItem({
 
   return (
     <Box>
-      <Flex
-        align="center"
-        gap="1"
-        style={{
-          paddingLeft: `${depth * 12 + 4}px`,
-          paddingRight: "8px",
-          height: "22px",
-          cursor: "pointer",
-        }}
-        className={
-          isActive
-            ? "border-accent-8 border-y bg-accent-4"
-            : "border-transparent border-y hover:bg-gray-3"
-        }
-        onClick={handleClick}
-        onDoubleClick={handleDoubleClick}
-        onContextMenu={handleContextMenu}
-      >
+      {isDirectory ? (
         <Box
-          style={{
-            width: "16px",
-            height: "16px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            flexShrink: 0,
-          }}
+          onDoubleClick={handleDoubleClick}
+          onContextMenu={handleContextMenu}
         >
-          {isDirectory && (
-            <CaretRight
-              size={10}
-              weight="bold"
-              color="var(--gray-10)"
-              style={{
-                transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
-                transition: "transform 0.1s ease",
-              }}
-            />
-          )}
+          <TreeDirectoryRow
+            name={entry.name}
+            depth={depth}
+            isExpanded={isExpanded}
+            onToggle={handleClick}
+          />
         </Box>
-        {isDirectory ? (
-          isExpanded ? (
-            <FolderOpenIcon
-              size={14}
-              weight="fill"
-              color="var(--accent-9)"
-              style={{ flexShrink: 0 }}
-            />
-          ) : (
-            <FolderIcon
-              size={14}
-              color="var(--accent-9)"
-              style={{ flexShrink: 0 }}
-            />
-          )
-        ) : (
-          <FileIcon filename={entry.name} size={14} />
-        )}
-        <span
-          className="select-none overflow-hidden text-ellipsis whitespace-nowrap text-[13px]"
-          style={{ marginLeft: "4px" }}
-        >
-          {entry.name}
-        </span>
-      </Flex>
+      ) : (
+        <TreeFileRow
+          fileName={entry.name}
+          depth={depth}
+          isActive={isActive}
+          onClick={handleClick}
+          onDoubleClick={handleDoubleClick}
+          onContextMenu={handleContextMenu}
+        />
+      )}
       {isExpanded &&
         children?.map((child) => (
           <LazyTreeItem


### PR DESCRIPTION
## Problem

changed files would be easier to parse as a tree

closes https://github.com/posthog/code/issues/1197

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

- extract some stuff from the existing file tree view
- make changed files render as a tree

| chat view | review panel |
| --- | --- |
| ![Screenshot 2026-04-03 at 1.21.38 PM.png](https://app.graphite.com/user-attachments/assets/36da3536-13e7-441e-93dd-47b1f909e0d1.png) | ![Screenshot 2026-04-03 at 1.21.41 PM.png](https://app.graphite.com/user-attachments/assets/53e3cbc3-4d64-407f-a81a-68aa17709d58.png)<br> |

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->