### PR TITLE
fix: anchor picker menus to ButtonGroup, remove overflow hidden

### DIFF
--- a/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
@@ -15,18 +15,21 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { trpcClient } from "@renderer/trpc";
+import type { RefObject } from "react";
 
 interface FolderPickerProps {
   value: string;
   onChange: (path: string) => void;
   placeholder?: string;
   size?: "1" | "2";
+  anchor?: RefObject<HTMLElement | null>;
 }
 
 export function FolderPicker({
   value,
   onChange,
   placeholder = "Select folder...",
+  anchor,
 }: FolderPickerProps) {
   const {
     getRecentFolders,
@@ -85,6 +88,7 @@ export function FolderPicker({
         }
       />
       <DropdownMenuContent
+        anchor={anchor}
         align="start"
         side="bottom"
         sideOffset={6}

--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -9,6 +9,7 @@ import {
   ComboboxList,
   ComboboxTrigger,
 } from "@posthog/quill";
+import type { RefObject } from "react";
 
 interface GitHubRepoPickerProps {
   value: string | null;
@@ -18,6 +19,7 @@ interface GitHubRepoPickerProps {
   placeholder?: string;
   size?: "1" | "2";
   disabled?: boolean;
+  anchor?: RefObject<HTMLElement | null>;
 }
 
 export function GitHubRepoPicker({
@@ -27,6 +29,7 @@ export function GitHubRepoPicker({
   isLoading,
   placeholder = "Select repository...",
   disabled = false,
+  anchor,
 }: GitHubRepoPickerProps) {
   if (isLoading) {
     return (
@@ -68,7 +71,12 @@ export function GitHubRepoPicker({
           </Button>
         }
       />
-      <ComboboxContent side="bottom" sideOffset={6} className="min-w-[280px]">
+      <ComboboxContent
+        anchor={anchor}
+        side="bottom"
+        sideOffset={6}
+        className="min-w-[280px]"
+      >
         <ComboboxInput placeholder="Search repositories..." />
         <ComboboxEmpty>No repositories found.</ComboboxEmpty>
         <ComboboxList>

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -16,7 +16,7 @@ import {
 import { useTRPC } from "@renderer/trpc";
 import { toast } from "@renderer/utils/toast";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 
 interface BranchSelectorProps {
   repoPath: string | null;
@@ -34,6 +34,7 @@ interface BranchSelectorProps {
   onCloudPickerOpen?: () => void;
   onCloudBranchCommit?: () => void;
   taskId?: string;
+  anchor?: RefObject<HTMLElement | null>;
 }
 
 export function BranchSelector({
@@ -51,9 +52,10 @@ export function BranchSelector({
   onCloudPickerOpen,
   onCloudBranchCommit,
   taskId,
+  anchor,
 }: BranchSelectorProps) {
   const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement>(null);
+  const localAnchorRef = useRef<HTMLButtonElement>(null);
   const trpc = useTRPC();
   const { actions } = useGitInteractionStore();
 
@@ -149,7 +151,7 @@ export function BranchSelector({
       <ComboboxTrigger
         render={
           <Button
-            ref={anchorRef}
+            ref={localAnchorRef}
             variant="outline"
             size="sm"
             disabled={isDisabled}
@@ -171,7 +173,7 @@ export function BranchSelector({
         }
       />
       <ComboboxContent
-        anchor={anchorRef}
+        anchor={anchor ?? localAnchorRef}
         side="bottom"
         sideOffset={6}
         className="min-w-[240px]"

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -73,6 +73,7 @@ export function TaskInput({
 
   const editorRef = useRef<EditorHandle>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const buttonGroupRef = useRef<HTMLDivElement>(null);
   const dragCounterRef = useRef(0);
 
   const [editorIsEmpty, setEditorIsEmpty] = useState(true);
@@ -404,7 +405,6 @@ export function TaskInput({
         position: "relative",
         height: "100%",
         width: "100%",
-        overflow: "hidden",
       }}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
@@ -459,11 +459,7 @@ export function TaskInput({
             zIndex: 1,
           }}
         >
-          <Flex
-            gap="2"
-            align="center"
-            style={{ minWidth: 0, overflow: "hidden" }}
-          >
+          <Flex gap="2" align="center" style={{ minWidth: 0 }}>
             <WorkspaceModeSelect
               value={workspaceMode}
               onChange={setWorkspaceMode}
@@ -479,7 +475,7 @@ export function TaskInput({
                 disabled={isCreatingTask}
               />
             )}
-            <ButtonGroup>
+            <ButtonGroup ref={buttonGroupRef}>
               {workspaceMode === "cloud" ? (
                 <GitHubRepoPicker
                   value={selectedRepository}
@@ -489,6 +485,7 @@ export function TaskInput({
                   placeholder="Select repository..."
                   size="1"
                   disabled={isCreatingTask}
+                  anchor={buttonGroupRef}
                 />
               ) : (
                 <FolderPicker
@@ -496,6 +493,7 @@ export function TaskInput({
                   onChange={setSelectedDirectory}
                   placeholder="Select repository..."
                   size="1"
+                  anchor={buttonGroupRef}
                 />
               )}
               <BranchSelector
@@ -521,6 +519,7 @@ export function TaskInput({
                 cloudBranchesFetchingMore={cloudBranchesFetchingMore}
                 onCloudPickerOpen={resumeCloudBranchesLoading}
                 onCloudBranchCommit={pauseCloudBranchesLoading}
+                anchor={buttonGroupRef}
               />
             </ButtonGroup>
             {cloudRegion === "dev" && (


### PR DESCRIPTION
## Summary
- Add `anchor` prop to `FolderPicker`, `GitHubRepoPicker`, and `BranchSelector` so their dropdown/combobox menus can anchor to a parent element
- `TaskInput` passes a `buttonGroupRef` from the `ButtonGroup` wrapper to all three pickers, so menus align to the group without breaking its layout
- Remove `overflow: hidden` from `TaskInput` container that was clipping focus rings and potentially popover content

<img width="1760" height="852" alt="2026-04-20 15 06 25" src="https://github.com/user-attachments/assets/2a993d5d-e7ce-48dd-a759-d3b886846de0" />

<img width="1760" height="852" alt="2026-04-20 15 08 17" src="https://github.com/user-attachments/assets/bfea080a-5dad-40ed-91fa-fb6dba87a0cd" />




## Test plan
- [x] Open folder picker — dropdown anchors to the button group
- [x] Open GitHub repo picker (cloud mode) — combobox anchors to the button group
- [ x Open branch selector — combobox anchors to the button group
- [ x Verify focus rings on inputs aren't clipped
- [x] Verify `BranchSelector` still works standalone (e.g. in HeaderRow) without an anchor prop — falls back to its own internal ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)