### PR TITLE
chore(code): batch releases on 16h cadence

### DIFF
--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -1,18 +1,13 @@
 name: Tag PostHog Code Release
 
 on:
-  push:
+  schedule:
+    - cron: "0 1,17 * * *"
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
     branches:
       - main
-    paths:
-      - "apps/code/**"
-      - "packages/agent/**"
-      - "packages/electron-trpc/**"
-      - "pnpm-lock.yaml"
-      - "package.json"
-      - "turbo.json"
-      - ".github/workflows/code-tag.yml"
-      - ".github/workflows/code-release.yml"
 
 concurrency:
   group: code-tag
@@ -20,6 +15,11 @@ concurrency:
 
 jobs:
   tag:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'create release'))
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -19,7 +19,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'create release'))
+       contains(github.event.pull_request.labels.*.name, 'Create release'))
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/apps/code/README.md
+++ b/apps/code/README.md
@@ -131,7 +131,7 @@ PostHog Code uses Electron's built-in `autoUpdater` pointed at the public `updat
 There are three ways a release can fire:
 
 1. **Scheduled (default)** — automatic at 17:00 and 01:00 UTC.
-2. **Hotfix** — add the `create release` label to a PR before it merges. On merge, the tag workflow runs immediately and ships whatever is on `main`.
+2. **Hotfix** — add the `Create release` label to a PR before it merges. On merge, the tag workflow runs immediately and ships whatever is on `main`.
 3. **Manual** — run `Tag PostHog Code Release` via `workflow_dispatch` from the Actions tab.
 
 Local prep (only needed for one-off manual builds):

--- a/apps/code/README.md
+++ b/apps/code/README.md
@@ -128,11 +128,18 @@ pnpm build-native
 
 PostHog Code uses Electron's built-in `autoUpdater` pointed at the public `update.electronjs.org` service for `PostHog/code`. Every time a non-draft GitHub release is published with the platform archives, packaged apps will automatically download and install the newest version on macOS and Windows.
 
-Publishing a new release:
+Releases are batched on a 12-hour cadence rather than firing on every merge to `main`. The `Tag PostHog Code Release` workflow runs at 17:00 UTC (18:00 CET / 09:00 PT) and 01:00 UTC (02:00 CET / 17:00 PT). It counts commits since the latest base tag and pushes a new `vX.Y.Z` tag if there's anything to ship. Tag pushes then trigger `code-release.yml`, which builds, signs, notarizes, and publishes the GitHub release.
+
+There are three ways a release can fire:
+
+1. **Scheduled (default)** — automatic at 00:00 and 12:00 UTC.
+2. **Hotfix** — add the `create release` label to a PR before it merges. On merge, the tag workflow runs immediately and ships whatever is on `main`.
+3. **Manual** — run `Tag PostHog Code Release` via `workflow_dispatch` from the Actions tab.
+
+Local prep (only needed for one-off manual builds):
 
 1. Export a GitHub token with `repo` scope as `GH_PUBLISH_TOKEN`; set both `GH_TOKEN` and `GITHUB_TOKEN` to its value locally (e.g., in `.envrc`). In GitHub, store the token as the `GH_PUBLISH_TOKEN` repository secret.
-2. Run `pnpm run make` locally to sanity check artifacts, then bump `package.json`'s version (e.g., `pnpm version patch`).
-3. Merge the version bump into `main`. The `Publish Release` GitHub Action auto-detects the new version, tags `vX.Y.Z`, runs `pnpm run publish`, and uploads the release artifacts. You can also run the workflow manually (`workflow_dispatch`) and supply a tag if you need to re-publish.
+2. Run `pnpm run make` to sanity check artifacts.
 
 Set `ELECTRON_DISABLE_AUTO_UPDATE=1` if you ever need to ship a build with auto updates disabled.
 

--- a/apps/code/README.md
+++ b/apps/code/README.md
@@ -128,11 +128,9 @@ pnpm build-native
 
 PostHog Code uses Electron's built-in `autoUpdater` pointed at the public `update.electronjs.org` service for `PostHog/code`. Every time a non-draft GitHub release is published with the platform archives, packaged apps will automatically download and install the newest version on macOS and Windows.
 
-Releases are batched on a 12-hour cadence rather than firing on every merge to `main`. The `Tag PostHog Code Release` workflow runs at 17:00 UTC (18:00 CET / 09:00 PT) and 01:00 UTC (02:00 CET / 17:00 PT). It counts commits since the latest base tag and pushes a new `vX.Y.Z` tag if there's anything to ship. Tag pushes then trigger `code-release.yml`, which builds, signs, notarizes, and publishes the GitHub release.
-
 There are three ways a release can fire:
 
-1. **Scheduled (default)** — automatic at 00:00 and 12:00 UTC.
+1. **Scheduled (default)** — automatic at 17:00 and 01:00 UTC.
 2. **Hotfix** — add the `create release` label to a PR before it merges. On merge, the tag workflow runs immediately and ships whatever is on `main`.
 3. **Manual** — run `Tag PostHog Code Release` via `workflow_dispatch` from the Actions tab.
 


### PR DESCRIPTION
Update our release schedule to release every 16 hours:
- Once at 17:00 UTC / 18:00 CET / 09:00 PT 
- Once at 01:00 UTC / 02:00 CET / 17:00 PT

I chose these timeframes so all your work is batched and released at the end of your workday (17:00 UTC or 17:00 PT)

updated readme
Also add a label `Create release` which can be used for hotfixes