### PR TITLE
feat(code): don't show cloud as option if git integration not existing

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -2649,6 +2649,96 @@ describe("SessionService", () => {
       );
     });
 
+    const mockPreBootFailedSession = (overrides: Partial<AgentSession> = {}) =>
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          isCloud: true,
+          cloudStatus: "failed",
+          status: "disconnected",
+          ...overrides,
+        }),
+      );
+
+    it("refuses to resume when the previous run failed before the agent booted", async () => {
+      const service = getSessionService();
+      mockPreBootFailedSession({
+        cloudErrorMessage: "Sandbox could not be provisioned",
+      });
+
+      await expect(service.sendPrompt("task-123", "retry?")).rejects.toThrow(
+        "Sandbox could not be provisioned",
+      );
+      expect(mockAuthenticatedClient.runTaskInCloud).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a generic message when the failed run has no error", async () => {
+      const service = getSessionService();
+      mockPreBootFailedSession();
+
+      await expect(service.sendPrompt("task-123", "retry?")).rejects.toThrow(
+        /Cloud run couldn't start/,
+      );
+      expect(mockAuthenticatedClient.runTaskInCloud).not.toHaveBeenCalled();
+    });
+
+    it("still resumes when a previously running agent failed mid-execution", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          isCloud: true,
+          cloudStatus: "failed",
+          status: "connected",
+          cloudBranch: "feature/mid-run",
+        }),
+      );
+      mockAuthenticatedClient.getTaskRun.mockResolvedValue({
+        id: "run-123",
+        task: "task-123",
+        team: 123,
+        branch: "feature/mid-run",
+        runtime_adapter: "claude",
+        model: "claude-sonnet-4-20250514",
+        reasoning_effort: null,
+        environment: "cloud",
+        status: "failed",
+        log_url: "https://example.com/logs/run-123",
+        error_message: "agent crashed",
+        output: {},
+        state: {},
+        created_at: "2026-04-14T00:00:00Z",
+        updated_at: "2026-04-14T00:00:00Z",
+        completed_at: "2026-04-14T00:05:00Z",
+      });
+      mockAuthenticatedClient.getTask.mockResolvedValue(createMockTask());
+      mockAuthenticatedClient.runTaskInCloud.mockResolvedValue(
+        createMockTask({
+          latest_run: {
+            id: "run-456",
+            task: "task-123",
+            team: 123,
+            branch: "feature/mid-run",
+            runtime_adapter: "claude",
+            model: "claude-sonnet-4-20250514",
+            reasoning_effort: null,
+            environment: "cloud",
+            status: "queued",
+            log_url: "https://example.com/logs/run-456",
+            error_message: null,
+            output: {},
+            state: {},
+            created_at: "2026-04-14T00:06:00Z",
+            updated_at: "2026-04-14T00:06:00Z",
+            completed_at: null,
+          },
+        }),
+      );
+
+      const result = await service.sendPrompt("task-123", "try again");
+
+      expect(result.stopReason).toBe("queued");
+      expect(mockAuthenticatedClient.runTaskInCloud).toHaveBeenCalledTimes(1);
+    });
+
     it("attempts automatic recovery on fatal error", async () => {
       const service = getSessionService();
       const mockSession = createMockSession({

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -1660,6 +1660,15 @@ export class SessionService {
     }
 
     if (isTerminalStatus(session.cloudStatus)) {
+      // If the agent never booted (no `run_started`), resuming spins another
+      // sandbox that hits the same provisioning failure — surface the error
+      // instead of looping.
+      if (session.cloudStatus === "failed" && session.status !== "connected") {
+        throw new Error(
+          session.cloudErrorMessage ??
+            "Cloud run couldn't start. Check that GitHub is connected for this project, then try again.",
+        );
+      }
       return this.resumeCloudRun(session, prompt);
     }
 

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -76,6 +76,7 @@ export function TaskInput({
     trpcReact.folders.getMostRecentlyAccessedRepository.queryOptions(),
   );
   const {
+    lastUsedLocalWorkspaceMode,
     setLastUsedLocalWorkspaceMode,
     lastUsedWorkspaceMode,
     setLastUsedWorkspaceMode,
@@ -115,7 +116,6 @@ export function TaskInput({
   );
 
   const [selectedDirectory, setSelectedDirectory] = useState("");
-  const workspaceMode = lastUsedWorkspaceMode || "local";
   const adapter = lastUsedAdapter;
   const prefillRequestKey = initialPromptKey ?? initialPrompt;
 
@@ -167,12 +167,6 @@ export function TaskInput({
     }
   }, [mostRecentRepo?.path, selectedDirectory]);
 
-  const setWorkspaceMode = (mode: WorkspaceMode) => {
-    setLastUsedWorkspaceMode(mode);
-    if (mode !== "cloud") {
-      setLastUsedLocalWorkspaceMode(mode);
-    }
-  };
   const setAdapter = (newAdapter: AgentAdapter) =>
     setLastUsedAdapter(newAdapter);
 
@@ -185,6 +179,20 @@ export function TaskInput({
     refreshRepositories,
     hasGithubIntegration,
   } = useUserRepositoryIntegration();
+
+  // Stay optimistic while the integration list resolves to avoid flicker.
+  const cloudAvailable = isLoadingRepos || hasGithubIntegration;
+  const workspaceMode: WorkspaceMode =
+    !cloudAvailable && lastUsedWorkspaceMode === "cloud"
+      ? lastUsedLocalWorkspaceMode
+      : lastUsedWorkspaceMode || "local";
+
+  const setWorkspaceMode = (mode: WorkspaceMode) => {
+    setLastUsedWorkspaceMode(mode);
+    if (mode !== "cloud") {
+      setLastUsedLocalWorkspaceMode(mode);
+    }
+  };
   const {
     repositories: visibleCloudRepositories,
     isPending: cloudRepositoriesLoading,
@@ -606,6 +614,7 @@ export function TaskInput({
               onChange={setWorkspaceMode}
               selectedCloudEnvironmentId={selectedCloudEnvId}
               onCloudEnvironmentChange={setSelectedCloudEnvId}
+              cloudAvailable={cloudAvailable}
               size="1"
             />
             {workspaceMode === "worktree" && (

--- a/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -36,6 +36,7 @@ interface WorkspaceModeSelectProps {
   overrideModes?: WorkspaceMode[];
   selectedCloudEnvironmentId?: string | null;
   onCloudEnvironmentChange?: (envId: string | null) => void;
+  cloudAvailable?: boolean;
 }
 
 const LOCAL_MODES: {
@@ -67,6 +68,7 @@ export function WorkspaceModeSelect({
   overrideModes,
   selectedCloudEnvironmentId,
   onCloudEnvironmentChange,
+  cloudAvailable = true,
 }: WorkspaceModeSelectProps) {
   const cloudModeEnabled =
     useFeatureFlag("twig-cloud-mode-toggle") || import.meta.env.DEV;
@@ -80,9 +82,9 @@ export function WorkspaceModeSelect({
     openSettings("cloud-environments", "create");
   }, [openSettings]);
 
-  const showCloud = overrideModes
-    ? overrideModes.includes("cloud")
-    : cloudModeEnabled;
+  const showCloud =
+    cloudAvailable &&
+    (overrideModes ? overrideModes.includes("cloud") : cloudModeEnabled);
 
   const localModes = useMemo(
     () =>


### PR DESCRIPTION
## Problem

Two related cloud session bugs needed fixing:

1. When a cloud run fails before the agent ever boots (e.g. sandbox provisioning failure), sending a new prompt would attempt to resume the run, spinning up another sandbox that hits the same failure in a loop. The error was never surfaced to the user.

2. When a user without a GitHub integration had previously used cloud mode, the workspace mode selector would briefly show "cloud" as selected on load before snapping to a local mode once the integration check resolved, causing a visible flicker.

## Changes

**Pre-boot cloud failure guard:** `sendPrompt` now checks whether a failed cloud session never reached a connected state. If so, it throws immediately with the stored error message (or a generic fallback) rather than attempting to resume, preventing the provisioning failure loop.

**Workspace mode flicker fix:** The `workspaceMode` value is now derived after the GitHub integration check resolves. While the integration list is still loading, the UI stays optimistic and keeps the current selection. Once loaded, if cloud is unavailable and the last-used mode was `"cloud"`, it falls back to the last-used local workspace mode. The cloud option in `WorkspaceModeSelect` is also hidden when `cloudAvailable` is `false`.