### PR TITLE
fix(code): invalidate queries on PR creation

### DIFF
--- a/apps/code/src/renderer/App.tsx
+++ b/apps/code/src/renderer/App.tsx
@@ -117,6 +117,16 @@ function App() {
   );
 
   useSubscription(
+    trpcReact.workspace.onLinkedBranchChanged.subscriptionOptions(undefined, {
+      onData: () => {
+        void queryClient.invalidateQueries(
+          trpcReact.workspace.getAll.pathFilter(),
+        );
+      },
+    }),
+  );
+
+  useSubscription(
     trpcReact.focus.onBranchRenamed.subscriptionOptions(undefined, {
       onData: ({ worktreePath, newBranch }) => {
         useFocusStore.getState().updateSessionBranch(worktreePath, newBranch);

--- a/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
@@ -296,6 +296,18 @@ export function useGitInteraction(
       }
 
       if (result.prUrl) {
+        const linkedBranchName = store.createPrNeedsBranch
+          ? store.branchName.trim()
+          : git.currentBranch;
+        if (linkedBranchName) {
+          queryClient.setQueryData(
+            trpc.git.getPrUrlForBranch.queryKey({
+              directoryPath: repoPath,
+              branchName: linkedBranchName,
+            }),
+            result.prUrl,
+          );
+        }
         await trpcClient.os.openExternal.mutate({ url: result.prUrl });
         attachPrUrlToTask(taskId, result.prUrl);
       }


### PR DESCRIPTION
## Problem

when a PR is created, we don't invalidate the git queries correctly, so the diff panel shows empty until the cache is stale

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

subscribes to PR creation to invalidate queries & passes PR URL directly to query when flow is complete to be even faster

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

[diff-invalidation-fix.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e8e3d15c-ba7c-4856-8d7d-9b3a4876ef4a.mp4" />](https://app.graphite.com/user-attachments/video/e8e3d15c-ba7c-4856-8d7d-9b3a4876ef4a.mp4)

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

no