### PR TITLE
fix(code): prevent GitHub repo picker from auto-selecting during remote search

### DIFF
--- a/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/GitHubRepoPicker.tsx
@@ -67,7 +67,8 @@ export function GitHubRepoPicker({
     controlledHasMore !== undefined ||
     onLoadMore !== undefined;
   const showInlineLoadingState = remoteMode && open && isLoading;
-  const onlyRepo = repositories.length === 1 ? repositories[0] : null;
+  const onlyRepo =
+    !remoteMode && repositories.length === 1 ? repositories[0] : null;
   const trimmedSearchQuery = searchQuery.trim();
   const filteredRepositoryCount = useMemo(() => {
     if (!trimmedSearchQuery) {


### PR DESCRIPTION
## Summary

- Cloud-mode GitHub repo picker auto-selected a repository as soon as a search narrowed results to one match, then collapsed to a disabled "Only one GitHub repository is connected" button — trapping the user with no way to reopen the dropdown or clear the query.
- Root cause: `onlyRepo` in `GitHubRepoPicker.tsx` treated `repositories.length === 1` as "one connected repo", but in remote mode the `repositories` prop is the server-filtered search result.
- Fix: gate `onlyRepo` on `!remoteMode` so the auto-select + disabled render only fire for the local picker (where the full list is always passed in). The cloud picker now keeps rendering the combobox regardless of match count.