### PR TITLE
chore(code): disable terminal tabs for cloud run

### DIFF
--- a/apps/code/src/renderer/features/message-editor/components/MessageEditor.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/MessageEditor.tsx
@@ -3,6 +3,7 @@ import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { BranchSelector } from "@features/git-interaction/components/BranchSelector";
 import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
 import { getUserPromptsForTask } from "@features/sessions/stores/sessionStore";
+import { useIsWorkspaceCloudRun } from "@features/workspace/hooks/useWorkspace";
 import { useConnectivity } from "@hooks/useConnectivity";
 import { ArrowUp, Circle, Stop } from "@phosphor-icons/react";
 import { Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
@@ -169,6 +170,7 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
     const clearFocusRequest = useDraftStore((s) => s.actions.clearFocusRequest);
     const { isOnline } = useConnectivity();
     const taskId = context?.taskId;
+    const isCloud = useIsWorkspaceCloudRun(taskId);
     const disabled = context?.disabled ?? false;
     const isLoading = context?.isLoading ?? false;
     const repoPath = context?.repoPath;
@@ -207,6 +209,7 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
       autoFocus,
       context: { taskId, repoPath },
       getPromptHistory,
+      capabilities: { bashMode: !isCloud },
       onSubmit,
       onBashCommand,
       onBashModeChange,

--- a/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -464,7 +464,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
 
     const text = editor.getText().trim();
 
-    if (text.startsWith("!")) {
+    if (enableBashMode && text.startsWith("!")) {
       // Bash mode requires immediate execution, can't be queued
       if (isLoading) {
         toast.error("Cannot run shell commands while agent is generating");
@@ -492,6 +492,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
     draft,
     clearOnSubmit,
     attachments,
+    enableBashMode,
   ]);
 
   submitRef.current = submit;

--- a/apps/code/src/renderer/features/panels/components/LeafNodeRenderer.tsx
+++ b/apps/code/src/renderer/features/panels/components/LeafNodeRenderer.tsx
@@ -1,6 +1,6 @@
 import { Cloud as CloudIcon } from "@phosphor-icons/react";
 import { Flex, Text } from "@radix-ui/themes";
-import { useWorkspace } from "@renderer/features/workspace/hooks/useWorkspace";
+import { useIsWorkspaceCloudRun } from "@renderer/features/workspace/hooks/useWorkspace";
 import type { Task } from "@shared/types";
 import type React from "react";
 import { useMemo } from "react";
@@ -40,8 +40,7 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
   onAddTerminal,
   onSplitPanel,
 }) => {
-  const workspace = useWorkspace(taskId);
-  const isCloud = workspace?.mode === "cloud";
+  const isCloud = useIsWorkspaceCloudRun(taskId);
   const inputTabs = useMemo(
     () =>
       isCloud

--- a/apps/code/src/renderer/features/panels/components/LeafNodeRenderer.tsx
+++ b/apps/code/src/renderer/features/panels/components/LeafNodeRenderer.tsx
@@ -40,16 +40,19 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
   onAddTerminal,
   onSplitPanel,
 }) => {
-  const tabs = useTabInjection(
-    node.content.tabs,
-    node.id,
-    taskId,
-    task,
-    closeTab,
-  );
-
   const workspace = useWorkspace(taskId);
   const isCloud = workspace?.mode === "cloud";
+  const inputTabs = useMemo(
+    () =>
+      isCloud
+        ? node.content.tabs.filter((t) => t.data.type !== "terminal")
+        : node.content.tabs,
+    [node.content.tabs, isCloud],
+  );
+  const tabs = useTabInjection(inputTabs, node.id, taskId, task, closeTab);
+  const activeTabId = tabs.some((t) => t.id === node.content.activeTabId)
+    ? node.content.activeTabId
+    : (tabs[0]?.id ?? node.content.activeTabId);
 
   const cloudEmptyState = useMemo(
     () =>
@@ -74,6 +77,7 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
   const contentWithComponents = {
     ...node.content,
     tabs,
+    activeTabId,
   };
 
   return (
@@ -87,7 +91,7 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
       onPanelFocus={onPanelFocus}
       draggingTabId={draggingTabId}
       draggingTabPanelId={draggingTabPanelId}
-      onAddTerminal={() => onAddTerminal(node.id)}
+      onAddTerminal={isCloud ? undefined : () => onAddTerminal(node.id)}
       onSplitPanel={(direction) => onSplitPanel(node.id, direction)}
       emptyState={cloudEmptyState}
     />

--- a/apps/code/src/renderer/features/workspace/hooks/useWorkspace.ts
+++ b/apps/code/src/renderer/features/workspace/hooks/useWorkspace.ts
@@ -52,6 +52,11 @@ export function useWorkspace(taskId: string | undefined): Workspace | null {
   );
 }
 
+export function useIsWorkspaceCloudRun(taskId: string | undefined): boolean {
+  const workspace = useWorkspace(taskId);
+  return workspace?.mode === "cloud";
+}
+
 export function useWorkspaceLoaded(): boolean {
   const { isFetched } = useWorkspacesQuery();
   return isFetched;


### PR DESCRIPTION
## Problem

Terminal doesn't work for cloud rins. The terminal tab and inline bash commands (`! command`) are local-only features that shouldn't be available for cloud runs. Currently the terminal tab renders but shows nothing useful, the "+" button lets users add more empty terminal tabs, and typing `! command` is silently dropped instead of being sent as a normal prompt.

  ## Changes

  - **Terminal tabs hidden for cloud runs** — `LeafNodeRenderer` filters out terminal tabs before they reach `useTabInjection`, so no `TabContentRenderer` or shell process is ever created. The "+" add terminal button is also hidden. If the active tab was a terminal, it falls back to the first available tab.
  - **Inline bash mode disabled for cloud runs** — `MessageEditor` uses a new `useIsWorkspaceCloudRun` hook to set `capabilities.bashMode` to `false`, which disables the `!` prefix visual indicator (blue ring). The submit function now also checks `enableBashMode` before routing `!` text to the bash handler, so `! text` is submitted as a normal prompt instead of being silently dropped.
  - **New `useIsWorkspaceCloudRun` hook** — Thin wrapper around `useWorkspace` that returns `workspace?.mode === "cloud"`, used by both `LeafNodeRenderer` and `MessageEditor` to avoid prop drilling.

  ## How did you test this?

  - `pnpm typecheck` — all 9 packages pass
  - `pnpm lint` — no new warnings
  - `pnpm --filter code test` — 584/584 tests pass