### PR TITLE
chore(code): tidy signals badge sizing and centering

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/items/HomeItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/HomeItem.tsx
@@ -59,7 +59,7 @@ export function InboxItem({ isActive, onClick, signalCount }: InboxItemProps) {
               Inbox
               {signalCount && signalCount > 0 ? (
                 <span
-                  className="ml-2 inline-flex h-[14px] min-w-[14px] shrink-0 items-center justify-center rounded-full bg-(--red-9) px-0.5 font-medium text-[9px] leading-none"
+                  className="ml-2 inline-flex shrink-0 items-center justify-center rounded-full bg-(--red-9) p-1 font-medium text-[10px] leading-none"
                   style={{
                     color: "white",
                   }}


### PR DESCRIPTION
Make the inbox signals count badge a clean centered pill.

### Before

<img width="452" height="44" alt="Screenshot 2026-05-04 a111t 17 40 25" src="https://github.com/user-attachments/assets/f167dc13-7506-47d1-a64e-c88ee4410687" />



### After
<img width="256" height="79" alt="Screenshot 2026-05-04 at 17 45 17" src="https://github.com/user-attachments/assets/460e1c8b-0532-4d50-8daf-f01666fed09c" />





---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*