### PR TITLE
fix(repo-selector): preserve results while searching

### DIFF
--- a/apps/code/src/renderer/hooks/useIntegrations.ts
+++ b/apps/code/src/renderer/hooks/useIntegrations.ts
@@ -121,6 +121,7 @@ export function useGithubRepositories(
       },
       enabled: queryEnabled,
       staleTime: 5 * 60 * 1000,
+      placeholderData: (prev: unknown) => prev,
       meta: AUTH_SCOPED_QUERY_META,
     })),
     combine: (results) => {


### PR DESCRIPTION
## Summary
- The repository selector flashed empty between keystrokes because each new search query key swapped the multi-query state to pending with no data.
- Pass `placeholderData: (prev) => prev` to the per-integration `useGithubRepositories` query so React Query keeps showing the prior page while the next search loads.
- First-open "Loading repositories..." state is unchanged (no prior data to fall back to).

## Test plan
- [ ] Open the repository selector and type a query — the existing list should remain visible while new results load instead of collapsing to empty.
- [ ] Confirm the initial "Loading repositories..." state still shows on first open.
- [ ] `pnpm --filter code typecheck` passes.