### PR TITLE
fix(code): render markdown italics in inherited font

### DIFF
--- a/apps/code/src/renderer/features/editor/components/MarkdownRenderer.tsx
+++ b/apps/code/src/renderer/features/editor/components/MarkdownRenderer.tsx
@@ -3,7 +3,7 @@ import { Divider } from "@components/Divider";
 import { HighlightedCode } from "@components/HighlightedCode";
 import { List, ListItem } from "@components/List";
 import { parseGithubIssueUrl } from "@features/message-editor/utils/githubIssueUrl";
-import { Blockquote, Checkbox, Code, Em, Kbd, Text } from "@radix-ui/themes";
+import { Blockquote, Checkbox, Code, Kbd, Text } from "@radix-ui/themes";
 import { memo, useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
@@ -71,7 +71,7 @@ export const baseComponents: Components = {
     );
   },
   pre: ({ children }) => <CodeBlock size="1">{children}</CodeBlock>,
-  em: ({ children }) => <Em>{children}</Em>,
+  em: ({ children }) => <em>{children}</em>,
   i: ({ children }) => <i>{children}</i>,
   strong: ({ children }) => (
     <strong className="text-(--accent-11)">{children}</strong>


### PR DESCRIPTION
## Summary
- Replaces Radix UI Themes' `<Em>` with a plain `<em>` in the markdown renderer so italicized text inherits the surrounding font instead of switching to Radix's serif italic, which made italics look noticeably larger/different.

<img width="764" height="83" alt="Screenshot 2026-04-27 at 19 46 33" src="https://github.com/user-attachments/assets/85db2414-ad37-414a-a65e-a9568eaa9674" />

## Test plan
- [ ] Render markdown containing italics (`*word*` / `_word_`) in `MarkdownRenderer` and confirm italic text matches the size and family of surrounding text.
- [ ] Verify markdown still renders correctly across affected surfaces: agent messages, user messages, queued messages, signal cards, skill detail panel, PR comment threads.