### PR TITLE
feat(inbox): include linear id in data source creation

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/DataSourceSetup.tsx
+++ b/apps/code/src/renderer/features/inbox/components/DataSourceSetup.tsx
@@ -250,6 +250,9 @@ function LinearSetup({ onComplete }: SetupFormProps) {
   const client = useAuthenticatedClient();
   const [loading, setLoading] = useState(false);
   const [oauthConnected, setOauthConnected] = useState(false);
+  const [linearIntegrationId, setLinearIntegrationId] = useState<
+    number | string | null
+  >(null);
   const [pollError, setPollError] = useState<string | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -283,13 +286,14 @@ function LinearSetup({ onComplete }: SetupFormProps) {
         try {
           const integrations =
             await client.getIntegrationsForProject(projectId);
-          const hasLinear = integrations.some(
+          const linearIntegration = integrations.find(
             (i: { kind: string }) => i.kind === "linear",
-          );
-          if (hasLinear) {
+          ) as { id: number | string } | undefined;
+          if (linearIntegration) {
             stopPolling();
             setLoading(false);
             setOauthConnected(true);
+            setLinearIntegrationId(linearIntegration.id);
             toast.success("Linear connected");
           }
         } catch {
@@ -312,13 +316,16 @@ function LinearSetup({ onComplete }: SetupFormProps) {
   }, [cloudRegion, projectId, client, stopPolling]);
 
   const handleSubmit = useCallback(async () => {
-    if (!projectId || !client) return;
+    if (!projectId || !client || !linearIntegrationId) return;
 
     setLoading(true);
     try {
       await client.createExternalDataSource(projectId, {
         source_type: "Linear",
-        payload: { schemas: schemasPayload("linear") },
+        payload: {
+          linear_integration_id: linearIntegrationId,
+          schemas: schemasPayload("linear"),
+        },
       });
       toast.success("Linear data source created");
       onComplete();
@@ -329,7 +336,7 @@ function LinearSetup({ onComplete }: SetupFormProps) {
     } finally {
       setLoading(false);
     }
-  }, [projectId, client, onComplete]);
+  }, [projectId, client, linearIntegrationId, onComplete]);
 
   return (
     <SetupFormContainer title="Connect Linear">


### PR DESCRIPTION
We were not passing our `linear_integration_id` into the external data source create call, causing it to fail and Linear integrations to not work.
 
Closes #1495
Closes #2005
https://discord.com/channels/1465397904901673123/1465397906977849612/1501995293884022795
https://posthog.slack.com/archives/C09G8Q32R6F/p1778194129515839

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*