### PR TITLE
fix: default cloud tasks to personal github auth

### DIFF
--- a/apps/code/src/renderer/sagas/task/task-creation.test.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.test.ts
@@ -152,7 +152,7 @@ describe("TaskCreationSaga", () => {
       model: "gpt-5.4",
       reasoningLevel: "high",
       sandboxEnvironmentId: undefined,
-      prAuthorshipMode: "bot",
+      prAuthorshipMode: "user",
       runSource: "manual",
       signalReportId: undefined,
       initialPermissionMode: "auto",
@@ -259,7 +259,7 @@ describe("TaskCreationSaga", () => {
       model: "gpt-5.4",
       reasoningLevel: "medium",
       sandboxEnvironmentId: undefined,
-      prAuthorshipMode: "bot",
+      prAuthorshipMode: "user",
       runSource: "manual",
       signalReportId: undefined,
       initialPermissionMode: "auto",
@@ -322,6 +322,55 @@ describe("TaskCreationSaga", () => {
       expect.objectContaining({
         prAuthorshipMode: "user",
         runSource: "manual",
+      }),
+    );
+  });
+
+  it("uses user authorship for signal report cloud task creation", async () => {
+    const createdTask = createTask({ origin_product: "signal_report" });
+    const startedTask = createTask({
+      origin_product: "signal_report",
+      latest_run: createRun(),
+    });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: createTaskRunMock,
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: vi.fn(),
+      } as never,
+    });
+
+    const result = await saga.run({
+      content: "Ship the report",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+      cloudRunSource: "signal_report",
+      signalReportId: "report-123",
+      githubIntegrationId: 123,
+    });
+
+    expect(result.success).toBe(true);
+    expect(createTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        github_integration: 123,
+        github_user_integration: undefined,
+        origin_product: "signal_report",
+      }),
+    );
+    expect(createTaskRunMock).toHaveBeenCalledWith(
+      "task-123",
+      expect.objectContaining({
+        prAuthorshipMode: "user",
+        runSource: "signal_report",
       }),
     );
   });

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -233,11 +233,7 @@ export class TaskCreationSaga extends Saga<
       task = await this.step({
         name: "cloud_run",
         execute: async () => {
-          const hasUserGitHubIntegration =
-            !!input.githubUserIntegrationId || !!task.github_user_integration;
-          const prAuthorshipMode =
-            input.cloudPrAuthorshipMode ??
-            (hasUserGitHubIntegration ? "user" : "bot");
+          const prAuthorshipMode = input.cloudPrAuthorshipMode ?? "user";
 
           const transport =
             (input.content || input.filePaths?.length) &&


### PR DESCRIPTION
## Problem

Manual cloud task creation could default to bot-authored GitHub writes when the client did not resolve a selected repository to a personal GitHub integration. That made cloud runs depend on the project-level GitHub installation even when the user had linked a personal installation for the repository.