### PR TITLE
fix(enricher): don't wipe dist on watch rebuilds

### DIFF
--- a/packages/enricher/package.json
+++ b/packages/enricher/package.json
@@ -10,7 +10,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "node ../../scripts/rimraf.mjs dist && tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "clean": "node ../../scripts/rimraf.mjs dist .turbo",

--- a/packages/enricher/tsup.config.ts
+++ b/packages/enricher/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   sourcemap: true,
-  clean: true,
+  clean: false,
   splitting: false,
   outDir: "dist",
   target: "node20",


### PR DESCRIPTION
## Problem

`pnpm run dev` at the repo root fails intermittently with DTS errors in`packages/agent/src/enrichment/file-enricher.ts`

`agent`'s `tsup --watch` runs its first DTS pass in that window, can't find enricher's `dist/*.d.ts`, silently falls back to bundling enricher's raw source, and the agent's stricter tsconfig seems to reject the narrow literal types rollup-plugin-dts synthesizes from the source


