### PR TITLE
fix: align option label with option number in ActionSelector rows

### DIFF
--- a/apps/code/src/renderer/components/action-selector/OptionRow.tsx
+++ b/apps/code/src/renderer/components/action-selector/OptionRow.tsx
@@ -125,9 +125,14 @@ export function OptionRow({
         ? "text-primary"
         : "text-gray-12";
 
+    // Match the index/arrow `leading-4` so the option number and the label
+    // text share a baseline. Without an explicit leading, the radix-themes
+    // <Text> default line-height is taller than the sibling number, which
+    // pushed the label down by a couple of pixels and made the column read
+    // as misaligned (issue #1922).
     return (
       <Text
-        className={`whitespace-pre-wrap font-medium text-[13px] ${textClass}`}
+        className={`whitespace-pre-wrap font-medium text-[13px] leading-4 ${textClass}`}
       >
         {displayText}
       </Text>


### PR DESCRIPTION
## Summary

Closes #1922.

The number column on each option row in \`ActionSelector\`
(\`OptionRow.tsx\`) declares \`leading-4\` on its number/index
\`<Text>\`, but the label \`<Text>\` does not. The default
radix-themes \`<Text>\` line-height is taller than \`leading-4\`,
which pushes the label down by a couple of pixels and makes the
column read as visibly misaligned — exactly what the screenshot in
the issue shows.

\`OptionRow\` is what every permission/command-approval prompt in
the app renders through (\`execute\`, \`edit\`, \`read\`, \`delete\`,
\`move\`, \`search\`, \`fetch\`, \`switch_mode\`, \`question\`,
\`think\`, plus the \`Default\` fallback), so this single fix is
the column alignment bug across the whole feature.

## Fix

One token in the \`renderLabel\` \`<Text>\` className: add
\`leading-4\` so the label shares the same line-box height as the
arrow indicator, the index number, and the optional checkbox/radio.
No layout/spacing change for any other component.

\`\`\`diff
- className={\`whitespace-pre-wrap font-medium text-[13px] \${textClass}\`}
+ className={\`whitespace-pre-wrap font-medium text-[13px] leading-4 \${textClass}\`}
\`\`\`

## Test plan

- [ ] Visual confirmation in the dev UI — I don't have the app
      running here so I'm relying on review for the runtime check.
      Easy to verify against the existing
      \`PermissionSelector.stories.tsx\` and \`ActionSelector.stories.tsx\`.
- [x] \`pnpm typecheck\` reports the same set of pre-existing errors
      (missing \`@posthog/platform/*\` declarations and
      \`@posthog/electron-trpc/main\`) whether the fix is applied
      or not — they reproduce on \`main\` without these changes, so
      they're unrelated.