### PR TITLE
chore(code): improve MCP proxy logs and dedupe posthog plugin

### DIFF
--- a/apps/code/src/main/services/agent/discover-plugins.test.ts
+++ b/apps/code/src/main/services/agent/discover-plugins.test.ts
@@ -241,6 +241,35 @@ describe("discoverExternalPlugins", () => {
       expect(result).toEqual([]);
     });
 
+    it("excludes the posthog marketplace plugin (bundled in-app)", async () => {
+      const posthogPath = "/mock/plugins/posthog";
+      const otherPath = "/mock/plugins/other";
+      vol.mkdirSync(posthogPath, { recursive: true });
+      vol.mkdirSync(otherPath, { recursive: true });
+
+      vol.mkdirSync("/mock/home/.claude/plugins", { recursive: true });
+      vol.writeFileSync(
+        INSTALLED_PLUGINS_PATH,
+        JSON.stringify({
+          version: 2,
+          plugins: {
+            "posthog@claude-plugins-official": [
+              { scope: "user", installPath: posthogPath, version: "1.0.0" },
+            ],
+            "other@claude-plugins-official": [
+              { scope: "user", installPath: otherPath, version: "1.0.0" },
+            ],
+          },
+        }),
+      );
+
+      const result = await discoverExternalPlugins({
+        userDataDir: USER_DATA_DIR,
+      });
+
+      expect(result).toEqual([{ type: "local", path: otherPath }]);
+    });
+
     it("handles multiple plugins with multiple entries", async () => {
       const pathA = "/mock/plugins/plugin-a";
       const pathB = "/mock/plugins/plugin-b";

--- a/apps/code/src/main/services/agent/discover-plugins.ts
+++ b/apps/code/src/main/services/agent/discover-plugins.ts
@@ -66,14 +66,17 @@ export async function getMarketplaceInstallPaths(): Promise<string[]> {
   try {
     const content = await fs.promises.readFile(installedPath, "utf-8");
     const data = JSON.parse(content) as InstalledPluginsFile;
-
+    logger.info("installed plugins", { plugins: data.plugins });
     if (!data.plugins || typeof data.plugins !== "object") {
       return [];
     }
 
     const paths: string[] = [];
-    for (const entries of Object.values(data.plugins)) {
+    for (const [key, entries] of Object.entries(data.plugins)) {
+      logger.info("installed plugin", { key, entries });
       if (!Array.isArray(entries)) continue;
+      // Skip the marketplace posthog plugin — the app bundles its own.
+      if (key.split("@")[0] === "posthog") continue;
       for (const entry of entries) {
         if (entry.installPath && fs.existsSync(entry.installPath)) {
           paths.push(entry.installPath);

--- a/apps/code/src/main/services/agent/discover-plugins.ts
+++ b/apps/code/src/main/services/agent/discover-plugins.ts
@@ -66,14 +66,13 @@ export async function getMarketplaceInstallPaths(): Promise<string[]> {
   try {
     const content = await fs.promises.readFile(installedPath, "utf-8");
     const data = JSON.parse(content) as InstalledPluginsFile;
-    logger.info("installed plugins", { plugins: data.plugins });
+
     if (!data.plugins || typeof data.plugins !== "object") {
       return [];
     }
 
     const paths: string[] = [];
     for (const [key, entries] of Object.entries(data.plugins)) {
-      logger.info("installed plugin", { key, entries });
       if (!Array.isArray(entries)) continue;
       // Skip the marketplace posthog plugin — the app bundles its own.
       if (key.split("@")[0] === "posthog") continue;

--- a/apps/code/src/main/services/mcp-proxy/service.ts
+++ b/apps/code/src/main/services/mcp-proxy/service.ts
@@ -6,6 +6,16 @@ import type { AuthService } from "../auth/service";
 
 const log = logger.scope("mcp-proxy");
 
+function truncateRequestBody(body: RequestInit["body"]): string | undefined {
+  if (body == null) return undefined;
+  if (typeof body === "string") return body.slice(0, 2000);
+  if (body instanceof Buffer) return body.toString("utf8").slice(0, 2000);
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body).toString("utf8").slice(0, 2000);
+  }
+  return `[${body.constructor.name}]`;
+}
+
 /**
  * Local HTTP proxy for MCP servers. Allows routing MCP requests through a
  * stable loopback URL while injecting a fresh access token on every forwarded
@@ -195,12 +205,20 @@ export class McpProxyService {
         }
 
         if (/"isError"\s*:\s*true/.test(bodyText) || response.status >= 400) {
-          log.warn("MCP proxy non-OK body", {
+          const details = {
             id,
             url,
+            method: options.method,
             status: response.status,
+            requestBody: truncateRequestBody(options.body),
+            responseHeaders: Object.fromEntries(response.headers.entries()),
             body: bodyText.slice(0, 2000),
-          });
+          };
+          if (response.status >= 500) {
+            log.error("MCP proxy server error", details);
+          } else {
+            log.warn("MCP proxy non-OK body", details);
+          }
         }
 
         this.writeBufferedResponse(response, buf, res);


### PR DESCRIPTION
## Problem

Two small issues in the agent/MCP plumbing:

1. **Duplicate posthog plugin** — the app bundles its own PostHog plugin via `PosthogPluginService`, but `discoverExternalPlugins` was also picking up the marketplace `posthog@claude-plugins-official` install, so the SDK saw the plugin twice.
2. **Opaque MCP proxy failures** — when an MCP server returned a 500, the log only included the response status and body (e.g. `"Internal server error"`), with no indication of which JSON-RPC call caused it or any response headers useful for correlating with the server side.

## Changes

- `discover-plugins.ts`: filter out entries keyed `posthog@…` in `getMarketplaceInstallPaths` (added unit test).
- `mcp-proxy/service.ts`: on non-OK responses, also log the request method, truncated request body (the JSON-RPC envelope), and response headers. Promote 5xx to `log.error` since those are server-side exceptions.

## How did you test this code?

- `pnpm --filter code test` — all 825 tests pass, including the new `excludes the posthog marketplace plugin` case.
- `pnpm --filter code typecheck` — clean.

## Publish to changelog?

no