### PR TITLE
feat: Make plan approval options contextual

### DIFF
--- a/packages/agent/src/adapters/claude/UPSTREAM.md
+++ b/packages/agent/src/adapters/claude/UPSTREAM.md
@@ -53,6 +53,7 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 | Auth methods | `claude-ai-login` + `console-login` | Returns empty `authMethods` | Auth handled externally |
 | Session fingerprinting | Implicit teardown on cwd/mcp change | Explicit `refreshSession()` | Caller-initiated is more predictable |
 | Shutdown on ACP close | Process exits | No standalone process | Agent is embedded in server |
+| ExitPlanMode options | Static list of all modes + bypass | Contextual: shows pre-plan mode as default, optional downgrade to manual | Reduces decision fatigue; user usually wants the mode they were in |
 
 ## Changes Ported in v0.30.0 Sync
 

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -142,7 +142,7 @@ async function requestPlanApproval(
   });
 
   return await client.requestPermission({
-    options: buildExitPlanModePermissionOptions(),
+    options: buildExitPlanModePermissionOptions(context.session.prePlanMode),
     sessionId,
     toolCall: {
       toolCallId: toolUseID,
@@ -210,6 +210,7 @@ async function handleEnterPlanModeTool(
 ): Promise<ToolPermissionResult> {
   const { session, toolInput } = context;
 
+  session.prePlanMode = session.permissionMode;
   session.permissionMode = "plan";
   await session.query.setPermissionMode("plan");
   await context.updateConfigOption("mode", "plan");

--- a/packages/agent/src/adapters/claude/permissions/permission-options.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-options.ts
@@ -1,5 +1,5 @@
 import type { PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
-import { IS_ROOT } from "../../../utils/common";
+import type { CodeExecutionMode } from "../../../execution-mode";
 import { BASH_TOOLS, READ_TOOLS, SEARCH_TOOLS, WRITE_TOOLS } from "../tools";
 
 export interface PermissionOption {
@@ -92,42 +92,40 @@ export function buildPermissionOptions(
   return permissionOptions("Yes, always allow");
 }
 
-const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX;
+const MODE_LABELS: Record<string, string> = {
+  default: "manual approval",
+  acceptEdits: "auto-accept edits",
+  bypassPermissions: "bypass permissions",
+  auto: "auto mode",
+};
 
-export function buildExitPlanModePermissionOptions(): PermissionOption[] {
-  const options: PermissionOption[] = [];
+export function buildExitPlanModePermissionOptions(
+  prePlanMode?: CodeExecutionMode,
+): PermissionOption[] {
+  const currentMode = prePlanMode ?? "default";
 
-  if (ALLOW_BYPASS) {
+  const options: PermissionOption[] = [
+    {
+      kind: "allow_always",
+      name: `Yes, continue with ${MODE_LABELS[currentMode] ?? currentMode}`,
+      optionId: currentMode,
+    },
+  ];
+
+  if (currentMode !== "default") {
     options.push({
-      kind: "allow_always",
-      name: "Yes, bypass all permissions",
-      optionId: "bypassPermissions",
-    });
-  }
-
-  options.push(
-    {
-      kind: "allow_always",
-      name: 'Yes, and use "auto" mode',
-      optionId: "auto",
-    },
-    {
-      kind: "allow_always",
-      name: "Yes, and auto-accept edits",
-      optionId: "acceptEdits",
-    },
-    {
       kind: "allow_once",
       name: "Yes, and manually approve edits",
       optionId: "default",
-    },
-    {
-      kind: "reject_once",
-      name: "No, and tell the agent what to do differently",
-      optionId: "reject_with_feedback",
-      _meta: { customInput: true },
-    },
-  );
+    });
+  }
+
+  options.push({
+    kind: "reject_once",
+    name: "No, and tell the agent what to do differently",
+    optionId: "reject_with_feedback",
+    _meta: { customInput: true },
+  });
 
   return options;
 }

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -45,6 +45,7 @@ export type Session = BaseSession & {
   input: Pushable<SDKUserMessage>;
   settingsManager: SettingsManager;
   permissionMode: CodeExecutionMode;
+  prePlanMode?: CodeExecutionMode;
   modelId?: string;
   cwd: string;
   taskRunId?: string;


### PR DESCRIPTION
## Problem

Plan approval shows N mode options every time, regardless of the user's current mode. This PR makes it contextual to their pre-plan mode similar to claude code.

The issue:<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## ![CleanShot 2026-04-21 at 17.20.28@2x.png](https://app.graphite.com/user-attachments/assets/7b3b1f31-e275-43fd-b151-768634f4c0c4.png)

## Changes

1. Track the pre-plan permission mode on the session (prePlanMode)
2. Show "continue with \<current mode>" as the default exit option instead of listing all modes
3. Offer a "manually approve edits" downgrade only when not already in manual mode
4. Remove the static bypass/auto/acceptEdits menu in favor of contextual options
5. Document the upstream divergence in upstream.md file

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->Manually