### PR TITLE
feat: track task creation with workspace mode and worktree file usage

### DIFF
--- a/apps/code/src/main/services/workspace/schemas.ts
+++ b/apps/code/src/main/services/workspace/schemas.ts
@@ -169,6 +169,15 @@ export const listGitWorktreesInput = z.object({
   mainRepoPath: z.string(),
 });
 
+export const getWorktreeFileUsageInput = z.object({
+  mainRepoPath: z.string(),
+});
+
+export const getWorktreeFileUsageOutput = z.object({
+  usesWorktreeLink: z.boolean(),
+  usesWorktreeInclude: z.boolean(),
+});
+
 export const gitWorktreeEntrySchema = z.object({
   worktreePath: z.string(),
   head: z.string(),

--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -59,6 +59,28 @@ type TaskAssociation =
       branchName: string | null;
     };
 
+/**
+ * True if a worktree exclude file (.worktreelink / .worktreeinclude) exists and has at least
+ * one non-empty, non-comment entry.
+ */
+async function hasExcludeFileEntries(
+  mainRepoPath: string,
+  fileName: string,
+): Promise<boolean> {
+  try {
+    const contents = await fsPromises.readFile(
+      path.join(mainRepoPath, fileName),
+      "utf8",
+    );
+    return contents.split("\n").some((line) => {
+      const trimmed = line.trim();
+      return trimmed.length > 0 && !trimmed.startsWith("#");
+    });
+  } catch {
+    return false;
+  }
+}
+
 async function hasAnyFiles(repoPath: string): Promise<boolean> {
   try {
     const entries = await fsPromises.readdir(repoPath);
@@ -1087,6 +1109,16 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         taskIds,
       };
     });
+  }
+
+  async getWorktreeFileUsage(
+    mainRepoPath: string,
+  ): Promise<{ usesWorktreeLink: boolean; usesWorktreeInclude: boolean }> {
+    const [usesWorktreeLink, usesWorktreeInclude] = await Promise.all([
+      hasExcludeFileEntries(mainRepoPath, ".worktreelink"),
+      hasExcludeFileEntries(mainRepoPath, ".worktreeinclude"),
+    ]);
+    return { usesWorktreeLink, usesWorktreeInclude };
   }
 
   async getWorktreeSize(worktreePath: string): Promise<{ sizeBytes: number }> {

--- a/apps/code/src/main/trpc/routers/workspace.ts
+++ b/apps/code/src/main/trpc/routers/workspace.ts
@@ -16,6 +16,8 @@ import {
   getTaskTimestampsOutput,
   getWorkspaceInfoInput,
   getWorkspaceInfoOutput,
+  getWorktreeFileUsageInput,
+  getWorktreeFileUsageOutput,
   getWorktreeSizeInput,
   getWorktreeSizeOutput,
   getWorktreeTasksInput,
@@ -105,6 +107,13 @@ export const workspaceRouter = router({
     .input(getWorktreeSizeInput)
     .output(getWorktreeSizeOutput)
     .query(({ input }) => getService().getWorktreeSize(input.worktreePath)),
+
+  getWorktreeFileUsage: publicProcedure
+    .input(getWorktreeFileUsageInput)
+    .output(getWorktreeFileUsageOutput)
+    .query(({ input }) =>
+      getService().getWorktreeFileUsage(input.mainRepoPath),
+    ),
 
   deleteWorktree: publicProcedure
     .input(deleteWorktreeInput)

--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -14,9 +14,12 @@ import { useConnectivity } from "@hooks/useConnectivity";
 import type { WorkspaceMode } from "@main/services/workspace/schemas";
 import { get } from "@renderer/di/container";
 import { RENDERER_TOKENS } from "@renderer/di/tokens";
+import { trpcClient } from "@renderer/trpc/client";
 import { toast } from "@renderer/utils/toast";
 import type { ExecutionMode, Task } from "@shared/types";
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { useNavigationStore } from "@stores/navigationStore";
+import { track } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { useCallback, useState } from "react";
 import type { TaskCreationInput, TaskService } from "../service/service";
@@ -102,6 +105,54 @@ function prepareTaskInput(
         : undefined,
     signalReportId: options.signalReportId,
   };
+}
+
+async function trackTaskCreated(
+  input: TaskCreationInput,
+  selectedDirectory: string,
+): Promise<void> {
+  try {
+    const workspaceMode = input.workspaceMode ?? "local";
+
+    let usesWorktreeLink: boolean | undefined;
+    let usesWorktreeInclude: boolean | undefined;
+    if (workspaceMode === "worktree" && selectedDirectory) {
+      try {
+        const usage = await trpcClient.workspace.getWorktreeFileUsage.query({
+          mainRepoPath: selectedDirectory,
+        });
+        usesWorktreeLink = usage.usesWorktreeLink;
+        usesWorktreeInclude = usage.usesWorktreeInclude;
+      } catch (error) {
+        log.warn("Failed to read worktree file usage for analytics", {
+          error,
+        });
+      }
+    }
+
+    track(ANALYTICS_EVENTS.TASK_CREATED, {
+      auto_run: !!input.executionMode,
+      created_from: "command-menu",
+      repository_provider: input.repository ? "github" : "none",
+      workspace_mode: workspaceMode,
+      has_branch: !!input.branch,
+      has_environment_setup:
+        workspaceMode === "worktree" ? !!input.environmentId : undefined,
+      has_sandbox_environment:
+        workspaceMode === "cloud" ? !!input.sandboxEnvironmentId : undefined,
+      cloud_run_source:
+        workspaceMode === "cloud"
+          ? (input.cloudRunSource ?? "manual")
+          : undefined,
+      cloud_pr_authorship_mode:
+        workspaceMode === "cloud" ? input.cloudPrAuthorshipMode : undefined,
+      uses_worktree_link: usesWorktreeLink,
+      uses_worktree_include: usesWorktreeInclude,
+      adapter: input.adapter,
+    });
+  } catch (error) {
+    log.warn("Failed to track Task created event", { error });
+  }
 }
 
 function getErrorTitle(failedStep: string): string {
@@ -201,6 +252,10 @@ export function useTaskCreation({
         useTourStore.getState().completeTour(createFirstTaskTour.id);
         editor.clear();
       });
+
+      if (result.success) {
+        void trackTaskCreated(input, selectedDirectory);
+      }
 
       if (!result.success) {
         const title = getErrorTitle(result.failedStep);

--- a/apps/code/src/renderer/features/tasks/hooks/useTasks.ts
+++ b/apps/code/src/renderer/features/tasks/hooks/useTasks.ts
@@ -8,9 +8,7 @@ import { useFocusStore } from "@renderer/stores/focusStore";
 import { useNavigationStore } from "@renderer/stores/navigationStore";
 import { trpcClient } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
-import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
-import { track } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { useCallback } from "react";
 
@@ -111,15 +109,6 @@ export function useCreateTask() {
         repository,
         github_integration,
       }) as unknown as Promise<Task>,
-    {
-      onSuccess: (_task, variables) => {
-        track(ANALYTICS_EVENTS.TASK_CREATED, {
-          auto_run: false,
-          created_from: variables.createdFrom || "cli",
-          repository_provider: variables.repository ? "github" : "none",
-        });
-      },
-    },
   );
 
   return { ...mutation, invalidateTasks };

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -47,6 +47,19 @@ export interface TaskCreateProperties {
   auto_run: boolean;
   created_from: TaskCreatedFrom;
   repository_provider?: RepositoryProvider;
+  workspace_mode?: "local" | "worktree" | "cloud";
+  has_branch?: boolean;
+  /** Worktree mode: a project environment with a setup script was selected */
+  has_environment_setup?: boolean;
+  /** Cloud mode: a sandbox environment was selected */
+  has_sandbox_environment?: boolean;
+  cloud_run_source?: "manual" | "signal_report";
+  cloud_pr_authorship_mode?: "user" | "bot";
+  /** Worktree mode: repo has a non-empty .worktreelink file */
+  uses_worktree_link?: boolean;
+  /** Worktree mode: repo has a non-empty .worktreeinclude file */
+  uses_worktree_include?: boolean;
+  adapter?: "claude" | "codex";
 }
 
 export interface TaskViewProperties {


### PR DESCRIPTION
## TL;DR

Adds comprehensive analytics tracking for task creation events, capturing workspace mode (local/worktree/cloud), worktree file usage (.worktreelink/.worktreeinclude), and environment configuration details to enable insights into user preferences across different workspace modes.

## Problem

We need to audit task creation events across different workspace modes (local, worktree, cloud) to understand which modes users prefer and identify feature usage patterns. The existing task creation tracking was incomplete and lacked the necessary data to build these insights.

Closes #2100

## Changes

### Backend (Workspace Service)
- Added `getWorktreeFileUsage()` method to detect whether `.worktreelink` or `.worktreeinclude` files exist and contain non-empty, non-comment entries
- Added `hasExcludeFileEntries()` helper to safely read and parse worktree exclude files
- Added new Zod schemas `getWorktreeFileUsageInput` and `getWorktreeFileUsageOutput` for type safety

### API (tRPC Router)
- Exposed `getWorktreeFileUsage` as a public tRPC procedure to allow frontend queries for worktree file usage data

### Frontend (Task Creation Tracking)
- Added `trackTaskCreated()` function to comprehensively track task creation with:
  - Workspace mode (local/worktree/cloud)
  - Auto-run status
  - Repository provider (GitHub or none)
  - Branch information
  - Environment/sandbox environment configuration
  - Cloud run source and PR authorship mode
  - Worktree file usage (`.worktreelink` and `.worktreeinclude`)
  - Adapter type
- Integrated tracking into task creation flow in `useTaskCreation` hook
- Removed incomplete task creation tracking from `useTasks` hook to consolidate in one place

## How did you test this?

- Verified the new tRPC endpoint is properly typed with input/output schemas
- Confirmed worktree file parsing correctly identifies non-empty, non-comment lines
- Validated task creation tracking captures all required analytics properties
- Error handling ensures failed analytics calls don't block task creation

## Publish to changelog?

yes

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*