### PR TITLE
fix: allow conventional commit for pr title gen

### DIFF
--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -1254,12 +1254,14 @@ ${truncatedDiff}${contextSection}`;
     ]);
 
     const head = currentBranch ?? undefined;
-    const [branchDiff, stagedDiff, unstagedDiff, commits] = await Promise.all([
-      getDiffAgainstRemote(directoryPath, defaultBranch),
-      getStagedDiff(directoryPath),
-      getUnstagedDiff(directoryPath),
-      getCommitsBetweenBranches(directoryPath, defaultBranch, head, 30),
-    ]);
+    const [branchDiff, stagedDiff, unstagedDiff, commits, conventions] =
+      await Promise.all([
+        getDiffAgainstRemote(directoryPath, defaultBranch),
+        getStagedDiff(directoryPath),
+        getUnstagedDiff(directoryPath),
+        getCommitsBetweenBranches(directoryPath, defaultBranch, head, 30),
+        getCommitConventions(directoryPath),
+      ]);
 
     const uncommittedDiff = [stagedDiff, unstagedDiff]
       .filter(Boolean)
@@ -1283,6 +1285,12 @@ ${truncatedDiff}${contextSection}`;
         )}`
       : "";
 
+    const conventionHint = conventions.conventionalCommits
+      ? `- Use conventional commit format for the title (e.g., "feat(scope): description"). Common prefixes: ${
+          conventions.commonPrefixes.join(", ") || "feat, fix, docs, chore"
+        }.`
+      : "";
+
     const system = `You are a PR description generator. Generate a title and detailed description for a pull request.
 
 Output format (use exactly this format):
@@ -1295,6 +1303,7 @@ Rules for the title:
 - Short and descriptive (max 72 chars)
 - Use imperative mood ("Add feature" not "Added feature")
 - Be specific about what the PR accomplishes
+${conventionHint}
 
 Rules for the body:
 - Start with a TL;DR section (1-2 sentences summarizing the change)
@@ -1326,6 +1335,7 @@ ${truncatedDiff || "(no diff available)"}${contextSection}`;
       diffLength: fullDiff.length,
       hasTemplate: !!prTemplate.template,
       hasConversationContext: !!conversationContext,
+      conventionalCommits: conventions.conventionalCommits,
     });
 
     const response = await this.llmGateway.prompt(


### PR DESCRIPTION
## Problem

Pull request descriptions generated by the AI assistant don't follow project-specific commit conventions, making them inconsistent with team standards and potentially causing issues with automated tooling that expects conventional commit formats.

## Changes

- Added `getCommitConventions()` call to retrieve project-specific commit convention settings
- Integrated conventional commit format hints into the AI prompt when conventional commits are enabled
- Updated the system prompt to include guidance on using conventional commit prefixes (feat, fix, docs, chore, etc.)
- Added `conventionalCommits` flag to telemetry tracking for monitoring adoption

The AI will now generate PR titles that follow conventional commit format when the project has this convention enabled, improving consistency across the codebase.