### PR TITLE
chore: require 7-day package release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 node-linker=hoisted
 shamefully-hoist=true
-minimumReleaseAge=10080

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 node-linker=hoisted
 shamefully-hoist=true
+minimumReleaseAge=10080

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b",
   "scripts": {
+    "preinstall": "node scripts/enforce-pnpm.mjs",
     "setup": "bash apps/code/bin/setup",
     "prepare": "husky",
     "dev": "pnpm build:deps && bash scripts/ensure-phrocs.sh && bin/phrocs --config mprocs.yaml",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ ignoredBuiltDependencies:
   - msw
   - protobufjs
 
-minimumReleaseAge: 1440
+minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
   - '@agentclientprotocol/sdk'

--- a/scripts/enforce-pnpm.mjs
+++ b/scripts/enforce-pnpm.mjs
@@ -1,0 +1,14 @@
+const userAgent = process.env.npm_config_user_agent ?? "";
+
+if (userAgent.startsWith("pnpm/")) {
+  process.exit(0);
+}
+
+console.error(
+  [
+    "This repository must be installed with pnpm.",
+    "Use `pnpm install` so the workspace minimumReleaseAge policy and exclusions are applied consistently.",
+  ].join("\n"),
+);
+
+process.exit(1);


### PR DESCRIPTION
## Summary
- raise the pnpm workspace minimum release age to 7 days
- require `pnpm install` so npm cannot bypass the workspace age policy or its exclusions

## Testing
- pnpm config get minimumReleaseAge
- npm_config_user_agent="pnpm/10.23.0 npm/? node/v22.0.0 darwin x64" node scripts/enforce-pnpm.mjs
- npm_config_user_agent="npm/11.0.0 node/v22.0.0 darwin x64" node scripts/enforce-pnpm.mjs