### PR TITLE
refactor: initial decoupling of electron

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build electron-trpc
         run: pnpm --filter @posthog/electron-trpc build
 
+      - name: Build platform
+        run: pnpm --filter @posthog/platform build
+
       - name: Build shared
         run: pnpm --filter @posthog/shared build
 

--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Build electron-trpc package
         run: pnpm --filter @posthog/electron-trpc run build
 
+      - name: Build platform package
+        run: pnpm --filter @posthog/platform run build
+
       - name: Build shared package
         run: pnpm --filter @posthog/shared run build
 
@@ -181,6 +184,9 @@ jobs:
 
       - name: Build electron-trpc package
         run: pnpm --filter @posthog/electron-trpc run build
+
+      - name: Build platform package
+        run: pnpm --filter @posthog/platform run build
 
       - name: Build shared package
         run: pnpm --filter @posthog/shared run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Build packages
         run: |
           pnpm --filter @posthog/electron-trpc build &
+          pnpm --filter @posthog/platform build &
           pnpm --filter @posthog/shared build
           pnpm --filter @posthog/git build
           pnpm --filter agent build &

--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -131,6 +131,7 @@
     "@posthog/git": "workspace:*",
     "@posthog/hedgehog-mode": "^0.0.48",
     "@posthog/quill": "0.1.0-alpha.7",
+    "@posthog/platform": "workspace:*",
     "@posthog/shared": "workspace:*",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-icons": "^1.3.2",

--- a/apps/code/scripts/postinstall.sh
+++ b/apps/code/scripts/postinstall.sh
@@ -8,6 +8,19 @@ set -e
 REPO_ROOT="$(cd ../.. && pwd)"
 SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Self-heal missing Electron binary.
+# pnpm skips package-level postinstall scripts when the lockfile is already
+# satisfied, so if node_modules/electron/dist gets wiped (interrupted download,
+# cache eviction, arch change, manual cleanup), `pnpm install` won't notice —
+# and `electron-forge start` then fails with "Electron failed to install
+# correctly, please delete node_modules/electron and try installing again".
+# Detect the missing binary and invoke Electron's own install script to fetch it.
+ELECTRON_DIST="$REPO_ROOT/node_modules/electron/dist"
+if [ ! -d "$ELECTRON_DIST" ] || [ -z "$(ls -A "$ELECTRON_DIST" 2>/dev/null)" ]; then
+  echo "Electron binary missing at $ELECTRON_DIST — downloading..."
+  node "$REPO_ROOT/node_modules/electron/install.js"
+fi
+
 echo "Rebuilding native modules for Electron..."
 
 cd "$REPO_ROOT"

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -9,6 +9,7 @@ import { SuspensionRepositoryImpl } from "../db/repositories/suspension-reposito
 import { WorkspaceRepository } from "../db/repositories/workspace-repository";
 import { WorktreeRepository } from "../db/repositories/worktree-repository";
 import { DatabaseService } from "../db/service";
+import { ElectronUrlLauncher } from "../platform-adapters/electron-url-launcher";
 import { AgentAuthAdapter } from "../services/agent/auth-adapter";
 import { AgentService } from "../services/agent/service";
 import { AppLifecycleService } from "../services/app-lifecycle/service";
@@ -52,6 +53,8 @@ import { MAIN_TOKENS } from "./tokens";
 export const container = new Container({
   defaultScope: "Singleton",
 });
+
+container.bind(MAIN_TOKENS.UrlLauncher).to(ElectronUrlLauncher);
 
 container.bind(MAIN_TOKENS.DatabaseService).to(DatabaseService);
 container

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -5,6 +5,9 @@
  * Never import this file from renderer code.
  */
 export const MAIN_TOKENS = Object.freeze({
+  // Platform ports (host-agnostic interfaces from @posthog/platform)
+  UrlLauncher: Symbol.for("Platform.UrlLauncher"),
+
   // Stores
   SettingsStore: Symbol.for("Main.SettingsStore"),
 

--- a/apps/code/src/main/platform-adapters/electron-url-launcher.ts
+++ b/apps/code/src/main/platform-adapters/electron-url-launcher.ts
@@ -1,0 +1,10 @@
+import type { IUrlLauncher } from "@posthog/platform/url-launcher";
+import { shell } from "electron";
+import { injectable } from "inversify";
+
+@injectable()
+export class ElectronUrlLauncher implements IUrlLauncher {
+  public async launch(url: string): Promise<void> {
+    await shell.openExternal(url);
+  }
+}

--- a/apps/code/src/main/services/github-integration/service.ts
+++ b/apps/code/src/main/services/github-integration/service.ts
@@ -1,6 +1,7 @@
+import type { IUrlLauncher } from "@posthog/platform/url-launcher";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
-import { shell } from "electron";
-import { injectable } from "inversify";
+import { inject, injectable } from "inversify";
+import { MAIN_TOKENS } from "../../di/tokens";
 import { logger } from "../../utils/logger";
 import type { CloudRegion, StartGitHubFlowOutput } from "./schemas";
 
@@ -8,6 +9,10 @@ const log = logger.scope("github-integration-service");
 
 @injectable()
 export class GitHubIntegrationService {
+  constructor(
+    @inject(MAIN_TOKENS.UrlLauncher) private readonly urlLauncher: IUrlLauncher,
+  ) {}
+
   public async startFlow(
     region: CloudRegion,
     projectId: number,
@@ -18,7 +23,7 @@ export class GitHubIntegrationService {
       const authorizeUrl = `${cloudUrl}/api/environments/${projectId}/integrations/authorize/?kind=github&next=${encodeURIComponent(next)}`;
 
       log.info("Opening GitHub authorization URL in browser");
-      await shell.openExternal(authorizeUrl);
+      await this.urlLauncher.launch(authorizeUrl);
 
       return { success: true };
     } catch (error) {

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -7,12 +7,16 @@ procs:
       - agent
       - git
       - enricher
+      - platform
 
   2-agent:
     shell: 'node scripts/pnpm-run.mjs --filter agent run dev'
 
   3-git:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/git run dev'
+
+  platform:
+    shell: 'node scripts/pnpm-run.mjs --filter @posthog/platform run dev'
 
   4-enricher:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/enricher run dev'

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@posthog/platform",
+  "version": "1.0.0",
+  "description": "Host-agnostic platform port interfaces. Zero runtime deps; implemented by per-host adapters (Electron, Node server, React Native, web).",
+  "type": "module",
+  "exports": {
+    "./url-launcher": {
+      "types": "./dist/url-launcher.d.ts",
+      "import": "./dist/url-launcher.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "node ../../scripts/rimraf.mjs dist .turbo"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^5.5.0"
+  },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ]
+}

--- a/packages/platform/src/url-launcher.ts
+++ b/packages/platform/src/url-launcher.ts
@@ -1,0 +1,3 @@
+export interface IUrlLauncher {
+  launch(url: string): Promise<void>;
+}

--- a/packages/platform/tsconfig.json
+++ b/packages/platform/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/platform/tsup.config.ts
+++ b/packages/platform/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/url-launcher.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  outDir: "dist",
+  target: "es2022",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@posthog/quill':
         specifier: 0.1.0-alpha.7
         version: 0.1.0-alpha.7(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.2.2)
+      '@posthog/platform':
+        specifier: workspace:*
+        version: link:../../packages/platform
       '@posthog/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -786,6 +789,15 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@25.2.0)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(terser@5.46.0)
+
+  packages/platform:
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
### What's going on?

When a user works on a task, the work happens somewhere, either locally on their machine or in a cloud sandbox. Right now, those two paths are different codepaths. Every feature that touches git, the filesystem, or the shell needs to know which mode it's in, which makes cloud parity with local very difficult.

That's one part of the problem. We also ideally want to be able to run PostHog Code on a bunch of different platforms:  
- Cloud  
- Mobile  
- Browser  
- Desktop

We also have a bunch of data/functionality dependencies:  
- Platform specific dependencies (Think clipboards, notifications, OS dialogues, etc, each platform thinks differently about these)  
- PostHog API (This one's easy to handle across different platforms)  
- Node server stuff; Think all our git handling, process spawning, file watchers etc.  Basically stuff we want to run and behave identically on both a sandbox and users local environment. Fortunately we know this will always run in a node environment, so we don't need a per platform implementation.

### What are we doing?

To make the above possible we need to split our node server (which we currently run inside electron) into two packages that can run anywhere. To achieve that, we need to get rid of the electron dependencies in the node server.

```
# This is node, running in a sandbox OR your local device, exposing TRPC procedures.
# It handles all workspace/task run specific logic, such as file changes.
packages/workspace-server

# This is node running on some web server/worker OR your local device, 
# and coordinates/talks to the workspace servers.
# It also handles non-task specific stuff.
# We can't run it in the sandbox because we might have multiple sandboxes 
# at the same time, plus they're ephemeral.
# This also exposes TRPC procedures
packages/app-server 

# Shared interfaces that all platforms must adhere to
# Toy example with clipboard usage, all electron related stuff goes here,
# it's also about stuff like path handling, file attachments, etc:
packages/platform <- interfaces such as (IClipboard, IExternalURL)

# These implement the behaviors described in packages/platform
apps/web/ <- WebClipboard
apps/desktop/ <- ElectronClipboard
apps/ui/ <- React DOM UI

# This one also implements it's own UI since we can't run React DOM here
apps/mobile <- MobileClipboard 
```

This makes the first step, by defining a package that all platforms must adhere to, in `packages/platform` .  
We make an initial start at implementing one of those interfaces via `apps/code/platform-adapters/electron-url-launcher.ts`. At runtime we inject this into our server. In a browser context we'd inject `web-url-launcher.ts etc.`. It's a toy example for the rest of the stack.

### That's great but aren't you just massively overengineering this?

Fully extracting electron will eventually allow us to split the node server we run in electron into `packages/server`, then expose that node server via the modal sandbox over hono with TRPC.

This is good because we can then route to either local or the sandbox based on whether the task run is cloud or local, which _IN THEORY_ could make cloud feel identical to local.  
  
It's a bigger lift, but IMO the right way to do this. As far as I can see it's the only way to prevent 50 (and soon more) `if workspace.mode === 'cloud'` statements scattered throughout our codebase. Without this, every feature that touches git/shell/files needs a local codepath and a cloud codepath, and that will become more painful as time goes on.
  
Instead we just call `trpc.git.getCurrentBranch` and route it to the right spot (either local or a sandbox) based on whether the task run is local or cloud.

It also open avenues to supporting other platforms such PostHog Code in the web :) (This is a nice side effect, definitely not the main concern). A more direct benefit is that we could share a lot of the code between PostHog Mobile and PostHog Code desktop   
  
---------  
  
I've spent quite a while thinking about this, and this architecture is loosely based on VSCode's internal structure. Happy to hear feedback

