### PR TITLE
feat(sessions): add prompt ID tracking to prevent stale response handling

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -1020,12 +1020,11 @@ export class SessionService {
       // Ignore responses that don't match the currently in-flight prompt id.
       // A late response from a cancelled prior turn must not drain the queue
       // or fire the "prompt complete" notification for the newer turn.
-      const currentSession = sessionStoreSetters.getSessions()[taskRunId];
-      const matchesCurrent =
-        !currentSession ||
-        currentSession.currentPromptId == null ||
-        currentSession.currentPromptId === msg.id;
-      if (!matchesCurrent) {
+      // We check against `session` (captured at the top of this function, pre-update),
+      // because updatePromptStateFromEvents above already cleared currentPromptId
+      // for a valid match — re-reading from the store would lose the distinction
+      // between "valid match just cleared" and "no turn was in flight".
+      if (session.currentPromptId !== msg.id) {
         return;
       }
 

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -959,6 +959,7 @@ export class SessionService {
           isPromptPending: true,
           promptStartedAt: acpMsg.ts,
           pausedDurationMs: 0,
+          currentPromptId: msg.id,
         });
       }
       if (
@@ -968,9 +969,17 @@ export class SessionService {
         msg.result !== null &&
         "stopReason" in msg.result
       ) {
+        // Only clear pending state if this response matches the currently
+        // in-flight prompt. A late response from a previously cancelled turn
+        // must not be allowed to mark a newer turn as done.
+        const session = sessionStoreSetters.getSessions()[taskRunId];
+        if (session && session.currentPromptId !== msg.id) {
+          continue;
+        }
         sessionStoreSetters.updateSession(taskRunId, {
           isPromptPending: false,
           promptStartedAt: null,
+          currentPromptId: null,
         });
       }
     }
@@ -1008,6 +1017,18 @@ export class SessionService {
       msg.result !== null &&
       "stopReason" in msg.result
     ) {
+      // Ignore responses that don't match the currently in-flight prompt id.
+      // A late response from a cancelled prior turn must not drain the queue
+      // or fire the "prompt complete" notification for the newer turn.
+      const currentSession = sessionStoreSetters.getSessions()[taskRunId];
+      const matchesCurrent =
+        !currentSession ||
+        currentSession.currentPromptId == null ||
+        currentSession.currentPromptId === msg.id;
+      if (!matchesCurrent) {
+        return;
+      }
+
       const stopReason = (msg.result as { stopReason?: string }).stopReason;
       const hasQueuedMessages = this.drainQueuedMessages(taskRunId, session);
 

--- a/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
@@ -44,6 +44,10 @@ export interface AgentSession {
   isPromptPending: boolean;
   isCompacting: boolean;
   promptStartedAt: number | null;
+  /** JSON-RPC id of the currently in-flight session/prompt request. Used to
+   * correlate late-arriving responses (e.g. from a cancelled prior turn) so
+   * they don't clear the pending state of a newer turn. */
+  currentPromptId?: number | null;
   logUrl?: string;
   processedLineCount?: number;
   framework?: "claude";

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -316,15 +316,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
-    this.session.cancelled = false;
-    this.session.interruptReason = undefined;
-    this.session.accumulatedUsage = {
-      inputTokens: 0,
-      outputTokens: 0,
-      cachedReadTokens: 0,
-      cachedWriteTokens: 0,
-    };
-
     const userMessage = promptToClaude(params);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
@@ -364,7 +355,19 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       this.session.input.push(userMessage);
     }
 
-    // Broadcast user message to client
+    // Reset session state here (after the queued-wait) rather than at the
+    // top of prompt(). Otherwise a new prompt() call would wipe cancelled=true
+    // on the previous still-running loop, causing it to return end_turn
+    // instead of the cancelled stop reason the spec requires.
+    this.session.cancelled = false;
+    this.session.interruptReason = undefined;
+    this.session.accumulatedUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    };
+
     await this.broadcastUserMessage(params);
 
     this.session.promptRunning = true;
@@ -652,10 +655,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
           case "user":
           case "assistant": {
-            if (this.session.cancelled) {
-              break;
-            }
-
             // Check for prompt replay (our own message echoed back)
             if (message.type === "user" && "uuid" in message && message.uuid) {
               if (message.uuid === promptUuid) {
@@ -670,10 +669,14 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                 pending.resolve(false);
                 this.session.pendingMessages.delete(message.uuid as string);
                 handedOff = true;
-                // the current loop stops with end_turn,
-                // the loop of the next prompt continues running
-                return { stopReason: "end_turn" };
+                return {
+                  stopReason: this.session.cancelled ? "cancelled" : "end_turn",
+                };
               }
+            }
+
+            if (this.session.cancelled) {
+              break;
             }
 
             // Skip replayed user messages that aren't pending prompts


### PR DESCRIPTION
Fixes two bugs:
- Agent reported `end_turn` instead of `cancelled` when the user interrupted their prompt.
- We did not track the turn id when ingesting events from the agent, meaning that stale turn ID events could update the UI. 

The second point fixes a bug where the agent could mark it's turn as completed while it still was responding! But turn completion is asynchronous, and the completion was from the last turn!

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*