### PR TITLE
Fix(mcp): "set all" button now follows active search

### DIFF
--- a/apps/code/src/renderer/features/mcp-servers/components/parts/ServerDetailView.tsx
+++ b/apps/code/src/renderer/features/mcp-servers/components/parts/ServerDetailView.tsx
@@ -252,35 +252,58 @@ export function ServerDetailView({
               <Text color="gray" className="text-[13px]">
                 Set all:
               </Text>
-              <Tooltip content="Approve all">
+              <Tooltip
+                content={toolSearch ? "Approve filtered" : "Approve all"}
+              >
                 <IconButton
                   variant="soft"
                   color="green"
                   size="1"
-                  disabled={bulkPending || tools.length === 0}
-                  onClick={() => setBulkApproval("approved")}
+                  disabled={bulkPending || filteredTools.length === 0}
+                  onClick={() =>
+                    setBulkApproval(
+                      "approved",
+                      toolSearch ? filteredTools : undefined,
+                    )
+                  }
                 >
                   <Check size={12} weight="bold" />
                 </IconButton>
               </Tooltip>
-              <Tooltip content="Require approval for all">
+              <Tooltip
+                content={
+                  toolSearch
+                    ? "Require approval for filtered"
+                    : "Require approval for all"
+                }
+              >
                 <IconButton
                   variant="soft"
                   color="amber"
                   size="1"
-                  disabled={bulkPending || tools.length === 0}
-                  onClick={() => setBulkApproval("needs_approval")}
+                  disabled={bulkPending || filteredTools.length === 0}
+                  onClick={() =>
+                    setBulkApproval(
+                      "needs_approval",
+                      toolSearch ? filteredTools : undefined,
+                    )
+                  }
                 >
                   <Shield size={12} weight="bold" />
                 </IconButton>
               </Tooltip>
-              <Tooltip content="Block all">
+              <Tooltip content={toolSearch ? "Block filtered" : "Block all"}>
                 <IconButton
                   variant="soft"
                   color="red"
                   size="1"
-                  disabled={bulkPending || tools.length === 0}
-                  onClick={() => setBulkApproval("do_not_use")}
+                  disabled={bulkPending || filteredTools.length === 0}
+                  onClick={() =>
+                    setBulkApproval(
+                      "do_not_use",
+                      toolSearch ? filteredTools : undefined,
+                    )
+                  }
                 >
                   <Prohibit size={12} weight="bold" />
                 </IconButton>

--- a/apps/code/src/renderer/features/mcp-servers/hooks/useMcpInstallationTools.ts
+++ b/apps/code/src/renderer/features/mcp-servers/hooks/useMcpInstallationTools.ts
@@ -77,15 +77,21 @@ export function useMcpInstallationTools(
   );
 
   const setBulkApprovalMutation = useAuthenticatedMutation(
-    (client, approval_state: McpApprovalState) => {
+    (
+      client,
+      vars: {
+        approval_state: McpApprovalState;
+        targetTools?: McpInstallationTool[];
+      },
+    ) => {
       if (!installationId) {
         return Promise.reject(new Error("No installation selected"));
       }
       return dispatchBulkApproval(
         client,
         installationId,
-        tools ?? [],
-        approval_state,
+        vars.targetTools ?? tools ?? [],
+        vars.approval_state,
       );
     },
     {
@@ -174,7 +180,10 @@ export function useMcpInstallationTools(
     tools: tools ?? [],
     isLoading,
     setToolApproval: setToolApprovalMutation.mutate,
-    setBulkApproval: setBulkApprovalMutation.mutate,
+    setBulkApproval: (
+      approval_state: McpApprovalState,
+      targetTools?: McpInstallationTool[],
+    ) => setBulkApprovalMutation.mutate({ approval_state, targetTools }),
     bulkPending: setBulkApprovalMutation.isPending,
     refresh: () => refreshMutation.mutate(undefined),
     refreshPending: refreshMutation.isPending,


### PR DESCRIPTION
## Problem

When a user searched for tools by name and clicked "Set all", the bulk approval action applied to **all** tools in the installation, not just the filtered results. This made it impossible to bulk-approve a subset of tools by name prefix (e.g. all `create_*` tools from a Linear MCP server).

Closes #2043 

## Changes

- `useMcpInstallationTools`: `setBulkApproval` now accepts an optional `targetTools` array. When provided, only those tools are updated; otherwise falls back to all tools (preserving existing behaviour).
- `ServerDetailView`: when a search is active, the "Set all" buttons pass `filteredTools` as the target. Tooltips update to say "Approve filtered" / "Require approval for filtered" / "Block filtered" to make the scope clear to the user.

## How did you test this?

Manually tested in the app: Settings → MCP Servers → connected server with >5 tools → typed a prefix in the search box → clicked each "Set all" button and confirmed only the matching tools were updated.

## Publish to changelog?

No
