### PR TITLE
feat(code): add useComboboxFilter hook to improve branch and repo picker performance

### DIFF
--- a/apps/code/src/renderer/components/ui/combobox/Combobox.stories.tsx
+++ b/apps/code/src/renderer/components/ui/combobox/Combobox.stories.tsx
@@ -338,6 +338,37 @@ export const EmptyState: Story = {
   },
 };
 
+export const FilteredContent: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+    const allFruits = [...fruits, ...tropicalFruits, ...citrusFruits];
+
+    return (
+      <Combobox.Root value={value} onValueChange={setValue}>
+        <Combobox.Trigger placeholder="Search fruits..." />
+        <Combobox.Content items={allFruits} getValue={(f) => f.label} limit={5}>
+          {({ filtered, hasMore, moreCount }) => (
+            <>
+              <Combobox.Input placeholder="Type to search..." />
+              <Combobox.Empty>No fruits found.</Combobox.Empty>
+              {filtered.map((fruit) => (
+                <Combobox.Item key={fruit.value} value={fruit.value}>
+                  {fruit.label}
+                </Combobox.Item>
+              ))}
+              {hasMore && (
+                <div className="combobox-label">
+                  {moreCount} more — type to filter
+                </div>
+              )}
+            </>
+          )}
+        </Combobox.Content>
+      </Combobox.Root>
+    );
+  },
+};
+
 export const ControlledSearch: Story = {
   render: () => {
     const [value, setValue] = useState("");

--- a/apps/code/src/renderer/components/ui/combobox/Combobox.tsx
+++ b/apps/code/src/renderer/components/ui/combobox/Combobox.tsx
@@ -12,6 +12,7 @@ import React, {
 } from "react";
 import { Tooltip } from "../Tooltip";
 import "./Combobox.css";
+import { useComboboxFilter } from "./useComboboxFilter";
 
 type ComboboxSize = "1" | "2" | "3";
 type ComboboxTriggerVariant =
@@ -43,6 +44,12 @@ function useComboboxContext() {
   }
   return context;
 }
+
+interface FilterContextValue {
+  onSearchChange: (value: string) => void;
+}
+
+const FilterContext = createContext<FilterContextValue | null>(null);
 
 interface ComboboxRootProps {
   children: React.ReactNode;
@@ -183,18 +190,44 @@ function ComboboxTrigger({
   );
 }
 
-interface ComboboxContentProps {
-  children: React.ReactNode;
+interface FilterResult<T> {
+  filtered: T[];
+  hasMore: boolean;
+  moreCount: number;
+}
+
+interface ComboboxContentBaseProps {
   className?: string;
   variant?: ComboboxContentVariant;
   side?: "top" | "right" | "bottom" | "left";
   sideOffset?: number;
   align?: "start" | "center" | "end";
   style?: React.CSSProperties;
-  shouldFilter?: boolean;
 }
 
-function ComboboxContent({
+interface ComboboxContentStaticProps extends ComboboxContentBaseProps {
+  items?: undefined;
+  shouldFilter?: boolean;
+  children: React.ReactNode;
+}
+
+interface ComboboxContentFilteredProps<T> extends ComboboxContentBaseProps {
+  /** Items to filter. Activates built-in fuzzy filtering (bypasses cmdk). */
+  items: T[];
+  /** Extract the searchable string from each item. Defaults to `String(item)`. */
+  getValue?: (item: T) => string;
+  /** Maximum items to render. Defaults to 50. */
+  limit?: number;
+  /** Values pinned to the top regardless of score. */
+  pinned?: string[];
+  children: (result: FilterResult<T>) => React.ReactNode;
+}
+
+type ComboboxContentProps<T = never> =
+  | ComboboxContentStaticProps
+  | ComboboxContentFilteredProps<T>;
+
+function ComboboxContent<T>({
   children,
   className = "",
   variant = "soft",
@@ -202,15 +235,36 @@ function ComboboxContent({
   sideOffset = 4,
   align = "start",
   style,
-  shouldFilter = true,
-}: ComboboxContentProps) {
-  const { size, onOpenChange } = useComboboxContext();
+  ...rest
+}: ComboboxContentProps<T>) {
+  const { size, open, onOpenChange } = useComboboxContext();
 
-  const hasInput = React.Children.toArray(children).some(
+  const hasItems = "items" in rest && rest.items !== undefined;
+  const filterItems = hasItems ? rest.items : ([] as T[]);
+  const getValue = hasItems ? rest.getValue : undefined;
+  const limit = hasItems ? rest.limit : undefined;
+  const pinned = hasItems ? rest.pinned : undefined;
+  const shouldFilter = hasItems
+    ? false
+    : "shouldFilter" in rest
+      ? (rest.shouldFilter ?? true)
+      : true;
+
+  const filter = useComboboxFilter(
+    filterItems,
+    { limit, pinned, open },
+    getValue,
+  );
+
+  const resolvedChildren = hasItems
+    ? (children as (result: FilterResult<T>) => React.ReactNode)(filter)
+    : (children as React.ReactNode);
+
+  const hasInput = React.Children.toArray(resolvedChildren).some(
     (child) => React.isValidElement(child) && child.type === ComboboxInput,
   );
 
-  return (
+  const content = (
     <Popover.Content
       className={`combobox-content size-${size} variant-${variant} ${className}`}
       side={side}
@@ -233,13 +287,13 @@ function ComboboxContent({
     >
       <CmdkCommand shouldFilter={shouldFilter} loop>
         {hasInput &&
-          React.Children.map(children, (child) =>
+          React.Children.map(resolvedChildren, (child) =>
             React.isValidElement(child) && child.type === ComboboxInput
               ? child
               : null,
           )}
         <CmdkCommand.List>
-          {React.Children.map(children, (child) =>
+          {React.Children.map(resolvedChildren, (child) =>
             React.isValidElement(child) &&
             child.type !== ComboboxInput &&
             child.type !== ComboboxFooter
@@ -247,7 +301,7 @@ function ComboboxContent({
               : null,
           )}
         </CmdkCommand.List>
-        {React.Children.map(children, (child) =>
+        {React.Children.map(resolvedChildren, (child) =>
           React.isValidElement(child) && child.type === ComboboxFooter
             ? child
             : null,
@@ -255,6 +309,16 @@ function ComboboxContent({
       </CmdkCommand>
     </Popover.Content>
   );
+
+  if (hasItems) {
+    return (
+      <FilterContext.Provider value={{ onSearchChange: filter.onSearchChange }}>
+        {content}
+      </FilterContext.Provider>
+    );
+  }
+
+  return content;
 }
 
 interface ComboboxInputProps {
@@ -268,6 +332,9 @@ const ComboboxInput = React.forwardRef<
   React.ElementRef<typeof CmdkCommand.Input>,
   ComboboxInputProps
 >(({ placeholder = "Search...", className, value, onValueChange }, ref) => {
+  const filterCtx = useContext(FilterContext);
+  const handleValueChange = onValueChange ?? filterCtx?.onSearchChange;
+
   return (
     <div className="combobox-input-wrapper">
       <MagnifyingGlass
@@ -280,7 +347,7 @@ const ComboboxInput = React.forwardRef<
         className={className}
         placeholder={placeholder}
         value={value}
-        onValueChange={onValueChange}
+        onValueChange={handleValueChange}
         autoFocus
       />
     </div>

--- a/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
+++ b/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
@@ -1,0 +1,113 @@
+import { defaultFilter } from "cmdk";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const DEFAULT_LIMIT = 50;
+const MIN_FUZZY_SCORE = 0.1;
+const DEBOUNCE_MS = 150;
+
+interface UseComboboxFilterOptions {
+  /** Maximum number of items to render. Defaults to 50. */
+  limit?: number;
+  /** Values pinned to the top regardless of score. */
+  pinned?: string[];
+  /** Popover open state. Search resets when this becomes false. */
+  open?: boolean;
+}
+
+interface UseComboboxFilterResult<T> {
+  filtered: T[];
+  onSearchChange: (value: string) => void;
+  hasMore: boolean;
+  moreCount: number;
+}
+
+/**
+ * Fuzzy-filters and caps a list of items for use with Combobox.
+ *
+ * Bypasses cmdk's built-in DOM-based filtering. The consumer should pass
+ * `shouldFilter={false}` to `Combobox.Content` and wire `onSearchChange`
+ * to `Combobox.Input`'s `onValueChange`. Do not pass a controlled `value`
+ * to the input -- let cmdk manage the input display natively.
+ */
+export function useComboboxFilter<T>(
+  items: T[],
+  options?: UseComboboxFilterOptions,
+  getValue?: (item: T) => string,
+): UseComboboxFilterResult<T> {
+  const [search, setSearch] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const limit = options?.limit ?? DEFAULT_LIMIT;
+  const pinned = options?.pinned;
+  const open = options?.open;
+
+  const debouncedSetSearch = useCallback((value: string) => {
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setSearch(value), DEBOUNCE_MS);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      clearTimeout(debounceRef.current);
+      setSearch("");
+    }
+  }, [open]);
+
+  useEffect(() => () => clearTimeout(debounceRef.current), []);
+
+  const resolve = useCallback(
+    (item: T): string => (getValue ? getValue(item) : String(item)),
+    [getValue],
+  );
+
+  const { filtered, totalMatches } = useMemo(() => {
+    const query = search.trim();
+
+    // Score and filter items. cmdk's fuzzy matcher can produce very low scores
+    // for scattered single-character matches (e.g. "vojta" matching v-o-j-t-a
+    // across "chore-remoVe-cOhort-Join-aTtempt"), so we require a minimum score
+    // to avoid noisy results.
+    let scored: Array<{ item: T; score: number }>;
+    if (query) {
+      scored = [];
+      for (const item of items) {
+        const score = defaultFilter(resolve(item), query);
+        if (score >= MIN_FUZZY_SCORE) scored.push({ item, score });
+      }
+    } else {
+      scored = items.map((item) => ({ item, score: 0 }));
+    }
+
+    const total = scored.length;
+
+    // Sort: pinned first (in order), then by score descending (stable for equal scores)
+    if (pinned) {
+      const pinnedSet = new Set(pinned);
+      scored.sort((a, b) => {
+        const aVal = resolve(a.item);
+        const bVal = resolve(b.item);
+        const aPinned = pinnedSet.has(aVal);
+        const bPinned = pinnedSet.has(bVal);
+        if (aPinned && !bPinned) return -1;
+        if (!aPinned && bPinned) return 1;
+        if (aPinned && bPinned) {
+          return pinned.indexOf(aVal) - pinned.indexOf(bVal);
+        }
+        return b.score - a.score;
+      });
+    } else if (query) {
+      scored.sort((a, b) => b.score - a.score);
+    }
+
+    return {
+      filtered: scored.slice(0, limit).map((s) => s.item),
+      totalMatches: total,
+    };
+  }, [items, search, limit, pinned, resolve]);
+
+  return {
+    filtered,
+    onSearchChange: debouncedSetSearch,
+    hasMore: totalMatches > filtered.length,
+    moreCount: Math.max(0, totalMatches - filtered.length),
+  };
+}

--- a/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
+++ b/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
@@ -24,10 +24,9 @@ interface UseComboboxFilterResult<T> {
 /**
  * Fuzzy-filters and caps a list of items for use with Combobox.
  *
- * Bypasses cmdk's built-in DOM-based filtering. The consumer should pass
- * `shouldFilter={false}` to `Combobox.Content` and wire `onSearchChange`
- * to `Combobox.Input`'s `onValueChange`. Do not pass a controlled `value`
- * to the input -- let cmdk manage the input display natively.
+ * Prefer passing `items` directly to `Combobox.Content` which handles all
+ * wiring automatically. Use this hook directly only when you need custom
+ * control over the filtering lifecycle.
  */
 export function useComboboxFilter<T>(
   items: T[],

--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -1,5 +1,4 @@
 import { Combobox } from "@components/ui/combobox/Combobox";
-import { useComboboxFilter } from "@components/ui/combobox/useComboboxFilter";
 import { GithubLogo } from "@phosphor-icons/react";
 import { Button, Flex, Text } from "@radix-ui/themes";
 import { useState } from "react";
@@ -24,12 +23,6 @@ export function GitHubRepoPicker({
   disabled = false,
 }: GitHubRepoPickerProps) {
   const [open, setOpen] = useState(false);
-  const {
-    filtered: filteredRepos,
-    onSearchChange,
-    hasMore,
-    moreCount,
-  } = useComboboxFilter(repositories, { limit: 50, open });
 
   if (isLoading) {
     return (
@@ -70,22 +63,23 @@ export function GitHubRepoPicker({
           </Text>
         </Flex>
       </Combobox.Trigger>
-      <Combobox.Content shouldFilter={false}>
-        <Combobox.Input
-          placeholder="Search repositories..."
-          onValueChange={onSearchChange}
-        />
-        <Combobox.Empty>No repositories found.</Combobox.Empty>
-        {filteredRepos.map((repo) => (
-          <Combobox.Item key={repo} value={repo} textValue={repo}>
-            {repo}
-          </Combobox.Item>
-        ))}
-        {hasMore && (
-          <div className="combobox-label">
-            {moreCount} more {moreCount === 1 ? "repo" : "repos"} — type to
-            filter
-          </div>
+      <Combobox.Content items={repositories} limit={50}>
+        {({ filtered, hasMore, moreCount }) => (
+          <>
+            <Combobox.Input placeholder="Search repositories..." />
+            <Combobox.Empty>No repositories found.</Combobox.Empty>
+            {filtered.map((repo) => (
+              <Combobox.Item key={repo} value={repo} textValue={repo}>
+                {repo}
+              </Combobox.Item>
+            ))}
+            {hasMore && (
+              <div className="combobox-label">
+                {moreCount} more {moreCount === 1 ? "repo" : "repos"} — type to
+                filter
+              </div>
+            )}
+          </>
         )}
       </Combobox.Content>
     </Combobox.Root>

--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -1,6 +1,8 @@
 import { Combobox } from "@components/ui/combobox/Combobox";
+import { useComboboxFilter } from "@components/ui/combobox/useComboboxFilter";
 import { GithubLogo } from "@phosphor-icons/react";
 import { Button, Flex, Text } from "@radix-ui/themes";
+import { useState } from "react";
 
 interface GitHubRepoPickerProps {
   value: string | null;
@@ -21,6 +23,14 @@ export function GitHubRepoPicker({
   size = "1",
   disabled = false,
 }: GitHubRepoPickerProps) {
+  const [open, setOpen] = useState(false);
+  const {
+    filtered: filteredRepos,
+    onSearchChange,
+    hasMore,
+    moreCount,
+  } = useComboboxFilter(repositories, { limit: 50, open });
+
   if (isLoading) {
     return (
       <Button color="gray" variant="outline" size={size} disabled>
@@ -47,6 +57,8 @@ export function GitHubRepoPicker({
     <Combobox.Root
       value={value ?? ""}
       onValueChange={onChange}
+      open={open}
+      onOpenChange={setOpen}
       size={size}
       disabled={disabled}
     >
@@ -58,14 +70,23 @@ export function GitHubRepoPicker({
           </Text>
         </Flex>
       </Combobox.Trigger>
-      <Combobox.Content>
-        <Combobox.Input placeholder="Search repositories..." />
+      <Combobox.Content shouldFilter={false}>
+        <Combobox.Input
+          placeholder="Search repositories..."
+          onValueChange={onSearchChange}
+        />
         <Combobox.Empty>No repositories found.</Combobox.Empty>
-        {repositories.map((repo) => (
+        {filteredRepos.map((repo) => (
           <Combobox.Item key={repo} value={repo} textValue={repo}>
             {repo}
           </Combobox.Item>
         ))}
+        {hasMore && (
+          <div className="combobox-label">
+            {moreCount} more {moreCount === 1 ? "repo" : "repos"} — type to
+            filter
+          </div>
+        )}
       </Combobox.Content>
     </Combobox.Root>
   );

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -1,5 +1,4 @@
 import { Combobox } from "@components/ui/combobox/Combobox";
-import { useComboboxFilter } from "@components/ui/combobox/useComboboxFilter";
 import { useGitInteractionStore } from "@features/git-interaction/state/gitInteractionStore";
 import { getSuggestedBranchName } from "@features/git-interaction/utils/getSuggestedBranchName";
 import { invalidateGitBranchQueries } from "@features/git-interaction/utils/gitCacheKeys";
@@ -63,17 +62,6 @@ export function BranchSelector({
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
 
-  const {
-    filtered: filteredBranches,
-    onSearchChange,
-    hasMore,
-    moreCount,
-  } = useComboboxFilter(branches, {
-    limit: 50,
-    pinned: [displayedBranch, defaultBranch].filter(Boolean) as string[],
-    open,
-  });
-
   const checkoutMutation = useMutation(
     trpc.git.checkoutBranch.mutationOptions({
       onSuccess: () => {
@@ -130,59 +118,67 @@ export function BranchSelector({
           {triggerContent}
         </Combobox.Trigger>
 
-        <Combobox.Content shouldFilter={false}>
-          <Combobox.Input
-            placeholder="Search branches"
-            onValueChange={onSearchChange}
-          />
-          <Combobox.Empty>No branches found.</Combobox.Empty>
+        <Combobox.Content
+          items={branches}
+          limit={50}
+          pinned={[displayedBranch, defaultBranch].filter(Boolean) as string[]}
+        >
+          {({ filtered, hasMore, moreCount }) => (
+            <>
+              <Combobox.Input placeholder="Search branches" />
+              <Combobox.Empty>No branches found.</Combobox.Empty>
 
-          {filteredBranches.length > 0 && (
-            <Combobox.Group
-              heading={isCloudMode ? "Remote branches" : "Local branches"}
-            >
-              {filteredBranches.map((branch) => (
-                <Combobox.Item
-                  key={branch}
-                  value={branch}
-                  icon={<GitBranch size={11} weight="regular" />}
+              {filtered.length > 0 && (
+                <Combobox.Group
+                  heading={isCloudMode ? "Remote branches" : "Local branches"}
                 >
-                  {branch}
-                </Combobox.Item>
-              ))}
-              {hasMore && (
-                <div className="combobox-label">
-                  {moreCount} more {moreCount === 1 ? "branch" : "branches"} —
-                  type to filter
-                </div>
+                  {filtered.map((branch) => (
+                    <Combobox.Item
+                      key={branch}
+                      value={branch}
+                      icon={<GitBranch size={11} weight="regular" />}
+                    >
+                      {branch}
+                    </Combobox.Item>
+                  ))}
+                  {hasMore && (
+                    <div className="combobox-label">
+                      {moreCount} more {moreCount === 1 ? "branch" : "branches"}{" "}
+                      — type to filter
+                    </div>
+                  )}
+                </Combobox.Group>
               )}
-            </Combobox.Group>
-          )}
 
-          {!isCloudMode && (
-            <Combobox.Footer>
-              <button
-                type="button"
-                className="combobox-footer-button"
-                onClick={() => {
-                  setOpen(false);
-                  actions.openBranch(
-                    taskId
-                      ? getSuggestedBranchName(taskId, repoPath ?? undefined)
-                      : undefined,
-                  );
-                }}
-              >
-                <Flex
-                  align="center"
-                  gap="2"
-                  style={{ color: "var(--accent-11)" }}
-                >
-                  <Plus size={11} weight="bold" />
-                  <span>Create new branch</span>
-                </Flex>
-              </button>
-            </Combobox.Footer>
+              {!isCloudMode && (
+                <Combobox.Footer>
+                  <button
+                    type="button"
+                    className="combobox-footer-button"
+                    onClick={() => {
+                      setOpen(false);
+                      actions.openBranch(
+                        taskId
+                          ? getSuggestedBranchName(
+                              taskId,
+                              repoPath ?? undefined,
+                            )
+                          : undefined,
+                      );
+                    }}
+                  >
+                    <Flex
+                      align="center"
+                      gap="2"
+                      style={{ color: "var(--accent-11)" }}
+                    >
+                      <Plus size={11} weight="bold" />
+                      <span>Create new branch</span>
+                    </Flex>
+                  </button>
+                </Combobox.Footer>
+              )}
+            </>
           )}
         </Combobox.Content>
       </Combobox.Root>

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -1,4 +1,5 @@
 import { Combobox } from "@components/ui/combobox/Combobox";
+import { useComboboxFilter } from "@components/ui/combobox/useComboboxFilter";
 import { useGitInteractionStore } from "@features/git-interaction/state/gitInteractionStore";
 import { getSuggestedBranchName } from "@features/git-interaction/utils/getSuggestedBranchName";
 import { invalidateGitBranchQueries } from "@features/git-interaction/utils/gitCacheKeys";
@@ -62,6 +63,17 @@ export function BranchSelector({
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
 
+  const {
+    filtered: filteredBranches,
+    onSearchChange,
+    hasMore,
+    moreCount,
+  } = useComboboxFilter(branches, {
+    limit: 50,
+    pinned: [displayedBranch, defaultBranch].filter(Boolean) as string[],
+    open,
+  });
+
   const checkoutMutation = useMutation(
     trpc.git.checkoutBranch.mutationOptions({
       onSuccess: () => {
@@ -118,23 +130,34 @@ export function BranchSelector({
           {triggerContent}
         </Combobox.Trigger>
 
-        <Combobox.Content>
-          <Combobox.Input placeholder="Search branches" />
+        <Combobox.Content shouldFilter={false}>
+          <Combobox.Input
+            placeholder="Search branches"
+            onValueChange={onSearchChange}
+          />
           <Combobox.Empty>No branches found.</Combobox.Empty>
 
-          <Combobox.Group
-            heading={isCloudMode ? "Remote branches" : "Local branches"}
-          >
-            {branches.map((branch) => (
-              <Combobox.Item
-                key={branch}
-                value={branch}
-                icon={<GitBranch size={11} weight="regular" />}
-              >
-                {branch}
-              </Combobox.Item>
-            ))}
-          </Combobox.Group>
+          {filteredBranches.length > 0 && (
+            <Combobox.Group
+              heading={isCloudMode ? "Remote branches" : "Local branches"}
+            >
+              {filteredBranches.map((branch) => (
+                <Combobox.Item
+                  key={branch}
+                  value={branch}
+                  icon={<GitBranch size={11} weight="regular" />}
+                >
+                  {branch}
+                </Combobox.Item>
+              ))}
+              {hasMore && (
+                <div className="combobox-label">
+                  {moreCount} more {moreCount === 1 ? "branch" : "branches"} —
+                  type to filter
+                </div>
+              )}
+            </Combobox.Group>
+          )}
 
           {!isCloudMode && (
             <Combobox.Footer>


### PR DESCRIPTION


  ## Problem

  The branch selector combobox was slow to open on repos with many branches. cmdk renders every item as a DOM node (no virtualization), and each `ComboboxItem` carries significant per-instance overhead (Tooltip, refs, effects). With hundreds of branches, opening the picker caused a noticeable lag.

  ## Solution

  Instead of rendering all items and letting cmdk filter via `display: none`, we:

  1. Disable cmdk's built-in filtering (`shouldFilter={false}`)
  2. Let cmdk manage the input natively (uncontrolled)
  3. Listen for search changes via `onValueChange` and debounce them
  4. Score items with cmdk's own `defaultFilter` (fuzzy matching), filter out noise below a 0.1 threshold, and cap rendered results at 50

Applying it to branch combobox and also to github repo combobox

## Showcase


https://github.com/user-attachments/assets/e2dae34d-5248-4356-adc1-e1d325e4cb8e

