### PR TITLE
feat(code): Set posthog-js project + organization groups

### DIFF
--- a/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
+++ b/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
@@ -12,7 +12,7 @@ import { useSeatStore } from "@features/billing/stores/seatStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { trpcClient } from "@renderer/trpc/client";
 import { BILLING_FLAG } from "@shared/constants";
-import { identifyUser, resetUser, setUserGroup } from "@utils/analytics";
+import { identifyUser, resetUser, setUserGroups } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { queryClient } from "@utils/queryClient";
 import { useEffect } from "react";
@@ -72,21 +72,7 @@ function useAuthAnalyticsIdentity(
       region: authState.cloudRegion ?? "",
     });
 
-    if (currentUser.team) {
-      setUserGroup("project", currentUser.team.uuid, {
-        id: currentUser.team.id,
-        uuid: currentUser.team.uuid,
-        name: currentUser.team.name,
-      });
-    }
-
-    if (currentUser.organization) {
-      setUserGroup("organization", currentUser.organization.id, {
-        id: currentUser.organization.id,
-        name: currentUser.organization.name,
-        slug: currentUser.organization.slug,
-      });
-    }
+    setUserGroups(currentUser);
 
     void trpcClient.analytics.setUserId.mutate({
       userId: distinctId,

--- a/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
+++ b/apps/code/src/renderer/features/auth/hooks/useAuthSession.ts
@@ -12,7 +12,7 @@ import { useSeatStore } from "@features/billing/stores/seatStore";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { trpcClient } from "@renderer/trpc/client";
 import { BILLING_FLAG } from "@shared/constants";
-import { identifyUser, resetUser } from "@utils/analytics";
+import { identifyUser, resetUser, setUserGroup } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { queryClient } from "@utils/queryClient";
 import { useEffect } from "react";
@@ -71,6 +71,22 @@ function useAuthAnalyticsIdentity(
       project_id: authState.projectId?.toString() ?? "",
       region: authState.cloudRegion ?? "",
     });
+
+    if (currentUser.team) {
+      setUserGroup("project", currentUser.team.uuid, {
+        id: currentUser.team.id,
+        uuid: currentUser.team.uuid,
+        name: currentUser.team.name,
+      });
+    }
+
+    if (currentUser.organization) {
+      setUserGroup("organization", currentUser.organization.id, {
+        id: currentUser.organization.id,
+        name: currentUser.organization.name,
+        slug: currentUser.organization.slug,
+      });
+    }
 
     void trpcClient.analytics.setUserId.mutate({
       userId: distinctId,

--- a/apps/code/src/renderer/features/auth/stores/authStore.test.ts
+++ b/apps/code/src/renderer/features/auth/stores/authStore.test.ts
@@ -55,6 +55,7 @@ vi.mock("@renderer/api/posthogClient", () => ({
 vi.mock("@utils/analytics", () => ({
   identifyUser: vi.fn(),
   resetUser: vi.fn(),
+  setUserGroups: vi.fn(),
   track: vi.fn(),
 }));
 
@@ -83,7 +84,7 @@ vi.mock("@stores/navigationStore", () => ({
   },
 }));
 
-import { resetUser } from "@utils/analytics";
+import { resetUser, setUserGroups } from "@utils/analytics";
 import { queryClient } from "@utils/queryClient";
 import { resetAuthStoreModuleStateForTest, useAuthStore } from "./authStore";
 
@@ -166,6 +167,7 @@ describe("authStore", () => {
     await useAuthStore.getState().checkCodeAccess();
 
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+    expect(setUserGroups).toHaveBeenCalledTimes(1);
   });
 
   it("clears user identity and cached current user on implicit auth loss", async () => {

--- a/apps/code/src/renderer/features/auth/stores/authStore.ts
+++ b/apps/code/src/renderer/features/auth/stores/authStore.ts
@@ -6,7 +6,7 @@ import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import type { CloudRegion } from "@shared/types/regions";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
 import { useNavigationStore } from "@stores/navigationStore";
-import { identifyUser, resetUser, track } from "@utils/analytics";
+import { identifyUser, resetUser, setUserGroup, track } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { queryClient } from "@utils/queryClient";
 import { create } from "zustand";
@@ -164,6 +164,22 @@ async function syncAuthState(): Promise<void> {
         project_id: authState.projectId?.toString() ?? "",
         region: authState.cloudRegion ?? "",
       });
+
+      if (user.team) {
+        setUserGroup("project", user.team.uuid, {
+          id: user.team.id,
+          uuid: user.team.uuid,
+          name: user.team.name,
+        });
+      }
+
+      if (user.organization) {
+        setUserGroup("organization", user.organization.id, {
+          id: user.organization.id,
+          name: user.organization.name,
+          slug: user.organization.slug,
+        });
+      }
 
       trpcClient.analytics.setUserId.mutate({
         userId: distinctId,

--- a/apps/code/src/renderer/features/auth/stores/authStore.ts
+++ b/apps/code/src/renderer/features/auth/stores/authStore.ts
@@ -6,7 +6,12 @@ import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import type { CloudRegion } from "@shared/types/regions";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
 import { useNavigationStore } from "@stores/navigationStore";
-import { identifyUser, resetUser, setUserGroup, track } from "@utils/analytics";
+import {
+  identifyUser,
+  resetUser,
+  setUserGroups,
+  track,
+} from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { queryClient } from "@utils/queryClient";
 import { create } from "zustand";
@@ -165,21 +170,7 @@ async function syncAuthState(): Promise<void> {
         region: authState.cloudRegion ?? "",
       });
 
-      if (user.team) {
-        setUserGroup("project", user.team.uuid, {
-          id: user.team.id,
-          uuid: user.team.uuid,
-          name: user.team.name,
-        });
-      }
-
-      if (user.organization) {
-        setUserGroup("organization", user.organization.id, {
-          id: user.organization.id,
-          name: user.organization.name,
-          slug: user.organization.slug,
-        });
-      }
+      setUserGroups(user);
 
       trpcClient.analytics.setUserId.mutate({
         userId: distinctId,

--- a/apps/code/src/renderer/utils/analytics.ts
+++ b/apps/code/src/renderer/utils/analytics.ts
@@ -100,6 +100,20 @@ export function identifyUser(
   posthog.identify(userId, properties);
 }
 
+type GroupProperties = Record<string, string | number | boolean | null>;
+
+export function setUserGroup(
+  groupType: "project" | "organization",
+  groupKey: string,
+  properties?: GroupProperties,
+) {
+  if (!isInitialized) {
+    return;
+  }
+
+  posthog.group(groupType, groupKey, properties);
+}
+
 export function resetUser() {
   if (!isInitialized) {
     return;

--- a/apps/code/src/renderer/utils/analytics.ts
+++ b/apps/code/src/renderer/utils/analytics.ts
@@ -100,18 +100,31 @@ export function identifyUser(
   posthog.identify(userId, properties);
 }
 
-type GroupProperties = Record<string, string | number | boolean | null>;
+type UserWithGroups = {
+  team?: { id: number; uuid: string; name: string } | null;
+  organization?: { id: string; name: string; slug: string } | null;
+};
 
-export function setUserGroup(
-  groupType: "project" | "organization",
-  groupKey: string,
-  properties?: GroupProperties,
-) {
+export function setUserGroups(user: UserWithGroups) {
   if (!isInitialized) {
     return;
   }
 
-  posthog.group(groupType, groupKey, properties);
+  if (user.team) {
+    posthog.group("project", user.team.uuid, {
+      id: user.team.id,
+      uuid: user.team.uuid,
+      name: user.team.name,
+    });
+  }
+
+  if (user.organization) {
+    posthog.group("organization", user.organization.id, {
+      id: user.organization.id,
+      name: user.organization.name,
+      slug: user.organization.slug,
+    });
+  }
 }
 
 export function resetUser() {


### PR DESCRIPTION
## Summary

We have a `inbox-gated-due-to-scale` flag to effectively put a more controlled waitlist. But it hasn't actually taken effect, because PH Code didn't set the group analytics properties.

Fixing by mirroring how the main PostHog frontend ([userLogic.ts](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/userLogic.ts)) attaches the user to `project` and `organization` groups via `posthog.group(...)` after identify. Groups update on login, project switch, and org switch. `posthog.reset()` on logout clears them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*