### PR TITLE
feat(code): fix padding on command center new task UI

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ReasoningLevelSelector.tsx
@@ -33,7 +33,7 @@ export function ReasoningLevelSelector({
   const activeLevel = thoughtOption.currentValue;
   const activeLabel =
     options.find((opt) => opt.value === activeLevel)?.name ?? activeLevel;
-  const triggerLabel = `${adapter === "codex" ? "Reasoning" : "Effort"}: ${activeLabel}`;
+  const prefix = adapter === "codex" ? "Reasoning" : "Effort";
 
   return (
     <DropdownMenu>
@@ -44,10 +44,10 @@ export function ReasoningLevelSelector({
             variant="default"
             size="sm"
             disabled={disabled}
-            aria-label={triggerLabel}
+            aria-label={`${prefix}: ${activeLabel}`}
           >
             <Brain size={14} className="text-muted-foreground" />
-            {triggerLabel}
+            {activeLabel}
             <CaretDown
               size={10}
               weight="bold"

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -565,7 +565,12 @@ export function TaskInput({
       className="relative h-full w-full"
     >
       <DropZoneOverlay isVisible={isDraggingFile} />
-      <Flex align="center" justify="center" height="100%" className="relative">
+      <Flex
+        align="center"
+        justify="center"
+        height="100%"
+        className="relative px-4"
+      >
         <DotPatternBackground className="h-[100.333%]" />
         <Flex
           direction="column"


### PR DESCRIPTION
## Problem

the new task UI in the command center, on small screen sizes, has no padding

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

- adds padding
- [lazy-fix, but good regardless imo] drops the "Effort"/"Reasoning" label from dropdown

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## ![Screenshot 2026-04-28 at 12.10.50 PM.png](https://app.graphite.com/user-attachments/assets/9ad4c879-3fe1-49f9-92fb-eb1399c07995.png)



## How did you test this?

manually