### PR TITLE
fix: use null auth store, use hook instead of zust store

### DIFF
--- a/apps/code/src/renderer/features/auth/hooks/authQueries.ts
+++ b/apps/code/src/renderer/features/auth/hooks/authQueries.ts
@@ -36,6 +36,13 @@ export async function fetchAuthState(): Promise<AuthState> {
   return await trpcClient.auth.getState.query();
 }
 
+export function getCachedAuthState(): AuthState {
+  return (
+    queryClient.getQueryData<AuthState>(trpc.auth.getState.queryKey()) ??
+    ANONYMOUS_AUTH_STATE
+  );
+}
+
 export async function refreshAuthStateQuery(): Promise<void> {
   await queryClient.invalidateQueries(trpc.auth.getState.pathFilter());
 }

--- a/apps/code/src/renderer/utils/posthogLinks.ts
+++ b/apps/code/src/renderer/utils/posthogLinks.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { getCachedAuthState } from "@features/auth/hooks/authQueries";
 import type { CloudRegion } from "@shared/types/regions";
 import { getPostHogUrl } from "@utils/urls";
 
@@ -9,7 +9,7 @@ export interface LinkOverrides {
 
 function resolveProjectId(override?: number | null): number | null {
   if (override != null) return override;
-  return useAuthStore.getState().projectId ?? null;
+  return getCachedAuthState().projectId ?? null;
 }
 
 function withProjectId(

--- a/apps/code/src/renderer/utils/urls.ts
+++ b/apps/code/src/renderer/utils/urls.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@features/auth/stores/authStore";
+import { getCachedAuthState } from "@features/auth/hooks/authQueries";
 import type { CloudRegion } from "@shared/types/regions";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
 
@@ -6,7 +6,7 @@ export function getPostHogUrl(
   path: string,
   regionOverride?: CloudRegion | null,
 ): string | null {
-  const region = regionOverride ?? useAuthStore.getState().cloudRegion;
+  const region = regionOverride ?? getCachedAuthState().cloudRegion;
   if (!region) return null;
   const base = getCloudUrlFromRegion(region);
   return `${base}${path.startsWith("/") ? path : `/${path}`}`;


### PR DESCRIPTION
## Problem

Auth state was being read directly from `useAuthStore` in utility functions outside of React components, which is stale if this isnt the first session

## Changes

- Added `getCachedAuthState()` helper that reads the current `AuthState` directly from the React Query cache, falling back to `ANONYMOUS_AUTH_STATE` if no cached value exists
- Replaced `useAuthStore.getState()` calls in `posthogLinks.ts` and `urls.ts` with `getCachedAuthState()`, making the query cache the single source of truth for auth state in non-component contexts