### PR TITLE
fix: remove mock branches and fix branch creation in combobox

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -74,16 +74,7 @@ export function BranchSelector({
     ),
   );
 
-  // TODO: remove mock branches
-  const MOCK_BRANCHES = Array.from(
-    { length: 50 },
-    (_, i) =>
-      `feature/branch-${i + 1}-${["auth-refactor", "fix-login", "add-analytics", "upgrade-deps", "redesign-sidebar", "perf-optimization", "migration-v2", "hotfix-crash", "experiment-ai", "cleanup-tests"][i % 10]}`,
-  );
-  const branches = [
-    ...(isCloudMode ? (cloudBranches ?? []) : localBranches),
-    ...MOCK_BRANCHES,
-  ];
+  const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
   const CREATE_BRANCH_ACTION = "__create_branch__";
   const allItems = isCloudMode ? branches : [...branches, CREATE_BRANCH_ACTION];
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
@@ -106,7 +97,7 @@ export function BranchSelector({
   );
 
   const handleBranchChange = (value: string | null) => {
-    if (!value) return;
+    if (!value || value === CREATE_BRANCH_ACTION) return;
     if (isSelectionOnly) {
       onBranchSelect?.(value || null);
     } else if (value && value !== currentBranch) {

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -404,7 +404,6 @@ export function TaskInput({
         position: "relative",
         height: "100%",
         width: "100%",
-        overflow: "hidden",
       }}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}


### PR DESCRIPTION
## Summary
- Remove leftover `MOCK_BRANCHES` array from `BranchSelector` that was polluting the branch dropdown with 50 fake entries
- Fix branch creation: selecting "Create new branch" was triggering a checkout of `"__create_branch__"` as a real branch name, causing an error. Now skipped in `handleBranchChange`
- Remove `overflow: hidden` from `TaskInput` wrapper so focus rings aren't clipped

<img width="1760" height="852" alt="2026-04-20 14 08 57" src="https://github.com/user-attachments/assets/5107cda0-36f3-4b57-a109-674505669063" />


## Test plan
- [x] Open branch selector dropdown — only real branches shown
- [x] Click "Create new branch" — dialog opens without checkout error
- [x] Verify focus rings on inputs aren't cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)