### PR TITLE
feat(code): fix flakey tesk

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -279,16 +279,27 @@ describe("AgentServer HTTP Mode", () => {
       const keepaliveCallback: { current: (() => void) | null } = {
         current: null,
       };
+      // Pass through to real setInterval for non-keepalive timers; otherwise
+      // unrelated internals (undici, http server, MSW) lose their periodic
+      // callbacks and can hang the test.
+      const realSetInterval = globalThis.setInterval;
       const setIntervalSpy = vi
         .spyOn(globalThis, "setInterval")
-        .mockImplementation(
-          (callback: (_: undefined) => void, timeout?: number) => {
-            if (timeout === SSE_KEEPALIVE_INTERVAL_MS) {
-              keepaliveCallback.current = () => callback(undefined);
-            }
+        .mockImplementation(((
+          callback: (_: undefined) => void,
+          timeout?: number,
+          ...args: unknown[]
+        ) => {
+          if (timeout === SSE_KEEPALIVE_INTERVAL_MS) {
+            keepaliveCallback.current = () => callback(undefined);
             return setTimeout(() => undefined, 60_000);
-          },
-        );
+          }
+          return (realSetInterval as (...rest: unknown[]) => unknown)(
+            callback,
+            timeout,
+            ...args,
+          );
+        }) as unknown as typeof setInterval);
 
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
       try {
@@ -307,8 +318,9 @@ describe("AgentServer HTTP Mode", () => {
           throw new Error("Expected SSE response body reader");
         }
 
-        await vi.waitFor(() =>
-          expect(keepaliveCallback.current).not.toBeNull(),
+        await vi.waitFor(
+          () => expect(keepaliveCallback.current).not.toBeNull(),
+          { timeout: 10_000, interval: 50 },
         );
         const emitKeepalive = keepaliveCallback.current;
         if (!emitKeepalive) {
@@ -318,7 +330,7 @@ describe("AgentServer HTTP Mode", () => {
 
         const decoder = new TextDecoder();
         let streamText = "";
-        for (let attempts = 0; attempts < 5; attempts++) {
+        for (let attempts = 0; attempts < 10; attempts++) {
           const { done, value } = await reader.read();
           if (done) break;
           streamText += decoder.decode(value, { stream: true });
@@ -331,7 +343,7 @@ describe("AgentServer HTTP Mode", () => {
         await reader?.cancel();
         setIntervalSpy.mockRestore();
       }
-    }, 20000);
+    }, 30000);
   });
 
   describe("POST /command", () => {


### PR DESCRIPTION
## Problem

The SSE keepalive test was intermittently hanging or failing because the `setInterval` mock was replacing **all** interval timers globally, including those used internally by undici, the HTTP server, and MSW. Without their periodic callbacks, those internals would stall and cause the test to hang.

## Changes

- The `setInterval` spy now passes non-keepalive timers through to the real `setInterval`, so only the SSE keepalive interval is intercepted and captured.
- Increased the `vi.waitFor` timeout to 10 seconds with a 50ms polling interval to give the keepalive callback more time to register reliably.
- Increased the read loop attempts from 5 to 10 to allow more time for SSE data to arrive.
- Increased the overall test timeout from 20 to 30 seconds to accommodate the more lenient waiting behavior.