### PR TITLE
chore: change inbox sidebar badge from Beta to Alpha

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/items/HomeItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/HomeItem.tsx
@@ -72,7 +72,7 @@ export function InboxItem({ isActive, onClick, signalCount }: InboxItemProps) {
           }
           isActive={isActive}
           onClick={onClick}
-          endContent={<Badge color="amber">Beta</Badge>}
+          endContent={<Badge color="amber">Alpha</Badge>}
         />
       </div>
     </Tooltip>


### PR DESCRIPTION
## Summary
- Update the amber stage badge next to the Inbox item in the left sidebar from "Beta" to "Alpha" to better reflect the feature's current maturity.

## Test plan
- [ ] `pnpm --filter code typecheck` passes
- [ ] Run `pnpm dev:code` and verify the Inbox row in the left sidebar shows an amber **Alpha** badge instead of **Beta**