### PR TITLE
feat(cloud-agent): wire cloud attachments into task creation and session display

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -728,20 +728,25 @@ export class PostHogAPIClient {
   async runTaskInCloud(
     taskId: string,
     branch?: string | null,
-    resumeOptions?: { resumeFromRunId: string; pendingUserMessage: string },
-    sandboxEnvironmentId?: string,
+    options?: {
+      resumeFromRunId?: string;
+      pendingUserMessage?: string;
+      sandboxEnvironmentId?: string;
+    },
   ): Promise<Task> {
     const teamId = await this.getTeamId();
     const body: Record<string, unknown> = { mode: "interactive" };
     if (branch) {
       body.branch = branch;
     }
-    if (resumeOptions) {
-      body.resume_from_run_id = resumeOptions.resumeFromRunId;
-      body.pending_user_message = resumeOptions.pendingUserMessage;
+    if (options?.resumeFromRunId) {
+      body.resume_from_run_id = options.resumeFromRunId;
     }
-    if (sandboxEnvironmentId) {
-      body.sandbox_environment_id = sandboxEnvironmentId;
+    if (options?.pendingUserMessage) {
+      body.pending_user_message = options.pendingUserMessage;
+    }
+    if (options?.sandboxEnvironmentId) {
+      body.sandbox_environment_id = options.sandboxEnvironmentId;
     }
 
     const data = await this.api.post(

--- a/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.test.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.test.tsx
@@ -1,0 +1,66 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSelectFiles = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/trpc/client", () => ({
+  trpcClient: {
+    os: {
+      selectFiles: {
+        query: mockSelectFiles,
+      },
+    },
+  },
+  useTRPC: () => ({
+    git: {
+      getGhStatus: {
+        queryOptions: () => ({}),
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined }),
+}));
+
+vi.mock("@renderer/utils/toast", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+import { AttachmentMenu } from "./AttachmentMenu";
+
+describe("AttachmentMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds attachments using absolute file paths from the OS picker", async () => {
+    const user = userEvent.setup();
+    const onAddAttachment = vi.fn();
+
+    mockSelectFiles.mockResolvedValue(["/tmp/demo/test.txt"]);
+
+    render(
+      <Theme>
+        <AttachmentMenu
+          onAddAttachment={onAddAttachment}
+          onInsertChip={vi.fn()}
+        />
+      </Theme>,
+    );
+
+    await user.click(screen.getByRole("button"));
+    await user.click(await screen.findByText("Add file"));
+
+    expect(mockSelectFiles).toHaveBeenCalledOnce();
+    expect(onAddAttachment).toHaveBeenCalledWith({
+      id: "/tmp/demo/test.txt",
+      label: "test.txt",
+    });
+  });
+});

--- a/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.tsx
@@ -1,11 +1,13 @@
 import "./AttachmentMenu.css";
-import { Tooltip } from "@components/ui/Tooltip";
 import { File, GithubLogo, Paperclip } from "@phosphor-icons/react";
 import { IconButton, Popover } from "@radix-ui/themes";
-import { useTRPC } from "@renderer/trpc/client";
+import { trpcClient, useTRPC } from "@renderer/trpc/client";
+import { toast } from "@renderer/utils/toast";
 import { useQuery } from "@tanstack/react-query";
+import { getFileName } from "@utils/path";
 import { useRef, useState } from "react";
 import type { FileAttachment, MentionChip } from "../utils/content";
+import { persistBrowserFile } from "../utils/persistFile";
 import { IssuePicker } from "./IssuePicker";
 
 type View = "menu" | "issues";
@@ -54,19 +56,41 @@ export function AttachmentMenu({
 
   const issueDisabledReason = getIssueDisabledReason(ghStatus, repoPath);
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (files && files.length > 0) {
-      const fileArray = Array.from(files);
-      for (const file of fileArray) {
-        const filePath =
-          (file as globalThis.File & { path?: string }).path || file.name;
-        onAddAttachment({ id: filePath, label: file.name });
-      }
-      onAttachFiles?.(fileArray);
-    }
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files ? Array.from(e.target.files) : [];
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
+    }
+
+    if (files.length === 0) {
+      return;
+    }
+
+    try {
+      const attachments = await Promise.all(
+        files.map(async (file) => {
+          const filePath = (file as globalThis.File & { path?: string }).path;
+          if (filePath) {
+            return { id: filePath, label: file.name } satisfies FileAttachment;
+          }
+
+          return await persistBrowserFile(file);
+        }),
+      );
+
+      for (const attachment of attachments) {
+        if (attachment) {
+          onAddAttachment(attachment);
+        }
+      }
+
+      onAttachFiles?.(files);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Unable to attach selected files from this picker",
+      );
     }
   };
 
@@ -77,8 +101,21 @@ export function AttachmentMenu({
     }
   };
 
-  const handleAddFile = () => {
+  const handleAddFile = async () => {
     setOpen(false);
+
+    try {
+      const filePaths = await trpcClient.os.selectFiles.query();
+      if (filePaths.length > 0) {
+        for (const filePath of filePaths) {
+          onAddAttachment({ id: filePath, label: getFileName(filePath) });
+        }
+      }
+      return;
+    } catch {
+      // Fall back to the input element for non-Electron environments.
+    }
+
     fileInputRef.current?.click();
   };
 
@@ -112,18 +149,17 @@ export function AttachmentMenu({
         style={{ display: "none" }}
       />
       <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        <Tooltip content={attachTooltip}>
-          <Popover.Trigger>
-            <IconButton
-              size="1"
-              variant="ghost"
-              color="gray"
-              disabled={disabled}
-            >
-              <Paperclip size={iconSize} weight="bold" />
-            </IconButton>
-          </Popover.Trigger>
-        </Tooltip>
+        <Popover.Trigger>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            disabled={disabled}
+            title={attachTooltip}
+          >
+            <Paperclip size={iconSize} weight="bold" />
+          </IconButton>
+        </Popover.Trigger>
         <Popover.Content side="top" align="start" style={{ padding: 0 }}>
           {view === "menu" ? (
             <div className="attachment-menu">
@@ -138,9 +174,7 @@ export function AttachmentMenu({
                 <span>Add file</span>
               </button>
               {issueDisabledReason ? (
-                <Tooltip content={issueDisabledReason} side="right">
-                  <span>{issueButton}</span>
-                </Tooltip>
+                <span title={issueDisabledReason}>{issueButton}</span>
               ) : (
                 issueButton
               )}

--- a/apps/code/src/renderer/features/message-editor/tiptap/useDraftSync.test.tsx
+++ b/apps/code/src/renderer/features/message-editor/tiptap/useDraftSync.test.tsx
@@ -1,0 +1,63 @@
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@utils/electronStorage", () => ({
+  electronStorage: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+}));
+
+import { useDraftStore } from "../stores/draftStore";
+import { useDraftSync } from "./useDraftSync";
+
+function DraftAttachmentsProbe({ sessionId }: { sessionId: string }) {
+  const { restoredAttachments } = useDraftSync(null, sessionId);
+  return (
+    <div>
+      {restoredAttachments.map((att) => att.label).join(",") || "empty"}
+    </div>
+  );
+}
+
+describe("useDraftSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDraftStore.setState((state) => ({
+      ...state,
+      drafts: {},
+      contexts: {},
+      commands: {},
+      focusRequested: {},
+      pendingContent: {},
+      _hasHydrated: true,
+    }));
+  });
+
+  it("clears restored attachments when a draft no longer has attachments", () => {
+    const { rerender } = render(
+      <DraftAttachmentsProbe sessionId="session-1" />,
+    );
+
+    act(() => {
+      useDraftStore.getState().actions.setDraft("session-1", {
+        segments: [{ type: "text", text: "hello" }],
+        attachments: [{ id: "/tmp/file.txt", label: "file.txt" }],
+      });
+    });
+
+    expect(screen.getByText("file.txt")).toBeInTheDocument();
+
+    act(() => {
+      useDraftStore.getState().actions.setDraft("session-1", {
+        segments: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    expect(screen.getByText("empty")).toBeInTheDocument();
+
+    rerender(<DraftAttachmentsProbe sessionId="session-2" />);
+    expect(screen.getByText("empty")).toBeInTheDocument();
+  });
+});

--- a/apps/code/src/renderer/features/message-editor/tiptap/useDraftSync.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/useDraftSync.ts
@@ -171,9 +171,12 @@ export function useDraftSync(
   >([]);
   useLayoutEffect(() => {
     if (!draft || typeof draft === "string") return;
-    if (draft.attachments && draft.attachments.length > 0) {
-      setRestoredAttachments(draft.attachments);
-    }
+    const incoming = draft.attachments ?? [];
+    // Short-circuit the common empty→empty case to avoid creating a new array
+    // reference that would trigger unnecessary re-renders.
+    setRestoredAttachments((prev) =>
+      prev.length === 0 && incoming.length === 0 ? prev : incoming,
+    );
   }, [draft]);
 
   const attachmentsRef = useRef<FileAttachment[]>([]);

--- a/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -1,6 +1,5 @@
 import { sessionStoreSetters } from "@features/sessions/stores/sessionStore";
 import { useSettingsStore as useFeatureSettingsStore } from "@features/settings/stores/settingsStore";
-import { trpcClient } from "@renderer/trpc/client";
 import { toast } from "@renderer/utils/toast";
 import { useSettingsStore } from "@stores/settingsStore";
 import type { EditorView } from "@tiptap/pm/view";
@@ -10,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { usePromptHistoryStore } from "../stores/promptHistoryStore";
 import type { FileAttachment, MentionChip } from "../utils/content";
 import { contentToXml, isContentEmpty } from "../utils/content";
+import { persistImageFile, persistTextContent } from "../utils/persistFile";
 import { getEditorExtensions } from "./extensions";
 import { type DraftContext, useDraftSync } from "./useDraftSync";
 
@@ -45,7 +45,7 @@ async function pasteTextAsFile(
   text: string,
   pasteCountRef: React.MutableRefObject<number>,
 ): Promise<void> {
-  const result = await trpcClient.os.saveClipboardText.mutate({ text });
+  const result = await persistTextContent(text);
   pasteCountRef.current += 1;
   const lineCount = text.split("\n").length;
   const label = `Pasted text #${pasteCountRef.current} (${lineCount} lines)`;
@@ -331,19 +331,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
                 if (!file) continue;
 
                 try {
-                  const arrayBuffer = await file.arrayBuffer();
-                  const base64 = btoa(
-                    new Uint8Array(arrayBuffer).reduce(
-                      (data, byte) => data + String.fromCharCode(byte),
-                      "",
-                    ),
-                  );
-
-                  const result = await trpcClient.os.saveClipboardImage.mutate({
-                    base64Data: base64,
-                    mimeType: file.type,
-                    originalName: file.name,
-                  });
+                  const result = await persistImageFile(file);
 
                   setAttachments((prev) => {
                     if (prev.some((a) => a.id === result.path)) return prev;
@@ -448,9 +436,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
 
   // Restore attachments from draft on mount
   useEffect(() => {
-    if (draft.restoredAttachments.length > 0) {
-      setAttachments(draft.restoredAttachments);
-    }
+    setAttachments(draft.restoredAttachments);
     // Only run on mount / session change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draft.restoredAttachments]);

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -146,6 +146,7 @@ export function ConversationView({
           return (
             <UserMessage
               content={item.content}
+              attachments={item.attachments}
               timestamp={item.timestamp}
               sourceUrl={
                 slackThreadUrl && item.id === firstUserMessageId

--- a/apps/code/src/renderer/features/sessions/components/buildConversationItems.test.ts
+++ b/apps/code/src/renderer/features/sessions/components/buildConversationItems.test.ts
@@ -1,0 +1,97 @@
+import type { AcpMessage } from "@shared/types/session-events";
+import { makeAttachmentUri } from "@utils/promptContent";
+import { describe, expect, it } from "vitest";
+import { buildConversationItems } from "./buildConversationItems";
+
+describe("buildConversationItems", () => {
+  it("extracts cloud prompt attachments into user messages", () => {
+    const uri = makeAttachmentUri("/tmp/hello world.txt");
+
+    const events: AcpMessage[] = [
+      {
+        type: "acp_message",
+        ts: 1,
+        message: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "session/prompt",
+          params: {
+            prompt: [
+              { type: "text", text: "read this file" },
+              {
+                type: "resource",
+                resource: {
+                  uri,
+                  text: "watup",
+                  mimeType: "text/plain",
+                },
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const result = buildConversationItems(events, null);
+
+    expect(result.items).toEqual([
+      {
+        type: "user_message",
+        id: "turn-1-1-user",
+        content: "read this file",
+        timestamp: 1,
+        attachments: [
+          {
+            id: uri,
+            label: "hello world.txt",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps attachment-only prompts visible", () => {
+    const uri = makeAttachmentUri("/tmp/test.txt");
+
+    const events: AcpMessage[] = [
+      {
+        type: "acp_message",
+        ts: 1,
+        message: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "session/prompt",
+          params: {
+            prompt: [
+              {
+                type: "resource",
+                resource: {
+                  uri,
+                  text: "watup",
+                  mimeType: "text/plain",
+                },
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const result = buildConversationItems(events, null);
+
+    expect(result.items).toEqual([
+      {
+        type: "user_message",
+        id: "turn-1-1-user",
+        content: "",
+        timestamp: 1,
+        attachments: [
+          {
+            id: uri,
+            label: "test.txt",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
+++ b/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
@@ -12,8 +12,10 @@ import {
   isJsonRpcResponse,
   type UserShellExecuteParams,
 } from "@shared/types/session-events";
+import { extractPromptDisplayContent } from "@utils/promptContent";
 import { type GitActionType, parseGitActionMessage } from "./GitActionMessage";
 import type { RenderItem } from "./session-update/SessionUpdateView";
+import type { UserMessageAttachment } from "./session-update/UserMessage";
 import type { UserShellExecute } from "./session-update/UserShellExecuteView";
 
 export interface TurnContext {
@@ -24,7 +26,13 @@ export interface TurnContext {
 }
 
 export type ConversationItem =
-  | { type: "user_message"; id: string; content: string; timestamp: number }
+  | {
+      type: "user_message";
+      id: string;
+      content: string;
+      timestamp: number;
+      attachments?: UserMessageAttachment[];
+    }
   | { type: "git_action"; id: string; actionType: GitActionType }
   | {
       type: "session_update";
@@ -197,9 +205,12 @@ function handlePromptRequest(
     b.currentTurn.context.turnComplete = true;
   }
 
-  const userContent = extractUserContent(msg.params);
+  const userPrompt = extractUserPrompt(msg.params);
+  const userContent = userPrompt.content;
 
-  if (userContent.trim().length === 0) return;
+  if (userContent.trim().length === 0 && userPrompt.attachments.length === 0) {
+    return;
+  }
 
   const turnId = `turn-${ts}-${msg.id}`;
   const toolCalls = new Map<string, ToolCall>();
@@ -238,6 +249,7 @@ function handlePromptRequest(
       id: `${turnId}-user`,
       content: userContent,
       timestamp: ts,
+      attachments: userPrompt.attachments,
     });
   }
 }
@@ -406,23 +418,19 @@ function ensureImplicitTurn(b: ItemBuilder, ts: number) {
   };
 }
 
-interface TextBlockWithMeta {
-  type: "text";
-  text: string;
-  _meta?: { ui?: { hidden?: boolean } };
-}
-
-function extractUserContent(params: unknown): string {
+function extractUserPrompt(params: unknown): {
+  content: string;
+  attachments: UserMessageAttachment[];
+} {
   const p = params as { prompt?: ContentBlock[] };
-  if (!p?.prompt?.length) return "";
+  if (!p?.prompt?.length) {
+    return { content: "", attachments: [] };
+  }
 
-  const visibleTextBlocks = p.prompt.filter((b): b is TextBlockWithMeta => {
-    if (b.type !== "text") return false;
-    const meta = (b as TextBlockWithMeta)._meta;
-    return !meta?.ui?.hidden;
+  const { text, attachments } = extractPromptDisplayContent(p.prompt, {
+    filterHidden: true,
   });
-
-  return visibleTextBlocks.map((b) => b.text).join("");
+  return { content: text, attachments };
 }
 
 function getParentToolCallId(update: SessionUpdate): string | undefined {

--- a/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.test.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.test.tsx
@@ -1,0 +1,24 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { UserMessage } from "./UserMessage";
+
+describe("UserMessage", () => {
+  it("renders attachment chips for cloud prompts", () => {
+    render(
+      <Theme>
+        <UserMessage
+          content="read this file"
+          attachments={[
+            { id: "attachment://test.txt", label: "test.txt" },
+            { id: "attachment://notes.md", label: "notes.md" },
+          ]}
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByText("read this file")).toBeInTheDocument();
+    expect(screen.getByText("test.txt")).toBeInTheDocument();
+    expect(screen.getByText("notes.md")).toBeInTheDocument();
+  });
+});

--- a/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
@@ -5,18 +5,29 @@ import {
   CaretUp,
   Check,
   Copy,
+  File,
   SlackLogo,
 } from "@phosphor-icons/react";
-import { Box, IconButton } from "@radix-ui/themes";
+import { Box, Flex, IconButton } from "@radix-ui/themes";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { hasFileMentions, parseFileMentions } from "./parseFileMentions";
+import {
+  hasFileMentions,
+  MentionChip,
+  parseFileMentions,
+} from "./parseFileMentions";
 
 const COLLAPSED_MAX_HEIGHT = 160;
+
+export interface UserMessageAttachment {
+  id: string;
+  label: string;
+}
 
 interface UserMessageProps {
   content: string;
   timestamp?: number;
   sourceUrl?: string;
+  attachments?: UserMessageAttachment[];
 }
 
 function formatTimestamp(ts: number): string {
@@ -34,8 +45,10 @@ export function UserMessage({
   content,
   timestamp,
   sourceUrl,
+  attachments = [],
 }: UserMessageProps) {
   const containsFileMentions = hasFileMentions(content);
+  const showAttachmentChips = attachments.length > 0 && !containsFileMentions;
   const [copied, setCopied] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -72,6 +85,17 @@ export function UserMessage({
           parseFileMentions(content)
         ) : (
           <MarkdownRenderer content={content} />
+        )}
+        {showAttachmentChips && (
+          <Flex wrap="wrap" gap="1" className={content.trim() ? "mt-1.5" : ""}>
+            {attachments.map((attachment) => (
+              <MentionChip
+                key={attachment.id}
+                icon={<File size={12} />}
+                label={attachment.label}
+              />
+            ))}
+          </Flex>
         )}
         {!isExpanded && isOverflowing && (
           <Box

--- a/apps/code/src/renderer/features/sessions/components/session-update/parseFileMentions.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/parseFileMentions.tsx
@@ -48,7 +48,7 @@ export const hasFileMentions = hasMentionTags;
 const chipClass =
   "inline-flex items-center gap-1 rounded-[var(--radius-1)] bg-[var(--accent-a3)] px-1 py-px align-middle font-medium text-[var(--accent-11)]";
 
-function MentionChip({
+export function MentionChip({
   icon,
   label,
   onClick,

--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -1,3 +1,4 @@
+import type { ContentBlock } from "@agentclientprotocol/sdk";
 import type { AgentSession } from "@features/sessions/stores/sessionStore";
 import type { Task } from "@shared/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -29,11 +30,16 @@ const mockTrpcLogs = vi.hoisted(() => ({
   writeLocalLogs: { mutate: vi.fn() },
 }));
 
+const mockTrpcCloudTask = vi.hoisted(() => ({
+  sendCommand: { mutate: vi.fn() },
+}));
+
 vi.mock("@renderer/trpc/client", () => ({
   trpcClient: {
     agent: mockTrpcAgent,
     workspace: mockTrpcWorkspace,
     logs: mockTrpcLogs,
+    cloudTask: mockTrpcCloudTask,
   },
 }));
 
@@ -581,6 +587,50 @@ describe("SessionService", () => {
         sessionId: "run-123",
         prompt: [{ type: "text", text: "Hello" }],
       });
+    });
+
+    it("serializes structured prompts before sending cloud follow-ups", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          isCloud: true,
+          cloudStatus: "in_progress",
+        }),
+      );
+      mockTrpcCloudTask.sendCommand.mutate.mockResolvedValue({
+        success: true,
+        result: { stopReason: "end_turn" },
+      });
+
+      const prompt: ContentBlock[] = [
+        { type: "text", text: "read this" },
+        {
+          type: "resource",
+          resource: {
+            uri: "attachment://test.txt",
+            text: "hello from file",
+            mimeType: "text/plain",
+          },
+        },
+      ];
+
+      const result = await service.sendPrompt("task-123", prompt);
+
+      expect(result.stopReason).toBe("end_turn");
+      expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledTimes(1);
+
+      const [args] = mockTrpcCloudTask.sendCommand.mutate.mock.calls[0] as [
+        {
+          params?: { content?: unknown };
+        },
+      ];
+
+      expect(args.params?.content).toEqual(
+        expect.stringContaining("__twig_cloud_prompt_v1__:"),
+      );
+      expect(args.params?.content).toEqual(
+        expect.stringContaining('"type":"resource"'),
+      );
     });
 
     it("sets session to error state on fatal error", async () => {

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -8,6 +8,11 @@ import {
   getAuthenticatedClient,
 } from "@features/auth/hooks/authClient";
 import { fetchAuthState } from "@features/auth/hooks/authQueries";
+import {
+  buildCloudPromptBlocks,
+  buildCloudTaskDescription,
+  serializeCloudPrompt,
+} from "@features/editor/utils/cloud-prompt";
 import { useSessionAdapterStore } from "@features/sessions/stores/sessionAdapterStore";
 import {
   getPersistedConfigOptions,
@@ -61,6 +66,7 @@ import {
 } from "@utils/session";
 
 const log = logger.scope("session-service");
+const TERMINAL_CLOUD_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
 interface AuthCredentials {
   apiHost: string;
@@ -1149,23 +1155,42 @@ export class SessionService {
 
   // --- Cloud Commands ---
 
+  private async prepareCloudPrompt(
+    prompt: string | ContentBlock[],
+  ): Promise<{ blocks: ContentBlock[]; promptText: string }> {
+    const blocks =
+      typeof prompt === "string"
+        ? await buildCloudPromptBlocks(prompt)
+        : prompt;
+
+    if (blocks.length === 0) {
+      throw new Error("Cloud prompt cannot be empty");
+    }
+
+    const promptText =
+      extractPromptText(blocks).trim() ||
+      (typeof prompt === "string" ? buildCloudTaskDescription(prompt) : "");
+
+    return { blocks, promptText };
+  }
+
   private async sendCloudPrompt(
     session: AgentSession,
     prompt: string | ContentBlock[],
     options?: { skipQueueGuard?: boolean },
   ): Promise<{ stopReason: string }> {
-    const promptText = extractPromptText(prompt);
-    if (!promptText.trim()) {
-      return { stopReason: "empty" };
-    }
-
-    const terminalStatuses = new Set(["completed", "failed", "cancelled"]);
-    if (session.cloudStatus && terminalStatuses.has(session.cloudStatus)) {
-      return this.resumeCloudRun(session, promptText);
+    if (
+      session.cloudStatus &&
+      TERMINAL_CLOUD_STATUSES.has(session.cloudStatus)
+    ) {
+      return this.resumeCloudRun(session, prompt);
     }
 
     if (!options?.skipQueueGuard && session.isPromptPending) {
-      sessionStoreSetters.enqueueMessage(session.taskId, promptText);
+      sessionStoreSetters.enqueueMessage(
+        session.taskId,
+        typeof prompt === "string" ? prompt : extractPromptText(prompt),
+      );
       log.info("Cloud message queued", {
         taskId: session.taskId,
         queueLength: session.messageQueue.length + 1,
@@ -1177,6 +1202,8 @@ export class SessionService {
     if (!auth) {
       throw new Error("Authentication required for cloud commands");
     }
+
+    const { blocks, promptText } = await this.prepareCloudPrompt(prompt);
 
     sessionStoreSetters.updateSession(session.taskRunId, {
       isPromptPending: true,
@@ -1196,7 +1223,11 @@ export class SessionService {
         apiHost: auth.apiHost,
         teamId: auth.teamId,
         method: "user_message",
-        params: { content: promptText },
+        params: {
+          // The live /command API still validates user_message content as a
+          // string, so structured prompts must go through the serialized form.
+          content: serializeCloudPrompt(blocks),
+        },
       });
 
       sessionStoreSetters.updateSession(session.taskRunId, {
@@ -1302,12 +1333,14 @@ export class SessionService {
 
   private async resumeCloudRun(
     session: AgentSession,
-    promptText: string,
+    prompt: string | ContentBlock[],
   ): Promise<{ stopReason: string }> {
     const client = await getAuthenticatedClient();
     if (!client) {
       throw new Error("Authentication required for cloud commands");
     }
+
+    const { blocks, promptText } = await this.prepareCloudPrompt(prompt);
 
     log.info("Creating resume run for terminal cloud task", {
       taskId: session.taskId,
@@ -1323,7 +1356,7 @@ export class SessionService {
       session.cloudBranch,
       {
         resumeFromRunId: session.taskRunId,
-        pendingUserMessage: promptText,
+        pendingUserMessage: serializeCloudPrompt(blocks),
       },
     );
     const newRun = updatedTask.latest_run;
@@ -1372,8 +1405,10 @@ export class SessionService {
   }
 
   private async cancelCloudPrompt(session: AgentSession): Promise<boolean> {
-    const terminalStatuses = new Set(["completed", "failed", "cancelled"]);
-    if (session.cloudStatus && terminalStatuses.has(session.cloudStatus)) {
+    if (
+      session.cloudStatus &&
+      TERMINAL_CLOUD_STATUSES.has(session.cloudStatus)
+    ) {
       log.info("Skipping cancel for terminal cloud run", {
         taskId: session.taskId,
         status: session.cloudStatus,
@@ -2029,8 +2064,7 @@ export class SessionService {
         }
       }
 
-      const terminalStatuses = new Set(["completed", "failed", "cancelled"]);
-      if (update.status && terminalStatuses.has(update.status)) {
+      if (update.status && TERMINAL_CLOUD_STATUSES.has(update.status)) {
         // Clean up any pending resume messages that couldn't be sent
         const session = sessionStoreSetters.getSessions()[taskRunId];
         if (

--- a/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInputEditor.tsx
@@ -12,7 +12,7 @@ import { UnifiedModelSelector } from "@features/sessions/components/UnifiedModel
 import type { AgentAdapter } from "@features/settings/stores/settingsStore";
 import { useConnectivity } from "@hooks/useConnectivity";
 import { ArrowUp } from "@phosphor-icons/react";
-import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
+import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { trpcClient } from "@renderer/trpc/client";
 import { EditorContent } from "@tiptap/react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle } from "react";
@@ -270,30 +270,29 @@ export const TaskInputEditor = forwardRef<
 
           <Flex align="center" gap="4">
             <TourHighlight active={tourHighlight === "submit-button"}>
-              <Tooltip content={getSubmitTooltip()}>
-                <IconButton
-                  size="1"
-                  variant="solid"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSubmit();
-                  }}
-                  disabled={!canSubmit || isSubmitDisabled}
-                  loading={isCreatingTask}
-                  style={{
-                    backgroundColor:
-                      !canSubmit || isSubmitDisabled
-                        ? "var(--accent-a4)"
-                        : undefined,
-                    color:
-                      !canSubmit || isSubmitDisabled
-                        ? "var(--accent-8)"
-                        : undefined,
-                  }}
-                >
-                  <ArrowUp size={16} weight="bold" />
-                </IconButton>
-              </Tooltip>
+              <IconButton
+                size="1"
+                variant="solid"
+                title={getSubmitTooltip()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSubmit();
+                }}
+                disabled={!canSubmit || isSubmitDisabled}
+                loading={isCreatingTask}
+                style={{
+                  backgroundColor:
+                    !canSubmit || isSubmitDisabled
+                      ? "var(--accent-a4)"
+                      : undefined,
+                  color:
+                    !canSubmit || isSubmitDisabled
+                      ? "var(--accent-8)"
+                      : undefined,
+                }}
+              >
+                <ArrowUp size={16} weight="bold" />
+              </IconButton>
             </TourHighlight>
           </Flex>
         </Flex>

--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -1,4 +1,5 @@
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
+import { buildCloudTaskDescription } from "@features/editor/utils/cloud-prompt";
 import type { MessageEditorHandle } from "@features/message-editor/components/MessageEditor";
 import { useTaskInputHistoryStore } from "@features/message-editor/stores/taskInputHistoryStore";
 import {
@@ -59,9 +60,16 @@ function prepareTaskInput(
     sandboxEnvironmentId?: string;
   },
 ): TaskCreationInput {
+  const serializedContent = contentToXml(content).trim();
+  const filePaths = extractFilePaths(content);
+
   return {
-    content: contentToXml(content).trim(),
-    filePaths: extractFilePaths(content),
+    content: serializedContent,
+    taskDescription:
+      options.workspaceMode === "cloud"
+        ? buildCloudTaskDescription(serializedContent, filePaths)
+        : undefined,
+    filePaths,
     repoPath: options.selectedDirectory,
     repository: options.selectedRepository,
     githubIntegrationId: options.githubIntegrationId,
@@ -81,6 +89,7 @@ function getErrorTitle(failedStep: string): string {
     repo_detection: "Failed to detect repository",
     task_creation: "Failed to create task",
     workspace_creation: "Failed to create workspace",
+    cloud_prompt_preparation: "Failed to prepare cloud attachments",
     cloud_run: "Failed to start cloud execution",
     agent_session: "Failed to start agent session",
   };

--- a/apps/code/src/renderer/sagas/task/task-creation.test.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.test.ts
@@ -4,12 +4,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockWorkspaceCreate = vi.hoisted(() => vi.fn());
 const mockWorkspaceDelete = vi.hoisted(() => vi.fn());
 const mockGetTaskDirectory = vi.hoisted(() => vi.fn());
+const mockReadAbsoluteFile = vi.hoisted(() => vi.fn());
+const mockReadFileAsBase64 = vi.hoisted(() => vi.fn());
 
 vi.mock("@renderer/trpc", () => ({
   trpcClient: {
     workspace: {
       create: { mutate: mockWorkspaceCreate },
       delete: { mutate: mockWorkspaceDelete },
+    },
+  },
+}));
+
+vi.mock("@renderer/trpc/client", () => ({
+  trpcClient: {
+    fs: {
+      readAbsoluteFile: { query: mockReadAbsoluteFile },
+      readFileAsBase64: { query: mockReadFileAsBase64 },
     },
   },
 }));
@@ -100,6 +111,8 @@ describe("TaskCreationSaga", () => {
     mockWorkspaceCreate.mockResolvedValue(undefined);
     mockWorkspaceDelete.mockResolvedValue(undefined);
     mockGetTaskDirectory.mockResolvedValue(null);
+    mockReadAbsoluteFile.mockResolvedValue(null);
+    mockReadFileAsBase64.mockResolvedValue(null);
   });
 
   it("waits for the cloud run response before surfacing the task", async () => {
@@ -107,6 +120,7 @@ describe("TaskCreationSaga", () => {
     const startedTask = createTask({ latest_run: createRun() });
     const createTaskMock = vi.fn().mockResolvedValue(createdTask);
     const runTaskInCloudMock = vi.fn().mockResolvedValue(startedTask);
+    const sendRunCommandMock = vi.fn();
     const onTaskReady = vi.fn();
 
     const saga = new TaskCreationSaga({
@@ -115,6 +129,7 @@ describe("TaskCreationSaga", () => {
         deleteTask: vi.fn(),
         getTask: vi.fn(),
         runTaskInCloud: runTaskInCloudMock,
+        sendRunCommand: sendRunCommandMock,
         updateTask: vi.fn(),
       } as never,
       onTaskReady,
@@ -135,9 +150,12 @@ describe("TaskCreationSaga", () => {
     expect(runTaskInCloudMock).toHaveBeenCalledWith(
       "task-123",
       "release/remembered-branch",
-      undefined,
-      undefined,
+      {
+        pendingUserMessage: "Ship the fix",
+        sandboxEnvironmentId: undefined,
+      },
     );
+    expect(sendRunCommandMock).not.toHaveBeenCalled();
     expect(onTaskReady).toHaveBeenCalledTimes(1);
     expect(onTaskReady.mock.calls[0][0].task.latest_run?.branch).toBe(
       "release/remembered-branch",
@@ -145,6 +163,63 @@ describe("TaskCreationSaga", () => {
     expect(result.data.task.latest_run?.branch).toBe(
       "release/remembered-branch",
     );
+    expect(runTaskInCloudMock.mock.invocationCallOrder[0]).toBeLessThan(
+      onTaskReady.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("sends initial cloud prompts with attachments as pending user messages", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const runTaskInCloudMock = vi.fn().mockResolvedValue(startedTask);
+    const sendRunCommandMock = vi.fn();
+    const onTaskReady = vi.fn();
+
+    mockReadAbsoluteFile.mockResolvedValue("hello from attachment");
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        runTaskInCloud: runTaskInCloudMock,
+        sendRunCommand: sendRunCommandMock,
+        updateTask: vi.fn(),
+      } as never,
+      onTaskReady,
+    });
+
+    const result = await saga.run({
+      content: 'read this file <file path="/tmp/test.txt" />',
+      taskDescription: "read this file\n\nAttached files: test.txt",
+      filePaths: ["/tmp/test.txt"],
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "release/remembered-branch",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected task creation to succeed");
+    }
+
+    expect(createTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "read this file\n\nAttached files: test.txt",
+      }),
+    );
+    expect(runTaskInCloudMock).toHaveBeenCalledWith(
+      "task-123",
+      "release/remembered-branch",
+      {
+        pendingUserMessage: expect.stringContaining(
+          "__twig_cloud_prompt_v1__:",
+        ),
+        sandboxEnvironmentId: undefined,
+      },
+    );
+    expect(sendRunCommandMock).not.toHaveBeenCalled();
     expect(runTaskInCloudMock.mock.invocationCallOrder[0]).toBeLessThan(
       onTaskReady.mock.invocationCallOrder[0],
     );

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -1,3 +1,7 @@
+import {
+  buildCloudPromptBlocks,
+  serializeCloudPrompt,
+} from "@features/editor/utils/cloud-prompt";
 import { buildPromptBlocks } from "@features/editor/utils/prompt-builder";
 import { DEFAULT_PANEL_IDS } from "@features/panels/constants/panelConstants";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
@@ -61,6 +65,7 @@ export interface TaskCreationInput {
   taskId?: string;
   // For creating new task (required if no taskId)
   content?: string;
+  taskDescription?: string;
   filePaths?: string[];
   repoPath?: string;
   repository?: string | null;
@@ -99,6 +104,13 @@ export class TaskCreationSaga extends Saga<
   protected async execute(
     input: TaskCreationInput,
   ): Promise<TaskCreationOutput> {
+    const initialCloudPrompt =
+      input.workspaceMode === "cloud" && !input.taskId && input.content
+        ? await this.readOnlyStep("cloud_prompt_preparation", () =>
+            buildCloudPromptBlocks(input.content ?? "", input.filePaths),
+          )
+        : null;
+
     // Step 1: Get or create task
     // For new tasks, start folder registration in parallel with task creation
     // since folder_registration only needs repoPath (from input), not task.id
@@ -116,7 +128,11 @@ export class TaskCreationSaga extends Saga<
 
     // Fire-and-forget: generate a proper LLM title for new tasks
     if (!taskId) {
-      generateTaskTitle(task.id, input.content ?? "", this.deps.posthogClient);
+      generateTaskTitle(
+        task.id,
+        input.taskDescription ?? input.content ?? "",
+        this.deps.posthogClient,
+      );
     }
 
     const repoKey = getTaskRepository(task);
@@ -260,12 +276,12 @@ export class TaskCreationSaga extends Saga<
       task = await this.step({
         name: "cloud_run",
         execute: () =>
-          this.deps.posthogClient.runTaskInCloud(
-            task.id,
-            branch,
-            undefined,
-            input.sandboxEnvironmentId,
-          ),
+          this.deps.posthogClient.runTaskInCloud(task.id, branch, {
+            pendingUserMessage: initialCloudPrompt
+              ? serializeCloudPrompt(initialCloudPrompt)
+              : undefined,
+            sandboxEnvironmentId: input.sandboxEnvironmentId,
+          }),
         rollback: async () => {
           log.info("Rolling back: cloud run (no-op)", { taskId: task.id });
         },
@@ -390,7 +406,7 @@ export class TaskCreationSaga extends Saga<
       name: "task_creation",
       execute: async () => {
         const result = await this.deps.posthogClient.createTask({
-          description: input.content ?? "",
+          description: input.taskDescription ?? input.content ?? "",
           repository: repository ?? undefined,
           github_integration:
             input.workspaceMode === "cloud"


### PR DESCRIPTION
## [ph_code_cloud_attachments.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0ac30a1e-e9d4-4b38-b5a9-8b07890dfbf0.mp4" />](https://app.graphite.com/user-attachments/video/0ac30a1e-e9d4-4b38-b5a9-8b07890dfbf0.mp4)



## Problem

Wire cloud prompt builder into file picker UI, task creation, and session display

## Changes

- Update `AttachmentMenu.tsx`: native file picker, browser file persistence
- Update `useTiptapEditor.ts`: use shared persist helpers
- Update `useDraftSync.ts`: fix attachment state clearing
- Refactor `runTaskInCloud` to options bag
- Update `task-creation.ts`: build cloud prompt blocks from attachments
- Update `buildConversationItems.ts` + `UserMessage.tsx`: render attachments in session view

## How did you test this?

Unit tests for AttachmentMenu, useDraftSync, buildConversationItems, UserMessage, task creation, and cloud session service