### PR TITLE
fix(code): prevent branch picker overflow with responsive shrink

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -180,6 +180,7 @@ export function BranchSelector({
             disabled={isDisabled}
             aria-label="Branch"
             title={displayedBranch ?? undefined}
+            className="min-w-0 max-w-[250px] shrink"
           >
             {showSpinner ? (
               <Spinner size={14} className="shrink-0 animate-spin" />


### PR DESCRIPTION
## Problem

Long branch names (e.g. `posthog-code/prevent-message-send-during-cloud-run-startup`) made the `BranchSelector` in the task header grow past the toolbar's `max-w-[50%]` container, pushing the diff badge, continue/handoff button, and task actions menu off the right edge of the window.

The inner span on the branch name already had `min-w-0 truncate`, but truncation never engaged: the underlying `Button` primitive ships with `inline-flex shrink-0` and no width cap, so the button always sized to its content.

## Solution

Override the primitive's flex constraints at the call site in `BranchSelector.tsx`:

- `shrink` — overrides `shrink-0` so the button is flex-shrinkable.
- `min-w-0` — lets it shrink below content width so the inner `truncate` span engages.
- `max-w-[250px]` — bounds it on wide layouts so it doesn't grow absurdly.

## Showcase

<img width="958" height="54" alt="Screenshot 2026-04-28 at 13 58 30" src="https://github.com/user-attachments/assets/1ccac034-1118-486f-99d3-7b000ff6dda3" />


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*