### PR TITLE
feat: Add bulk archive and clean up task context menu

### DIFF
--- a/apps/code/src/main/services/context-menu/schemas.ts
+++ b/apps/code/src/main/services/context-menu/schemas.ts
@@ -3,7 +3,9 @@ import { z } from "zod";
 export const taskContextMenuInput = z.object({
   taskTitle: z.string(),
   worktreePath: z.string().optional(),
+  folderPath: z.string().optional(),
   isPinned: z.boolean().optional(),
+  isSuspended: z.boolean().optional(),
 });
 
 export const archivedTaskContextMenuInput = z.object({

--- a/apps/code/src/main/services/context-menu/schemas.ts
+++ b/apps/code/src/main/services/context-menu/schemas.ts
@@ -36,6 +36,7 @@ const taskAction = z.discriminatedUnion("type", [
   z.object({ type: z.literal("copy-task-id") }),
   z.object({ type: z.literal("suspend") }),
   z.object({ type: z.literal("archive") }),
+  z.object({ type: z.literal("archive-prior") }),
   z.object({ type: z.literal("delete") }),
   z.object({ type: z.literal("external-app"), action: externalAppAction }),
 ]);

--- a/apps/code/src/main/services/context-menu/service.ts
+++ b/apps/code/src/main/services/context-menu/service.ts
@@ -108,13 +108,18 @@ export class ContextMenuService {
     const { apps, lastUsedAppId } = await this.getExternalAppsData();
 
     return this.showMenu<TaskAction>([
-      this.item("Rename", { type: "rename" }),
       this.item(isPinned ? "Unpin" : "Pin", { type: "pin" }),
+      this.item("Rename", { type: "rename" }),
       this.item("Copy Task ID", { type: "copy-task-id" }),
-      this.separator(),
       ...(worktreePath
-        ? [this.item("Suspend", { type: "suspend" as const })]
+        ? [
+            this.separator(),
+            this.item("Suspend", { type: "suspend" as const }),
+            ...this.externalAppItems<TaskAction>(apps, lastUsedAppId),
+          ]
         : []),
+      this.separator(),
+      this.item("Delete", { type: "delete" }),
       this.item("Archive", { type: "archive" }),
       this.item(
         "Archive prior tasks",
@@ -129,13 +134,6 @@ export class ContextMenuService {
           },
         },
       ),
-      this.item("Delete", { type: "delete" }),
-      ...(worktreePath
-        ? [
-            this.separator(),
-            ...this.externalAppItems<TaskAction>(apps, lastUsedAppId),
-          ]
-        : []),
     ]);
   }
 

--- a/apps/code/src/main/services/context-menu/service.ts
+++ b/apps/code/src/main/services/context-menu/service.ts
@@ -104,8 +104,9 @@ export class ContextMenuService {
   async showTaskContextMenu(
     input: TaskContextMenuInput,
   ): Promise<TaskContextMenuResult> {
-    const { worktreePath, isPinned } = input;
+    const { worktreePath, folderPath, isPinned, isSuspended } = input;
     const { apps, lastUsedAppId } = await this.getExternalAppsData();
+    const hasPath = worktreePath || folderPath;
 
     return this.showMenu<TaskAction>([
       this.item(isPinned ? "Unpin" : "Pin", { type: "pin" }),
@@ -114,7 +115,14 @@ export class ContextMenuService {
       ...(worktreePath
         ? [
             this.separator(),
-            this.item("Suspend", { type: "suspend" as const }),
+            this.item(isSuspended ? "Unsuspend" : "Suspend", {
+              type: "suspend" as const,
+            }),
+          ]
+        : []),
+      ...(hasPath
+        ? [
+            ...(worktreePath ? [] : [this.separator()]),
             ...this.externalAppItems<TaskAction>(apps, lastUsedAppId),
           ]
         : []),

--- a/apps/code/src/main/services/context-menu/service.ts
+++ b/apps/code/src/main/services/context-menu/service.ts
@@ -116,6 +116,19 @@ export class ContextMenuService {
         ? [this.item("Suspend", { type: "suspend" as const })]
         : []),
       this.item("Archive", { type: "archive" }),
+      this.item(
+        "Archive prior tasks",
+        { type: "archive-prior" },
+        {
+          confirm: {
+            title: "Archive Prior Tasks",
+            message: "Archive all tasks older than this one?",
+            detail:
+              "This will archive every task created before this one. You can unarchive them later.",
+            confirmLabel: "Archive",
+          },
+        },
+      ),
       this.item("Delete", { type: "delete" }),
       ...(worktreePath
         ? [

--- a/apps/code/src/main/services/context-menu/service.ts
+++ b/apps/code/src/main/services/context-menu/service.ts
@@ -127,7 +127,6 @@ export class ContextMenuService {
           ]
         : []),
       this.separator(),
-      this.item("Delete", { type: "delete" }),
       this.item("Archive", { type: "archive" }),
       this.item(
         "Archive prior tasks",

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -120,6 +120,11 @@ function SidebarMenuComponent() {
     }
   };
 
+  const allSidebarTasks = [
+    ...sidebarData.pinnedTasks,
+    ...sidebarData.flatTasks,
+  ];
+
   const handleTaskContextMenu = (
     taskId: string,
     e: React.MouseEvent,
@@ -128,10 +133,12 @@ function SidebarMenuComponent() {
     const task = taskMap.get(taskId);
     if (task) {
       const workspace = workspaces[taskId];
-      const effectivePath = workspace?.worktreePath ?? workspace?.folderPath;
+      const taskData = allSidebarTasks.find((t) => t.id === taskId);
       showContextMenu(task, e, {
-        worktreePath: effectivePath ?? undefined,
+        worktreePath: workspace?.worktreePath ?? undefined,
+        folderPath: workspace?.folderPath ?? undefined,
         isPinned,
+        isSuspended: taskData?.isSuspended,
         onTogglePin: () => togglePin(taskId),
         onArchivePrior: handleArchivePrior,
       });

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -6,7 +6,10 @@ import {
   INBOX_REFETCH_INTERVAL_MS,
 } from "@features/inbox/utils/inboxConstants";
 import { getSessionService } from "@features/sessions/service/service";
-import { useArchiveTask } from "@features/tasks/hooks/useArchiveTask";
+import {
+  archiveTaskImperative,
+  useArchiveTask,
+} from "@features/tasks/hooks/useArchiveTask";
 import { useTasks, useUpdateTask } from "@features/tasks/hooks/useTasks";
 import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import { useTaskContextMenu } from "@hooks/useTaskContextMenu";
@@ -16,6 +19,7 @@ import { useNavigationStore } from "@stores/navigationStore";
 import { useRendererWindowFocusStore } from "@stores/rendererWindowFocusStore";
 import { useQueryClient } from "@tanstack/react-query";
 import { logger } from "@utils/logger";
+import { toast } from "@utils/toast";
 import { memo, useCallback, useEffect, useRef } from "react";
 import { usePinnedTasks } from "../hooks/usePinnedTasks";
 import { useSidebarData } from "../hooks/useSidebarData";
@@ -129,6 +133,7 @@ function SidebarMenuComponent() {
         worktreePath: effectivePath ?? undefined,
         isPinned,
         onTogglePin: () => togglePin(taskId),
+        onArchivePrior: handleArchivePrior,
       });
     }
   };
@@ -139,6 +144,55 @@ function SidebarMenuComponent() {
 
   const updateTask = useUpdateTask();
   const queryClient = useQueryClient();
+
+  const handleArchivePrior = useCallback(
+    async (taskId: string) => {
+      const allVisible = [...sidebarData.pinnedTasks, ...sidebarData.flatTasks];
+      const clickedTask = allVisible.find((t) => t.id === taskId);
+      if (!clickedTask) return;
+
+      const sortKey = "createdAt" as const;
+      const threshold = clickedTask[sortKey];
+      const priorTaskIds = allVisible
+        .filter((t) => t.id !== taskId && t[sortKey] < threshold)
+        .map((t) => t.id);
+
+      if (priorTaskIds.length === 0) {
+        toast.info("No older tasks to archive");
+        return;
+      }
+
+      const nav = useNavigationStore.getState();
+      const priorSet = new Set(priorTaskIds);
+      if (
+        nav.view.type === "task-detail" &&
+        nav.view.data &&
+        priorSet.has(nav.view.data.id)
+      ) {
+        nav.navigateToTaskInput();
+      }
+
+      let done = 0;
+      let failed = 0;
+      for (const id of priorTaskIds) {
+        try {
+          await archiveTaskImperative(id, queryClient, {
+            skipNavigate: true,
+          });
+          done++;
+        } catch {
+          failed++;
+        }
+      }
+
+      if (failed === 0) {
+        toast.success(`${done} ${done === 1 ? "task" : "tasks"} archived`);
+      } else {
+        toast.error(`${done} archived, ${failed} failed`);
+      }
+    },
+    [sidebarData.pinnedTasks, sidebarData.flatTasks, queryClient],
+  );
   const log = logger.scope("sidebar-menu");
 
   const handleTaskDoubleClick = useCallback(

--- a/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
+++ b/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
@@ -7,90 +7,97 @@ import { trpc, trpcClient } from "@renderer/trpc";
 import type { ArchivedTask } from "@shared/types/archive";
 import { useFocusStore } from "@stores/focusStore";
 import { useNavigationStore } from "@stores/navigationStore";
-import { useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { logger } from "@utils/logger";
 import { toast } from "@utils/toast";
 
 const log = logger.scope("archive-task");
 
-interface ArchiveTaskInput {
-  taskId: string;
+interface ArchiveTaskOptions {
+  skipNavigate?: boolean;
+}
+
+export async function archiveTaskImperative(
+  taskId: string,
+  queryClient: QueryClient,
+  options?: ArchiveTaskOptions,
+): Promise<void> {
+  const focusStore = useFocusStore.getState();
+  const workspace = await workspaceApi.get(taskId);
+  const pinnedTaskIds = await pinnedTasksApi.getPinnedTaskIds();
+  const wasPinned = pinnedTaskIds.includes(taskId);
+
+  if (!options?.skipNavigate) {
+    const nav = useNavigationStore.getState();
+    if (nav.view.type === "task-detail" && nav.view.data?.id === taskId) {
+      nav.navigateToTaskInput();
+    }
+  }
+
+  pinnedTasksApi.unpin(taskId);
+  useTerminalStore.getState().clearTerminalStatesForTask(taskId);
+  useCommandCenterStore.getState().removeTaskById(taskId);
+
+  queryClient.setQueryData<string[]>(
+    trpc.archive.archivedTaskIds.queryKey(),
+    (old) => (old ? [...old, taskId] : [taskId]),
+  );
+
+  const optimisticArchived: ArchivedTask = {
+    taskId,
+    archivedAt: new Date().toISOString(),
+    folderId: workspace?.folderId ?? "",
+    mode: workspace?.mode ?? "worktree",
+    worktreeName: workspace?.worktreeName ?? null,
+    branchName: workspace?.branchName ?? null,
+    checkpointId: null,
+  };
+  queryClient.setQueryData<ArchivedTask[]>(
+    trpc.archive.list.queryKey(),
+    (old) => (old ? [...old, optimisticArchived] : [optimisticArchived]),
+  );
+
+  if (
+    workspace?.worktreePath &&
+    focusStore.session?.worktreePath === workspace.worktreePath
+  ) {
+    log.info("Unfocusing workspace before archiving");
+    await focusStore.disableFocus();
+  }
+
+  try {
+    await getSessionService().disconnectFromTask(taskId);
+
+    await trpcClient.archive.archive.mutate({
+      taskId,
+    });
+
+    queryClient.invalidateQueries(trpc.archive.pathFilter());
+  } catch (error) {
+    log.error("Failed to archive task", error);
+
+    queryClient.setQueryData<string[]>(
+      trpc.archive.archivedTaskIds.queryKey(),
+      (old) => (old ? old.filter((id) => id !== taskId) : []),
+    );
+    queryClient.setQueryData<ArchivedTask[]>(
+      trpc.archive.list.queryKey(),
+      (old) => (old ? old.filter((a) => a.taskId !== taskId) : []),
+    );
+    if (wasPinned) {
+      pinnedTasksApi.togglePin(taskId);
+    }
+
+    throw error;
+  }
 }
 
 export function useArchiveTask() {
   const queryClient = useQueryClient();
 
-  const archiveTask = async (input: ArchiveTaskInput) => {
-    const { taskId } = input;
-    const focusStore = useFocusStore.getState();
-    const workspace = await workspaceApi.get(taskId);
-    const pinnedTaskIds = await pinnedTasksApi.getPinnedTaskIds();
-    const wasPinned = pinnedTaskIds.includes(taskId);
-
-    const nav = useNavigationStore.getState();
-    if (nav.view.type === "task-detail" && nav.view.data?.id === taskId) {
-      nav.navigateToTaskInput();
-    }
-
-    pinnedTasksApi.unpin(taskId);
-    useTerminalStore.getState().clearTerminalStatesForTask(taskId);
-    useCommandCenterStore.getState().removeTaskById(taskId);
-
-    queryClient.setQueryData<string[]>(
-      trpc.archive.archivedTaskIds.queryKey(),
-      (old) => (old ? [...old, taskId] : [taskId]),
-    );
-
-    const optimisticArchived: ArchivedTask = {
-      taskId,
-      archivedAt: new Date().toISOString(),
-      folderId: workspace?.folderId ?? "",
-      mode: workspace?.mode ?? "worktree",
-      worktreeName: workspace?.worktreeName ?? null,
-      branchName: workspace?.branchName ?? null,
-      checkpointId: null,
-    };
-    queryClient.setQueryData<ArchivedTask[]>(
-      trpc.archive.list.queryKey(),
-      (old) => (old ? [...old, optimisticArchived] : [optimisticArchived]),
-    );
-
-    if (
-      workspace?.worktreePath &&
-      focusStore.session?.worktreePath === workspace.worktreePath
-    ) {
-      log.info("Unfocusing workspace before archiving");
-      await focusStore.disableFocus();
-    }
-
-    try {
-      await getSessionService().disconnectFromTask(taskId);
-
-      await trpcClient.archive.archive.mutate({
-        taskId,
-      });
-
-      queryClient.invalidateQueries(trpc.archive.pathFilter());
-
-      toast.success("Task archived");
-    } catch (error) {
-      log.error("Failed to archive task", error);
-      toast.error("Failed to archive task");
-
-      queryClient.setQueryData<string[]>(
-        trpc.archive.archivedTaskIds.queryKey(),
-        (old) => (old ? old.filter((id) => id !== taskId) : []),
-      );
-      queryClient.setQueryData<ArchivedTask[]>(
-        trpc.archive.list.queryKey(),
-        (old) => (old ? old.filter((a) => a.taskId !== taskId) : []),
-      );
-      if (wasPinned) {
-        pinnedTasksApi.togglePin(taskId);
-      }
-
-      throw error;
-    }
+  const archiveTask = async ({ taskId }: { taskId: string }) => {
+    await archiveTaskImperative(taskId, queryClient);
+    toast.success("Task archived");
   };
 
   return { archiveTask };

--- a/apps/code/src/renderer/hooks/useTaskContextMenu.ts
+++ b/apps/code/src/renderer/hooks/useTaskContextMenu.ts
@@ -25,12 +25,14 @@ export function useTaskContextMenu() {
         worktreePath?: string;
         isPinned?: boolean;
         onTogglePin?: () => void;
+        onArchivePrior?: (taskId: string) => void;
       },
     ) => {
       event.preventDefault();
       event.stopPropagation();
 
-      const { worktreePath, isPinned, onTogglePin } = options ?? {};
+      const { worktreePath, isPinned, onTogglePin, onArchivePrior } =
+        options ?? {};
 
       try {
         const result = await trpcClient.contextMenu.showTaskContextMenu.mutate({
@@ -57,6 +59,9 @@ export function useTaskContextMenu() {
             break;
           case "archive":
             await archiveTask({ taskId: task.id });
+            break;
+          case "archive-prior":
+            await onArchivePrior?.(task.id);
             break;
           case "delete":
             await deleteWithConfirm({

--- a/apps/code/src/renderer/hooks/useTaskContextMenu.ts
+++ b/apps/code/src/renderer/hooks/useTaskContextMenu.ts
@@ -1,3 +1,4 @@
+import { useRestoreTask } from "@features/suspension/hooks/useRestoreTask";
 import { useSuspendTask } from "@features/suspension/hooks/useSuspendTask";
 import { useArchiveTask } from "@features/tasks/hooks/useArchiveTask";
 import { useDeleteTask } from "@features/tasks/hooks/useTasks";
@@ -16,6 +17,7 @@ export function useTaskContextMenu() {
   const { deleteWithConfirm } = useDeleteTask();
   const { archiveTask } = useArchiveTask();
   const { suspendTask } = useSuspendTask();
+  const { restoreTask } = useRestoreTask();
 
   const showContextMenu = useCallback(
     async (
@@ -23,7 +25,9 @@ export function useTaskContextMenu() {
       event: React.MouseEvent,
       options?: {
         worktreePath?: string;
+        folderPath?: string;
         isPinned?: boolean;
+        isSuspended?: boolean;
         onTogglePin?: () => void;
         onArchivePrior?: (taskId: string) => void;
       },
@@ -31,14 +35,22 @@ export function useTaskContextMenu() {
       event.preventDefault();
       event.stopPropagation();
 
-      const { worktreePath, isPinned, onTogglePin, onArchivePrior } =
-        options ?? {};
+      const {
+        worktreePath,
+        folderPath,
+        isPinned,
+        isSuspended,
+        onTogglePin,
+        onArchivePrior,
+      } = options ?? {};
 
       try {
         const result = await trpcClient.contextMenu.showTaskContextMenu.mutate({
           taskTitle: task.title,
           worktreePath,
+          folderPath,
           isPinned,
+          isSuspended,
         });
 
         if (!result.action) return;
@@ -55,7 +67,11 @@ export function useTaskContextMenu() {
             toast.success("Task ID copied");
             break;
           case "suspend":
-            await suspendTask({ taskId: task.id, reason: "manual" });
+            if (isSuspended) {
+              await restoreTask(task.id);
+            } else {
+              await suspendTask({ taskId: task.id, reason: "manual" });
+            }
             break;
           case "archive":
             await archiveTask({ taskId: task.id });
@@ -70,12 +86,13 @@ export function useTaskContextMenu() {
               hasWorktree: !!worktreePath,
             });
             break;
-          case "external-app":
-            if (worktreePath) {
+          case "external-app": {
+            const effectivePath = worktreePath ?? folderPath;
+            if (effectivePath) {
               const workspace = await workspaceApi.get(task.id);
               await handleExternalAppAction(
                 result.action.action,
-                worktreePath,
+                effectivePath,
                 task.title,
                 {
                   workspace,
@@ -84,12 +101,13 @@ export function useTaskContextMenu() {
               );
             }
             break;
+          }
         }
       } catch (error) {
         log.error("Failed to show context menu", error);
       }
     },
-    [deleteWithConfirm, archiveTask, suspendTask],
+    [deleteWithConfirm, archiveTask, suspendTask, restoreTask],
   );
 
   return {


### PR DESCRIPTION
## Problem

Archiving old tasks one at a time is tedious and the context menu had disorganized grouping with incorrect suspend visibility.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## ![CleanShot 2026-04-13 at 11.00.59@2x.png](https://app.graphite.com/user-attachments/assets/dee250ea-6bf4-40e2-820a-227f2f744aff.png)

## Changes

1. Add "Archive prior tasks" context menu action that archives all tasks older than the clicked one
2. Extract archiveTaskImperative for reuse outside React hooks
3. Reorganize context menu: quick actions on top, workspace actions in middle, archive at bottom
4. Fix Suspend showing for non-worktree tasks (was incorrectly using folderPath fallback)
5. Toggle Suspend/Unsuspend label based on task state
6. Remove Delete from context menu in favor of archiving

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->