### PR TITLE
fix(code): don't include timestamp overlay when copying user messages

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
@@ -155,7 +155,7 @@ export function UserMessage({
             <span>View Slack thread</span>
           </a>
         )}
-        <Box className="absolute top-1 right-1 flex items-center gap-1.5 rounded-md bg-gray-2 py-0.5 pr-1 pl-2 opacity-0 shadow-sm transition-opacity group-hover/msg:opacity-100">
+        <Box className="absolute top-1 right-1 flex select-none items-center gap-1.5 rounded-md bg-gray-2 py-0.5 pr-1 pl-2 opacity-0 shadow-sm transition-opacity group-hover/msg:opacity-100">
           {timestamp != null && (
             <span aria-hidden className="text-[11px] text-gray-10">
               {formatTimestamp(timestamp)}


### PR DESCRIPTION
Selecting a one-line user message used to drag the hover timestamp into the copy. Marking the overlay `select-none` keeps copies clean; the copy button still works.

Fixes feedback from [this Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1777394643878509?thread_ts=1777394074.730869&cid=C09G8Q32R6F).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*