### PR TITLE
refactor(inbox): rename flag to posthog-code-inbox-hidden with inverted logic

### DIFF
--- a/apps/code/src/renderer/components/GlobalEventHandlers.tsx
+++ b/apps/code/src/renderer/components/GlobalEventHandlers.tsx
@@ -171,14 +171,14 @@ export function GlobalEventHandlers({
     setReviewMode(currentTaskId, mode === "closed" ? "split" : "closed");
   }, [currentTaskId, getReviewMode, setReviewMode]);
 
-  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const inboxHidden = useFeatureFlag("posthog-code-inbox-hidden");
 
   useHotkeys(SHORTCUTS.TOGGLE_LEFT_SIDEBAR, toggleLeftSidebar, globalOptions);
   useHotkeys(SHORTCUTS.TOGGLE_REVIEW_PANEL, handleToggleReview, globalOptions);
   useHotkeys(SHORTCUTS.SHORTCUTS_SHEET, onToggleShortcutsSheet, globalOptions);
   useHotkeys(SHORTCUTS.INBOX, navigateToInbox, {
     ...globalOptions,
-    enabled: inboxEnabled,
+    enabled: !inboxHidden,
   });
   useHotkeys(SHORTCUTS.PREV_TASK, handlePrevTask, globalOptions, [
     handlePrevTask,

--- a/apps/code/src/renderer/components/KeyboardShortcutsSheet.tsx
+++ b/apps/code/src/renderer/components/KeyboardShortcutsSheet.tsx
@@ -131,14 +131,14 @@ function ShortcutsHeader() {
 }
 
 export function KeyboardShortcutsList() {
-  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const inboxHidden = useFeatureFlag("posthog-code-inbox-hidden");
   const shortcutsByCategory = useMemo(() => {
     const grouped = getShortcutsByCategory();
-    if (!inboxEnabled) {
+    if (inboxHidden) {
       grouped.navigation = grouped.navigation.filter((s) => s.id !== "inbox");
     }
     return grouped;
-  }, [inboxEnabled]);
+  }, [inboxHidden]);
 
   const categoryOrder: ShortcutCategory[] = [
     "general",

--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -51,7 +51,7 @@ export function MainLayout() {
   } = useShortcutsSheetStore();
   const { data: tasks } = useTasks();
   const { showPrompt, isChecking, check, dismiss } = useConnectivity();
-  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const inboxHidden = useFeatureFlag("posthog-code-inbox-hidden");
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
 
   // Space switcher data
@@ -109,7 +109,7 @@ export function MainLayout() {
 
           {view.type === "folder-settings" && <FolderSettingsView />}
 
-          {view.type === "inbox" && inboxEnabled && <InboxView />}
+          {view.type === "inbox" && !inboxHidden && <InboxView />}
 
           {view.type === "archived" && <ArchivedTasksView />}
 

--- a/apps/code/src/renderer/features/onboarding/components/WelcomeScreen.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/WelcomeScreen.tsx
@@ -60,13 +60,13 @@ const CYCLE_INTERVAL_MS = 2500;
 const CYCLE_START_DELAY_MS = ALL_FEATURES.length * 100 + 400;
 
 export function WelcomeScreen({ onNext }: WelcomeScreenProps) {
-  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const inboxHidden = useFeatureFlag("posthog-code-inbox-hidden");
   const features = useMemo(
     () =>
-      inboxEnabled
-        ? ALL_FEATURES
-        : ALL_FEATURES.filter((f) => f.id !== "signals-inbox"),
-    [inboxEnabled],
+      inboxHidden
+        ? ALL_FEATURES.filter((f) => f.id !== "signals-inbox")
+        : ALL_FEATURES,
+    [inboxHidden],
   );
   const [activeIndex, setActiveIndex] = useState(-1);
   const timerRef = useRef<ReturnType<typeof setInterval>>(null);

--- a/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
@@ -79,18 +79,18 @@ export function useOnboardingFlow() {
   );
 
   const hasCodeAccess = useAuthStateValue((state) => state.hasCodeAccess);
-  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const inboxHidden = useFeatureFlag("posthog-code-inbox-hidden");
 
   const activeSteps = useMemo(() => {
     let steps = ONBOARDING_STEPS as OnboardingStep[];
     if (hasCodeAccess === true) {
       steps = steps.filter((s) => s !== "invite-code");
     }
-    if (!inboxEnabled) {
+    if (inboxHidden) {
       steps = steps.filter((s) => s !== "signals");
     }
     return steps;
-  }, [hasCodeAccess, inboxEnabled]);
+  }, [hasCodeAccess, inboxHidden]);
 
   useEffect(() => {
     if (!activeSteps.includes(currentStep)) {

--- a/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
+++ b/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
@@ -129,7 +129,7 @@ export function SettingsDialog() {
   const client = useOptionalAuthenticatedClient();
   const { data: user } = useCurrentUser({ client });
   const { seat, planLabel } = useSeat();
-  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const inboxHidden = useFeatureFlag("posthog-code-inbox-hidden");
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const logoutMutation = useLogoutMutation();
 
@@ -137,10 +137,10 @@ export function SettingsDialog() {
     () =>
       SIDEBAR_ITEMS.filter((item) => {
         if (item.id === "plan-usage" && !billingEnabled) return false;
-        if (item.id === "signals" && !inboxEnabled) return false;
+        if (item.id === "signals" && inboxHidden) return false;
         return true;
       }),
-    [billingEnabled, inboxEnabled],
+    [billingEnabled, inboxHidden],
   );
 
   useHotkeys("escape", close, {

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -56,12 +56,12 @@ function SidebarMenuComponent() {
   const sidebarData = useSidebarData({
     activeView: view,
   });
-  const inboxEnabled = useFeatureFlag("posthog-code-inbox");
+  const inboxHidden = useFeatureFlag("posthog-code-inbox-hidden");
   const inboxPollingActive = useRendererWindowFocusStore((s) => s.focused);
   const { data: inboxProbe } = useInboxReports(
     { status: INBOX_PIPELINE_STATUS_FILTER },
     {
-      enabled: inboxEnabled,
+      enabled: !inboxHidden,
       refetchInterval: inboxPollingActive ? INBOX_REFETCH_INTERVAL_MS : false,
       refetchIntervalInBackground: false,
       staleTime: inboxPollingActive ? INBOX_REFETCH_INTERVAL_MS : 15_000,
@@ -280,7 +280,7 @@ function SidebarMenuComponent() {
             />
           </Box>
 
-          {inboxEnabled && (
+          {!inboxHidden && (
             <Box>
               <InboxItem
                 isActive={sidebarData.isInboxActive}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `posthog-code-inbox` flag requires being turned **on** to show the inbox, which means new users/teams see no inbox by default. We want the inbox visible by default and only hidden for specific teams or users when needed.

## Changes

- Renamed the feature flag from `posthog-code-inbox` to `posthog-code-inbox-hidden`
- Inverted all boolean logic across 7 files so the inbox is **shown by default** and only hidden when the flag is enabled
- Updated variable names from `inboxEnabled` to `inboxHidden` for clarity

Files changed:
- `SidebarMenu.tsx` — sidebar inbox item + polling gated on `!inboxHidden`
- `MainLayout.tsx` — inbox view render gated on `!inboxHidden`
- `GlobalEventHandlers.tsx` — `mod+i` hotkey enabled when `!inboxHidden`
- `KeyboardShortcutsSheet.tsx` — inbox shortcut filtered when `inboxHidden`
- `SettingsDialog.tsx` — signals settings entry filtered when `inboxHidden`
- `useOnboardingFlow.ts` — signals onboarding step filtered when `inboxHidden`
- `WelcomeScreen.tsx` — signals inbox feature bullet filtered when `inboxHidden`

**Note:** The corresponding PostHog feature flag needs to be renamed from `posthog-code-inbox` to `posthog-code-inbox-hidden` and kept at 0% rollout (off for everyone, so inbox is visible to all by default). Enable it only for specific users/teams you want to hide the inbox from.

## How did you test this?

- Verified all 7 references updated with `grep` — no remaining `posthog-code-inbox` (without `-hidden`) references
- Typecheck passes (pre-existing errors in unrelated `@posthog/platform` modules only)
- Biome lint passes cleanly
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1776858877338979?thread_ts=1776858877.338979&cid=C09SK2PAGKF)

<div><a href="https://cursor.com/agents/bc-289b8d64-9973-5e60-a649-b722787a2bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-289b8d64-9973-5e60-a649-b722787a2bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

