### PR TITLE
fix: Prevent auto-generated title from overwriting manual rename

### DIFF
--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
@@ -7,7 +7,7 @@ import {
 import type { Task } from "@shared/types";
 import { generateTitleAndSummary } from "@utils/generateTitle";
 import { logger } from "@utils/logger";
-import { queryClient } from "@utils/queryClient";
+import { getCachedTask, queryClient } from "@utils/queryClient";
 import { extractUserPromptsFromEvents } from "@utils/session";
 import { useEffect, useRef } from "react";
 
@@ -65,13 +65,7 @@ export function useChatTitleGenerator(taskId: string): void {
 
     const run = async () => {
       try {
-        const allTaskQueries = queryClient.getQueriesData<Task[]>({
-          queryKey: ["tasks", "list"],
-        });
-        const cachedTask = allTaskQueries
-          .flatMap(([, tasks]) => tasks ?? [])
-          .find((t) => t.id === taskId);
-        if (cachedTask?.title_manually_set) {
+        if (getCachedTask(taskId)?.title_manually_set) {
           log.debug("Skipping auto-title, user renamed task", { taskId });
           return;
         }
@@ -80,6 +74,13 @@ export function useChatTitleGenerator(taskId: string): void {
         if (result) {
           const { title, summary } = result;
           if (title) {
+            if (getCachedTask(taskId)?.title_manually_set) {
+              log.debug(
+                "Skipping auto-title, user renamed task during generation",
+                { taskId },
+              );
+              return;
+            }
             const client = await getAuthenticatedClient();
             if (client) {
               await client.updateTask(taskId, { title });

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
@@ -65,8 +65,12 @@ export function useChatTitleGenerator(taskId: string): void {
 
     const run = async () => {
       try {
-        const cachedTasks = queryClient.getQueryData<Task[]>(["tasks", "list"]);
-        const cachedTask = cachedTasks?.find((t) => t.id === taskId);
+        const allTaskQueries = queryClient.getQueriesData<Task[]>({
+          queryKey: ["tasks", "list"],
+        });
+        const cachedTask = allTaskQueries
+          .flatMap(([, tasks]) => tasks ?? [])
+          .find((t) => t.id === taskId);
         if (cachedTask?.title_manually_set) {
           log.debug("Skipping auto-title, user renamed task", { taskId });
           return;

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
@@ -65,20 +65,12 @@ export function useChatTitleGenerator(taskId: string): void {
 
     const run = async () => {
       try {
-        if (getCachedTask(taskId)?.title_manually_set) {
-          log.debug("Skipping auto-title, user renamed task", { taskId });
-          return;
-        }
-
         const result = await generateTitleAndSummary(content);
         if (result) {
           const { title, summary } = result;
           if (title) {
             if (getCachedTask(taskId)?.title_manually_set) {
-              log.debug(
-                "Skipping auto-title, user renamed task during generation",
-                { taskId },
-              );
+              log.debug("Skipping auto-title, user renamed task", { taskId });
               return;
             }
             const client = await getAuthenticatedClient();

--- a/apps/code/src/renderer/sagas/task/task-creation.test.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.test.ts
@@ -6,6 +6,7 @@ const mockWorkspaceDelete = vi.hoisted(() => vi.fn());
 const mockGetTaskDirectory = vi.hoisted(() => vi.fn());
 const mockReadAbsoluteFile = vi.hoisted(() => vi.fn());
 const mockReadFileAsBase64 = vi.hoisted(() => vi.fn());
+const mockGetCachedTask = vi.hoisted(() => vi.fn());
 
 vi.mock("@renderer/trpc", () => ({
   trpcClient: {
@@ -52,14 +53,16 @@ vi.mock("@features/sessions/service/service", () => ({
   }),
 }));
 
+const mockGenerateTitleAndSummary = vi.hoisted(() => vi.fn());
 vi.mock("@renderer/utils/generateTitle", () => ({
-  generateTitleAndSummary: vi.fn(async () => null),
+  generateTitleAndSummary: mockGenerateTitleAndSummary,
 }));
 
 vi.mock("@utils/queryClient", () => ({
   queryClient: {
     setQueriesData: vi.fn(),
   },
+  getCachedTask: mockGetCachedTask,
 }));
 
 vi.mock("@utils/logger", () => ({
@@ -177,6 +180,79 @@ describe("TaskCreationSaga", () => {
     expect(runTaskInCloudMock.mock.invocationCallOrder[0]).toBeLessThan(
       onTaskReady.mock.invocationCallOrder[0],
     );
+  });
+
+  it("skips auto-title when task has been manually renamed", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const runTaskInCloudMock = vi.fn().mockResolvedValue(startedTask);
+    const updateTaskMock = vi.fn();
+
+    mockGenerateTitleAndSummary.mockResolvedValue({ title: "Auto title" });
+    mockGetCachedTask.mockReturnValue({
+      id: "task-123",
+      title_manually_set: true,
+    });
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        runTaskInCloud: runTaskInCloudMock,
+        sendRunCommand: vi.fn(),
+        updateTask: updateTaskMock,
+      } as never,
+    });
+
+    await saga.run({
+      content: "Ship the fix",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockGenerateTitleAndSummary).toHaveBeenCalled();
+    });
+
+    expect(updateTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("applies auto-title when task has not been manually renamed", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const runTaskInCloudMock = vi.fn().mockResolvedValue(startedTask);
+    const updateTaskMock = vi.fn().mockResolvedValue(undefined);
+
+    mockGenerateTitleAndSummary.mockResolvedValue({ title: "Auto title" });
+    mockGetCachedTask.mockReturnValue(undefined);
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        runTaskInCloud: runTaskInCloudMock,
+        sendRunCommand: vi.fn(),
+        updateTask: updateTaskMock,
+      } as never,
+    });
+
+    await saga.run({
+      content: "Ship the fix",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    await vi.waitFor(() => {
+      expect(updateTaskMock).toHaveBeenCalledWith("task-123", {
+        title: "Auto title",
+      });
+    });
   });
 
   it("sends initial cloud prompts with attachments as pending user messages", async () => {

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -24,7 +24,7 @@ import type { ExecutionMode, Task } from "@shared/types";
 import type { CloudRunSource, PrAuthorshipMode } from "@shared/types/cloud";
 import { getGhUserTokenOrThrow } from "@utils/github";
 import { logger } from "@utils/logger";
-import { queryClient } from "@utils/queryClient";
+import { getCachedTask, queryClient } from "@utils/queryClient";
 
 const log = logger.scope("task-creation-saga");
 
@@ -39,13 +39,7 @@ async function generateTaskTitle(
   if (!result?.title) return;
   const { title } = result;
 
-  const allTaskQueries = queryClient.getQueriesData<Task[]>({
-    queryKey: ["tasks", "list"],
-  });
-  const cachedTask = allTaskQueries
-    .flatMap(([, tasks]) => tasks ?? [])
-    .find((t) => t.id === taskId);
-  if (cachedTask?.title_manually_set) {
+  if (getCachedTask(taskId)?.title_manually_set) {
     log.debug("Skipping auto-title, user renamed task", { taskId });
     return;
   }

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -39,6 +39,17 @@ async function generateTaskTitle(
   if (!result?.title) return;
   const { title } = result;
 
+  const allTaskQueries = queryClient.getQueriesData<Task[]>({
+    queryKey: ["tasks", "list"],
+  });
+  const cachedTask = allTaskQueries
+    .flatMap(([, tasks]) => tasks ?? [])
+    .find((t) => t.id === taskId);
+  if (cachedTask?.title_manually_set) {
+    log.debug("Skipping auto-title, user renamed task", { taskId });
+    return;
+  }
+
   try {
     await posthogClient.updateTask(taskId, { title });
 

--- a/apps/code/src/renderer/utils/queryClient.test.ts
+++ b/apps/code/src/renderer/utils/queryClient.test.ts
@@ -1,0 +1,63 @@
+import type { Task } from "@shared/types";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getCachedTask, queryClient } from "./queryClient";
+
+const createTask = (overrides: Partial<Task> = {}): Task => ({
+  id: "task-1",
+  task_number: 1,
+  slug: "task-1",
+  title: "Test task",
+  description: "",
+  origin_product: "user_created",
+  repository: null,
+  created_at: "2026-04-15T00:00:00Z",
+  updated_at: "2026-04-15T00:00:00Z",
+  ...overrides,
+});
+
+describe("getCachedTask", () => {
+  beforeEach(() => {
+    queryClient.clear();
+  });
+
+  it("returns matching task from cache", () => {
+    const tasks = [createTask({ id: "task-1" }), createTask({ id: "task-2" })];
+    queryClient.setQueryData(["tasks", "list"], tasks);
+
+    expect(getCachedTask("task-1")?.id).toBe("task-1");
+    expect(getCachedTask("task-2")?.id).toBe("task-2");
+  });
+
+  it("returns undefined when task is not in cache", () => {
+    queryClient.setQueryData(["tasks", "list"], [createTask({ id: "task-1" })]);
+
+    expect(getCachedTask("nonexistent")).toBeUndefined();
+  });
+
+  it("returns undefined when no task queries exist", () => {
+    expect(getCachedTask("task-1")).toBeUndefined();
+  });
+
+  it("searches across multiple task list queries", () => {
+    queryClient.setQueryData(
+      ["tasks", "list", { folder: "a" }],
+      [createTask({ id: "task-a" })],
+    );
+    queryClient.setQueryData(
+      ["tasks", "list", { folder: "b" }],
+      [createTask({ id: "task-b" })],
+    );
+
+    expect(getCachedTask("task-a")?.id).toBe("task-a");
+    expect(getCachedTask("task-b")?.id).toBe("task-b");
+  });
+
+  it("preserves title_manually_set flag", () => {
+    queryClient.setQueryData(
+      ["tasks", "list"],
+      [createTask({ id: "task-1", title_manually_set: true })],
+    );
+
+    expect(getCachedTask("task-1")?.title_manually_set).toBe(true);
+  });
+});

--- a/apps/code/src/renderer/utils/queryClient.ts
+++ b/apps/code/src/renderer/utils/queryClient.ts
@@ -1,3 +1,4 @@
+import type { Task } from "@shared/types";
 import { QueryClient } from "@tanstack/react-query";
 
 export const queryClient = new QueryClient({
@@ -8,3 +9,10 @@ export const queryClient = new QueryClient({
     },
   },
 });
+
+export function getCachedTask(taskId: string): Task | undefined {
+  return queryClient
+    .getQueriesData<Task[]>({ queryKey: ["tasks", "list"] })
+    .flatMap(([, tasks]) => tasks ?? [])
+    .find((t) => t.id === taskId);
+}


### PR DESCRIPTION
## Problem

Auto-title generation silently bypassed the title_manually_set guard because getQueryData used exact key matching while task queries include filter objects in their keys.

Closes https://github.com/PostHog/code/issues/1669<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Fix cache lookup in useChatTitleGenerator to use getQueriesData (prefix match) instead of getQueryData (exact match)
2. Add title_manually_set guard to generateTaskTitle at task creation time

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->