### PR TITLE
fix(code): preserve session scroll position across window focus

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -50,6 +50,7 @@ export function ConversationView({
   compact = false,
 }: ConversationViewProps) {
   const listRef = useRef<VirtualizedListHandle>(null);
+  const isAtBottomRef = useRef(true);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const debugLogsCloudRuns = useSettingsStore((s) => s.debugLogsCloudRuns);
   const showDebugLogs = debugLogsCloudRuns;
@@ -129,6 +130,7 @@ export function ConversationView({
   }, [items]);
 
   const handleScrollStateChange = useCallback((isAtBottom: boolean) => {
+    isAtBottomRef.current = isAtBottom;
     setShowScrollButton(!isAtBottom);
   }, []);
 
@@ -139,7 +141,7 @@ export function ConversationView({
 
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (!document.hidden) {
+      if (!document.hidden && isAtBottomRef.current) {
         listRef.current?.scrollToBottom();
         setShowScrollButton(false);
       }


### PR DESCRIPTION
## Summary
- The conversation view's `visibilitychange` handler in `ConversationView.tsx` was calling `scrollToBottom()` unconditionally whenever the document became visible — so cmd+tab away and back always reset the user's scroll position.
- Mirror the at-bottom state already reported by `VirtualizedList` into a ref and only re-pin to the bottom on visibility return when the user was already following the stream. Manual scroll positions are now preserved across focus changes; streaming auto-scroll continues to work because it has its own at-bottom check.

## Test plan
- [x] `pnpm --filter code typecheck`
- [x] `pnpm --filter code test` (947 pass; one unrelated `archive/service.integration.test.ts > unarchive with recreateBranch` timeout in main-process git code)
- [ ] Manual: scroll up mid-conversation, cmd+tab away and back → position preserved, scroll-to-bottom button stays visible
- [ ] Manual: scroll to bottom, cmd+tab away and back → still pinned to bottom
- [ ] Manual: while at bottom with a streaming response, hide the window and return → newest content visible