### PR TITLE
feat: Add auto permission mode for Claude adapter

### DIFF
--- a/apps/code/src/renderer/features/message-editor/components/ModeSelector.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/ModeSelector.tsx
@@ -6,6 +6,7 @@ import {
   LockOpen,
   Pause,
   Pencil,
+  Robot,
   ShieldCheck,
 } from "@phosphor-icons/react";
 import {
@@ -42,8 +43,8 @@ const MODE_STYLES: Record<string, ModeStyle> = {
     className: "text-red-11",
   },
   auto: {
-    icon: <Pencil size={12} />,
-    className: "text-gray-11",
+    icon: <Robot size={12} weight="fill" />,
+    className: "text-blue-11",
   },
   "read-only": {
     icon: <Eye size={12} />,

--- a/apps/code/src/renderer/features/settings/components/sections/ClaudeCodeSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/ClaudeCodeSettings.tsx
@@ -196,9 +196,9 @@ export function ClaudeCodeSettings() {
             <Warning weight="fill" />
           </Callout.Icon>
           <Callout.Text>
-            Auto-accept is enabled. All actions (shell commands, file edits, web
-            requests) run without approval. Pick this mode from the mode menu in
-            the prompt input per session.
+            Bypass Permissions is enabled. All actions (shell commands, file
+            edits, web requests) run without approval. Pick this mode from the
+            mode menu in the prompt input per session.
           </Callout.Text>
         </Callout.Root>
       )}

--- a/packages/agent/src/adapters/claude/UPSTREAM.md
+++ b/packages/agent/src/adapters/claude/UPSTREAM.md
@@ -51,7 +51,6 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 | Session storage | `this.sessions[sessionId]` (multi) | `this.session` (single) | Architectural choice |
 | bypassPermissions | `updatedPermissions` with `destination: "session"` | No `updatedPermissions` | Different permission persistence |
 | Auth methods | `claude-ai-login` + `console-login` | Returns empty `authMethods` | Auth handled externally |
-| `auto` mode | Model classifier for auto-approval | Not implemented | PostHog uses its own permission model |
 | Session fingerprinting | Implicit teardown on cwd/mcp change | Explicit `refreshSession()` | Caller-initiated is more predictable |
 | Shutdown on ACP close | Process exits | No standalone process | Agent is embedded in server |
 
@@ -65,10 +64,10 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 - **Mid-stream usage updates** (v0.29.1): Fire `usage_update` from `message_start`/`message_delta` stream events
 - **Raw SDK message relay** (v0.27.0): `emitRawSDKMessages` on `NewSessionMeta` for opt-in diagnostics
 - **Effort level sync** (v0.25.x): `xhigh` level added, `applyFlagSettings` on effort change
+- **Auto permission mode** (v0.25.0): Added to `CODE_EXECUTION_MODES`, available modes, ExitPlanMode options
 
 ## Skipped in v0.30.0 Sync
 
-- **`auto` permission mode** (v0.25.0): PostHog has its own permission model
 - **Separate auth methods** (v0.25.0): PostHog returns empty authMethods
 - **Session fingerprinting** (v0.25.3): PostHog uses explicit `refreshSession()` instead
 - **Process exit on ACP close** (v0.27.0): PostHog embeds agent in server

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -164,7 +164,8 @@ async function applyPlanApproval(
 
   if (
     response.outcome?.outcome === "selected" &&
-    (response.outcome.optionId === "default" ||
+    (response.outcome.optionId === "auto" ||
+      response.outcome.optionId === "default" ||
       response.outcome.optionId === "acceptEdits" ||
       response.outcome.optionId === "bypassPermissions")
   ) {

--- a/packages/agent/src/adapters/claude/permissions/permission-options.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-options.ts
@@ -108,6 +108,11 @@ export function buildExitPlanModePermissionOptions(): PermissionOption[] {
   options.push(
     {
       kind: "allow_always",
+      name: 'Yes, and use "auto" mode',
+      optionId: "auto",
+    },
+    {
+      kind: "allow_always",
       name: "Yes, and auto-accept edits",
       optionId: "acceptEdits",
     },

--- a/packages/agent/src/adapters/claude/tools.ts
+++ b/packages/agent/src/adapters/claude/tools.ts
@@ -41,10 +41,10 @@ const BASE_ALLOWED_TOOLS = [
 ];
 
 const AUTO_ALLOWED_TOOLS: Record<string, Set<string>> = {
+  auto: new Set(BASE_ALLOWED_TOOLS),
   default: new Set(BASE_ALLOWED_TOOLS),
   acceptEdits: new Set([...BASE_ALLOWED_TOOLS, ...WRITE_TOOLS]),
   plan: new Set(BASE_ALLOWED_TOOLS),
-  // dontAsk: new Set(BASE_ALLOWED_TOOLS),
 };
 
 export function isToolAllowedForMode(

--- a/packages/agent/src/adapters/codex/codex-agent.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.ts
@@ -124,6 +124,7 @@ function prependPrContext(params: PromptRequest): PromptRequest {
 }
 
 const CODEX_NATIVE_MODE: Record<CodeExecutionMode, CodexNativeMode> = {
+  auto: "auto",
   default: "auto",
   acceptEdits: "auto",
   plan: "read-only",

--- a/packages/agent/src/execution-mode.test.ts
+++ b/packages/agent/src/execution-mode.test.ts
@@ -4,6 +4,7 @@ import { getAvailableCodexModes, getAvailableModes } from "./execution-mode";
 describe("execution modes", () => {
   it("includes auto-accept permissions for claude sessions", () => {
     expect(getAvailableModes().map((mode) => mode.id)).toEqual([
+      "auto",
       "default",
       "acceptEdits",
       "plan",

--- a/packages/agent/src/execution-mode.test.ts
+++ b/packages/agent/src/execution-mode.test.ts
@@ -4,11 +4,11 @@ import { getAvailableCodexModes, getAvailableModes } from "./execution-mode";
 describe("execution modes", () => {
   it("includes auto-accept permissions for claude sessions", () => {
     expect(getAvailableModes().map((mode) => mode.id)).toEqual([
-      "auto",
       "default",
       "acceptEdits",
       "plan",
       "bypassPermissions",
+      "auto",
     ]);
   });
 

--- a/packages/agent/src/execution-mode.ts
+++ b/packages/agent/src/execution-mode.ts
@@ -11,11 +11,6 @@ const ALLOW_BYPASS = !IS_ROOT;
 
 const availableModes: ModeInfo[] = [
   {
-    id: "auto",
-    name: "Auto",
-    description: "Use a model classifier to approve/deny permission prompts",
-  },
-  {
     id: "default",
     name: "Default",
     description: "Standard behavior, prompts for dangerous operations",
@@ -33,20 +28,27 @@ const availableModes: ModeInfo[] = [
 ];
 
 if (ALLOW_BYPASS) {
-  availableModes.push({
-    id: "bypassPermissions",
-    name: "Auto-accept Permissions",
-    description: "Auto-accept all permission requests",
-  });
+  availableModes.push(
+    {
+      id: "bypassPermissions",
+      name: "Bypass Permissions",
+      description: "Auto-accept all permission requests",
+    },
+    {
+      id: "auto",
+      name: "Auto Mode",
+      description: "Use a model classifier to approve/deny permission prompts",
+    },
+  );
 }
 
 // Expose execution mode IDs in type-safe order for type checks
 export const CODE_EXECUTION_MODES = [
-  "auto",
   "default",
   "acceptEdits",
   "plan",
   "bypassPermissions",
+  "auto",
 ] as const;
 
 export type CodeExecutionMode = (typeof CODE_EXECUTION_MODES)[number];

--- a/packages/agent/src/execution-mode.ts
+++ b/packages/agent/src/execution-mode.ts
@@ -11,6 +11,11 @@ const ALLOW_BYPASS = !IS_ROOT;
 
 const availableModes: ModeInfo[] = [
   {
+    id: "auto",
+    name: "Auto",
+    description: "Use a model classifier to approve/deny permission prompts",
+  },
+  {
     id: "default",
     name: "Default",
     description: "Standard behavior, prompts for dangerous operations",
@@ -25,11 +30,6 @@ const availableModes: ModeInfo[] = [
     name: "Plan Mode",
     description: "Planning mode, no actual tool execution",
   },
-  // {
-  //   id: "dontAsk",
-  //   name: "Don't Ask",
-  //   description: "Don't prompt for permissions, deny if not pre-approved",
-  // },
 ];
 
 if (ALLOW_BYPASS) {
@@ -42,10 +42,10 @@ if (ALLOW_BYPASS) {
 
 // Expose execution mode IDs in type-safe order for type checks
 export const CODE_EXECUTION_MODES = [
+  "auto",
   "default",
   "acceptEdits",
   "plan",
-  // "dontAsk",
   "bypassPermissions",
 ] as const;
 


### PR DESCRIPTION
## Problem

Claude upstream supports an auto mode that uses a model classifier to approve/deny permission prompts, but it was previously skipped in our fork.

## ![CleanShot 2026-04-20 at 20.30.50@2x.png](https://app.graphite.com/user-attachments/assets/301def01-e5d0-4879-995f-48709643caae.png)



## Changes

1. Add auto to CODE_EXECUTION_MODES, available modes and AUTO_ALLOWED_TOOLS
2. Add "auto" option to ExitPlanMode permission options and approval handler
3. Map auto mode to Codex native auto mode
4. Update ModeSelector UI with Robot icon and blue styling for auto mode
5. Update [UPSTREAM.md](http://UPSTREAM.md) to reflect auto mode is now adopted

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->