### PR TITLE
fix(code): fix styling on inline file links

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -75,11 +75,7 @@ function InlineFileLink({
         type="button"
         onClick={taskId ? handleClick : undefined}
         disabled={!taskId}
-        className={`inline text-(--accent-11) ${taskId ? "cursor-pointer underline-offset-2 hover:underline" : ""}`}
-        style={{
-          all: "unset",
-          font: "inherit",
-        }}
+        className={`m-0 inline border-0 bg-transparent p-0 font-[inherit] text-(--accent-11) text-[length:inherit] ${taskId ? "cursor-pointer underline decoration-(--accent-a8) underline-offset-2 hover:decoration-(--accent-11)" : ""}`}
       >
         {filename}
         {lineSuffix ? `:${lineSuffix}` : ""}


### PR DESCRIPTION
## Problem

it's not obvious that inline file links in agent output are actually links

when i'm fidgeting and spam clicking / highlighting text while reading, i accidentally open files all the time

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

renders inline links as actual links

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->