### PR TITLE
feat: enrich view in file viewer

### DIFF
--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -128,6 +128,7 @@
     "@pierre/diffs": "^1.1.7",
     "@posthog/agent": "workspace:*",
     "@posthog/electron-trpc": "workspace:*",
+    "@posthog/enricher": "workspace:*",
     "@posthog/git": "workspace:*",
     "@posthog/hedgehog-mode": "^0.0.48",
     "@posthog/quill": "0.1.0-alpha.7",

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -34,6 +34,7 @@ import { CloudTaskService } from "../services/cloud-task/service";
 import { ConnectivityService } from "../services/connectivity/service";
 import { ContextMenuService } from "../services/context-menu/service";
 import { DeepLinkService } from "../services/deep-link/service";
+import { EnrichmentService } from "../services/enrichment/service";
 import { EnvironmentService } from "../services/environment/service";
 import { ExternalAppsService } from "../services/external-apps/service";
 import { FileWatcherService } from "../services/file-watcher/service";
@@ -108,6 +109,7 @@ container.bind(MAIN_TOKENS.CloudTaskService).to(CloudTaskService);
 container.bind(MAIN_TOKENS.ConnectivityService).to(ConnectivityService);
 container.bind(MAIN_TOKENS.ContextMenuService).to(ContextMenuService);
 container.bind(MAIN_TOKENS.DeepLinkService).to(DeepLinkService);
+container.bind(MAIN_TOKENS.EnrichmentService).to(EnrichmentService);
 container.bind(MAIN_TOKENS.EnvironmentService).to(EnvironmentService);
 container.bind(MAIN_TOKENS.ProvisioningService).to(ProvisioningService);
 

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -76,4 +76,5 @@ export const MAIN_TOKENS = Object.freeze({
   EnvironmentService: Symbol.for("Main.EnvironmentService"),
   ProvisioningService: Symbol.for("Main.ProvisioningService"),
   WorkspaceService: Symbol.for("Main.WorkspaceService"),
+  EnrichmentService: Symbol.for("Main.EnrichmentService"),
 });

--- a/apps/code/src/main/services/enrichment/service.ts
+++ b/apps/code/src/main/services/enrichment/service.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import {
+  enrichSource,
+  PostHogEnricher,
+  type SerializedEnrichment,
+  setLogger as setEnricherLogger,
+  toSerializable,
+} from "@posthog/enricher";
+import { inject, injectable } from "inversify";
+import { MAIN_TOKENS } from "../../di/tokens";
+import { logger } from "../../utils/logger";
+import type { AuthService } from "../auth/service";
+
+const log = logger.scope("enrichment-service");
+
+setEnricherLogger({
+  warn: (message, ...args) => log.warn(message, ...args),
+});
+
+const MAX_CACHE_ENTRIES = 200;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+interface CacheEntry {
+  value: SerializedEnrichment | null;
+  expiresAt: number;
+}
+
+export interface EnrichFileInput {
+  taskId: string;
+  filePath: string;
+  absolutePath?: string;
+  content: string;
+}
+
+@injectable()
+export class EnrichmentService {
+  private enricher: PostHogEnricher | null = null;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(
+    @inject(MAIN_TOKENS.AuthService)
+    private readonly authService: AuthService,
+  ) {}
+
+  async enrichFile(
+    input: EnrichFileInput,
+  ): Promise<SerializedEnrichment | null> {
+    const { taskId, filePath, absolutePath, content } = input;
+    const cacheKey = this.buildCacheKey(taskId, filePath, content);
+
+    const cached = this.cache.get(cacheKey);
+    const now = Date.now();
+    if (cached && cached.expiresAt > now) {
+      this.cache.delete(cacheKey);
+      this.cache.set(cacheKey, cached);
+      return cached.value;
+    }
+    if (cached) {
+      this.cache.delete(cacheKey);
+    }
+
+    const result = await this.runEnrichment(filePath, absolutePath, content);
+    this.setCache(cacheKey, result);
+    return result;
+  }
+
+  private async runEnrichment(
+    filePath: string,
+    absolutePath: string | undefined,
+    content: string,
+  ): Promise<SerializedEnrichment | null> {
+    const state = this.authService.getState();
+    if (
+      state.status !== "authenticated" ||
+      !state.projectId ||
+      !state.cloudRegion
+    ) {
+      return null;
+    }
+
+    let apiKey: string;
+    let apiHost: string;
+    try {
+      const auth = await this.authService.getValidAccessToken();
+      apiKey = auth.accessToken;
+      apiHost = auth.apiHost;
+    } catch (err) {
+      log.debug("Failed to resolve access token for enrichment", {
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+
+    const enricher = this.getEnricher();
+    const enriched = await enrichSource({
+      enricher,
+      apiConfig: {
+        apiKey,
+        host: apiHost,
+        projectId: state.projectId,
+      },
+      filePath,
+      absolutePath,
+      content,
+      onDebug: (message: string, data?: Record<string, unknown>) => {
+        log.debug(message, { filePath, ...(data ?? {}) });
+      },
+    });
+
+    if (!enriched) return null;
+    return toSerializable(enriched);
+  }
+
+  private getEnricher(): PostHogEnricher {
+    if (!this.enricher) {
+      this.enricher = new PostHogEnricher();
+    }
+    return this.enricher;
+  }
+
+  private buildCacheKey(
+    taskId: string,
+    filePath: string,
+    content: string,
+  ): string {
+    const hash = createHash("sha1").update(content).digest("hex");
+    return `${taskId}::${filePath}::${hash}`;
+  }
+
+  private setCache(key: string, value: SerializedEnrichment | null): void {
+    this.cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+    while (this.cache.size > MAX_CACHE_ENTRIES) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest === undefined) break;
+      this.cache.delete(oldest);
+    }
+  }
+
+  dispose(): void {
+    this.enricher?.dispose();
+    this.enricher = null;
+    this.cache.clear();
+  }
+}

--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -7,6 +7,7 @@ import { connectivityRouter } from "./routers/connectivity";
 import { contextMenuRouter } from "./routers/context-menu";
 import { deepLinkRouter } from "./routers/deep-link";
 import { encryptionRouter } from "./routers/encryption";
+import { enrichmentRouter } from "./routers/enrichment";
 import { environmentRouter } from "./routers/environment";
 import { externalAppsRouter } from "./routers/external-apps";
 import { fileWatcherRouter } from "./routers/file-watcher";
@@ -45,6 +46,7 @@ export const trpcRouter = router({
   connectivity: connectivityRouter,
   contextMenu: contextMenuRouter,
 
+  enrichment: enrichmentRouter,
   environment: environmentRouter,
   encryption: encryptionRouter,
   externalApps: externalAppsRouter,

--- a/apps/code/src/main/trpc/routers/enrichment.ts
+++ b/apps/code/src/main/trpc/routers/enrichment.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { container } from "../../di/container";
+import { MAIN_TOKENS } from "../../di/tokens";
+import type { EnrichmentService } from "../../services/enrichment/service";
+import { publicProcedure, router } from "../trpc";
+
+const getService = () =>
+  container.get<EnrichmentService>(MAIN_TOKENS.EnrichmentService);
+
+const enrichFileInput = z.object({
+  taskId: z.string(),
+  filePath: z.string(),
+  absolutePath: z.string().optional(),
+  content: z.string(),
+});
+
+export const enrichmentRouter = router({
+  enrichFile: publicProcedure
+    .input(enrichFileInput)
+    .query(({ input }) => getService().enrichFile(input)),
+});

--- a/apps/code/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
+++ b/apps/code/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
@@ -1,7 +1,9 @@
 import { PanelMessage } from "@components/ui/PanelMessage";
 import { Tooltip } from "@components/ui/Tooltip";
 import { CodeMirrorEditor } from "@features/code-editor/components/CodeMirrorEditor";
+import { EnrichmentPopover } from "@features/code-editor/components/EnrichmentPopover";
 import { useCloudFileContent } from "@features/code-editor/hooks/useCloudFileContent";
+import { useFileEnrichment } from "@features/code-editor/hooks/useFileEnrichment";
 import { useMarkdownViewerStore } from "@features/code-editor/stores/markdownViewerStore";
 import { getImageMimeType } from "@features/code-editor/utils/imageUtils";
 import { isMarkdownFile } from "@features/code-editor/utils/markdownUtils";
@@ -119,6 +121,13 @@ export function CodeEditorPanel({
   const isLoading = isCloudRun ? cloudFile.isLoading : localQuery.isLoading;
   const error = isCloudRun ? null : localQuery.error;
 
+  const enrichment = useFileEnrichment({
+    taskId,
+    filePath,
+    absolutePath: isInsideRepo ? absolutePath : undefined,
+    content: isImage ? null : fileContent,
+  });
+
   if (isImage) {
     if (isCloudRun) {
       return (
@@ -234,13 +243,15 @@ export function CodeEditorPanel({
   }
 
   return (
-    <Box height="100%" className="overflow-hidden">
+    <Box height="100%" className="relative overflow-hidden">
       <CodeMirrorEditor
         content={fileContent}
         filePath={absolutePath}
         relativePath={filePath}
         readOnly
+        enrichment={enrichment}
       />
+      <EnrichmentPopover />
     </Box>
   );
 }

--- a/apps/code/src/renderer/features/code-editor/components/CodeMirrorEditor.tsx
+++ b/apps/code/src/renderer/features/code-editor/components/CodeMirrorEditor.tsx
@@ -1,7 +1,9 @@
 import { openSearchPanel } from "@codemirror/search";
 import { EditorView } from "@codemirror/view";
+import type { SerializedEnrichment } from "@posthog/enricher";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { useEffect, useMemo } from "react";
+import { setEnrichmentEffect } from "../extensions/postHogEnrichment";
 import { useCodeMirror } from "../hooks/useCodeMirror";
 import { useEditorExtensions } from "../hooks/useEditorExtensions";
 import { usePendingScrollStore } from "../stores/pendingScrollStore";
@@ -11,6 +13,7 @@ interface CodeMirrorEditorProps {
   filePath?: string;
   relativePath?: string;
   readOnly?: boolean;
+  enrichment?: SerializedEnrichment | null;
 }
 
 export function CodeMirrorEditor({
@@ -18,13 +21,25 @@ export function CodeMirrorEditor({
   filePath,
   relativePath,
   readOnly = false,
+  enrichment,
 }: CodeMirrorEditorProps) {
-  const extensions = useEditorExtensions(filePath, readOnly);
+  const enrichmentEnabled = enrichment !== undefined;
+  const extensions = useEditorExtensions(filePath, readOnly, enrichmentEnabled);
   const options = useMemo(
     () => ({ doc: content, extensions, filePath }),
     [content, extensions, filePath],
   );
   const { containerRef, instanceRef } = useCodeMirror(options);
+
+  useEffect(() => {
+    if (!enrichmentEnabled) return;
+    const view = instanceRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: setEnrichmentEffect.of(enrichment ?? null),
+    });
+  }, [enrichment, enrichmentEnabled, instanceRef]);
+
   useEffect(() => {
     if (!filePath) return;
     const scrollToLine = () => {

--- a/apps/code/src/renderer/features/code-editor/components/EnrichmentPopover.tsx
+++ b/apps/code/src/renderer/features/code-editor/components/EnrichmentPopover.tsx
@@ -1,0 +1,310 @@
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
+import { ArrowSquareOut } from "@phosphor-icons/react";
+import type { SerializedEvent, SerializedFlag } from "@posthog/enricher";
+import { Badge, Button, Card } from "@posthog/quill";
+import { trpcClient } from "@renderer/trpc/client";
+import {
+  eventDefinitionUrl,
+  experimentUrl,
+  flagUrl,
+  flagUrlByKey,
+  type LinkOverrides,
+} from "@utils/posthogLinks";
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useEnrichmentPopoverStore } from "../stores/enrichmentPopoverStore";
+
+const POPOVER_WIDTH = 320;
+const GAP = 8;
+
+function compactNumber(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function relativeTime(iso: string | null): string | null {
+  if (!iso) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+  const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMon = Math.round(diffDay / 30);
+  if (diffMon < 12) return `${diffMon}mo ago`;
+  return `${Math.round(diffMon / 12)}y ago`;
+}
+
+function openExternal(url: string) {
+  void trpcClient.os.openExternal.mutate({ url });
+}
+
+function FlagBody({
+  flag,
+  linkOverrides,
+}: {
+  flag: SerializedFlag;
+  linkOverrides: LinkOverrides;
+}) {
+  const href =
+    flag.flagId !== null
+      ? flagUrl(flag.flagId, linkOverrides)
+      : flagUrlByKey(flag.flagKey, linkOverrides);
+  const expHref = flag.experiment
+    ? experimentUrl(flag.experiment.id, linkOverrides)
+    : null;
+
+  const stalenessLabel: Record<NonNullable<typeof flag.staleness>, string> = {
+    fully_rolled_out: "Fully rolled out",
+    inactive: "Inactive",
+    not_in_posthog: "Not in PostHog",
+    experiment_complete: "Experiment complete",
+  };
+
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Badge variant="info">Flag</Badge>
+          <span className="truncate font-mono text-sm" title={flag.flagKey}>
+            {flag.flagKey}
+          </span>
+        </div>
+        <Badge variant="default">{flag.flagType}</Badge>
+      </div>
+
+      {flag.staleness && (
+        <div>
+          <Badge
+            variant={flag.staleness === "inactive" ? "destructive" : "warning"}
+          >
+            {stalenessLabel[flag.staleness]}
+          </Badge>
+        </div>
+      )}
+
+      {flag.rollout !== null && flag.variants.length === 0 && (
+        <div>
+          <div className="mb-1 flex justify-between text-muted-foreground text-xs">
+            <span>Rollout</span>
+            <span>{flag.rollout}%</span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded bg-[var(--gray-4)]">
+            <div
+              className="h-full bg-[var(--accent-9)]"
+              style={{ width: `${Math.min(100, Math.max(0, flag.rollout))}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {flag.variants.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <div className="text-muted-foreground text-xs">Variants</div>
+          <div className="flex flex-col gap-1">
+            {flag.variants.map((v) => (
+              <div
+                key={v.key}
+                className="flex items-center justify-between text-xs"
+              >
+                <span className="font-mono">{v.key}</span>
+                <span className="text-muted-foreground">
+                  {v.rolloutPercentage}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {flag.experiment && (
+        <div className="flex items-center justify-between gap-2 rounded border border-[var(--gray-5)] p-2 text-xs">
+          <div className="min-w-0">
+            <div className="text-muted-foreground">Experiment</div>
+            <div className="truncate" title={flag.experiment.name}>
+              {flag.experiment.name}
+            </div>
+          </div>
+          <Badge
+            variant={
+              flag.experiment.status === "running" ? "success" : "default"
+            }
+          >
+            {flag.experiment.status}
+          </Badge>
+        </div>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        {href && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => openExternal(href)}
+          >
+            <ArrowSquareOut size={12} weight="bold" />
+            Open flag
+          </Button>
+        )}
+        {expHref && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => openExternal(expHref)}
+          >
+            <ArrowSquareOut size={12} weight="bold" />
+            Experiment
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EventBody({
+  event,
+  linkOverrides,
+}: {
+  event: SerializedEvent;
+  linkOverrides: LinkOverrides;
+}) {
+  const href = event.definitionId
+    ? eventDefinitionUrl(event.definitionId, linkOverrides)
+    : null;
+  const lastSeen = relativeTime(event.lastSeenAt);
+
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Badge variant="info">Event</Badge>
+          <span className="truncate font-mono text-sm" title={event.eventName}>
+            {event.eventName}
+          </span>
+        </div>
+        {event.verified && <Badge variant="success">Verified</Badge>}
+      </div>
+
+      {event.description && (
+        <div className="text-muted-foreground text-xs">{event.description}</div>
+      )}
+
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        {event.volume !== null && (
+          <div>
+            <div className="text-muted-foreground">30-day volume</div>
+            <div className="font-medium">{compactNumber(event.volume)}</div>
+          </div>
+        )}
+        {event.uniqueUsers !== null && (
+          <div>
+            <div className="text-muted-foreground">Unique users</div>
+            <div className="font-medium">
+              {compactNumber(event.uniqueUsers)}
+            </div>
+          </div>
+        )}
+        {lastSeen && (
+          <div className="col-span-2">
+            <div className="text-muted-foreground">Last seen</div>
+            <div className="font-medium">{lastSeen}</div>
+          </div>
+        )}
+      </div>
+
+      {event.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {event.tags.map((tag) => (
+            <Badge key={tag} variant="default">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {href && (
+        <div className="pt-1">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => openExternal(href)}
+          >
+            <ArrowSquareOut size={12} weight="bold" />
+            Open event
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function EnrichmentPopover() {
+  const open = useEnrichmentPopoverStore((s) => s.open);
+  const entry = useEnrichmentPopoverStore((s) => s.entry);
+  const anchorRect = useEnrichmentPopoverStore((s) => s.anchorRect);
+  const close = useEnrichmentPopoverStore((s) => s.close);
+  const projectId = useAuthStateValue((s) => s.projectId);
+  const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) close();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open, close]);
+
+  if (!open || !entry || !anchorRect) return null;
+
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const preferredLeft = anchorRect.right + GAP;
+  const fitsRight = preferredLeft + POPOVER_WIDTH + 8 <= viewportWidth;
+  const left = fitsRight
+    ? preferredLeft
+    : Math.max(8, anchorRect.left - POPOVER_WIDTH - GAP);
+  const top = Math.max(8, Math.min(anchorRect.top, viewportHeight - 200));
+
+  return createPortal(
+    <div
+      ref={ref}
+      style={{
+        position: "fixed",
+        top,
+        left,
+        width: POPOVER_WIDTH,
+        zIndex: 1000,
+      }}
+    >
+      <Card size="sm" className="gap-0 py-0 shadow-lg">
+        {entry.kind === "flag" ? (
+          <FlagBody
+            flag={entry.data}
+            linkOverrides={{ projectId, cloudRegion }}
+          />
+        ) : (
+          <EventBody
+            event={entry.data}
+            linkOverrides={{ projectId, cloudRegion }}
+          />
+        )}
+      </Card>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/code/src/renderer/features/code-editor/extensions/postHogEnrichment.ts
+++ b/apps/code/src/renderer/features/code-editor/extensions/postHogEnrichment.ts
@@ -1,0 +1,178 @@
+import {
+  type Extension,
+  RangeSetBuilder,
+  StateEffect,
+  StateField,
+} from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from "@codemirror/view";
+import type { SerializedEnrichment } from "@posthog/enricher";
+import {
+  type EnrichmentPopoverEntry,
+  useEnrichmentPopoverStore,
+} from "../stores/enrichmentPopoverStore";
+
+export const setEnrichmentEffect =
+  StateEffect.define<SerializedEnrichment | null>();
+
+interface Occurrence {
+  /** 1-indexed CodeMirror line number. */
+  line: number;
+  startCol: number;
+  endCol: number;
+  entry: EnrichmentPopoverEntry;
+  summary: string;
+}
+
+function buildOccurrences(data: SerializedEnrichment | null): Occurrence[] {
+  if (!data) return [];
+  const out: Occurrence[] = [];
+
+  for (const flag of data.flags) {
+    for (const occ of flag.occurrences) {
+      out.push({
+        line: occ.line + 1,
+        startCol: occ.startCol,
+        endCol: occ.endCol,
+        entry: { kind: "flag", data: flag },
+        summary: `Flag: ${flag.flagKey}`,
+      });
+    }
+  }
+  for (const event of data.events) {
+    for (const occ of event.occurrences) {
+      out.push({
+        line: occ.line + 1,
+        startCol: occ.startCol,
+        endCol: occ.endCol,
+        entry: { kind: "event", data: event },
+        summary: `Event: ${event.eventName}`,
+      });
+    }
+  }
+
+  // RangeSetBuilder requires ranges in document order.
+  out.sort((a, b) =>
+    a.line !== b.line ? a.line - b.line : a.startCol - b.startCol,
+  );
+  return out;
+}
+
+const enrichmentField = StateField.define<Occurrence[]>({
+  create: () => [],
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setEnrichmentEffect)) {
+        return buildOccurrences(effect.value);
+      }
+    }
+    return value;
+  },
+});
+
+const pillStyles = EditorView.baseTheme({
+  ".cm-posthog-pill": {
+    backgroundColor:
+      "color-mix(in srgb, var(--accent-9, #6b46c1) 18%, transparent)",
+    borderRadius: "3px",
+    padding: "0 3px",
+    margin: "0 -3px",
+    boxShadow:
+      "inset 0 0 0 1px color-mix(in srgb, var(--accent-9, #6b46c1) 40%, transparent)",
+    cursor: "pointer",
+  },
+  ".cm-posthog-pill:hover": {
+    backgroundColor:
+      "color-mix(in srgb, var(--accent-9, #6b46c1) 30%, transparent)",
+  },
+});
+
+function openPopoverFor(view: EditorView, occurrence: Occurrence): void {
+  const line = view.state.doc.line(occurrence.line);
+  const from = Math.min(line.from + occurrence.startCol, line.to);
+  const to = Math.min(line.from + occurrence.endCol, line.to);
+  const start = view.coordsAtPos(from);
+  if (!start) return;
+  const end = view.coordsAtPos(to) ?? start;
+  useEnrichmentPopoverStore.getState().show(
+    {
+      top: start.top,
+      bottom: start.bottom,
+      left: start.left,
+      right: end.right,
+    },
+    occurrence.entry,
+  );
+}
+
+const pillPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = this.build(view);
+    }
+    update(update: ViewUpdate) {
+      const prev = update.startState.field(enrichmentField, false);
+      const next = update.state.field(enrichmentField, false);
+      if (prev !== next || update.docChanged) {
+        this.decorations = this.build(update.view);
+      }
+    }
+    build(view: EditorView): DecorationSet {
+      const occurrences = view.state.field(enrichmentField, false) ?? [];
+      const builder = new RangeSetBuilder<Decoration>();
+      const doc = view.state.doc;
+      for (const occ of occurrences) {
+        if (occ.line < 1 || occ.line > doc.lines) continue;
+        const line = doc.line(occ.line);
+        const from = line.from + Math.max(0, occ.startCol);
+        const to = line.from + Math.max(occ.startCol, occ.endCol);
+        if (to <= from || to > line.to) continue;
+        builder.add(
+          from,
+          to,
+          Decoration.mark({
+            class: "cm-posthog-pill",
+            attributes: {
+              "data-posthog-pill": "1",
+              title: occ.summary,
+            },
+          }),
+        );
+      }
+      return builder.finish();
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+    eventHandlers: {
+      click(event, view) {
+        const target = event.target as HTMLElement | null;
+        if (!target) return false;
+        const pill = target.closest<HTMLElement>("[data-posthog-pill]");
+        if (!pill) return false;
+        const pos = view.posAtDOM(pill);
+        const occurrences = view.state.field(enrichmentField, false) ?? [];
+        const line = view.state.doc.lineAt(pos).number;
+        const col = pos - view.state.doc.line(line).from;
+        const match = occurrences.find(
+          (o) => o.line === line && col >= o.startCol && col <= o.endCol,
+        );
+        if (!match) return false;
+        event.preventDefault();
+        event.stopPropagation();
+        openPopoverFor(view, match);
+        return true;
+      },
+    },
+  },
+);
+
+export function postHogEnrichmentExtension(): Extension {
+  return [enrichmentField, pillPlugin, pillStyles];
+}

--- a/apps/code/src/renderer/features/code-editor/hooks/useEditorExtensions.ts
+++ b/apps/code/src/renderer/features/code-editor/hooks/useEditorExtensions.ts
@@ -12,10 +12,15 @@ import {
 } from "@codemirror/view";
 import { useThemeStore } from "@stores/themeStore";
 import { useMemo } from "react";
+import { postHogEnrichmentExtension } from "../extensions/postHogEnrichment";
 import { oneDark, oneLight } from "../theme/editorTheme";
 import { getLanguageExtension } from "../utils/languages";
 
-export function useEditorExtensions(filePath?: string, readOnly = false) {
+export function useEditorExtensions(
+  filePath?: string,
+  readOnly = false,
+  enableEnrichment = false,
+) {
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
 
   return useMemo(() => {
@@ -33,6 +38,7 @@ export function useEditorExtensions(filePath?: string, readOnly = false) {
       EditorView.editable.of(!readOnly),
       ...(readOnly ? [EditorState.readOnly.of(true)] : []),
       ...(languageExtension ? [languageExtension] : []),
+      ...(enableEnrichment ? [postHogEnrichmentExtension()] : []),
     ];
-  }, [filePath, isDarkMode, readOnly]);
+  }, [filePath, isDarkMode, readOnly, enableEnrichment]);
 }

--- a/apps/code/src/renderer/features/code-editor/hooks/useFileEnrichment.ts
+++ b/apps/code/src/renderer/features/code-editor/hooks/useFileEnrichment.ts
@@ -1,0 +1,46 @@
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
+import type { SerializedEnrichment } from "@posthog/enricher";
+import { useTRPC } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+
+const SUPPORTED_EXT = /\.(?:ts|tsx|js|jsx|mjs|cjs|py|rb|go)$/i;
+
+interface UseFileEnrichmentOptions {
+  taskId: string;
+  filePath: string;
+  absolutePath?: string;
+  content: string | null | undefined;
+}
+
+export function useFileEnrichment({
+  taskId,
+  filePath,
+  absolutePath,
+  content,
+}: UseFileEnrichmentOptions): SerializedEnrichment | null {
+  const trpc = useTRPC();
+  const isAuthenticated = useAuthStateValue(
+    (s) => s.status === "authenticated",
+  );
+
+  // Wrapper helpers like `track(...)` don't mention `posthog` literally, so we
+  // only require the extension + supported size. The enrichment pipeline on
+  // the server bails out if there's no direct usage AND no resolvable wrapper.
+  const hasContent =
+    typeof content === "string" &&
+    content.length > 0 &&
+    content.length <= 1_000_000;
+  const extSupported = SUPPORTED_EXT.test(filePath);
+
+  const query = useQuery(
+    trpc.enrichment.enrichFile.queryOptions(
+      { taskId, filePath, absolutePath, content: content ?? "" },
+      {
+        enabled: hasContent && extSupported && isAuthenticated,
+        staleTime: Infinity,
+      },
+    ),
+  );
+
+  return query.data ?? null;
+}

--- a/apps/code/src/renderer/features/code-editor/stores/enrichmentPopoverStore.ts
+++ b/apps/code/src/renderer/features/code-editor/stores/enrichmentPopoverStore.ts
@@ -1,0 +1,31 @@
+import type { SerializedEvent, SerializedFlag } from "@posthog/enricher";
+import { create } from "zustand";
+
+export type EnrichmentPopoverEntry =
+  | { kind: "flag"; data: SerializedFlag }
+  | { kind: "event"; data: SerializedEvent };
+
+export interface PopoverAnchorRect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+interface EnrichmentPopoverState {
+  open: boolean;
+  anchorRect: PopoverAnchorRect | null;
+  entry: EnrichmentPopoverEntry | null;
+  show: (rect: PopoverAnchorRect, entry: EnrichmentPopoverEntry) => void;
+  close: () => void;
+}
+
+export const useEnrichmentPopoverStore = create<EnrichmentPopoverState>(
+  (set) => ({
+    open: false,
+    anchorRect: null,
+    entry: null,
+    show: (rect, entry) => set({ open: true, anchorRect: rect, entry }),
+    close: () => set({ open: false, entry: null, anchorRect: null }),
+  }),
+);

--- a/apps/code/src/renderer/utils/posthogLinks.ts
+++ b/apps/code/src/renderer/utils/posthogLinks.ts
@@ -1,0 +1,67 @@
+import { useAuthStore } from "@features/auth/stores/authStore";
+import type { CloudRegion } from "@shared/types/regions";
+import { getPostHogUrl } from "@utils/urls";
+
+export interface LinkOverrides {
+  projectId?: number | null;
+  cloudRegion?: CloudRegion | null;
+}
+
+function resolveProjectId(override?: number | null): number | null {
+  if (override != null) return override;
+  return useAuthStore.getState().projectId ?? null;
+}
+
+function withProjectId(
+  path: (projectId: number) => string,
+  overrides?: LinkOverrides,
+): string | null {
+  const projectId = resolveProjectId(overrides?.projectId);
+  if (!projectId) return null;
+  return getPostHogUrl(path(projectId), overrides?.cloudRegion);
+}
+
+export function flagUrl(
+  flagId: number,
+  overrides?: LinkOverrides,
+): string | null {
+  return withProjectId(
+    (pid) => `/project/${pid}/feature_flags/${flagId}`,
+    overrides,
+  );
+}
+
+export function flagUrlByKey(
+  flagKey: string,
+  overrides?: LinkOverrides,
+): string | null {
+  return withProjectId(
+    (pid) =>
+      `/project/${pid}/feature_flags?search=${encodeURIComponent(flagKey)}`,
+    overrides,
+  );
+}
+
+export function eventDefinitionUrl(
+  definitionId: string,
+  overrides?: LinkOverrides,
+): string | null {
+  return withProjectId(
+    (pid) => `/project/${pid}/data-management/events/${definitionId}`,
+    overrides,
+  );
+}
+
+export function experimentUrl(
+  experimentId: number,
+  overrides?: LinkOverrides,
+): string | null {
+  return withProjectId(
+    (pid) => `/project/${pid}/experiments/${experimentId}`,
+    overrides,
+  );
+}
+
+export function featureFlagsIndexUrl(overrides?: LinkOverrides): string | null {
+  return withProjectId((pid) => `/project/${pid}/feature_flags`, overrides);
+}

--- a/apps/code/src/renderer/utils/urls.ts
+++ b/apps/code/src/renderer/utils/urls.ts
@@ -1,8 +1,12 @@
 import { useAuthStore } from "@features/auth/stores/authStore";
+import type { CloudRegion } from "@shared/types/regions";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
 
-export function getPostHogUrl(path: string): string {
-  const region = useAuthStore.getState().cloudRegion;
+export function getPostHogUrl(
+  path: string,
+  regionOverride?: CloudRegion | null,
+): string {
+  const region = regionOverride ?? useAuthStore.getState().cloudRegion;
   const base = region ? getCloudUrlFromRegion(region) : "http://localhost:8010";
   return `${base}${path.startsWith("/") ? path : `/${path}`}`;
 }

--- a/packages/enricher/src/enrich-source.ts
+++ b/packages/enricher/src/enrich-source.ts
@@ -1,0 +1,172 @@
+import type { EnrichedResult } from "./enriched-result.js";
+import type { PostHogEnricher } from "./enricher.js";
+import { EXT_TO_LANG_ID } from "./languages.js";
+import type { LocalWrapper, ParseContext } from "./types.js";
+
+export interface EnrichSourceApiConfig {
+  apiKey: string;
+  host: string;
+  projectId: number;
+  /** Timeout in ms for each PostHog API request (default: 5000). */
+  timeoutMs?: number;
+}
+
+export interface EnrichSourceOptions {
+  enricher: PostHogEnricher;
+  apiConfig: EnrichSourceApiConfig;
+  filePath: string;
+  /**
+   * Absolute filesystem path of the file. When provided, enrichment will
+   * resolve relative imports to pick up wrapper functions (e.g. a `track(…)`
+   * helper that internally calls `posthog.capture`).
+   */
+  absolutePath?: string;
+  content: string;
+  /** Skip files larger than this. Default: 1,000,000 bytes. */
+  maxBytes?: number;
+  onDebug?: (message: string, data?: Record<string, unknown>) => void;
+}
+
+const DEFAULT_MAX_BYTES = 1_000_000;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_RELATIVE_IMPORTS = 64;
+const RELATIVE_IMPORT_REGEX =
+  /(?:^|\n)\s*(?:import\b[^\n]*['"]\.{1,2}\/|from\s+\.)/;
+
+function extOf(filePath: string): string {
+  const idx = filePath.lastIndexOf(".");
+  return idx === -1 ? "" : filePath.slice(idx).toLowerCase();
+}
+
+async function buildParseContext(
+  enricher: PostHogEnricher,
+  content: string,
+  langId: string,
+  absolutePath: string | undefined,
+  onDebug?: (message: string, data?: Record<string, unknown>) => void,
+): Promise<ParseContext | undefined> {
+  const wrappersByLocalName = new Map<string, LocalWrapper>();
+  const namespaceWrappers = new Map<string, Map<string, LocalWrapper>>();
+
+  const localWrappers = await enricher.findWrappersInSource(content, langId);
+  for (const w of localWrappers) {
+    wrappersByLocalName.set(w.name, w);
+  }
+
+  if (absolutePath && RELATIVE_IMPORT_REGEX.test(content)) {
+    try {
+      const edges = await enricher.findImportsInSource(
+        content,
+        langId,
+        absolutePath,
+      );
+      const bounded = edges.slice(0, MAX_RELATIVE_IMPORTS);
+
+      const resolutions = await Promise.all(
+        bounded.map(async (edge) => {
+          if (!edge.resolvedAbsPath) return null;
+          const wrappers = await enricher.getWrappersForFile(
+            edge.resolvedAbsPath,
+          );
+          if (!wrappers.length) return null;
+          return { edge, wrappers };
+        }),
+      );
+
+      for (const entry of resolutions) {
+        if (!entry) continue;
+        const { edge, wrappers } = entry;
+
+        if (edge.isNamespace) {
+          const nsMap = new Map<string, LocalWrapper>();
+          for (const w of wrappers) {
+            if (w.isNamedExport || w.isDefaultExport) {
+              nsMap.set(w.name, w);
+            }
+          }
+          if (nsMap.size) namespaceWrappers.set(edge.localName, nsMap);
+          continue;
+        }
+
+        if (edge.isDefault) {
+          const target = wrappers.find((w) => w.isDefaultExport);
+          if (target) wrappersByLocalName.set(edge.localName, target);
+          continue;
+        }
+
+        const target = wrappers.find(
+          (w) => w.name === edge.importedName && w.isNamedExport,
+        );
+        if (target) wrappersByLocalName.set(edge.localName, target);
+      }
+    } catch (err) {
+      onDebug?.("enrichSource: import resolution failed", {
+        absolutePath,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (!wrappersByLocalName.size && !namespaceWrappers.size) return undefined;
+  return { wrappersByLocalName, namespaceWrappers };
+}
+
+/**
+ * Shared enrichment pipeline used by both the agent (which then renders
+ * inline comments) and the renderer (which consumes a serialised form).
+ *
+ * Returns `null` when the file is too large, has no PostHog references,
+ * is an unsupported language, or the API call fails.
+ */
+export async function enrichSource({
+  enricher,
+  apiConfig,
+  filePath,
+  absolutePath,
+  content,
+  maxBytes = DEFAULT_MAX_BYTES,
+  onDebug,
+}: EnrichSourceOptions): Promise<EnrichedResult | null> {
+  if (!content || content.length > maxBytes) return null;
+
+  const langId = EXT_TO_LANG_ID[extOf(filePath)];
+  if (!langId || !enricher.isSupported(langId)) return null;
+
+  const parseContext = await buildParseContext(
+    enricher,
+    content,
+    langId,
+    absolutePath,
+    onDebug,
+  );
+
+  const hasPostHogLiteral = /posthog/i.test(content);
+  if (!hasPostHogLiteral && !parseContext) return null;
+
+  try {
+    const parsed = await enricher.parse(content, langId, parseContext);
+    if (parsed.calls.length === 0 && parsed.initCalls.length === 0) {
+      return null;
+    }
+
+    const enriched = await parsed.enrichFromApi({
+      apiKey: apiConfig.apiKey,
+      host: apiConfig.host,
+      projectId: apiConfig.projectId,
+      timeoutMs: apiConfig.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    });
+
+    onDebug?.("enrichSource: enriched", {
+      filePath,
+      flags: enriched.flags.length,
+      events: enriched.events.length,
+    });
+    return enriched;
+  } catch (err) {
+    onDebug?.("enrichSource: failed", {
+      filePath,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/packages/enricher/src/enricher.ts
+++ b/packages/enricher/src/enricher.ts
@@ -76,6 +76,19 @@ export class PostHogEnricher {
     );
   }
 
+  /**
+   * Detect wrapper functions (functions that internally call a PostHog SDK
+   * method) defined in the given source. Used by callers like `enrichSource`
+   * to pick up same-file wrappers such as `track(...)` without threading
+   * through filesystem I/O.
+   */
+  async findWrappersInSource(
+    source: string,
+    languageId: string,
+  ): Promise<LocalWrapper[]> {
+    return this.detector.findWrappers(source, languageId);
+  }
+
   async parseFile(filePath: string): Promise<ParseResult> {
     const ext = path.extname(filePath).toLowerCase();
     const languageId = EXT_TO_LANG_ID[ext];

--- a/packages/enricher/src/index.ts
+++ b/packages/enricher/src/index.ts
@@ -61,3 +61,24 @@ export type {
   FlagCheck,
   ListItem,
 } from "./types.js";
+
+// ── Shared enrichment pipeline ──
+
+export type {
+  EnrichSourceApiConfig,
+  EnrichSourceOptions,
+} from "./enrich-source.js";
+export { enrichSource } from "./enrich-source.js";
+
+// ── Serialisation (tRPC/IPC boundary) ──
+
+export type {
+  SerializedEnrichment,
+  SerializedEvent,
+  SerializedEventOccurrence,
+  SerializedFlag,
+  SerializedFlagExperiment,
+  SerializedFlagOccurrence,
+  SerializedFlagVariant,
+} from "./serialize.js";
+export { toSerializable } from "./serialize.js";

--- a/packages/enricher/src/parse-result.ts
+++ b/packages/enricher/src/parse-result.ts
@@ -50,6 +50,8 @@ export class ParseResult {
       .map((c) => ({
         name: c.key,
         line: c.line,
+        keyStartCol: c.keyStartCol,
+        keyEndCol: c.keyEndCol,
         dynamic: c.dynamic ?? false,
         viaWrapper: c.viaWrapper,
         inJsx: c.inJsx,
@@ -63,6 +65,8 @@ export class ParseResult {
         method: c.method,
         flagKey: c.key,
         line: c.line,
+        keyStartCol: c.keyStartCol,
+        keyEndCol: c.keyEndCol,
         viaWrapper: c.viaWrapper,
         inJsx: c.inJsx,
       }));

--- a/packages/enricher/src/serialize.test.ts
+++ b/packages/enricher/src/serialize.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "vitest";
+import { EnrichedResult } from "./enriched-result.js";
+import { ParseResult } from "./parse-result.js";
+import { toSerializable } from "./serialize.js";
+import type {
+  EventDefinition,
+  Experiment,
+  FeatureFlag,
+  PostHogCall,
+} from "./types.js";
+
+const call = (
+  method: string,
+  key: string,
+  line: number,
+  dynamic = false,
+): PostHogCall => ({
+  method,
+  key,
+  line,
+  keyStartCol: 0,
+  keyEndCol: 0,
+  dynamic,
+});
+
+function makeParse(calls: PostHogCall[]): ParseResult {
+  return new ParseResult("", "javascript", calls, [], [], [], []);
+}
+
+describe("toSerializable", () => {
+  test("serialises flags with experiment + variants and drops runtime objects", () => {
+    const flag: FeatureFlag = {
+      id: 42,
+      key: "new-onboarding",
+      name: "New onboarding",
+      active: true,
+      filters: {
+        multivariate: {
+          variants: [
+            { key: "control", rollout_percentage: 50 },
+            { key: "test", rollout_percentage: 50 },
+          ],
+        },
+        groups: [{ rollout_percentage: 100 }],
+      } as unknown as Record<string, unknown>,
+      created_at: "2026-01-01T00:00:00Z",
+      created_by: null,
+      deleted: false,
+    };
+    const experiment: Experiment = {
+      id: 7,
+      name: "Onboarding test",
+      description: null,
+      start_date: "2026-01-01",
+      end_date: null,
+      feature_flag_key: "new-onboarding",
+      created_at: "2026-01-01T00:00:00Z",
+      created_by: null,
+    };
+
+    const parsed = makeParse([call("isFeatureEnabled", "new-onboarding", 10)]);
+    const enriched = new EnrichedResult(parsed, {
+      flags: new Map([["new-onboarding", flag]]),
+      experiments: [experiment],
+    });
+
+    const out = toSerializable(enriched);
+    expect(out.events).toEqual([]);
+    expect(out.flags).toHaveLength(1);
+
+    const serialized = out.flags[0];
+    expect(serialized.flagKey).toBe("new-onboarding");
+    expect(serialized.flagId).toBe(42);
+    expect(serialized.active).toBe(true);
+    expect(serialized.flagType).toBe("multivariate");
+    expect(serialized.variants).toEqual([
+      { key: "control", rolloutPercentage: 50 },
+      { key: "test", rolloutPercentage: 50 },
+    ]);
+    expect(serialized.occurrences).toEqual([
+      { method: "isFeatureEnabled", line: 10, startCol: 0, endCol: 0 },
+    ]);
+    expect(serialized.experiment).toEqual({
+      id: 7,
+      name: "Onboarding test",
+      status: "running",
+    });
+
+    // Must be JSON-safe (no class instances, Maps, etc.)
+    expect(() => JSON.stringify(out)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(out))).toEqual(out);
+  });
+
+  test("marks experiment as complete when end_date is set", () => {
+    const flag: FeatureFlag = {
+      id: 1,
+      key: "f",
+      name: "F",
+      active: true,
+      filters: {},
+      created_at: "2026-01-01T00:00:00Z",
+      created_by: null,
+      deleted: false,
+    };
+    const experiment: Experiment = {
+      id: 3,
+      name: "Done",
+      description: null,
+      start_date: "2026-01-01",
+      end_date: "2026-02-01",
+      feature_flag_key: "f",
+      created_at: "2026-01-01T00:00:00Z",
+      created_by: null,
+    };
+
+    const parsed = makeParse([call("isFeatureEnabled", "f", 5)]);
+    const enriched = new EnrichedResult(parsed, {
+      flags: new Map([["f", flag]]),
+      experiments: [experiment],
+    });
+
+    const out = toSerializable(enriched);
+    expect(out.flags[0].experiment?.status).toBe("complete");
+  });
+
+  test("serialises events with stats and description, skips dynamic occurrences", () => {
+    const def: EventDefinition = {
+      id: "def-abc",
+      name: "signup_completed",
+      description: "Fires when a user finishes signup",
+      tags: ["onboarding"],
+      last_seen_at: "2026-04-20T10:00:00Z",
+      verified: true,
+    };
+    const parsed = makeParse([
+      call("capture", "signup_completed", 12),
+      call("capture", "signup_completed", 20),
+      call("capture", "dynamic_event", 30, true),
+    ]);
+    const enriched = new EnrichedResult(parsed, {
+      eventDefinitions: new Map([["signup_completed", def]]),
+      eventStats: new Map([
+        [
+          "signup_completed",
+          {
+            volume: 1234,
+            uniqueUsers: 456,
+            lastSeenAt: "2026-04-22T10:00:00Z",
+          },
+        ],
+      ]),
+    });
+
+    const out = toSerializable(enriched);
+    expect(out.events).toHaveLength(1);
+    const event = out.events[0];
+    expect(event.eventName).toBe("signup_completed");
+    expect(event.definitionId).toBe("def-abc");
+    expect(event.verified).toBe(true);
+    expect(event.description).toBe("Fires when a user finishes signup");
+    expect(event.tags).toEqual(["onboarding"]);
+    expect(event.volume).toBe(1234);
+    expect(event.uniqueUsers).toBe(456);
+    expect(event.lastSeenAt).toBe("2026-04-22T10:00:00Z");
+    expect(event.occurrences).toEqual([
+      { line: 12, dynamic: false, startCol: 0, endCol: 0 },
+      { line: 20, dynamic: false, startCol: 0, endCol: 0 },
+    ]);
+  });
+
+  test("returns empty arrays when nothing enriched", () => {
+    const parsed = makeParse([]);
+    const enriched = new EnrichedResult(parsed, {});
+    expect(toSerializable(enriched)).toEqual({ flags: [], events: [] });
+  });
+});

--- a/packages/enricher/src/serialize.ts
+++ b/packages/enricher/src/serialize.ts
@@ -1,0 +1,103 @@
+import type { EnrichedResult } from "./enriched-result.js";
+import type { FlagType, StalenessReason } from "./types.js";
+
+export interface SerializedFlagOccurrence {
+  method: string;
+  line: number;
+  startCol: number;
+  endCol: number;
+}
+
+export interface SerializedFlagVariant {
+  key: string;
+  rolloutPercentage: number;
+}
+
+export interface SerializedFlagExperiment {
+  id: number;
+  name: string;
+  status: "running" | "complete";
+}
+
+export interface SerializedFlag {
+  flagKey: string;
+  flagId: number | null;
+  flagType: FlagType;
+  staleness: StalenessReason | null;
+  rollout: number | null;
+  active: boolean;
+  variants: SerializedFlagVariant[];
+  occurrences: SerializedFlagOccurrence[];
+  experiment: SerializedFlagExperiment | null;
+}
+
+export interface SerializedEventOccurrence {
+  line: number;
+  startCol: number;
+  endCol: number;
+  dynamic: boolean;
+}
+
+export interface SerializedEvent {
+  eventName: string;
+  definitionId: string | null;
+  verified: boolean;
+  description: string | null;
+  tags: string[];
+  lastSeenAt: string | null;
+  volume: number | null;
+  uniqueUsers: number | null;
+  occurrences: SerializedEventOccurrence[];
+}
+
+export interface SerializedEnrichment {
+  flags: SerializedFlag[];
+  events: SerializedEvent[];
+}
+
+export function toSerializable(enriched: EnrichedResult): SerializedEnrichment {
+  const flags: SerializedFlag[] = enriched.flags.map((f) => ({
+    flagKey: f.flagKey,
+    flagId: f.flag?.id ?? null,
+    flagType: f.flagType,
+    staleness: f.staleness,
+    rollout: f.rollout,
+    active: f.flag?.active ?? false,
+    variants: f.variants.map((v) => ({
+      key: v.key,
+      rolloutPercentage: v.rollout_percentage,
+    })),
+    occurrences: f.occurrences.map((o) => ({
+      method: o.method,
+      line: o.line,
+      startCol: o.keyStartCol,
+      endCol: o.keyEndCol,
+    })),
+    experiment: f.experiment
+      ? {
+          id: f.experiment.id,
+          name: f.experiment.name,
+          status: f.experiment.end_date ? "complete" : "running",
+        }
+      : null,
+  }));
+
+  const events: SerializedEvent[] = enriched.events.map((e) => ({
+    eventName: e.eventName,
+    definitionId: e.definition?.id ?? null,
+    verified: e.verified,
+    description: e.definition?.description ?? null,
+    tags: e.tags,
+    lastSeenAt: e.lastSeenAt,
+    volume: e.stats?.volume ?? null,
+    uniqueUsers: e.stats?.uniqueUsers ?? null,
+    occurrences: e.occurrences.map((o) => ({
+      line: o.line,
+      startCol: o.keyStartCol,
+      endCol: o.keyEndCol,
+      dynamic: o.dynamic,
+    })),
+  }));
+
+  return { flags, events };
+}

--- a/packages/enricher/src/types.ts
+++ b/packages/enricher/src/types.ts
@@ -189,6 +189,8 @@ export type FlagType = "boolean" | "multivariate" | "remote_config";
 export interface CapturedEvent {
   name: string;
   line: number;
+  keyStartCol: number;
+  keyEndCol: number;
   dynamic: boolean;
   viaWrapper?: string;
   inJsx?: boolean;
@@ -198,6 +200,8 @@ export interface FlagCheck {
   method: string;
   flagKey: string;
   line: number;
+  keyStartCol: number;
+  keyEndCol: number;
   viaWrapper?: string;
   inJsx?: boolean;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@posthog/electron-trpc':
         specifier: workspace:*
         version: link:../../packages/electron-trpc
+      '@posthog/enricher':
+        specifier: workspace:*
+        version: link:../../packages/enricher
       '@posthog/git':
         specifier: workspace:*
         version: link:../../packages/git


### PR DESCRIPTION
## TLDR

When viewing a file in the code editor, there was no way to see contextual PostHog information (feature flags, events) referenced in the code without leaving the editor.

## Changes

- Adds an `EnrichmentService` on the main process that calls the `@posthog/enricher` pipeline to analyze open files for PostHog SDK usage (feature flag checks and event captures). Results are cached by content hash with a 10-minute TTL and a 200-entry cap.
- Exposes the service via a new `enrichment.enrichFile` tRPC route, accepting a task ID, file path, optional absolute path, and file content.
- Adds a `useFileEnrichment` hook in the renderer that queries the tRPC route for supported file extensions (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.py`, `.rb`, `.go`) when the user is authenticated.
- Adds a `postHogEnrichmentExtension` CodeMirror extension that reads enrichment data from a `StateField`, builds inline pill decorations over flag keys and event names, and handles click events to open a detail popover.
- Adds `EnrichmentPopover`, a fixed-position portal popover that renders flag details (rollout percentage, variants, experiment status, staleness) or event details (volume, unique users, last seen, tags, description) with deep-link buttons to the relevant PostHog project pages.
- Adds a `toSerializable` function and associated serialized types (`SerializedEnrichment`, `SerializedFlag`, `SerializedEvent`, etc.) to convert `EnrichedResult` class instances into plain JSON-safe objects suitable for crossing the tRPC/IPC boundary.
- Extracts a shared `enrichSource` pipeline function from the enricher package so both the agent (inline comments) and the renderer (popover) use the same enrichment logic, including relative-import wrapper resolution.
- Adds `keyStartCol`/`keyEndCol` column offsets to `CapturedEvent`, `FlagCheck`, and their serialized forms so decorations can be positioned precisely within a line.
- Adds a `posthogLinks` utility module for constructing deep links to flags, events, experiments, and feature flag index pages, with optional project ID and cloud region overrides.