### PR TITLE
chore(cloud-agent): extract agentsh runtime logging

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -48,6 +48,7 @@ import { resourceLink } from "../utils/acp-content";
 import { AsyncMutex } from "../utils/async-mutex";
 import { getLlmGatewayUrl } from "../utils/gateway";
 import { Logger } from "../utils/logger";
+import { logAgentshRuntimeInfo } from "./agentsh-runtime";
 import {
   normalizeCloudPromptContent,
   promptBlocksToText,
@@ -954,6 +955,7 @@ export class AgentServer {
     this.logger.debug(
       `Agent version: ${this.config.version ?? packageJson.version}`,
     );
+    await logAgentshRuntimeInfo(this.logger);
     this.logger.debug(`Initial permission mode: ${initialPermissionMode}`);
 
     // Signal in_progress so the UI can start polling for updates

--- a/packages/agent/src/server/agentsh-runtime.test.ts
+++ b/packages/agent/src/server/agentsh-runtime.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveAgentshRuntimeInfo } from "./agentsh-runtime";
+
+describe("agentsh runtime detection", () => {
+  it("returns null when no agentsh session marker exists", async () => {
+    const getVersion = vi.fn();
+    const result = await resolveAgentshRuntimeInfo({
+      readSessionId: async () => {
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        throw error;
+      },
+      getVersion,
+    });
+
+    expect(result).toBeNull();
+    expect(getVersion).not.toHaveBeenCalled();
+  });
+
+  it("returns the agentsh session id and version", async () => {
+    const result = await resolveAgentshRuntimeInfo({
+      readSessionId: async () => "session-123\n",
+      getVersion: async () => ({
+        stdout: "agentsh version 0.16.7\n",
+        stderr: "",
+      }),
+    });
+
+    expect(result).toEqual({
+      sessionId: "session-123",
+      version: "agentsh version 0.16.7",
+    });
+  });
+
+  it("keeps the agentsh signal when version lookup fails", async () => {
+    const result = await resolveAgentshRuntimeInfo({
+      readSessionId: async () => "session-123\n",
+      getVersion: async () => {
+        throw new Error("agentsh not found");
+      },
+    });
+
+    expect(result).toEqual({
+      sessionId: "session-123",
+      version: null,
+      versionLookupError: "agentsh not found",
+    });
+  });
+});

--- a/packages/agent/src/server/agentsh-runtime.test.ts
+++ b/packages/agent/src/server/agentsh-runtime.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveAgentshRuntimeInfo } from "./agentsh-runtime";
+import {
+  logAgentshRuntimeInfo,
+  resolveAgentshRuntimeInfo,
+} from "./agentsh-runtime";
 
 describe("agentsh runtime detection", () => {
   it("returns null when no agentsh session marker exists", async () => {
@@ -17,8 +20,55 @@ describe("agentsh runtime detection", () => {
     expect(getVersion).not.toHaveBeenCalled();
   });
 
-  it("returns the agentsh session id and version", async () => {
+  it("rethrows unexpected session marker read errors", async () => {
+    const error = new Error("permission denied") as NodeJS.ErrnoException;
+    error.code = "EACCES";
+
+    await expect(
+      resolveAgentshRuntimeInfo({
+        readSessionId: async () => {
+          throw error;
+        },
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it.each([
+    {
+      name: "returns the agentsh session id and version",
+      getVersion: async () => ({
+        stdout: "agentsh version 0.16.7\n",
+        stderr: "",
+      }),
+      expected: {
+        sessionId: "session-123",
+        version: "agentsh version 0.16.7",
+      },
+    },
+    {
+      name: "keeps the agentsh signal when version lookup fails",
+      getVersion: async () => {
+        throw new Error("agentsh not found");
+      },
+      expected: {
+        sessionId: "session-123",
+        version: null,
+        versionLookupError: "agentsh not found",
+      },
+    },
+  ])("$name", async ({ getVersion, expected }) => {
     const result = await resolveAgentshRuntimeInfo({
+      readSessionId: async () => "session-123\n",
+      getVersion,
+    });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("logs session id and version details", async () => {
+    const logger = { debug: vi.fn() };
+
+    await logAgentshRuntimeInfo(logger, {
       readSessionId: async () => "session-123\n",
       getVersion: async () => ({
         stdout: "agentsh version 0.16.7\n",
@@ -26,24 +76,32 @@ describe("agentsh runtime detection", () => {
       }),
     });
 
-    expect(result).toEqual({
-      sessionId: "session-123",
-      version: "agentsh version 0.16.7",
-    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Agentsh session ID: session-123",
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Agentsh hardening version: agentsh version 0.16.7",
+    );
   });
 
-  it("keeps the agentsh signal when version lookup fails", async () => {
-    const result = await resolveAgentshRuntimeInfo({
+  it("logs version lookup failures", async () => {
+    const logger = { debug: vi.fn() };
+
+    await logAgentshRuntimeInfo(logger, {
       readSessionId: async () => "session-123\n",
       getVersion: async () => {
         throw new Error("agentsh not found");
       },
     });
 
-    expect(result).toEqual({
-      sessionId: "session-123",
-      version: null,
-      versionLookupError: "agentsh not found",
-    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Agentsh session ID: session-123",
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Agentsh hardening version: unknown",
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Agentsh version lookup failed: agentsh not found",
+    );
   });
 });

--- a/packages/agent/src/server/agentsh-runtime.ts
+++ b/packages/agent/src/server/agentsh-runtime.ts
@@ -1,0 +1,86 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import type { Logger } from "../utils/logger";
+
+export const AGENTSH_SESSION_ID_FILE = "/tmp/agentsh-session-id";
+
+const execFileAsync = promisify(execFile);
+
+interface AgentshVersionOutput {
+  stdout: string;
+  stderr: string;
+}
+
+interface ResolveAgentshRuntimeInfoOptions {
+  sessionIdPath?: string;
+  readSessionId?: (path: string) => Promise<string>;
+  getVersion?: () => Promise<AgentshVersionOutput>;
+}
+
+export interface AgentshRuntimeInfo {
+  sessionId: string;
+  version: string | null;
+  versionLookupError?: string;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseAgentshVersion(output: AgentshVersionOutput): string | null {
+  const version = `${output.stdout}\n${output.stderr}`
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
+  return version ?? null;
+}
+
+async function getAgentshVersion(): Promise<AgentshVersionOutput> {
+  const { stdout, stderr } = await execFileAsync("agentsh", ["--version"], {
+    timeout: 5_000,
+  });
+  return { stdout, stderr };
+}
+
+export async function resolveAgentshRuntimeInfo({
+  sessionIdPath = AGENTSH_SESSION_ID_FILE,
+  readSessionId = async (path: string) => readFile(path, "utf8"),
+  getVersion = getAgentshVersion,
+}: ResolveAgentshRuntimeInfoOptions = {}): Promise<AgentshRuntimeInfo | null> {
+  let sessionId: string;
+  try {
+    sessionId = (await readSessionId(sessionIdPath)).trim();
+  } catch {
+    return null;
+  }
+
+  if (!sessionId) {
+    return null;
+  }
+
+  try {
+    const output = await getVersion();
+    return {
+      sessionId,
+      version: parseAgentshVersion(output),
+    };
+  } catch (error) {
+    return {
+      sessionId,
+      version: null,
+      versionLookupError: errorMessage(error),
+    };
+  }
+}
+
+export async function logAgentshRuntimeInfo(
+  logger: Pick<Logger, "debug">,
+): Promise<void> {
+  const agentsh = await resolveAgentshRuntimeInfo();
+  if (!agentsh) {
+    return;
+  }
+
+  logger.debug(`Agentsh hardening version: ${agentsh.version ?? "unknown"}`);
+}

--- a/packages/agent/src/server/agentsh-runtime.ts
+++ b/packages/agent/src/server/agentsh-runtime.ts
@@ -51,8 +51,12 @@ export async function resolveAgentshRuntimeInfo({
   let sessionId: string;
   try {
     sessionId = (await readSessionId(sessionIdPath)).trim();
-  } catch {
-    return null;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return null;
+    }
+    throw error;
   }
 
   if (!sessionId) {
@@ -76,11 +80,18 @@ export async function resolveAgentshRuntimeInfo({
 
 export async function logAgentshRuntimeInfo(
   logger: Pick<Logger, "debug">,
+  options?: ResolveAgentshRuntimeInfoOptions,
 ): Promise<void> {
-  const agentsh = await resolveAgentshRuntimeInfo();
+  const agentsh = await resolveAgentshRuntimeInfo(options);
   if (!agentsh) {
     return;
   }
 
+  logger.debug(`Agentsh session ID: ${agentsh.sessionId}`);
   logger.debug(`Agentsh hardening version: ${agentsh.version ?? "unknown"}`);
+  if (agentsh.versionLookupError) {
+    logger.debug(
+      `Agentsh version lookup failed: ${agentsh.versionLookupError}`,
+    );
+  }
 }


### PR DESCRIPTION
## Problem

Let's have more understanding at cloud runtime for `agentsh` versioning and testing purposes.
