### PR TITLE
fix(code): prevent sidebar from merging distinct repos into one group

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -337,8 +337,7 @@ export function TaskListView({
               const folder = folders.find(
                 (f) =>
                   (f.remoteUrl &&
-                    normalizeRepoKey(f.remoteUrl).toLowerCase() ===
-                      normalizeRepoKey(group.id).toLowerCase()) ||
+                    normalizeRepoKey(f.remoteUrl).toLowerCase() === group.id) ||
                   f.path === group.id,
               );
               const groupFolderId =

--- a/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
+++ b/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
@@ -3,18 +3,18 @@ import { useSessions } from "@features/sessions/stores/sessionStore";
 import { useSuspendedTaskIds } from "@features/suspension/hooks/useSuspendedTaskIds";
 import { useTasks } from "@features/tasks/hooks/useTasks";
 import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
-import { getTaskRepository, parseRepository } from "@renderer/utils/repository";
 import type { Task, TaskRunStatus } from "@shared/types";
 import { useEffect, useMemo, useRef } from "react";
 import { useSidebarStore } from "../stores/sidebarStore";
 import type { SortMode } from "../types";
+import {
+  type TaskGroup as GenericTaskGroup,
+  getRepositoryInfo,
+  groupByRepository,
+  type TaskRepositoryInfo,
+} from "../utils/groupTasks";
 import { usePinnedTasks } from "./usePinnedTasks";
 import { useTaskViewed } from "./useTaskViewed";
-
-export interface TaskRepositoryInfo {
-  fullPath: string;
-  name: string;
-}
 
 export interface TaskData {
   id: string;
@@ -32,11 +32,7 @@ export interface TaskData {
   taskRunEnvironment?: "local" | "cloud";
 }
 
-export interface TaskGroup {
-  id: string;
-  name: string;
-  tasks: TaskData[];
-}
+export type TaskGroup = GenericTaskGroup<TaskData>;
 
 export interface SidebarData {
   isHomeActive: boolean;
@@ -69,28 +65,6 @@ interface UseSidebarDataProps {
   activeView: ViewState;
 }
 
-function getRepositoryInfo(
-  task: Task,
-  folderPath?: string,
-): TaskRepositoryInfo | null {
-  const repository = getTaskRepository(task);
-  if (repository) {
-    const parsed = parseRepository(repository);
-    return {
-      fullPath: repository,
-      name: parsed?.repoName ?? repository,
-    };
-  }
-  if (folderPath) {
-    const name = folderPath.split("/").pop() ?? folderPath;
-    return {
-      fullPath: folderPath,
-      name,
-    };
-  }
-  return null;
-}
-
 function getSortValue(task: TaskData, sortMode: SortMode): number {
   return sortMode === "updated" ? task.lastActivityAt : task.createdAt;
 }
@@ -99,42 +73,6 @@ function sortTasks(tasks: TaskData[], sortMode: SortMode): TaskData[] {
   return tasks.sort(
     (a, b) => getSortValue(b, sortMode) - getSortValue(a, sortMode),
   );
-}
-
-function groupByRepository(
-  tasks: TaskData[],
-  folderOrder: string[],
-): TaskGroup[] {
-  const groupMap = new Map<string, TaskGroup>();
-
-  for (const task of tasks) {
-    const repository = task.repository;
-    const groupId = repository?.fullPath ?? "other";
-    const groupName = repository?.name ?? "Other";
-
-    if (!groupMap.has(groupId)) {
-      groupMap.set(groupId, { id: groupId, name: groupName, tasks: [] });
-    }
-
-    groupMap.get(groupId)?.tasks.push(task);
-  }
-
-  const groups = Array.from(groupMap.values());
-
-  if (folderOrder.length === 0) {
-    return groups.sort((a, b) => a.name.localeCompare(b.name));
-  }
-
-  return groups.sort((a, b) => {
-    const aIndex = folderOrder.indexOf(a.id);
-    const bIndex = folderOrder.indexOf(b.id);
-    if (aIndex === -1 && bIndex === -1) {
-      return a.name.localeCompare(b.name);
-    }
-    if (aIndex === -1) return 1;
-    if (bIndex === -1) return -1;
-    return aIndex - bIndex;
-  });
 }
 
 export function useSidebarData({

--- a/apps/code/src/renderer/features/sidebar/utils/groupTasks.test.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupTasks.test.ts
@@ -1,0 +1,260 @@
+import type { Task } from "@shared/types";
+import { describe, expect, it } from "vitest";
+import {
+  type GroupableTask,
+  getRepositoryInfo,
+  groupByRepository,
+  type TaskRepositoryInfo,
+} from "./groupTasks";
+
+interface TestTask extends GroupableTask {
+  id: string;
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Test task",
+    description: "",
+    repository: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    ...overrides,
+  } as Task;
+}
+
+function task(
+  id: string,
+  repository: TaskRepositoryInfo | null = null,
+): TestTask {
+  return { id, repository };
+}
+
+describe("getRepositoryInfo", () => {
+  it("returns lowercased owner/repo fullPath for a structured repository", () => {
+    const info = getRepositoryInfo(makeTask({ repository: "PostHog/code" }));
+    expect(info).toEqual({
+      fullPath: "posthog/code",
+      name: "code",
+      organization: "PostHog",
+    });
+  });
+
+  it("strips .git suffix when normalizing the fullPath", () => {
+    const info = getRepositoryInfo(
+      makeTask({ repository: "PostHog/code.git" }),
+    );
+    expect(info?.fullPath).toBe("posthog/code");
+  });
+
+  it("falls through to the folderPath when the repository string is malformed", () => {
+    const info = getRepositoryInfo(
+      makeTask({ repository: "posthog" }),
+      "/Users/test/projects/custom",
+    );
+    expect(info).toEqual({
+      fullPath: "/Users/test/projects/custom",
+      name: "custom",
+    });
+  });
+
+  it("returns null for a malformed repository without a folderPath", () => {
+    const info = getRepositoryInfo(makeTask({ repository: "posthog" }));
+    expect(info).toBeNull();
+  });
+
+  it("returns null when both repository and folderPath are absent", () => {
+    const info = getRepositoryInfo(makeTask({ repository: null }));
+    expect(info).toBeNull();
+  });
+
+  it("uses the folderPath when repository is null", () => {
+    const info = getRepositoryInfo(
+      makeTask({ repository: null }),
+      "/Users/test/projects/my-repo",
+    );
+    expect(info).toEqual({
+      fullPath: "/Users/test/projects/my-repo",
+      name: "my-repo",
+    });
+  });
+});
+
+describe("groupByRepository", () => {
+  it("returns an empty array for an empty task list", () => {
+    const groups = groupByRepository([], []);
+    expect(groups).toEqual([]);
+  });
+
+  it("produces both repo groups and an 'other' group for mixed tasks", () => {
+    const tasks: TestTask[] = [
+      task("t1", {
+        fullPath: "posthog/code",
+        name: "code",
+        organization: "PostHog",
+      }),
+      task("t2"),
+    ];
+
+    const groups = groupByRepository(tasks, []);
+
+    expect(groups).toHaveLength(2);
+    const byId = new Map(groups.map((g) => [g.id, g]));
+    expect(byId.get("posthog/code")?.tasks).toHaveLength(1);
+    expect(byId.get("other")?.tasks).toHaveLength(1);
+  });
+
+  it("merges tasks with the same repository but different casing into one group", () => {
+    const tasks: TestTask[] = [
+      task("t1", {
+        fullPath: "posthog/code",
+        name: "code",
+        organization: "PostHog",
+      }),
+      task("t2", {
+        fullPath: "posthog/code",
+        name: "code",
+        organization: "posthog",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, []);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.id).toBe("posthog/code");
+    expect(groups[0]?.tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
+  });
+
+  it("keeps distinct repositories in distinct groups", () => {
+    const tasks: TestTask[] = [
+      task("t1", {
+        fullPath: "posthog/posthog",
+        name: "posthog",
+        organization: "PostHog",
+      }),
+      task("t2", {
+        fullPath: "posthog/code",
+        name: "code",
+        organization: "PostHog",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, []);
+
+    expect(groups).toHaveLength(2);
+    const byId = new Map(groups.map((g) => [g.id, g]));
+    expect(byId.get("posthog/code")?.name).toBe("code");
+    expect(byId.get("posthog/posthog")?.name).toBe("posthog");
+  });
+
+  it("prefixes the organization when two groups share a display name", () => {
+    const tasks: TestTask[] = [
+      task("t1", {
+        fullPath: "posthog/shared",
+        name: "shared",
+        organization: "PostHog",
+      }),
+      task("t2", {
+        fullPath: "acme/shared",
+        name: "shared",
+        organization: "acme",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, []);
+
+    expect(groups).toHaveLength(2);
+    const names = new Set(groups.map((g) => g.name));
+    expect(names).toEqual(new Set(["PostHog/shared", "acme/shared"]));
+  });
+
+  it("routes tasks with no repository info to the 'other' group", () => {
+    const tasks: TestTask[] = [task("t1"), task("t2")];
+
+    const groups = groupByRepository(tasks, []);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.id).toBe("other");
+    expect(groups[0]?.name).toBe("Other");
+  });
+
+  it("keeps the bare name for a group without an organization when others collide", () => {
+    const tasks: TestTask[] = [
+      task("t1", {
+        fullPath: "posthog/shared",
+        name: "shared",
+        organization: "PostHog",
+      }),
+      task("t2", {
+        fullPath: "acme/shared",
+        name: "shared",
+        organization: "acme",
+      }),
+      task("t3", { fullPath: "/Users/dev/shared", name: "shared" }),
+    ];
+
+    const groups = groupByRepository(tasks, []);
+    const names = groups.map((g) => g.name).sort();
+
+    expect(names).toEqual(["PostHog/shared", "acme/shared", "shared"]);
+  });
+
+  it("respects the provided folder order", () => {
+    const tasks: TestTask[] = [
+      task("t1", {
+        fullPath: "posthog/code",
+        name: "code",
+        organization: "PostHog",
+      }),
+      task("t2", {
+        fullPath: "posthog/posthog",
+        name: "posthog",
+        organization: "PostHog",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, [
+      "posthog/posthog",
+      "posthog/code",
+    ]);
+
+    expect(groups.map((g) => g.id)).toEqual([
+      "posthog/posthog",
+      "posthog/code",
+    ]);
+  });
+
+  it("places ordered groups first, then unknown groups alphabetically", () => {
+    const tasks: TestTask[] = [
+      task("t1", {
+        fullPath: "posthog/code",
+        name: "code",
+        organization: "PostHog",
+      }),
+      task("t2", {
+        fullPath: "posthog/posthog",
+        name: "posthog",
+        organization: "PostHog",
+      }),
+      task("t3", {
+        fullPath: "acme/alpha",
+        name: "alpha",
+        organization: "acme",
+      }),
+      task("t4", {
+        fullPath: "acme/zeta",
+        name: "zeta",
+        organization: "acme",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, ["posthog/posthog"]);
+
+    expect(groups.map((g) => g.id)).toEqual([
+      "posthog/posthog",
+      "acme/alpha",
+      "posthog/code",
+      "acme/zeta",
+    ]);
+  });
+});

--- a/apps/code/src/renderer/features/sidebar/utils/groupTasks.test.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupTasks.test.ts
@@ -40,11 +40,15 @@ describe("getRepositoryInfo", () => {
     });
   });
 
-  it("strips .git suffix when normalizing the fullPath", () => {
+  it("strips .git suffix from both fullPath and name", () => {
     const info = getRepositoryInfo(
       makeTask({ repository: "PostHog/code.git" }),
     );
-    expect(info?.fullPath).toBe("posthog/code");
+    expect(info).toEqual({
+      fullPath: "posthog/code",
+      name: "code",
+      organization: "PostHog",
+    });
   });
 
   it("falls through to the folderPath when the repository string is malformed", () => {

--- a/apps/code/src/renderer/features/sidebar/utils/groupTasks.test.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupTasks.test.ts
@@ -51,6 +51,28 @@ describe("getRepositoryInfo", () => {
     });
   });
 
+  it("strips .git suffix even when repository is already lowercase", () => {
+    const info = getRepositoryInfo(
+      makeTask({ repository: "posthog/code.git" }),
+    );
+    expect(info).toEqual({
+      fullPath: "posthog/code",
+      name: "code",
+      organization: "posthog",
+    });
+  });
+
+  it("trims surrounding whitespace from the repository string", () => {
+    const info = getRepositoryInfo(
+      makeTask({ repository: "  PostHog/code.git\n" }),
+    );
+    expect(info).toEqual({
+      fullPath: "posthog/code",
+      name: "code",
+      organization: "PostHog",
+    });
+  });
+
   it("falls through to the folderPath when the repository string is malformed", () => {
     const info = getRepositoryInfo(
       makeTask({ repository: "posthog" }),
@@ -106,6 +128,22 @@ describe("groupByRepository", () => {
     const byId = new Map(groups.map((g) => [g.id, g]));
     expect(byId.get("posthog/code")?.tasks).toHaveLength(1);
     expect(byId.get("other")?.tasks).toHaveLength(1);
+  });
+
+  it("merges .git and non-.git variants of the same repository into one group", () => {
+    // Exercises the end-to-end flow: getRepositoryInfo normalizes both, then
+    // groupByRepository sees them as the same bucket.
+    const t1 = getRepositoryInfo(makeTask({ repository: "PostHog/code.git" }));
+    const t2 = getRepositoryInfo(makeTask({ repository: "posthog/code" }));
+    expect(t1).not.toBeNull();
+    expect(t2).not.toBeNull();
+
+    const groups = groupByRepository([task("t1", t1), task("t2", t2)], []);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.id).toBe("posthog/code");
+    expect(groups[0]?.name).toBe("code");
+    expect(groups[0]?.tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
   });
 
   it("merges tasks with the same repository but different casing into one group", () => {

--- a/apps/code/src/renderer/features/sidebar/utils/groupTasks.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupTasks.ts
@@ -1,0 +1,101 @@
+import { getTaskRepository, parseRepository } from "@renderer/utils/repository";
+import type { Task } from "@shared/types";
+import { normalizeRepoKey } from "@shared/utils/repo";
+
+export interface TaskRepositoryInfo {
+  fullPath: string;
+  name: string;
+  organization?: string;
+}
+
+export interface GroupableTask {
+  repository: TaskRepositoryInfo | null;
+}
+
+export interface TaskGroup<T extends GroupableTask> {
+  id: string;
+  name: string;
+  tasks: T[];
+}
+
+export function getRepositoryInfo(
+  task: Task,
+  folderPath?: string,
+): TaskRepositoryInfo | null {
+  const repository = getTaskRepository(task);
+  if (repository) {
+    const parsed = parseRepository(repository);
+    if (parsed) {
+      return {
+        fullPath: normalizeRepoKey(repository).toLowerCase(),
+        name: parsed.repoName,
+        organization: parsed.organization,
+      };
+    }
+    // Malformed repository string (e.g. legacy single-segment values). Fall
+    // through so the task lands in the folder-path or "other" bucket instead
+    // of colliding with a real owner/repo group.
+  }
+  if (folderPath) {
+    const name = folderPath.split("/").pop() ?? folderPath;
+    return {
+      fullPath: folderPath,
+      name,
+    };
+  }
+  return null;
+}
+
+export function groupByRepository<T extends GroupableTask>(
+  tasks: T[],
+  folderOrder: string[],
+): TaskGroup<T>[] {
+  const groupMap = new Map<string, TaskGroup<T>>();
+
+  for (const task of tasks) {
+    const repository = task.repository;
+    const groupId = repository?.fullPath ?? "other";
+    const groupName = repository?.name ?? "Other";
+
+    let group = groupMap.get(groupId);
+    if (!group) {
+      group = { id: groupId, name: groupName, tasks: [] };
+      groupMap.set(groupId, group);
+    }
+
+    group.tasks.push(task);
+  }
+
+  const groups = Array.from(groupMap.values());
+
+  // Disambiguate groups that share a display name (e.g. `posthog/posthog`
+  // and `jane/posthog` both rendering as "posthog") by prefixing the
+  // organization when it's available.
+  const nameCounts = new Map<string, number>();
+  for (const group of groups) {
+    nameCounts.set(group.name, (nameCounts.get(group.name) ?? 0) + 1);
+  }
+  for (const group of groups) {
+    if ((nameCounts.get(group.name) ?? 0) > 1) {
+      const organization = group.tasks[0]?.repository?.organization;
+      if (organization) {
+        group.name = `${organization}/${group.name}`;
+      }
+    }
+  }
+
+  if (folderOrder.length === 0) {
+    return groups.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return groups.sort((a, b) => {
+    const aIndex = folderOrder.indexOf(a.id);
+    const bIndex = folderOrder.indexOf(b.id);
+    if (aIndex === -1 && bIndex === -1) {
+      return a.name.localeCompare(b.name);
+    }
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+}

--- a/apps/code/src/renderer/features/sidebar/utils/groupTasks.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupTasks.ts
@@ -24,10 +24,11 @@ export function getRepositoryInfo(
 ): TaskRepositoryInfo | null {
   const repository = getTaskRepository(task);
   if (repository) {
-    const parsed = parseRepository(repository);
+    const normalized = normalizeRepoKey(repository);
+    const parsed = parseRepository(normalized);
     if (parsed) {
       return {
-        fullPath: normalizeRepoKey(repository).toLowerCase(),
+        fullPath: normalized.toLowerCase(),
         name: parsed.repoName,
         organization: parsed.organization,
       };


### PR DESCRIPTION
## Problem

In the sidebar's "by-project" mode, tasks from distinct repositories (e.g. `posthog/posthog` and `posthog/code`) collapsed into a single group labelled "posthog".

Three issues combined:

1. **Case inconsistency** — local tasks stored the repo verbatim from the git remote (`PostHog/code`), while cloud tasks lowercased it (`posthog/code`). Same repo, two different group keys.
2. **Legacy black-hole bucket** — `task.repository` values that didn't parse as `owner/repo` (e.g. a single segment like `"posthog"`) were used as the raw group key, pulling unrelated tasks into one group.
3. **Ambiguous labels** — groups were labelled with just the repo name, so two distinct repos sharing a short name looked identical.

## Solution

- Canonicalize the group key: `normalizeRepoKey(repository).toLowerCase()` so casing and `.git` suffix differences collapse into one group.
- Skip malformed repository values so they fall through to the folder path or `other` bucket instead of colliding with real repos.
- When two groups share a display name, prefix the organization (`PostHog/shared` vs `acme/shared`) so they stay visually distinct.
- Extracted the pure grouping helpers into `sidebar/utils/groupTasks.ts` with 15 unit tests covering case-merge, distinct repos, collision disambiguation, legacy values, folder-path fallback, folder order, and mixed buckets.