### PR TITLE
fix(agent): include posthog-code/ branch prefix in global instructions

### DIFF
--- a/packages/agent/src/adapters/claude/session/instructions.ts
+++ b/packages/agent/src/adapters/claude/session/instructions.ts
@@ -2,6 +2,8 @@ const BRANCH_NAMING = `
 # Branch Naming
 
 When working in a detached HEAD state, create a descriptive branch name based on the work being done before committing. Do this automatically without asking the user.
+
+When creating a new branch, prefix it with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`).
 `;
 
 const PLAN_MODE = `


### PR DESCRIPTION
## Summary

- The `posthog-code/` branch prefix convention was only injected into the auto-create-PR cloud prompt (`agent-server.ts:1621`).
- When a cloud session ran through the review-only `!shouldAutoCreatePr` branch and the user later asked the agent to create a branch, the agent had no convention loaded and fell back to its own default (`<user>/<slug>`).
- Move the prefix instruction into the globally-appended `BRANCH_NAMING` block in `packages/agent/src/adapters/claude/session/instructions.ts` so it applies to every prompt branch — cloud auto-PR, cloud review-only, no-repo, and local.

## Test plan

- [ ] Start a cloud task in review-only mode, then ask the agent to create a branch — verify it uses the `posthog-code/` prefix
- [ ] Start a cloud task in auto-PR mode — verify the prefix still appears
- [ ] Start a local task and ask for a branch — verify the prefix still appears