### PR TITLE
fix(signals): Use Zendesk ticket URLs instead of API URLs

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
@@ -142,6 +142,15 @@ function truncateBody(body: string, maxLength = COLLAPSE_THRESHOLD): string {
   return `${result}\n\n…`;
 }
 
+function zendeskWebUrl(apiUrl: string): string {
+  const match = apiUrl.match(
+    /^(https?:\/\/[^/]+)\/api\/v2\/tickets\/(\d+)(?:\.json)?(?:[?#].*)?$/,
+  );
+  if (!match) return apiUrl;
+  const [, origin, id] = match;
+  return `${origin}/agent/tickets/${id}`;
+}
+
 function parseExtra(raw: Record<string, unknown>): Record<string, unknown> {
   if (typeof raw === "string") {
     try {
@@ -416,7 +425,7 @@ function ZendeskTicketSignalCard({
         <span className="flex-1" />
         {extra.url && (
           <a
-            href={extra.url}
+            href={zendeskWebUrl(extra.url)}
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-1 text-[11px] text-gray-10 hover:text-gray-12"


### PR DESCRIPTION
## Problem
- We linked to the API JSON, so clicking "Open" didn't allow to see actual human conversation

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes
- Now we link to the ticket

<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->
