### PR TITLE
feat(inbox): Show implementation tasks

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -17,6 +17,7 @@ import type {
   SignalReportsQueryParams,
   SignalReportsResponse,
   SignalReportTask,
+  SignalReportTaskRelationship,
   SignalTeamConfig,
   SignalUserAutonomyConfig,
   SuggestedReviewersArtefact,
@@ -657,6 +658,8 @@ export class PostHogAPIClient {
         >
       > & {
         github_integration?: number | null;
+        /** POST-only: `SignalReportTask.relationship` to create when linking to `signal_report`. */
+        signal_report_task_relationship?: SignalReportTaskRelationship;
       },
   ) {
     const teamId = await this.getTeamId();

--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@components/ui/Tooltip";
 import { GithubLogo } from "@phosphor-icons/react";
 import {
   Button,
@@ -9,7 +10,7 @@ import {
   ComboboxList,
   ComboboxTrigger,
 } from "@posthog/quill";
-import type { RefObject } from "react";
+import { type RefObject, useEffect, useRef } from "react";
 
 interface GitHubRepoPickerProps {
   value: string | null;
@@ -20,6 +21,8 @@ interface GitHubRepoPickerProps {
   size?: "1" | "2";
   disabled?: boolean;
   anchor?: RefObject<HTMLElement | null>;
+  /** When false, the list is shown without a filter field (e.g. short lists in modals). */
+  showSearchInput?: boolean;
 }
 
 export function GitHubRepoPicker({
@@ -30,7 +33,17 @@ export function GitHubRepoPicker({
   placeholder = "Select repository...",
   disabled = false,
   anchor,
+  showSearchInput = true,
 }: GitHubRepoPickerProps) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const onlyRepo = repositories.length === 1 ? repositories[0] : null;
+
+  useEffect(() => {
+    if (onlyRepo && value !== onlyRepo) {
+      onChange(onlyRepo);
+    }
+  }, [onlyRepo, value, onChange]);
+
   if (isLoading) {
     return (
       <Button variant="outline" disabled size="sm">
@@ -49,6 +62,26 @@ export function GitHubRepoPicker({
     );
   }
 
+  if (onlyRepo) {
+    return (
+      <Tooltip content="Only one GitHub repository is connected, so there's nothing to pick.">
+        <span className="inline-flex min-w-0 max-w-full">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled
+            aria-label="Repository"
+            className="pointer-events-none min-w-0 max-w-full cursor-default justify-start disabled:opacity-100"
+          >
+            <GithubLogo size={14} weight="regular" className="shrink-0" />
+            <span className="min-w-0 truncate">{onlyRepo}</span>
+          </Button>
+        </span>
+      </Tooltip>
+    );
+  }
+
   return (
     <Combobox
       items={repositories}
@@ -61,6 +94,7 @@ export function GitHubRepoPicker({
       <ComboboxTrigger
         render={
           <Button
+            ref={triggerRef}
             variant="outline"
             size="sm"
             disabled={disabled}
@@ -72,12 +106,14 @@ export function GitHubRepoPicker({
         }
       />
       <ComboboxContent
-        anchor={anchor}
+        anchor={anchor ?? triggerRef}
         side="bottom"
         sideOffset={6}
         className="min-w-[280px]"
       >
-        <ComboboxInput placeholder="Search repositories..." />
+        {showSearchInput ? (
+          <ComboboxInput placeholder="Search repositories..." />
+        ) : null}
         <ComboboxEmpty>No repositories found.</ComboboxEmpty>
         <ComboboxList>
           {(repo: string) => (

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -1,14 +1,13 @@
 import { Badge } from "@components/ui/Badge";
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
+import { GitHubRepoPicker } from "@features/folder-picker/components/GitHubRepoPicker";
 import {
   useInboxReportArtefacts,
   useInboxReportSignals,
 } from "@features/inbox/hooks/useInboxReports";
 import { useInboxCloudTaskStore } from "@features/inbox/stores/inboxCloudTaskStore";
 import { buildSignalTaskPrompt } from "@features/inbox/utils/buildSignalTaskPrompt";
-import { useDraftStore } from "@features/message-editor/stores/draftStore";
 import { useCreateTask } from "@features/tasks/hooks/useTasks";
-import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useRepositoryIntegration } from "@hooks/useIntegrations";
 import { useMeQuery } from "@hooks/useMeQuery";
 import {
@@ -17,9 +16,8 @@ import {
   CaretRightIcon,
   ClockIcon,
   Cloud as CloudIcon,
-  CommandIcon,
   EyeIcon,
-  KeyReturnIcon,
+  GitPullRequestIcon,
   WarningIcon,
   XIcon,
 } from "@phosphor-icons/react";
@@ -29,8 +27,8 @@ import {
   Button,
   Flex,
   ScrollArea,
-  Select,
   Text,
+  TextArea,
   Tooltip,
 } from "@radix-ui/themes";
 import type {
@@ -51,6 +49,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { toast } from "sonner";
@@ -58,7 +57,7 @@ import { SignalReportActionabilityBadge } from "../utils/SignalReportActionabili
 import { SignalReportPriorityBadge } from "../utils/SignalReportPriorityBadge";
 import { SignalReportStatusBadge } from "../utils/SignalReportStatusBadge";
 import { SignalReportSummaryMarkdown } from "../utils/SignalReportSummaryMarkdown";
-import { ReportTaskLogs } from "./ReportTaskLogs";
+import { getPrNumberFromUrl, ReportTaskLogs } from "./ReportTaskLogs";
 import { SignalCard } from "./SignalCard";
 
 function isSuggestedReviewerRowMe(
@@ -217,13 +216,10 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
   const signals = signalsQuery.data?.signals ?? [];
 
   // ── Task creation ───────────────────────────────────────────────────────
-  const { navigateToTaskInput, navigateToTask } = useNavigationStore();
-  const draftActions = useDraftStore((s) => s.actions);
+  const { navigateToTask } = useNavigationStore();
   const { invalidateTasks } = useCreateTask();
-  const { repositories, getIntegrationIdForRepo } = useRepositoryIntegration();
-  const cloudModeEnabled = useFeatureFlag("twig-cloud-mode-toggle");
-
-  const isRunningCloudTask = useInboxCloudTaskStore((s) => s.isRunning);
+  const { repositories, getIntegrationIdForRepo, isLoadingRepos } =
+    useRepositoryIntegration();
   const showCloudConfirm = useInboxCloudTaskStore((s) => s.showConfirm);
   const selectedRepo = useInboxCloudTaskStore((s) => s.selectedRepo);
   const openCloudConfirm = useInboxCloudTaskStore((s) => s.openConfirm);
@@ -231,47 +227,40 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
   const setSelectedRepo = useInboxCloudTaskStore((s) => s.setSelectedRepo);
   const runCloudTask = useInboxCloudTaskStore((s) => s.runCloudTask);
 
-  const canActOnReport = report.status === "ready";
+  /** Matches server autostart rules: ready + immediately actionable + not already fixed. */
+  const canCreateImplementationPr =
+    report.status === "ready" &&
+    report.actionability === "immediately_actionable" &&
+    report.already_addressed !== true;
+
+  const [implementationPrUrl, setImplementationPrUrl] = useState<string | null>(
+    null,
+  );
+  const [cloudPromptDraft, setCloudPromptDraft] = useState("");
+  const cloudRepoPickerAnchorRef = useRef<HTMLDivElement>(null);
 
   const buildPrompt = useCallback(() => {
+    const repository = selectedRepo ?? repositories[0] ?? "";
     return buildSignalTaskPrompt({
       report,
-      artefacts: videoSegments,
-      signals,
-      replayBaseUrl,
+      repository,
+      priorityExplanation,
     });
-  }, [report, videoSegments, signals, replayBaseUrl]);
+  }, [report, selectedRepo, repositories, priorityExplanation]);
 
-  const handleCreateTask = useCallback(() => {
-    if (!canActOnReport) return;
-    const prompt = buildPrompt();
-    if (!prompt) return;
-
-    draftActions.setPendingContent("task-input", {
-      segments: [{ type: "text", text: prompt }],
-    });
-    navigateToTaskInput();
-  }, [canActOnReport, buildPrompt, draftActions, navigateToTaskInput]);
-
-  // Cmd/Ctrl+Enter shortcut to create task
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        handleCreateTask();
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [handleCreateTask]);
+    if (showCloudConfirm) {
+      setCloudPromptDraft(buildPrompt() ?? "");
+    }
+  }, [showCloudConfirm, buildPrompt]);
 
   const handleOpenCloudConfirm = useCallback(() => {
     openCloudConfirm(repositories[0] ?? null);
   }, [repositories, openCloudConfirm]);
 
   const handleRunCloudTask = useCallback(async () => {
-    if (!canActOnReport) return;
-    const prompt = buildPrompt();
+    if (!canCreateImplementationPr) return;
+    const prompt = cloudPromptDraft.trim();
     if (!prompt) return;
 
     const result = await runCloudTask({
@@ -289,8 +278,8 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
       toast.error(result.error ?? "Failed to create cloud task");
     }
   }, [
-    canActOnReport,
-    buildPrompt,
+    canCreateImplementationPr,
+    cloudPromptDraft,
     runCloudTask,
     invalidateTasks,
     navigateToTask,
@@ -303,14 +292,16 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
     <>
       {/* ── Header bar ──────────────────────────────────────────── */}
       <Flex
-        direction="column"
+        align="center"
+        justify="between"
         gap="2"
         px="3"
         py="2"
         className="shrink-0"
         style={{ borderBottom: "1px solid var(--gray-5)" }}
       >
-        <Flex align="start" justify="between" gap="2">
+        <Flex align="center" gap="2" className="min-w-0">
+          <SignalReportStatusBadge status={report.status} />
           <Text
             size="1"
             weight="medium"
@@ -318,49 +309,27 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
           >
             {report.title ?? "Untitled signal"}
           </Text>
-          <button
-            type="button"
-            onClick={onClose}
-            className="shrink-0 rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-          >
-            <XIcon size={14} />
-          </button>
-        </Flex>
-        <Flex align="center" justify="between" gap="2">
-          <Flex align="center" gap="1">
-            <Button
-              size="1"
-              variant="soft"
-              onClick={handleCreateTask}
-              disabled={!canActOnReport}
-              className="text-[12px]"
-            >
-              <CloudIcon size={12} />
-              {isRunningCloudTask ? "Running..." : "Run task"}
-              <span className="ml-1 inline-flex items-center gap-px text-gray-9">
-                <CommandIcon size={11} />
-                <KeyReturnIcon size={11} />
-              </span>
-            </Button>
-            {cloudModeEnabled && (
-              <Button
-                size="1"
-                variant="solid"
-                onClick={handleOpenCloudConfirm}
-                disabled={
-                  !canActOnReport ||
-                  isRunningCloudTask ||
-                  repositories.length === 0
-                }
-                className="text-[12px]"
+          {implementationPrUrl && (
+            <Tooltip content={implementationPrUrl}>
+              <a
+                href={implementationPrUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-green-5 px-2 py-0.5 font-medium text-[11px] text-green-12 hover:bg-green-6"
               >
-                <CloudIcon size={12} />
-                {isRunningCloudTask ? "Running..." : "Run cloud"}
-              </Button>
-            )}
-          </Flex>
-          <SignalReportStatusBadge status={report.status} />
+                <GitPullRequestIcon size={12} weight="bold" />
+                {getPrNumberFromUrl(implementationPrUrl) ?? "PR"}
+              </a>
+            </Tooltip>
+          )}
         </Flex>
+        <button
+          type="button"
+          onClick={onClose}
+          className="shrink-0 rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+        >
+          <XIcon size={14} />
+        </button>
       </Flex>
 
       {/* ── Scrollable detail area ──────────────────────────────── */}
@@ -624,6 +593,10 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
         key={report.id}
         reportId={report.id}
         reportStatus={report.status}
+        onRunInCloud={
+          canCreateImplementationPr ? handleOpenCloudConfirm : undefined
+        }
+        onPrUrlChange={setImplementationPrUrl}
       />
 
       {/* ── Cloud task confirmation dialog ────────────────────── */}
@@ -633,51 +606,49 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
           if (!open) closeCloudConfirm();
         }}
       >
-        <AlertDialog.Content maxWidth="420px">
+        <AlertDialog.Content maxWidth="560px" className="overflow-visible">
           <AlertDialog.Title>
             <Flex align="center" gap="2">
               <CloudIcon size={18} />
               <Text weight="bold">Run cloud task</Text>
             </Flex>
           </AlertDialog.Title>
-          <AlertDialog.Description size="2">
-            <Flex direction="column" gap="3">
+          <AlertDialog.Description size="2" className="overflow-visible">
+            <Flex direction="column" gap="3" className="overflow-visible">
               <Text className="text-[13px]">
                 This will create and run a cloud task from this signal report.
+                You can edit the prompt below before running.
               </Text>
-              {repositories.length > 1 ? (
+              <Flex direction="column" gap="1">
+                <Text size="1" weight="medium" className="text-[12px]">
+                  Task prompt
+                </Text>
+                <TextArea
+                  size="2"
+                  rows={10}
+                  value={cloudPromptDraft}
+                  onChange={(e) => setCloudPromptDraft(e.target.value)}
+                  className="min-h-[140px] resize-y font-mono text-[12px] leading-relaxed"
+                  placeholder="Describe what the agent should do…"
+                />
+              </Flex>
+              <Box ref={cloudRepoPickerAnchorRef} className="overflow-visible">
                 <Flex direction="column" gap="1">
                   <Text size="1" weight="medium" className="text-[12px]">
                     Target repository
                   </Text>
-                  <Select.Root
-                    value={selectedRepo ?? undefined}
-                    onValueChange={setSelectedRepo}
-                  >
-                    <Select.Trigger className="text-[13px]" />
-                    <Select.Content>
-                      {repositories.map((repo) => (
-                        <Select.Item
-                          key={repo}
-                          value={repo}
-                          className="text-[13px]"
-                        >
-                          {repo}
-                        </Select.Item>
-                      ))}
-                    </Select.Content>
-                  </Select.Root>
+                  <GitHubRepoPicker
+                    value={selectedRepo}
+                    onChange={setSelectedRepo}
+                    repositories={repositories}
+                    isLoading={isLoadingRepos}
+                    placeholder="Select repository..."
+                    size="1"
+                    anchor={cloudRepoPickerAnchorRef}
+                    showSearchInput={false}
+                  />
                 </Flex>
-              ) : selectedRepo ? (
-                <Flex direction="column" gap="1">
-                  <Text size="1" weight="medium" className="text-[12px]">
-                    Target repository
-                  </Text>
-                  <Text size="2" className="text-[13px]">
-                    {selectedRepo}
-                  </Text>
-                </Flex>
-              ) : null}
+              </Box>
             </Flex>
           </AlertDialog.Description>
           <Flex gap="3" mt="4" justify="end">
@@ -687,7 +658,11 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
               </Button>
             </AlertDialog.Cancel>
             <AlertDialog.Action>
-              <Button variant="solid" onClick={() => void handleRunCloudTask()}>
+              <Button
+                variant="solid"
+                disabled={!cloudPromptDraft.trim()}
+                onClick={() => void handleRunCloudTask()}
+              >
                 <CloudIcon size={14} />
                 Run
               </Button>

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportTaskLogs.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportTaskLogs.tsx
@@ -4,39 +4,54 @@ import {
   CaretUpIcon,
   CheckCircleIcon,
   CircleNotchIcon,
+  Cloud,
+  DotOutlineIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
-import { Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
+import { Button, Spinner, Text, Tooltip } from "@radix-ui/themes";
 import type { SignalReportStatus, SignalReportTask, Task } from "@shared/types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-const RELATIONSHIP_LABELS: Record<SignalReportTask["relationship"], string> = {
+type Relationship = SignalReportTask["relationship"];
+
+const RELATIONSHIP_LABELS: Record<Relationship, string> = {
   repo_selection: "Repository selection",
   research: "Research task",
   implementation: "Implementation task",
 };
 
+// We display relationships in this order, top to bottom.
+const DISPLAYED_RELATIONSHIPS: Relationship[] = ["implementation", "research"];
+
 interface ReportTaskData {
   task: Task;
-  relationship: SignalReportTask["relationship"];
+  relationship: Relationship;
 }
 
-function useReportTask(reportId: string, reportStatus: SignalReportStatus) {
+function useReportTasks(reportId: string, reportStatus: SignalReportStatus) {
   const isActive =
     reportStatus === "candidate" ||
     reportStatus === "in_progress" ||
     reportStatus === "pending_input";
 
-  return useAuthenticatedQuery<ReportTaskData | null>(
-    ["inbox", "report-task", reportId],
+  return useAuthenticatedQuery<ReportTaskData[]>(
+    ["inbox", "report-tasks", reportId],
     async (client) => {
-      const reportTasks = await client.getSignalReportTasks(reportId, {
-        relationship: "research",
-      });
-      const match = reportTasks[0];
-      if (!match) return null;
-      const task = await client.getTask(match.task_id);
-      return { task, relationship: match.relationship };
+      const reportTasks = await client.getSignalReportTasks(reportId);
+      const relevant = reportTasks.filter((rt) =>
+        DISPLAYED_RELATIONSHIPS.includes(rt.relationship),
+      );
+      const tasks = await Promise.all(
+        relevant.map(async (rt) => {
+          const task = (await client.getTask(rt.task_id)) as unknown as Task;
+          return { task, relationship: rt.relationship };
+        }),
+      );
+      return tasks.sort(
+        (a, b) =>
+          DISPLAYED_RELATIONSHIPS.indexOf(a.relationship) -
+          DISPLAYED_RELATIONSHIPS.indexOf(b.relationship),
+      );
     },
     {
       enabled: !!reportId,
@@ -46,11 +61,13 @@ function useReportTask(reportId: string, reportStatus: SignalReportStatus) {
   );
 }
 
-function getTaskStatusSummary(task: Task): {
+interface BarSummary {
   label: string;
   color: string;
   icon: React.ReactNode;
-} {
+}
+
+function getTaskStatusSummary(task: Task): BarSummary {
   const status = task.latest_run?.status;
   switch (status) {
     case "queued":
@@ -89,26 +106,160 @@ function getTaskStatusSummary(task: Task): {
   }
 }
 
+function getResearchPendingSummary(
+  reportStatus: SignalReportStatus,
+  isLoading: boolean,
+): { summary: BarSummary; tooltip: string } {
+  if (isLoading) {
+    return {
+      summary: {
+        label: "Loading…",
+        color: "var(--gray-9)",
+        icon: <Spinner size="1" />,
+      },
+      tooltip: "Checking if a research task exists for this report.",
+    };
+  }
+  if (reportStatus === "candidate") {
+    return {
+      summary: {
+        label: "Queued",
+        color: "var(--gray-9)",
+        icon: <Spinner size="1" />,
+      },
+      tooltip:
+        "This report has been queued. A repository will be selected and then an AI agent will research it.",
+    };
+  }
+  if (reportStatus === "in_progress") {
+    return {
+      summary: {
+        label: "Starting…",
+        color: "var(--amber-9)",
+        icon: <CircleNotchIcon size={14} className="animate-spin" />,
+      },
+      tooltip:
+        "An AI research agent is being set up. Logs will appear here once the agent starts running.",
+    };
+  }
+  return {
+    summary: {
+      label: "Unavailable",
+      color: "var(--gray-9)",
+      icon: <XCircleIcon size={14} />,
+    },
+    tooltip:
+      "No research task is recorded for this report. It may have been created before research tracking was in place.",
+  };
+}
+
+export function getTaskPrUrl(task: Task): string | null {
+  const output = task.latest_run?.output;
+  if (output && typeof output === "object" && !Array.isArray(output)) {
+    const prUrl = (output as Record<string, unknown>).pr_url;
+    if (typeof prUrl === "string" && prUrl.length > 0) {
+      return prUrl;
+    }
+  }
+  return null;
+}
+
+export function getPrNumberFromUrl(prUrl: string): string | null {
+  const match = prUrl.match(/\/pull\/(\d+)(?:$|[/?#])/);
+  return match ? `#${match[1]}` : null;
+}
+
 const BAR_HEIGHT = 38;
+
+interface Bar {
+  relationship: Relationship;
+  task: Task | null;
+  summary: BarSummary;
+  /** Tooltip shown on hover (e.g. pipeline status explanation). */
+  tooltip?: string;
+  /** When true, render a "Create PR" control instead of the status label. */
+  showRunAction?: boolean;
+}
 
 interface ReportTaskLogsProps {
   reportId: string;
   reportStatus: SignalReportStatus;
+  /** Open the cloud task confirmation flow. */
+  onRunInCloud?: () => void;
+  /** Called when the implementation PR URL changes (or becomes null). */
+  onPrUrlChange?: (prUrl: string | null) => void;
 }
 
 export function ReportTaskLogs({
   reportId,
   reportStatus,
+  onRunInCloud,
+  onPrUrlChange,
 }: ReportTaskLogsProps) {
-  const { data, isLoading } = useReportTask(reportId, reportStatus);
-  const [expanded, setExpanded] = useState(false);
+  const { data, isLoading } = useReportTasks(reportId, reportStatus);
+  const [expanded, setExpanded] = useState<Relationship | null>(null);
 
-  const task = data?.task ?? null;
-  const relationship = data?.relationship ?? null;
+  const tasks = data ?? [];
+  const researchTask =
+    tasks.find((t) => t.relationship === "research")?.task ?? null;
+  const implementationTask =
+    tasks.find((t) => t.relationship === "implementation")?.task ?? null;
 
+  const prUrl = implementationTask ? getTaskPrUrl(implementationTask) : null;
+  useEffect(() => {
+    onPrUrlChange?.(prUrl);
+  }, [prUrl, onPrUrlChange]);
+
+  // Build the stacked bars we'll render. We always surface the research bar
+  // (using a pending/unavailable placeholder if no research task exists yet).
+  // For `ready` reports without an implementation task yet, we still show the
+  // implementation row ("Not started"); the Create PR control only appears when
+  // the parent passes `onRunInCloud` (ready + actionable).
+  const bars: Bar[] = [];
+
+  if (researchTask) {
+    bars.push({
+      relationship: "research",
+      task: researchTask,
+      summary: getTaskStatusSummary(researchTask),
+    });
+  } else {
+    const { summary, tooltip } = getResearchPendingSummary(
+      reportStatus,
+      isLoading,
+    );
+    bars.push({
+      relationship: "research",
+      task: null,
+      summary,
+      tooltip,
+    });
+  }
+
+  if (implementationTask) {
+    bars.push({
+      relationship: "implementation",
+      task: implementationTask,
+      summary: getTaskStatusSummary(implementationTask),
+    });
+  } else if (reportStatus === "ready") {
+    bars.push({
+      relationship: "implementation",
+      task: null,
+      summary: {
+        label: "Not started",
+        color: "var(--gray-9)",
+        icon: <DotOutlineIcon size={14} />,
+      },
+      showRunAction: !!onRunInCloud,
+    });
+  }
+
+  // Hide entirely when the report isn't actionable (e.g. POTENTIAL) and we
+  // have no tasks to show — matches the previous behavior.
   const showBar =
     isLoading ||
-    !!task ||
+    tasks.length > 0 ||
     reportStatus === "candidate" ||
     reportStatus === "in_progress" ||
     reportStatus === "ready";
@@ -117,73 +268,32 @@ export function ReportTaskLogs({
     return null;
   }
 
-  const hasTask = !isLoading && !!task;
-
-  // No task yet — show pipeline status with tooltip explaining what's happening
-  if (!hasTask) {
-    let statusText: string;
-    let tooltipText: string;
-    if (isLoading) {
-      statusText = "Loading task…";
-      tooltipText = "Checking if a research task exists for this report.";
-    } else if (reportStatus === "candidate") {
-      statusText = "Queued for research";
-      tooltipText =
-        "This report has been queued. A repository will be selected and then an AI agent will research it.";
-    } else if (reportStatus === "in_progress") {
-      statusText = "Research is starting…";
-      tooltipText =
-        "An AI research agent is being set up. Logs will appear here once the agent starts running.";
-    } else {
-      statusText = "Waiting for research task";
-      tooltipText =
-        "No research task has been created yet. One will appear when the report is picked up for investigation.";
-    }
-
-    return (
-      <Flex
-        align="center"
-        gap="2"
-        px="3"
-        py="2"
-        className="shrink-0 border-gray-5 border-t"
-        style={{ height: BAR_HEIGHT }}
-      >
-        <Tooltip content={tooltipText}>
-          <Flex align="center" gap="2" className="cursor-help">
-            <Spinner size="1" />
-            <Text size="1" color="gray" className="text-[12px]">
-              {statusText}
-            </Text>
-          </Flex>
-        </Tooltip>
-      </Flex>
-    );
-  }
-
-  const status = getTaskStatusSummary(task);
+  const expandedBar = expanded
+    ? (bars.find((b) => b.relationship === expanded && b.task) ?? null)
+    : null;
+  const totalBarsHeight = BAR_HEIGHT * bars.length;
 
   return (
     <>
-      {/* In-flow spacer — same height as the bar */}
+      {/* In-flow spacer — same height as the stacked bars. */}
       <div
         className="shrink-0 border-gray-5 border-t"
-        style={{ height: BAR_HEIGHT }}
+        style={{ height: totalBarsHeight }}
       />
 
       {/* Scrim — biome-ignore: scrim is a non-semantic dismissal target */}
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: scrim dismiss */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: scrim dismiss */}
       <div
-        onClick={expanded ? () => setExpanded(false) : undefined}
+        onClick={expandedBar ? () => setExpanded(null) : undefined}
         style={{
           position: "absolute",
           inset: 0,
           zIndex: 10,
           background: "rgba(0, 0, 0, 0.32)",
-          opacity: expanded ? 1 : 0,
+          opacity: expandedBar ? 1 : 0,
           transition: "opacity 0.2s ease",
-          pointerEvents: expanded ? "auto" : "none",
+          pointerEvents: expandedBar ? "auto" : "none",
         }}
       />
 
@@ -201,51 +311,127 @@ export function ReportTaskLogs({
           borderTop: "1px solid var(--gray-6)",
           background: "var(--color-background)",
           pointerEvents: "none",
-          top: expanded ? "15%" : `calc(100% - ${BAR_HEIGHT}px)`,
+          top: expandedBar ? "15%" : `calc(100% - ${totalBarsHeight}px)`,
           transition: "top 0.25s cubic-bezier(0.32, 0.72, 0, 1)",
         }}
       >
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          style={{ pointerEvents: "auto" }}
-          className="flex w-full shrink-0 cursor-pointer items-center gap-2 border-gray-5 border-b bg-transparent px-3 py-2 text-left transition-colors hover:bg-gray-2"
-        >
-          <span style={{ color: status.color }}>{status.icon}</span>
-          <Text size="1" weight="medium" className="flex-1 text-[12px]">
-            {relationship ? RELATIONSHIP_LABELS[relationship] : "Research task"}
-          </Text>
-          <Text
-            size="1"
-            className="text-[11px]"
-            style={{ color: status.color }}
-          >
-            {status.label}
-          </Text>
-          <span
-            className="inline-flex text-gray-9"
-            style={{
-              transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
-              transition: "transform 0.2s ease",
-            }}
-          >
-            <CaretUpIcon size={12} />
-          </span>
-        </button>
+        {/* Stacked header bars — one per task relationship. */}
+        <div className="shrink-0" style={{ pointerEvents: "auto" }}>
+          {bars.map((bar, index) => {
+            const { relationship, task, summary, tooltip, showRunAction } = bar;
+            const isExpanded = expanded === relationship;
+            const isInteractive = !!task;
 
+            const rowClassName = [
+              "flex w-full items-center gap-2 bg-transparent px-3 py-2 text-left transition-colors",
+              index > 0 ? "border-gray-5 border-t" : "",
+              showRunAction
+                ? "cursor-default"
+                : isInteractive
+                  ? "cursor-pointer hover:bg-gray-2"
+                  : "cursor-default opacity-70",
+              isExpanded && isInteractive ? "bg-gray-2" : "",
+            ]
+              .filter(Boolean)
+              .join(" ");
+
+            const rowInner = (
+              <>
+                <span style={{ color: summary.color }}>{summary.icon}</span>
+                <Text size="1" weight="medium" className="text-[12px]">
+                  {RELATIONSHIP_LABELS[relationship]}
+                </Text>
+                {showRunAction ? (
+                  <span className="flex-1" />
+                ) : (
+                  <Text
+                    size="1"
+                    className="flex-1 text-[11px]"
+                    style={{ color: summary.color }}
+                  >
+                    {summary.label}
+                  </Text>
+                )}
+                {showRunAction && (
+                  <Button
+                    size="1"
+                    variant="solid"
+                    className="gap-1 font-medium text-[11px]"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRunInCloud?.();
+                    }}
+                  >
+                    <Cloud size={12} />
+                    Create PR
+                  </Button>
+                )}
+                {isInteractive && !showRunAction && (
+                  <span
+                    className="inline-flex text-gray-9"
+                    style={{
+                      transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+                      transition: "transform 0.2s ease",
+                    }}
+                  >
+                    <CaretUpIcon size={12} />
+                  </span>
+                )}
+              </>
+            );
+
+            const row =
+              isInteractive && !showRunAction ? (
+                <button
+                  key={relationship}
+                  type="button"
+                  onClick={() =>
+                    setExpanded((curr) =>
+                      curr === relationship ? null : relationship,
+                    )
+                  }
+                  className={rowClassName}
+                  style={{ height: BAR_HEIGHT }}
+                >
+                  {rowInner}
+                </button>
+              ) : (
+                <div
+                  key={relationship}
+                  className={rowClassName}
+                  style={{ height: BAR_HEIGHT }}
+                >
+                  {rowInner}
+                </div>
+              );
+
+            return tooltip ? (
+              <Tooltip key={relationship} content={tooltip}>
+                {row}
+              </Tooltip>
+            ) : (
+              row
+            );
+          })}
+        </div>
+
+        {/* Expanded logs body — only rendered for the selected task. */}
         <div
           style={{
             flex: 1,
             minHeight: 0,
             overflow: "hidden",
-            pointerEvents: expanded ? "auto" : "none",
+            pointerEvents: expandedBar ? "auto" : "none",
           }}
         >
-          <TaskLogsPanel
-            taskId={task.id}
-            task={task}
-            hideInput={reportStatus !== "ready"}
-          />
+          {expandedBar?.task && (
+            <TaskLogsPanel
+              key={expandedBar.task.id}
+              taskId={expandedBar.task.id}
+              task={expandedBar.task}
+              hideInput={reportStatus !== "ready"}
+            />
+          )}
         </div>
       </div>
     </>

--- a/apps/code/src/renderer/features/inbox/utils/buildSignalTaskPrompt.ts
+++ b/apps/code/src/renderer/features/inbox/utils/buildSignalTaskPrompt.ts
@@ -1,63 +1,37 @@
-import type { Signal, SignalReport, SignalReportArtefact } from "@shared/types";
+import type { SignalReport } from "@shared/types";
+
+/** Same mandate string as PostHog autostart; in Code we surface it first for readability. */
+const AUTOSTART_TASK_MANDATE =
+  "Act on this signal report. Investigate the root cause, implement the fix, " +
+  "and open a PR if appropriate.";
 
 export interface SignalPromptInput {
   report: SignalReport;
-  artefacts: SignalReportArtefact[];
-  signals: Signal[];
-  replayBaseUrl: string | null;
+  /** `organization/repository` — same argument as autostart’s `repository`. */
+  repository: string;
+  /** `priority_judgment` artefact explanation; autostart uses `result.priority.explanation`. */
+  priorityExplanation?: string | null;
 }
 
+/**
+ * Build the initial task description for a signal-report cloud task.
+ * Body (summary, priority, repository) matches `_build_autostart_task_description`;
+ * the mandate line is prepended so it reads first in the UI.
+ */
 export function buildSignalTaskPrompt({
   report,
-  artefacts,
-  signals,
-  replayBaseUrl,
+  repository,
+  priorityExplanation,
 }: SignalPromptInput): string {
-  const title = report.title ?? "Untitled signal";
-  const summary = report.summary ?? "No summary available.";
-
-  const lines: string[] = [
-    `# Investigate: ${title}`,
-    "",
-    "## Summary",
-    "",
-    summary,
-    "",
-    `**Signal strength:** ${report.signal_count} occurrences`,
-  ];
-
-  if (signals.length > 0) {
-    lines.push("", "## Signals");
-
-    for (const signal of signals) {
-      const timestamp = new Date(signal.timestamp).toLocaleString();
-      lines.push(
-        "",
-        `### ${signal.source_product} / ${signal.source_type} (${timestamp})`,
-        "",
-        signal.content,
-        "",
-        `- Weight: ${signal.weight}`,
-      );
-      if (signal.source_id) {
-        lines.push(`- Source ID: ${signal.source_id}`);
-      }
-    }
-  }
-
-  if (artefacts.length > 0) {
-    lines.push("", "## Evidence");
-
-    for (const artefact of artefacts) {
-      const timestamp = new Date(artefact.content.start_time).toLocaleString();
-      lines.push("", `### Session ${timestamp}`, "", artefact.content.content);
-      if (replayBaseUrl) {
-        lines.push(
-          `[View replay](${replayBaseUrl}/${artefact.content.session_id})`,
-        );
-      }
-    }
-  }
-
-  return lines.join("\n");
+  const summary = report.summary ?? "";
+  const priorityLine =
+    report.priority != null
+      ? `Priority: ${report.priority}\nReason: ${priorityExplanation ?? ""}\n\n`
+      : "";
+  return (
+    `${AUTOSTART_TASK_MANDATE}\n\n` +
+    `${summary}\n\n` +
+    `${priorityLine}` +
+    `Repository: ${repository}\n`
+  );
 }

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -20,7 +20,11 @@ import type { PostHogAPIClient } from "@renderer/api/posthogClient";
 import { trpcClient } from "@renderer/trpc";
 import { generateTitleAndSummary } from "@renderer/utils/generateTitle";
 import { getTaskRepository } from "@renderer/utils/repository";
-import type { ExecutionMode, Task } from "@shared/types";
+import {
+  type ExecutionMode,
+  SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP,
+  type Task,
+} from "@shared/types";
 import type { CloudRunSource, PrAuthorshipMode } from "@shared/types/cloud";
 import { getGhUserTokenOrThrow } from "@utils/github";
 import { logger } from "@utils/logger";
@@ -436,6 +440,9 @@ export class TaskCreationSaga extends Saga<
               : undefined,
           origin_product: input.signalReportId ? "signal_report" : undefined,
           signal_report: input.signalReportId ?? undefined,
+          signal_report_task_relationship: input.signalReportId
+            ? SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP
+            : undefined,
         });
         return result as unknown as Task;
       },

--- a/apps/code/src/shared/types.ts
+++ b/apps/code/src/shared/types.ts
@@ -458,9 +458,23 @@ export interface SignalReportsQueryParams {
   suggested_reviewers?: string;
 }
 
+/** Values match `SignalReportTask.Relationship` on the PostHog API. */
+export const SIGNAL_REPORT_TASK_RELATIONSHIPS = [
+  "repo_selection",
+  "research",
+  "implementation",
+] as const;
+
+export type SignalReportTaskRelationship =
+  (typeof SIGNAL_REPORT_TASK_RELATIONSHIPS)[number];
+
+/** Inbox / cloud PR tasks must use this when creating the `SignalReportTask` link. */
+export const SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP: SignalReportTaskRelationship =
+  "implementation";
+
 export interface SignalReportTask {
   id: string;
-  relationship: "repo_selection" | "research" | "implementation";
+  relationship: SignalReportTaskRelationship;
   task_id: string;
   created_at: string;
 }


### PR DESCRIPTION
## Problem

We weren't showing implementation tasks associated with reports.

## Changes

Now we are:

<img width="540" height="202" alt="Screenshot 2026-04-20 at 19 22 02@2x" src="https://github.com/user-attachments/assets/4562903e-0561-49b0-8bfb-6624283b50ae" />

Plus, removed the "Run local" or "Run cloud" buttons.