### PR TITLE
fix(code): auto-highlight first branch result in selector

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -158,6 +158,7 @@ export function BranchSelector({
     <Combobox
       items={branches}
       limit={COMBOBOX_LIMIT}
+      autoHighlight
       value={displayedBranch}
       inputValue={inputValue}
       onInputValueChange={


### PR DESCRIPTION
## Problem

In the `BranchSelector`, when a user types to filter branches, no item is highlighted. To pick the top match they have to press <kbd>↓</kbd> followed by <kbd>Enter</kbd>, even when the first result is unambiguously what they want.

Closes #1807.

## Solution

Pass `autoHighlight` to the underlying Base UI `Combobox.Root`. The first matching item is highlighted automatically while filtering, so <kbd>Enter</kbd> commits it directly. Arrow-key navigation continues to work the same way.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*