### PR TITLE
fix(permissions): persist allow rules across worktrees of a repo

### DIFF
--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -350,7 +350,7 @@ async function handleDefaultPermissionFlow(
   const options = buildPermissionOptions(
     toolName,
     toolInput as Record<string, unknown>,
-    session?.cwd,
+    session.settingsManager.getRepoRoot(),
     suggestions,
   );
 

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -2,7 +2,10 @@ import type {
   AgentSideConnection,
   RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
-import type { PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  PermissionRuleValue,
+  PermissionUpdate,
+} from "@anthropic-ai/claude-agent-sdk";
 import { text } from "../../../utils/acp-content";
 import type { Logger } from "../../../utils/logger";
 import { toolInfoFromToolUse } from "../conversion/tool-use-to-acp";
@@ -374,17 +377,19 @@ async function handleDefaultPermissionFlow(
       response.outcome.optionId === "allow_always")
   ) {
     if (response.outcome.optionId === "allow_always") {
+      const rules = extractAllowRules(suggestions, toolName);
+      try {
+        await session.settingsManager.addAllowRules(rules);
+      } catch (error) {
+        context.logger.warn(
+          "[canUseTool] Failed to persist allow rules to repository settings",
+          { error: error instanceof Error ? error.message : String(error) },
+        );
+      }
       return {
         behavior: "allow",
         updatedInput: toolInput as Record<string, unknown>,
-        updatedPermissions: suggestions ?? [
-          {
-            type: "addRules",
-            rules: [{ toolName }],
-            behavior: "allow",
-            destination: "localSettings",
-          },
-        ],
+        updatedPermissions: buildSessionPermissions(suggestions, rules),
       };
     }
     return {
@@ -427,6 +432,44 @@ function handlePlanFileException(
     behavior: "allow",
     updatedInput: toolInput as Record<string, unknown>,
   };
+}
+
+function extractAllowRules(
+  suggestions: PermissionUpdate[] | undefined,
+  toolName: string,
+): PermissionRuleValue[] {
+  if (!suggestions || suggestions.length === 0) {
+    return [{ toolName }];
+  }
+  return suggestions
+    .filter(
+      (update) => update.type === "addRules" && update.behavior === "allow",
+    )
+    .flatMap((update) => ("rules" in update ? update.rules : []));
+}
+
+/**
+ * Forwards any non-addRules suggestions from the SDK (e.g. addDirectories)
+ * with their destination remapped to `session`. Our own allow rules are
+ * persisted via `settingsManager.addAllowRules`, so the SDK must not write
+ * them to its default per-cwd location.
+ */
+function buildSessionPermissions(
+  suggestions: PermissionUpdate[] | undefined,
+  rules: PermissionRuleValue[],
+): PermissionUpdate[] {
+  const passthrough = (suggestions ?? [])
+    .filter(
+      (update) => !(update.type === "addRules" && update.behavior === "allow"),
+    )
+    .map((update) => ({ ...update, destination: "session" as const }));
+  if (rules.length === 0) {
+    return passthrough;
+  }
+  return [
+    { type: "addRules", rules, behavior: "allow", destination: "session" },
+    ...passthrough,
+  ];
 }
 
 function extractDomainFromUrl(url: string): string | null {

--- a/packages/agent/src/adapters/claude/permissions/permission-options.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-options.ts
@@ -25,7 +25,7 @@ function permissionOptions(allowAlwaysLabel: string): PermissionOption[] {
 export function buildPermissionOptions(
   toolName: string,
   toolInput: Record<string, unknown>,
-  cwd?: string,
+  _cwd?: string,
   suggestions?: PermissionUpdate[],
 ): PermissionOption[] {
   if (BASH_TOOLS.has(toolName)) {
@@ -36,12 +36,9 @@ export function buildPermissionOptions(
 
     const command = toolInput?.command as string | undefined;
     const cmdName = command?.split(/\s+/)[0] ?? "this command";
-    const cwdLabel = cwd ? ` in ${cwd}` : "";
     const label = ruleContent ?? `\`${cmdName}\` commands`;
 
-    return permissionOptions(
-      `Yes, and don't ask again for ${label}${cwdLabel}`,
-    );
+    return permissionOptions(`Yes, and don't ask again for ${label}`);
   }
 
   if (toolName === "BashOutput") {

--- a/packages/agent/src/adapters/claude/permissions/permission-options.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-options.ts
@@ -25,7 +25,7 @@ function permissionOptions(allowAlwaysLabel: string): PermissionOption[] {
 export function buildPermissionOptions(
   toolName: string,
   toolInput: Record<string, unknown>,
-  _cwd?: string,
+  repoRoot?: string,
   suggestions?: PermissionUpdate[],
 ): PermissionOption[] {
   if (BASH_TOOLS.has(toolName)) {
@@ -36,9 +36,12 @@ export function buildPermissionOptions(
 
     const command = toolInput?.command as string | undefined;
     const cmdName = command?.split(/\s+/)[0] ?? "this command";
+    const scopeLabel = repoRoot ? ` in ${repoRoot}` : "";
     const label = ruleContent ?? `\`${cmdName}\` commands`;
 
-    return permissionOptions(`Yes, and don't ask again for ${label}`);
+    return permissionOptions(
+      `Yes, and don't ask again for ${label}${scopeLabel}`,
+    );
   }
 
   if (toolName === "BashOutput") {

--- a/packages/agent/src/adapters/claude/session/repo-path.ts
+++ b/packages/agent/src/adapters/claude/session/repo-path.ts
@@ -1,8 +1,4 @@
-import { execFile } from "node:child_process";
-import * as path from "node:path";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { listWorktrees } from "@posthog/git/queries";
 
 /**
  * Resolves the primary worktree (main repository) path for a given cwd.
@@ -12,25 +8,14 @@ const execFileAsync = promisify(execFile);
  * settings — such as "don't ask again" permission rules — to a single
  * location that every worktree of the same repository can read from.
  *
+ * `git worktree list --porcelain` always emits the primary worktree first.
  * Returns `cwd` when the directory is not inside a git repository or when
- * `git` is unavailable.
+ * git is unavailable.
  */
 export async function resolveMainRepoPath(cwd: string): Promise<string> {
   try {
-    const { stdout } = await execFileAsync(
-      "git",
-      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-      { cwd, timeout: 2_000 },
-    );
-    const commonDir = stdout.trim();
-    if (!commonDir) {
-      return cwd;
-    }
-    // `--git-common-dir` points to the primary worktree's `.git` directory,
-    // whose parent is the primary worktree root. For bare repositories the
-    // common dir is the repo itself; in that case `cwd` is the best guess.
-    const parent = path.dirname(commonDir);
-    return path.basename(commonDir) === ".git" ? parent : cwd;
+    const worktrees = await listWorktrees(cwd);
+    return worktrees[0]?.path ?? cwd;
   } catch {
     return cwd;
   }

--- a/packages/agent/src/adapters/claude/session/repo-path.ts
+++ b/packages/agent/src/adapters/claude/session/repo-path.ts
@@ -1,0 +1,37 @@
+import { execFile } from "node:child_process";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Resolves the primary worktree (main repository) path for a given cwd.
+ *
+ * Secondary git worktrees share a `.git` common directory with the primary
+ * worktree. Returning the primary worktree path lets us scope per-repo
+ * settings — such as "don't ask again" permission rules — to a single
+ * location that every worktree of the same repository can read from.
+ *
+ * Returns `cwd` when the directory is not inside a git repository or when
+ * `git` is unavailable.
+ */
+export async function resolveMainRepoPath(cwd: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      { cwd, timeout: 2_000 },
+    );
+    const commonDir = stdout.trim();
+    if (!commonDir) {
+      return cwd;
+    }
+    // `--git-common-dir` points to the primary worktree's `.git` directory,
+    // whose parent is the primary worktree root. For bare repositories the
+    // common dir is the repo itself; in that case `cwd` is the best guess.
+    const parent = path.dirname(commonDir);
+    return path.basename(commonDir) === ".git" ? parent : cwd;
+  } catch {
+    return cwd;
+  }
+}

--- a/packages/agent/src/adapters/claude/session/settings.test.ts
+++ b/packages/agent/src/adapters/claude/session/settings.test.ts
@@ -110,6 +110,23 @@ describe("SettingsManager per-repo persistence", () => {
     expect(decision.decision).toBe("allow");
   });
 
+  it("refuses to overwrite the file when existing contents cannot be parsed", async () => {
+    const manager = new SettingsManager(worktree);
+    await manager.initialize();
+
+    const filePath = path.join(mainRepo, ".claude", "settings.local.json");
+    const original = "{ this is not valid json";
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.promises.writeFile(filePath, original);
+
+    await expect(
+      manager.addAllowRules([{ toolName: "TodoWrite" }]),
+    ).rejects.toThrow();
+
+    // File must be untouched — overwriting would wipe whatever the user had.
+    expect(await fs.promises.readFile(filePath, "utf-8")).toBe(original);
+  });
+
   it("concurrent addAllowRules calls do not clobber each other", async () => {
     const manager = new SettingsManager(worktree);
     await manager.initialize();

--- a/packages/agent/src/adapters/claude/session/settings.test.ts
+++ b/packages/agent/src/adapters/claude/session/settings.test.ts
@@ -70,21 +70,27 @@ describe("SettingsManager per-repo persistence", () => {
     expect(decision.decision).toBe("allow");
   });
 
-  it("only widens name-based matching for argumentless rules", async () => {
+  it("widens name-based matching for argumentless rules", async () => {
     const manager = new SettingsManager(worktree);
     await manager.initialize();
 
-    // Argumentless rule should match a bare tool name.
     await manager.addAllowRules([{ toolName: "TodoWrite" }]);
-    expect(manager.checkPermission("TodoWrite", {}).decision).toBe("allow");
 
-    // A rule *with* an argument for a tool we don't have an accessor for
-    // must NOT match regardless of the actual input — otherwise a deny rule
-    // like `Bash(rm -rf)` applied to a non-ACP Bash invocation would match
-    // any command.
+    expect(manager.checkPermission("TodoWrite", {}).decision).toBe("allow");
+  });
+
+  it("does not widen name-based matching when the rule has an argument", async () => {
+    // A rule *with* an argument for a tool we don't have an accessor for must
+    // not match regardless of the actual input — otherwise a deny rule like
+    // `Bash(rm -rf)` applied to a non-ACP Bash invocation would match any
+    // command.
+    const manager = new SettingsManager(worktree);
+    await manager.initialize();
+
     await manager.addAllowRules([
       { toolName: "UnknownTool", ruleContent: "something" },
     ]);
+
     expect(
       manager.checkPermission("UnknownTool", { command: "anything" }).decision,
     ).toBe("ask");

--- a/packages/agent/src/adapters/claude/session/settings.test.ts
+++ b/packages/agent/src/adapters/claude/session/settings.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveMainRepoPath } from "./repo-path";
+import { SettingsManager } from "./settings";
+
+function runGit(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "ignore", "pipe"] });
+}
+
+describe("SettingsManager per-repo persistence", () => {
+  let mainRepo: string;
+  let worktree: string;
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.promises.realpath(
+      await fs.promises.mkdtemp(path.join(os.tmpdir(), "settings-manager-")),
+    );
+    mainRepo = path.join(tmpRoot, "main");
+    worktree = path.join(tmpRoot, "wt");
+    await fs.promises.mkdir(mainRepo, { recursive: true });
+
+    runGit(mainRepo, ["init", "-b", "main"]);
+    runGit(mainRepo, ["config", "user.email", "test@example.com"]);
+    runGit(mainRepo, ["config", "user.name", "test"]);
+    runGit(mainRepo, ["commit", "--allow-empty", "-m", "init"]);
+    runGit(mainRepo, ["worktree", "add", "-b", "feat", worktree]);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("persists allow rules to the primary worktree when invoked from a secondary worktree", async () => {
+    const manager = new SettingsManager(worktree);
+    await manager.initialize();
+
+    await manager.addAllowRules([
+      { toolName: "Bash", ruleContent: "pnpm test:*" },
+    ]);
+
+    const repoLocalPath = path.join(mainRepo, ".claude", "settings.local.json");
+    const contents = JSON.parse(
+      await fs.promises.readFile(repoLocalPath, "utf-8"),
+    );
+    expect(contents.permissions.allow).toContain("Bash(pnpm test:*)");
+
+    const worktreeLocalPath = path.join(
+      worktree,
+      ".claude",
+      "settings.local.json",
+    );
+    expect(fs.existsSync(worktreeLocalPath)).toBe(false);
+  });
+
+  it("sees rules persisted by a sibling worktree after re-initialization", async () => {
+    const writer = new SettingsManager(worktree);
+    await writer.initialize();
+    await writer.addAllowRules([{ toolName: "TodoWrite" }]);
+
+    const sibling = path.join(tmpRoot, "wt2");
+    runGit(mainRepo, ["worktree", "add", "-b", "other", sibling]);
+
+    const reader = new SettingsManager(sibling);
+    await reader.initialize();
+    const decision = reader.checkPermission("TodoWrite", {});
+    expect(decision.decision).toBe("allow");
+  });
+
+  it("only widens name-based matching for argumentless rules", async () => {
+    const manager = new SettingsManager(worktree);
+    await manager.initialize();
+
+    // Argumentless rule should match a bare tool name.
+    await manager.addAllowRules([{ toolName: "TodoWrite" }]);
+    expect(manager.checkPermission("TodoWrite", {}).decision).toBe("allow");
+
+    // A rule *with* an argument for a tool we don't have an accessor for
+    // must NOT match regardless of the actual input — otherwise a deny rule
+    // like `Bash(rm -rf)` applied to a non-ACP Bash invocation would match
+    // any command.
+    await manager.addAllowRules([
+      { toolName: "UnknownTool", ruleContent: "something" },
+    ]);
+    expect(
+      manager.checkPermission("UnknownTool", { command: "anything" }).decision,
+    ).toBe("ask");
+  });
+
+  it("still allows ACP-prefixed Bash invocations when a Bash(...) rule is persisted", async () => {
+    const manager = new SettingsManager(worktree);
+    await manager.initialize();
+
+    await manager.addAllowRules([
+      { toolName: "Bash", ruleContent: "pnpm test:*" },
+    ]);
+
+    const decision = manager.checkPermission("mcp__acp__Bash", {
+      command: "pnpm test --filter agent",
+    });
+    expect(decision.decision).toBe("allow");
+  });
+
+  it("concurrent addAllowRules calls do not clobber each other", async () => {
+    const manager = new SettingsManager(worktree);
+    await manager.initialize();
+
+    await Promise.all([
+      manager.addAllowRules([{ toolName: "A" }]),
+      manager.addAllowRules([{ toolName: "B" }]),
+      manager.addAllowRules([{ toolName: "C" }]),
+    ]);
+
+    const filePath = path.join(mainRepo, ".claude", "settings.local.json");
+    const contents = JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
+    expect(contents.permissions.allow).toEqual(
+      expect.arrayContaining(["A", "B", "C"]),
+    );
+  });
+});
+
+describe("resolveMainRepoPath", () => {
+  it("returns cwd when the directory is not inside a git repository", async () => {
+    const tmp = await fs.promises.realpath(
+      await fs.promises.mkdtemp(path.join(os.tmpdir(), "repo-path-")),
+    );
+    try {
+      expect(await resolveMainRepoPath(tmp)).toBe(tmp);
+    } finally {
+      await fs.promises.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent/src/adapters/claude/session/settings.ts
+++ b/packages/agent/src/adapters/claude/session/settings.ts
@@ -357,7 +357,7 @@ export class SettingsManager {
    */
   async addAllowRules(rules: PermissionRuleValue[]): Promise<void> {
     if (rules.length === 0) return;
-    if (this.initPromise) await this.initPromise;
+    if (!this.initialized) await this.initialize();
     await this.writeMutex.acquire();
     try {
       const filePath = this.getLocalSettingsPath();

--- a/packages/agent/src/adapters/claude/session/settings.ts
+++ b/packages/agent/src/adapters/claude/session/settings.ts
@@ -346,6 +346,10 @@ export class SettingsManager {
     return this.cwd;
   }
 
+  getRepoRoot(): string {
+    return this.repoRoot;
+  }
+
   /**
    * Persists allow rules to `<primary-worktree>/.claude/settings.local.json`.
    * Because local settings are resolved against the primary worktree, every

--- a/packages/agent/src/adapters/claude/session/settings.ts
+++ b/packages/agent/src/adapters/claude/session/settings.ts
@@ -1,7 +1,10 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { PermissionRuleValue } from "@anthropic-ai/claude-agent-sdk";
 import { minimatch } from "minimatch";
+import { AsyncMutex } from "../../../utils/async-mutex";
+import { resolveMainRepoPath } from "./repo-path";
 
 const ACP_TOOL_NAME_PREFIX = "mcp__acp__";
 
@@ -86,7 +89,8 @@ function matchesRule(
   const ruleAppliesToTool =
     (rule.toolName === "Bash" && toolName === acpToolNames.bash) ||
     (rule.toolName === "Edit" && FILE_EDITING_TOOLS.includes(toolName)) ||
-    (rule.toolName === "Read" && FILE_READING_TOOLS.includes(toolName));
+    (rule.toolName === "Read" && FILE_READING_TOOLS.includes(toolName)) ||
+    (rule.toolName === toolName && !rule.argument);
 
   if (!ruleAppliesToTool) {
     return false;
@@ -121,6 +125,23 @@ function matchesRule(
   }
 
   return matchesGlob(rule.argument, actualArg, cwd);
+}
+
+function formatRule(rule: PermissionRuleValue): string {
+  return rule.ruleContent
+    ? `${rule.toolName}(${rule.ruleContent})`
+    : rule.toolName;
+}
+
+async function writeFileAtomic(filePath: string, data: string): Promise<void> {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.promises.writeFile(tmpPath, data);
+  try {
+    await fs.promises.rename(tmpPath, filePath);
+  } catch (error) {
+    await fs.promises.rm(tmpPath, { force: true });
+    throw error;
+  }
 }
 
 async function loadSettingsFile(
@@ -177,8 +198,10 @@ export function getManagedSettingsPath(): string {
       return "/etc/claude-code/managed-settings.json";
   }
 }
+
 export class SettingsManager {
   private cwd: string;
+  private repoRoot: string;
   private userSettings: ClaudeCodeSettings = {};
   private projectSettings: ClaudeCodeSettings = {};
   private localSettings: ClaudeCodeSettings = {};
@@ -186,9 +209,11 @@ export class SettingsManager {
   private mergedSettings: ClaudeCodeSettings = {};
   private initialized = false;
   private initPromise: Promise<void> | null = null;
+  private writeMutex = new AsyncMutex();
 
   constructor(cwd: string) {
     this.cwd = cwd;
+    this.repoRoot = cwd;
   }
 
   async initialize(): Promise<void> {
@@ -211,11 +236,17 @@ export class SettingsManager {
     return path.join(this.cwd, ".claude", "settings.json");
   }
 
+  /**
+   * Local settings are anchored to the primary worktree so every worktree of
+   * the same repository shares a single `.claude/settings.local.json`. This
+   * avoids re-prompting for the same permission in every worktree.
+   */
   private getLocalSettingsPath(): string {
-    return path.join(this.cwd, ".claude", "settings.local.json");
+    return path.join(this.repoRoot, ".claude", "settings.local.json");
   }
 
   private async loadAllSettings(): Promise<void> {
+    this.repoRoot = await resolveMainRepoPath(this.cwd);
     const [userSettings, projectSettings, localSettings, enterpriseSettings] =
       await Promise.all([
         loadSettingsFile(this.getUserSettingsPath()),
@@ -278,10 +309,6 @@ export class SettingsManager {
   }
 
   checkPermission(toolName: string, toolInput: unknown): PermissionCheckResult {
-    if (!toolName.startsWith(ACP_TOOL_NAME_PREFIX)) {
-      return { decision: "ask" };
-    }
-
     const permissions = this.mergedSettings.permissions;
     if (!permissions) {
       return { decision: "ask" };
@@ -317,6 +344,41 @@ export class SettingsManager {
 
   getCwd(): string {
     return this.cwd;
+  }
+
+  /**
+   * Persists allow rules to `<primary-worktree>/.claude/settings.local.json`.
+   * Because local settings are resolved against the primary worktree, every
+   * worktree of the same repository picks up the new rule on next load.
+   *
+   * Writes are serialised via `writeMutex` to prevent concurrent callers from
+   * clobbering each other, and use a temp-file + rename to keep the file
+   * consistent if the process dies mid-write.
+   */
+  async addAllowRules(rules: PermissionRuleValue[]): Promise<void> {
+    if (rules.length === 0) return;
+    if (this.initPromise) await this.initPromise;
+    await this.writeMutex.acquire();
+    try {
+      const filePath = this.getLocalSettingsPath();
+      const existing = await loadSettingsFile(filePath);
+      const permissions: PermissionSettings = {
+        ...(existing.permissions ?? {}),
+      };
+      const current = new Set(permissions.allow ?? []);
+      for (const rule of rules) {
+        current.add(formatRule(rule));
+      }
+      permissions.allow = Array.from(current);
+      const next: ClaudeCodeSettings = { ...existing, permissions };
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await writeFileAtomic(filePath, `${JSON.stringify(next, null, 2)}\n`);
+
+      this.localSettings = next;
+      this.mergeAllSettings();
+    } finally {
+      this.writeMutex.release();
+    }
   }
 
   async setCwd(cwd: string): Promise<void> {

--- a/packages/agent/src/adapters/claude/session/settings.ts
+++ b/packages/agent/src/adapters/claude/session/settings.ts
@@ -164,6 +164,26 @@ async function loadSettingsFile(
   }
 }
 
+/**
+ * Reads a settings file for a read-modify-write cycle. Unlike
+ * `loadSettingsFile`, this throws on any error other than ENOENT — we refuse
+ * to overwrite a file we couldn't parse, because doing so would wipe the
+ * user's existing settings (other allow/deny/ask rules, env, model, etc).
+ */
+async function readSettingsFileForUpdate(
+  filePath: string,
+): Promise<ClaudeCodeSettings> {
+  try {
+    const content = await fs.promises.readFile(filePath, "utf-8");
+    return JSON.parse(content) as ClaudeCodeSettings;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+}
+
 export interface PermissionSettings {
   allow?: string[];
   deny?: string[];
@@ -365,7 +385,7 @@ export class SettingsManager {
     await this.writeMutex.acquire();
     try {
       const filePath = this.getLocalSettingsPath();
-      const existing = await loadSettingsFile(filePath);
+      const existing = await readSettingsFileForUpdate(filePath);
       const permissions: PermissionSettings = {
         ...(existing.permissions ?? {}),
       };


### PR DESCRIPTION
## Problem

Closes #1447.

Clicking "Yes, don't ask again" in one worktree only remembered the approval for that specific worktree. Opening a sibling worktree of the same repository re-prompted the user for every command they had already approved. The root cause: Claude's `localSettings` scope resolves to `<cwd>/.claude/settings.local.json`, and each worktree has its own `cwd`.

## Changes

Anchor the `localSettings` scope in `SettingsManager` to the **primary worktree** (resolved via `listWorktrees` from `@posthog/git`) instead of the current working directory. Every worktree of a repo now reads and writes a single `.claude/settings.local.json` at the primary worktree's root. No new setting scope is introduced; the existing Claude settings hierarchy is preserved.

**`packages/agent/src/adapters/claude/session/repo-path.ts`** (new)
- `resolveMainRepoPath(cwd)` is a thin wrapper around `listWorktrees` from `@posthog/git/queries`. The primary worktree is always the first entry in `git worktree list --porcelain`. Falls back to `cwd` if not inside a git repo.

**`packages/agent/src/adapters/claude/session/settings.ts`**
- `SettingsManager` gains a `repoRoot` field, resolved in `loadAllSettings()`.
- `getLocalSettingsPath()` returns `<repoRoot>/.claude/settings.local.json` so every worktree shares a single file.
- New `addAllowRules(rules)` method persists rules to that file with:
  - `if (!this.initialized) await this.initialize()` guard so the method can't write to the wrong path if called pre-init.
  - An `AsyncMutex` (existing shared util) around the read/merge/write cycle so concurrent callers can't clobber each other.
  - A strict `readSettingsFileForUpdate` helper that throws on any read/parse error other than ENOENT — we refuse to overwrite a file we couldn't read, so a malformed `settings.local.json` is never wiped.
  - Atomic write via a `.tmp` file + `rename`, with cleanup on failure.
- `matchesRule` widened with a narrow catch-all (`rule.toolName === toolName && !rule.argument`) so argumentless rules persisted at the primary worktree auto-allow in secondary worktrees for non-ACP tools (TodoWrite, Task, WebSearch). The `!rule.argument` constraint prevents a deny rule like `Bash(rm -rf)` applied to a non-ACP Bash from matching any arbitrary command.
- ACP-prefix early-return in `checkPermission` dropped — our `SettingsManager` is now the only party that sees rules from the primary worktree in secondary-worktree sessions.

**`packages/agent/src/adapters/claude/permissions/permission-handlers.ts`**
- The `allow_always` flow now calls `settingsManager.addAllowRules(rules)` inside a try/catch (disk/parse failures fall back to session-scoped approval with a warning log) and returns `destination: "session"` to the SDK so it doesn't also persist to `<cwd>`.
- Non-`addRules` suggestions from the SDK (e.g. `addDirectories`) are forwarded with destination remapped to `session` via a `buildSessionPermissions` helper.
- `buildPermissionOptions` receives `settingsManager.getRepoRoot()` (new getter) instead of `session.cwd`, so the Bash "don't ask again" prompt reads e.g. *"don't ask again for `pnpm` commands in /Users/richard/dev/posthog"* — the primary worktree, consistent with where the rule actually lives.

**`packages/agent/src/adapters/claude/permissions/permission-options.ts`**
- Renamed the 3rd parameter `cwd` → `repoRoot` (the value now passed by the caller is the repo root, not the working directory).

**Cloud**: no-op. Cloud runs default to `bypassPermissions`, so the `allow_always` path is never entered.

## How did you test this?

Added `packages/agent/src/adapters/claude/session/settings.test.ts` with 8 tests that spin up a real `git init` + `git worktree add`:

- Allow rule persisted from a secondary worktree lands in the primary worktree's `.claude/settings.local.json`, not the secondary worktree's.
- A sibling worktree created *after* the write sees the rule on init and auto-allows.
- Name-based matching widens only for argumentless rules (argumentless `TodoWrite` allows; `UnknownTool(something)` with arbitrary input does not match).
- ACP-prefixed `mcp__acp__Bash` still auto-allows with a `Bash(pnpm test:*)` rule persisted at the primary worktree.
- `addAllowRules` refuses to overwrite a file whose contents are malformed JSON — throws, original bytes preserved.
- Three concurrent `addAllowRules` calls produce a file containing all three rules (no clobber).
- `resolveMainRepoPath` returns `cwd` for a non-git directory.

Ran:
- `pnpm --filter @posthog/agent test` — 208 passing.
- `pnpm lint` — no new warnings.
- `pnpm typecheck` — clean.

Manual: drove it through the desktop app with a repo that had two worktrees, clicked "don't ask again" for `pnpm` in worktree A, confirmed the file appeared only at the primary worktree, and confirmed worktree B ran `pnpm` without re-prompting.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*