### PR TITLE
fix/macos-packaged-readonly-startup

### DIFF
--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import os from "node:os";
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import log from "electron-log/main";
 import "./utils/logger";
 import "./services/index.js";
@@ -34,6 +34,7 @@ import {
   getLogFilePath,
   readChromiumLogTail,
 } from "./utils/logger";
+import { isMacosPackagedUnsafeBundleLocation } from "./utils/macos-packaged-install-guard";
 import { createWindow } from "./window";
 
 // Single instance lock must be acquired FIRST before any other app setup
@@ -180,6 +181,31 @@ registerDeepLinkHandlers();
 initializePostHog();
 
 app.whenReady().then(async () => {
+  if (
+    process.platform === "darwin" &&
+    app.isPackaged &&
+    isMacosPackagedUnsafeBundleLocation(app.getAppPath(), process.execPath)
+  ) {
+    const appPath = app.getAppPath();
+    const exePath = process.execPath;
+    log.warn(
+      "Refusing to start: packaged app is on App Translocation or a read-only non-root volume",
+      { appPath, exePath },
+    );
+    dialog.showMessageBoxSync({
+      type: "warning",
+      title: "Read-only install location",
+      message:
+        "PostHog Code is running from a location with read-only access (for example App Translocation or a read-only disk image). The exact folder can differ depending on how you opened the app.",
+      detail:
+        "This prevents updates and tasks from running correctly. Move PostHog Code to the Applications folder (or another folder on a writable disk), quit the app completely, then open it again from the new location.",
+      buttons: ["OK"],
+      defaultId: 0,
+    });
+    app.quit();
+    return;
+  }
+
   const commit = __BUILD_COMMIT__ ?? "dev";
   const buildDate = __BUILD_DATE__ ?? "dev";
   log.info(

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -188,18 +188,18 @@ app.whenReady().then(async () => {
   ) {
     const appPath = app.getAppPath();
     const exePath = process.execPath;
+    const bundleRoot = exePath.replace(/\/Contents\/MacOS\/[^/]+$/, "");
     log.warn(
       "Refusing to start: packaged app is on App Translocation or a read-only non-root volume",
       { appPath, exePath },
     );
     dialog.showMessageBoxSync({
       type: "warning",
-      title: "Read-only install location",
-      message:
-        "PostHog Code is running from a location with read-only access (for example App Translocation or a read-only disk image). The exact folder can differ depending on how you opened the app.",
+      title: "Move PostHog Code to Applications",
+      message: `PostHog Code is running from a location with read-only access:\n\n${bundleRoot}`,
       detail:
-        "This prevents updates and tasks from running correctly. Move PostHog Code to the Applications folder (or another folder on a writable disk), quit the app completely, then open it again from the new location.",
-      buttons: ["OK"],
+        "After quitting, move PostHog Code to your Applications folder, then open it from there.",
+      buttons: ["Quit"],
       defaultId: 0,
     });
     app.quit();

--- a/apps/code/src/main/utils/macos-packaged-install-guard.test.ts
+++ b/apps/code/src/main/utils/macos-packaged-install-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   isMacosAppTranslocationPath,
   isMacosPackagedUnsafeBundleLocation,
@@ -119,13 +119,24 @@ describe("isMacosPathOnReadOnlyNonRootMountFromTable", () => {
 });
 
 describe("isMacosPackagedUnsafeBundleLocation", () => {
-  it("is true when translocated", () => {
+  const writableMountTable = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+/dev/disk5s1 on /Volumes/build (apfs, local, journaled)
+/dev/disk6s1 on /Applications (apfs, local, journaled)
+`;
+  const readOnlyMountTable = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+/dev/disk7s1 on /Volumes/ReadOnlyVol (apfs, local, read-only, journaled)
+`;
+
+  it("is true when translocated (mount table never consulted)", () => {
+    const readMountTable = vi.fn(() => writableMountTable);
     expect(
       isMacosPackagedUnsafeBundleLocation(
         "/private/var/.../AppTranslocation/UUID/d/PostHog Code.app/Contents/Resources/app.asar",
         "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+        readMountTable,
       ),
     ).toBe(true);
+    expect(readMountTable).not.toHaveBeenCalled();
   });
 
   it("is false for ordinary non-translocated paths on writable mounts", () => {
@@ -133,6 +144,27 @@ describe("isMacosPackagedUnsafeBundleLocation", () => {
       isMacosPackagedUnsafeBundleLocation(
         "/Volumes/build/out/PostHog Code.app/Contents/Resources/app.asar",
         "/Volumes/build/out/PostHog Code.app/Contents/MacOS/PostHog Code",
+        () => writableMountTable,
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when the bundle lives on a read-only non-root volume", () => {
+    expect(
+      isMacosPackagedUnsafeBundleLocation(
+        "/Volumes/ReadOnlyVol/PostHog Code.app/Contents/Resources/app.asar",
+        "/Volumes/ReadOnlyVol/PostHog Code.app/Contents/MacOS/PostHog Code",
+        () => readOnlyMountTable,
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when the mount table cannot be read (degrade to non-blocking)", () => {
+    expect(
+      isMacosPackagedUnsafeBundleLocation(
+        "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+        () => null,
       ),
     ).toBe(false);
   });

--- a/apps/code/src/main/utils/macos-packaged-install-guard.test.ts
+++ b/apps/code/src/main/utils/macos-packaged-install-guard.test.ts
@@ -1,120 +1,137 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  type DarwinMountEntry,
   isMacosAppTranslocationPath,
   isMacosPackagedUnsafeBundleLocation,
   isMacosPathOnReadOnlyNonRootMountFromTable,
   parseDarwinMountTable,
+  type ReadDarwinMountTable,
 } from "./macos-packaged-install-guard";
 
 describe("isMacosAppTranslocationPath", () => {
-  it("returns true when appPath contains AppTranslocation", () => {
-    expect(
-      isMacosAppTranslocationPath(
+  it.each([
+    {
+      case: "appPath is translocated",
+      appPath:
         "/private/var/folders/yf/xx/AppTranslocation/C6283C3C-9D6E-4D81-A7D5-8BA2567ED486/d/PostHog Code.app/Contents/Resources/app.asar",
-        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
-      ),
-    ).toBe(true);
-  });
-
-  it("returns true when exePath contains AppTranslocation", () => {
-    expect(
-      isMacosAppTranslocationPath(
-        "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+      exePath: "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      expected: true,
+    },
+    {
+      case: "exePath is translocated",
+      appPath: "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+      exePath:
         "/private/var/folders/yf/xx/AppTranslocation/C6283C3C/d/PostHog Code.app/Contents/MacOS/PostHog Code",
-      ),
-    ).toBe(true);
-  });
-
-  it("returns false for normal /Applications paths", () => {
-    expect(
-      isMacosAppTranslocationPath(
-        "/Applications/PostHog Code.app/Contents/Resources/app.asar",
-        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
-      ),
-    ).toBe(false);
-  });
-
-  it("returns false when neither path is translocated", () => {
-    expect(
-      isMacosAppTranslocationPath(
-        "/Users/dev/PostHog Code.app/Contents/Resources/app.asar",
-        "/Users/dev/PostHog Code.app/Contents/MacOS/PostHog Code",
-      ),
-    ).toBe(false);
+      expected: true,
+    },
+    {
+      case: "neither path is translocated (/Applications)",
+      appPath: "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+      exePath: "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      expected: false,
+    },
+    {
+      case: "neither path is translocated (/Users)",
+      appPath: "/Users/dev/PostHog Code.app/Contents/Resources/app.asar",
+      exePath: "/Users/dev/PostHog Code.app/Contents/MacOS/PostHog Code",
+      expected: false,
+    },
+  ])("$case → $expected", ({ appPath, exePath, expected }) => {
+    expect(isMacosAppTranslocationPath(appPath, exePath)).toBe(expected);
   });
 });
 
 describe("parseDarwinMountTable", () => {
-  it("parses standard macOS mount lines", () => {
-    const sample = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+  it.each<{
+    case: string;
+    input: string;
+    expected: DarwinMountEntry[];
+  }>([
+    {
+      case: "standard macOS mount lines",
+      input: `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
 /dev/disk7s1 on /Volumes/My Dmg (apfs, local, read-only, journaled)
 /dev/disk5s1 on /Volumes/Writable (apfs, local, journaled)
-`;
-    const entries = parseDarwinMountTable(sample);
-    expect(entries).toEqual([
-      { mountPoint: "/", options: "apfs, sealed, local, read-only, journaled" },
-      {
-        mountPoint: "/Volumes/My Dmg",
-        options: "apfs, local, read-only, journaled",
-      },
-      { mountPoint: "/Volumes/Writable", options: "apfs, local, journaled" },
-    ]);
+`,
+      expected: [
+        {
+          mountPoint: "/",
+          options: "apfs, sealed, local, read-only, journaled",
+        },
+        {
+          mountPoint: "/Volumes/My Dmg",
+          options: "apfs, local, read-only, journaled",
+        },
+        { mountPoint: "/Volumes/Writable", options: "apfs, local, journaled" },
+      ],
+    },
+    {
+      case: "mount point name contains ' (' — anchors to trailing options",
+      input:
+        "/dev/disk9s1 on /Volumes/My Backup (2) (apfs, local, read-only, journaled)\n",
+      expected: [
+        {
+          mountPoint: "/Volumes/My Backup (2)",
+          options: "apfs, local, read-only, journaled",
+        },
+      ],
+    },
+  ])("parses: $case", ({ input, expected }) => {
+    expect(parseDarwinMountTable(input)).toEqual(expected);
   });
 });
 
 describe("isMacosPathOnReadOnlyNonRootMountFromTable", () => {
-  const table = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+  const baseTable = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
 /dev/disk7s1 on /Volumes/ReadOnlyVol (apfs, local, read-only, journaled)
 /dev/disk5s1 on /Volumes/Writable (apfs, local, journaled)
 `;
-
-  it("returns false for paths only under read-only / (root is ignored)", () => {
-    expect(
-      isMacosPathOnReadOnlyNonRootMountFromTable("/Users/me/app", table),
-    ).toBe(false);
-    expect(
-      isMacosPathOnReadOnlyNonRootMountFromTable(
-        "/Applications/Foo.app",
-        table,
-      ),
-    ).toBe(false);
-  });
-
-  it("returns true for paths on a read-only non-root volume", () => {
-    expect(
-      isMacosPathOnReadOnlyNonRootMountFromTable(
-        "/Volumes/ReadOnlyVol/PostHog Code.app/Contents/MacOS/PostHog Code",
-        table,
-      ),
-    ).toBe(true);
-  });
-
-  it("returns false for paths on a writable volume", () => {
-    expect(
-      isMacosPathOnReadOnlyNonRootMountFromTable(
-        "/Volumes/Writable/out/PostHog Code.app/Contents/MacOS/PostHog Code",
-        table,
-      ),
-    ).toBe(false);
-  });
-
-  it("picks the longest matching mount prefix", () => {
-    const nested = `/dev/x on / (apfs, read-only)
+  const nestedTable = `/dev/x on / (apfs, read-only)
 /dev/y on /Volumes/RW (apfs, local, journaled)
 /dev/z on /Volumes/RW/nested (apfs, local, read-only)
 `;
-    expect(
-      isMacosPathOnReadOnlyNonRootMountFromTable(
-        "/Volumes/RW/nested/app",
-        nested,
-      ),
-    ).toBe(true);
-    expect(
-      isMacosPathOnReadOnlyNonRootMountFromTable(
-        "/Volumes/RW/other/app",
-        nested,
-      ),
-    ).toBe(false);
+
+  it.each([
+    {
+      case: "path under read-only / is ignored (Users)",
+      table: baseTable,
+      path: "/Users/me/app",
+      expected: false,
+    },
+    {
+      case: "path under read-only / is ignored (Applications)",
+      table: baseTable,
+      path: "/Applications/Foo.app",
+      expected: false,
+    },
+    {
+      case: "read-only non-root volume",
+      table: baseTable,
+      path: "/Volumes/ReadOnlyVol/PostHog Code.app/Contents/MacOS/PostHog Code",
+      expected: true,
+    },
+    {
+      case: "writable non-root volume",
+      table: baseTable,
+      path: "/Volumes/Writable/out/PostHog Code.app/Contents/MacOS/PostHog Code",
+      expected: false,
+    },
+    {
+      case: "nested read-only mount wins over writable parent",
+      table: nestedTable,
+      path: "/Volumes/RW/nested/app",
+      expected: true,
+    },
+    {
+      case: "writable parent wins when no deeper match",
+      table: nestedTable,
+      path: "/Volumes/RW/other/app",
+      expected: false,
+    },
+  ])("$case → $expected", ({ table, path, expected }) => {
+    expect(isMacosPathOnReadOnlyNonRootMountFromTable(path, table)).toBe(
+      expected,
+    );
   });
 });
 
@@ -127,45 +144,59 @@ describe("isMacosPackagedUnsafeBundleLocation", () => {
 /dev/disk7s1 on /Volumes/ReadOnlyVol (apfs, local, read-only, journaled)
 `;
 
-  it("is true when translocated (mount table never consulted)", () => {
-    const readMountTable = vi.fn(() => writableMountTable);
-    expect(
-      isMacosPackagedUnsafeBundleLocation(
+  it.each<{
+    case: string;
+    appPath: string;
+    exePath: string;
+    readMountTable: ReadDarwinMountTable;
+    expected: boolean;
+  }>([
+    {
+      case: "translocated bundle",
+      appPath:
         "/private/var/.../AppTranslocation/UUID/d/PostHog Code.app/Contents/Resources/app.asar",
-        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
-        readMountTable,
-      ),
-    ).toBe(true);
-    expect(readMountTable).not.toHaveBeenCalled();
-  });
-
-  it("is false for ordinary non-translocated paths on writable mounts", () => {
-    expect(
-      isMacosPackagedUnsafeBundleLocation(
+      exePath: "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      readMountTable: () => writableMountTable,
+      expected: true,
+    },
+    {
+      case: "ordinary non-translocated path on a writable mount",
+      appPath:
         "/Volumes/build/out/PostHog Code.app/Contents/Resources/app.asar",
+      exePath:
         "/Volumes/build/out/PostHog Code.app/Contents/MacOS/PostHog Code",
-        () => writableMountTable,
-      ),
-    ).toBe(false);
-  });
-
-  it("is true when the bundle lives on a read-only non-root volume", () => {
-    expect(
-      isMacosPackagedUnsafeBundleLocation(
+      readMountTable: () => writableMountTable,
+      expected: false,
+    },
+    {
+      case: "bundle on a read-only non-root volume",
+      appPath:
         "/Volumes/ReadOnlyVol/PostHog Code.app/Contents/Resources/app.asar",
+      exePath:
         "/Volumes/ReadOnlyVol/PostHog Code.app/Contents/MacOS/PostHog Code",
-        () => readOnlyMountTable,
-      ),
-    ).toBe(true);
+      readMountTable: () => readOnlyMountTable,
+      expected: true,
+    },
+    {
+      case: "mount table cannot be read (degrade to non-blocking)",
+      appPath: "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+      exePath: "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      readMountTable: () => null,
+      expected: false,
+    },
+  ])("$case → $expected", ({ appPath, exePath, readMountTable, expected }) => {
+    expect(
+      isMacosPackagedUnsafeBundleLocation(appPath, exePath, readMountTable),
+    ).toBe(expected);
   });
 
-  it("is false when the mount table cannot be read (degrade to non-blocking)", () => {
-    expect(
-      isMacosPackagedUnsafeBundleLocation(
-        "/Applications/PostHog Code.app/Contents/Resources/app.asar",
-        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
-        () => null,
-      ),
-    ).toBe(false);
+  it("short-circuits on translocation without reading the mount table", () => {
+    const readMountTable = vi.fn(() => writableMountTable);
+    isMacosPackagedUnsafeBundleLocation(
+      "/private/var/.../AppTranslocation/UUID/d/PostHog Code.app/Contents/Resources/app.asar",
+      "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      readMountTable,
+    );
+    expect(readMountTable).not.toHaveBeenCalled();
   });
 });

--- a/apps/code/src/main/utils/macos-packaged-install-guard.test.ts
+++ b/apps/code/src/main/utils/macos-packaged-install-guard.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMacosAppTranslocationPath,
+  isMacosPackagedUnsafeBundleLocation,
+  isMacosPathOnReadOnlyNonRootMountFromTable,
+  parseDarwinMountTable,
+} from "./macos-packaged-install-guard";
+
+describe("isMacosAppTranslocationPath", () => {
+  it("returns true when appPath contains AppTranslocation", () => {
+    expect(
+      isMacosAppTranslocationPath(
+        "/private/var/folders/yf/xx/AppTranslocation/C6283C3C-9D6E-4D81-A7D5-8BA2567ED486/d/PostHog Code.app/Contents/Resources/app.asar",
+        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when exePath contains AppTranslocation", () => {
+    expect(
+      isMacosAppTranslocationPath(
+        "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+        "/private/var/folders/yf/xx/AppTranslocation/C6283C3C/d/PostHog Code.app/Contents/MacOS/PostHog Code",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for normal /Applications paths", () => {
+    expect(
+      isMacosAppTranslocationPath(
+        "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when neither path is translocated", () => {
+    expect(
+      isMacosAppTranslocationPath(
+        "/Users/dev/PostHog Code.app/Contents/Resources/app.asar",
+        "/Users/dev/PostHog Code.app/Contents/MacOS/PostHog Code",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("parseDarwinMountTable", () => {
+  it("parses standard macOS mount lines", () => {
+    const sample = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+/dev/disk7s1 on /Volumes/My Dmg (apfs, local, read-only, journaled)
+/dev/disk5s1 on /Volumes/Writable (apfs, local, journaled)
+`;
+    const entries = parseDarwinMountTable(sample);
+    expect(entries).toEqual([
+      { mountPoint: "/", options: "apfs, sealed, local, read-only, journaled" },
+      {
+        mountPoint: "/Volumes/My Dmg",
+        options: "apfs, local, read-only, journaled",
+      },
+      { mountPoint: "/Volumes/Writable", options: "apfs, local, journaled" },
+    ]);
+  });
+});
+
+describe("isMacosPathOnReadOnlyNonRootMountFromTable", () => {
+  const table = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+/dev/disk7s1 on /Volumes/ReadOnlyVol (apfs, local, read-only, journaled)
+/dev/disk5s1 on /Volumes/Writable (apfs, local, journaled)
+`;
+
+  it("returns false for paths only under read-only / (root is ignored)", () => {
+    expect(
+      isMacosPathOnReadOnlyNonRootMountFromTable("/Users/me/app", table),
+    ).toBe(false);
+    expect(
+      isMacosPathOnReadOnlyNonRootMountFromTable(
+        "/Applications/Foo.app",
+        table,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for paths on a read-only non-root volume", () => {
+    expect(
+      isMacosPathOnReadOnlyNonRootMountFromTable(
+        "/Volumes/ReadOnlyVol/PostHog Code.app/Contents/MacOS/PostHog Code",
+        table,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for paths on a writable volume", () => {
+    expect(
+      isMacosPathOnReadOnlyNonRootMountFromTable(
+        "/Volumes/Writable/out/PostHog Code.app/Contents/MacOS/PostHog Code",
+        table,
+      ),
+    ).toBe(false);
+  });
+
+  it("picks the longest matching mount prefix", () => {
+    const nested = `/dev/x on / (apfs, read-only)
+/dev/y on /Volumes/RW (apfs, local, journaled)
+/dev/z on /Volumes/RW/nested (apfs, local, read-only)
+`;
+    expect(
+      isMacosPathOnReadOnlyNonRootMountFromTable(
+        "/Volumes/RW/nested/app",
+        nested,
+      ),
+    ).toBe(true);
+    expect(
+      isMacosPathOnReadOnlyNonRootMountFromTable(
+        "/Volumes/RW/other/app",
+        nested,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isMacosPackagedUnsafeBundleLocation", () => {
+  it("is true when translocated", () => {
+    expect(
+      isMacosPackagedUnsafeBundleLocation(
+        "/private/var/.../AppTranslocation/UUID/d/PostHog Code.app/Contents/Resources/app.asar",
+        "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for ordinary non-translocated paths on writable mounts", () => {
+    expect(
+      isMacosPackagedUnsafeBundleLocation(
+        "/Volumes/build/out/PostHog Code.app/Contents/Resources/app.asar",
+        "/Volumes/build/out/PostHog Code.app/Contents/MacOS/PostHog Code",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/code/src/main/utils/macos-packaged-install-guard.ts
+++ b/apps/code/src/main/utils/macos-packaged-install-guard.ts
@@ -2,11 +2,18 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 
 const APP_TRANSLOCATION_SEGMENT = "AppTranslocation";
+const MOUNT_READ_TIMEOUT_MS = 3000;
 
 export type DarwinMountEntry = {
   mountPoint: string;
   options: string;
 };
+
+/**
+ * Reads the Darwin mount table. Returns `null` when the table cannot be
+ * obtained (e.g. `/sbin/mount` is missing, times out, or exits non-zero).
+ */
+export type ReadDarwinMountTable = () => string | null;
 
 /** Parse `/sbin/mount` lines: `<device> on <mountPoint> (<opts>)` */
 export function parseDarwinMountTable(output: string): DarwinMountEntry[] {
@@ -35,7 +42,12 @@ function longestMatchingMount(
   let best: DarwinMountEntry | null = null;
   for (const e of entries) {
     const mp = e.mountPoint;
-    const under = resolvedPath === mp || resolvedPath.startsWith(`${mp}/`);
+    // For `/` we'd otherwise build `//` which no real path starts with, so the
+    // root mount would silently drop out of the comparison and the
+    // `best.mountPoint === "/"` guard below would be unreachable.
+    const under =
+      resolvedPath === mp ||
+      resolvedPath.startsWith(mp === "/" ? "/" : `${mp}/`);
     if (!under) continue;
     if (!best || mp.length > best.mountPoint.length) {
       best = e;
@@ -64,22 +76,22 @@ export function isMacosPathOnReadOnlyNonRootMountFromTable(
   return mountOptionsImplyReadOnly(best.options);
 }
 
-function isMacosPathOnReadOnlyNonRootMount(
-  resolvedAbsolutePath: string,
-): boolean {
-  let output: string;
+/**
+ * Reads `/sbin/mount` synchronously. A short timeout keeps a hung NFS/SMB
+ * share from freezing app startup — the exact failure mode this guard exists
+ * to prevent. Returns `null` on any failure so callers can degrade to "don't
+ * block".
+ */
+function readDarwinMountTableSync(): string | null {
   try {
-    output = execFileSync("/sbin/mount", {
+    return execFileSync("/sbin/mount", {
       encoding: "utf8",
       maxBuffer: 10 * 1024 * 1024,
+      timeout: MOUNT_READ_TIMEOUT_MS,
     });
   } catch {
-    return false;
+    return null;
   }
-  return isMacosPathOnReadOnlyNonRootMountFromTable(
-    resolvedAbsolutePath,
-    output,
-  );
 }
 
 /**
@@ -96,13 +108,27 @@ export function isMacosAppTranslocationPath(
   );
 }
 
-/** Packaged macOS: translocated bundle path, or binary on a non-root read-only mount (see mount(8)). */
+/**
+ * Packaged macOS: translocated bundle path, or binary on a non-root read-only
+ * mount (see mount(8)).
+ *
+ * `readMountTable` is injectable so tests can drive the mount-table branch
+ * deterministically instead of relying on the host's real `/sbin/mount`.
+ */
 export function isMacosPackagedUnsafeBundleLocation(
   appPath: string,
   exePath: string,
+  readMountTable: ReadDarwinMountTable = readDarwinMountTableSync,
 ): boolean {
   if (isMacosAppTranslocationPath(appPath, exePath)) {
     return true;
   }
-  return isMacosPathOnReadOnlyNonRootMount(path.resolve(exePath));
+  const table = readMountTable();
+  if (table === null) {
+    return false;
+  }
+  return isMacosPathOnReadOnlyNonRootMountFromTable(
+    path.resolve(exePath),
+    table,
+  );
 }

--- a/apps/code/src/main/utils/macos-packaged-install-guard.ts
+++ b/apps/code/src/main/utils/macos-packaged-install-guard.ts
@@ -22,7 +22,11 @@ export function parseDarwinMountTable(output: string): DarwinMountEntry[] {
     const onMarker = line.indexOf(" on ");
     if (onMarker === -1) continue;
     const afterOn = line.slice(onMarker + 4);
-    const openParen = afterOn.indexOf(" (");
+    // `lastIndexOf` anchors to the trailing options block, so mount points
+    // whose display names contain " (" (e.g. "/Volumes/My Backup (2)") still
+    // parse correctly. The `line.endsWith(")")` check guarantees those parens
+    // really are the options.
+    const openParen = afterOn.lastIndexOf(" (");
     if (openParen === -1 || !line.endsWith(")")) continue;
     const mountPoint = afterOn.slice(0, openParen);
     const options = afterOn.slice(openParen + 2, -1);

--- a/apps/code/src/main/utils/macos-packaged-install-guard.ts
+++ b/apps/code/src/main/utils/macos-packaged-install-guard.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const APP_TRANSLOCATION_SEGMENT = "AppTranslocation";
+
+export type DarwinMountEntry = {
+  mountPoint: string;
+  options: string;
+};
+
+/** Parse `/sbin/mount` lines: `<device> on <mountPoint> (<opts>)` */
+export function parseDarwinMountTable(output: string): DarwinMountEntry[] {
+  const entries: DarwinMountEntry[] = [];
+  for (const line of output.split("\n")) {
+    const onMarker = line.indexOf(" on ");
+    if (onMarker === -1) continue;
+    const afterOn = line.slice(onMarker + 4);
+    const openParen = afterOn.indexOf(" (");
+    if (openParen === -1 || !line.endsWith(")")) continue;
+    const mountPoint = afterOn.slice(0, openParen);
+    const options = afterOn.slice(openParen + 2, -1);
+    entries.push({ mountPoint, options });
+  }
+  return entries;
+}
+
+function mountOptionsImplyReadOnly(options: string): boolean {
+  return options.toLowerCase().includes("read-only");
+}
+
+function longestMatchingMount(
+  resolvedPath: string,
+  entries: DarwinMountEntry[],
+): DarwinMountEntry | null {
+  let best: DarwinMountEntry | null = null;
+  for (const e of entries) {
+    const mp = e.mountPoint;
+    const under = resolvedPath === mp || resolvedPath.startsWith(`${mp}/`);
+    if (!under) continue;
+    if (!best || mp.length > best.mountPoint.length) {
+      best = e;
+    }
+  }
+  return best;
+}
+
+/**
+ * True when `resolvedAbsolutePath` sits on a **non-root** mount that `mount(8)`
+ * reports as read-only (e.g. many DMGs, some external volumes).
+ *
+ * Ignores read-only `/` — on sealed macOS the system volume is read-only while
+ * normal apps under /Applications or /Users still work.
+ */
+export function isMacosPathOnReadOnlyNonRootMountFromTable(
+  resolvedAbsolutePath: string,
+  mountTable: string,
+): boolean {
+  const normalized = path.resolve(resolvedAbsolutePath);
+  const entries = parseDarwinMountTable(mountTable);
+  const best = longestMatchingMount(normalized, entries);
+  if (!best || best.mountPoint === "/") {
+    return false;
+  }
+  return mountOptionsImplyReadOnly(best.options);
+}
+
+function isMacosPathOnReadOnlyNonRootMount(
+  resolvedAbsolutePath: string,
+): boolean {
+  let output: string;
+  try {
+    output = execFileSync("/sbin/mount", {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  } catch {
+    return false;
+  }
+  return isMacosPathOnReadOnlyNonRootMountFromTable(
+    resolvedAbsolutePath,
+    output,
+  );
+}
+
+/**
+ * True when either path is under macOS App Translocation (read-only runtime).
+ * Caller should gate on packaged darwin before using this to block startup.
+ */
+export function isMacosAppTranslocationPath(
+  appPath: string,
+  exePath: string,
+): boolean {
+  return (
+    appPath.includes(APP_TRANSLOCATION_SEGMENT) ||
+    exePath.includes(APP_TRANSLOCATION_SEGMENT)
+  );
+}
+
+/** Packaged macOS: translocated bundle path, or binary on a non-root read-only mount (see mount(8)). */
+export function isMacosPackagedUnsafeBundleLocation(
+  appPath: string,
+  exePath: string,
+): boolean {
+  if (isMacosAppTranslocationPath(appPath, exePath)) {
+    return true;
+  }
+  return isMacosPathOnReadOnlyNonRootMount(path.resolve(exePath));
+}


### PR DESCRIPTION
Fixes: #2098

## Problem

Packaged PostHog Code users on macOS can end up launching from **App Translocation** or a **read-only volume** (e.g. DMG). The app may start partially, then updates, local tasks, or cloud flows misbehave with little in-app explanation. This hurts anyone installing from Downloads, disk images, or other flows that Gatekeeper exposes as a restricted runtime path—not only power users reading `main.log`.

Closes [#2098](https://github.com/PostHog/code/issues/2098)

## Changes

- **Early startup gate** (first step inside `app.whenReady()`, before logs, window creation, or `initializeServices()`): **packaged macOS only**. If we detect an unsafe bundle location, show a **blocking** `dialog.showMessageBoxSync` explaining read-only/translocation-style behavior, then `app.quit()`.
- **`macos-packaged-install-guard.ts`**: consolidated helpers—
  - **`AppTranslocation`** in `app.getAppPath()` or `process.execPath`.
  - **`/sbin/mount`** output: longest prefix match for resolved `exePath`; unsafe if mount options contain **`read-only`** and mount point is **not `/`** (avoids sealed-root false positives).
- **`macos-packaged-install-guard.test.ts`**: table-driven tests for mount parsing and combined `isMacosPackagedUnsafeBundleLocation`.

No renderer UI screenshots (native Electron dialog only).

## How did you test this?

- **Automated:** `pnpm --filter code exec vitest run src/main/utils/macos-packaged-install-guard.test.ts` (all tests passing when run).
- **Manual (recommended):** `pnpm --filter code package`; open **`PostHog Code.app`** from a normal writable path (should behave as before); open from a **read-only-mounted** DMG/volume or a **translocated** path—expect the blocking dialog and exit after OK. Dev **`pnpm dev`** should be unchanged (`app.isPackaged`).