### PR TITLE
feat(inbox): priority sort — actionable ready before not_actionable

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -155,10 +155,7 @@ function normalizeActionabilityJudgmentArtefact(
   const contentValue = isObjectRecord(value.content) ? value.content : null;
   if (!contentValue) return null;
 
-  // Support both agentic ("actionability") and legacy ("choice") field names
-  const actionability =
-    optionalString(contentValue.actionability) ??
-    optionalString(contentValue.choice);
+  const actionability = optionalString(contentValue.actionability);
   if (!actionability || !ACTIONABILITY_VALUES.has(actionability)) return null;
 
   return {

--- a/apps/code/src/renderer/features/inbox/utils/filterReports.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/filterReports.test.ts
@@ -114,6 +114,15 @@ describe("buildSignalReportListOrdering", () => {
       "status,-is_suggested_reviewer,-signal_count",
     );
   });
+
+  it("priority sort orders actionable ready before not_actionable then by priority", () => {
+    expect(buildSignalReportListOrdering("priority", "desc")).toBe(
+      "status,actionability_ready_rank,-is_suggested_reviewer,-priority",
+    );
+    expect(buildSignalReportListOrdering("priority", "asc")).toBe(
+      "status,actionability_ready_rank,-is_suggested_reviewer,priority",
+    );
+  });
 });
 
 describe("buildSuggestedReviewerFilterParam", () => {

--- a/apps/code/src/renderer/features/inbox/utils/filterReports.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/filterReports.test.ts
@@ -115,12 +115,12 @@ describe("buildSignalReportListOrdering", () => {
     );
   });
 
-  it("priority sort orders actionable ready before not_actionable then by priority", () => {
+  it("priority sort uses the same status + reviewer + field chain", () => {
     expect(buildSignalReportListOrdering("priority", "desc")).toBe(
-      "status,actionability_ready_rank,-is_suggested_reviewer,-priority",
+      "status,-is_suggested_reviewer,-priority",
     );
     expect(buildSignalReportListOrdering("priority", "asc")).toBe(
-      "status,actionability_ready_rank,-is_suggested_reviewer,priority",
+      "status,-is_suggested_reviewer,priority",
     );
   });
 });

--- a/apps/code/src/renderer/features/inbox/utils/filterReports.ts
+++ b/apps/code/src/renderer/features/inbox/utils/filterReports.ts
@@ -34,14 +34,18 @@ export function buildStatusFilterParam(statuses: SignalReportStatus[]): string {
 /**
  * Comma-separated `ordering` for the signal report list API:
  * 1. Status rank (ready first — semantic server-side rank, always applied)
- * 2. Suggested reviewer (current user's reports first)
- * 3. Toolbar-selected field (priority, total_weight, created_at, etc.)
+ * 2. For priority sort only: actionable ready reports before not_actionable (`actionability_ready_rank`)
+ * 3. Suggested reviewer (current user's reports first; server forces false for not_actionable)
+ * 4. Toolbar-selected field (priority, total_weight, created_at, etc.)
  */
 export function buildSignalReportListOrdering(
   field: SignalReportOrderingField,
   direction: "asc" | "desc",
 ): string {
   const fieldKey = direction === "desc" ? `-${field}` : field;
+  if (field === "priority") {
+    return `status,actionability_ready_rank,-is_suggested_reviewer,${fieldKey}`;
+  }
   return `status,-is_suggested_reviewer,${fieldKey}`;
 }
 

--- a/apps/code/src/renderer/features/inbox/utils/filterReports.ts
+++ b/apps/code/src/renderer/features/inbox/utils/filterReports.ts
@@ -33,19 +33,15 @@ export function buildStatusFilterParam(statuses: SignalReportStatus[]): string {
 
 /**
  * Comma-separated `ordering` for the signal report list API:
- * 1. Status rank (ready first — semantic server-side rank, always applied)
- * 2. For priority sort only: actionable ready reports before not_actionable (`actionability_ready_rank`)
- * 3. Suggested reviewer (current user's reports first; server forces false for not_actionable)
- * 4. Toolbar-selected field (priority, total_weight, created_at, etc.)
+ * 1. Status rank (semantic server-side rank: ready splits into actionable vs not_actionable before other stages)
+ * 2. Suggested reviewer (current user's reports first; server forces false for not_actionable)
+ * 3. Toolbar-selected field (priority, total_weight, created_at, etc.)
  */
 export function buildSignalReportListOrdering(
   field: SignalReportOrderingField,
   direction: "asc" | "desc",
 ): string {
   const fieldKey = direction === "desc" ? `-${field}` : field;
-  if (field === "priority") {
-    return `status,actionability_ready_rank,-is_suggested_reviewer,${fieldKey}`;
-  }
   return `status,-is_suggested_reviewer,${fieldKey}`;
 }
 


### PR DESCRIPTION
## Problem

The Code inbox must request list ordering consistent with the signal-report API: actionable ready before not-actionable as part of `status`. Artefact parsing should match the API (`actionability` only).

Companion backend PR: https://github.com/PostHog/posthog/pull/55359


## Changes

- **`buildSignalReportListOrdering`**: unchanged shape `status,-is_suggested_reviewer,<field>` — the server now encodes actionable vs not_actionable inside **`status`**.
- **`posthogClient`**: `actionability_judgment` content uses **`actionability` only** (legacy **`choice`** fallback removed).

No visual layout changes.

## How did you test this?

- `pnpm exec vitest run src/renderer/features/inbox/utils/filterReports.test.ts` (passed).

<!-- If there are frontend changes, include screenshots. -->