### PR TITLE
Use keyed event channels for per-taskRunId subscriptions

### DIFF
--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -1182,8 +1182,10 @@ For git operations while detached:
     const service = this;
 
     const emitToRenderer = (payload: unknown) => {
-      // Emit event via TypedEventEmitter for tRPC subscription
-      this.emit(AgentServiceEvent.SessionEvent, {
+      // Emit event via TypedEventEmitter for tRPC subscription.
+      // Routed on a per-taskRunId sub-channel so each task's subscription only
+      // wakes for its own events (avoids O(N) fan-out across the Command Center).
+      this.emitFor(AgentServiceEvent.SessionEvent, taskRunId, {
         taskRunId,
         payload,
       });
@@ -1269,10 +1271,11 @@ For git operations while detached:
                   toolCallId,
                 });
                 const { sessionId: _agentSessionId, ...rest } = params;
-                service.emit(AgentServiceEvent.PermissionRequest, {
-                  ...rest,
+                service.emitFor(
+                  AgentServiceEvent.PermissionRequest,
                   taskRunId,
-                });
+                  { ...rest, taskRunId },
+                );
               },
             );
 

--- a/apps/code/src/main/trpc/routers/agent.ts
+++ b/apps/code/src/main/trpc/routers/agent.ts
@@ -76,15 +76,14 @@ export const agentRouter = router({
     .input(subscribeSessionInput)
     .subscription(async function* (opts) {
       const service = getService();
-      const targetTaskRunId = opts.input.taskRunId;
-      const iterable = service.toIterable(AgentServiceEvent.SessionEvent, {
-        signal: opts.signal,
-      });
+      const iterable = service.toIterableFor(
+        AgentServiceEvent.SessionEvent,
+        opts.input.taskRunId,
+        { signal: opts.signal },
+      );
 
       for await (const event of iterable) {
-        if (event.taskRunId === targetTaskRunId) {
-          yield event.payload;
-        }
+        yield event.payload;
       }
     }),
 
@@ -93,15 +92,14 @@ export const agentRouter = router({
     .input(subscribeSessionInput)
     .subscription(async function* (opts) {
       const service = getService();
-      const targetTaskRunId = opts.input.taskRunId;
-      const iterable = service.toIterable(AgentServiceEvent.PermissionRequest, {
-        signal: opts.signal,
-      });
+      const iterable = service.toIterableFor(
+        AgentServiceEvent.PermissionRequest,
+        opts.input.taskRunId,
+        { signal: opts.signal },
+      );
 
       for await (const event of iterable) {
-        if (event.taskRunId === targetTaskRunId) {
-          yield event;
-        }
+        yield event;
       }
     }),
 

--- a/apps/code/src/main/utils/typed-event-emitter.ts
+++ b/apps/code/src/main/utils/typed-event-emitter.ts
@@ -35,4 +35,27 @@ export class TypedEventEmitter<TEvents> extends EventEmitter {
       yield payload as TEvents[K];
     }
   }
+
+  // Keyed dispatch — emits on a sub-channel (`${event}:${key}`) so listeners
+  // that only care about one key (e.g. a single taskRunId) don't pay the cost
+  // of receiving and filtering every other key's events. Critical for the
+  // Command Center, where N concurrent subscriptions would otherwise turn each
+  // emit into N filtered wake-ups.
+  emitFor<K extends keyof TEvents & string>(
+    event: K,
+    key: string,
+    payload: TEvents[K],
+  ): boolean {
+    return super.emit(`${event}:${key}`, payload);
+  }
+
+  async *toIterableFor<K extends keyof TEvents & string>(
+    event: K,
+    key: string,
+    opts?: { signal?: AbortSignal },
+  ): AsyncIterable<TEvents[K]> {
+    for await (const [payload] of on(this, `${event}:${key}`, opts)) {
+      yield payload as TEvents[K];
+    }
+  }
 }


### PR DESCRIPTION
## Problem

When multiple concurrent subscriptions exist in the Command Center, each event emission triggers filtering across all active subscriptions. This creates O(N) wake-ups per emit, where N is the number of concurrent tasks. With many concurrent subscriptions, this becomes a performance bottleneck.

## Changes

Introduced keyed event dispatch to the `TypedEventEmitter` class:
- Added `emitFor(event, key, payload)` method that emits on a sub-channel (`${event}:${key}`)
- Added `toIterableFor(event, key, opts)` method that listens only to a specific key's sub-channel

Updated agent service and tRPC router to use keyed channels:
- Session event subscriptions now use `emitFor(AgentServiceEvent.SessionEvent, taskRunId, ...)`
- Permission request subscriptions now use `emitFor(AgentServiceEvent.PermissionRequest, taskRunId, ...)`
- Removed manual filtering logic in subscription handlers since events are now pre-filtered by key

This allows each subscription to receive only events for its own taskRunId without paying the cost of filtering every other task's events. Critical for scalability when many tasks run concurrently.

## How did you test this?

Existing tRPC subscription tests cover the router changes. The keyed event dispatch is a transparent optimization—subscriptions receive the same events as before, just more efficiently routed.

## Publish to changelog?

no

https://claude.ai/code/session_01NBy8uLzj4g38WfHf2vewMF