### PR TITLE
fix: show generating indicator during cloud runs

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -242,11 +242,15 @@ vi.mock("@utils/queryClient", () => ({
 vi.mock("@shared/utils/urls", () => ({
   getCloudUrlFromRegion: () => "https://api.anthropic.com",
 }));
+const mockConvertStoredEntriesToEvents = vi.hoisted(() =>
+  vi.fn<(entries: unknown[]) => unknown[]>(() => []),
+);
+
 vi.mock("@utils/session", async () => {
   const actual =
     await vi.importActual<typeof import("@utils/session")>("@utils/session");
   return {
-    convertStoredEntriesToEvents: vi.fn(() => []),
+    convertStoredEntriesToEvents: mockConvertStoredEntriesToEvents,
     createUserPromptEvent: vi.fn((prompt, ts) => ({
       type: "acp_message",
       ts,
@@ -318,6 +322,7 @@ const createMockSession = (
 describe("SessionService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConvertStoredEntriesToEvents.mockImplementation(() => []);
     resetSessionService();
     mockSettingsState.customInstructions = "";
     mockGetIsOnline.mockReturnValue(true);
@@ -710,6 +715,119 @@ describe("SessionService", () => {
             isCloud: true,
             logUrl: "https://logs.example.com/run-123",
             processedLineCount: 1,
+          }),
+        );
+      });
+    });
+
+    it("flips isPromptPending on hydration when the log tail has an in-flight prompt", async () => {
+      const service = getSessionService();
+      const hydratedSession = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "disconnected",
+        isCloud: true,
+        events: [],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        hydratedSession,
+      );
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue("");
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue("{}");
+      mockTrpcLogs.writeLocalLogs.mutate.mockResolvedValue(undefined);
+
+      const inFlightPrompt = {
+        type: "acp_message" as const,
+        ts: 1700000000,
+        message: {
+          jsonrpc: "2.0" as const,
+          id: 42,
+          method: "session/prompt",
+          params: { prompt: [{ type: "text", text: "hi" }] },
+        },
+      };
+      mockConvertStoredEntriesToEvents.mockReturnValueOnce([inFlightPrompt]);
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run-123",
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          expect.objectContaining({
+            isPromptPending: true,
+            promptStartedAt: inFlightPrompt.ts,
+            currentPromptId: 42,
+          }),
+        );
+      });
+    });
+
+    it("leaves isPromptPending false on hydration when the log tail has a completed prompt", async () => {
+      const service = getSessionService();
+      const hydratedSession = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "disconnected",
+        isCloud: true,
+        events: [],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        hydratedSession,
+      );
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": { ...hydratedSession, currentPromptId: 42 },
+      });
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue("");
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue("{}");
+      mockTrpcLogs.writeLocalLogs.mutate.mockResolvedValue(undefined);
+
+      const promptRequest = {
+        type: "acp_message" as const,
+        ts: 1700000000,
+        message: {
+          jsonrpc: "2.0" as const,
+          id: 42,
+          method: "session/prompt",
+          params: { prompt: [{ type: "text", text: "hi" }] },
+        },
+      };
+      const promptResponse = {
+        type: "acp_message" as const,
+        ts: 1700000005,
+        message: {
+          jsonrpc: "2.0" as const,
+          id: 42,
+          result: { stopReason: "end_turn" },
+        },
+      };
+      mockConvertStoredEntriesToEvents.mockReturnValueOnce([
+        promptRequest,
+        promptResponse,
+      ]);
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run-123",
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          expect.objectContaining({
+            isPromptPending: false,
+            promptStartedAt: null,
+            currentPromptId: null,
           }),
         );
       });

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -2542,12 +2542,17 @@ export class SessionService {
         return;
       }
 
+      const events = convertStoredEntriesToEvents(rawEntries);
       sessionStoreSetters.updateSession(taskRunId, {
-        events: convertStoredEntriesToEvents(rawEntries),
+        events,
         isCloud: true,
         logUrl: logUrl ?? session.logUrl,
         processedLineCount: rawEntries.length,
       });
+      // Without this the "Galumphing…" indicator stays hidden when the hydrated
+      // baseline already contains an in-flight session/prompt — the live delta
+      // path otherwise sees delta <= 0 and never re-evaluates the tail.
+      this.updatePromptStateFromEvents(taskRunId, events);
     })().catch((err: unknown) => {
       log.warn("Failed to hydrate cloud task session from logs", {
         taskId,


### PR DESCRIPTION
## Summary

- Cloud-task views inconsistently rendered the "Galumphing…" generating indicator: sometimes it appeared, sometimes not, even though the task was actively producing tokens.
- Root cause: a startup race in `watchCloudTask` between `hydrateCloudTaskSessionFromLogs` (async log fetch) and the live snapshot replay from the cloud watcher. Only the live-update path called `updatePromptStateFromEvents`, so when hydration won the race, the snapshot delta was zero and the in-flight `session/prompt` already in the hydrated tail was never re-evaluated. `isPromptPending` stayed `false` and the indicator stayed hidden for the rest of the turn.
- Fix: after hydrating events from logs, run them through the existing `updatePromptStateFromEvents` helper so the same prompt-pending derivation applies to the hydrated baseline regardless of which path wins.

## Test plan

- [x] `pnpm --filter code typecheck`
- [x] `pnpm exec biome check` on changed files
- [x] `pnpm --filter code test` — all 945 tests pass, including two new cases:
  - hydrating a tail with an unmatched `session/prompt` flips `isPromptPending` to `true`
  - hydrating a tail with both request and matching response leaves `isPromptPending` at `false`
- [x] Manual: open a long-running cloud task several times mid-turn — the "Galumphing… (Esc to stop • Ns)" indicator should appear on every load, not flake. (Throttling the renderer to Slow 3G in DevTools makes the hydration-wins ordering reliable for testing.)
- [x] Manual: open a finished cloud task — indicator should not render.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*