### PR TITLE
fix: hide data queried dropdown when empty

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
@@ -570,7 +570,7 @@ function CodePathsCollapsible({ paths }: { paths: string[] }) {
 function DataQueriedCollapsible({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false);
 
-  if (!text) return null;
+  if (!text.trim()) return null;
 
   return (
     <Box mt="2" style={{ borderTop: "1px solid var(--gray-5)" }} pt="2">


### PR DESCRIPTION
## Problem

Fixes #1574

The "Data queried" collapsible button shows up even when there is no data queried, because whitespace-only or empty strings pass the falsy check.

## Solution

Changed `if (!text) return null` to `if (!text.trim()) return null` in `DataQueriedCollapsible`. This hides the dropdown when the content is empty, whitespace-only, or undefined.

## Files Changed

- `apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx` — 1 line changed