### PR TITLE
feat(code): use chosen diff source for badge

### DIFF
--- a/apps/code/src/renderer/features/code-review/components/DiffStatsBadge.tsx
+++ b/apps/code/src/renderer/features/code-review/components/DiffStatsBadge.tsx
@@ -1,7 +1,12 @@
 import { Tooltip } from "@components/ui/Tooltip";
-import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
-import { computeDiffStats } from "@features/git-interaction/utils/diffStats";
-import { useCwd } from "@features/sidebar/hooks/useCwd";
+import {
+  useBranchChangedFiles,
+  usePrChangedFiles,
+} from "@features/git-interaction/hooks/useGitQueries";
+import {
+  computeDiffStats,
+  type DiffStats,
+} from "@features/git-interaction/utils/diffStats";
 import { useCloudChangedFiles } from "@features/task-detail/hooks/useCloudChangedFiles";
 import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
 import { GitDiff } from "@phosphor-icons/react";
@@ -14,51 +19,74 @@ import {
 import { useReviewNavigationStore } from "@renderer/features/code-review/stores/reviewNavigationStore";
 import type { Task } from "@shared/types";
 import { useMemo } from "react";
+import { useEffectiveDiffSource } from "../hooks/useEffectiveDiffSource";
 
 interface DiffStatsBadgeProps {
   task: Task;
 }
 
-function useChangedFileStats(task: Task) {
-  const taskId = task.id;
-  const workspace = useWorkspace(taskId);
+export function DiffStatsBadge({ task }: DiffStatsBadgeProps) {
+  const workspace = useWorkspace(task.id);
   const isCloud =
     workspace?.mode === "cloud" || task.latest_run?.environment === "cloud";
-  const repoPath = useCwd(taskId);
-
-  const { diffStats: localDiffStats } = useGitQueries(
-    isCloud ? undefined : repoPath,
+  return isCloud ? (
+    <CloudDiffStatsBadge task={task} />
+  ) : (
+    <LocalDiffStatsBadge task={task} />
   );
-
-  const { reviewFiles } = useCloudChangedFiles(taskId, task);
-
-  return useMemo(() => {
-    if (isCloud) {
-      const stats = computeDiffStats(reviewFiles);
-      return {
-        filesChanged: stats.filesChanged,
-        linesAdded: stats.linesAdded,
-        linesRemoved: stats.linesRemoved,
-      };
-    }
-    return {
-      filesChanged: localDiffStats.filesChanged,
-      linesAdded: localDiffStats.linesAdded,
-      linesRemoved: localDiffStats.linesRemoved,
-    };
-  }, [isCloud, reviewFiles, localDiffStats]);
 }
 
-export function DiffStatsBadge({ task }: DiffStatsBadgeProps) {
+function CloudDiffStatsBadge({ task }: { task: Task }) {
+  const { reviewFiles } = useCloudChangedFiles(task.id, task);
+  const stats = useMemo(() => computeDiffStats(reviewFiles), [reviewFiles]);
+  return <DiffStatsButton taskId={task.id} stats={stats} />;
+}
+
+function LocalDiffStatsBadge({ task }: { task: Task }) {
   const taskId = task.id;
-  const { filesChanged, linesAdded, linesRemoved } = useChangedFileStats(task);
+  const {
+    effectiveSource,
+    repoSlug,
+    linkedBranch,
+    prUrl,
+    diffStats: localDiffStats,
+  } = useEffectiveDiffSource(taskId);
+
+  const { data: branchFiles } = useBranchChangedFiles(
+    effectiveSource === "branch" ? repoSlug : null,
+    effectiveSource === "branch" ? linkedBranch : null,
+  );
+  const { data: prFiles } = usePrChangedFiles(
+    effectiveSource === "pr" ? prUrl : null,
+  );
+
+  const stats = useMemo<DiffStats>(() => {
+    if (effectiveSource === "branch" && branchFiles) {
+      return computeDiffStats(branchFiles);
+    }
+    if (effectiveSource === "pr" && prFiles) {
+      return computeDiffStats(prFiles);
+    }
+    return localDiffStats;
+  }, [effectiveSource, branchFiles, prFiles, localDiffStats]);
+
+  return <DiffStatsButton taskId={taskId} stats={stats} />;
+}
+
+function DiffStatsButton({
+  taskId,
+  stats,
+}: {
+  taskId: string;
+  stats: DiffStats;
+}) {
   const reviewMode = useReviewNavigationStore(
     (s) => s.reviewModes[taskId] ?? "closed",
   );
   const setReviewMode = useReviewNavigationStore((s) => s.setReviewMode);
 
+  const { filesChanged, linesAdded, linesRemoved } = stats;
   const hasChanges = filesChanged > 0;
-
   const isOpen = reviewMode !== "closed";
 
   const handleClick = () => {

--- a/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewPage.tsx
@@ -1,14 +1,10 @@
-import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
 import {
   useBranchChangedFiles,
-  useGitQueries,
   usePrChangedFiles,
 } from "@features/git-interaction/hooks/useGitQueries";
-import { useLinkedBranchPrUrl } from "@features/git-interaction/hooks/useLinkedBranchPrUrl";
 import { makeFileKey } from "@features/git-interaction/utils/fileKey";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
 import type { parsePatchFiles } from "@pierre/diffs";
 import { Flex, Text } from "@radix-ui/themes";
 import { useReviewNavigationStore } from "@renderer/features/code-review/stores/reviewNavigationStore";
@@ -16,12 +12,10 @@ import { useTRPC } from "@renderer/trpc/client";
 import type { ChangedFile, Task } from "@shared/types";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { useEffectiveDiffSource } from "../hooks/useEffectiveDiffSource";
 import { useReviewDiffs } from "../hooks/useReviewDiffs";
 import type { DiffOptions } from "../types";
-import {
-  type ResolvedDiffSource,
-  resolveDiffSource,
-} from "../utils/resolveDiffSource";
+import type { ResolvedDiffSource } from "../utils/resolveDiffSource";
 import { InteractiveFileDiff } from "./InteractiveFileDiff";
 import { LazyDiff } from "./LazyDiff";
 import { RemoteDiffList } from "./RemoteDiffList";
@@ -44,36 +38,21 @@ interface ReviewPageProps {
 export function ReviewPage({ task }: ReviewPageProps) {
   const taskId = task.id;
   const repoPath = useCwd(taskId);
-  const workspace = useWorkspace(taskId);
-  const linkedBranch = workspace?.linkedBranch ?? null;
   const openFile = usePanelLayoutStore((s) => s.openFile);
 
   const isReviewOpen = useReviewNavigationStore(
     (s) => (s.reviewModes[taskId] ?? "closed") !== "closed",
   );
 
-  const configuredSource = useDiffViewerStore(
-    (s) => s.diffSource[taskId] ?? null,
-  );
-
   const {
-    repoInfo,
-    aheadOfDefault,
-    defaultBranch,
-    changedFiles: workspaceFiles,
-  } = useGitQueries(repoPath);
-  const prUrl = useLinkedBranchPrUrl(taskId);
-  const hasLocalChanges = workspaceFiles.length > 0;
-  const branchSourceAvailable = !!linkedBranch && aheadOfDefault > 0;
-  const prSourceAvailable = !!prUrl;
-
-  const effectiveSource = resolveDiffSource({
-    configured: configuredSource,
-    hasLocalChanges,
+    effectiveSource,
+    prUrl,
     linkedBranch,
-    aheadOfDefault,
+    defaultBranch,
+    repoSlug,
+    branchSourceAvailable,
     prSourceAvailable,
-  });
+  } = useEffectiveDiffSource(taskId);
 
   const isLocalActive = isReviewOpen && effectiveSource === "local";
 
@@ -123,7 +102,7 @@ export function ReviewPage({ task }: ReviewPageProps) {
       <BranchReviewPage
         task={task}
         branch={linkedBranch as string}
-        repoInfo={repoInfo ?? undefined}
+        repoSlug={repoSlug}
         defaultBranch={defaultBranch}
         isReviewOpen={isReviewOpen}
         effectiveSource={effectiveSource}
@@ -216,7 +195,7 @@ export function ReviewPage({ task }: ReviewPageProps) {
 function BranchReviewPage({
   task,
   branch,
-  repoInfo,
+  repoSlug,
   defaultBranch,
   isReviewOpen,
   effectiveSource,
@@ -225,7 +204,7 @@ function BranchReviewPage({
 }: {
   task: Task;
   branch: string;
-  repoInfo: { organization: string; repository: string } | undefined;
+  repoSlug: string | null;
   defaultBranch: string | null;
   isReviewOpen: boolean;
   effectiveSource: ResolvedDiffSource;
@@ -233,9 +212,6 @@ function BranchReviewPage({
   prSourceAvailable: boolean;
 }) {
   const taskId = task.id;
-  const repoSlug = repoInfo
-    ? `${repoInfo.organization}/${repoInfo.repository}`
-    : null;
 
   const { data: files = EMPTY_BRANCH_FILES, isLoading } = useBranchChangedFiles(
     isReviewOpen ? repoSlug : null,

--- a/apps/code/src/renderer/features/code-review/hooks/useEffectiveDiffSource.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/useEffectiveDiffSource.ts
@@ -1,0 +1,65 @@
+import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
+import { useGitQueries } from "@features/git-interaction/hooks/useGitQueries";
+import { useLinkedBranchPrUrl } from "@features/git-interaction/hooks/useLinkedBranchPrUrl";
+import type { DiffStats } from "@features/git-interaction/utils/diffStats";
+import { useCwd } from "@features/sidebar/hooks/useCwd";
+import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
+import {
+  type ResolvedDiffSource,
+  resolveDiffSource,
+} from "../utils/resolveDiffSource";
+
+export interface EffectiveDiffSource {
+  effectiveSource: ResolvedDiffSource;
+  prUrl: string | null;
+  linkedBranch: string | null;
+  defaultBranch: string | null;
+  repoSlug: string | null;
+  branchSourceAvailable: boolean;
+  prSourceAvailable: boolean;
+  diffStats: DiffStats;
+}
+
+/**
+ * Resolves which diff source should be shown for a local task, plus all the
+ * context needed to actually fetch that source. Callers (review panel, diff
+ * stats badge) share one source-of-truth so UI surfaces never disagree.
+ */
+export function useEffectiveDiffSource(taskId: string): EffectiveDiffSource {
+  const repoPath = useCwd(taskId);
+  const workspace = useWorkspace(taskId);
+  const linkedBranch = workspace?.linkedBranch ?? null;
+
+  const configured = useDiffViewerStore((s) => s.diffSource[taskId] ?? null);
+
+  const { repoInfo, aheadOfDefault, defaultBranch, changedFiles, diffStats } =
+    useGitQueries(repoPath);
+  const hasLocalChanges = changedFiles.length > 0;
+  const branchSourceAvailable = !!linkedBranch && aheadOfDefault > 0;
+
+  const prUrl = useLinkedBranchPrUrl(taskId);
+  const prSourceAvailable = !!prUrl;
+
+  const repoSlug = repoInfo
+    ? `${repoInfo.organization}/${repoInfo.repository}`
+    : null;
+
+  const effectiveSource = resolveDiffSource({
+    configured,
+    hasLocalChanges,
+    linkedBranch,
+    aheadOfDefault,
+    prSourceAvailable,
+  });
+
+  return {
+    effectiveSource,
+    prUrl,
+    linkedBranch,
+    defaultBranch,
+    repoSlug,
+    branchSourceAvailable,
+    prSourceAvailable,
+    diffStats,
+  };
+}

--- a/apps/code/src/renderer/features/git-interaction/hooks/useGitQueries.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useGitQueries.ts
@@ -180,8 +180,8 @@ export function useBranchChangedFiles(
       { repo: repo as string, branch: branch as string },
       {
         enabled: !!repo && !!branch,
-        staleTime: pollFast ? 10_000 : 30_000,
-        refetchInterval: pollFast ? 10_000 : 30_000,
+        staleTime: pollFast ? 10_000 : 5 * 60_000,
+        refetchInterval: pollFast ? 10_000 : false,
         retry: 1,
       },
     ),


### PR DESCRIPTION
## Problem

diff badge always shows counts from local state even when another source is chosen

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

updates diff badge to use the same diff source as the review panel (user-selected, or automatically selected)

![Screenshot 2026-04-23 at 10.48.58 AM.png](https://app.graphite.com/user-attachments/assets/95315fc5-86af-43d5-912c-401698758a3c.png)

![Screenshot 2026-04-23 at 10.49.10 AM.png](https://app.graphite.com/user-attachments/assets/1f035da0-fd2a-42e0-a403-7f52c979152c.png)



<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->