### PR TITLE
fix: Remove double scrollbar from repo selector

### DIFF
--- a/apps/code/src/renderer/components/ui/combobox/Combobox.css
+++ b/apps/code/src/renderer/components/ui/combobox/Combobox.css
@@ -3,6 +3,7 @@
   background: transparent;
   border: none;
   box-shadow: none;
+  overflow: hidden;
 }
 
 .combobox-content [cmdk-root] {

--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -62,7 +62,7 @@ export function GitHubRepoPicker({
           </Text>
         </Flex>
       </Combobox.Trigger>
-      <Combobox.Content style={{ maxHeight: "300px" }}>
+      <Combobox.Content>
         <Combobox.Input placeholder="Search repositories..." />
         <Combobox.Empty>No repositories found.</Combobox.Empty>
         {repositories.map((repo) => (


### PR DESCRIPTION
## Problem

Repo selector dropdown shows two scrollbars when the list overflows.

Closes https://github.com/PostHog/code/issues/1490

## Changes

  1. Add overflow: hidden to .rt-PopoverContent combobox reset so the outer wrapper never scrolls
  2. Remove redundant inline maxHeight: "300px" from GitHubRepoPicker, deferring to the existing [cmdk-root] CSS constraint

## How did you test this?

Manually
