### PR TITLE
feat(inbox): gate remaining inbox surfaces behind posthog-code-inbox flag

### DIFF
--- a/apps/code/src/renderer/components/GlobalEventHandlers.tsx
+++ b/apps/code/src/renderer/components/GlobalEventHandlers.tsx
@@ -8,6 +8,7 @@ import { useSidebarStore } from "@features/sidebar/stores/sidebarStore";
 import { useTasks } from "@features/tasks/hooks/useTasks";
 import { useFocusWorkspace } from "@features/workspace/hooks/useFocusWorkspace";
 import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { SHORTCUTS } from "@renderer/constants/keyboard-shortcuts";
 import { useTRPC } from "@renderer/trpc";
 import type { Task } from "@shared/types";
@@ -170,10 +171,15 @@ export function GlobalEventHandlers({
     setReviewMode(currentTaskId, mode === "closed" ? "split" : "closed");
   }, [currentTaskId, getReviewMode, setReviewMode]);
 
+  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+
   useHotkeys(SHORTCUTS.TOGGLE_LEFT_SIDEBAR, toggleLeftSidebar, globalOptions);
   useHotkeys(SHORTCUTS.TOGGLE_REVIEW_PANEL, handleToggleReview, globalOptions);
   useHotkeys(SHORTCUTS.SHORTCUTS_SHEET, onToggleShortcutsSheet, globalOptions);
-  useHotkeys(SHORTCUTS.INBOX, navigateToInbox, globalOptions);
+  useHotkeys(SHORTCUTS.INBOX, navigateToInbox, {
+    ...globalOptions,
+    enabled: inboxEnabled,
+  });
   useHotkeys(SHORTCUTS.PREV_TASK, handlePrevTask, globalOptions, [
     handlePrevTask,
   ]);

--- a/apps/code/src/renderer/components/KeyboardShortcutsSheet.tsx
+++ b/apps/code/src/renderer/components/KeyboardShortcutsSheet.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { Box, Dialog, Flex, Text } from "@radix-ui/themes";
 import {
   CATEGORY_LABELS,
@@ -130,7 +131,14 @@ function ShortcutsHeader() {
 }
 
 export function KeyboardShortcutsList() {
-  const shortcutsByCategory = useMemo(() => getShortcutsByCategory(), []);
+  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const shortcutsByCategory = useMemo(() => {
+    const grouped = getShortcutsByCategory();
+    if (!inboxEnabled) {
+      grouped.navigation = grouped.navigation.filter((s) => s.id !== "inbox");
+    }
+    return grouped;
+  }, [inboxEnabled]);
 
   const categoryOrder: ShortcutCategory[] = [
     "general",

--- a/apps/code/src/renderer/features/onboarding/components/WelcomeScreen.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/WelcomeScreen.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import {
   ArrowRight,
   ChartLine,
@@ -8,37 +9,42 @@ import {
 } from "@phosphor-icons/react";
 import { Button, Flex, Text } from "@radix-ui/themes";
 import explorerHog from "@renderer/assets/images/hedgehogs/explorer-hog.png";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FeatureListItem } from "./FeatureListItem";
 import { OnboardingHogTip } from "./OnboardingHogTip";
 import { StepActions } from "./StepActions";
 
-const FEATURES = [
+const ALL_FEATURES = [
   {
+    id: "signals-inbox",
     icon: <Tray size={24} />,
     title: "Your signals inbox",
     description:
       "Automatically surfaces the highest-impact work from your product data so you always know what to do next.",
   },
   {
+    id: "product-data",
     icon: <ChartLine size={24} />,
     title: "Product data as context",
     description:
       "Your agents have context from your analytics, session replays and feature flags built in.",
   },
   {
+    id: "any-model",
     icon: <Robot size={24} />,
     title: "Any model, any harness",
     description:
       "Bring your own agent framework or use our built-in harnesses. Swap models without changing your workflow.",
   },
   {
+    id: "ship-work",
     icon: <Cloud size={24} />,
     title: "Ship work, not messages",
     description:
       "Run tasks in parallel across local and cloud environments. Work gets done whether you're watching or not.",
   },
   {
+    id: "review-ship",
     icon: <GitPullRequest size={24} />,
     title: "Review and ship with confidence",
     description:
@@ -51,18 +57,26 @@ interface WelcomeScreenProps {
 }
 
 const CYCLE_INTERVAL_MS = 2500;
-const CYCLE_START_DELAY_MS = FEATURES.length * 100 + 400;
+const CYCLE_START_DELAY_MS = ALL_FEATURES.length * 100 + 400;
 
 export function WelcomeScreen({ onNext }: WelcomeScreenProps) {
+  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const features = useMemo(
+    () =>
+      inboxEnabled
+        ? ALL_FEATURES
+        : ALL_FEATURES.filter((f) => f.id !== "signals-inbox"),
+    [inboxEnabled],
+  );
   const [activeIndex, setActiveIndex] = useState(-1);
   const timerRef = useRef<ReturnType<typeof setInterval>>(null);
 
   const startCycling = useCallback(() => {
     if (timerRef.current) clearInterval(timerRef.current);
     timerRef.current = setInterval(() => {
-      setActiveIndex((prev) => (prev + 1) % FEATURES.length);
+      setActiveIndex((prev) => (prev + 1) % features.length);
     }, CYCLE_INTERVAL_MS);
-  }, []);
+  }, [features.length]);
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -126,7 +140,7 @@ export function WelcomeScreen({ onNext }: WelcomeScreenProps) {
             </Flex>
 
             <Flex direction="column" style={{ width: "100%", gap: 8 }}>
-              {FEATURES.map((feature, index) => (
+              {features.map((feature, index) => (
                 <FeatureListItem
                   key={feature.title}
                   icon={feature.icon}

--- a/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
@@ -1,5 +1,6 @@
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { trpcClient } from "@renderer/trpc/client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ONBOARDING_STEPS, type OnboardingStep } from "../types";
@@ -78,13 +79,18 @@ export function useOnboardingFlow() {
   );
 
   const hasCodeAccess = useAuthStateValue((state) => state.hasCodeAccess);
+  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
 
   const activeSteps = useMemo(() => {
+    let steps = ONBOARDING_STEPS as OnboardingStep[];
     if (hasCodeAccess === true) {
-      return ONBOARDING_STEPS.filter((s) => s !== "invite-code");
+      steps = steps.filter((s) => s !== "invite-code");
     }
-    return ONBOARDING_STEPS;
-  }, [hasCodeAccess]);
+    if (!inboxEnabled) {
+      steps = steps.filter((s) => s !== "signals");
+    }
+    return steps;
+  }, [hasCodeAccess, inboxEnabled]);
 
   useEffect(() => {
     if (!activeSteps.includes(currentStep)) {

--- a/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
+++ b/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
@@ -129,14 +129,17 @@ export function SettingsDialog() {
   const { data: user } = useCurrentUser({ client });
   const { seat, planLabel } = useSeat();
   const billingEnabled = useFeatureFlag("posthog-code-billing");
+  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
   const logoutMutation = useLogoutMutation();
 
   const sidebarItems = useMemo(
     () =>
-      billingEnabled
-        ? SIDEBAR_ITEMS
-        : SIDEBAR_ITEMS.filter((item) => item.id !== "plan-usage"),
-    [billingEnabled],
+      SIDEBAR_ITEMS.filter((item) => {
+        if (item.id === "plan-usage" && !billingEnabled) return false;
+        if (item.id === "signals" && !inboxEnabled) return false;
+        return true;
+      }),
+    [billingEnabled, inboxEnabled],
   );
 
   useHotkeys("escape", close, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #1828 gated the sidebar inbox item and inbox view behind the `posthog-code-inbox` feature flag, but several other surfaces still reference the inbox unconditionally. When the flag is off, users can still see signals-related UI in onboarding, settings, the welcome screen, and the keyboard shortcuts sheet — which is confusing and defeats the purpose of the kill switch.

Stacks on #1828.

## Changes

Gates all remaining inbox/signals surfaces behind `posthog-code-inbox`:

- **Onboarding flow** (`useOnboardingFlow.ts`): Filters out the `"signals"` onboarding step when the flag is off, using the same pattern already used for `"invite-code"`.
- **Settings dialog** (`SettingsDialog.tsx`): Hides the "Signals" sidebar entry when the flag is off, using the same filter pattern already used for `"plan-usage"` / billing.
- **Welcome screen** (`WelcomeScreen.tsx`): Removes the "Your signals inbox" feature bullet from the welcome features list when the flag is off.
- **Keyboard shortcut** (`GlobalEventHandlers.tsx`): Disables the `mod+i` inbox hotkey when the flag is off via `enabled: inboxEnabled`.
- **Shortcuts sheet** (`KeyboardShortcutsSheet.tsx`): Hides the "Open inbox" shortcut from the keyboard shortcuts list when the flag is off.

## How did you test this?

- Verified typecheck passes (all errors are pre-existing unrelated `@posthog/platform` / `@posthog/git` module resolution issues)
- Verified biome lint passes with no new warnings
- Reviewed all changes manually for correctness
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1776858877338979?thread_ts=1776858877.338979&cid=C09SK2PAGKF)

<div><a href="https://cursor.com/agents/bc-876f09bd-96b2-57b4-a31a-883fa1d66eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-876f09bd-96b2-57b4-a31a-883fa1d66eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

