### PR TITLE
feat(inbox): Show when replay analysis is in progress

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -53,6 +53,7 @@ export interface SignalSourceConfig {
   config: Record<string, unknown>;
   created_at: string;
   updated_at: string;
+  status: "running" | "completed" | "failed" | null;
 }
 
 export interface ExternalDataSourceSchema {

--- a/apps/code/src/renderer/features/inbox/components/SignalSourceToggles.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalSourceToggles.tsx
@@ -2,6 +2,7 @@ import {
   ArrowSquareOutIcon,
   BrainIcon,
   BugIcon,
+  CircleNotchIcon,
   GithubLogoIcon,
   KanbanIcon,
   TicketIcon,
@@ -16,7 +17,10 @@ import {
   Switch,
   Text,
 } from "@radix-ui/themes";
-import type { Evaluation } from "@renderer/api/posthogClient";
+import type {
+  Evaluation,
+  SignalSourceConfig,
+} from "@renderer/api/posthogClient";
 import { memo, useCallback } from "react";
 
 export interface SignalSourceValues {
@@ -37,6 +41,7 @@ interface SignalSourceToggleCardProps {
   requiresSetup?: boolean;
   onSetup?: () => void;
   loading?: boolean;
+  statusSection?: React.ReactNode;
 }
 
 const SignalSourceToggleCard = memo(function SignalSourceToggleCard({
@@ -49,6 +54,7 @@ const SignalSourceToggleCard = memo(function SignalSourceToggleCard({
   requiresSetup,
   onSetup,
   loading,
+  statusSection,
 }: SignalSourceToggleCardProps) {
   return (
     <Box
@@ -101,6 +107,7 @@ const SignalSourceToggleCard = memo(function SignalSourceToggleCard({
           />
         )}
       </Flex>
+      {statusSection && <Box style={{ marginLeft: 32 }}>{statusSection}</Box>}
     </Box>
   );
 });
@@ -210,6 +217,30 @@ export const EvaluationsSection = memo(function EvaluationsSection({
   );
 });
 
+function SourceRunningIndicator({
+  status,
+  message,
+}: {
+  status: SignalSourceConfig["status"];
+  message: string;
+}) {
+  if (status !== "running") {
+    return null;
+  }
+  return (
+    <Flex align="center" gap="2" mt="2">
+      <CircleNotchIcon
+        size={14}
+        className="animate-spin"
+        style={{ color: "var(--accent-11)" }}
+      />
+      <Text size="1" style={{ color: "var(--accent-11)" }}>
+        {message}
+      </Text>
+    </Flex>
+  );
+}
+
 interface SignalSourceTogglesProps {
   value: SignalSourceValues;
   onToggle: (source: keyof SignalSourceValues, enabled: boolean) => void;
@@ -220,6 +251,7 @@ interface SignalSourceTogglesProps {
       { requiresSetup: boolean; loading: boolean }
     >
   >;
+  sessionAnalysisStatus?: SignalSourceConfig["status"];
   onSetup?: (source: keyof SignalSourceValues) => void;
   evaluations?: Evaluation[];
   evaluationsUrl?: string;
@@ -231,6 +263,7 @@ export function SignalSourceToggles({
   onToggle,
   disabled,
   sourceStates,
+  sessionAnalysisStatus,
   onSetup,
   evaluations,
   evaluationsUrl,
@@ -269,6 +302,14 @@ export function SignalSourceToggles({
         checked={value.session_replay}
         onCheckedChange={toggleSessionReplay}
         disabled={disabled}
+        statusSection={
+          value.session_replay ? (
+            <SourceRunningIndicator
+              status={sessionAnalysisStatus ?? null}
+              message="Session analysis run in progress now…"
+            />
+          ) : undefined
+        }
       />
       <SignalSourceToggleCard
         icon={<BugIcon size={20} />}

--- a/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
@@ -130,6 +130,15 @@ export function useSignalSourceManager() {
     [configs],
   );
 
+  const sessionAnalysisStatus = useMemo(() => {
+    const config = configs?.find(
+      (c) =>
+        c.source_product === "session_replay" &&
+        c.source_type === "session_analysis_cluster",
+    );
+    return config?.status ?? null;
+  }, [configs]);
+
   // Merge: optimistic overrides take precedence over server values.
   const displayValues = useMemo<SignalSourceValues>(() => {
     if (Object.keys(optimistic).length === 0) return serverValues;
@@ -396,6 +405,7 @@ export function useSignalSourceManager() {
   return {
     displayValues,
     sourceStates,
+    sessionAnalysisStatus,
     setupSource,
     isLoading,
     handleToggle,

--- a/apps/code/src/renderer/features/settings/components/sections/SignalSourcesSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SignalSourcesSettings.tsx
@@ -7,6 +7,7 @@ export function SignalSourcesSettings() {
   const {
     displayValues,
     sourceStates,
+    sessionAnalysisStatus,
     setupSource,
     isLoading,
     handleToggle,
@@ -44,6 +45,7 @@ export function SignalSourcesSettings() {
           value={displayValues}
           onToggle={(source, enabled) => void handleToggle(source, enabled)}
           sourceStates={sourceStates}
+          sessionAnalysisStatus={sessionAnalysisStatus}
           onSetup={handleSetup}
           evaluations={evaluations}
           evaluationsUrl={evaluationsUrl}


### PR DESCRIPTION
## Problem

It wasn't possible to see when a round of replay analysis is happening in signal source config, which is especially good feedback right after enabling the Session Replay source. We already had this in the Cloud inbox, but haven't hooked up here. Now that we're back onto Session Replay, it's time to get the info in.

## Changes

Source config status is now hooked up for Session Replay:

<img width="976" height="294" alt="CleanShot 2026-04-13 at 17 29 45@2x" src="https://github.com/user-attachments/assets/c55e570d-a8bb-4275-9f66-85be1f0454e5" />

Feels like we should also have it for Error Tracking, but that works a little differently from Session Replay background analysis, needs to be connected to `SignalSourceConfig.status`. @oliverb123