### PR TITLE
chore(code): show retry button in command center on cloud stream disconnect

### DIFF
--- a/apps/code/src/renderer/features/command-center/components/CommandCenterSessionView.tsx
+++ b/apps/code/src/renderer/features/command-center/components/CommandCenterSessionView.tsx
@@ -66,7 +66,7 @@ export function CommandCenterSessionView({
         hasError={hasError}
         errorTitle={errorTitle}
         errorMessage={errorMessage ?? undefined}
-        onRetry={isCloud ? undefined : handleRetry}
+        onRetry={handleRetry}
         onNewSession={isCloud ? undefined : handleNewSession}
         isInitializing={isInitializing}
         isCloud={isCloud}


### PR DESCRIPTION
## Problem

When a cloud-run stream disconnects in the command center 2x2 grid, the error overlay shows "Cloud stream disconnected — Lost connection to the cloud run stream. Retry to reconnect." but no Retry button. The regular task detail view shows the button just fine.

## Cause

`CommandCenterSessionView.tsx` was passing `onRetry={isCloud ? undefined : handleRetry}`. The `isCloud` gate is correct for `onBashCommand` and `onNewSession` (those don't apply to cloud sessions), but `handleRetry` already handles cloud via `retryCloudTaskWatch` — the gate just suppressed a working action.

## Fix

Pass `onRetry={handleRetry}` unconditionally, matching `TaskLogsPanel.tsx`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*