### PR TITLE
feat: Replace task item icons with clearer state indicators

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/items/TaskItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/TaskItem.tsx
@@ -3,16 +3,14 @@ import { Tooltip } from "@components/ui/Tooltip";
 import type { WorkspaceMode } from "@main/services/workspace/schemas";
 import {
   Archive,
-  ArrowsClockwise,
-  ArrowsSplit,
-  BellRinging,
+  ChatCircle,
+  Circle,
   Cloud as CloudIcon,
-  Laptop as LaptopIcon,
+  HandPalm,
   Pause,
   PushPin,
 } from "@phosphor-icons/react";
 import { isTerminalStatus, type TaskRunStatus } from "@shared/types";
-import { selectIsFocusedOnWorktree, useFocusStore } from "@stores/focusStore";
 import { formatRelativeTimeShort } from "@utils/time";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SidebarItem } from "../SidebarItem";
@@ -156,7 +154,6 @@ export function TaskItem({
   label,
   isActive,
   workspaceMode,
-  worktreePath,
   isSuspended = false,
   isGenerating,
   isUnread,
@@ -173,62 +170,35 @@ export function TaskItem({
   onEditSubmit,
   onEditCancel,
 }: TaskItemProps) {
-  const isFocused = useFocusStore(
-    selectIsFocusedOnWorktree(worktreePath ?? ""),
-  );
-
-  const isWorktreeTask = workspaceMode === "worktree";
   const isCloudTask = workspaceMode === "cloud";
-
   const isTerminalCloud = isCloudTask && isTerminalStatus(taskRunStatus);
 
-  const icon = isSuspended ? (
-    <Tooltip content="Suspended" side="right">
+  const icon = needsPermission ? (
+    <Tooltip content="Needs permission" side="right">
       <span className="flex items-center justify-center">
-        <Pause size={ICON_SIZE} className="text-gray-9" />
+        <HandPalm size={ICON_SIZE} className="text-blue-11" />
       </span>
     </Tooltip>
-  ) : needsPermission ? (
-    <BellRinging size={ICON_SIZE} className="text-blue-11" />
   ) : isTerminalCloud ? (
     <CloudStatusIcon taskRunStatus={taskRunStatus} />
   ) : isGenerating ? (
     <DotsCircleSpinner size={ICON_SIZE} className="text-accent-11" />
   ) : isCloudTask ? (
     <CloudStatusIcon taskRunStatus={taskRunStatus} />
+  ) : isSuspended ? (
+    <Tooltip content="Suspended" side="right">
+      <span className="flex items-center justify-center">
+        <Pause size={ICON_SIZE} className="text-gray-9" />
+      </span>
+    </Tooltip>
   ) : isUnread ? (
-    <span className="flex items-center justify-center text-[8px] text-green-11">
-      ■
+    <span className="flex items-center justify-center">
+      <Circle size={8} weight="fill" className="text-green-11" />
     </span>
   ) : isPinned ? (
     <PushPin size={ICON_SIZE} className="text-accent-11" />
-  ) : isWorktreeTask ? (
-    isFocused ? (
-      <Tooltip content="Worktree (syncing)" side="right">
-        <span className="flex items-center justify-center">
-          <ArrowsClockwise
-            size={ICON_SIZE}
-            weight="duotone"
-            className="animate-sync-rotate text-blue-11"
-          />
-        </span>
-      </Tooltip>
-    ) : (
-      <Tooltip content="Worktree" side="right">
-        <span className="flex items-center justify-center">
-          <ArrowsSplit
-            size={ICON_SIZE}
-            style={{ transform: "rotate(270deg)" }}
-          />
-        </span>
-      </Tooltip>
-    )
   ) : (
-    <Tooltip content="Local" side="right">
-      <span className="flex items-center justify-center">
-        <LaptopIcon size={ICON_SIZE} />
-      </span>
-    </Tooltip>
+    <ChatCircle size={ICON_SIZE} className="text-gray-10" />
   );
 
   const timestampNode = timestamp ? (


### PR DESCRIPTION
## Problem

The sidebar task icons conflated workspace mode (local/worktree) with task state, and the ArrowsSplit worktree icon read as a share icon at small sizes.

![CleanShot 2026-04-13 at 00.44.02@2x.png](https://app.graphite.com/user-attachments/assets/f0ba7550-b68b-40cb-872c-098b7389b2f9.png)

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Replace BellRinging with HandPalm for permission-needed state
2. Replace Laptop/ArrowsSplit default icons with ChatCircle
3. Replace unread ■ square with filled Circle dot
4. Promote needsPermission to highest priority in the icon chain
5. Remove worktree-specific icons and useFocusStore dependency

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->