### PR TITLE
fix: Fix stacked chevrons in project select dropdowns

### DIFF
--- a/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
@@ -167,13 +167,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                       <Popover.Trigger>
                         <button
                           type="button"
-                          className="box-border flex w-full cursor-pointer items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] text-sm"
-                          style={{
-                            all: "unset",
-                            boxShadow:
-                              "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
-                            fontFamily: "inherit",
-                          }}
+                          className="box-border flex w-full cursor-pointer appearance-none items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-inherit text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]"
                         >
                           <Text className="font-medium text-(--gray-12) text-sm">
                             {currentOrg?.name ?? "Select organization..."}
@@ -262,13 +256,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                       <Popover.Trigger>
                         <button
                           type="button"
-                          className="box-border flex w-full cursor-pointer items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] text-sm"
-                          style={{
-                            all: "unset",
-                            boxShadow:
-                              "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
-                            fontFamily: "inherit",
-                          }}
+                          className="box-border flex w-full cursor-pointer appearance-none items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-inherit text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]"
                         >
                           <Flex direction="column" gap="1">
                             <Text className="font-medium text-(--gray-12) text-sm">

--- a/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
@@ -167,7 +167,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                       <Popover.Trigger>
                         <button
                           type="button"
-                          className="box-border flex w-full cursor-pointer appearance-none items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-inherit text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]"
+                          className="box-border flex w-full cursor-pointer appearance-none items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]"
                         >
                           <Text className="font-medium text-(--gray-12) text-sm">
                             {currentOrg?.name ?? "Select organization..."}
@@ -256,7 +256,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                       <Popover.Trigger>
                         <button
                           type="button"
-                          className="box-border flex w-full cursor-pointer appearance-none items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-inherit text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]"
+                          className="box-border flex w-full cursor-pointer appearance-none items-center justify-between rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]"
                         >
                           <Flex direction="column" gap="1">
                             <Text className="font-medium text-(--gray-12) text-sm">


### PR DESCRIPTION
## Problem

all: "unset" on dropdown buttons nukes display: flex, causing the chevron icon to stack below the label text instead of sitting inline.

<img width="1118" height="978" alt="image (60)" src="https://github.com/user-attachments/assets/1768c69d-cf73-4d40-a4a5-081bcbbaeebd" />

## Changes

1. Remove all: "unset" inline style from both org and project dropdown buttons
2. Replace with appearance-none Tailwind class for button reset
3. Move boxShadow and fontFamily from inline styles to Tailwind utilities

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->