### PR TITLE
fix(code): tame space switcher cmd-hold eagerness

### DIFF
--- a/apps/code/src/renderer/components/SpaceSwitcher.tsx
+++ b/apps/code/src/renderer/components/SpaceSwitcher.tsx
@@ -17,6 +17,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 const ICON_SIZE = 16;
 const MOD_KEY = isMac ? "Meta" : "Control";
+const HOLD_DELAY_MS = 1000;
 const ITEM_HEIGHT = 64;
 const ITEM_GAP = 4;
 const ITEM_STRIDE = ITEM_HEIGHT + ITEM_GAP;
@@ -318,7 +319,7 @@ export function SpaceSwitcher({
           if (metaHeldRef.current && !otherKeyRef.current) {
             show();
           }
-        }, 500);
+        }, HOLD_DELAY_MS);
       } else if (metaHeldRef.current && !e.repeat) {
         // Any key during hold cancels the show timer.
         // Minimap only appears from a pure Cmd hold with no other keys.
@@ -401,6 +402,7 @@ export function SpaceSwitcher({
 
   return (
     <div
+      data-overlay="space-switcher"
       className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-200 ease-out ${
         animIn ? "opacity-100" : "pointer-events-none opacity-0"
       }`}


### PR DESCRIPTION
**TLDR: switcher shows after 1s instead of .5s, pressing ESC while open doesn't interrupt agent below.**

## Summary
- Bump hold dwell from 500ms to 1000ms so quick cmd-key bursts (cmd+c, cmd+tab, cmd+shift+tab) stop tripping the minimap.
- Mark the switcher root with `data-overlay` so `PromptInput`'s escape-to-cancel guard (`hasOpenOverlay()`) skips it — pressing escape while the minimap is visible now hides the minimap without canceling an in-progress agent run.

## Test plan
- [x] Hold cmd quietly for ~1s → minimap appears.
- [x] Quick cmd+c, cmd+v, cmd+tab in normal use → minimap does **not** appear.
- [x] With an agent generating in the active task, hold cmd to show the minimap, press escape → minimap hides, agent continues.
- [x] cmd+up / cmd+down still navigate spaces (with or without minimap visible).
- [x] Pressing escape with minimap closed still cancels a running agent (existing behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)