### PR TITLE
fix: add custom focus manager for react query

### DIFF
--- a/apps/code/src/renderer/utils/queryClient.test.ts
+++ b/apps/code/src/renderer/utils/queryClient.test.ts
@@ -1,4 +1,5 @@
 import type { Task } from "@shared/types";
+import { focusManager } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getCachedTask, queryClient } from "./queryClient";
 
@@ -59,5 +60,15 @@ describe("getCachedTask", () => {
     );
 
     expect(getCachedTask("task-1")?.title_manually_set).toBe(true);
+  });
+});
+
+describe("focusManager", () => {
+  it("flips focus state on window focus/blur events", () => {
+    window.dispatchEvent(new Event("blur"));
+    expect(focusManager.isFocused()).toBe(false);
+
+    window.dispatchEvent(new Event("focus"));
+    expect(focusManager.isFocused()).toBe(true);
   });
 });

--- a/apps/code/src/renderer/utils/queryClient.ts
+++ b/apps/code/src/renderer/utils/queryClient.ts
@@ -1,5 +1,5 @@
 import type { Task } from "@shared/types";
-import { QueryClient } from "@tanstack/react-query";
+import { focusManager, QueryClient } from "@tanstack/react-query";
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -8,6 +8,28 @@ export const queryClient = new QueryClient({
       refetchOnWindowFocus: true,
     },
   },
+});
+
+// Electron renderers stay visible when the BrowserWindow loses OS focus, so
+// `document.visibilitychange` (TanStack's default signal) never fires on
+// app-switch. Listen to window `focus`/`blur` as well so refetchOnWindowFocus
+// actually triggers when the user returns from an external browser.
+focusManager.setEventListener((handleFocus) => {
+  if (typeof window === "undefined") return;
+
+  const onFocus = () => handleFocus(true);
+  const onBlur = () => handleFocus(false);
+  const onVisibilityChange = () => handleFocus(!document.hidden);
+
+  window.addEventListener("focus", onFocus);
+  window.addEventListener("blur", onBlur);
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
+  return () => {
+    window.removeEventListener("focus", onFocus);
+    window.removeEventListener("blur", onBlur);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  };
 });
 
 export function getCachedTask(taskId: string): Task | undefined {


### PR DESCRIPTION
For queries that refetched on window focus, that doesn’t work reliably in electron since popping open a browser window doesn’t fire `visibilitychange`, adds a custom focus manager that fires on focus / blur