### PR TITLE
feat: Add usage limit detection and upgrade prompt

### DIFF
--- a/apps/code/src/main/services/llm-gateway/service.ts
+++ b/apps/code/src/main/services/llm-gateway/service.ts
@@ -1,4 +1,5 @@
 import {
+  getGatewayInvalidatePlanCacheUrl,
   getGatewayUsageUrl,
   getLlmGatewayUrl,
 } from "@posthog/agent/posthog-api";
@@ -157,5 +158,25 @@ export class LlmGatewayService {
     }
 
     return usageOutput.parse(await response.json());
+  }
+
+  async invalidatePlanCache(): Promise<void> {
+    const auth = await this.authService.getValidAccessToken();
+    const url = getGatewayInvalidatePlanCacheUrl(auth.apiHost);
+
+    log.debug("Invalidating plan cache", { url });
+
+    const response = await this.authService.authenticatedFetch(fetch, url, {
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      throw new LlmGatewayError(
+        `Failed to invalidate plan cache: HTTP ${response.status}`,
+        "plan_cache_error",
+        undefined,
+        response.status,
+      );
+    }
   }
 }

--- a/apps/code/src/main/trpc/routers/llm-gateway.ts
+++ b/apps/code/src/main/trpc/routers/llm-gateway.ts
@@ -26,4 +26,8 @@ export const llmGatewayRouter = router({
   usage: publicProcedure
     .output(usageOutput)
     .query(() => getService().fetchUsage()),
+
+  invalidatePlanCache: publicProcedure.mutation(() =>
+    getService().invalidatePlanCache(),
+  ),
 });

--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -4,6 +4,8 @@ import { HedgehogMode } from "@components/HedgehogMode";
 import { KeyboardShortcutsSheet } from "@components/KeyboardShortcutsSheet";
 
 import { ArchivedTasksView } from "@features/archive/components/ArchivedTasksView";
+import { UsageLimitModal } from "@features/billing/components/UsageLimitModal";
+import { useUsageLimitDetection } from "@features/billing/hooks/useUsageLimitDetection";
 import { CommandMenu } from "@features/command/components/CommandMenu";
 import { CommandCenterView } from "@features/command-center/components/CommandCenterView";
 import { InboxView } from "@features/inbox/components/InboxView";
@@ -20,6 +22,7 @@ import { TourOverlay } from "@features/tour/components/TourOverlay";
 import { useTourStore } from "@features/tour/stores/tourStore";
 import { createFirstTaskTour } from "@features/tour/tours/createFirstTaskTour";
 import { useConnectivity } from "@hooks/useConnectivity";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useIntegrations } from "@hooks/useIntegrations";
 import { Box, Flex } from "@radix-ui/themes";
 import { useCommandMenuStore } from "@stores/commandMenuStore";
@@ -43,12 +46,14 @@ export function MainLayout() {
   } = useShortcutsSheetStore();
   const { data: tasks } = useTasks();
   const { showPrompt, isChecking, check, dismiss } = useConnectivity();
+  const billingEnabled = useFeatureFlag("posthog-code-billing");
 
   const startTour = useTourStore((s) => s.startTour);
   const isFirstTaskTourDone = useTourStore((s) =>
     s.completedTourIds.includes(createFirstTaskTour.id),
   );
 
+  useUsageLimitDetection();
   useIntegrations();
   useTaskDeepLink();
   useInboxDeepLink();
@@ -119,6 +124,7 @@ export function MainLayout() {
       />
       <SettingsDialog />
       <TourOverlay />
+      {billingEnabled && <UsageLimitModal />}
       <HedgehogMode />
     </Flex>
   );

--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -53,7 +53,7 @@ export function MainLayout() {
     s.completedTourIds.includes(createFirstTaskTour.id),
   );
 
-  useUsageLimitDetection();
+  useUsageLimitDetection(billingEnabled);
   useIntegrations();
   useTaskDeepLink();
   useInboxDeepLink();

--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -25,6 +25,7 @@ import { useConnectivity } from "@hooks/useConnectivity";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useIntegrations } from "@hooks/useIntegrations";
 import { Box, Flex } from "@radix-ui/themes";
+import { BILLING_FLAG } from "@shared/constants";
 import { useCommandMenuStore } from "@stores/commandMenuStore";
 import { useNavigationStore } from "@stores/navigationStore";
 import { useShortcutsSheetStore } from "@stores/shortcutsSheetStore";
@@ -46,7 +47,7 @@ export function MainLayout() {
   } = useShortcutsSheetStore();
   const { data: tasks } = useTasks();
   const { showPrompt, isChecking, check, dismiss } = useConnectivity();
-  const billingEnabled = useFeatureFlag("posthog-code-billing");
+  const billingEnabled = useFeatureFlag(BILLING_FLAG);
 
   const startTour = useTourStore((s) => s.startTour);
   const isFirstTaskTourDone = useTourStore((s) =>

--- a/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
+++ b/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
@@ -11,6 +11,7 @@ import { useAuthUiStateStore } from "@features/auth/stores/authUiStateStore";
 import { useSeatStore } from "@features/billing/stores/seatStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { trpcClient } from "@renderer/trpc/client";
+import { BILLING_FLAG } from "@shared/constants";
 import { identifyUser, resetUser } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { useEffect } from "react";
@@ -104,7 +105,7 @@ export function useAuthSession() {
   const { data: currentUser } = useCurrentUser({ client });
   const authIdentity = getAuthIdentity(authState);
 
-  const billingEnabled = useFeatureFlag("posthog-code-billing");
+  const billingEnabled = useFeatureFlag(BILLING_FLAG);
 
   useAuthSubscriptionSync();
   useAuthIdentitySync(authIdentity, authState.cloudRegion);

--- a/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
+++ b/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
@@ -4,9 +4,10 @@ import { useSettingsDialogStore } from "@features/settings/stores/settingsDialog
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSeat } from "@hooks/useSeat";
 import { Circle } from "@phosphor-icons/react";
+import { BILLING_FLAG } from "@shared/constants";
 
 export function SidebarUsageBar() {
-  const billingEnabled = useFeatureFlag("posthog-code-billing");
+  const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const { seat, isPro } = useSeat();
   const seatLoaded = seat !== null;
   const { usage } = useUsage({

--- a/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
+++ b/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
@@ -3,7 +3,7 @@ import { isUsageExceeded } from "@features/billing/utils";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSeat } from "@hooks/useSeat";
-import { Box, Flex, Progress, Text } from "@radix-ui/themes";
+import { Circle } from "@phosphor-icons/react";
 
 export function SidebarUsageBar() {
   const billingEnabled = useFeatureFlag("posthog-code-billing");
@@ -23,26 +23,33 @@ export function SidebarUsageBar() {
   };
 
   return (
-    <Box px="2" py="1.5" className="shrink-0 border-gray-6 border-t">
-      <Flex direction="column" gap="1">
-        <Flex justify="between" align="center">
-          <Text size="1" className="text-gray-11">
+    <div className="shrink-0 border-gray-6 border-t px-3 py-3">
+      <div className="flex items-center justify-between">
+        <span className="font-medium text-gray-11 text-xs">
+          Free plan
+          <Circle
+            size={4}
+            weight="fill"
+            className="mx-1.5 inline text-gray-8"
+          />
+          <span className="font-normal text-gray-10">
             {exceeded ? "Limit reached" : `${Math.round(usagePercent)}% used`}
-          </Text>
-          <button
-            type="button"
-            className="bg-transparent font-medium text-[11px] text-accent-11 transition-colors hover:text-accent-12"
-            onClick={handleUpgrade}
-          >
-            Upgrade
-          </button>
-        </Flex>
-        <Progress
-          value={Math.min(usagePercent, 100)}
-          size="1"
-          color={exceeded ? "red" : undefined}
+          </span>
+        </span>
+        <button
+          type="button"
+          className="bg-transparent font-medium text-accent-11 text-xs transition-colors hover:text-accent-12"
+          onClick={handleUpgrade}
+        >
+          Upgrade
+        </button>
+      </div>
+      <div className="mt-2 h-2.5 w-full overflow-hidden rounded-full bg-gray-4">
+        <div
+          className={`h-full rounded-full transition-all ${exceeded ? "bg-red-9" : "bg-accent-9"}`}
+          style={{ width: `${Math.min(Math.ceil(usagePercent), 100)}%` }}
         />
-      </Flex>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
+++ b/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
@@ -1,20 +1,15 @@
-import { useUsage } from "@features/billing/hooks/useUsage";
+import { useFreeUsage } from "@features/billing/hooks/useFreeUsage";
 import { isUsageExceeded } from "@features/billing/utils";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
-import { useSeat } from "@hooks/useSeat";
 import { Circle } from "@phosphor-icons/react";
 import { BILLING_FLAG } from "@shared/constants";
 
 export function SidebarUsageBar() {
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
-  const { seat, isPro } = useSeat();
-  const seatLoaded = seat !== null;
-  const { usage } = useUsage({
-    enabled: billingEnabled && seatLoaded && !isPro,
-  });
+  const usage = useFreeUsage(billingEnabled);
 
-  if (!billingEnabled || !seatLoaded || isPro || !usage) return null;
+  if (!usage) return null;
 
   const usagePercent = Math.max(
     usage.sustained.used_percent,

--- a/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
+++ b/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
@@ -1,14 +1,16 @@
 import { useUsage } from "@features/billing/hooks/useUsage";
 import { isUsageExceeded } from "@features/billing/utils";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSeat } from "@hooks/useSeat";
 import { Box, Flex, Progress, Text } from "@radix-ui/themes";
 
 export function SidebarUsageBar() {
+  const billingEnabled = useFeatureFlag("posthog-code-billing");
   const { isPro } = useSeat();
-  const { usage } = useUsage({ enabled: !isPro });
+  const { usage } = useUsage({ enabled: billingEnabled && !isPro });
 
-  if (isPro || !usage) return null;
+  if (!billingEnabled || isPro || !usage) return null;
 
   const usagePercent = Math.max(
     usage.sustained.used_percent,

--- a/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
+++ b/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
@@ -1,0 +1,46 @@
+import { useUsage } from "@features/billing/hooks/useUsage";
+import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
+import { useSeat } from "@hooks/useSeat";
+import { Box, Flex, Progress, Text } from "@radix-ui/themes";
+
+export function SidebarUsageBar() {
+  const { usage } = useUsage();
+  const { isPro } = useSeat();
+
+  if (isPro || !usage) return null;
+
+  const usagePercent = Math.max(
+    usage.sustained.used_percent,
+    usage.burst.used_percent,
+  );
+  const exceeded =
+    usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded;
+
+  const handleUpgrade = () => {
+    useSettingsDialogStore.getState().open("plan-usage");
+  };
+
+  return (
+    <Box px="2" py="1.5" className="shrink-0 border-gray-6 border-t">
+      <Flex direction="column" gap="1">
+        <Flex justify="between" align="center">
+          <Text size="1" className="text-gray-11">
+            {exceeded ? "Limit reached" : `${Math.round(usagePercent)}% used`}
+          </Text>
+          <button
+            type="button"
+            className="bg-transparent font-medium text-[11px] text-accent-11 transition-colors hover:text-accent-12"
+            onClick={handleUpgrade}
+          >
+            Upgrade
+          </button>
+        </Flex>
+        <Progress
+          value={Math.min(usagePercent, 100)}
+          size="1"
+          color={exceeded ? "red" : undefined}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
+++ b/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
@@ -7,10 +7,13 @@ import { Circle } from "@phosphor-icons/react";
 
 export function SidebarUsageBar() {
   const billingEnabled = useFeatureFlag("posthog-code-billing");
-  const { isPro } = useSeat();
-  const { usage } = useUsage({ enabled: billingEnabled && !isPro });
+  const { seat, isPro } = useSeat();
+  const seatLoaded = seat !== null;
+  const { usage } = useUsage({
+    enabled: billingEnabled && seatLoaded && !isPro,
+  });
 
-  if (!billingEnabled || isPro || !usage) return null;
+  if (!billingEnabled || !seatLoaded || isPro || !usage) return null;
 
   const usagePercent = Math.max(
     usage.sustained.used_percent,

--- a/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
+++ b/apps/code/src/renderer/features/billing/components/SidebarUsageBar.tsx
@@ -1,11 +1,12 @@
 import { useUsage } from "@features/billing/hooks/useUsage";
+import { isUsageExceeded } from "@features/billing/utils";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
 import { useSeat } from "@hooks/useSeat";
 import { Box, Flex, Progress, Text } from "@radix-ui/themes";
 
 export function SidebarUsageBar() {
-  const { usage } = useUsage();
   const { isPro } = useSeat();
+  const { usage } = useUsage({ enabled: !isPro });
 
   if (isPro || !usage) return null;
 
@@ -13,8 +14,7 @@ export function SidebarUsageBar() {
     usage.sustained.used_percent,
     usage.burst.used_percent,
   );
-  const exceeded =
-    usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded;
+  const exceeded = isUsageExceeded(usage);
 
   const handleUpgrade = () => {
     useSettingsDialogStore.getState().open("plan-usage");

--- a/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
+++ b/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
@@ -1,0 +1,47 @@
+import { useUsageLimitStore } from "@features/billing/stores/usageLimitStore";
+import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
+import { WarningCircle } from "@phosphor-icons/react";
+import { Button, Dialog, Flex, Text } from "@radix-ui/themes";
+
+export function UsageLimitModal() {
+  const isOpen = useUsageLimitStore((s) => s.isOpen);
+  const context = useUsageLimitStore((s) => s.context);
+  const hide = useUsageLimitStore((s) => s.hide);
+
+  const handleUpgrade = () => {
+    hide();
+    useSettingsDialogStore.getState().open("plan-usage");
+  };
+
+  return (
+    <Dialog.Root open={isOpen}>
+      <Dialog.Content
+        maxWidth="400px"
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <Flex direction="column" gap="3">
+          <Flex align="center" gap="2">
+            <WarningCircle size={20} weight="bold" color="var(--red-9)" />
+            <Dialog.Title className="mb-0">Usage limit reached</Dialog.Title>
+          </Flex>
+          <Dialog.Description>
+            <Text size="2" color="gray">
+              {context === "mid-task"
+                ? "You've hit your free plan usage limit. Your current task can't continue until usage resets or you upgrade to Pro."
+                : "You've reached your free plan usage limit. Upgrade to Pro for unlimited usage."}
+            </Text>
+          </Dialog.Description>
+          <Flex justify="end" gap="3" mt="2">
+            <Button type="button" variant="soft" color="gray" onClick={hide}>
+              Not now
+            </Button>
+            <Button type="button" onClick={handleUpgrade}>
+              View upgrade options
+            </Button>
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
+++ b/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
@@ -17,8 +17,8 @@ export function UsageLimitModal() {
     <Dialog.Root open={isOpen}>
       <Dialog.Content
         maxWidth="400px"
-        onEscapeKeyDown={(e) => e.preventDefault()}
         onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={hide}
       >
         <Flex direction="column" gap="3">
           <Flex align="center" gap="2">

--- a/apps/code/src/renderer/features/billing/hooks/useFreeUsage.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useFreeUsage.ts
@@ -1,0 +1,14 @@
+import { useSeat } from "@hooks/useSeat";
+import type { UsageOutput } from "@main/services/llm-gateway/schemas";
+import { useUsage } from "./useUsage";
+
+export function useFreeUsage(billingEnabled: boolean): UsageOutput | null {
+  const { seat, isPro } = useSeat();
+  const seatLoaded = seat !== null;
+  const { usage } = useUsage({
+    enabled: billingEnabled && seatLoaded && !isPro,
+  });
+
+  if (!billingEnabled || !seatLoaded || isPro || !usage) return null;
+  return usage;
+}

--- a/apps/code/src/renderer/features/billing/hooks/useUsage.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsage.ts
@@ -4,12 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 
 const USAGE_REFETCH_INTERVAL_MS = 60_000;
 
-export function useUsage() {
+export function useUsage({ enabled = true }: { enabled?: boolean } = {}) {
   const trpc = useTRPC();
   const focused = useRendererWindowFocusStore((s) => s.focused);
   const { data: usage, isLoading } = useQuery({
     ...trpc.llmGateway.usage.queryOptions(),
-    refetchInterval: focused ? USAGE_REFETCH_INTERVAL_MS : false,
+    enabled,
+    refetchInterval: focused && enabled ? USAGE_REFETCH_INTERVAL_MS : false,
     refetchIntervalInBackground: false,
   });
   return { usage: usage ?? null, isLoading };

--- a/apps/code/src/renderer/features/billing/hooks/useUsage.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsage.ts
@@ -1,0 +1,16 @@
+import { useTRPC } from "@renderer/trpc";
+import { useRendererWindowFocusStore } from "@stores/rendererWindowFocusStore";
+import { useQuery } from "@tanstack/react-query";
+
+const USAGE_REFETCH_INTERVAL_MS = 60_000;
+
+export function useUsage() {
+  const trpc = useTRPC();
+  const focused = useRendererWindowFocusStore((s) => s.focused);
+  const { data: usage, isLoading } = useQuery({
+    ...trpc.llmGateway.usage.queryOptions(),
+    refetchInterval: focused ? USAGE_REFETCH_INTERVAL_MS : false,
+    refetchIntervalInBackground: false,
+  });
+  return { usage: usage ?? null, isLoading };
+}

--- a/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
@@ -1,13 +1,11 @@
 import { useUsageLimitStore } from "@features/billing/stores/usageLimitStore";
 import { isUsageExceeded } from "@features/billing/utils";
 import { useSessionStore } from "@features/sessions/stores/sessionStore";
-import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSeat } from "@hooks/useSeat";
 import { useEffect, useRef } from "react";
 import { useUsage } from "./useUsage";
 
-export function useUsageLimitDetection() {
-  const billingEnabled = useFeatureFlag("posthog-code-billing");
+export function useUsageLimitDetection(billingEnabled: boolean) {
   const { isPro } = useSeat();
   const { usage } = useUsage({ enabled: billingEnabled && !isPro });
   const hasAlertedRef = useRef(false);

--- a/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
@@ -1,20 +1,15 @@
 import { useUsageLimitStore } from "@features/billing/stores/usageLimitStore";
 import { isUsageExceeded } from "@features/billing/utils";
 import { useSessionStore } from "@features/sessions/stores/sessionStore";
-import { useSeat } from "@hooks/useSeat";
 import { useEffect, useRef } from "react";
-import { useUsage } from "./useUsage";
+import { useFreeUsage } from "./useFreeUsage";
 
 export function useUsageLimitDetection(billingEnabled: boolean) {
-  const { seat, isPro } = useSeat();
-  const seatLoaded = seat !== null;
-  const { usage } = useUsage({
-    enabled: billingEnabled && seatLoaded && !isPro,
-  });
+  const usage = useFreeUsage(billingEnabled);
   const hasAlertedRef = useRef(false);
 
   useEffect(() => {
-    if (!billingEnabled || !seatLoaded || isPro || !usage) return;
+    if (!usage) return;
 
     const exceeded = isUsageExceeded(usage);
 
@@ -34,5 +29,5 @@ export function useUsageLimitDetection(billingEnabled: boolean) {
     if (!exceeded) {
       hasAlertedRef.current = false;
     }
-  }, [billingEnabled, seatLoaded, isPro, usage]);
+  }, [usage]);
 }

--- a/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
@@ -1,0 +1,46 @@
+import { useUsageLimitStore } from "@features/billing/stores/usageLimitStore";
+import { useSessionStore } from "@features/sessions/stores/sessionStore";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
+import { useSeat } from "@hooks/useSeat";
+import { useEffect, useRef } from "react";
+import { useUsage } from "./useUsage";
+
+function isExceeded(usage: {
+  sustained: { exceeded: boolean };
+  burst: { exceeded: boolean };
+  is_rate_limited: boolean;
+}): boolean {
+  return (
+    usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded
+  );
+}
+
+export function useUsageLimitDetection() {
+  const billingEnabled = useFeatureFlag("posthog-code-billing");
+  const { isPro } = useSeat();
+  const { usage } = useUsage();
+  const hasAlertedRef = useRef(false);
+
+  useEffect(() => {
+    if (!billingEnabled || isPro || !usage) return;
+
+    const exceeded = isExceeded(usage);
+
+    if (exceeded && !hasAlertedRef.current) {
+      hasAlertedRef.current = true;
+
+      const sessions = useSessionStore.getState().sessions;
+      const hasActiveSession = Object.values(sessions).some(
+        (s) => s.status === "connected" && s.isPromptPending,
+      );
+
+      useUsageLimitStore
+        .getState()
+        .show(hasActiveSession ? "mid-task" : "idle");
+    }
+
+    if (!exceeded) {
+      hasAlertedRef.current = false;
+    }
+  }, [billingEnabled, isPro, usage]);
+}

--- a/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
@@ -1,30 +1,21 @@
 import { useUsageLimitStore } from "@features/billing/stores/usageLimitStore";
+import { isUsageExceeded } from "@features/billing/utils";
 import { useSessionStore } from "@features/sessions/stores/sessionStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSeat } from "@hooks/useSeat";
 import { useEffect, useRef } from "react";
 import { useUsage } from "./useUsage";
 
-function isExceeded(usage: {
-  sustained: { exceeded: boolean };
-  burst: { exceeded: boolean };
-  is_rate_limited: boolean;
-}): boolean {
-  return (
-    usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded
-  );
-}
-
 export function useUsageLimitDetection() {
   const billingEnabled = useFeatureFlag("posthog-code-billing");
   const { isPro } = useSeat();
-  const { usage } = useUsage();
+  const { usage } = useUsage({ enabled: billingEnabled && !isPro });
   const hasAlertedRef = useRef(false);
 
   useEffect(() => {
     if (!billingEnabled || isPro || !usage) return;
 
-    const exceeded = isExceeded(usage);
+    const exceeded = isUsageExceeded(usage);
 
     if (exceeded && !hasAlertedRef.current) {
       hasAlertedRef.current = true;

--- a/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsageLimitDetection.ts
@@ -6,12 +6,15 @@ import { useEffect, useRef } from "react";
 import { useUsage } from "./useUsage";
 
 export function useUsageLimitDetection(billingEnabled: boolean) {
-  const { isPro } = useSeat();
-  const { usage } = useUsage({ enabled: billingEnabled && !isPro });
+  const { seat, isPro } = useSeat();
+  const seatLoaded = seat !== null;
+  const { usage } = useUsage({
+    enabled: billingEnabled && seatLoaded && !isPro,
+  });
   const hasAlertedRef = useRef(false);
 
   useEffect(() => {
-    if (!billingEnabled || isPro || !usage) return;
+    if (!billingEnabled || !seatLoaded || isPro || !usage) return;
 
     const exceeded = isUsageExceeded(usage);
 
@@ -31,5 +34,5 @@ export function useUsageLimitDetection(billingEnabled: boolean) {
     if (!exceeded) {
       hasAlertedRef.current = false;
     }
-  }, [billingEnabled, isPro, usage]);
+  }, [billingEnabled, seatLoaded, isPro, usage]);
 }

--- a/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
@@ -45,6 +45,14 @@ vi.mock("@utils/urls", () => ({
   getPostHogUrl: (path: string) => `https://posthog.com${path}`,
 }));
 
+vi.mock("@renderer/trpc", () => ({
+  trpcClient: {
+    llmGateway: {
+      invalidatePlanCache: { mutate: vi.fn().mockResolvedValue(undefined) },
+    },
+  },
+}));
+
 import { useSeatStore } from "./seatStore";
 
 function makeSeat(overrides: Partial<SeatData> = {}): SeatData {

--- a/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
@@ -1,5 +1,6 @@
 import type { SeatData } from "@shared/types/seat";
-import { PLAN_FREE, PLAN_PRO } from "@shared/types/seat";
+import { PLAN_FREE, PLAN_PRO, PLAN_PRO_ALPHA } from "@shared/types/seat";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetAuthenticatedClient = vi.hoisted(() => vi.fn());
@@ -183,6 +184,20 @@ describe("seatStore", () => {
 
       expect(client.upgradeSeat).not.toHaveBeenCalled();
       expect(client.createSeat).not.toHaveBeenCalled();
+      expect(useSeatStore.getState().seat).toEqual(proSeat);
+    });
+
+    it("upgrades alpha pro seat to paid pro", async () => {
+      const alphaSeat = makeSeat({ plan_key: PLAN_PRO_ALPHA });
+      const proSeat = makeSeat({ plan_key: PLAN_PRO });
+      const client = mockClient({
+        getMySeat: vi.fn().mockResolvedValue(alphaSeat),
+        upgradeSeat: vi.fn().mockResolvedValue(proSeat),
+      });
+
+      await useSeatStore.getState().upgradeToPro();
+
+      expect(client.upgradeSeat).toHaveBeenCalledWith(PLAN_PRO);
       expect(useSeatStore.getState().seat).toEqual(proSeat);
     });
 

--- a/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
@@ -53,7 +53,12 @@ vi.mock("@renderer/trpc", () => ({
   },
 }));
 
+import { trpcClient } from "@renderer/trpc";
 import { useSeatStore } from "./seatStore";
+
+const mockInvalidatePlanCache = vi.mocked(
+  trpcClient.llmGateway.invalidatePlanCache.mutate,
+);
 
 function makeSeat(overrides: Partial<SeatData> = {}): SeatData {
   return {
@@ -196,6 +201,7 @@ describe("seatStore", () => {
 
       expect(client.createSeat).toHaveBeenCalledWith(PLAN_FREE);
       expect(useSeatStore.getState().seat).toEqual(seat);
+      expect(mockInvalidatePlanCache).toHaveBeenCalled();
     });
 
     it("uses existing seat instead of creating", async () => {
@@ -209,6 +215,7 @@ describe("seatStore", () => {
 
       expect(client.createSeat).not.toHaveBeenCalled();
       expect(useSeatStore.getState().seat).toEqual(existing);
+      expect(mockInvalidatePlanCache).not.toHaveBeenCalled();
     });
   });
 
@@ -226,6 +233,7 @@ describe("seatStore", () => {
 
       expect(client.upgradeSeat).toHaveBeenCalledWith(PLAN_PRO);
       expect(useSeatStore.getState().seat).toEqual(proSeat);
+      expect(mockInvalidatePlanCache).toHaveBeenCalled();
     });
 
     it("no-ops when already on pro", async () => {
@@ -252,6 +260,7 @@ describe("seatStore", () => {
       await useSeatStore.getState().upgradeToPro();
 
       expect(client.createSeat).toHaveBeenCalledWith(PLAN_PRO);
+      expect(mockInvalidatePlanCache).toHaveBeenCalled();
     });
   });
 
@@ -267,6 +276,7 @@ describe("seatStore", () => {
 
       expect(client.cancelSeat).toHaveBeenCalled();
       expect(useSeatStore.getState().seat).toEqual(canceledSeat);
+      expect(mockInvalidatePlanCache).toHaveBeenCalled();
     });
   });
 
@@ -281,6 +291,7 @@ describe("seatStore", () => {
       await useSeatStore.getState().reactivateSeat();
 
       expect(useSeatStore.getState().seat).toEqual(seat);
+      expect(mockInvalidatePlanCache).toHaveBeenCalled();
     });
   });
 
@@ -321,6 +332,17 @@ describe("seatStore", () => {
       await useSeatStore.getState().fetchSeat();
 
       expect(useSeatStore.getState().error).toBe("Card declined");
+    });
+
+    it("does not invalidate plan cache on failure", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
+      mockClient({
+        getMySeat: vi.fn().mockRejectedValue(new Error("Network error")),
+      });
+
+      await useSeatStore.getState().upgradeToPro();
+
+      expect(mockInvalidatePlanCache).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
@@ -2,12 +2,7 @@ import type { SeatData } from "@shared/types/seat";
 import { PLAN_FREE, PLAN_PRO } from "@shared/types/seat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockIsFeatureFlagEnabled = vi.hoisted(() => vi.fn());
 const mockGetAuthenticatedClient = vi.hoisted(() => vi.fn());
-
-vi.mock("@utils/analytics", () => ({
-  isFeatureFlagEnabled: mockIsFeatureFlagEnabled,
-}));
 
 vi.mock("@features/auth/hooks/authClient", () => ({
   getAuthenticatedClient: mockGetAuthenticatedClient,
@@ -99,61 +94,8 @@ describe("seatStore", () => {
     });
   });
 
-  describe("billing flag gate", () => {
-    it("fetchSeat does not call API when billing is disabled", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(false);
-      const client = mockClient();
-
-      await useSeatStore.getState().fetchSeat({ autoProvision: true });
-
-      expect(client.getMySeat).not.toHaveBeenCalled();
-      expect(client.createSeat).not.toHaveBeenCalled();
-      expect(useSeatStore.getState().seat).toBeNull();
-      expect(useSeatStore.getState().error).toBe("Billing is not enabled");
-    });
-
-    it("provisionFreeSeat does not call API when billing is disabled", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(false);
-      const client = mockClient();
-
-      await useSeatStore.getState().provisionFreeSeat();
-
-      expect(client.getMySeat).not.toHaveBeenCalled();
-      expect(client.createSeat).not.toHaveBeenCalled();
-    });
-
-    it("upgradeToPro does not call API when billing is disabled", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(false);
-      const client = mockClient();
-
-      await useSeatStore.getState().upgradeToPro();
-
-      expect(client.getMySeat).not.toHaveBeenCalled();
-      expect(client.upgradeSeat).not.toHaveBeenCalled();
-    });
-
-    it("cancelSeat does not call API when billing is disabled", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(false);
-      const client = mockClient();
-
-      await useSeatStore.getState().cancelSeat();
-
-      expect(client.cancelSeat).not.toHaveBeenCalled();
-    });
-
-    it("reactivateSeat does not call API when billing is disabled", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(false);
-      const client = mockClient();
-
-      await useSeatStore.getState().reactivateSeat();
-
-      expect(client.reactivateSeat).not.toHaveBeenCalled();
-    });
-  });
-
   describe("fetchSeat", () => {
     it("fetches existing seat", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat();
       mockClient({ getMySeat: vi.fn().mockResolvedValue(seat) });
 
@@ -165,7 +107,6 @@ describe("seatStore", () => {
     });
 
     it("auto-provisions free seat when none exists", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat();
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(null),
@@ -179,7 +120,6 @@ describe("seatStore", () => {
     });
 
     it("does not auto-provision when option is false", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const client = mockClient();
 
       await useSeatStore.getState().fetchSeat();
@@ -191,7 +131,6 @@ describe("seatStore", () => {
 
   describe("provisionFreeSeat", () => {
     it("creates free seat when none exists", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat();
       const client = mockClient({
         createSeat: vi.fn().mockResolvedValue(seat),
@@ -205,7 +144,6 @@ describe("seatStore", () => {
     });
 
     it("uses existing seat instead of creating", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const existing = makeSeat();
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(existing),
@@ -221,7 +159,6 @@ describe("seatStore", () => {
 
   describe("upgradeToPro", () => {
     it("upgrades existing free seat to pro", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const freeSeat = makeSeat({ plan_key: PLAN_FREE });
       const proSeat = makeSeat({ plan_key: PLAN_PRO });
       const client = mockClient({
@@ -237,7 +174,6 @@ describe("seatStore", () => {
     });
 
     it("no-ops when already on pro", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const proSeat = makeSeat({ plan_key: PLAN_PRO });
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(proSeat),
@@ -251,7 +187,6 @@ describe("seatStore", () => {
     });
 
     it("creates pro seat when none exists", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const proSeat = makeSeat({ plan_key: PLAN_PRO });
       const client = mockClient({
         createSeat: vi.fn().mockResolvedValue(proSeat),
@@ -266,7 +201,6 @@ describe("seatStore", () => {
 
   describe("cancelSeat", () => {
     it("cancels and re-fetches seat", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const canceledSeat = makeSeat({ status: "canceling" });
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(canceledSeat),
@@ -282,7 +216,6 @@ describe("seatStore", () => {
 
   describe("reactivateSeat", () => {
     it("reactivates seat", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat({ status: "active" });
       mockClient({
         reactivateSeat: vi.fn().mockResolvedValue(seat),
@@ -297,7 +230,6 @@ describe("seatStore", () => {
 
   describe("error handling", () => {
     it("sets redirect URL on subscription required error", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const { SeatSubscriptionRequiredError } = await import(
         "@renderer/api/posthogClient"
       );
@@ -319,7 +251,6 @@ describe("seatStore", () => {
     });
 
     it("sets error on payment failure", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const { SeatPaymentFailedError } = await import(
         "@renderer/api/posthogClient"
       );
@@ -335,7 +266,6 @@ describe("seatStore", () => {
     });
 
     it("does not invalidate plan cache on failure", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true);
       mockClient({
         getMySeat: vi.fn().mockRejectedValue(new Error("Network error")),
       });

--- a/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.test.ts
@@ -2,7 +2,12 @@ import type { SeatData } from "@shared/types/seat";
 import { PLAN_FREE, PLAN_PRO } from "@shared/types/seat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockIsFeatureFlagEnabled = vi.hoisted(() => vi.fn());
 const mockGetAuthenticatedClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@utils/analytics", () => ({
+  isFeatureFlagEnabled: mockIsFeatureFlagEnabled,
+}));
 
 vi.mock("@features/auth/hooks/authClient", () => ({
   getAuthenticatedClient: mockGetAuthenticatedClient,
@@ -94,8 +99,61 @@ describe("seatStore", () => {
     });
   });
 
+  describe("billing flag gate", () => {
+    it("fetchSeat does not call API when billing is disabled", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(false);
+      const client = mockClient();
+
+      await useSeatStore.getState().fetchSeat({ autoProvision: true });
+
+      expect(client.getMySeat).not.toHaveBeenCalled();
+      expect(client.createSeat).not.toHaveBeenCalled();
+      expect(useSeatStore.getState().seat).toBeNull();
+      expect(useSeatStore.getState().error).toBe("Billing is not enabled");
+    });
+
+    it("provisionFreeSeat does not call API when billing is disabled", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(false);
+      const client = mockClient();
+
+      await useSeatStore.getState().provisionFreeSeat();
+
+      expect(client.getMySeat).not.toHaveBeenCalled();
+      expect(client.createSeat).not.toHaveBeenCalled();
+    });
+
+    it("upgradeToPro does not call API when billing is disabled", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(false);
+      const client = mockClient();
+
+      await useSeatStore.getState().upgradeToPro();
+
+      expect(client.getMySeat).not.toHaveBeenCalled();
+      expect(client.upgradeSeat).not.toHaveBeenCalled();
+    });
+
+    it("cancelSeat does not call API when billing is disabled", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(false);
+      const client = mockClient();
+
+      await useSeatStore.getState().cancelSeat();
+
+      expect(client.cancelSeat).not.toHaveBeenCalled();
+    });
+
+    it("reactivateSeat does not call API when billing is disabled", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(false);
+      const client = mockClient();
+
+      await useSeatStore.getState().reactivateSeat();
+
+      expect(client.reactivateSeat).not.toHaveBeenCalled();
+    });
+  });
+
   describe("fetchSeat", () => {
     it("fetches existing seat", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat();
       mockClient({ getMySeat: vi.fn().mockResolvedValue(seat) });
 
@@ -107,6 +165,7 @@ describe("seatStore", () => {
     });
 
     it("auto-provisions free seat when none exists", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat();
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(null),
@@ -120,6 +179,7 @@ describe("seatStore", () => {
     });
 
     it("does not auto-provision when option is false", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const client = mockClient();
 
       await useSeatStore.getState().fetchSeat();
@@ -131,6 +191,7 @@ describe("seatStore", () => {
 
   describe("provisionFreeSeat", () => {
     it("creates free seat when none exists", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat();
       const client = mockClient({
         createSeat: vi.fn().mockResolvedValue(seat),
@@ -144,6 +205,7 @@ describe("seatStore", () => {
     });
 
     it("uses existing seat instead of creating", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const existing = makeSeat();
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(existing),
@@ -159,6 +221,7 @@ describe("seatStore", () => {
 
   describe("upgradeToPro", () => {
     it("upgrades existing free seat to pro", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const freeSeat = makeSeat({ plan_key: PLAN_FREE });
       const proSeat = makeSeat({ plan_key: PLAN_PRO });
       const client = mockClient({
@@ -174,6 +237,7 @@ describe("seatStore", () => {
     });
 
     it("no-ops when already on pro", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const proSeat = makeSeat({ plan_key: PLAN_PRO });
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(proSeat),
@@ -187,6 +251,7 @@ describe("seatStore", () => {
     });
 
     it("creates pro seat when none exists", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const proSeat = makeSeat({ plan_key: PLAN_PRO });
       const client = mockClient({
         createSeat: vi.fn().mockResolvedValue(proSeat),
@@ -201,6 +266,7 @@ describe("seatStore", () => {
 
   describe("cancelSeat", () => {
     it("cancels and re-fetches seat", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const canceledSeat = makeSeat({ status: "canceling" });
       const client = mockClient({
         getMySeat: vi.fn().mockResolvedValue(canceledSeat),
@@ -216,6 +282,7 @@ describe("seatStore", () => {
 
   describe("reactivateSeat", () => {
     it("reactivates seat", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const seat = makeSeat({ status: "active" });
       mockClient({
         reactivateSeat: vi.fn().mockResolvedValue(seat),
@@ -230,6 +297,7 @@ describe("seatStore", () => {
 
   describe("error handling", () => {
     it("sets redirect URL on subscription required error", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const { SeatSubscriptionRequiredError } = await import(
         "@renderer/api/posthogClient"
       );
@@ -251,6 +319,7 @@ describe("seatStore", () => {
     });
 
     it("sets error on payment failure", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       const { SeatPaymentFailedError } = await import(
         "@renderer/api/posthogClient"
       );
@@ -266,6 +335,7 @@ describe("seatStore", () => {
     });
 
     it("does not invalidate plan cache on failure", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true);
       mockClient({
         getMySeat: vi.fn().mockRejectedValue(new Error("Network error")),
       });

--- a/apps/code/src/renderer/features/billing/stores/seatStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.ts
@@ -6,7 +6,6 @@ import {
 import { trpcClient } from "@renderer/trpc";
 import type { SeatData } from "@shared/types/seat";
 import { PLAN_FREE, PLAN_PRO } from "@shared/types/seat";
-import { isFeatureFlagEnabled } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { getPostHogUrl } from "@utils/urls";
 import { create } from "zustand";
@@ -31,14 +30,6 @@ interface SeatStoreActions {
 }
 
 type SeatStore = SeatStoreState & SeatStoreActions;
-
-const BILLING_FLAG = "posthog-code-billing";
-
-function assertBillingEnabled(): void {
-  if (!isFeatureFlagEnabled(BILLING_FLAG)) {
-    throw new Error("Billing is not enabled");
-  }
-}
 
 async function getClient() {
   const client = await getAuthenticatedClient();
@@ -95,7 +86,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   fetchSeat: async (options?: { autoProvision?: boolean }) => {
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
-      assertBillingEnabled();
       const client = await getClient();
       let seat = await client.getMySeat();
       if (!seat && options?.autoProvision) {
@@ -112,7 +102,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
     log.info("Provisioning free seat");
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
-      assertBillingEnabled();
       const client = await getClient();
       const existing = await client.getMySeat();
       if (existing) {
@@ -136,7 +125,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   upgradeToPro: async () => {
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
-      assertBillingEnabled();
       const client = await getClient();
       const existing = await client.getMySeat();
       if (existing) {
@@ -160,7 +148,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   cancelSeat: async () => {
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
-      assertBillingEnabled();
       const client = await getClient();
       await client.cancelSeat();
       const seat = await client.getMySeat();
@@ -174,7 +161,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   reactivateSeat: async () => {
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
-      assertBillingEnabled();
       const client = await getClient();
       const seat = await client.reactivateSeat();
       set({ seat, isLoading: false });

--- a/apps/code/src/renderer/features/billing/stores/seatStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.ts
@@ -3,6 +3,7 @@ import {
   SeatPaymentFailedError,
   SeatSubscriptionRequiredError,
 } from "@renderer/api/posthogClient";
+import { trpcClient } from "@renderer/trpc";
 import type { SeatData } from "@shared/types/seat";
 import { PLAN_FREE, PLAN_PRO } from "@shared/types/seat";
 import { isFeatureFlagEnabled } from "@utils/analytics";
@@ -75,6 +76,12 @@ function handleSeatError(
   set({ isLoading: false, error: error.message });
 }
 
+function invalidatePlanCache(): void {
+  trpcClient.llmGateway.invalidatePlanCache.mutate().catch((err) => {
+    log.warn("Failed to invalidate plan cache", err);
+  });
+}
+
 const initialState: SeatStoreState = {
   seat: null,
   isLoading: false,
@@ -119,6 +126,7 @@ export const useSeatStore = create<SeatStore>()((set) => ({
       const seat = await client.createSeat(PLAN_FREE);
       log.info("Free seat created", { id: seat.id, plan: seat.plan_key });
       set({ seat, isLoading: false });
+      invalidatePlanCache();
     } catch (error) {
       log.error("provisionFreeSeat failed", error);
       handleSeatError(error, set);
@@ -138,10 +146,12 @@ export const useSeatStore = create<SeatStore>()((set) => ({
         }
         const seat = await client.upgradeSeat(PLAN_PRO);
         set({ seat, isLoading: false });
+        invalidatePlanCache();
         return;
       }
       const seat = await client.createSeat(PLAN_PRO);
       set({ seat, isLoading: false });
+      invalidatePlanCache();
     } catch (error) {
       handleSeatError(error, set);
     }
@@ -155,6 +165,7 @@ export const useSeatStore = create<SeatStore>()((set) => ({
       await client.cancelSeat();
       const seat = await client.getMySeat();
       set({ seat, isLoading: false });
+      invalidatePlanCache();
     } catch (error) {
       handleSeatError(error, set);
     }
@@ -167,6 +178,7 @@ export const useSeatStore = create<SeatStore>()((set) => ({
       const client = await getClient();
       const seat = await client.reactivateSeat();
       set({ seat, isLoading: false });
+      invalidatePlanCache();
     } catch (error) {
       handleSeatError(error, set);
     }

--- a/apps/code/src/renderer/features/billing/stores/seatStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.ts
@@ -4,10 +4,8 @@ import {
   SeatSubscriptionRequiredError,
 } from "@renderer/api/posthogClient";
 import { trpcClient } from "@renderer/trpc";
-import { BILLING_FLAG } from "@shared/constants";
 import type { SeatData } from "@shared/types/seat";
 import { PLAN_FREE, PLAN_PRO } from "@shared/types/seat";
-import { isFeatureFlagEnabled } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { getPostHogUrl } from "@utils/urls";
 import { create } from "zustand";
@@ -86,10 +84,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   ...initialState,
 
   fetchSeat: async (options?: { autoProvision?: boolean }) => {
-    if (!isFeatureFlagEnabled(BILLING_FLAG)) {
-      set({ error: "Billing is not enabled" });
-      return;
-    }
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();
@@ -105,7 +99,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   provisionFreeSeat: async () => {
-    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     log.info("Provisioning free seat");
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
@@ -130,7 +123,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   upgradeToPro: async () => {
-    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();
@@ -154,7 +146,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   cancelSeat: async () => {
-    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();
@@ -168,7 +159,6 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   reactivateSeat: async () => {
-    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();

--- a/apps/code/src/renderer/features/billing/stores/seatStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/seatStore.ts
@@ -4,8 +4,10 @@ import {
   SeatSubscriptionRequiredError,
 } from "@renderer/api/posthogClient";
 import { trpcClient } from "@renderer/trpc";
+import { BILLING_FLAG } from "@shared/constants";
 import type { SeatData } from "@shared/types/seat";
 import { PLAN_FREE, PLAN_PRO } from "@shared/types/seat";
+import { isFeatureFlagEnabled } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { getPostHogUrl } from "@utils/urls";
 import { create } from "zustand";
@@ -84,6 +86,10 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   ...initialState,
 
   fetchSeat: async (options?: { autoProvision?: boolean }) => {
+    if (!isFeatureFlagEnabled(BILLING_FLAG)) {
+      set({ error: "Billing is not enabled" });
+      return;
+    }
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();
@@ -99,6 +105,7 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   provisionFreeSeat: async () => {
+    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     log.info("Provisioning free seat");
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
@@ -123,6 +130,7 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   upgradeToPro: async () => {
+    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();
@@ -146,6 +154,7 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   cancelSeat: async () => {
+    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();
@@ -159,6 +168,7 @@ export const useSeatStore = create<SeatStore>()((set) => ({
   },
 
   reactivateSeat: async () => {
+    if (!isFeatureFlagEnabled(BILLING_FLAG)) return;
     set({ isLoading: true, error: null, redirectUrl: null });
     try {
       const client = await getClient();

--- a/apps/code/src/renderer/features/billing/stores/usageLimitStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/usageLimitStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useUsageLimitStore } from "./usageLimitStore";
+
+describe("usageLimitStore", () => {
+  beforeEach(() => {
+    useUsageLimitStore.setState({ isOpen: false, context: null });
+  });
+
+  it("starts closed with no context", () => {
+    const state = useUsageLimitStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.context).toBeNull();
+  });
+
+  it("show opens with mid-task context", () => {
+    useUsageLimitStore.getState().show("mid-task");
+    const state = useUsageLimitStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.context).toBe("mid-task");
+  });
+
+  it("show opens with idle context", () => {
+    useUsageLimitStore.getState().show("idle");
+    const state = useUsageLimitStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.context).toBe("idle");
+  });
+
+  it("hide closes and clears context", () => {
+    useUsageLimitStore.getState().show("mid-task");
+    useUsageLimitStore.getState().hide();
+    const state = useUsageLimitStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.context).toBeNull();
+  });
+});

--- a/apps/code/src/renderer/features/billing/stores/usageLimitStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/usageLimitStore.test.ts
@@ -26,11 +26,11 @@ describe("usageLimitStore", () => {
     expect(state.context).toBe("idle");
   });
 
-  it("hide closes and clears context", () => {
+  it("hide closes but preserves context for exit animation", () => {
     useUsageLimitStore.getState().show("mid-task");
     useUsageLimitStore.getState().hide();
     const state = useUsageLimitStore.getState();
     expect(state.isOpen).toBe(false);
-    expect(state.context).toBeNull();
+    expect(state.context).toBe("mid-task");
   });
 });

--- a/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+type UsageLimitContext = "mid-task" | "idle";
+
+interface UsageLimitState {
+  isOpen: boolean;
+  context: UsageLimitContext | null;
+}
+
+interface UsageLimitActions {
+  show: (context: UsageLimitContext) => void;
+  hide: () => void;
+}
+
+type UsageLimitStore = UsageLimitState & UsageLimitActions;
+
+export const useUsageLimitStore = create<UsageLimitStore>()((set) => ({
+  isOpen: false,
+  context: null,
+
+  show: (context) => set({ isOpen: true, context }),
+  hide: () => set({ isOpen: false, context: null }),
+}));

--- a/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
@@ -19,5 +19,5 @@ export const useUsageLimitStore = create<UsageLimitStore>()((set) => ({
   context: null,
 
   show: (context) => set({ isOpen: true, context }),
-  hide: () => set({ isOpen: false, context: null }),
+  hide: () => set({ isOpen: false }),
 }));

--- a/apps/code/src/renderer/features/billing/utils.test.ts
+++ b/apps/code/src/renderer/features/billing/utils.test.ts
@@ -1,0 +1,53 @@
+import type { UsageOutput } from "@main/services/llm-gateway/schemas";
+import { describe, expect, it } from "vitest";
+import { isUsageExceeded } from "./utils";
+
+function makeUsage(
+  overrides: Partial<{
+    sustained: boolean;
+    burst: boolean;
+    isRateLimited: boolean;
+  }> = {},
+): UsageOutput {
+  return {
+    product: "posthog_code",
+    user_id: 1,
+    sustained: {
+      used_percent: 50,
+      resets_in_seconds: 3600,
+      exceeded: overrides.sustained ?? false,
+    },
+    burst: {
+      used_percent: 30,
+      resets_in_seconds: 600,
+      exceeded: overrides.burst ?? false,
+    },
+    is_rate_limited: overrides.isRateLimited ?? false,
+  };
+}
+
+describe("isUsageExceeded", () => {
+  it("returns false when nothing is exceeded", () => {
+    expect(isUsageExceeded(makeUsage())).toBe(false);
+  });
+
+  it("returns true when sustained is exceeded", () => {
+    expect(isUsageExceeded(makeUsage({ sustained: true }))).toBe(true);
+  });
+
+  it("returns true when burst is exceeded", () => {
+    expect(isUsageExceeded(makeUsage({ burst: true }))).toBe(true);
+  });
+
+  it("returns true when rate limited", () => {
+    expect(isUsageExceeded(makeUsage({ isRateLimited: true }))).toBe(true);
+  });
+
+  it("returns true when all flags are set", () => {
+    expect(
+      isUsageExceeded(
+        makeUsage({ sustained: true, burst: true, isRateLimited: true }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/code/src/renderer/features/billing/utils.ts
+++ b/apps/code/src/renderer/features/billing/utils.ts
@@ -1,10 +1,6 @@
-interface UsageLimitCheck {
-  sustained: { exceeded: boolean };
-  burst: { exceeded: boolean };
-  is_rate_limited: boolean;
-}
+import type { UsageOutput } from "@main/services/llm-gateway/schemas";
 
-export function isUsageExceeded(usage: UsageLimitCheck): boolean {
+export function isUsageExceeded(usage: UsageOutput): boolean {
   return (
     usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded
   );

--- a/apps/code/src/renderer/features/billing/utils.ts
+++ b/apps/code/src/renderer/features/billing/utils.ts
@@ -1,0 +1,11 @@
+interface UsageLimitCheck {
+  sustained: { exceeded: boolean };
+  burst: { exceeded: boolean };
+  is_rate_limited: boolean;
+}
+
+export function isUsageExceeded(usage: UsageLimitCheck): boolean {
+  return (
+    usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded
+  );
+}

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportTaskLogs.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportTaskLogs.tsx
@@ -408,8 +408,6 @@ export function ReportTaskLogs({
             const row = isInteractive ? (
               showRunAction ? (
                 // biome-ignore lint/a11y/useSemanticElements: a <button> can't contain the nested run-action <button>
-                // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled via onKeyDown
-                // biome-ignore lint/a11y/noStaticElementInteractions: role="button" makes this interactive
                 <div
                   key={relationship}
                   role="button"

--- a/apps/code/src/renderer/features/sessions/components/session-update/McpToolBlock.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/McpToolBlock.tsx
@@ -5,11 +5,7 @@ import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { useTRPC } from "@renderer/trpc/client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSubscription } from "@trpc/tanstack-react-query";
-import { logger } from "@utils/logger";
-import { useEffect } from "react";
 import type { ToolViewProps } from "./toolCallUtils";
-
-const log = logger.scope("mcp-tool-block");
 
 interface McpToolBlockProps extends ToolViewProps {
   mcpToolName: string;
@@ -34,15 +30,6 @@ export function McpToolBlock(props: McpToolBlockProps) {
       },
     ),
   );
-
-  // TODO: Remove this, used for local debugging only
-  useEffect(() => {
-    log.debug("McpToolBlock render", {
-      mcpToolName,
-      hasUi,
-      isDisabledForServer,
-    });
-  }, [mcpToolName, hasUi, isDisabledForServer]);
 
   // When MCP Apps discovery completes (possibly after this component mounted),
   // invalidate the hasUiForTool query so we pick up newly-discovered UIs.

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -2127,35 +2127,6 @@ export class SessionService {
   }
 
   /**
-   * Append a user shell execute event (synchronous version for backwards compatibility).
-   */
-  async appendUserShellExecute(
-    taskId: string,
-    command: string,
-    cwd: string,
-    result: { stdout: string; stderr: string; exitCode: number },
-  ): Promise<void> {
-    const id = `user-shell-${Date.now()}-${Math.random()
-      .toString(36)
-      .slice(2, 9)}`;
-    const session = sessionStoreSetters.getSessionByTaskId(taskId);
-    if (!session) return;
-
-    const storedEntry: StoredLogEntry = {
-      type: "notification",
-      timestamp: new Date().toISOString(),
-      notification: {
-        method: "_array/user_shell_execute",
-        params: { id, command, cwd, result },
-      },
-    };
-
-    const event = createUserShellExecuteEvent(command, cwd, result, id);
-
-    await this.appendAndPersist(taskId, session, event, storedEntry);
-  }
-
-  /**
    * Retry connecting to the existing session (resume attempt using
    * the sessionId from logs). Does NOT tear down — avoids the connect
    * effect loop.

--- a/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
+++ b/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
@@ -29,6 +29,7 @@ import {
   Wrench,
 } from "@phosphor-icons/react";
 import { Avatar, Box, Flex, ScrollArea, Text } from "@radix-ui/themes";
+import { BILLING_FLAG } from "@shared/constants";
 import { type ReactNode, useEffect, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { AdvancedSettings } from "./sections/AdvancedSettings";
@@ -128,7 +129,7 @@ export function SettingsDialog() {
   const client = useOptionalAuthenticatedClient();
   const { data: user } = useCurrentUser({ client });
   const { seat, planLabel } = useSeat();
-  const billingEnabled = useFeatureFlag("posthog-code-billing");
+  const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const logoutMutation = useLogoutMutation();
 
   const sidebarItems = useMemo(

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -1,5 +1,6 @@
 import { useUsage } from "@features/billing/hooks/useUsage";
 import { useSeatStore } from "@features/billing/stores/seatStore";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSeat } from "@hooks/useSeat";
 import {
   ArrowSquareOut,
@@ -17,6 +18,7 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { Tooltip } from "@renderer/components/ui/Tooltip";
+import { BILLING_FLAG } from "@shared/constants";
 import { getPostHogUrl } from "@utils/urls";
 import { useState } from "react";
 
@@ -47,6 +49,7 @@ export function PlanUsageSettings() {
     error,
     redirectUrl,
   } = useSeat();
+  const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const { upgradeToPro, cancelSeat, reactivateSeat, clearError } =
     useSeatStore();
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
@@ -188,7 +191,7 @@ export function PlanUsageSettings() {
               borderRadius: "var(--radius-3)",
             }}
           >
-            {isLoading ? (
+            {isLoading || !billingEnabled ? (
               <Spinner size="2" />
             ) : (
               <Text size="2" color="gray">

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -19,6 +19,7 @@ import {
 } from "@radix-ui/themes";
 import { Tooltip } from "@renderer/components/ui/Tooltip";
 import { BILLING_FLAG } from "@shared/constants";
+import { PLAN_PRO_ALPHA } from "@shared/types/seat";
 import { getPostHogUrl } from "@utils/urls";
 import { useState } from "react";
 
@@ -53,6 +54,7 @@ export function PlanUsageSettings() {
   const { upgradeToPro, cancelSeat, reactivateSeat, clearError } =
     useSeatStore();
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
+  const isAlpha = seat?.plan_key === PLAN_PRO_ALPHA;
   const { usage, isLoading: usageLoading } = useUsage({
     enabled: seat !== null && !isPro,
   });
@@ -130,20 +132,23 @@ export function PlanUsageSettings() {
               price="$200"
               period="/mo"
               features={[
-                "Unlimited usage*",
+                "Higher usage limits",
                 "Local and cloud execution",
                 "All Claude and Codex models",
               ]}
-              isCurrent={isPro}
+              isCurrent={isPro && !isAlpha}
               resetLabel={
-                isPro && isCanceling && formattedActiveUntil
+                isPro && !isAlpha && isCanceling && formattedActiveUntil
                   ? `Cancels ${formattedActiveUntil}`
-                  : isPro && formattedActiveUntil && daysUntilReset !== null
+                  : isPro &&
+                      !isAlpha &&
+                      formattedActiveUntil &&
+                      daysUntilReset !== null
                     ? `Resets ${formattedActiveUntil} (${daysUntilReset} days)`
                     : undefined
               }
               action={
-                isPro ? (
+                isPro && !isAlpha ? (
                   isCanceling ? (
                     <Button
                       size="1"
@@ -201,6 +206,27 @@ export function PlanUsageSettings() {
           </Flex>
         )}
       </Flex>
+
+      {isAlpha && (
+        <Flex
+          p="4"
+          style={{
+            border: "1px solid var(--accent-7)",
+            borderRadius: "var(--radius-3)",
+            background: "var(--accent-2)",
+          }}
+        >
+          <Flex direction="column" gap="2">
+            <Text size="2" weight="medium">
+              Alpha plan
+            </Text>
+            <Text size="2" style={{ color: "var(--gray-11)" }}>
+              You're on the free alpha Pro plan with full Pro features. You can
+              upgrade to the paid Pro plan anytime for higher usage limits.
+            </Text>
+          </Flex>
+        </Flex>
+      )}
 
       <Flex direction="column" gap="3">
         <Text size="2" weight="medium" style={{ color: "var(--gray-9)" }}>
@@ -294,7 +320,7 @@ export function PlanUsageSettings() {
                 weight="bold"
                 style={{ color: "var(--accent-9)" }}
               />
-              <Text size="2">Unlimited token usage</Text>
+              <Text size="2">Higher usage limits</Text>
             </Flex>
             <Flex align="center" gap="2">
               <Check

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -50,7 +50,9 @@ export function PlanUsageSettings() {
   const { upgradeToPro, cancelSeat, reactivateSeat, clearError } =
     useSeatStore();
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
-  const { usage, isLoading: usageLoading } = useUsage({ enabled: !isPro });
+  const { usage, isLoading: usageLoading } = useUsage({
+    enabled: seat !== null && !isPro,
+  });
 
   const formattedActiveUntil = activeUntil
     ? activeUntil.toLocaleDateString(undefined, {

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -50,7 +50,7 @@ export function PlanUsageSettings() {
   const { upgradeToPro, cancelSeat, reactivateSeat, clearError } =
     useSeatStore();
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
-  const { usage, isLoading: usageLoading } = useUsage();
+  const { usage, isLoading: usageLoading } = useUsage({ enabled: !isPro });
 
   const formattedActiveUntil = activeUntil
     ? activeUntil.toLocaleDateString(undefined, {

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -1,3 +1,4 @@
+import { useUsage } from "@features/billing/hooks/useUsage";
 import { useSeatStore } from "@features/billing/stores/seatStore";
 import { useSeat } from "@hooks/useSeat";
 import {
@@ -16,8 +17,6 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { Tooltip } from "@renderer/components/ui/Tooltip";
-import { useTRPC } from "@renderer/trpc";
-import { useQuery } from "@tanstack/react-query";
 import { getPostHogUrl } from "@utils/urls";
 import { useState } from "react";
 
@@ -36,14 +35,6 @@ function formatResetTime(seconds: number): string {
   const days = Math.ceil(seconds / 86400);
   if (days === 1) return "1 day";
   return `${days} days`;
-}
-
-function useUsage() {
-  const trpc = useTRPC();
-  const { data: usage, isLoading } = useQuery(
-    trpc.llmGateway.usage.queryOptions(),
-  );
-  return { usage: usage ?? null, isLoading };
 }
 
 export function PlanUsageSettings() {

--- a/apps/code/src/renderer/features/sidebar/components/SidebarContent.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarContent.tsx
@@ -1,4 +1,6 @@
 import { useArchivedTaskIds } from "@features/archive/hooks/useArchivedTaskIds";
+import { SidebarUsageBar } from "@features/billing/components/SidebarUsageBar";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { ArchiveIcon } from "@phosphor-icons/react";
 import { Box, Flex } from "@radix-ui/themes";
 import { useNavigationStore } from "@stores/navigationStore";
@@ -12,6 +14,7 @@ export const SidebarContent: React.FC = () => {
   const navigateToArchived = useNavigationStore(
     (state) => state.navigateToArchived,
   );
+  const billingEnabled = useFeatureFlag("posthog-code-billing");
 
   return (
     <Flex direction="column" height="100%">
@@ -19,6 +22,7 @@ export const SidebarContent: React.FC = () => {
         <SidebarMenu />
       </Box>
       <UpdateBanner />
+      {billingEnabled && <SidebarUsageBar />}
       {archivedTaskIds.size > 0 && (
         <Box className="shrink-0 border-gray-6 border-t">
           <button

--- a/apps/code/src/renderer/features/sidebar/components/SidebarContent.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarContent.tsx
@@ -1,6 +1,5 @@
 import { useArchivedTaskIds } from "@features/archive/hooks/useArchivedTaskIds";
 import { SidebarUsageBar } from "@features/billing/components/SidebarUsageBar";
-import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { ArchiveIcon } from "@phosphor-icons/react";
 import { Box, Flex } from "@radix-ui/themes";
 import { useNavigationStore } from "@stores/navigationStore";
@@ -14,15 +13,13 @@ export const SidebarContent: React.FC = () => {
   const navigateToArchived = useNavigationStore(
     (state) => state.navigateToArchived,
   );
-  const billingEnabled = useFeatureFlag("posthog-code-billing");
-
   return (
     <Flex direction="column" height="100%">
       <Box flexGrow="1" overflow="hidden">
         <SidebarMenu />
       </Box>
       <UpdateBanner />
-      {billingEnabled && <SidebarUsageBar />}
+      <SidebarUsageBar />
       {archivedTaskIds.size > 0 && (
         <Box className="shrink-0 border-gray-6 border-t">
           <button

--- a/apps/code/src/renderer/features/workspace/hooks/useBranchMismatchDialog.test.ts
+++ b/apps/code/src/renderer/features/workspace/hooks/useBranchMismatchDialog.test.ts
@@ -109,12 +109,12 @@ describe("useBranchMismatchDialog", () => {
       const { result } = renderDialog({ shouldWarn: true });
       const clearEditor = vi.fn();
 
-      let allowed: boolean;
+      let allowed = true;
       act(() => {
         allowed = result.current.handleBeforeSubmit("hello", clearEditor);
       });
 
-      expect(allowed!).toBe(false);
+      expect(allowed).toBe(false);
       expect(result.current.dialogProps?.open).toBe(true);
       expect(clearEditor).not.toHaveBeenCalled();
       expect(mockTrack).toHaveBeenCalledWith(

--- a/apps/code/src/renderer/hooks/useSeat.ts
+++ b/apps/code/src/renderer/hooks/useSeat.ts
@@ -1,5 +1,5 @@
 import { useSeatStore } from "@features/billing/stores/seatStore";
-import { PLAN_PRO, seatHasAccess } from "@shared/types/seat";
+import { isProPlan, seatHasAccess } from "@shared/types/seat";
 
 export function useSeat() {
   const seat = useSeatStore((s) => s.seat);
@@ -7,7 +7,7 @@ export function useSeat() {
   const error = useSeatStore((s) => s.error);
   const redirectUrl = useSeatStore((s) => s.redirectUrl);
 
-  const isPro = seat?.plan_key === PLAN_PRO;
+  const isPro = isProPlan(seat?.plan_key);
   const hasAccess = seat ? seatHasAccess(seat.status) : false;
   const isCanceling = seat?.status === "canceling";
   const planLabel = isPro ? "Pro" : "Free";

--- a/apps/code/src/renderer/stores/settingsStore.ts
+++ b/apps/code/src/renderer/stores/settingsStore.ts
@@ -1,5 +1,8 @@
+import { logger } from "@utils/logger";
 import { create } from "zustand";
 import { trpcClient } from "../trpc";
+
+const log = logger.scope("settings-store");
 
 export type SendMessagesWith = "enter" | "cmd+enter";
 
@@ -20,7 +23,9 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
       if (mode === "enter" || mode === "cmd+enter") {
         set({ sendMessagesWith: mode });
       }
-    } catch (_error) {}
+    } catch (error) {
+      log.warn("Failed to load sendMessagesWith preference", { error });
+    }
   },
 
   setSendMessagesWith: async (mode: SendMessagesWith) => {
@@ -30,6 +35,8 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
         value: mode,
       });
       set({ sendMessagesWith: mode });
-    } catch (_error) {}
+    } catch (error) {
+      log.warn("Failed to persist sendMessagesWith preference", { error });
+    }
   },
 }));

--- a/apps/code/src/renderer/types/electron.d.ts
+++ b/apps/code/src/renderer/types/electron.d.ts
@@ -1,7 +1,5 @@
 import "@main/services/types";
 
-// No legacy IPC interfaces - all communication now uses tRPC
-
 declare global {
   interface Window {
     electronUtils?: {

--- a/apps/code/src/shared/constants.ts
+++ b/apps/code/src/shared/constants.ts
@@ -1,3 +1,4 @@
+export const BILLING_FLAG = "posthog-code-billing";
 export const BRANCH_PREFIX = "posthog-code/";
 export const DATA_DIR = ".posthog-code";
 export const WORKTREES_DIR = ".posthog-code/worktrees";

--- a/apps/code/src/shared/types/seat.ts
+++ b/apps/code/src/shared/types/seat.ts
@@ -20,7 +20,14 @@ export interface SeatData {
 
 export const SEAT_PRODUCT_KEY = "posthog_code";
 export const PLAN_FREE = "posthog-code-free-20260301";
-export const PLAN_PRO = "posthog-code-200-20260301";
+export const PLAN_PRO = "posthog-code-pro-200-20260301";
+export const PLAN_PRO_ALPHA = "posthog-code-pro-0-20260422";
+
+const PRO_PLANS = new Set([PLAN_PRO, PLAN_PRO_ALPHA]);
+
+export function isProPlan(planKey: string | undefined | null): boolean {
+  return planKey != null && PRO_PLANS.has(planKey);
+}
 
 export function seatHasAccess(status: SeatStatus): boolean {
   return status === "active" || status === "canceling";

--- a/knip.json
+++ b/knip.json
@@ -3,10 +3,11 @@
   "ignoreWorkspaces": ["apps/mobile"],
   "workspaces": {
     ".": {
-      "entry": ["mprocs.yaml"]
+      "entry": ["mprocs.yaml", "scripts/pnpm-run.mjs", "scripts/test-access-token.js"]
     },
     "apps/code": {
       "entry": [
+        "src/main/bootstrap.ts",
         "src/main/index.ts",
         "src/main/preload.ts",
         "src/renderer/main.tsx",
@@ -42,6 +43,21 @@
       "entry": ["src/*.ts"],
       "project": ["src/**/*.ts"],
       "ignore": ["tests/**"],
+      "includeEntryExports": true
+    },
+    "packages/electron-trpc": {
+      "entry": [
+        "src/main/index.ts",
+        "src/renderer/index.ts",
+        "main.d.ts",
+        "renderer.d.ts"
+      ],
+      "project": ["src/**/*.ts"],
+      "includeEntryExports": true
+    },
+    "packages/shared": {
+      "entry": ["src/index.ts", "src/**/*.test.ts"],
+      "project": ["src/**/*.ts"],
       "includeEntryExports": true
     }
   }

--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,11 @@
   "ignoreWorkspaces": ["apps/mobile"],
   "workspaces": {
     ".": {
-      "entry": ["mprocs.yaml", "scripts/pnpm-run.mjs", "scripts/test-access-token.js"]
+      "entry": [
+        "mprocs.yaml",
+        "scripts/pnpm-run.mjs",
+        "scripts/test-access-token.js"
+      ]
     },
     "apps/code": {
       "entry": [

--- a/packages/agent/src/adapters/claude/hooks.ts
+++ b/packages/agent/src/adapters/claude/hooks.ts
@@ -131,7 +131,7 @@ interface CreatePostToolUseHookParams {
 }
 
 export const createPostToolUseHook =
-  ({ onModeChange, logger }: CreatePostToolUseHookParams): HookCallback =>
+  ({ onModeChange }: CreatePostToolUseHookParams): HookCallback =>
   async (
     input: HookInput,
     toolUseID: string | undefined,

--- a/packages/agent/src/posthog-api.ts
+++ b/packages/agent/src/posthog-api.ts
@@ -7,9 +7,17 @@ import type {
   TaskRun,
   TaskRunArtifact,
 } from "./types";
-import { getGatewayUsageUrl, getLlmGatewayUrl } from "./utils/gateway";
+import {
+  getGatewayInvalidatePlanCacheUrl,
+  getGatewayUsageUrl,
+  getLlmGatewayUrl,
+} from "./utils/gateway";
 
-export { getGatewayUsageUrl, getLlmGatewayUrl };
+export {
+  getGatewayInvalidatePlanCacheUrl,
+  getGatewayUsageUrl,
+  getLlmGatewayUrl,
+};
 
 const DEFAULT_USER_AGENT = `posthog/agent.hog.dev; version: ${packageJson.version}`;
 

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -29,3 +29,7 @@ export function getGatewayUsageUrl(
 ): string {
   return `${getGatewayBaseUrl(posthogHost)}/v1/usage/${product}`;
 }
+
+export function getGatewayInvalidatePlanCacheUrl(posthogHost: string): string {
+  return `${getGatewayBaseUrl(posthogHost)}/invalidate-plan-cache`;
+}


### PR DESCRIPTION
## Problem

**NOTE TO REVIEWER:** You might not be able to test this without enabling the feature flag in a SEPERATE org, feel free to yolo stamp.

Free-tier users have no visibility into usage limits until requests start failing silently.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## ![CleanShot 2026-04-21 at 22.43.53@2x.png](https://app.graphite.com/user-attachments/assets/c064297f-25f1-46ef-a833-be9d99783837.png)

## ![CleanShot 2026-04-21 at 22.10.51@2x.png](https://app.graphite.com/user-attachments/assets/45e20c28-4e49-4c82-a442-931626a7cde2.png)

## ![CleanShot 2026-04-21 at 22.44.01@2x.png](https://app.graphite.com/user-attachments/assets/f8d81e7c-6ff7-460d-9f20-ca200bb92db3.png)

## Changes

1. Extract useUsage hook from PlanUsageSettings into shared billing/hooks for reuse
2. Add useUsageLimitDetection hook to detect when free users exceed sustained/burst limits
3. Add UsageLimitModal with context-aware messaging (mid-task vs idle)
4. Add SidebarUsageBar showing usage percentage and upgrade link
5. Gate all billing UI behind posthog-code-billing feature flag
6. Rremove assertBillingEnabled() from all store actions. The callers own that responsibility. 

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

Manually