### PR TITLE
fix: Show both local and remote repo name when they differ

### DIFF
--- a/apps/code/src/main/services/folders/service.test.ts
+++ b/apps/code/src/main/services/folders/service.test.ts
@@ -296,11 +296,11 @@ describe("FoldersService", () => {
       ]);
     });
 
-    it("strips .git suffix from remote repo name in display name", async () => {
+    it("strips .git suffix from remote repo name in display name (defensive against legacy data)", async () => {
       const repos = [
         {
           id: "folder-1",
-          path: "/home/user/MURZINI",
+          path: "/home/user/my-billing-fork",
           remoteUrl: "PostHog/billing.git",
           lastAccessedAt: "2024-01-01T00:00:00.000Z",
           createdAt: "2024-01-01T00:00:00.000Z",
@@ -312,7 +312,7 @@ describe("FoldersService", () => {
 
       const result = await service.getFolders();
 
-      expect(result[0].name).toBe("MURZINI (billing)");
+      expect(result[0].name).toBe("my-billing-fork (billing)");
     });
 
     it("uses remote repo name in display name when it differs from local dir", async () => {

--- a/apps/code/src/main/services/folders/service.ts
+++ b/apps/code/src/main/services/folders/service.ts
@@ -3,12 +3,14 @@ import path from "node:path";
 import { getRemoteUrl, isGitRepository } from "@posthog/git/queries";
 import { InitRepositorySaga } from "@posthog/git/sagas/init";
 
+import { normalizeRepoKey } from "@shared/utils/repo";
+
 function extractRepoKey(url: string): string | null {
   const httpsMatch = url.match(/github\.com\/([^/]+\/[^/]+)/);
-  if (httpsMatch) return httpsMatch[1].replace(/\.git$/, "");
+  if (httpsMatch) return normalizeRepoKey(httpsMatch[1]);
 
   const sshMatch = url.match(/github\.com:([^/]+\/[^/]+)/);
-  if (sshMatch) return sshMatch[1].replace(/\.git$/, "");
+  if (sshMatch) return normalizeRepoKey(sshMatch[1]);
 
   return null;
 }
@@ -86,12 +88,7 @@ export class FoldersService {
   ): string {
     const localName = path.basename(repoPath);
     if (remoteUrl) {
-      const repoName = remoteUrl
-        .trim()
-        .split("/")
-        .pop()
-        ?.replace(/\.git$/, "")
-        ?.trim();
+      const repoName = normalizeRepoKey(remoteUrl).split("/").pop();
       if (repoName && repoName.toLowerCase() !== localName.toLowerCase()) {
         return `${localName} (${repoName})`;
       }

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -15,6 +15,7 @@ import {
 } from "@phosphor-icons/react";
 import { Box, Flex, Popover, Text } from "@radix-ui/themes";
 import { useWorkspace } from "@renderer/features/workspace/hooks/useWorkspace";
+import { normalizeRepoKey } from "@shared/utils/repo";
 import { useNavigationStore } from "@stores/navigationStore";
 import { useCallback, useEffect } from "react";
 import type { TaskData, TaskGroup } from "../hooks/useSidebarData";
@@ -378,10 +379,9 @@ export function TaskListView({
               const isExpanded = !collapsedSections.has(group.id);
               const folder = folders.find(
                 (f) =>
-                  f.remoteUrl
-                    ?.trim()
-                    .replace(/\.git$/, "")
-                    .toLowerCase() === group.id.trim().toLowerCase() ||
+                  (f.remoteUrl &&
+                    normalizeRepoKey(f.remoteUrl).toLowerCase() ===
+                      normalizeRepoKey(group.id).toLowerCase()) ||
                   f.path === group.id,
               );
               const groupFolderId =

--- a/apps/code/src/shared/utils/repo.ts
+++ b/apps/code/src/shared/utils/repo.ts
@@ -1,0 +1,3 @@
+export function normalizeRepoKey(key: string): string {
+  return key.trim().replace(/\.git$/, "");
+}


### PR DESCRIPTION
## Problem

Folder display names only used path.basename(), so when a local directory name differed from the GitHub repo name, the dropdown showed one name and the sidebar showed another.

Closes https://github.com/PostHog/code/issues/1283

## Changes

1. Add getDisplayName that appends remote repo name when it differs from the local dir (e.g. ph-tour-demo (hogotchi))
2. Extract shared normalizeRepoKey helper to strip .git suffixes consistently
3. Use normalizeRepoKey in sidebar folder matching to fix .git suffix mismatches
4. Use [folder.name](http://folder.name) instead of [group.name](http://group.name) in sidebar labels for consistency
5. Add four unit tests covering suffix stripping, mismatch, match and case-insensitive match

## How did you test this?

Manually