### PR TITLE
chore(code): show live diffs during cloud runs before PR exists

### DIFF
--- a/apps/code/src/renderer/features/code-review/components/CloudReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/CloudReviewPage.tsx
@@ -1,6 +1,7 @@
 import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
 import { usePrDetails } from "@features/git-interaction/hooks/usePrDetails";
 import { useCloudChangedFiles } from "@features/task-detail/hooks/useCloudChangedFiles";
+import { extractCloudFileDiff } from "@features/task-detail/utils/cloudToolChanges";
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { processFile } from "@pierre/diffs";
 import { Flex, Spinner, Text } from "@radix-ui/themes";
@@ -28,13 +29,20 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
     (s) => (s.reviewModes[taskId] ?? "closed") !== "closed",
   );
   const showReviewComments = useDiffViewerStore((s) => s.showReviewComments);
-  const { effectiveBranch, prUrl, isRunActive, remoteFiles, isLoading } =
-    useCloudChangedFiles(taskId, task, isReviewOpen);
+  const {
+    effectiveBranch,
+    prUrl,
+    isRunActive,
+    remoteFiles,
+    reviewFiles,
+    toolCalls,
+    isLoading,
+  } = useCloudChangedFiles(taskId, task, isReviewOpen);
   const { commentThreads } = usePrDetails(prUrl, {
     includeComments: isReviewOpen && showReviewComments,
   });
 
-  const allPaths = useMemo(() => remoteFiles.map((f) => f.path), [remoteFiles]);
+  const allPaths = useMemo(() => reviewFiles.map((f) => f.path), [reviewFiles]);
 
   const {
     diffOptions,
@@ -47,9 +55,22 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
     uncollapseFile,
     revealFile,
     getDeferredReason,
-  } = useReviewState(remoteFiles, allPaths);
+  } = useReviewState(reviewFiles, allPaths);
 
-  if (!prUrl && !effectiveBranch && remoteFiles.length === 0) {
+  const toolCallDiffs = useMemo(() => {
+    if (remoteFiles.length > 0) return null;
+    const diffs = new Map<
+      string,
+      { oldText: string | null; newText: string | null }
+    >();
+    for (const file of reviewFiles) {
+      const diff = extractCloudFileDiff(toolCalls, file.path);
+      if (diff) diffs.set(file.path, diff);
+    }
+    return diffs;
+  }, [remoteFiles.length, toolCalls, reviewFiles]);
+
+  if (!prUrl && !effectiveBranch && reviewFiles.length === 0) {
     if (isRunActive) {
       return (
         <Flex
@@ -71,17 +92,17 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
   return (
     <ReviewShell
       task={task}
-      fileCount={remoteFiles.length}
+      fileCount={reviewFiles.length}
       linesAdded={linesAdded}
       linesRemoved={linesRemoved}
-      isLoading={isLoading && remoteFiles.length === 0}
-      isEmpty={remoteFiles.length === 0}
+      isLoading={isLoading && reviewFiles.length === 0}
+      isEmpty={reviewFiles.length === 0}
       allExpanded={collapsedFiles.size === 0}
       onExpandAll={expandAll}
       onCollapseAll={collapseAll}
       onUncollapseFile={uncollapseFile}
     >
-      {remoteFiles.map((file) => {
+      {reviewFiles.map((file) => {
         const isCollapsed = collapsedFiles.has(file.path);
         const deferredReason = getDeferredReason(file.path);
 
@@ -112,6 +133,7 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
                 collapsed={isCollapsed}
                 onToggle={() => toggleFile(file.path)}
                 commentThreads={showReviewComments ? commentThreads : undefined}
+                toolCallDiff={toolCallDiffs?.get(file.path) ?? null}
               />
             </LazyDiff>
           </div>
@@ -129,6 +151,7 @@ function CloudFileDiff({
   collapsed,
   onToggle,
   commentThreads,
+  toolCallDiff,
 }: {
   file: ChangedFile;
   taskId: string;
@@ -137,13 +160,26 @@ function CloudFileDiff({
   collapsed: boolean;
   onToggle: () => void;
   commentThreads?: Map<number, PrCommentThread>;
+  toolCallDiff: { oldText: string | null; newText: string | null } | null;
 }) {
   const fileDiff = useMemo((): FileDiffMetadata | undefined => {
     if (!file.patch) return undefined;
     return processFile(file.patch, { isGitDiff: true });
   }, [file.patch]);
 
-  if (!fileDiff) {
+  const diffSourceProps = useMemo(() => {
+    if (fileDiff) return { fileDiff };
+    if (toolCallDiff) {
+      const name = file.path.split("/").pop() || file.path;
+      return {
+        oldFile: { name, contents: toolCallDiff.oldText ?? "" },
+        newFile: { name, contents: toolCallDiff.newText ?? "" },
+      };
+    }
+    return null;
+  }, [fileDiff, toolCallDiff, file.path]);
+
+  if (!diffSourceProps) {
     const hasChanges = (file.linesAdded ?? 0) + (file.linesRemoved ?? 0) > 0;
     const reason = hasChanges ? "large" : "unavailable";
     const githubFileUrl = prUrl
@@ -164,7 +200,7 @@ function CloudFileDiff({
 
   return (
     <InteractiveFileDiff
-      fileDiff={fileDiff}
+      {...diffSourceProps}
       options={{ ...options, collapsed }}
       taskId={taskId}
       prUrl={prUrl}

--- a/apps/code/src/renderer/features/code-review/components/DiffStatsBadge.tsx
+++ b/apps/code/src/renderer/features/code-review/components/DiffStatsBadge.tsx
@@ -29,11 +29,11 @@ function useChangedFileStats(task: Task) {
     isCloud ? undefined : repoPath,
   );
 
-  const { changedFiles: cloudFiles } = useCloudChangedFiles(taskId, task);
+  const { reviewFiles } = useCloudChangedFiles(taskId, task);
 
   return useMemo(() => {
     if (isCloud) {
-      const stats = computeDiffStats(cloudFiles);
+      const stats = computeDiffStats(reviewFiles);
       return {
         filesChanged: stats.filesChanged,
         linesAdded: stats.linesAdded,
@@ -45,7 +45,7 @@ function useChangedFileStats(task: Task) {
       linesAdded: localDiffStats.linesAdded,
       linesRemoved: localDiffStats.linesRemoved,
     };
-  }, [isCloud, cloudFiles, localDiffStats]);
+  }, [isCloud, reviewFiles, localDiffStats]);
 }
 
 export function DiffStatsBadge({ task }: DiffStatsBadgeProps) {

--- a/apps/code/src/renderer/features/git-interaction/components/CloudGitInteractionHeader.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/CloudGitInteractionHeader.tsx
@@ -1,10 +1,10 @@
+import { useCloudPrUrl } from "@features/git-interaction/hooks/useCloudPrUrl";
 import { usePrActions } from "@features/git-interaction/hooks/usePrActions";
 import { usePrDetails } from "@features/git-interaction/hooks/usePrDetails";
 import {
   getPrVisualConfig,
   parsePrNumber,
 } from "@features/git-interaction/utils/prStatus";
-import { useSessionForTask } from "@features/sessions/hooks/useSession";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { Button, DropdownMenu, Flex, Spinner, Text } from "@radix-ui/themes";
 
@@ -15,8 +15,7 @@ interface CloudGitInteractionHeaderProps {
 export function CloudGitInteractionHeader({
   taskId,
 }: CloudGitInteractionHeaderProps) {
-  const session = useSessionForTask(taskId);
-  const prUrl = (session?.cloudOutput?.pr_url as string) ?? null;
+  const prUrl = useCloudPrUrl(taskId);
   const {
     meta: { state, merged, draft },
   } = usePrDetails(prUrl);

--- a/apps/code/src/renderer/features/git-interaction/hooks/useCloudPrUrl.test.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useCloudPrUrl.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@features/sessions/hooks/useSession", () => ({
+  useSessionForTask: vi.fn(),
+}));
+
+vi.mock("@features/tasks/hooks/useTasks", () => ({
+  useTasks: vi.fn(() => ({ data: [] })),
+}));
+
+import type { AgentSession } from "@features/sessions/stores/sessionStore";
+import type { Task } from "@shared/types";
+import { resolveCloudPrUrl } from "./useCloudPrUrl";
+
+function makeTask(prUrl?: unknown): Task {
+  return {
+    id: "task-1",
+    latest_run: { output: { pr_url: prUrl } },
+  } as unknown as Task;
+}
+
+function makeSession(prUrl?: unknown): AgentSession {
+  return { cloudOutput: { pr_url: prUrl } } as unknown as AgentSession;
+}
+
+describe("resolveCloudPrUrl", () => {
+  it("returns null when both task and session are undefined", () => {
+    expect(resolveCloudPrUrl(undefined, undefined)).toBeNull();
+  });
+
+  it("returns task PR URL when available", () => {
+    const task = makeTask("https://github.com/org/repo/pull/1");
+    expect(resolveCloudPrUrl(task, undefined)).toBe(
+      "https://github.com/org/repo/pull/1",
+    );
+  });
+
+  it("returns session PR URL when task has none", () => {
+    const task = makeTask(undefined);
+    const session = makeSession("https://github.com/org/repo/pull/2");
+    expect(resolveCloudPrUrl(task, session)).toBe(
+      "https://github.com/org/repo/pull/2",
+    );
+  });
+
+  it("prefers task PR URL over session", () => {
+    const task = makeTask("https://github.com/org/repo/pull/1");
+    const session = makeSession("https://github.com/org/repo/pull/2");
+    expect(resolveCloudPrUrl(task, session)).toBe(
+      "https://github.com/org/repo/pull/1",
+    );
+  });
+
+  it("ignores non-string pr_url values", () => {
+    expect(resolveCloudPrUrl(makeTask(123), makeSession(true))).toBeNull();
+    expect(resolveCloudPrUrl(makeTask(null), makeSession(null))).toBeNull();
+  });
+
+  it("ignores empty string pr_url", () => {
+    expect(resolveCloudPrUrl(makeTask(""), makeSession(""))).toBeNull();
+  });
+
+  it("falls back to session when task pr_url is empty", () => {
+    const session = makeSession("https://github.com/org/repo/pull/3");
+    expect(resolveCloudPrUrl(makeTask(""), session)).toBe(
+      "https://github.com/org/repo/pull/3",
+    );
+  });
+});

--- a/apps/code/src/renderer/features/git-interaction/hooks/useCloudPrUrl.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useCloudPrUrl.ts
@@ -1,0 +1,29 @@
+import { useSessionForTask } from "@features/sessions/hooks/useSession";
+import type { AgentSession } from "@features/sessions/stores/sessionStore";
+import { useTasks } from "@features/tasks/hooks/useTasks";
+import type { Task } from "@shared/types";
+
+/**
+ * Extracts the PR URL from a task and/or session. The URL can arrive via the
+ * persisted TaskRun output or the live session's cloudOutput (pushed over SSE
+ * while the run is active), so both sources are consulted.
+ */
+export function resolveCloudPrUrl(
+  task: Task | undefined,
+  session: AgentSession | undefined,
+): string | null {
+  const taskPrUrl = task?.latest_run?.output?.pr_url;
+  const sessionPrUrl = session?.cloudOutput?.pr_url;
+
+  if (typeof taskPrUrl === "string" && taskPrUrl) return taskPrUrl;
+  if (typeof sessionPrUrl === "string" && sessionPrUrl) return sessionPrUrl;
+  return null;
+}
+
+/** Hook wrapper for components that don't already have the task/session. */
+export function useCloudPrUrl(taskId: string): string | null {
+  const { data: tasks = [] } = useTasks();
+  const task = tasks.find((t) => t.id === taskId);
+  const session = useSessionForTask(taskId);
+  return resolveCloudPrUrl(task, session);
+}

--- a/apps/code/src/renderer/features/task-detail/hooks/useCloudChangedFiles.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useCloudChangedFiles.ts
@@ -14,8 +14,7 @@ export function useCloudChangedFiles(
   isActive = true,
 ) {
   const cloudRunState = useCloudRunState(taskId, task);
-  const { prUrl, effectiveBranch, repo, fallbackFiles, isRunActive } =
-    cloudRunState;
+  const { prUrl, effectiveBranch, repo, isRunActive } = cloudRunState;
 
   const {
     data: prFiles,
@@ -41,14 +40,22 @@ export function useCloudChangedFiles(
   const isLoading = prUrl ? prPending : effectiveBranch ? branchPending : false;
   const hasError = prUrl ? prError : effectiveBranch ? branchError : false;
 
-  // changedFiles: sidebar list, built from remote with agent output fallback
-  // remoteFiles: review panel, always uses PR changes with remote branch fallback
-  const changedFiles = remoteFiles.length > 0 ? remoteFiles : fallbackFiles;
+  // changedFiles: sidebar list — prefers remote, falls back to tree snapshot (which
+  // has complete file status coverage) or tool calls.
+  const changedFiles =
+    remoteFiles.length > 0 ? remoteFiles : cloudRunState.fallbackFiles;
+
+  // reviewFiles: review panel diffs and +/- stats. Tool calls carry patches and line
+  // counts, so they're preferred over tree snapshots (path+status only) when remote
+  // data isn't available yet.
+  const reviewFiles =
+    remoteFiles.length > 0 ? remoteFiles : cloudRunState.toolCallFiles;
 
   return {
     ...cloudRunState,
     changedFiles,
     remoteFiles,
+    reviewFiles,
     isLoading,
     hasError,
   };

--- a/apps/code/src/renderer/features/task-detail/hooks/useCloudRunState.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useCloudRunState.ts
@@ -1,3 +1,4 @@
+import { resolveCloudPrUrl } from "@features/git-interaction/hooks/useCloudPrUrl";
 import { useSessionForTask } from "@features/sessions/hooks/useSession";
 import { useCloudEventSummary } from "@features/task-detail/hooks/useCloudEventSummary";
 import { extractCloudToolChangedFiles } from "@features/task-detail/utils/cloudToolChanges";
@@ -14,8 +15,7 @@ export function useCloudRunState(taskId: string, task: Task) {
 
   const session = useSessionForTask(taskId);
 
-  const rawPrUrl = freshTask.latest_run?.output?.pr_url;
-  const prUrl = typeof rawPrUrl === "string" ? rawPrUrl : null;
+  const prUrl = resolveCloudPrUrl(freshTask, session);
   const branch = freshTask.latest_run?.branch ?? null;
   const cloudBranch = session?.cloudBranch ?? null;
   const effectiveBranch = branch ?? cloudBranch;
@@ -33,10 +33,9 @@ export function useCloudRunState(taskId: string, task: Task) {
     () => extractCloudToolChangedFiles(summary.toolCalls),
     [summary],
   );
+  const treeSnapshotFiles = summary.treeSnapshotFiles;
   const fallbackFiles: ChangedFile[] =
-    summary.treeSnapshotFiles.length > 0
-      ? summary.treeSnapshotFiles
-      : toolCallFiles;
+    treeSnapshotFiles.length > 0 ? treeSnapshotFiles : toolCallFiles;
 
   return {
     freshTask,
@@ -47,5 +46,8 @@ export function useCloudRunState(taskId: string, task: Task) {
     cloudStatus,
     isRunActive,
     fallbackFiles,
+    toolCallFiles,
+    treeSnapshotFiles,
+    toolCalls: summary.toolCalls,
   };
 }


### PR DESCRIPTION
## Problem

  The cloud review page only showed diffs once a PR or branch existed on GitHub. During a cloud run, before anything was pushed, the review panel and diff stats badge were empty.

  ## Changes

  - Fall back to tool-call-derived diffs (`reviewFiles`) when GitHub API data isn't available yet, so diffs render live as the agent writes files
  - Use tool-call files for the diff stats badge, which carry line counts (tree snapshots only have path and status)
  - Extract `resolveCloudPrUrl` to check both task output and session output for the PR URL, fixing an inconsistency where each callsite only checked one source

## Showcase


https://github.com/user-attachments/assets/cf2c68cb-c4aa-4f8a-85ce-505da75993af

