### PR TITLE
fix(code): skip file-watcher flush after shutdown

### DIFF
--- a/apps/code/src/main/services/file-watcher/service.test.ts
+++ b/apps/code/src/main/services/file-watcher/service.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FileWatcherEvent } from "./schemas";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: {
+    scope: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@parcel/watcher", () => ({ subscribe: vi.fn() }));
+
+import type { WatcherRegistryService } from "../watcher-registry/service";
+import { FileWatcherService } from "./service";
+
+interface PendingChanges {
+  dirs: Set<string>;
+  files: Set<string>;
+  deletes: Set<string>;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const makePending = (
+  overrides: Partial<PendingChanges> = {},
+): PendingChanges => ({
+  dirs: new Set(["/repo/src"]),
+  files: new Set(["/repo/src/a.ts"]),
+  deletes: new Set(["/repo/src/b.ts"]),
+  timer: setTimeout(() => {}, 1_000_000),
+  ...overrides,
+});
+
+describe("FileWatcherService.flushPending", () => {
+  let registry: { isShutdown: boolean };
+  let service: FileWatcherService;
+
+  beforeEach(() => {
+    registry = { isShutdown: false };
+    service = new FileWatcherService(
+      registry as unknown as WatcherRegistryService,
+    );
+  });
+
+  it("does not emit events when the watcher registry is shut down", () => {
+    registry.isShutdown = true;
+    const emitSpy = vi.spyOn(service, "emit");
+    const pending = makePending();
+
+    (
+      service as unknown as {
+        flushPending: (repoPath: string, pending: PendingChanges) => void;
+      }
+    ).flushPending("/repo", pending);
+
+    expect(emitSpy).not.toHaveBeenCalled();
+    expect(pending.dirs.size).toBe(0);
+    expect(pending.files.size).toBe(0);
+    expect(pending.deletes.size).toBe(0);
+    expect(pending.timer).toBeNull();
+  });
+
+  it("emits per-path events when the registry is active", () => {
+    const emitSpy = vi.spyOn(service, "emit");
+    const pending = makePending();
+
+    (
+      service as unknown as {
+        flushPending: (repoPath: string, pending: PendingChanges) => void;
+      }
+    ).flushPending("/repo", pending);
+
+    expect(emitSpy).toHaveBeenCalledWith(FileWatcherEvent.DirectoryChanged, {
+      repoPath: "/repo",
+      dirPath: "/repo/src",
+    });
+    expect(emitSpy).toHaveBeenCalledWith(FileWatcherEvent.FileChanged, {
+      repoPath: "/repo",
+      filePath: "/repo/src/a.ts",
+    });
+    expect(emitSpy).toHaveBeenCalledWith(FileWatcherEvent.FileDeleted, {
+      repoPath: "/repo",
+      filePath: "/repo/src/b.ts",
+    });
+    expect(pending.timer).toBeNull();
+  });
+});

--- a/apps/code/src/main/services/file-watcher/service.ts
+++ b/apps/code/src/main/services/file-watcher/service.ts
@@ -161,6 +161,14 @@ export class FileWatcherService extends TypedEventEmitter<FileWatcherEvents> {
   }
 
   private flushPending(repoPath: string, pending: PendingChanges): void {
+    if (this.watcherRegistry.isShutdown) {
+      pending.dirs.clear();
+      pending.files.clear();
+      pending.deletes.clear();
+      pending.timer = null;
+      return;
+    }
+
     const totalChanges = pending.files.size + pending.deletes.size;
 
     // For bulk changes, emit a single event instead of per-file events


### PR DESCRIPTION
## Problem

We saw the following unhandled rejection during app shutdown:

```
Unhandled rejection Error: Database not initialized — call initialize() first
    at get db (DatabaseService)
    at WorkspaceRepository.findAll
    at WorkspaceService.getAllTaskAssociations
    at WorkspaceService.handleGitStateChanged
    at FileWatcherService.emit
    at FileWatcherService.flushPending
    at Timeout._onTimeout
```

`FileWatcherService.queueEvents` schedules a 500 ms `setTimeout(flushPending, …)` per repo whenever `@parcel/watcher` reports changes. During shutdown, `AppLifecycleService.doShutdown` runs `watcherRegistry.shutdownAll()` (sets `isShutdown = true`, unsubscribes parcel watchers) and then closes the database. A pending `flushPending` timer can fire **after** `db.close()` has nulled the connection — `flushPending` emits `GitStateChanged`, `WorkspaceService.handleGitStateChanged` calls `WorkspaceRepository.findAll`, and the DB getter throws.

The two parcel watcher callbacks already guard with `if (this.watcherRegistry.isShutdown) return;`, but the in-flight debounce timer that lands in `flushPending` slips past that guard.

## Solution

Add the same `isShutdown` early-return at the top of `FileWatcherService.flushPending` and clear the pending buffers/timer so the in-flight timer is a no-op once the registry is down. This mirrors the existing guards in `watchFiles` and `watchGit`, so behavior is uniform across all three places where the service decides whether to emit. No changes are needed in `WorkspaceService`, `DatabaseService`, or `AppLifecycleService` — the lifecycle ordering is fine, the file-watcher just needs to stop emitting after shutdown.

Added a unit test covering both branches (shut-down: silent + cleared; active: emits per-path events).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*