### PR TITLE
feat(code): fix github chip margins

### DIFF
--- a/apps/code/src/renderer/features/editor/components/GithubRefChip.tsx
+++ b/apps/code/src/renderer/features/editor/components/GithubRefChip.tsx
@@ -17,7 +17,7 @@ export function GithubRefChip({
       size="xs"
       variant="outline"
       onClick={() => window.open(href, "_blank")}
-      className="cli-file-mention relative top-px max-w-full cursor-pointer! whitespace-nowrap pl-1 active:translate-y-0"
+      className="cli-file-mention mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1 align-middle active:translate-y-0"
     >
       <Icon size={10} />
       <span className="min-w-0 truncate">{children}</span>


### PR DESCRIPTION
## Problem

github chips look good in the input box, but render differently (without any horizontal margin) when submitted

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds some horiz margin to the chips

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## ![Screenshot 2026-04-28 at 11.54.21 AM.png](https://app.graphite.com/user-attachments/assets/bde1e372-c2aa-417f-8ee2-f4e5cfb25e9f.png)



## How did you test this?

manually