### PR TITLE
fix(code): do not re-sort on task click

### DIFF
--- a/apps/code/src/renderer/features/sessions/hooks/useSessionCallbacks.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionCallbacks.ts
@@ -52,9 +52,9 @@ export function useSessionCallbacks({
 
       try {
         markAsViewed(taskId);
+        markActivity(taskId);
         const result = await getSessionService().sendPrompt(taskId, text);
         log.info("Prompt completed", { stopReason: result.stopReason });
-        markActivity(taskId);
 
         const view = useNavigationStore.getState().view;
         const isViewingTask =

--- a/apps/code/src/renderer/features/sessions/hooks/useSessionConnection.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionConnection.ts
@@ -1,4 +1,3 @@
-import { useTaskViewed } from "@features/sidebar/hooks/useTaskViewed";
 import { useConnectivity } from "@hooks/useConnectivity";
 import { trpcClient } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
@@ -31,7 +30,6 @@ export function useSessionConnection({
   isSuspended,
 }: UseSessionConnectionOptions) {
   const queryClient = useQueryClient();
-  const { markActivity } = useTaskViewed();
   const { isOnline } = useConnectivity();
 
   useChatTitleGenerator(taskId);
@@ -98,8 +96,6 @@ export function useSessionConnection({
       sessionStatus: session?.status ?? "none",
     });
 
-    markActivity(task.id);
-
     getSessionService()
       .connectToTask({
         task,
@@ -112,16 +108,7 @@ export function useSessionConnection({
     return () => {
       connectingTasks.delete(taskId);
     };
-  }, [
-    task,
-    taskId,
-    repoPath,
-    session,
-    markActivity,
-    isOnline,
-    isCloud,
-    isSuspended,
-  ]);
+  }, [task, taskId, repoPath, session, isOnline, isCloud, isSuspended]);
 
   const cannotConnect = !repoPath && !isCloud;
   useEffect(() => {


### PR DESCRIPTION
## Problem

clicking a task re-sorts the entire list. this is kinda jarring and makes it hard to click around tasks looking for things

root cause: we consider opening a task "activity" , which updates client-side and backend storage, and i think that's just probably not the right move? we could instrument this as a posthog event, but i don't think clicking a task is a meaningful-enough interaction to consider it "updated"

closes https://github.com/posthog/code/issues/1489

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

- removes the call to `markActivity` from session connection
- moves activity call in prompt handler to fire before the agent turn

**new** **behavior:**

- clicking a task does not re-sort the list
- task is updated & re-sorted as soon as a prompt is submitted

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->