### PR TITLE
fix: Several small issues reported by Cory

### DIFF
--- a/apps/code/scripts/patch-electron-name.sh
+++ b/apps/code/scripts/patch-electron-name.sh
@@ -10,10 +10,10 @@ if [ ! -f "$PLIST_FILE" ]; then
   exit 0
 fi
 
-if /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$PLIST_FILE" | grep -q "Array (Development)"; then
+if /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$PLIST_FILE" | grep -q "PostHog Code (Development)"; then
   exit 0
 fi
 
-/usr/libexec/PlistBuddy -c "Set :CFBundleName 'Array (Development)'" "$PLIST_FILE"
-/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName 'Array (Development)'" "$PLIST_FILE"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName 'PostHog Code (Development)'" "$PLIST_FILE"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName 'PostHog Code (Development)'" "$PLIST_FILE"
 /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier 'com.posthog.array.dev'" "$PLIST_FILE"

--- a/apps/code/src/renderer/features/auth/hooks/authMutations.ts
+++ b/apps/code/src/renderer/features/auth/hooks/authMutations.ts
@@ -76,13 +76,13 @@ export function useLogoutMutation() {
 
       track(ANALYTICS_EVENTS.USER_LOGGED_OUT);
       resetSessionService();
-      clearAuthScopedQueries();
 
       const state = await trpcClient.auth.logout.mutate();
       return { state, previousState };
     },
     onSuccess: async ({ previousState }) => {
       await refreshAuthStateQuery();
+      clearAuthScopedQueries();
       useAuthUiStateStore.getState().setStaleRegion(previousState.cloudRegion);
       useNavigationStore.getState().navigateToTaskInput();
       useOnboardingStore.getState().resetSelections();

--- a/apps/code/src/renderer/features/command-center/hooks/useCommandCenterData.ts
+++ b/apps/code/src/renderer/features/command-center/hooks/useCommandCenterData.ts
@@ -87,7 +87,7 @@ export function useCommandCenterData(): {
   }, [storeCells, taskMap, sessionByTaskId]);
 
   const summary = useMemo(() => {
-    const populated = cells.filter((c) => c.taskId);
+    const populated = cells.filter((c) => c.taskId && c.task);
     return {
       total: populated.length,
       running: populated.filter((c) => c.status === "running").length,

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -63,9 +63,14 @@ function SidebarMenuComponent() {
     (r) => r.status === "ready",
   ).length;
 
+  const taskMap = new Map<string, Task>();
+  for (const task of allTasks) {
+    taskMap.set(task.id, task);
+  }
+
   const commandCenterCells = useCommandCenterStore((s) => s.cells);
   const commandCenterActiveCount = commandCenterCells.filter(
-    (taskId) => taskId != null,
+    (taskId) => taskId != null && taskMap.has(taskId),
   ).length;
 
   const previousTaskIdRef = useRef<string | null>(null);
@@ -87,11 +92,6 @@ function SidebarMenuComponent() {
 
     previousTaskIdRef.current = currentTaskId;
   }, [view, markAsViewed]);
-
-  const taskMap = new Map<string, Task>();
-  for (const task of allTasks) {
-    taskMap.set(task.id, task);
-  }
 
   const handleNewTaskClick = () => {
     navigateToTaskInput();


### PR DESCRIPTION
## Problem

Several small issues reported by Cory: command center counts empty windows, logout triggers an error boundary and dev plist still references "Array."

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Exclude cells with no task from command center window count
2. Move clearAuthScopedQueries to onSuccess so it runs after auth state refreshes
3. Rename "Array (Development)" to "PostHog Code (Development)" in plist patch script
4. Hoist taskMap above its first usage in SidebarMenu

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->