### PR TITLE
fix(inbox): omit initial_permission_mode when no adapter is selected

### DIFF
--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -298,9 +298,10 @@ export class TaskCreationSaga extends Saga<
             runSource: input.cloudRunSource ?? "manual",
             signalReportId: input.signalReportId,
             githubUserToken,
-            initialPermissionMode:
-              input.executionMode ??
-              (input.adapter === "codex" ? "auto" : "plan"),
+            initialPermissionMode: input.adapter
+              ? (input.executionMode ??
+                (input.adapter === "codex" ? "auto" : "plan"))
+              : input.executionMode,
           });
         },
         rollback: async () => {


### PR DESCRIPTION
## Problem

Inbox-initiated cloud tasks (signal reports) fail with a 400:

```
{"type":"validation_error","code":"invalid_input",
 "detail":"This field requires runtime_adapter to be set.",
 "attr":"initial_permission_mode"}
```

## Changes

Only include `initialPermissionMode` when an adapter is actually selected. If the user hasn't picked an adapter, let the server apply its default run config (same shape the inbox sent before #1690).