### PR TITLE
feat(mcp): show PostHog exec payload in permission dialog

### DIFF
--- a/apps/code/src/renderer/components/permissions/McpPermission.tsx
+++ b/apps/code/src/renderer/components/permissions/McpPermission.tsx
@@ -1,9 +1,10 @@
 import { ActionSelector } from "@components/ActionSelector";
 import { parseMcpToolKey } from "@features/mcp-apps/utils/mcp-app-host-utils";
 import {
+  formatPosthogExecBody,
   getPostHogExecDisplay,
   isPostHogExecTool,
-} from "@features/mcp-apps/utils/posthog-exec-display";
+} from "@features/posthog-mcp/utils/posthog-exec-display";
 import { formatInput } from "@features/sessions/components/session-update/toolCallUtils";
 import { Box, Code } from "@radix-ui/themes";
 import { DefaultPermission } from "./DefaultPermission";
@@ -37,7 +38,9 @@ export function McpPermission({
     : null;
   const serverName = posthogDisplay ? "posthog" : defaultServerName;
   const toolName = posthogDisplay?.label ?? defaultToolName;
-  const fullInput = formatInput(toolCall.rawInput);
+  const fullInput = posthogDisplay
+    ? formatPosthogExecBody(posthogDisplay.input)
+    : formatInput(toolCall.rawInput);
 
   return (
     <ActionSelector

--- a/apps/code/src/renderer/components/permissions/PermissionSelector.stories.tsx
+++ b/apps/code/src/renderer/components/permissions/PermissionSelector.stories.tsx
@@ -501,6 +501,39 @@ export const McpPostHogExec: Story = {
   },
 };
 
+const posthogExecInfoInput = { command: "info execute-sql" };
+export const McpPostHogExecInfo: Story = {
+  args: {
+    toolCall: buildMcpToolCallData("mcp__posthog__exec", posthogExecInfoInput),
+    options: buildPermissionOptions("mcp__posthog__exec", posthogExecInfoInput),
+  },
+};
+
+const posthogExecToolsInput = { command: "tools" };
+export const McpPostHogExecTools: Story = {
+  args: {
+    toolCall: buildMcpToolCallData("mcp__posthog__exec", posthogExecToolsInput),
+    options: buildPermissionOptions(
+      "mcp__posthog__exec",
+      posthogExecToolsInput,
+    ),
+  },
+};
+
+const posthogExecSearchInput = { command: "search query-" };
+export const McpPostHogExecSearch: Story = {
+  args: {
+    toolCall: buildMcpToolCallData(
+      "mcp__posthog__exec",
+      posthogExecSearchInput,
+    ),
+    options: buildPermissionOptions(
+      "mcp__posthog__exec",
+      posthogExecSearchInput,
+    ),
+  },
+};
+
 const githubIssueInput = {
   owner: "PostHog",
   repo: "posthog",

--- a/apps/code/src/renderer/features/mcp-apps/components/McpToolView.tsx
+++ b/apps/code/src/renderer/features/mcp-apps/components/McpToolView.tsx
@@ -1,4 +1,8 @@
 import {
+  getPostHogExecDisplay,
+  isPostHogExecTool,
+} from "@features/posthog-mcp/utils/posthog-exec-display";
+import {
   compactInput,
   ExpandableIcon,
   ExpandedContentBox,
@@ -15,10 +19,6 @@ import { Plugs } from "@phosphor-icons/react";
 import { Box, Flex } from "@radix-ui/themes";
 import { useState } from "react";
 import { parseMcpToolKey } from "../utils/mcp-app-host-utils";
-import {
-  getPostHogExecDisplay,
-  isPostHogExecTool,
-} from "../utils/posthog-exec-display";
 
 const POSTHOG_EXEC_INPUT_PREVIEW_MAX_LENGTH = 60;
 

--- a/apps/code/src/renderer/features/posthog-mcp/utils/posthog-exec-display.test.ts
+++ b/apps/code/src/renderer/features/posthog-mcp/utils/posthog-exec-display.test.ts
@@ -212,7 +212,7 @@ describe("formatPosthogExecBody", () => {
   });
 
   it("pretty-prints JSON array payloads", () => {
-    expect(formatPosthogExecBody('[1,2]')).toBe("[\n  1,\n  2\n]");
+    expect(formatPosthogExecBody("[1,2]")).toBe("[\n  1,\n  2\n]");
   });
 
   it("returns non-JSON strings unchanged (e.g. search regex)", () => {

--- a/apps/code/src/renderer/features/posthog-mcp/utils/posthog-exec-display.test.ts
+++ b/apps/code/src/renderer/features/posthog-mcp/utils/posthog-exec-display.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatPosthogExecBody,
   getPostHogExecDisplay,
   isPostHogExecTool,
 } from "./posthog-exec-display";
@@ -197,5 +198,33 @@ describe("getPostHogExecDisplay", () => {
         getPostHogExecDisplay({ command: "  call execute-sql  " }),
       ).toEqual({ label: "execute-sql", input: undefined });
     });
+  });
+});
+
+describe("formatPosthogExecBody", () => {
+  it("returns undefined for empty input", () => {
+    expect(formatPosthogExecBody(undefined)).toBeUndefined();
+    expect(formatPosthogExecBody("")).toBeUndefined();
+  });
+
+  it("pretty-prints JSON object payloads", () => {
+    expect(formatPosthogExecBody('{"id":3}')).toBe('{\n  "id": 3\n}');
+  });
+
+  it("pretty-prints JSON array payloads", () => {
+    expect(formatPosthogExecBody('[1,2]')).toBe("[\n  1,\n  2\n]");
+  });
+
+  it("returns non-JSON strings unchanged (e.g. search regex)", () => {
+    expect(formatPosthogExecBody("query-")).toBe("query-");
+  });
+
+  it("returns malformed JSON unchanged", () => {
+    expect(formatPosthogExecBody('{"id":')).toBe('{"id":');
+  });
+
+  it("returns JSON primitives unchanged (not pretty-printable)", () => {
+    expect(formatPosthogExecBody("42")).toBe("42");
+    expect(formatPosthogExecBody('"hello"')).toBe('"hello"');
   });
 });

--- a/apps/code/src/renderer/features/posthog-mcp/utils/posthog-exec-display.ts
+++ b/apps/code/src/renderer/features/posthog-mcp/utils/posthog-exec-display.ts
@@ -108,3 +108,23 @@ function readExplicitInput(value: unknown): string | undefined {
     return undefined;
   }
 }
+
+/**
+ * Pretty-prints the unwrapped exec args for display in the permission dialog
+ * body — JSON payloads (the `call` case) render multi-line; non-JSON args
+ * (e.g. a `search` regex) pass through unchanged.
+ */
+export function formatPosthogExecBody(
+  input: string | undefined,
+): string | undefined {
+  if (!input) return undefined;
+  try {
+    const parsed = JSON.parse(input);
+    if (parsed && typeof parsed === "object") {
+      return JSON.stringify(parsed, null, 2);
+    }
+  } catch {
+    // not JSON — fall through and show raw
+  }
+  return input;
+}

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -237,6 +237,7 @@ describe("canUseTool MCP approval enforcement", () => {
       expect.objectContaining({
         toolCall: expect.objectContaining({
           title: "The agent wants to run `notebooks-destroy` on PostHog",
+          _meta: { claudeCode: { toolName: "mcp__posthog__exec" } },
         }),
       }),
     );

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -528,6 +528,7 @@ async function handlePostHogExecApprovalFlow(
         },
       ],
       rawInput: { ...(toolInput as Record<string, unknown>), toolName },
+      _meta: { claudeCode: { toolName } },
     },
   });
 


### PR DESCRIPTION
## Problem

Beautify the formatting of PostHog MCP tools.

<img width="762" height="361" alt="Screenshot 2026-05-07 at 09 32 30" src="https://github.com/user-attachments/assets/bd18a114-6165-4796-bf5a-7dc75439946f" />


## Changes

- Agent: set `_meta.claudeCode.toolName` on the `requestPermission` toolCall in `handlePostHogExecApprovalFlow` so the renderer routes the dialog to `McpPermission`.
- Renderer: in `McpPermission`, format the body via a new `formatPosthogExecBody` helper that pretty-prints JSON `call` payloads (and passes other args — e.g. `search` regex — through unchanged); verbs without args (`tools`/`info`/`schema`) render no body since the title already conveys the action.
- Move the PostHog-specific exec-display helpers out of the generic `mcp-apps` feature into a new `posthog-mcp` feature.
- Storybook fixtures for `info` / `tools` / `search` verbs alongside the existing `call` story.

## How did you test this code?

- 14 agent permission-handler tests + 28 renderer posthog-exec-display tests pass (including a new assertion that `_meta.claudeCode.toolName` is set in the destructive PostHog flow, and new tests for `formatPosthogExecBody`).
- Storybook: `Permissions/PermissionSelector → McpPostHogExec` shows pretty-printed `{ "query": "select 1" }` body; sibling stories (`McpPostHogExecInfo`/`Tools`/`Search`) show no body or the regex.

## Publish to changelog?

no