### PR TITLE
fix: Add missing enricher build step to release workflows

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Build git (agent dependency)
         run: pnpm --filter @posthog/git run build
 
+      - name: Build enricher (agent dependency)
+        run: pnpm --filter @posthog/enricher run build
+
       - name: Build the package
         run: pnpm --filter agent run build
 

--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Build git package
         run: pnpm --filter @posthog/git run build
 
+      - name: Build enricher package
+        run: pnpm --filter @posthog/enricher run build
+
       - name: Build agent package
         run: pnpm --filter @posthog/agent run build
 
@@ -193,6 +196,9 @@ jobs:
 
       - name: Build git package
         run: pnpm --filter @posthog/git run build
+
+      - name: Build enricher package
+        run: pnpm --filter @posthog/enricher run build
 
       - name: Build agent package
         run: pnpm --filter @posthog/agent run build


### PR DESCRIPTION
## Problem

Release workflows fail to build @posthog/agent because @posthog/enricher (a bundled dependency via noExternal) is never built beforehand. The PR check workflow (build.yml) has the correct order but the release workflows were never updated.<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add Build enricher package step to code-release.yml macOS job
2. Add Build enricher package step to code-release.yml Windows job
3. Add Build enricher (agent dependency) step to agent-release.yml

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->