### PR TITLE
Properly handle origin === "signal_report"

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -489,6 +489,16 @@ describe("AgentServer HTTP Mode", () => {
       delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
     });
 
+    it("returns auto-PR prompt for signal_report-origin runs", () => {
+      process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "signal_report";
+      const s = createServer();
+      const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt();
+      expect(prompt).toContain("posthog-code/");
+      expect(prompt).toContain("Create a draft pull request");
+      expect(prompt).toContain("gh pr create --draft");
+      delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+    });
+
     it("returns PR-update prompt for existing PRs on Slack-origin runs", () => {
       process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
       const s = createServer();

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1265,13 +1265,14 @@ export class AgentServer {
   }
 
   /**
-   * Slack-origin cloud runs auto-publish by default. Every other origin is
+   * Automated-origin cloud runs auto-publish by default. Every other origin is
    * review-first unless the user explicitly asks, and createPr=false always
    * disables publishing.
    */
   private shouldAutoPublishCloudChanges(): boolean {
+    const origin = this.getCloudInteractionOrigin();
     return (
-      this.getCloudInteractionOrigin() === "slack" &&
+      (origin === "slack" || origin === "signal_report") &&
       this.config.createPr !== false
     );
   }

--- a/packages/agent/src/test/mocks/claude-sdk.ts
+++ b/packages/agent/src/test/mocks/claude-sdk.ts
@@ -101,6 +101,10 @@ export function createMockQuery(
     toggleMcpServer: vi.fn().mockResolvedValue(undefined),
     supportedAgents: vi.fn().mockResolvedValue([]),
     stopTask: vi.fn().mockResolvedValue(undefined),
+    applyFlagSettings: vi.fn().mockResolvedValue(undefined),
+    getContextUsage: vi.fn().mockResolvedValue({}),
+    reloadPlugins: vi.fn().mockResolvedValue(undefined),
+    seedReadState: vi.fn().mockResolvedValue(undefined),
     [Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
     _abortController: abortController,
     _mockHelpers: {

--- a/packages/agent/src/test/mocks/claude-sdk.ts
+++ b/packages/agent/src/test/mocks/claude-sdk.ts
@@ -101,10 +101,6 @@ export function createMockQuery(
     toggleMcpServer: vi.fn().mockResolvedValue(undefined),
     supportedAgents: vi.fn().mockResolvedValue([]),
     stopTask: vi.fn().mockResolvedValue(undefined),
-    applyFlagSettings: vi.fn().mockResolvedValue(undefined),
-    getContextUsage: vi.fn().mockResolvedValue({}),
-    reloadPlugins: vi.fn().mockResolvedValue(undefined),
-    seedReadState: vi.fn().mockResolvedValue(undefined),
     [Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
     _abortController: abortController,
     _mockHelpers: {


### PR DESCRIPTION
## Changes

Companion to https://github.com/PostHog/posthog/pull/54553 for task origin handling.
