### PR TITLE
feat(code): warn on local task branch mismatch

### DIFF
--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -369,6 +369,8 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       branchName,
     });
     trackAppEvent("branch_linked", {
+      task_id: taskId,
+      branch_name: branchName,
       source: source ?? "unknown",
     });
     log.info("Linked branch to task", { taskId, branchName, source });
@@ -381,6 +383,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       branchName: null,
     });
     trackAppEvent("branch_unlinked", {
+      task_id: taskId,
       source: source ?? "unknown",
     });
     log.info("Unlinked branch from task", { taskId, source });

--- a/apps/code/src/renderer/features/message-editor/components/PromptInput.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/PromptInput.tsx
@@ -45,6 +45,7 @@ export interface PromptInputProps {
   // prompt history provider
   getPromptHistory?: () => string[];
   // callbacks
+  onBeforeSubmit?: (text: string, clearEditor: () => void) => boolean;
   onSubmit?: (text: string) => void;
   onBashCommand?: (command: string) => void;
   onBashModeChange?: (isBashMode: boolean) => void;
@@ -80,6 +81,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       reasoningSelector,
       tourHighlightSubmit = false,
       getPromptHistory,
+      onBeforeSubmit,
       onSubmit,
       onBashCommand,
       onBashModeChange,
@@ -127,6 +129,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
         commands: enableCommands,
       },
       getPromptHistory,
+      onBeforeSubmit,
       onSubmit,
       onBashCommand,
       onBashModeChange,

--- a/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -30,6 +30,7 @@ export interface UseTiptapEditorOptions {
   };
   clearOnSubmit?: boolean;
   getPromptHistory?: () => string[];
+  onBeforeSubmit?: (text: string, clearEditor: () => void) => boolean;
   onSubmit?: (text: string) => void;
   onBashCommand?: (command: string) => void;
   onBashModeChange?: (isBashMode: boolean) => void;
@@ -85,6 +86,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
     capabilities = {},
     clearOnSubmit = true,
     getPromptHistory,
+    onBeforeSubmit,
     onSubmit,
     onBashCommand,
     onBashModeChange,
@@ -100,6 +102,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
   } = capabilities;
 
   const callbackRefs = useRef({
+    onBeforeSubmit,
     onSubmit,
     onBashCommand,
     onBashModeChange,
@@ -108,6 +111,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
     onBlur,
   });
   callbackRefs.current = {
+    onBeforeSubmit,
     onSubmit,
     onBashCommand,
     onBashModeChange,
@@ -450,8 +454,19 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
 
     const text = editor.getText().trim();
 
+    const doClear = () => {
+      if (!clearOnSubmit) return;
+      editor.commands.clearContent();
+      prevBashModeRef.current = false;
+      pasteCountRef.current = 0;
+      setAttachments([]);
+      draft.clearDraft();
+    };
+
     if (enableBashMode && text.startsWith("!")) {
-      // Bash mode requires immediate execution, can't be queued
+      // Bash mode requires immediate execution, can't be queued.
+      // Intentionally bypasses onBeforeSubmit — bash commands run inline and
+      // cannot be deferred the way normal prompts can.
       if (isLoading) {
         toast.error("Cannot run shell commands while agent is generating");
         return;
@@ -459,17 +474,19 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
       const command = text.slice(1).trim();
       if (command) callbackRefs.current.onBashCommand?.(command);
     } else {
+      const serialized = contentToXml(content);
+
+      if (callbackRefs.current.onBeforeSubmit) {
+        if (!callbackRefs.current.onBeforeSubmit(serialized, doClear)) {
+          return;
+        }
+      }
+
       // Normal prompts can be queued when loading
-      callbackRefs.current.onSubmit?.(contentToXml(content));
+      callbackRefs.current.onSubmit?.(serialized);
     }
 
-    if (clearOnSubmit) {
-      editor.commands.clearContent();
-      prevBashModeRef.current = false;
-      pasteCountRef.current = 0;
-      setAttachments([]);
-      draft.clearDraft();
-    }
+    doClear();
   }, [
     editor,
     disabled,

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -39,6 +39,7 @@ interface SessionViewProps {
   isRunning: boolean;
   isPromptPending?: boolean | null;
   promptStartedAt?: number | null;
+  onBeforeSubmit?: (text: string, clearEditor: () => void) => boolean;
   onSendPrompt: (text: string) => void;
   onBashCommand?: (command: string) => void;
   onCancelPrompt: () => void;
@@ -69,6 +70,7 @@ export function SessionView({
   isRunning,
   isPromptPending = false,
   promptStartedAt,
+  onBeforeSubmit,
   onSendPrompt,
   onBashCommand,
   onCancelPrompt,
@@ -531,6 +533,7 @@ export function SessionView({
                             disabled={!isRunning}
                           />
                         }
+                        onBeforeSubmit={onBeforeSubmit}
                         onSubmit={handleSubmit}
                         onBashCommand={onBashCommand}
                         onCancel={onCancelPrompt}

--- a/apps/code/src/renderer/features/task-detail/components/BranchMismatchDialog.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/BranchMismatchDialog.tsx
@@ -1,0 +1,148 @@
+import { GitBranch, Warning } from "@phosphor-icons/react";
+import {
+  AlertDialog,
+  Button,
+  Callout,
+  Code,
+  Flex,
+  Text,
+} from "@radix-ui/themes";
+
+interface BranchMismatchDialogProps {
+  open: boolean;
+  linkedBranch: string;
+  currentBranch: string;
+  hasUncommittedChanges: boolean;
+  switchError: string | null;
+  onSwitch: () => void;
+  onContinue: () => void;
+  onCancel: () => void;
+  isSwitching?: boolean;
+}
+
+function BranchLabel({ name }: { name: string }) {
+  return (
+    <Code
+      size="2"
+      variant="ghost"
+      truncate
+      style={{
+        maxWidth: "100%",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "4px",
+      }}
+    >
+      <GitBranch size={12} style={{ flexShrink: 0 }} />
+      <span
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {name}
+      </span>
+    </Code>
+  );
+}
+
+export function BranchMismatchDialog({
+  open,
+  linkedBranch,
+  currentBranch,
+  hasUncommittedChanges,
+  switchError,
+  onSwitch,
+  onContinue,
+  onCancel,
+  isSwitching,
+}: BranchMismatchDialogProps) {
+  return (
+    <AlertDialog.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onCancel();
+      }}
+    >
+      <AlertDialog.Content maxWidth="420px" size="2">
+        <AlertDialog.Title size="3">
+          <Flex align="center" gap="2">
+            <Warning size={18} weight="fill" color="var(--orange-9)" />
+            Wrong branch
+          </Flex>
+        </AlertDialog.Title>
+        <AlertDialog.Description size="2">
+          This task is linked to a different branch than the one you're
+          currently on. The agent will make changes on the current branch.
+        </AlertDialog.Description>
+        <Flex direction="column" gap="1" mt="3" style={{ minWidth: 0 }}>
+          <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+            <Text
+              size="1"
+              color="gray"
+              style={{ flexShrink: 0, width: "64px" }}
+            >
+              Linked
+            </Text>
+            <BranchLabel name={linkedBranch} />
+          </Flex>
+          <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+            <Text
+              size="1"
+              color="gray"
+              style={{ flexShrink: 0, width: "64px" }}
+            >
+              Current
+            </Text>
+            <BranchLabel name={currentBranch} />
+          </Flex>
+        </Flex>
+
+        {hasUncommittedChanges && !switchError && (
+          <Callout.Root size="1" color="gray" mt="3">
+            <Callout.Text size="1">
+              You have uncommitted changes on your current branch. If needed,
+              commit or stash them first.
+            </Callout.Text>
+          </Callout.Root>
+        )}
+
+        {switchError && (
+          <Callout.Root size="1" color="red" mt="3">
+            <Callout.Text size="1">{switchError}</Callout.Text>
+          </Callout.Root>
+        )}
+
+        <Flex justify="end" gap="2" mt="4">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray" size="1" disabled={isSwitching}>
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+
+          <Button
+            variant="soft"
+            color="orange"
+            size="1"
+            onClick={onContinue}
+            disabled={isSwitching}
+          >
+            Continue anyway
+          </Button>
+
+          <AlertDialog.Action>
+            <Button
+              variant="solid"
+              size="1"
+              onClick={onSwitch}
+              loading={isSwitching}
+            >
+              Switch branch
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -10,7 +10,9 @@ import { useSessionConnection } from "@features/sessions/hooks/useSessionConnect
 import { useSessionViewState } from "@features/sessions/hooks/useSessionViewState";
 import { useRestoreTask } from "@features/suspension/hooks/useRestoreTask";
 import { useSuspendedTaskIds } from "@features/suspension/hooks/useSuspendedTaskIds";
+import { BranchMismatchDialog } from "@features/task-detail/components/BranchMismatchDialog";
 import { WorkspaceSetupPrompt } from "@features/task-detail/components/WorkspaceSetupPrompt";
+import { useBranchMismatchDialog } from "@features/workspace/hooks/useBranchMismatchDialog";
 import {
   useCreateWorkspace,
   useWorkspaceLoaded,
@@ -76,6 +78,12 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
     handleBashCommand,
   } = useSessionCallbacks({ taskId, task, session, repoPath });
 
+  const { handleBeforeSubmit, dialogProps } = useBranchMismatchDialog({
+    taskId,
+    repoPath,
+    onSendPrompt: handleSendPrompt,
+  });
+
   const slackThreadUrl =
     typeof task.latest_run?.state?.slack_thread_url === "string"
       ? task.latest_run.state.slack_thread_url
@@ -126,6 +134,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
               isRestoring={isRestoring}
               isPromptPending={isPromptPending}
               promptStartedAt={promptStartedAt}
+              onBeforeSubmit={handleBeforeSubmit}
               onSendPrompt={handleSendPrompt}
               onBashCommand={isCloud ? undefined : handleBashCommand}
               onCancelPrompt={handleCancelPrompt}
@@ -143,6 +152,8 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
           </ErrorBoundary>
         </Box>
       </Flex>
+
+      {dialogProps && <BranchMismatchDialog {...dialogProps} />}
     </BackgroundWrapper>
   );
 }

--- a/apps/code/src/renderer/features/workspace/hooks/useBranchMismatch.test.ts
+++ b/apps/code/src/renderer/features/workspace/hooks/useBranchMismatch.test.ts
@@ -1,0 +1,138 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseWorkspace = vi.hoisted(() =>
+  vi.fn((): { branchName: string; linkedBranch: string | null } | null => null),
+);
+vi.mock("./useWorkspace", () => ({ useWorkspace: mockUseWorkspace }));
+
+import {
+  useBranchMismatchGuard,
+  useBranchWarningStore,
+} from "./useBranchMismatch";
+
+describe("useBranchWarningStore", () => {
+  beforeEach(() => {
+    useBranchWarningStore.setState({ dismissed: {} });
+  });
+
+  it("starts with no dismissed tasks", () => {
+    expect(useBranchWarningStore.getState().dismissed).toEqual({});
+  });
+
+  it("dismiss marks task as dismissed", () => {
+    useBranchWarningStore.getState().dismiss("task-1");
+    expect(useBranchWarningStore.getState().dismissed["task-1"]).toBe(true);
+  });
+
+  it("reset clears dismissed for a task", () => {
+    useBranchWarningStore.getState().dismiss("task-1");
+    useBranchWarningStore.getState().reset("task-1");
+    expect(useBranchWarningStore.getState().dismissed["task-1"]).toBe(false);
+  });
+
+  it("dismiss/reset are independent per task", () => {
+    useBranchWarningStore.getState().dismiss("task-1");
+    useBranchWarningStore.getState().dismiss("task-2");
+    useBranchWarningStore.getState().reset("task-1");
+
+    expect(useBranchWarningStore.getState().dismissed["task-1"]).toBe(false);
+    expect(useBranchWarningStore.getState().dismissed["task-2"]).toBe(true);
+  });
+});
+
+describe("useBranchMismatchGuard", () => {
+  beforeEach(() => {
+    useBranchWarningStore.setState({ dismissed: {} });
+    mockUseWorkspace.mockReturnValue(null);
+  });
+
+  it("shouldWarn is false when no workspace", () => {
+    const { result } = renderHook(() => useBranchMismatchGuard("task-1"));
+    expect(result.current.shouldWarn).toBe(false);
+  });
+
+  it("shouldWarn is false when no linked branch", () => {
+    mockUseWorkspace.mockReturnValue({
+      branchName: "main",
+      linkedBranch: null,
+    });
+    const { result } = renderHook(() => useBranchMismatchGuard("task-1"));
+    expect(result.current.shouldWarn).toBe(false);
+  });
+
+  it("shouldWarn is false when branches match", () => {
+    mockUseWorkspace.mockReturnValue({
+      branchName: "feat/foo",
+      linkedBranch: "feat/foo",
+    });
+    const { result } = renderHook(() => useBranchMismatchGuard("task-1"));
+    expect(result.current.shouldWarn).toBe(false);
+  });
+
+  it("shouldWarn is true when branches mismatch", () => {
+    mockUseWorkspace.mockReturnValue({
+      branchName: "main",
+      linkedBranch: "feat/foo",
+    });
+    const { result } = renderHook(() => useBranchMismatchGuard("task-1"));
+
+    expect(result.current.shouldWarn).toBe(true);
+    expect(result.current.linkedBranch).toBe("feat/foo");
+    expect(result.current.currentBranch).toBe("main");
+  });
+
+  it("dismissWarning stops shouldWarn", () => {
+    mockUseWorkspace.mockReturnValue({
+      branchName: "main",
+      linkedBranch: "feat/foo",
+    });
+    const { result } = renderHook(() => useBranchMismatchGuard("task-1"));
+    expect(result.current.shouldWarn).toBe(true);
+
+    act(() => result.current.dismissWarning());
+
+    expect(result.current.shouldWarn).toBe(false);
+  });
+
+  it("shouldWarn resets when currentBranch changes", () => {
+    mockUseWorkspace.mockReturnValue({
+      branchName: "main",
+      linkedBranch: "feat/foo",
+    });
+    const { result, rerender } = renderHook(() =>
+      useBranchMismatchGuard("task-1"),
+    );
+
+    act(() => result.current.dismissWarning());
+    expect(result.current.shouldWarn).toBe(false);
+
+    // Simulate switching to a different (still mismatched) branch
+    mockUseWorkspace.mockReturnValue({
+      branchName: "develop",
+      linkedBranch: "feat/foo",
+    });
+    rerender();
+
+    expect(result.current.shouldWarn).toBe(true);
+  });
+
+  it("shouldWarn is false after switching to the linked branch", () => {
+    mockUseWorkspace.mockReturnValue({
+      branchName: "main",
+      linkedBranch: "feat/foo",
+    });
+    const { result, rerender } = renderHook(() =>
+      useBranchMismatchGuard("task-1"),
+    );
+    expect(result.current.shouldWarn).toBe(true);
+
+    mockUseWorkspace.mockReturnValue({
+      branchName: "feat/foo",
+      linkedBranch: "feat/foo",
+    });
+    rerender();
+
+    expect(result.current.shouldWarn).toBe(false);
+  });
+});

--- a/apps/code/src/renderer/features/workspace/hooks/useBranchMismatch.ts
+++ b/apps/code/src/renderer/features/workspace/hooks/useBranchMismatch.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef } from "react";
+import { create } from "zustand";
+import { useWorkspace } from "./useWorkspace";
+
+interface BranchWarningState {
+  dismissed: Record<string, boolean>;
+  dismiss: (taskId: string) => void;
+  reset: (taskId: string) => void;
+}
+
+export const useBranchWarningStore = create<BranchWarningState>()((set) => ({
+  dismissed: {},
+  dismiss: (taskId) =>
+    set((state) => ({
+      dismissed: { ...state.dismissed, [taskId]: true },
+    })),
+  reset: (taskId) =>
+    set((state) => ({
+      dismissed: { ...state.dismissed, [taskId]: false },
+    })),
+}));
+
+function useBranchMismatch(taskId: string) {
+  const workspace = useWorkspace(taskId);
+  const linkedBranch = workspace?.linkedBranch ?? null;
+  const currentBranch = workspace?.branchName ?? null;
+  const isMismatch =
+    !!linkedBranch && !!currentBranch && linkedBranch !== currentBranch;
+
+  const branchWarningDismissed = useBranchWarningStore(
+    (s) => s.dismissed[taskId] ?? false,
+  );
+  const reset = useBranchWarningStore((s) => s.reset);
+
+  const prevBranchRef = useRef(currentBranch);
+  useEffect(() => {
+    if (prevBranchRef.current !== currentBranch) {
+      prevBranchRef.current = currentBranch;
+      reset(taskId);
+    }
+  }, [currentBranch, taskId, reset]);
+
+  const shouldWarn = isMismatch && !branchWarningDismissed;
+
+  return {
+    linkedBranch,
+    currentBranch,
+    isMismatch,
+    shouldWarn,
+  };
+}
+
+export function useBranchMismatchGuard(taskId: string) {
+  const { shouldWarn, linkedBranch, currentBranch } = useBranchMismatch(taskId);
+  const dismiss = useBranchWarningStore((s) => s.dismiss);
+
+  const dismissWarning = useCallback(() => {
+    dismiss(taskId);
+  }, [dismiss, taskId]);
+
+  return { shouldWarn, linkedBranch, currentBranch, dismissWarning };
+}

--- a/apps/code/src/renderer/features/workspace/hooks/useBranchMismatchDialog.test.ts
+++ b/apps/code/src/renderer/features/workspace/hooks/useBranchMismatchDialog.test.ts
@@ -1,0 +1,285 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockShouldWarn = false;
+const mockDismissWarning = vi.fn();
+
+const mockGuard = vi.hoisted(() => ({
+  useBranchMismatchGuard: vi.fn(
+    (): {
+      shouldWarn: boolean;
+      linkedBranch: string | null;
+      currentBranch: string | null;
+      dismissWarning: () => void;
+    } => ({
+      shouldWarn: mockShouldWarn,
+      linkedBranch: "feat/foo",
+      currentBranch: "main",
+      dismissWarning: mockDismissWarning,
+    }),
+  ),
+}));
+vi.mock("@features/workspace/hooks/useBranchMismatch", () => mockGuard);
+
+vi.mock("@features/git-interaction/hooks/useGitQueries", () => ({
+  useGitQueries: () => ({ hasChanges: false }),
+}));
+
+vi.mock("@features/git-interaction/utils/gitCacheKeys", () => ({
+  invalidateGitBranchQueries: vi.fn(),
+}));
+
+let capturedMutationOptions: {
+  onSuccess?: () => void;
+  onError?: (e: Error) => void;
+} = {};
+const mockMutate = vi.fn();
+
+vi.mock("@renderer/trpc/client", () => ({
+  useTRPC: () => ({
+    git: {
+      checkoutBranch: {
+        mutationOptions: (opts: Record<string, unknown>) => {
+          capturedMutationOptions = opts as typeof capturedMutationOptions;
+          return opts;
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({
+    mutate: mockMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@utils/logger", () => ({
+  logger: { scope: () => ({ error: vi.fn() }) },
+}));
+
+const mockTrack = vi.fn();
+vi.mock("@utils/analytics", () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
+import { useBranchMismatchDialog } from "./useBranchMismatchDialog";
+
+function renderDialog(overrides?: { shouldWarn?: boolean }) {
+  mockShouldWarn = overrides?.shouldWarn ?? false;
+  mockGuard.useBranchMismatchGuard.mockReturnValue({
+    shouldWarn: mockShouldWarn,
+    linkedBranch: "feat/foo",
+    currentBranch: "main",
+    dismissWarning: mockDismissWarning,
+  });
+
+  const onSendPrompt = vi.fn();
+  const hook = renderHook(() =>
+    useBranchMismatchDialog({
+      taskId: "task-1",
+      repoPath: "/repo",
+      onSendPrompt,
+    }),
+  );
+  return { ...hook, onSendPrompt };
+}
+
+describe("useBranchMismatchDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedMutationOptions = {};
+    mockShouldWarn = false;
+  });
+
+  describe("handleBeforeSubmit", () => {
+    it("returns true when shouldWarn is false", () => {
+      const { result } = renderDialog({ shouldWarn: false });
+      const clearEditor = vi.fn();
+
+      const allowed = result.current.handleBeforeSubmit("hello", clearEditor);
+
+      expect(allowed).toBe(true);
+      expect(result.current.dialogProps?.open).toBeFalsy();
+    });
+
+    it("returns false and opens dialog when shouldWarn is true", () => {
+      const { result } = renderDialog({ shouldWarn: true });
+      const clearEditor = vi.fn();
+
+      let allowed: boolean;
+      act(() => {
+        allowed = result.current.handleBeforeSubmit("hello", clearEditor);
+      });
+
+      expect(allowed!).toBe(false);
+      expect(result.current.dialogProps?.open).toBe(true);
+      expect(clearEditor).not.toHaveBeenCalled();
+      expect(mockTrack).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.BRANCH_MISMATCH_WARNING_SHOWN,
+        {
+          task_id: "task-1",
+          linked_branch: "feat/foo",
+          current_branch: "main",
+          has_uncommitted_changes: false,
+        },
+      );
+    });
+  });
+
+  describe("handleContinue", () => {
+    it("sends the pending message and clears editor", () => {
+      const { result, onSendPrompt } = renderDialog({ shouldWarn: true });
+      const clearEditor = vi.fn();
+
+      act(() => {
+        result.current.handleBeforeSubmit("hello", clearEditor);
+      });
+
+      mockTrack.mockClear();
+      act(() => {
+        result.current.dialogProps?.onContinue();
+      });
+
+      expect(onSendPrompt).toHaveBeenCalledWith("hello");
+      expect(clearEditor).toHaveBeenCalled();
+      expect(mockDismissWarning).toHaveBeenCalled();
+      expect(result.current.dialogProps?.open).toBe(false);
+      expect(mockTrack).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.BRANCH_MISMATCH_ACTION,
+        {
+          task_id: "task-1",
+          action: "continue",
+          linked_branch: "feat/foo",
+          current_branch: "main",
+        },
+      );
+    });
+  });
+
+  describe("handleCancel", () => {
+    it("clears state without sending or clearing editor", () => {
+      const { result, onSendPrompt } = renderDialog({ shouldWarn: true });
+      const clearEditor = vi.fn();
+
+      act(() => {
+        result.current.handleBeforeSubmit("hello", clearEditor);
+      });
+      expect(result.current.dialogProps?.open).toBe(true);
+
+      mockTrack.mockClear();
+      act(() => {
+        result.current.dialogProps?.onCancel();
+      });
+
+      expect(onSendPrompt).not.toHaveBeenCalled();
+      expect(clearEditor).not.toHaveBeenCalled();
+      expect(result.current.dialogProps?.open).toBe(false);
+      expect(mockTrack).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.BRANCH_MISMATCH_ACTION,
+        {
+          task_id: "task-1",
+          action: "cancel",
+          linked_branch: "feat/foo",
+          current_branch: "main",
+        },
+      );
+    });
+  });
+
+  describe("handleSwitch", () => {
+    it("calls checkoutBranch mutation and tracks switch action", () => {
+      const { result } = renderDialog({ shouldWarn: true });
+      const clearEditor = vi.fn();
+
+      act(() => {
+        result.current.handleBeforeSubmit("hello", clearEditor);
+      });
+
+      mockTrack.mockClear();
+      act(() => {
+        result.current.dialogProps?.onSwitch();
+      });
+
+      expect(mockMutate).toHaveBeenCalledWith({
+        directoryPath: "/repo",
+        branchName: "feat/foo",
+      });
+      expect(mockTrack).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.BRANCH_MISMATCH_ACTION,
+        {
+          task_id: "task-1",
+          action: "switch",
+          linked_branch: "feat/foo",
+          current_branch: "main",
+        },
+      );
+    });
+
+    it("on success: sends pending message and clears editor", () => {
+      const { result, onSendPrompt } = renderDialog({ shouldWarn: true });
+      const clearEditor = vi.fn();
+
+      act(() => {
+        result.current.handleBeforeSubmit("hello", clearEditor);
+      });
+
+      act(() => {
+        result.current.dialogProps?.onSwitch();
+      });
+
+      // Simulate mutation success
+      act(() => {
+        capturedMutationOptions.onSuccess?.();
+      });
+
+      expect(onSendPrompt).toHaveBeenCalledWith("hello");
+      expect(clearEditor).toHaveBeenCalled();
+      expect(mockDismissWarning).toHaveBeenCalled();
+    });
+
+    it("on error: shows error without sending message", () => {
+      const { result, onSendPrompt } = renderDialog({ shouldWarn: true });
+      const clearEditor = vi.fn();
+
+      act(() => {
+        result.current.handleBeforeSubmit("hello", clearEditor);
+      });
+
+      act(() => {
+        result.current.dialogProps?.onSwitch();
+      });
+
+      act(() => {
+        capturedMutationOptions.onError?.(new Error("dirty worktree"));
+      });
+
+      expect(onSendPrompt).not.toHaveBeenCalled();
+      expect(clearEditor).not.toHaveBeenCalled();
+      expect(result.current.dialogProps?.switchError).toBe("dirty worktree");
+    });
+  });
+
+  describe("dialogProps", () => {
+    it("is null when no linked branch", () => {
+      mockGuard.useBranchMismatchGuard.mockReturnValue({
+        shouldWarn: false,
+        linkedBranch: null,
+        currentBranch: "main",
+        dismissWarning: mockDismissWarning,
+      });
+
+      const { result } = renderHook(() =>
+        useBranchMismatchDialog({
+          taskId: "task-1",
+          repoPath: "/repo",
+          onSendPrompt: vi.fn(),
+        }),
+      );
+
+      expect(result.current.dialogProps).toBeNull();
+    });
+  });
+});

--- a/apps/code/src/renderer/features/workspace/hooks/useBranchMismatchDialog.ts
+++ b/apps/code/src/renderer/features/workspace/hooks/useBranchMismatchDialog.ts
@@ -1,0 +1,150 @@
+import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
+import { invalidateGitBranchQueries } from "@features/git-interaction/utils/gitCacheKeys";
+import { useBranchMismatchGuard } from "@features/workspace/hooks/useBranchMismatch";
+import { useTRPC } from "@renderer/trpc/client";
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
+import { useMutation } from "@tanstack/react-query";
+import { track } from "@utils/analytics";
+import { logger } from "@utils/logger";
+import { useCallback, useRef, useState } from "react";
+
+const log = logger.scope("branch-mismatch");
+
+interface UseBranchMismatchDialogOptions {
+  taskId: string;
+  repoPath: string | null;
+  onSendPrompt: (text: string) => void;
+}
+
+export function useBranchMismatchDialog({
+  taskId,
+  repoPath,
+  onSendPrompt,
+}: UseBranchMismatchDialogOptions) {
+  const { shouldWarn, linkedBranch, currentBranch, dismissWarning } =
+    useBranchMismatchGuard(taskId);
+
+  // State drives dialog visibility (`open`), refs avoid stale closures in
+  // mutation callbacks (onSuccess / handleContinue) that capture at mount time.
+  const [pendingMessage, setPendingMessage] = useState<string | null>(null);
+  const pendingMessageRef = useRef<string | null>(null);
+  const pendingClearRef = useRef<(() => void) | null>(null);
+  const onSendPromptRef = useRef(onSendPrompt);
+  onSendPromptRef.current = onSendPrompt;
+  const [switchError, setSwitchError] = useState<string | null>(null);
+
+  const { hasChanges: hasUncommittedChanges } = useGitQueries(
+    repoPath ?? undefined,
+  );
+
+  const trpc = useTRPC();
+  const { mutate: checkoutBranch, isPending: isSwitching } = useMutation(
+    trpc.git.checkoutBranch.mutationOptions({
+      onSuccess: () => {
+        if (repoPath) invalidateGitBranchQueries(repoPath);
+        dismissWarning();
+        pendingClearRef.current?.();
+        pendingClearRef.current = null;
+        const message = pendingMessageRef.current;
+        if (message) onSendPromptRef.current(message);
+        setPendingMessage(null);
+        pendingMessageRef.current = null;
+      },
+      onError: (error) => {
+        log.error("Failed to switch branch", error);
+        setSwitchError(
+          error instanceof Error ? error.message : "Failed to switch branch",
+        );
+      },
+    }),
+  );
+
+  const handleBeforeSubmit = useCallback(
+    (text: string, clearEditor: () => void): boolean => {
+      if (shouldWarn) {
+        setPendingMessage(text);
+        pendingMessageRef.current = text;
+        pendingClearRef.current = clearEditor;
+        if (linkedBranch && currentBranch) {
+          track(ANALYTICS_EVENTS.BRANCH_MISMATCH_WARNING_SHOWN, {
+            task_id: taskId,
+            linked_branch: linkedBranch,
+            current_branch: currentBranch,
+            has_uncommitted_changes: hasUncommittedChanges,
+          });
+        }
+        return false;
+      }
+      return true;
+    },
+    [shouldWarn, taskId, linkedBranch, currentBranch, hasUncommittedChanges],
+  );
+
+  const handleSwitch = useCallback(() => {
+    if (!linkedBranch || !repoPath) return;
+    setSwitchError(null);
+    if (currentBranch) {
+      track(ANALYTICS_EVENTS.BRANCH_MISMATCH_ACTION, {
+        task_id: taskId,
+        action: "switch",
+        linked_branch: linkedBranch,
+        current_branch: currentBranch,
+      });
+    }
+    checkoutBranch({
+      directoryPath: repoPath,
+      branchName: linkedBranch,
+    });
+  }, [linkedBranch, currentBranch, repoPath, taskId, checkoutBranch]);
+
+  const handleContinue = useCallback(() => {
+    if (linkedBranch && currentBranch) {
+      track(ANALYTICS_EVENTS.BRANCH_MISMATCH_ACTION, {
+        task_id: taskId,
+        action: "continue",
+        linked_branch: linkedBranch,
+        current_branch: currentBranch,
+      });
+    }
+    dismissWarning();
+    pendingClearRef.current?.();
+    pendingClearRef.current = null;
+    const message = pendingMessageRef.current;
+    if (message) onSendPromptRef.current(message);
+    setPendingMessage(null);
+    pendingMessageRef.current = null;
+    setSwitchError(null);
+  }, [dismissWarning, taskId, linkedBranch, currentBranch]);
+
+  const handleCancel = useCallback(() => {
+    if (linkedBranch && currentBranch) {
+      track(ANALYTICS_EVENTS.BRANCH_MISMATCH_ACTION, {
+        task_id: taskId,
+        action: "cancel",
+        linked_branch: linkedBranch,
+        current_branch: currentBranch,
+      });
+    }
+    setPendingMessage(null);
+    pendingMessageRef.current = null;
+    pendingClearRef.current = null;
+    setSwitchError(null);
+  }, [taskId, linkedBranch, currentBranch]);
+
+  const dialogProps =
+    linkedBranch && currentBranch
+      ? {
+          open: pendingMessage !== null,
+          linkedBranch,
+          currentBranch,
+          hasUncommittedChanges,
+          switchError,
+          onSwitch: handleSwitch,
+          onContinue: handleContinue,
+          onCancel: handleCancel,
+          isSwitching,
+        }
+      : null;
+
+  return { handleBeforeSubmit, dialogProps };
+}

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -198,6 +198,23 @@ export interface SessionConfigChangedProperties {
   to_value: string;
 }
 
+// Branch mismatch events
+type BranchMismatchAction = "switch" | "continue" | "cancel";
+
+export interface BranchMismatchWarningShownProperties {
+  task_id: string;
+  linked_branch: string;
+  current_branch: string;
+  has_uncommitted_changes: boolean;
+}
+
+export interface BranchMismatchActionProperties {
+  task_id: string;
+  action: BranchMismatchAction;
+  linked_branch: string;
+  current_branch: string;
+}
+
 // Feedback events
 export interface TaskFeedbackProperties {
   task_id: string;
@@ -266,6 +283,10 @@ export const ANALYTICS_EVENTS = {
   // Feedback events
   TASK_FEEDBACK: "Task feedback",
 
+  // Branch mismatch events
+  BRANCH_MISMATCH_WARNING_SHOWN: "Branch mismatch warning shown",
+  BRANCH_MISMATCH_ACTION: "Branch mismatch action",
+
   // Error events
   TASK_CREATION_FAILED: "Task creation failed",
   AGENT_SESSION_ERROR: "Agent session error",
@@ -321,6 +342,10 @@ export type EventPropertyMap = {
 
   // Feedback events
   [ANALYTICS_EVENTS.TASK_FEEDBACK]: TaskFeedbackProperties;
+
+  // Branch mismatch events
+  [ANALYTICS_EVENTS.BRANCH_MISMATCH_WARNING_SHOWN]: BranchMismatchWarningShownProperties;
+  [ANALYTICS_EVENTS.BRANCH_MISMATCH_ACTION]: BranchMismatchActionProperties;
 
   // Error events
   [ANALYTICS_EVENTS.TASK_CREATION_FAILED]: TaskCreationFailedProperties;


### PR DESCRIPTION
## Problem

we want task isolation, but we can only do so much with local tasks, since they are simply not in an isolated environment

downstack #1594 + #1595 add automatic branch linking to tasks, so when an agent touches a file, or an agent/human creates a branch from posthog code, we associate that branch to that task

now, we need a way to keep the user in the loop on what's happening, and steer them in the right direction

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds a UI warning if you send a prompt in a task that has a linked branch, but that branch is not currently checked out

details:

- hooks into tiptap with a new `onBeforeSend`so prompt is never lost if you cancel
- the warning is "blocking" in the sense that you have to make a decision. you can:
    - "continue anyway" -> ignore the warning, agent works in your current branch
        - automatic branch linking will still occur and maybe overwrite the current link, per the standard rules (see #1595 )
    - "switch branch" - checks out the task's linked branch
        - warns if there are uncommitted changes on current branch. this does not block, and surfaces errors from the switch (if any) in the dialog

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->