### PR TITLE
feat(handoff): reduce size of packs, update stale remoteURLs

### DIFF
--- a/apps/code/src/main/services/folders/schemas.ts
+++ b/apps/code/src/main/services/folders/schemas.ts
@@ -17,6 +17,7 @@ export const getFoldersOutput = z.array(registeredFolderWithExistsSchema);
 
 export const addFolderInput = z.object({
   folderPath: z.string().min(2, "Folder path must be a valid directory path"),
+  remoteUrl: z.string().min(1).optional(),
 });
 
 export const addFolderOutput = registeredFolderWithExistsSchema;

--- a/apps/code/src/main/services/folders/service.test.ts
+++ b/apps/code/src/main/services/folders/service.test.ts
@@ -445,6 +445,51 @@ describe("FoldersService", () => {
       expect(result.name).toBe("project");
     });
 
+    it("tags a new folder with the supplied remoteUrl override", async () => {
+      vi.mocked(isGitRepository).mockResolvedValue(true);
+      mockRepositoryRepo.findByPath.mockReturnValue(null);
+      mockRepositoryRepo.create.mockReturnValue({
+        id: "folder-new",
+        path: "/home/user/fork",
+        remoteUrl: "PostHog/posthog",
+        lastAccessedAt: "2024-01-01T00:00:00.000Z",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      });
+
+      await service.addFolder("/home/user/fork", {
+        remoteUrl: "https://github.com/PostHog/posthog",
+      });
+
+      expect(mockRepositoryRepo.create).toHaveBeenCalledWith({
+        path: "/home/user/fork",
+        remoteUrl: "PostHog/posthog",
+      });
+    });
+
+    it("backfills remoteUrl on an existing folder when override is supplied", async () => {
+      vi.mocked(isGitRepository).mockResolvedValue(true);
+      const existing = {
+        id: "folder-existing",
+        path: "/home/user/project",
+        remoteUrl: null,
+        lastAccessedAt: "2024-01-01T00:00:00.000Z",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      };
+      mockRepositoryRepo.findByPath.mockReturnValue(existing);
+      mockRepositoryRepo.findById.mockReturnValue(existing);
+
+      await service.addFolder("/home/user/project", {
+        remoteUrl: "https://github.com/PostHog/posthog",
+      });
+
+      expect(mockRepositoryRepo.updateRemoteUrl).toHaveBeenCalledWith(
+        "folder-existing",
+        "PostHog/posthog",
+      );
+    });
+
     it("throws error when user cancels git init", async () => {
       vi.mocked(isGitRepository).mockResolvedValue(false);
       mockDialog.confirm.mockResolvedValue(1);

--- a/apps/code/src/main/services/folders/service.ts
+++ b/apps/code/src/main/services/folders/service.ts
@@ -114,6 +114,7 @@ export class FoldersService {
 
   async addFolder(
     folderPath: string,
+    options: { remoteUrl?: string } = {},
   ): Promise<RegisteredFolder & { exists: boolean }> {
     const folderName = path.basename(folderPath);
     if (!folderPath || !folderName) {
@@ -152,6 +153,7 @@ export class FoldersService {
       }
     }
 
+    const repoKey = await this.resolveRepoKey(folderPath, options.remoteUrl);
     const existingRepo = this.repositoryRepo.findByPath(folderPath);
     let repo: Repository;
 
@@ -163,23 +165,17 @@ export class FoldersService {
       }
       repo = updated;
 
-      if (!repo.remoteUrl) {
-        const remoteUrl = await getRemoteUrl(folderPath);
-        const repoKey = remoteUrl ? extractRepoKey(remoteUrl) : null;
-        if (repoKey) {
-          this.repositoryRepo.updateRemoteUrl(repo.id, repoKey);
-          const refreshed = this.repositoryRepo.findById(repo.id);
-          if (!refreshed) {
-            throw new Error(
-              `Repository ${repo.id} not found after remote URL update`,
-            );
-          }
-          repo = refreshed;
+      if (repoKey && repo.remoteUrl !== repoKey) {
+        this.repositoryRepo.updateRemoteUrl(repo.id, repoKey);
+        const refreshed = this.repositoryRepo.findById(repo.id);
+        if (!refreshed) {
+          throw new Error(
+            `Repository ${repo.id} not found after remote URL update`,
+          );
         }
+        repo = refreshed;
       }
     } else {
-      const remoteUrl = await getRemoteUrl(folderPath);
-      const repoKey = remoteUrl ? extractRepoKey(remoteUrl) : null;
       repo = this.repositoryRepo.create({
         path: folderPath,
         remoteUrl: repoKey ?? undefined,
@@ -246,6 +242,19 @@ export class FoldersService {
     const associatedWorktreePaths = allWorktrees.map((wt) => wt.path);
 
     await manager.cleanupOrphanedWorktrees(associatedWorktreePaths);
+  }
+
+  private async resolveRepoKey(
+    folderPath: string,
+    overrideRemoteUrl: string | undefined,
+  ): Promise<string | null> {
+    if (overrideRemoteUrl) {
+      const overrideKey = extractRepoKey(overrideRemoteUrl);
+      if (overrideKey) return overrideKey;
+      return normalizeRepoKey(overrideRemoteUrl);
+    }
+    const localRemoteUrl = await getRemoteUrl(folderPath);
+    return localRemoteUrl ? extractRepoKey(localRemoteUrl) : null;
   }
 
   getRepositoryByRemoteUrl(

--- a/apps/code/src/main/trpc/routers/folders.ts
+++ b/apps/code/src/main/trpc/routers/folders.ts
@@ -24,7 +24,9 @@ export const foldersRouter = router({
     .input(addFolderInput)
     .output(addFolderOutput)
     .mutation(({ input }) => {
-      return getService().addFolder(input.folderPath);
+      return getService().addFolder(input.folderPath, {
+        remoteUrl: input.remoteUrl,
+      });
     }),
 
   removeFolder: publicProcedure

--- a/apps/code/src/renderer/components/HeaderRow.tsx
+++ b/apps/code/src/renderer/components/HeaderRow.tsx
@@ -28,7 +28,8 @@ function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
   const workspace = useWorkspace(taskId);
   const repoPath = workspace?.folderPath ?? null;
   const authStatus = useAuthStateValue((s) => s.status);
-  const cloudHandoffEnabled = useFeatureFlag(CLOUD_HANDOFF_FLAG);
+  const cloudHandoffEnabled =
+    useFeatureFlag(CLOUD_HANDOFF_FLAG) || import.meta.env.DEV;
   const { initiateHandoffToCloud } = useSessionCallbacks({
     taskId,
     task,

--- a/apps/code/src/renderer/features/sessions/service/localHandoffService.ts
+++ b/apps/code/src/renderer/features/sessions/service/localHandoffService.ts
@@ -17,15 +17,16 @@ async function resolveRepoPathFromRemote(
   return repo?.path ?? null;
 }
 
-async function resolveRepoPathFromPicker(): Promise<string | null> {
+async function resolveRepoPathFromPicker(
+  remoteUrl: string | null | undefined,
+): Promise<string | null> {
   const selectedPath = await trpcClient.os.selectDirectory.query();
   if (!selectedPath) return null;
 
-  const folders = await trpcClient.folders.getFolders.query();
-  const folder = folders.find((f) => f.path === selectedPath);
-  if (!folder) {
-    await trpcClient.folders.addFolder.mutate({ folderPath: selectedPath });
-  }
+  await trpcClient.folders.addFolder.mutate({
+    folderPath: selectedPath,
+    remoteUrl: remoteUrl ?? undefined,
+  });
 
   return selectedPath;
 }
@@ -66,7 +67,7 @@ export class LocalHandoffService {
     try {
       const targetPath =
         (await resolveRepoPathFromRemote(task.repository)) ??
-        (await resolveRepoPathFromPicker());
+        (await resolveRepoPathFromPicker(task.repository));
 
       if (!targetPath) return;
 

--- a/packages/git/src/handoff.test.ts
+++ b/packages/git/src/handoff.test.ts
@@ -180,6 +180,31 @@ describe("GitHandoffTracker", () => {
     });
   }, 15000);
 
+  it("keeps shipped index consistent with worktreeTree for staged large files", async () => {
+    await withRepos(async (repos) => {
+      const largePath = path.join(repos.cloudRepo, "tracked.txt");
+      const modified = Buffer.alloc(1024 * 1024 + 1, 9);
+      await writeFile(largePath, modified);
+      await repos.cloudGit.add(["tracked.txt"]);
+
+      const capture = await captureAndApply(repos);
+
+      try {
+        const restored = await readFile(
+          path.join(repos.localRepo, "tracked.txt"),
+          "utf-8",
+        );
+        expect(restored).toBe("base\n");
+
+        const status = await repos.localGit.raw(["status", "--porcelain"]);
+        expect(status).not.toMatch(/^M[ M] tracked\.txt/m);
+        expect(status).not.toMatch(/^MM tracked\.txt/m);
+      } finally {
+        await cleanupCapture(capture);
+      }
+    });
+  }, 20000);
+
   it("removes tracked files absent from the checkpoint worktree", async () => {
     await withRepos(async (repos) => {
       await rm(path.join(repos.cloudRepo, "tracked.txt"));

--- a/packages/git/src/handoff.ts
+++ b/packages/git/src/handoff.ts
@@ -8,6 +8,7 @@ import { CaptureCheckpointSaga, deleteCheckpoint } from "./sagas/checkpoint";
 
 const HANDOFF_HEAD_REF_PREFIX = "refs/posthog-code-handoff/head/";
 const CHECKPOINT_REF_PREFIX = "refs/posthog-code-checkpoint/";
+const MAX_HANDOFF_FILE_BYTES = 1024 * 1024;
 
 export interface HandoffLocalGitState {
   head: string | null;
@@ -107,22 +108,31 @@ export class GitHandoffTracker {
     const git = createGitClient(this.repositoryPath);
     const tempDir = await this.createTempDir(checkpoint.checkpointId);
     const checkpointRef = `${CHECKPOINT_REF_PREFIX}${checkpoint.checkpointId}`;
-    const packBaseline = localGitState?.upstreamHead ?? null;
-    const packRefs = [
-      checkpoint.head,
-      checkpoint.indexTree,
-      checkpoint.worktreeTree,
-      packBaseline ? `^${packBaseline}` : null,
-    ].filter((ref): ref is string => !!ref);
-    const headRef = checkpoint.head
-      ? `${HANDOFF_HEAD_REF_PREFIX}${checkpoint.checkpointId}`
-      : undefined;
-    const packPrefix = path.join(tempDir, checkpoint.checkpointId);
 
     try {
+      const reconciledIndex = await this.reconcileHandoffIndex(
+        git,
+        checkpoint.head,
+        checkpoint.indexTree,
+        tempDir,
+        checkpoint.checkpointId,
+      );
+
+      const packBaseline = localGitState?.upstreamHead ?? null;
+      const packRefs = [
+        checkpoint.head,
+        reconciledIndex.indexTree,
+        checkpoint.worktreeTree,
+        packBaseline ? `^${packBaseline}` : null,
+      ].filter((ref): ref is string => !!ref);
+      const headRef = checkpoint.head
+        ? `${HANDOFF_HEAD_REF_PREFIX}${checkpoint.checkpointId}`
+        : undefined;
+      const packPrefix = path.join(tempDir, checkpoint.checkpointId);
+
       const [headPack, indexFile, tracking] = await Promise.all([
         this.captureObjectPack(packPrefix, packRefs),
-        this.copyIndexFile(git, checkpoint.checkpointId, tempDir),
+        this.statFileArtifact(reconciledIndex.indexFilePath),
         getTrackingMetadata(git, checkpoint.branch),
       ]);
 
@@ -134,7 +144,7 @@ export class GitHandoffTracker {
           headRef,
           head: checkpoint.head,
           branch: checkpoint.branch,
-          indexTree: checkpoint.indexTree,
+          indexTree: reconciledIndex.indexTree,
           worktreeTree: checkpoint.worktreeTree,
           timestamp: checkpoint.timestamp,
           upstreamRemote: tracking.upstreamRemote,
@@ -226,18 +236,113 @@ export class GitHandoffTracker {
     return { path: packPath, rawBytes };
   }
 
-  private async copyIndexFile(
+  private async reconcileHandoffIndex(
     git: GitClient,
-    checkpointId: string,
+    head: string | null,
+    indexTree: string,
     tempDir: string,
+    checkpointId: string,
+  ): Promise<{ indexTree: string; indexFilePath: string }> {
+    const realIndexPath = await this.getGitPath(git, "index");
+    const tempIndexPath = path.join(tempDir, `${checkpointId}.index`);
+    await copyFile(realIndexPath, tempIndexPath);
+
+    const largePaths = await this.listLargeBlobsInTree(
+      indexTree,
+      MAX_HANDOFF_FILE_BYTES,
+    );
+    if (largePaths.length === 0) {
+      return { indexTree, indexFilePath: tempIndexPath };
+    }
+
+    const headBlobs = head
+      ? await this.readHeadBlobsForPaths(head, largePaths)
+      : new Map<string, { mode: string; hash: string }>();
+
+    const env = { ...process.env, GIT_INDEX_FILE: tempIndexPath };
+    for (const filePath of largePaths) {
+      const headBlob = headBlobs.get(filePath);
+      if (headBlob) {
+        await this.runGitWithEnv(env, [
+          "update-index",
+          "--cacheinfo",
+          `${headBlob.mode},${headBlob.hash},${filePath}`,
+        ]);
+      } else {
+        await this.runGitWithEnv(env, [
+          "update-index",
+          "--force-remove",
+          filePath,
+        ]).catch(() => {});
+      }
+    }
+
+    const reconciledTree = (
+      await this.runGitWithEnv(env, ["write-tree"])
+    ).trim();
+    return { indexTree: reconciledTree, indexFilePath: tempIndexPath };
+  }
+
+  private async listLargeBlobsInTree(
+    tree: string,
+    maxBytes: number,
+  ): Promise<string[]> {
+    const { stdout } = await this.runGitProcess(
+      ["ls-tree", "-r", "-l", tree],
+      "",
+    );
+    const result: string[] = [];
+    for (const line of stdout.split("\n")) {
+      if (!line) continue;
+      const tabIndex = line.indexOf("\t");
+      if (tabIndex < 0) continue;
+      const meta = line.slice(0, tabIndex);
+      const filePath = line.slice(tabIndex + 1);
+      const parts = meta.split(/\s+/);
+      if (parts.length < 4) continue;
+      const [, type, , sizeStr] = parts;
+      if (type !== "blob") continue;
+      if (sizeStr === "-") continue;
+      const size = Number.parseInt(sizeStr, 10);
+      if (Number.isFinite(size) && size > maxBytes) {
+        result.push(filePath);
+      }
+    }
+    return result;
+  }
+
+  private async readHeadBlobsForPaths(
+    head: string,
+    paths: string[],
+  ): Promise<Map<string, { mode: string; hash: string }>> {
+    const result = new Map<string, { mode: string; hash: string }>();
+    const CHUNK_SIZE = 100;
+    for (let i = 0; i < paths.length; i += CHUNK_SIZE) {
+      const chunk = paths.slice(i, i + CHUNK_SIZE);
+      const { stdout } = await this.runGitProcess(
+        ["ls-tree", "-r", head, "--", ...chunk],
+        "",
+      ).catch(() => ({ stdout: "", stderr: "" }));
+      for (const line of stdout.split("\n")) {
+        if (!line) continue;
+        const tabIndex = line.indexOf("\t");
+        if (tabIndex < 0) continue;
+        const meta = line.slice(0, tabIndex);
+        const filePath = line.slice(tabIndex + 1);
+        const parts = meta.split(/\s+/);
+        if (parts.length < 3) continue;
+        const [mode, type, hash] = parts;
+        if (type !== "blob") continue;
+        result.set(filePath, { mode, hash });
+      }
+    }
+    return result;
+  }
+
+  private async statFileArtifact(
+    filePath: string,
   ): Promise<GitHandoffArtifactFile> {
-    const indexPath = await this.getGitPath(git, "index");
-    const copiedIndexPath = path.join(tempDir, `${checkpointId}.index`);
-    await copyFile(indexPath, copiedIndexPath);
-    return {
-      path: copiedIndexPath,
-      rawBytes: await this.getFileSize(copiedIndexPath),
-    };
+    return { path: filePath, rawBytes: await this.getFileSize(filePath) };
   }
 
   private async restoreIndexFile(
@@ -302,9 +407,13 @@ export class GitHandoffTracker {
     await git
       .raw(["fetch", tracking.upstreamRemote, tracking.upstreamMergeRef])
       .catch((err) => {
-        this.logger?.warn(
-          "Handoff baseline fetch failed; continuing with locally available history",
-          { err: String(err) },
+        this.logger?.error(
+          "Handoff baseline fetch failed; if the pack excludes commits the receiver does not already have, the subsequent unpack/read-tree will fail with an object-missing error",
+          {
+            err: String(err),
+            remote: tracking.upstreamRemote,
+            ref: tracking.upstreamMergeRef,
+          },
         );
       });
   }
@@ -503,6 +612,37 @@ export class GitHandoffTracker {
           return;
         }
         resolve(code);
+      });
+    });
+  }
+
+  private async runGitWithEnv(
+    env: NodeJS.ProcessEnv,
+    args: string[],
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const child = spawn("git", args, {
+        cwd: this.repositoryPath,
+        stdio: ["ignore", "pipe", "pipe"],
+        env,
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk: Buffer | string) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk: Buffer | string) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", reject);
+      child.on("close", (code) => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(
+          new Error(stderr || `git ${args.join(" ")} failed with code ${code}`),
+        );
       });
     });
   }

--- a/packages/git/src/handoff.ts
+++ b/packages/git/src/handoff.ts
@@ -93,7 +93,7 @@ export class GitHandoffTracker {
   }
 
   async captureForHandoff(
-    _localGitState?: HandoffLocalGitState,
+    localGitState?: HandoffLocalGitState,
   ): Promise<GitHandoffCaptureResult> {
     const captureSaga = new CaptureCheckpointSaga(this.logger);
     const result = await captureSaga.run({ baseDir: this.repositoryPath });
@@ -107,10 +107,12 @@ export class GitHandoffTracker {
     const git = createGitClient(this.repositoryPath);
     const tempDir = await this.createTempDir(checkpoint.checkpointId);
     const checkpointRef = `${CHECKPOINT_REF_PREFIX}${checkpoint.checkpointId}`;
+    const packBaseline = localGitState?.upstreamHead ?? null;
     const packRefs = [
       checkpoint.head,
       checkpoint.indexTree,
       checkpoint.worktreeTree,
+      packBaseline ? `^${packBaseline}` : null,
     ].filter((ref): ref is string => !!ref);
     const headRef = checkpoint.head
       ? `${HANDOFF_HEAD_REF_PREFIX}${checkpoint.checkpointId}`
@@ -161,6 +163,7 @@ export class GitHandoffTracker {
     const git = createGitClient(this.repositoryPath);
 
     if (headPackPath) {
+      await this.ensureBaselineForApply(git, checkpoint, localGitState);
       await this.unpackPackFile(headPackPath);
     }
 
@@ -285,6 +288,25 @@ export class GitHandoffTracker {
         (tracking.upstreamRemote !== null ||
           tracking.upstreamMergeRef !== null))
     );
+  }
+
+  private async ensureBaselineForApply(
+    git: GitClient,
+    checkpoint: GitHandoffCheckpoint,
+    localGitState: HandoffLocalGitState | undefined,
+  ): Promise<void> {
+    const tracking = this.getPreferredTracking(localGitState, checkpoint);
+    if (!tracking.upstreamRemote || !tracking.upstreamMergeRef) return;
+
+    await this.ensureRemoteForTracking(git, tracking).catch(() => {});
+    await git
+      .raw(["fetch", tracking.upstreamRemote, tracking.upstreamMergeRef])
+      .catch((err) => {
+        this.logger?.warn(
+          "Handoff baseline fetch failed; continuing with locally available history",
+          { err: String(err) },
+        );
+      });
   }
 
   private async ensureRemoteForTracking(

--- a/packages/git/src/handoff.ts
+++ b/packages/git/src/handoff.ts
@@ -677,6 +677,7 @@ export class GitHandoffTracker {
         );
       });
 
+      child.stdin.on("error", () => {});
       child.stdin.end(input);
     });
   }

--- a/packages/git/src/handoff.ts
+++ b/packages/git/src/handoff.ts
@@ -553,6 +553,13 @@ export async function readHandoffLocalGitState(
   const head = await readCurrentHead(git);
   const branch = await getCurrentBranchName(git);
   const tracking = await getTrackingMetadata(git, branch);
+
+  if (tracking.upstreamRemote && tracking.upstreamMergeRef) {
+    await git
+      .raw(["fetch", tracking.upstreamRemote, tracking.upstreamMergeRef])
+      .catch(() => {});
+  }
+
   const upstreamHead =
     tracking.upstreamRemote && tracking.upstreamMergeRef
       ? await resolveUpstreamHead(

--- a/packages/git/src/sagas/checkpoint.test.ts
+++ b/packages/git/src/sagas/checkpoint.test.ts
@@ -400,6 +400,77 @@ describe("checkpoint sagas", () => {
     });
   });
 
+  it("drops untracked files larger than the worktree size cap", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      const largePath = path.join(repoPath, "large.bin");
+      await writeFile(largePath, Buffer.alloc(1024 * 1024 + 1, 7));
+      await writeFile(path.join(repoPath, "small.txt"), "tiny\n");
+
+      await captureCheckpoint(repoPath, "large-untracked");
+
+      await rm(largePath);
+      await rm(path.join(repoPath, "small.txt"));
+
+      await revertCheckpoint(repoPath, "large-untracked");
+
+      await expect(readFile(largePath)).rejects.toBeTruthy();
+      const small = await readFile(path.join(repoPath, "small.txt"), "utf8");
+      expect(small).toBe("tiny\n");
+
+      const status = await git.raw(["status", "--porcelain"]);
+      expect(status).not.toContain("large.bin");
+    });
+  });
+
+  it("preserves tracked files larger than the cap when content is unchanged", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      const largePath = path.join(repoPath, "tracked-large.bin");
+      const data = Buffer.alloc(1024 * 1024 + 1, 3);
+      await writeFile(largePath, data);
+      await git.add(["tracked-large.bin"]);
+      await git.commit("add large tracked");
+
+      await writeFile(path.join(repoPath, "a.txt"), "edited\n");
+
+      await captureCheckpoint(repoPath, "large-tracked-unchanged");
+
+      await writeFile(path.join(repoPath, "a.txt"), "after\n");
+      await rm(largePath);
+
+      await revertCheckpoint(repoPath, "large-tracked-unchanged");
+
+      const a = await readFile(path.join(repoPath, "a.txt"), "utf8");
+      expect(a).toBe("edited\n");
+      const restored = await readFile(largePath);
+      expect(Buffer.compare(restored, data)).toBe(0);
+    });
+  });
+
+  it("rolls tracked large files back to HEAD when modified locally", async () => {
+    await withRepo(async (repoPath) => {
+      const git = createGitClient(repoPath);
+      const largePath = path.join(repoPath, "tracked-large.bin");
+      const original = Buffer.alloc(1024 * 1024 + 1, 1);
+      await writeFile(largePath, original);
+      await git.add(["tracked-large.bin"]);
+      await git.commit("add large tracked");
+
+      const modified = Buffer.alloc(1024 * 1024 + 1, 9);
+      await writeFile(largePath, modified);
+
+      await captureCheckpoint(repoPath, "large-tracked-modified");
+
+      await writeFile(largePath, Buffer.alloc(1024 * 1024 + 1, 5));
+
+      await revertCheckpoint(repoPath, "large-tracked-modified");
+
+      const restored = await readFile(largePath);
+      expect(Buffer.compare(restored, original)).toBe(0);
+    });
+  });
+
   it("does not leak temp index into normal git operations", async () => {
     await withRepo(async (repoPath) => {
       const git = createGitClient(repoPath);

--- a/packages/git/src/sagas/checkpoint.ts
+++ b/packages/git/src/sagas/checkpoint.ts
@@ -440,6 +440,8 @@ export async function getGitBusyState(git: GitClient): Promise<GitBusyState> {
   return { busy: false };
 }
 
+const MAX_WORKTREE_FILE_BYTES = 1024 * 1024;
+
 async function createWorktreeTree(
   git: GitClient,
   baseDir: string,
@@ -459,11 +461,99 @@ async function createWorktreeTree(
     }
 
     await tempGit.raw(["add", "-A", "--", "."]);
+    await reconcileLargeBlobs(tempGit, head, MAX_WORKTREE_FILE_BYTES);
     const treeHash = await tempGit.raw(["write-tree"]);
     return treeHash.trim();
   } finally {
     await fs.rm(tempIndexPath, { force: true }).catch(() => {});
   }
+}
+
+async function reconcileLargeBlobs(
+  tempGit: GitClient,
+  head: string | null,
+  maxBytes: number,
+): Promise<void> {
+  const intermediateTree = (await tempGit.raw(["write-tree"])).trim();
+  const largePaths = await listLargeBlobPaths(
+    tempGit,
+    intermediateTree,
+    maxBytes,
+  );
+  if (largePaths.length === 0) return;
+
+  const headEntries = head
+    ? await readHeadBlobEntries(tempGit, head, largePaths)
+    : new Map<string, { mode: string; hash: string }>();
+
+  for (const filePath of largePaths) {
+    const headEntry = headEntries.get(filePath);
+    if (headEntry) {
+      await tempGit.raw([
+        "update-index",
+        "--cacheinfo",
+        `${headEntry.mode},${headEntry.hash},${filePath}`,
+      ]);
+    } else {
+      await tempGit
+        .raw(["update-index", "--force-remove", filePath])
+        .catch(() => {});
+    }
+  }
+}
+
+async function listLargeBlobPaths(
+  tempGit: GitClient,
+  tree: string,
+  maxBytes: number,
+): Promise<string[]> {
+  const output = await tempGit.raw(["ls-tree", "-r", "-l", tree]);
+  const result: string[] = [];
+  for (const line of output.split("\n")) {
+    if (!line) continue;
+    const tabIndex = line.indexOf("\t");
+    if (tabIndex < 0) continue;
+    const meta = line.slice(0, tabIndex);
+    const filePath = line.slice(tabIndex + 1);
+    const parts = meta.split(/\s+/);
+    if (parts.length < 4) continue;
+    const [, type, , sizeStr] = parts;
+    if (type !== "blob") continue;
+    if (sizeStr === "-") continue;
+    const size = Number.parseInt(sizeStr, 10);
+    if (Number.isFinite(size) && size > maxBytes) {
+      result.push(filePath);
+    }
+  }
+  return result;
+}
+
+async function readHeadBlobEntries(
+  tempGit: GitClient,
+  head: string,
+  paths: string[],
+): Promise<Map<string, { mode: string; hash: string }>> {
+  const result = new Map<string, { mode: string; hash: string }>();
+  const CHUNK_SIZE = 100;
+  for (let i = 0; i < paths.length; i += CHUNK_SIZE) {
+    const chunk = paths.slice(i, i + CHUNK_SIZE);
+    const output = await tempGit
+      .raw(["ls-tree", "-r", head, "--", ...chunk])
+      .catch(() => "");
+    for (const line of output.split("\n")) {
+      if (!line) continue;
+      const tabIndex = line.indexOf("\t");
+      if (tabIndex < 0) continue;
+      const meta = line.slice(0, tabIndex);
+      const filePath = line.slice(tabIndex + 1);
+      const parts = meta.split(/\s+/);
+      if (parts.length < 3) continue;
+      const [mode, type, hash] = parts;
+      if (type !== "blob") continue;
+      result.set(filePath, { mode, hash });
+    }
+  }
+  return result;
 }
 
 async function createMetaTree(


### PR DESCRIPTION
- Git's handover pack files sent to S3 are now smaller. They used to dump your whole git history, now it's only the relevant parts, and it excludes irrelevant/remote commits
- Fixed a bug where remote URL wasn't updated if the upstreams remote URL changed

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*