### PR TITLE
fix(code): Limit combobox items to 50 in branch and repo pickers

### DIFF
--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -10,7 +10,9 @@ import {
   ComboboxList,
   ComboboxTrigger,
 } from "@posthog/quill";
-import { type RefObject, useEffect, useRef } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+const COMBOBOX_LIMIT = 50;
 
 interface GitHubRepoPickerProps {
   value: string | null;
@@ -36,6 +38,7 @@ export function GitHubRepoPicker({
   showSearchInput = true,
 }: GitHubRepoPickerProps) {
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const onlyRepo = repositories.length === 1 ? repositories[0] : null;
 
   useEffect(() => {
@@ -85,10 +88,13 @@ export function GitHubRepoPicker({
   return (
     <Combobox
       items={repositories}
+      limit={COMBOBOX_LIMIT}
       value={value}
       onValueChange={(v) => {
         if (v) onChange(v as string);
       }}
+      inputValue={searchQuery}
+      onInputValueChange={setSearchQuery}
       disabled={disabled}
     >
       <ComboboxTrigger
@@ -122,6 +128,14 @@ export function GitHubRepoPicker({
             </ComboboxItem>
           )}
         </ComboboxList>
+
+        {repositories.length > COMBOBOX_LIMIT && (
+          <div className="px-2 py-1.5 text-center text-muted-foreground text-xs">
+            {searchQuery
+              ? `Showing up to ${COMBOBOX_LIMIT} matches — refine your search`
+              : `Showing ${COMBOBOX_LIMIT} of ${repositories.length} — type to filter`}
+          </div>
+        )}
       </ComboboxContent>
     </Combobox>
   );

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -10,13 +10,14 @@ import {
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  ComboboxListFooter,
   ComboboxTrigger,
 } from "@posthog/quill";
 import { useTRPC } from "@renderer/trpc";
 import { toast } from "@renderer/utils/toast";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { type RefObject, useEffect, useRef, useState } from "react";
+
+const COMBOBOX_LIMIT = 50;
 
 interface BranchSelectorProps {
   repoPath: string | null;
@@ -55,6 +56,7 @@ export function BranchSelector({
   anchor,
 }: BranchSelectorProps) {
   const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const localAnchorRef = useRef<HTMLButtonElement>(null);
   const trpc = useTRPC();
   const { actions } = useGitInteractionStore();
@@ -77,8 +79,6 @@ export function BranchSelector({
   );
 
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
-  const CREATE_BRANCH_ACTION = "__create_branch__";
-  const allItems = isCloudMode ? branches : [...branches, CREATE_BRANCH_ACTION];
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
   const cloudStillLoading =
     isCloudMode && cloudBranchesLoading && branches.length === 0;
@@ -99,7 +99,7 @@ export function BranchSelector({
   );
 
   const handleBranchChange = (value: string | null) => {
-    if (!value || value === CREATE_BRANCH_ACTION) return;
+    if (!value) return;
     if (isSelectionOnly) {
       onBranchSelect?.(value || null);
     } else if (value && value !== currentBranch) {
@@ -132,9 +132,12 @@ export function BranchSelector({
 
   return (
     <Combobox
-      items={allItems}
+      items={branches}
+      limit={COMBOBOX_LIMIT}
       value={displayedBranch}
       onValueChange={(v) => handleBranchChange(v as string | null)}
+      inputValue={searchQuery}
+      onInputValueChange={setSearchQuery}
       open={open}
       onOpenChange={(nextOpen) => handleOpenChange(nextOpen)}
       disabled={isDisabled}
@@ -181,36 +184,43 @@ export function BranchSelector({
         <ComboboxEmpty>No branches found.</ComboboxEmpty>
 
         <ComboboxList className="max-h-[min(14rem,calc(var(--available-height,14rem)-5rem))] pe-2">
-          {(item: string) =>
-            item === CREATE_BRANCH_ACTION ? (
-              <ComboboxListFooter key="footer">
-                <ComboboxItem
-                  value={CREATE_BRANCH_ACTION}
-                  onClick={() => {
-                    setOpen(false);
-                    actions.openBranch(
-                      taskId
-                        ? getSuggestedBranchName(taskId, repoPath ?? undefined)
-                        : undefined,
-                    );
-                  }}
-                >
-                  <Plus size={11} weight="bold" />
-                  Create new branch
-                </ComboboxItem>
-              </ComboboxListFooter>
-            ) : (
-              <ComboboxItem
-                key={item}
-                value={item}
-                title={item}
-                className="relative"
-              >
-                {item}
-              </ComboboxItem>
-            )
-          }
+          {(item: string) => (
+            <ComboboxItem
+              key={item}
+              value={item}
+              title={item}
+              className="relative"
+            >
+              {item}
+            </ComboboxItem>
+          )}
         </ComboboxList>
+
+        {!isCloudMode && (
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 border-t px-2 py-1.5 text-accent-foreground text-xs hover:bg-accent/10"
+            onClick={() => {
+              setOpen(false);
+              actions.openBranch(
+                taskId
+                  ? getSuggestedBranchName(taskId, repoPath ?? undefined)
+                  : undefined,
+              );
+            }}
+          >
+            <Plus size={11} weight="bold" />
+            Create new branch
+          </button>
+        )}
+
+        {branches.length > COMBOBOX_LIMIT && (
+          <div className="px-2 py-1.5 text-center text-muted-foreground text-xs">
+            {searchQuery
+              ? `Showing up to ${COMBOBOX_LIMIT} matches — refine your search`
+              : `Showing ${COMBOBOX_LIMIT} of ${branches.length} — type to filter`}
+          </div>
+        )}
       </ComboboxContent>
     </Combobox>
   );


### PR DESCRIPTION
## Problem

  PR #1588 added performance optimizations to the branch and repo picker comboboxes — capping rendered items at 50 and showing a "type to filter" hint when truncated. PR #1725 rewrote the Combobox from the custom compound component to `@posthog/quill`, but dropped these optimizations in the process. All items now render to the DOM, causing noticeable lag when opening the picker on repos with hundreds of branches.

  ## Solution

  Pass `limit={50}` to the quill Combobox in both `BranchSelector` and `GitHubRepoPicker`, and show a "Showing 50 of N — type to filter" footer when the list is truncated.

## Showcase


https://github.com/user-attachments/assets/0e160d74-6d2f-4b46-b47f-c36439393328

