### PR TITLE
fix(code): keep repo and branch pickers open on empty search results

### DIFF
--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -97,7 +97,14 @@ export function GitHubRepoPicker({
     );
   }
 
-  if (repositories.length === 0 && !showInlineLoadingState) {
+  const hasActiveRemoteSearch =
+    remoteMode && (open || trimmedSearchQuery.length > 0);
+
+  if (
+    repositories.length === 0 &&
+    !showInlineLoadingState &&
+    !hasActiveRemoteSearch
+  ) {
     return (
       <Button variant="outline" disabled size="sm">
         <GithubLogo size={16} weight="regular" style={{ flexShrink: 0 }} />

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -102,7 +102,7 @@ export function BranchSelector({
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
   const cloudStillLoading =
-    isCloudMode && cloudBranchesLoading && branches.length === 0;
+    isCloudMode && cloudBranchesLoading && branches.length === 0 && !open;
 
   const checkoutMutation = useMutation(
     trpc.git.checkoutBranch.mutationOptions({


### PR DESCRIPTION
## Problem

In cloud workspace mode, typing a search with zero results broke both pickers:

- **Repo picker** collapsed into a disabled `No GitHub repos` button that couldn't be reopened — the only escape was reloading the app.
- **Branch picker** snapped shut mid-type on every empty intermediate state.


https://github.com/user-attachments/assets/fec73999-a91d-4d3d-b4b0-39e752a8ff82



### Root cause

- `GitHubRepoPicker` has a long-standing early return for the "no repos connected" case. After remote search was added in #1854, the parent passes the search-filtered API response — so an empty search result unmounted the `<Combobox>` and replaced it with the disabled fallback.
- `BranchSelector` computed `cloudStillLoading = loading && branches.length === 0`, which briefly flipped true during every remote search and disabled the trigger — Radix Popover closes on disabled.

## Solution

- **`GitHubRepoPicker.tsx`** — only show the empty-account fallback when the picker is closed and no search is active; otherwise keep the `<Combobox>` mounted so `ComboboxEmpty` renders inside it.
- **`BranchSelector.tsx`** — add `&& !open` to `cloudStillLoading` so active searches don't toggle the trigger's disabled state.

