### PR TITLE
fix: Show "edit" instead of "create" in permission prompt for existing files

### DIFF
--- a/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
@@ -226,11 +226,19 @@ export function toolInfoFromToolUse(
         : undefined;
       const contentStr = input?.content ? String(input.content) : undefined;
       if (writeFilePath) {
-        const oldContent =
+        let oldContent: string | null = null;
+        if (
           options?.cachedFileContent &&
           writeFilePath in options.cachedFileContent
-            ? options.cachedFileContent[writeFilePath]
-            : null;
+        ) {
+          oldContent = options.cachedFileContent[writeFilePath];
+        } else {
+          try {
+            oldContent = fs.readFileSync(writeFilePath, "utf-8");
+          } catch {
+            // File doesn't exist — genuinely a new file
+          }
+        }
         contentResult = toolContent()
           .diff(writeFilePath, oldContent, contentStr ?? "")
           .build();

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -338,7 +338,10 @@ async function handleDefaultPermissionFlow(
     suggestions,
   } = context;
 
-  const toolInfo = toolInfoFromToolUse({ name: toolName, input: toolInput });
+  const toolInfo = toolInfoFromToolUse(
+    { name: toolName, input: toolInput },
+    { cachedFileContent: context.fileContentCache, cwd: session?.cwd },
+  );
 
   const options = buildPermissionOptions(
     toolName,


### PR DESCRIPTION
## Problem

Write tool permission prompts always say "Create new file" even when overwriting an existing file, because the old file content was never resolved during the permission request flow.

Closes https://github.com/PostHog/code/issues/1529

## Changes

  1. Add disk-read fallback in Write tool case when file isn't in the content cache
  2. Pass fileContentCache and cwd to toolInfoFromToolUse in permission flow so cached content and relative paths are available

## How did you test this?

Manually
