### PR TITLE
feat(code): render cloud attachment prompts

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/buildConversationItems.test.ts
+++ b/apps/code/src/renderer/features/sessions/components/buildConversationItems.test.ts
@@ -94,4 +94,47 @@ describe("buildConversationItems", () => {
       },
     ]);
   });
+
+  it("extracts cloud resource_link attachments into user messages", () => {
+    const fileUri = "file:///tmp/workspace/attachments/Receipt-2264-0277.pdf";
+
+    const events: AcpMessage[] = [
+      {
+        type: "acp_message",
+        ts: 1,
+        message: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "session/prompt",
+          params: {
+            prompt: [
+              { type: "text", text: "what is this about?" },
+              {
+                type: "resource_link",
+                uri: fileUri,
+                name: "Receipt-2264-0277.pdf",
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const result = buildConversationItems(events, null);
+
+    expect(result.items).toEqual([
+      {
+        type: "user_message",
+        id: "turn-1-1-user",
+        content: "what is this about?",
+        timestamp: 1,
+        attachments: [
+          {
+            id: fileUri,
+            label: "Receipt-2264-0277.pdf",
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/apps/code/src/renderer/utils/promptContent.test.ts
+++ b/apps/code/src/renderer/utils/promptContent.test.ts
@@ -47,4 +47,22 @@ describe("promptContent", () => {
       { id: secondUri, label: "README.md" },
     ]);
   });
+
+  it("extracts cloud resource_link attachments from file URIs", () => {
+    const fileUri = "file:///tmp/workspace/attachments/Receipt-2264-0277.pdf";
+
+    const result = extractPromptDisplayContent([
+      { type: "text", text: "what is this about?" },
+      {
+        type: "resource_link",
+        uri: fileUri,
+        name: "Receipt-2264-0277.pdf",
+      },
+    ]);
+
+    expect(result.text).toBe("what is this about?");
+    expect(result.attachments).toEqual([
+      { id: fileUri, label: "Receipt-2264-0277.pdf" },
+    ]);
+  });
 });

--- a/apps/code/src/renderer/utils/promptContent.ts
+++ b/apps/code/src/renderer/utils/promptContent.ts
@@ -44,13 +44,46 @@ export function parseAttachmentUri(uri: string): AttachmentRef | null {
   return { id: uri, label };
 }
 
-function getBlockAttachmentUri(block: ContentBlock): string | null {
+function parseFileUri(
+  uri: string,
+  fallbackLabel?: string,
+): AttachmentRef | null {
+  if (!uri.startsWith("file://")) {
+    return null;
+  }
+
+  try {
+    const pathname = decodeURIComponent(new URL(uri).pathname);
+    const label =
+      fallbackLabel?.trim() || getFileName(pathname) || "attachment";
+    return { id: uri, label };
+  } catch {
+    const label = fallbackLabel?.trim() || getFileName(uri) || "attachment";
+    return { id: uri, label };
+  }
+}
+
+function getBlockAttachmentRef(block: ContentBlock): AttachmentRef | null {
   if (block.type === "resource") {
-    return block.resource.uri ?? null;
+    const uri = block.resource.uri;
+    if (!uri) {
+      return null;
+    }
+
+    return parseAttachmentUri(uri) ?? parseFileUri(uri);
   }
 
   if (block.type === "image") {
-    return block.uri ?? null;
+    const uri = block.uri;
+    if (!uri) {
+      return null;
+    }
+
+    return parseAttachmentUri(uri) ?? parseFileUri(uri);
+  }
+
+  if (block.type === "resource_link") {
+    return parseAttachmentUri(block.uri) ?? parseFileUri(block.uri, block.name);
   }
 
   return null;
@@ -80,11 +113,11 @@ export function extractPromptDisplayContent(
   const seen = new Set<string>();
   const attachments: AttachmentRef[] = [];
   for (const block of blocks) {
-    const uri = getBlockAttachmentUri(block);
-    if (!uri || seen.has(uri)) continue;
-    const ref = parseAttachmentUri(uri);
-    if (!ref) continue;
-    seen.add(uri);
+    const ref = getBlockAttachmentRef(block);
+    if (!ref || seen.has(ref.id)) continue;
+    const { id } = ref;
+    if (!id) continue;
+    seen.add(id);
     attachments.push(ref);
   }
 

--- a/apps/code/src/renderer/utils/session.ts
+++ b/apps/code/src/renderer/utils/session.ts
@@ -57,27 +57,6 @@ export function createUserMessageEvent(text: string, ts: number): AcpMessage {
 }
 
 /**
- * Create a user prompt event from structured content blocks for display.
- */
-export function createUserPromptEvent(
-  prompt: ContentBlock[],
-  ts: number,
-): AcpMessage {
-  return {
-    type: "acp_message",
-    ts,
-    message: {
-      jsonrpc: "2.0",
-      id: ts,
-      method: "session/prompt",
-      params: {
-        prompt,
-      },
-    } as JsonRpcRequest,
-  };
-}
-
-/**
  * Create a user shell execute event.
  * When id is provided, it's used to track async execution (start/complete).
  * When result is undefined, it represents a command that's still running.

--- a/apps/code/src/renderer/utils/session.ts
+++ b/apps/code/src/renderer/utils/session.ts
@@ -34,7 +34,10 @@ function storedEntryToAcpMessage(entry: StoredLogEntry): AcpMessage {
 /**
  * Create a user message event for display.
  */
-export function createUserMessageEvent(text: string, ts: number): AcpMessage {
+export function createUserPromptEvent(
+  prompt: ContentBlock[],
+  ts: number,
+): AcpMessage {
   return {
     type: "acp_message",
     ts,
@@ -43,10 +46,14 @@ export function createUserMessageEvent(text: string, ts: number): AcpMessage {
       id: ts,
       method: "session/prompt",
       params: {
-        prompt: [{ type: "text", text }],
+        prompt,
       },
     } as JsonRpcRequest,
   };
+}
+
+export function createUserMessageEvent(text: string, ts: number): AcpMessage {
+  return createUserPromptEvent([{ type: "text", text }], ts);
 }
 
 /**


### PR DESCRIPTION
## Problem

Cloud prompt messages should render attachment chips in the conversation UI the same way local prompts do.

https://github.com/user-attachments/assets/535243cb-e761-45b8-8bf1-298031ab7fb1

## Changes

- teach prompt parsing to recognize cloud resource links
- render cloud attachment chips in conversation items and cover the new path with tests