### PR TITLE
fix(git): prioritize commit/push over create-pr when PR exists

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.test.ts
+++ b/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.test.ts
@@ -143,7 +143,7 @@ describe("computeGitInteractionState", () => {
   });
 
   describe("on feature branch with existing PR", () => {
-    it("still offers create-pr for stacking", () => {
+    it("returns commit as primary when PR exists and there are uncommitted changes", () => {
       const result = computeGitInteractionState(
         makeState({
           currentBranch: "feature/test",
@@ -156,8 +156,58 @@ describe("computeGitInteractionState", () => {
           },
         }),
       );
-      // create-pr still enabled — creates a new stacked branch
-      expect(result.primaryAction.id).toBe("create-pr");
+      expect(result.primaryAction.id).toBe("commit");
+    });
+
+    it("returns push as primary when PR exists and there are unpushed commits", () => {
+      const result = computeGitInteractionState(
+        makeState({
+          currentBranch: "feature/test",
+          hasChanges: false,
+          aheadOfRemote: 2,
+          prStatus: {
+            prExists: true,
+            baseBranch: "main",
+            headBranch: "feature/test",
+            prUrl: "https://github.com/test/test/pull/1",
+          },
+        }),
+      );
+      expect(result.primaryAction.id).toBe("push");
+    });
+
+    it("returns view-pr as primary when PR exists and tree is clean", () => {
+      const result = computeGitInteractionState(
+        makeState({
+          currentBranch: "feature/test",
+          hasChanges: false,
+          aheadOfDefault: 3,
+          prStatus: {
+            prExists: true,
+            baseBranch: "main",
+            headBranch: "feature/test",
+            prUrl: "https://github.com/test/test/pull/1",
+          },
+        }),
+      );
+      expect(result.primaryAction.id).toBe("view-pr");
+    });
+
+    it("excludes create-pr from actions when a PR already exists", () => {
+      const result = computeGitInteractionState(
+        makeState({
+          currentBranch: "feature/test",
+          hasChanges: true,
+          prStatus: {
+            prExists: true,
+            baseBranch: "main",
+            headBranch: "feature/test",
+            prUrl: "https://github.com/test/test/pull/1",
+          },
+        }),
+      );
+      expect(actionIds(result)).not.toContain("create-pr");
+      expect(actionIds(result)).toContain("view-pr");
     });
   });
 

--- a/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.ts
+++ b/apps/code/src/renderer/features/git-interaction/state/gitInteractionLogic.ts
@@ -106,9 +106,7 @@ function getCreatePrDisabledReason(
     return "Authenticate GitHub CLI with `gh auth login`";
   if (!s.repoInfo) return "No GitHub remote detected.";
 
-  if (s.prStatus?.prExists) {
-    if (!s.hasChanges) return "PR already exists.";
-  }
+  if (s.prStatus?.prExists) return "PR already exists.";
 
   // Something must be shippable: uncommitted changes or unpushed commits
   const hasShippableWork =
@@ -156,13 +154,17 @@ function getPrimaryAction(
   pushAction: GitMenuAction,
   viewPrAction: GitMenuAction | null,
 ): GitMenuAction {
-  // createPr handles most cases for getting to a PR (branch creation,
-  // commit, push, etc), so it's always primary when available
-  if (createPrAction.enabled) return createPrAction;
+  // When a PR already exists, the user usually wants to ship more work to it
+  // (commit → push) rather than create a new one. View PR is the fallback.
+  if (viewPrAction) {
+    if (commitAction.enabled) return commitAction;
+    if (pushAction.enabled) return pushAction;
+    return viewPrAction;
+  }
 
+  if (createPrAction.enabled) return createPrAction;
   if (commitAction.enabled) return commitAction;
   if (pushAction.enabled) return pushAction;
-  if (viewPrAction) return viewPrAction;
   return commitAction;
 }
 


### PR DESCRIPTION
When a PR already exists on a feature branch, the primary action should prioritize committing or pushing work to that PR rather than creating a new one.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*