### PR TITLE
fix(branch-selector): show loading state instead of "No branches"

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -94,17 +94,21 @@ export function BranchSelector({
     }
   }, [isSelectionOnly, defaultBranch, selectedBranch, onBranchSelect]);
 
-  const { data: localBranches = [] } = useQuery(
-    trpc.git.getAllBranches.queryOptions(
-      { directoryPath: repoPath as string },
-      { enabled: !isCloudMode && !!repoPath && open, staleTime: 10_000 },
-    ),
-  );
+  const { data: localBranches = [], isLoading: localBranchesLoading } =
+    useQuery(
+      trpc.git.getAllBranches.queryOptions(
+        { directoryPath: repoPath as string },
+        { enabled: !isCloudMode && !!repoPath && open, staleTime: 10_000 },
+      ),
+    );
 
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
   const cloudStillLoading =
     isCloudMode && cloudBranchesLoading && branches.length === 0 && !open;
+  const branchListLoading = isCloudMode
+    ? !!cloudBranchesLoading
+    : localBranchesLoading;
 
   const checkoutMutation = useMutation(
     trpc.git.checkoutBranch.mutationOptions({
@@ -250,7 +254,14 @@ export function BranchSelector({
           </div>
         ) : null}
 
-        <ComboboxEmpty>No branches found.</ComboboxEmpty>
+        {branchListLoading && branches.length === 0 ? (
+          <div className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground text-xs">
+            <Spinner size={12} className="animate-spin" />
+            Loading branches…
+          </div>
+        ) : (
+          <ComboboxEmpty>No branches found.</ComboboxEmpty>
+        )}
 
         <ComboboxList className="max-h-[min(14rem,calc(var(--available-height,14rem)-5rem))] pe-2">
           {(item: string) => (

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -27,6 +27,15 @@ import { type RefObject, useEffect, useRef, useState } from "react";
 
 const COMBOBOX_LIMIT = 50;
 
+function LoadingRow({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground text-xs">
+      <Spinner size={12} className="animate-spin" />
+      {label}
+    </div>
+  );
+}
+
 interface BranchSelectorProps {
   repoPath: string | null;
   currentBranch: string | null;
@@ -248,17 +257,11 @@ export function BranchSelector({
         </div>
 
         {isCloudMode && cloudBranchesFetchingMore ? (
-          <div className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground text-xs">
-            <Spinner size={12} className="animate-spin" />
-            Loading more ({branches.length})…
-          </div>
+          <LoadingRow label={`Loading more (${branches.length})…`} />
         ) : null}
 
         {branchListLoading && branches.length === 0 ? (
-          <div className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground text-xs">
-            <Spinner size={12} className="animate-spin" />
-            Loading branches…
-          </div>
+          <LoadingRow label="Loading branches…" />
         ) : (
           <ComboboxEmpty>No branches found.</ComboboxEmpty>
         )}


### PR DESCRIPTION
## Summary

When the branch list in the branch selector is loading, the dropdown previously showed "No branches found." next to the trigger spinner — confusing UX implying the repo had no branches. This change surfaces a dedicated "Loading branches…" row while the fetch is in flight, so the empty state only appears once the query completes.

- Captured the previously discarded `isLoading` flag from the local-mode `getAllBranches` query.
- Combined local + cloud loading sources into a single `branchListLoading` flag.
- Replaced the always-on `<ComboboxEmpty>` with a conditional that renders an inline spinner + "Loading branches…" row (mirroring the existing "Loading more (N)…" pattern) while loading and empty, falling back to "No branches found." otherwise so search filtering still works.

## Test plan

- [ ] Open branch selector on a fresh local repo — verify "Loading branches…" row appears, then list populates.
- [ ] Open branch selector in cloud mode — verify same loading row, then branches populate.
- [ ] Type a query that matches no branches after load — verify "No branches found." still shows.
- [ ] Open branch selector when branches are already cached — verify no flash of loading row.

Generated-By: PostHog Code
Task-Id: 322fe270-1290-4c9d-b505-1eed6961381f