### PR TITLE
chore(code): make Combobox search and footer sticky

### DIFF
--- a/apps/code/src/renderer/components/ui/combobox/Combobox.css
+++ b/apps/code/src/renderer/components/ui/combobox/Combobox.css
@@ -33,6 +33,9 @@
 }
 
 .combobox-input-wrapper {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -87,8 +90,9 @@
 }
 
 .combobox-content [cmdk-list] {
-  flex: 1;
+  flex: 1 1 auto;
   min-height: 0;
+  max-height: 240px;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: contain;
@@ -286,6 +290,9 @@
 }
 
 .combobox-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
   border-top: 1px solid var(--gray-a6);
   padding: var(--combobox-content-padding);
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

- Pin `.combobox-input-wrapper` with `position: sticky; top: 0` and `.combobox-footer` with `position: sticky; bottom: 0`.
- Add an explicit `max-height: 240px` to `[cmdk-list]` so cmdk's own height tracking can't push the footer outside the popover.
- Fixes the Command Center `TaskSelector` where "+ New task" required scrolling past the task list when a project had many tasks.

The custom `Combobox` (built on `cmdk`) is currently only used by `TaskSelector`. Other pickers (`BranchSelector`, `GitHubRepoPicker`) use `@posthog/quill`'s Combobox, which already has a sticky footer slot — they are unaffected.

## Showcase


https://github.com/user-attachments/assets/8bc3f26d-88f5-4e33-b123-2b717ffd2629



---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*