### PR TITLE
feat(inbox): Add PostHog Conversations signal source toggle

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -40,6 +40,7 @@ export interface SignalSourceConfig {
     | "github"
     | "linear"
     | "zendesk"
+    | "conversations"
     | "error_tracking";
   source_type:
     | "session_analysis_cluster"

--- a/apps/code/src/renderer/features/inbox/components/SignalSourceToggles.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalSourceToggles.tsx
@@ -2,6 +2,7 @@ import {
   ArrowSquareOutIcon,
   BrainIcon,
   BugIcon,
+  ChatsIcon,
   CircleNotchIcon,
   GithubLogoIcon,
   KanbanIcon,
@@ -31,6 +32,7 @@ export interface SignalSourceValues {
   github: boolean;
   linear: boolean;
   zendesk: boolean;
+  conversations: boolean;
 }
 
 interface SignalSourceToggleCardProps {
@@ -315,6 +317,10 @@ export function SignalSourceToggles({
     (checked: boolean) => onToggle("zendesk", checked),
     [onToggle],
   );
+  const toggleConversations = useCallback(
+    (checked: boolean) => onToggle("conversations", checked),
+    [onToggle],
+  );
   const setupGithub = useCallback(() => onSetup?.("github"), [onSetup]);
   const setupLinear = useCallback(() => onSetup?.("linear"), [onSetup]);
   const setupZendesk = useCallback(() => onSetup?.("zendesk"), [onSetup]);
@@ -327,6 +333,14 @@ export function SignalSourceToggles({
         description="Surface new issues, reopenings, and volume spikes"
         checked={value.error_tracking}
         onCheckedChange={toggleErrorTracking}
+        disabled={disabled}
+      />
+      <SignalSourceToggleCard
+        icon={<ChatsIcon size={20} />}
+        label="PostHog Conversations"
+        description="Turn support conversations into signals for the inbox"
+        checked={value.conversations}
+        onCheckedChange={toggleConversations}
         disabled={disabled}
       />
       <SignalSourceToggleCard

--- a/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
@@ -24,6 +24,7 @@ const SOURCE_TYPE_MAP: Record<
   github: "issue",
   linear: "issue",
   zendesk: "ticket",
+  conversations: "ticket",
 };
 
 const ERROR_TRACKING_SOURCE_TYPES: SourceType[] = [
@@ -38,6 +39,7 @@ const SOURCE_LABELS: Record<keyof SignalSourceValues, string> = {
   github: "GitHub Issues",
   linear: "Linear Issues",
   zendesk: "Zendesk Tickets",
+  conversations: "PostHog Conversations",
 };
 
 const DATA_WAREHOUSE_SOURCES: Record<
@@ -55,6 +57,7 @@ const ALL_SOURCE_PRODUCTS: (keyof SignalSourceValues)[] = [
   "github",
   "linear",
   "zendesk",
+  "conversations",
 ];
 
 function computeValues(
@@ -66,6 +69,7 @@ function computeValues(
     github: false,
     linear: false,
     zendesk: false,
+    conversations: false,
   };
   if (!configs?.length) return result;
   for (const product of ALL_SOURCE_PRODUCTS) {

--- a/apps/code/src/renderer/features/onboarding/hooks/useTutorialTour.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useTutorialTour.ts
@@ -75,6 +75,10 @@ export function useTutorialTour() {
       zendesk:
         configs?.some((c) => c.source_product === "zendesk" && c.enabled) ??
         false,
+      conversations:
+        configs?.some(
+          (c) => c.source_product === "conversations" && c.enabled,
+        ) ?? false,
       error_tracking:
         configs?.some(
           (c) => c.source_product === "error_tracking" && c.enabled,


### PR DESCRIPTION
## Problem

Users running signals emission for Conversations (e.g. `conversations` / `ticket`) need a `SignalSourceConfig` row enabled. Code had toggles for other inbox sources but not Conversations, so there was no way to enable that config from the desktop app (or any app).

## Changes

<img width="998" height="254" alt="Screenshot 2026-04-15 at 18 30 47@2x" src="https://github.com/user-attachments/assets/3d862270-bf48-44c5-911c-43089f1aa8a7" />

Adding a PostHog Conversations toggle in signal source settings, placed directly below PostHog Error Tracking. Plus associated typing updates.
