### PR TITLE
chore(onboarding): signals step papercut

### DIFF
--- a/apps/code/src/renderer/features/onboarding/components/SignalsStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/SignalsStep.tsx
@@ -68,7 +68,7 @@ export function SignalsStep({ onNext, onBack }: SignalsStepProps) {
 
         <Flex
           direction="column"
-          justify="center"
+          mt="4"
           style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
         >
           <Flex direction="column" gap="6">


### PR DESCRIPTION
## Problem

papercut: the "Enable Inbox" title and description on the onboarding signals step were clipped and unreachable + scrollbar didn't show them

## Changes

inner context flex used `justify="center"` to vertically center content. `justify-content: center` + `overflow: auto`
makes top-overflow inaccessible

removed `justify="center"` and added `mt="4"` to preserve the spacing between the logo and content

_before:_

https://github.com/user-attachments/assets/f34af347-159e-4dea-ac57-aed74ae1a17e

_after:_

https://github.com/user-attachments/assets/20550758-2c72-48eb-bb87-9e1820d95658

## How did you test this?

ran the app locally, reset onboarding state from local storage,  navigated to the signals step, and resized the window to a to confirm the title and description are fully visible in both views
