### PR TITLE
fix(agent): only attach PR URLs from gh pr create

### DIFF
--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -35,6 +35,7 @@ import {
   isOpenAIModel,
 } from "@posthog/agent/gateway-models";
 import { getLlmGatewayUrl } from "@posthog/agent/posthog-api";
+import { extractCreatedPrUrl } from "@posthog/agent/pr-url-detector";
 import type * as AgentTypes from "@posthog/agent/types";
 import { getCurrentBranch } from "@posthog/git/queries";
 import type { IAppMeta } from "@posthog/platform/app-meta";
@@ -1524,6 +1525,7 @@ For git operations while detached:
               claudeCode?: {
                 toolName?: string;
                 toolResponse?: unknown;
+                bashCommand?: string;
               };
             };
             content?: Array<{ type?: string; text?: string }>;
@@ -1542,10 +1544,7 @@ For git operations while detached:
 
       const session = this.sessions.get(taskRunId);
 
-      // PR URLs only appear in Bash tool output
-      if (toolName.includes("Bash") || toolName.includes("bash")) {
-        this.detectAndAttachPrUrl(taskRunId, session, toolMeta, update.content);
-      }
+      this.detectAndAttachPrUrl(taskRunId, session, toolMeta, update.content);
 
       this.trackAgentFileActivity(taskRunId, session, toolName);
     } catch (err) {
@@ -1557,60 +1556,37 @@ For git operations while detached:
   }
 
   /**
-   * Detect GitHub PR URLs in bash tool results and attach to task.
-   * This enables webhook tracking by populating the pr_url in TaskRun output.
+   * Detect GitHub PR URLs in `gh pr create` output and attach to task.
+   * Gated on the originating bash command so that unrelated PR URLs (e.g.
+   * `gh pr view`, `gh search prs`) don't get latched onto the run.
    */
   private detectAndAttachPrUrl(
     taskRunId: string,
     session: ManagedSession | undefined,
-    toolMeta: { toolName?: string; toolResponse?: unknown },
+    toolMeta:
+      | {
+          toolName?: string;
+          toolResponse?: unknown;
+          bashCommand?: string;
+        }
+      | undefined,
     content?: Array<{ type?: string; text?: string }>,
   ): void {
-    let textToSearch = "";
+    const prUrl = extractCreatedPrUrl({
+      toolName: toolMeta?.toolName,
+      bashCommand: toolMeta?.bashCommand,
+      toolResponse: toolMeta?.toolResponse,
+      content,
+    });
+    if (!prUrl) return;
 
-    // Check toolResponse (hook response with raw output)
-    const toolResponse = toolMeta?.toolResponse;
-    if (toolResponse) {
-      if (typeof toolResponse === "string") {
-        textToSearch = toolResponse;
-      } else if (typeof toolResponse === "object" && toolResponse !== null) {
-        // May be { stdout?: string, stderr?: string } or similar
-        const respObj = toolResponse as Record<string, unknown>;
-        textToSearch =
-          String(respObj.stdout || "") + String(respObj.stderr || "");
-        if (!textToSearch && respObj.output) {
-          textToSearch = String(respObj.output);
-        }
-      }
-    }
+    log.info("Detected PR URL from gh pr create", { taskRunId, prUrl });
 
-    // Also check content array
-    if (Array.isArray(content)) {
-      for (const item of content) {
-        if (item.type === "text" && item.text) {
-          textToSearch += ` ${item.text}`;
-        }
-      }
-    }
-
-    if (!textToSearch) return;
-
-    // Match GitHub PR URLs
-    const prUrlMatch = textToSearch.match(
-      /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/,
-    );
-    if (!prUrlMatch) return;
-
-    const prUrl = prUrlMatch[0];
-    log.info("Detected PR URL in bash output", { taskRunId, prUrl });
-
-    // Attach PR URL
     if (!session) {
       log.warn("Session not found for PR attachment", { taskRunId });
       return;
     }
 
-    // Attach asynchronously without blocking message flow
     session.agent
       .attachPullRequestToTask(session.taskId, prUrl)
       .then(() => {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -20,6 +20,10 @@
       "types": "./dist/posthog-api.d.ts",
       "import": "./dist/posthog-api.js"
     },
+    "./pr-url-detector": {
+      "types": "./dist/pr-url-detector.d.ts",
+      "import": "./dist/pr-url-detector.js"
+    },
     "./types": {
       "types": "./dist/types.d.ts",
       "import": "./dist/types.js"

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -90,11 +90,21 @@ function toolMeta(
   toolName: string,
   toolResponse?: unknown,
   parentToolCallId?: string,
+  bashCommand?: string,
 ): ToolUpdateMeta {
   const meta: ToolUpdateMeta["claudeCode"] = { toolName };
   if (toolResponse !== undefined) meta.toolResponse = toolResponse;
   if (parentToolCallId) meta.parentToolCallId = parentToolCallId;
+  if (bashCommand) meta.bashCommand = bashCommand;
   return { claudeCode: meta };
+}
+
+function bashCommandFromToolUse(
+  toolUse: ToolUseCache[string] | undefined,
+): string | undefined {
+  if (!toolUse || toolUse.name !== "Bash") return undefined;
+  const command = (toolUse.input as { command?: unknown } | undefined)?.command;
+  return typeof command === "string" ? command : undefined;
 }
 
 function handleTextChunk(
@@ -181,7 +191,12 @@ function handleToolUseChunk(
           await ctx.client.sessionUpdate({
             sessionId: ctx.sessionId,
             update: {
-              _meta: toolMeta(toolUse.name, toolResponse, ctx.parentToolCallId),
+              _meta: toolMeta(
+                toolUse.name,
+                toolResponse,
+                ctx.parentToolCallId,
+                bashCommandFromToolUse(toolUse),
+              ),
               toolCallId: toolUseId,
               sessionUpdate: "tool_call_update",
               ...(editUpdate ? editUpdate : {}),
@@ -211,7 +226,12 @@ function handleToolUseChunk(
   });
 
   const meta: Record<string, unknown> = {
-    ...toolMeta(chunk.name, undefined, ctx.parentToolCallId),
+    ...toolMeta(
+      chunk.name,
+      undefined,
+      ctx.parentToolCallId,
+      bashCommandFromToolUse(chunk),
+    ),
   };
   if (chunk.name === "Bash" && ctx.supportsTerminalOutput && !alreadyCached) {
     meta.terminal_info = { terminal_id: chunk.id };
@@ -351,7 +371,12 @@ function handleToolResultChunk(
   }
 
   const meta: Record<string, unknown> = {
-    ...toolMeta(toolUse.name, undefined, ctx.parentToolCallId),
+    ...toolMeta(
+      toolUse.name,
+      undefined,
+      ctx.parentToolCallId,
+      bashCommandFromToolUse(toolUse),
+    ),
     ...(resultMeta?.terminal_exit
       ? { terminal_exit: resultMeta.terminal_exit }
       : {}),

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -106,6 +106,7 @@ export type ToolUpdateMeta = {
     toolName: string;
     toolResponse?: unknown;
     parentToolCallId?: string;
+    bashCommand?: string;
   };
   terminal_info?: TerminalInfo;
   terminal_output?: TerminalOutput;

--- a/packages/agent/src/pr-url-detector.test.ts
+++ b/packages/agent/src/pr-url-detector.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ExtractCreatedPrUrlInput,
+  extractCreatedPrUrl,
+} from "./pr-url-detector";
+
+const PR_URL = "https://github.com/PostHog/posthog/pull/12345";
+
+interface Case {
+  name: string;
+  input: ExtractCreatedPrUrlInput;
+  expected: string | null;
+}
+
+const cases: Case[] = [
+  {
+    name: "returns the URL when gh pr create produced it (string toolResponse)",
+    input: {
+      toolName: "Bash",
+      bashCommand: 'gh pr create --title "x" --body "y"',
+      toolResponse: `${PR_URL}\n`,
+    },
+    expected: PR_URL,
+  },
+  {
+    name: "returns the URL when gh pr create produced it (object toolResponse)",
+    input: {
+      toolName: "Bash",
+      bashCommand: "gh pr create --fill",
+      toolResponse: { stdout: `${PR_URL}\n`, stderr: "" },
+    },
+    expected: PR_URL,
+  },
+  {
+    name: "ignores PR URLs from gh pr view",
+    input: {
+      toolName: "Bash",
+      bashCommand: `gh pr view ${PR_URL}`,
+      toolResponse: { stdout: PR_URL },
+    },
+    expected: null,
+  },
+  {
+    name: "ignores PR URLs from gh search prs",
+    input: {
+      toolName: "Bash",
+      bashCommand: 'gh search prs "fix login"',
+      toolResponse: PR_URL,
+    },
+    expected: null,
+  },
+  {
+    name: "ignores PR URLs from gh pr list",
+    input: {
+      toolName: "Bash",
+      bashCommand: "gh pr list --json url",
+      toolResponse: PR_URL,
+    },
+    expected: null,
+  },
+  {
+    name: "returns null when bashCommand is missing",
+    input: {
+      toolName: "Bash",
+      bashCommand: undefined,
+      toolResponse: PR_URL,
+    },
+    expected: null,
+  },
+  {
+    name: "returns null for non-Bash tools",
+    input: {
+      toolName: "Edit",
+      bashCommand: "gh pr create",
+      toolResponse: PR_URL,
+    },
+    expected: null,
+  },
+  {
+    name: "accepts the lowercase 'bash' tool variant",
+    input: {
+      toolName: "bash",
+      bashCommand: "gh pr create",
+      toolResponse: PR_URL,
+    },
+    expected: PR_URL,
+  },
+  {
+    name: "returns null when output has no PR URL",
+    input: {
+      toolName: "Bash",
+      bashCommand: "gh pr create",
+      toolResponse: "no pr was created",
+    },
+    expected: null,
+  },
+  {
+    name: "finds the URL in the content array when toolResponse is empty",
+    input: {
+      toolName: "Bash",
+      bashCommand: "gh pr create --fill",
+      toolResponse: undefined,
+      content: [{ type: "text", text: `Created: ${PR_URL}` }],
+    },
+    expected: PR_URL,
+  },
+  {
+    name: "handles output field on object toolResponse",
+    input: {
+      toolName: "Bash",
+      bashCommand: "gh pr create",
+      toolResponse: { output: PR_URL },
+    },
+    expected: PR_URL,
+  },
+  {
+    name: "matches gh pr create even with a chained command",
+    input: {
+      toolName: "Bash",
+      bashCommand: "git push -u origin feat/x && gh pr create --fill",
+      toolResponse: { stdout: PR_URL },
+    },
+    expected: PR_URL,
+  },
+  {
+    name: "does not match a fake command containing 'pr create' as text",
+    input: {
+      toolName: "Bash",
+      bashCommand: "echo 'i should pr create later'",
+      toolResponse: PR_URL,
+    },
+    expected: null,
+  },
+];
+
+describe("extractCreatedPrUrl", () => {
+  it.each(cases)("$name", ({ input, expected }) => {
+    expect(extractCreatedPrUrl(input)).toBe(expected);
+  });
+});

--- a/packages/agent/src/pr-url-detector.ts
+++ b/packages/agent/src/pr-url-detector.ts
@@ -1,0 +1,46 @@
+const PR_URL_REGEX = /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/;
+const GH_PR_CREATE_REGEX = /\bgh\s+pr\s+create\b/;
+
+export interface ExtractCreatedPrUrlInput {
+  toolName: string | undefined;
+  bashCommand: string | undefined;
+  toolResponse: unknown;
+  content?: Array<{ type?: string; text?: string }>;
+}
+
+export function extractCreatedPrUrl(
+  input: ExtractCreatedPrUrlInput,
+): string | null {
+  const { toolName, bashCommand, toolResponse, content } = input;
+
+  if (!toolName || !/bash/i.test(toolName)) return null;
+  if (!bashCommand || !GH_PR_CREATE_REGEX.test(bashCommand)) return null;
+
+  let textToSearch = "";
+
+  if (toolResponse) {
+    if (typeof toolResponse === "string") {
+      textToSearch = toolResponse;
+    } else if (typeof toolResponse === "object" && toolResponse !== null) {
+      const respObj = toolResponse as Record<string, unknown>;
+      textToSearch =
+        String(respObj.stdout || "") + String(respObj.stderr || "");
+      if (!textToSearch && respObj.output) {
+        textToSearch = String(respObj.output);
+      }
+    }
+  }
+
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (item.type === "text" && item.text) {
+        textToSearch += ` ${item.text}`;
+      }
+    }
+  }
+
+  if (!textToSearch) return null;
+
+  const match = textToSearch.match(PR_URL_REGEX);
+  return match ? match[0] : null;
+}

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -625,7 +625,7 @@ describe("AgentServer HTTP Mode", () => {
   });
 
   describe("detectedPrUrl tracking", () => {
-    it("stores PR URL when detectAndAttachPrUrl finds a match", () => {
+    it("stores PR URL when gh pr create produces it", () => {
       const s = createServer();
       const payload = {
         task_id: "test-task-id",
@@ -635,6 +635,7 @@ describe("AgentServer HTTP Mode", () => {
         _meta: {
           claudeCode: {
             toolName: "Bash",
+            bashCommand: 'gh pr create --title "x" --body "y"',
             toolResponse: {
               stdout:
                 "https://github.com/PostHog/posthog/pull/42\nCreating pull request...",
@@ -659,7 +660,73 @@ describe("AgentServer HTTP Mode", () => {
         _meta: {
           claudeCode: {
             toolName: "Bash",
+            bashCommand: "gh pr create",
             toolResponse: { stdout: "just some output" },
+          },
+        },
+      };
+
+      (s as unknown as TestableServer).detectAndAttachPrUrl(payload, update);
+      expect((s as unknown as TestableServer).detectedPrUrl).toBeNull();
+    });
+
+    it("does not attach PR URL when the bash command is gh pr view", () => {
+      const s = createServer();
+      const payload = {
+        task_id: "test-task-id",
+        run_id: "test-run-id",
+      };
+      const update = {
+        _meta: {
+          claudeCode: {
+            toolName: "Bash",
+            bashCommand: "gh pr view 42 --json url",
+            toolResponse: {
+              stdout: "https://github.com/PostHog/posthog/pull/42",
+            },
+          },
+        },
+      };
+
+      (s as unknown as TestableServer).detectAndAttachPrUrl(payload, update);
+      expect((s as unknown as TestableServer).detectedPrUrl).toBeNull();
+    });
+
+    it("does not attach PR URL when the bash command is gh search prs", () => {
+      const s = createServer();
+      const payload = {
+        task_id: "test-task-id",
+        run_id: "test-run-id",
+      };
+      const update = {
+        _meta: {
+          claudeCode: {
+            toolName: "Bash",
+            bashCommand: 'gh search prs "fix login"',
+            toolResponse: {
+              stdout: "https://github.com/PostHog/posthog/pull/42",
+            },
+          },
+        },
+      };
+
+      (s as unknown as TestableServer).detectAndAttachPrUrl(payload, update);
+      expect((s as unknown as TestableServer).detectedPrUrl).toBeNull();
+    });
+
+    it("does not attach PR URL when bashCommand is missing", () => {
+      const s = createServer();
+      const payload = {
+        task_id: "test-task-id",
+        run_id: "test-run-id",
+      };
+      const update = {
+        _meta: {
+          claudeCode: {
+            toolName: "Bash",
+            toolResponse: {
+              stdout: "https://github.com/PostHog/posthog/pull/42",
+            },
           },
         },
       };

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -29,6 +29,7 @@ import type { PermissionMode } from "../execution-mode";
 import { DEFAULT_CODEX_MODEL } from "../gateway-models";
 import { HandoffCheckpointTracker } from "../handoff-checkpoint";
 import { PostHogAPIClient } from "../posthog-api";
+import { extractCreatedPrUrl } from "../pr-url-detector";
 import {
   formatConversationForResume,
   type ResumeState,
@@ -2131,45 +2132,21 @@ ${attributionInstructions}
       const meta = (update?._meta as Record<string, unknown>)?.claudeCode as
         | Record<string, unknown>
         | undefined;
-      const toolResponse = meta?.toolResponse;
 
-      // Extract text content from tool response
-      let textToSearch = "";
+      const content = update?.content as
+        | Array<{ type?: string; text?: string }>
+        | undefined;
 
-      if (toolResponse) {
-        if (typeof toolResponse === "string") {
-          textToSearch = toolResponse;
-        } else if (typeof toolResponse === "object" && toolResponse !== null) {
-          const respObj = toolResponse as Record<string, unknown>;
-          textToSearch =
-            String(respObj.stdout || "") + String(respObj.stderr || "");
-          if (!textToSearch && respObj.output) {
-            textToSearch = String(respObj.output);
-          }
-        }
-      }
+      const prUrl = extractCreatedPrUrl({
+        toolName: meta?.toolName as string | undefined,
+        bashCommand: meta?.bashCommand as string | undefined,
+        toolResponse: meta?.toolResponse,
+        content,
+      });
+      if (!prUrl) return;
 
-      // Also check content array
-      const content = update?.content;
-      if (Array.isArray(content)) {
-        for (const item of content) {
-          if (item.type === "text" && item.text) {
-            textToSearch += ` ${item.text}`;
-          }
-        }
-      }
-
-      if (!textToSearch) return;
-
-      // Match GitHub PR URLs
-      const prUrlMatch = textToSearch.match(
-        /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/,
-      );
-      if (!prUrlMatch) return;
-
-      const prUrl = prUrlMatch[0];
       this.detectedPrUrl = prUrl;
-      this.logger.debug("Detected PR URL in bash output", {
+      this.logger.debug("Detected PR URL from gh pr create", {
         runId: payload.run_id,
         prUrl,
       });

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -76,6 +76,7 @@ export default defineConfig([
       "src/gateway-models.ts",
       "src/handoff-checkpoint.ts",
       "src/posthog-api.ts",
+      "src/pr-url-detector.ts",
       "src/resume.ts",
       "src/types.ts",
       "src/adapters/claude/questions/utils.ts",


### PR DESCRIPTION
## Summary

- Gate PR-URL attachment on the originating bash command containing `gh pr create`, eliminating false positives from `gh pr view`, `gh search prs`, `gh pr list`, etc.
- Extract the detection logic into a shared `pr-url-detector` helper, replacing two byte-identical implementations in the desktop service and the cloud agent-server.
- Thread the bash command through `_meta.claudeCode.bashCommand` in the SDK→ACP converter so consumers don't have to correlate `tool_call` → `tool_call_update`.

### Why

Today any GitHub PR URL printed by a bash tool gets latched onto `TaskRun.output.pr_url`. That fires downstream Slack notifications and PR-status UI off URLs the agent merely *referenced* (e.g. when looking up a historical PR). A real instance of this misfire produced four \"Pull request opened\" Slack messages from a single `gh pr view` call.

The most robust signal that a URL is a PR the agent just created is: the command was `gh pr create`. `git push` only ever prints `pull/new/<branch>`, which doesn't match the URL regex; `gh pr edit/merge/view/list/search` operate on existing PRs.

## Test plan

- [x] \`pnpm --filter @posthog/agent test\` — 13 new helper tests + 4 new agent-server regression cases pass (317 / 317)
- [x] \`pnpm --filter code test\` — desktop suite green (982 / 982)
- [x] \`pnpm --filter @posthog/agent typecheck\` and \`pnpm --filter code typecheck\` clean
- [x] \`pnpm lint\` clean
- [ ] Manual end-to-end smoke: with \`pnpm dev\`, ask the agent to look up an existing PR via \`gh pr view <existing-pr>\` and confirm \`pr_url\` is **not** attached and no Slack notification fires; then ask it to create a PR via \`gh pr create\` and confirm the existing flow still works.

Generated-By: PostHog Code
Task-Id: 302a50dd-3e6e-4f4c-abbf-4ca0e0f9250d