### PR TITLE
Make diff stats indicator clickable to toggle review mode

### DIFF
--- a/apps/code/src/renderer/features/message-editor/components/DiffStatsIndicator.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/DiffStatsIndicator.tsx
@@ -1,16 +1,19 @@
 import type { DiffStats } from "@features/git-interaction/utils/diffStats";
-import { Flex, Text } from "@radix-ui/themes";
+import { Text } from "@radix-ui/themes";
+import { useReviewNavigationStore } from "@renderer/features/code-review/stores/reviewNavigationStore";
 import { useTRPC } from "@renderer/trpc";
 import { useQuery } from "@tanstack/react-query";
 
 interface DiffStatsIndicatorProps {
   repoPath: string | null | undefined;
   overrideStats?: DiffStats | null;
+  taskId?: string;
 }
 
 export function DiffStatsIndicator({
   repoPath,
   overrideStats,
+  taskId,
 }: DiffStatsIndicatorProps) {
   const trpc = useTRPC();
   const { data: localStats } = useQuery(
@@ -26,13 +29,28 @@ export function DiffStatsIndicator({
   );
 
   const diffStats = overrideStats ?? localStats;
+  const reviewMode = useReviewNavigationStore((s) =>
+    taskId ? (s.reviewModes[taskId] ?? "closed") : "closed",
+  );
+  const setReviewMode = useReviewNavigationStore((s) => s.setReviewMode);
 
   if (!diffStats || diffStats.filesChanged === 0) {
     return null;
   }
 
+  const handleClick = () => {
+    if (taskId) {
+      setReviewMode(taskId, reviewMode !== "closed" ? "closed" : "split");
+    }
+  };
+
   return (
-    <Flex align="center" gap="2" style={{ whiteSpace: "nowrap" }}>
+    <button
+      type="button"
+      onClick={handleClick}
+      className="inline-flex cursor-pointer items-center gap-2 border-none bg-transparent px-1.5 py-0.5"
+      style={{ whiteSpace: "nowrap" }}
+    >
       <Text
         size="1"
         style={{
@@ -61,6 +79,6 @@ export function DiffStatsIndicator({
       >
         -{diffStats.linesRemoved}
       </Text>
-    </Flex>
+    </button>
   );
 }

--- a/apps/code/src/renderer/features/message-editor/components/MessageEditor.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/MessageEditor.tsx
@@ -104,6 +104,7 @@ function ModeAndBranchRow({
         <DiffStatsIndicator
           repoPath={repoPath}
           overrideStats={cloudDiffStats}
+          taskId={taskId}
         />
         {showBranchSelector && showDiffStats && (
           <Flex


### PR DESCRIPTION
## TL;DR
The diff stats indicator in the message editor is now clickable to toggle between split and closed review modes, providing a more intuitive way for users to control the code review interface.

## Problem
Users need a quick way to toggle the code review mode without using alternative controls. Making the diff stats indicator interactive provides an obvious, discoverable control point.

## Changes
- **DiffStatsIndicator component**: 
  - Converted from a `Flex` container to a clickable `button` element with transparent background and pointer cursor
  - Added `taskId` prop to identify which review task to control
  - Integrated with `useReviewNavigationStore` to read and update review mode state
  - Added click handler that toggles review mode between "closed" and "split" states
  - Applied inline-flex styling to maintain visual layout while functioning as a button

- **MessageEditor component**:
  - Passed `taskId` prop to `DiffStatsIndicator` component

## How did you test this?
The changes maintain the visual appearance of the diff stats while converting it to a functional button element. The component will properly read the current review mode state and toggle it when clicked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*