### PR TITLE
fix: Skip seat provisioning on org switch when billing flag disabled

### DIFF
--- a/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
@@ -12,6 +12,7 @@ import {
   type ProjectInfo,
   useProjects,
 } from "@features/projects/hooks/useProjects";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import {
   ArrowLeft,
   ArrowRight,
@@ -30,6 +31,7 @@ import {
 } from "@posthog/quill";
 import { Button, Flex, Spinner, Text } from "@radix-ui/themes";
 import happyHog from "@renderer/assets/images/hedgehogs/happy-hog.png";
+import { BILLING_FLAG } from "@shared/constants";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { logger } from "@utils/logger";
 import { AnimatePresence, motion } from "framer-motion";
@@ -72,6 +74,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
   const client = useOptionalAuthenticatedClient();
   const queryClient = useQueryClient();
   const { data: fullUser } = useCurrentUser({ client });
+  const billingEnabled = useFeatureFlag(BILLING_FLAG);
 
   const organizations = useMemo<Org[]>(() => {
     if (!fullUser?.organizations) return [];
@@ -108,7 +111,9 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
       await queryClient.invalidateQueries({
         queryKey: authKeys.currentUsers(),
       });
-      void useSeatStore.getState().fetchSeat({ autoProvision: true });
+      if (billingEnabled) {
+        void useSeatStore.getState().fetchSeat({ autoProvision: true });
+      }
     },
     onMutate: () => {
       setIsSwitchingOrg(true);


### PR DESCRIPTION
## Problem

I introduced this in the previous release. Switching organizations during onboarding triggered a free seat auto-provision for users without the billing flag enabled, even though every other entry point gates this behind BILLING_FLAG.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Read BILLING_FLAG via useFeatureFlag in ProjectSelectStep
2. Wrap the post-switch fetchSeat({ autoProvision: true }) call in a billingEnabled check
3. Align org switch behavior with the gating pattern in useSeatSync

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually