### PR TITLE
fix(agent): move @posthog/enricher to devDependencies

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -90,6 +90,7 @@
   "devDependencies": {
     "@posthog/shared": "workspace:*",
     "@posthog/git": "workspace:*",
+    "@posthog/enricher": "workspace:*",
     "@types/bun": "latest",
     "@types/tar": "^6.1.13",
     "msw": "^2.12.7",
@@ -109,7 +110,6 @@
     "@opentelemetry/resources": "^2.0.0",
     "@opentelemetry/sdk-logs": "^0.208.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
-    "@posthog/enricher": "workspace:*",
     "@types/jsonwebtoken": "^9.0.10",
     "commander": "^14.0.2",
     "hono": "^4.11.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,9 +657,6 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.28.0
         version: 1.39.0
-      '@posthog/enricher':
-        specifier: workspace:*
-        version: link:../enricher
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
@@ -691,6 +688,9 @@ importers:
         specifier: ^4.2.0
         version: 4.3.6
     devDependencies:
+      '@posthog/enricher':
+        specifier: workspace:*
+        version: link:../enricher
       '@posthog/git':
         specifier: workspace:*
         version: link:../git


### PR DESCRIPTION
## Problem

`enricher` is not published and this makes `agent` package build fail when running cloud tasks.
Last working version is `2.3.326` and latest released is `2.3.346`, let's fix and jump
