### PR TITLE
fix(code): preserve inherited PATH so husky hooks work in Create PR

### DIFF
--- a/apps/code/src/main/utils/fixPath.test.ts
+++ b/apps/code/src/main/utils/fixPath.test.ts
@@ -151,6 +151,46 @@ describe("fixPath", () => {
     expect(parts).toContain("/opt/homebrew/bin");
   });
 
+  it("preserves entries from the inherited PATH that the login shell lacks", async () => {
+    // Simulate launching from a terminal where .zshrc has added nvm/mise
+    // paths that the -lc resolution (only sources .zprofile) won't see.
+    process.env.PATH =
+      "/Users/me/.nvm/versions/node/v22.0.0/bin:/Users/me/.local/share/pnpm:/usr/bin:/bin";
+    mockSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: shellOutput("/opt/homebrew/bin:/usr/bin:/bin"),
+    });
+
+    const { fixPath } = await import("./fixPath");
+    fixPath();
+
+    const parts = process.env.PATH?.split(":") ?? [];
+    // Inherited entries (added by .zshrc, missing from .zprofile) survive.
+    expect(parts).toContain("/Users/me/.nvm/versions/node/v22.0.0/bin");
+    expect(parts).toContain("/Users/me/.local/share/pnpm");
+    // Shell-resolved entries are still merged in.
+    expect(parts).toContain("/opt/homebrew/bin");
+  });
+
+  it("preserves inherited PATH entries when reading from the cache", async () => {
+    process.env.PATH = "/Users/me/.nvm/versions/node/v22.0.0/bin:/usr/bin:/bin";
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        path: "/opt/homebrew/bin:/usr/bin:/bin",
+        timestamp: Date.now(),
+      }),
+    );
+
+    const { fixPath } = await import("./fixPath");
+    fixPath();
+
+    const parts = process.env.PATH?.split(":") ?? [];
+    expect(parts).toContain("/Users/me/.nvm/versions/node/v22.0.0/bin");
+    expect(parts).toContain("/opt/homebrew/bin");
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
   it("returns early on win32 without touching PATH", async () => {
     setPlatform("win32");
     process.env.PATH = "C:\\Windows\\System32";

--- a/apps/code/src/main/utils/fixPath.ts
+++ b/apps/code/src/main/utils/fixPath.ts
@@ -4,7 +4,7 @@
  * includes /opt/homebrew/bin, ~/.local/bin, etc.
  *
  * This reads the PATH from the user's default shell (in login mode) and
- * applies it to process.env.PATH so child processes have access to
+ * merges it into process.env.PATH so child processes have access to
  * user-installed binaries.
  *
  * IMPORTANT: We use `-lc` (login, non-interactive) instead of `-ilc`
@@ -12,6 +12,13 @@
  * include heavy plugins (Oh My Zsh, NVM, thefuck, etc.) that spawn
  * subprocesses and cause zombie process chains when the timeout kills
  * only the parent shell.
+ *
+ * Because `-lc` skips .zshrc, version-manager paths (nvm, mise, volta) and
+ * other entries added there are missing from the resolved shell PATH. We
+ * therefore *merge* with the inherited process.env.PATH rather than
+ * replacing it — when launched from a terminal (e.g. `pnpm dev`), the
+ * inherited PATH already has those entries and must be preserved so git
+ * pre-commit hooks (husky, lint-staged, etc.) can find their tools.
  *
  * See: https://github.com/PostHog/code/issues/1399
  */
@@ -170,11 +177,19 @@ function getShellPath(shell: string): string | undefined {
   return env?.PATH;
 }
 
-function mergeFallbackPaths(basePath: string | undefined): string {
-  const base = basePath ? basePath.split(":").filter(Boolean) : [];
-  const existing = new Set(base);
-  const additions = FALLBACK_PATHS.filter((p) => !existing.has(p));
-  return [...additions, ...base].join(":");
+function mergePaths(sources: (string | undefined)[]): string {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const source of sources) {
+    if (!source) continue;
+    for (const segment of source.split(":")) {
+      if (segment && !seen.has(segment)) {
+        seen.add(segment);
+        result.push(segment);
+      }
+    }
+  }
+  return result.join(":");
 }
 
 export function fixPath(): void {
@@ -182,9 +197,11 @@ export function fixPath(): void {
     return;
   }
 
+  const originalPath = process.env.PATH;
+
   const cached = readCachedPath();
   if (cached) {
-    process.env.PATH = mergeFallbackPaths(cached);
+    process.env.PATH = mergePaths([...FALLBACK_PATHS, originalPath, cached]);
     return;
   }
 
@@ -193,10 +210,9 @@ export function fixPath(): void {
 
   if (shellPath) {
     const cleaned = stripAnsi(shellPath);
-    const merged = mergeFallbackPaths(cleaned);
-    process.env.PATH = merged;
+    process.env.PATH = mergePaths([...FALLBACK_PATHS, originalPath, cleaned]);
     writeCachedPath(cleaned);
   } else {
-    process.env.PATH = mergeFallbackPaths(process.env.PATH);
+    process.env.PATH = mergePaths([...FALLBACK_PATHS, originalPath]);
   }
 }


### PR DESCRIPTION
## Summary

- The Create PR button failed when the underlying repo had husky pre-commit hooks, even though running the same hook from a terminal worked fine.
- Root cause: `fixPath` was *replacing* `process.env.PATH` with what `zsh -lc` returns. `-lc` only sources `.zprofile`, not `.zshrc`, so version-manager paths added by `.zshrc` (nvm/mise/volta — where `pnpm`, `node`, `husky` typically live) got wiped out. When `getCleanEnv` later snapshotted PATH for git child processes, the husky hook ran without those tools and failed with "command not found".
- Fix: merge the inherited PATH with the resolved shell PATH and fallbacks (deduped), instead of replacing. Terminal launches keep their rich PATH; Finder/Spotlight launches still get the shell PATH filled in. We can't safely switch to `-ilc` (full `.zshrc`) because of the zombie-process risk called out in [#1399](https://github.com/PostHog/code/issues/1399), so merging is the safer fix.

## Test plan

- [x] `pnpm --filter code test src/main/utils/fixPath.test.ts` — 8/8 passing (added 2 new tests for the inherited-PATH scenario, both with shell-resolved and cached paths)
- [x] `pnpm --filter code typecheck` — clean
- [ ] Manual: launch the app from a terminal in a repo with husky hooks and click Create PR — pre-commit hook should now run successfully
- [ ] Manual: launch the app from Finder/Spotlight and confirm the resolved shell PATH is still applied (regression check)

Note: existing users may need to wait up to 1h for the cached PATH to refresh, or delete \`~/Library/Application Support/@posthog/posthog-code/shell-env-cache.json\`. The cache only stores the shell PATH, which is now merged on top of the inherited PATH on every boot.

Generated-By: PostHog Code
Task-Id: cf740c81-d28c-4ce9-9573-c016a5c0e773