### PR TITLE
chore(code): close SpaceSwitcher on escape

### DIFF
--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -375,6 +375,15 @@ export function SpaceSwitcher({
     SPACE_HOTKEY_OPTIONS,
     [navigateNext, mounted],
   );
+  useHotkeys(
+    SHORTCUTS.BLUR,
+    (e) => {
+      e.preventDefault();
+      hide();
+    },
+    { ...SPACE_HOTKEY_OPTIONS, enabled: mounted },
+    [hide, mounted],
+  );
 
   if (!mounted || tasks.length === 0) return null;
 


### PR DESCRIPTION
## Problem

Holding Cmd for 500ms opens the `SpaceSwitcher` minimap, but sometimes it stays stuck on screen with no way to dismiss it — the only way to close it was to release Cmd or blur the window, and in edge cases (e.g. key events getting lost, focus shifting) the switcher would remain visible indefinitely. Users had no escape hatch.

## Solution

Wire `Escape` up to `hide()` when the switcher is mounted. Reuses the existing `SHORTCUTS.BLUR` constant and the same hotkey options as the other `SpaceSwitcher` bindings so it works across form tags and contenteditable elements.