### PR TITLE
feat(mobile): user-level GitHub repo + branch picker for new tasks

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm exec *)"
+    ]
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -62,6 +62,7 @@
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "^15.15.1",
+    "react-native-web": "^0.21.2",
     "react-native-webview": "^13.13.5",
     "zustand": "^4.5.7"
   },

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,78 +1,25 @@
-import { Icon, Label, NativeTabs } from "expo-router/unstable-native-tabs";
-import { DynamicColorIOS, Platform } from "react-native";
-import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
+import { Stack } from "expo-router";
+import { View } from "react-native";
+import { NavDrawer } from "@/features/navigation/components/NavDrawer";
 import { useThemeColors } from "@/lib/theme";
 
 export default function TabsLayout() {
   const themeColors = useThemeColors();
-  const aiChatEnabled = usePreferencesStore((s) => s.aiChatEnabled);
-
-  // Dynamic colors for liquid glass effect on iOS
-  const dynamicTextColor =
-    Platform.OS === "ios"
-      ? DynamicColorIOS({
-          dark: themeColors.gray[12],
-          light: themeColors.gray[12],
-        })
-      : themeColors.gray[12];
-
-  const dynamicTintColor =
-    Platform.OS === "ios"
-      ? DynamicColorIOS({
-          dark: themeColors.accent[9],
-          light: themeColors.accent[9],
-        })
-      : themeColors.accent[9];
 
   return (
-    <NativeTabs
-      labelStyle={{
-        color: dynamicTextColor,
-      }}
-      tintColor={dynamicTintColor}
-      minimizeBehavior="onScrollDown"
-    >
-      {/* Conversations - Chats tab, hidden by default to focus on Code */}
-      {aiChatEnabled && (
-        <NativeTabs.Trigger name="index">
-          <Label>Chats</Label>
-          <Icon
-            sf={{
-              default: "bubble.left.and.bubble.right",
-              selected: "bubble.left.and.bubble.right.fill",
-            }}
-            drawable="ic_menu_send"
-          />
-        </NativeTabs.Trigger>
-      )}
-
-      {/* Code tab (task list for PostHog Code) */}
-      <NativeTabs.Trigger name="tasks">
-        <Label>Code</Label>
-        <Icon
-          sf={{ default: "checklist", selected: "checklist" }}
-          drawable="ic_menu_agenda"
-        />
-      </NativeTabs.Trigger>
-
-      {/* Settings Tab */}
-      <NativeTabs.Trigger name="settings">
-        <Label>Settings</Label>
-        <Icon
-          sf={{ default: "gearshape", selected: "gearshape.fill" }}
-          drawable="ic_menu_preferences"
-        />
-      </NativeTabs.Trigger>
-
-      {/* TODO: Fix this and use NativeTabs.Trigger for opening the chat */}
-      {/* Chat - Separate floating button (iOS search role style) */}
-      {/* <NativeTabs.Trigger name="chat" role="search">
-        <Label hidden />
-        <Icon
-          sf={{ default: "plus", selected: "plus" }}
-          drawable="ic_menu_add"
-        />
-      </NativeTabs.Trigger> */}
-    </NativeTabs>
+    <View className="flex-1 bg-background">
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: themeColors.background },
+        }}
+      >
+        <Stack.Screen name="tasks" />
+        <Stack.Screen name="inbox" />
+        <Stack.Screen name="settings" />
+        <Stack.Screen name="index" />
+      </Stack>
+      <NavDrawer />
+    </View>
   );
 }

--- a/apps/mobile/src/app/(tabs)/inbox.tsx
+++ b/apps/mobile/src/app/(tabs)/inbox.tsx
@@ -1,0 +1,37 @@
+import { Text } from "@components/text";
+import { Tray } from "phosphor-react-native";
+import { View } from "react-native";
+import { MenuButton } from "@/features/navigation/components/MenuButton";
+import { useThemeColors } from "@/lib/theme";
+
+export default function InboxScreen() {
+  const themeColors = useThemeColors();
+
+  return (
+    <View className="flex-1 bg-background">
+      <View className="border-gray-6 border-b px-3 pt-14 pb-4">
+        <View className="flex-row items-center gap-2">
+          <MenuButton />
+          <View className="flex-1">
+            <Text className="font-bold text-2xl text-gray-12">Inbox</Text>
+            <Text className="text-gray-11 text-sm">
+              Signals and notifications
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      <View className="flex-1 items-center justify-center p-6">
+        <View className="mb-6 h-16 w-16 items-center justify-center rounded-full bg-gray-3">
+          <Tray size={28} color={themeColors.gray[9]} />
+        </View>
+        <Text className="mb-2 text-center font-semibold text-gray-12 text-lg">
+          Inbox coming soon
+        </Text>
+        <Text className="text-center text-gray-11 text-sm">
+          Signals and notifications will show up here.
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/(tabs)/settings.tsx
+++ b/apps/mobile/src/app/(tabs)/settings.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from "react-native";
 import { useAuthStore, useUserQuery } from "@/features/auth";
+import { MenuButton } from "@/features/navigation/components/MenuButton";
 import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
 
 export default function SettingsScreen() {
@@ -33,7 +34,8 @@ export default function SettingsScreen() {
     <ScrollView className="flex-1 bg-background">
       <View className="px-6 pt-12 pb-12">
         {/* Header */}
-        <View className="mb-8">
+        <View className="mb-8 flex-row items-center gap-2">
+          <MenuButton className="-ml-2" />
           <Text className="font-bold text-3xl text-gray-12">Settings</Text>
         </View>
 

--- a/apps/mobile/src/app/(tabs)/tasks.tsx
+++ b/apps/mobile/src/app/(tabs)/tasks.tsx
@@ -2,6 +2,7 @@ import { Text } from "@components/text";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useRef } from "react";
 import { InteractionManager, Pressable, View } from "react-native";
+import { MenuButton } from "@/features/navigation/components/MenuButton";
 import { TaskList } from "@/features/tasks";
 
 export default function TasksScreen() {
@@ -42,9 +43,10 @@ export default function TasksScreen() {
   return (
     <View className="flex-1 bg-background">
       {/* Header */}
-      <View className="border-gray-6 border-b px-4 pt-16 pb-4">
-        <View className="flex-row items-center justify-between">
-          <View>
+      <View className="border-gray-6 border-b px-3 pt-14 pb-4">
+        <View className="flex-row items-center gap-2">
+          <MenuButton />
+          <View className="flex-1">
             <Text className="font-bold text-2xl text-gray-12">Code</Text>
             <Text className="text-gray-11 text-sm">
               Your PostHog Code sessions

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -4,9 +4,9 @@ import { useAuthStore } from "@/features/auth";
 export default function Index() {
   const { isAuthenticated } = useAuthStore();
 
-  // Redirect to tabs if authenticated, otherwise to login
+  // Redirect to tasks if authenticated, otherwise to login
   if (isAuthenticated) {
-    return <Redirect href="/(tabs)" />;
+    return <Redirect href="/(tabs)/tasks" />;
   }
 
   return <Redirect href="/auth" />;

--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -223,8 +223,9 @@ export default function NewTaskScreen() {
     if (isLoadingRepos) return;
     if (!repositories.includes(selectedRepo)) {
       setSelectedRepo(null);
+      setLastUsedCloudRepository(null);
     }
-  }, [selectedRepo, repositories, isLoadingRepos]);
+  }, [selectedRepo, repositories, isLoadingRepos, setLastUsedCloudRepository]);
 
   // Auto-select when there's exactly one repo (matches desktop GitHubRepoPicker).
   useEffect(() => {

--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -1,6 +1,7 @@
 import { Text } from "@components/text";
 import { Stack, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
+import { ArrowClockwise, Check } from "phosphor-react-native";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
@@ -12,14 +13,17 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { useAuthStore } from "@/features/auth";
+import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
 import {
   createTask,
-  getGithubRepositories,
-  getIntegrations,
-  type Integration,
   runTaskInCloud,
+  startGithubUserConnect,
 } from "@/features/tasks";
+import {
+  useUserGithubBranches,
+  useUserGithubRepositories,
+  useUserRepositoryIntegration,
+} from "@/features/tasks/hooks/useIntegrations";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
@@ -30,27 +34,31 @@ interface ConnectGitHubPromptProps {
 }
 
 function ConnectGitHubPrompt({ onConnected }: ConnectGitHubPromptProps) {
-  const { cloudRegion, projectId, getCloudUrlFromRegion } = useAuthStore();
   const themeColors = useThemeColors();
+  const [starting, setStarting] = useState(false);
 
   const handleConnectGitHub = async () => {
-    if (!cloudRegion || !projectId) return;
-    const baseUrl = getCloudUrlFromRegion(cloudRegion);
-    const authorizeUrl = `${baseUrl}/api/environments/${projectId}/integrations/authorize/?kind=github`;
+    if (starting) return;
+    setStarting(true);
+    try {
+      const { install_url } = await startGithubUserConnect();
 
-    // Open in-app browser - will auto-detect when user returns
-    const result = await WebBrowser.openAuthSessionAsync(
-      authorizeUrl,
-      "posthog://github/callback",
-    );
+      const result = await WebBrowser.openAuthSessionAsync(
+        install_url,
+        "posthog://github/callback",
+      );
 
-    // When browser session ends, refresh integrations
-    if (
-      result.type === "dismiss" ||
-      result.type === "cancel" ||
-      result.type === "success"
-    ) {
-      onConnected?.();
+      if (
+        result.type === "dismiss" ||
+        result.type === "cancel" ||
+        result.type === "success"
+      ) {
+        onConnected?.();
+      }
+    } catch (error) {
+      log.error("Failed to start GitHub connect", error);
+    } finally {
+      setStarting(false);
     }
   };
 
@@ -79,83 +87,254 @@ function ConnectGitHubPrompt({ onConnected }: ConnectGitHubPromptProps) {
   );
 }
 
+interface SelectableListProps {
+  items: string[];
+  selectedValue: string | null;
+  onSelect: (value: string) => void;
+  emptyText: string;
+  searchActive: boolean;
+  isRefreshing: boolean;
+  hasMore: boolean;
+  onLoadMore: () => void;
+  isFetchingMore?: boolean;
+}
+
+function SelectableList({
+  items,
+  selectedValue,
+  onSelect,
+  emptyText,
+  searchActive,
+  isRefreshing,
+  hasMore,
+  onLoadMore,
+  isFetchingMore,
+}: SelectableListProps) {
+  const themeColors = useThemeColors();
+
+  return (
+    <ScrollView
+      className="mb-4 max-h-48 rounded-lg border border-gray-6"
+      keyboardShouldPersistTaps="handled"
+      nestedScrollEnabled
+    >
+      {items.length === 0 && !isRefreshing ? (
+        <View className="px-3 py-4">
+          <Text className="text-center text-gray-9 text-sm">
+            {searchActive ? "No matches" : emptyText}
+          </Text>
+        </View>
+      ) : (
+        <>
+          {items.map((item) => {
+            const selected = selectedValue === item;
+            return (
+              <Pressable
+                key={item}
+                onPress={() => onSelect(item)}
+                className={`flex-row items-center justify-between border-gray-6 border-b px-3 py-3 ${
+                  selected ? "bg-accent-3" : ""
+                }`}
+              >
+                <Text
+                  className={`flex-1 text-sm ${selected ? "text-accent-11" : "text-gray-11"}`}
+                  numberOfLines={1}
+                >
+                  {item}
+                </Text>
+                {selected ? (
+                  <Check size={14} color={themeColors.accent[11]} />
+                ) : null}
+              </Pressable>
+            );
+          })}
+          {isRefreshing ? (
+            <View className="items-center px-3 py-3">
+              <ActivityIndicator size="small" color={themeColors.accent[9]} />
+            </View>
+          ) : null}
+          {hasMore ? (
+            <Pressable
+              onPress={onLoadMore}
+              disabled={isFetchingMore}
+              className="items-center px-3 py-3"
+            >
+              {isFetchingMore ? (
+                <ActivityIndicator size="small" color={themeColors.accent[9]} />
+              ) : (
+                <Text className="text-accent-11 text-sm">Load more</Text>
+              )}
+            </Pressable>
+          ) : null}
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
 export default function NewTaskScreen() {
   const router = useRouter();
   const themeColors = useThemeColors();
-  const [integrations, setIntegrations] = useState<Integration[]>([]);
-  const [repositories, setRepositories] = useState<string[]>([]);
-  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+
+  const lastUsedCloudRepository = usePreferencesStore(
+    (s) => s.lastUsedCloudRepository,
+  );
+  const setLastUsedCloudRepository = usePreferencesStore(
+    (s) => s.setLastUsedCloudRepository,
+  );
+
   const [repoSearch, setRepoSearch] = useState("");
+  const [branchSearch, setBranchSearch] = useState("");
   const [prompt, setPrompt] = useState("");
   const [creating, setCreating] = useState(false);
-  const [loadingRepos, setLoadingRepos] = useState(true);
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(
+    lastUsedCloudRepository?.toLowerCase() ?? null,
+  );
+  const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
 
-  const filteredRepositories = useMemo(() => {
-    const query = repoSearch.trim().toLowerCase();
-    if (!query) return repositories;
-    return repositories.filter((repo) => repo.toLowerCase().includes(query));
-  }, [repositories, repoSearch]);
+  const {
+    repositories,
+    getUserIntegrationIdForRepo,
+    getInstallationIdForRepo,
+    isLoadingRepos,
+    isRefreshingRepos,
+    refreshRepositories,
+    hasGithubIntegration,
+  } = useUserRepositoryIntegration();
 
-  const loadIntegrations = useCallback(async () => {
-    try {
-      setLoadingRepos(true);
-      const data = await getIntegrations();
-      const githubIntegrations = data.filter((i) => i.kind === "github");
-      setIntegrations(githubIntegrations);
+  const trimmedRepoSearch = repoSearch.trim();
+  const repoPickerActive = trimmedRepoSearch.length > 0;
+  const {
+    repositories: searchedRepositories,
+    isPending: searchPending,
+    isRefreshing: searchRefreshing,
+    hasMore: searchHasMore,
+    loadMore: loadMoreSearchedRepos,
+  } = useUserGithubRepositories(repoSearch, repoPickerActive);
 
-      if (githubIntegrations.length > 0) {
-        const allRepos: string[] = [];
-        for (const integration of githubIntegrations) {
-          const repos = await getGithubRepositories(integration.id);
-          allRepos.push(...repos);
-        }
-        setRepositories(allRepos.sort());
-      }
-    } catch (error) {
-      log.error("Failed to fetch integrations", error);
-    } finally {
-      setLoadingRepos(false);
-    }
-  }, []);
+  const visibleRepositories = useMemo(() => {
+    if (repoPickerActive) return searchedRepositories;
+    return repositories;
+  }, [repoPickerActive, repositories, searchedRepositories]);
 
+  // Validate persisted selection against the loaded list; clear if missing.
   useEffect(() => {
-    loadIntegrations();
-  }, [loadIntegrations]);
+    if (!selectedRepo) return;
+    if (isLoadingRepos) return;
+    if (!repositories.includes(selectedRepo)) {
+      setSelectedRepo(null);
+    }
+  }, [selectedRepo, repositories, isLoadingRepos]);
+
+  // Auto-select when there's exactly one repo (matches desktop GitHubRepoPicker).
+  useEffect(() => {
+    if (selectedRepo) return;
+    if (repositories.length === 1) {
+      setSelectedRepo(repositories[0]);
+    }
+  }, [selectedRepo, repositories]);
+
+  const selectedInstallationId = selectedRepo
+    ? getInstallationIdForRepo(selectedRepo)
+    : undefined;
+
+  const {
+    data: branchData,
+    isPending: branchesPending,
+    isRefreshing: branchesRefreshing,
+    isFetchingMore: branchesFetchingMore,
+    hasMore: branchesHasMore,
+    loadMore: loadMoreBranches,
+    refresh: refreshBranches,
+  } = useUserGithubBranches(
+    selectedInstallationId,
+    selectedRepo,
+    branchSearch,
+    !!selectedRepo,
+  );
+
+  const branches = branchData?.branches ?? [];
+  const defaultBranch = branchData?.defaultBranch ?? null;
+
+  // Pre-fill the default branch when one becomes available and no branch picked.
+  useEffect(() => {
+    if (selectedBranch) return;
+    if (defaultBranch) {
+      setSelectedBranch(defaultBranch);
+    }
+  }, [selectedBranch, defaultBranch]);
+
+  // Reset branch when repo changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset only on repo change
+  useEffect(() => {
+    setSelectedBranch(null);
+    setBranchSearch("");
+  }, [selectedRepo]);
+
+  const handleSelectRepo = useCallback(
+    (repo: string) => {
+      const normalized = repo.toLowerCase();
+      setSelectedRepo(normalized);
+      setLastUsedCloudRepository(normalized);
+    },
+    [setLastUsedCloudRepository],
+  );
+
+  const handleRefreshRepos = useCallback(async () => {
+    try {
+      await refreshRepositories();
+    } catch (error) {
+      log.error("Failed to refresh repositories", error);
+    }
+  }, [refreshRepositories]);
+
+  const handleRefreshBranches = useCallback(async () => {
+    try {
+      await refreshBranches();
+    } catch (error) {
+      log.error("Failed to refresh branches", error);
+    }
+  }, [refreshBranches]);
 
   const handleCreateTask = useCallback(async () => {
     if (!prompt.trim() || !selectedRepo) return;
 
     setCreating(true);
     try {
-      const githubIntegration = integrations.find((i) => i.kind === "github");
-
       const trimmedPrompt = prompt.trim();
+      const userIntegrationId = getUserIntegrationIdForRepo(selectedRepo);
       const task = await createTask({
         description: trimmedPrompt,
         title: trimmedPrompt.slice(0, 100),
         repository: selectedRepo,
-        github_integration: githubIntegration?.id,
+        github_user_integration: userIntegrationId,
       });
 
-      // Pass the prompt as pending_user_message so the cloud agent has
-      // something to process on start — matches how the desktop launches
-      // new cloud runs. Without this the sandbox starts idle and the UI
-      // stays stuck on "Thinking...".
       await runTaskInCloud(task.id, {
         pendingUserMessage: trimmedPrompt,
+        branch: selectedBranch ?? undefined,
       });
 
-      // Navigate to task detail (replaces current modal)
       router.replace(`/task/${task.id}`);
     } catch (error) {
       log.error("Failed to create task", error);
     } finally {
       setCreating(false);
     }
-  }, [prompt, selectedRepo, integrations, router]);
+  }, [
+    prompt,
+    selectedRepo,
+    selectedBranch,
+    getUserIntegrationIdForRepo,
+    router,
+  ]);
 
-  const hasGithubIntegration = integrations.length > 0;
-  const canSubmit = prompt.trim() && selectedRepo && !creating;
+  const canSubmit = !!prompt.trim() && !!selectedRepo && !creating;
+  const showLoading = isLoadingRepos && !hasGithubIntegration;
+  const branchSearchActive = branchSearch.trim().length > 0;
+  const repoListLoading = repoPickerActive
+    ? searchPending || searchRefreshing
+    : isRefreshingRepos;
 
   return (
     <>
@@ -179,7 +358,7 @@ export default function NewTaskScreen() {
           contentContainerStyle={{ paddingBottom: 40 }}
         >
           <Pressable onPress={Keyboard.dismiss} accessible={false}>
-            {loadingRepos ? (
+            {showLoading ? (
               <View className="mb-4 items-center rounded-lg border border-gray-6 p-4">
                 <ActivityIndicator size="small" color={themeColors.accent[9]} />
                 <Text className="mt-2 text-gray-11 text-sm">
@@ -187,10 +366,24 @@ export default function NewTaskScreen() {
                 </Text>
               </View>
             ) : !hasGithubIntegration ? (
-              <ConnectGitHubPrompt onConnected={loadIntegrations} />
+              <ConnectGitHubPrompt onConnected={() => refreshRepositories()} />
             ) : (
               <>
-                <Text className="mb-2 text-gray-9 text-xs">Repository</Text>
+                <View className="mb-2 flex-row items-center justify-between">
+                  <Text className="text-gray-9 text-xs">Repository</Text>
+                  <Pressable
+                    onPress={handleRefreshRepos}
+                    disabled={isRefreshingRepos}
+                    hitSlop={8}
+                    accessibilityLabel="Refresh repositories"
+                  >
+                    <ArrowClockwise
+                      size={14}
+                      color={themeColors.gray[11]}
+                      style={isRefreshingRepos ? { opacity: 0.5 } : undefined}
+                    />
+                  </Pressable>
+                </View>
                 <TextInput
                   className="mb-2 rounded-lg border border-gray-6 px-3 py-2 text-gray-12 text-sm"
                   placeholder="Search repositories"
@@ -201,41 +394,68 @@ export default function NewTaskScreen() {
                   autoCorrect={false}
                   clearButtonMode="while-editing"
                 />
-                <ScrollView
-                  className="mb-4 max-h-48 rounded-lg border border-gray-6"
-                  keyboardShouldPersistTaps="handled"
-                  nestedScrollEnabled
-                >
-                  {filteredRepositories.length === 0 ? (
-                    <View className="px-3 py-4">
-                      <Text className="text-center text-gray-9 text-sm">
-                        {repoSearch
-                          ? `No repositories match "${repoSearch}"`
-                          : "No repositories available"}
-                      </Text>
-                    </View>
-                  ) : (
-                    filteredRepositories.map((item) => (
+                <SelectableList
+                  items={visibleRepositories}
+                  selectedValue={selectedRepo}
+                  onSelect={handleSelectRepo}
+                  emptyText="No repositories available"
+                  searchActive={repoPickerActive}
+                  isRefreshing={repoListLoading}
+                  hasMore={repoPickerActive ? searchHasMore : false}
+                  onLoadMore={loadMoreSearchedRepos}
+                  isFetchingMore={searchRefreshing}
+                />
+
+                {selectedRepo ? (
+                  <>
+                    <View className="mb-2 flex-row items-center justify-between">
+                      <Text className="text-gray-9 text-xs">Branch</Text>
                       <Pressable
-                        key={item}
-                        onPress={() => setSelectedRepo(item)}
-                        className={`border-gray-6 border-b px-3 py-3 ${
-                          selectedRepo === item ? "bg-accent-3" : ""
-                        }`}
+                        onPress={handleRefreshBranches}
+                        disabled={branchesRefreshing}
+                        hitSlop={8}
+                        accessibilityLabel="Refresh branches"
                       >
-                        <Text
-                          className={`text-sm ${
-                            selectedRepo === item
-                              ? "text-accent-11"
-                              : "text-gray-11"
-                          }`}
-                        >
-                          {item}
-                        </Text>
+                        <ArrowClockwise
+                          size={14}
+                          color={themeColors.gray[11]}
+                          style={
+                            branchesRefreshing ? { opacity: 0.5 } : undefined
+                          }
+                        />
                       </Pressable>
-                    ))
-                  )}
-                </ScrollView>
+                    </View>
+                    <TextInput
+                      className="mb-2 rounded-lg border border-gray-6 px-3 py-2 text-gray-12 text-sm"
+                      placeholder={
+                        defaultBranch
+                          ? `Search branches (default: ${defaultBranch})`
+                          : "Search branches"
+                      }
+                      placeholderTextColor={themeColors.gray[9]}
+                      value={branchSearch}
+                      onChangeText={setBranchSearch}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      clearButtonMode="while-editing"
+                    />
+                    <SelectableList
+                      items={branches}
+                      selectedValue={selectedBranch}
+                      onSelect={setSelectedBranch}
+                      emptyText={
+                        branchesPending
+                          ? "Loading branches..."
+                          : "No branches available"
+                      }
+                      searchActive={branchSearchActive}
+                      isRefreshing={branchesPending || branchesRefreshing}
+                      hasMore={branchesHasMore}
+                      onLoadMore={loadMoreBranches}
+                      isFetchingMore={branchesFetchingMore}
+                    />
+                  </>
+                ) : null}
 
                 <Text className="mb-2 text-gray-9 text-xs">
                   Task description

--- a/apps/mobile/src/features/navigation/components/MenuButton.tsx
+++ b/apps/mobile/src/features/navigation/components/MenuButton.tsx
@@ -1,0 +1,25 @@
+import { List } from "phosphor-react-native";
+import { Pressable } from "react-native";
+import { useThemeColors } from "@/lib/theme";
+import { useNavDrawerStore } from "../stores/navDrawerStore";
+
+interface MenuButtonProps {
+  className?: string;
+}
+
+export function MenuButton({ className }: MenuButtonProps) {
+  const open = useNavDrawerStore((s) => s.open);
+  const themeColors = useThemeColors();
+
+  return (
+    <Pressable
+      onPress={open}
+      hitSlop={12}
+      className={`h-10 w-10 items-center justify-center rounded-lg active:bg-gray-3 ${className ?? ""}`}
+      accessibilityLabel="Open navigation menu"
+      accessibilityRole="button"
+    >
+      <List size={24} color={themeColors.gray[12]} />
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/features/navigation/components/NavDrawer.tsx
+++ b/apps/mobile/src/features/navigation/components/NavDrawer.tsx
@@ -1,0 +1,176 @@
+import { Text } from "@components/text";
+import { useRouter } from "expo-router";
+import { GearSix, Plus, Tray } from "phosphor-react-native";
+import { useEffect, useRef } from "react";
+import {
+  Animated,
+  Dimensions,
+  Easing,
+  Modal,
+  Pressable,
+  ScrollView,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTasks } from "@/features/tasks/hooks/useTasks";
+import { useThemeColors } from "@/lib/theme";
+import { useNavDrawerStore } from "../stores/navDrawerStore";
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+const DRAWER_WIDTH = Math.min(320, Math.round(SCREEN_WIDTH * 0.85));
+
+export function NavDrawer() {
+  const isOpen = useNavDrawerStore((s) => s.isOpen);
+  const close = useNavDrawerStore((s) => s.close);
+  const router = useRouter();
+  const themeColors = useThemeColors();
+  const insets = useSafeAreaInsets();
+  const { tasks } = useTasks();
+
+  const translateX = useRef(new Animated.Value(-DRAWER_WIDTH)).current;
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(translateX, {
+        toValue: isOpen ? 0 : -DRAWER_WIDTH,
+        duration: isOpen ? 240 : 200,
+        easing: isOpen ? Easing.out(Easing.cubic) : Easing.in(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      Animated.timing(backdropOpacity, {
+        toValue: isOpen ? 1 : 0,
+        duration: isOpen ? 240 : 200,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [isOpen, translateX, backdropOpacity]);
+
+  const handleNewTask = () => {
+    close();
+    router.push("/task");
+  };
+
+  const handleInbox = () => {
+    close();
+    router.replace("/inbox");
+  };
+
+  const handleSettings = () => {
+    close();
+    router.replace("/settings");
+  };
+
+  const handleTaskPress = (taskId: string) => {
+    close();
+    router.push(`/task/${taskId}`);
+  };
+
+  return (
+    <Modal
+      visible={isOpen}
+      transparent
+      animationType="none"
+      onRequestClose={close}
+      statusBarTranslucent
+    >
+      <View className="flex-1">
+        <Animated.View
+          className="absolute inset-0 bg-black/40"
+          style={{ opacity: backdropOpacity }}
+        >
+          <Pressable className="flex-1" onPress={close} />
+        </Animated.View>
+
+        <Animated.View
+          className="absolute top-0 bottom-0 left-0 border-gray-6 border-r bg-background"
+          style={{
+            width: DRAWER_WIDTH,
+            paddingTop: insets.top + 12,
+            paddingBottom: insets.bottom,
+            transform: [{ translateX }],
+          }}
+        >
+          <Pressable
+            onPress={() => {
+              close();
+              router.replace("/tasks");
+            }}
+            className="px-4 pb-3 active:opacity-60"
+          >
+            <Text className="font-bold text-2xl text-gray-12">PostHog</Text>
+          </Pressable>
+
+          <View className="gap-1 px-2 pb-2">
+            <Pressable
+              onPress={handleNewTask}
+              className="flex-row items-center gap-3 rounded-lg px-3 py-3 active:bg-gray-3"
+            >
+              <Plus size={20} color={themeColors.gray[12]} weight="bold" />
+              <Text className="font-medium text-base text-gray-12">
+                New task
+              </Text>
+            </Pressable>
+
+            <Pressable
+              onPress={handleInbox}
+              className="flex-row items-center gap-3 rounded-lg px-3 py-3 active:bg-gray-3"
+            >
+              <Tray size={20} color={themeColors.gray[12]} />
+              <Text className="font-medium text-base text-gray-12">Inbox</Text>
+            </Pressable>
+          </View>
+
+          <View className="mx-3 my-1 border-gray-6 border-t" />
+
+          <View className="px-4 pt-3 pb-2">
+            <Text className="font-medium text-gray-9 text-xs uppercase tracking-wide">
+              Tasks
+            </Text>
+          </View>
+
+          <ScrollView
+            className="flex-1"
+            contentContainerStyle={{ paddingBottom: 12 }}
+          >
+            {tasks.length === 0 ? (
+              <View className="px-4 py-3">
+                <Text className="text-gray-9 text-sm">No tasks yet</Text>
+              </View>
+            ) : (
+              tasks.map((task) => (
+                <Pressable
+                  key={task.id}
+                  onPress={() => handleTaskPress(task.id)}
+                  className="px-4 py-3 active:bg-gray-3"
+                >
+                  <Text
+                    className="text-gray-12 text-sm"
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                  >
+                    {task.title}
+                  </Text>
+                </Pressable>
+              ))
+            )}
+          </ScrollView>
+
+          <View className="mx-3 mt-1 border-gray-6 border-t" />
+
+          <View className="gap-1 px-2 pt-2">
+            <Pressable
+              onPress={handleSettings}
+              className="flex-row items-center gap-3 rounded-lg px-3 py-3 active:bg-gray-3"
+            >
+              <GearSix size={20} color={themeColors.gray[12]} />
+              <Text className="font-medium text-base text-gray-12">
+                Settings
+              </Text>
+            </Pressable>
+          </View>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/features/navigation/stores/navDrawerStore.ts
+++ b/apps/mobile/src/features/navigation/stores/navDrawerStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface NavDrawerState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+export const useNavDrawerStore = create<NavDrawerState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+}));

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.ts
@@ -7,6 +7,8 @@ interface PreferencesState {
   setAiChatEnabled: (enabled: boolean) => void;
   pingsEnabled: boolean;
   setPingsEnabled: (enabled: boolean) => void;
+  lastUsedCloudRepository: string | null;
+  setLastUsedCloudRepository: (repo: string | null) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -16,6 +18,9 @@ export const usePreferencesStore = create<PreferencesState>()(
       setAiChatEnabled: (enabled) => set({ aiChatEnabled: enabled }),
       pingsEnabled: true,
       setPingsEnabled: (enabled) => set({ pingsEnabled: enabled }),
+      lastUsedCloudRepository: null,
+      setLastUsedCloudRepository: (repo) =>
+        set({ lastUsedCloudRepository: repo }),
     }),
     {
       name: "posthog-preferences",
@@ -23,6 +28,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       partialize: (state) => ({
         aiChatEnabled: state.aiChatEnabled,
         pingsEnabled: state.pingsEnabled,
+        lastUsedCloudRepository: state.lastUsedCloudRepository,
       }),
     },
   ),

--- a/apps/mobile/src/features/tasks/api.ts
+++ b/apps/mobile/src/features/tasks/api.ts
@@ -3,10 +3,12 @@ import { getBaseUrl, getHeaders, getProjectId } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import type {
   CreateTaskOptions,
-  Integration,
+  GithubBranchesPage,
+  GithubRepositoriesPage,
   StoredLogEntry,
   Task,
   TaskRun,
+  UserGitHubIntegration,
 } from "./types";
 
 const log = logger.scope("tasks-api");
@@ -438,13 +440,96 @@ export async function fetchS3Logs(logUrl: string): Promise<string> {
   );
 }
 
-export async function getIntegrations(): Promise<Integration[]> {
+function normalizeGithubRepositories(data: unknown): string[] {
+  const repos =
+    (data as { repositories?: unknown[] }).repositories ??
+    (data as { results?: unknown[] }).results ??
+    (Array.isArray(data) ? data : []);
+
+  return (repos as Array<string | { full_name?: string; name?: string }>)
+    .map((repo) => {
+      if (typeof repo === "string") return repo.toLowerCase();
+      return (repo.full_name ?? repo.name ?? "").toLowerCase();
+    })
+    .filter((name) => name.length > 0);
+}
+
+export async function startGithubUserConnect(): Promise<{
+  install_url: string;
+  connect_flow?: "oauth_authorize" | "oauth_discover" | "app_install";
+}> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
   const headers = getHeaders();
 
   const response = await fetch(
-    `${baseUrl}/api/environments/${projectId}/integrations/`,
+    `${baseUrl}/api/users/@me/integrations/github/start/`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        team_id: projectId,
+        connect_from: "posthog_mobile",
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    log.error("Start GitHub user connect failed", errorText);
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      "Failed to start GitHub connection",
+    );
+  }
+
+  return await response.json();
+}
+
+export async function getGithubUserIntegrations(): Promise<
+  UserGitHubIntegration[]
+> {
+  const baseUrl = getBaseUrl();
+  const headers = getHeaders();
+
+  const response = await fetch(`${baseUrl}/api/users/@me/integrations/`, {
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      "Failed to fetch personal GitHub integrations",
+    );
+  }
+
+  const data = (await response.json()) as {
+    results?: UserGitHubIntegration[];
+  };
+  return data.results ?? [];
+}
+
+export async function getGithubUserRepositoriesPage(
+  installationId: string,
+  offset: number,
+  limit: number,
+  search?: string,
+): Promise<GithubRepositoriesPage> {
+  const baseUrl = getBaseUrl();
+  const headers = getHeaders();
+
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  });
+  if (search?.trim()) {
+    params.set("search", search.trim());
+  }
+
+  const response = await fetch(
+    `${baseUrl}/api/users/@me/integrations/github/${installationId}/repos/?${params}`,
     { headers },
   );
 
@@ -452,61 +537,98 @@ export async function getIntegrations(): Promise<Integration[]> {
     throw new HttpError(
       response.status,
       response.statusText,
-      "Failed to fetch integrations",
+      "Failed to fetch personal GitHub repositories",
     );
   }
 
   const data = await response.json();
-  return data.results ?? data ?? [];
+  return {
+    repositories: normalizeGithubRepositories(data),
+    hasMore: data.has_more ?? false,
+  };
 }
 
-const GITHUB_REPOS_PAGE_SIZE = 500;
-
-export async function getGithubRepositories(
-  integrationId: number,
+export async function getGithubUserRepositories(
+  installationId: string,
 ): Promise<string[]> {
-  const baseUrl = getBaseUrl();
-  const projectId = getProjectId();
-  const headers = getHeaders();
-
-  const allRepos: string[] = [];
+  const repositories: string[] = [];
   let offset = 0;
 
   while (true) {
-    const params = new URLSearchParams({
-      limit: String(GITHUB_REPOS_PAGE_SIZE),
-      offset: String(offset),
-    });
-    const response = await fetch(
-      `${baseUrl}/api/environments/${projectId}/integrations/${integrationId}/github_repos/?${params}`,
-      { headers },
+    const page = await getGithubUserRepositoriesPage(
+      installationId,
+      offset,
+      500,
     );
+    repositories.push(...page.repositories);
 
-    if (!response.ok) {
-      throw new HttpError(
-        response.status,
-        response.statusText,
-        "Failed to fetch repositories",
-      );
+    if (!page.hasMore || page.repositories.length === 0) {
+      return repositories;
     }
 
-    const data = await response.json();
-    const repos: Array<string | { full_name?: string; name?: string }> =
-      data.repositories ?? data.results ?? data ?? [];
-
-    const normalized = repos
-      .map((repo) => {
-        if (typeof repo === "string") return repo.toLowerCase();
-        return (repo.full_name ?? repo.name ?? "").toLowerCase();
-      })
-      .filter((name) => name.length > 0);
-
-    allRepos.push(...normalized);
-
-    if (!data.has_more || repos.length === 0) {
-      return allRepos;
-    }
-
-    offset += repos.length;
+    offset += page.repositories.length;
   }
+}
+
+export async function refreshGithubUserRepositories(
+  installationId: string,
+): Promise<string[]> {
+  const baseUrl = getBaseUrl();
+  const headers = getHeaders();
+
+  const response = await fetch(
+    `${baseUrl}/api/users/@me/integrations/github/${installationId}/repos/refresh/`,
+    { method: "POST", headers },
+  );
+
+  if (!response.ok) {
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      "Failed to refresh personal GitHub repositories",
+    );
+  }
+
+  const data = await response.json();
+  return normalizeGithubRepositories(data);
+}
+
+export async function getGithubUserBranchesPage(
+  installationId: string,
+  repo: string,
+  offset: number,
+  limit: number,
+  search?: string,
+): Promise<GithubBranchesPage> {
+  const baseUrl = getBaseUrl();
+  const headers = getHeaders();
+
+  const params = new URLSearchParams({
+    repo,
+    offset: String(offset),
+    limit: String(limit),
+  });
+  if (search?.trim()) {
+    params.set("search", search.trim());
+  }
+
+  const response = await fetch(
+    `${baseUrl}/api/users/@me/integrations/github/${installationId}/branches/?${params}`,
+    { headers },
+  );
+
+  if (!response.ok) {
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      "Failed to fetch personal GitHub branches",
+    );
+  }
+
+  const data = await response.json();
+  return {
+    branches: data.branches ?? data.results ?? data ?? [],
+    defaultBranch: data.default_branch ?? null,
+    hasMore: data.has_more ?? false,
+  };
 }

--- a/apps/mobile/src/features/tasks/components/TaskList.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskList.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-native";
 import { useAuthStore } from "@/features/auth";
 import { useThemeColors } from "@/lib/theme";
-import { useIntegrations } from "../hooks/useIntegrations";
+import { useUserGithubIntegrations } from "../hooks/useIntegrations";
 import { useTasks } from "../hooks/useTasks";
 import { useArchivedTasksStore } from "../stores/archivedTasksStore";
 import type { Task } from "../types";
@@ -117,8 +117,14 @@ type ListItem =
 
 export function TaskList({ onTaskPress, onCreateTask }: TaskListProps) {
   const { tasks, isLoading, error, refetch } = useTasks();
-  const { hasGithubIntegration, refetch: refetchIntegrations } =
-    useIntegrations();
+  const {
+    data: githubIntegrations = [],
+    isFetched: integrationsFetched,
+    refetch: refetchIntegrations,
+  } = useUserGithubIntegrations();
+  const hasGithubIntegration = integrationsFetched
+    ? githubIntegrations.length > 0
+    : null;
   const themeColors = useThemeColors();
   const { archivedTasks, archive, unarchive } = useArchivedTasksStore();
   const [archivedExpanded, setArchivedExpanded] = useState(false);

--- a/apps/mobile/src/features/tasks/hooks/useIntegrations.ts
+++ b/apps/mobile/src/features/tasks/hooks/useIntegrations.ts
@@ -168,21 +168,23 @@ export function useUserRepositoryIntegration() {
     setIsRefreshingRepos(true);
 
     try {
-      await Promise.all(
+      const refreshResults = await Promise.allSettled(
         githubIntegrations.map((integration) =>
           refreshGithubUserRepositories(integration.installation_id),
         ),
       );
 
-      await Promise.all(
-        githubIntegrations.map((integration) =>
-          queryClient.refetchQueries({
-            queryKey: userGithubIntegrationKeys.repositories(
-              integration.installation_id,
-            ),
-            exact: true,
-          }),
-        ),
+      await Promise.allSettled(
+        githubIntegrations
+          .filter((_, i) => refreshResults[i]?.status === "fulfilled")
+          .map((integration) =>
+            queryClient.refetchQueries({
+              queryKey: userGithubIntegrationKeys.repositories(
+                integration.installation_id,
+              ),
+              exact: true,
+            }),
+          ),
       );
 
       await queryClient.refetchQueries({
@@ -218,9 +220,10 @@ export function useUserGithubRepositories(
   const queryEnabled =
     enabled && !!oauthAccessToken && githubIntegrations.length > 0;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset pagination when search changes
   useEffect(() => {
     setRequestedLimit(REPOSITORIES_PAGE_SIZE);
-  }, []);
+  }, [deferredSearch]);
 
   const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
     queries: githubIntegrations.map((integration) => ({

--- a/apps/mobile/src/features/tasks/hooks/useIntegrations.ts
+++ b/apps/mobile/src/features/tasks/hooks/useIntegrations.ts
@@ -1,62 +1,374 @@
-import { useQuery } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useAuthStore } from "@/features/auth";
-import { getGithubRepositories, getIntegrations } from "../api";
+import {
+  getGithubUserBranchesPage,
+  getGithubUserIntegrations,
+  getGithubUserRepositories,
+  getGithubUserRepositoriesPage,
+  refreshGithubUserRepositories,
+} from "../api";
+import type { GithubBranchesPage, UserGitHubIntegration } from "../types";
 
-export const integrationKeys = {
-  all: ["integrations"] as const,
-  lists: () => [...integrationKeys.all, "list"] as const,
-  github: () => [...integrationKeys.all, "github"] as const,
-  repos: (integrationId: number) =>
-    [...integrationKeys.all, "repos", integrationId] as const,
+const REPOSITORIES_PAGE_SIZE = 50;
+const BRANCHES_FIRST_PAGE_SIZE = 50;
+const BRANCHES_PAGE_SIZE = 100;
+const STALE_TIME_MS = 5 * 60 * 1000;
+
+export const userGithubIntegrationKeys = {
+  all: ["user-github-integrations"] as const,
+  list: () => [...userGithubIntegrationKeys.all, "list"] as const,
+  repositories: (installationId?: string) =>
+    [...userGithubIntegrationKeys.all, "repositories", installationId] as const,
+  repositoryPicker: (
+    installationId?: string,
+    search?: string,
+    limit?: number,
+  ) =>
+    [
+      ...userGithubIntegrationKeys.all,
+      "repository-picker",
+      installationId,
+      search,
+      limit,
+    ] as const,
+  branches: (installationId?: string, repo?: string | null, search?: string) =>
+    [
+      ...userGithubIntegrationKeys.all,
+      "branches",
+      installationId,
+      repo,
+      search,
+    ] as const,
 };
 
-export function useIntegrations() {
+interface UserRepositoryIntegrationRef {
+  userIntegrationId: string;
+  installationId: string;
+}
+
+export function useUserGithubIntegrations() {
   const { projectId, oauthAccessToken } = useAuthStore();
 
-  const integrationsQuery = useQuery({
-    queryKey: integrationKeys.github(),
-    queryFn: async () => {
-      const data = await getIntegrations();
-      return data.filter((i) => i.kind === "github");
-    },
+  return useQuery({
+    queryKey: userGithubIntegrationKeys.list(),
+    queryFn: () => getGithubUserIntegrations(),
     enabled: !!projectId && !!oauthAccessToken,
+    staleTime: STALE_TIME_MS,
   });
+}
 
-  const githubIntegrations = integrationsQuery.data ?? [];
+function useAllUserGithubRepositories(
+  githubIntegrations: UserGitHubIntegration[],
+) {
+  const { oauthAccessToken } = useAuthStore();
 
-  const repositoriesQuery = useQuery({
-    queryKey: [
-      ...integrationKeys.all,
-      "repos",
-      githubIntegrations.map((i) => i.id),
-    ],
-    queryFn: async () => {
-      const allRepos: string[] = [];
-      for (const integration of githubIntegrations) {
-        const repos = await getGithubRepositories(integration.id);
-        allRepos.push(...repos);
-      }
-      return allRepos.sort();
+  return useQueries({
+    queries: githubIntegrations.map((integration) => ({
+      queryKey: userGithubIntegrationKeys.repositories(
+        integration.installation_id,
+      ),
+      queryFn: async () => {
+        const repos = await getGithubUserRepositories(
+          integration.installation_id,
+        );
+        return {
+          userIntegrationId: integration.id,
+          installationId: integration.installation_id,
+          repos,
+        };
+      },
+      enabled: !!oauthAccessToken,
+      staleTime: STALE_TIME_MS,
+    })),
+    combine: (results) => {
+      const map: Record<string, UserRepositoryIntegrationRef> = {};
+      const reposByInstallationId: Record<string, string[]> = {};
+      const failedInstallationIds: string[] = [];
+      let pending = false;
+      results.forEach((result, index) => {
+        if (result.isPending) pending = true;
+        if (result.isError) {
+          const installationId =
+            githubIntegrations[index]?.installation_id ?? null;
+          if (installationId) failedInstallationIds.push(installationId);
+        }
+        if (!result.data) return;
+        const installationRepos = result.data.repos ?? [];
+        reposByInstallationId[result.data.installationId] = installationRepos;
+        for (const repo of installationRepos) {
+          if (!(repo in map)) {
+            map[repo] = {
+              userIntegrationId: result.data.userIntegrationId,
+              installationId: result.data.installationId,
+            };
+          }
+        }
+      });
+      return {
+        repositoryMap: map,
+        reposByInstallationId,
+        isPending: pending,
+        failedInstallationIds,
+      };
     },
-    enabled: githubIntegrations.length > 0,
   });
+}
 
-  const refetch = async () => {
-    await integrationsQuery.refetch();
-    await repositoriesQuery.refetch();
-  };
+export function useUserRepositoryIntegration() {
+  const queryClient = useQueryClient();
+  const { data: githubIntegrations = [], isPending: integrationsPending } =
+    useUserGithubIntegrations();
+  const [isRefreshingRepos, setIsRefreshingRepos] = useState(false);
+
+  const {
+    repositoryMap,
+    reposByInstallationId,
+    isPending: reposPending,
+    failedInstallationIds,
+  } = useAllUserGithubRepositories(githubIntegrations);
+
+  const repositories = useMemo(
+    () => Object.keys(repositoryMap),
+    [repositoryMap],
+  );
+
+  const getUserIntegrationIdForRepo = useCallback(
+    (repoKey: string) =>
+      repositoryMap[repoKey?.toLowerCase()]?.userIntegrationId,
+    [repositoryMap],
+  );
+
+  const getInstallationIdForRepo = useCallback(
+    (repoKey: string) => repositoryMap[repoKey?.toLowerCase()]?.installationId,
+    [repositoryMap],
+  );
+
+  const isRepoInIntegration = useCallback(
+    (repoKey: string) => !repoKey || repoKey.toLowerCase() in repositoryMap,
+    [repositoryMap],
+  );
+
+  const refreshRepositories = useCallback(async () => {
+    if (!githubIntegrations.length) {
+      return;
+    }
+
+    setIsRefreshingRepos(true);
+
+    try {
+      await Promise.all(
+        githubIntegrations.map((integration) =>
+          refreshGithubUserRepositories(integration.installation_id),
+        ),
+      );
+
+      await Promise.all(
+        githubIntegrations.map((integration) =>
+          queryClient.refetchQueries({
+            queryKey: userGithubIntegrationKeys.repositories(
+              integration.installation_id,
+            ),
+            exact: true,
+          }),
+        ),
+      );
+
+      await queryClient.refetchQueries({
+        queryKey: [...userGithubIntegrationKeys.all, "repository-picker"],
+      });
+    } finally {
+      setIsRefreshingRepos(false);
+    }
+  }, [githubIntegrations, queryClient]);
 
   return {
-    hasGithubIntegration: integrationsQuery.isFetched
-      ? githubIntegrations.length > 0
-      : null,
-    githubIntegrations,
-    repositories: repositoriesQuery.data ?? [],
-    isLoading: integrationsQuery.isLoading || repositoriesQuery.isLoading,
-    error:
-      integrationsQuery.error?.message ??
-      repositoriesQuery.error?.message ??
-      null,
-    refetch,
+    repositories,
+    getUserIntegrationIdForRepo,
+    getInstallationIdForRepo,
+    isRepoInIntegration,
+    isLoadingRepos: integrationsPending || reposPending,
+    isRefreshingRepos,
+    refreshRepositories,
+    hasGithubIntegration: githubIntegrations.length > 0,
+    failedInstallationIds,
+    reposByInstallationId,
+  };
+}
+
+export function useUserGithubRepositories(
+  search?: string,
+  enabled: boolean = true,
+) {
+  const { oauthAccessToken } = useAuthStore();
+  const { data: githubIntegrations = [] } = useUserGithubIntegrations();
+  const deferredSearch = useDeferredValue(search?.trim() ?? "");
+  const [requestedLimit, setRequestedLimit] = useState(REPOSITORIES_PAGE_SIZE);
+  const queryEnabled =
+    enabled && !!oauthAccessToken && githubIntegrations.length > 0;
+
+  useEffect(() => {
+    setRequestedLimit(REPOSITORIES_PAGE_SIZE);
+  }, []);
+
+  const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
+    queries: githubIntegrations.map((integration) => ({
+      queryKey: userGithubIntegrationKeys.repositoryPicker(
+        integration.installation_id,
+        deferredSearch,
+        requestedLimit,
+      ),
+      queryFn: async () => {
+        const page = await getGithubUserRepositoriesPage(
+          integration.installation_id,
+          0,
+          requestedLimit,
+          deferredSearch,
+        );
+
+        return {
+          userIntegrationId: integration.id,
+          installationId: integration.installation_id,
+          ...page,
+        };
+      },
+      enabled: queryEnabled,
+      staleTime: STALE_TIME_MS,
+      placeholderData: (prev: unknown) => prev,
+    })),
+    combine: (results) => {
+      const map: Record<string, UserRepositoryIntegrationRef> = {};
+      let pending = false;
+      let refreshing = false;
+      let hasMoreResults = false;
+
+      for (const result of results) {
+        if (result.isPending) pending = true;
+        if (result.isRefetching) refreshing = true;
+        if (!result.data) continue;
+
+        if (result.data.hasMore) {
+          hasMoreResults = true;
+        }
+
+        for (const repo of result.data.repositories ?? []) {
+          if (!(repo in map)) {
+            map[repo] = {
+              userIntegrationId: result.data.userIntegrationId,
+              installationId: result.data.installationId,
+            };
+          }
+        }
+      }
+
+      return {
+        repositoryMap: map,
+        isPending: pending,
+        isRefreshing: refreshing,
+        hasMore: hasMoreResults,
+      };
+    },
+  });
+
+  const loadMore = useCallback(() => {
+    setRequestedLimit((currentLimit) => currentLimit + REPOSITORIES_PAGE_SIZE);
+  }, []);
+
+  return {
+    repositories: Object.keys(repositoryMap),
+    isPending: queryEnabled ? isPending : false,
+    isRefreshing: queryEnabled ? isRefreshing : false,
+    hasMore,
+    loadMore,
+  };
+}
+
+export function useUserGithubBranches(
+  installationId?: string,
+  repo?: string | null,
+  search?: string,
+  enabled: boolean = true,
+) {
+  const { oauthAccessToken } = useAuthStore();
+  const deferredSearch = useDeferredValue(search?.trim() ?? "");
+  const queryEnabled =
+    enabled && !!oauthAccessToken && !!installationId && !!repo;
+
+  const query = useInfiniteQuery<
+    GithubBranchesPage,
+    Error,
+    { pages: GithubBranchesPage[]; pageParams: number[] },
+    ReturnType<typeof userGithubIntegrationKeys.branches>,
+    number
+  >({
+    queryKey: userGithubIntegrationKeys.branches(
+      installationId,
+      repo,
+      deferredSearch,
+    ),
+    queryFn: async ({ pageParam }) => {
+      if (!installationId || !repo) {
+        return { branches: [], defaultBranch: null, hasMore: false };
+      }
+      const pageSize =
+        pageParam === 0 ? BRANCHES_FIRST_PAGE_SIZE : BRANCHES_PAGE_SIZE;
+      return await getGithubUserBranchesPage(
+        installationId,
+        repo,
+        pageParam,
+        pageSize,
+        deferredSearch,
+      );
+    },
+    enabled: queryEnabled,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.hasMore) return undefined;
+      return allPages.reduce((n, p) => n + p.branches.length, 0);
+    },
+    staleTime: STALE_TIME_MS,
+  });
+
+  const data = useMemo(() => {
+    if (!query.data?.pages.length) {
+      return { branches: [] as string[], defaultBranch: null };
+    }
+    return {
+      branches: query.data.pages.flatMap((p) => p.branches),
+      defaultBranch: query.data.pages[0]?.defaultBranch ?? null,
+    };
+  }, [query.data?.pages]);
+
+  const loadMore = useCallback(() => {
+    if (!query.hasNextPage || query.isFetchingNextPage) {
+      return;
+    }
+
+    void query.fetchNextPage();
+  }, [query.fetchNextPage, query.hasNextPage, query.isFetchingNextPage]);
+
+  const refresh = useCallback(async () => {
+    await query.refetch();
+  }, [query.refetch]);
+
+  return {
+    data,
+    isPending: queryEnabled ? query.isPending : false,
+    isRefreshing: queryEnabled ? query.isRefetching : false,
+    isFetchingMore: query.isFetchingNextPage,
+    hasMore: query.hasNextPage ?? false,
+    loadMore,
+    refresh,
   };
 }

--- a/apps/mobile/src/features/tasks/index.ts
+++ b/apps/mobile/src/features/tasks/index.ts
@@ -7,7 +7,13 @@ export { TaskItem } from "./components/TaskItem";
 export { TaskList } from "./components/TaskList";
 export { TaskSessionView } from "./components/TaskSessionView";
 // Hooks
-export { useIntegrations } from "./hooks/useIntegrations";
+export {
+  userGithubIntegrationKeys,
+  useUserGithubBranches,
+  useUserGithubIntegrations,
+  useUserGithubRepositories,
+  useUserRepositoryIntegration,
+} from "./hooks/useIntegrations";
 export {
   taskKeys,
   useCreateTask,

--- a/apps/mobile/src/features/tasks/types.ts
+++ b/apps/mobile/src/features/tasks/types.ts
@@ -93,9 +93,33 @@ export interface Integration {
   };
 }
 
+export interface UserGitHubIntegration {
+  id: string;
+  kind: "github";
+  installation_id: string;
+  repository_selection?: string | null;
+  account?: {
+    type?: string | null;
+    name?: string | null;
+  } | null;
+  uses_shared_installation?: boolean;
+  created_at?: string;
+}
+
+export interface GithubRepositoriesPage {
+  repositories: string[];
+  hasMore: boolean;
+}
+
+export interface GithubBranchesPage {
+  branches: string[];
+  defaultBranch: string | null;
+  hasMore: boolean;
+}
+
 export interface CreateTaskOptions {
   description: string;
   title?: string;
   repository?: string;
-  github_integration?: number;
+  github_user_integration?: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,10 +547,10 @@ importers:
         version: 7.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       expo-av:
         specifier: ~16.0.8
-        version: 16.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
+        version: 16.0.8(expo@54.0.33)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       expo-camera:
         specifier: ^55.0.15
-        version: 55.0.15(@types/emscripten@1.41.5)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
+        version: 55.0.15(@types/emscripten@1.41.5)(expo@54.0.33)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       expo-clipboard:
         specifier: ^55.0.13
         version: 55.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
@@ -589,7 +589,7 @@ importers:
         version: 17.0.8(expo@54.0.33)(react@19.1.0)
       expo-router:
         specifier: ~6.0.17
-        version: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
+        version: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       expo-secure-store:
         specifier: ^15.0.8
         version: 15.0.8(expo@54.0.33)
@@ -604,7 +604,7 @@ importers:
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       expo-system-ui:
         specifier: ~6.0.9
-        version: 6.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))
+        version: 6.0.9(expo@54.0.33)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))
       expo-web-browser:
         specifier: ^15.0.10
         version: 15.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))
@@ -641,6 +641,9 @@ importers:
       react-native-svg:
         specifier: ^15.15.1
         version: 15.15.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
+      react-native-web:
+        specifier: ^0.21.2
+        version: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-native-webview:
         specifier: ^13.13.5
         version: 13.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
@@ -4496,6 +4499,9 @@ packages:
     resolution: {integrity: sha512-fB7M1CMOCIUudTRuj7kzxIBTVw2KXnsgbQ6+4cbqSxo8NmRRhA0Ul4ZUzZj3rFd3VznTL4Brmocv1oiN0bWZ8w==}
     engines: {node: '>= 20.19.4'}
 
+  '@react-native/normalize-colors@0.74.89':
+    resolution: {integrity: sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==}
+
   '@react-native/normalize-colors@0.81.5':
     resolution: {integrity: sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==}
 
@@ -6317,6 +6323,9 @@ packages:
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -6332,6 +6341,9 @@ packages:
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
+
+  css-in-js-utils@3.1.0:
+    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -7228,6 +7240,12 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fbjs-css-vars@1.0.2:
+    resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
+
+  fbjs@3.0.5:
+    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
 
@@ -7761,6 +7779,9 @@ packages:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
 
+  hyphenate-style-name@1.1.0:
+    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -7835,6 +7856,9 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  inline-style-prefixer@7.0.1:
+    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -8710,6 +8734,9 @@ packages:
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -9783,6 +9810,9 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
@@ -10043,6 +10073,12 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-web@0.21.2:
+    resolution: {integrity: sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-native-webview@13.16.0:
     resolution: {integrity: sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==}
@@ -10444,6 +10480,9 @@ packages:
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -10778,6 +10817,9 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  styleq@0.1.3:
+    resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -11206,6 +11248,10 @@ packages:
 
   ua-parser-js@0.7.41:
     resolution: {integrity: sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==}
+    hasBin: true
+
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -13743,7 +13789,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0
     optionalDependencies:
-      expo-router: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
+      expo-router: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -16250,6 +16296,8 @@ snapshots:
 
   '@react-native/js-polyfills@0.81.5': {}
 
+  '@react-native/normalize-colors@0.74.89': {}
+
   '@react-native/normalize-colors@0.81.5': {}
 
   '@react-native/virtualized-lists@0.81.5(@types/react@19.2.11)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)':
@@ -18230,6 +18278,12 @@ snapshots:
 
   cross-dirname@0.1.0: {}
 
+  cross-fetch@3.2.0(encoding@0.1.13):
+    dependencies:
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
@@ -18247,6 +18301,10 @@ snapshots:
   cross-zip@4.0.1: {}
 
   crypto-random-string@2.0.0: {}
+
+  css-in-js-utils@3.1.0:
+    dependencies:
+      hyphenate-style-name: 1.1.0
 
   css-select@5.2.2:
     dependencies:
@@ -18842,18 +18900,22 @@ snapshots:
       - expo
       - supports-color
 
-  expo-av@16.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0):
+  expo-av@16.0.8(expo@54.0.33)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native-webview@13.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)
+    optionalDependencies:
+      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  expo-camera@55.0.15(@types/emscripten@1.41.5)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0):
+  expo-camera@55.0.15(@types/emscripten@1.41.5)(expo@54.0.33)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0):
     dependencies:
       barcode-detector: 3.1.2(@types/emscripten@1.41.5)
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native-webview@13.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)
+    optionalDependencies:
+      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@types/emscripten'
 
@@ -18984,7 +19046,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)
 
-  expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0):
+  expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.2.11))(@types/react@19.2.11)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
@@ -19019,6 +19081,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.1.0(react@19.1.0)
       react-native-reanimated: 4.1.6(@babel/core@7.29.0)(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
+      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - '@types/react'
@@ -19050,12 +19113,14 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)
       react-native-is-edge-to-edge: 1.2.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
 
-  expo-system-ui@6.0.9(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)):
+  expo-system-ui@6.0.9(expo@54.0.33)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)):
     dependencies:
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native-webview@13.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)
+    optionalDependencies:
+      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19185,6 +19250,20 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fbjs-css-vars@1.0.2: {}
+
+  fbjs@3.0.5(encoding@0.1.13):
+    dependencies:
+      cross-fetch: 3.2.0(encoding@0.1.13)
+      fbjs-css-vars: 1.0.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 1.0.41
+    transitivePeerDependencies:
+      - encoding
 
   fd-package-json@2.0.0:
     dependencies:
@@ -19819,6 +19898,8 @@ snapshots:
 
   hyperdyperid@1.2.0: {}
 
+  hyphenate-style-name@1.1.0: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -19876,6 +19957,10 @@ snapshots:
   ini@2.0.0: {}
 
   inline-style-parser@0.2.7: {}
+
+  inline-style-prefixer@7.0.1:
+    dependencies:
+      css-in-js-utils: 3.1.0
 
   interpret@3.1.1: {}
 
@@ -20878,6 +20963,8 @@ snapshots:
       tslib: 2.8.1
 
   memoize-one@5.2.1: {}
+
+  memoize-one@6.0.0: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -22153,6 +22240,10 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
+
   promise@8.3.0:
     dependencies:
       asap: 2.0.6
@@ -22548,6 +22639,21 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0)
       warn-once: 0.1.1
+
+  react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@react-native/normalize-colors': 0.74.89
+      fbjs: 3.0.5(encoding@0.1.13)
+      inline-style-prefixer: 7.0.1
+      memoize-one: 6.0.0
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      styleq: 0.1.3
+    transitivePeerDependencies:
+      - encoding
 
   react-native-webview@13.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -23073,6 +23179,8 @@ snapshots:
 
   server-only@0.0.1: {}
 
+  setimmediate@1.0.5: {}
+
   setprototypeof@1.2.0: {}
 
   sf-symbols-typescript@2.2.0: {}
@@ -23449,6 +23557,8 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  styleq@0.1.3: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -23866,6 +23976,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ua-parser-js@0.7.41: {}
+
+  ua-parser-js@1.0.41: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
## Summary

Brings mobile `NewTaskScreen` to parity with desktop `TaskInput`'s cloud flow:

- **Switches to user-level integrations** (`/api/users/@me/integrations/`) — desktop has been on this path for a while; mobile was still on the legacy team-level `/api/environments/.../integrations/`.
- **TanStack Query caching** with `staleTime: 5min` and proper query-key namespaces, replacing the per-modal `useState` snapshot.
- **Debounced server-side search** (via `useDeferredValue`) + paginated **"Load more"** (page size 50), replacing client-side substring filtering over a bulk-fetched list.
- **Multi-installation merge** with first-seen dedup and `failedInstallationIds` tracking.
- **Refresh button** that POSTs `/repos/refresh/` per installation and refetches.
- **Auto-select** when exactly one repo is connected.
- **Last-used repo** persisted via AsyncStorage (`usePreferencesStore.lastUsedCloudRepository`).
- New **branch picker** powered by `useUserGithubBranches` (infinite query, first page 50 / next 100), pre-filling the default branch.
- Task creation now sends `github_user_integration` (string user-integration id) plus `branch` on `runTaskInCloud`, matching desktop's saga (`apps/code/src/renderer/sagas/task/task-creation.ts:405-426`).
- `ConnectGitHubPrompt` now calls `POST /api/users/@me/integrations/github/start/` so a fresh OAuth connect produces a user-level integration the new hooks can see.
- `TaskList` migrated off the removed `useIntegrations` to `useUserGithubIntegrations`, preserving the `hasGithubIntegration === null` "not yet checked" semantics.

Hooks mirror the structure of `apps/code/src/renderer/hooks/useIntegrations.ts` 1:1 (same query-key namespaces, same `combine` shape, same `useDeferredValue` + `placeholderData: prev` patterns).

## Test plan

- [ ] `pnpm --filter @posthog/mobile lint` clean
- [ ] `npx tsc --noEmit` in `apps/mobile` adds no new errors (the existing `ConversationList.tsx` error is pre-existing and unrelated)
- [ ] Authenticated user with **multiple** GitHub installations: open New Task → repos from all installations appear, deduped by first-seen
- [ ] Typing in the search field triggers `GET /repos/?search=...` (not just a client-side filter)
- [ ] Scroll / tap "Load more" — confirm next page request fires with bumped `limit`
- [ ] Tap refresh — confirm `POST /repos/refresh/` fires for each installation and list re-renders
- [ ] Select a repo → branch picker pre-selects the default branch from the first branches page
- [ ] Search branches and "Load more" — same paginated behavior as repos
- [ ] Create task — request body has `github_user_integration` (string), `repository` (lowercased `org/repo`), and `branch` when a non-default branch is picked
- [ ] Reopen New Task → `lastUsedCloudRepository` is preselected (and silently cleared if it no longer appears in the list)
- [ ] User with exactly one repo → auto-selected (mirrors desktop `GitHubRepoPicker`)
- [ ] User with no GitHub integration → `ConnectGitHubPrompt` renders; tapping launches user-level OAuth and the list recovers after connect