### PR TITLE
fix(cloud-agent): broadcast user prompt on codex cloud runs

### DIFF
--- a/packages/agent/src/adapters/codex/codex-agent.test.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.test.ts
@@ -60,20 +60,32 @@ describe("CodexAcpAgent", () => {
     vi.clearAllMocks();
   });
 
-  function createAgent(): CodexAcpAgent {
+  function createAgent(overrides: Partial<AgentSideConnection> = {}): {
+    agent: CodexAcpAgent;
+    client: AgentSideConnection & {
+      extNotification: ReturnType<typeof vi.fn>;
+      sessionUpdate: ReturnType<typeof vi.fn>;
+    };
+  } {
     const client = {
       extNotification: vi.fn(),
-    } as unknown as AgentSideConnection;
+      sessionUpdate: vi.fn(),
+      ...overrides,
+    } as unknown as AgentSideConnection & {
+      extNotification: ReturnType<typeof vi.fn>;
+      sessionUpdate: ReturnType<typeof vi.fn>;
+    };
 
-    return new CodexAcpAgent(client, {
+    const agent = new CodexAcpAgent(client, {
       codexProcessOptions: {
         cwd: process.cwd(),
       },
     });
+    return { agent, client };
   }
 
   it("applies the requested initial mode for a new session", async () => {
-    const agent = createAgent();
+    const { agent } = createAgent();
     mockCodexConnection.newSession.mockResolvedValue({
       sessionId: "session-1",
       modes: { currentModeId: "auto", availableModes: [] },
@@ -96,7 +108,7 @@ describe("CodexAcpAgent", () => {
   });
 
   it("preserves the live session mode when loading an existing session", async () => {
-    const agent = createAgent();
+    const { agent } = createAgent();
     mockCodexConnection.loadSession.mockResolvedValue({
       modes: { currentModeId: "read-only", availableModes: [] },
       configOptions: [],
@@ -113,5 +125,54 @@ describe("CodexAcpAgent", () => {
       (agent as unknown as { sessionState: { permissionMode: string } })
         .sessionState.permissionMode,
     ).toBe("read-only");
+  });
+
+  it("broadcasts user prompt as user_message_chunk before delegating to codex-acp", async () => {
+    const { agent, client } = createAgent();
+    // Seed an active session so prompt() has the state it expects.
+    mockCodexConnection.newSession.mockResolvedValue({
+      sessionId: "session-1",
+      modes: { currentModeId: "auto", availableModes: [] },
+      configOptions: [],
+    } satisfies Partial<NewSessionResponse>);
+    await agent.newSession({
+      cwd: process.cwd(),
+    } as never);
+
+    const callOrder: string[] = [];
+    client.sessionUpdate.mockImplementation(async () => {
+      callOrder.push("sessionUpdate");
+    });
+    mockCodexConnection.prompt.mockImplementation(async () => {
+      callOrder.push("prompt");
+      return { stopReason: "end_turn" };
+    });
+
+    await agent.prompt({
+      sessionId: "session-1",
+      prompt: [
+        { type: "text", text: "first chunk" },
+        { type: "text", text: "second chunk" },
+      ],
+    } as never);
+
+    expect(client.sessionUpdate).toHaveBeenCalledTimes(2);
+    expect(client.sessionUpdate).toHaveBeenNthCalledWith(1, {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: "first chunk" },
+      },
+    });
+    expect(client.sessionUpdate).toHaveBeenNthCalledWith(2, {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: "second chunk" },
+      },
+    });
+    // Broadcast must land before the prompt reaches codex-acp so the user
+    // turn is persisted even if the underlying prompt fails.
+    expect(callOrder).toEqual(["sessionUpdate", "sessionUpdate", "prompt"]);
   });
 });

--- a/packages/agent/src/adapters/codex/codex-agent.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.ts
@@ -369,6 +369,12 @@ export class CodexAcpAgent extends BaseAcpAgent {
     this.session.interruptReason = undefined;
     resetUsage(this.sessionState);
 
+    // codex-acp does not echo the user prompt back on the agent→client
+    // channel, so without this broadcast the tapped stream (persisted to S3
+    // and rendered by the PostHog web UI) never sees a user turn and only
+    // the assistant reply shows up. Mirrors ClaudeAcpAgent.broadcastUserMessage.
+    await this.broadcastUserMessage(params);
+
     const response = await this.codexConnection.prompt(params);
 
     // Usage is already accumulated via sessionUpdate notifications in
@@ -415,6 +421,20 @@ export class CodexAcpAgent extends BaseAcpAgent {
     await this.codexConnection.cancel({
       sessionId: this.sessionId,
     });
+  }
+
+  private async broadcastUserMessage(params: PromptRequest): Promise<void> {
+    for (const chunk of params.prompt) {
+      const notification = {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "user_message_chunk" as const,
+          content: chunk,
+        },
+      };
+      await this.client.sessionUpdate(notification);
+      this.appendNotification(params.sessionId, notification);
+    }
   }
 
   async setSessionMode(


### PR DESCRIPTION
## Problem

Cloud tasks running on the codex adapter don't display the user's message in the PostHog web UI log. codex-acp doesn't echo `session/prompt` back as a `session/update`, so the tapped stream persisted to S3 never sees a user turn and only the agent reply shows up.

Regressed by #1644 (first time codex became a cloud adapter — Claude had always broadcast).

## Changes

Mirror `ClaudeAcpAgent.broadcastUserMessage` in `CodexAcpAgent.prompt`: emit one `user_message_chunk` session update per prompt chunk before delegating to `codexConnection.prompt`.

## How did you test this?

- New unit test in `codex-agent.test.ts` asserting `client.sessionUpdate` is called with `user_message_chunk` for each chunk before `codexConnection.prompt` resolves.
- Full `@posthog/agent` suite green.
