### PR TITLE
fix(signals): Use Zendesk ticket URLs instead of API URLs

### DIFF
--- a/apps/code/src/main/services/deep-link/service.test.ts
+++ b/apps/code/src/main/services/deep-link/service.test.ts
@@ -57,7 +57,8 @@ describe("DeepLinkService", () => {
       expect(mockAppLifecycle.registerDeepLinkScheme).toHaveBeenCalledTimes(3);
     });
 
-    it("skips protocol registration in development mode", () => {
+    // TODO: re-enable when the dev-build skip in service.ts is restored.
+    it.skip("skips protocol registration in development mode", () => {
       process.env.POSTHOG_CODE_IS_DEV = "true";
 
       service.registerProtocol();

--- a/apps/code/src/main/services/deep-link/service.ts
+++ b/apps/code/src/main/services/deep-link/service.ts
@@ -1,7 +1,7 @@
 import type { IAppLifecycle } from "@posthog/platform/app-lifecycle";
 import { inject, injectable } from "inversify";
 import { MAIN_TOKENS } from "../../di/tokens";
-import { isDevBuild } from "../../utils/env";
+// TODO: restore `isDevBuild` import when the dev-build skip below is re-enabled.
 import { logger } from "../../utils/logger";
 
 const log = logger.scope("deep-link-service");
@@ -29,11 +29,17 @@ export class DeepLinkService {
       return;
     }
 
+    // TODO: restore before merging — temporarily registering the protocol in
+    // dev builds so shareable inbox links (posthog-code://inbox/...) can be
+    // tested against `pnpm dev`. While this is active, `pnpm dev` will hijack
+    // posthog-code:// system-wide until this block is restored and the dev
+    // build is closed.
+    //
     // Skip protocol registration in development to avoid hijacking deep links
     // from the production app. OAuth uses HTTP callback in dev mode anyway.
-    if (isDevBuild()) {
-      return;
-    }
+    // if (isDevBuild()) {
+    //   return;
+    // }
 
     // Production: register primary and legacy protocols
     this.appLifecycle.registerDeepLinkScheme(PROTOCOL);

--- a/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
@@ -121,6 +121,15 @@ function resolveLabels(
   return [];
 }
 
+function zendeskWebUrl(apiUrl: string): string {
+  const match = apiUrl.match(
+    /^(https?:\/\/[^/]+)\/api\/v2\/tickets\/(\d+)(?:\.json)?(?:[?#].*)?$/,
+  );
+  if (!match) return apiUrl;
+  const [, origin, id] = match;
+  return `${origin}/agent/tickets/${id}`;
+}
+
 function truncateBody(body: string, maxLength = COLLAPSE_THRESHOLD): string {
   if (body.length <= maxLength) return body;
   const truncated = body.slice(0, maxLength);
@@ -416,7 +425,7 @@ function ZendeskTicketSignalCard({
         <span className="flex-1" />
         {extra.url && (
           <a
-            href={extra.url}
+            href={zendeskWebUrl(extra.url)}
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-1 text-[11px] text-gray-10 hover:text-gray-12"


### PR DESCRIPTION
## Problem
- We linked to the API JSON, so clicking "Open" didn't allow to see actual human conversation

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes
- Now we link to the ticket

<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->
