### PR TITLE
chore: hook up change logs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,11 @@
 
 <!-- Describe what you tested -- manual steps, automated tests, or both. -->
 <!-- If you're an agent, only list tests you actually ran. -->
+
+## Publish to changelog?
+
+<!-- For features only -->
+
+<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->
+
+<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->


### PR DESCRIPTION
## Problem

We don't generate changelog entries in this repo rn.

## Changes

Hooks up a new [workflow in relay](https://run.relay.app/workflows/cmoizmjnt02ku0pkoc6wt0mn6) for this repo to get changelog entries.

## How did you test this?

I haven't yet :P I need to put this up first
