### PR TITLE
fix(code): truncate footer text to avoid weird wrapping

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/SessionFooter.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionFooter.tsx
@@ -33,7 +33,7 @@ export function SessionFooter({
   usage,
 }: SessionFooterProps) {
   const rightSide = (
-    <Flex align="center" gap="3">
+    <Flex align="center" gap="3" className="shrink-0">
       {task && <DiffStatsChip task={task} />}
       <ContextUsageIndicator usage={usage ?? null} />
     </Flex>
@@ -46,11 +46,13 @@ export function SessionFooter({
             <Flex
               align="center"
               gap="2"
-              className="select-none select-none text-gray-10"
+              className="min-w-0 select-none select-none text-gray-10"
               style={{ WebkitUserSelect: "none" }}
             >
-              <Pause size={14} weight="fill" />
-              <Text className="text-[13px]">Awaiting permission...</Text>
+              <Pause size={14} weight="fill" className="shrink-0" />
+              <Text className="truncate text-[13px]">
+                Awaiting permission...
+              </Text>
             </Flex>
             {rightSide}
           </Flex>
@@ -61,13 +63,13 @@ export function SessionFooter({
     return (
       <Box className="pt-3 pb-1">
         <Flex align="center" justify="between" gap="2">
-          <Flex align="center" gap="2">
+          <Flex align="center" gap="2" className="min-w-0">
             <GeneratingIndicator
               startedAt={promptStartedAt}
               pausedDurationMs={pausedDurationMs}
             />
             {queuedCount > 0 && (
-              <Text color="gray" className="text-[13px]">
+              <Text color="gray" className="truncate text-[13px]">
                 ({queuedCount} queued)
               </Text>
             )}
@@ -90,12 +92,16 @@ export function SessionFooter({
     <Box className="pb-1">
       <Flex align="center" justify="between" gap="2">
         {showDuration && (
-          <Flex align="center" gap="2" className="select-none text-gray-10">
-            <Brain size={12} />
+          <Flex
+            align="center"
+            gap="2"
+            className="min-w-0 select-none text-gray-10"
+          >
+            <Brain size={12} className="shrink-0" />
             <Text
               color="gray"
               style={{ fontVariantNumeric: "tabular-nums" }}
-              className="text-[13px]"
+              className="truncate text-[13px]"
             >
               Generated in {formatDuration(lastGenerationDuration)}
             </Text>


### PR DESCRIPTION
## Problem

sometimes on smaller screens, and/or when a side column is opened, the msg footer bar wraps weird

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## ![Screenshot 2026-05-07 at 2.48.26 PM.png](https://app.graphite.com/user-attachments/assets/e54ddc08-4301-4400-a061-27ef551db81c.png)

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

no