### PR TITLE
feat(integrations): filter integrations by kind server-side

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -1341,15 +1341,18 @@ export class PostHogAPIClient {
     }
   }
 
-  async getIntegrations() {
+  async getIntegrations(kind?: string) {
     const teamId = await this.getTeamId();
-    return this.getIntegrationsForProject(teamId);
+    return this.getIntegrationsForProject(teamId, kind);
   }
 
-  async getIntegrationsForProject(projectId: number) {
+  async getIntegrationsForProject(projectId: number, kind?: string) {
     const url = new URL(
       `${this.api.baseUrl}/api/environments/${projectId}/integrations/`,
     );
+    if (kind) {
+      url.searchParams.set("kind", kind);
+    }
     const response = await this.api.fetcher.fetch({
       method: "get",
       url,

--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -1473,15 +1473,18 @@ export class PostHogAPIClient {
     }
   }
 
-  async getIntegrations() {
+  async getIntegrations(kind?: string) {
     const teamId = await this.getTeamId();
-    return this.getIntegrationsForProject(teamId);
+    return this.getIntegrationsForProject(teamId, kind);
   }
 
-  async getIntegrationsForProject(projectId: number) {
+  async getIntegrationsForProject(projectId: number, kind?: string) {
     const url = new URL(
       `${this.api.baseUrl}/api/environments/${projectId}/integrations/`,
     );
+    if (kind) {
+      url.searchParams.set("kind", kind);
+    }
     const response = await this.api.fetcher.fetch({
       method: "get",
       url,

--- a/apps/code/src/renderer/features/inbox/components/DataSourceSetup.tsx
+++ b/apps/code/src/renderer/features/inbox/components/DataSourceSetup.tsx
@@ -136,8 +136,10 @@ function GitHubSetup({ onComplete, onCancel }: SetupFormProps) {
         try {
           if (!client) return;
           // Trigger a refetch of integrations
-          const integrations =
-            await client.getIntegrationsForProject(projectId);
+          const integrations = await client.getIntegrationsForProject(
+            projectId,
+            "github",
+          );
           const hasGithub = integrations.some(
             (i: { kind: string }) => i.kind === "github",
           );

--- a/apps/code/src/renderer/features/onboarding/hooks/usePrefetchSignalData.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/usePrefetchSignalData.ts
@@ -36,7 +36,7 @@ export function usePrefetchSignalData(): void {
     queryClient.prefetchQuery({
       queryKey: ["integrations", "list"],
       queryFn: async () => {
-        const integrations = await client.getIntegrations();
+        const integrations = await client.getIntegrations("github");
         const ghIntegration = (
           integrations as { id: number; kind: string }[]
         ).find((i) => i.kind === "github");

--- a/apps/code/src/renderer/hooks/useIntegrations.ts
+++ b/apps/code/src/renderer/hooks/useIntegrations.ts
@@ -38,7 +38,7 @@ export function useIntegrations() {
 
   const query = useAuthenticatedQuery(
     integrationKeys.list(),
-    (client) => client.getIntegrations() as Promise<Integration[]>,
+    (client) => client.getIntegrations("github") as Promise<Integration[]>,
   );
 
   useEffect(() => {

--- a/apps/code/src/renderer/hooks/useIntegrations.ts
+++ b/apps/code/src/renderer/hooks/useIntegrations.ts
@@ -71,7 +71,7 @@ export function useIntegrations() {
 
   const query = useAuthenticatedQuery(
     integrationKeys.list(),
-    (client) => client.getIntegrations() as Promise<Integration[]>,
+    (client) => client.getIntegrations("github") as Promise<Integration[]>,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Use the new `kind` query parameter on `GET /api/environments/{projectId}/integrations/` so the desktop app fetches only GitHub integrations instead of pulling every integration kind and filtering client-side.

Backend support: PostHog/posthog#57135.

The client-side `kind === "github"` filter in `integrationStore` is kept as a safety net for self-hosted PostHog instances that pre-date that PR.

## Test plan

- [x] `pnpm --filter code typecheck` passes
- [x] `posthogClient.test.ts` passes
- [ ] Manual smoke check: open the app on a GitHub-connected project; confirm `…/integrations/?kind=github` in the network panel and that GitHub repos still load in the inbox / onboarding flows