### PR TITLE
fix: hide error tracking fingerprint from signal reports

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
@@ -7,7 +7,6 @@ import {
   CheckCircleIcon,
   QuestionIcon,
   TagIcon,
-  WarningIcon,
 } from "@phosphor-icons/react";
 import { Badge, Box, Flex, Text } from "@radix-ui/themes";
 import type { Signal, SignalFindingContent } from "@shared/types";
@@ -474,51 +473,19 @@ function LlmEvalSignalCard({
 
 function ErrorTrackingSignalCard({
   signal,
-  extra,
   verified,
   codePaths,
   dataQueried,
 }: {
   signal: Signal;
-  extra: ErrorTrackingExtra;
   verified?: boolean;
   codePaths?: string[];
   dataQueried?: string;
 }) {
-  const fingerprint = extra.fingerprint ?? "";
-
   return (
     <Box className="min-w-0 overflow-hidden rounded-lg border border-gray-6 bg-gray-1 p-3">
       <SignalCardHeader signal={signal} verified={verified} />
       <CollapsibleBody body={signal.content} />
-      <Flex
-        align="center"
-        gap="2"
-        wrap="wrap"
-        mt="2"
-        className="text-[11px]"
-        style={{ color: "var(--gray-10)" }}
-      >
-        <Flex align="center" gap="1">
-          <WarningIcon
-            size={14}
-            weight="bold"
-            className="shrink-0"
-            style={{ color: "var(--amber-9)" }}
-          />
-          <span>
-            Fingerprint{" "}
-            <span
-              className="break-all font-mono"
-              style={{ color: "var(--gray-12)" }}
-            >
-              {fingerprint}
-            </span>
-          </span>
-        </Flex>
-        <span className="flex-1" />
-        {/* No "View issue" link in Code — error tracking lives in Cloud */}
-      </Flex>
       <CodePathsCollapsible paths={codePaths ?? []} />
       <DataQueriedCollapsible text={dataQueried ?? ""} />
     </Box>
@@ -644,7 +611,6 @@ export function SignalCard({
     return (
       <ErrorTrackingSignalCard
         signal={signal}
-        extra={extra}
         verified={verified}
         codePaths={codePaths}
         dataQueried={dataQueried}


### PR DESCRIPTION
### Problem
The fingerprint string in error tracking signal cards is very long, not human-readable, and clutters the UI.

### Fix
Removed the fingerprint display block (WarningIcon + fingerprint text) from `ErrorTrackingSignalCard`. Kept the `fingerprint` field in the type definition since it is part of the API contract.

Fixes #1573