### PR TITLE
fix(onboarding): complete onboarding when last step continue is pressed

### DIFF
--- a/apps/code/src/renderer/features/onboarding/components/OnboardingFlow.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/OnboardingFlow.tsx
@@ -28,6 +28,7 @@ export function OnboardingFlow() {
   const {
     currentStep,
     activeSteps,
+    isLastStep,
     direction,
     next,
     back,
@@ -46,12 +47,10 @@ export function OnboardingFlow() {
   );
   usePrefetchSignalData();
 
-  useHotkeys("right", next, { enableOnFormTags: false }, [next]);
-  useHotkeys("left", back, { enableOnFormTags: false }, [back]);
+  const handleNext = isLastStep ? completeOnboarding : next;
 
-  const handleComplete = () => {
-    completeOnboarding();
-  };
+  useHotkeys("right", handleNext, { enableOnFormTags: false }, [handleNext]);
+  useHotkeys("left", back, { enableOnFormTags: false }, [back]);
 
   const footerRight = (
     <Flex gap="5">
@@ -75,7 +74,7 @@ export function OnboardingFlow() {
           size="1"
           variant="ghost"
           color="gray"
-          onClick={handleComplete}
+          onClick={completeOnboarding}
           style={{ opacity: 0.5 }}
         >
           <ArrowRight size={14} weight="bold" />
@@ -100,7 +99,7 @@ export function OnboardingFlow() {
               transition={{ duration: 0.3 }}
               style={{ width: "100%", flex: 1, minHeight: 0 }}
             >
-              <WelcomeScreen onNext={next} />
+              <WelcomeScreen onNext={handleNext} />
             </motion.div>
           )}
 
@@ -115,7 +114,7 @@ export function OnboardingFlow() {
               transition={{ duration: 0.3 }}
               style={{ width: "100%", flex: 1, minHeight: 0 }}
             >
-              <ProjectSelectStep onNext={next} onBack={back} />
+              <ProjectSelectStep onNext={handleNext} onBack={back} />
             </motion.div>
           )}
 
@@ -130,7 +129,7 @@ export function OnboardingFlow() {
               transition={{ duration: 0.3 }}
               style={{ width: "100%", flex: 1, minHeight: 0 }}
             >
-              <InviteCodeStep onNext={next} onBack={back} />
+              <InviteCodeStep onNext={handleNext} onBack={back} />
             </motion.div>
           )}
 
@@ -146,7 +145,7 @@ export function OnboardingFlow() {
               style={{ width: "100%", flex: 1, minHeight: 0 }}
             >
               <GitIntegrationStep
-                onNext={next}
+                onNext={handleNext}
                 onBack={back}
                 selectedDirectory={selectedDirectory}
                 detectedRepo={detectedRepo}
@@ -167,7 +166,7 @@ export function OnboardingFlow() {
               transition={{ duration: 0.3 }}
               style={{ width: "100%", flex: 1, minHeight: 0 }}
             >
-              <CliInstallStep onNext={next} onBack={back} />
+              <CliInstallStep onNext={handleNext} onBack={back} />
             </motion.div>
           )}
 
@@ -182,7 +181,7 @@ export function OnboardingFlow() {
               transition={{ duration: 0.3 }}
               style={{ width: "100%", flex: 1, minHeight: 0 }}
             >
-              <SignalsStep onNext={handleComplete} onBack={back} />
+              <SignalsStep onNext={handleNext} onBack={back} />
             </motion.div>
           )}
         </AnimatePresence>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the `posthog-code-inbox` feature flag is off, pressing "Continue" (or "Skip for now") on the "Install required tools" step does nothing — the user is stuck and can't finish onboarding.

## Changes

The `"signals"` step is filtered out of `activeSteps` when the flag is off, making `"install-cli"` the last step. But `next()` is a no-op on the last step, and `completeOnboarding()` was only wired to the signals step's `onNext` handler.

Replaced the per-step `onNext` wiring with a unified `handleNext` that calls `completeOnboarding` when on the last active step and `next()` otherwise. This works regardless of which step ends up being last (whether signals is filtered out or not).

## How did you test this?

- Verified typecheck passes (no onboarding-related errors)
- Verified biome lint passes with no fixes needed
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1776858877338979?thread_ts=1776858877.338979&cid=C09SK2PAGKF)

<div><a href="https://cursor.com/agents/bc-261c6e6f-e719-5fde-ae2c-7582f5eda5a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-261c6e6f-e719-5fde-ae2c-7582f5eda5a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

