### PR TITLE
fix(agent): allow bypassPermissions switch in sandboxed sessions

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -24,6 +24,7 @@ import {
 import { getFilePath } from "@utils/getFilePath";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getSessionService } from "../service/service";
+import { flattenSelectOptions } from "../stores/sessionStore";
 import {
   useSessionViewActions,
   useShowRawLogs,
@@ -67,6 +68,25 @@ interface SessionViewProps {
 
 const DEFAULT_ERROR_MESSAGE =
   "Failed to resume this session. The working directory may have been deleted. Please start a new session.";
+
+/**
+ * When an allow_always permission is granted outside a mode-switch prompt,
+ * ratchet the session to the closest "auto-accept edits" preset offered by
+ * this adapter's mode catalog. Claude exposes `acceptEdits`; Codex has no
+ * exact equivalent, so fall back to `auto`. Returns undefined if neither is
+ * available (in which case leave the current mode untouched).
+ */
+function resolveAllowAlwaysUpgradeMode(
+  modeOption: ReturnType<typeof useModeConfigOptionForTask>,
+): string | undefined {
+  if (modeOption?.type !== "select") return undefined;
+  const availableIds = new Set(
+    flattenSelectOptions(modeOption.options).map((opt) => opt.value),
+  );
+  if (availableIds.has("acceptEdits")) return "acceptEdits";
+  if (availableIds.has("auto")) return "auto";
+  return undefined;
+}
 
 export function SessionView({
   events,
@@ -228,11 +248,18 @@ export function SessionView({
       const isModeSwitch =
         firstPendingPermission.toolCall?.kind === "switch_mode";
       if (selectedOption?.kind === "allow_always" && !isModeSwitch) {
-        getSessionService().setSessionConfigOptionByCategory(
-          taskId,
-          "mode",
-          "acceptEdits",
-        );
+        // Pick the adapter-appropriate "upgrade" mode. Claude exposes
+        // acceptEdits; Codex does not — its closest analogue is auto. Resolve
+        // against the session's advertised mode catalog so the footer label
+        // stays coherent with the dropdown contents.
+        const upgradeMode = resolveAllowAlwaysUpgradeMode(modeOption);
+        if (upgradeMode) {
+          getSessionService().setSessionConfigOptionByCategory(
+            taskId,
+            "mode",
+            upgradeMode,
+          );
+        }
       }
 
       if (customInput) {
@@ -269,7 +296,14 @@ export function SessionView({
 
       requestFocus(sessionId);
     },
-    [firstPendingPermission, taskId, onSendPrompt, requestFocus, sessionId],
+    [
+      firstPendingPermission,
+      taskId,
+      onSendPrompt,
+      requestFocus,
+      sessionId,
+      modeOption,
+    ],
   );
 
   const handlePermissionCancel = useCallback(async () => {

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -105,6 +105,11 @@ export function SessionView({
 
   useEffect(() => {
     if (allowBypassPermissions) return;
+    // Cloud runs execute in an isolated sandbox where bypass is safe, and the
+    // agent's own gate (ALLOW_BYPASS = !IS_ROOT || IS_SANDBOX) already permits
+    // it regardless of this local preference. Auto-reverting here would clobber
+    // the user's explicit plan-approval choice and strand them in Plan Mode.
+    if (isCloud) return;
     const isBypass =
       currentModeId === "bypassPermissions" || currentModeId === "full-access";
     if (isBypass && taskId) {
@@ -114,7 +119,7 @@ export function SessionView({
         "default",
       );
     }
-  }, [allowBypassPermissions, currentModeId, taskId]);
+  }, [allowBypassPermissions, currentModeId, taskId, isCloud]);
 
   const handleModeChange = useCallback(
     (nextMode: string) => {

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -98,6 +98,35 @@ const LOCAL_SESSION_RECOVERY_FAILED_MESSAGE =
  * trpc query, which is async. Callers populate them by calling
  * `fetchAndApplyCloudPreviewOptions` after the session exists in the store.
  */
+function extractLatestConfigOptionsFromEntries(
+  entries: StoredLogEntry[],
+): SessionConfigOption[] | undefined {
+  let latest: SessionConfigOption[] | undefined;
+  for (const entry of entries) {
+    if (
+      entry.type !== "notification" ||
+      entry.notification?.method !== "session/update"
+    ) {
+      continue;
+    }
+    const params = entry.notification.params as
+      | {
+          update?: {
+            sessionUpdate?: string;
+            configOptions?: SessionConfigOption[];
+          };
+        }
+      | undefined;
+    if (
+      params?.update?.sessionUpdate === "config_option_update" &&
+      params.update.configOptions
+    ) {
+      latest = params.update.configOptions;
+    }
+  }
+  return latest;
+}
+
 function buildCloudDefaultConfigOptions(
   initialMode: string | undefined,
   adapter: Adapter = "claude",
@@ -2607,6 +2636,20 @@ export class SessionService {
       (update.kind === "logs" || update.kind === "snapshot") &&
       update.newEntries.length > 0
     ) {
+      // Cloud streams deliver `session/update` notifications as regular log
+      // entries rather than live ACP messages. Without this, config changes
+      // made mid-run (e.g. plan-approval switching to bypassPermissions) never
+      // reach the session store and the footer mode selector stays stale.
+      const latestConfigOptions = extractLatestConfigOptionsFromEntries(
+        update.newEntries,
+      );
+      if (latestConfigOptions) {
+        sessionStoreSetters.updateSession(taskRunId, {
+          configOptions: latestConfigOptions,
+        });
+        setPersistedConfigOptions(taskRunId, latestConfigOptions);
+      }
+
       const session = sessionStoreSetters.getSessions()[taskRunId];
       const currentCount = session?.processedLineCount ?? 0;
       const expectedCount = update.totalEntryCount;

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1314,6 +1314,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         logger: this.logger,
         updateConfigOption: (configId: string, value: string) =>
           this.updateConfigOption(configId, value),
+        applySessionMode: (modeId: string) => this.applySessionMode(modeId),
         allowedDomains,
       });
   }

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1022,6 +1022,19 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         configOptions: this.session.configOptions,
       },
     });
+
+    // Notify the agent-server so its cached permissionMode stays in sync.
+    // Without this, cloud sessions that change mode via plan approval or
+    // setSessionMode use a stale mode for relay decisions.
+    if (configId === "mode") {
+      await this.client.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: "current_mode_update",
+          currentModeId: value,
+        },
+      });
+    }
   }
 
   private async applySessionMode(modeId: string): Promise<void> {

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -52,6 +52,7 @@ interface ToolHandlerContext {
   fileContentCache: { [key: string]: string };
   logger: Logger;
   updateConfigOption: (configId: string, value: string) => Promise<void>;
+  applySessionMode: (modeId: string) => Promise<void>;
   allowedDomains?: string[];
 }
 
@@ -163,8 +164,6 @@ async function applyPlanApproval(
   context: ToolHandlerContext,
   updatedInput: Record<string, unknown>,
 ): Promise<ToolPermissionResult> {
-  const { session } = context;
-
   if (
     response.outcome?.outcome === "selected" &&
     (response.outcome.optionId === "auto" ||
@@ -172,16 +171,7 @@ async function applyPlanApproval(
       response.outcome.optionId === "acceptEdits" ||
       response.outcome.optionId === "bypassPermissions")
   ) {
-    session.permissionMode = response.outcome
-      .optionId as typeof session.permissionMode;
-    await session.query.setPermissionMode(response.outcome.optionId);
-    await context.client.sessionUpdate({
-      sessionId: context.sessionId,
-      update: {
-        sessionUpdate: "current_mode_update",
-        currentModeId: response.outcome.optionId,
-      },
-    });
+    await context.applySessionMode(response.outcome.optionId);
     await context.updateConfigOption("mode", response.outcome.optionId);
 
     return {
@@ -211,10 +201,9 @@ async function applyPlanApproval(
 async function handleEnterPlanModeTool(
   context: ToolHandlerContext,
 ): Promise<ToolPermissionResult> {
-  const { session, toolInput } = context;
+  const { toolInput } = context;
 
-  session.permissionMode = "plan";
-  await session.query.setPermissionMode("plan");
+  await context.applySessionMode("plan");
   await context.updateConfigOption("mode", "plan");
 
   return {

--- a/packages/agent/src/adapters/claude/permissions/permission-options.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-options.ts
@@ -1,5 +1,5 @@
 import type { PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
-import { IS_ROOT } from "../../../utils/common";
+import { ALLOW_BYPASS } from "../../../utils/common";
 import { BASH_TOOLS, READ_TOOLS, SEARCH_TOOLS, WRITE_TOOLS } from "../tools";
 
 export interface PermissionOption {
@@ -91,8 +91,6 @@ export function buildPermissionOptions(
 
   return permissionOptions("Yes, always allow");
 }
-
-const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX;
 
 export function buildExitPlanModePermissionOptions(): PermissionOption[] {
   const options: PermissionOption[] = [];

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -317,7 +317,7 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     stderr: (err) => params.logger.error(err),
     cwd: params.cwd,
     includePartialMessages: true,
-    allowDangerouslySkipPermissions: !IS_ROOT,
+    allowDangerouslySkipPermissions: !IS_ROOT || !!process.env.IS_SANDBOX,
     permissionMode: params.permissionMode,
     canUseTool: params.canUseTool,
     executable: "node",

--- a/packages/agent/src/adapters/codex/codex-agent.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.ts
@@ -667,6 +667,20 @@ export class CodexAcpAgent extends BaseAcpAgent {
     if (response.configOptions) {
       this.sessionState.configOptions = response.configOptions;
     }
+    if (params.configId === "mode" && typeof params.value === "string") {
+      // Signal the mode change to agent-server so its session.permissionMode
+      // cache (used by shouldRelayPermissionToClient) stays in sync with the
+      // real Codex mode. Claude emits the same signal from its equivalent
+      // handler; without it, the agent-server's relay decisions for cloud
+      // runs would use a stale mode and silently auto-approve tool calls.
+      await this.client.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: "current_mode_update",
+          currentModeId: params.value,
+        },
+      });
+    }
     return response;
   }
 

--- a/packages/agent/src/execution-mode.ts
+++ b/packages/agent/src/execution-mode.ts
@@ -1,13 +1,10 @@
-import { IS_ROOT } from "./utils/common";
+import { ALLOW_BYPASS } from "./utils/common";
 
 export interface ModeInfo {
   id: string;
   name: string;
   description: string;
 }
-
-// Helper constant that can easily be toggled for env/feature flag/etc
-const ALLOW_BYPASS = !IS_ROOT;
 
 const availableModes: ModeInfo[] = [
   {
@@ -58,9 +55,9 @@ export function isCodeExecutionMode(mode: string): mode is CodeExecutionMode {
 }
 
 export function getAvailableModes(): ModeInfo[] {
-  return IS_ROOT
-    ? availableModes.filter((m) => m.id !== "bypassPermissions")
-    : availableModes;
+  return ALLOW_BYPASS
+    ? availableModes
+    : availableModes.filter((m) => m.id !== "bypassPermissions");
 }
 
 // --- Codex-native modes ---
@@ -98,7 +95,7 @@ if (ALLOW_BYPASS) {
 }
 
 export function getAvailableCodexModes(): ModeInfo[] {
-  return IS_ROOT
-    ? codexModes.filter((m) => m.id !== "full-access")
-    : codexModes;
+  return ALLOW_BYPASS
+    ? codexModes
+    : codexModes.filter((m) => m.id !== "full-access");
 }

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -293,7 +293,7 @@ export class AgentServer {
   }
 
   private shouldRelayPermissionToClient(mode: PermissionMode): boolean {
-    return mode === "default" || mode === "auto";
+    return mode === "default" || mode === "auto" || mode === "read-only";
   }
 
   private createApp(): Hono {

--- a/packages/agent/src/utils/common.ts
+++ b/packages/agent/src/utils/common.ts
@@ -23,6 +23,8 @@ export const IS_ROOT =
   typeof process !== "undefined" &&
   (process.geteuid?.() ?? process.getuid?.()) === 0;
 
+export const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX;
+
 export function unreachable(value: never, logger: Logger): void {
   let valueAsString: string;
   try {


### PR DESCRIPTION

## Problem

Approving a plan with "Yes, bypass all permissions" in a cloud run did nothing: the agent refused to proceed, the footer stayed on **Plan Mode**, and the next tool call re-prompted.

## Root cause

Three stacked gaps:

1. **SDK locked out of bypass.** The agent launches the Claude SDK with `allowDangerouslySkipPermissions: !IS_ROOT`. Cloud sandboxes run as root, so this was always `false` — the SDK rejected every bypass switch. The UI-side gate already handled this via `!IS_ROOT || IS_SANDBOX` (sandbox overrides root because the blast radius is a throwaway container). The SDK gate didn't. Aligned them.

2. **Cloud UI never saw the mode change.** Cloud runs receive `session/update` notifications through an SSE relay that only classifies `task_run_state` and `permission_request` — `config_option_update` fell through to the display log, never updating the store. The hydration path already knew to extract it; added the same scan to the live-update path.

3. **UI auto-reverted bypass → default.** A `SessionView` effect force-reset the mode when the user's local `allowBypassPermissions` preference was off. Correct for local sessions; wrong for cloud (sandboxed, the agent's `ALLOW_BYPASS` gate already said bypass is safe, user just explicitly picked it). Skip the revert when `isCloud`.

Also consolidated plan-approval mode-switch handlers onto the existing `applySessionMode + updateConfigOption` pattern used by `setSessionMode`, dropping a legacy `current_mode_update` emit the renderer no longer listens for.