### PR TITLE
feat(inbox): Show failed reports

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -15,6 +15,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { Box, Flex, ScrollArea, Text, Tooltip } from "@radix-ui/themes";
+import { EXTERNAL_LINKS } from "@renderer/utils/links";
 import { getDeeplinkProtocol } from "@shared/deeplink";
 import type {
   ActionabilityJudgmentArtefact,
@@ -294,6 +295,42 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
           gap="2"
           className="min-w-0 @2xl:px-6 @3xl:px-8 @4xl:px-10 @5xl:px-12 @lg:px-4 @md:px-3 @xl:px-5 px-2 @2xl:pt-3 @3xl:pt-4 @4xl:pt-5 @5xl:pt-6 @lg:pt-2 @md:pt-1.5 @xl:pt-2.5 pt-1 @2xl:pb-6 @3xl:pb-8 @4xl:pb-10 @5xl:pb-12 @lg:pb-4 @md:pb-3 @xl:pb-5 pb-2"
         >
+          {/* ── Failed report error ──────────────────────────── */}
+          {report.status === "failed" && (
+            <Flex
+              align="start"
+              gap="2"
+              px="2"
+              py="2"
+              className="user-select-none rounded-sm border border-red-6 bg-red-2"
+            >
+              <WarningIcon
+                size={14}
+                weight="fill"
+                className="mt-0.5 shrink-0 text-(--red-9)"
+              />
+              <Flex direction="column" className="min-w-0 flex-1">
+                <Text className="font-medium text-(--red-11) text-[12px]">
+                  Report processing failed
+                </Text>
+                <Text className="text-(--red-9) text-[11px]">
+                  There was an issue processing this report. This has been
+                  reported to the PostHog Code team.
+                  <br />
+                  To get in touch with the team directly,{" "}
+                  <a
+                    href={EXTERNAL_LINKS.discord}
+                    target="_blank"
+                    className="text-(--red-9) underline hover:text-(--red-11)"
+                  >
+                    join our Discord
+                  </a>
+                  .
+                </Text>
+              </Flex>
+            </Flex>
+          )}
+
           {/* ── Description ─────────────────────────────────────── */}
           {report.status !== "ready" ? (
             <Tooltip content="This is a preliminary description. A full researched summary will replace it when the research agent completes its work.">

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -315,7 +315,7 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
                 </Text>
                 <Text className="text-(--red-9) text-[11px]">
                   There was an issue processing this report. This has been
-                  reported to the PostHog Code team.
+                  reported to the team.
                   <br />
                   To get in touch with the team directly,{" "}
                   <a

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -302,7 +302,7 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
               gap="2"
               px="2"
               py="2"
-              className="user-select-none rounded-sm border border-red-6 bg-red-2"
+              className="select-none rounded-sm border border-red-6 bg-red-2"
             >
               <WarningIcon
                 size={14}

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -324,6 +324,8 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
                     rel="noreferrer"
                     className="text-(--red-9) underline hover:text-(--red-11)"
                   >
+                    Discord
+                  </a>
                   .
                 </Text>
               </Flex>

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -321,10 +321,9 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
                   <a
                     href={EXTERNAL_LINKS.discord}
                     target="_blank"
+                    rel="noreferrer"
                     className="text-(--red-9) underline hover:text-(--red-11)"
                   >
-                    join our Discord
-                  </a>
                   .
                 </Text>
               </Flex>

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -324,7 +324,7 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
                     rel="noreferrer"
                     className="text-(--red-9) underline hover:text-(--red-11)"
                   >
-                    Discord
+                    join our Discord
                   </a>
                   .
                 </Text>

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -315,7 +315,7 @@ export function ReportDetailPane({ report, onClose }: ReportDetailPaneProps) {
                 </Text>
                 <Text className="text-(--red-9) text-[11px]">
                   There was an issue processing this report. This has been
-                  reported to the team.
+                  reported to our team.
                   <br />
                   To get in touch with the team directly,{" "}
                   <a

--- a/apps/code/src/renderer/features/inbox/components/list/FilterSortMenu.tsx
+++ b/apps/code/src/renderer/features/inbox/components/list/FilterSortMenu.tsx
@@ -70,6 +70,7 @@ const FILTERABLE_STATUSES: SignalReportStatus[] = [
   "ready",
   "pending_input",
   "in_progress",
+  "failed",
   "candidate",
   "potential",
 ];

--- a/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.test.ts
+++ b/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.test.ts
@@ -12,6 +12,7 @@ describe("inboxSignalsFilterStore", () => {
         "ready",
         "pending_input",
         "in_progress",
+        "failed",
         "candidate",
         "potential",
       ],
@@ -29,6 +30,7 @@ describe("inboxSignalsFilterStore", () => {
       "ready",
       "pending_input",
       "in_progress",
+      "failed",
       "candidate",
       "potential",
     ]);
@@ -119,6 +121,7 @@ describe("inboxSignalsFilterStore", () => {
       "ready",
       "pending_input",
       "in_progress",
+      "failed",
       "candidate",
       "potential",
     ]);

--- a/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/apps/code/src/renderer/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -25,6 +25,7 @@ const DEFAULT_STATUS_FILTER: SignalReportStatus[] = [
   "ready",
   "pending_input",
   "in_progress",
+  "failed",
   "candidate",
   "potential",
 ];

--- a/packages/agent/src/handoff-checkpoint.ts
+++ b/packages/agent/src/handoff-checkpoint.ts
@@ -18,7 +18,7 @@ export interface HandoffCheckpointTrackerConfig {
   logger?: Logger;
 }
 
-type ArtifactTransfer<T extends object = {}> = T & {
+type ArtifactTransfer<T extends object = Record<string, never>> = T & {
   rawBytes: number;
   wireBytes: number;
 };


### PR DESCRIPTION
## Problem

Users have reported being surprised that reports mysteriously disappear from the inbox. In reality, some of these fail due to to process due to various reasons. We're looking into these reasons separately, but the important thing is not to surprise users.

## Changes

Letting people see failed reports, with clear information about this:

<img width="1658" height="778" alt="Screenshot 2026-04-30 at 11 21 06@2x" src="https://github.com/user-attachments/assets/9afa93bf-0806-4104-ac1a-93cbd610ab4a" />
