### PR TITLE
fix(agent): Request-limit-unrecoverable-thread

### DIFF
--- a/apps/code/src/renderer/features/editor/utils/cloud-prompt.test.ts
+++ b/apps/code/src/renderer/features/editor/utils/cloud-prompt.test.ts
@@ -117,6 +117,27 @@ describe("cloud-prompt", () => {
     expect(mockFs.readAbsoluteFile.query).not.toHaveBeenCalled();
   });
 
+  it("encodes Windows drive paths as file URIs", async () => {
+    const blocks = await buildCloudPromptBlocks(
+      'read <file path="C:\\\\tmp\\\\100%\\\\a#b?.txt" />',
+    );
+
+    const uris = resourceLinksFrom(blocks);
+    expect(uris).toHaveLength(1);
+    // C:\tmp\100%\a#b?.txt → file:///C:/tmp/100%25/a%23b%3F.txt
+    expect(uris[0]).toBe("file:///C:/tmp/100%25/a%23b%3F.txt");
+  });
+
+  it("encodes Windows UNC paths as file URIs", async () => {
+    const blocks = await buildCloudPromptBlocks(
+      'read <file path="\\\\\\\\server\\\\share\\\\My Folder\\\\file.txt" />',
+    );
+
+    const uris = resourceLinksFrom(blocks);
+    expect(uris).toHaveLength(1);
+    expect(uris[0]).toBe("file://server/share/My%20Folder/file.txt");
+  });
+
   it("embeds image attachments as ACP image blocks", async () => {
     const fakeBase64 = btoa("tiny-image-data");
     mockFs.readFileAsBase64.query.mockResolvedValue(fakeBase64);

--- a/apps/code/src/renderer/features/editor/utils/cloud-prompt.test.ts
+++ b/apps/code/src/renderer/features/editor/utils/cloud-prompt.test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+import type { ContentBlock } from "@agentclientprotocol/sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFs = vi.hoisted(() => ({
@@ -31,13 +33,18 @@ vi.mock("@renderer/trpc/client", () => ({
   },
 }));
 
-import { parseAttachmentUri } from "@utils/promptContent";
 import {
   buildCloudPromptBlocks,
   buildCloudTaskDescription,
   serializeCloudPrompt,
   stripAbsoluteFileTags,
 } from "./cloud-prompt";
+
+function resourceLinksFrom(blocks: ContentBlock[]): string[] {
+  return blocks.flatMap((b) =>
+    b.type === "resource_link" && typeof b.uri === "string" ? [b.uri] : [],
+  );
+}
 
 describe("cloud-prompt", () => {
   beforeEach(() => {
@@ -63,8 +70,6 @@ describe("cloud-prompt", () => {
   });
 
   it("excludes folder paths from absolute attachment list", async () => {
-    mockFs.readAbsoluteFile.query.mockResolvedValue("hi");
-
     const prompt =
       'scan <folder path="/abs/dir" /> and <file path="/tmp/test.txt" />';
     const blocks = await buildCloudPromptBlocks(prompt, [
@@ -72,15 +77,10 @@ describe("cloud-prompt", () => {
       "/tmp/test.txt",
     ]);
 
-    const uris = blocks.flatMap((b) =>
-      b.type === "resource" ? [b.resource.uri] : [],
-    );
+    const uris = resourceLinksFrom(blocks);
     expect(uris).toHaveLength(1);
     expect(uris[0]).toContain("test.txt");
-    expect(mockFs.readAbsoluteFile.query).toHaveBeenCalledTimes(1);
-    expect(mockFs.readAbsoluteFile.query).toHaveBeenCalledWith({
-      filePath: "/tmp/test.txt",
-    });
+    expect(mockFs.readAbsoluteFile.query).not.toHaveBeenCalled();
   });
 
   it("builds a safe cloud task description for local attachments", () => {
@@ -93,34 +93,28 @@ describe("cloud-prompt", () => {
     );
   });
 
-  it("embeds text attachments as ACP resources", async () => {
-    mockFs.readAbsoluteFile.query.mockResolvedValue("hello from file");
-
+  it("uses resource_link path references for text attachments", async () => {
     const blocks = await buildCloudPromptBlocks(
       'read this <file path="/tmp/test.txt" />',
     );
 
     expect(blocks).toEqual([
       { type: "text", text: "read this" },
-      expect.objectContaining({
-        type: "resource",
-        resource: expect.objectContaining({
-          text: "hello from file",
-          mimeType: "text/plain",
-        }),
-      }),
+      {
+        type: "resource_link",
+        uri: expect.stringMatching(/^file:\/\/.+/),
+        name: "test.txt",
+      },
     ]);
 
     const attachmentBlock = blocks[1];
-    expect(attachmentBlock.type).toBe("resource");
-    if (attachmentBlock.type !== "resource") {
-      throw new Error("Expected a resource attachment block");
+    expect(attachmentBlock.type).toBe("resource_link");
+    if (attachmentBlock.type !== "resource_link") {
+      throw new Error("Expected a resource_link attachment block");
     }
 
-    expect(parseAttachmentUri(attachmentBlock.resource.uri)).toEqual({
-      id: attachmentBlock.resource.uri,
-      label: "test.txt",
-    });
+    expect(fileURLToPath(attachmentBlock.uri)).toBe("/tmp/test.txt");
+    expect(mockFs.readAbsoluteFile.query).not.toHaveBeenCalled();
   });
 
   it("embeds image attachments as ACP image blocks", async () => {
@@ -156,12 +150,17 @@ describe("cloud-prompt", () => {
     ).rejects.toThrow(/Unsupported image/);
   });
 
-  it("throws when readAbsoluteFile returns null", async () => {
+  it("does not rely on readAbsoluteFile for txt attachments", async () => {
     mockFs.readAbsoluteFile.query.mockResolvedValue(null);
 
-    await expect(
-      buildCloudPromptBlocks('read <file path="/tmp/missing.txt" />'),
-    ).rejects.toThrow(/Unable to read/);
+    const blocks = await buildCloudPromptBlocks(
+      'read <file path="/tmp/maybe-missing-on-disk.txt" />',
+    );
+    expect(blocks[1]).toMatchObject({
+      type: "resource_link",
+      name: "maybe-missing-on-disk.txt",
+    });
+    expect(mockFs.readAbsoluteFile.query).not.toHaveBeenCalled();
   });
 
   it("throws when readFileAsBase64 returns falsy for images", async () => {
@@ -180,16 +179,13 @@ describe("cloud-prompt", () => {
     const serialized = serializeCloudPrompt([
       { type: "text", text: "read this" },
       {
-        type: "resource",
-        resource: {
-          uri: "attachment://test.txt",
-          text: "hello from file",
-          mimeType: "text/plain",
-        },
+        type: "resource_link",
+        uri: "file:///tmp/test.txt",
+        name: "test.txt",
       },
     ]);
 
     expect(serialized).toContain("__twig_cloud_prompt_v1__:");
-    expect(serialized).toContain('"type":"resource"');
+    expect(serialized).toContain('"type":"resource_link"');
   });
 });

--- a/apps/code/src/renderer/features/editor/utils/cloud-prompt.test.ts
+++ b/apps/code/src/renderer/features/editor/utils/cloud-prompt.test.ts
@@ -129,8 +129,9 @@ describe("cloud-prompt", () => {
   });
 
   it("encodes Windows UNC paths as file URIs", async () => {
+    // Actual UNC path: \\server\share\My Folder\file.txt
     const blocks = await buildCloudPromptBlocks(
-      'read <file path="\\\\\\\\server\\\\share\\\\My Folder\\\\file.txt" />',
+      'read <file path="\\\\server\\share\\My Folder\\file.txt" />',
     );
 
     const uris = resourceLinksFrom(blocks);
@@ -172,8 +173,6 @@ describe("cloud-prompt", () => {
   });
 
   it("does not rely on readAbsoluteFile for txt attachments", async () => {
-    mockFs.readAbsoluteFile.query.mockResolvedValue(null);
-
     const blocks = await buildCloudPromptBlocks(
       'read <file path="/tmp/maybe-missing-on-disk.txt" />',
     );

--- a/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
+++ b/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
@@ -1,9 +1,13 @@
-import { pathToFileURL } from "node:url";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import { CLOUD_PROMPT_PREFIX, serializeCloudPrompt } from "@posthog/shared";
 import { trpcClient } from "@renderer/trpc/client";
 import { getImageMimeType, isImageFile } from "@shared/constants/image";
-import { getFileExtension, getFileName, isAbsolutePath } from "@utils/path";
+import {
+  getFileExtension,
+  getFileName,
+  isAbsolutePath,
+  pathToFileUri,
+} from "@utils/path";
 import { unescapeXmlAttr } from "@utils/xml";
 
 const ABSOLUTE_FILE_TAG_REGEX = /<file\s+path="([^"]+)"\s*\/>/g;
@@ -80,10 +84,6 @@ function estimateBase64Bytes(base64: string): number {
   return Math.floor((base64.length * 3) / 4) - padding;
 }
 
-function pathToFileUri(filePath: string): string {
-  return pathToFileURL(filePath).href;
-}
-
 function collectAbsoluteFileTagPaths(prompt: string): string[] {
   const filePaths: string[] = [];
 
@@ -133,7 +133,15 @@ export function getAbsoluteAttachmentPaths(
     ...collectAbsoluteFileTagPaths(prompt),
     ...filePaths.filter(isAbsolutePath),
   ];
-  return unique(absolutePaths).filter((p) => !folderPaths.has(p));
+  const normalizedFolderPaths = new Set(
+    Array.from(folderPaths, (p) => p.replaceAll("\\", "/")),
+  );
+  const normalizedAbsolutePaths = absolutePaths.map((p) =>
+    p.replaceAll("\\", "/"),
+  );
+  return unique(normalizedAbsolutePaths).filter(
+    (p) => !normalizedFolderPaths.has(p),
+  );
 }
 
 export function buildCloudTaskDescription(

--- a/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
+++ b/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
@@ -3,7 +3,6 @@ import { CLOUD_PROMPT_PREFIX, serializeCloudPrompt } from "@posthog/shared";
 import { trpcClient } from "@renderer/trpc/client";
 import { getImageMimeType, isImageFile } from "@shared/constants/image";
 import { getFileExtension, getFileName, isAbsolutePath } from "@utils/path";
-import { makeAttachmentUri } from "@utils/promptContent";
 import { unescapeXmlAttr } from "@utils/xml";
 
 const ABSOLUTE_FILE_TAG_REGEX = /<file\s+path="([^"]+)"\s*\/>/g;
@@ -58,25 +57,13 @@ const TEXT_FILENAMES = new Set([
   "README.md",
 ]);
 const CLOUD_IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp"]);
-const TEXT_MIME_TYPES: Record<string, string> = {
-  json: "application/json",
-  md: "text/markdown",
-  svg: "image/svg+xml",
-  xml: "application/xml",
-};
 
-const MAX_EMBEDDED_TEXT_CHARS = 100_000;
 const MAX_EMBEDDED_IMAGE_BYTES = 5 * 1024 * 1024;
 
 function isTextAttachment(filePath: string): boolean {
   const fileName = getFileName(filePath);
   const ext = getFileExtension(filePath);
   return TEXT_FILENAMES.has(fileName) || TEXT_EXTENSIONS.has(ext);
-}
-
-function getTextMimeType(filePath: string): string {
-  const ext = getFileExtension(filePath);
-  return TEXT_MIME_TYPES[ext] ?? "text/plain";
 }
 
 export function isSupportedCloudImageAttachment(filePath: string): boolean {
@@ -92,12 +79,12 @@ function estimateBase64Bytes(base64: string): number {
   return Math.floor((base64.length * 3) / 4) - padding;
 }
 
-function truncateText(text: string): string {
-  if (text.length <= MAX_EMBEDDED_TEXT_CHARS) {
-    return text;
-  }
-
-  return `${text.slice(0, MAX_EMBEDDED_TEXT_CHARS)}\n\n[Attachment truncated to ${MAX_EMBEDDED_TEXT_CHARS.toLocaleString()} characters for this cloud prompt.]`;
+function pathToFileUri(filePath: string): string {
+  const encoded = filePath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `file://${encoded}`;
 }
 
 function collectAbsoluteFileTagPaths(prompt: string): string[] {
@@ -173,7 +160,7 @@ export function buildCloudTaskDescription(
 
 async function buildAttachmentBlock(filePath: string): Promise<ContentBlock> {
   const fileName = getFileName(filePath);
-  const uri = makeAttachmentUri(filePath);
+  const uri = pathToFileUri(filePath);
 
   if (isSupportedCloudImageAttachment(fileName)) {
     const base64 = await trpcClient.fs.readFileAsBase64.query({ filePath });
@@ -207,21 +194,15 @@ async function buildAttachmentBlock(filePath: string): Promise<ContentBlock> {
     );
   }
 
-  const text = await trpcClient.fs.readAbsoluteFile.query({ filePath });
-  if (text === null) {
-    throw new Error(`Unable to read attached file ${fileName}`);
-  }
-
+  // Path-only: workspace text via `resource_link`; images above still embed base64.
   return {
-    type: "resource",
-    resource: {
-      uri,
-      text: truncateText(text),
-      mimeType: getTextMimeType(fileName),
-    },
+    type: "resource_link",
+    uri,
+    name: fileName,
   };
 }
 
+/** Test/harness prompts: text → `resource_link` only (production cloud uses uploads + artifact_ids). */
 export async function buildCloudPromptBlocks(
   prompt: string,
   filePaths: string[] = [],

--- a/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
+++ b/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import { CLOUD_PROMPT_PREFIX, serializeCloudPrompt } from "@posthog/shared";
 import { trpcClient } from "@renderer/trpc/client";
@@ -80,11 +81,7 @@ function estimateBase64Bytes(base64: string): number {
 }
 
 function pathToFileUri(filePath: string): string {
-  const encoded = filePath
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-  return `file://${encoded}`;
+  return pathToFileURL(filePath).href;
 }
 
 function collectAbsoluteFileTagPaths(prompt: string): string[] {

--- a/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
+++ b/apps/code/src/renderer/features/editor/utils/cloud-prompt.ts
@@ -128,19 +128,15 @@ export function getAbsoluteAttachmentPaths(
   prompt: string,
   filePaths: string[] = [],
 ): string[] {
+  const normalize = (p: string) => p.replaceAll("\\", "/");
   const folderPaths = collectFolderTagPaths(prompt);
+  const normalizedFolderPaths = new Set(Array.from(folderPaths, normalize));
   const absolutePaths = [
     ...collectAbsoluteFileTagPaths(prompt),
     ...filePaths.filter(isAbsolutePath),
   ];
-  const normalizedFolderPaths = new Set(
-    Array.from(folderPaths, (p) => p.replaceAll("\\", "/")),
-  );
-  const normalizedAbsolutePaths = absolutePaths.map((p) =>
-    p.replaceAll("\\", "/"),
-  );
-  return unique(normalizedAbsolutePaths).filter(
-    (p) => !normalizedFolderPaths.has(p),
+  return unique(absolutePaths).filter(
+    (p) => !normalizedFolderPaths.has(normalize(p)),
   );
 }
 

--- a/apps/code/src/renderer/features/editor/utils/prompt-builder.ts
+++ b/apps/code/src/renderer/features/editor/utils/prompt-builder.ts
@@ -1,13 +1,5 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
-import { isAbsolutePath } from "@utils/path";
-
-function pathToFileUri(filePath: string): string {
-  const encoded = filePath
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-  return `file://${encoded}`;
-}
+import { isAbsolutePath, pathToFileUri } from "@utils/path";
 
 export async function buildPromptBlocks(
   textContent: string,

--- a/apps/code/src/renderer/features/sessions/utils/cloudArtifacts.ts
+++ b/apps/code/src/renderer/features/sessions/utils/cloudArtifacts.ts
@@ -10,7 +10,7 @@ import type {
   TaskArtifactUploadRequest,
 } from "@renderer/api/posthogClient";
 import { trpcClient } from "@renderer/trpc/client";
-import { getFileName } from "@utils/path";
+import { getFileName, pathToFileUri } from "@utils/path";
 import type { EditorContent } from "../../message-editor/utils/content";
 
 const FILE_URI_PREFIX = "file://";
@@ -63,14 +63,6 @@ interface LoadedCloudAttachment {
   filePath: string;
   bytes: Uint8Array<ArrayBuffer>;
   upload: TaskArtifactUploadRequest;
-}
-
-function pathToFileUri(filePath: string): string {
-  const encoded = filePath
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-  return `file://${encoded}`;
 }
 
 export interface CloudPromptTransport {

--- a/apps/code/src/renderer/utils/path.test.ts
+++ b/apps/code/src/renderer/utils/path.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { isAbsolutePath, pathToFileUri } from "./path";
+
+describe("isAbsolutePath", () => {
+  it.each([
+    ["/tmp/file.txt", true],
+    ["C:\\Users\\me\\file.txt", true],
+    ["C:/Users/me/file.txt", true],
+    ["d:\\downloads\\file.txt", true],
+    ["\\\\server\\share\\file.txt", true],
+    ["//server/share/file.txt", true],
+    ["relative/path.txt", false],
+    ["./file.txt", false],
+    ["../file.txt", false],
+    ["file.txt", false],
+    ["", false],
+  ])("isAbsolutePath(%j) === %s", (input, expected) => {
+    expect(isAbsolutePath(input)).toBe(expected);
+  });
+});
+
+describe("pathToFileUri", () => {
+  it("encodes a POSIX absolute path", () => {
+    expect(pathToFileUri("/tmp/test.txt")).toBe("file:///tmp/test.txt");
+  });
+
+  it("percent-encodes POSIX path segments with spaces and reserved chars", () => {
+    expect(pathToFileUri("/tmp/My Folder/a#b?.txt")).toBe(
+      "file:///tmp/My%20Folder/a%23b%3F.txt",
+    );
+  });
+
+  it("encodes a Windows drive path with single backslashes", () => {
+    expect(pathToFileUri("C:\\tmp\\file.txt")).toBe("file:///C:/tmp/file.txt");
+  });
+
+  it("encodes a Windows drive path that already uses forward slashes", () => {
+    expect(pathToFileUri("C:/tmp/file.txt")).toBe("file:///C:/tmp/file.txt");
+  });
+
+  it("uppercases the drive letter", () => {
+    expect(pathToFileUri("c:\\tmp\\file.txt")).toBe("file:///C:/tmp/file.txt");
+  });
+
+  it("percent-encodes Windows drive path segments with special chars", () => {
+    expect(pathToFileUri("C:\\tmp\\100%\\a#b?.txt")).toBe(
+      "file:///C:/tmp/100%25/a%23b%3F.txt",
+    );
+  });
+
+  it("encodes a UNC path with the host as the URI authority", () => {
+    expect(pathToFileUri("\\\\server\\share\\My Folder\\file.txt")).toBe(
+      "file://server/share/My%20Folder/file.txt",
+    );
+  });
+
+  it("encodes a UNC path already normalized to forward slashes", () => {
+    expect(pathToFileUri("//server/share/file.txt")).toBe(
+      "file://server/share/file.txt",
+    );
+  });
+
+  it("returns existing file:// URIs unchanged", () => {
+    const uri = "file:///tmp/file.txt";
+    expect(pathToFileUri(uri)).toBe(uri);
+  });
+
+  it("round-trips literal percent signs via re-encoding", () => {
+    // Already-encoded segments are re-encoded so the original characters round-trip
+    // through decodeURIComponent.
+    expect(pathToFileUri("/tmp/100%25")).toBe("file:///tmp/100%2525");
+  });
+});

--- a/apps/code/src/renderer/utils/path.ts
+++ b/apps/code/src/renderer/utils/path.ts
@@ -3,7 +3,15 @@
  * Handles both Unix (/path) and Windows (C:\path) formats.
  */
 export function isAbsolutePath(filePath: string): boolean {
-  return filePath.startsWith("/") || /^[a-zA-Z]:/.test(filePath);
+  return (
+    filePath.startsWith("/") ||
+    // Windows drive, e.g. C:\path or C:/path
+    /^[a-zA-Z]:/.test(filePath) ||
+    // Windows UNC, e.g. \\server\share\path
+    filePath.startsWith("\\\\") ||
+    // UNC normalized to forward slashes, e.g. //server/share/path
+    filePath.startsWith("//")
+  );
 }
 
 /**
@@ -45,4 +53,49 @@ export function getFileExtension(filePath: string): string {
   const name = getFileName(filePath);
   const lastDot = name.lastIndexOf(".");
   return lastDot >= 0 ? name.slice(lastDot + 1).toLowerCase() : "";
+}
+
+/**
+ * Convert a local file path to a `file://` URI.
+ * Renderer-safe (no `node:*` imports) and supports Windows drive and UNC paths.
+ */
+export function pathToFileUri(filePath: string): string {
+  if (filePath.startsWith("file://")) {
+    return filePath;
+  }
+
+  // Normalize Windows separators for string processing.
+  const normalized = filePath.replaceAll("\\", "/");
+
+  // UNC path: \\server\share\dir\file.txt → file://server/share/dir/file.txt
+  if (normalized.startsWith("//")) {
+    const withoutPrefix = normalized.slice(2);
+    const parts = withoutPrefix.split("/").filter(Boolean);
+    const host = parts.shift() ?? "";
+    const encodedPath = parts.map(encodeURIComponent).join("/");
+    return `file://${host}/${encodedPath}`;
+  }
+
+  // Drive path: C:\dir\file.txt or C:/dir/file.txt → file:///C:/dir/file.txt
+  const drive = normalized.match(/^([A-Za-z]):\/(.*)$/);
+  if (drive) {
+    const letter = drive[1].toUpperCase();
+    const rest = drive[2];
+    const encoded = rest
+      .split("/")
+      .filter((segment) => segment.length > 0)
+      .map(encodeURIComponent)
+      .join("/");
+    return `file:///${letter}:/${encoded}`;
+  }
+
+  // POSIX absolute path: /tmp/test.txt → file:///tmp/test.txt
+  if (normalized.startsWith("/")) {
+    const encoded = normalized.split("/").map(encodeURIComponent).join("/");
+    return `file://${encoded}`;
+  }
+
+  // Fallback.
+  const encoded = normalized.split("/").map(encodeURIComponent).join("/");
+  return `file://${encoded}`;
 }

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
@@ -1,8 +1,33 @@
+import type { PromptRequest } from "@agentclientprotocol/sdk";
 import { describe, expect, it } from "vitest";
-import { promptToClaude } from "./acp-to-sdk";
+import {
+  promptToClaude,
+  readToolGuidanceForPath,
+  workspacePromptFromFileUri,
+} from "./acp-to-sdk";
+
+describe("readToolGuidanceForPath", () => {
+  it("guides PDF reads with optional pages ranges", () => {
+    expect(readToolGuidanceForPath("/docs/x.pdf")).toContain("pages");
+  });
+
+  it("guides arbitrary text extensions with offset and limit", () => {
+    const g = readToolGuidanceForPath("/proj/app.ts");
+    expect(g).toContain("offset");
+    expect(g).toContain("limit");
+  });
+});
+
+describe("workspacePromptFromFileUri", () => {
+  it("includes file_path and Read-oriented chunking hints", () => {
+    const s = workspacePromptFromFileUri("file:///tmp/x.pdf");
+    expect(s).toContain("Read");
+    expect(s).toContain("file_path: /tmp/x.pdf");
+  });
+});
 
 describe("promptToClaude", () => {
-  it("renders file resource links as explicit workspace attachments", () => {
+  it("maps file resource_link to workspace path + Read guidance", () => {
     const result = promptToClaude({
       sessionId: "session-1",
       prompt: [
@@ -14,17 +39,87 @@ describe("promptToClaude", () => {
       ],
     });
 
-    expect(result.message.content).toEqual([
-      {
-        type: "text",
-        text: [
-          "Attached file available in the workspace:",
-          "- name: report.pdf",
-          "- path: /tmp/workspace/.posthog/attachments/run-1/report.pdf",
-          "Use the available tools to inspect this file if needed.",
-        ].join("\n"),
-      },
-    ]);
+    expect(result.message.content.length).toBe(1);
+    expect(result.message.content[0]).toMatchObject({
+      type: "text",
+      text: expect.any(String),
+    });
+    expect(
+      (result.message.content[0] as { type: string; text: string }).text,
+    ).toContain("file_path:");
+    expect(
+      (result.message.content[0] as { type: string; text: string }).text,
+    ).toContain("/tmp/workspace/.posthog/attachments/run-1/report.pdf");
+    const text = (result.message.content[0] as { text: string }).text;
+    expect(text.toLowerCase()).toContain("read");
+    expect(text).toContain("pages");
+  });
+
+  it("drops embedded body for file:// resource but keeps attachment:// payload", () => {
+    const hugeInline = `${"y".repeat(30_000)}KEEP_ATTACH${"y".repeat(30_000)}`;
+    const fileRes = promptToClaude({
+      sessionId: "x",
+      prompt: [
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///tmp/note.txt",
+            text: `${"x".repeat(50_000)}DROP_THIS${"x".repeat(50_000)}`,
+            mimeType: "text/plain",
+          },
+        },
+      ],
+    });
+    expect(fileRes.message.content.length).toBe(1);
+    expect(JSON.stringify(fileRes)).not.toContain("DROP_THIS");
+    expect(fileRes.message.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("file_path: /tmp/note.txt"),
+    });
+
+    const attachRes = promptToClaude({
+      sessionId: "y",
+      prompt: [
+        {
+          type: "resource",
+          resource: {
+            uri: "attachment://z?label=f.txt",
+            text: hugeInline,
+            mimeType: "text/plain",
+          },
+        },
+      ],
+    });
+    expect(attachRes.message.content.length).toBe(2);
+    expect(JSON.stringify(attachRes)).toContain("KEEP_ATTACH");
+  });
+
+  it("maps file URI-only image blocks to workspace Read prompt text", () => {
+    const req: PromptRequest = {
+      sessionId: "session-1",
+      prompt: [
+        {
+          type: "image",
+          uri: "file:///tmp/ui/screenshot.png",
+          mimeType: "image/png",
+        } as PromptRequest["prompt"][number],
+      ],
+    };
+    const result = promptToClaude(req);
+
+    expect(result.message.content).toHaveLength(1);
+    expect(result.message.content[0]).toMatchObject({
+      type: "text",
+      text: expect.any(String),
+    });
+    expect(
+      (result.message.content[0] as { type: string; text: string }).text,
+    ).toContain("/tmp/ui/screenshot.png");
+    expect(
+      (
+        result.message.content[0] as { type: string; text: string }
+      ).text.toLowerCase(),
+    ).toContain("read");
   });
 
   it("preserves non-file resource links as links", () => {

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
@@ -7,14 +7,15 @@ import {
 } from "./acp-to-sdk";
 
 describe("readToolGuidanceForPath", () => {
-  it("guides PDF reads with optional pages ranges", () => {
-    expect(readToolGuidanceForPath("/docs/x.pdf")).toContain("pages");
-  });
-
-  it("guides arbitrary text extensions with offset and limit", () => {
-    const g = readToolGuidanceForPath("/proj/app.ts");
-    expect(g).toContain("offset");
-    expect(g).toContain("limit");
+  it.each([
+    ["/docs/x.pdf", ["pages"]],
+    ["/proj/app.ts", ["offset", "limit"]],
+    ["/assets/logo.png", ["Binary", "file_path"]],
+  ])("guides reads for %s", (filePath, keywords) => {
+    const guidance = readToolGuidanceForPath(filePath);
+    for (const keyword of keywords) {
+      expect(guidance).toContain(keyword);
+    }
   });
 });
 

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
@@ -6,6 +6,31 @@ import type { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 
 type ImageMimeType = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
 
+const PDF_EXTENSIONS = new Set(["pdf"]);
+
+const COMMON_IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "bmp",
+  "svg",
+  "heic",
+  "tif",
+  "tiff",
+]);
+
+const VIDEO_EXTENSIONS = new Set([
+  "mp4",
+  "mov",
+  "webm",
+  "mkv",
+  "avi",
+  "mpeg",
+  "mpg",
+]);
+
 function sdkText(value: string): ContentBlockParam {
   return { type: "text", text: value };
 }
@@ -22,19 +47,44 @@ function formatUriAsLink(uri: string): string {
   }
 }
 
-function formatFileAttachment(uri: string): string {
+/** Chunking hints for Claude Code `Read` (`file_path`, optional `pages` / `offset` / `limit`). */
+export function readToolGuidanceForPath(filePath: string): string {
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  if (PDF_EXTENSIONS.has(ext)) {
+    return 'Optional `pages` string (e.g. "1-5") per Read call instead of loading the entire PDF.';
+  }
+  if (COMMON_IMAGE_EXTENSIONS.has(ext) || VIDEO_EXTENSIONS.has(ext)) {
+    return "Binary file — use Read with `file_path`; prefer bounded reads where supported.";
+  }
+  return "Large text — use multiple Read calls with optional `offset` and `limit`.";
+}
+
+/** Path-only workspace attach text (never embed `resource.text` from disk). */
+export function workspacePromptFromFileUri(uri: string): string {
   try {
     const filePath = fileURLToPath(uri);
     const name = path.basename(filePath) || filePath;
     return [
-      "Attached file available in the workspace:",
-      `- name: ${name}`,
-      `- path: ${filePath}`,
-      "Use the available tools to inspect this file if needed.",
+      "Attached workspace file — use Read with required `file_path`:",
+      `- file_path: ${filePath}`,
+      `- name (context): ${name}`,
+      readToolGuidanceForPath(filePath),
     ].join("\n");
   } catch {
-    return `Attached file available at ${uri}`;
+    return [
+      "Attached file — decode path from URI, call Read with that path as `file_path`:",
+      uri,
+      'Chunk PDFs with `pages` (e.g. "1-5"); long text with `offset`/`limit`.',
+    ].join("\n");
   }
+}
+
+function formatFileAttachment(uri: string): string {
+  return workspacePromptFromFileUri(uri);
+}
+
+function isFileSchemeUri(uri: string | undefined | null): boolean {
+  return Boolean(uri?.startsWith("file://"));
 }
 
 function transformMcpCommand(text: string): string {
@@ -68,10 +118,16 @@ function processPromptChunk(
 
     case "resource":
       if ("text" in chunk.resource) {
-        content.push(sdkText(formatUriAsLink(chunk.resource.uri)));
+        const uri = chunk.resource.uri;
+        if (uri != null && isFileSchemeUri(uri)) {
+          content.push(sdkText(workspacePromptFromFileUri(uri)));
+          break;
+        }
+
+        content.push(sdkText(formatUriAsLink(uri ?? "")));
         context.push(
           sdkText(
-            `\n<context ref="${chunk.resource.uri}">\n${chunk.resource.text}\n</context>`,
+            `\n<context ref="${uri ?? ""}">\n${chunk.resource.text}\n</context>`,
           ),
         );
       }
@@ -92,6 +148,8 @@ function processPromptChunk(
           type: "image",
           source: { type: "url", url: chunk.uri },
         });
+      } else if (chunk.uri != null && isFileSchemeUri(chunk.uri)) {
+        content.push(sdkText(workspacePromptFromFileUri(chunk.uri)));
       }
       break;
 

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
@@ -79,10 +79,6 @@ export function workspacePromptFromFileUri(uri: string): string {
   }
 }
 
-function formatFileAttachment(uri: string): string {
-  return workspacePromptFromFileUri(uri);
-}
-
 function isFileSchemeUri(uri: string | undefined | null): boolean {
   return Boolean(uri?.startsWith("file://"));
 }
@@ -110,7 +106,7 @@ function processPromptChunk(
       content.push(
         sdkText(
           chunk.uri.startsWith("file://")
-            ? formatFileAttachment(chunk.uri)
+            ? workspacePromptFromFileUri(chunk.uri)
             : formatUriAsLink(chunk.uri),
         ),
       );


### PR DESCRIPTION
Fixes: #2048 

## Problem

Sometimes the prompt path was putting **whole file bodies into the user message payload** instead of only referencing paths:

- When an ACP **`resource`** chunk used a **`file://`** URI, our conversion logic was taking **`resource.text`** and embedding it as a `<context>...</context>` block in the Claude Agent SDK user message. That meant a large (or mistakenly huge) attachment could blow the **serialized HTTP request size** before the agent could even behave “normally.”
- The **`buildCloudPromptBlocks`** test/harness helper was also **reading text off disk** and emitting **`resource`** blobs with inlined (truncated) content — structurally the same problem, and inconsistent with how production cloud flow stays path/artifact-centric.

This is independent of **`READ_TOOLS` / permission labels** in our agent package: those only classify tool names like **`Read`** ([Claude Code tools reference — **`Read`](https://code.claude.com/docs/en/tools-reference)). They don’t fetch files; the model invokes **`Read`** at runtime.

Anthropic’s **Request too large** doc explains pressure from big payloads and recommends patterns like chunked reads and PDF **`pages`** rather than dumping everything into one turn ([Request too large](https://code.claude.com/docs/en/errors#request-too-large)).

Closes: #2048 

## Changes

1. **`promptToClaude` (`acp-to-sdk.ts`)**  
   For **`file://`** on **`resource_link`** and **`resource`**, I only emit short **path-first** copy that aligns with Claude Code’s **`Read`** **`FileReadInput`**: **`file_path`**, optional **`offset`** / **`limit`** for large text, and optional **`pages`** (string ranges, e.g. `"1-5"`) for PDFs ([Agent SDK TypeScript — **Read**](https://code.claude.com/docs/en/agent-sdk/typescript#read)).  
   For **`resource` + `file://`**, I **stop forwarding `resource.text`** into `<context>` so workspace files can’t be inlined that way anymore.

2. **`file://` `image` blocks without base64 `data`**  
   I map those to the same **path + Read** style text instead of dropping them or silently doing nothing useful.

3. **Non filesystem schemes**  
   Where we still rely on inlined payloads for tests/other flows (e.g. **`attachment://`**), I keep **link + `<context>`** behavior so those cases don’t regress.

4. **`buildCloudPromptBlocks` (harness)**  
   Text attaches become **`resource_link`** with **`file://`** URIs (same idea as production **`cloudPromptToBlocks`**), **without** **`readAbsoluteFile`** for TXT. Images in that harness stay **embedded `image`** (separate topic from `resource`). Production cloud stays **uploads + `artifact_ids`**.

5. **Tests**  
   I added/updated Vitest coverage so **`file://` + huge `resource.text`** never appears in the SDK message, **`attachment://`** inline behavior still works, and the cloud harness emits **`resource_link`** for text.


## How did you test this?

- `pnpm test`
- `pnpm --filter @posthog/agent test`
- `pnpm --filter code test`
- `pnpm --filter @posthog/git test`
