### PR TITLE
feat(mobile): move "New task" button to the tab bar

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -66,7 +66,7 @@ export default function TabsLayout() {
 
       {/* New task — opens the new-task modal via a trampoline route */}
       <NativeTabs.Trigger name="new-task">
-        <Label hidden />
+        <Label>New task</Label>
         <Icon
           sf={{ default: "plus", selected: "plus" }}
           drawable="ic_menu_add"

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -64,15 +64,14 @@ export default function TabsLayout() {
         />
       </NativeTabs.Trigger>
 
-      {/* TODO: Fix this and use NativeTabs.Trigger for opening the chat */}
-      {/* Chat - Separate floating button (iOS search role style) */}
-      {/* <NativeTabs.Trigger name="chat" role="search">
+      {/* New task — opens the new-task modal via a trampoline route */}
+      <NativeTabs.Trigger name="new-task">
         <Label hidden />
         <Icon
           sf={{ default: "plus", selected: "plus" }}
           drawable="ic_menu_add"
         />
-      </NativeTabs.Trigger> */}
+      </NativeTabs.Trigger>
     </NativeTabs>
   );
 }

--- a/apps/mobile/src/app/(tabs)/new-task.tsx
+++ b/apps/mobile/src/app/(tabs)/new-task.tsx
@@ -1,11 +1,18 @@
 import { router, useFocusEffect } from "expo-router";
 import { useCallback } from "react";
+import { InteractionManager } from "react-native";
 
 export default function NewTaskTrampoline() {
   useFocusEffect(
     useCallback(() => {
-      router.replace("/tasks");
-      router.push("/task");
+      // Wait for any in-flight transitions (e.g. a previous modal's
+      // dismiss animation) to finish before pushing /task, so rapid
+      // re-taps don't race the navigator.
+      const handle = InteractionManager.runAfterInteractions(() => {
+        router.replace("/tasks");
+        router.push("/task");
+      });
+      return () => handle.cancel();
     }, []),
   );
   return null;

--- a/apps/mobile/src/app/(tabs)/new-task.tsx
+++ b/apps/mobile/src/app/(tabs)/new-task.tsx
@@ -1,0 +1,12 @@
+import { router, useFocusEffect } from "expo-router";
+import { useCallback } from "react";
+
+export default function NewTaskTrampoline() {
+  useFocusEffect(
+    useCallback(() => {
+      router.replace("/tasks");
+      router.push("/task");
+    }, []),
+  );
+  return null;
+}

--- a/apps/mobile/src/app/(tabs)/tasks.tsx
+++ b/apps/mobile/src/app/(tabs)/tasks.tsx
@@ -44,9 +44,7 @@ export default function TasksScreen() {
       {/* Header */}
       <View className="border-gray-6 border-b px-4 pt-16 pb-4">
         <Text className="font-bold text-2xl text-gray-12">Code</Text>
-        <Text className="text-gray-11 text-sm">
-          Your PostHog Code sessions
-        </Text>
+        <Text className="text-gray-11 text-sm">Your PostHog Code sessions</Text>
       </View>
 
       {/* Task List */}

--- a/apps/mobile/src/app/(tabs)/tasks.tsx
+++ b/apps/mobile/src/app/(tabs)/tasks.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@components/text";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useRef } from "react";
-import { InteractionManager, Pressable, View } from "react-native";
+import { InteractionManager, View } from "react-native";
 import { TaskList } from "@/features/tasks";
 
 export default function TasksScreen() {
@@ -43,22 +43,10 @@ export default function TasksScreen() {
     <View className="flex-1 bg-background">
       {/* Header */}
       <View className="border-gray-6 border-b px-4 pt-16 pb-4">
-        <View className="flex-row items-center justify-between">
-          <View>
-            <Text className="font-bold text-2xl text-gray-12">Code</Text>
-            <Text className="text-gray-11 text-sm">
-              Your PostHog Code sessions
-            </Text>
-          </View>
-          <Pressable
-            onPress={handleCreateTask}
-            className="rounded-lg bg-accent-9 px-4 py-2"
-          >
-            <Text className="font-semibold text-accent-contrast text-sm">
-              New task
-            </Text>
-          </Pressable>
-        </View>
+        <Text className="font-bold text-2xl text-gray-12">Code</Text>
+        <Text className="text-gray-11 text-sm">
+          Your PostHog Code sessions
+        </Text>
       </View>
 
       {/* Task List */}


### PR DESCRIPTION
## Summary

- Replace the text "New task" button in the Code screen header with a plus icon in the native tab bar, alongside **Code** and **Settings**.
- Wire the plus trigger to the existing `/task` modal via a focus-only trampoline route at `(tabs)/new-task.tsx`. `NativeTabs.Trigger` requires a real file-system route and doesn't expose a `tabPress` listener, so the trampoline `replace`s back to `/tasks` then `push`es the modal so dismissal returns the user to the Code tab.
- Picks up the previous TODO/commented-out `NativeTabs.Trigger` block in `(tabs)/_layout.tsx` and replaces it with a working version.
- The empty-state "Create task" button inside `TaskList` is intentionally left in place — only the header button moves.

## Test plan

- [ ] `pnpm install && pnpm --filter @posthog/mobile lint` passes
- [ ] iOS simulator: tab bar shows **Code**, **Settings**, **+**; tapping **+** opens the new-task modal; dismissing returns to the Code tab; tapping **+** a second time still works
- [ ] Android emulator: same as above (drawable `ic_menu_add` renders)
- [ ] Code screen header no longer has the "New task" text button
- [ ] Empty-state "Create task" button inside `TaskList` still navigates correctly
- [ ] Toggling the `aiChatEnabled` preference still shows/hides the Chats tab alongside the new plus trigger