### PR TITLE
fix(code): suppress space switcher during tour and on cmd+shift

### DIFF
--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -306,6 +306,10 @@ export function SpaceSwitcher({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === MOD_KEY && !e.repeat) {
+        // Suppress while a tour is active or Shift is held (screenshot shortcut).
+        if (e.shiftKey || document.body.classList.contains("tour-active")) {
+          return;
+        }
         metaHeldRef.current = true;
         otherKeyRef.current = false;
         clearTimeout(hideTimerRef.current);
@@ -320,6 +324,10 @@ export function SpaceSwitcher({
         // Minimap only appears from a pure Cmd hold with no other keys.
         otherKeyRef.current = true;
         clearTimeout(showTimerRef.current);
+        // Shift during hold = screenshot intent. Hide if already shown.
+        if (e.key === "Shift") {
+          hide();
+        }
       }
     };
 

--- a/apps/code/src/renderer/features/tour/components/TourOverlay.tsx
+++ b/apps/code/src/renderer/features/tour/components/TourOverlay.tsx
@@ -46,6 +46,12 @@ export function TourOverlay() {
   const advance = useTourStore((s) => s.advance);
   const dismiss = useTourStore((s) => s.dismiss);
 
+  useEffect(() => {
+    if (!activeTourId) return;
+    document.body.classList.add("tour-active");
+    return () => document.body.classList.remove("tour-active");
+  }, [activeTourId]);
+
   const tour = activeTourId ? TOUR_REGISTRY[activeTourId] : null;
   const step = tour?.steps[activeStepIndex] ?? null;
 


### PR DESCRIPTION
## Summary
- Tour overlay now toggles a `tour-active` body class while a tour is active so the SpaceSwitcher minimap does not pop in over onboarding spotlights.
- SpaceSwitcher bails its 500ms Cmd-hold show when the body has `tour-active` or when Shift is held (Cmd+Shift+3/4/5 screenshot shortcuts).
- If Shift is pressed mid-hold while the minimap is already shown, it hides immediately.

<img width="2280" height="1654" alt="2026-04-24 13 02 30" src="https://github.com/user-attachments/assets/a1db457a-03d1-4141-a5ec-f62d23454f97" />

<img width="2280" height="1654" alt="2026-04-24 13 03 20" src="https://github.com/user-attachments/assets/5965b433-a60a-413d-969d-d75e53827416" />


## Test plan
- [x] Trigger the first-task tour: hold Cmd for >500ms, confirm minimap does NOT appear; complete or dismiss the tour and confirm minimap re-enables.
- [x] With no tour active, press Cmd+Shift+4 (or Cmd+Shift+3): confirm minimap does NOT appear and screenshot tool launches normally.
- [x] Hold Cmd alone for >500ms, then press Shift: confirm minimap hides.
- [x] Hold Cmd alone for >500ms with no other keys: confirm minimap still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)