### PR TITLE
chore: Remove leftover wordmark logo

### DIFF
--- a/apps/code/src/renderer/components/FullScreenLayout.tsx
+++ b/apps/code/src/renderer/components/FullScreenLayout.tsx
@@ -1,8 +1,6 @@
 import { UpdateBanner } from "@features/sidebar/components/UpdateBanner";
 import { Lifebuoy } from "@phosphor-icons/react";
 import { Button, Flex, Theme } from "@radix-ui/themes";
-import phWordmark from "@renderer/assets/images/wordmark.svg";
-import phWordmarkWhite from "@renderer/assets/images/wordmark-white.svg";
 import { trpcClient } from "@renderer/trpc/client";
 import { useThemeStore } from "@stores/themeStore";
 import { EXTERNAL_LINKS } from "@utils/links";
@@ -44,12 +42,6 @@ export function FullScreenLayout({
           flexGrow="1"
           className="relative z-[1] min-h-0 w-full"
         >
-          <img
-            src={isDarkMode ? phWordmarkWhite : phWordmark}
-            alt="PostHog"
-            className="mt-[clamp(24px,6vh,80px)] ml-8 h-10 shrink-0 self-start object-contain"
-          />
-
           <Flex
             direction="column"
             flexGrow="1"


### PR DESCRIPTION
## Problem

A leftover PostHog Code wordmark was rendering in the top-left of every full-screen layout (welcome and onboarding steps).

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Remove the ![]() rendering wordmark.svg / wordmark-white.svg from FullScreenLayout
2. Drop the now-unused phWordmark and phWordmarkWhite imports

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->