### PR TITLE
chore(agent): restore provider-specific mode definitions

### DIFF
--- a/packages/agent/src/execution-mode.test.ts
+++ b/packages/agent/src/execution-mode.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getAvailableCodexModes, getAvailableModes } from "./execution-mode";
+
+describe("execution modes", () => {
+  it("includes auto-accept permissions for claude sessions", () => {
+    expect(getAvailableModes().map((mode) => mode.id)).toEqual([
+      "default",
+      "acceptEdits",
+      "plan",
+      "bypassPermissions",
+    ]);
+  });
+
+  it("includes full access for codex sessions", () => {
+    expect(getAvailableCodexModes().map((mode) => mode.id)).toEqual([
+      "read-only",
+      "auto",
+      "full-access",
+    ]);
+  });
+});

--- a/packages/agent/src/execution-mode.ts
+++ b/packages/agent/src/execution-mode.ts
@@ -35,8 +35,8 @@ const availableModes: ModeInfo[] = [
 if (ALLOW_BYPASS) {
   availableModes.push({
     id: "bypassPermissions",
-    name: "Bypass Permissions",
-    description: "Bypass all permission prompts",
+    name: "Auto-accept Permissions",
+    description: "Auto-accept all permission requests",
   });
 }
 
@@ -51,8 +51,11 @@ export const CODE_EXECUTION_MODES = [
 
 export type CodeExecutionMode = (typeof CODE_EXECUTION_MODES)[number];
 
+export function isCodeExecutionMode(mode: string): mode is CodeExecutionMode {
+  return (CODE_EXECUTION_MODES as readonly string[]).includes(mode);
+}
+
 export function getAvailableModes(): ModeInfo[] {
-  // When IS_ROOT, do not allow bypassPermissions
   return IS_ROOT
     ? availableModes.filter((m) => m.id !== "bypassPermissions")
     : availableModes;
@@ -66,6 +69,10 @@ export type CodexNativeMode = (typeof CODEX_NATIVE_MODES)[number];
 
 /** Union of all permission mode IDs across adapters */
 export type PermissionMode = CodeExecutionMode | CodexNativeMode;
+
+export function isCodexNativeMode(mode: string): mode is CodexNativeMode {
+  return (CODEX_NATIVE_MODES as readonly string[]).includes(mode);
+}
 
 const codexModes: ModeInfo[] = [
   {
@@ -84,7 +91,7 @@ if (ALLOW_BYPASS) {
   codexModes.push({
     id: "full-access",
     name: "Full Access",
-    description: "Bypass all permission prompts",
+    description: "Auto-accept all permission requests",
   });
 }
 


### PR DESCRIPTION
this restores the canonical mode sets and shared types for Claude and Codex in the agent package.
shared agent-packaged drifter so the vailable modes sets didn't reflect original provider behaviour.