### PR TITLE
fix(billing): correct URL construction and prevent double-redirecting

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -22,7 +22,7 @@ import {
 import { Tooltip } from "@renderer/components/ui/Tooltip";
 import { PLAN_PRO_ALPHA } from "@shared/types/seat";
 import { logger } from "@utils/logger";
-import { getBillingUrl } from "@utils/urls";
+import { getBillingUrl, getPostHogUrl } from "@utils/urls";
 import { useEffect, useState } from "react";
 
 const log = logger.scope("plan-usage");
@@ -68,7 +68,9 @@ export function PlanUsageSettings() {
     useSeatStore();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const billingUrl = getBillingUrl(cloudRegion);
-  const redirectFullUrl = redirectUrl ? billingUrl : null;
+  const redirectFullUrl = redirectUrl
+    ? (getPostHogUrl(redirectUrl, cloudRegion) ?? billingUrl)
+    : null;
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
 
   const isAlpha = seat?.plan_key === PLAN_PRO_ALPHA;

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -22,7 +22,7 @@ import {
 import { Tooltip } from "@renderer/components/ui/Tooltip";
 import { PLAN_PRO_ALPHA } from "@shared/types/seat";
 import { logger } from "@utils/logger";
-import { getPostHogUrl } from "@utils/urls";
+import { getBillingUrl } from "@utils/urls";
 import { useEffect, useState } from "react";
 
 const log = logger.scope("plan-usage");
@@ -38,7 +38,7 @@ async function openBillingPage(orgId: string | null): Promise<void> {
       log.warn("Failed to switch org before opening billing", err);
     }
   }
-  const url = getPostHogUrl("/organization/billing");
+  const url = getBillingUrl();
   if (url) window.open(url, "_blank");
 }
 
@@ -67,10 +67,8 @@ export function PlanUsageSettings() {
   const { fetchSeat, upgradeToPro, cancelSeat, reactivateSeat, clearError } =
     useSeatStore();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
-  const billingUrl = getPostHogUrl("/organization/billing", cloudRegion);
-  const redirectFullUrl = redirectUrl
-    ? getPostHogUrl(redirectUrl, cloudRegion)
-    : null;
+  const billingUrl = getBillingUrl(cloudRegion);
+  const redirectFullUrl = redirectUrl ? billingUrl : null;
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
 
   const isAlpha = seat?.plan_key === PLAN_PRO_ALPHA;

--- a/apps/code/src/renderer/utils/urls.test.ts
+++ b/apps/code/src/renderer/utils/urls.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@features/auth/hooks/authQueries", () => ({
+  getCachedAuthState: () => ({ cloudRegion: null }),
+}));
+
+import { getBillingUrl, getPostHogUrl } from "./urls";
+
+describe("getPostHogUrl", () => {
+  it("returns null when no region is available", () => {
+    expect(getPostHogUrl("/foo")).toBeNull();
+  });
+
+  it("joins base and path for us region", () => {
+    expect(getPostHogUrl("/foo", "us")).toBe("https://us.posthog.com/foo");
+  });
+
+  it("adds a leading slash if missing", () => {
+    expect(getPostHogUrl("foo", "us")).toBe("https://us.posthog.com/foo");
+  });
+
+  it("uses the eu base for eu region", () => {
+    expect(getPostHogUrl("/foo", "eu")).toBe("https://eu.posthog.com/foo");
+  });
+});
+
+describe("getBillingUrl", () => {
+  it("points at /organization/billing/overview on us", () => {
+    expect(getBillingUrl("us")).toBe(
+      "https://us.posthog.com/organization/billing/overview",
+    );
+  });
+
+  it("points at /organization/billing/overview on eu", () => {
+    expect(getBillingUrl("eu")).toBe(
+      "https://eu.posthog.com/organization/billing/overview",
+    );
+  });
+
+  it("returns null when no region is available", () => {
+    expect(getBillingUrl()).toBeNull();
+  });
+
+  it("does not produce the malformed double-scheme URL we used to ship", () => {
+    const url = getBillingUrl("us");
+    expect(url).not.toMatch(/https?:\/\/[^/]+\/https?:/);
+    expect(url).not.toContain("/project/");
+  });
+});

--- a/apps/code/src/renderer/utils/urls.test.ts
+++ b/apps/code/src/renderer/utils/urls.test.ts
@@ -7,35 +7,40 @@ vi.mock("@features/auth/hooks/authQueries", () => ({
 import { getBillingUrl, getPostHogUrl } from "./urls";
 
 describe("getPostHogUrl", () => {
-  it("returns null when no region is available", () => {
+  it("returns null when no region is available and the input is a path", () => {
     expect(getPostHogUrl("/foo")).toBeNull();
   });
 
-  it("joins base and path for us region", () => {
-    expect(getPostHogUrl("/foo", "us")).toBe("https://us.posthog.com/foo");
-  });
+  it.each([
+    ["us", "/foo", "https://us.posthog.com/foo"],
+    ["us", "foo", "https://us.posthog.com/foo"],
+    ["eu", "/foo", "https://eu.posthog.com/foo"],
+  ] as const)(
+    "joins base and path for %s region (path=%s)",
+    (region, path, expected) => {
+      expect(getPostHogUrl(path, region)).toBe(expected);
+    },
+  );
 
-  it("adds a leading slash if missing", () => {
-    expect(getPostHogUrl("foo", "us")).toBe("https://us.posthog.com/foo");
-  });
-
-  it("uses the eu base for eu region", () => {
-    expect(getPostHogUrl("/foo", "eu")).toBe("https://eu.posthog.com/foo");
+  it.each([
+    "https://app.posthog.com/organization/billing",
+    "http://localhost:8000/checkout",
+    "HTTPS://us.posthog.com/foo",
+  ])("passes absolute URLs through unchanged: %s", (url) => {
+    expect(getPostHogUrl(url, "us")).toBe(url);
   });
 });
 
 describe("getBillingUrl", () => {
-  it("points at /organization/billing/overview on us", () => {
-    expect(getBillingUrl("us")).toBe(
-      "https://us.posthog.com/organization/billing/overview",
-    );
-  });
-
-  it("points at /organization/billing/overview on eu", () => {
-    expect(getBillingUrl("eu")).toBe(
-      "https://eu.posthog.com/organization/billing/overview",
-    );
-  });
+  it.each([
+    ["us", "https://us.posthog.com/organization/billing/overview"],
+    ["eu", "https://eu.posthog.com/organization/billing/overview"],
+  ] as const)(
+    "points at /organization/billing/overview on %s",
+    (region, expected) => {
+      expect(getBillingUrl(region)).toBe(expected);
+    },
+  );
 
   it("returns null when no region is available", () => {
     expect(getBillingUrl()).toBeNull();

--- a/apps/code/src/renderer/utils/urls.ts
+++ b/apps/code/src/renderer/utils/urls.ts
@@ -3,13 +3,14 @@ import type { CloudRegion } from "@shared/types/regions";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
 
 export function getPostHogUrl(
-  path: string,
+  pathOrUrl: string,
   regionOverride?: CloudRegion | null,
 ): string | null {
+  if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
   const region = regionOverride ?? getCachedAuthState().cloudRegion;
   if (!region) return null;
   const base = getCloudUrlFromRegion(region);
-  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  return `${base}${pathOrUrl.startsWith("/") ? pathOrUrl : `/${pathOrUrl}`}`;
 }
 
 export function getBillingUrl(

--- a/apps/code/src/renderer/utils/urls.ts
+++ b/apps/code/src/renderer/utils/urls.ts
@@ -11,3 +11,9 @@ export function getPostHogUrl(
   const base = getCloudUrlFromRegion(region);
   return `${base}${path.startsWith("/") ? path : `/${path}`}`;
 }
+
+export function getBillingUrl(
+  regionOverride?: CloudRegion | null,
+): string | null {
+  return getPostHogUrl("/organization/billing/overview", regionOverride);
+}


### PR DESCRIPTION
## TL;DR

Fixes a critical billing navigation bug where the billing link was constructing malformed URLs with double schemes (e.g., `https://us.posthog.com/project/219767/https://app.posthog.com/organization/billing`), resulting in 404 errors. Introduces a dedicated `getBillingUrl()` function to ensure consistent, correct billing URL construction across the application.

## What changed?

- **Added `getBillingUrl()` function** in `urls.ts` that constructs the correct billing URL (`/organization/billing/overview`) with proper region handling
- **Fixed billing URL construction** in `PlanUsageSettings.tsx`:
  - Replaced `getPostHogUrl("/organization/billing")` with `getBillingUrl()` 
  - Fixed redirect URL logic to use the billing URL directly instead of attempting to construct a separate redirect URL that was causing double-scheme concatenation
- **Added comprehensive test coverage** in `urls.test.ts` to prevent regression:
  - Tests for `getPostHogUrl()` behavior with different regions
  - Tests for `getBillingUrl()` returning correct URLs for US and EU regions
  - Explicit test case verifying the malformed double-scheme URL is no longer produced

## How did you test this?

The changes include new unit tests in `urls.test.ts` that verify:
- Correct URL construction for both US and EU regions
- Proper handling of missing regions (returns null)
- Prevention of malformed double-scheme URLs
- No accidental inclusion of `/project/` paths in billing URLs

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*