### PR TITLE
fix(code): inline pasted text for task title generation

### DIFF
--- a/apps/code/src/main/trpc/routers/os.ts
+++ b/apps/code/src/main/trpc/routers/os.ts
@@ -296,6 +296,24 @@ export const osRouter = router({
     }),
 
   /**
+   * Read a clipboard-paste text file by its path. Restricted to the clipboard
+   * temp dir so callers can't probe arbitrary files on disk.
+   */
+  readClipboardText: publicProcedure
+    .input(z.object({ filePath: z.string() }))
+    .output(z.string().nullable())
+    .query(async ({ input }) => {
+      const resolved = path.resolve(input.filePath);
+      const clipboardRoot = CLIPBOARD_TEMP_DIR + path.sep;
+      if (!resolved.startsWith(clipboardRoot)) return null;
+      try {
+        return await fsPromises.readFile(resolved, "utf-8");
+      } catch {
+        return null;
+      }
+    }),
+
+  /**
    * Save pasted text to a temp file
    * Returns the file path for use as a file attachment
    */

--- a/apps/code/src/renderer/sagas/task/task-creation.test.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.test.ts
@@ -272,6 +272,46 @@ describe("TaskCreationSaga", () => {
     });
   });
 
+  it("preserves $-tokens in pasted clipboard text", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+    const updateTaskMock = vi.fn().mockResolvedValue(undefined);
+
+    // `$&` is a String.replace replacement token — it would otherwise be
+    // expanded to the full match, leaking the file tag back into the title.
+    const pasted = "Refactor cost($&) helper and price($1) lookups";
+    mockReadClipboardText.mockResolvedValue(pasted);
+    mockGenerateTitleAndSummary.mockResolvedValue({ title: "Auto title" });
+    mockGetCachedTask.mockReturnValue(undefined);
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: createTaskRunMock,
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: updateTaskMock,
+      } as never,
+    });
+
+    await saga.run({
+      content:
+        '<file path="/tmp/posthog-code-clipboard/attachment-x/pasted-text.txt" />',
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockGenerateTitleAndSummary).toHaveBeenCalledWith(pasted);
+    });
+  });
+
   it("applies auto-title when task has not been manually renamed", async () => {
     const createdTask = createTask();
     const startedTask = createTask({ latest_run: createRun() });

--- a/apps/code/src/renderer/sagas/task/task-creation.test.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.test.ts
@@ -6,6 +6,7 @@ const mockWorkspaceDelete = vi.hoisted(() => vi.fn());
 const mockGetTaskDirectory = vi.hoisted(() => vi.fn());
 const mockReadAbsoluteFile = vi.hoisted(() => vi.fn());
 const mockReadFileAsBase64 = vi.hoisted(() => vi.fn());
+const mockReadClipboardText = vi.hoisted(() => vi.fn());
 const mockGetCachedTask = vi.hoisted(() => vi.fn());
 
 vi.mock("@renderer/trpc", () => ({
@@ -13,6 +14,9 @@ vi.mock("@renderer/trpc", () => ({
     workspace: {
       create: { mutate: mockWorkspaceCreate },
       delete: { mutate: mockWorkspaceDelete },
+    },
+    os: {
+      readClipboardText: { query: mockReadClipboardText },
     },
   },
 }));
@@ -116,6 +120,7 @@ describe("TaskCreationSaga", () => {
     mockGetTaskDirectory.mockResolvedValue(null);
     mockReadAbsoluteFile.mockResolvedValue(null);
     mockReadFileAsBase64.mockResolvedValue(null);
+    mockReadClipboardText.mockResolvedValue(null);
   });
 
   it("waits for the cloud run response before surfacing the task", async () => {
@@ -223,6 +228,48 @@ describe("TaskCreationSaga", () => {
     });
 
     expect(updateTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("inlines pasted clipboard text before generating title", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+    const updateTaskMock = vi.fn().mockResolvedValue(undefined);
+
+    mockReadClipboardText.mockResolvedValue("Investigate flaky CI on main");
+    mockGenerateTitleAndSummary.mockResolvedValue({ title: "Auto title" });
+    mockGetCachedTask.mockReturnValue(undefined);
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: createTaskRunMock,
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: updateTaskMock,
+      } as never,
+    });
+
+    await saga.run({
+      content:
+        '<file path="/tmp/posthog-code-clipboard/attachment-x/pasted-text.txt" />',
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockGenerateTitleAndSummary).toHaveBeenCalledWith(
+        "Investigate flaky CI on main",
+      );
+    });
+    expect(mockReadClipboardText).toHaveBeenCalledWith({
+      filePath: "/tmp/posthog-code-clipboard/attachment-x/pasted-text.txt",
+    });
   });
 
   it("applies auto-title when task has not been manually renamed", async () => {

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -65,7 +65,7 @@ async function expandClipboardTextTags(description: string): Promise<string> {
     if (text === null) continue;
     const trimmed = text.length > remaining ? text.slice(0, remaining) : text;
     remaining -= trimmed.length;
-    result = result.replace(tag, trimmed);
+    result = result.replace(tag, () => trimmed);
     if (remaining <= 0) break;
   }
   return result;

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -28,8 +28,48 @@ import {
 import type { CloudRunSource, PrAuthorshipMode } from "@shared/types/cloud";
 import { logger } from "@utils/logger";
 import { getCachedTask, queryClient } from "@utils/queryClient";
+import { unescapeXmlAttr } from "@utils/xml";
 
 const log = logger.scope("task-creation-saga");
+
+const FILE_TAG_REGEX = /<file path="([^"]*)" \/>/g;
+const MAX_INLINED_CLIPBOARD_CHARS = 8000;
+
+// When a user pastes a long block of text into the prompt, the editor turns it
+// into a clipboard file attachment, leaving the prompt as just `<file path=… />`.
+// The title generator would otherwise see no real content and fall back to
+// "Untitled". Inline the file's text so the LLM has something to summarise.
+async function expandClipboardTextTags(description: string): Promise<string> {
+  const matches = [...description.matchAll(FILE_TAG_REGEX)];
+  if (matches.length === 0) return description;
+
+  const reads = await Promise.all(
+    matches.map(async (match) => {
+      const filePath = unescapeXmlAttr(match[1]);
+      try {
+        const text = await trpcClient.os.readClipboardText.query({ filePath });
+        return { tag: match[0], text };
+      } catch (error) {
+        log.debug("Failed to read clipboard text for title", {
+          filePath,
+          error,
+        });
+        return { tag: match[0], text: null };
+      }
+    }),
+  );
+
+  let remaining = MAX_INLINED_CLIPBOARD_CHARS;
+  let result = description;
+  for (const { tag, text } of reads) {
+    if (text === null) continue;
+    const trimmed = text.length > remaining ? text.slice(0, remaining) : text;
+    remaining -= trimmed.length;
+    result = result.replace(tag, trimmed);
+    if (remaining <= 0) break;
+  }
+  return result;
+}
 
 async function generateTaskTitle(
   taskId: string,
@@ -38,7 +78,8 @@ async function generateTaskTitle(
 ): Promise<void> {
   if (!description.trim()) return;
 
-  const result = await generateTitleAndSummary(description);
+  const expanded = await expandClipboardTextTags(description);
+  const result = await generateTitleAndSummary(expanded);
   if (!result?.title) return;
   const { title } = result;
 


### PR DESCRIPTION
## Problem

When a user pastes a long block of text into the prompt input, the editor converts it into a clipboard file attachment, leaving the prompt as a bare `<file path="/var/folders/.../pasted-text.txt" />` tag. The title generator received that XML, had no real content to summarise, and the new task ended up named "Untitled".

## Changes

- Added `os.readClipboardText` tRPC query that reads a file but only when its path lives inside the clipboard temp dir, so it can't be used to probe arbitrary files on disk.
- In the task-creation saga, expand any `<file path=… />` tags pointing at clipboard files into their text contents (capped at 8k chars total) before calling `generateTitleAndSummary`.
- Only the title generator sees the inlined text — the actual prompt sent to the agent is unchanged and still goes through `buildPromptBlocks` as a `resource_link` attachment.

## How did you test this?

- Added a unit test (`inlines pasted clipboard text before generating title`) that asserts the LLM is called with the file's contents rather than the bare tag.
- `pnpm --filter code test` — full suite (1008 tests) passes.
- `pnpm --filter code typecheck` passes.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*