### PR TITLE
fix(inbox): Pulse inbox dot in sync with polling requests

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -475,6 +475,7 @@ export function InboxSignalsTab() {
                     filteredCount={reports.length}
                     isSearchActive={!!searchQuery.trim()}
                     livePolling={inboxPollingActive}
+                    isFetching={isFetching}
                     readyCount={readyCount}
                     processingCount={processingCount}
                     pipelinePausedUntil={signalProcessingState?.paused_until}

--- a/apps/code/src/renderer/features/inbox/components/list/SignalsToolbar.tsx
+++ b/apps/code/src/renderer/features/inbox/components/list/SignalsToolbar.tsx
@@ -180,12 +180,14 @@ export function SignalsToolbar({
                     className="inline-flex h-1.5 w-1.5 shrink-0 cursor-default rounded-full"
                     style={{
                       backgroundColor: "var(--red-9)",
-                      boxShadow: "0 0 8px var(--red-9)",
-                      opacity: isFetching ? 1 : 0.55,
-                      transform: isFetching ? "scale(1)" : "scale(0.92)",
+                      boxShadow: isFetching
+                        ? "0 0 6px var(--red-9)"
+                        : "0 0 4px var(--red-9)",
+                      opacity: isFetching ? 1 : 0.6,
+                      transform: isFetching ? "scale(1.05)" : "scale(0.92)",
                       transition: isFetching
-                        ? "opacity 0.1s ease-out, transform 0.1s ease-out"
-                        : "opacity 0.4s ease-in, transform 0.4s ease-in",
+                        ? "opacity 0.15s ease-out, transform 0.15s ease-out, box-shadow 0.15s ease-out"
+                        : "opacity 0.6s ease-in, transform 0.6s ease-in, box-shadow 0.6s ease-in",
                     }}
                     aria-label="Live inbox refresh active"
                   />


### PR DESCRIPTION
## Summary

The red dot in the report list toolbar now subtly pulses up when a polling fetch begins and eases back down when it completes, giving a visual heartbeat tied to actual network activity. This worked before, I think in some refactor we lost it.