### PR TITLE
fix: properly recover from idle kill

### DIFF
--- a/apps/code/src/renderer/features/sessions/hooks/useSessionConnection.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionConnection.ts
@@ -131,7 +131,9 @@ export function useSessionConnection({
         .finally(() => {
           connectingTasks.delete(taskId);
         });
-      return;
+      return () => {
+        connectingTasks.delete(taskId);
+      };
     }
 
     if (

--- a/apps/code/src/renderer/features/sessions/hooks/useSessionConnection.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionConnection.ts
@@ -4,10 +4,13 @@ import { trpcClient } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
 import { useQueryClient } from "@tanstack/react-query";
+import { logger } from "@utils/logger";
 import { useEffect } from "react";
 import { getSessionService } from "../service/service";
-import type { AgentSession } from "../stores/sessionStore";
+import { type AgentSession, sessionStoreSetters } from "../stores/sessionStore";
 import { useChatTitleGenerator } from "./useChatTitleGenerator";
+
+const log = logger.scope("session-connection");
 
 const connectingTasks = new Set<string>();
 const activityRecorded = new Set<string>();
@@ -111,6 +114,25 @@ export function useSessionConnection({
     if (!isOnline) return;
     if (isCloud) return;
     if (isSuspended) return;
+
+    if (session?.status === "error" && session?.idleKilled) {
+      const taskRunId = session.taskRunId;
+      connectingTasks.add(taskId);
+      getSessionService()
+        .clearSessionError(taskId, repoPath)
+        .catch((error) => {
+          log.error("Auto-reconnect after idle kill failed", error);
+          sessionStoreSetters.updateSession(taskRunId, {
+            idleKilled: false,
+            errorMessage:
+              "Session disconnected due to inactivity. Click Retry to reconnect.",
+          });
+        })
+        .finally(() => {
+          connectingTasks.delete(taskId);
+        });
+      return;
+    }
 
     if (
       session?.status === "connected" ||

--- a/apps/code/src/renderer/features/sessions/hooks/useSessionViewState.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionViewState.ts
@@ -17,7 +17,7 @@ export function useSessionViewState(taskId: string, task: Task) {
     (!cloudStatus || cloudStatus === "queued" || cloudStatus === "in_progress");
   const isCloudRunTerminal = isCloud && !isCloudRunNotTerminal;
 
-  const hasError = session?.status === "error";
+  const hasError = session?.status === "error" && !session?.idleKilled;
   const isRunning = isCloud ? !hasError : session?.status === "connected";
 
   const events = session?.events ?? [];

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -585,11 +585,11 @@ export class SessionService {
     this.unsubscribeFromChannel(taskRunId);
     sessionStoreSetters.updateSession(taskRunId, {
       status: "error",
-      errorMessage:
-        "Session disconnected due to inactivity. Click Retry to reconnect.",
+      errorMessage: "Session disconnected due to inactivity. Reconnecting…",
       isPromptPending: false,
       isCompacting: false,
       promptStartedAt: null,
+      idleKilled: true,
     });
   }
 

--- a/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
@@ -78,6 +78,7 @@ export interface AgentSession {
   contextSize?: number;
   /** Pre-computed conversation summary for commit/PR generation context */
   conversationSummary?: string;
+  idleKilled?: boolean;
 }
 
 // --- Config Option Helpers ---


### PR DESCRIPTION
## Problem

We kill any session after 15 minutes because each claude/codex instance takes up .5GB - 1.5GB each. We weren't properly recovering after killing it though. This should prevent people from having to manually reconnect themselves.
<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->


## Changes

Add idle kill detection + recovery
<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

reduced timeout to 10s and verified it recovers by itself.

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->
