### PR TITLE
fix: Reduce update check interval from 24h to 1h

### DIFF
--- a/apps/code/src/main/services/updates/service.test.ts
+++ b/apps/code/src/main/services/updates/service.test.ts
@@ -713,18 +713,18 @@ describe("UpdatesService", () => {
       expect(mockUpdater.check).toHaveBeenCalled();
     });
 
-    it("performs check every 24 hours", async () => {
+    it("performs check every hour", async () => {
       await initializeService(service);
 
       const initialCallCount = mockUpdater.check.mock.calls.length;
 
-      // Advance 24 hours
-      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+      // Advance 1 hour
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
 
       expect(mockUpdater.check.mock.calls.length).toBe(initialCallCount + 1);
 
-      // Advance another 24 hours
-      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+      // Advance another hour
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
 
       expect(mockUpdater.check.mock.calls.length).toBe(initialCallCount + 2);
     });

--- a/apps/code/src/main/services/updates/service.ts
+++ b/apps/code/src/main/services/updates/service.ts
@@ -25,7 +25,7 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
   private static readonly SERVER_HOST = "https://update.electronjs.org";
   private static readonly REPO_OWNER = "PostHog";
   private static readonly REPO_NAME = "code";
-  private static readonly CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+  private static readonly CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
   private static readonly CHECK_TIMEOUT_MS = 60 * 1000; // 1 minute timeout for checks
   private static readonly DISABLE_ENV_FLAG = "ELECTRON_DISABLE_AUTO_UPDATE";
   private static readonly SUPPORTED_PLATFORMS = ["darwin", "win32"];


### PR DESCRIPTION
## Problem

The 24h update check interval causes users to download a stale update, restart and immediately see another update waiting. The client already re-checks even when an update is staged (periodic checks bypass the updateReady guard), but the 24h window is too long to catch newer versions before the user clicks restart.

**NOTE:** Since #1938, releases are batched on a 16h cadence instead of shipping on every merge, so it should no longer be the responsibility of the clients to scatter updates and we should actually want to pull the latest updates as soon as possible now because if we push a hotfix we want users to get it sooner than later and we are no longer spammy with our normal commit updates.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Reduce CHECK_INTERVAL_MS from 24 hours to 1 hour
2. Update test to match new interval

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually