### PR TITLE
feat(sidebar): open sidebar automatically after onboarding completion

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/MainSidebar.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/MainSidebar.tsx
@@ -1,3 +1,4 @@
+import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import { Box } from "@radix-ui/themes";
 import { useEffect } from "react";
@@ -6,14 +7,17 @@ import { Sidebar, SidebarContent } from "./index";
 
 export function MainSidebar() {
   const { data: workspaces = {}, isFetched } = useWorkspaces();
+  const hasCompletedOnboarding = useOnboardingStore(
+    (state) => state.hasCompletedOnboarding,
+  );
   const setOpenAuto = useSidebarStore((state) => state.setOpenAuto);
 
   useEffect(() => {
     if (isFetched) {
       const workspaceCount = Object.keys(workspaces).length;
-      setOpenAuto(workspaceCount > 0);
+      setOpenAuto(hasCompletedOnboarding || workspaceCount > 0);
     }
-  }, [isFetched, workspaces, setOpenAuto]);
+  }, [isFetched, workspaces, hasCompletedOnboarding, setOpenAuto]);
 
   return (
     <Box flexShrink="0" className="shrink-0">


### PR DESCRIPTION
## TL;DR

The sidebar now opens automatically when users complete onboarding, improving the post-onboarding experience by showing the sidebar by default alongside the existing behavior of opening it when workspaces exist.

## Problem

After completing onboarding, users would not see the sidebar opened automatically, requiring them to manually open it. This creates a suboptimal user experience for newly onboarded users.

## Changes

- Added `useOnboardingStore` import to access onboarding completion state in `MainSidebar` component
- Updated the sidebar auto-open logic to consider both onboarding completion status and workspace count
- Modified `setOpenAuto` call to open the sidebar when either:
    - User has completed onboarding, OR
    - User has existing workspaces (existing behavior)
- Added `hasCompletedOnboarding` to the dependency array of the `useEffect` hook to ensure proper reactivity

## How did you test this?

This change integrates with existing onboarding and sidebar state management. The logic ensures backward compatibility by maintaining the original behavior of opening the sidebar when workspaces exist, while adding the new condition for onboarding completion.

## Publish to changelog?

no

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)