### PR TITLE
feat(settings): add configurable default effort level

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
@@ -4,6 +4,7 @@ import {
   type AutoConvertLongText,
   type CompletionSound,
   type DefaultInitialTaskMode,
+  type DefaultReasoningEffort,
   type DiffOpenMode,
   type SendMessagesWith,
   useSettingsStore,
@@ -77,6 +78,7 @@ export function GeneralSettings() {
     completionVolume,
     autoConvertLongText,
     defaultInitialTaskMode,
+    defaultReasoningEffort,
     diffOpenMode,
     sendMessagesWith,
     hedgehogMode,
@@ -87,6 +89,7 @@ export function GeneralSettings() {
     setCompletionVolume,
     setAutoConvertLongText,
     setDefaultInitialTaskMode,
+    setDefaultReasoningEffort,
     setDiffOpenMode,
     setSendMessagesWith,
     setHedgehogMode,
@@ -188,6 +191,18 @@ export function GeneralSettings() {
       setDefaultInitialTaskMode(value);
     },
     [defaultInitialTaskMode, setDefaultInitialTaskMode],
+  );
+
+  const handleDefaultReasoningEffortChange = useCallback(
+    (value: DefaultReasoningEffort) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "default_reasoning_effort",
+        new_value: value,
+        old_value: defaultReasoningEffort,
+      });
+      setDefaultReasoningEffort(value);
+    },
+    [defaultReasoningEffort, setDefaultReasoningEffort],
   );
 
   const handleSendMessagesWithChange = useCallback(
@@ -382,6 +397,29 @@ export function GeneralSettings() {
           <Select.Content>
             <Select.Item value="plan">Plan</Select.Item>
             <Select.Item value="last_used">Last used</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </SettingRow>
+
+      <SettingRow
+        label="Default effort level"
+        description="Choose the default reasoning effort for new tasks, or remember your last-used level"
+      >
+        <Select.Root
+          value={defaultReasoningEffort}
+          onValueChange={(value) =>
+            handleDefaultReasoningEffortChange(value as DefaultReasoningEffort)
+          }
+          size="1"
+        >
+          <Select.Trigger className="min-w-[100px]" />
+          <Select.Content>
+            <Select.Item value="last_used">Last used</Select.Item>
+            <Select.Item value="low">Low</Select.Item>
+            <Select.Item value="medium">Medium</Select.Item>
+            <Select.Item value="high">High</Select.Item>
+            <Select.Item value="xhigh">Extra High</Select.Item>
+            <Select.Item value="max">Max</Select.Item>
           </Select.Content>
         </Select.Root>
       </SettingRow>

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.ts
@@ -10,6 +10,13 @@ export type DefaultRunMode = "local" | "cloud" | "last_used";
 export type LocalWorkspaceMode = "worktree" | "local";
 export type AgentAdapter = "claude" | "codex";
 export type DefaultInitialTaskMode = "plan" | "last_used";
+export type DefaultReasoningEffort =
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "last_used";
 
 export type SendMessagesWith = "enter" | "cmd+enter";
 export type AutoConvertLongText = "off" | "1000" | "2500" | "5000" | "10000";
@@ -56,6 +63,7 @@ interface SettingsStore {
   lastUsedEnvironments: Record<string, string>;
   defaultInitialTaskMode: DefaultInitialTaskMode;
   lastUsedInitialTaskMode: ExecutionMode;
+  defaultReasoningEffort: DefaultReasoningEffort;
   setDefaultRunMode: (mode: DefaultRunMode) => void;
   setLastUsedRunMode: (mode: "local" | "cloud") => void;
   setLastUsedLocalWorkspaceMode: (mode: LocalWorkspaceMode) => void;
@@ -71,6 +79,7 @@ interface SettingsStore {
   getLastUsedEnvironment: (repoPath: string) => string | null;
   setDefaultInitialTaskMode: (mode: DefaultInitialTaskMode) => void;
   setLastUsedInitialTaskMode: (mode: ExecutionMode) => void;
+  setDefaultReasoningEffort: (effort: DefaultReasoningEffort) => void;
 
   // Notifications
   desktopNotifications: boolean;
@@ -140,6 +149,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedEnvironments: {},
       defaultInitialTaskMode: "plan",
       lastUsedInitialTaskMode: "plan",
+      defaultReasoningEffort: "last_used",
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
       setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
       setLastUsedLocalWorkspaceMode: (mode) =>
@@ -167,6 +177,8 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ defaultInitialTaskMode: mode }),
       setLastUsedInitialTaskMode: (mode) =>
         set({ lastUsedInitialTaskMode: mode }),
+      setDefaultReasoningEffort: (effort) =>
+        set({ defaultReasoningEffort: effort }),
 
       // Notifications
       desktopNotifications: true,
@@ -264,6 +276,7 @@ export const useSettingsStore = create<SettingsStore>()(
         lastUsedEnvironments: state.lastUsedEnvironments,
         defaultInitialTaskMode: state.defaultInitialTaskMode,
         lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,
+        defaultReasoningEffort: state.defaultReasoningEffort,
 
         // Notifications
         desktopNotifications: state.desktopNotifications,

--- a/apps/code/src/renderer/features/task-detail/hooks/usePreviewConfig.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/usePreviewConfig.ts
@@ -70,6 +70,7 @@ export function usePreviewConfig(
         const {
           defaultInitialTaskMode,
           lastUsedInitialTaskMode,
+          defaultReasoningEffort,
           lastUsedReasoningEffort,
         } = useSettingsStore.getState();
 
@@ -121,13 +122,22 @@ export function usePreviewConfig(
               options?: Array<{ value: string }>;
             }>,
           );
-          if (
-            lastUsedReasoningEffort &&
-            validValues.includes(lastUsedReasoningEffort)
-          ) {
+          if (defaultReasoningEffort === "last_used") {
+            if (
+              lastUsedReasoningEffort &&
+              validValues.includes(lastUsedReasoningEffort)
+            ) {
+              return {
+                ...opt,
+                currentValue: lastUsedReasoningEffort,
+              } as SessionConfigOption;
+            }
+            return opt;
+          }
+          if (validValues.includes(defaultReasoningEffort)) {
             return {
               ...opt,
-              currentValue: lastUsedReasoningEffort,
+              currentValue: defaultReasoningEffort,
             } as SessionConfigOption;
           }
           return opt;
@@ -168,26 +178,33 @@ export function usePreviewConfig(
                 ? "reasoning_effort"
                 : "effort";
 
-          const { lastUsedReasoningEffort } = useSettingsStore.getState();
+          const { lastUsedReasoningEffort, defaultReasoningEffort } =
+            useSettingsStore.getState();
           const isValidEffort = (effort: unknown): effort is string =>
             typeof effort === "string" &&
             !!effortOpts?.some((e) => e.value === effort);
+          const resolveEffortFallback = (): string => {
+            if (defaultReasoningEffort !== "last_used") {
+              return isValidEffort(defaultReasoningEffort)
+                ? defaultReasoningEffort
+                : "high";
+            }
+            return isValidEffort(lastUsedReasoningEffort)
+              ? lastUsedReasoningEffort
+              : "high";
+          };
           if (effortOpts && existingIdx >= 0) {
             const currentEffort = updated[existingIdx].currentValue;
             const nextEffort = isValidEffort(currentEffort)
               ? currentEffort
-              : isValidEffort(lastUsedReasoningEffort)
-                ? lastUsedReasoningEffort
-                : "high";
+              : resolveEffortFallback();
             updated[existingIdx] = {
               ...updated[existingIdx],
               currentValue: nextEffort,
               options: effortOpts,
             } as SessionConfigOption;
           } else if (effortOpts && existingIdx === -1) {
-            const nextEffort = isValidEffort(lastUsedReasoningEffort)
-              ? lastUsedReasoningEffort
-              : "high";
+            const nextEffort = resolveEffortFallback();
             updated = [
               ...updated,
               {

--- a/apps/code/src/renderer/features/task-detail/hooks/usePreviewConfig.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/usePreviewConfig.ts
@@ -35,6 +35,45 @@ function flattenValues(
   );
 }
 
+const EFFORT_RANK: Record<string, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  xhigh: 3,
+  max: 4,
+};
+
+/**
+ * Clamp a desired effort to the nearest level the current model supports.
+ * Falls back to the highest supported level when the desired level has no
+ * known rank (e.g. unrecognized value from older settings).
+ */
+function clampEffortToAvailable(
+  desired: string,
+  available: string[],
+): string | null {
+  if (available.length === 0) return null;
+  if (available.includes(desired)) return desired;
+
+  const desiredRank = EFFORT_RANK[desired];
+  if (desiredRank === undefined) {
+    return available[available.length - 1];
+  }
+
+  const ranked = available
+    .map((value) => ({ value, rank: EFFORT_RANK[value] }))
+    .filter((entry): entry is { value: string; rank: number } =>
+      Number.isFinite(entry.rank),
+    );
+  if (ranked.length === 0) return available[0];
+
+  return ranked.reduce((closest, entry) =>
+    Math.abs(entry.rank - desiredRank) < Math.abs(closest.rank - desiredRank)
+      ? entry
+      : closest,
+  ).value;
+}
+
 /**
  * Fetches config options (models, modes, effort levels) for the task input
  * page via a lightweight tRPC query. No agent session is created.
@@ -134,10 +173,14 @@ export function usePreviewConfig(
             }
             return opt;
           }
-          if (validValues.includes(defaultReasoningEffort)) {
+          const clamped = clampEffortToAvailable(
+            defaultReasoningEffort,
+            validValues,
+          );
+          if (clamped) {
             return {
               ...opt,
-              currentValue: defaultReasoningEffort,
+              currentValue: clamped,
             } as SessionConfigOption;
           }
           return opt;
@@ -180,18 +223,21 @@ export function usePreviewConfig(
 
           const { lastUsedReasoningEffort, defaultReasoningEffort } =
             useSettingsStore.getState();
+          const availableValues: string[] =
+            effortOpts?.map((e) => e.value) ?? [];
           const isValidEffort = (effort: unknown): effort is string =>
-            typeof effort === "string" &&
-            !!effortOpts?.some((e) => e.value === effort);
+            typeof effort === "string" && availableValues.includes(effort);
           const resolveEffortFallback = (): string => {
-            if (defaultReasoningEffort !== "last_used") {
-              return isValidEffort(defaultReasoningEffort)
-                ? defaultReasoningEffort
-                : "high";
-            }
-            return isValidEffort(lastUsedReasoningEffort)
-              ? lastUsedReasoningEffort
-              : "high";
+            const desired =
+              defaultReasoningEffort === "last_used"
+                ? lastUsedReasoningEffort
+                : defaultReasoningEffort;
+            if (isValidEffort(desired)) return desired;
+            const clamped =
+              typeof desired === "string"
+                ? clampEffortToAvailable(desired, availableValues)
+                : null;
+            return clamped ?? availableValues[0] ?? "high";
           };
           if (effortOpts && existingIdx >= 0) {
             const currentEffort = updated[existingIdx].currentValue;

--- a/apps/code/src/renderer/features/task-detail/hooks/usePreviewConfig.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/usePreviewConfig.ts
@@ -223,21 +223,19 @@ export function usePreviewConfig(
 
           const { lastUsedReasoningEffort, defaultReasoningEffort } =
             useSettingsStore.getState();
-          const availableValues: string[] =
-            effortOpts?.map((e) => e.value) ?? [];
           const isValidEffort = (effort: unknown): effort is string =>
-            typeof effort === "string" && availableValues.includes(effort);
+            typeof effort === "string" &&
+            !!effortOpts?.some((e) => e.value === effort);
           const resolveEffortFallback = (): string => {
-            const desired =
-              defaultReasoningEffort === "last_used"
-                ? lastUsedReasoningEffort
-                : defaultReasoningEffort;
-            if (isValidEffort(desired)) return desired;
-            const clamped =
-              typeof desired === "string"
-                ? clampEffortToAvailable(desired, availableValues)
-                : null;
-            return clamped ?? availableValues[0] ?? "high";
+            if (
+              defaultReasoningEffort !== "last_used" &&
+              isValidEffort(defaultReasoningEffort)
+            ) {
+              return defaultReasoningEffort;
+            }
+            return isValidEffort(lastUsedReasoningEffort)
+              ? lastUsedReasoningEffort
+              : "high";
           };
           if (effortOpts && existingIdx >= 0) {
             const currentEffort = updated[existingIdx].currentValue;


### PR DESCRIPTION
## Summary

Resolves #1846

Adds a "Default effort level" setting so users can configure the default reasoning effort for new tasks instead of always defaulting to "high".

### Problem
There was no way to configure a default effort level in PostHog Code. Users who preferred a specific effort level had to manually change it every time they started a new task. The effort level always defaulted to "high" with no persistence beyond "last used".

### Solution
Mirrors the existing `defaultInitialTaskMode` pattern — a setting that controls whether new tasks use a fixed value or "Last used":

- **`defaultReasoningEffort`** setting in `settingsStore` with type `DefaultReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max" | "last_used"`
- Default value: `"last_used"` (preserves existing behavior for all users)
- Applied in `usePreviewConfig` when resolving the initial effort for new sessions
- Applied in the model-change handler fallback when the effort option needs re-resolving
- UI: New "Default effort level" select in Settings > General > Input section

### Files changed
| File | Change |
|------|--------|
| `settingsStore.ts` | Add `DefaultReasoningEffort` type, `defaultReasoningEffort` state + setter, persisted |
| `usePreviewConfig.ts` | Use `defaultReasoningEffort` to resolve initial effort (mirrors `defaultInitialTaskMode` logic) |
| `GeneralSettings.tsx` | Add "Default effort level" setting row with analytics tracking |

### How to test
1. Open Settings > General > Input
2. Change "Default effort level" from "Last used" to e.g. "Max"
3. Start a new task — effort selector should default to "Max"
4. Change it to "Last used" — effort selector should remember the last value you used
5. Switch models — effort fallback should respect the configured default

### Screenshots

Setting appears right below "Initial task mode" in the Input section:

```
Input
├── Initial task mode      [Plan ▾]
├── Default effort level   [Last used ▾]   ← NEW
├── Send messages with     [Enter ▾]
└── ...
```