### PR TITLE
fix(cloud-agent): improve cloud run reconnection

### DIFF
--- a/apps/code/src/main/services/cloud-task/service.test.ts
+++ b/apps/code/src/main/services/cloud-task/service.test.ts
@@ -328,6 +328,111 @@ describe("CloudTaskService", () => {
     );
   });
 
+  it("replays a current snapshot when a subscriber attaches to an existing watcher", async () => {
+    const updates: unknown[] = [];
+    service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));
+
+    const historicalEntry = {
+      type: "notification",
+      timestamp: "2026-01-01T00:00:00Z",
+      notification: {
+        jsonrpc: "2.0",
+        method: "_posthog/console",
+        params: {
+          sessionId: "run-1",
+          level: "info",
+          message: "older history",
+        },
+      },
+    };
+    const liveEntry = {
+      type: "notification",
+      timestamp: "2026-01-01T00:00:01Z",
+      notification: {
+        jsonrpc: "2.0",
+        method: "_posthog/console",
+        params: {
+          sessionId: "run-1",
+          level: "info",
+          message: "live tail",
+        },
+      },
+    };
+
+    const runResponse = {
+      id: "run-1",
+      status: "in_progress",
+      stage: "build",
+      output: null,
+      error_message: null,
+      branch: "main",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    mockNetFetch
+      .mockResolvedValueOnce(createJsonResponse(runResponse))
+      .mockResolvedValueOnce(
+        createJsonResponse([historicalEntry], 200, { "X-Has-More": "false" }),
+      )
+      .mockResolvedValueOnce(createJsonResponse(runResponse))
+      .mockResolvedValueOnce(
+        createJsonResponse([historicalEntry], 200, { "X-Has-More": "false" }),
+      );
+
+    mockStreamFetch.mockResolvedValueOnce(
+      createOpenSseResponse(`id: 1\ndata: ${JSON.stringify(liveEntry)}\n\n`),
+    );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => updates.length >= 2);
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() =>
+      updates.some(
+        (update) =>
+          typeof update === "object" &&
+          update !== null &&
+          (update as { kind?: string; totalEntryCount?: number }).kind ===
+            "snapshot" &&
+          (update as { totalEntryCount?: number }).totalEntryCount === 2,
+      ),
+    );
+
+    const replayedSnapshot = updates.find(
+      (update) =>
+        typeof update === "object" &&
+        update !== null &&
+        (update as { kind?: string; totalEntryCount?: number }).kind ===
+          "snapshot" &&
+        (update as { totalEntryCount?: number }).totalEntryCount === 2,
+    );
+
+    expect(replayedSnapshot).toEqual({
+      taskId: "task-1",
+      runId: "run-1",
+      kind: "snapshot",
+      newEntries: [historicalEntry, liveEntry],
+      totalEntryCount: 2,
+      status: "in_progress",
+      stage: "build",
+      output: null,
+      errorMessage: null,
+      branch: "main",
+    });
+  });
+
   it("ignores keepalive SSE events while keeping the stream open", async () => {
     const updates: unknown[] = [];
     service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));

--- a/apps/code/src/main/services/cloud-task/service.test.ts
+++ b/apps/code/src/main/services/cloud-task/service.test.ts
@@ -431,6 +431,32 @@ describe("CloudTaskService", () => {
       errorMessage: null,
       branch: "main",
     });
+
+    const getWatcherEmittedEntryCount = (): number => {
+      const watcher = (
+        service as unknown as {
+          watchers: Map<string, { emittedLogEntries: unknown[] }>;
+        }
+      ).watchers.get("task-1:run-1");
+      return watcher?.emittedLogEntries.length ?? 0;
+    };
+
+    expect(getWatcherEmittedEntryCount()).toBe(1);
+
+    mockNetFetch.mockResolvedValueOnce(
+      createJsonResponse([historicalEntry, liveEntry], 200, {
+        "X-Has-More": "false",
+      }),
+    );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => getWatcherEmittedEntryCount() === 0);
   });
 
   it("ignores keepalive SSE events while keeping the stream open", async () => {

--- a/apps/code/src/main/services/cloud-task/service.ts
+++ b/apps/code/src/main/services/cloud-task/service.ts
@@ -92,6 +92,7 @@ interface WatcherState {
   isBootstrapping: boolean;
   hasEmittedSnapshot: boolean;
   bufferedLogBatches: StoredLogEntry[][];
+  emittedLogEntries: StoredLogEntry[];
   failed: boolean;
   needsPostBootstrapReconnect: boolean;
   needsStopAfterBootstrap: boolean;
@@ -224,6 +225,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
         key,
         subscribers: existing.subscriberCount,
       });
+      void this.emitCurrentSnapshot(key);
       return;
     }
 
@@ -399,6 +401,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       isBootstrapping: false,
       hasEmittedSnapshot: false,
       bufferedLogBatches: [],
+      emittedLogEntries: [],
       failed: false,
       needsPostBootstrapReconnect: false,
       needsStopAfterBootstrap: false,
@@ -767,6 +770,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     }
 
     watcher.totalEntryCount += entries.length;
+    this.rememberEmittedLogEntries(watcher, entries);
 
     this.emit(CloudTaskEvent.Update, {
       taskId: watcher.taskId,
@@ -812,6 +816,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       }
 
       watcher.totalEntryCount += dedupedEntries.length;
+      this.rememberEmittedLogEntries(watcher, dedupedEntries);
       this.emit(CloudTaskEvent.Update, {
         taskId: watcher.taskId,
         runId: watcher.runId,
@@ -822,6 +827,84 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     }
 
     watcher.bufferedLogBatches = [];
+  }
+
+  private rememberEmittedLogEntries(
+    watcher: WatcherState,
+    entries: StoredLogEntry[],
+  ): void {
+    watcher.emittedLogEntries.push(...entries);
+  }
+
+  private mergeHistoricalAndEmittedEntries(
+    historicalEntries: StoredLogEntry[],
+    emittedEntries: StoredLogEntry[],
+  ): StoredLogEntry[] {
+    if (emittedEntries.length === 0) {
+      return historicalEntries;
+    }
+
+    const historicalCounts = new Map<string, number>();
+    for (const entry of historicalEntries) {
+      const serialized = JSON.stringify(entry);
+      historicalCounts.set(
+        serialized,
+        (historicalCounts.get(serialized) ?? 0) + 1,
+      );
+    }
+
+    const missingEmittedEntries = emittedEntries.filter((entry) => {
+      const serialized = JSON.stringify(entry);
+      const remaining = historicalCounts.get(serialized) ?? 0;
+      if (remaining <= 0) {
+        return true;
+      }
+
+      historicalCounts.set(serialized, remaining - 1);
+      return false;
+    });
+
+    return [...historicalEntries, ...missingEmittedEntries];
+  }
+
+  private async emitCurrentSnapshot(key: string): Promise<void> {
+    const watcher = this.watchers.get(key);
+    if (!watcher || watcher.failed) return;
+
+    const historicalEntries = await this.fetchAllSessionLogs(watcher);
+    const currentWatcher = this.watchers.get(key);
+    if (!currentWatcher || currentWatcher !== watcher || watcher.failed) {
+      return;
+    }
+
+    if (!historicalEntries) {
+      log.warn("Cloud task snapshot replay failed", {
+        taskId: watcher.taskId,
+        runId: watcher.runId,
+      });
+      return;
+    }
+
+    const snapshotEntries = this.mergeHistoricalAndEmittedEntries(
+      historicalEntries,
+      watcher.emittedLogEntries,
+    );
+    if (snapshotEntries.length > watcher.totalEntryCount) {
+      watcher.totalEntryCount = snapshotEntries.length;
+    }
+
+    this.emit(CloudTaskEvent.Update, {
+      taskId: watcher.taskId,
+      runId: watcher.runId,
+      kind: "snapshot",
+      newEntries: snapshotEntries,
+      totalEntryCount: snapshotEntries.length,
+      status: watcher.lastStatus ?? undefined,
+      stage: watcher.lastStage,
+      output: watcher.lastOutput,
+      errorMessage: watcher.lastErrorMessage,
+      branch: watcher.lastBranch,
+    });
   }
 
   private failWatcher(key: string, error: CloudTaskConnectionError): void {

--- a/apps/code/src/main/services/cloud-task/service.ts
+++ b/apps/code/src/main/services/cloud-task/service.ts
@@ -839,9 +839,12 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
   private mergeHistoricalAndEmittedEntries(
     historicalEntries: StoredLogEntry[],
     emittedEntries: StoredLogEntry[],
-  ): StoredLogEntry[] {
+  ): {
+    snapshotEntries: StoredLogEntry[];
+    missingEmittedEntries: StoredLogEntry[];
+  } {
     if (emittedEntries.length === 0) {
-      return historicalEntries;
+      return { snapshotEntries: historicalEntries, missingEmittedEntries: [] };
     }
 
     const historicalCounts = new Map<string, number>();
@@ -864,7 +867,10 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       return false;
     });
 
-    return [...historicalEntries, ...missingEmittedEntries];
+    return {
+      snapshotEntries: [...historicalEntries, ...missingEmittedEntries],
+      missingEmittedEntries,
+    };
   }
 
   private async emitCurrentSnapshot(key: string): Promise<void> {
@@ -885,10 +891,12 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       return;
     }
 
-    const snapshotEntries = this.mergeHistoricalAndEmittedEntries(
-      historicalEntries,
-      watcher.emittedLogEntries,
-    );
+    const { snapshotEntries, missingEmittedEntries } =
+      this.mergeHistoricalAndEmittedEntries(
+        historicalEntries,
+        watcher.emittedLogEntries,
+      );
+    watcher.emittedLogEntries = missingEmittedEntries;
     if (snapshotEntries.length > watcher.totalEntryCount) {
       watcher.totalEntryCount = snapshotEntries.length;
     }

--- a/apps/code/src/main/trpc/routers/cloud-task.ts
+++ b/apps/code/src/main/trpc/routers/cloud-task.ts
@@ -37,15 +37,19 @@ export const cloudTaskRouter = router({
     .input(onUpdateInput)
     .subscription(async function* (opts) {
       const service = getService();
-      for await (const data of service.toIterable(CloudTaskEvent.Update, {
-        signal: opts.signal,
-      })) {
-        if (
-          data.taskId === opts.input.taskId &&
-          data.runId === opts.input.runId
-        ) {
-          yield data;
+      try {
+        for await (const data of service.toIterable(CloudTaskEvent.Update, {
+          signal: opts.signal,
+        })) {
+          if (
+            data.taskId === opts.input.taskId &&
+            data.runId === opts.input.runId
+          ) {
+            yield data;
+          }
         }
+      } finally {
+        service.unwatch(opts.input.taskId, opts.input.runId);
       }
     }),
 });

--- a/apps/code/src/renderer/features/sessions/components/buildConversationItems.test.ts
+++ b/apps/code/src/renderer/features/sessions/components/buildConversationItems.test.ts
@@ -62,6 +62,18 @@ function promptResponseMsg(ts: number, id: number): AcpMessage {
   };
 }
 
+function turnCompleteMsg(ts: number, stopReason = "end_turn"): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "_posthog/turn_complete",
+      params: { sessionId: "session-1", stopReason },
+    },
+  };
+}
+
 describe("buildConversationItems", () => {
   it("extracts cloud prompt attachments into user messages", () => {
     const uri = makeAttachmentUri("/tmp/hello world.txt");
@@ -107,6 +119,19 @@ describe("buildConversationItems", () => {
         ],
       },
     ]);
+  });
+
+  it("marks cloud turns complete from structured turn completion notifications", () => {
+    const result = buildConversationItems(
+      [userPromptMsg(10, 42, "hello"), turnCompleteMsg(25)],
+      null,
+    );
+
+    expect(result.lastTurnInfo).toEqual({
+      isComplete: true,
+      durationMs: 15,
+      stopReason: "end_turn",
+    });
   });
 
   it("keeps attachment-only prompts visible", () => {

--- a/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
+++ b/apps/code/src/renderer/features/sessions/components/buildConversationItems.ts
@@ -292,15 +292,31 @@ function handlePromptResponse(
 ) {
   const turn = b.pendingPrompts.get(msg.id);
   if (!turn) return;
-  turn.isComplete = true;
-  turn.durationMs += ts;
-
   const result = msg.result as {
     stopReason?: string;
     _meta?: { interruptReason?: string };
   };
+  completePromptTurn(b, turn, ts, {
+    stopReason: result?.stopReason,
+    interruptReason: result?._meta?.interruptReason,
+  });
+}
+
+function completePromptTurn(
+  b: ItemBuilder,
+  turn: TurnState,
+  ts: number,
+  result: { stopReason?: string; interruptReason?: string } = {},
+) {
+  if (turn.isComplete) return;
+
+  turn.isComplete = true;
+  if (turn.promptId !== -1) {
+    turn.durationMs += ts;
+  }
+
   turn.stopReason = result?.stopReason;
-  turn.interruptReason = result?._meta?.interruptReason;
+  turn.interruptReason = result?.interruptReason;
   turn.context.turnComplete = true;
 
   const wasCancelled = turn.stopReason === "cancelled";
@@ -323,7 +339,9 @@ function handlePromptResponse(
     });
   }
 
-  b.pendingPrompts.delete(msg.id);
+  if (turn.promptId !== -1) {
+    b.pendingPrompts.delete(turn.promptId);
+  }
 }
 
 function handleNotification(
@@ -358,6 +376,15 @@ function handleNotification(
       ensureImplicitTurn(b, ts);
     }
     processSessionUpdate(b, update);
+    return;
+  }
+
+  if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.TURN_COMPLETE)) {
+    const params = msg.params as { stopReason?: string } | undefined;
+    if (!b.currentTurn) return;
+    completePromptTurn(b, b.currentTurn, ts, {
+      stopReason: params?.stopReason,
+    });
     return;
   }
 

--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -668,6 +668,53 @@ describe("SessionService", () => {
       );
     });
 
+    it("keeps the cloud watcher alive when the caller cleanup runs", () => {
+      const service = getSessionService();
+      const unsubscribe = vi.fn();
+      mockTrpcCloudTask.onUpdate.subscribe.mockReturnValueOnce({
+        unsubscribe,
+      });
+
+      const cleanup = service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+      cleanup();
+
+      expect(unsubscribe).not.toHaveBeenCalled();
+      expect(mockTrpcCloudTask.unwatch.mutate).not.toHaveBeenCalled();
+    });
+
+    it("reuses the existing watcher across effect churn", () => {
+      const service = getSessionService();
+      const unsubscribe = vi.fn();
+      mockTrpcCloudTask.onUpdate.subscribe.mockReturnValueOnce({
+        unsubscribe,
+      });
+
+      const firstCleanup = service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+      firstCleanup();
+      const secondCleanup = service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+
+      expect(unsubscribe).not.toHaveBeenCalled();
+      expect(mockTrpcCloudTask.watch.mutate).toHaveBeenCalledTimes(1);
+
+      secondCleanup();
+      expect(unsubscribe).not.toHaveBeenCalled();
+    });
+
     it("hydrates a fresh cloud session from persisted logs before replay arrives", async () => {
       const service = getSessionService();
       const hydratedSession = createMockSession({
@@ -834,6 +881,151 @@ describe("SessionService", () => {
       });
     });
 
+    it("clears isPromptPending from structured turn completion logs on hydration", async () => {
+      const service = getSessionService();
+      const hydratedSession = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "disconnected",
+        isCloud: true,
+        events: [],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        hydratedSession,
+      );
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": { ...hydratedSession, currentPromptId: 42 },
+      });
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue("");
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue("{}");
+      mockTrpcLogs.writeLocalLogs.mutate.mockResolvedValue(undefined);
+
+      const promptRequest = {
+        type: "acp_message" as const,
+        ts: 1700000000,
+        message: {
+          jsonrpc: "2.0" as const,
+          id: 42,
+          method: "session/prompt",
+          params: { prompt: [{ type: "text", text: "hi" }] },
+        },
+      };
+      const completion = {
+        type: "acp_message" as const,
+        ts: 1700000005,
+        message: {
+          jsonrpc: "2.0" as const,
+          method: "_posthog/turn_complete",
+          params: {
+            sessionId: "session-1",
+            stopReason: "end_turn",
+          },
+        },
+      };
+      mockConvertStoredEntriesToEvents.mockReturnValueOnce([
+        promptRequest,
+        completion,
+      ]);
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run-123",
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          expect.objectContaining({
+            isPromptPending: false,
+            promptStartedAt: null,
+            currentPromptId: null,
+          }),
+        );
+      });
+    });
+
+    it("reconciles cloud log gaps from persisted logs", async () => {
+      const service = getSessionService();
+      const existingSession = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "connected",
+        isCloud: true,
+        logUrl: "https://logs.example.com/run-123",
+        processedLineCount: 5,
+        events: [
+          {
+            type: "acp_message",
+            ts: 1,
+            message: { method: "existing" },
+          },
+        ],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        existingSession,
+      );
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": existingSession,
+      });
+
+      const storedLine = JSON.stringify({
+        type: "notification",
+        timestamp: "2024-01-01T00:00:00Z",
+        notification: {
+          method: "session/update",
+          params: { update: { sessionUpdate: "assistant_message" } },
+        },
+      });
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue(
+        Array.from({ length: 14 }, () => storedLine).join("\n"),
+      );
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+      const subscribeOptions = mockTrpcCloudTask.onUpdate.subscribe.mock
+        .calls[0][1] as {
+        onData: (update: unknown) => void;
+      };
+
+      subscribeOptions.onData({
+        kind: "logs",
+        taskId: "task-123",
+        runId: "run-123",
+        totalEntryCount: 14,
+        newEntries: [
+          {
+            type: "notification",
+            timestamp: "2024-01-01T00:00:01Z",
+            notification: {
+              method: "session/update",
+              params: { update: { sessionUpdate: "assistant_message" } },
+            },
+          },
+        ],
+      });
+
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          expect.objectContaining({
+            events: [],
+            isCloud: true,
+            logUrl: "https://logs.example.com/run-123",
+            processedLineCount: 14,
+          }),
+        );
+      });
+      expect(mockSessionStoreSetters.appendEvents).not.toHaveBeenCalled();
+    });
+
     it("ignores stale async starts when the same watcher is replaced", async () => {
       const service = getSessionService();
       let resolveFirstWatchStart!: () => void;
@@ -898,13 +1090,13 @@ describe("SessionService", () => {
       );
 
       service.stopCloudTaskWatch("task-123");
-      expect(mockTrpcCloudTask.unwatch.mutate).toHaveBeenCalledTimes(1);
+      expect(mockTrpcCloudTask.unwatch.mutate).not.toHaveBeenCalled();
 
       resolveWatchStart();
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(mockTrpcCloudTask.unwatch.mutate).toHaveBeenCalledTimes(2);
+      expect(mockTrpcCloudTask.unwatch.mutate).toHaveBeenCalledTimes(1);
       expect(mockTrpcCloudTask.unwatch.mutate).toHaveBeenLastCalledWith({
         taskId: "task-123",
         runId: "run-123",

--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -1026,6 +1026,222 @@ describe("SessionService", () => {
       expect(mockSessionStoreSetters.appendEvents).not.toHaveBeenCalled();
     });
 
+    it("falls back to remote logs when local gap repair cache is stale", async () => {
+      const service = getSessionService();
+      const existingSession = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "connected",
+        isCloud: true,
+        logUrl: "https://logs.example.com/run-123",
+        processedLineCount: 5,
+        events: [
+          {
+            type: "acp_message",
+            ts: 1,
+            message: { method: "existing" },
+          },
+        ],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        existingSession,
+      );
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": existingSession,
+      });
+
+      const storedLine = JSON.stringify({
+        type: "notification",
+        timestamp: "2024-01-01T00:00:00Z",
+        notification: {
+          method: "session/update",
+          params: { update: { sessionUpdate: "assistant_message" } },
+        },
+      });
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue(
+        Array.from({ length: 5 }, () => storedLine).join("\n"),
+      );
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue(
+        Array.from({ length: 14 }, () => storedLine).join("\n"),
+      );
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+      const subscribeOptions = mockTrpcCloudTask.onUpdate.subscribe.mock
+        .calls[0][1] as {
+        onData: (update: unknown) => void;
+      };
+
+      subscribeOptions.onData({
+        kind: "logs",
+        taskId: "task-123",
+        runId: "run-123",
+        totalEntryCount: 14,
+        newEntries: [
+          {
+            type: "notification",
+            timestamp: "2024-01-01T00:00:01Z",
+            notification: {
+              method: "session/update",
+              params: { update: { sessionUpdate: "assistant_message" } },
+            },
+          },
+        ],
+      });
+
+      await vi.waitFor(() => {
+        expect(mockTrpcLogs.fetchS3Logs.query).toHaveBeenCalledWith({
+          logUrl: "https://logs.example.com/run-123",
+        });
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          expect.objectContaining({
+            processedLineCount: 14,
+          }),
+        );
+      });
+      expect(mockSessionStoreSetters.appendEvents).not.toHaveBeenCalled();
+    });
+
+    it("processes a pending cloud log gap after active reconciliation finishes", async () => {
+      const service = getSessionService();
+      let sessionState = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "connected",
+        isCloud: true,
+        logUrl: "https://logs.example.com/run-123",
+        processedLineCount: 5,
+        events: [
+          {
+            type: "acp_message",
+            ts: 1,
+            message: { method: "existing" },
+          },
+        ],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockImplementation(
+        () => sessionState,
+      );
+      mockSessionStoreSetters.getSessions.mockImplementation(() => ({
+        "run-123": sessionState,
+      }));
+      mockSessionStoreSetters.appendEvents.mockImplementation(
+        (_taskRunId, events, processedLineCount) => {
+          sessionState = {
+            ...sessionState,
+            events: [...sessionState.events, ...events],
+            processedLineCount,
+          };
+        },
+      );
+
+      let resolveFirstLocalLogs!: (content: string) => void;
+      mockTrpcLogs.readLocalLogs.query
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveFirstLocalLogs = resolve;
+            }),
+        )
+        .mockResolvedValue("");
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue("");
+      mockConvertStoredEntriesToEvents.mockImplementation((entries) =>
+        entries.map((entry, index) => ({
+          type: "acp_message",
+          ts: index,
+          message: {
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: { entry },
+          },
+        })),
+      );
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+      const subscribeOptions = mockTrpcCloudTask.onUpdate.subscribe.mock
+        .calls[0][1] as {
+        onData: (update: unknown) => void;
+      };
+      const firstEntry = {
+        type: "notification",
+        timestamp: "2024-01-01T00:00:01Z",
+        notification: { method: "session/update" },
+      };
+      const secondEntry = {
+        type: "notification",
+        timestamp: "2024-01-01T00:00:02Z",
+        notification: { method: "session/update" },
+      };
+      const thirdEntry = {
+        type: "notification",
+        timestamp: "2024-01-01T00:00:03Z",
+        notification: { method: "session/update" },
+      };
+
+      subscribeOptions.onData({
+        kind: "logs",
+        taskId: "task-123",
+        runId: "run-123",
+        totalEntryCount: 14,
+        newEntries: [firstEntry],
+      });
+      await vi.waitFor(() => {
+        expect(mockTrpcLogs.readLocalLogs.query).toHaveBeenCalledTimes(1);
+      });
+
+      subscribeOptions.onData({
+        kind: "logs",
+        taskId: "task-123",
+        runId: "run-123",
+        totalEntryCount: 16,
+        newEntries: [secondEntry, thirdEntry],
+      });
+      resolveFirstLocalLogs("");
+
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.appendEvents).toHaveBeenCalledTimes(2);
+      });
+      expect(mockSessionStoreSetters.appendEvents).toHaveBeenNthCalledWith(
+        1,
+        "run-123",
+        [
+          expect.objectContaining({
+            message: expect.objectContaining({
+              params: { entry: firstEntry },
+            }),
+          }),
+        ],
+        6,
+      );
+      expect(mockSessionStoreSetters.appendEvents).toHaveBeenNthCalledWith(
+        2,
+        "run-123",
+        [
+          expect.objectContaining({
+            message: expect.objectContaining({
+              params: { entry: secondEntry },
+            }),
+          }),
+          expect.objectContaining({
+            message: expect.objectContaining({
+              params: { entry: thirdEntry },
+            }),
+          }),
+        ],
+        8,
+      );
+    });
+
     it("ignores stale async starts when the same watcher is replaced", async () => {
       const service = getSessionService();
       let resolveFirstWatchStart!: () => void;

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -175,6 +175,19 @@ interface AuthCredentials {
   client: NonNullable<Awaited<ReturnType<typeof getAuthenticatedClient>>>;
 }
 
+interface CloudLogGapReconcileRequest {
+  taskId: string;
+  taskRunId: string;
+  expectedCount: number;
+  currentCount: number;
+  newEntries: StoredLogEntry[];
+  logUrl?: string;
+}
+
+interface CloudLogGapReconcileState {
+  pendingRequest?: CloudLogGapReconcileRequest;
+}
+
 export interface ConnectParams {
   task: Task;
   repoPath: string;
@@ -233,7 +246,7 @@ export class SessionService {
       onStatusChange?: () => void;
     }
   >();
-  private cloudLogGapReconciles = new Set<string>();
+  private cloudLogGapReconciles = new Map<string, CloudLogGapReconcileState>();
   /** Maps toolCallId → cloud requestId for routing permission responses */
   private cloudPermissionRequestIds = new Map<string, string>();
   private idleKilledSubscription: { unsubscribe: () => void } | null = null;
@@ -3178,12 +3191,20 @@ export class SessionService {
   private async fetchSessionLogs(
     logUrl: string | undefined,
     taskRunId?: string,
+    options: { minEntryCount?: number } = {},
   ): Promise<{
     rawEntries: StoredLogEntry[];
     sessionId?: string;
     adapter?: Adapter;
   }> {
     if (!logUrl && !taskRunId) return { rawEntries: [] };
+    let localResult:
+      | {
+          rawEntries: StoredLogEntry[];
+          sessionId?: string;
+          adapter?: Adapter;
+        }
+      | undefined;
 
     if (taskRunId) {
       try {
@@ -3191,7 +3212,13 @@ export class SessionService {
           taskRunId,
         });
         if (localContent?.trim()) {
-          return this.parseLogContent(localContent);
+          localResult = this.parseLogContent(localContent);
+          if (
+            !options.minEntryCount ||
+            localResult.rawEntries.length >= options.minEntryCount
+          ) {
+            return localResult;
+          }
         }
       } catch {
         log.warn("Failed to read local logs, falling back to S3", {
@@ -3200,11 +3227,11 @@ export class SessionService {
       }
     }
 
-    if (!logUrl) return { rawEntries: [] };
+    if (!logUrl) return localResult ?? { rawEntries: [] };
 
     try {
       const content = await trpcClient.logs.fetchS3Logs.query({ logUrl });
-      if (!content?.trim()) return { rawEntries: [] };
+      if (!content?.trim()) return localResult ?? { rawEntries: [] };
 
       const result = this.parseLogContent(content);
 
@@ -3216,72 +3243,33 @@ export class SessionService {
           });
       }
 
+      if (
+        localResult &&
+        localResult.rawEntries.length > result.rawEntries.length
+      ) {
+        return localResult;
+      }
+
       return result;
     } catch {
-      return { rawEntries: [] };
+      return localResult ?? { rawEntries: [] };
     }
   }
 
-  private reconcileCloudLogGap({
-    taskId,
-    taskRunId,
-    expectedCount,
-    currentCount,
-    newEntries,
-    logUrl,
-  }: {
-    taskId: string;
-    taskRunId: string;
-    expectedCount: number;
-    currentCount: number;
-    newEntries: StoredLogEntry[];
-    logUrl?: string;
-  }): void {
+  private reconcileCloudLogGap(request: CloudLogGapReconcileRequest): void {
+    const { taskId, taskRunId } = request;
     const reconcileKey = `${taskId}:${taskRunId}`;
-    if (this.cloudLogGapReconciles.has(reconcileKey)) {
+    const existing = this.cloudLogGapReconciles.get(reconcileKey);
+    if (existing) {
+      existing.pendingRequest = this.mergeCloudLogGapRequests(
+        existing.pendingRequest,
+        request,
+      );
       return;
     }
 
-    this.cloudLogGapReconciles.add(reconcileKey);
-    void (async () => {
-      const { rawEntries } = await this.fetchSessionLogs(logUrl, taskRunId);
-      const session = sessionStoreSetters.getSessions()[taskRunId];
-      if (!session || session.taskId !== taskId) {
-        return;
-      }
-
-      const latestCount = session.processedLineCount ?? 0;
-      if (latestCount >= expectedCount) {
-        return;
-      }
-
-      if (rawEntries.length >= expectedCount) {
-        const events = convertStoredEntriesToEvents(rawEntries);
-        sessionStoreSetters.updateSession(taskRunId, {
-          events,
-          isCloud: true,
-          logUrl: logUrl ?? session.logUrl,
-          processedLineCount: rawEntries.length,
-        });
-        this.updatePromptStateFromEvents(taskRunId, events);
-        return;
-      }
-
-      log.warn("Cloud task log count inconsistency", {
-        taskRunId,
-        currentCount,
-        expectedCount,
-        entriesReceived: newEntries.length,
-      });
-      let newEvents = convertStoredEntriesToEvents(newEntries);
-      newEvents = this.filterSkippedPromptEvents(taskRunId, session, newEvents);
-      sessionStoreSetters.appendEvents(
-        taskRunId,
-        newEvents,
-        latestCount + newEntries.length,
-      );
-      this.updatePromptStateFromEvents(taskRunId, newEvents);
-    })()
+    this.cloudLogGapReconciles.set(reconcileKey, {});
+    void this.runCloudLogGapReconciles(reconcileKey, request)
       .catch((err: unknown) => {
         log.warn("Failed to reconcile cloud task log gap", {
           taskId,
@@ -3292,6 +3280,87 @@ export class SessionService {
       .finally(() => {
         this.cloudLogGapReconciles.delete(reconcileKey);
       });
+  }
+
+  private mergeCloudLogGapRequests(
+    current: CloudLogGapReconcileRequest | undefined,
+    next: CloudLogGapReconcileRequest,
+  ): CloudLogGapReconcileRequest {
+    if (!current) return next;
+
+    return {
+      taskId: next.taskId,
+      taskRunId: next.taskRunId,
+      currentCount: Math.min(current.currentCount, next.currentCount),
+      expectedCount: Math.max(current.expectedCount, next.expectedCount),
+      newEntries: [...current.newEntries, ...next.newEntries],
+      logUrl: next.logUrl ?? current.logUrl,
+    };
+  }
+
+  private async runCloudLogGapReconciles(
+    reconcileKey: string,
+    initialRequest: CloudLogGapReconcileRequest,
+  ): Promise<void> {
+    let request: CloudLogGapReconcileRequest | undefined = initialRequest;
+
+    while (request) {
+      await this.reconcileCloudLogGapOnce(request);
+      const state = this.cloudLogGapReconciles.get(reconcileKey);
+      request = state?.pendingRequest;
+      if (state) {
+        state.pendingRequest = undefined;
+      }
+    }
+  }
+
+  private async reconcileCloudLogGapOnce({
+    taskId,
+    taskRunId,
+    expectedCount,
+    currentCount,
+    newEntries,
+    logUrl,
+  }: CloudLogGapReconcileRequest): Promise<void> {
+    const { rawEntries } = await this.fetchSessionLogs(logUrl, taskRunId, {
+      minEntryCount: expectedCount,
+    });
+    const session = sessionStoreSetters.getSessions()[taskRunId];
+    if (!session || session.taskId !== taskId) {
+      return;
+    }
+
+    const latestCount = session.processedLineCount ?? 0;
+    if (latestCount >= expectedCount) {
+      return;
+    }
+
+    if (rawEntries.length >= expectedCount) {
+      const events = convertStoredEntriesToEvents(rawEntries);
+      sessionStoreSetters.updateSession(taskRunId, {
+        events,
+        isCloud: true,
+        logUrl: logUrl ?? session.logUrl,
+        processedLineCount: rawEntries.length,
+      });
+      this.updatePromptStateFromEvents(taskRunId, events);
+      return;
+    }
+
+    log.warn("Cloud task log count inconsistency", {
+      taskRunId,
+      currentCount,
+      expectedCount,
+      entriesReceived: newEntries.length,
+    });
+    let newEvents = convertStoredEntriesToEvents(newEntries);
+    newEvents = this.filterSkippedPromptEvents(taskRunId, session, newEvents);
+    sessionStoreSetters.appendEvents(
+      taskRunId,
+      newEvents,
+      latestCount + newEntries.length,
+    );
+    this.updatePromptStateFromEvents(taskRunId, newEvents);
   }
 
   private createBaseSession(

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -161,6 +161,14 @@ function buildCloudDefaultConfigOptions(
   ];
 }
 
+function isCloudTurnCompleteEvent(event: AcpMessage): boolean {
+  const msg = event.message;
+  return (
+    "method" in msg &&
+    isNotification(msg.method, POSTHOG_NOTIFICATIONS.TURN_COMPLETE)
+  );
+}
+
 interface AuthCredentials {
   apiHost: string;
   projectId: number;
@@ -225,6 +233,7 @@ export class SessionService {
       onStatusChange?: () => void;
     }
   >();
+  private cloudLogGapReconciles = new Set<string>();
   /** Maps toolCallId → cloud requestId for routing permission responses */
   private cloudPermissionRequestIds = new Map<string, string>();
   private idleKilledSubscription: { unsubscribe: () => void } | null = null;
@@ -979,6 +988,7 @@ export class SessionService {
     this.localRepoPaths.clear();
     this.localRecoveryAttempts.clear();
     this.cloudPermissionRequestIds.clear();
+    this.cloudLogGapReconciles.clear();
     this.idleKilledSubscription?.unsubscribe();
     this.idleKilledSubscription = null;
   }
@@ -1011,6 +1021,13 @@ export class SessionService {
         if (session && session.currentPromptId !== msg.id) {
           continue;
         }
+        sessionStoreSetters.updateSession(taskRunId, {
+          isPromptPending: false,
+          promptStartedAt: null,
+          currentPromptId: null,
+        });
+      }
+      if (isCloudTurnCompleteEvent(acpMsg)) {
         sessionStoreSetters.updateSession(taskRunId, {
           isPromptPending: false,
           promptStartedAt: null,
@@ -2393,7 +2410,6 @@ export class SessionService {
     initialModel?: string,
   ): () => void {
     const taskRunId = runId;
-    const startToken = ++this.nextCloudTaskWatchToken;
     const existingWatcher = this.cloudTaskWatchers.get(taskId);
 
     // Resuming same run — reuse the existing watcher.
@@ -2435,6 +2451,8 @@ export class SessionService {
     if (existingWatcher) {
       this.stopCloudTaskWatch(taskId);
     }
+
+    const startToken = ++this.nextCloudTaskWatchToken;
 
     // Create session in the store
     const existing = sessionStoreSetters.getSessionByTaskId(taskId);
@@ -2615,8 +2633,9 @@ export class SessionService {
   }
 
   /**
-   * Fully stop a cloud task watcher — unsubscribe, unwatch, remove from map.
-   * Called on terminal status or when a new run replaces the old one.
+   * Fully stop a cloud task watcher. The tRPC subscription unwatches from the
+   * main process in its finally handler; the in-flight watch path below sends a
+   * compensating unwatch if teardown wins before watch.mutate lands.
    */
   stopCloudTaskWatch(taskId: string): void {
     const watcher = this.cloudTaskWatchers.get(taskId);
@@ -2624,11 +2643,6 @@ export class SessionService {
 
     watcher.subscription.unsubscribe();
     this.cloudTaskWatchers.delete(taskId);
-    trpcClient.cloudTask.unwatch
-      .mutate({ taskId, runId: watcher.runId })
-      .catch((err: unknown) =>
-        log.warn("Failed to unwatch cloud task", { taskId, err }),
-      );
   }
 
   async preflightToLocal(taskId: string, repoPath: string) {
@@ -2964,25 +2978,14 @@ export class SessionService {
         sessionStoreSetters.appendEvents(taskRunId, newEvents, expectedCount);
         this.updatePromptStateFromEvents(taskRunId, newEvents);
       } else {
-        // Gap in data — append everything we have but don't jump processedLineCount
-        log.warn("Cloud task log count inconsistency", {
+        this.reconcileCloudLogGap({
+          taskId: update.taskId,
           taskRunId,
-          currentCount,
           expectedCount,
-          entriesReceived: update.newEntries.length,
+          currentCount,
+          newEntries: update.newEntries,
+          logUrl: session?.logUrl,
         });
-        let newEvents = convertStoredEntriesToEvents(update.newEntries);
-        newEvents = this.filterSkippedPromptEvents(
-          taskRunId,
-          session,
-          newEvents,
-        );
-        sessionStoreSetters.appendEvents(
-          taskRunId,
-          newEvents,
-          currentCount + update.newEntries.length,
-        );
-        this.updatePromptStateFromEvents(taskRunId, newEvents);
       }
     }
 
@@ -3217,6 +3220,78 @@ export class SessionService {
     } catch {
       return { rawEntries: [] };
     }
+  }
+
+  private reconcileCloudLogGap({
+    taskId,
+    taskRunId,
+    expectedCount,
+    currentCount,
+    newEntries,
+    logUrl,
+  }: {
+    taskId: string;
+    taskRunId: string;
+    expectedCount: number;
+    currentCount: number;
+    newEntries: StoredLogEntry[];
+    logUrl?: string;
+  }): void {
+    const reconcileKey = `${taskId}:${taskRunId}`;
+    if (this.cloudLogGapReconciles.has(reconcileKey)) {
+      return;
+    }
+
+    this.cloudLogGapReconciles.add(reconcileKey);
+    void (async () => {
+      const { rawEntries } = await this.fetchSessionLogs(logUrl, taskRunId);
+      const session = sessionStoreSetters.getSessions()[taskRunId];
+      if (!session || session.taskId !== taskId) {
+        return;
+      }
+
+      const latestCount = session.processedLineCount ?? 0;
+      if (latestCount >= expectedCount) {
+        return;
+      }
+
+      if (rawEntries.length >= expectedCount) {
+        const events = convertStoredEntriesToEvents(rawEntries);
+        sessionStoreSetters.updateSession(taskRunId, {
+          events,
+          isCloud: true,
+          logUrl: logUrl ?? session.logUrl,
+          processedLineCount: rawEntries.length,
+        });
+        this.updatePromptStateFromEvents(taskRunId, events);
+        return;
+      }
+
+      log.warn("Cloud task log count inconsistency", {
+        taskRunId,
+        currentCount,
+        expectedCount,
+        entriesReceived: newEntries.length,
+      });
+      let newEvents = convertStoredEntriesToEvents(newEntries);
+      newEvents = this.filterSkippedPromptEvents(taskRunId, session, newEvents);
+      sessionStoreSetters.appendEvents(
+        taskRunId,
+        newEvents,
+        latestCount + newEntries.length,
+      );
+      this.updatePromptStateFromEvents(taskRunId, newEvents);
+    })()
+      .catch((err: unknown) => {
+        log.warn("Failed to reconcile cloud task log gap", {
+          taskId,
+          taskRunId,
+          err,
+        });
+      })
+      .finally(() => {
+        this.cloudLogGapReconciles.delete(reconcileKey);
+      });
   }
 
   private createBaseSession(

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -202,6 +202,44 @@ describe("AgentServer HTTP Mode", () => {
     }, 30000);
   });
 
+  describe("turn completion", () => {
+    it("persists structured turn completion notifications", () => {
+      const appendRawLine = vi.fn();
+      const testServer = new AgentServer({
+        port,
+        jwtPublicKey: TEST_PUBLIC_KEY,
+        repositoryPath: repo.path,
+        apiUrl: "http://localhost:8000",
+        apiKey: "test-api-key",
+        projectId: 1,
+        mode: "interactive",
+        taskId: "test-task-id",
+        runId: "test-run-id",
+      }) as unknown as {
+        session: unknown;
+        broadcastTurnComplete(stopReason: string): void;
+      };
+      testServer.session = {
+        acpSessionId: "session-1",
+        payload: { run_id: "run-1" },
+        logWriter: { appendRawLine },
+      };
+
+      testServer.broadcastTurnComplete("end_turn");
+
+      expect(appendRawLine).toHaveBeenCalledTimes(1);
+      expect(appendRawLine.mock.calls[0][0]).toBe("run-1");
+      expect(JSON.parse(appendRawLine.mock.calls[0][1])).toEqual({
+        jsonrpc: "2.0",
+        method: "_posthog/turn_complete",
+        params: {
+          sessionId: "session-1",
+          stopReason: "end_turn",
+        },
+      });
+    });
+  });
+
   describe("GET /events", () => {
     it("returns 401 without authorization header", async () => {
       await createServer().start();

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -2226,18 +2226,25 @@ ${attributionInstructions}
 
   private broadcastTurnComplete(stopReason: string): void {
     if (!this.session) return;
+    const notification = {
+      jsonrpc: "2.0",
+      method: POSTHOG_NOTIFICATIONS.TURN_COMPLETE,
+      params: {
+        sessionId: this.session.acpSessionId,
+        stopReason,
+      },
+    };
+
     this.broadcastEvent({
       type: "notification",
       timestamp: new Date().toISOString(),
-      notification: {
-        jsonrpc: "2.0",
-        method: POSTHOG_NOTIFICATIONS.TURN_COMPLETE,
-        params: {
-          sessionId: this.session.acpSessionId,
-          stopReason,
-        },
-      },
+      notification,
     });
+
+    this.session.logWriter.appendRawLine(
+      this.session.payload.run_id,
+      JSON.stringify(notification),
+    );
   }
 
   private broadcastEvent(event: Record<string, unknown>): void {


### PR DESCRIPTION
## Problem

cloud task runs could look stale in ph-code after renderer refreshes or route churn. 
renderer could miss earlier log updates from an already-running watcher, remain behind after log count gaps, or keep showing a prompt as pending after the cloud agent had already completed the turn.
