### PR TITLE
feat(code): toast when manual update check finds no update

### DIFF
--- a/apps/code/src/renderer/stores/updateStore.ts
+++ b/apps/code/src/renderer/stores/updateStore.ts
@@ -1,8 +1,11 @@
 import { trpcClient } from "@renderer/trpc/client";
 import { logger } from "@utils/logger";
+import { toast } from "@utils/toast";
 import { create } from "zustand";
 
 const log = logger.scope("update-store");
+
+let menuCheckPending = false;
 
 type UpdateStatus =
   | "idle"
@@ -70,12 +73,26 @@ export function initializeUpdateStore() {
         if (current === "checking" || current === "downloading") {
           useUpdateStore.setState({ status: "idle" });
         }
+        if (menuCheckPending) {
+          menuCheckPending = false;
+          toast.success("You're on the latest version");
+        }
       } else if (status.error) {
         log.error("Update check failed", { error: status.error });
         const current = useUpdateStore.getState().status;
         if (current === "checking" || current === "downloading") {
           useUpdateStore.setState({ status: "idle" });
         }
+        if (menuCheckPending) {
+          menuCheckPending = false;
+          toast.error("Failed to check for updates", {
+            description: status.error,
+          });
+        }
+      } else if (status.checking === false && menuCheckPending) {
+        // Check finished and an update was found (download in progress / ready) —
+        // the UpdateBanner will surface it, so suppress the menu-check toast.
+        menuCheckPending = false;
       }
     },
     onError: (error) => {
@@ -97,7 +114,22 @@ export function initializeUpdateStore() {
 
   const menuCheckSub = trpcClient.updates.onCheckFromMenu.subscribe(undefined, {
     onData: () => {
-      useUpdateStore.getState().checkForUpdates();
+      menuCheckPending = true;
+      trpcClient.updates.check
+        .mutate()
+        .then((result) => {
+          if (!result.success && result.errorCode === "disabled") {
+            menuCheckPending = false;
+            toast.error(result.errorMessage ?? "Updates not available");
+          }
+          // For "already_checking", keep the flag so the in-flight check
+          // surfaces the toast when it resolves.
+        })
+        .catch((error: unknown) => {
+          menuCheckPending = false;
+          log.error("Failed to check for updates", { error });
+          toast.error("Failed to check for updates");
+        });
     },
     onError: (error) => {
       log.error("Update menu check subscription error", { error });

--- a/apps/code/src/renderer/stores/updateStore.ts
+++ b/apps/code/src/renderer/stores/updateStore.ts
@@ -118,12 +118,17 @@ export function initializeUpdateStore() {
       trpcClient.updates.check
         .mutate()
         .then((result) => {
-          if (!result.success && result.errorCode === "disabled") {
-            menuCheckPending = false;
-            toast.error(result.errorMessage ?? "Updates not available");
+          if (!result.success) {
+            if (result.errorCode === "disabled") {
+              menuCheckPending = false;
+              toast.error(result.errorMessage ?? "Updates not available");
+            } else if (result.errorCode !== "already_checking") {
+              // Unknown/future error code — reset the flag so it never gets stuck.
+              menuCheckPending = false;
+            }
+            // For "already_checking", keep the flag so the in-flight check
+            // surfaces the toast when it resolves.
           }
-          // For "already_checking", keep the flag so the in-flight check
-          // surfaces the toast when it resolves.
         })
         .catch((error: unknown) => {
           menuCheckPending = false;

--- a/apps/code/src/renderer/stores/updateStore.ts
+++ b/apps/code/src/renderer/stores/updateStore.ts
@@ -97,6 +97,7 @@ export function initializeUpdateStore() {
     },
     onError: (error) => {
       log.error("Update status subscription error", { error });
+      menuCheckPending = false;
     },
   });
 


### PR DESCRIPTION
## Summary

Addresses Marcus's papercut: clicking **Check for Updates…** in the app menu was silent when no update was available. Now a "You're on the latest version" success toast surfaces, while automatic background checks remain quiet.

## How it works

- Tracks a `menuCheckPending` flag in `updateStore` that's only set when the `onCheckFromMenu` subscription fires (the menu-triggered path).
- When the next status update reports `upToDate`, the flag is consumed and a success toast is shown.
- If the check fails, an error toast is shown instead.
- If an update was found, the existing `UpdateBanner` already surfaces it, so the toast is suppressed.
- Periodic/automatic checks never set the flag, so they stay silent.
- The Settings page bypasses the store and runs its own mutation, so its inline status text isn't double-shown as a toast.

## Test plan

- [ ] Run `pnpm typecheck`, `pnpm lint`, `pnpm test` — all pass locally.
- [ ] Manual: in a packaged build, click **Check for Updates…** when on the latest version → expect "You're on the latest version" toast.
- [ ] Manual: when an update is available → expect the existing UpdateBanner (no extra toast).
- [ ] Manual: with no network → expect "Failed to check for updates" toast.
- [ ] Manual: leave the app open and confirm hourly periodic checks remain silent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*