### PR TITLE
feat(code): show PR comments in review panel

### DIFF
--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -186,6 +186,8 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
     "reflect-metadata": "^0.2.2",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "smol-toml": "^1.6.0",

--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -336,6 +336,48 @@ export const getPrDetailsByUrlOutput = z.object({
 });
 export type PrDetailsByUrlOutput = z.infer<typeof getPrDetailsByUrlOutput>;
 
+// getPrReviewComments schemas
+export const prReviewCommentUserSchema = z.object({
+  login: z.string(),
+  avatar_url: z.string(),
+});
+
+export const prReviewCommentSchema = z.object({
+  id: z.number(),
+  body: z.string(),
+  path: z.string(),
+  line: z.number().nullable(),
+  original_line: z.number().nullable(),
+  side: z.enum(["LEFT", "RIGHT"]),
+  start_line: z.number().nullable(),
+  start_side: z.enum(["LEFT", "RIGHT"]).nullable(),
+  diff_hunk: z.string(),
+  in_reply_to_id: z.number().nullish(),
+  user: prReviewCommentUserSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+  subject_type: z.enum(["line", "file"]).nullable(),
+});
+
+export type PrReviewComment = z.infer<typeof prReviewCommentSchema>;
+
+export const getPrReviewCommentsInput = z.object({
+  prUrl: z.string(),
+});
+export const getPrReviewCommentsOutput = z.array(prReviewCommentSchema);
+
+// replyToPrComment schemas
+export const replyToPrCommentInput = z.object({
+  prUrl: z.string(),
+  commentId: z.number(),
+  body: z.string(),
+});
+export const replyToPrCommentOutput = z.object({
+  success: z.boolean(),
+  comment: prReviewCommentSchema.nullable(),
+});
+export type ReplyToPrCommentOutput = z.infer<typeof replyToPrCommentOutput>;
+
 // updatePrByUrl schemas
 export const prActionType = z.enum(["close", "reopen", "ready", "draft"]);
 export type PrActionType = z.infer<typeof prActionType>;

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -57,10 +57,12 @@ import type {
   OpenPrOutput,
   PrActionType,
   PrDetailsByUrlOutput,
+  PrReviewComment,
   PrStatusOutput,
   PublishOutput,
   PullOutput,
   PushOutput,
+  ReplyToPrCommentOutput,
   SyncOutput,
   UpdatePrByUrlOutput,
 } from "./schemas";
@@ -1007,6 +1009,71 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
         success: false,
         message: error instanceof Error ? error.message : "Unknown error",
       };
+    }
+  }
+
+  public async getPrReviewComments(prUrl: string): Promise<PrReviewComment[]> {
+    const pr = parsePrUrl(prUrl);
+    if (!pr) return [];
+
+    const { owner, repo, number } = pr;
+
+    try {
+      const result = await execGh([
+        "api",
+        `repos/${owner}/${repo}/pulls/${number}/comments`,
+        "--paginate",
+        "--slurp",
+      ]);
+
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `Failed to fetch PR review comments: ${result.stderr || result.error || "Unknown error"}`,
+        );
+      }
+
+      const pages = JSON.parse(result.stdout) as PrReviewComment[][];
+      return pages.flat();
+    } catch (error) {
+      log.warn("Failed to fetch PR review comments", { prUrl, error });
+      throw error;
+    }
+  }
+
+  public async replyToPrComment(
+    prUrl: string,
+    commentId: number,
+    body: string,
+  ): Promise<ReplyToPrCommentOutput> {
+    const pr = parsePrUrl(prUrl);
+    if (!pr) {
+      return { success: false, comment: null };
+    }
+
+    try {
+      const result = await execGh([
+        "api",
+        `repos/${pr.owner}/${pr.repo}/pulls/${pr.number}/comments/${commentId}/replies`,
+        "-X",
+        "POST",
+        "-f",
+        `body=${body}`,
+      ]);
+
+      if (result.exitCode !== 0) {
+        log.warn("Failed to reply to PR comment", {
+          prUrl,
+          commentId,
+          error: result.stderr || result.error,
+        });
+        return { success: false, comment: null };
+      }
+
+      const data = JSON.parse(result.stdout) as PrReviewComment;
+      return { success: true, comment: data };
+    } catch (error) {
+      log.warn("Failed to reply to PR comment", { prUrl, commentId, error });
+      return { success: false, comment: null };
     }
   }
 

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -44,6 +44,8 @@ import {
   getPrChangedFilesOutput,
   getPrDetailsByUrlInput,
   getPrDetailsByUrlOutput,
+  getPrReviewCommentsInput,
+  getPrReviewCommentsOutput,
   getPrTemplateInput,
   getPrTemplateOutput,
   ghAuthTokenOutput,
@@ -59,6 +61,8 @@ import {
   pullOutput,
   pushInput,
   pushOutput,
+  replyToPrCommentInput,
+  replyToPrCommentOutput,
   searchGithubIssuesInput,
   searchGithubIssuesOutput,
   stageFilesInput,
@@ -318,6 +322,18 @@ export const gitRouter = router({
     .output(updatePrByUrlOutput)
     .mutation(({ input }) =>
       getService().updatePrByUrl(input.prUrl, input.action),
+    ),
+
+  getPrReviewComments: publicProcedure
+    .input(getPrReviewCommentsInput)
+    .output(getPrReviewCommentsOutput)
+    .query(({ input }) => getService().getPrReviewComments(input.prUrl)),
+
+  replyToPrComment: publicProcedure
+    .input(replyToPrCommentInput)
+    .output(replyToPrCommentOutput)
+    .mutation(({ input }) =>
+      getService().replyToPrComment(input.prUrl, input.commentId, input.body),
     ),
 
   getBranchChangedFiles: publicProcedure

--- a/apps/code/src/renderer/features/code-editor/stores/diffViewerStore.ts
+++ b/apps/code/src/renderer/features/code-editor/stores/diffViewerStore.ts
@@ -11,6 +11,7 @@ interface DiffViewerStoreState {
   loadFullFiles: boolean;
   wordDiffs: boolean;
   hideWhitespaceChanges: boolean;
+  showReviewComments: boolean;
 }
 
 interface DiffViewerStoreActions {
@@ -20,6 +21,7 @@ interface DiffViewerStoreActions {
   toggleLoadFullFiles: () => void;
   toggleWordDiffs: () => void;
   toggleHideWhitespaceChanges: () => void;
+  toggleShowReviewComments: () => void;
 }
 
 type DiffViewerStore = DiffViewerStoreState & DiffViewerStoreActions;
@@ -32,6 +34,7 @@ export const useDiffViewerStore = create<DiffViewerStore>()(
       loadFullFiles: false,
       wordDiffs: true,
       hideWhitespaceChanges: false,
+      showReviewComments: true,
       setViewMode: (mode) =>
         set((state) => {
           if (state.viewMode === mode) {
@@ -64,6 +67,8 @@ export const useDiffViewerStore = create<DiffViewerStore>()(
       toggleWordDiffs: () => set((s) => ({ wordDiffs: !s.wordDiffs })),
       toggleHideWhitespaceChanges: () =>
         set((s) => ({ hideWhitespaceChanges: !s.hideWhitespaceChanges })),
+      toggleShowReviewComments: () =>
+        set((s) => ({ showReviewComments: !s.showReviewComments })),
     }),
     {
       name: "diff-viewer-storage",

--- a/apps/code/src/renderer/features/code-review/components/CloudReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/CloudReviewPage.tsx
@@ -1,3 +1,5 @@
+import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
+import { usePrDetails } from "@features/git-interaction/hooks/usePrDetails";
 import { useCloudChangedFiles } from "@features/task-detail/hooks/useCloudChangedFiles";
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { processFile } from "@pierre/diffs";
@@ -6,6 +8,7 @@ import { useReviewNavigationStore } from "@renderer/features/code-review/stores/
 import type { ChangedFile, Task } from "@shared/types";
 import { useMemo } from "react";
 import type { DiffOptions } from "../types";
+import type { PrCommentThread } from "../utils/prCommentAnnotations";
 import { InteractiveFileDiff } from "./InteractiveFileDiff";
 import {
   DeferredDiffPlaceholder,
@@ -23,8 +26,12 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
   const isReviewOpen = useReviewNavigationStore(
     (s) => (s.reviewModes[taskId] ?? "closed") !== "closed",
   );
+  const showReviewComments = useDiffViewerStore((s) => s.showReviewComments);
   const { effectiveBranch, prUrl, isRunActive, remoteFiles, isLoading } =
     useCloudChangedFiles(taskId, task, isReviewOpen);
+  const { commentThreads } = usePrDetails(prUrl, {
+    includeComments: isReviewOpen && showReviewComments,
+  });
 
   const allPaths = useMemo(() => remoteFiles.map((f) => f.path), [remoteFiles]);
 
@@ -44,23 +51,20 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
   if (!prUrl && !effectiveBranch && remoteFiles.length === 0) {
     if (isRunActive) {
       return (
-        <Flex align="center" justify="center" height="100%">
-          <Flex align="center" gap="2">
-            <Spinner size="1" />
-            <Text size="2" color="gray">
-              Waiting for changes...
-            </Text>
+        <Flex
+          align="center"
+          justify="center"
+          height="100%"
+          className="text-gray-10"
+        >
+          <Flex direction="column" align="center" gap="2">
+            <Spinner size="2" />
+            <Text size="2">Waiting for changes...</Text>
           </Flex>
         </Flex>
       );
     }
-    return (
-      <Flex align="center" justify="center" height="100%">
-        <Text size="2" color="gray">
-          No file changes yet
-        </Text>
-      </Flex>
-    );
+    return null;
   }
 
   return (
@@ -105,6 +109,7 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
               options={diffOptions}
               collapsed={isCollapsed}
               onToggle={() => toggleFile(file.path)}
+              commentThreads={showReviewComments ? commentThreads : undefined}
             />
           </div>
         );
@@ -120,6 +125,7 @@ function CloudFileDiff({
   options,
   collapsed,
   onToggle,
+  commentThreads,
 }: {
   file: ChangedFile;
   taskId: string;
@@ -127,6 +133,7 @@ function CloudFileDiff({
   options: DiffOptions;
   collapsed: boolean;
   onToggle: () => void;
+  commentThreads?: Map<number, PrCommentThread>;
 }) {
   const fileDiff = useMemo((): FileDiffMetadata | undefined => {
     if (!file.patch) return undefined;
@@ -157,6 +164,8 @@ function CloudFileDiff({
       fileDiff={fileDiff}
       options={{ ...options, collapsed }}
       taskId={taskId}
+      prUrl={prUrl}
+      commentThreads={commentThreads}
       renderCustomHeader={(fd) => (
         <DiffFileHeader
           fileDiff={fd}

--- a/apps/code/src/renderer/features/code-review/components/DiffSettingsMenu.tsx
+++ b/apps/code/src/renderer/features/code-review/components/DiffSettingsMenu.tsx
@@ -13,6 +13,10 @@ export function DiffSettingsMenu() {
   const toggleHideWhitespaceChanges = useDiffViewerStore(
     (s) => s.toggleHideWhitespaceChanges,
   );
+  const showReviewComments = useDiffViewerStore((s) => s.showReviewComments);
+  const toggleShowReviewComments = useDiffViewerStore(
+    (s) => s.toggleShowReviewComments,
+  );
 
   return (
     <DropdownMenu.Root>
@@ -40,6 +44,14 @@ export function DiffSettingsMenu() {
         <DropdownMenu.Item onSelect={toggleHideWhitespaceChanges}>
           <Text size="1">
             {hideWhitespaceChanges ? "Show whitespace" : "Hide whitespace"}
+          </Text>
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item onSelect={toggleShowReviewComments}>
+          <Text size="1">
+            {showReviewComments
+              ? "Hide review comments"
+              : "Show review comments"}
           </Text>
         </DropdownMenu.Item>
       </DropdownMenu.Content>

--- a/apps/code/src/renderer/features/code-review/components/InteractiveFileDiff.tsx
+++ b/apps/code/src/renderer/features/code-review/components/InteractiveFileDiff.tsx
@@ -19,7 +19,77 @@ import {
   buildCommentMergedOptions,
   buildHunkAnnotations,
 } from "../utils/diffAnnotations";
+import { buildFileAnnotations } from "../utils/prCommentAnnotations";
 import { CommentAnnotation } from "./CommentAnnotation";
+import { PrCommentThread } from "./PrCommentThread";
+
+function renderSharedAnnotation(
+  annotation: DiffLineAnnotation<AnnotationMetadata>,
+  filePath: string,
+  taskId: string,
+  prUrl: string | null,
+  reset: () => void,
+): React.ReactNode {
+  if (annotation.metadata.kind === "comment") {
+    const { startLine, endLine, side } = annotation.metadata;
+    return (
+      <CommentAnnotation
+        taskId={taskId}
+        filePath={filePath}
+        startLine={startLine}
+        endLine={endLine}
+        side={side}
+        onDismiss={reset}
+      />
+    );
+  }
+
+  if (annotation.metadata.kind === "pr-comment") {
+    return (
+      <PrCommentThread
+        taskId={taskId}
+        prUrl={prUrl}
+        filePath={filePath}
+        metadata={annotation.metadata}
+      />
+    );
+  }
+
+  return null;
+}
+
+function HunkRevertButton({
+  isReverting,
+  onRevert,
+}: {
+  isReverting: boolean;
+  onRevert: () => void;
+}) {
+  return (
+    <div className="relative w-full overflow-visible" style={{ height: 0 }}>
+      <button
+        type="button"
+        disabled={isReverting}
+        onClick={onRevert}
+        className={`absolute top-0 right-2 inline-flex items-center gap-0.5 rounded border-none text-white transition-opacity ${
+          isReverting ? "opacity-60" : "opacity-0 hover:opacity-100"
+        }`}
+        style={{
+          background: "var(--red-9)",
+          padding: "1px 6px",
+          fontSize: "10px",
+          fontWeight: 500,
+          lineHeight: "18px",
+          cursor: isReverting ? "default" : "pointer",
+          zIndex: 10,
+        }}
+      >
+        <ArrowCounterClockwise size={12} />
+        {isReverting ? "Reverting..." : "Revert"}
+      </button>
+    </div>
+  );
+}
 
 function isPatchDiff(props: InteractiveFileDiffProps): props is PatchDiffProps {
   return "fileDiff" in props && props.fileDiff != null;
@@ -38,6 +108,8 @@ function PatchDiffView({
   options,
   renderCustomHeader,
   taskId,
+  prUrl,
+  commentThreads,
 }: PatchDiffProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -70,13 +142,18 @@ function PatchDiffView({
     () => (repoPath ? buildHunkAnnotations(fileDiff) : []),
     [fileDiff, repoPath],
   );
-  const annotations = useMemo(
+  const prAnnotations = useMemo(
     () =>
-      commentAnnotation
-        ? [...hunkAnnotations, commentAnnotation]
-        : hunkAnnotations,
-    [hunkAnnotations, commentAnnotation],
+      commentThreads
+        ? buildFileAnnotations(commentThreads, currentFilePath)
+        : [],
+    [commentThreads, currentFilePath],
   );
+  const annotations = useMemo(() => {
+    const all = [...hunkAnnotations, ...prAnnotations];
+    if (commentAnnotation) all.push(commentAnnotation);
+    return all;
+  }, [hunkAnnotations, prAnnotations, commentAnnotation]);
 
   const handleRevert = useCallback(
     async (hunkIndex: number) => {
@@ -133,50 +210,25 @@ function PatchDiffView({
 
   const renderAnnotation = useCallback(
     (annotation: DiffLineAnnotation<AnnotationMetadata>) => {
-      if (annotation.metadata.kind === "comment") {
-        const { startLine, endLine, side } = annotation.metadata;
+      if (annotation.metadata.kind === "hunk-revert") {
+        const { hunkIndex } = annotation.metadata;
         return (
-          <CommentAnnotation
-            taskId={taskId ?? ""}
-            filePath={currentFilePath}
-            startLine={startLine}
-            endLine={endLine}
-            side={side}
-            onDismiss={reset}
+          <HunkRevertButton
+            isReverting={revertingHunks.has(hunkIndex)}
+            onRevert={() => handleRevert(hunkIndex)}
           />
         );
       }
 
-      if (annotation.metadata.kind !== "hunk-revert") return null;
-      const { hunkIndex } = annotation.metadata;
-      const isReverting = revertingHunks.has(hunkIndex);
-
-      return (
-        <div className="relative w-full overflow-visible" style={{ height: 0 }}>
-          <button
-            type="button"
-            disabled={isReverting}
-            onClick={() => handleRevert(hunkIndex)}
-            className={`absolute top-0 right-2 inline-flex items-center gap-0.5 rounded border-none text-white transition-opacity ${
-              isReverting ? "opacity-60" : "opacity-0 hover:opacity-100"
-            }`}
-            style={{
-              background: "var(--red-9)",
-              padding: "1px 6px",
-              fontSize: "10px",
-              fontWeight: 500,
-              lineHeight: "18px",
-              cursor: isReverting ? "default" : "pointer",
-              zIndex: 10,
-            }}
-          >
-            <ArrowCounterClockwise size={12} />
-            {isReverting ? "Reverting..." : "Revert"}
-          </button>
-        </div>
+      return renderSharedAnnotation(
+        annotation,
+        currentFilePath,
+        taskId ?? "",
+        prUrl ?? null,
+        reset,
       );
     },
-    [handleRevert, reset, revertingHunks, taskId, currentFilePath],
+    [handleRevert, revertingHunks, reset, taskId, prUrl, currentFilePath],
   );
 
   const mergedOptions = useMemo(
@@ -207,6 +259,8 @@ function FilesDiffView({
   options,
   renderCustomHeader,
   taskId,
+  prUrl,
+  commentThreads,
 }: FilesDiffProps) {
   const {
     selectedRange,
@@ -218,27 +272,27 @@ function FilesDiffView({
 
   const filePath = newFile.name || oldFile.name;
 
-  const annotations = useMemo(
-    () => (commentAnnotation ? [commentAnnotation] : []),
-    [commentAnnotation],
+  const prAnnotations = useMemo(
+    () =>
+      commentThreads ? buildFileAnnotations(commentThreads, filePath) : [],
+    [commentThreads, filePath],
   );
+  const annotations = useMemo(() => {
+    const all = [...prAnnotations];
+    if (commentAnnotation) all.push(commentAnnotation);
+    return all;
+  }, [prAnnotations, commentAnnotation]);
 
   const renderAnnotation = useCallback(
-    (annotation: DiffLineAnnotation<AnnotationMetadata>) => {
-      if (annotation.metadata.kind !== "comment") return null;
-      const { startLine, endLine, side } = annotation.metadata;
-      return (
-        <CommentAnnotation
-          taskId={taskId ?? ""}
-          filePath={filePath}
-          startLine={startLine}
-          endLine={endLine}
-          side={side}
-          onDismiss={reset}
-        />
-      );
-    },
-    [reset, taskId, filePath],
+    (annotation: DiffLineAnnotation<AnnotationMetadata>) =>
+      renderSharedAnnotation(
+        annotation,
+        filePath,
+        taskId ?? "",
+        prUrl ?? null,
+        reset,
+      ),
+    [reset, taskId, prUrl, filePath],
   );
 
   const mergedOptions = useMemo(

--- a/apps/code/src/renderer/features/code-review/components/PrCommentThread.tsx
+++ b/apps/code/src/renderer/features/code-review/components/PrCommentThread.tsx
@@ -1,0 +1,402 @@
+import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
+import { sendPromptToAgent } from "@features/sessions/utils/sendPromptToAgent";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
+import type { PrReviewComment } from "@main/services/git/schemas";
+import {
+  CaretDown,
+  CaretUp,
+  ChatCircle,
+  File,
+  Robot,
+  WarningCircle,
+  X,
+} from "@phosphor-icons/react";
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Flex,
+  IconButton,
+  Text,
+} from "@radix-ui/themes";
+import { formatRelativeTimeShort } from "@utils/time";
+import { useCallback, useEffect, useRef, useState } from "react";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import type { PluggableList } from "unified";
+import { usePrCommentActions } from "../hooks/usePrCommentActions";
+import type { PrCommentMetadata } from "../types";
+import {
+  buildAskAboutPrCommentPrompt,
+  buildFixPrCommentPrompt,
+} from "../utils/reviewPrompts";
+
+const ghRehypePlugins: PluggableList = [
+  rehypeRaw,
+  [rehypeSanitize, defaultSchema],
+];
+
+const MAX_COMMENT_HEIGHT = 120;
+
+interface ThreadActionBarProps {
+  prUrl: string | null;
+  taskId: string;
+  filePath: string;
+  endLine: number;
+  side: "old" | "new";
+  comments: PrReviewComment[];
+  showReplyBox: boolean;
+  pendingReply: string | null;
+  onShowReplyBox: () => void;
+  onHideReplyBox: () => void;
+  onSubmitReply: () => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  textareaRefCallback: (el: HTMLTextAreaElement | null) => void;
+}
+
+function ThreadActionBar({
+  prUrl,
+  taskId,
+  filePath,
+  endLine,
+  side,
+  comments,
+  showReplyBox,
+  pendingReply,
+  onShowReplyBox,
+  onHideReplyBox,
+  onSubmitReply,
+  onKeyDown,
+  textareaRefCallback,
+}: ThreadActionBarProps) {
+  const agentActionsEnabled = useFeatureFlag("posthog-code-pr-agent-actions");
+
+  if (showReplyBox) {
+    return (
+      <div className="mt-1.5 border-[var(--gray-4)] border-t pt-1.5">
+        <textarea
+          ref={textareaRefCallback}
+          placeholder="Write a reply..."
+          onKeyDown={onKeyDown}
+          className="w-full resize-none rounded border border-[var(--gray-6)] bg-[var(--color-background)] p-1.5 text-[13px] text-[var(--gray-12)] leading-normal outline-none"
+          style={{ minHeight: 48 }}
+        />
+        <Flex align="center" gap="3" className="mt-1.5">
+          <Button size="1" onClick={onSubmitReply} disabled={!!pendingReply}>
+            <ChatCircle size={12} />
+            {pendingReply ? "Sending..." : "Reply"}
+          </Button>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={onHideReplyBox}
+          >
+            <X size={12} />
+          </IconButton>
+        </Flex>
+      </div>
+    );
+  }
+
+  return (
+    <Flex
+      align="center"
+      gap="1"
+      className="mt-1 border-[var(--gray-4)] border-t pt-1.5"
+    >
+      {prUrl && (
+        <Button size="1" variant="ghost" color="gray" onClick={onShowReplyBox}>
+          <ChatCircle size={12} />
+          Reply
+        </Button>
+      )}
+      {/* TODO: remove this flag when https://github.com/posthog/code/issues/1533 is fixed
+          currently set to 0% rollout. didn't discover the cloud bug until i had already built this
+          xoxo, adboio */}
+      {agentActionsEnabled && (
+        <>
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={() =>
+              sendPromptToAgent(
+                taskId,
+                buildFixPrCommentPrompt(filePath, endLine, side, comments),
+              )
+            }
+          >
+            <Robot size={12} />
+            Fix with agent
+          </Button>
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={() =>
+              sendPromptToAgent(
+                taskId,
+                buildAskAboutPrCommentPrompt(filePath, endLine, side, comments),
+              )
+            }
+          >
+            <Robot size={12} />
+            Ask agent
+          </Button>
+        </>
+      )}
+    </Flex>
+  );
+}
+
+interface PrCommentThreadProps {
+  taskId: string;
+  prUrl: string | null;
+  filePath: string;
+  metadata: PrCommentMetadata;
+}
+
+function CommentBody({
+  comment,
+  showLineAbove = false,
+  showLineBelow = false,
+}: {
+  comment: PrReviewComment;
+  showLineAbove?: boolean;
+  showLineBelow?: boolean;
+}) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (el) {
+      setIsOverflowing(el.scrollHeight > MAX_COMMENT_HEIGHT);
+    }
+  }, []);
+
+  return (
+    <div className="flex gap-2">
+      <div className="flex flex-col items-center">
+        {showLineAbove ? (
+          <div className="h-1.5 w-0.5 rounded-full bg-[var(--gray-5)]" />
+        ) : (
+          <div className="h-1.5" />
+        )}
+        <Avatar
+          size="1"
+          radius="full"
+          src={comment.user.avatar_url}
+          fallback={comment.user.login[0]?.toUpperCase() ?? "?"}
+          className="shrink-0"
+        />
+        {showLineBelow && (
+          <div className="w-0.5 flex-1 rounded-full bg-[var(--gray-5)]" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1 pt-1.5 pb-1.5">
+        <Flex align="center" gap="2" className="mb-0.5">
+          <Text size="1" weight="medium" className="text-[var(--gray-12)]">
+            {comment.user.login}
+          </Text>
+          <Text size="1" className="text-[var(--gray-9)]">
+            {formatRelativeTimeShort(comment.created_at)}
+          </Text>
+        </Flex>
+        <Box
+          ref={contentRef}
+          className="relative overflow-hidden text-[13px] text-[var(--gray-11)] leading-relaxed [&_code]:break-all [&_img]:max-w-full [&_p]:m-0 [&_pre]:max-w-full [&_pre]:overflow-x-auto"
+          style={{
+            maxHeight:
+              isExpanded || !isOverflowing
+                ? undefined
+                : `${MAX_COMMENT_HEIGHT}px`,
+            overflowWrap: "break-word",
+            wordBreak: "break-word",
+          }}
+        >
+          <MarkdownRenderer
+            content={comment.body}
+            rehypePlugins={ghRehypePlugins}
+          />
+          {!isExpanded && isOverflowing && (
+            <Box
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-12"
+              style={{
+                background: "linear-gradient(transparent, var(--gray-2))",
+              }}
+            />
+          )}
+        </Box>
+        {isOverflowing && (
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            className="mt-1"
+          >
+            {isExpanded ? (
+              <>
+                <CaretUp size={12} />
+                Show less
+              </>
+            ) : (
+              <>
+                <CaretDown size={12} />
+                Show more
+              </>
+            )}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function PrCommentThread({
+  taskId,
+  prUrl,
+  filePath,
+  metadata,
+}: PrCommentThreadProps) {
+  const {
+    threadId,
+    comments,
+    isOutdated,
+    isFileLevel,
+    endLine,
+    side: annotationSide,
+  } = metadata;
+  const side = annotationSide === "deletions" ? "old" : "new";
+  const { reply } = usePrCommentActions(prUrl);
+  const [showReplyBox, setShowReplyBox] = useState(false);
+  const [pendingReply, setPendingReply] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Clear pending reply once the real comments list includes it
+  const lastCommentId = comments[comments.length - 1]?.id;
+  const prevLastCommentIdRef = useRef(lastCommentId);
+  useEffect(() => {
+    if (lastCommentId !== prevLastCommentIdRef.current && pendingReply) {
+      setPendingReply(null);
+    }
+    prevLastCommentIdRef.current = lastCommentId;
+  }, [lastCommentId, pendingReply]);
+
+  const handleReplySubmit = useCallback(async () => {
+    const text = textareaRef.current?.value?.trim();
+    if (text) {
+      setPendingReply(text);
+      setShowReplyBox(false);
+      const success = await reply(threadId, text);
+      if (!success) {
+        setPendingReply(null);
+      }
+    }
+  }, [reply, threadId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleReplySubmit();
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setShowReplyBox(false);
+      }
+    },
+    [handleReplySubmit],
+  );
+
+  const setTextareaRefCallback = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      textareaRef.current = el;
+      if (el) {
+        requestAnimationFrame(() => el.focus());
+      }
+    },
+    [],
+  );
+
+  return (
+    <div className="px-3 py-1.5" style={{ contain: "inline-size" }}>
+      <div
+        data-pr-comment-thread=""
+        className="overflow-hidden whitespace-normal rounded-md border border-[var(--gray-5)] bg-[var(--gray-2)] px-2.5 py-2 font-sans"
+      >
+        {(isOutdated || isFileLevel) && (
+          <Flex align="center" gap="1" className="mb-1.5">
+            {isFileLevel && (
+              <Badge color="gray" size="1" variant="soft">
+                <File size={12} />
+                File comment
+              </Badge>
+            )}
+            {isOutdated && (
+              <Badge color="yellow" size="1" variant="soft">
+                <WarningCircle size={12} weight="fill" />
+                Outdated
+              </Badge>
+            )}
+          </Flex>
+        )}
+
+        {comments.map((comment, index) => (
+          <CommentBody
+            key={comment.id}
+            comment={comment}
+            showLineAbove={index > 0}
+            showLineBelow={index < comments.length - 1 || !!pendingReply}
+          />
+        ))}
+
+        {pendingReply && (
+          <div className="flex gap-2 opacity-50">
+            <div className="flex flex-col items-center">
+              <div className="h-1.5 w-0.5 rounded-full bg-[var(--gray-5)]" />
+              <Avatar size="1" radius="full" fallback="" className="shrink-0" />
+            </div>
+            <div className="min-w-0 flex-1 pt-1.5 pb-1.5">
+              <Flex align="center" gap="2" className="mb-0.5">
+                <Text
+                  size="1"
+                  weight="medium"
+                  className="text-[var(--gray-12)]"
+                >
+                  Sending...
+                </Text>
+              </Flex>
+              <div className="text-[13px] text-[var(--gray-11)] leading-relaxed">
+                <MarkdownRenderer
+                  content={pendingReply}
+                  rehypePlugins={ghRehypePlugins}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <ThreadActionBar
+          prUrl={prUrl}
+          taskId={taskId}
+          filePath={filePath}
+          endLine={endLine}
+          side={side}
+          comments={comments}
+          showReplyBox={showReplyBox}
+          pendingReply={pendingReply}
+          onShowReplyBox={() => setShowReplyBox(true)}
+          onHideReplyBox={() => setShowReplyBox(false)}
+          onSubmitReply={handleReplySubmit}
+          onKeyDown={handleKeyDown}
+          textareaRefCallback={setTextareaRefCallback}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/code/src/renderer/features/code-review/hooks/usePrCommentActions.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/usePrCommentActions.ts
@@ -1,0 +1,37 @@
+import { useTRPC } from "@renderer/trpc";
+import { trpcClient } from "@renderer/trpc/client";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { toast } from "sonner";
+
+export function usePrCommentActions(prUrl: string | null) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const reply = useCallback(
+    async (commentId: number, body: string): Promise<boolean> => {
+      if (!prUrl) return false;
+      try {
+        const result = await trpcClient.git.replyToPrComment.mutate({
+          prUrl,
+          commentId,
+          body,
+        });
+        if (!result.success) {
+          toast.error("Failed to post reply");
+          return false;
+        }
+        await queryClient.invalidateQueries(
+          trpc.git.getPrReviewComments.queryFilter({ prUrl }),
+        );
+        return true;
+      } catch {
+        toast.error("Failed to post reply");
+        return false;
+      }
+    },
+    [prUrl, queryClient, trpc],
+  );
+
+  return { reply };
+}

--- a/apps/code/src/renderer/features/code-review/types.ts
+++ b/apps/code/src/renderer/features/code-review/types.ts
@@ -1,5 +1,7 @@
+import type { PrReviewComment } from "@main/services/git/schemas";
 import type { AnnotationSide, FileDiffOptions } from "@pierre/diffs";
 import type { FileDiffProps, MultiFileDiffProps } from "@pierre/diffs/react";
+import type { PrCommentThread } from "./utils/prCommentAnnotations";
 
 export interface HunkRevertMetadata {
   kind: "hunk-revert";
@@ -13,17 +15,36 @@ export interface CommentMetadata {
   side: AnnotationSide;
 }
 
-export type AnnotationMetadata = HunkRevertMetadata | CommentMetadata;
+export interface PrCommentMetadata {
+  kind: "pr-comment";
+  threadId: number;
+  comments: PrReviewComment[];
+  isOutdated: boolean;
+  isFileLevel: boolean;
+  startLine: number | null;
+  endLine: number;
+  side: AnnotationSide;
+}
+
+export type AnnotationMetadata =
+  | HunkRevertMetadata
+  | CommentMetadata
+  | PrCommentMetadata;
 
 export type DiffOptions = FileDiffOptions<AnnotationMetadata>;
 
-export type PatchDiffProps = FileDiffProps<AnnotationMetadata> & {
-  repoPath?: string;
+interface PrCommentProps {
   taskId?: string;
-};
+  prUrl?: string | null;
+  commentThreads?: Map<number, PrCommentThread>;
+}
 
-export type FilesDiffProps = MultiFileDiffProps<AnnotationMetadata> & {
-  taskId?: string;
-};
+export type PatchDiffProps = FileDiffProps<AnnotationMetadata> &
+  PrCommentProps & {
+    repoPath?: string;
+  };
+
+export type FilesDiffProps = MultiFileDiffProps<AnnotationMetadata> &
+  PrCommentProps;
 
 export type InteractiveFileDiffProps = PatchDiffProps | FilesDiffProps;

--- a/apps/code/src/renderer/features/code-review/utils/prCommentAnnotations.ts
+++ b/apps/code/src/renderer/features/code-review/utils/prCommentAnnotations.ts
@@ -1,0 +1,55 @@
+import type { PrReviewComment } from "@main/services/git/schemas";
+import type { DiffLineAnnotation } from "@pierre/diffs";
+import type { AnnotationMetadata } from "../types";
+
+export interface PrCommentThread {
+  rootId: number;
+  comments: PrReviewComment[];
+  filePath: string;
+}
+
+function buildAnnotation(
+  thread: PrCommentThread,
+): DiffLineAnnotation<AnnotationMetadata> | null {
+  const root = thread.comments[0];
+  if (!root) return null;
+
+  const isFileLevel = root.line == null && root.original_line == null;
+  const line = root.line ?? root.original_line ?? 1;
+
+  const isOutdated =
+    !isFileLevel && root.line == null && root.original_line != null;
+  const side = isFileLevel
+    ? "additions"
+    : root.side === "LEFT"
+      ? "deletions"
+      : "additions";
+
+  return {
+    side,
+    lineNumber: line,
+    metadata: {
+      kind: "pr-comment",
+      threadId: thread.rootId,
+      comments: thread.comments,
+      isOutdated,
+      isFileLevel,
+      startLine: root.start_line,
+      endLine: line,
+      side,
+    },
+  };
+}
+
+export function buildFileAnnotations(
+  threads: Map<number, PrCommentThread>,
+  filePath: string,
+): DiffLineAnnotation<AnnotationMetadata>[] {
+  const annotations: DiffLineAnnotation<AnnotationMetadata>[] = [];
+  for (const thread of threads.values()) {
+    if (thread.filePath !== filePath) continue;
+    const annotation = buildAnnotation(thread);
+    if (annotation) annotations.push(annotation);
+  }
+  return annotations;
+}

--- a/apps/code/src/renderer/features/code-review/utils/reviewPrompts.ts
+++ b/apps/code/src/renderer/features/code-review/utils/reviewPrompts.ts
@@ -1,3 +1,4 @@
+import type { PrReviewComment } from "@main/services/git/schemas";
 import type { AnnotationSide } from "@pierre/diffs";
 
 function escapeXmlAttr(value: string): string {
@@ -7,6 +8,10 @@ function escapeXmlAttr(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+}
+
+function formatThreadForPrompt(comments: PrReviewComment[]): string {
+  return comments.map((c) => `@${c.user.login}:\n> ${c.body}`).join("\n\n");
 }
 
 export function buildInlineCommentPrompt(
@@ -23,4 +28,26 @@ export function buildInlineCommentPrompt(
   const sideLabel = side === "deletions" ? "old" : "new";
   const escapedPath = escapeXmlAttr(filePath);
   return `In file <file path="${escapedPath}" />, ${lineRef} (${sideLabel}):\n\n${comment}`;
+}
+
+export function buildFixPrCommentPrompt(
+  filePath: string,
+  line: number,
+  side: "old" | "new",
+  comments: PrReviewComment[],
+): string {
+  const escapedPath = escapeXmlAttr(filePath);
+  const thread = formatThreadForPrompt(comments);
+  return `Fix this PR review comment on <file path="${escapedPath}" />, line ${line} (${side}):\n\n${thread}`;
+}
+
+export function buildAskAboutPrCommentPrompt(
+  filePath: string,
+  line: number,
+  side: "old" | "new",
+  comments: PrReviewComment[],
+): string {
+  const escapedPath = escapeXmlAttr(filePath);
+  const thread = formatThreadForPrompt(comments);
+  return `Help me understand this PR review comment on <file path="${escapedPath}" />, line ${line} (${side}):\n\n${thread}\n\nWhat is this comment asking for and how should I address it? Do not make any changes, your job is simply to chat with me about this comment. If I need further changes, I'll ask.`;
 }

--- a/apps/code/src/renderer/features/editor/components/MarkdownRenderer.tsx
+++ b/apps/code/src/renderer/features/editor/components/MarkdownRenderer.tsx
@@ -13,6 +13,7 @@ interface MarkdownRendererProps {
   content: string;
   remarkPluginsOverride?: PluggableList;
   componentsOverride?: Partial<Components>;
+  rehypePlugins?: PluggableList;
 }
 
 // Preprocessor to prevent setext heading interpretation of horizontal rules
@@ -172,6 +173,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   content,
   remarkPluginsOverride,
   componentsOverride,
+  rehypePlugins,
 }: MarkdownRendererProps) {
   const processedContent = useMemo(
     () => preprocessMarkdown(content),
@@ -186,7 +188,11 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
     [componentsOverride],
   );
   return (
-    <ReactMarkdown remarkPlugins={plugins} components={components}>
+    <ReactMarkdown
+      remarkPlugins={plugins}
+      rehypePlugins={rehypePlugins}
+      components={components}
+    >
       {processedContent}
     </ReactMarkdown>
   );

--- a/apps/code/src/renderer/features/git-interaction/hooks/usePrDetails.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/usePrDetails.ts
@@ -1,7 +1,44 @@
+import type { PrReviewComment } from "@main/services/git/schemas";
+import type { PrCommentThread } from "@renderer/features/code-review/utils/prCommentAnnotations";
 import { useTRPC } from "@renderer/trpc";
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 
-export function usePrDetails(prUrl: string | null) {
+interface UsePrDetailsOptions {
+  includeComments?: boolean;
+}
+
+function groupCommentsIntoThreads(
+  comments: PrReviewComment[],
+): Map<number, PrCommentThread> {
+  const threads = new Map<number, PrCommentThread>();
+
+  for (const comment of comments) {
+    const rootId = comment.in_reply_to_id ?? comment.id;
+    const existing = threads.get(rootId);
+    if (existing) {
+      existing.comments.push(comment);
+    } else {
+      threads.set(rootId, {
+        rootId,
+        comments: [comment],
+        filePath: comment.path,
+      });
+    }
+  }
+
+  for (const thread of threads.values()) {
+    thread.comments.sort((a, b) => a.created_at.localeCompare(b.created_at));
+  }
+
+  return threads;
+}
+
+export function usePrDetails(
+  prUrl: string | null,
+  options?: UsePrDetailsOptions,
+) {
+  const { includeComments = false } = options ?? {};
   const trpc = useTRPC();
 
   const metaQuery = useQuery(
@@ -15,6 +52,24 @@ export function usePrDetails(prUrl: string | null) {
     ),
   );
 
+  const commentsQuery = useQuery(
+    trpc.git.getPrReviewComments.queryOptions(
+      { prUrl: prUrl as string },
+      {
+        enabled: !!prUrl && includeComments,
+        staleTime: 30_000,
+        refetchInterval: 30_000,
+        retry: 1,
+        structuralSharing: true,
+      },
+    ),
+  );
+
+  const commentThreads = useMemo(
+    () => groupCommentsIntoThreads(commentsQuery.data ?? []),
+    [commentsQuery.data],
+  );
+
   return {
     meta: {
       state: metaQuery.data?.state ?? null,
@@ -22,5 +77,6 @@ export function usePrDetails(prUrl: string | null) {
       draft: metaQuery.data?.draft ?? false,
       isLoading: metaQuery.isLoading,
     },
+    commentThreads,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,12 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -7365,14 +7371,32 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
@@ -9774,6 +9798,12 @@ packages:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
 
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
   remark-breaks@4.0.0:
     resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
@@ -10902,6 +10932,9 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -11100,6 +11133,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
@@ -18848,6 +18884,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -18882,9 +18955,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   headers-polyfill@4.0.3: {}
 
@@ -21798,6 +21889,17 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
   remark-breaks@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -22977,6 +23079,11 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -23218,6 +23325,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-namespaces@2.0.1: {}
 
   web-vitals@5.1.0: {}
 


### PR DESCRIPTION
## Problem

let's help our users get their PRs across the finish line

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

**_[only for cloud tasks right now - will bring over to local later too, just a bit differently]_**

- displays github PR comments in the review panel
    - (only grabs inline file comments for now)
- adds agent buttons for "fix with agent" and "ask agent"
    - **^ this is behind a feature flag** because the cloud resume stuff is a bit busted, and enabling it just creates a poor experience. i'll enable once we fix that
- allows replying to github comments from the UI

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## ![Screenshot 2026-04-08 at 3.26.40 PM.png](https://app.graphite.com/user-attachments/assets/93e90737-0536-4b36-a69b-39b37f667d61.png)

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->