### PR TITLE
fix(phai): route _posthog/refresh_session through HTTP /command

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -12,7 +12,7 @@ import { type ServerType, serve } from "@hono/node-server";
 import { getCurrentBranch } from "@posthog/git/queries";
 import { Hono } from "hono";
 import packageJson from "../../package.json" with { type: "json" };
-import { POSTHOG_NOTIFICATIONS } from "../acp-extensions";
+import { POSTHOG_METHODS, POSTHOG_NOTIFICATIONS } from "../acp-extensions";
 import {
   createAcpConnection,
   type InProcessAcpConnection,
@@ -642,6 +642,23 @@ export class AgentServer {
         return {
           configOptions: result.configOptions,
         };
+      }
+
+      case POSTHOG_METHODS.REFRESH_SESSION:
+      case "posthog/refresh_session":
+      case "refresh_session": {
+        const mcpServers = Array.isArray(params.mcpServers)
+          ? params.mcpServers
+          : [];
+
+        this.logger.info("Refresh session requested", {
+          serverCount: mcpServers.length,
+        });
+
+        return await this.session.clientConnection.extMethod(
+          POSTHOG_METHODS.REFRESH_SESSION,
+          { mcpServers },
+        );
       }
 
       case POSTHOG_NOTIFICATIONS.PERMISSION_RESPONSE:

--- a/packages/agent/src/server/schemas.test.ts
+++ b/packages/agent/src/server/schemas.test.ts
@@ -184,4 +184,44 @@ describe("validateCommandParams", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("accepts _posthog/refresh_session with mcpServers", () => {
+    const result = validateCommandParams("_posthog/refresh_session", {
+      mcpServers: [
+        { type: "http", name: "mcp", url: "https://mcp.example.com" },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts posthog/refresh_session with empty mcpServers", () => {
+    const result = validateCommandParams("posthog/refresh_session", {
+      mcpServers: [],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts bare refresh_session", () => {
+    const result = validateCommandParams("refresh_session", {
+      mcpServers: [],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects refresh_session without mcpServers", () => {
+    const result = validateCommandParams("_posthog/refresh_session", {});
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects refresh_session with invalid mcpServers entry", () => {
+    const result = validateCommandParams("_posthog/refresh_session", {
+      mcpServers: [{ type: "stdio", name: "bad", command: "/bin/x" }],
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/agent/src/server/schemas.ts
+++ b/packages/agent/src/server/schemas.ts
@@ -60,6 +60,10 @@ export const setConfigOptionParamsSchema = z.object({
   value: z.string().min(1, "value is required"),
 });
 
+export const refreshSessionParamsSchema = z.object({
+  mcpServers: mcpServersSchema,
+});
+
 export const commandParamsSchemas = {
   user_message: userMessageParamsSchema,
   "posthog/user_message": userMessageParamsSchema,
@@ -71,6 +75,9 @@ export const commandParamsSchemas = {
   "posthog/permission_response": permissionResponseParamsSchema,
   set_config_option: setConfigOptionParamsSchema,
   "posthog/set_config_option": setConfigOptionParamsSchema,
+  refresh_session: refreshSessionParamsSchema,
+  "posthog/refresh_session": refreshSessionParamsSchema,
+  "_posthog/refresh_session": refreshSessionParamsSchema,
 } as const;
 
 export type CommandMethod = keyof typeof commandParamsSchemas;
@@ -82,7 +89,7 @@ export function validateCommandParams(
   const schema =
     commandParamsSchemas[method as CommandMethod] ??
     commandParamsSchemas[
-      method.replace("posthog/", "") as keyof typeof commandParamsSchemas
+      method.replace(/^_?posthog\//, "") as keyof typeof commandParamsSchemas
     ];
 
   if (!schema) {


### PR DESCRIPTION
## Problem

The backend sandbox calls `POST /command` with `_posthog/refresh_session` (to refresh the Claude/Codex session with newly provisioned MCP servers), but the sandbox agent-server rejected it with JSON-RPC `-32602 Unknown method: _posthog/refresh_session`. As a result, the Temporal `send_refresh_session` activity failed and `mark_mcp_token_issued` never wrote the Redis key, leaving downstream MCP state inconsistent.

Two layers were missing:

- `commandParamsSchemas` in `server/schemas.ts` whitelists allowed methods. `_posthog/refresh_session` was not there, and the `posthog/` strip fallback did not match the `_posthog/` form.
- `executeCommand` in `agent-server.ts` has a `switch` that dispatches validated methods, but had no `REFRESH_SESSION` case. The handler already existed at the ACP layer (`ClaudeAcpAgent.extMethod` / `CodexAcpAgent.extMethod`) — it just wasn't reachable over HTTP.

## Changes

- Add `refreshSessionParamsSchema = z.object({ mcpServers: mcpServersSchema })` and register it under `refresh_session`, `posthog/refresh_session`, and `_posthog/refresh_session`.
- Broaden the prefix-strip fallback from `.replace("posthog/", "")` to `.replace(/^_?posthog\//, "")` so the `_posthog/` form cleanly resolves to the bare key.
- In `executeCommand`, add a `POSTHOG_METHODS.REFRESH_SESSION` case that forwards via `clientConnection.extMethod(POSTHOG_METHODS.REFRESH_SESSION, { mcpServers })` — reusing the existing Claude/Codex refresh implementations (no new refresh logic).

## How did you test this code?

- `pnpm --filter agent typecheck` — clean.
- `pnpm --filter agent exec vitest run src/server/schemas.test.ts` — 25/25 passing, including 5 new tests covering the three method aliases, missing `mcpServers`, and invalid MCP server entries.
- `pnpm --filter agent exec vitest run src/server/agent-server.test.ts` — 30/30 passing (no regressions in the existing HTTP dispatch tests).

Note: consumers need to bump their `@posthog/agent` pin (and rebuild the sandbox image) after this is published for the fix to take effect end-to-end.

## Publish to changelog?

no