### PR TITLE
feat(onboarding): auto-enable PostHog internal signal sources

### DIFF
--- a/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
@@ -62,6 +62,15 @@ const ALL_SOURCE_PRODUCTS: (keyof SignalSourceValues)[] = [
   "conversations",
 ];
 
+// Sources powered by PostHog itself (no external integration required). These
+// are auto-enabled the first time a project reaches the onboarding signals step
+// so the inbox is opt-out, not opt-in.
+const POSTHOG_INTERNAL_SOURCES: (keyof SignalSourceValues)[] = [
+  "error_tracking",
+  "conversations",
+  "session_replay",
+];
+
 function computeValues(
   configs: SignalSourceConfig[] | undefined,
 ): SignalSourceValues {
@@ -378,6 +387,22 @@ export function useSignalSourceManager() {
     ],
   );
 
+  // Create configs (enabled) for any PostHog-internal source that has none.
+  // Sources with an existing config (enabled or disabled) are left alone so we
+  // never override an explicit user choice.
+  const autoEnableInternalSources = useCallback(async () => {
+    if (!client || !projectId || !configs) return;
+
+    const missing = POSTHOG_INTERNAL_SOURCES.filter(
+      (product) => !configs.some((c) => c.source_product === product),
+    );
+    if (missing.length === 0) return;
+
+    for (const product of missing) {
+      void handleToggle(product, true);
+    }
+  }, [client, projectId, configs, handleToggle]);
+
   const handleSetupComplete = useCallback(async () => {
     const completedSource = setupSource;
     setSetupSource(null);
@@ -476,6 +501,7 @@ export function useSignalSourceManager() {
     handleSetup,
     handleSetupComplete,
     handleSetupCancel,
+    autoEnableInternalSources,
     evaluations: displayEvaluations,
     evaluationsUrl,
     handleToggleEvaluation,

--- a/apps/code/src/renderer/features/onboarding/components/SignalsStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/SignalsStep.tsx
@@ -7,6 +7,7 @@ import { Button, Flex, Text } from "@radix-ui/themes";
 import detectiveHog from "@renderer/assets/images/hedgehogs/detective-hog.png";
 import { useQueryClient } from "@tanstack/react-query";
 import { motion } from "framer-motion";
+import { useEffect, useRef } from "react";
 import { OnboardingHogTip } from "./OnboardingHogTip";
 import { StepActions } from "./StepActions";
 
@@ -27,9 +28,20 @@ export function SignalsStep({ onNext, onBack }: SignalsStepProps) {
     handleSetupComplete,
     handleSetupCancel,
     evaluationsUrl,
+    autoEnableInternalSources,
   } = useSignalSourceManager();
   const { data: me } = useMeQuery();
   const isStaff = me?.is_staff ?? false;
+
+  // Auto-enable PostHog-internal sources on first load so the inbox is opt-out
+  // during onboarding. The manager skips any source that already has a config.
+  const autoEnabledRef = useRef(false);
+  useEffect(() => {
+    if (autoEnabledRef.current) return;
+    if (isLoading) return;
+    autoEnabledRef.current = true;
+    void autoEnableInternalSources();
+  }, [isLoading, autoEnableInternalSources]);
 
   const anyEnabled =
     displayValues.session_replay ||


### PR DESCRIPTION
## Summary

Make the **PostHog data** signal sources (Error Tracking, Support, Session Replay) opt-out during onboarding instead of opt-in. New projects land on the Signals step with these toggles already on, so the inbox starts populated without the user having to flip three switches before the next step.

## How it works

- New `autoEnableInternalSources` method on `useSignalSourceManager` — for each PostHog-internal source that has **no** existing `SignalSourceConfig`, it calls the existing `handleToggle(source, true)` path, which creates the config server-side with `enabled: true` and uses the same optimistic-update path as a manual toggle.
- `SignalsStep` fires it once via `useEffect` after configs finish loading (guarded by a ref so navigating back/forward doesn't re-trigger).
- Sources that already have a config — enabled or disabled — are skipped, so an explicit user choice is never overwritten. External sources (GitHub / Linear / Zendesk) are untouched and remain opt-in (they require setup).

## Test plan

- [ ] Brand-new project: open onboarding → reach the Signals step → Error Tracking, Support, and Session Replay are toggled on automatically; "Continue to setup" shows instead of "Skip for now"
- [ ] Toggle one of the three off mid-step, navigate away and back: the off state sticks (no re-enable on remount)
- [ ] Existing project that has previously disabled all internal sources: revisiting the Signals step does not re-enable them
- [ ] External sources (GitHub / Linear / Zendesk) still require setup and remain off until configured

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*