### PR TITLE
feat(code): add method for finding PR for branch

### DIFF
--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -258,6 +258,16 @@ export const prStatusOutput = z.object({
 export type PrStatusInput = z.infer<typeof prStatusInput>;
 export type PrStatusOutput = z.infer<typeof prStatusOutput>;
 
+// Look up the PR for an arbitrary branch (not necessarily the current one).
+export const getPrUrlForBranchInput = z.object({
+  directoryPath: z.string(),
+  branchName: z.string(),
+});
+export const getPrUrlForBranchOutput = z.string().nullable();
+
+export type GetPrUrlForBranchInput = z.infer<typeof getPrUrlForBranchInput>;
+export type GetPrUrlForBranchOutput = z.infer<typeof getPrUrlForBranchOutput>;
+
 // Create PR operation
 export const createPrInput = z.object({
   directoryPath: z.string(),

--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecGh = vi.hoisted(() => vi.fn());
+const mockGetRemoteUrl = vi.hoisted(() => vi.fn());
 
 vi.mock("@posthog/git/gh", () => ({
   execGh: mockExecGh,
 }));
+
+vi.mock("@posthog/git/queries", async () => {
+  const actual = await vi.importActual<object>("@posthog/git/queries");
+  return { ...actual, getRemoteUrl: mockGetRemoteUrl };
+});
 
 vi.mock("../../utils/logger.js", () => ({
   logger: {
@@ -183,5 +189,82 @@ describe("GitService.getGhAuthToken", () => {
       token: null,
       error: "GitHub auth token is empty",
     });
+  });
+});
+
+describe("GitService.getPrUrlForBranch", () => {
+  let service: GitService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitService({} as LlmGatewayService);
+  });
+
+  it("returns the PR URL for a branch via gh pr list", async () => {
+    mockGetRemoteUrl.mockResolvedValue("https://github.com/posthog/code.git");
+    mockExecGh.mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify([
+        { url: "https://github.com/posthog/code/pull/42" },
+      ]),
+    });
+
+    const result = await service.getPrUrlForBranch("/repo", "feat/x");
+
+    expect(mockExecGh).toHaveBeenCalledWith([
+      "pr",
+      "list",
+      "--head",
+      "feat/x",
+      "--state",
+      "all",
+      "--json",
+      "url",
+      "--limit",
+      "1",
+      "--repo",
+      "posthog/code",
+    ]);
+    expect(result).toBe("https://github.com/posthog/code/pull/42");
+  });
+
+  it("returns null when no PR exists for the branch", async () => {
+    mockGetRemoteUrl.mockResolvedValue("https://github.com/posthog/code.git");
+    mockExecGh.mockResolvedValue({ exitCode: 0, stdout: "[]" });
+
+    const result = await service.getPrUrlForBranch("/repo", "feat/no-pr");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a non-GitHub remote", async () => {
+    mockGetRemoteUrl.mockResolvedValue("https://gitlab.com/foo/bar.git");
+
+    const result = await service.getPrUrlForBranch("/repo", "feat/x");
+
+    expect(result).toBeNull();
+    expect(mockExecGh).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the repo has no remote", async () => {
+    mockGetRemoteUrl.mockResolvedValue(null);
+
+    const result = await service.getPrUrlForBranch("/repo", "feat/x");
+
+    expect(result).toBeNull();
+    expect(mockExecGh).not.toHaveBeenCalled();
+  });
+
+  it("returns null when gh command fails", async () => {
+    mockGetRemoteUrl.mockResolvedValue("https://github.com/posthog/code.git");
+    mockExecGh.mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "auth required",
+    });
+
+    const result = await service.getPrUrlForBranch("/repo", "feat/x");
+
+    expect(result).toBeNull();
   });
 });

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -850,6 +850,54 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     }
   }
 
+  /**
+   * Look up the PR URL for any branch name (not just the currently checked-out
+   * one). Uses `gh pr list --head` rather than `gh pr view` so the lookup works
+   * regardless of which branch the working tree is on.
+   */
+  public async getPrUrlForBranch(
+    directoryPath: string,
+    branchName: string,
+  ): Promise<string | null> {
+    try {
+      const remoteUrl = await getRemoteUrl(directoryPath);
+      if (!remoteUrl) return null;
+
+      const parsed = parseGitHubUrl(remoteUrl);
+      if (!parsed) return null;
+
+      const repoSlug = `${parsed.organization}/${parsed.repository}`;
+      const result = await execGh([
+        "pr",
+        "list",
+        "--head",
+        branchName,
+        "--state",
+        "all",
+        "--json",
+        "url",
+        "--limit",
+        "1",
+        "--repo",
+        repoSlug,
+      ]);
+
+      if (result.exitCode !== 0) {
+        log.warn("Failed to list PRs for branch", {
+          branchName,
+          error: result.stderr || result.error,
+        });
+        return null;
+      }
+
+      const data = JSON.parse(result.stdout) as Array<{ url?: string }>;
+      return data[0]?.url ?? null;
+    } catch (error) {
+      log.warn("Failed to resolve PR URL for branch", { branchName, error });
+      return null;
+    }
+  }
+
   private async createPrViaGh(
     directoryPath: string,
     title?: string,

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -52,6 +52,8 @@ import {
   getPrReviewCommentsOutput,
   getPrTemplateInput,
   getPrTemplateOutput,
+  getPrUrlForBranchInput,
+  getPrUrlForBranchOutput,
   ghAuthTokenOutput,
   ghStatusOutput,
   gitStateSnapshotSchema,
@@ -296,6 +298,13 @@ export const gitRouter = router({
     .input(prStatusInput)
     .output(prStatusOutput)
     .query(({ input }) => getService().getPrStatus(input.directoryPath)),
+
+  getPrUrlForBranch: publicProcedure
+    .input(getPrUrlForBranchInput)
+    .output(getPrUrlForBranchOutput)
+    .query(({ input }) =>
+      getService().getPrUrlForBranch(input.directoryPath, input.branchName),
+    ),
 
   createPr: publicProcedure
     .input(createPrInput)

--- a/apps/code/src/renderer/features/git-interaction/hooks/useLinkedBranchPrUrl.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useLinkedBranchPrUrl.ts
@@ -1,0 +1,32 @@
+import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
+import { useTRPC } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Resolves the PR URL for a local task's linked branch by looking it up via
+ * `gh pr list --head`. Returns `null` when the task has no linked branch, no
+ * folder path, or the branch has no associated PR on GitHub.
+ */
+export function useLinkedBranchPrUrl(taskId: string): string | null {
+  const workspace = useWorkspace(taskId);
+  const linkedBranch = workspace?.linkedBranch ?? null;
+  const folderPath = workspace?.folderPath ?? null;
+
+  const trpc = useTRPC();
+  const { data } = useQuery(
+    trpc.git.getPrUrlForBranch.queryOptions(
+      {
+        directoryPath: folderPath as string,
+        branchName: linkedBranch as string,
+      },
+      {
+        enabled: !!folderPath && !!linkedBranch,
+        staleTime: 60_000,
+        refetchInterval: 5 * 60_000,
+        retry: 1,
+      },
+    ),
+  );
+
+  return data ?? null;
+}


### PR DESCRIPTION
## Problem

now that local tasks have linked branches, we can find PR details

but we need a lil bit of infra to find a PR for an arbitrary branch

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds `getPrUrlForBranch` and `useLinkedBranchPrUrl`so we can easily fetch a PR for a local task

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

tested upstack