### PR TITLE
fix: Stop renderer from overriding plan approval permission mode

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -20,7 +20,7 @@ import {
   isJsonRpcNotification,
   isJsonRpcResponse,
 } from "@shared/types/session-events";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { getSessionService } from "../service/service";
 import {
@@ -99,6 +99,19 @@ export function SessionView({
   const modeOption = useModeConfigOptionForTask(taskId);
   const { allowBypassPermissions } = useSettingsStore();
   const currentModeId = modeOption?.currentValue;
+
+  useEffect(() => {
+    if (allowBypassPermissions) return;
+    const isBypass =
+      currentModeId === "bypassPermissions" || currentModeId === "full-access";
+    if (isBypass && taskId) {
+      getSessionService().setSessionConfigOptionByCategory(
+        taskId,
+        "mode",
+        "default",
+      );
+    }
+  }, [allowBypassPermissions, currentModeId, taskId]);
 
   const handleModeChange = useCallback(() => {
     if (!taskId) return;


### PR DESCRIPTION
## Problem

Selecting "Yes, auto-accept all permissions" on plan approval enters default mode instead of bypass because the renderer overwrites the agent's mode setting.

Closes https://github.com/PostHog/code/issues/1502

## Changes

  1. Skip generic "acceptEdits" override in handlePermissionSelect for switch_mode permissions (plan approval manages its own mode via the agent)
  2. Cleanup useEffect that reverted bypass mode whenever allowBypassPermissions was false. 

## How did you test this?

Manually