### PR TITLE
chore(code): make branch selector disabled when cloud run

### DIFF
--- a/apps/code/src/renderer/components/ui/combobox/Combobox.tsx
+++ b/apps/code/src/renderer/components/ui/combobox/Combobox.tsx
@@ -173,9 +173,11 @@ function ComboboxTrigger({
         style={style}
       >
         <span className="combobox-trigger-inner">{displayValue}</span>
-        <span className="combobox-trigger-icon">
-          <CaretDown weight="bold" />
-        </span>
+        {!disabled && (
+          <span className="combobox-trigger-icon">
+            <CaretDown weight="bold" />
+          </span>
+        )}
       </button>
     </Popover.Trigger>
   );

--- a/apps/code/src/renderer/features/message-editor/components/MessageEditor.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/MessageEditor.tsx
@@ -33,6 +33,7 @@ interface ModeAndBranchRowProps {
   } | null;
   disabled?: boolean;
   isBashMode?: boolean;
+  isCloud?: boolean;
   taskId?: string;
 }
 
@@ -44,6 +45,7 @@ function ModeAndBranchRow({
   cloudDiffStats,
   disabled,
   isBashMode,
+  isCloud,
   taskId,
 }: ModeAndBranchRowProps) {
   const { currentBranch: gitBranch, diffStats } = useGitQueries(
@@ -120,7 +122,7 @@ function ModeAndBranchRow({
             <BranchSelector
               repoPath={repoPath ?? null}
               currentBranch={currentBranch}
-              disabled={disabled}
+              disabled={disabled || isCloud}
               variant="ghost"
               taskId={taskId}
             />
@@ -362,6 +364,7 @@ export const MessageEditor = forwardRef<EditorHandle, MessageEditorProps>(
           cloudDiffStats={cloudDiffStats}
           disabled={disabled}
           isBashMode={isBashMode}
+          isCloud={isCloud}
           taskId={taskId}
         />
       </Flex>


### PR DESCRIPTION
## Summary

  - Disable branch selector in chat UI for cloud runs
  - Hide dropdown chevron on disabled combobox triggers

  ## Problem

  Branch selector in the message editor doesn't work for cloud runs.

  ## Changes

  - Disabled the branch selector for cloud runs
  - Removed the dropdown chevron icon from disabled combobox triggers

## Screenshot

<img width="803" height="297" alt="Screenshot 2026-04-09 at 14 56 09" src="https://github.com/user-attachments/assets/af918d1f-22a0-4a81-b7c8-65d428e79dfd" />
