### PR TITLE
fix(code): clear cloud repository when creating worktree task

### DIFF
--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -74,7 +74,10 @@ function prepareTaskInput(
     filePaths,
     repoPath:
       options.workspaceMode === "cloud" ? undefined : options.selectedDirectory,
-    repository: options.selectedRepository,
+    repository:
+      options.workspaceMode === "cloud"
+        ? options.selectedRepository
+        : undefined,
     githubIntegrationId: options.githubIntegrationId,
     workspaceMode: options.workspaceMode,
     branch: options.branch,


### PR DESCRIPTION
## Problem

When creating a task, switching to **cloud** mode and picking a repo, then switching back to **worktree**/local mode and submitting, the resulting local task carried the cloud repo identifier. The left sidebar then grouped it under the cloud `org/repo` bucket instead of its local folder.

## Solution

Only attach the selected repository to the task when the workspace mode is `cloud`, matching how `repoPath` is already handled. Worktree/local tasks fall back to grouping by their workspace folder path.

Fixes #1836
