### PR TITLE
feat: Allow filtering inbox by Conversations source and report UUID

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/list/FilterSortMenu.tsx
+++ b/apps/code/src/renderer/features/inbox/components/list/FilterSortMenu.tsx
@@ -15,6 +15,7 @@ import {
   FunnelSimple as FunnelSimpleIcon,
   GithubLogoIcon,
   KanbanIcon,
+  LifebuoyIcon,
   ListNumbers,
   TicketIcon,
   TrendUp,
@@ -96,6 +97,11 @@ const SOURCE_PRODUCT_OPTIONS: {
   { value: "github", label: "GitHub", icon: <GithubLogoIcon size={14} /> },
   { value: "linear", label: "Linear", icon: <KanbanIcon size={14} /> },
   { value: "zendesk", label: "Zendesk", icon: <TicketIcon size={14} /> },
+  {
+    value: "conversations",
+    label: "Conversations",
+    icon: <LifebuoyIcon size={14} />,
+  },
 ];
 
 const ITEM_CLASS_NAME =

--- a/apps/code/src/renderer/features/inbox/components/utils/source-product-icons.tsx
+++ b/apps/code/src/renderer/features/inbox/components/utils/source-product-icons.tsx
@@ -4,6 +4,7 @@ import {
   BugIcon,
   GithubLogoIcon,
   KanbanIcon,
+  LifebuoyIcon,
   TicketIcon,
   VideoIcon,
 } from "@phosphor-icons/react";
@@ -46,5 +47,10 @@ export const SOURCE_PRODUCT_META: Record<
     Icon: TicketIcon,
     color: "var(--green-9)",
     label: "Zendesk",
+  },
+  conversations: {
+    Icon: LifebuoyIcon,
+    color: "var(--cyan-9)",
+    label: "Conversations",
   },
 };

--- a/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -18,7 +18,8 @@ export type SourceProduct =
   | "llm_analytics"
   | "github"
   | "linear"
-  | "zendesk";
+  | "zendesk"
+  | "conversations";
 
 const DEFAULT_STATUS_FILTER: SignalReportStatus[] = [
   "ready",

--- a/apps/code/src/renderer/features/inbox/utils/filterReports.ts
+++ b/apps/code/src/renderer/features/inbox/utils/filterReports.ts
@@ -19,7 +19,8 @@ export function filterReportsBySearch(
   return reports.filter(
     (report) =>
       report.title?.toLowerCase().includes(lower) ||
-      report.summary?.toLowerCase().includes(lower),
+      report.summary?.toLowerCase().includes(lower) ||
+      report.id.toLowerCase().includes(lower),
   );
 }
 


### PR DESCRIPTION
## Problem
- Filter doesn't support conversations
- Hard to find a specific report I want to check

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes
- Adds conversations to the filter
<img width="1222" height="1316" alt="CleanShot 2026-04-20 at 11 21 57@2x" src="https://github.com/user-attachments/assets/ad5061f2-006d-4c44-b2e0-4951e4ce28cd" />

---

- Allows searching by the report UUID
<img width="1236" height="380" alt="CleanShot 2026-04-20 at 11 21 41@2x" src="https://github.com/user-attachments/assets/8b854c64-48a0-49b4-822a-65e87d05715d" />


<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->
