### PR TITLE
fix(code): use cloud region for PostHog URLs instead of localhost fallback

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
@@ -34,6 +34,7 @@ export function GeneralSettings() {
   const isAuthenticated = useAuthStateValue(
     (state) => state.status === "authenticated",
   );
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
 
   // Appearance state
   const theme = useThemeStore((state) => state.theme);
@@ -213,7 +214,7 @@ export function GeneralSettings() {
     [hedgehogMode, setHedgehogMode],
   );
 
-  const accountUrl = getPostHogUrl("/settings/user");
+  const accountUrl = getPostHogUrl("/settings/user", cloudRegion);
 
   return (
     <Flex direction="column">
@@ -225,7 +226,10 @@ export function GeneralSettings() {
           <Button
             size="1"
             variant="outline"
-            onClick={() => window.open(accountUrl, "_blank")}
+            disabled={!accountUrl}
+            onClick={() => {
+              if (accountUrl) window.open(accountUrl, "_blank");
+            }}
           >
             Manage
             <ArrowSquareOut size={12} />
@@ -489,9 +493,13 @@ export function GeneralSettings() {
 
 function HedgehogDescription() {
   const projectId = useAuthStateValue((state) => state.projectId);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
 
   const customizeUrl = projectId
-    ? getPostHogUrl(`/project/${projectId}/settings/user-customization`)
+    ? getPostHogUrl(
+        `/project/${projectId}/settings/user-customization`,
+        cloudRegion,
+      )
     : null;
 
   return (

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -1,3 +1,4 @@
+import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { useUsage } from "@features/billing/hooks/useUsage";
 import { useSeatStore } from "@features/billing/stores/seatStore";
 import { useSeat } from "@hooks/useSeat";
@@ -45,6 +46,8 @@ export function PlanUsageSettings() {
   } = useSeat();
   const { fetchSeat, upgradeToPro, cancelSeat, reactivateSeat, clearError } =
     useSeatStore();
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const billingUrl = getPostHogUrl("/organization/billing", cloudRegion);
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
 
   const isAlpha = seat?.plan_key === PLAN_PRO_ALPHA;
@@ -274,9 +277,9 @@ export function PlanUsageSettings() {
             <Button
               size="1"
               variant="outline"
+              disabled={!billingUrl}
               onClick={() => {
-                const url = getPostHogUrl("/organization/billing");
-                window.open(url, "_blank");
+                if (billingUrl) window.open(billingUrl, "_blank");
               }}
             >
               Open

--- a/apps/code/src/renderer/utils/urls.ts
+++ b/apps/code/src/renderer/utils/urls.ts
@@ -5,8 +5,9 @@ import { getCloudUrlFromRegion } from "@shared/utils/urls";
 export function getPostHogUrl(
   path: string,
   regionOverride?: CloudRegion | null,
-): string {
+): string | null {
   const region = regionOverride ?? useAuthStore.getState().cloudRegion;
-  const base = region ? getCloudUrlFromRegion(region) : "http://localhost:8010";
+  if (!region) return null;
+  const base = getCloudUrlFromRegion(region);
   return `${base}${path.startsWith("/") ? path : `/${path}`}`;
 }


### PR DESCRIPTION
## Summary

`getPostHogUrl` fell back to `http://localhost:8010` whenever `cloudRegion` was null, so a user authenticated to us/eu could click **Manage Account** (or **Manage Billing**) and be sent to a non-running localhost. The function now returns `string | null` and call sites disable the action when no URL can be resolved. The dev region path (`cloudRegion === "dev"`) is unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*