### PR TITLE
fix(cloud-task): drop unsafe append in log-gap inconsistency path

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -1527,7 +1527,7 @@ describe("SessionService", () => {
       expect(mockSessionStoreSetters.appendEvents).not.toHaveBeenCalled();
     });
 
-    it("processes a pending cloud log gap after active reconciliation finishes", async () => {
+    it("queues a pending cloud log gap when stale fetches can't fill it, without appending", async () => {
       const service = getSessionService();
       let sessionState = createMockSession({
         taskRunId: "run-123",
@@ -1628,38 +1628,18 @@ describe("SessionService", () => {
       });
       resolveFirstLocalLogs("");
 
+      // The pending request must drain after the in-flight one resolves —
+      // verify the second readLocalLogs call eventually happens.
       await vi.waitFor(() => {
-        expect(mockSessionStoreSetters.appendEvents).toHaveBeenCalledTimes(2);
+        expect(mockTrpcLogs.readLocalLogs.query).toHaveBeenCalledTimes(2);
       });
-      expect(mockSessionStoreSetters.appendEvents).toHaveBeenNthCalledWith(
-        1,
-        "run-123",
-        [
-          expect.objectContaining({
-            message: expect.objectContaining({
-              params: { entry: firstEntry },
-            }),
-          }),
-        ],
-        6,
-      );
-      expect(mockSessionStoreSetters.appendEvents).toHaveBeenNthCalledWith(
-        2,
-        "run-123",
-        [
-          expect.objectContaining({
-            message: expect.objectContaining({
-              params: { entry: secondEntry },
-            }),
-          }),
-          expect.objectContaining({
-            message: expect.objectContaining({
-              params: { entry: thirdEntry },
-            }),
-          }),
-        ],
-        8,
-      );
+      // Stale fetches can't fill the gap; we must NOT append the snapshot's
+      // tail slice (positions [expectedCount-N, expectedCount]) on top of an
+      // events array that's still at processedLineCount=5 — that path used
+      // to corrupt the array with duplicates/gaps and ratchet
+      // processedLineCount past entries we don't actually have, leading to
+      // unbounded growth on long-running cloud runs.
+      expect(mockSessionStoreSetters.appendEvents).not.toHaveBeenCalled();
     });
     it("flips status to connected on _posthog/run_started", async () => {
       const service = getSessionService();

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -3569,6 +3569,7 @@ export class SessionService {
       taskRunId,
       currentCount,
       expectedCount,
+      fetchedCount: rawEntries.length,
       entriesReceived: newEntries.length,
     });
   }

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -3560,23 +3560,17 @@ export class SessionService {
       return;
     }
 
+    // The fetched logs lag behind expectedCount and `newEntries` is the latest
+    // tail slice of the snapshot — appending it here would create duplicates
+    // and gaps in `session.events` (and bump processedLineCount past entries
+    // we don't actually have). Skip; the next snapshot/log update will retry
+    // once the source has caught up.
     log.warn("Cloud task log count inconsistency", {
       taskRunId,
       currentCount,
       expectedCount,
       entriesReceived: newEntries.length,
     });
-    let newEvents = convertStoredEntriesToEvents(newEntries);
-    newEvents = this.filterSkippedPromptEvents(taskRunId, session, newEvents);
-    if (hasSessionPromptEvent(newEvents)) {
-      sessionStoreSetters.clearTailOptimisticItems(taskRunId);
-    }
-    sessionStoreSetters.appendEvents(
-      taskRunId,
-      newEvents,
-      latestCount + newEntries.length,
-    );
-    this.updatePromptStateFromEvents(taskRunId, newEvents);
   }
 
   private createBaseSession(


### PR DESCRIPTION
## Summary

Fixes a renderer OOM crash loop on long-running cloud tasks. Observed: 16 V8 OOM renderer crashes between 06:12 and 06:34 on 2026-05-08 against task `aab06c8f-…` (run accumulated 11k+ log entries).

`reconcileCloudLogGapOnce` had a fallback that appended `update.newEntries` on top of `session.events` whenever local + S3 fetches couldn't catch up to `expectedCount`. But `newEntries` is the snapshot's tail slice (positions `[expectedCount-N, expectedCount]`) — it's not contiguous with the renderer's `processedLineCount`. So each invocation:

- pushed unaligned events onto `session.events` (duplicates **and** gaps)
- bumped `processedLineCount = latestCount + newEntries.length` past entries we never actually had

With cloud-task watchers reconnecting every ~2 min on `error: 'terminated'`, this stacked indefinitely until V8 OOM'd the renderer.

The fix: when the fetched logs lag behind `expectedCount`, log the existing `Cloud task log count inconsistency` warning and return. The next snapshot or `logs` update retries once the source has caught up. The success branch (S3/local catches up to `expectedCount`) is unchanged.

## Test plan

- [x] `pnpm --filter code typecheck`
- [x] `pnpm exec vitest run src/renderer/features/sessions/service/service.test.ts` — all 80 tests pass
- [x] Updated `processes a pending cloud log gap…` test to assert the corrected behavior: queue still drains (verified via second `readLocalLogs` call) but no append happens when fetches stay stale
- [ ] Manually exercise a long-running cloud task with intermittent stream `terminated` errors and confirm the renderer no longer OOMs

## Notes

Two other related leaks remain (out of scope here, deferred):
1. `emittedLogEntries` in `apps/code/src/main/services/cloud-task/service.ts` grows unbounded on single-subscriber runs (only pruned in `emitCurrentSnapshot`, which only fires for 2nd+ subscribers).
2. `emitCurrentSnapshot` ships the full historical log (`newEntries: snapshotEntries`) to every newly-attached renderer subscriber — for an 11k-entry run that's a multi-MB IPC payload per re-attach.

Both are worth a follow-up. This PR is the conservative hotfix.