### PR TITLE
feat(code): do not show task list empty state until fetch is complete

### DIFF
--- a/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
+++ b/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
@@ -79,13 +79,13 @@ export function useSidebarData({
   activeView,
 }: UseSidebarDataProps): SidebarData {
   const showAllUsers = useSidebarStore((state) => state.showAllUsers);
-  const { data: rawTasks = [], isLoading: isLoadingTasks } = useTasks({
+  const { data: rawTasks = [], isFetched: isTasksFetched } = useTasks({
     showAllUsers,
   });
   const { data: workspaces, isFetched: isWorkspacesFetched } = useWorkspaces();
   const archivedTaskIds = useArchivedTaskIds();
   const suspendedTaskIds = useSuspendedTaskIds();
-  const isLoading = isLoadingTasks || !isWorkspacesFetched;
+  const isLoading = !isTasksFetched || !isWorkspacesFetched;
   const allTasks = useMemo(
     () =>
       rawTasks.filter(


### PR DESCRIPTION
## Problem

when launching the app, the task list instantly shows the empty state, _then_ transitions to the loading state, creating a weird UX flash of the empty state when we don't actually know if it's empty yet

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

updates so we don't show the empty state til the fetch is done

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually