### PR TITLE
feat(code): add diff source selector

### DIFF
--- a/apps/code/src/renderer/features/code-editor/stores/diffViewerStore.ts
+++ b/apps/code/src/renderer/features/code-editor/stores/diffViewerStore.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 export type ViewMode = "split" | "unified";
+export type DiffSource = "local" | "branch";
 
 interface DiffViewerStoreState {
   viewMode: ViewMode;
@@ -12,6 +13,7 @@ interface DiffViewerStoreState {
   wordDiffs: boolean;
   hideWhitespaceChanges: boolean;
   showReviewComments: boolean;
+  diffSource: Record<string, DiffSource>;
 }
 
 interface DiffViewerStoreActions {
@@ -22,6 +24,7 @@ interface DiffViewerStoreActions {
   toggleWordDiffs: () => void;
   toggleHideWhitespaceChanges: () => void;
   toggleShowReviewComments: () => void;
+  setDiffSource: (taskId: string, source: DiffSource) => void;
 }
 
 type DiffViewerStore = DiffViewerStoreState & DiffViewerStoreActions;
@@ -35,6 +38,7 @@ export const useDiffViewerStore = create<DiffViewerStore>()(
       wordDiffs: true,
       hideWhitespaceChanges: false,
       showReviewComments: true,
+      diffSource: {},
       setViewMode: (mode) =>
         set((state) => {
           if (state.viewMode === mode) {
@@ -69,6 +73,10 @@ export const useDiffViewerStore = create<DiffViewerStore>()(
         set((s) => ({ hideWhitespaceChanges: !s.hideWhitespaceChanges })),
       toggleShowReviewComments: () =>
         set((s) => ({ showReviewComments: !s.showReviewComments })),
+      setDiffSource: (taskId, source) =>
+        set((s) => ({
+          diffSource: { ...s.diffSource, [taskId]: source },
+        })),
     }),
     {
       name: "diff-viewer-storage",

--- a/apps/code/src/renderer/features/code-review/components/CloudReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/CloudReviewPage.tsx
@@ -2,19 +2,14 @@ import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore
 import { usePrDetails } from "@features/git-interaction/hooks/usePrDetails";
 import { useCloudChangedFiles } from "@features/task-detail/hooks/useCloudChangedFiles";
 import { extractCloudFileDiff } from "@features/task-detail/utils/cloudToolChanges";
-import type { FileDiffMetadata } from "@pierre/diffs";
-import { processFile } from "@pierre/diffs";
 import { Flex, Spinner, Text } from "@radix-ui/themes";
 import { useReviewNavigationStore } from "@renderer/features/code-review/stores/reviewNavigationStore";
-import type { ChangedFile, Task } from "@shared/types";
+import type { Task } from "@shared/types";
 import { useMemo } from "react";
-import type { DiffOptions } from "../types";
-import type { PrCommentThread } from "../utils/prCommentAnnotations";
-import { InteractiveFileDiff } from "./InteractiveFileDiff";
 import { LazyDiff } from "./LazyDiff";
+import { PatchedFileDiff } from "./PatchedFileDiff";
 import {
   DeferredDiffPlaceholder,
-  DiffFileHeader,
   ReviewShell,
   useReviewState,
 } from "./ReviewShell";
@@ -122,10 +117,14 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
           );
         }
 
+        const githubFileUrl = prUrl
+          ? `${prUrl}/files#diff-${file.path.replaceAll("/", "-")}`
+          : undefined;
+
         return (
           <div key={file.path} data-file-path={file.path}>
             <LazyDiff>
-              <CloudFileDiff
+              <PatchedFileDiff
                 file={file}
                 taskId={taskId}
                 prUrl={prUrl}
@@ -133,85 +132,13 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
                 collapsed={isCollapsed}
                 onToggle={() => toggleFile(file.path)}
                 commentThreads={showReviewComments ? commentThreads : undefined}
-                toolCallDiff={toolCallDiffs?.get(file.path) ?? null}
+                fallback={toolCallDiffs?.get(file.path) ?? null}
+                externalUrl={githubFileUrl}
               />
             </LazyDiff>
           </div>
         );
       })}
     </ReviewShell>
-  );
-}
-
-function CloudFileDiff({
-  file,
-  taskId,
-  prUrl,
-  options,
-  collapsed,
-  onToggle,
-  commentThreads,
-  toolCallDiff,
-}: {
-  file: ChangedFile;
-  taskId: string;
-  prUrl: string | null;
-  options: DiffOptions;
-  collapsed: boolean;
-  onToggle: () => void;
-  commentThreads?: Map<number, PrCommentThread>;
-  toolCallDiff: { oldText: string | null; newText: string | null } | null;
-}) {
-  const fileDiff = useMemo((): FileDiffMetadata | undefined => {
-    if (!file.patch) return undefined;
-    return processFile(file.patch, { isGitDiff: true });
-  }, [file.patch]);
-
-  const diffSourceProps = useMemo(() => {
-    if (fileDiff) return { fileDiff };
-    if (toolCallDiff) {
-      const name = file.path.split("/").pop() || file.path;
-      return {
-        oldFile: { name, contents: toolCallDiff.oldText ?? "" },
-        newFile: { name, contents: toolCallDiff.newText ?? "" },
-      };
-    }
-    return null;
-  }, [fileDiff, toolCallDiff, file.path]);
-
-  if (!diffSourceProps) {
-    const hasChanges = (file.linesAdded ?? 0) + (file.linesRemoved ?? 0) > 0;
-    const reason = hasChanges ? "large" : "unavailable";
-    const githubFileUrl = prUrl
-      ? `${prUrl}/files#diff-${file.path.replaceAll("/", "-")}`
-      : undefined;
-    return (
-      <DeferredDiffPlaceholder
-        filePath={file.path}
-        linesAdded={file.linesAdded ?? 0}
-        linesRemoved={file.linesRemoved ?? 0}
-        reason={reason}
-        collapsed={collapsed}
-        onToggle={onToggle}
-        externalUrl={githubFileUrl}
-      />
-    );
-  }
-
-  return (
-    <InteractiveFileDiff
-      {...diffSourceProps}
-      options={{ ...options, collapsed }}
-      taskId={taskId}
-      prUrl={prUrl}
-      commentThreads={commentThreads}
-      renderCustomHeader={(fd) => (
-        <DiffFileHeader
-          fileDiff={fd}
-          collapsed={collapsed}
-          onToggle={onToggle}
-        />
-      )}
-    />
   );
 }

--- a/apps/code/src/renderer/features/code-review/components/DiffSourceSelector.tsx
+++ b/apps/code/src/renderer/features/code-review/components/DiffSourceSelector.tsx
@@ -1,0 +1,66 @@
+import { CaretDown, GitBranch, HardDrives } from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@posthog/quill";
+import { useDiffViewerStore } from "@renderer/features/code-editor/stores/diffViewerStore";
+import type { ResolvedDiffSource } from "../utils/resolveDiffSource";
+
+interface DiffSourceSelectorProps {
+  taskId: string;
+  effectiveSource: ResolvedDiffSource;
+  branchAvailable: boolean;
+  defaultBranch: string | null;
+}
+
+export function DiffSourceSelector({
+  taskId,
+  effectiveSource,
+  branchAvailable,
+  defaultBranch,
+}: DiffSourceSelectorProps) {
+  const setDiffSource = useDiffViewerStore((s) => s.setDiffSource);
+
+  if (!branchAvailable || !defaultBranch) return null;
+
+  const Icon = effectiveSource === "branch" ? GitBranch : HardDrives;
+  const branchLabel = `Branch vs. ${defaultBranch}`;
+  const triggerLabel = effectiveSource === "branch" ? branchLabel : "Local";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            size="sm"
+            variant="default"
+            className="rounded-xs"
+            aria-label="Diff source"
+          >
+            <Icon size={12} />
+            <span className="whitespace-nowrap">{triggerLabel}</span>
+            <CaretDown size={10} weight="bold" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent
+        align="end"
+        side="bottom"
+        sideOffset={6}
+        className="min-w-[160px]"
+      >
+        <DropdownMenuItem onClick={() => setDiffSource(taskId, "local")}>
+          <HardDrives size={12} />
+          Local changes
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setDiffSource(taskId, "branch")}>
+          <GitBranch size={12} />
+          {branchLabel}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/code/src/renderer/features/code-review/components/PatchedFileDiff.tsx
+++ b/apps/code/src/renderer/features/code-review/components/PatchedFileDiff.tsx
@@ -1,0 +1,80 @@
+import { type FileDiffMetadata, processFile } from "@pierre/diffs";
+import type { ChangedFile } from "@shared/types";
+import { useMemo } from "react";
+import type { DiffOptions } from "../types";
+import type { PrCommentThread } from "../utils/prCommentAnnotations";
+import { InteractiveFileDiff } from "./InteractiveFileDiff";
+import { DeferredDiffPlaceholder, DiffFileHeader } from "./ReviewShell";
+
+interface PatchedFileDiffProps {
+  file: ChangedFile;
+  taskId: string;
+  options: DiffOptions;
+  collapsed: boolean;
+  onToggle: () => void;
+  fallback?: { oldText: string | null; newText: string | null } | null;
+  externalUrl?: string;
+  prUrl?: string | null;
+  commentThreads?: Map<number, PrCommentThread>;
+}
+
+export function PatchedFileDiff({
+  file,
+  taskId,
+  options,
+  collapsed,
+  onToggle,
+  fallback,
+  externalUrl,
+  prUrl,
+  commentThreads,
+}: PatchedFileDiffProps) {
+  const fileDiff = useMemo((): FileDiffMetadata | undefined => {
+    if (!file.patch) return undefined;
+    return processFile(file.patch, { isGitDiff: true });
+  }, [file.patch]);
+
+  const diffSourceProps = useMemo(() => {
+    if (fileDiff) return { fileDiff };
+    if (fallback) {
+      const name = file.path.split("/").pop() || file.path;
+      return {
+        oldFile: { name, contents: fallback.oldText ?? "" },
+        newFile: { name, contents: fallback.newText ?? "" },
+      };
+    }
+    return null;
+  }, [fileDiff, fallback, file.path]);
+
+  if (!diffSourceProps) {
+    const hasChanges = (file.linesAdded ?? 0) + (file.linesRemoved ?? 0) > 0;
+    return (
+      <DeferredDiffPlaceholder
+        filePath={file.path}
+        linesAdded={file.linesAdded ?? 0}
+        linesRemoved={file.linesRemoved ?? 0}
+        reason={hasChanges ? "large" : "unavailable"}
+        collapsed={collapsed}
+        onToggle={onToggle}
+        externalUrl={externalUrl}
+      />
+    );
+  }
+
+  return (
+    <InteractiveFileDiff
+      {...diffSourceProps}
+      options={{ ...options, collapsed }}
+      taskId={taskId}
+      prUrl={prUrl}
+      commentThreads={commentThreads}
+      renderCustomHeader={(fd) => (
+        <DiffFileHeader
+          fileDiff={fd}
+          collapsed={collapsed}
+          onToggle={onToggle}
+        />
+      )}
+    />
+  );
+}

--- a/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
@@ -1,6 +1,9 @@
+import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
+import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
 import { makeFileKey } from "@features/git-interaction/utils/fileKey";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
+import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
 import type { parsePatchFiles } from "@pierre/diffs";
 import { Flex, Text } from "@radix-ui/themes";
 import { useReviewNavigationStore } from "@renderer/features/code-review/stores/reviewNavigationStore";
@@ -10,8 +13,13 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useReviewDiffs } from "../hooks/useReviewDiffs";
 import type { DiffOptions } from "../types";
+import {
+  type ResolvedDiffSource,
+  resolveDiffSource,
+} from "../utils/resolveDiffSource";
 import { InteractiveFileDiff } from "./InteractiveFileDiff";
 import { LazyDiff } from "./LazyDiff";
+import { PatchedFileDiff } from "./PatchedFileDiff";
 import {
   DeferredDiffPlaceholder,
   type DeferredReason,
@@ -21,6 +29,8 @@ import {
   useReviewState,
 } from "./ReviewShell";
 
+const EMPTY_BRANCH_FILES: ChangedFile[] = [];
+
 interface ReviewPageProps {
   task: Task;
 }
@@ -28,10 +38,36 @@ interface ReviewPageProps {
 export function ReviewPage({ task }: ReviewPageProps) {
   const taskId = task.id;
   const repoPath = useCwd(taskId);
+  const workspace = useWorkspace(taskId);
+  const linkedBranch = workspace?.linkedBranch ?? null;
   const openFile = usePanelLayoutStore((s) => s.openFile);
+
   const isReviewOpen = useReviewNavigationStore(
     (s) => (s.reviewModes[taskId] ?? "closed") !== "closed",
   );
+
+  const configuredSource = useDiffViewerStore(
+    (s) => s.diffSource[taskId] ?? null,
+  );
+
+  const {
+    repoInfo,
+    aheadOfDefault,
+    defaultBranch,
+    changedFiles: workspaceFiles,
+  } = useGitQueries(repoPath);
+  const hasLocalChanges = workspaceFiles.length > 0;
+  const branchSourceAvailable = !!linkedBranch && aheadOfDefault > 0;
+
+  const effectiveSource = resolveDiffSource({
+    configured: configuredSource,
+    hasLocalChanges,
+    linkedBranch,
+    aheadOfDefault,
+  });
+
+  const isLocalActive = isReviewOpen && effectiveSource === "local";
+
   const {
     changedFiles,
     changesLoading,
@@ -43,7 +79,7 @@ export function ReviewPage({ task }: ReviewPageProps) {
     allPaths,
     diffLoading,
     refetch,
-  } = useReviewDiffs(repoPath, isReviewOpen);
+  } = useReviewDiffs(repoPath, isLocalActive);
 
   const {
     diffOptions,
@@ -65,6 +101,20 @@ export function ReviewPage({ task }: ReviewPageProps) {
           No repository path available
         </Text>
       </Flex>
+    );
+  }
+
+  if (effectiveSource === "branch") {
+    return (
+      <BranchReviewPage
+        task={task}
+        branch={linkedBranch as string}
+        repoInfo={repoInfo ?? undefined}
+        defaultBranch={defaultBranch}
+        isReviewOpen={isReviewOpen}
+        effectiveSource={effectiveSource}
+        branchSourceAvailable={branchSourceAvailable}
+      />
     );
   }
 
@@ -92,6 +142,9 @@ export function ReviewPage({ task }: ReviewPageProps) {
       onCollapseAll={collapseAll}
       onUncollapseFile={uncollapseFile}
       onRefresh={refetch}
+      effectiveSource={effectiveSource}
+      branchSourceAvailable={branchSourceAvailable}
+      defaultBranch={defaultBranch}
     >
       {hasStagedFiles && stagedParsedFiles.length > 0 && (
         <>
@@ -117,6 +170,113 @@ export function ReviewPage({ task }: ReviewPageProps) {
                 collapsed={isCollapsed}
                 onToggle={() => toggleFile(key)}
                 taskId={taskId}
+              />
+            </LazyDiff>
+          </div>
+        );
+      })}
+    </ReviewShell>
+  );
+}
+
+function BranchReviewPage({
+  task,
+  branch,
+  repoInfo,
+  defaultBranch,
+  isReviewOpen,
+  effectiveSource,
+  branchSourceAvailable,
+}: {
+  task: Task;
+  branch: string;
+  repoInfo: { organization: string; repository: string } | undefined;
+  defaultBranch: string | null;
+  isReviewOpen: boolean;
+  effectiveSource: ResolvedDiffSource;
+  branchSourceAvailable: boolean;
+}) {
+  const taskId = task.id;
+  const trpc = useTRPC();
+
+  const repoSlug = repoInfo
+    ? `${repoInfo.organization}/${repoInfo.repository}`
+    : null;
+
+  const { data: files = EMPTY_BRANCH_FILES, isLoading } = useQuery(
+    trpc.git.getBranchChangedFiles.queryOptions(
+      { repo: repoSlug as string, branch },
+      {
+        enabled: isReviewOpen && !!repoSlug,
+        staleTime: 30_000,
+        refetchInterval: 30_000,
+        retry: 1,
+      },
+    ),
+  );
+
+  const allPaths = useMemo(() => files.map((f) => f.path), [files]);
+
+  const {
+    diffOptions,
+    linesAdded,
+    linesRemoved,
+    collapsedFiles,
+    toggleFile,
+    expandAll,
+    collapseAll,
+    uncollapseFile,
+    revealFile,
+    getDeferredReason,
+  } = useReviewState(files, allPaths);
+
+  return (
+    <ReviewShell
+      task={task}
+      fileCount={files.length}
+      linesAdded={linesAdded}
+      linesRemoved={linesRemoved}
+      isLoading={
+        (isLoading || (!repoSlug && isReviewOpen)) && files.length === 0
+      }
+      isEmpty={files.length === 0}
+      allExpanded={collapsedFiles.size === 0}
+      onExpandAll={expandAll}
+      onCollapseAll={collapseAll}
+      onUncollapseFile={uncollapseFile}
+      effectiveSource={effectiveSource}
+      branchSourceAvailable={branchSourceAvailable}
+      defaultBranch={defaultBranch}
+    >
+      {files.map((file) => {
+        const isCollapsed = collapsedFiles.has(file.path);
+        const deferredReason = getDeferredReason(file.path);
+
+        if (deferredReason) {
+          return (
+            <div key={file.path} data-file-path={file.path}>
+              <DeferredDiffPlaceholder
+                filePath={file.path}
+                linesAdded={file.linesAdded ?? 0}
+                linesRemoved={file.linesRemoved ?? 0}
+                reason={deferredReason}
+                collapsed={isCollapsed}
+                onToggle={() => toggleFile(file.path)}
+                onShow={() => revealFile(file.path)}
+              />
+            </div>
+          );
+        }
+
+        return (
+          <div key={file.path} data-file-path={file.path}>
+            <LazyDiff>
+              <PatchedFileDiff
+                file={file}
+                taskId={taskId}
+                options={diffOptions}
+                collapsed={isCollapsed}
+                onToggle={() => toggleFile(file.path)}
               />
             </LazyDiff>
           </div>

--- a/apps/code/src/renderer/features/code-review/components/ReviewShell.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewShell.tsx
@@ -18,6 +18,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ResolvedDiffSource } from "../utils/resolveDiffSource";
 import { ReviewToolbar } from "./ReviewToolbar";
 
 function splitFilePath(fullPath: string): {
@@ -306,6 +307,9 @@ export interface ReviewShellProps {
   onExpandAll: () => void;
   onCollapseAll: () => void;
   onRefresh?: () => void;
+  effectiveSource?: ResolvedDiffSource;
+  branchSourceAvailable?: boolean;
+  defaultBranch?: string | null;
 }
 
 export function ReviewShell({
@@ -321,6 +325,9 @@ export function ReviewShell({
   onExpandAll,
   onCollapseAll,
   onRefresh,
+  effectiveSource,
+  branchSourceAvailable,
+  defaultBranch,
 }: ReviewShellProps) {
   const taskId = task.id;
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -409,24 +416,6 @@ export function ReviewShell({
     return () => observer.disconnect();
   }, [taskId, setActiveFilePath]);
 
-  if (isLoading) {
-    return (
-      <Flex align="center" justify="center" height="100%">
-        <Spinner size="2" />
-      </Flex>
-    );
-  }
-
-  if (isEmpty) {
-    return (
-      <Flex align="center" justify="center" height="100%">
-        <Text size="2" color="gray">
-          No file changes to review
-        </Text>
-      </Flex>
-    );
-  }
-
   return (
     <WorkerPoolContextProvider
       poolOptions={{ workerFactory }}
@@ -444,6 +433,9 @@ export function ReviewShell({
           onExpandAll={onExpandAll}
           onCollapseAll={onCollapseAll}
           onRefresh={onRefresh}
+          effectiveSource={effectiveSource}
+          branchSourceAvailable={branchSourceAvailable}
+          defaultBranch={defaultBranch}
         />
         <Flex style={{ flex: 1, minHeight: 0 }}>
           <div
@@ -452,7 +444,19 @@ export function ReviewShell({
             id="review-shell-diff-container"
             style={{ minWidth: 0 }}
           >
-            {children}
+            {isLoading ? (
+              <Flex align="center" justify="center" height="100%">
+                <Spinner size="2" />
+              </Flex>
+            ) : isEmpty ? (
+              <Flex align="center" justify="center" height="100%">
+                <Text size="2" color="gray">
+                  No file changes to review
+                </Text>
+              </Flex>
+            ) : (
+              children
+            )}
           </div>
 
           {isExpanded && <ExpandedSidebar task={task} />}

--- a/apps/code/src/renderer/features/code-review/components/ReviewToolbar.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewToolbar.tsx
@@ -4,10 +4,12 @@ import { ArrowsClockwise, Columns, Rows, X } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import { Flex, Separator, Text } from "@radix-ui/themes";
 import { DiffSettingsMenu } from "@renderer/features/code-review/components/DiffSettingsMenu";
+import { DiffSourceSelector } from "@renderer/features/code-review/components/DiffSourceSelector";
 import {
   type ReviewMode,
   useReviewNavigationStore,
 } from "@renderer/features/code-review/stores/reviewNavigationStore";
+import type { ResolvedDiffSource } from "@renderer/features/code-review/utils/resolveDiffSource";
 import { FoldVertical, Maximize, Minimize, UnfoldVertical } from "lucide-react";
 import { memo } from "react";
 
@@ -20,6 +22,9 @@ interface ReviewToolbarProps {
   onExpandAll: () => void;
   onCollapseAll: () => void;
   onRefresh?: () => void;
+  effectiveSource?: ResolvedDiffSource;
+  branchSourceAvailable?: boolean;
+  defaultBranch?: string | null;
 }
 
 export const ReviewToolbar = memo(function ReviewToolbar({
@@ -29,6 +34,9 @@ export const ReviewToolbar = memo(function ReviewToolbar({
   onExpandAll,
   onCollapseAll,
   onRefresh,
+  effectiveSource,
+  branchSourceAvailable,
+  defaultBranch,
 }: ReviewToolbarProps) {
   const viewMode = useDiffViewerStore((s) => s.viewMode);
   const toggleViewMode = useDiffViewerStore((s) => s.toggleViewMode);
@@ -62,9 +70,19 @@ export const ReviewToolbar = memo(function ReviewToolbar({
         flexShrink: 0,
       }}
     >
-      <Text size="1" weight="medium">
-        {fileCount} file{fileCount !== 1 ? "s" : ""} changed
-      </Text>
+      <Flex align="center" gap="2">
+        <Text size="1" weight="medium">
+          {fileCount} file{fileCount !== 1 ? "s" : ""} changed
+        </Text>
+        {effectiveSource && (
+          <DiffSourceSelector
+            taskId={taskId}
+            effectiveSource={effectiveSource}
+            branchAvailable={branchSourceAvailable ?? false}
+            defaultBranch={defaultBranch ?? null}
+          />
+        )}
+      </Flex>
 
       <Flex align="center" gap="1" ml="auto">
         {onRefresh && (

--- a/apps/code/src/renderer/features/code-review/utils/resolveDiffSource.test.ts
+++ b/apps/code/src/renderer/features/code-review/utils/resolveDiffSource.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ResolveDiffSourceInput,
+  type ResolvedDiffSource,
+  resolveDiffSource,
+} from "./resolveDiffSource";
+
+describe("resolveDiffSource", () => {
+  it.each<
+    ResolveDiffSourceInput & { expected: ResolvedDiffSource; desc: string }
+  >([
+    {
+      desc: "heuristic: uncommitted changes → local",
+      configured: null,
+      hasLocalChanges: true,
+      linkedBranch: "feat/x",
+      aheadOfDefault: 3,
+      expected: "local",
+    },
+    {
+      desc: "heuristic: clean tree with commits ahead → branch",
+      configured: null,
+      hasLocalChanges: false,
+      linkedBranch: "feat/x",
+      aheadOfDefault: 2,
+      expected: "branch",
+    },
+    {
+      desc: "heuristic: no linked branch → local",
+      configured: null,
+      hasLocalChanges: false,
+      linkedBranch: null,
+      aheadOfDefault: 0,
+      expected: "local",
+    },
+    {
+      desc: "heuristic: linked branch but no commits ahead → local",
+      configured: null,
+      hasLocalChanges: false,
+      linkedBranch: "feat/x",
+      aheadOfDefault: 0,
+      expected: "local",
+    },
+    {
+      desc: "explicit local respected even when branch is available",
+      configured: "local",
+      hasLocalChanges: false,
+      linkedBranch: "feat/x",
+      aheadOfDefault: 5,
+      expected: "local",
+    },
+    {
+      desc: "explicit branch respected when available",
+      configured: "branch",
+      hasLocalChanges: true,
+      linkedBranch: "feat/x",
+      aheadOfDefault: 1,
+      expected: "branch",
+    },
+    {
+      desc: "explicit branch falls back to local when no linked branch",
+      configured: "branch",
+      hasLocalChanges: false,
+      linkedBranch: null,
+      aheadOfDefault: 0,
+      expected: "local",
+    },
+    {
+      desc: "explicit branch falls back to local when no commits ahead",
+      configured: "branch",
+      hasLocalChanges: false,
+      linkedBranch: "feat/x",
+      aheadOfDefault: 0,
+      expected: "local",
+    },
+  ])("$desc", ({ expected, ...input }) => {
+    expect(resolveDiffSource(input)).toBe(expected);
+  });
+});

--- a/apps/code/src/renderer/features/code-review/utils/resolveDiffSource.ts
+++ b/apps/code/src/renderer/features/code-review/utils/resolveDiffSource.ts
@@ -1,0 +1,30 @@
+import type { DiffSource } from "@features/code-editor/stores/diffViewerStore";
+
+export type ResolvedDiffSource = DiffSource;
+
+export interface ResolveDiffSourceInput {
+  configured: DiffSource | null;
+  hasLocalChanges: boolean;
+  linkedBranch: string | null;
+  aheadOfDefault: number;
+}
+
+export function resolveDiffSource({
+  configured,
+  hasLocalChanges,
+  linkedBranch,
+  aheadOfDefault,
+}: ResolveDiffSourceInput): ResolvedDiffSource {
+  const branchAvailable = !!linkedBranch && aheadOfDefault > 0;
+
+  if (configured === "branch") {
+    return branchAvailable ? "branch" : "local";
+  }
+  if (configured === "local") {
+    return "local";
+  }
+
+  if (hasLocalChanges) return "local";
+  if (branchAvailable) return "branch";
+  return "local";
+}


### PR DESCRIPTION
## Problem

for local tasks we only show one diff - just the local diff state

this means when you push changes or open a PR, the diff panel becomes empty

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds a new diff source selector dropdown menu

right now it has two options:

1. local (what we had already)
2. branch vs. default

this will include "PR" as an option soon!

|  |  |
| --- | --- |
| ![Screenshot 2026-04-21 at 4.06.41 PM.png](https://app.graphite.com/user-attachments/assets/f73209ab-8d06-44b2-b0f3-56f709fef6f9.png)<br> | ![Screenshot 2026-04-21 at 4.06.43 PM.png](https://app.graphite.com/user-attachments/assets/4922a31b-c2d4-4b55-b5ef-ca15f9c7c97b.png)<br> |





<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. --> manully