### PR TITLE
fix: deduplicate task api call

### DIFF
--- a/apps/code/src/renderer/features/tasks/hooks/useTasks.ts
+++ b/apps/code/src/renderer/features/tasks/hooks/useTasks.ts
@@ -37,7 +37,7 @@ export function useTasks(filters?: {
   const createdBy = filters?.showAllUsers ? undefined : currentUser?.id;
 
   return useAuthenticatedQuery(
-    taskKeys.list({ ...filters, createdBy }),
+    taskKeys.list({ repository: filters?.repository, createdBy }),
     (client) =>
       client.getTasks({
         repository: filters?.repository,


### PR DESCRIPTION
We were making 2 identical calls to the API for listing our tasks.   
Each call takes around 3s, which meant loading the tasks in the sidebar took about 6🫲🤪 🫱7 seconds  
This reduces it to one call  
  
partially solves #1364 but i'll need a ID filter on the task endpoint to optimize this further