### PR TITLE
feat: Make phrocs the default dev runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@
 ## Commands
 
 - `pnpm install` - Install all dependencies
-- `pnpm dev` - Run both agent (watch) and code app via mprocs
-- `pnpm dev:ph` - Run both agent (watch) and code app via phrocs
+- `pnpm dev` - Run both agent (watch) and code app via phrocs
+- `pnpm dev:mprocs` - Run both agent (watch) and code app via mprocs
 - `pnpm dev:agent` - Run agent package in watch mode only
 - `pnpm dev:code` - Run code desktop app only
 - `pnpm build` - Build all packages (turbo)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cp .env.example .env
 
 ### Running in Development
 
-By default, `pnpm dev` uses [mprocs](https://github.com/pvolok/mprocs) to run the agent and code app in parallel.
+By default, `pnpm dev` uses phrocs (our custom process runner) to run the agent and code app in parallel. phrocs auto-installs on first run and reads the `mprocs.yaml` config file. The binary is downloaded to `bin/phrocs` and is git-ignored.
 
 ```bash
 # Run both agent (watch mode) and code app in parallel
@@ -43,21 +43,13 @@ pnpm dev
 # Or run them separately:
 pnpm dev:agent  # Run agent in watch mode
 pnpm dev:code   # Run code app
-```
-
-### phrocs (alpha)
-
-phrocs is our custom process runner built as a replacement for mprocs. It's currently in alpha and can be used as an alternative dev runner. phrocs does not auto-update — you must manually run the update command to pull the latest version.
-
-```bash
-# Run dev with phrocs (auto-installs on first run)
-pnpm dev:ph
 
 # Manually update phrocs to the latest version
 pnpm update:phrocs
-```
 
-phrocs reads the same `mprocs.yaml` config file. The binary is downloaded to `bin/phrocs` and is git-ignored.
+# Use mprocs instead of phrocs
+pnpm dev:mprocs
+```
 
 > **Want to connect to a local PostHog instance?** See [docs/LOCAL-DEVELOPMENT.md](./docs/LOCAL-DEVELOPMENT.md) for OAuth setup and connecting to localhost:8010.
 

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,25 +1,26 @@
 procs:
-  code:
+  1-code:
     shell: 'node scripts/pnpm-run.mjs --filter code run start'
     env:
       DEBUG: "false"
     depends_on:
       - agent
       - git
+      - enricher
 
-  agent:
+  2-agent:
     shell: 'node scripts/pnpm-run.mjs --filter agent run dev'
 
-  git:
+  3-git:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/git run dev'
 
-  enricher:
+  4-enricher:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/enricher run dev'
 
-  storybook:
+  5-storybook:
     shell: 'node scripts/pnpm-run.mjs --filter code run storybook'
     autostart: false
 
-  mobile-ios:
+  6-mobile-ios:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/mobile run ios'
     autostart: false

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "setup": "bash apps/code/bin/setup",
     "prepare": "husky",
-    "dev": "pnpm build:deps && mprocs",
-    "dev:ph": "pnpm build:deps && bash scripts/ensure-phrocs.sh && bin/phrocs --config mprocs.yaml",
+    "dev": "pnpm build:deps && bash scripts/ensure-phrocs.sh && bin/phrocs --config mprocs.yaml",
+    "dev:mprocs": "pnpm build:deps && mprocs",
     "dev:agent": "pnpm --filter agent dev",
     "dev:git": "pnpm --filter @posthog/git dev",
     "dev:code": "pnpm --filter code start",


### PR DESCRIPTION
## Problem

phrocs is now stable enough to replace mprocs as the default dev runner. <!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Swap pnpm dev to use phrocs, move mprocs to pnpm dev:mprocs
2. Number-prefix mprocs.yaml procs for consistent ordering and add enricher dependency to code
3. Update [CLAUDE.md](http://CLAUDE.md) and [README.md](http://README.md) to reflect the new default
4. Remove the separate "phrocs (alpha)" section from README

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->