### PR TITLE
fix(code): clean up custom-input styling in choice selector

### DIFF
--- a/apps/code/src/renderer/components/action-selector/ActionSelector.tsx
+++ b/apps/code/src/renderer/components/action-selector/ActionSelector.tsx
@@ -228,7 +228,7 @@ export function ActionSelector({
         )}
 
         {title && (
-          <Text className="font-medium text-[13px] text-blue-11" title={title}>
+          <Text className="font-medium text-[13px] text-primary" title={title}>
             {compactHomePath(title)}
           </Text>
         )}
@@ -240,7 +240,7 @@ export function ActionSelector({
             {question}
           </Text>
 
-          <Flex direction="column" gap="1">
+          <Flex direction="column" gap="1" px="2">
             {allOptions.map((option, index) => {
               if (isSubmitOption(option.id) || isCancelOption(option.id)) {
                 return null;

--- a/apps/code/src/renderer/components/action-selector/InlineEditableText.tsx
+++ b/apps/code/src/renderer/components/action-selector/InlineEditableText.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 
+const MAX_HEIGHT = 200;
+
 interface InlineEditableTextProps {
   value: string;
   placeholder: string;
@@ -9,6 +11,15 @@ interface InlineEditableTextProps {
   onNavigateDown: () => void;
   onEscape: () => void;
   onSubmit: () => void;
+}
+
+function autosize(el: HTMLTextAreaElement) {
+  el.style.height = "auto";
+  const next = Math.min(el.scrollHeight, MAX_HEIGHT);
+  el.style.height = `${next}px`;
+  // Only enable scrolling when content actually exceeds the cap. Leaving it
+  // on "auto" surfaces a track on macOS when "Always show scrollbars" is set.
+  el.style.overflowY = el.scrollHeight > MAX_HEIGHT ? "auto" : "hidden";
 }
 
 export function InlineEditableText({
@@ -29,6 +40,11 @@ export function InlineEditableText({
       el.focus();
     }
   }, [active]);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (el) autosize(el);
+  }, []);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -68,17 +84,13 @@ export function InlineEditableText({
       placeholder={placeholder}
       onChange={(e) => {
         onChange(e.target.value);
-        const el = e.target;
-        el.style.height = "auto";
-        el.style.height = `${el.scrollHeight}px`;
+        autosize(e.target);
       }}
       onKeyDown={handleKeyDown}
       onClick={(e) => e.stopPropagation()}
       rows={1}
-      className="block max-h-[120px] w-full cursor-text overflow-auto break-words font-medium text-[13px] text-gray-12 placeholder:text-gray-10"
+      className="block max-h-[200px] w-full cursor-text resize-none overflow-y-hidden break-words border-0 bg-transparent p-0 font-medium text-[13px] text-gray-12 leading-4 outline-none placeholder:text-gray-10 focus:outline-none"
       style={{
-        all: "unset",
-        resize: "none",
         userSelect: active ? "auto" : "none",
         pointerEvents: active ? "auto" : "none",
       }}

--- a/apps/code/src/renderer/components/action-selector/InlineEditableText.tsx
+++ b/apps/code/src/renderer/components/action-selector/InlineEditableText.tsx
@@ -41,10 +41,14 @@ export function InlineEditableText({
     }
   }, [active]);
 
+  // Re-run on external value changes so the height tracks parent-driven
+  // updates (e.g. clearing after submit). `value` isn't referenced in the
+  // body — we read it via the DOM — so silence the exhaustive-deps lint.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: value drives autosize via the rendered DOM
   useEffect(() => {
     const el = textareaRef.current;
     if (el) autosize(el);
-  }, []);
+  }, [value]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -89,7 +93,7 @@ export function InlineEditableText({
       onKeyDown={handleKeyDown}
       onClick={(e) => e.stopPropagation()}
       rows={1}
-      className="block max-h-[200px] w-full cursor-text resize-none overflow-y-hidden break-words border-0 bg-transparent p-0 font-medium text-[13px] text-gray-12 leading-4 outline-none placeholder:text-gray-10 focus:outline-none"
+      className="block w-full cursor-text resize-none overflow-y-hidden break-words border-0 bg-transparent p-0 font-medium text-[13px] text-gray-12 leading-4 outline-none placeholder:text-gray-10 focus:outline-none"
       style={{
         userSelect: active ? "auto" : "none",
         pointerEvents: active ? "auto" : "none",

--- a/apps/code/src/renderer/components/action-selector/OptionRow.tsx
+++ b/apps/code/src/renderer/components/action-selector/OptionRow.tsx
@@ -120,9 +120,9 @@ export function OptionRow({
 
     const displayText = compactHomePath(option.label);
     const textClass = isSelected
-      ? "text-blue-11"
+      ? "text-primary"
       : isHovered
-        ? "text-blue-11"
+        ? "text-primary"
         : "text-gray-12";
 
     return (
@@ -142,24 +142,24 @@ export function OptionRow({
       py="1"
       className={`-mx-3 cursor-pointer select-none rounded-(--radius-2) pt-[4px] pr-3 pb-[4px] pl-3 ${
         isSelected
-          ? "bg-(--blue-3)"
+          ? "bg-primary/10"
           : isHovered
-            ? "bg-(--gray-a3)"
+            ? "bg-fill-hover"
             : "bg-transparent"
       }`}
     >
       <Flex align="center" gap="2" className="leading-4">
         <Text
-          className={`w-[1ch] shrink-0 text-[13px] leading-4 ${isSelected ? "text-blue-11" : "text-gray-11"}`}
+          className={`w-[1ch] shrink-0 text-[13px] leading-4 ${isSelected ? "text-primary" : "text-gray-11"}`}
         >
           {isSelected ? "›" : ""}
         </Text>
         <Text
           className={`min-w-[16px] shrink-0 whitespace-nowrap text-right text-[13px] leading-4 ${
             isSelected
-              ? "text-blue-11"
+              ? "text-primary"
               : isHovered
-                ? "text-blue-11"
+                ? "text-primary"
                 : "text-gray-11"
           }`}
         >


### PR DESCRIPTION
TLDR: fix massive text for question tool user input, remove blue tints and use posthog styling + padding around options (rounded corners against container didn't look nice)

## Problem
<img width="1506" height="1090" alt="image" src="https://github.com/user-attachments/assets/56c5a32d-a453-4f51-8e86-0d42303c00d1" />


## Summary
- Replace `style={{ all: "unset" }}` on the choice-selector custom-input \<textarea\> with targeted resets so the Tailwind utilities (`block w-full font-medium text-[13px] leading-4 text-gray-12`) actually apply. Before: inline-display element with wrong font size, no weight, parent flex item shrunk to intrinsic content width.
- Auto-size on mount and on external value changes (not just inside `onChange`). Fixes a phantom scrollbar caused by the browser-default `rows={1}` height being a fractional pixel taller than `scrollHeight`.
- Cap textarea height at 200px and only enable `overflow-y: auto` when content actually exceeds the cap. Leaving it on always renders a track under macOS "Always show scrollbars" even when nothing is scrollable.
- Swap hardcoded `blue-11` / `bg-(--blue-3)` / `bg-(--gray-a3)` for theme-aware `text-primary` / `bg-primary/10` / `bg-fill-hover`, and add horizontal padding to the options column so rows align with the title and question text.

<img width="1688" height="968" alt="2026-04-27 12 39 40" src="https://github.com/user-attachments/assets/9e555d74-7616-42dc-bea6-261472724aa7" />

<img width="1688" height="968" alt="2026-04-27 12 40 17" src="https://github.com/user-attachments/assets/c256aba5-b915-478e-8886-082ef0489451" />


## Test plan
- [x] Open a choice prompt with a custom-input ("Other / Type your answer") row.
- [x] Empty state: input is full-width within the row, font matches the other options' `text-[13px]` weight, **no** scrollbar visible (verify on a Mac with "Always show scrollbars" enabled).
- [x] Type a short answer → height stays single-line, no scrollbar.
- [x] Type a long multi-line answer → height grows naturally up to 200px, then scrollbar appears and the cap holds.
- [x] Keyboard nav still works inside the input: ArrowUp at start, ArrowDown at end, Tab, Enter to submit, Esc to cancel.
- [x] Selected/hovered option colors pick up the current accent (`text-primary`) instead of always-blue, including under custom theme accents.
- [x] Option rows visually align with the title and question text above them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)