### PR TITLE
chore(code): backward-compat cloud queue drain for old agents

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -1039,6 +1039,87 @@ describe("SessionService", () => {
       });
     });
 
+    it("upgrades status to connected on turn_complete when run_started was never received", async () => {
+      const service = getSessionService();
+      mockBuildAuthenticatedClient.mockReturnValue(mockAuthenticatedClient);
+      const queuedMessage = {
+        id: "q-1",
+        content: "follow up",
+        queuedAt: 1700000000,
+      };
+      // Session starts disconnected — simulates an old agent that never
+      // emitted _posthog/run_started.
+      const sessionWithQueue = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "disconnected",
+        isCloud: true,
+        cloudStatus: "in_progress",
+        events: [],
+        messageQueue: [queuedMessage],
+      });
+      // After the turn_complete handler flips status to "connected",
+      // sendQueuedCloudMessages reads the session again via
+      // getSessionByTaskId. We return the disconnected version first
+      // (for the turn_complete handler) then the connected version
+      // (for the queue dispatcher's canSendNow check).
+      const connectedSession = createMockSession({
+        ...sessionWithQueue,
+        status: "connected",
+      });
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": sessionWithQueue,
+      });
+      mockSessionStoreSetters.getSessionByTaskId
+        .mockReturnValueOnce(sessionWithQueue)
+        .mockReturnValue(connectedSession);
+      mockSessionStoreSetters.dequeueMessages.mockReturnValue([queuedMessage]);
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue("");
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue("{}");
+      mockTrpcLogs.writeLocalLogs.mutate.mockResolvedValue(undefined);
+      mockTrpcCloudTask.sendCommand.mutate.mockResolvedValue({
+        success: true,
+        result: { stopReason: "end_turn" },
+      });
+
+      const turnCompleteEvent = {
+        type: "acp_message" as const,
+        ts: 1700000001,
+        message: {
+          jsonrpc: "2.0" as const,
+          method: "_posthog/turn_complete",
+          params: { sessionId: "acp-session", stopReason: "end_turn" },
+        },
+      };
+      mockConvertStoredEntriesToEvents.mockReturnValueOnce([turnCompleteEvent]);
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run-123",
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          { status: "connected" },
+        );
+      });
+
+      await vi.waitFor(() => {
+        expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            taskId: "task-123",
+            method: "user_message",
+            params: expect.objectContaining({ content: "follow up" }),
+          }),
+        );
+      });
+    });
+
     it("clears isPromptPending from structured turn completion logs on hydration", async () => {
       const service = getSessionService();
       const hydratedSession = createMockSession({

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -1087,16 +1087,25 @@ export class SessionService {
         isNotification(msg.method, POSTHOG_NOTIFICATIONS.TURN_COMPLETE)
       ) {
         const session = sessionStoreSetters.getSessions()[taskRunId];
-        if (session?.isCloud && session.messageQueue.length > 0) {
-          const taskId = session.taskId;
-          setTimeout(() => {
-            this.sendQueuedCloudMessages(taskId).catch((err) =>
-              log.error("turn_complete-driven cloud queue flush failed", {
-                taskId,
-                error: err,
-              }),
-            );
-          }, 0);
+        if (session?.isCloud) {
+          // Backward compat: treat turn_complete as an implicit run_started
+          // for agents that predate the run_started notification.
+          if (session.status !== "connected") {
+            sessionStoreSetters.updateSession(taskRunId, {
+              status: "connected",
+            });
+          }
+          if (session.messageQueue.length > 0) {
+            const taskId = session.taskId;
+            setTimeout(() => {
+              this.sendQueuedCloudMessages(taskId).catch((err) =>
+                log.error("turn_complete-driven cloud queue flush failed", {
+                  taskId,
+                  error: err,
+                }),
+              );
+            }, 0);
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem

PR #1905 gates cloud message queue dispatch on `_posthog/run_started` and `_posthog/turn_complete` notifications. The sandbox base image hasn't been rebuilt since April 28 and runs agent v2.3.425, which doesn't emit `_posthog/run_started`. This means `session.status` never flips to `"connected"` and queued follow-up messages are stuck forever.

## Solution

Treat `_posthog/turn_complete` as an implicit `run_started` — if the session is still disconnected when a turn completes, upgrade status to `"connected"` before draining the queue. No-op for new agents that already emitted `run_started`.

## Test plan

- [x] New test: `turn_complete` without prior `run_started` upgrades status and drains queue
- [x] Existing tests pass

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*