### PR TITLE
ci: shadow typecheck/unit/integration jobs on Blacksmith

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,19 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: "pnpm"
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ matrix.runner }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ matrix.runner }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -63,7 +75,19 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: "pnpm"
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ matrix.runner }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ matrix.runner }}-
 
       - name: Cache Playwright browsers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,12 @@ concurrency:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(vars.BLACKSMITH_SHADOW_ENABLED == 'true' && '["ubuntu-latest","blacksmith-4vcpu-ubuntu-2404"]' || '["ubuntu-latest"]') }}
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.runner != 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -37,7 +42,12 @@ jobs:
         run: pnpm test
 
   integration-test:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(vars.BLACKSMITH_SHADOW_ENABLED == 'true' && '["macos-latest","blacksmith-6vcpu-macos-latest"]' || '["macos-latest"]') }}
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.runner != 'macos-latest' }}
     permissions:
       contents: read
     steps:
@@ -60,17 +70,17 @@ jobs:
         id: playwright-cache
         with:
           path: ~/Library/Caches/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: playwright-${{ matrix.runner }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            playwright-${{ runner.os }}-
+            playwright-${{ matrix.runner }}-
 
       - name: Cache Electron binary
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/Library/Caches/electron
-          key: electron-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: electron-${{ matrix.runner }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            electron-${{ runner.os }}-
+            electron-${{ matrix.runner }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -103,7 +113,7 @@ jobs:
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: failure()
+        if: failure() && matrix.runner == 'macos-latest'
         with:
           name: playwright-report
           path: apps/code/playwright-report/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   unit-test:
+    name: ${{ matrix.runner == 'ubuntu-latest' && 'unit-test' || format('unit-test ({0})', matrix.runner) }}
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +55,7 @@ jobs:
         run: pnpm test
 
   integration-test:
+    name: ${{ matrix.runner == 'macos-latest' && 'integration-test' || format('integration-test ({0})', matrix.runner) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -30,7 +30,19 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: "pnpm"
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ matrix.runner }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ matrix.runner }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,7 +9,12 @@ concurrency:
 
 jobs:
   typecheck:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(vars.BLACKSMITH_SHADOW_ENABLED == 'true' && '["ubuntu-latest","blacksmith-4vcpu-ubuntu-2404"]' || '["ubuntu-latest"]') }}
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.runner != 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   typecheck:
+    name: ${{ matrix.runner == 'ubuntu-latest' && 'typecheck' || format('typecheck ({0})', matrix.runner) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Adds a `runner` matrix dimension to `typecheck`, `unit-test`, and `integration-test` so each job can run head-to-head on GitHub-hosted and Blacksmith runners for apples-to-apples comparison data. Inspired by [PostHog/posthog#54559](https://github.com/PostHog/posthog/pull/54559).
- Gated behind repo variable `BLACKSMITH_SHADOW_ENABLED` so shadows can be toggled without a code change. Pairs `ubuntu-latest` ↔ `blacksmith-4vcpu-ubuntu-2404` and `macos-latest` ↔ `blacksmith-6vcpu-macos-latest`.
- Shadow entries are `continue-on-error: true` so Blacksmith failures don't block PRs. Cache keys are scoped to `matrix.runner` to avoid cross-runner poisoning, and the Playwright report only uploads from the `macos-latest` primary.

## Before this is useful

- [ ] Set repo variable `BLACKSMITH_SHADOW_ENABLED=true` in Settings → Variables → Actions.
- [ ] Install the Blacksmith GitHub App on the repo.
- [ ] Update branch protection: matrix expansion renames required checks (e.g. `typecheck` → `typecheck (ubuntu-latest)`), and Blacksmith entries should be excluded from required checks.

## Test plan

- [ ] Leave `BLACKSMITH_SHADOW_ENABLED` unset and confirm this PR's CI still runs exactly one entry per job (original behavior).
- [ ] After flipping the flag, confirm both runners pick up jobs and produce paired durations on the same SHA.
- [ ] Confirm the Playwright report artifact uploads only once on failure (from `macos-latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)