### PR TITLE
fix(agent): use zod/v4 imports in agent-server

### DIFF
--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command } from "commander";
-import { z } from "zod";
+import { z } from "zod/v4";
 import { AgentServer } from "./agent-server";
 import { claudeCodeConfigSchema, mcpServersSchema } from "./schemas";
 

--- a/packages/agent/src/server/schemas.ts
+++ b/packages/agent/src/server/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 
 const httpHeaderSchema = z.object({
   name: z.string(),


### PR DESCRIPTION
## Summary
- The Zod 4 upgrade (#1461) converted `schemas.ts` and `bin.ts` to v4 APIs (`z.url()`, `error` shorthand) but kept the `"zod"` import, which resolves to the v3 compat layer which resulted  breaking typechecks.
- Fix: `"zod"` → `"zod/v4"` in both files.