### PR TITLE
fix(inbox): Show real PR status in inbox list rows

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/utils/ReportCardContent.tsx
+++ b/apps/code/src/renderer/features/inbox/components/utils/ReportCardContent.tsx
@@ -79,10 +79,7 @@ export function ReportCardContent({
           )}
         </Flex>
         {report.implementation_pr_url && (
-          <ReportImplementationPrLink
-            prUrl={report.implementation_pr_url}
-            skipStatusFetch={compact}
-          />
+          <ReportImplementationPrLink prUrl={report.implementation_pr_url} />
         )}
       </Flex>
 

--- a/apps/code/src/renderer/features/inbox/components/utils/ReportImplementationPrLink.tsx
+++ b/apps/code/src/renderer/features/inbox/components/utils/ReportImplementationPrLink.tsx
@@ -9,11 +9,6 @@ interface ReportImplementationPrLinkProps {
   prUrl: string;
   /** `sm`: inbox list row. `md`: implementation task panel bar. */
   size?: ImplementationPrLinkSize;
-  /**
-   * When true, skips the tRPC/GitHub status fetch and renders the badge in the
-   * default open state. Use in list rows to avoid N parallel API calls on mount.
-   */
-  skipStatusFetch?: boolean;
 }
 
 function parseGitHubPrReference(prUrl: string): {
@@ -46,22 +41,20 @@ function parseGitHubPrReference(prUrl: string): {
 export function ReportImplementationPrLink({
   prUrl,
   size = "sm",
-  skipStatusFetch = false,
 }: ReportImplementationPrLinkProps) {
   const {
     meta: { state, merged, isLoading },
-  } = usePrDetails(skipStatusFetch ? null : prUrl);
+  } = usePrDetails(prUrl);
 
   const isSm = size === "sm";
 
-  const colorClass =
-    isLoading || skipStatusFetch
-      ? "bg-green-4 text-green-11 hover:bg-green-5"
-      : merged
-        ? "bg-violet-4 text-violet-11 hover:bg-violet-5"
-        : state === "closed"
-          ? "bg-red-4 text-red-11 hover:bg-red-5"
-          : "bg-green-4 text-green-11 hover:bg-green-5";
+  const colorClass = isLoading
+    ? "bg-gray-4 text-gray-11 hover:bg-gray-5"
+    : merged
+      ? "bg-violet-4 text-violet-11 hover:bg-violet-5"
+      : state === "closed"
+        ? "bg-red-4 text-red-11 hover:bg-red-5"
+        : "bg-green-4 text-green-11 hover:bg-green-5";
 
   const { reference: prReference, prNumber } = parseGitHubPrReference(prUrl);
 


### PR DESCRIPTION
## Summary

In the Inbox, the implementation-PR badge in the list rows looked like an "open" PR even when the PR had been merged or closed, while the same badge in the report detail pane (and in the implementation-task bar) correctly showed merged/closed. So the same PR appeared in two states at once, depending on where you looked.

SlackHog: https://posthog.slack.com/archives/C09SK2PAGKF/p1778066950541599

## Changes

Always fetch status of PR.