### PR TITLE
feat: add POSTHOG_CODE=1 env var to workspace shell

### DIFF
--- a/apps/code/src/main/services/workspace/workspaceEnv.ts
+++ b/apps/code/src/main/services/workspace/workspaceEnv.ts
@@ -60,6 +60,7 @@ export async function buildWorkspaceEnv(
   const portAllocation = allocateWorkspacePorts(context.taskId);
 
   return {
+    POSTHOG_CODE: "1",
     POSTHOG_CODE_WORKSPACE_NAME: workspaceName,
     POSTHOG_CODE_WORKSPACE_PATH: workspacePath,
     POSTHOG_CODE_ROOT_PATH: rootPath,


### PR DESCRIPTION
## Summary
- Adds `POSTHOG_CODE=1` to the environment variables set in the task shell tab
- Lets scripts and tools detect they are running inside a PostHog Code shell session

## Test plan
- [x] Open a task shell tab and verify `echo $POSTHOG_CODE` outputs `1`
<img width="711" height="305" alt="Screenshot 2026-04-14 at 14 14 16" src="https://github.com/user-attachments/assets/23c6a7d8-d386-4542-969c-756d9fa2ef87" />

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*