### PR TITLE
feat(code): add PR status and actions to cloud tasks

### DIFF
--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -325,6 +325,31 @@ export const getPrChangedFilesInput = z.object({
 });
 export const getPrChangedFilesOutput = z.array(changedFileSchema);
 
+// getPrDetailsByUrl schemas
+export const getPrDetailsByUrlInput = z.object({
+  prUrl: z.string(),
+});
+export const getPrDetailsByUrlOutput = z.object({
+  state: z.string(),
+  merged: z.boolean(),
+  draft: z.boolean(),
+});
+export type PrDetailsByUrlOutput = z.infer<typeof getPrDetailsByUrlOutput>;
+
+// updatePrByUrl schemas
+export const prActionType = z.enum(["close", "reopen", "ready", "draft"]);
+export type PrActionType = z.infer<typeof prActionType>;
+
+export const updatePrByUrlInput = z.object({
+  prUrl: z.string(),
+  action: prActionType,
+});
+export const updatePrByUrlOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+export type UpdatePrByUrlOutput = z.infer<typeof updatePrByUrlOutput>;
+
 export const getBranchChangedFilesInput = z.object({
   repo: z.string(),
   branch: z.string(),

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -28,7 +28,7 @@ import { CommitSaga } from "@posthog/git/sagas/commit";
 import { DiscardFileChangesSaga } from "@posthog/git/sagas/discard";
 import { PullSaga } from "@posthog/git/sagas/pull";
 import { PushSaga } from "@posthog/git/sagas/push";
-import { parseGitHubUrl } from "@posthog/git/utils";
+import { parseGitHubUrl, parsePrUrl } from "@posthog/git/utils";
 import { inject, injectable } from "inversify";
 import { MAIN_TOKENS } from "../../di/tokens";
 import { logger } from "../../utils/logger";
@@ -55,11 +55,14 @@ import type {
   GitStateSnapshot,
   GitSyncStatus,
   OpenPrOutput,
+  PrActionType,
+  PrDetailsByUrlOutput,
   PrStatusOutput,
   PublishOutput,
   PullOutput,
   PushOutput,
   SyncOutput,
+  UpdatePrByUrlOutput,
 } from "./schemas";
 
 const fsPromises = fs.promises;
@@ -865,10 +868,10 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
   }
 
   public async getPrChangedFiles(prUrl: string): Promise<ChangedFile[]> {
-    const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
-    if (!match) return [];
+    const pr = parsePrUrl(prUrl);
+    if (!pr) return [];
 
-    const [, owner, repo, number] = match;
+    const { owner, repo, number } = pr;
 
     try {
       const result = await execGh([
@@ -932,6 +935,78 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     } catch (error) {
       log.warn("Failed to fetch PR changed files", { prUrl, error });
       throw error;
+    }
+  }
+
+  public async getPrDetailsByUrl(
+    prUrl: string,
+  ): Promise<PrDetailsByUrlOutput | null> {
+    const pr = parsePrUrl(prUrl);
+    if (!pr) return null;
+
+    try {
+      const result = await execGh([
+        "api",
+        `repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`,
+        "--jq",
+        "{state,merged,draft}",
+      ]);
+
+      if (result.exitCode !== 0) {
+        log.warn("Failed to fetch PR details", {
+          prUrl,
+          error: result.stderr || result.error,
+        });
+        return null;
+      }
+
+      const data = JSON.parse(result.stdout) as {
+        state: string;
+        merged: boolean;
+        draft: boolean;
+      };
+
+      return data;
+    } catch (error) {
+      log.warn("Failed to fetch PR details", { prUrl, error });
+      return null;
+    }
+  }
+
+  public async updatePrByUrl(
+    prUrl: string,
+    action: PrActionType,
+  ): Promise<UpdatePrByUrlOutput> {
+    const pr = parsePrUrl(prUrl);
+    if (!pr) {
+      return { success: false, message: "Invalid PR URL" };
+    }
+
+    try {
+      const args =
+        action === "draft"
+          ? ["pr", "ready", "--undo", String(pr.number)]
+          : ["pr", action, String(pr.number)];
+
+      const result = await execGh([
+        ...args,
+        "--repo",
+        `${pr.owner}/${pr.repo}`,
+      ]);
+
+      if (result.exitCode !== 0) {
+        const errorMsg = result.stderr || result.error || "Unknown error";
+        log.warn("Failed to update PR", { prUrl, action, error: errorMsg });
+        return { success: false, message: errorMsg };
+      }
+
+      return { success: true, message: result.stdout };
+    } catch (error) {
+      log.warn("Failed to update PR", { prUrl, action, error });
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : "Unknown error",
+      };
     }
   }
 

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -42,6 +42,8 @@ import {
   getLatestCommitOutput,
   getPrChangedFilesInput,
   getPrChangedFilesOutput,
+  getPrDetailsByUrlInput,
+  getPrDetailsByUrlOutput,
   getPrTemplateInput,
   getPrTemplateOutput,
   ghAuthTokenOutput,
@@ -62,6 +64,8 @@ import {
   stageFilesInput,
   syncInput,
   syncOutput,
+  updatePrByUrlInput,
+  updatePrByUrlOutput,
   validateRepoInput,
   validateRepoOutput,
 } from "../../services/git/schemas";
@@ -300,6 +304,21 @@ export const gitRouter = router({
     .input(getPrChangedFilesInput)
     .output(getPrChangedFilesOutput)
     .query(({ input }) => getService().getPrChangedFiles(input.prUrl)),
+
+  getPrDetailsByUrl: publicProcedure
+    .input(getPrDetailsByUrlInput)
+    .output(getPrDetailsByUrlOutput)
+    .query(async ({ input }) => {
+      const result = await getService().getPrDetailsByUrl(input.prUrl);
+      return result ?? { state: "unknown", merged: false, draft: false };
+    }),
+
+  updatePrByUrl: publicProcedure
+    .input(updatePrByUrlInput)
+    .output(updatePrByUrlOutput)
+    .mutation(({ input }) =>
+      getService().updatePrByUrl(input.prUrl, input.action),
+    ),
 
   getBranchChangedFiles: publicProcedure
     .input(getBranchChangedFilesInput)

--- a/apps/code/src/renderer/features/git-interaction/components/CloudGitInteractionHeader.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/CloudGitInteractionHeader.tsx
@@ -1,6 +1,12 @@
+import { usePrActions } from "@features/git-interaction/hooks/usePrActions";
+import { usePrDetails } from "@features/git-interaction/hooks/usePrDetails";
+import {
+  getPrVisualConfig,
+  parsePrNumber,
+} from "@features/git-interaction/utils/prStatus";
 import { useSessionForTask } from "@features/sessions/hooks/useSession";
-import { Eye } from "@phosphor-icons/react";
-import { Button, Flex, Text } from "@radix-ui/themes";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+import { Button, DropdownMenu, Flex, Spinner, Text } from "@radix-ui/themes";
 
 interface CloudGitInteractionHeaderProps {
   taskId: string;
@@ -11,19 +17,71 @@ export function CloudGitInteractionHeader({
 }: CloudGitInteractionHeaderProps) {
   const session = useSessionForTask(taskId);
   const prUrl = (session?.cloudOutput?.pr_url as string) ?? null;
+  const {
+    meta: { state, merged, draft },
+  } = usePrDetails(prUrl);
+  const { execute, isPending } = usePrActions(prUrl);
 
-  if (!prUrl) return null;
+  if (!prUrl || state === null) return null;
+
+  const config = getPrVisualConfig(state, merged, draft);
+  const prNumber = parsePrNumber(prUrl);
+  const hasDropdown = config.actions.length > 0;
 
   return (
-    <div className="no-drag">
-      <Button size="1" variant="solid" asChild>
+    <Flex align="center" gap="0" className="no-drag">
+      <Button
+        size="1"
+        variant="soft"
+        color={config.color}
+        asChild
+        style={
+          hasDropdown
+            ? { borderTopRightRadius: 0, borderBottomRightRadius: 0 }
+            : undefined
+        }
+      >
         <a href={prUrl} target="_blank" rel="noopener noreferrer">
           <Flex align="center" gap="2">
-            <Eye size={12} weight="bold" />
-            <Text size="1">View PR</Text>
+            {isPending ? <Spinner size="1" /> : config.icon}
+            <Text size="1">
+              {config.label}
+              {prNumber && ` #${prNumber}`}
+            </Text>
           </Flex>
         </a>
       </Button>
-    </div>
+      {hasDropdown && (
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger>
+            <Button
+              size="1"
+              variant="soft"
+              color={config.color}
+              disabled={isPending}
+              style={{
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                borderLeft: `1px solid var(--${config.color}-6)`,
+                paddingLeft: "6px",
+                paddingRight: "6px",
+              }}
+            >
+              <ChevronDownIcon />
+            </Button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content size="1" align="end">
+            {config.actions.map((action) => (
+              <DropdownMenu.Item
+                key={action.id}
+                onSelect={() => execute(action.id)}
+              >
+                <Text size="1">{action.label}</Text>
+              </DropdownMenu.Item>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+      )}
+    </Flex>
   );
 }

--- a/apps/code/src/renderer/features/git-interaction/hooks/usePrActions.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/usePrActions.ts
@@ -1,0 +1,42 @@
+import {
+  getOptimisticPrState,
+  PR_ACTION_LABELS,
+} from "@features/git-interaction/utils/prStatus";
+import type { PrActionType } from "@main/services/git/schemas";
+import { useTRPC } from "@renderer/trpc";
+import { toast } from "@renderer/utils/toast";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function usePrActions(prUrl: string | null) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation(
+    trpc.git.updatePrByUrl.mutationOptions({
+      onSuccess: (data, variables) => {
+        if (data.success) {
+          toast.success(PR_ACTION_LABELS[variables.action]);
+          queryClient.setQueryData(
+            trpc.git.getPrDetailsByUrl.queryKey({ prUrl: variables.prUrl }),
+            getOptimisticPrState(variables.action),
+          );
+        } else {
+          toast.error("Failed to update PR", { description: data.message });
+        }
+      },
+      onError: (error) => {
+        toast.error("Failed to update PR", {
+          description: error instanceof Error ? error.message : "Unknown error",
+        });
+      },
+    }),
+  );
+
+  return {
+    execute: (action: PrActionType) => {
+      if (!prUrl) return;
+      mutation.mutate({ prUrl, action });
+    },
+    isPending: mutation.isPending,
+  };
+}

--- a/apps/code/src/renderer/features/git-interaction/hooks/usePrDetails.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/usePrDetails.ts
@@ -1,0 +1,26 @@
+import { useTRPC } from "@renderer/trpc";
+import { useQuery } from "@tanstack/react-query";
+
+export function usePrDetails(prUrl: string | null) {
+  const trpc = useTRPC();
+
+  const metaQuery = useQuery(
+    trpc.git.getPrDetailsByUrl.queryOptions(
+      { prUrl: prUrl as string },
+      {
+        enabled: !!prUrl,
+        staleTime: 60_000,
+        retry: 1,
+      },
+    ),
+  );
+
+  return {
+    meta: {
+      state: metaQuery.data?.state ?? null,
+      merged: metaQuery.data?.merged ?? false,
+      draft: metaQuery.data?.draft ?? false,
+      isLoading: metaQuery.isLoading,
+    },
+  };
+}

--- a/apps/code/src/renderer/features/git-interaction/utils/prStatus.tsx
+++ b/apps/code/src/renderer/features/git-interaction/utils/prStatus.tsx
@@ -1,0 +1,81 @@
+import type { PrActionType } from "@main/services/git/schemas";
+import { GitMerge, GitPullRequest } from "@phosphor-icons/react";
+
+export interface PrAction {
+  id: PrActionType;
+  label: string;
+}
+
+export interface PrVisualConfig {
+  color: "gray" | "green" | "red" | "purple";
+  icon: React.ReactNode;
+  label: string;
+  actions: PrAction[];
+}
+
+export function getPrVisualConfig(
+  state: string,
+  merged: boolean,
+  draft: boolean,
+): PrVisualConfig {
+  if (merged) {
+    return {
+      color: "purple",
+      icon: <GitMerge size={12} weight="bold" />,
+      label: "Merged",
+      actions: [],
+    };
+  }
+  if (state === "closed") {
+    return {
+      color: "red",
+      icon: <GitPullRequest size={12} weight="bold" />,
+      label: "Closed",
+      actions: [{ id: "reopen", label: "Reopen PR" }],
+    };
+  }
+  if (draft) {
+    return {
+      color: "gray",
+      icon: <GitPullRequest size={12} weight="bold" />,
+      label: "Draft",
+      actions: [
+        { id: "ready", label: "Ready for review" },
+        { id: "close", label: "Close PR" },
+      ],
+    };
+  }
+  return {
+    color: "green",
+    icon: <GitPullRequest size={12} weight="bold" />,
+    label: "Open",
+    actions: [
+      { id: "draft", label: "Convert to draft" },
+      { id: "close", label: "Close PR" },
+    ],
+  };
+}
+
+export function getOptimisticPrState(action: PrActionType) {
+  switch (action) {
+    case "close":
+      return { state: "closed", merged: false, draft: false };
+    case "reopen":
+      return { state: "open", merged: false, draft: false };
+    case "ready":
+      return { state: "open", merged: false, draft: false };
+    case "draft":
+      return { state: "open", merged: false, draft: true };
+  }
+}
+
+export const PR_ACTION_LABELS: Record<PrActionType, string> = {
+  close: "PR closed",
+  reopen: "PR reopened",
+  ready: "PR marked as ready for review",
+  draft: "PR converted to draft",
+};
+
+export function parsePrNumber(prUrl: string): string | undefined {
+  return prUrl.match(/\/pull\/(\d+)/)?.[1];
+}

--- a/packages/git/src/utils.ts
+++ b/packages/git/src/utils.ts
@@ -107,6 +107,18 @@ function execFileAsync(
   });
 }
 
+export interface GitHubPr {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+export function parsePrUrl(prUrl: string): GitHubPr | null {
+  const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: Number(match[3]) };
+}
+
 export function parseGitHubUrl(url: string): GitHubRepo | null {
   // Trim whitespace/newlines that git commands may include
   const trimmedUrl = url.trim();


### PR DESCRIPTION
## Problem

you can't take any actions on your PR from a cloud task

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

as a first step in the direction of "ph code helping you merge PRs", adding some logic to fetch PR details and add simple actions for draft/open/close/etc... notes:

- this will be used as the foundation for more PR stuff like comments and CI
- much of this will also be re-used for local tasks when we get to that point

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## [cloud-pr-actions.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2b275b0b-0ace-41f3-a950-f2ac22978d0c.mp4" />](https://app.graphite.com/user-attachments/video/2b275b0b-0ace-41f3-a950-f2ac22978d0c.mp4)

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->