### PR TITLE
feat: enrich wrapped functions and support jsx

### DIFF
--- a/packages/agent/src/enrichment/file-enricher.test.ts
+++ b/packages/agent/src/enrichment/file-enricher.test.ts
@@ -8,11 +8,15 @@ function makeDeps(overrides: {
   parseRejects?: Error;
   isSupported?: boolean;
   getApiKey?: () => string | Promise<string>;
+  findImportsInSource?: () => Promise<unknown[]>;
+  getWrappersForFile?: () => Promise<unknown[]>;
 }): {
   deps: FileEnrichmentDeps;
   parseSpy: ReturnType<typeof vi.fn>;
   enrichFromApiSpy: ReturnType<typeof vi.fn>;
   getApiKeySpy: ReturnType<typeof vi.fn>;
+  findImportsSpy: ReturnType<typeof vi.fn>;
+  getWrappersSpy: ReturnType<typeof vi.fn>;
 } {
   const enrichFromApiSpy = vi.fn(async () => ({
     toInlineComments: () =>
@@ -29,11 +33,19 @@ function makeDeps(overrides: {
   });
 
   const getApiKeySpy = vi.fn(overrides.getApiKey ?? (() => "phx_test"));
+  const findImportsSpy = vi.fn(
+    overrides.findImportsInSource ?? (async () => []),
+  );
+  const getWrappersSpy = vi.fn(
+    overrides.getWrappersForFile ?? (async () => []),
+  );
 
   const deps: FileEnrichmentDeps = {
     enricher: {
       isSupported: vi.fn(() => overrides.isSupported ?? true),
       parse: parseSpy,
+      findImportsInSource: findImportsSpy,
+      getWrappersForFile: getWrappersSpy,
     } as unknown as FileEnrichmentDeps["enricher"],
     apiConfig: {
       apiUrl: "https://test.posthog.com",
@@ -42,7 +54,14 @@ function makeDeps(overrides: {
     },
   };
 
-  return { deps, parseSpy, enrichFromApiSpy, getApiKeySpy };
+  return {
+    deps,
+    parseSpy,
+    enrichFromApiSpy,
+    getApiKeySpy,
+    findImportsSpy,
+    getWrappersSpy,
+  };
 }
 
 describe("enrichFileForAgent", () => {
@@ -97,8 +116,8 @@ describe("enrichFileForAgent", () => {
     expect(enrichFromApiSpy).not.toHaveBeenCalled();
   });
 
-  test("returns null and skips parse when content has no posthog reference", async () => {
-    const { deps, parseSpy } = makeDeps({});
+  test("returns null and skips parse when content has no posthog reference AND no relative imports", async () => {
+    const { deps, parseSpy, findImportsSpy } = makeDeps({});
     const result = await enrichFileForAgent(
       deps,
       "/tmp/code.ts",
@@ -106,6 +125,121 @@ describe("enrichFileForAgent", () => {
     );
     expect(result).toBeNull();
     expect(parseSpy).not.toHaveBeenCalled();
+    expect(findImportsSpy).not.toHaveBeenCalled();
+  });
+
+  test("relative import with no resolvable wrapper → skips parse", async () => {
+    const { deps, parseSpy, findImportsSpy, getWrappersSpy } = makeDeps({
+      findImportsInSource: async () => [
+        {
+          localName: "foo",
+          importedName: "foo",
+          resolvedAbsPath: "/tmp/foo.ts",
+        },
+      ],
+      getWrappersForFile: async () => [],
+    });
+    const result = await enrichFileForAgent(
+      deps,
+      "/tmp/app.ts",
+      'import { foo } from "./foo";\nfoo("x");',
+    );
+    expect(result).toBeNull();
+    expect(findImportsSpy).toHaveBeenCalled();
+    expect(getWrappersSpy).toHaveBeenCalledWith("/tmp/foo.ts");
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  test("relative import hitting a named wrapper triggers parse with context", async () => {
+    const wrapper = {
+      name: "track",
+      methodKind: "capture",
+      posthogMethod: "capture",
+      classification: { kind: "pass-through", paramIndex: 0 },
+      isNamedExport: true,
+      isDefaultExport: false,
+    };
+    const { deps, parseSpy, findImportsSpy, getWrappersSpy } = makeDeps({
+      findImportsInSource: async () => [
+        {
+          localName: "track",
+          importedName: "track",
+          resolvedAbsPath: "/tmp/telemetry.ts",
+        },
+      ],
+      getWrappersForFile: async () => [wrapper],
+    });
+    const result = await enrichFileForAgent(
+      deps,
+      "/tmp/app.ts",
+      'import { track } from "./telemetry";\ntrack("x");',
+    );
+    expect(result).toBe("enriched content");
+    expect(findImportsSpy).toHaveBeenCalled();
+    expect(getWrappersSpy).toHaveBeenCalledWith("/tmp/telemetry.ts");
+    expect(parseSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        wrappersByLocalName: expect.any(Map),
+      }),
+    );
+    const ctxArg = parseSpy.mock.calls[0][2] as {
+      wrappersByLocalName: Map<string, unknown>;
+    };
+    expect(ctxArg.wrappersByLocalName.get("track")).toEqual(wrapper);
+  });
+
+  test("file with posthog literal and no relative imports skips import resolution", async () => {
+    const { deps, findImportsSpy, parseSpy } = makeDeps({});
+    await enrichFileForAgent(deps, "/tmp/code.ts", "posthog.capture('x');");
+    expect(findImportsSpy).not.toHaveBeenCalled();
+    expect(parseSpy).toHaveBeenCalled();
+  });
+
+  test("file with only bare-package imports does not trigger import resolution", async () => {
+    const { deps, findImportsSpy } = makeDeps({});
+    const content = [
+      'import React from "react";',
+      'import { useState } from "react";',
+      'import posthog from "posthog-js";',
+      "posthog.capture('x');",
+    ].join("\n");
+    await enrichFileForAgent(deps, "/tmp/page.tsx", content);
+    expect(findImportsSpy).not.toHaveBeenCalled();
+  });
+
+  test("file with direct posthog AND wrapper imports gets both enriched", async () => {
+    const wrapper = {
+      name: "track",
+      methodKind: "capture",
+      posthogMethod: "capture",
+      classification: { kind: "pass-through", paramIndex: 0 },
+      isNamedExport: true,
+      isDefaultExport: false,
+    };
+    const { deps, findImportsSpy, parseSpy } = makeDeps({
+      findImportsInSource: async () => [
+        {
+          localName: "track",
+          importedName: "track",
+          resolvedAbsPath: "/tmp/utils.ts",
+        },
+      ],
+      getWrappersForFile: async () => [wrapper],
+    });
+    const content = [
+      'import posthog from "posthog-js";',
+      'import { track } from "./utils";',
+      "posthog.capture('direct');",
+      'track("wrapper_call");',
+    ].join("\n");
+    await enrichFileForAgent(deps, "/tmp/page.tsx", content);
+    expect(findImportsSpy).toHaveBeenCalled();
+    const ctx = parseSpy.mock.calls[0][2] as {
+      wrappersByLocalName: Map<string, unknown>;
+    };
+    expect(ctx.wrappersByLocalName.get("track")).toEqual(wrapper);
   });
 
   test("returns null when getApiKey yields empty string", async () => {

--- a/packages/agent/src/enrichment/file-enricher.ts
+++ b/packages/agent/src/enrichment/file-enricher.ts
@@ -1,5 +1,11 @@
 import * as path from "node:path";
-import { EXT_TO_LANG_ID, PostHogEnricher } from "@posthog/enricher";
+import {
+  EXT_TO_LANG_ID,
+  type ImportEdge,
+  type LocalWrapper,
+  type ParseContext,
+  PostHogEnricher,
+} from "@posthog/enricher";
 import type { PostHogAPIConfig } from "../types";
 import type { Logger } from "../utils/logger";
 
@@ -27,6 +33,10 @@ export function createEnrichment(
 }
 
 const MAX_ENRICHMENT_BYTES = 1_000_000;
+const MAX_RELATIVE_IMPORTS = 64;
+const RELATIVE_IMPORT_REGEX =
+  /(?:^|\n)\s*(?:import\b[^\n]*['"]\.{1,2}\/|from\s+\.)/;
+const POSTHOG_LITERAL_REGEX = /posthog/i;
 
 export async function enrichFileForAgent(
   deps: FileEnrichmentDeps,
@@ -35,15 +45,29 @@ export async function enrichFileForAgent(
 ): Promise<string | null> {
   if (!content || content.length > MAX_ENRICHMENT_BYTES) return null;
 
-  // Skip the tree-sitter parse for files with no PostHog references.
-  if (!/posthog/i.test(content)) return null;
-
   const ext = path.extname(filePath).toLowerCase();
   const langId = EXT_TO_LANG_ID[ext];
   if (!langId || !deps.enricher.isSupported(langId)) return null;
 
+  const hasPostHogLiteral = POSTHOG_LITERAL_REGEX.test(content);
+  const hasRelativeImport = RELATIVE_IMPORT_REGEX.test(content);
+  let parseContext: ParseContext | undefined;
+
+  // Build wrapper context whenever the file has relative imports — direct PostHog
+  // usage and wrapper usage can coexist in the same file, so we don't skip this
+  // just because `posthog` already appears literally.
+  if (hasRelativeImport) {
+    const absPath = path.resolve(filePath);
+    const ctx = await buildWrapperContext(deps, content, langId, absPath);
+    if (ctx) parseContext = ctx;
+  }
+
+  // Bail only when nothing at all could be enriched: no direct posthog literal
+  // AND no resolvable wrappers.
+  if (!hasPostHogLiteral && !parseContext) return null;
+
   try {
-    const parsed = await deps.enricher.parse(content, langId);
+    const parsed = await deps.enricher.parse(content, langId, parseContext);
     if (parsed.calls.length === 0 && parsed.initCalls.length === 0) {
       return null;
     }
@@ -69,6 +93,7 @@ export async function enrichFileForAgent(
     deps.logger?.debug("File enriched", {
       filePath,
       calls: parsed.calls.length,
+      viaWrappers: parsed.calls.filter((c) => c.viaWrapper).length,
     });
     return annotated;
   } catch (err) {
@@ -79,4 +104,70 @@ export async function enrichFileForAgent(
     deps.logger?.debug("File enrichment failed", { filePath, ...detail });
     return null;
   }
+}
+
+async function buildWrapperContext(
+  deps: FileEnrichmentDeps,
+  content: string,
+  langId: string,
+  absPath: string,
+): Promise<ParseContext | null> {
+  let edges: ImportEdge[];
+  try {
+    edges = await deps.enricher.findImportsInSource(content, langId, absPath);
+  } catch (err) {
+    deps.logger?.debug("Import resolution failed", {
+      absPath,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  if (!edges.length) return null;
+  const bounded = edges.slice(0, MAX_RELATIVE_IMPORTS);
+
+  const wrappersByLocalName = new Map<string, LocalWrapper>();
+  const namespaceWrappers = new Map<string, Map<string, LocalWrapper>>();
+
+  const resolutions = await Promise.all(
+    bounded.map(async (edge) => {
+      if (!edge.resolvedAbsPath) return null;
+      const wrappers = await deps.enricher.getWrappersForFile(
+        edge.resolvedAbsPath,
+      );
+      if (!wrappers.length) return null;
+      return { edge, wrappers };
+    }),
+  );
+
+  for (const entry of resolutions) {
+    if (!entry) continue;
+    const { edge, wrappers } = entry;
+
+    if (edge.isNamespace) {
+      const nsMap = new Map<string, LocalWrapper>();
+      for (const w of wrappers) {
+        if (w.isNamedExport || w.isDefaultExport) {
+          nsMap.set(w.name, w);
+        }
+      }
+      if (nsMap.size) namespaceWrappers.set(edge.localName, nsMap);
+      continue;
+    }
+
+    if (edge.isDefault) {
+      const target = wrappers.find((w) => w.isDefaultExport);
+      if (target) wrappersByLocalName.set(edge.localName, target);
+      continue;
+    }
+
+    const target = wrappers.find(
+      (w) => w.name === edge.importedName && w.isNamedExport,
+    );
+    if (target) wrappersByLocalName.set(edge.localName, target);
+  }
+
+  if (!wrappersByLocalName.size && !namespaceWrappers.size) return null;
+
+  return { wrappersByLocalName, namespaceWrappers };
 }

--- a/packages/enricher/src/ast-helpers.ts
+++ b/packages/enricher/src/ast-helpers.ts
@@ -158,3 +158,26 @@ export function walkNodes(
   };
   visit(root);
 }
+
+const JSX_NODE_TYPES = new Set([
+  "jsx_element",
+  "jsx_fragment",
+  "jsx_self_closing_element",
+  "jsx_opening_element",
+  "jsx_closing_element",
+  "jsx_attribute",
+]);
+
+/**
+ * Returns true when `node` lives anywhere inside a JSX element — i.e. appending
+ * a trailing `// …` comment to the call's line would land inside JSX content
+ * rather than in a JavaScript statement context.
+ */
+export function isInsideJsx(node: Parser.SyntaxNode): boolean {
+  let cur: Parser.SyntaxNode | null = node.parent;
+  while (cur) {
+    if (JSX_NODE_TYPES.has(cur.type)) return true;
+    cur = cur.parent;
+  }
+  return false;
+}

--- a/packages/enricher/src/call-detector.ts
+++ b/packages/enricher/src/call-detector.ts
@@ -9,11 +9,14 @@ import {
   extractClientName,
   extractParams,
   getCapture,
+  isInsideJsx,
 } from "./ast-helpers.js";
 import type { ParserManager } from "./parser-manager.js";
 import type {
   FlagAssignment,
   FunctionInfo,
+  LocalWrapper,
+  ParseContext,
   PostHogCall,
   PostHogInitCall,
 } from "./types.js";
@@ -25,6 +28,7 @@ export async function findPostHogCalls(
   pm: ParserManager,
   source: string,
   languageId: string,
+  context?: ParseContext,
 ): Promise<PostHogCall[]> {
   const ready = await pm.ensureReady(languageId);
   if (!ready) {
@@ -60,6 +64,7 @@ export async function findPostHogCalls(
       const clientNode = getCapture(match.captures, "client");
       const methodNode = getCapture(match.captures, "method");
       const keyNode = getCapture(match.captures, "key");
+      const callNode = getCapture(match.captures, "call");
 
       if (!clientNode || !methodNode || !keyNode) {
         continue;
@@ -102,6 +107,7 @@ export async function findPostHogCalls(
         line: keyNode.startPosition.row,
         keyStartCol: keyNode.startPosition.column,
         keyEndCol: keyNode.endPosition.column,
+        inJsx: callNode ? isInsideJsx(callNode) : undefined,
       });
     }
   }
@@ -167,6 +173,7 @@ export async function findPostHogCalls(
       const methodNode = getCapture(match.captures, "method");
       const propNameNode = getCapture(match.captures, "prop_name");
       const keyNode = getCapture(match.captures, "key");
+      const callNode = getCapture(match.captures, "call");
 
       if (!clientNode || !methodNode || !propNameNode || !keyNode) {
         continue;
@@ -194,6 +201,7 @@ export async function findPostHogCalls(
         line: keyNode.startPosition.row,
         keyStartCol: keyNode.startPosition.column,
         keyEndCol: keyNode.endPosition.column,
+        inJsx: callNode ? isInsideJsx(callNode) : undefined,
       });
     }
   }
@@ -310,6 +318,7 @@ export async function findPostHogCalls(
       for (const match of matches) {
         const funcNode = getCapture(match.captures, "func_name");
         const keyNode = getCapture(match.captures, "key");
+        const callNode = getCapture(match.captures, "call");
         if (!funcNode || !keyNode) {
           continue;
         }
@@ -322,6 +331,7 @@ export async function findPostHogCalls(
             line: keyNode.startPosition.row,
             keyStartCol: keyNode.startPosition.column,
             keyEndCol: keyNode.endPosition.column,
+            inJsx: callNode ? isInsideJsx(callNode) : undefined,
           });
         }
       }
@@ -340,6 +350,7 @@ export async function findPostHogCalls(
       for (const match of matches) {
         const funcNode = getCapture(match.captures, "func_name");
         const keyNode = getCapture(match.captures, "key");
+        const callNode = getCapture(match.captures, "call");
         if (!funcNode || !keyNode) {
           continue;
         }
@@ -351,6 +362,7 @@ export async function findPostHogCalls(
             line: keyNode.startPosition.row,
             keyStartCol: keyNode.startPosition.column,
             keyEndCol: keyNode.endPosition.column,
+            inJsx: callNode ? isInsideJsx(callNode) : undefined,
           });
         }
       }
@@ -367,6 +379,7 @@ export async function findPostHogCalls(
         const clientNode = getCapture(match.captures, "client");
         const methodNode = getCapture(match.captures, "method");
         const argNode = getCapture(match.captures, "arg_id");
+        const callNode = getCapture(match.captures, "call");
         if (!clientNode || !methodNode || !argNode) {
           continue;
         }
@@ -401,6 +414,7 @@ export async function findPostHogCalls(
           line,
           keyStartCol: argNode.startPosition.column,
           keyEndCol: argNode.endPosition.column,
+          inJsx: callNode ? isInsideJsx(callNode) : undefined,
         });
       }
     }
@@ -415,6 +429,7 @@ export async function findPostHogCalls(
       const clientNode = getCapture(match.captures, "client");
       const methodNode = getCapture(match.captures, "method");
       const firstArgNode = getCapture(match.captures, "first_arg");
+      const callNode = getCapture(match.captures, "call");
       if (!clientNode || !methodNode || !firstArgNode) {
         continue;
       }
@@ -443,12 +458,206 @@ export async function findPostHogCalls(
         keyStartCol: firstArgNode.startPosition.column,
         keyEndCol: firstArgNode.endPosition.column,
         dynamic: true,
+        inJsx: callNode ? isInsideJsx(callNode) : undefined,
       });
       matchedLines.add(line);
     }
   }
 
+  if (context?.wrappersByLocalName?.size) {
+    synthesizeBareWrapperCalls(
+      pm,
+      lang,
+      tree,
+      languageId,
+      context.wrappersByLocalName,
+      constantMap,
+      calls,
+      matchedLines,
+    );
+  }
+
+  if (context?.namespaceWrappers?.size) {
+    synthesizeNamespaceWrapperCalls(
+      pm,
+      lang,
+      tree,
+      languageId,
+      context.namespaceWrappers,
+      constantMap,
+      calls,
+      matchedLines,
+    );
+  }
+
   return calls;
+}
+
+const WRAPPER_BARE_CALL_QUERIES: Record<string, string | undefined> = {
+  javascript: `(call_expression function: (identifier) @func_name arguments: (arguments) @args) @call`,
+  javascriptreact: `(call_expression function: (identifier) @func_name arguments: (arguments) @args) @call`,
+  typescript: `(call_expression function: (identifier) @func_name arguments: (arguments) @args) @call`,
+  typescriptreact: `(call_expression function: (identifier) @func_name arguments: (arguments) @args) @call`,
+  python: `(call function: (identifier) @func_name arguments: (argument_list) @args) @call`,
+};
+
+const WRAPPER_NAMESPACE_CALL_QUERIES: Record<string, string | undefined> = {
+  javascript: `(call_expression function: (member_expression object: (identifier) @ns property: (property_identifier) @method) arguments: (arguments) @args) @call`,
+  javascriptreact: `(call_expression function: (member_expression object: (identifier) @ns property: (property_identifier) @method) arguments: (arguments) @args) @call`,
+  typescript: `(call_expression function: (member_expression object: (identifier) @ns property: (property_identifier) @method) arguments: (arguments) @args) @call`,
+  typescriptreact: `(call_expression function: (member_expression object: (identifier) @ns property: (property_identifier) @method) arguments: (arguments) @args) @call`,
+  python: `(call function: (attribute object: (identifier) @ns attribute: (identifier) @method) arguments: (argument_list) @args) @call`,
+};
+
+function synthesizeBareWrapperCalls(
+  pm: ParserManager,
+  lang: Parser.Language,
+  tree: Parser.Tree,
+  languageId: string,
+  wrappers: Map<string, LocalWrapper>,
+  constantMap: Map<string, string>,
+  calls: PostHogCall[],
+  matchedLines: Set<number>,
+): void {
+  const queryStr = WRAPPER_BARE_CALL_QUERIES[languageId];
+  if (!queryStr) return;
+  const query = pm.getQuery(lang, queryStr);
+  if (!query) return;
+
+  for (const match of query.matches(tree.rootNode)) {
+    const funcNode = getCapture(match.captures, "func_name");
+    const argsNode = getCapture(match.captures, "args");
+    const callNode = getCapture(match.captures, "call");
+    if (!funcNode || !argsNode) continue;
+    const wrapper = wrappers.get(funcNode.text);
+    if (!wrapper) continue;
+    pushWrapperCall(
+      wrapper,
+      funcNode,
+      argsNode,
+      callNode,
+      constantMap,
+      calls,
+      matchedLines,
+    );
+  }
+}
+
+function synthesizeNamespaceWrapperCalls(
+  pm: ParserManager,
+  lang: Parser.Language,
+  tree: Parser.Tree,
+  languageId: string,
+  namespaceWrappers: Map<string, Map<string, LocalWrapper>>,
+  constantMap: Map<string, string>,
+  calls: PostHogCall[],
+  matchedLines: Set<number>,
+): void {
+  const queryStr = WRAPPER_NAMESPACE_CALL_QUERIES[languageId];
+  if (!queryStr) return;
+  const query = pm.getQuery(lang, queryStr);
+  if (!query) return;
+
+  for (const match of query.matches(tree.rootNode)) {
+    const nsNode = getCapture(match.captures, "ns");
+    const methodNode = getCapture(match.captures, "method");
+    const argsNode = getCapture(match.captures, "args");
+    const callNode = getCapture(match.captures, "call");
+    if (!nsNode || !methodNode || !argsNode) continue;
+    const nsWrappers = namespaceWrappers.get(nsNode.text);
+    if (!nsWrappers) continue;
+    const wrapper = nsWrappers.get(methodNode.text);
+    if (!wrapper) continue;
+    pushWrapperCall(
+      wrapper,
+      methodNode,
+      argsNode,
+      callNode,
+      constantMap,
+      calls,
+      matchedLines,
+    );
+  }
+}
+
+function pushWrapperCall(
+  wrapper: LocalWrapper,
+  callerNode: Parser.SyntaxNode,
+  argsNode: Parser.SyntaxNode,
+  callNode: Parser.SyntaxNode | null,
+  constantMap: Map<string, string>,
+  calls: PostHogCall[],
+  matchedLines: Set<number>,
+): void {
+  let line = callerNode.startPosition.row;
+  let keyStartCol = callerNode.startPosition.column;
+  let keyEndCol = callerNode.endPosition.column;
+  let key = "";
+  let dynamic = false;
+
+  if (wrapper.classification.kind === "fixed-key") {
+    key = wrapper.classification.key;
+  } else {
+    const positional = argsNode.namedChildren.filter(
+      (c) => c.type !== "comment" && c.type !== "keyword_argument",
+    );
+    const arg = positional[wrapper.classification.paramIndex];
+    if (!arg) return;
+    line = arg.startPosition.row;
+    keyStartCol = arg.startPosition.column;
+    keyEndCol = arg.endPosition.column;
+
+    if (arg.type === "string") {
+      const fragment = arg.namedChildren.find(
+        (c) => c.type === "string_fragment" || c.type === "string_content",
+      );
+      if (fragment) {
+        key = fragment.text;
+      } else {
+        dynamic = true;
+      }
+    } else if (arg.type === "template_string") {
+      const fragments = arg.namedChildren.filter(
+        (c) => c.type === "string_fragment",
+      );
+      const hasInterp = arg.namedChildren.some(
+        (c) => c.type === "template_substitution",
+      );
+      if (!hasInterp && fragments.length === 1) {
+        key = fragments[0].text;
+      } else {
+        dynamic = true;
+      }
+    } else if (arg.type === "interpreted_string_literal") {
+      key = arg.text.slice(1, -1);
+    } else if (arg.type === "identifier") {
+      const resolved = constantMap.get(arg.text);
+      if (resolved) {
+        key = resolved;
+      } else {
+        dynamic = true;
+      }
+    } else {
+      dynamic = true;
+    }
+  }
+
+  if (matchedLines.has(line) && dynamic) {
+    // Direct PostHog call already annotated this line — don't overwrite with opaque wrapper data.
+    return;
+  }
+
+  calls.push({
+    method: wrapper.posthogMethod,
+    key,
+    line,
+    keyStartCol,
+    keyEndCol,
+    dynamic: dynamic ? true : undefined,
+    viaWrapper: wrapper.name,
+    inJsx: callNode ? isInsideJsx(callNode) : undefined,
+  });
+  matchedLines.add(line);
 }
 
 export async function findInitCalls(
@@ -961,6 +1170,7 @@ export async function findFunctions(
         : [];
 
     const bodyLine = bodyNode.startPosition.row;
+    const bodyEndLine = bodyNode.endPosition.row;
     const nextLineIdx = bodyLine + 1;
     const lines = text.split("\n");
     const nextLine = nextLineIdx < lines.length ? lines[nextLineIdx] : "";
@@ -971,6 +1181,7 @@ export async function findFunctions(
       params,
       isComponent: /^[A-Z]/.test(name),
       bodyLine,
+      bodyEndLine,
       bodyIndent,
     });
   }

--- a/packages/enricher/src/comment-formatter.test.ts
+++ b/packages/enricher/src/comment-formatter.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import { formatInlineComments } from "./comment-formatter.js";
+import type { EnrichedEvent, EnrichedFlag, EnrichedListItem } from "./types.js";
+
+function eventItem(
+  name: string,
+  line: number,
+  inJsx: boolean,
+): EnrichedListItem {
+  return {
+    type: "event",
+    line,
+    name,
+    method: "capture",
+    inJsx,
+    verified: true,
+  };
+}
+
+function enrichedEvent(name: string): EnrichedEvent {
+  return {
+    eventName: name,
+    verified: true,
+  } as EnrichedEvent;
+}
+
+describe("formatInlineComments", () => {
+  test("pure JS line uses // suffix", () => {
+    const source = `posthog.capture('a');`;
+    const items = [eventItem("a", 0, false)];
+    const events = new Map([["a", enrichedEvent("a")]]);
+    const out = formatInlineComments(
+      source,
+      "javascript",
+      items,
+      new Map<string, EnrichedFlag>(),
+      events,
+    );
+    expect(out).toBe(
+      `posthog.capture('a'); // [PostHog] Event: "a" \u2014 (verified)`,
+    );
+  });
+
+  test("pure JSX line uses {/* */} suffix", () => {
+    const source = `<Button onClick={() => track('a')} />`;
+    const items = [eventItem("a", 0, true)];
+    const events = new Map([["a", enrichedEvent("a")]]);
+    const out = formatInlineComments(
+      source,
+      "javascript",
+      items,
+      new Map<string, EnrichedFlag>(),
+      events,
+    );
+    expect(out).toBe(
+      `<Button onClick={() => track('a')} /> {/* [PostHog] Event: "a" \u2014 (verified) */}`,
+    );
+  });
+
+  test("mixed JSX and JS items on the same line fall back to a leading JSX comment", () => {
+    const source = `  <Button onClick={() => track('a')} />; posthog.capture('b');`;
+    const items = [eventItem("a", 0, true), eventItem("b", 0, false)];
+    const events = new Map([
+      ["a", enrichedEvent("a")],
+      ["b", enrichedEvent("b")],
+    ]);
+    const out = formatInlineComments(
+      source,
+      "javascript",
+      items,
+      new Map<string, EnrichedFlag>(),
+      events,
+    );
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(
+      `  {/* [PostHog] Event: "b" \u2014 (verified) | Event: "a" \u2014 (verified) */}`,
+    );
+    expect(lines[1]).toBe(source);
+  });
+
+  test("multiple mixed-context lines insert leading comments without shifting indices", () => {
+    const source = [
+      `<A onClick={() => track('a')} />; posthog.capture('b');`,
+      `const x = 1;`,
+      `<C onClick={() => track('c')} />; posthog.capture('d');`,
+    ].join("\n");
+    const items = [
+      eventItem("a", 0, true),
+      eventItem("b", 0, false),
+      eventItem("c", 2, true),
+      eventItem("d", 2, false),
+    ];
+    const events = new Map([
+      ["a", enrichedEvent("a")],
+      ["b", enrichedEvent("b")],
+      ["c", enrichedEvent("c")],
+      ["d", enrichedEvent("d")],
+    ]);
+    const out = formatInlineComments(
+      source,
+      "javascript",
+      items,
+      new Map<string, EnrichedFlag>(),
+      events,
+    );
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toMatch(/^\{\/\* \[PostHog\] .*"b".*"a".* \*\/\}$/);
+    expect(lines[1]).toBe(
+      `<A onClick={() => track('a')} />; posthog.capture('b');`,
+    );
+    expect(lines[2]).toBe(`const x = 1;`);
+    expect(lines[3]).toMatch(/^\{\/\* \[PostHog\] .*"d".*"c".* \*\/\}$/);
+    expect(lines[4]).toBe(
+      `<C onClick={() => track('c')} />; posthog.capture('d');`,
+    );
+  });
+});

--- a/packages/enricher/src/comment-formatter.ts
+++ b/packages/enricher/src/comment-formatter.ts
@@ -23,7 +23,10 @@ function formatFlagComment(flag: EnrichedFlag): string {
   if (flag.evaluationStats) {
     const evals = flag.evaluationStats.evaluations.toLocaleString();
     const users = flag.evaluationStats.uniqueUsers.toLocaleString();
-    parts.push(`${evals} evals / ${users} users (7d)`);
+    const days = flag.evaluationStats.windowDays;
+    parts.push(`${evals} evals / ${users} users (${days}d)`);
+  } else if (flag.evaluationStatsError) {
+    parts.push("eval stats unavailable");
   }
   if (flag.experiment) {
     const status = flag.experiment.end_date ? "complete" : "running";
@@ -61,21 +64,26 @@ function buildCommentBody(
   enrichedFlags: Map<string, EnrichedFlag>,
   enrichedEvents: Map<string, EnrichedEvent>,
 ): string | null {
+  let body: string | null = null;
   if (item.type === "flag") {
     const flag = enrichedFlags.get(item.name);
-    if (flag) return formatFlagComment(flag);
-    return null;
-  }
-  if (item.type === "event") {
+    body = flag ? formatFlagComment(flag) : null;
+  } else if (item.type === "event") {
     const event = enrichedEvents.get(item.name);
-    if (event) return formatEventComment(event);
-    if (item.detail) return `Event: ${item.detail}`;
-    return null;
+    if (event) {
+      body = formatEventComment(event);
+    } else if (item.detail) {
+      body = `Event: ${item.detail}`;
+    }
+  } else if (item.type === "init") {
+    body = `Init: token "${item.name}"`;
   }
-  if (item.type === "init") {
-    return `Init: token "${item.name}"`;
+
+  if (!body) return null;
+  if (item.viaWrapper) {
+    body = `${body} (via ${item.viaWrapper})`;
   }
-  return null;
+  return body;
 }
 
 export function formatComments(
@@ -96,7 +104,9 @@ export function formatComments(
     const body = buildCommentBody(item, enrichedFlags, enrichedEvents);
     if (!body) continue;
 
-    const comment = `${prefix} [PostHog] ${body}`;
+    const comment = item.inJsx
+      ? `{/* [PostHog] ${body} */}`
+      : `${prefix} [PostHog] ${body}`;
     const indent = lines[targetLine]?.match(/^(\s*)/)?.[1] ?? "";
     lines.splice(targetLine, 0, `${indent}${comment}`);
     offset++;
@@ -114,20 +124,53 @@ export function formatInlineComments(
 ): string {
   const prefix = commentPrefix(languageId);
   const lines = source.split("\n");
-  const byLine = new Map<number, string[]>();
+  // Per line, separate bodies by JSX vs JS context. Inline suffixes use
+  // different comment syntax in each context, so we can't safely coalesce
+  // mixed-context items into a single inline suffix.
+  const byLine = new Map<
+    number,
+    { jsxBodies: string[]; nonJsxBodies: string[] }
+  >();
 
   for (const item of items) {
     const body = buildCommentBody(item, enrichedFlags, enrichedEvents);
     if (!body) continue;
-    const arr = byLine.get(item.line) ?? [];
-    arr.push(body);
-    byLine.set(item.line, arr);
+    const entry = byLine.get(item.line) ?? { jsxBodies: [], nonJsxBodies: [] };
+    (item.inJsx ? entry.jsxBodies : entry.nonJsxBodies).push(body);
+    byLine.set(item.line, entry);
   }
 
-  for (const [lineIdx, bodies] of byLine) {
+  // When a single line mixes JSX and JS items we can't append one inline
+  // suffix without risking invalid syntax in one context or the other, so
+  // fall back to a JSX-style leading comment (valid as both an empty-block
+  // statement in JS and a JSX expression comment in JSX trees).
+  const leadingInserts: Array<{ atLine: number; text: string }> = [];
+
+  for (const [lineIdx, { jsxBodies, nonJsxBodies }] of byLine) {
     if (lineIdx < 0 || lineIdx >= lines.length) continue;
-    const suffix = ` ${prefix} [PostHog] ${bodies.join(" | ")}`;
+
+    if (jsxBodies.length > 0 && nonJsxBodies.length > 0) {
+      const joined = [...nonJsxBodies, ...jsxBodies].join(" | ");
+      const indent = lines[lineIdx]?.match(/^(\s*)/)?.[1] ?? "";
+      leadingInserts.push({
+        atLine: lineIdx,
+        text: `${indent}{/* [PostHog] ${joined} */}`,
+      });
+      continue;
+    }
+
+    const isJsx = jsxBodies.length > 0;
+    const bodies = isJsx ? jsxBodies : nonJsxBodies;
+    const joined = bodies.join(" | ");
+    const suffix = isJsx
+      ? ` {/* [PostHog] ${joined} */}`
+      : ` ${prefix} [PostHog] ${joined}`;
     lines[lineIdx] = `${lines[lineIdx]}${suffix}`;
+  }
+
+  leadingInserts.sort((a, b) => b.atLine - a.atLine);
+  for (const { atLine, text } of leadingInserts) {
+    lines.splice(atLine, 0, text);
   }
 
   return lines.join("\n");

--- a/packages/enricher/src/detector.ts
+++ b/packages/enricher/src/detector.ts
@@ -4,16 +4,21 @@ import {
   findInitCalls as _findInitCalls,
   findPostHogCalls as _findPostHogCalls,
 } from "./call-detector.js";
+import { findImports as _findImports } from "./import-resolver.js";
 import { ParserManager } from "./parser-manager.js";
 import type {
   DetectionConfig,
   FlagAssignment,
   FunctionInfo,
+  ImportEdge,
+  LocalWrapper,
+  ParseContext,
   PostHogCall,
   PostHogInitCall,
   VariantBranch,
 } from "./types.js";
 import { findVariantBranches as _findVariantBranches } from "./variant-detector.js";
+import { findWrappers as _findWrappers } from "./wrapper-detector.js";
 
 export class PostHogDetector {
   private pm = new ParserManager();
@@ -33,8 +38,9 @@ export class PostHogDetector {
   async findPostHogCalls(
     source: string,
     languageId: string,
+    context?: ParseContext,
   ): Promise<PostHogCall[]> {
-    return _findPostHogCalls(this.pm, source, languageId);
+    return _findPostHogCalls(this.pm, source, languageId, context);
   }
 
   async findInitCalls(
@@ -63,6 +69,21 @@ export class PostHogDetector {
     languageId: string,
   ): Promise<FlagAssignment[]> {
     return _findFlagAssignments(this.pm, source, languageId);
+  }
+
+  async findWrappers(
+    source: string,
+    languageId: string,
+  ): Promise<LocalWrapper[]> {
+    return _findWrappers(this.pm, source, languageId);
+  }
+
+  async findImports(
+    source: string,
+    languageId: string,
+    callerAbsPath: string,
+  ): Promise<ImportEdge[]> {
+    return _findImports(this.pm, source, languageId, callerAbsPath);
   }
 
   dispose(): void {

--- a/packages/enricher/src/enriched-result.ts
+++ b/packages/enricher/src/enriched-result.ts
@@ -5,7 +5,6 @@ import {
   extractVariants,
 } from "./flag-classification.js";
 import type { ParseResult } from "./parse-result.js";
-import { buildFlagUrl } from "./posthog-api.js";
 import { classifyStaleness } from "./stale-flags.js";
 import type {
   EnrichedEvent,
@@ -34,15 +33,11 @@ export class EnrichedResult {
     const checks = this.parsed.flagChecks;
     const experiments = this.context.experiments ?? [];
 
-    const { host, projectId } = this.context;
     for (const check of checks) {
       let entry = flagMap.get(check.flagKey);
       if (!entry) {
         const flag = this.context.flags?.get(check.flagKey);
-        const url =
-          flag && host && projectId !== undefined
-            ? buildFlagUrl(host, projectId, flag.id)
-            : null;
+        const url = this.context.flagUrls?.get(check.flagKey) ?? null;
         entry = {
           flagKey: check.flagKey,
           occurrences: [],
@@ -61,6 +56,7 @@ export class EnrichedResult {
           ),
           url,
           evaluationStats: this.context.flagEvaluationStats?.get(check.flagKey),
+          evaluationStatsError: this.context.flagEvaluationStatsError ?? false,
         };
         flagMap.set(check.flagKey, entry);
       }

--- a/packages/enricher/src/enricher.test.ts
+++ b/packages/enricher/src/enricher.test.ts
@@ -409,6 +409,7 @@ describeWithGrammars("PostHogEnricher", () => {
       expect(enriched.flags[0].evaluationStats).toEqual({
         evaluations: 1240,
         uniqueUsers: 230,
+        windowDays: 7,
       });
     });
 
@@ -494,6 +495,58 @@ describeWithGrammars("PostHogEnricher", () => {
       const body = String(queryPost?.[1]?.body ?? "");
       expect(body).toContain("$feature_flag_called");
       expect(body).toContain("tracked-flag");
+    });
+
+    test("toComments renders 'eval stats unavailable' when query rejects", async () => {
+      const code = `posthog.getFeatureFlag('broken-flag');`;
+      const result = await enricher.parse(code, "javascript");
+
+      const mockFetch = vi.fn(async (url: string, init?: RequestInit) => {
+        const urlStr = typeof url === "string" ? url : String(url);
+        if (urlStr.includes("/feature_flags/")) {
+          return Response.json({ results: [makeFlag("broken-flag")] });
+        }
+        if (urlStr.includes("/experiments/")) {
+          return Response.json({ results: [] });
+        }
+        if (urlStr.includes("/event_definitions/")) {
+          return Response.json({ results: [] });
+        }
+        if (urlStr.includes("/query/") && init?.method === "POST") {
+          const body =
+            typeof init.body === "string"
+              ? init.body
+              : init.body instanceof Uint8Array
+                ? new TextDecoder().decode(init.body)
+                : "";
+          if (body.includes("$feature_flag_called")) {
+            return new Response("forbidden", { status: 403 });
+          }
+          return Response.json({ results: [] });
+        }
+        return Response.json({});
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const enriched = await result.enrichFromApi(API_CONFIG);
+      const annotated = enriched.toComments();
+      expect(annotated).toContain("eval stats unavailable");
+      expect(annotated).not.toContain("evals /");
+    });
+
+    test("enrichedFlags url handles host with trailing slash", async () => {
+      const code = `posthog.getFeatureFlag('slashy');`;
+      const result = await enricher.parse(code, "javascript");
+
+      mockApiResponses({ flags: [makeFlag("slashy", { id: 9 })] });
+      const enriched = await result.enrichFromApi({
+        ...API_CONFIG,
+        host: "https://test.posthog.com/",
+      });
+
+      expect(enriched.flags[0].url).toBe(
+        "https://test.posthog.com/project/1/feature_flags/9",
+      );
     });
 
     test("enrichFromApi with no detected usage returns empty enrichment", async () => {

--- a/packages/enricher/src/enricher.ts
+++ b/packages/enricher/src/enricher.ts
@@ -4,13 +4,29 @@ import { PostHogDetector } from "./detector.js";
 import { EXT_TO_LANG_ID } from "./languages.js";
 import { warn } from "./log.js";
 import { ParseResult } from "./parse-result.js";
-import type { DetectionConfig } from "./types.js";
+import type {
+  DetectionConfig,
+  ImportEdge,
+  LocalWrapper,
+  ParseContext,
+} from "./types.js";
+
+const MAX_WRAPPER_SOURCE_BYTES = 1_000_000;
+const WRAPPER_CACHE_MAX = 1024;
+const POSTHOG_LITERAL_REGEX = /posthog/i;
+
+interface WrapperCacheEntry {
+  mtimeMs: number;
+  wrappers: LocalWrapper[];
+}
 
 export class PostHogEnricher {
   private detector = new PostHogDetector();
+  private wrapperCache = new Map<string, WrapperCacheEntry>();
 
   updateConfig(config: DetectionConfig): void {
     this.detector.updateConfig(config);
+    this.wrapperCache.clear();
   }
 
   isSupported(langId: string): boolean {
@@ -21,9 +37,13 @@ export class PostHogEnricher {
     return this.detector.supportedLanguages;
   }
 
-  async parse(source: string, languageId: string): Promise<ParseResult> {
+  async parse(
+    source: string,
+    languageId: string,
+    context?: ParseContext,
+  ): Promise<ParseResult> {
     const results = await Promise.allSettled([
-      this.detector.findPostHogCalls(source, languageId),
+      this.detector.findPostHogCalls(source, languageId, context),
       this.detector.findInitCalls(source, languageId),
       this.detector.findFlagAssignments(source, languageId),
       this.detector.findVariantBranches(source, languageId),
@@ -66,7 +86,88 @@ export class PostHogEnricher {
     return this.parse(source, languageId);
   }
 
+  /**
+   * Parse a file for wrapper definitions (functions that directly call PostHog SDK methods).
+   * Results are cached per absolute path + mtime so subsequent calls within the same session
+   * are cheap. Returns [] for unsupported extensions, unreadable files, or files larger than
+   * `MAX_WRAPPER_SOURCE_BYTES`.
+   */
+  async getWrappersForFile(absPath: string): Promise<LocalWrapper[]> {
+    const ext = path.extname(absPath).toLowerCase();
+    const languageId = EXT_TO_LANG_ID[ext];
+    if (!languageId || !this.isSupported(languageId)) {
+      return this.setWrapperCache(absPath, 0, []);
+    }
+
+    let mtimeMs = 0;
+    try {
+      const stat = await fs.stat(absPath);
+      mtimeMs = stat.mtimeMs;
+      if (stat.size > MAX_WRAPPER_SOURCE_BYTES) {
+        return this.setWrapperCache(absPath, mtimeMs, []);
+      }
+    } catch {
+      return this.setWrapperCache(absPath, 0, []);
+    }
+
+    const cached = this.wrapperCache.get(absPath);
+    if (cached && cached.mtimeMs === mtimeMs) {
+      this.touchCache(absPath);
+      return cached.wrappers;
+    }
+
+    let source: string;
+    try {
+      source = await fs.readFile(absPath, "utf-8");
+    } catch {
+      return this.setWrapperCache(absPath, mtimeMs, []);
+    }
+
+    // Cheap text-level guard: wrapper source must reference posthog/PostHog.
+    if (!POSTHOG_LITERAL_REGEX.test(source)) {
+      return this.setWrapperCache(absPath, mtimeMs, []);
+    }
+
+    const wrappers = await this.detector.findWrappers(source, languageId);
+    return this.setWrapperCache(absPath, mtimeMs, wrappers);
+  }
+
+  async findImportsInSource(
+    source: string,
+    languageId: string,
+    callerAbsPath: string,
+  ): Promise<ImportEdge[]> {
+    return this.detector.findImports(source, languageId, callerAbsPath);
+  }
+
+  clearWrapperCache(): void {
+    this.wrapperCache.clear();
+  }
+
   dispose(): void {
     this.detector.dispose();
+    this.wrapperCache.clear();
+  }
+
+  private setWrapperCache(
+    absPath: string,
+    mtimeMs: number,
+    wrappers: LocalWrapper[],
+  ): LocalWrapper[] {
+    if (this.wrapperCache.size >= WRAPPER_CACHE_MAX) {
+      const oldest = this.wrapperCache.keys().next().value;
+      if (oldest !== undefined) {
+        this.wrapperCache.delete(oldest);
+      }
+    }
+    this.wrapperCache.set(absPath, { mtimeMs, wrappers });
+    return wrappers;
+  }
+
+  private touchCache(absPath: string): void {
+    const entry = this.wrapperCache.get(absPath);
+    if (!entry) return;
+    this.wrapperCache.delete(absPath);
+    this.wrapperCache.set(absPath, entry);
   }
 }

--- a/packages/enricher/src/import-resolver.test.ts
+++ b/packages/enricher/src/import-resolver.test.ts
@@ -1,0 +1,158 @@
+import * as fs from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { PostHogDetector } from "./detector.js";
+
+const GRAMMARS_DIR = path.join(__dirname, "..", "grammars");
+const hasGrammars = fs.existsSync(
+  path.join(GRAMMARS_DIR, "tree-sitter-javascript.wasm"),
+);
+const describeWithGrammars = hasGrammars ? describe : describe.skip;
+
+describeWithGrammars("findImports", () => {
+  let detector: PostHogDetector;
+  let workDir: string;
+  let callerTs: string;
+  let callerPy: string;
+
+  beforeAll(() => {
+    detector = new PostHogDetector();
+    workDir = mkdtempSync(path.join(tmpdir(), "enricher-imports-"));
+
+    // JS/TS sibling modules
+    writeFileSync(
+      path.join(workDir, "telemetry.ts"),
+      "export function track() {}\nexport default function dflt() {}\n",
+    );
+    writeFileSync(path.join(workDir, "sibling.js"), "module.exports = {};\n");
+    mkdirSync(path.join(workDir, "helpers"), { recursive: true });
+    writeFileSync(
+      path.join(workDir, "helpers", "index.ts"),
+      "export function helperTrack() {}\n",
+    );
+
+    // Python sibling module
+    writeFileSync(
+      path.join(workDir, "tel.py"),
+      "def track(event_name):\n    pass\n",
+    );
+    // Python package dir
+    mkdirSync(path.join(workDir, "pkg"), { recursive: true });
+    writeFileSync(
+      path.join(workDir, "pkg", "__init__.py"),
+      "def helper():\n    pass\n",
+    );
+
+    callerTs = path.join(workDir, "caller.ts");
+    callerPy = path.join(workDir, "caller.py");
+  });
+
+  afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("named JS import resolves to .ts neighbor", async () => {
+    const src = `import { track } from "./telemetry";\ntrack("x");`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].localName).toBe("track");
+    expect(edges[0].importedName).toBe("track");
+    expect(edges[0].resolvedAbsPath).toBe(path.join(workDir, "telemetry.ts"));
+    expect(edges[0].isDefault).toBeFalsy();
+    expect(edges[0].isNamespace).toBeFalsy();
+  });
+
+  test("aliased named import records both names", async () => {
+    const src = `import { track as t } from "./telemetry";`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    const edge = edges.find((e) => e.localName === "t");
+    expect(edge).toBeDefined();
+    expect(edge?.importedName).toBe("track");
+  });
+
+  test("default import", async () => {
+    const src = `import track from "./telemetry";`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      localName: "track",
+      importedName: "default",
+      isDefault: true,
+    });
+  });
+
+  test("namespace import", async () => {
+    const src = `import * as tel from "./telemetry";`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      localName: "tel",
+      importedName: "*",
+      isNamespace: true,
+    });
+  });
+
+  test("index.ts in folder resolves", async () => {
+    const src = `import { helperTrack } from "./helpers";`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    expect(edges[0].resolvedAbsPath).toBe(
+      path.join(workDir, "helpers", "index.ts"),
+    );
+  });
+
+  test("missing target → null", async () => {
+    const src = `import { x } from "./missing";`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    expect(edges[0].resolvedAbsPath).toBeNull();
+  });
+
+  test("non-relative specifier is ignored", async () => {
+    const src = `import { capture } from "posthog-js";\nimport foo from "@scope/pkg";`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    expect(edges).toEqual([]);
+  });
+
+  test(".js extension also probes", async () => {
+    const src = `import sib from "./sibling";`;
+    const edges = await detector.findImports(src, "typescript", callerTs);
+    expect(edges[0].resolvedAbsPath).toBe(path.join(workDir, "sibling.js"));
+  });
+
+  test("Python: relative from-import resolves to .py", async () => {
+    const src = `from .tel import track\n`;
+    const edges = await detector.findImports(src, "python", callerPy);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].localName).toBe("track");
+    expect(edges[0].importedName).toBe("track");
+    expect(edges[0].resolvedAbsPath).toBe(path.join(workDir, "tel.py"));
+  });
+
+  test("Python: aliased from-import", async () => {
+    const src = `from .tel import track as t\n`;
+    const edges = await detector.findImports(src, "python", callerPy);
+    expect(edges[0]).toMatchObject({
+      localName: "t",
+      importedName: "track",
+    });
+  });
+
+  test("Python: package __init__ resolves", async () => {
+    const src = `from .pkg import helper\n`;
+    const edges = await detector.findImports(src, "python", callerPy);
+    expect(edges[0].resolvedAbsPath).toBe(
+      path.join(workDir, "pkg", "__init__.py"),
+    );
+  });
+
+  test("Go import query is absent — returns empty", async () => {
+    const src = `import "fmt"`;
+    const edges = await detector.findImports(
+      src,
+      "go",
+      path.join(workDir, "caller.go"),
+    );
+    expect(edges).toEqual([]);
+  });
+});

--- a/packages/enricher/src/import-resolver.ts
+++ b/packages/enricher/src/import-resolver.ts
@@ -1,0 +1,217 @@
+import { statSync } from "node:fs";
+import * as path from "node:path";
+import type { Capture } from "./ast-helpers.js";
+import { getCapture } from "./ast-helpers.js";
+import type { ParserManager } from "./parser-manager.js";
+import type { ImportEdge } from "./types.js";
+
+const JS_EXTENSION_PROBES = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+
+const PY_EXTENSION_PROBES = [".py"];
+
+function isRelativeSpecifier(spec: string): boolean {
+  return spec.startsWith("./") || spec.startsWith("../") || spec === ".";
+}
+
+function resolveJsPath(
+  callerAbsPath: string,
+  specifier: string,
+): string | null {
+  if (!isRelativeSpecifier(specifier)) return null;
+
+  const dir = path.dirname(callerAbsPath);
+  const base = path.resolve(dir, specifier);
+
+  // If the specifier already includes a concrete supported file extension,
+  // try that exact path first before probing extension variants.
+  if (JS_EXTENSION_PROBES.includes(path.extname(specifier))) {
+    return isFile(base) ? base : null;
+  }
+
+  if (isFile(base)) return base;
+
+  for (const ext of JS_EXTENSION_PROBES) {
+    const candidate = base + ext;
+    if (isFile(candidate)) return candidate;
+  }
+
+  for (const ext of JS_EXTENSION_PROBES) {
+    const candidate = path.join(base, `index${ext}`);
+    if (isFile(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+function isFile(p: string): boolean {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolvePythonModule(
+  callerAbsPath: string,
+  relativePrefix: string,
+  moduleName: string | null,
+): string | null {
+  if (!relativePrefix) return null;
+
+  // `.tel` → dots = 1, up 0 levels. `..foo` → dots = 2, up 1 level.
+  const dots = relativePrefix.length;
+  const levelsUp = dots - 1;
+
+  let baseDir = path.dirname(callerAbsPath);
+  for (let i = 0; i < levelsUp; i++) {
+    baseDir = path.dirname(baseDir);
+  }
+
+  if (!moduleName) {
+    const init = path.join(baseDir, "__init__.py");
+    return isFile(init) ? init : null;
+  }
+
+  const parts = moduleName.split(".");
+  const joined = path.join(baseDir, ...parts);
+
+  for (const ext of PY_EXTENSION_PROBES) {
+    const candidate = joined + ext;
+    if (isFile(candidate)) return candidate;
+  }
+
+  const pkgInit = path.join(joined, "__init__.py");
+  if (isFile(pkgInit)) return pkgInit;
+
+  return null;
+}
+
+export async function findImports(
+  pm: ParserManager,
+  source: string,
+  languageId: string,
+  callerAbsPath: string,
+): Promise<ImportEdge[]> {
+  const ready = await pm.ensureReady(languageId);
+  if (!ready) return [];
+  const { lang, family } = ready;
+  if (!family.queries.imports) return [];
+
+  const tree = pm.parse(source, lang);
+  if (!tree) return [];
+
+  const query = pm.getQuery(lang, family.queries.imports);
+  if (!query) return [];
+
+  const edges: ImportEdge[] = [];
+  const isPython = languageId === "python";
+
+  for (const match of query.matches(tree.rootNode)) {
+    if (isPython) {
+      pushPythonEdge(match.captures, callerAbsPath, edges);
+    } else {
+      pushJsEdge(match.captures, callerAbsPath, edges);
+    }
+  }
+
+  return dedupe(edges);
+}
+
+function pushJsEdge(
+  captures: Capture[],
+  callerAbsPath: string,
+  out: ImportEdge[],
+): void {
+  const sourceNode = getCapture(captures, "source");
+  if (!sourceNode) return;
+  const specifier = sourceNode.text;
+  if (!isRelativeSpecifier(specifier)) return;
+
+  const resolvedAbsPath = resolveJsPath(callerAbsPath, specifier);
+
+  const defaultNode = getCapture(captures, "default_name");
+  if (defaultNode) {
+    out.push({
+      localName: defaultNode.text,
+      importedName: "default",
+      isDefault: true,
+      resolvedAbsPath,
+    });
+    return;
+  }
+
+  const namespaceNode = getCapture(captures, "namespace_name");
+  if (namespaceNode) {
+    out.push({
+      localName: namespaceNode.text,
+      importedName: "*",
+      isNamespace: true,
+      resolvedAbsPath,
+    });
+    return;
+  }
+
+  const importedNode = getCapture(captures, "imported_name");
+  if (importedNode) {
+    const localNode = getCapture(captures, "local_name");
+    out.push({
+      localName: (localNode ?? importedNode).text,
+      importedName: importedNode.text,
+      resolvedAbsPath,
+    });
+  }
+}
+
+function pushPythonEdge(
+  captures: Capture[],
+  callerAbsPath: string,
+  out: ImportEdge[],
+): void {
+  const importedNode = getCapture(captures, "imported_name");
+  if (!importedNode) return;
+
+  const relativePrefix = getCapture(captures, "relative_prefix");
+  const relativeName = getCapture(captures, "relative_name");
+  const sourceNode = getCapture(captures, "source");
+
+  let resolvedAbsPath: string | null = null;
+
+  if (relativePrefix) {
+    resolvedAbsPath = resolvePythonModule(
+      callerAbsPath,
+      relativePrefix.text,
+      relativeName ? relativeName.text : null,
+    );
+  } else if (sourceNode) {
+    // Absolute-style `from tel import track` — v1: only resolve as sibling module.
+    resolvedAbsPath = resolvePythonModule(callerAbsPath, ".", sourceNode.text);
+  }
+
+  const localNode = getCapture(captures, "local_name");
+  out.push({
+    localName: (localNode ?? importedNode).text,
+    importedName: importedNode.text,
+    resolvedAbsPath,
+  });
+}
+
+function dedupe(edges: ImportEdge[]): ImportEdge[] {
+  const seen = new Set<string>();
+  const out: ImportEdge[] = [];
+  for (const e of edges) {
+    const key = `${e.localName}|${e.importedName}|${e.resolvedAbsPath ?? ""}|${e.isDefault ? "d" : ""}|${e.isNamespace ? "n" : ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(e);
+  }
+  return out;
+}

--- a/packages/enricher/src/index.ts
+++ b/packages/enricher/src/index.ts
@@ -31,12 +31,16 @@ export type {
   FlagAssignment,
   FlagType,
   FunctionInfo,
+  ImportEdge,
+  LocalWrapper,
+  ParseContext,
   PostHogCall,
   PostHogInitCall,
   StalenessCheckOptions,
   StalenessReason,
   SupportedLanguage,
   VariantBranch,
+  WrapperClassification,
 } from "./types.js";
 export { DEFAULT_CONFIG } from "./types.js";
 

--- a/packages/enricher/src/languages.ts
+++ b/packages/enricher/src/languages.ts
@@ -14,6 +14,8 @@ export interface QueryStrings {
   constructorAliases: string;
   destructuredMethods: string;
   bareFunctionCalls: string;
+  /** Import statements — only populated for languages where cross-file wrapper resolution is supported. */
+  imports?: string;
 }
 
 export interface LangFamily {
@@ -233,6 +235,34 @@ const JS_QUERIES: QueryStrings = {
         property: (property_identifier) @method)
       arguments: (arguments . (_) @first_arg)) @call
   `,
+
+  imports: `
+    (import_statement
+      (import_clause
+        (identifier) @default_name)
+      source: (string (string_fragment) @source)) @stmt
+
+    (import_statement
+      (import_clause
+        (named_imports
+          (import_specifier
+            name: (identifier) @imported_name) @spec))
+      source: (string (string_fragment) @source)) @stmt
+
+    (import_statement
+      (import_clause
+        (named_imports
+          (import_specifier
+            name: (identifier) @imported_name
+            alias: (identifier) @local_name) @spec))
+      source: (string (string_fragment) @source)) @stmt
+
+    (import_statement
+      (import_clause
+        (namespace_import
+          (identifier) @namespace_name))
+      source: (string (string_fragment) @source)) @stmt
+  `,
 };
 
 const PY_QUERIES: QueryStrings = {
@@ -319,6 +349,32 @@ const PY_QUERIES: QueryStrings = {
         object: (_) @client
         attribute: (identifier) @method)
       arguments: (argument_list . (_) @first_arg)) @call
+  `,
+
+  imports: `
+    (import_from_statement
+      module_name: (dotted_name) @source
+      name: (dotted_name) @imported_name) @stmt
+
+    (import_from_statement
+      module_name: (dotted_name) @source
+      name: (aliased_import
+        name: (dotted_name) @imported_name
+        alias: (identifier) @local_name)) @stmt
+
+    (import_from_statement
+      module_name: (relative_import
+        (import_prefix) @relative_prefix
+        (dotted_name)? @relative_name)
+      name: (dotted_name) @imported_name) @stmt
+
+    (import_from_statement
+      module_name: (relative_import
+        (import_prefix) @relative_prefix
+        (dotted_name)? @relative_name)
+      name: (aliased_import
+        name: (dotted_name) @imported_name
+        alias: (identifier) @local_name)) @stmt
   `,
 };
 

--- a/packages/enricher/src/parse-result.ts
+++ b/packages/enricher/src/parse-result.ts
@@ -51,6 +51,8 @@ export class ParseResult {
         name: c.key,
         line: c.line,
         dynamic: c.dynamic ?? false,
+        viaWrapper: c.viaWrapper,
+        inJsx: c.inJsx,
       }));
   }
 
@@ -61,6 +63,8 @@ export class ParseResult {
         method: c.method,
         flagKey: c.key,
         line: c.line,
+        viaWrapper: c.viaWrapper,
+        inJsx: c.inJsx,
       }));
   }
 
@@ -94,6 +98,8 @@ export class ParseResult {
         name: call.key,
         method: call.method,
         detail: call.dynamic ? "dynamic event name" : undefined,
+        viaWrapper: call.viaWrapper,
+        inJsx: call.inJsx,
       });
     }
 
@@ -154,6 +160,7 @@ export class ParseResult {
       flagEvalStatsResult.status === "fulfilled"
         ? flagEvalStatsResult.value
         : new Map<string, FlagEvaluationStats>();
+    const flagEvaluationStatsError = flagEvalStatsResult.status === "rejected";
 
     const flagKeySet = new Set(flagKeys);
     const flags = new Map(
@@ -170,14 +177,23 @@ export class ParseResult {
         .map((d) => [d.name, d]),
     );
 
+    const host = config.host.replace(/\/$/, "");
+    const flagUrls = new Map<string, string>();
+    for (const [key, flag] of flags) {
+      flagUrls.set(
+        key,
+        `${host}/project/${config.projectId}/feature_flags/${flag.id}`,
+      );
+    }
+
     return new EnrichedResult(this, {
       flags,
       experiments,
       eventDefinitions,
       eventStats,
       flagEvaluationStats,
-      host: config.host,
-      projectId: config.projectId,
+      flagEvaluationStatsError,
+      flagUrls,
     });
   }
 }

--- a/packages/enricher/src/parser-manager.ts
+++ b/packages/enricher/src/parser-manager.ts
@@ -22,6 +22,7 @@ function resolveGrammarsDir(): string {
 export class ParserManager {
   private parser: Parser | null = null;
   private languages = new Map<string, Parser.Language>();
+  private languageKeys = new WeakMap<Parser.Language, string>();
   private queryCache = new Map<string, Parser.Query>();
   private maxCacheSize = 256;
   private initPromise: Promise<void> | null = null;
@@ -80,6 +81,7 @@ export class ParserManager {
         const wasmPath = path.join(this.wasmDir, family.wasm);
         lang = await Parser.Language.load(wasmPath);
         this.languages.set(family.wasm, lang);
+        this.languageKeys.set(lang, family.wasm);
       } catch (err) {
         warn(`Failed to load grammar ${family.wasm}`, err);
         return null;
@@ -102,7 +104,8 @@ export class ParserManager {
       return null;
     }
 
-    const cacheKey = `${lang.toString()}:${queryStr}`;
+    const langKey = this.languageKeys.get(lang) ?? lang.toString();
+    const cacheKey = `${langKey}:${queryStr}`;
     let query = this.queryCache.get(cacheKey);
     if (query) {
       // LRU: move to end by deleting and re-inserting
@@ -133,6 +136,7 @@ export class ParserManager {
     this.parser = null;
     this.initPromise = null;
     this.languages.clear();
+    this.languageKeys = new WeakMap();
     this.queryCache.clear();
   }
 }

--- a/packages/enricher/src/posthog-api.ts
+++ b/packages/enricher/src/posthog-api.ts
@@ -7,14 +7,6 @@ import type {
   FlagEvaluationStats,
 } from "./types.js";
 
-export function buildFlagUrl(
-  host: string,
-  projectId: number,
-  flagId: number,
-): string {
-  return `${host.replace(/\/$/, "")}/project/${projectId}/feature_flags/${flagId}`;
-}
-
 export class PostHogApi {
   private config: EnricherApiConfig;
 
@@ -140,6 +132,8 @@ export class PostHogApi {
       return new Map();
     }
 
+    // HogQL over `/query/` rejects typed placeholders (`{name:Type}`) and
+    // placeholder values in INTERVAL, so `days` is inlined (clamped).
     const days = Math.max(1, Math.min(365, Math.floor(daysBack)));
     const query = `
       SELECT
@@ -165,7 +159,7 @@ export class PostHogApi {
 
     const stats = new Map<string, FlagEvaluationStats>();
     for (const [flagKey, evaluations, uniqueUsers] of data.results) {
-      stats.set(flagKey, { evaluations, uniqueUsers });
+      stats.set(flagKey, { evaluations, uniqueUsers, windowDays: days });
     }
     return stats;
   }

--- a/packages/enricher/src/types.ts
+++ b/packages/enricher/src/types.ts
@@ -8,6 +8,10 @@ export interface PostHogCall {
   keyEndCol: number;
   /** True when the first argument is a non-literal expression (ternary, variable, etc.) */
   dynamic?: boolean;
+  /** Name of the user-defined wrapper function this call was synthesized from, if any. */
+  viaWrapper?: string;
+  /** True when the call sits inside a JSX element so `//` comments aren't valid on its line. */
+  inJsx?: boolean;
 }
 
 export interface FunctionInfo {
@@ -15,7 +19,52 @@ export interface FunctionInfo {
   params: string[];
   isComponent: boolean;
   bodyLine: number;
+  bodyEndLine: number;
   bodyIndent: string;
+}
+
+// ── Wrapper detection ──
+
+export type WrapperClassification =
+  | { kind: "fixed-key"; key: string }
+  | { kind: "pass-through"; paramIndex: number };
+
+export interface LocalWrapper {
+  /** Function name as defined (e.g. `track`). */
+  name: string;
+  /** Whether this wrapper calls a capture method or a flag method. */
+  methodKind: "capture" | "flag";
+  /** The underlying PostHog SDK method (`capture`, `getFeatureFlag`, `isFeatureEnabled`, …). */
+  posthogMethod: string;
+  classification: WrapperClassification;
+  isDefaultExport?: boolean;
+  isNamedExport?: boolean;
+}
+
+// ── Parse context ──
+
+/**
+ * Optional context threaded into `findPostHogCalls` so the caller can inject
+ * cross-file wrapper knowledge without turning the detector into an I/O layer.
+ */
+export interface ParseContext {
+  /** Wrappers keyed by the local identifier they appear as in the caller file. */
+  wrappersByLocalName?: Map<string, LocalWrapper>;
+  /** `import * as ns from "..."` → `Map<methodName, wrapper>` per namespace. */
+  namespaceWrappers?: Map<string, Map<string, LocalWrapper>>;
+}
+
+// ── Import resolution ──
+
+export interface ImportEdge {
+  /** Local identifier in the importing file. */
+  localName: string;
+  /** Original exported name from the source module (same as localName unless aliased). */
+  importedName: string;
+  isDefault?: boolean;
+  isNamespace?: boolean;
+  /** Absolute path of the resolved source file, or `null` if resolution failed. */
+  resolvedAbsPath: string | null;
 }
 
 export interface VariantBranch {
@@ -141,12 +190,16 @@ export interface CapturedEvent {
   name: string;
   line: number;
   dynamic: boolean;
+  viaWrapper?: string;
+  inJsx?: boolean;
 }
 
 export interface FlagCheck {
   method: string;
   flagKey: string;
   line: number;
+  viaWrapper?: string;
+  inJsx?: boolean;
 }
 
 export interface ListItem {
@@ -155,6 +208,8 @@ export interface ListItem {
   name: string;
   method: string;
   detail?: string;
+  viaWrapper?: string;
+  inJsx?: boolean;
 }
 
 export interface EnrichedListItem extends ListItem {
@@ -184,6 +239,7 @@ export interface EventStats {
 export interface FlagEvaluationStats {
   evaluations: number;
   uniqueUsers: number;
+  windowDays: number;
 }
 
 export interface EnrichmentContext {
@@ -192,9 +248,9 @@ export interface EnrichmentContext {
   eventDefinitions?: Map<string, EventDefinition>;
   eventStats?: Map<string, EventStats>;
   flagEvaluationStats?: Map<string, FlagEvaluationStats>;
+  flagEvaluationStatsError?: boolean;
+  flagUrls?: Map<string, string>;
   stalenessOptions?: StalenessCheckOptions;
-  host?: string;
-  projectId?: number;
 }
 
 export interface StalenessCheckOptions {
@@ -212,6 +268,7 @@ export interface EnrichedFlag {
   experiment: Experiment | undefined;
   url: string | null;
   evaluationStats: FlagEvaluationStats | undefined;
+  evaluationStatsError: boolean;
 }
 
 export interface EnrichedEvent {

--- a/packages/enricher/src/wrapper-detector.test.ts
+++ b/packages/enricher/src/wrapper-detector.test.ts
@@ -1,0 +1,264 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { beforeAll, describe, expect, test } from "vitest";
+import { PostHogDetector } from "./detector.js";
+import type { LocalWrapper } from "./types.js";
+
+const GRAMMARS_DIR = path.join(__dirname, "..", "grammars");
+const hasGrammars = fs.existsSync(
+  path.join(GRAMMARS_DIR, "tree-sitter-javascript.wasm"),
+);
+const describeWithGrammars = hasGrammars ? describe : describe.skip;
+
+function summary(w: LocalWrapper) {
+  return {
+    name: w.name,
+    methodKind: w.methodKind,
+    posthogMethod: w.posthogMethod,
+    classification: w.classification,
+    isNamedExport: w.isNamedExport ?? false,
+    isDefaultExport: w.isDefaultExport ?? false,
+  };
+}
+
+describeWithGrammars("findWrappers (JS/TS)", () => {
+  let detector: PostHogDetector;
+
+  beforeAll(() => {
+    detector = new PostHogDetector();
+  });
+
+  test("pass-through wrapper at param 0", async () => {
+    const src = `
+      export function track(event, props) {
+        posthog.capture(event, props);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers.map(summary)).toEqual([
+      {
+        name: "track",
+        methodKind: "capture",
+        posthogMethod: "capture",
+        classification: { kind: "pass-through", paramIndex: 0 },
+        isNamedExport: true,
+        isDefaultExport: false,
+      },
+    ]);
+  });
+
+  test("pass-through wrapper at param 1", async () => {
+    const src = `
+      export function trackAt(ctx, eventName) {
+        posthog.capture(eventName);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0].classification).toEqual({
+      kind: "pass-through",
+      paramIndex: 1,
+    });
+  });
+
+  test("fixed-key wrapper", async () => {
+    const src = `
+      export function trackPurchase(data) {
+        posthog.capture("purchase", data);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0].classification).toEqual({
+      kind: "fixed-key",
+      key: "purchase",
+    });
+  });
+
+  test("flag wrapper returns methodKind=flag", async () => {
+    const src = `
+      export function useFlag(key) {
+        return posthog.isFeatureEnabled(key);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers[0]).toMatchObject({
+      name: "useFlag",
+      methodKind: "flag",
+      posthogMethod: "isFeatureEnabled",
+      classification: { kind: "pass-through", paramIndex: 0 },
+    });
+  });
+
+  test("arrow function wrapper", async () => {
+    const src = `
+      export const track = (event) => {
+        posthog.capture(event);
+      };
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0].name).toBe("track");
+    expect(wrappers[0].isNamedExport).toBe(true);
+  });
+
+  test("typed arrow function wrapper (real demo shape)", async () => {
+    const src = `import posthog from "posthog-js";
+export const track = (event_name: string) => {
+  posthog.capture(event_name);
+};
+`;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0]).toMatchObject({
+      name: "track",
+      methodKind: "capture",
+      posthogMethod: "capture",
+      classification: { kind: "pass-through", paramIndex: 0 },
+      isNamedExport: true,
+    });
+  });
+
+  test("default export wrapper", async () => {
+    const src = `
+      export default function track(event) {
+        posthog.capture(event);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers[0]).toMatchObject({
+      name: "track",
+      isDefaultExport: true,
+    });
+  });
+
+  test("non-exported function still detected as wrapper", async () => {
+    const src = `
+      function track(event) {
+        posthog.capture(event);
+      }
+      track("hello");
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0].isNamedExport).toBe(false);
+    expect(wrappers[0].isDefaultExport).toBe(false);
+  });
+
+  test("opaque body (dynamic key) is NOT registered", async () => {
+    const src = `
+      export function log(flavor) {
+        posthog.capture(computeName(flavor));
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toEqual([]);
+  });
+
+  test("function with no PostHog call is ignored", async () => {
+    const src = `
+      export function noop(event) {
+        console.log(event);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toEqual([]);
+  });
+
+  test("constructor-aliased client inside body still detected", async () => {
+    const src = `
+      const client = new PostHog("phc_x");
+      export function track(event) {
+        client.capture(event);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0].name).toBe("track");
+  });
+
+  test("nested wrapper: outer does not get registered when inner calls PostHog", async () => {
+    const src = `
+      export function outer(event) {
+        function inner(e) {
+          posthog.capture(e);
+        }
+        inner(event);
+      }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    // "inner" is the wrapper; "outer" is NOT — it only calls inner.
+    const names = wrappers.map((w) => w.name).sort();
+    expect(names).toContain("inner");
+    expect(names).not.toContain("outer");
+  });
+
+  test("multiple wrappers in one file", async () => {
+    const src = `
+      export function track(event) { posthog.capture(event); }
+      export function useFlag(key) { return posthog.getFeatureFlag(key); }
+    `;
+    const wrappers = await detector.findWrappers(src, "typescript");
+    expect(wrappers.map((w) => w.name).sort()).toEqual(["track", "useFlag"]);
+  });
+});
+
+describeWithGrammars("findWrappers (Python)", () => {
+  let detector: PostHogDetector;
+
+  beforeAll(() => {
+    detector = new PostHogDetector();
+  });
+
+  test("pass-through wrapper — event is second positional", async () => {
+    const src = `
+def track(distinct_id, event_name, props=None):
+    posthog.capture(distinct_id, event_name, props)
+`;
+    const wrappers = await detector.findWrappers(src, "python");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0]).toMatchObject({
+      name: "track",
+      posthogMethod: "capture",
+      classification: { kind: "pass-through", paramIndex: 1 },
+    });
+  });
+
+  test("fixed-key wrapper", async () => {
+    const src = `
+def track_purchase(data):
+    posthog.capture("user1", "purchase", data)
+`;
+    const wrappers = await detector.findWrappers(src, "python");
+    expect(wrappers[0].classification).toEqual({
+      kind: "fixed-key",
+      key: "purchase",
+    });
+  });
+
+  test("flag wrapper using get_feature_flag", async () => {
+    const src = `
+def use_flag(key):
+    return posthog.get_feature_flag(key)
+`;
+    const wrappers = await detector.findWrappers(src, "python");
+    expect(wrappers[0]).toMatchObject({
+      name: "use_flag",
+      methodKind: "flag",
+      posthogMethod: "get_feature_flag",
+      classification: { kind: "pass-through", paramIndex: 0 },
+    });
+  });
+
+  test("event=keyword argument also counts as key arg", async () => {
+    const src = `
+def track(event_name):
+    posthog.capture(distinct_id="u", event=event_name)
+`;
+    const wrappers = await detector.findWrappers(src, "python");
+    expect(wrappers[0].classification).toEqual({
+      kind: "pass-through",
+      paramIndex: 0,
+    });
+  });
+});

--- a/packages/enricher/src/wrapper-detector.ts
+++ b/packages/enricher/src/wrapper-detector.ts
@@ -1,0 +1,375 @@
+import type Parser from "web-tree-sitter";
+import { findAliases, getEffectiveClients } from "./alias-resolver.js";
+import {
+  extractClientName,
+  extractStringFromNode,
+  getCapture,
+} from "./ast-helpers.js";
+import type { LangFamily } from "./languages.js";
+import type { ParserManager } from "./parser-manager.js";
+import type { LocalWrapper, WrapperClassification } from "./types.js";
+
+const CONTROL_FLOW_KEYWORDS = new Set([
+  "if",
+  "for",
+  "while",
+  "switch",
+  "catch",
+  "else",
+]);
+
+type KeyArgLocator = {
+  /** Zero-based positional arg index that carries the event/flag key for this method. */
+  positionalIndex: number;
+  /** Python/Ruby keyword-arg name that may carry the key instead of a positional. */
+  kwargName?: string;
+};
+
+function getKeyArgLocator(
+  method: string,
+  family: LangFamily,
+  languageId: string,
+): KeyArgLocator | null {
+  if (languageId === "python") {
+    if (family.captureMethods.has(method)) {
+      return { positionalIndex: 1, kwargName: "event" };
+    }
+    if (family.flagMethods.has(method)) {
+      return { positionalIndex: 0, kwargName: "key" };
+    }
+    return null;
+  }
+  // JS / TS / TSX / JSX: first positional for all SDK methods.
+  if (family.allMethods.has(method)) {
+    return { positionalIndex: 0 };
+  }
+  return null;
+}
+
+function extractRawParams(
+  paramsNode: Parser.SyntaxNode | null,
+  singleParamNode: Parser.SyntaxNode | null,
+  languageId: string,
+): string[] {
+  if (singleParamNode) {
+    return [singleParamNode.text];
+  }
+  if (!paramsNode) {
+    return [];
+  }
+  const names: string[] = [];
+  for (const child of paramsNode.namedChildren) {
+    const n = extractParamName(child, languageId);
+    if (n) {
+      names.push(n);
+    } else {
+      names.push("");
+    }
+  }
+  return names;
+}
+
+function extractParamName(
+  node: Parser.SyntaxNode,
+  languageId: string,
+): string | null {
+  switch (node.type) {
+    case "identifier":
+      return node.text;
+    case "required_parameter":
+    case "optional_parameter": {
+      const pat = node.childForFieldName("pattern");
+      if (pat) return extractParamName(pat, languageId);
+      const name = node.childForFieldName("name");
+      if (name) return extractParamName(name, languageId);
+      const id = node.namedChildren.find((c) => c.type === "identifier");
+      return id?.text ?? null;
+    }
+    case "assignment_pattern": {
+      const left = node.childForFieldName("left");
+      return left ? extractParamName(left, languageId) : null;
+    }
+    case "typed_parameter":
+    case "default_parameter":
+    case "typed_default_parameter": {
+      const name = node.childForFieldName("name");
+      if (name) return extractParamName(name, languageId);
+      const id = node.namedChildren.find((c) => c.type === "identifier");
+      return id?.text ?? null;
+    }
+    case "parameter": {
+      const id = node.namedChildren.find(
+        (c) => c.type === "identifier" || c.type === "field_identifier",
+      );
+      return id?.text ?? null;
+    }
+    default: {
+      const id = node.namedChildren.find((c) => c.type === "identifier");
+      return id?.text ?? null;
+    }
+  }
+}
+
+interface PostHogCallInBody {
+  method: string;
+  keyArgNode: Parser.SyntaxNode | null;
+  kwargName: string | null;
+}
+
+function findPostHogCallInBody(
+  body: Parser.SyntaxNode,
+  allClients: Set<string>,
+  family: LangFamily,
+  languageId: string,
+  detectNested: boolean,
+): PostHogCallInBody | null {
+  let found: PostHogCallInBody | null = null;
+
+  const visit = (node: Parser.SyntaxNode) => {
+    if (found) return;
+
+    const call = matchPostHogCall(
+      node,
+      allClients,
+      family,
+      languageId,
+      detectNested,
+    );
+    if (call) {
+      found = call;
+      return;
+    }
+
+    for (const child of node.namedChildren) {
+      if (found) return;
+      visit(child);
+    }
+  };
+
+  visit(body);
+  return found;
+}
+
+function matchPostHogCall(
+  node: Parser.SyntaxNode,
+  allClients: Set<string>,
+  family: LangFamily,
+  languageId: string,
+  detectNested: boolean,
+): PostHogCallInBody | null {
+  if (node.type !== "call_expression" && node.type !== "call") return null;
+  const funcNode = node.childForFieldName("function");
+  if (!funcNode) return null;
+
+  let method: string | null = null;
+  if (funcNode.type === "member_expression" || funcNode.type === "attribute") {
+    const objNode =
+      funcNode.childForFieldName("object") ||
+      funcNode.childForFieldName("operand");
+    const propNode =
+      funcNode.childForFieldName("property") ||
+      funcNode.childForFieldName("attribute");
+    if (!objNode || !propNode) return null;
+    const clientName = extractClientName(objNode, detectNested);
+    if (!clientName || !allClients.has(clientName)) return null;
+    method = propNode.text;
+  } else if (funcNode.type === "selector_expression") {
+    const opNode = funcNode.childForFieldName("operand");
+    const fieldNode = funcNode.childForFieldName("field");
+    if (!opNode || !fieldNode) return null;
+    const clientName = extractClientName(opNode, detectNested);
+    if (!clientName || !allClients.has(clientName)) return null;
+    method = fieldNode.text;
+  } else {
+    return null;
+  }
+
+  if (!method || !family.allMethods.has(method)) return null;
+
+  const locator = getKeyArgLocator(method, family, languageId);
+  if (!locator) return null;
+
+  const argsNode =
+    node.childForFieldName("arguments") ||
+    node.namedChildren.find(
+      (c) => c.type === "arguments" || c.type === "argument_list",
+    ) ||
+    null;
+  if (!argsNode) return null;
+
+  const { keyNode, kwargName } = pickKeyArg(argsNode, locator);
+  return {
+    method,
+    keyArgNode: keyNode,
+    kwargName,
+  };
+}
+
+function pickKeyArg(
+  argsNode: Parser.SyntaxNode,
+  locator: KeyArgLocator,
+): { keyNode: Parser.SyntaxNode | null; kwargName: string | null } {
+  const positional: Parser.SyntaxNode[] = [];
+  let kwargHit: Parser.SyntaxNode | null = null;
+  let kwargName: string | null = null;
+
+  for (const child of argsNode.namedChildren) {
+    if (child.type === "keyword_argument") {
+      const nameNode = child.childForFieldName("name");
+      const valueNode = child.childForFieldName("value");
+      if (
+        nameNode &&
+        valueNode &&
+        locator.kwargName &&
+        nameNode.text === locator.kwargName
+      ) {
+        kwargHit = valueNode;
+        kwargName = nameNode.text;
+      }
+      continue;
+    }
+    positional.push(child);
+  }
+
+  if (kwargHit) {
+    return { keyNode: kwargHit, kwargName };
+  }
+  const positionalHit = positional[locator.positionalIndex] ?? null;
+  return { keyNode: positionalHit, kwargName: null };
+}
+
+function classifyKeyArg(
+  keyArgNode: Parser.SyntaxNode | null,
+  params: string[],
+): WrapperClassification | null {
+  if (!keyArgNode) return null;
+
+  if (
+    keyArgNode.type === "string" ||
+    keyArgNode.type === "interpreted_string_literal"
+  ) {
+    const key = extractStringFromNode(keyArgNode);
+    return key !== null ? { kind: "fixed-key", key } : null;
+  }
+  if (keyArgNode.type === "template_string") {
+    const hasInterpolation = keyArgNode.namedChildren.some(
+      (c) => c.type === "template_substitution",
+    );
+    if (hasInterpolation) return null;
+    const key = extractStringFromNode(keyArgNode);
+    return key !== null ? { kind: "fixed-key", key } : null;
+  }
+
+  if (keyArgNode.type === "identifier") {
+    const idx = params.indexOf(keyArgNode.text);
+    if (idx >= 0) return { kind: "pass-through", paramIndex: idx };
+    return null;
+  }
+
+  return null;
+}
+
+function getExportStatus(
+  nameNode: Parser.SyntaxNode,
+  languageId: string,
+): { isDefaultExport: boolean; isNamedExport: boolean } {
+  // Walk up starting from the wrapper's own definition node (nameNode.parent).
+  // Skip it so we examine its surrounding context, not itself.
+  const defNode = nameNode.parent;
+  if (!defNode) return { isDefaultExport: false, isNamedExport: false };
+
+  if (languageId === "python") {
+    let cur: Parser.SyntaxNode | null = defNode.parent;
+    while (cur) {
+      if (cur.type === "module") {
+        return { isDefaultExport: false, isNamedExport: true };
+      }
+      if (
+        cur.type === "function_definition" ||
+        cur.type === "class_definition"
+      ) {
+        return { isDefaultExport: false, isNamedExport: false };
+      }
+      cur = cur.parent;
+    }
+    return { isDefaultExport: false, isNamedExport: false };
+  }
+
+  let cur: Parser.SyntaxNode | null = defNode.parent;
+  while (cur) {
+    if (cur.type === "export_statement") {
+      const hasDefault = cur.children.some((c) => c.type === "default");
+      return { isDefaultExport: hasDefault, isNamedExport: !hasDefault };
+    }
+    if (cur.type === "program" || cur.type === "module") break;
+    cur = cur.parent;
+  }
+  return { isDefaultExport: false, isNamedExport: false };
+}
+
+export async function findWrappers(
+  pm: ParserManager,
+  source: string,
+  languageId: string,
+): Promise<LocalWrapper[]> {
+  const ready = await pm.ensureReady(languageId);
+  if (!ready) return [];
+
+  const { lang, family } = ready;
+  const tree = pm.parse(source, lang);
+  if (!tree) return [];
+
+  const functionQuery = pm.getQuery(lang, family.queries.functions);
+  if (!functionQuery) return [];
+
+  const allClients = getEffectiveClients(pm.config);
+  const { clientAliases } = findAliases(pm, lang, tree, family);
+  for (const a of clientAliases) allClients.add(a);
+
+  const wrappers: LocalWrapper[] = [];
+  const seen = new Set<string>();
+
+  for (const match of functionQuery.matches(tree.rootNode)) {
+    const nameNode = getCapture(match.captures, "func_name");
+    const paramsNode = getCapture(match.captures, "func_params");
+    const singleParamNode = getCapture(match.captures, "func_single_param");
+    const bodyNode = getCapture(match.captures, "func_body");
+    if (!nameNode || !bodyNode) continue;
+
+    const name = nameNode.text;
+    if (CONTROL_FLOW_KEYWORDS.has(name)) continue;
+    if (seen.has(name)) continue;
+
+    const params = extractRawParams(paramsNode, singleParamNode, languageId);
+
+    const call = findPostHogCallInBody(
+      bodyNode,
+      allClients,
+      family,
+      languageId,
+      pm.config.detectNestedClients,
+    );
+    if (!call) continue;
+
+    const classification = classifyKeyArg(call.keyArgNode, params);
+    if (!classification) continue;
+
+    const methodKind = family.captureMethods.has(call.method)
+      ? "capture"
+      : "flag";
+    const posthogMethod = call.method === "Enqueue" ? "capture" : call.method;
+
+    const exportStatus = getExportStatus(nameNode, languageId);
+    seen.add(name);
+
+    wrappers.push({
+      name,
+      methodKind,
+      posthogMethod,
+      classification,
+      ...exportStatus,
+    });
+  }
+
+  return wrappers;
+}

--- a/packages/enricher/src/wrapper-integration.test.ts
+++ b/packages/enricher/src/wrapper-integration.test.ts
@@ -1,0 +1,364 @@
+import * as fs from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { PostHogEnricher } from "./enricher.js";
+import type { LocalWrapper } from "./types.js";
+
+const GRAMMARS_DIR = path.join(__dirname, "..", "grammars");
+const hasGrammars = fs.existsSync(
+  path.join(GRAMMARS_DIR, "tree-sitter-javascript.wasm"),
+);
+const describeWithGrammars = hasGrammars ? describe : describe.skip;
+
+async function buildContext(
+  enricher: PostHogEnricher,
+  source: string,
+  langId: string,
+  callerAbsPath: string,
+): Promise<{
+  wrappersByLocalName: Map<string, LocalWrapper>;
+  namespaceWrappers: Map<string, Map<string, LocalWrapper>>;
+}> {
+  const edges = await enricher.findImportsInSource(
+    source,
+    langId,
+    callerAbsPath,
+  );
+  const wrappersByLocalName = new Map<string, LocalWrapper>();
+  const namespaceWrappers = new Map<string, Map<string, LocalWrapper>>();
+  for (const edge of edges) {
+    if (!edge.resolvedAbsPath) continue;
+    const wrappers = await enricher.getWrappersForFile(edge.resolvedAbsPath);
+    if (!wrappers.length) continue;
+
+    if (edge.isNamespace) {
+      const nsMap = new Map<string, LocalWrapper>();
+      for (const w of wrappers) {
+        if (w.isNamedExport || w.isDefaultExport) nsMap.set(w.name, w);
+      }
+      if (nsMap.size) namespaceWrappers.set(edge.localName, nsMap);
+      continue;
+    }
+    if (edge.isDefault) {
+      const target = wrappers.find((w) => w.isDefaultExport);
+      if (target) wrappersByLocalName.set(edge.localName, target);
+      continue;
+    }
+    const target = wrappers.find(
+      (w) => w.name === edge.importedName && w.isNamedExport,
+    );
+    if (target) wrappersByLocalName.set(edge.localName, target);
+  }
+  return { wrappersByLocalName, namespaceWrappers };
+}
+
+describeWithGrammars("Wrapper-aware enrichment (cross-file)", () => {
+  let enricher: PostHogEnricher;
+  let workDir: string;
+
+  beforeAll(() => {
+    enricher = new PostHogEnricher();
+    workDir = mkdtempSync(path.join(tmpdir(), "enricher-wrapper-"));
+  });
+
+  afterAll(() => {
+    enricher.dispose();
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("JS named import of pass-through wrapper synthesizes PostHogCall", async () => {
+    const tracker = path.join(workDir, "telemetry.ts");
+    writeFileSync(
+      tracker,
+      `export function track(event, props) {\n  posthog.capture(event, props);\n}\n`,
+    );
+
+    const app = path.join(workDir, "app.ts");
+    const appSrc = `import { track } from "./telemetry";\ntrack("checkout_completed");\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescript", app);
+    expect(ctx.wrappersByLocalName.has("track")).toBe(true);
+
+    const parsed = await enricher.parse(appSrc, "typescript", ctx);
+    expect(parsed.calls).toHaveLength(1);
+    expect(parsed.calls[0]).toMatchObject({
+      method: "capture",
+      key: "checkout_completed",
+      viaWrapper: "track",
+    });
+  });
+
+  test("JS default import of wrapper synthesizes PostHogCall", async () => {
+    const tracker = path.join(workDir, "default-tel.ts");
+    writeFileSync(
+      tracker,
+      `export default function track(event) {\n  posthog.capture(event);\n}\n`,
+    );
+
+    const app = path.join(workDir, "app-default.ts");
+    const appSrc = `import track from "./default-tel";\ntrack("signup");\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescript", app);
+    const parsed = await enricher.parse(appSrc, "typescript", ctx);
+    expect(parsed.calls[0]).toMatchObject({
+      method: "capture",
+      key: "signup",
+      viaWrapper: "track",
+    });
+  });
+
+  test("JS namespace import of wrapper synthesizes PostHogCall", async () => {
+    const tracker = path.join(workDir, "ns-tel.ts");
+    writeFileSync(
+      tracker,
+      `export function track(event) {\n  posthog.capture(event);\n}\n`,
+    );
+
+    const app = path.join(workDir, "app-ns.ts");
+    const appSrc = `import * as tel from "./ns-tel";\ntel.track("event_via_ns");\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescript", app);
+    expect(ctx.namespaceWrappers.has("tel")).toBe(true);
+
+    const parsed = await enricher.parse(appSrc, "typescript", ctx);
+    expect(parsed.calls[0]).toMatchObject({
+      method: "capture",
+      key: "event_via_ns",
+      viaWrapper: "track",
+    });
+  });
+
+  test("fixed-key wrapper produces the baked-in key", async () => {
+    const tracker = path.join(workDir, "fixed-tel.ts");
+    writeFileSync(
+      tracker,
+      `export function trackPurchase(data) {\n  posthog.capture("purchase", data);\n}\n`,
+    );
+
+    const app = path.join(workDir, "app-fixed.ts");
+    const appSrc = `import { trackPurchase } from "./fixed-tel";\ntrackPurchase({ amount: 42 });\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescript", app);
+    const parsed = await enricher.parse(appSrc, "typescript", ctx);
+    expect(parsed.calls[0]).toMatchObject({
+      method: "capture",
+      key: "purchase",
+      viaWrapper: "trackPurchase",
+    });
+  });
+
+  test("flag-method wrapper synthesizes a flag check", async () => {
+    const tracker = path.join(workDir, "flag-tel.ts");
+    writeFileSync(
+      tracker,
+      `export function useFlag(key) {\n  return posthog.isFeatureEnabled(key);\n}\n`,
+    );
+
+    const app = path.join(workDir, "app-flag.ts");
+    const appSrc = `import { useFlag } from "./flag-tel";\nconst on = useFlag("new-checkout");\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescript", app);
+    const parsed = await enricher.parse(appSrc, "typescript", ctx);
+    expect(parsed.flagChecks).toHaveLength(1);
+    expect(parsed.flagChecks[0]).toMatchObject({
+      method: "isFeatureEnabled",
+      flagKey: "new-checkout",
+      viaWrapper: "useFlag",
+    });
+  });
+
+  test("Python cross-file wrapper", async () => {
+    const tracker = path.join(workDir, "tel.py");
+    writeFileSync(
+      tracker,
+      `def track(distinct_id, event_name):\n    posthog.capture(distinct_id, event_name)\n`,
+    );
+
+    const app = path.join(workDir, "app.py");
+    const appSrc = `from .tel import track\ntrack("user1", "payment_succeeded")\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "python", app);
+    expect(ctx.wrappersByLocalName.has("track")).toBe(true);
+
+    const parsed = await enricher.parse(appSrc, "python", ctx);
+    expect(parsed.calls[0]).toMatchObject({
+      method: "capture",
+      key: "payment_succeeded",
+      viaWrapper: "track",
+    });
+  });
+
+  test("identifier arg resolved through constant map", async () => {
+    const tracker = path.join(workDir, "const-tel.ts");
+    writeFileSync(
+      tracker,
+      `export function track(event) {\n  posthog.capture(event);\n}\n`,
+    );
+
+    const app = path.join(workDir, "app-const.ts");
+    const appSrc = `import { track } from "./const-tel";\nconst EVT = "user_signed_up";\ntrack(EVT);\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescript", app);
+    const parsed = await enricher.parse(appSrc, "typescript", ctx);
+    expect(parsed.calls[0]).toMatchObject({
+      method: "capture",
+      key: "user_signed_up",
+      viaWrapper: "track",
+    });
+  });
+
+  test("unresolvable identifier arg marks call as dynamic", async () => {
+    const tracker = path.join(workDir, "dyn-tel.ts");
+    writeFileSync(
+      tracker,
+      `export function track(event) {\n  posthog.capture(event);\n}\n`,
+    );
+
+    const app = path.join(workDir, "app-dyn.ts");
+    const appSrc = `import { track } from "./dyn-tel";\ntrack(computedEventName);\n`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescript", app);
+    const parsed = await enricher.parse(appSrc, "typescript", ctx);
+    expect(parsed.calls).toHaveLength(1);
+    expect(parsed.calls[0]).toMatchObject({
+      method: "capture",
+      dynamic: true,
+      viaWrapper: "track",
+    });
+  });
+
+  test("wrapper registry mtime invalidates cache", async () => {
+    const target = path.join(workDir, "mtime-tel.ts");
+    writeFileSync(
+      target,
+      `export function track(event) {\n  posthog.capture(event);\n}\n`,
+    );
+    const first = await enricher.getWrappersForFile(target);
+    expect(first.map((w) => w.name)).toEqual(["track"]);
+
+    // Rewrite with a different wrapper; bump mtime by 2s to avoid fs resolution issues.
+    writeFileSync(
+      target,
+      `export function log(flag) {\n  return posthog.getFeatureFlag(flag);\n}\n`,
+    );
+    const future = new Date(Date.now() + 2000);
+    fs.utimesSync(target, future, future);
+
+    const second = await enricher.getWrappersForFile(target);
+    expect(second.map((w) => w.name)).toEqual(["log"]);
+  });
+
+  test("TSX caller with direct posthog AND wrapper call gets both synthesized", async () => {
+    const utils = path.join(workDir, "utils.ts");
+    writeFileSync(
+      utils,
+      `import posthog from "posthog-js";\nexport const track = (event_name: string) => {\n  posthog.capture(event_name);\n};\n`,
+    );
+
+    const app = path.join(workDir, "page.tsx");
+    const appSrc = `"use client";
+import posthog from "posthog-js";
+import { track } from "./utils";
+
+export default function Home() {
+  posthog.capture("purchase_completed", { price: 99 });
+  return (
+    <button onClick={() => track("event_123")}>New button</button>
+  );
+}
+`;
+
+    // Sanity-check the building blocks first.
+    const edges = await enricher.findImportsInSource(
+      appSrc,
+      "typescriptreact",
+      app,
+    );
+    const trackEdge = edges.find((e) => e.localName === "track");
+    expect(
+      trackEdge,
+      "imports to include { track } from ./utils",
+    ).toBeDefined();
+    expect(trackEdge?.resolvedAbsPath).toBe(utils);
+
+    const wrappers = await enricher.getWrappersForFile(utils);
+    expect(wrappers.map((w) => w.name)).toContain("track");
+
+    const ctx = await buildContext(enricher, appSrc, "typescriptreact", app);
+    expect(ctx.wrappersByLocalName.has("track")).toBe(true);
+
+    const parsed = await enricher.parse(appSrc, "typescriptreact", ctx);
+    const events = parsed.events.map((e) => ({
+      name: e.name,
+      viaWrapper: e.viaWrapper,
+    }));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        { name: "purchase_completed", viaWrapper: undefined },
+        { name: "event_123", viaWrapper: "track" },
+      ]),
+    );
+  });
+
+  test("wrapper call inside JSX sets inJsx and renders as JSX comment", async () => {
+    const utils = path.join(workDir, "jsx-utils.ts");
+    writeFileSync(
+      utils,
+      `import posthog from "posthog-js";\nexport const track = (event_name: string) => {\n  posthog.capture(event_name);\n};\n`,
+    );
+
+    const app = path.join(workDir, "jsx-page.tsx");
+    const appSrc = `"use client";
+import posthog from "posthog-js";
+import { track } from "./jsx-utils";
+
+export default function Home() {
+  posthog.capture("direct_event");
+  return (
+    <div>
+      <button onClick={() => track("event_123")}>New button</button>
+    </div>
+  );
+}
+`;
+
+    const ctx = await buildContext(enricher, appSrc, "typescriptreact", app);
+    const parsed = await enricher.parse(appSrc, "typescriptreact", ctx);
+
+    const directCall = parsed.calls.find((c) => c.key === "direct_event");
+    const wrapperCall = parsed.calls.find((c) => c.key === "event_123");
+    expect(directCall?.inJsx).toBeFalsy();
+    expect(wrapperCall?.inJsx).toBe(true);
+
+    const annotated = (
+      await parsed.enrichFromApi({
+        apiKey: "k",
+        host: "https://example.com",
+        projectId: 1,
+        timeoutMs: 1,
+      })
+    ).toInlineComments();
+
+    // The wrapper-call line lives inside JSX, so its annotation must use a JSX-safe comment.
+    const wrapperLine = annotated
+      .split("\n")
+      .find((l) => l.includes('track("event_123")'));
+    expect(wrapperLine).toContain("{/* [PostHog]");
+    expect(wrapperLine).toContain("*/}");
+
+    // The direct call is in a JS statement context, so the existing `//` form is correct.
+    const directLine = annotated
+      .split("\n")
+      .find((l) => l.includes('posthog.capture("direct_event")'));
+    expect(directLine).toContain("// [PostHog]");
+  });
+
+  test("non-wrapper file is cached as empty", async () => {
+    const target = path.join(workDir, "not-a-wrapper.ts");
+    writeFileSync(target, `export function noop() {\n  return 42;\n}\n`);
+    const wrappers = await enricher.getWrappersForFile(target);
+    expect(wrappers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## TLDR

Adds cross-file PostHog wrapper detection so the enricher can recognize and annotate calls to user-defined functions that wrap PostHog SDK methods, and fixes JSX comment rendering to use `{/* */}` syntax instead of `//` when calls appear inside JSX elements.

## Problem

Previously, the enricher only detected direct PostHog SDK calls (e.g. `posthog.capture(...)`). If a codebase wrapped PostHog in a utility function like `track(event)` and imported it across files, those calls were invisible to the enricher. Additionally, inline comment annotations appended `// [PostHog] ...` suffixes unconditionally, which produces invalid syntax when the call site is inside a JSX tree.

## Changes

**Wrapper detection**
- Adds `wrapper-detector.ts` which analyzes function bodies to identify functions that directly call PostHog SDK methods, classifying them as either `fixed-key` (hardcoded event name) or `pass-through` (event name forwarded from a parameter). Supports JS/TS and Python.
- Adds `import-resolver.ts` which resolves relative import specifiers to absolute file paths for JS/TS (with extension probing and `index.*` fallback) and Python (relative dot-prefix syntax and `__init__.py` packages).
- `PostHogEnricher` gains `getWrappersForFile(absPath)` (with mtime-based LRU cache) and `findImportsInSource(source, langId, callerAbsPath)`.
- `file-enricher.ts` now detects relative imports in a file, resolves wrappers from those imported modules, and passes a `ParseContext` (containing `wrappersByLocalName` and `namespaceWrappers`) into `parse()`. Files with no direct `posthog` literal but with resolvable wrappers are still enriched.
- `call-detector.ts` consumes `ParseContext` to synthesize `PostHogCall` entries for bare and namespace wrapper calls, reusing the existing constant-map for identifier resolution.
- Import query strings added to `languages.ts` for JS/TS and Python.

**JSX-aware comment rendering**
- Adds `isInsideJsx()` helper in `ast-helpers.ts` that walks the AST upward to detect JSX element ancestry.
- `PostHogCall`, `CapturedEvent`, `FlagCheck`, `ListItem`, and `EnrichedListItem` gain an `inJsx` field.
- `comment-formatter.ts` now emits `{/* [PostHog] ... */}` for JSX-context items and handles mixed JSX/JS items on the same line by inserting a leading JSX-style block comment instead of an inline suffix.

**Other fixes**
- `FlagEvaluationStats` now includes `windowDays` so the comment formatter can render the actual query window instead of a hardcoded `7d`.
- Flag evaluation stat fetch failures are surfaced as `evaluationStatsError` and rendered as `"eval stats unavailable"` rather than silently omitting the stat.
- Flag URLs are now pre-computed in `parse-result.ts` (with trailing-slash normalization) and passed via `flagUrls` on `EnrichmentContext`, removing the `host`/`projectId` fields from that interface.
- `FunctionInfo` gains `bodyEndLine`.
- `ParserManager` uses a stable string key for query cache entries instead of `lang.toString()`.