### PR TITLE
fix: Prevent watcher leaks when subscribe times out

### DIFF
--- a/apps/code/src/main/services/focus/sync-service.ts
+++ b/apps/code/src/main/services/focus/sync-service.ts
@@ -10,6 +10,7 @@ import { ApplyPatchSaga } from "@posthog/git/sagas/patch";
 import ignore, { type Ignore } from "ignore";
 import { inject, injectable } from "inversify";
 import { MAIN_TOKENS } from "../../di/tokens";
+import { subscribeWithTimeout } from "../../utils/async";
 import { logger } from "../../utils/logger";
 import type { WatcherRegistryService } from "../watcher-registry/service";
 
@@ -115,18 +116,20 @@ export class FocusSyncService {
         { ignore: watcherIgnore },
       );
 
-      const mainSubResult = await Promise.race([
-        mainSubPromise.then((sub) => ({ sub, timeout: false })),
-        new Promise<{ sub: null; timeout: true }>((resolve) =>
-          setTimeout(() => resolve({ sub: null, timeout: true }), 5000),
-        ),
-      ]);
+      const mainSubResult = await subscribeWithTimeout(
+        mainSubPromise,
+        5000,
+        `focus-sync:main:${mainRepoPath}`,
+      );
 
-      if (mainSubResult.timeout) {
+      if (mainSubResult.result === "timeout") {
         log.warn("Main repo watcher subscription timed out");
-      } else if (mainSubResult.sub) {
+      } else {
         this.mainWatcherId = `focus-sync:main:${mainRepoPath}`;
-        this.watcherRegistry.register(this.mainWatcherId, mainSubResult.sub);
+        this.watcherRegistry.register(
+          this.mainWatcherId,
+          mainSubResult.subscription,
+        );
       }
     } catch (error) {
       log.error("Failed to subscribe to main repo watcher:", error);
@@ -146,20 +149,19 @@ export class FocusSyncService {
         { ignore: watcherIgnore },
       );
 
-      const worktreeSubResult = await Promise.race([
-        worktreeSubPromise.then((sub) => ({ sub, timeout: false })),
-        new Promise<{ sub: null; timeout: true }>((resolve) =>
-          setTimeout(() => resolve({ sub: null, timeout: true }), 5000),
-        ),
-      ]);
+      const worktreeSubResult = await subscribeWithTimeout(
+        worktreeSubPromise,
+        5000,
+        `focus-sync:worktree:${worktreePath}`,
+      );
 
-      if (worktreeSubResult.timeout) {
+      if (worktreeSubResult.result === "timeout") {
         log.warn("Worktree watcher subscription timed out");
-      } else if (worktreeSubResult.sub) {
+      } else {
         this.worktreeWatcherId = `focus-sync:worktree:${worktreePath}`;
         this.watcherRegistry.register(
           this.worktreeWatcherId,
-          worktreeSubResult.sub,
+          worktreeSubResult.subscription,
         );
       }
     } catch (error) {

--- a/apps/code/src/main/services/focus/sync-service.ts
+++ b/apps/code/src/main/services/focus/sync-service.ts
@@ -101,12 +101,15 @@ export class FocusSyncService {
     }
 
     const watcherIgnore = ALWAYS_IGNORE.map((p) => `**/${p}/**`);
+    const mainWatcherId = `focus-sync:main:${mainRepoPath}`;
+    const worktreeWatcherId = `focus-sync:worktree:${worktreePath}`;
 
+    let mainRegistered = false;
     try {
       const mainSubPromise = watcher.subscribe(
         mainRepoPath,
         (err, events) => {
-          if (this.watcherRegistry.isShutdown) return;
+          if (!mainRegistered || this.watcherRegistry.isShutdown) return;
           if (err) {
             log.error("Main repo watcher error:", err);
             return;
@@ -119,13 +122,14 @@ export class FocusSyncService {
       const mainSubResult = await subscribeWithTimeout(
         mainSubPromise,
         5000,
-        `focus-sync:main:${mainRepoPath}`,
+        mainWatcherId,
       );
 
       if (mainSubResult.result === "timeout") {
         log.warn("Main repo watcher subscription timed out");
       } else {
-        this.mainWatcherId = `focus-sync:main:${mainRepoPath}`;
+        mainRegistered = true;
+        this.mainWatcherId = mainWatcherId;
         this.watcherRegistry.register(
           this.mainWatcherId,
           mainSubResult.subscription,
@@ -135,11 +139,12 @@ export class FocusSyncService {
       log.error("Failed to subscribe to main repo watcher:", error);
     }
 
+    let worktreeRegistered = false;
     try {
       const worktreeSubPromise = watcher.subscribe(
         worktreePath,
         (err, events) => {
-          if (this.watcherRegistry.isShutdown) return;
+          if (!worktreeRegistered || this.watcherRegistry.isShutdown) return;
           if (err) {
             log.error("Worktree watcher error:", err);
             return;
@@ -152,13 +157,14 @@ export class FocusSyncService {
       const worktreeSubResult = await subscribeWithTimeout(
         worktreeSubPromise,
         5000,
-        `focus-sync:worktree:${worktreePath}`,
+        worktreeWatcherId,
       );
 
       if (worktreeSubResult.result === "timeout") {
         log.warn("Worktree watcher subscription timed out");
       } else {
-        this.worktreeWatcherId = `focus-sync:worktree:${worktreePath}`;
+        worktreeRegistered = true;
+        this.worktreeWatcherId = worktreeWatcherId;
         this.watcherRegistry.register(
           this.worktreeWatcherId,
           worktreeSubResult.subscription,

--- a/apps/code/src/main/utils/async.test.ts
+++ b/apps/code/src/main/utils/async.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const warn = vi.hoisted(() => vi.fn());
+
+vi.mock("./logger", () => ({
+  logger: {
+    scope: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn,
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+import { subscribeWithTimeout, withTimeout } from "./async";
+
+interface FakeSubscription {
+  unsubscribe: () => Promise<unknown>;
+}
+
+const makeSubscription = (
+  unsubscribeImpl: () => Promise<unknown> = () => Promise.resolve(),
+): FakeSubscription & { unsubscribe: ReturnType<typeof vi.fn> } => {
+  const unsubscribe = vi.fn(
+    unsubscribeImpl,
+  ) as unknown as (() => Promise<unknown>) & ReturnType<typeof vi.fn>;
+  return { unsubscribe };
+};
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("withTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns success with the value when the operation resolves first", async () => {
+    const result = await withTimeout(Promise.resolve("done"), 1000);
+    expect(result).toEqual({ result: "success", value: "done" });
+  });
+
+  it("returns timeout when the operation is slower than the deadline", async () => {
+    const { promise } = deferred<string>();
+    const racePromise = withTimeout(promise, 1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(await racePromise).toEqual({ result: "timeout" });
+  });
+
+  it("clears the timeout timer on success", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    await withTimeout(Promise.resolve("done"), 1000);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("subscribeWithTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns success and the subscription when subscribe resolves first", async () => {
+    const sub = makeSubscription();
+    const result = await subscribeWithTimeout(
+      Promise.resolve(sub),
+      1000,
+      "test",
+    );
+    expect(result).toEqual({ result: "success", subscription: sub });
+    expect(sub.unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it("clears the timeout timer on success", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    await subscribeWithTimeout(
+      Promise.resolve(makeSubscription()),
+      1000,
+      "test",
+    );
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns timeout and unsubscribes the late subscription", async () => {
+    const sub = makeSubscription();
+    const { promise, resolve } = deferred<FakeSubscription>();
+
+    const racePromise = subscribeWithTimeout(promise, 1000, "late-sub");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(await racePromise).toEqual({ result: "timeout" });
+
+    resolve(sub);
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(sub.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a warning when the late unsubscribe rejects", async () => {
+    const sub = makeSubscription(() => Promise.reject(new Error("nope")));
+    const { promise, resolve } = deferred<FakeSubscription>();
+
+    const racePromise = subscribeWithTimeout(promise, 1000, "boom");
+    await vi.advanceTimersByTimeAsync(1000);
+    await racePromise;
+
+    resolve(sub);
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to tear down late subscription (boom)"),
+      expect.any(Error),
+    );
+  });
+
+  it("logs a warning when the subscribe promise rejects after the timeout", async () => {
+    const { promise, reject } = deferred<FakeSubscription>();
+
+    const racePromise = subscribeWithTimeout(promise, 1000, "rejected-late");
+    await vi.advanceTimersByTimeAsync(1000);
+    await racePromise;
+
+    reject(new Error("subscribe blew up"));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Late subscribe rejected after timeout (rejected-late)",
+      ),
+      expect.any(Error),
+    );
+  });
+
+  it("propagates a subscribe rejection that beats the timeout", async () => {
+    const failing = Promise.reject(new Error("immediate fail"));
+    await expect(
+      subscribeWithTimeout(failing, 1000, "early-fail"),
+    ).rejects.toThrow("immediate fail");
+  });
+});

--- a/apps/code/src/main/utils/async.ts
+++ b/apps/code/src/main/utils/async.ts
@@ -1,3 +1,7 @@
+import { logger } from "./logger";
+
+const log = logger.scope("async-utils");
+
 /**
  * Races an operation against a timeout.
  * Returns success with the value if the operation completes in time,
@@ -15,4 +19,43 @@ export async function withTimeout<T>(
     value,
   }));
   return Promise.race([operationPromise, timeoutPromise]);
+}
+
+/**
+ * Races a subscribe-style promise against a timeout. If the timeout wins,
+ * any late-arriving subscription is torn down via its `unsubscribe()` method
+ * so the underlying resource (e.g. FSEvents/inotify fd, callback closure)
+ * does not leak.
+ */
+export async function subscribeWithTimeout<
+  T extends { unsubscribe(): Promise<unknown> },
+>(
+  subscribePromise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<{ result: "success"; subscription: T } | { result: "timeout" }> {
+  const timeoutPromise = new Promise<{ result: "timeout" }>((resolve) =>
+    setTimeout(() => resolve({ result: "timeout" }), timeoutMs),
+  );
+  const successPromise = subscribePromise.then((subscription) => ({
+    result: "success" as const,
+    subscription,
+  }));
+
+  const race = await Promise.race([successPromise, timeoutPromise]);
+
+  if (race.result === "timeout") {
+    subscribePromise
+      .then((sub) =>
+        sub.unsubscribe().catch((err) => {
+          log.warn(`Failed to tear down late subscription (${label}):`, err);
+        }),
+      )
+      .catch((err) => {
+        log.warn(`Late subscribe rejected after timeout (${label}):`, err);
+      });
+    return { result: "timeout" };
+  }
+
+  return race;
 }

--- a/apps/code/src/main/utils/async.ts
+++ b/apps/code/src/main/utils/async.ts
@@ -11,14 +11,19 @@ export async function withTimeout<T>(
   operation: Promise<T>,
   timeoutMs: number,
 ): Promise<{ result: "success"; value: T } | { result: "timeout" }> {
-  const timeoutPromise = new Promise<{ result: "timeout" }>((resolve) =>
-    setTimeout(() => resolve({ result: "timeout" }), timeoutMs),
-  );
+  let timeoutHandle!: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<{ result: "timeout" }>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ result: "timeout" }), timeoutMs);
+  });
   const operationPromise = operation.then((value) => ({
     result: "success" as const,
     value,
   }));
-  return Promise.race([operationPromise, timeoutPromise]);
+  try {
+    return await Promise.race([operationPromise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
 }
 
 /**
@@ -26,6 +31,10 @@ export async function withTimeout<T>(
  * any late-arriving subscription is torn down via its `unsubscribe()` method
  * so the underlying resource (e.g. FSEvents/inotify fd, callback closure)
  * does not leak.
+ *
+ * The late teardown is fire-and-forget: the caller does not await it. Errors
+ * during teardown (or a late rejection of the subscribe promise) are logged
+ * at warn level with `label` for diagnostic context.
  */
 export async function subscribeWithTimeout<
   T extends { unsubscribe(): Promise<unknown> },
@@ -34,15 +43,17 @@ export async function subscribeWithTimeout<
   timeoutMs: number,
   label: string,
 ): Promise<{ result: "success"; subscription: T } | { result: "timeout" }> {
-  const timeoutPromise = new Promise<{ result: "timeout" }>((resolve) =>
-    setTimeout(() => resolve({ result: "timeout" }), timeoutMs),
-  );
+  let timeoutHandle!: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<{ result: "timeout" }>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ result: "timeout" }), timeoutMs);
+  });
   const successPromise = subscribePromise.then((subscription) => ({
     result: "success" as const,
     subscription,
   }));
 
   const race = await Promise.race([successPromise, timeoutPromise]);
+  clearTimeout(timeoutHandle);
 
   if (race.result === "timeout") {
     subscribePromise


### PR DESCRIPTION
## Problem

Focus-sync watcher subscriptions that exceeded the 5s timeout leaked the underlying file watcher (FSEvents/inotify fd) and kept firing callbacks against a never-registered watcher.

## Changes

  1. Add `subscribeWithTimeout` helper that fire-and-forget unsubscribes any late-arriving subscription
  2. Gate the watcher callbacks behind `mainRegistered`/`worktreeRegistered` flags so late events no-op
  3. Clear the `withTimeout` timer in a `finally` block to stop leaking node timers on success
  4. Log late teardown / late rejection failures at warn with a label for diagnostics
  5. Add unit tests for `withTimeout` and `subscribeWithTimeout` covering success, timeout, and late rejection