### PR TITLE
fix(code): excluding cc plans from the cloud diff

### DIFF
--- a/apps/code/src/renderer/features/task-detail/utils/cloudToolChanges.test.ts
+++ b/apps/code/src/renderer/features/task-detail/utils/cloudToolChanges.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractCloudFileContent,
+  extractCloudToolChangedFiles,
   type ParsedToolCall,
 } from "./cloudToolChanges";
 
@@ -33,6 +34,35 @@ function makeToolCalls(
 ): Map<string, ParsedToolCall> {
   return new Map(calls.map((tc, i) => [tc.toolCallId || `tc-${i}`, tc]));
 }
+
+describe("extractCloudToolChangedFiles", () => {
+  it("excludes plan files from changed files", () => {
+    const calls = makeToolCalls(
+      toolCall({
+        toolCallId: "tc-plan",
+        kind: "write",
+        locations: [
+          {
+            path: "/home/user/.claude/plans/breezy-squishing-twilight.md",
+          },
+        ],
+        content: diffContent(
+          "/home/user/.claude/plans/breezy-squishing-twilight.md",
+          "# Plan\n\nDo stuff",
+        ),
+      }),
+      toolCall({
+        toolCallId: "tc-real",
+        kind: "edit",
+        locations: [{ path: "src/app.ts" }],
+        content: diffContent("src/app.ts", "new code", "old code"),
+      }),
+    );
+    const result = extractCloudToolChangedFiles(calls);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("src/app.ts");
+  });
+});
 
 describe("extractCloudFileContent", () => {
   it("returns untouched for an empty tool calls map", () => {

--- a/apps/code/src/renderer/features/task-detail/utils/cloudToolChanges.ts
+++ b/apps/code/src/renderer/features/task-detail/utils/cloudToolChanges.ts
@@ -252,6 +252,7 @@ export function extractCloudToolChangedFiles(
     const path =
       diff?.path ?? (kind === "move" ? destinationPath : locationPath);
     if (!path) continue;
+    if (path.includes(".claude/plans/")) continue;
 
     let file: ChangedFile;
     if (kind === "move") {


### PR DESCRIPTION
## Summary

  - Exclude Claude Code plan files (`.claude/plans/`) from the cloud diff file list so they don't show up as changed files in the task detail view