### PR TITLE
feat(code): harden branch linking during PR creation flow

### DIFF
--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../utils/logger.js", () => ({
 }));
 
 import type { LlmGatewayService } from "../llm-gateway/service";
+import type { WorkspaceService } from "../workspace/service";
 import { GitService } from "./service";
 
 describe("GitService.getPrChangedFiles", () => {
@@ -31,7 +32,7 @@ describe("GitService.getPrChangedFiles", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new GitService({} as LlmGatewayService);
+    service = new GitService({} as LlmGatewayService, {} as WorkspaceService);
   });
 
   it("flattens paginated GH API results and maps file statuses", async () => {
@@ -139,7 +140,7 @@ describe("GitService.getGhAuthToken", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new GitService({} as LlmGatewayService);
+    service = new GitService({} as LlmGatewayService, {} as WorkspaceService);
   });
 
   it("returns the authenticated GitHub CLI token", async () => {
@@ -197,7 +198,7 @@ describe("GitService.getPrUrlForBranch", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new GitService({} as LlmGatewayService);
+    service = new GitService({} as LlmGatewayService, {} as WorkspaceService);
   });
 
   it("returns the PR URL for a branch via gh pr list", async () => {

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -41,6 +41,7 @@ import { MAIN_TOKENS } from "../../di/tokens";
 import { logger } from "../../utils/logger";
 import { TypedEventEmitter } from "../../utils/typed-event-emitter";
 import type { LlmGatewayService } from "../llm-gateway/service";
+import type { WorkspaceService } from "../workspace/service";
 import { CreatePrSaga } from "./create-pr-saga";
 import type {
   ChangedFile,
@@ -117,6 +118,8 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
   constructor(
     @inject(MAIN_TOKENS.LlmGatewayService)
     private readonly llmGateway: LlmGatewayService,
+    @inject(MAIN_TOKENS.WorkspaceService)
+    private readonly workspaceService: WorkspaceService,
   ) {
     super();
   }
@@ -625,6 +628,14 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     const state = await this.getStateSnapshot(directoryPath, {
       includePrStatus: true,
     });
+
+    if (input.taskId) {
+      const linkedBranch =
+        input.branchName ?? (await getCurrentBranch(directoryPath));
+      if (linkedBranch) {
+        this.workspaceService.linkBranch(input.taskId, linkedBranch, "user");
+      }
+    }
 
     emitProgress(
       "complete",

--- a/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/useGitInteraction.ts
@@ -282,17 +282,6 @@ export function useGitInteraction(
       }
       if (store.createPrNeedsBranch) {
         invalidateGitBranchQueries(repoPath);
-        trpcClient.workspace.linkBranch
-          .mutate({ taskId, branchName: store.branchName.trim() })
-          .catch((err) =>
-            log.warn("Failed to link branch to task", { taskId, err }),
-          );
-      } else if (git.currentBranch) {
-        trpcClient.workspace.linkBranch
-          .mutate({ taskId, branchName: git.currentBranch })
-          .catch((err) =>
-            log.warn("Failed to link branch to task", { taskId, err }),
-          );
       }
 
       if (result.prUrl) {


### PR DESCRIPTION
## **Problem**

The unified PR badge in the task header sometimes wouldn't render even though a PR existed — the simpler "View PR" + git options menu would show instead. Worse, it would only "fix itself" once the agent next edited a file.

The badge depends on `workspace.linkedBranch` being set. Linking happened via a fire-and-forget `workspace.linkBranch.mutate()` call in the renderer (`useGitInteraction.runCreatePr`) right after the create-PR mutation returned. If the renderer reloaded mid-flow (e.g. Vite HMR during dev, or any IPC tear-down), that second mutation never landed on the main process, the link was silently lost (only `log.warn`'d), and the only recovery was `handleAgentFileActivity` re-linking on the next agent edit.

#1947 made the happy path fast (subscription invalidation + optimistic `getPrUrlForBranch` cache prime) but didn't address the durability of the link itself — when the fire-and-forget call is dropped, neither leg of #1947 has anything to act on.

closes https://github.com/posthog/code/issues/1959

## **Changes**

Move the `linkBranch` call into the main-process `GitService.createPr` flow so it's atomic with PR creation and survives renderer reloads.

- Inject `WorkspaceService` into `GitService` (no circular dep — `WorkspaceService` doesn't depend on `GitService`).
- After a successful PR creation, call `workspaceService.linkBranch(taskId, branchName, "user")`. Branch resolved as `input.branchName ?? getCurrentBranch(directoryPath)`.
- Drop both fire-and-forget `linkBranch.mutate()` blocks in `useGitInteraction.runCreatePr`. Kept `invalidateGitBranchQueries` and the optimistic `getPrUrlForBranch` cache prime — those still provide the latency win from #1947, just no longer load-bearing for correctness.
- Updated `GitService` test instantiations to pass a `WorkspaceService` stub.

## **How did you test this?**

- `pnpm --filter code typecheck` clean
- `pnpm --filter code test` — all 982 tests pass
- Need to verify manually: create a PR via the UI, confirm the unified PR badge appears immediately, and that it still appears after a hot reload mid-flow.

## **Publish to changelog?**

no