### PR TITLE
feat(code): prompt for microphone permission for custom completion sounds

### DIFF
--- a/apps/code/build/entitlements.mac.plist
+++ b/apps/code/build/entitlements.mac.plist
@@ -13,5 +13,9 @@
 	<!-- Enable JIT compilation for V8 -->
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+
+	<!-- Required for recording custom completion sounds via MediaRecorder -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/code/forge.config.ts
+++ b/apps/code/forge.config.ts
@@ -152,11 +152,11 @@ const config: ForgeConfig = {
     appBundleId: "com.posthog.array",
     appCategoryType: "public.app-category.productivity",
     extraResource: existsSync("build/Assets.car") ? ["build/Assets.car"] : [],
-    extendInfo: existsSync("build/Assets.car")
-      ? {
-          CFBundleIconName: "Icon",
-        }
-      : {},
+    extendInfo: {
+      NSMicrophoneUsageDescription:
+        "PostHog Code uses the microphone to let you record a custom completion sound.",
+      ...(existsSync("build/Assets.car") ? { CFBundleIconName: "Icon" } : {}),
+    },
     ...(osxSignConfig
       ? {
           osxSign: osxSignConfig,

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -18,6 +18,7 @@ import { ElectronDialog } from "../platform-adapters/electron-dialog";
 import { ElectronFileIcon } from "../platform-adapters/electron-file-icon";
 import { ElectronImageProcessor } from "../platform-adapters/electron-image-processor";
 import { ElectronMainWindow } from "../platform-adapters/electron-main-window";
+import { ElectronMediaAccess } from "../platform-adapters/electron-media-access";
 import { ElectronNotifier } from "../platform-adapters/electron-notifier";
 import { ElectronPowerManager } from "../platform-adapters/electron-power-manager";
 import { ElectronSecureStorage } from "../platform-adapters/electron-secure-storage";
@@ -86,6 +87,7 @@ container.bind(MAIN_TOKENS.Notifier).to(ElectronNotifier);
 container.bind(MAIN_TOKENS.ContextMenu).to(ElectronContextMenu);
 container.bind(MAIN_TOKENS.BundledResources).to(ElectronBundledResources);
 container.bind(MAIN_TOKENS.ImageProcessor).to(ElectronImageProcessor);
+container.bind(MAIN_TOKENS.MediaAccess).to(ElectronMediaAccess);
 
 container.bind(MAIN_TOKENS.DatabaseService).to(DatabaseService);
 container

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -21,6 +21,7 @@ export const MAIN_TOKENS = Object.freeze({
   ContextMenu: Symbol.for("Platform.ContextMenu"),
   BundledResources: Symbol.for("Platform.BundledResources"),
   ImageProcessor: Symbol.for("Platform.ImageProcessor"),
+  MediaAccess: Symbol.for("Platform.MediaAccess"),
 
   // Stores
   SettingsStore: Symbol.for("Main.SettingsStore"),

--- a/apps/code/src/main/platform-adapters/electron-media-access.ts
+++ b/apps/code/src/main/platform-adapters/electron-media-access.ts
@@ -1,0 +1,21 @@
+import type {
+  IMediaAccess,
+  MediaAccessStatus,
+} from "@posthog/platform/media-access";
+import { systemPreferences } from "electron";
+import { injectable } from "inversify";
+
+@injectable()
+export class ElectronMediaAccess implements IMediaAccess {
+  public getMicrophoneStatus(): MediaAccessStatus {
+    if (process.platform !== "darwin") return "granted";
+    return systemPreferences.getMediaAccessStatus(
+      "microphone",
+    ) as MediaAccessStatus;
+  }
+
+  public async requestMicrophoneAccess(): Promise<boolean> {
+    if (process.platform !== "darwin") return true;
+    return systemPreferences.askForMediaAccess("microphone");
+  }
+}

--- a/apps/code/src/main/trpc/routers/os.ts
+++ b/apps/code/src/main/trpc/routers/os.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { IAppMeta } from "@posthog/platform/app-meta";
 import type { DialogSeverity, IDialog } from "@posthog/platform/dialog";
 import type { IImageProcessor } from "@posthog/platform/image-processor";
+import type { IMediaAccess } from "@posthog/platform/media-access";
 import type { IUrlLauncher } from "@posthog/platform/url-launcher";
 import { IMAGE_MIME_TYPES } from "@shared/constants/image";
 import { z } from "zod";
@@ -20,6 +21,8 @@ const getDialog = () => container.get<IDialog>(MAIN_TOKENS.Dialog);
 const getAppMeta = () => container.get<IAppMeta>(MAIN_TOKENS.AppMeta);
 const getImageProcessor = () =>
   container.get<IImageProcessor>(MAIN_TOKENS.ImageProcessor);
+const getMediaAccess = () =>
+  container.get<IMediaAccess>(MAIN_TOKENS.MediaAccess);
 
 const messageBoxOptionsSchema = z.object({
   type: z.enum(["none", "info", "error", "question", "warning"]).optional(),
@@ -277,6 +280,24 @@ export const osRouter = router({
    * Get the user's home directory.
    */
   getHomeDir: publicProcedure.output(z.string()).query(() => os.homedir()),
+
+  /**
+   * Get the macOS microphone permission status.
+   * Returns "not-determined" | "granted" | "denied" | "restricted" | "unknown".
+   * On non-macOS platforms returns "granted".
+   */
+  getMicrophoneAccessStatus: publicProcedure
+    .output(z.string())
+    .query(() => getMediaAccess().getMicrophoneStatus()),
+
+  /**
+   * Trigger the macOS microphone permission prompt (or return existing decision).
+   * Resolves to true if access is granted, false otherwise.
+   * On non-macOS platforms always returns true.
+   */
+  requestMicrophoneAccess: publicProcedure
+    .output(z.boolean())
+    .mutation(() => getMediaAccess().requestMicrophoneAccess()),
 
   /**
    * Read a file and return it as a base64 data URL

--- a/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
+++ b/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
@@ -1,4 +1,5 @@
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
+import { trpcClient } from "@renderer/trpc";
 import { logger } from "@utils/logger";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -65,6 +66,14 @@ export function useSoundRecorder(): SoundRecorder {
   const start = useCallback(async () => {
     if (recorderRef.current) return;
     try {
+      // Trigger macOS prompt up front when status is unknown. In dev mode this
+      // can be flaky (adhoc-signed Electron); the getUserMedia call below will
+      // re-trigger the prompt if needed and the catch handles denial cleanly.
+      const status = await trpcClient.os.getMicrophoneAccessStatus.query();
+      log.info("Microphone status", { status });
+      if (status === "not-determined") {
+        await trpcClient.os.requestMicrophoneAccess.mutate();
+      }
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       const mimeType = pickMimeType();
       const recorder = new MediaRecorder(
@@ -109,15 +118,33 @@ export function useSoundRecorder(): SoundRecorder {
       timeoutRef.current = setTimeout(() => {
         if (recorderRef.current?.state === "recording") {
           recorderRef.current.stop();
+          toast.error(`Recording capped at ${MAX_RECORDING_MS / 1000} seconds`);
         }
       }, MAX_RECORDING_MS);
     } catch (error) {
       log.error("Failed to start recording", error);
       cleanup();
       setIsRecording(false);
-      toast.error(
-        "Microphone access denied. Allow microphone access to record a custom sound.",
-      );
+      const isPermissionError =
+        error instanceof Error &&
+        (error.name === "NotAllowedError" ||
+          error.name === "SecurityError" ||
+          error.message.toLowerCase().includes("permission"));
+      if (isPermissionError) {
+        toast.error("Microphone access denied", {
+          description:
+            "Enable microphone access for PostHog Code in System Settings.",
+          action: {
+            label: "Open Settings",
+            onClick: () =>
+              trpcClient.os.openExternal.mutate({
+                url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+              }),
+          },
+        });
+      } else {
+        toast.error("Could not start recording");
+      }
     }
   }, [cleanup, setCustomCompletionSound]);
 

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -63,6 +63,10 @@
     "./image-processor": {
       "types": "./dist/image-processor.d.ts",
       "import": "./dist/image-processor.js"
+    },
+    "./media-access": {
+      "types": "./dist/media-access.d.ts",
+      "import": "./dist/media-access.js"
     }
   },
   "scripts": {

--- a/packages/platform/src/media-access.ts
+++ b/packages/platform/src/media-access.ts
@@ -1,0 +1,11 @@
+export type MediaAccessStatus =
+  | "not-determined"
+  | "granted"
+  | "denied"
+  | "restricted"
+  | "unknown";
+
+export interface IMediaAccess {
+  getMicrophoneStatus(): MediaAccessStatus;
+  requestMicrophoneAccess(): Promise<boolean>;
+}

--- a/packages/platform/tsup.config.ts
+++ b/packages/platform/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     "src/context-menu.ts",
     "src/bundled-resources.ts",
     "src/image-processor.ts",
+    "src/media-access.ts",
   ],
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
## Summary
- Wires up the macOS plumbing so the custom completion-sound recorder can actually capture audio (previously the mic stream returned silent ~1 KB blobs because Electron never asked for permission).
- New `IMediaAccess` platform port + `ElectronMediaAccess` adapter wrapping `systemPreferences.getMediaAccessStatus` / `askForMediaAccess`, exposed via two new `os.*` tRPC procedures.
- `useSoundRecorder` triggers the macOS prompt up front when status is `not-determined`, surfaces a toast with an "Open Settings" deeplink on denial, and shows a "Recording capped at 10 seconds" toast on auto-stop.
- Adds `NSMicrophoneUsageDescription` to the packaged Info.plist via `extendInfo` and `com.apple.security.device.audio-input` to the hardened-runtime entitlements file.

## Test plan
- [ ] Fresh-install scenario on macOS: pick Settings → General → Sound effect → "Custom recording" → Record → macOS shows the native mic permission prompt with our usage string → click Allow → speak → Stop → Test plays back the recording.
- [ ] Denied scenario: at the prompt click "Don't Allow" → toast appears with "Open Settings" action that opens System Settings → Privacy & Security → Microphone.
- [ ] Auto-stop scenario: start recording and let it run for 10 seconds without clicking Stop → recording auto-stops and "Recording capped at 10 seconds" toast appears.
- [ ] Packaged build (`pnpm --filter code package`) launches cleanly and the app appears in Privacy & Security → Microphone after the first prompt.
- [ ] Non-macOS smoke (Linux/Windows): `requestMicrophoneAccess` returns true without prompting; recording works via the standard Chromium getUserMedia flow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*