### PR TITLE
feat: add code copy and diff expansion improvements

### DIFF
--- a/apps/code/src/renderer/components/CodeBlock.test.tsx
+++ b/apps/code/src/renderer/components/CodeBlock.test.tsx
@@ -1,0 +1,50 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { CodeBlock } from "./CodeBlock";
+import { HighlightedCode } from "./HighlightedCode";
+
+vi.mock("@stores/themeStore", () => ({
+  useThemeStore: (selector: (state: { isDarkMode: boolean }) => unknown) =>
+    selector({ isDarkMode: false }),
+}));
+
+vi.mock("@utils/syntax-highlight", () => ({
+  highlightSyntax: () => null,
+}));
+
+function renderInTheme(ui: ReactElement) {
+  return render(<Theme>{ui}</Theme>);
+}
+
+describe("CodeBlock copy", () => {
+  it("copies plain string children", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderInTheme(
+      <CodeBlock>
+        <code>hello world</code>
+      </CodeBlock>,
+    );
+
+    await userEvent.click(screen.getByLabelText("Copy code"));
+    expect(writeText).toHaveBeenCalledWith("hello world");
+  });
+
+  it("copies source code from HighlightedCode children", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderInTheme(
+      <CodeBlock>
+        <HighlightedCode code="const x = 5;" language="typescript" />
+      </CodeBlock>,
+    );
+
+    await userEvent.click(screen.getByLabelText("Copy code"));
+    expect(writeText).toHaveBeenCalledWith("const x = 5;");
+  });
+});

--- a/apps/code/src/renderer/components/CodeBlock.tsx
+++ b/apps/code/src/renderer/components/CodeBlock.tsx
@@ -36,9 +36,11 @@ function extractText(children: ReactNode): string {
   if (typeof children === "string") return children;
   if (Array.isArray(children)) return children.map(extractText).join("");
   if (children && typeof children === "object" && "props" in children) {
-    return extractText(
-      (children as { props: { children?: ReactNode } }).props.children,
-    );
+    const props = (
+      children as { props: { children?: ReactNode; code?: string } }
+    ).props;
+    if (typeof props.code === "string") return props.code;
+    return extractText(props.children);
   }
   return "";
 }

--- a/apps/code/src/renderer/features/code-review/components/InteractiveFileDiff.tsx
+++ b/apps/code/src/renderer/features/code-review/components/InteractiveFileDiff.tsx
@@ -9,6 +9,7 @@ import { trpcClient, useTRPC } from "@renderer/trpc/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useCommentState } from "../hooks/useCommentState";
+import { useExpandableFileDiff } from "../hooks/useExpandableFileDiff";
 import type {
   AnnotationMetadata,
   FilesDiffProps,
@@ -103,8 +104,9 @@ export function InteractiveFileDiff(props: InteractiveFileDiffProps) {
 }
 
 function PatchDiffView({
-  fileDiff: initialFileDiff,
+  fileDiff: patchFileDiff,
   repoPath,
+  skipExpansion = false,
   options,
   renderCustomHeader,
   taskId,
@@ -113,6 +115,11 @@ function PatchDiffView({
 }: PatchDiffProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const initialFileDiff = useExpandableFileDiff(
+    patchFileDiff,
+    repoPath,
+    skipExpansion,
+  );
   const [fileDiff, setFileDiff] = useState(initialFileDiff);
   const [revertingHunks, setRevertingHunks] = useState<Set<number>>(
     () => new Set(),
@@ -126,12 +133,17 @@ function PatchDiffView({
     handleLineSelectionEnd,
   } = useCommentState();
 
+  const [lastPatch, setLastPatch] = useState(patchFileDiff);
+  if (patchFileDiff !== lastPatch) {
+    setLastPatch(patchFileDiff);
+    setRevertingHunks(new Set());
+    reset();
+  }
+
   const [lastInitial, setLastInitial] = useState(initialFileDiff);
   if (initialFileDiff !== lastInitial) {
     setLastInitial(initialFileDiff);
     setFileDiff(initialFileDiff);
-    setRevertingHunks(new Set());
-    reset();
   }
 
   const currentFilePath = fileDiff.name ?? fileDiff.prevName ?? "";

--- a/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
@@ -58,6 +58,11 @@ export function ReviewPage({ task }: ReviewPageProps) {
     uncollapseFile,
   } = useReviewState(changedFiles, allPaths);
 
+  const stagedPathSet = useMemo(
+    () => new Set(stagedParsedFiles.map((f) => f.name ?? f.prevName ?? "")),
+    [stagedParsedFiles],
+  );
+
   if (!repoPath) {
     return (
       <Flex align="center" justify="center" height="100%">
@@ -103,7 +108,11 @@ export function ReviewPage({ task }: ReviewPageProps) {
         (unstagedParsedFiles.length > 0 || untrackedFiles.length > 0) && (
           <SectionLabel label="Changes" />
         )}
-      <FileDiffList files={unstagedParsedFiles} {...sharedDiffProps} />
+      <FileDiffList
+        files={unstagedParsedFiles}
+        alsoStagedPaths={stagedPathSet}
+        {...sharedDiffProps}
+      />
       {untrackedFiles.map((file) => {
         const key = makeFileKey(file.staged, file.path);
         const isCollapsed = collapsedFiles.has(key);
@@ -139,6 +148,7 @@ function SectionLabel({ label }: { label: string }) {
 interface FileDiffListProps {
   files: ReturnType<typeof parsePatchFiles>[number]["files"];
   staged?: boolean;
+  alsoStagedPaths?: Set<string>;
   repoPath: string;
   taskId: string;
   diffOptions: DiffOptions;
@@ -152,6 +162,7 @@ interface FileDiffListProps {
 function FileDiffList({
   files,
   staged = false,
+  alsoStagedPaths,
   repoPath,
   taskId,
   diffOptions,
@@ -166,6 +177,7 @@ function FileDiffList({
     const key = makeFileKey(staged, filePath);
     const isCollapsed = collapsedFiles.has(key);
     const deferredReason = getDeferredReason(key);
+    const skipExpansion = staged || (alsoStagedPaths?.has(filePath) ?? false);
 
     if (deferredReason) {
       const { additions, deletions } = sumHunkStats(fileDiff.hunks);
@@ -190,6 +202,7 @@ function FileDiffList({
           <InteractiveFileDiff
             fileDiff={fileDiff}
             repoPath={repoPath}
+            skipExpansion={skipExpansion}
             options={{ ...diffOptions, collapsed: isCollapsed }}
             taskId={taskId}
             renderCustomHeader={(fd) => (

--- a/apps/code/src/renderer/features/code-review/hooks/useExpandableFileDiff.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/useExpandableFileDiff.ts
@@ -1,0 +1,38 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { useTRPC } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import {
+  buildExpandedFileDiff,
+  canExpandFileDiff,
+} from "../utils/fileDiffExpansion";
+
+export function useExpandableFileDiff(
+  patchFileDiff: FileDiffMetadata,
+  repoPath: string | undefined,
+  skip: boolean,
+): FileDiffMetadata {
+  const trpc = useTRPC();
+  const filePath = patchFileDiff.name ?? patchFileDiff.prevName ?? "";
+  const prevPath = patchFileDiff.prevName ?? filePath;
+  const enabled = canExpandFileDiff(patchFileDiff, repoPath, skip);
+
+  const { data: headContent } = useQuery(
+    trpc.git.getFileAtHead.queryOptions(
+      { directoryPath: repoPath ?? "", filePath: prevPath },
+      { enabled, staleTime: 30_000 },
+    ),
+  );
+
+  const { data: workingContent } = useQuery(
+    trpc.fs.readRepoFile.queryOptions(
+      { repoPath: repoPath ?? "", filePath },
+      { enabled, staleTime: 30_000 },
+    ),
+  );
+
+  return useMemo(() => {
+    if (!enabled) return patchFileDiff;
+    return buildExpandedFileDiff(patchFileDiff, headContent, workingContent);
+  }, [enabled, patchFileDiff, headContent, workingContent]);
+}

--- a/apps/code/src/renderer/features/code-review/types.ts
+++ b/apps/code/src/renderer/features/code-review/types.ts
@@ -42,6 +42,7 @@ interface PrCommentProps {
 export type PatchDiffProps = FileDiffProps<AnnotationMetadata> &
   PrCommentProps & {
     repoPath?: string;
+    skipExpansion?: boolean;
   };
 
 export type FilesDiffProps = MultiFileDiffProps<AnnotationMetadata> &

--- a/apps/code/src/renderer/features/code-review/utils/fileDiffExpansion.test.ts
+++ b/apps/code/src/renderer/features/code-review/utils/fileDiffExpansion.test.ts
@@ -1,0 +1,66 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { describe, expect, it } from "vitest";
+import { buildExpandedFileDiff, canExpandFileDiff } from "./fileDiffExpansion";
+
+function makePatch(
+  overrides: Partial<FileDiffMetadata> = {},
+): FileDiffMetadata {
+  return {
+    name: "foo.ts",
+    type: "change",
+    hunks: [],
+    splitLineCount: 0,
+    unifiedLineCount: 0,
+    isPartial: true,
+    deletionLines: [],
+    additionLines: [],
+    ...overrides,
+  } as FileDiffMetadata;
+}
+
+describe("canExpandFileDiff", () => {
+  it("returns false when skip is true", () => {
+    expect(canExpandFileDiff(makePatch(), "/repo", true)).toBe(false);
+  });
+
+  it("returns false when repoPath is missing", () => {
+    expect(canExpandFileDiff(makePatch(), undefined, false)).toBe(false);
+  });
+
+  it("returns false for deleted files", () => {
+    expect(
+      canExpandFileDiff(makePatch({ type: "deleted" }), "/repo", false),
+    ).toBe(false);
+  });
+
+  it("returns false for pure renames", () => {
+    expect(
+      canExpandFileDiff(makePatch({ type: "rename-pure" }), "/repo", false),
+    ).toBe(false);
+  });
+
+  it("returns true for normal change with repo", () => {
+    expect(canExpandFileDiff(makePatch(), "/repo", false)).toBe(true);
+  });
+});
+
+describe("buildExpandedFileDiff", () => {
+  it("returns original patch when content undefined", () => {
+    const patch = makePatch();
+    expect(buildExpandedFileDiff(patch, undefined, "new")).toBe(patch);
+    expect(buildExpandedFileDiff(patch, "old", undefined)).toBe(patch);
+  });
+
+  it("produces a non-partial diff when both contents provided", () => {
+    const patch = makePatch();
+    const result = buildExpandedFileDiff(patch, "a\nb\nc\n", "a\nB\nc\n");
+    expect(result).not.toBe(patch);
+    expect(result.isPartial).toBe(false);
+  });
+
+  it("treats null content as empty string", () => {
+    const patch = makePatch({ type: "new" });
+    const result = buildExpandedFileDiff(patch, null, "hello\n");
+    expect(result.isPartial).toBe(false);
+  });
+});

--- a/apps/code/src/renderer/features/code-review/utils/fileDiffExpansion.ts
+++ b/apps/code/src/renderer/features/code-review/utils/fileDiffExpansion.ts
@@ -1,0 +1,35 @@
+import { type FileDiffMetadata, parseDiffFromFile } from "@pierre/diffs";
+
+export function canExpandFileDiff(
+  patchFileDiff: FileDiffMetadata,
+  repoPath: string | undefined,
+  skip: boolean,
+): boolean {
+  const filePath = patchFileDiff.name ?? patchFileDiff.prevName ?? "";
+  return (
+    !skip &&
+    !!repoPath &&
+    !!filePath &&
+    patchFileDiff.type !== "deleted" &&
+    patchFileDiff.type !== "rename-pure"
+  );
+}
+
+export function buildExpandedFileDiff(
+  patchFileDiff: FileDiffMetadata,
+  headContent: string | null | undefined,
+  workingContent: string | null | undefined,
+): FileDiffMetadata {
+  if (headContent === undefined || workingContent === undefined)
+    return patchFileDiff;
+  const filePath = patchFileDiff.name ?? patchFileDiff.prevName ?? "";
+  const prevPath = patchFileDiff.prevName ?? filePath;
+  try {
+    return parseDiffFromFile(
+      { name: prevPath, contents: headContent ?? "" },
+      { name: filePath, contents: workingContent ?? "" },
+    );
+  } catch {
+    return patchFileDiff;
+  }
+}


### PR DESCRIPTION
We previously did not support expanding file hunks in the diff viewer, b.c. we did not load in the entire file. Now we do.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*