### PR TITLE
fix(sessions): disable message send when offline

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -623,6 +623,9 @@ export function SessionView({
                           submitDisabledExternal={
                             handoffInProgress || !isOnline
                           }
+                          submitTooltipOverride={
+                            !isOnline ? "No internet connection" : undefined
+                          }
                           isLoading={!!isPromptPending}
                           isActiveSession={isActiveSession}
                           taskId={taskId}

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -18,6 +18,7 @@ import type { Plan } from "@features/sessions/types";
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { useIsWorkspaceCloudRun } from "@features/workspace/hooks/useWorkspace";
 import { useAutoFocusOnTyping } from "@hooks/useAutoFocusOnTyping";
+import { useConnectivity } from "@hooks/useConnectivity";
 import { Pause, Spinner, Warning } from "@phosphor-icons/react";
 import { Box, Button, ContextMenu, Flex, Text } from "@radix-ui/themes";
 import { toast } from "@renderer/utils/toast";
@@ -131,6 +132,7 @@ export function SessionView({
   const thoughtOption = useThoughtLevelConfigOptionForTask(taskId);
   const adapter = useAdapterForTask(taskId);
   const { allowBypassPermissions } = useSettingsStore();
+  const { isOnline } = useConnectivity();
   const currentModeId = modeOption?.currentValue;
   const handoffInProgress =
     useSessionForTask(taskId)?.handoffInProgress ?? false;
@@ -618,7 +620,9 @@ export function SessionView({
                           sessionId={sessionId}
                           placeholder="Type a message... @ to mention files, ! for bash mode, / for skills"
                           disabled={!isRunning && !handoffInProgress}
-                          submitDisabledExternal={handoffInProgress}
+                          submitDisabledExternal={
+                            handoffInProgress || !isOnline
+                          }
                           isLoading={!!isPromptPending}
                           isActiveSession={isActiveSession}
                           taskId={taskId}


### PR DESCRIPTION
## Summary

When the connectivity store reports offline, the session view's `PromptInput` now disables submit. Previously, pressing Enter offline cleared the editor without sending anything — losing the user's text.

The task-creation composer (`TaskInput`) already gated submit on `isOnline`; this brings the follow-up-message composer in `SessionView` in line by adding `!isOnline` to `submitDisabledExternal`. Reuses the existing disable mechanism, so:

- The send button greys out
- Enter is a no-op (handled in `useTiptapEditor` via `submitDisabledRef`)
- The typed message stays in the editor and sends as soon as connectivity returns

Refs SupportHog ticket #758.

## Test plan

- [ ] In a session with an active agent, simulate offline (DevTools → Network → Offline). Confirm the "No internet connection" toast appears.
- [ ] Type a message and press Enter. Confirm the text is preserved in the editor and the send button is disabled.
- [ ] Restore connectivity. Confirm the message can be sent.
- [ ] Verify the existing `TaskInput` (new task composer) behavior is unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*