### PR TITLE
feat(code): show fast-path GitHub sign-in when current project has team install

### DIFF
--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -78,6 +78,7 @@ export function GitIntegrationStep({
     useGithubUserConnect({ projectId: selectedProjectId });
   const isConnecting = connectState === "connecting";
   const timedOut = connectState === "timed-out";
+  const canTakeAction = !isConnecting && !timedOut;
 
   const selectedProject = useMemo(
     () => projects.find((p) => p.id === selectedProjectId),
@@ -356,10 +357,29 @@ export function GitIntegrationStep({
                         </Flex>
                       </Flex>
                     ) : !isLoading && !githubUserIntegrationsLoading ? (
-                      selectedAlternative &&
-                      selectedProject &&
-                      !isConnecting &&
-                      !timedOut ? (
+                      selectedProject?.hasGithubIntegration && canTakeAction ? (
+                        <Flex direction="column" gap="3">
+                          <Text className="text-(--gray-11) text-sm">
+                            GitHub is already set up on{" "}
+                            <Text className="font-bold">
+                              {selectedProject.name}
+                            </Text>
+                            . Sign in with one click to link your account — no
+                            admin approval needed.
+                          </Text>
+                          <Button
+                            size="1"
+                            variant="solid"
+                            onClick={() => void handleConnectGitHub()}
+                            className="self-start"
+                          >
+                            Sign in with GitHub
+                            <ArrowSquareOut size={12} />
+                          </Button>
+                        </Flex>
+                      ) : selectedAlternative &&
+                        selectedProject &&
+                        canTakeAction ? (
                         <Flex direction="column" gap="3">
                           <Text className="text-(--gray-11) text-sm">
                             GitHub is already connected on{" "}


### PR DESCRIPTION
## Problem

When a project already has a GitHub integration configured, users were not shown a streamlined sign-in flow. Instead, they were only presented with the alternative connection path, which required admin approval. Users on projects with an existing GitHub integration should be able to link their account with a single click, without needing admin involvement.

## Changes

Adds a dedicated UI branch for projects that already have a GitHub integration (`hasGithubIntegration`). When this condition is met, users see a simplified "Sign in with GitHub" prompt that explains no admin approval is needed. The existing alternative connection flow is preserved for projects without an existing integration.