### PR TITLE
fix: Fix stale context usage after compaction + usage calculation

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -371,8 +371,18 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         switch (message.type) {
           case "system":
             if (message.subtype === "compact_boundary") {
+              // Send used:0 immediately so the client doesn't keep showing
+              // the stale pre-compaction context size until the next turn.
               lastAssistantTotalUsage = 0;
               promptReplayed = true;
+              await this.client.sessionUpdate({
+                sessionId: params.sessionId,
+                update: {
+                  sessionUpdate: "usage_update",
+                  used: 0,
+                  size: lastContextWindowSize,
+                },
+              });
             }
             if (message.subtype === "local_command_output") {
               promptReplayed = true;


### PR DESCRIPTION
## Problem

1. Context usage calculation omitted output_tokens, under-reporting total token occupancy.
2. Context usage bar shows stale pre-compaction values until the next agent turn, making it look like context is still full after compaction.

## Changes

1. Include output_tokens in context usage calculation (they become input on the next turn)
2. Emit a usage_update with used:0 immediately on compact_boundary
3. Reset local usage counter on compaction so subsequent turns start fresh

## How did you test this?

Manually