### PR TITLE
feat: convert pasted links to gh chip, support PRs

### DIFF
--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -508,27 +508,52 @@ export const discardFileChangesOutput = z.object({
 
 export type DiscardFileChangesOutput = z.infer<typeof discardFileChangesOutput>;
 
-export const githubIssueStateSchema = z.enum(["OPEN", "CLOSED"]);
-export type GithubIssueState = z.infer<typeof githubIssueStateSchema>;
+export const githubRefKindSchema = z.enum(["issue", "pr"]);
+export type GithubRefKind = z.infer<typeof githubRefKindSchema>;
 
-export const githubIssueSchema = z.object({
+export const githubRefStateSchema = z.enum(["OPEN", "CLOSED", "MERGED"]);
+export type GithubRefState = z.infer<typeof githubRefStateSchema>;
+
+export const githubRefSchema = z.object({
+  kind: githubRefKindSchema,
   number: z.number(),
   title: z.string(),
-  state: githubIssueStateSchema,
+  state: githubRefStateSchema,
   labels: z.array(z.string()),
   url: z.string(),
   repo: z.string(),
+  isDraft: z.boolean().optional(),
 });
 
-export type GitHubIssue = z.infer<typeof githubIssueSchema>;
+export type GithubRef = z.infer<typeof githubRefSchema>;
 
-export const searchGithubIssuesInput = z.object({
+// Legacy alias kept so callers that previously consumed only issues continue to work.
+export const githubIssueStateSchema = githubRefStateSchema;
+export type GithubIssueState = GithubRefState;
+export const githubIssueSchema = githubRefSchema;
+export type GitHubIssue = GithubRef;
+export type GithubPullRequest = GithubRef;
+
+export const searchGithubRefsInput = z.object({
   directoryPath: z.string(),
   query: z.string().optional(),
   limit: z.number().default(25),
+  kinds: z.array(githubRefKindSchema).optional(),
 });
 
-export const searchGithubIssuesOutput = z.array(githubIssueSchema);
+export const searchGithubRefsOutput = z.array(githubRefSchema);
+
+export const getGithubIssueInput = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  number: z.number().int().positive(),
+});
+
+export const getGithubIssueOutput = githubRefSchema.nullable();
+
+export const getGithubPullRequestInput = getGithubIssueInput;
+
+export const getGithubPullRequestOutput = getGithubIssueOutput;
 
 export const createPrProgressPayload = z.object({
   flowId: z.string(),

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -55,7 +55,8 @@ import type {
   GhStatusOutput,
   GitCommitInfo,
   GitFileStatus,
-  GitHubIssue,
+  GithubRef,
+  GithubRefKind,
   GitRepoInfo,
   GitStateSnapshot,
   GitStatusOutput,
@@ -1403,90 +1404,188 @@ ${truncatedDiff || "(no diff available)"}${contextSection}`;
     return result.stdout.trim() || repo;
   }
 
-  private parseGhIssues(stdout: string, repo: string): GitHubIssue[] {
+  private normalizeRefState(raw: string): GithubRef["state"] {
+    const upper = raw.toUpperCase();
+    if (upper === "OPEN") return "OPEN";
+    if (upper === "MERGED") return "MERGED";
+    return "CLOSED";
+  }
+
+  private parseGhRefs(
+    stdout: string,
+    repo: string,
+    kind: GithubRefKind,
+  ): GithubRef[] {
     const raw = JSON.parse(stdout) as Array<{
       number: number;
       title: string;
       state: string;
-      labels: Array<{ name: string }>;
+      labels?: Array<{ name: string }>;
       url: string;
+      isDraft?: boolean;
     }>;
     const items = Array.isArray(raw) ? raw : [raw];
-    return items.map((issue) => ({
-      number: issue.number,
-      title: issue.title,
-      state: issue.state.toUpperCase() === "OPEN" ? "OPEN" : "CLOSED",
-      labels: issue.labels.map((l) => l.name),
-      url: issue.url,
-      repo,
-    }));
+    return items.map((item) => {
+      // GitHub's issues API returns PRs too, so derive kind from the URL path.
+      const resolvedKind: GithubRefKind = item.url.includes("/pull/")
+        ? "pr"
+        : kind;
+      return {
+        kind: resolvedKind,
+        number: item.number,
+        title: item.title,
+        state: this.normalizeRefState(item.state),
+        labels: (item.labels ?? []).map((l) => l.name),
+        url: item.url,
+        repo,
+        isDraft: resolvedKind === "pr" ? Boolean(item.isDraft) : undefined,
+      };
+    });
   }
 
-  public async searchGithubIssues(
+  public async searchGithubRefs(
     directoryPath: string,
     query?: string,
     limit = 5,
-  ): Promise<GitHubIssue[]> {
+    kinds: GithubRefKind[] = ["issue", "pr"],
+  ): Promise<GithubRef[]> {
     const repoInfo = await this.getGitRepoInfo(directoryPath);
     if (!repoInfo) return [];
 
     const repo = await this.resolveCanonicalRepo(
       `${repoInfo.organization}/${repoInfo.repository}`,
     );
+
     const trimmed = query?.trim().replace(/^#/, "");
-    const issueNumber = trimmed ? Number(trimmed) : Number.NaN;
+    const refNumber = trimmed ? Number(trimmed) : Number.NaN;
 
-    if (!Number.isNaN(issueNumber) && Number.isInteger(issueNumber)) {
-      return this.fetchGhIssues(
-        ["issue", "view", String(issueNumber), "--repo", repo],
+    // Number lookup: `gh issue view` returns PRs too (shared number space).
+    if (!Number.isNaN(refNumber) && Number.isInteger(refNumber)) {
+      return this.fetchGhRefs(
+        ["issue", "view", String(refNumber), "--repo", repo],
         repo,
-      );
-    }
-
-    if (trimmed) {
-      return this.fetchGhIssues(
-        [
-          "search",
-          "issues",
-          trimmed,
-          "--repo",
-          repo,
-          "--limit",
-          String(limit),
-          "--match",
-          "title",
-        ],
-        repo,
-      );
-    }
-
-    return this.fetchGhIssues(
-      [
         "issue",
-        "list",
+      );
+    }
+
+    // Text search: one call via `gh search issues --include-prs` when both kinds are wanted.
+    if (trimmed) {
+      const includeIssues = kinds.includes("issue");
+      const includePrs = kinds.includes("pr");
+      const searchNoun = !includeIssues && includePrs ? "prs" : "issues";
+      const args = [
+        "search",
+        searchNoun,
+        trimmed,
         "--repo",
         repo,
         "--limit",
         String(limit),
-        "--state",
-        "all",
-      ],
-      repo,
-    );
+        "--match",
+        "title",
+      ];
+      if (searchNoun === "issues" && includePrs) args.push("--include-prs");
+      return this.fetchGhRefs(args, repo, "issue");
+    }
+
+    // Empty query: list defaults per-kind in parallel (`gh search` requires a query).
+    const tasks: Promise<GithubRef[]>[] = [];
+    if (kinds.includes("issue")) {
+      tasks.push(
+        this.fetchGhRefs(
+          [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--limit",
+            String(limit),
+            "--state",
+            "all",
+          ],
+          repo,
+          "issue",
+        ),
+      );
+    }
+    if (kinds.includes("pr")) {
+      tasks.push(
+        this.fetchGhRefs(
+          [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--limit",
+            String(limit),
+            "--state",
+            "all",
+          ],
+          repo,
+          "pr",
+        ),
+      );
+    }
+    const results = await Promise.all(tasks);
+    return this.sortRefs(this.dedupeRefsByUrl(results.flat()));
   }
 
-  private async fetchGhIssues(
+  private dedupeRefsByUrl(refs: GithubRef[]): GithubRef[] {
+    const byUrl = new Map<string, GithubRef>();
+    for (const ref of refs) {
+      if (!byUrl.has(ref.url)) byUrl.set(ref.url, ref);
+    }
+    return [...byUrl.values()];
+  }
+
+  private sortRefs(refs: GithubRef[]): GithubRef[] {
+    return refs.sort((a, b) => b.number - a.number);
+  }
+
+  public async getGithubIssue(
+    owner: string,
+    repo: string,
+    number: number,
+  ): Promise<GithubRef | null> {
+    const repoSlug = `${owner}/${repo}`;
+    const refs = await this.fetchGhRefs(
+      ["issue", "view", String(number), "--repo", repoSlug],
+      repoSlug,
+      "issue",
+    );
+    return refs[0] ?? null;
+  }
+
+  public async getGithubPullRequest(
+    owner: string,
+    repo: string,
+    number: number,
+  ): Promise<GithubRef | null> {
+    const repoSlug = `${owner}/${repo}`;
+    const refs = await this.fetchGhRefs(
+      ["pr", "view", String(number), "--repo", repoSlug],
+      repoSlug,
+      "pr",
+    );
+    return refs[0] ?? null;
+  }
+
+  private async fetchGhRefs(
     args: string[],
     repo: string,
-  ): Promise<GitHubIssue[]> {
-    const jsonFields = "number,title,state,labels,url";
+    kind: GithubRefKind,
+  ): Promise<GithubRef[]> {
+    const jsonFields =
+      kind === "pr"
+        ? "number,title,state,url,isDraft"
+        : "number,title,state,labels,url";
     const result = await execGh([...args, "--json", jsonFields]);
     if (result.exitCode !== 0) return [];
 
     try {
-      return this.parseGhIssues(result.stdout, repo);
+      return this.parseGhRefs(result.stdout, repo, kind);
     } catch {
-      log.warn("Failed to parse GitHub issues response", { repo, args });
+      log.warn("Failed to parse GitHub refs response", { repo, kind, args });
       return [];
     }
   }

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -35,6 +35,10 @@ import {
   getDiffStatsOutput,
   getFileAtHeadInput,
   getFileAtHeadOutput,
+  getGithubIssueInput,
+  getGithubIssueOutput,
+  getGithubPullRequestInput,
+  getGithubPullRequestOutput,
   getGitRepoInfoInput,
   getGitRepoInfoOutput,
   getGitSyncStatusOutput,
@@ -64,8 +68,8 @@ import {
   pushOutput,
   replyToPrCommentInput,
   replyToPrCommentOutput,
-  searchGithubIssuesInput,
-  searchGithubIssuesOutput,
+  searchGithubRefsInput,
+  searchGithubRefsOutput,
   stageFilesInput,
   syncInput,
   syncOutput,
@@ -374,15 +378,30 @@ export const gitRouter = router({
       ),
     ),
 
-  searchGithubIssues: publicProcedure
-    .input(searchGithubIssuesInput)
-    .output(searchGithubIssuesOutput)
+  searchGithubRefs: publicProcedure
+    .input(searchGithubRefsInput)
+    .output(searchGithubRefsOutput)
     .query(({ input }) =>
-      getService().searchGithubIssues(
+      getService().searchGithubRefs(
         input.directoryPath,
         input.query,
         input.limit,
+        input.kinds,
       ),
+    ),
+
+  getGithubIssue: publicProcedure
+    .input(getGithubIssueInput)
+    .output(getGithubIssueOutput)
+    .query(({ input }) =>
+      getService().getGithubIssue(input.owner, input.repo, input.number),
+    ),
+
+  getGithubPullRequest: publicProcedure
+    .input(getGithubPullRequestInput)
+    .output(getGithubPullRequestOutput)
+    .query(({ input }) =>
+      getService().getGithubPullRequest(input.owner, input.repo, input.number),
     ),
 
   onCreatePrProgress: publicProcedure.subscription(async function* (opts) {

--- a/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.test.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.test.tsx
@@ -59,7 +59,7 @@ vi.mock("@renderer/trpc/client", () => ({
       getGhStatus: {
         queryOptions: () => ({}),
       },
-      searchGithubIssues: {
+      searchGithubRefs: {
         queryOptions: () => ({}),
       },
     },

--- a/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/AttachmentMenu.tsx
@@ -158,7 +158,7 @@ export function AttachmentMenu({
           align="start"
           side="top"
           sideOffset={6}
-          className="min-w-[180px]"
+          className="min-w-[200px]"
         >
           <DropdownMenuItem onClick={handleAddFile}>
             <File size={14} weight="bold" />
@@ -170,7 +170,7 @@ export function AttachmentMenu({
             title={issueDisabledReason ?? undefined}
           >
             <GithubLogo size={14} weight="bold" />
-            Add issue
+            Add issue or pull request
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/code/src/renderer/features/message-editor/components/IssuePicker.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/IssuePicker.tsx
@@ -9,10 +9,14 @@ import {
 import { useTRPC } from "@renderer/trpc/client";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-import type { GithubIssueState } from "../types";
+import type { GithubRefKind, GithubRefState } from "../types";
 import type { MentionChip } from "../utils/content";
-import { githubIssueToMentionChip } from "../utils/githubIssueChip";
+import {
+  githubIssueToMentionChip,
+  githubPullRequestToMentionChip,
+} from "../utils/githubIssueChip";
 import { IssueRow } from "./IssueRow";
+import { SuggestionStatus } from "./SuggestionStatus";
 
 interface IssuePickerProps {
   repoPath: string;
@@ -22,13 +26,15 @@ interface IssuePickerProps {
   anchor: React.RefObject<HTMLElement | null>;
 }
 
-type Issue = {
+type Ref = {
+  kind: GithubRefKind;
   number: number;
   title: string;
   url: string;
   repo: string;
-  state: GithubIssueState;
+  state: GithubRefState;
   labels: string[];
+  isDraft?: boolean;
 };
 
 export function IssuePicker({
@@ -60,8 +66,8 @@ export function IssuePicker({
     }
   }, [open]);
 
-  const { data: issues = [], isFetching } = useQuery(
-    trpc.git.searchGithubIssues.queryOptions(
+  const { data: refs = [], isFetching } = useQuery(
+    trpc.git.searchGithubRefs.queryOptions(
       {
         directoryPath: repoPath,
         query: debouncedQuery || undefined,
@@ -71,19 +77,25 @@ export function IssuePicker({
     ),
   );
 
-  const handleValueChange = (value: Issue | null) => {
+  const isLoading = isFetching || query !== debouncedQuery;
+
+  const handleValueChange = (value: Ref | null) => {
     if (!value) return;
-    onSelect(githubIssueToMentionChip(value));
+    onSelect(
+      value.kind === "pr"
+        ? githubPullRequestToMentionChip(value)
+        : githubIssueToMentionChip(value),
+    );
   };
 
   return (
-    <Combobox<Issue>
-      items={issues as Issue[]}
+    <Combobox<Ref>
+      items={refs as Ref[]}
       open={open}
       onOpenChange={(nextOpen) => onOpenChange(nextOpen)}
       inputValue={query}
       onInputValueChange={(value) => setQuery(value ?? "")}
-      onValueChange={(value) => handleValueChange(value as Issue | null)}
+      onValueChange={(value) => handleValueChange(value as Ref | null)}
       filter={null}
     >
       <ComboboxContent
@@ -96,19 +108,22 @@ export function IssuePicker({
         <ComboboxInput
           autoFocus
           showTrigger={false}
-          placeholder="Search issues..."
+          placeholder="Search issues or pull requests..."
         />
         <ComboboxEmpty>
-          {isFetching ? "Searching..." : "No issues found."}
+          <SuggestionStatus
+            loading={isLoading}
+            emptyMessage="No issues or pull requests found."
+          />
         </ComboboxEmpty>
         <ComboboxList>
-          {(issue: Issue) => (
+          {(ref: Ref) => (
             <ComboboxItem
-              key={issue.number}
-              value={issue}
+              key={`${ref.kind}-${ref.number}`}
+              value={ref}
               className="relative h-auto"
             >
-              <IssueRow issue={issue} />
+              <IssueRow issue={ref} />
             </ComboboxItem>
           )}
         </ComboboxList>

--- a/apps/code/src/renderer/features/message-editor/components/IssueRow.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/IssueRow.tsx
@@ -5,18 +5,26 @@ import {
   ItemMedia,
   ItemTitle,
 } from "@posthog/quill";
-import type { GithubIssueState } from "../types";
+import type { GithubRefKind, GithubRefState } from "../types";
 import { githubIssueStateColor } from "../utils/githubIssueChip";
 
 export interface IssueRowData {
+  kind: GithubRefKind;
   number: number;
   title: string;
-  state: GithubIssueState;
+  state: GithubRefState;
   repo: string;
   labels: string[];
+  isDraft?: boolean;
+}
+
+function refStateLabel(ref: IssueRowData): string {
+  if (ref.kind === "pr" && ref.isDraft && ref.state === "OPEN") return "Draft";
+  return ref.state.charAt(0) + ref.state.slice(1).toLowerCase();
 }
 
 export function IssueRow({ issue }: { issue: IssueRowData }) {
+  const kindLabel = issue.kind === "pr" ? "Pull request" : "Issue";
   return (
     <Item size="xs" className="border-0 p-0">
       <ItemMedia variant="icon" className="mt-1 self-start">
@@ -31,7 +39,7 @@ export function IssueRow({ issue }: { issue: IssueRowData }) {
           #{issue.number} - {issue.title}
         </ItemTitle>
         <ItemDescription className="text-left">
-          {issue.repo}
+          {kindLabel} · {refStateLabel(issue)} · {issue.repo}
           {issue.labels.length > 0 && ` · ${issue.labels.join(", ")}`}
         </ItemDescription>
       </ItemContent>

--- a/apps/code/src/renderer/features/message-editor/components/SuggestionStatus.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/SuggestionStatus.tsx
@@ -1,0 +1,25 @@
+import { Spinner } from "@posthog/quill";
+
+interface SuggestionStatusProps {
+  loading: boolean;
+  emptyMessage: string;
+  loadingMessage?: string;
+  className?: string;
+}
+
+export function SuggestionStatus({
+  loading,
+  emptyMessage,
+  loadingMessage = "Loading...",
+  className = "flex items-center gap-2 text-[var(--gray-11)]",
+}: SuggestionStatusProps) {
+  if (loading) {
+    return (
+      <span className={className}>
+        <Spinner className="h-3.5 w-3.5" />
+        <span>{loadingMessage}</span>
+      </span>
+    );
+  }
+  return <span className={className}>{emptyMessage}</span>;
+}

--- a/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
+++ b/apps/code/src/renderer/features/message-editor/suggestions/getSuggestions.ts
@@ -16,7 +16,10 @@ import type {
   FileSuggestionItem,
   IssueSuggestionItem,
 } from "../types";
-import { githubIssueToMentionChip } from "../utils/githubIssueChip";
+import {
+  githubIssueToMentionChip,
+  githubPullRequestToMentionChip,
+} from "../utils/githubIssueChip";
 
 const COMMAND_FUSE_OPTIONS: IFuseOptions<AvailableCommand> = {
   keys: [
@@ -110,8 +113,8 @@ export async function getIssueSuggestions(
   if (!repoPath) return [];
 
   try {
-    const issues = await queryClient.fetchQuery({
-      ...trpc.git.searchGithubIssues.queryOptions({
+    const refs = await queryClient.fetchQuery({
+      ...trpc.git.searchGithubRefs.queryOptions({
         directoryPath: repoPath,
         query: query || undefined,
         limit: 25,
@@ -119,17 +122,23 @@ export async function getIssueSuggestions(
       staleTime: 30_000,
     });
 
-    return issues.map((issue) => {
-      const chip = githubIssueToMentionChip(issue);
+    return refs.map((ref) => {
+      const chip =
+        ref.kind === "pr"
+          ? githubPullRequestToMentionChip(ref)
+          : githubIssueToMentionChip(ref);
       return {
         id: chip.id,
         label: chip.label,
-        number: issue.number,
-        title: issue.title,
-        url: issue.url,
-        repo: issue.repo,
-        state: issue.state,
-        labels: issue.labels,
+        chipType: chip.type,
+        kind: ref.kind,
+        number: ref.number,
+        title: ref.title,
+        url: ref.url,
+        repo: ref.repo,
+        state: ref.state,
+        labels: ref.labels,
+        isDraft: ref.isDraft,
       };
     });
   } catch {

--- a/apps/code/src/renderer/features/message-editor/tiptap/MentionChipNode.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/MentionChipNode.ts
@@ -9,7 +9,8 @@ export type ChipType =
   | "experiment"
   | "insight"
   | "feature_flag"
-  | "github_issue";
+  | "github_issue"
+  | "github_pr";
 
 export interface MentionChipAttrs {
   type: ChipType;

--- a/apps/code/src/renderer/features/message-editor/tiptap/MentionChipView.tsx
+++ b/apps/code/src/renderer/features/message-editor/tiptap/MentionChipView.tsx
@@ -6,6 +6,7 @@ import {
   FlagIcon,
   FlaskIcon,
   GithubLogoIcon,
+  GitPullRequestIcon,
   TerminalIcon,
   WarningIcon,
   XIcon,
@@ -25,6 +26,7 @@ const typeIconMap: Record<ChipType, React.ComponentType<{ size: number }>> = {
   file: FileTextIcon,
   command: TerminalIcon,
   github_issue: GithubLogoIcon,
+  github_pr: GitPullRequestIcon,
   error: WarningIcon,
   experiment: FlaskIcon,
   insight: ChartLineIcon,
@@ -76,19 +78,23 @@ function DefaultChip({
   const isCommand = type === "command";
   const prefix = isCommand ? "/" : "@";
   const isFile = type === "file";
+  const isGithubRef = type === "github_issue" || type === "github_pr";
+  const canOpenUrl = isGithubRef && /^https:\/\//.test(id);
 
   const chipContent = (
     <Chip
       size="xs"
       variant="outline"
       contentEditable={false}
-      onClick={
-        type === "github_issue" ? () => window.open(id, "_blank") : undefined
-      }
-      className={`${chipBase} ${type === "github_issue" ? "cursor-pointer!" : "cursor-default! active:translate-y-0!"} ${isCommand ? "cli-slash-command" : "cli-file-mention"} ${selected ? selectedRing : ""}`}
+      onClick={canOpenUrl ? () => window.open(id, "_blank") : undefined}
+      className={`${chipBase} max-w-full whitespace-nowrap ${isGithubRef ? "cursor-pointer!" : "cursor-default! active:translate-y-0!"} ${isCommand ? "cli-slash-command" : "cli-file-mention"} ${selected ? selectedRing : ""}`}
     >
       <IconCloseButton type={type as ChipType} onRemove={onRemove} />
-      {type === "github_issue" ? label : `${prefix}${label}`}
+      {isGithubRef ? (
+        <span className="min-w-0 truncate">{label}</span>
+      ) : (
+        `${prefix}${label}`
+      )}
     </Chip>
   );
 

--- a/apps/code/src/renderer/features/message-editor/tiptap/SuggestionList.tsx
+++ b/apps/code/src/renderer/features/message-editor/tiptap/SuggestionList.tsx
@@ -6,7 +6,6 @@ import {
   ItemMedia,
   ItemTitle,
   Kbd,
-  Spinner,
 } from "@posthog/quill";
 import {
   forwardRef,
@@ -16,6 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { SuggestionStatus } from "../components/SuggestionStatus";
 import type { SuggestionItem } from "../types";
 
 export interface SuggestionListRef {
@@ -96,15 +96,8 @@ export const SuggestionList = forwardRef<
   if (items.length === 0) {
     return (
       <div className={CONTAINER_CLASS}>
-        <div className="flex items-center gap-2 p-2 text-[var(--gray-11)]">
-          {loading ? (
-            <>
-              <Spinner className="h-3.5 w-3.5" />
-              <span>Loading...</span>
-            </>
-          ) : (
-            "No results found"
-          )}
+        <div className="p-2">
+          <SuggestionStatus loading={loading} emptyMessage="No results found" />
         </div>
       </div>
     );

--- a/apps/code/src/renderer/features/message-editor/tiptap/createSuggestionMention.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/createSuggestionMention.ts
@@ -146,7 +146,7 @@ export function createSuggestionMention<T extends SuggestionItem>(
           {
             type: "mentionChip",
             attrs: {
-              type: chipType,
+              type: item.chipType ?? chipType,
               id: item.id,
               label: item.label,
             },

--- a/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/apps/code/src/renderer/features/message-editor/tiptap/useTiptapEditor.ts
@@ -1,15 +1,25 @@
 import { sessionStoreSetters } from "@features/sessions/stores/sessionStore";
 import { useSettingsStore as useFeatureSettingsStore } from "@features/settings/stores/settingsStore";
+import { trpc } from "@renderer/trpc/client";
 import { toast } from "@renderer/utils/toast";
 import type { EditorView } from "@tiptap/pm/view";
 import { useEditor } from "@tiptap/react";
 import { getFilePath } from "@utils/getFilePath";
+import { queryClient } from "@utils/queryClient";
 import { isSendMessageSubmitKey } from "@utils/sendMessageKey";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePromptHistoryStore } from "../stores/promptHistoryStore";
 import type { FileAttachment, MentionChip } from "../utils/content";
 import { contentToXml, isContentEmpty } from "../utils/content";
+import {
+  githubIssueToMentionChip,
+  githubPullRequestToMentionChip,
+} from "../utils/githubIssueChip";
+import {
+  type ParsedGithubIssueUrl,
+  parseGithubIssueUrl,
+} from "../utils/githubIssueUrl";
 import { persistImageFile, persistTextContent } from "../utils/persistFile";
 import { getEditorExtensions } from "./extensions";
 import { type DraftContext, useDraftSync } from "./useDraftSync";
@@ -42,6 +52,25 @@ export interface UseTiptapEditorOptions {
 const EDITOR_CLASS =
   "cli-editor min-h-[1.5em] w-full break-words border-none bg-transparent pr-2 text-[14px] text-[var(--gray-12)] outline-none [overflow-wrap:break-word] [white-space:pre-wrap] [word-break:break-word]";
 
+function insertChipWithTrailingSpace(
+  view: EditorView,
+  attrs: {
+    type: MentionChip["type"];
+    id: string;
+    label: string;
+    pastedText?: boolean;
+  },
+): void {
+  const chipNode = view.state.schema.nodes.mentionChip.create({
+    pastedText: false,
+    ...attrs,
+  });
+  const space = view.state.schema.text(" ");
+  const { tr } = view.state;
+  tr.replaceSelectionWith(chipNode).insert(tr.selection.from, space);
+  view.dispatch(tr);
+}
+
 async function pasteTextAsFile(
   view: EditorView,
   text: string,
@@ -50,18 +79,93 @@ async function pasteTextAsFile(
   const result = await persistTextContent(text);
   pasteCountRef.current += 1;
   const lineCount = text.split("\n").length;
-  const label = `Pasted text #${pasteCountRef.current} (${lineCount} lines)`;
-  const chipNode = view.state.schema.nodes.mentionChip.create({
+  insertChipWithTrailingSpace(view, {
     type: "file",
     id: result.path,
-    label,
+    label: `Pasted text #${pasteCountRef.current} (${lineCount} lines)`,
     pastedText: true,
   });
-  const space = view.state.schema.text(" ");
-  const { tr } = view.state;
-  tr.replaceSelectionWith(chipNode).insert(tr.selection.from, space);
-  view.dispatch(tr);
   view.focus();
+}
+
+function buildGithubRefPlaceholderChip(
+  parsed: ParsedGithubIssueUrl,
+): MentionChip {
+  const source = {
+    number: parsed.number,
+    title: "Loading...",
+    url: parsed.normalizedUrl,
+  };
+  return parsed.kind === "pr"
+    ? githubPullRequestToMentionChip(source)
+    : githubIssueToMentionChip(source);
+}
+
+function insertGithubRefPlaceholder(
+  view: EditorView,
+  parsed: ParsedGithubIssueUrl,
+): void {
+  insertChipWithTrailingSpace(view, buildGithubRefPlaceholderChip(parsed));
+}
+
+async function fetchGithubRefTitle(
+  parsed: ParsedGithubIssueUrl,
+): Promise<string | null> {
+  const input = {
+    owner: parsed.owner,
+    repo: parsed.repo,
+    number: parsed.number,
+  };
+  try {
+    if (parsed.kind === "pr") {
+      const pr = await queryClient.fetchQuery({
+        ...trpc.git.getGithubPullRequest.queryOptions(input),
+        staleTime: 60_000,
+      });
+      return pr?.title ?? null;
+    }
+    const issue = await queryClient.fetchQuery({
+      ...trpc.git.getGithubIssue.queryOptions(input),
+      staleTime: 60_000,
+    });
+    return issue?.title ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveGithubRefChip(
+  view: EditorView,
+  parsed: ParsedGithubIssueUrl,
+): Promise<void> {
+  const chipType = parsed.kind === "pr" ? "github_pr" : "github_issue";
+  const placeholderLabel = `#${parsed.number} - Loading...`;
+  const title = await fetchGithubRefTitle(parsed);
+  const resolvedLabel =
+    title !== null ? `#${parsed.number} - ${title}` : `#${parsed.number}`;
+
+  if (view.isDestroyed) return;
+
+  const { doc, tr } = view.state;
+  let updated = false;
+  doc.descendants((node, pos) => {
+    if (
+      node.type.name !== "mentionChip" ||
+      node.attrs.type !== chipType ||
+      node.attrs.id !== parsed.normalizedUrl ||
+      node.attrs.label !== placeholderLabel
+    ) {
+      return true;
+    }
+    tr.setNodeMarkup(pos, undefined, {
+      ...node.attrs,
+      label: resolvedLabel,
+    });
+    updated = true;
+    return false;
+  });
+
+  if (updated) view.dispatch(tr);
 }
 
 function showPasteHint(message: string, description: string): void {
@@ -285,23 +389,36 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
           return false;
         },
         handlePaste: (view, event) => {
-          // Auto-wrap selected text as markdown link when pasting a URL
           const { from, to } = view.state.selection;
-          if (from !== to) {
-            const pastedUrl = event.clipboardData
-              ?.getData("text/plain")
-              ?.trim();
-            if (pastedUrl && /^https?:\/\/\S+$/.test(pastedUrl)) {
+          const clipboardText = event.clipboardData?.getData("text/plain");
+          const trimmedClipboardText = clipboardText?.trim();
+
+          // Auto-wrap selected text as markdown link when pasting a URL
+          if (
+            from !== to &&
+            trimmedClipboardText &&
+            /^https?:\/\/\S+$/.test(trimmedClipboardText)
+          ) {
+            event.preventDefault();
+            const selectedText = view.state.doc.textBetween(from, to);
+            const linkMarkdown = `[${selectedText}](${trimmedClipboardText})`;
+            view.dispatch(
+              view.state.tr.replaceWith(
+                from,
+                to,
+                view.state.schema.text(linkMarkdown),
+              ),
+            );
+            return true;
+          }
+
+          // Auto-convert a pasted GitHub issue or PR URL into a chip
+          if (from === to && trimmedClipboardText) {
+            const parsedRef = parseGithubIssueUrl(trimmedClipboardText);
+            if (parsedRef) {
               event.preventDefault();
-              const selectedText = view.state.doc.textBetween(from, to);
-              const linkMarkdown = `[${selectedText}](${pastedUrl})`;
-              view.dispatch(
-                view.state.tr.replaceWith(
-                  from,
-                  to,
-                  view.state.schema.text(linkMarkdown),
-                ),
-              );
+              insertGithubRefPlaceholder(view, parsedRef);
+              void resolveGithubRefChip(view, parsedRef);
               return true;
             }
           }
@@ -342,19 +459,18 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
           }
 
           // Auto-convert long pasted text into a file attachment
-          const pastedText = event.clipboardData?.getData("text/plain");
           const autoConvertThreshold =
             useFeatureSettingsStore.getState().autoConvertLongText;
           if (
-            pastedText &&
+            clipboardText &&
             autoConvertThreshold !== "off" &&
-            pastedText.length > Number(autoConvertThreshold)
+            clipboardText.length > Number(autoConvertThreshold)
           ) {
             event.preventDefault();
 
             (async () => {
               try {
-                await pasteTextAsFile(view, pastedText, pasteCountRef);
+                await pasteTextAsFile(view, clipboardText, pasteCountRef);
                 showPasteHint(
                   "Pasted as file attachment",
                   "Click the chip to convert back to text.",
@@ -367,7 +483,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
             return true;
           }
 
-          if (pastedText && pastedText.length > 200) {
+          if (clipboardText && clipboardText.length > 200) {
             showPasteHint(
               "Pasted as text",
               "Use ⌘⇧V to paste as a file attachment instead.",

--- a/apps/code/src/renderer/features/message-editor/types.ts
+++ b/apps/code/src/renderer/features/message-editor/types.ts
@@ -1,12 +1,13 @@
 import type { AvailableCommand } from "@agentclientprotocol/sdk";
-import type { GithubIssueState } from "@main/services/git/schemas";
+import type { GithubRefKind, GithubRefState } from "@main/services/git/schemas";
 import type {
   EditorContent,
   FileAttachment,
   MentionChip,
 } from "./utils/content";
 
-export type { GithubIssueState };
+export type GithubIssueState = GithubRefState;
+export type { GithubRefKind, GithubRefState };
 
 export interface EditorHandle {
   focus: () => void;
@@ -26,6 +27,7 @@ export interface SuggestionItem {
   label: string;
   description?: string;
   filename?: string;
+  chipType?: MentionChip["type"];
 }
 
 export interface FileSuggestionItem extends SuggestionItem {
@@ -37,12 +39,14 @@ export interface CommandSuggestionItem extends SuggestionItem {
 }
 
 export interface IssueSuggestionItem extends SuggestionItem {
+  kind: GithubRefKind;
   number: number;
   title: string;
   url: string;
   repo: string;
-  state: GithubIssueState;
+  state: GithubRefState;
   labels: string[];
+  isDraft?: boolean;
 }
 
 export type SuggestionLoadingState = "idle" | "loading" | "error" | "success";

--- a/apps/code/src/renderer/features/message-editor/utils/content.test.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/content.test.ts
@@ -58,6 +58,57 @@ describe("xmlToContent", () => {
     }
   });
 
+  it("parses github_pr tags with title", () => {
+    const xml =
+      '<github_pr number="123" title="Ship it" url="https://github.com/org/repo/pull/123" />';
+    expect(xmlToContent(xml).segments).toEqual([
+      {
+        type: "chip",
+        chip: {
+          type: "github_pr",
+          id: "https://github.com/org/repo/pull/123",
+          label: "#123 - Ship it",
+        },
+      },
+    ]);
+  });
+
+  it("serializes a fallback-labeled github_issue chip with an empty title", () => {
+    const content: EditorContent = {
+      segments: [
+        {
+          type: "chip",
+          chip: {
+            type: "github_issue",
+            id: "https://github.com/org/repo/issues/1454",
+            label: "#1454",
+          },
+        },
+      ],
+    };
+    expect(contentToXml(content)).toBe(
+      '<github_issue number="1454" title="" url="https://github.com/org/repo/issues/1454" />',
+    );
+  });
+
+  it("round-trips a github_pr chip", () => {
+    const content: EditorContent = {
+      segments: [
+        {
+          type: "chip",
+          chip: {
+            type: "github_pr",
+            id: "https://github.com/org/repo/pull/42",
+            label: "#42 - Fix thing",
+          },
+        },
+      ],
+    };
+    expect(xmlToContent(contentToXml(content)).segments).toEqual(
+      content.segments,
+    );
+  });
+
   it.each([
     ["error", "err-1"],
     ["experiment", "exp-1"],

--- a/apps/code/src/renderer/features/message-editor/utils/content.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/content.ts
@@ -8,7 +8,8 @@ export interface MentionChip {
     | "experiment"
     | "insight"
     | "feature_flag"
-    | "github_issue";
+    | "github_issue"
+    | "github_pr";
   id: string;
   label: string;
 }
@@ -57,11 +58,12 @@ export function contentToXml(content: EditorContent): string {
         return `<insight id="${escapedId}" />`;
       case "feature_flag":
         return `<feature_flag id="${escapedId}" />`;
-      case "github_issue": {
-        const numberMatch = chip.label.match(/^#(\d+)/);
-        const number = numberMatch ? numberMatch[1] : "";
-        const title = chip.label.replace(/^#\d+\s*-\s*/, "");
-        return `<github_issue number="${escapeXmlAttr(number)}" title="${escapeXmlAttr(title)}" url="${escapedId}" />`;
+      case "github_issue":
+      case "github_pr": {
+        const labelMatch = chip.label.match(/^#(\d+)(?:\s*-\s*(.*))?$/);
+        const number = labelMatch?.[1] ?? "";
+        const title = labelMatch?.[2] ?? "";
+        return `<${chip.type} number="${escapeXmlAttr(number)}" title="${escapeXmlAttr(title)}" url="${escapedId}" />`;
       }
       default:
         return `@${chip.label}`;
@@ -81,7 +83,7 @@ export function contentToXml(content: EditorContent): string {
 }
 
 const CHIP_TAG_REGEX =
-  /<(file|error|experiment|insight|feature_flag|github_issue)\b([^>]*?)\s*\/>/g;
+  /<(file|error|experiment|insight|feature_flag|github_issue|github_pr)\b([^>]*?)\s*\/>/g;
 const ATTR_REGEX = /(\w+)="([^"]*)"/g;
 
 function deriveFileLabel(filePath: string): string {
@@ -115,13 +117,14 @@ function chipFromTag(tag: string, rawAttrs: string): MentionChip | null {
       if (!id) return null;
       return { type: tag, id, label: id };
     }
-    case "github_issue": {
+    case "github_issue":
+    case "github_pr": {
       const number = attrs.number ?? "";
       const title = attrs.title ?? "";
       const url = attrs.url ?? "";
       if (!number && !url) return null;
       const label = title ? `#${number} - ${title}` : `#${number}`;
-      return { type: "github_issue", id: url, label };
+      return { type: tag, id: url, label };
     }
     default:
       return null;

--- a/apps/code/src/renderer/features/message-editor/utils/githubIssueChip.test.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/githubIssueChip.test.ts
@@ -22,13 +22,19 @@ describe("githubIssueToMentionChip", () => {
 });
 
 describe("githubIssueStateColor", () => {
-  it("returns the OPEN color for open issues", () => {
+  it("returns the OPEN color", () => {
     expect(githubIssueStateColor("OPEN")).toBe(GITHUB_ISSUE_STATE_COLORS.OPEN);
   });
 
-  it("returns the CLOSED color for closed issues", () => {
+  it("returns the CLOSED color", () => {
     expect(githubIssueStateColor("CLOSED")).toBe(
       GITHUB_ISSUE_STATE_COLORS.CLOSED,
+    );
+  });
+
+  it("returns the MERGED color", () => {
+    expect(githubIssueStateColor("MERGED")).toBe(
+      GITHUB_ISSUE_STATE_COLORS.MERGED,
     );
   });
 });

--- a/apps/code/src/renderer/features/message-editor/utils/githubIssueChip.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/githubIssueChip.ts
@@ -1,4 +1,4 @@
-import type { GithubIssueState } from "../types";
+import type { GithubRefState } from "../types";
 import type { MentionChip } from "./content";
 
 export interface GithubIssueChipSource {
@@ -17,11 +17,22 @@ export function githubIssueToMentionChip(
   };
 }
 
-export const GITHUB_ISSUE_STATE_COLORS: Record<GithubIssueState, string> = {
+export function githubPullRequestToMentionChip(
+  pr: GithubIssueChipSource,
+): MentionChip {
+  return {
+    type: "github_pr",
+    id: pr.url,
+    label: `#${pr.number} - ${pr.title}`,
+  };
+}
+
+export const GITHUB_ISSUE_STATE_COLORS: Record<GithubRefState, string> = {
   OPEN: "#238636",
   CLOSED: "#AB7DF8",
+  MERGED: "#8957E5",
 };
 
-export function githubIssueStateColor(state: GithubIssueState): string {
+export function githubIssueStateColor(state: GithubRefState): string {
   return GITHUB_ISSUE_STATE_COLORS[state];
 }

--- a/apps/code/src/renderer/features/message-editor/utils/githubIssueUrl.test.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/githubIssueUrl.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ParsedGithubIssueUrl,
+  parseGithubIssueUrl,
+} from "./githubIssueUrl";
+
+describe("parseGithubIssueUrl", () => {
+  const accepts: Array<{
+    name: string;
+    input: string;
+    expected: ParsedGithubIssueUrl;
+  }> = [
+    {
+      name: "canonical issue URL",
+      input: "https://github.com/PostHog/code/issues/1808",
+      expected: {
+        kind: "issue",
+        owner: "PostHog",
+        repo: "code",
+        number: 1808,
+        normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+      },
+    },
+    {
+      name: "pull request URL",
+      input: "https://github.com/PostHog/code/pull/1454",
+      expected: {
+        kind: "pr",
+        owner: "PostHog",
+        repo: "code",
+        number: 1454,
+        normalizedUrl: "https://github.com/PostHog/code/pull/1454",
+      },
+    },
+    {
+      name: "pull request URL with files tab suffix",
+      input: "https://github.com/PostHog/code/pull/1454/files",
+      expected: {
+        kind: "pr",
+        owner: "PostHog",
+        repo: "code",
+        number: 1454,
+        normalizedUrl: "https://github.com/PostHog/code/pull/1454",
+      },
+    },
+    {
+      name: "surrounding whitespace",
+      input: "  https://github.com/PostHog/code/issues/1808\n",
+      expected: {
+        kind: "issue",
+        owner: "PostHog",
+        repo: "code",
+        number: 1808,
+        normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+      },
+    },
+    {
+      name: "fragment is stripped from normalized URL",
+      input: "https://github.com/PostHog/code/issues/1808#issuecomment-123",
+      expected: {
+        kind: "issue",
+        owner: "PostHog",
+        repo: "code",
+        number: 1808,
+        normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+      },
+    },
+    {
+      name: "query string is stripped from normalized URL",
+      input: "https://github.com/PostHog/code/issues/1808?foo=bar",
+      expected: {
+        kind: "issue",
+        owner: "PostHog",
+        repo: "code",
+        number: 1808,
+        normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+      },
+    },
+    {
+      name: "http scheme",
+      input: "http://github.com/PostHog/code/issues/1",
+      expected: {
+        kind: "issue",
+        owner: "PostHog",
+        repo: "code",
+        number: 1,
+        normalizedUrl: "https://github.com/PostHog/code/issues/1",
+      },
+    },
+  ];
+
+  it.each(accepts)("accepts $name", ({ input, expected }) => {
+    expect(parseGithubIssueUrl(input)).toEqual(expected);
+  });
+
+  const rejects: Array<{ name: string; input: string }> = [
+    {
+      name: "non-github host",
+      input: "https://gitlab.com/PostHog/code/issues/1808",
+    },
+    { name: "non-URL text", input: "not a url" },
+    { name: "empty string", input: "" },
+    {
+      name: "missing issue number",
+      input: "https://github.com/PostHog/code/issues/",
+    },
+    {
+      name: "missing PR number",
+      input: "https://github.com/PostHog/code/pull/",
+    },
+    {
+      name: "unknown path segment",
+      input: "https://github.com/PostHog/code/blob/main/README.md",
+    },
+  ];
+
+  it.each(rejects)("rejects $name", ({ input }) => {
+    expect(parseGithubIssueUrl(input)).toBeNull();
+  });
+});

--- a/apps/code/src/renderer/features/message-editor/utils/githubIssueUrl.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/githubIssueUrl.ts
@@ -1,0 +1,33 @@
+import type { GithubRefKind } from "../types";
+
+export type { GithubRefKind };
+
+export interface ParsedGithubIssueUrl {
+  kind: GithubRefKind;
+  owner: string;
+  repo: string;
+  number: number;
+  normalizedUrl: string;
+}
+
+const GITHUB_ISSUE_URL_PATTERN =
+  /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(issues|pull)\/(\d+)(?:[/?#].*)?$/;
+
+export function parseGithubIssueUrl(text: string): ParsedGithubIssueUrl | null {
+  const trimmed = text.trim();
+  const match = trimmed.match(GITHUB_ISSUE_URL_PATTERN);
+  if (!match) return null;
+
+  const [, owner, repo, segment, rawNumber] = match;
+  const number = Number(rawNumber);
+  if (!Number.isInteger(number) || number <= 0) return null;
+
+  const kind: GithubRefKind = segment === "pull" ? "pr" : "issue";
+  return {
+    kind,
+    owner,
+    repo,
+    number,
+    normalizedUrl: `https://github.com/${owner}/${repo}/${segment}/${number}`,
+  };
+}


### PR DESCRIPTION
This started as a humble small PR to automatically convert pasted issues into GH issue chips  
But then I realise I wanted to support mentioning PRs too, so I refactored the whole thing for that  
Closes #1816  
  
![CleanShot 2026-04-22 at 16.24.26.gif](https://app.graphite.com/user-attachments/assets/d360b639-c8d2-4e5a-a805-ba6ab9d67479.gif)

