### PR TITLE
feat(code): space switcher for quick task navigation

### DIFF
--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -2,6 +2,7 @@ import { ConnectivityPrompt } from "@components/ConnectivityPrompt";
 import { HeaderRow } from "@components/HeaderRow";
 import { HedgehogMode } from "@components/HedgehogMode";
 import { KeyboardShortcutsSheet } from "@components/KeyboardShortcutsSheet";
+import { SpaceSwitcher } from "@components/SpaceSwitcher";
 
 import { ArchivedTasksView } from "@features/archive/components/ArchivedTasksView";
 import { CommandMenu } from "@features/command/components/CommandMenu";
@@ -12,6 +13,8 @@ import { FolderSettingsView } from "@features/settings/components/FolderSettings
 import { SettingsDialog } from "@features/settings/components/SettingsDialog";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
 import { MainSidebar } from "@features/sidebar/components/MainSidebar";
+import { useSidebarData } from "@features/sidebar/hooks/useSidebarData";
+import { useVisualTaskOrder } from "@features/sidebar/hooks/useVisualTaskOrder";
 import { SkillsView } from "@features/skills/components/SkillsView";
 import { TaskDetail } from "@features/task-detail/components/TaskDetail";
 import { TaskInput } from "@features/task-detail/components/TaskInput";
@@ -30,7 +33,8 @@ import { useTaskDeepLink } from "../hooks/useTaskDeepLink";
 import { GlobalEventHandlers } from "./GlobalEventHandlers";
 
 export function MainLayout() {
-  const { view, hydrateTask, navigateToTaskInput } = useNavigationStore();
+  const { view, hydrateTask, navigateToTaskInput, navigateToTask } =
+    useNavigationStore();
   const {
     isOpen: commandMenuOpen,
     setOpen: setCommandMenuOpen,
@@ -43,6 +47,12 @@ export function MainLayout() {
   } = useShortcutsSheetStore();
   const { data: tasks } = useTasks();
   const { showPrompt, isChecking, check, dismiss } = useConnectivity();
+
+  // Space switcher data
+  const sidebarData = useSidebarData({ activeView: view });
+  const visualTaskOrder = useVisualTaskOrder(sidebarData);
+  const activeTaskId =
+    view.type === "task-detail" && view.data ? view.data.id : null;
 
   const startTour = useTourStore((s) => s.startTour);
   const isFirstTaskTourDone = useTourStore((s) =>
@@ -102,6 +112,14 @@ export function MainLayout() {
         </Box>
       </Flex>
 
+      <SpaceSwitcher
+        tasks={visualTaskOrder}
+        activeTaskId={activeTaskId}
+        allTasks={tasks ?? []}
+        isOnNewTask={view.type === "task-input"}
+        onNavigateToTask={navigateToTask}
+        onNewTask={navigateToTaskInput}
+      />
       <CommandMenu open={commandMenuOpen} onOpenChange={setCommandMenuOpen} />
       <KeyboardShortcutsSheet
         open={shortcutsSheetOpen}

--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -26,8 +26,20 @@ const ITEM_WIDTH = 260;
 const SPACE_HOTKEY_OPTIONS = {
   enableOnFormTags: true,
   enableOnContentEditable: true,
-  preventDefault: true,
+  preventDefault: false,
 } as const;
+
+function isInputWithContent(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return el.value.length > 0;
+  }
+  if (el instanceof HTMLElement && el.isContentEditable) {
+    return (el.textContent?.length ?? 0) > 0;
+  }
+  return false;
+}
 
 const MASK_STYLE = {
   maskImage:
@@ -343,12 +355,26 @@ export function SpaceSwitcher({
     };
   }, [show, hide]);
 
-  useHotkeys(SHORTCUTS.SPACE_UP, navigatePrev, SPACE_HOTKEY_OPTIONS, [
-    navigatePrev,
-  ]);
-  useHotkeys(SHORTCUTS.SPACE_DOWN, navigateNext, SPACE_HOTKEY_OPTIONS, [
-    navigateNext,
-  ]);
+  useHotkeys(
+    SHORTCUTS.SPACE_UP,
+    (e) => {
+      if (isInputWithContent()) return;
+      e.preventDefault();
+      navigatePrev();
+    },
+    SPACE_HOTKEY_OPTIONS,
+    [navigatePrev],
+  );
+  useHotkeys(
+    SHORTCUTS.SPACE_DOWN,
+    (e) => {
+      if (isInputWithContent()) return;
+      e.preventDefault();
+      navigateNext();
+    },
+    SPACE_HOTKEY_OPTIONS,
+    [navigateNext],
+  );
 
   if (!mounted || tasks.length === 0) return null;
 

--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -23,9 +23,9 @@ const ITEM_STRIDE = ITEM_HEIGHT + ITEM_GAP;
 const CONTAINER_HEIGHT = 420;
 const ITEM_WIDTH = 260;
 
-const HOTKEY_OPTIONS = {
-  enableOnFormTags: true,
-  enableOnContentEditable: true,
+const SPACE_HOTKEY_OPTIONS = {
+  enableOnFormTags: false,
+  enableOnContentEditable: false,
   preventDefault: true,
 } as const;
 
@@ -239,11 +239,13 @@ export function SpaceSwitcher({
     return map;
   }, [allTasks]);
 
-  // Slot 0 = new task, slots 1..n = tasks
+  // Slot 0 = new task, slots 1..n = tasks, -1 = no active slot
   const totalSlots = tasks.length + 1;
   const currentSlot = isOnNewTask
     ? 0
-    : tasks.findIndex((t) => t.id === activeTaskId) + 1;
+    : activeTaskId !== null
+      ? tasks.findIndex((t) => t.id === activeTaskId) + 1
+      : -1;
 
   const navigateToSlot = useCallback(
     (slot: number) => {
@@ -259,16 +261,26 @@ export function SpaceSwitcher({
   );
 
   const navigatePrev = useCallback(() => {
-    if (totalSlots === 0) return;
+    if (tasks.length === 0) return;
+    // No active slot → go to last task
+    if (currentSlot === -1) {
+      navigateToSlot(totalSlots - 1);
+      return;
+    }
     const prev = currentSlot <= 0 ? totalSlots - 1 : currentSlot - 1;
     navigateToSlot(prev);
-  }, [totalSlots, currentSlot, navigateToSlot]);
+  }, [tasks.length, totalSlots, currentSlot, navigateToSlot]);
 
   const navigateNext = useCallback(() => {
-    if (totalSlots === 0) return;
+    if (tasks.length === 0) return;
+    // No active slot → go to first (new task)
+    if (currentSlot === -1) {
+      navigateToSlot(0);
+      return;
+    }
     const next = currentSlot >= totalSlots - 1 ? 0 : currentSlot + 1;
     navigateToSlot(next);
-  }, [totalSlots, currentSlot, navigateToSlot]);
+  }, [tasks.length, totalSlots, currentSlot, navigateToSlot]);
 
   const handleItemClick = useCallback(
     (taskId: string) => {
@@ -331,15 +343,18 @@ export function SpaceSwitcher({
     };
   }, [show, hide]);
 
-  useHotkeys(SHORTCUTS.SPACE_UP, navigatePrev, HOTKEY_OPTIONS, [navigatePrev]);
-  useHotkeys(SHORTCUTS.SPACE_DOWN, navigateNext, HOTKEY_OPTIONS, [
+  useHotkeys(SHORTCUTS.SPACE_UP, navigatePrev, SPACE_HOTKEY_OPTIONS, [
+    navigatePrev,
+  ]);
+  useHotkeys(SHORTCUTS.SPACE_DOWN, navigateNext, SPACE_HOTKEY_OPTIONS, [
     navigateNext,
   ]);
 
   if (!mounted || tasks.length === 0) return null;
 
   const centerOffset = CONTAINER_HEIGHT / 2 - ITEM_HEIGHT / 2;
-  const translateY = centerOffset - Math.max(0, currentSlot) * ITEM_STRIDE;
+  const centeredSlot = currentSlot === -1 ? 0 : currentSlot;
+  const translateY = centerOffset - centeredSlot * ITEM_STRIDE;
 
   return (
     <div
@@ -367,12 +382,12 @@ export function SpaceSwitcher({
               transition: "transform 200ms cubic-bezier(0.25, 1, 0.5, 1)",
             }}
           >
-            <NewTaskItem isActive={isOnNewTask} onClick={onNewTask} />
+            <NewTaskItem isActive={currentSlot === 0} onClick={onNewTask} />
             {tasks.map((task, index) => (
               <SpaceItem
                 key={task.id}
                 task={task}
-                isActive={!isOnNewTask && task.id === activeTaskId}
+                isActive={currentSlot > 0 && task.id === activeTaskId}
                 index={index}
                 onClick={() => handleItemClick(task.id)}
               />

--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -24,8 +24,8 @@ const CONTAINER_HEIGHT = 420;
 const ITEM_WIDTH = 260;
 
 const SPACE_HOTKEY_OPTIONS = {
-  enableOnFormTags: false,
-  enableOnContentEditable: false,
+  enableOnFormTags: true,
+  enableOnContentEditable: true,
   preventDefault: true,
 } as const;
 

--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -358,22 +358,22 @@ export function SpaceSwitcher({
   useHotkeys(
     SHORTCUTS.SPACE_UP,
     (e) => {
-      if (isInputWithContent()) return;
+      if (!mounted && isInputWithContent()) return;
       e.preventDefault();
       navigatePrev();
     },
     SPACE_HOTKEY_OPTIONS,
-    [navigatePrev],
+    [navigatePrev, mounted],
   );
   useHotkeys(
     SHORTCUTS.SPACE_DOWN,
     (e) => {
-      if (isInputWithContent()) return;
+      if (!mounted && isInputWithContent()) return;
       e.preventDefault();
       navigateNext();
     },
     SPACE_HOTKEY_OPTIONS,
-    [navigateNext],
+    [navigateNext, mounted],
   );
 
   if (!mounted || tasks.length === 0) return null;

--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -1,0 +1,385 @@
+import { DotsCircleSpinner } from "@components/DotsCircleSpinner";
+import type { TaskData } from "@features/sidebar/hooks/useSidebarData";
+import {
+  ChatCircleIcon,
+  CheckCircleIcon,
+  CircleNotchIcon,
+  HandPalmIcon,
+  PauseIcon,
+  PlusIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import { SHORTCUTS } from "@renderer/constants/keyboard-shortcuts";
+import type { Task } from "@shared/types";
+import { isMac } from "@utils/platform";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+
+const ICON_SIZE = 16;
+const MOD_KEY = isMac ? "Meta" : "Control";
+const ITEM_HEIGHT = 64;
+const ITEM_GAP = 4;
+const ITEM_STRIDE = ITEM_HEIGHT + ITEM_GAP;
+const CONTAINER_HEIGHT = 420;
+const ITEM_WIDTH = 260;
+
+const HOTKEY_OPTIONS = {
+  enableOnFormTags: true,
+  enableOnContentEditable: true,
+  preventDefault: true,
+} as const;
+
+const MASK_STYLE = {
+  maskImage:
+    "linear-gradient(to bottom, transparent 0%, black 18%, black 82%, transparent 100%)",
+  WebkitMaskImage:
+    "linear-gradient(to bottom, transparent 0%, black 18%, black 82%, transparent 100%)",
+} as const;
+
+interface SpaceSwitcherProps {
+  tasks: TaskData[];
+  activeTaskId: string | null;
+  allTasks: Task[];
+  isOnNewTask: boolean;
+  onNavigateToTask: (task: Task) => void;
+  onNewTask: () => void;
+}
+
+function getStatusIcon(task: TaskData) {
+  if (task.needsPermission) {
+    return (
+      <HandPalmIcon size={ICON_SIZE} weight="fill" className="text-blue-11" />
+    );
+  }
+  if (task.isGenerating) {
+    return <DotsCircleSpinner size={ICON_SIZE} className="text-accent-11" />;
+  }
+  if (task.taskRunStatus === "completed") {
+    return (
+      <CheckCircleIcon
+        size={ICON_SIZE}
+        weight="fill"
+        className="text-green-11"
+      />
+    );
+  }
+  if (task.taskRunStatus === "failed" || task.taskRunStatus === "cancelled") {
+    return (
+      <XCircleIcon size={ICON_SIZE} weight="fill" className="text-red-11" />
+    );
+  }
+  if (task.taskRunStatus === "in_progress" || task.taskRunStatus === "queued") {
+    return (
+      <CircleNotchIcon
+        size={ICON_SIZE}
+        className="animate-spin text-accent-11"
+      />
+    );
+  }
+  if (task.isSuspended) {
+    return <PauseIcon size={ICON_SIZE} className="text-gray-9" />;
+  }
+  return <ChatCircleIcon size={ICON_SIZE} className="text-gray-10" />;
+}
+
+function getStatusText(task: TaskData): string | null {
+  if (task.needsPermission) return "Needs permission";
+  if (task.isGenerating) return "Working...";
+  if (task.taskRunStatus === "completed") return "Completed";
+  if (task.taskRunStatus === "failed") return "Failed";
+  if (task.taskRunStatus === "cancelled") return "Cancelled";
+  if (task.taskRunStatus === "in_progress") return "In progress";
+  if (task.taskRunStatus === "queued") return "Queued";
+  if (task.isSuspended) return "Suspended";
+  return null;
+}
+
+const SpaceItem = memo(function SpaceItem({
+  task,
+  isActive,
+  index,
+  onClick,
+}: {
+  task: TaskData;
+  isActive: boolean;
+  index: number;
+  onClick: () => void;
+}) {
+  const statusText = getStatusText(task);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-3 rounded-lg border px-3 transition-colors duration-150 ${
+        isActive
+          ? "border-accent-9 bg-accent-3"
+          : "border-transparent bg-gray-3 hover:bg-gray-4"
+      }`}
+      style={{
+        height: ITEM_HEIGHT,
+        width: ITEM_WIDTH,
+        boxShadow: isActive
+          ? "0 0 16px color-mix(in srgb, var(--accent-9), transparent 70%)"
+          : undefined,
+      }}
+    >
+      {/* Status icon */}
+      <span className="flex shrink-0 items-center justify-center">
+        {getStatusIcon(task)}
+      </span>
+
+      {/* Text content */}
+      <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+        <span
+          className={`w-full truncate text-left text-[13px] leading-tight ${
+            isActive ? "font-medium text-gray-12" : "text-gray-11"
+          }`}
+        >
+          {task.title}
+        </span>
+        {statusText && (
+          <span
+            className={`text-[11px] leading-tight ${
+              isActive ? "text-accent-11" : "text-gray-9"
+            }`}
+          >
+            {statusText}
+          </span>
+        )}
+      </span>
+
+      {/* Position number */}
+      <span className="shrink-0 text-[11px] text-gray-9 tabular-nums">
+        {index + 1}
+      </span>
+    </button>
+  );
+});
+
+const NewTaskItem = memo(function NewTaskItem({
+  isActive,
+  onClick,
+}: {
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-3 rounded-lg border px-3 transition-colors duration-150 ${
+        isActive
+          ? "border-accent-9 bg-accent-3"
+          : "border-gray-6 border-dashed bg-gray-3 hover:bg-gray-4"
+      }`}
+      style={{
+        height: ITEM_HEIGHT,
+        width: ITEM_WIDTH,
+        boxShadow: isActive
+          ? "0 0 16px color-mix(in srgb, var(--accent-9), transparent 70%)"
+          : undefined,
+      }}
+    >
+      <span className="flex shrink-0 items-center justify-center">
+        <PlusIcon size={ICON_SIZE} className="text-gray-10" />
+      </span>
+      <span
+        className={`text-[13px] leading-tight ${
+          isActive ? "font-medium text-gray-12" : "text-gray-11"
+        }`}
+      >
+        New task
+      </span>
+    </button>
+  );
+});
+
+export function SpaceSwitcher({
+  tasks,
+  activeTaskId,
+  allTasks,
+  isOnNewTask,
+  onNavigateToTask,
+  onNewTask,
+}: SpaceSwitcherProps) {
+  // mounted = DOM present, animIn = opacity target.
+  // Mount first, then set animIn on next frame for CSS transition.
+  const [mounted, setMounted] = useState(false);
+  const [animIn, setAnimIn] = useState(false);
+  const metaHeldRef = useRef(false);
+  const showTimerRef = useRef<number | undefined>(undefined);
+  const hideTimerRef = useRef<number | undefined>(undefined);
+  const unmountTimerRef = useRef<number | undefined>(undefined);
+  const otherKeyRef = useRef(false);
+
+  const show = useCallback(() => {
+    clearTimeout(hideTimerRef.current);
+    clearTimeout(unmountTimerRef.current);
+    setMounted(true);
+    // Next frame: trigger CSS transition
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setAnimIn(true));
+    });
+  }, []);
+
+  const hide = useCallback(() => {
+    setAnimIn(false);
+    // Unmount after transition (200ms)
+    unmountTimerRef.current = window.setTimeout(() => {
+      setMounted(false);
+    }, 200);
+  }, []);
+
+  const taskById = useMemo(() => {
+    const map = new Map<string, Task>();
+    for (const task of allTasks) {
+      map.set(task.id, task);
+    }
+    return map;
+  }, [allTasks]);
+
+  // Slot 0 = new task, slots 1..n = tasks
+  const totalSlots = tasks.length + 1;
+  const currentSlot = isOnNewTask
+    ? 0
+    : tasks.findIndex((t) => t.id === activeTaskId) + 1;
+
+  const navigateToSlot = useCallback(
+    (slot: number) => {
+      if (slot === 0) {
+        onNewTask();
+      } else {
+        const taskData = tasks[slot - 1];
+        const task = taskData ? taskById.get(taskData.id) : undefined;
+        if (task) onNavigateToTask(task);
+      }
+    },
+    [tasks, taskById, onNavigateToTask, onNewTask],
+  );
+
+  const navigatePrev = useCallback(() => {
+    if (totalSlots === 0) return;
+    const prev = currentSlot <= 0 ? totalSlots - 1 : currentSlot - 1;
+    navigateToSlot(prev);
+  }, [totalSlots, currentSlot, navigateToSlot]);
+
+  const navigateNext = useCallback(() => {
+    if (totalSlots === 0) return;
+    const next = currentSlot >= totalSlots - 1 ? 0 : currentSlot + 1;
+    navigateToSlot(next);
+  }, [totalSlots, currentSlot, navigateToSlot]);
+
+  const handleItemClick = useCallback(
+    (taskId: string) => {
+      const task = taskById.get(taskId);
+      if (task) onNavigateToTask(task);
+    },
+    [taskById, onNavigateToTask],
+  );
+
+  // Meta key hold detection — only pure hold (no other keys) shows minimap
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === MOD_KEY && !e.repeat) {
+        metaHeldRef.current = true;
+        otherKeyRef.current = false;
+        clearTimeout(hideTimerRef.current);
+        clearTimeout(unmountTimerRef.current);
+        showTimerRef.current = window.setTimeout(() => {
+          if (metaHeldRef.current && !otherKeyRef.current) {
+            show();
+          }
+        }, 500);
+      } else if (metaHeldRef.current && !e.repeat) {
+        // Any key during hold cancels the show timer.
+        // Minimap only appears from a pure Cmd hold with no other keys.
+        otherKeyRef.current = true;
+        clearTimeout(showTimerRef.current);
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === MOD_KEY) {
+        metaHeldRef.current = false;
+        clearTimeout(showTimerRef.current);
+        hideTimerRef.current = window.setTimeout(() => {
+          hide();
+        }, 100);
+      }
+    };
+
+    const handleBlur = () => {
+      metaHeldRef.current = false;
+      clearTimeout(showTimerRef.current);
+      clearTimeout(hideTimerRef.current);
+      setAnimIn(false);
+      setMounted(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleBlur);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleBlur);
+      clearTimeout(showTimerRef.current);
+      clearTimeout(hideTimerRef.current);
+      clearTimeout(unmountTimerRef.current);
+    };
+  }, [show, hide]);
+
+  useHotkeys(SHORTCUTS.SPACE_UP, navigatePrev, HOTKEY_OPTIONS, [navigatePrev]);
+  useHotkeys(SHORTCUTS.SPACE_DOWN, navigateNext, HOTKEY_OPTIONS, [
+    navigateNext,
+  ]);
+
+  if (!mounted || tasks.length === 0) return null;
+
+  const centerOffset = CONTAINER_HEIGHT / 2 - ITEM_HEIGHT / 2;
+  const translateY = centerOffset - Math.max(0, currentSlot) * ITEM_STRIDE;
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-200 ease-out ${
+        animIn ? "opacity-100" : "pointer-events-none opacity-0"
+      }`}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/10" />
+
+      {/* Vertical list with fade edges */}
+      <div
+        className="relative overflow-hidden rounded-xl border border-gray-6 bg-gray-2 shadow-2xl backdrop-blur-xl"
+        style={{
+          height: CONTAINER_HEIGHT,
+          width: ITEM_WIDTH + 24,
+        }}
+      >
+        <div className="absolute inset-0" style={MASK_STYLE}>
+          <div
+            className="flex flex-col p-3"
+            style={{
+              gap: ITEM_GAP,
+              transform: `translateY(${translateY}px)`,
+              transition: "transform 200ms cubic-bezier(0.25, 1, 0.5, 1)",
+            }}
+          >
+            <NewTaskItem isActive={isOnNewTask} onClick={onNewTask} />
+            {tasks.map((task, index) => (
+              <SpaceItem
+                key={task.id}
+                task={task}
+                isActive={!isOnNewTask && task.id === activeTaskId}
+                index={index}
+                onClick={() => handleItemClick(task.id)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/code/src/renderer/constants/keyboard-shortcuts.ts
+++ b/apps/code/src/renderer/constants/keyboard-shortcuts.ts
@@ -89,6 +89,12 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     alternateKeys: "ctrl+tab",
   },
   {
+    id: "space-minimap",
+    keys: "mod",
+    description: "Show space minimap (hold)",
+    category: "navigation",
+  },
+  {
     id: "space-up",
     keys: SHORTCUTS.SPACE_UP,
     description: "Previous space",

--- a/apps/code/src/renderer/constants/keyboard-shortcuts.ts
+++ b/apps/code/src/renderer/constants/keyboard-shortcuts.ts
@@ -2,7 +2,7 @@ import { isMac } from "@utils/platform";
 
 export const SHORTCUTS = {
   COMMAND_MENU: "mod+k",
-  NEW_TASK: "mod+n,mod+t",
+  NEW_TASK: "mod+n,mod+t,mod+0",
   SETTINGS: "mod+,",
   SHORTCUTS_SHEET: "mod+/",
   GO_BACK: "mod+[",
@@ -19,6 +19,8 @@ export const SHORTCUTS = {
   TOGGLE_FOCUS: "mod+r",
   PASTE_AS_FILE: "mod+shift+v",
   INBOX: "mod+i",
+  SPACE_UP: "mod+up",
+  SPACE_DOWN: "mod+down",
   BLUR: "escape",
   SUBMIT_BLUR: "mod+enter",
 } as const;
@@ -40,7 +42,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     keys: "mod+n",
     description: "New task",
     category: "general",
-    alternateKeys: "mod+t",
+    alternateKeys: "mod+t, mod+0",
   },
   {
     id: "command-menu",
@@ -85,6 +87,18 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     description: "Next task",
     category: "navigation",
     alternateKeys: "ctrl+tab",
+  },
+  {
+    id: "space-up",
+    keys: SHORTCUTS.SPACE_UP,
+    description: "Previous space",
+    category: "navigation",
+  },
+  {
+    id: "space-down",
+    keys: SHORTCUTS.SPACE_DOWN,
+    description: "Next space",
+    category: "navigation",
   },
   {
     id: "go-back",


### PR DESCRIPTION
## Summary

<img width="3000" height="1962" alt="2026-04-22 14 04 19" src="https://github.com/user-attachments/assets/5d7dc287-6313-4034-8fd7-1f95c3b0dea5" />

Doesn't break cmd up/cmd down for going "home" when text is present in text box
<img width="3000" height="1962" alt="2026-04-22 20 15 34" src="https://github.com/user-attachments/assets/b69771b9-ad4d-4c67-a458-77cc6ee76d23" />


- **Cmd+Up/Down** navigates between tasks (wraps around)
- **Hold Cmd 500ms** shows a vertical minimap overlay centered on active task
- Each item shows status icon + title + status text (Needs permission, Working, Completed, Failed, etc.)
- Top/bottom edges fade to transparent for long lists
- **"New task" item** at top of list, navigable via arrows
- **Cmd+0** added as alias for new task (alongside Cmd+N/T)
- Overlay unmounts from DOM when hidden (no backdrop-blur leak)

### Cmd+Up/Down behavior in inputs
- **Input with text** → native cursor movement (Cmd+Up to start, Cmd+Down to end)
- **Empty input or no input** → task navigation
- **Minimap visible** → always navigates, regardless of input content

### Minimap trigger
- Only appears from a pure Cmd hold (500ms) with no other keys pressed
- Cmd+Up/Down alone does NOT show the minimap
- Other shortcuts (Cmd+K, Cmd+B, etc.) cancel the hold timer

### Non-task views (inbox, settings, etc.)
- No item highlighted in minimap (uses -1 sentinel for no active slot)
- Arrow navigation starts from first/last item



## Test plan

- [x] Cmd+Up/Down switches tasks without showing overlay
- [x] Hold Cmd for ~500ms to see minimap appear
- [x] Arrow keys navigate within visible minimap (even with input focused)
- [x] Release Cmd to dismiss minimap
- [x] "New task" item at top, clickable and arrow-navigable
- [x] Cmd+0 opens new task view
- [x] Other Cmd shortcuts (Cmd+K, Cmd+B, etc.) don't trigger minimap
- [x] Status icons match task states (generating, completed, failed, needs permission)
- [x] Cmd+Up/Down in input with text → cursor moves to start/end (not task switch)
- [x] Cmd+Up/Down in empty input → switches task
- [x] On inbox/settings view, no item highlighted in minimap
- [x] With zero tasks, Cmd+Up/Down does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)