### PR TITLE
chore(cloud): add floating hedgehog waiting screen for queued cloud tasks

### DIFF
--- a/apps/code/src/renderer/features/command-center/components/CommandCenterSessionView.tsx
+++ b/apps/code/src/renderer/features/command-center/components/CommandCenterSessionView.tsx
@@ -31,6 +31,7 @@ export function CommandCenterSessionView({
     promptStartedAt,
     isInitializing,
     cloudBranch,
+    cloudStatus,
     errorTitle,
     errorMessage,
   } = useSessionViewState(taskId, task);
@@ -68,6 +69,8 @@ export function CommandCenterSessionView({
         onRetry={isCloud ? undefined : handleRetry}
         onNewSession={isCloud ? undefined : handleNewSession}
         isInitializing={isInitializing}
+        isCloud={isCloud}
+        cloudStatus={cloudStatus}
         compact
         isActiveSession={isActiveSession}
       />

--- a/apps/code/src/renderer/features/sessions/components/CloudInitializingView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/CloudInitializingView.tsx
@@ -1,0 +1,87 @@
+import { Spinner } from "@phosphor-icons/react";
+import { Flex, Text } from "@radix-ui/themes";
+import zenHedgehog from "@renderer/assets/images/zen.png";
+import type { TaskRunStatus } from "@shared/types";
+import { useEffect, useState } from "react";
+
+interface CloudInitializingViewProps {
+  cloudStatus: TaskRunStatus | null;
+}
+
+const REVEAL_DELAY_MS = 2000;
+
+function copyFor(cloudStatus: TaskRunStatus | null): {
+  heading: string;
+  subtitle: string;
+} {
+  switch (cloudStatus) {
+    case "queued":
+      return {
+        heading: "Waiting in the queue…",
+        subtitle: "Reserving a cloud sandbox — this can take a few seconds.",
+      };
+    case "in_progress":
+      return {
+        heading: "Starting the sandbox…",
+        subtitle: "Connecting to your cloud runner.",
+      };
+    default:
+      return {
+        heading: "Getting things ready…",
+        subtitle: "Connecting to your cloud runner.",
+      };
+  }
+}
+
+export function CloudInitializingView({
+  cloudStatus,
+}: CloudInitializingViewProps) {
+  const { heading, subtitle } = copyFor(cloudStatus);
+
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setRevealed(true), REVEAL_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!revealed) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        className="absolute inset-0 bg-background"
+      >
+        <Spinner size={32} className="animate-spin text-gray-9" />
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      align="center"
+      justify="center"
+      direction="column"
+      gap="5"
+      className="absolute inset-0 bg-background"
+    >
+      <div className="zen-float">
+        <img
+          src={zenHedgehog}
+          alt=""
+          style={{ width: "160px", display: "block" }}
+        />
+      </div>
+      <Flex direction="column" align="center" gap="2">
+        <Flex align="center" gap="2">
+          <Spinner size={16} className="animate-spin text-gray-9" />
+          <Text size="3" weight="medium">
+            {heading}
+          </Text>
+        </Flex>
+        <Text size="2" color="gray">
+          {subtitle}
+        </Text>
+      </Flex>
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -15,6 +15,7 @@ import { useIsWorkspaceCloudRun } from "@features/workspace/hooks/useWorkspace";
 import { useAutoFocusOnTyping } from "@hooks/useAutoFocusOnTyping";
 import { Pause, Spinner, Warning } from "@phosphor-icons/react";
 import { Box, Button, ContextMenu, Flex, Text } from "@radix-ui/themes";
+import type { TaskRunStatus } from "@shared/types";
 import {
   type AcpMessage,
   isJsonRpcNotification,
@@ -27,6 +28,7 @@ import {
   useSessionViewActions,
   useShowRawLogs,
 } from "../stores/sessionViewStore";
+import { CloudInitializingView } from "./CloudInitializingView";
 import { ConversationView } from "./ConversationView";
 import { DropZoneOverlay } from "./DropZoneOverlay";
 import { ModelSelector } from "./ModelSelector";
@@ -53,6 +55,8 @@ interface SessionViewProps {
   onRetry?: () => void;
   onNewSession?: () => void;
   isInitializing?: boolean;
+  isCloud?: boolean;
+  cloudStatus?: TaskRunStatus | null;
   slackThreadUrl?: string;
   compact?: boolean;
   isActiveSession?: boolean;
@@ -83,6 +87,8 @@ export function SessionView({
   onRetry,
   onNewSession,
   isInitializing = false,
+  isCloud = false,
+  cloudStatus = null,
   slackThreadUrl,
   compact = false,
   isActiveSession = true,
@@ -409,13 +415,17 @@ export function SessionView({
               </Box>
             </>
           ) : isInitializing ? (
-            <Flex
-              align="center"
-              justify="center"
-              className="absolute inset-0 bg-background"
-            >
-              <Spinner size={32} className="animate-spin text-gray-9" />
-            </Flex>
+            isCloud ? (
+              <CloudInitializingView cloudStatus={cloudStatus} />
+            ) : (
+              <Flex
+                align="center"
+                justify="center"
+                className="absolute inset-0 bg-background"
+              >
+                <Spinner size={32} className="animate-spin text-gray-9" />
+              </Flex>
+            )
           ) : (
             <>
               <DropZoneOverlay isVisible={isDraggingFile} />

--- a/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -55,6 +55,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
     promptStartedAt,
     isInitializing,
     cloudBranch,
+    cloudStatus,
     errorTitle,
     errorMessage,
   } = useSessionViewState(taskId, task);
@@ -138,6 +139,8 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
               onRetry={handleRetry}
               onNewSession={isCloud ? undefined : handleNewSession}
               isInitializing={isInitializing}
+              isCloud={isCloud}
+              cloudStatus={cloudStatus}
               slackThreadUrl={slackThreadUrl}
             />
           </ErrorBoundary>


### PR DESCRIPTION
## Problem

Cloud tasks live in Modal's queue for an unpredictable amount of time before a sandbox is ready. While that happens, we showed a bare spinner on a blank background — no text, no animation, no indication of *what* we were waiting on. If Modal was slow, users got to stare at a lonely throbber wondering if we'd forgotten about them.

## Solution

A friendlier waiting screen: the zen hedgehog gently floats while we wait, with copy that reflects the actual `cloudStatus`:

- `queued` → "Waiting in the queue… — Reserving a cloud sandbox, this can take a few seconds."
- `in_progress` → "Starting the sandbox… — Connecting to your cloud runner."
- default → "Getting things ready…"

To avoid flashing the hedgehog on fast starts, the fancy screen only reveals after 2s of initializing — quick launches still get the plain spinner and never see the swap.

## Showcase


https://github.com/user-attachments/assets/90d94e8c-883d-4b5c-bf22-093735e0e2fb

