### PR TITLE
fix: make sure cancel actually aborts push

### DIFF
--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -435,6 +435,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     remote = "origin",
     branch?: string,
     setUpstream = false,
+    signal?: AbortSignal,
   ): Promise<PushOutput> {
     const saga = new PushSaga();
     const result = await saga.run({
@@ -442,6 +443,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
       remote,
       branch: branch || undefined,
       setUpstream,
+      signal,
     });
     if (!result.success) {
       return { success: false, message: result.error };
@@ -464,12 +466,14 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     directoryPath: string,
     remote = "origin",
     branch?: string,
+    signal?: AbortSignal,
   ): Promise<PullOutput> {
     const saga = new PullSaga();
     const result = await saga.run({
       baseDir: directoryPath,
       remote,
       branch: branch || undefined,
+      signal,
     });
     if (!result.success) {
       return { success: false, message: result.error };
@@ -488,6 +492,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
   public async publish(
     directoryPath: string,
     remote = "origin",
+    signal?: AbortSignal,
   ): Promise<PublishOutput> {
     const currentBranch = await getCurrentBranch(directoryPath);
     if (!currentBranch) {
@@ -499,6 +504,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
       remote,
       currentBranch,
       true,
+      signal,
     );
     return {
       success: pushResult.success,
@@ -511,8 +517,14 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
   public async sync(
     directoryPath: string,
     remote = "origin",
+    signal?: AbortSignal,
   ): Promise<SyncOutput> {
-    const pullResult = await this.pull(directoryPath, remote);
+    const pullResult = await this.pull(
+      directoryPath,
+      remote,
+      undefined,
+      signal,
+    );
     if (!pullResult.success) {
       return {
         success: false,
@@ -521,7 +533,13 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
       };
     }
 
-    const pushResult = await this.push(directoryPath, remote);
+    const pushResult = await this.push(
+      directoryPath,
+      remote,
+      undefined,
+      false,
+      signal,
+    );
 
     const state = await this.getStateSnapshot(directoryPath);
 

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -240,34 +240,40 @@ export const gitRouter = router({
   push: publicProcedure
     .input(pushInput)
     .output(pushOutput)
-    .mutation(({ input }) =>
+    .mutation(({ input, signal }) =>
       getService().push(
         input.directoryPath,
         input.remote,
         input.branch,
         input.setUpstream,
+        signal,
       ),
     ),
 
   pull: publicProcedure
     .input(pullInput)
     .output(pullOutput)
-    .mutation(({ input }) =>
-      getService().pull(input.directoryPath, input.remote, input.branch),
+    .mutation(({ input, signal }) =>
+      getService().pull(
+        input.directoryPath,
+        input.remote,
+        input.branch,
+        signal,
+      ),
     ),
 
   publish: publicProcedure
     .input(publishInput)
     .output(publishOutput)
-    .mutation(({ input }) =>
-      getService().publish(input.directoryPath, input.remote),
+    .mutation(({ input, signal }) =>
+      getService().publish(input.directoryPath, input.remote, signal),
     ),
 
   sync: publicProcedure
     .input(syncInput)
     .output(syncOutput)
-    .mutation(({ input }) =>
-      getService().sync(input.directoryPath, input.remote),
+    .mutation(({ input, signal }) =>
+      getService().sync(input.directoryPath, input.remote, signal),
     ),
 
   getGitStatus: publicProcedure

--- a/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
@@ -28,7 +28,7 @@ import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { useQueryClient } from "@tanstack/react-query";
 import { track } from "@utils/analytics";
 import { logger } from "@utils/logger";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 const log = logger.scope("git-interaction");
 
@@ -151,6 +151,7 @@ export function useGitInteraction(
   const queryClient = useQueryClient();
   const store = useGitInteractionStore();
   const { actions: modal } = store;
+  const pushAbortRef = useRef<AbortController | null>(null);
 
   const git = useGitQueries(repoPath);
 
@@ -427,6 +428,10 @@ export function useGitInteraction(
 
     const pushMode = mode ?? useGitInteractionStore.getState().pushMode;
 
+    pushAbortRef.current?.abort();
+    const controller = new AbortController();
+    pushAbortRef.current = controller;
+
     modal.setIsSubmitting(true);
     modal.setPushError(null);
 
@@ -438,7 +443,10 @@ export function useGitInteraction(
             ? trpcClient.git.publish
             : trpcClient.git.push;
 
-      const result = await pushFn.mutate({ directoryPath: repoPath });
+      const result = await pushFn.mutate(
+        { directoryPath: repoPath },
+        { signal: controller.signal },
+      );
 
       if (!result.success) {
         const message =
@@ -458,9 +466,31 @@ export function useGitInteraction(
       }
 
       modal.setPushState("success");
+    } catch (error) {
+      trackGitAction(taskId, pushMode, false);
+      if (controller.signal.aborted) {
+        return;
+      }
+      log.error("Push failed", error);
+      const message = error instanceof Error ? error.message : "Push failed.";
+      modal.setPushError(message);
+      modal.setPushState("error");
     } finally {
+      if (pushAbortRef.current === controller) {
+        pushAbortRef.current = null;
+      }
       modal.setIsSubmitting(false);
     }
+  };
+
+  const abortPush = () => {
+    pushAbortRef.current?.abort();
+    pushAbortRef.current = null;
+  };
+
+  const closePush = () => {
+    abortPush();
+    modal.closePush();
   };
 
   const generateCommitMessage = async () => {
@@ -590,7 +620,7 @@ export function useGitInteraction(
     actions: {
       openAction,
       closeCommit: modal.closeCommit,
-      closePush: modal.closePush,
+      closePush,
       closeBranch: modal.closeBranch,
       setCommitMessage: modal.setCommitMessage,
       setCommitNextStep: modal.setCommitNextStep,

--- a/packages/electron-trpc/src/main/__tests__/handleIPCMessage.test.ts
+++ b/packages/electron-trpc/src/main/__tests__/handleIPCMessage.test.ts
@@ -56,7 +56,7 @@ describe("api", () => {
         },
       },
       router: testRouter,
-      subscriptions: new Map(),
+      operations: new Map(),
     });
 
     expect(event.reply).toHaveBeenCalledOnce();
@@ -96,14 +96,14 @@ describe("api", () => {
         },
       },
       router: testRouter,
-      subscriptions: new Map(),
+      operations: new Map(),
     });
 
     expect(event.reply).not.toHaveBeenCalled();
   });
 
   test("handles subscriptions using observables", async () => {
-    const subscriptions = new Map();
+    const operations = new Map();
     const ee = new EventEmitter();
     const t = trpc.initTRPC.create();
     const testRouter = t.router({
@@ -143,7 +143,7 @@ describe("api", () => {
         },
       },
       internalId: "1-1:1",
-      subscriptions,
+      operations,
       router: testRouter,
       event,
     });
@@ -176,7 +176,7 @@ describe("api", () => {
         id: 1,
       },
       internalId: "1-1:1",
-      subscriptions,
+      operations,
       router: testRouter,
       event,
     });
@@ -194,7 +194,7 @@ describe("api", () => {
   });
 
   test("handles subscriptions using async generators", async () => {
-    const subscriptions = new Map();
+    const operations = new Map();
     const t = trpc.initTRPC.create();
 
     // Simple async generator that yields a single value
@@ -226,7 +226,7 @@ describe("api", () => {
         },
       },
       internalId: "1-1:1",
-      subscriptions,
+      operations,
       router: testRouter,
       event,
     });
@@ -252,6 +252,110 @@ describe("api", () => {
         data: "test response",
       },
     });
+  });
+
+  test("operation.cancel aborts in-flight mutation signal", async () => {
+    const event = makeEvent({
+      reply: vi.fn(),
+      sender: {
+        isDestroyed: () => false,
+        on: () => {},
+      },
+    });
+
+    const signalCaptured = vi.fn();
+    const t = trpc.initTRPC.create();
+    const cancelRouter = t.router({
+      slowMutation: t.procedure.mutation(async ({ signal }) => {
+        signalCaptured(signal);
+        await new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        });
+        return "should not reach";
+      }),
+    });
+
+    const operations = new Map();
+
+    const mutationCall = handleIPCMessage({
+      createContext: async () => ({}),
+      event,
+      internalId: "1-1:1",
+      message: {
+        method: "request",
+        operation: {
+          context: {},
+          id: 1,
+          input: undefined,
+          path: "slowMutation",
+          type: "mutation",
+          signal: undefined,
+        },
+      },
+      router: cancelRouter,
+      operations,
+    });
+
+    await vi.waitFor(() => {
+      expect(signalCaptured).toHaveBeenCalled();
+    });
+
+    expect(operations.has("1-1:1")).toBe(true);
+
+    await handleIPCMessage({
+      createContext: async () => ({}),
+      event,
+      internalId: "1-1:1",
+      message: { method: "operation.cancel", id: 1 },
+      router: cancelRouter,
+      operations,
+    });
+
+    await mutationCall;
+
+    expect(signalCaptured.mock.calls[0][0].aborted).toBe(true);
+    expect(event.reply).toHaveBeenCalled();
+    const lastResponse = event.reply.mock.lastCall?.[1] as {
+      id: number;
+      error?: unknown;
+    };
+    expect(lastResponse).toMatchObject({ id: 1, error: expect.anything() });
+    expect(operations.has("1-1:1")).toBe(false);
+  });
+
+  test("query removes itself from operations map on success", async () => {
+    const event = makeEvent({
+      reply: vi.fn(),
+      sender: {
+        isDestroyed: () => false,
+        on: () => {},
+      },
+    });
+
+    const operations = new Map();
+
+    await handleIPCMessage({
+      createContext: async () => ({}),
+      event,
+      internalId: "1-1:9",
+      message: {
+        method: "request",
+        operation: {
+          context: {},
+          id: 9,
+          input: { id: "test" },
+          path: "testQuery",
+          type: "query",
+          signal: undefined,
+        },
+      },
+      router: testRouter,
+      operations,
+    });
+
+    expect(operations.has("1-1:9")).toBe(false);
   });
 
   test("subscription responds using custom serializer", async () => {
@@ -304,7 +408,7 @@ describe("api", () => {
         },
       },
       internalId: "1-1:1",
-      subscriptions: new Map(),
+      operations: new Map(),
       router: testRouter,
       event,
     });

--- a/packages/electron-trpc/src/main/createIPCHandler.ts
+++ b/packages/electron-trpc/src/main/createIPCHandler.ts
@@ -17,7 +17,7 @@ const getInternalId = (event: IpcMainEvent, request: ETRPCRequest) => {
 
 class IPCHandler<TRouter extends AnyTRPCRouter> {
   #windows: BrowserWindow[] = [];
-  #subscriptions: Map<string, AbortController> = new Map();
+  #operations: Map<string, AbortController> = new Map();
   #listener: (event: IpcMainEvent, request: ETRPCRequest) => void;
 
   constructor({
@@ -42,7 +42,7 @@ class IPCHandler<TRouter extends AnyTRPCRouter> {
         internalId: getInternalId(event, request),
         event,
         message: request,
-        subscriptions: this.#subscriptions,
+        operations: this.#operations,
       });
     };
     ipcMain.on(ELECTRON_TRPC_CHANNEL, this.#listener);
@@ -50,10 +50,10 @@ class IPCHandler<TRouter extends AnyTRPCRouter> {
 
   destroy() {
     ipcMain.removeListener(ELECTRON_TRPC_CHANNEL, this.#listener);
-    for (const sub of this.#subscriptions.values()) {
+    for (const sub of this.#operations.values()) {
       sub.abort();
     }
-    this.#subscriptions.clear();
+    this.#operations.clear();
   }
 
   attachWindow(win: BrowserWindow) {
@@ -86,10 +86,10 @@ class IPCHandler<TRouter extends AnyTRPCRouter> {
     webContentsId: number;
     frameRoutingId?: number;
   }) {
-    for (const [key, sub] of this.#subscriptions.entries()) {
+    for (const [key, sub] of this.#operations.entries()) {
       if (key.startsWith(`${webContentsId}-${frameRoutingId ?? ""}`)) {
         sub.abort();
-        this.#subscriptions.delete(key);
+        this.#operations.delete(key);
       }
     }
   }

--- a/packages/electron-trpc/src/main/handleIPCMessage.ts
+++ b/packages/electron-trpc/src/main/handleIPCMessage.ts
@@ -25,7 +25,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
   internalId,
   message,
   event,
-  subscriptions,
+  operations,
 }: {
   router: TRouter;
   createContext?: (
@@ -34,10 +34,13 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
   internalId: string;
   message: ETRPCRequest;
   event: IpcMainEvent;
-  subscriptions: Map<string, AbortController>;
+  operations: Map<string, AbortController>;
 }) {
-  if (message.method === "subscription.stop") {
-    subscriptions.get(internalId)?.abort();
+  if (
+    message.method === "subscription.stop" ||
+    message.method === "operation.cancel"
+  ) {
+    operations.get(internalId)?.abort();
     return;
   }
 
@@ -45,6 +48,34 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
   const input = serializedInput
     ? router._def._config.transformer.input.deserialize(serializedInput)
     : undefined;
+
+  const abortController = new AbortController();
+
+  if (operations.has(internalId)) {
+    const error = getTRPCErrorFromUnknown(
+      new TRPCError({
+        message: `Duplicate id ${internalId}`,
+        code: "BAD_REQUEST",
+      }),
+    );
+    if (event.sender.isDestroyed()) return;
+    event.reply(
+      ELECTRON_TRPC_CHANNEL,
+      transformTRPCResponse(router._def._config, {
+        id,
+        error: getErrorShape({
+          config: router._def._config,
+          error,
+          type,
+          path,
+          input,
+          ctx: {},
+        }),
+      }),
+    );
+    return;
+  }
+  operations.set(internalId, abortController);
 
   const ctx = (await createContext?.({ event })) ?? {};
 
@@ -57,7 +88,6 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
   };
 
   try {
-    const abortController = new AbortController();
     const result = await callTRPCProcedure({
       ctx,
       path,
@@ -84,6 +114,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
           data: result,
         },
       });
+      operations.delete(internalId);
       return;
     }
 
@@ -91,15 +122,6 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
       throw new TRPCError({
         message: `Subscription ${path} did not return an observable or a AsyncGenerator`,
         code: "INTERNAL_SERVER_ERROR",
-      });
-    }
-
-    if (subscriptions.has(internalId)) {
-      // duplicate request ids for client
-
-      throw new TRPCError({
-        message: `Duplicate id ${internalId}`,
-        code: "BAD_REQUEST",
       });
     }
 
@@ -180,7 +202,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
           type: "stopped",
         },
       });
-      subscriptions.delete(internalId);
+      operations.delete(internalId);
     }).catch((cause) => {
       const error = getTRPCErrorFromUnknown(cause);
       respond({
@@ -195,6 +217,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
         }),
       });
       abortController.abort();
+      operations.delete(internalId);
     });
 
     respond({
@@ -203,8 +226,8 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
         type: "started",
       },
     });
-    subscriptions.set(internalId, abortController);
   } catch (cause) {
+    operations.delete(internalId);
     const error: TRPCError = getTRPCErrorFromUnknown(cause);
 
     return respond({

--- a/packages/electron-trpc/src/renderer/ipcLink.ts
+++ b/packages/electron-trpc/src/renderer/ipcLink.ts
@@ -69,9 +69,18 @@ class IPCClient {
   }
 
   request(op: Operation, callbacks: IPCCallbacks) {
-    const { type } = op;
+    const { type, signal } = op;
     const scopedId = `${this.#sessionId}:${op.id}`;
     const scopedOp = { ...op, id: scopedId };
+
+    if (signal?.aborted) {
+      callbacks.error(
+        TRPCClientError.from(
+          new DOMException("The operation was aborted.", "AbortError"),
+        ),
+      );
+      return () => {};
+    }
 
     this.#pendingRequests.set(scopedId, {
       type,
@@ -84,10 +93,20 @@ class IPCClient {
       operation: scopedOp as unknown as Operation,
     });
 
+    const onAbort = () => {
+      if (!this.#pendingRequests.has(scopedId)) return;
+      this.#electronTRPC.sendMessage({
+        id: scopedId,
+        method: "operation.cancel",
+      });
+    };
+    signal?.addEventListener("abort", onAbort);
+
     return () => {
       const callbacks = this.#pendingRequests.get(scopedId)?.callbacks;
 
       this.#pendingRequests.delete(scopedId);
+      signal?.removeEventListener("abort", onAbort);
 
       callbacks?.complete();
 

--- a/packages/electron-trpc/src/types.ts
+++ b/packages/electron-trpc/src/types.ts
@@ -3,7 +3,8 @@ import type { TRPCResponseMessage } from "@trpc/server/rpc";
 
 export type ETRPCRequest =
   | { method: "request"; operation: Operation }
-  | { method: "subscription.stop"; id: string | number };
+  | { method: "subscription.stop"; id: string | number }
+  | { method: "operation.cancel"; id: string | number };
 
 export interface RendererGlobalElectronTRPC {
   sendMessage: (args: ETRPCRequest) => void;


### PR DESCRIPTION
Now that we immediately push on `push & commit` we should let the user abort the push with the cancel button in the UI. HOWEVER we do not support canceling TRPC procedures via `electron-trpc` so we had to add that in as well.