### PR TITLE
feat: Add task search and sidebar context menu integration to command center

### DIFF
--- a/apps/code/src/main/services/context-menu/schemas.ts
+++ b/apps/code/src/main/services/context-menu/schemas.ts
@@ -6,6 +6,8 @@ export const taskContextMenuInput = z.object({
   folderPath: z.string().optional(),
   isPinned: z.boolean().optional(),
   isSuspended: z.boolean().optional(),
+  isInCommandCenter: z.boolean().optional(),
+  hasEmptyCommandCenterCell: z.boolean().optional(),
 });
 
 export const archivedTaskContextMenuInput = z.object({
@@ -40,6 +42,7 @@ const taskAction = z.discriminatedUnion("type", [
   z.object({ type: z.literal("archive") }),
   z.object({ type: z.literal("archive-prior") }),
   z.object({ type: z.literal("delete") }),
+  z.object({ type: z.literal("add-to-command-center") }),
   z.object({ type: z.literal("external-app"), action: externalAppAction }),
 ]);
 

--- a/apps/code/src/main/services/context-menu/service.ts
+++ b/apps/code/src/main/services/context-menu/service.ts
@@ -104,7 +104,14 @@ export class ContextMenuService {
   async showTaskContextMenu(
     input: TaskContextMenuInput,
   ): Promise<TaskContextMenuResult> {
-    const { worktreePath, folderPath, isPinned, isSuspended } = input;
+    const {
+      worktreePath,
+      folderPath,
+      isPinned,
+      isSuspended,
+      isInCommandCenter,
+      hasEmptyCommandCenterCell,
+    } = input;
     const { apps, lastUsedAppId } = await this.getExternalAppsData();
     const hasPath = worktreePath || folderPath;
 
@@ -124,6 +131,16 @@ export class ContextMenuService {
         ? [
             ...(worktreePath ? [] : [this.separator()]),
             ...this.externalAppItems<TaskAction>(apps, lastUsedAppId),
+          ]
+        : []),
+      ...(!isInCommandCenter
+        ? [
+            this.separator(),
+            this.item(
+              "Add to Command Center",
+              { type: "add-to-command-center" as const },
+              { enabled: hasEmptyCommandCenterCell ?? true },
+            ),
           ]
         : []),
       this.separator(),

--- a/apps/code/src/renderer/features/command-center/components/TaskSelector.tsx
+++ b/apps/code/src/renderer/features/command-center/components/TaskSelector.tsx
@@ -74,7 +74,7 @@ export function TaskSelector({
             ))}
             {hasMore && (
               <div className="combobox-label">
-                {moreCount} more {moreCount === 1 ? "task" : "tasks"} — type to
+                {moreCount} more {moreCount === 1 ? "task" : "tasks"}; type to
                 filter
               </div>
             )}

--- a/apps/code/src/renderer/features/command-center/components/TaskSelector.tsx
+++ b/apps/code/src/renderer/features/command-center/components/TaskSelector.tsx
@@ -1,5 +1,6 @@
+import { Combobox } from "@components/ui/combobox/Combobox";
 import { Plus } from "@phosphor-icons/react";
-import { Popover, Separator } from "@radix-ui/themes";
+import { Popover } from "@radix-ui/themes";
 import { useNavigationStore } from "@stores/navigationStore";
 import { type ReactNode, useCallback } from "react";
 import { useAvailableTasks } from "../hooks/useAvailableTasks";
@@ -42,42 +43,54 @@ export function TaskSelector({
   }, [onOpenChange, onNewTask, navigateToTaskInput]);
 
   return (
-    <Popover.Root open={open} onOpenChange={onOpenChange}>
+    <Combobox.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      value=""
+      onValueChange={handleSelect}
+      size="1"
+    >
       <Popover.Trigger>{children}</Popover.Trigger>
-      <Popover.Content
+      <Combobox.Content
+        items={availableTasks}
+        getValue={(task) => task.title}
         side="bottom"
         align="center"
         sideOffset={4}
-        style={{ padding: 4, minWidth: 240, maxHeight: 300 }}
+        style={{ minWidth: 240 }}
       >
-        <button
-          type="button"
-          onClick={handleNewTask}
-          className="flex w-full items-center gap-1.5 rounded-sm px-2 py-1.5 text-left text-[12px] text-gray-12 transition-colors hover:bg-gray-3"
-        >
-          <Plus size={12} />
-          New task
-        </button>
-        <Separator size="4" className="my-1" />
-        <div className="overflow-y-auto" style={{ maxHeight: 240 }}>
-          {availableTasks.length === 0 ? (
-            <div className="px-2 py-3 text-center font-mono text-[11px] text-gray-10">
-              No available tasks
-            </div>
-          ) : (
-            availableTasks.map((task) => (
-              <button
+        {({ filtered, hasMore, moreCount }) => (
+          <>
+            <Combobox.Input placeholder="Search tasks..." />
+            <Combobox.Empty>No matching tasks</Combobox.Empty>
+            {filtered.map((task) => (
+              <Combobox.Item
                 key={task.id}
-                type="button"
-                onClick={() => handleSelect(task.id)}
-                className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] text-gray-12 transition-colors hover:bg-gray-3"
+                value={task.id}
+                textValue={task.title}
               >
-                <span className="min-w-0 flex-1 truncate">{task.title}</span>
+                {task.title}
+              </Combobox.Item>
+            ))}
+            {hasMore && (
+              <div className="combobox-label">
+                {moreCount} more {moreCount === 1 ? "task" : "tasks"} — type to
+                filter
+              </div>
+            )}
+            <Combobox.Footer>
+              <button
+                type="button"
+                className="combobox-footer-button"
+                onClick={handleNewTask}
+              >
+                <Plus size={11} weight="bold" />
+                New task
               </button>
-            ))
-          )}
-        </div>
-      </Popover.Content>
-    </Popover.Root>
+            </Combobox.Footer>
+          </>
+        )}
+      </Combobox.Content>
+    </Combobox.Root>
   );
 }

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -140,7 +140,9 @@ function SidebarMenuComponent() {
       const workspace = workspaces[taskId];
       const taskData = allSidebarTasks.find((t) => t.id === taskId);
       const isInCommandCenter = commandCenterCells.includes(taskId);
-      const firstEmptyIndex = commandCenterCells.indexOf(null);
+      const firstEmptyIndex = commandCenterCells.findIndex(
+        (id) => id == null || !taskMap.has(id),
+      );
       const hasEmptyCommandCenterCell = firstEmptyIndex !== -1;
 
       showContextMenu(task, e, {
@@ -156,6 +158,8 @@ function SidebarMenuComponent() {
           if (firstEmptyIndex !== -1) {
             assignTaskToCommandCenter(firstEmptyIndex, taskId);
             navigateToCommandCenter();
+          } else {
+            toast.info("Command center is full");
           }
         },
       });

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -139,11 +139,12 @@ function SidebarMenuComponent() {
     if (task) {
       const workspace = workspaces[taskId];
       const taskData = allSidebarTasks.find((t) => t.id === taskId);
-      const isInCommandCenter = commandCenterCells.includes(taskId);
-      const firstEmptyIndex = commandCenterCells.findIndex(
+      const isInCommandCenter = commandCenterCells.some(
+        (id) => id === taskId && taskMap.has(id),
+      );
+      const hasEmptyCommandCenterCell = commandCenterCells.some(
         (id) => id == null || !taskMap.has(id),
       );
-      const hasEmptyCommandCenterCell = firstEmptyIndex !== -1;
 
       showContextMenu(task, e, {
         worktreePath: workspace?.worktreePath ?? undefined,
@@ -155,8 +156,10 @@ function SidebarMenuComponent() {
         onTogglePin: () => togglePin(taskId),
         onArchivePrior: handleArchivePrior,
         onAddToCommandCenter: () => {
-          if (firstEmptyIndex !== -1) {
-            assignTaskToCommandCenter(firstEmptyIndex, taskId);
+          const cells = useCommandCenterStore.getState().cells;
+          const idx = cells.findIndex((id) => id == null || !taskMap.has(id));
+          if (idx !== -1) {
+            assignTaskToCommandCenter(idx, taskId);
             navigateToCommandCenter();
           } else {
             toast.info("Command center is full");

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -77,6 +77,7 @@ function SidebarMenuComponent() {
   }
 
   const commandCenterCells = useCommandCenterStore((s) => s.cells);
+  const assignTaskToCommandCenter = useCommandCenterStore((s) => s.assignTask);
   const commandCenterActiveCount = commandCenterCells.filter(
     (taskId) => taskId != null && taskMap.has(taskId),
   ).length;
@@ -138,13 +139,25 @@ function SidebarMenuComponent() {
     if (task) {
       const workspace = workspaces[taskId];
       const taskData = allSidebarTasks.find((t) => t.id === taskId);
+      const isInCommandCenter = commandCenterCells.includes(taskId);
+      const firstEmptyIndex = commandCenterCells.indexOf(null);
+      const hasEmptyCommandCenterCell = firstEmptyIndex !== -1;
+
       showContextMenu(task, e, {
         worktreePath: workspace?.worktreePath ?? undefined,
         folderPath: workspace?.folderPath ?? undefined,
         isPinned,
         isSuspended: taskData?.isSuspended,
+        isInCommandCenter,
+        hasEmptyCommandCenterCell,
         onTogglePin: () => togglePin(taskId),
         onArchivePrior: handleArchivePrior,
+        onAddToCommandCenter: () => {
+          if (firstEmptyIndex !== -1) {
+            assignTaskToCommandCenter(firstEmptyIndex, taskId);
+            navigateToCommandCenter();
+          }
+        },
       });
     }
   };

--- a/apps/code/src/renderer/hooks/useTaskContextMenu.ts
+++ b/apps/code/src/renderer/hooks/useTaskContextMenu.ts
@@ -28,8 +28,11 @@ export function useTaskContextMenu() {
         folderPath?: string;
         isPinned?: boolean;
         isSuspended?: boolean;
+        isInCommandCenter?: boolean;
+        hasEmptyCommandCenterCell?: boolean;
         onTogglePin?: () => void;
         onArchivePrior?: (taskId: string) => void;
+        onAddToCommandCenter?: () => void;
       },
     ) => {
       event.preventDefault();
@@ -40,8 +43,11 @@ export function useTaskContextMenu() {
         folderPath,
         isPinned,
         isSuspended,
+        isInCommandCenter,
+        hasEmptyCommandCenterCell,
         onTogglePin,
         onArchivePrior,
+        onAddToCommandCenter,
       } = options ?? {};
 
       try {
@@ -51,6 +57,8 @@ export function useTaskContextMenu() {
           folderPath,
           isPinned,
           isSuspended,
+          isInCommandCenter,
+          hasEmptyCommandCenterCell,
         });
 
         if (!result.action) return;
@@ -85,6 +93,9 @@ export function useTaskContextMenu() {
               taskTitle: task.title,
               hasWorktree: !!worktreePath,
             });
+            break;
+          case "add-to-command-center":
+            onAddToCommandCenter?.();
             break;
           case "external-app": {
             const effectivePath = worktreePath ?? folderPath;


### PR DESCRIPTION
## Problem

Command center has no search when adding tasks and no way to add tasks from the sidebar.

Context menu addition:<!-- Who is this for and what problem does it solve? -->

![CleanShot 2026-04-15 at 14.54.58@2x.png](https://app.graphite.com/user-attachments/assets/bbf88cca-c5b2-48df-8323-31d8ad98dd25.png)

Search:

## ![CleanShot 2026-04-15 at 14.30.59@2x.png](https://app.graphite.com/user-attachments/assets/af43bf52-7fc3-47b8-ba1a-11b7657c2b23.png)

## Changes

1. Replace plain task list in TaskSelector with searchable Combobox (fuzzy filter by title)
2. Add "Add to Command Center" to sidebar task right-click context menu
3. Hide context menu item when task is already in command center, disable when no empty cells
4. Navigate to command center after adding a task via context menu

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->