### PR TITLE
style: Clean up AI approval screen

### DIFF
--- a/apps/code/src/main/services/github-integration/service.ts
+++ b/apps/code/src/main/services/github-integration/service.ts
@@ -61,7 +61,7 @@ export class GitHubIntegrationService extends TypedEventEmitter<GitHubIntegratio
   ): Promise<StartGitHubFlowOutput> {
     try {
       const cloudUrl = getCloudUrlFromRegion(region);
-      const nextPath = `/account-connected/github-login?provider=github&project_id=${projectId}&connect_from=posthog_code`;
+      const nextPath = `/account-connected/github-integration?provider=github&project_id=${projectId}&connect_from=posthog_code`;
       const authorizeUrl = `${cloudUrl}/api/environments/${projectId}/integrations/authorize/?kind=github&next=${encodeURIComponent(nextPath)}`;
 
       this.clearFlowTimeout();

--- a/apps/code/src/renderer/features/ai-approval/components/AiApprovalScreen.tsx
+++ b/apps/code/src/renderer/features/ai-approval/components/AiApprovalScreen.tsx
@@ -80,7 +80,7 @@ export function AiApprovalScreen({ orgName, isAdmin }: AiApprovalScreenProps) {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3 }}
             >
-              <Flex direction="column" gap="5">
+              <Flex direction="column" gap="4">
                 <Flex direction="column" gap="2">
                   <Flex align="center" gap="2">
                     <Robot
@@ -93,11 +93,21 @@ export function AiApprovalScreen({ orgName, isAdmin }: AiApprovalScreenProps) {
                     </Text>
                   </Flex>
                   <Text className="text-(--gray-11) text-sm">
-                    {orgName
-                      ? `The "${orgName}" organization hasn't approved AI data processing yet.`
-                      : "Your organization hasn't approved AI data processing yet."}{" "}
-                    PostHog AI may process identifying user data with external
-                    AI providers. Your data won't be used for training models.
+                    {orgName ? (
+                      <>
+                        Your "<strong>{orgName}</strong>" organization hasn't
+                        approved AI data processing yet.
+                      </>
+                    ) : (
+                      "Your organization hasn't approved AI data processing yet."
+                    )}
+                  </Text>
+                  <Text className="text-(--gray-11) text-sm">
+                    PostHog AI features process identifying user data with
+                    external AI providers.
+                    <br />
+                    Importantly: Your data won't be used for training models by
+                    these providers.
                   </Text>
                 </Flex>
 
@@ -106,10 +116,16 @@ export function AiApprovalScreen({ orgName, isAdmin }: AiApprovalScreenProps) {
                     <WarningCircle />
                   </Callout.Icon>
                   <Callout.Text>
-                    This feature is not HIPAA-compliant and is not intended for
-                    the processing of Protected Health Information ("PHI"). Any
-                    Business Associate Agreement ("BAA") you may have entered
-                    into with PostHog does not apply to this functionality.
+                    <h4 className="mb-1 font-bold">
+                      Legal bits about Protected Health Information
+                    </h4>
+                    PostHog Code isn't <i>yet</i> HIPAA-compliant and is not
+                    intended for processing of Protected Health Information
+                    ("PHI").
+                    <br />
+                    If you've entered into a Business Associate Agreement
+                    ("BAA") with PostHog, it does not currently apply to PostHog
+                    Code features.
                   </Callout.Text>
                 </Callout.Root>
 


### PR DESCRIPTION
## Problem

The org AI approval screen is friction-heavy due to taking the away into PostHog Cloud, _but_ it's also been breaking a few UI rules, making for a less successful user experience:

<img width="1252" height="730" alt="Screenshot 2026-05-10 at 16 47 03@2x" src="https://github.com/user-attachments/assets/0b66a333-6109-484e-9d40-f50267c69538" />

1. Disclose information progressively - with a single unformatted paragraph of information, it's hard to say as a user what all this commotion is about
1. Thoughtful line breaks are part of layout – here, the line breaks appear random, despite this part of the UI being static width
1. PostHog-specific: Writing should feel PostHoggy, i.e. professional and clean, but without taking itself too seriously, maybe especially so when talking about genuinely important topics like privacy agreements - overall this is fairly light, but then the legal note is unusually dry

## Changes

Improved version:

1. The most important fact explaining why you're seeing this is on its first line, with the organization in bold
1. Line breaks are intentional to create a smooth flow of reading
1. The legal note gets a heading so that most users know to simply skip it, and its style is subtly more PostHoggy without any change in meaning

<img width="1210" height="778" alt="Screenshot 2026-05-10 at 16 41 20@2x" src="https://github.com/user-attachments/assets/4e8bb7bf-200b-468f-993e-bd514509e027" />

