### PR TITLE
feat(code): record a custom task-completion sound

### DIFF
--- a/apps/code/build/entitlements.mac.plist
+++ b/apps/code/build/entitlements.mac.plist
@@ -13,5 +13,9 @@
 	<!-- Enable JIT compilation for V8 -->
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+
+	<!-- Required for recording custom completion sounds via MediaRecorder -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/code/forge.config.ts
+++ b/apps/code/forge.config.ts
@@ -152,11 +152,11 @@ const config: ForgeConfig = {
     appBundleId: "com.posthog.array",
     appCategoryType: "public.app-category.productivity",
     extraResource: existsSync("build/Assets.car") ? ["build/Assets.car"] : [],
-    extendInfo: existsSync("build/Assets.car")
-      ? {
-          CFBundleIconName: "Icon",
-        }
-      : {},
+    extendInfo: {
+      NSMicrophoneUsageDescription:
+        "PostHog Code uses the microphone to let you record a custom completion sound.",
+      ...(existsSync("build/Assets.car") ? { CFBundleIconName: "Icon" } : {}),
+    },
     ...(osxSignConfig
       ? {
           osxSign: osxSignConfig,

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -18,6 +18,7 @@ import { ElectronDialog } from "../platform-adapters/electron-dialog";
 import { ElectronFileIcon } from "../platform-adapters/electron-file-icon";
 import { ElectronImageProcessor } from "../platform-adapters/electron-image-processor";
 import { ElectronMainWindow } from "../platform-adapters/electron-main-window";
+import { ElectronMediaAccess } from "../platform-adapters/electron-media-access";
 import { ElectronNotifier } from "../platform-adapters/electron-notifier";
 import { ElectronPowerManager } from "../platform-adapters/electron-power-manager";
 import { ElectronSecureStorage } from "../platform-adapters/electron-secure-storage";
@@ -86,6 +87,7 @@ container.bind(MAIN_TOKENS.Notifier).to(ElectronNotifier);
 container.bind(MAIN_TOKENS.ContextMenu).to(ElectronContextMenu);
 container.bind(MAIN_TOKENS.BundledResources).to(ElectronBundledResources);
 container.bind(MAIN_TOKENS.ImageProcessor).to(ElectronImageProcessor);
+container.bind(MAIN_TOKENS.MediaAccess).to(ElectronMediaAccess);
 
 container.bind(MAIN_TOKENS.DatabaseService).to(DatabaseService);
 container

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -21,6 +21,7 @@ export const MAIN_TOKENS = Object.freeze({
   ContextMenu: Symbol.for("Platform.ContextMenu"),
   BundledResources: Symbol.for("Platform.BundledResources"),
   ImageProcessor: Symbol.for("Platform.ImageProcessor"),
+  MediaAccess: Symbol.for("Platform.MediaAccess"),
 
   // Stores
   SettingsStore: Symbol.for("Main.SettingsStore"),

--- a/apps/code/src/main/platform-adapters/electron-media-access.ts
+++ b/apps/code/src/main/platform-adapters/electron-media-access.ts
@@ -1,0 +1,21 @@
+import type {
+  IMediaAccess,
+  MediaAccessStatus,
+} from "@posthog/platform/media-access";
+import { systemPreferences } from "electron";
+import { injectable } from "inversify";
+
+@injectable()
+export class ElectronMediaAccess implements IMediaAccess {
+  public getMicrophoneStatus(): MediaAccessStatus {
+    if (process.platform !== "darwin") return "granted";
+    return systemPreferences.getMediaAccessStatus(
+      "microphone",
+    ) as MediaAccessStatus;
+  }
+
+  public async requestMicrophoneAccess(): Promise<boolean> {
+    if (process.platform !== "darwin") return true;
+    return systemPreferences.askForMediaAccess("microphone");
+  }
+}

--- a/apps/code/src/main/trpc/routers/os.ts
+++ b/apps/code/src/main/trpc/routers/os.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { IAppMeta } from "@posthog/platform/app-meta";
 import type { DialogSeverity, IDialog } from "@posthog/platform/dialog";
 import type { IImageProcessor } from "@posthog/platform/image-processor";
+import type { IMediaAccess } from "@posthog/platform/media-access";
 import type { IUrlLauncher } from "@posthog/platform/url-launcher";
 import { IMAGE_MIME_TYPES } from "@shared/constants/image";
 import { z } from "zod";
@@ -20,6 +21,8 @@ const getDialog = () => container.get<IDialog>(MAIN_TOKENS.Dialog);
 const getAppMeta = () => container.get<IAppMeta>(MAIN_TOKENS.AppMeta);
 const getImageProcessor = () =>
   container.get<IImageProcessor>(MAIN_TOKENS.ImageProcessor);
+const getMediaAccess = () =>
+  container.get<IMediaAccess>(MAIN_TOKENS.MediaAccess);
 
 const messageBoxOptionsSchema = z.object({
   type: z.enum(["none", "info", "error", "question", "warning"]).optional(),
@@ -272,6 +275,24 @@ export const osRouter = router({
    * Get the worktree base location (e.g., ~/.posthog-code)
    */
   getWorktreeLocation: publicProcedure.query(() => getWorktreeLocation()),
+
+  /**
+   * Get the macOS microphone permission status.
+   * Returns "not-determined" | "granted" | "denied" | "restricted" | "unknown".
+   * On non-macOS platforms returns "granted".
+   */
+  getMicrophoneAccessStatus: publicProcedure
+    .output(z.string())
+    .query(() => getMediaAccess().getMicrophoneStatus()),
+
+  /**
+   * Trigger the macOS microphone permission prompt (or return existing decision).
+   * Resolves to true if access is granted, false otherwise.
+   * On non-macOS platforms always returns true.
+   */
+  requestMicrophoneAccess: publicProcedure
+    .output(z.boolean())
+    .mutation(() => getMediaAccess().requestMicrophoneAccess()),
 
   /**
    * Read a file and return it as a base64 data URL

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -250,7 +250,6 @@ export function SessionView({
     [onSendPrompt],
   );
 
-  const { isOnline } = useConnectivity();
   const handleBeforeSubmit = useCallback(
     (text: string, clearEditor: () => void): boolean => {
       if (!isOnline) {

--- a/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
@@ -1,5 +1,6 @@
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { SettingRow } from "@features/settings/components/SettingRow";
+import { useSoundRecorder } from "@features/settings/hooks/useSoundRecorder";
 import {
   type AutoConvertLongText,
   type CompletionSound,
@@ -8,7 +9,7 @@ import {
   type SendMessagesWith,
   useSettingsStore,
 } from "@features/settings/stores/settingsStore";
-import { ArrowSquareOut } from "@phosphor-icons/react";
+import { ArrowSquareOut, Trash } from "@phosphor-icons/react";
 import {
   Button,
   Flex,
@@ -153,6 +154,8 @@ export function GeneralSettings() {
   const handleTestSound = useCallback(() => {
     playCompletionSound(completionSound, completionVolume);
   }, [completionSound, completionVolume]);
+
+  const recorder = useSoundRecorder();
 
   const handleAutoConvertLongTextChange = useCallback(
     (value: AutoConvertLongText) => {
@@ -310,7 +313,7 @@ export function GeneralSettings() {
         description="Play a sound when the agent finishes a task or needs your input"
         noBorder={completionSound === "none"}
       >
-        <Flex align="center" gap="2">
+        <Flex align="center" gap="2" wrap="wrap" justify="end">
           <Select.Root
             value={completionSound}
             onValueChange={(value) =>
@@ -333,10 +336,59 @@ export function GeneralSettings() {
               <Select.Item value="slide">Slide</Select.Item>
               <Select.Item value="switch">Switch</Select.Item>
               <Select.Item value="wilhelm">Wilhelm scream</Select.Item>
+              <Select.Item value="custom">Custom recording</Select.Item>
             </Select.Content>
           </Select.Root>
+          {completionSound === "custom" &&
+            (recorder.isRecording ? (
+              <Flex align="center" gap="2">
+                <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-(--red-9)" />
+                <Text color="gray" className="text-[13px]">
+                  Recording…
+                </Text>
+                <Button
+                  variant="soft"
+                  color="red"
+                  size="1"
+                  onClick={recorder.stop}
+                >
+                  Stop
+                </Button>
+              </Flex>
+            ) : (
+              <>
+                <Button
+                  variant="soft"
+                  size="1"
+                  onClick={() => {
+                    void recorder.start();
+                  }}
+                >
+                  {recorder.hasRecording ? "Re-record" : "Record"}
+                </Button>
+                {recorder.hasRecording && (
+                  <Button
+                    variant="soft"
+                    color="gray"
+                    size="1"
+                    onClick={recorder.clear}
+                    aria-label="Clear recording"
+                  >
+                    <Trash size={12} />
+                  </Button>
+                )}
+              </>
+            ))}
           {completionSound !== "none" && (
-            <Button variant="soft" size="1" onClick={handleTestSound}>
+            <Button
+              variant="soft"
+              size="1"
+              onClick={handleTestSound}
+              disabled={
+                completionSound === "custom" &&
+                (!recorder.hasRecording || recorder.isRecording)
+              }
+            >
               Test
             </Button>
           )}

--- a/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
+++ b/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
@@ -72,7 +72,12 @@ export function useSoundRecorder(): SoundRecorder {
       const status = await trpcClient.os.getMicrophoneAccessStatus.query();
       log.info("Microphone status", { status });
       if (status === "not-determined") {
-        await trpcClient.os.requestMicrophoneAccess.mutate();
+        const granted = await trpcClient.os.requestMicrophoneAccess.mutate();
+        if (!granted) {
+          throw Object.assign(new Error("Microphone access denied"), {
+            name: "NotAllowedError",
+          });
+        }
       }
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       const mimeType = pickMimeType();

--- a/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
+++ b/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
@@ -142,9 +142,11 @@ export function useSoundRecorder(): SoundRecorder {
           action: {
             label: "Open Settings",
             onClick: () =>
-              trpcClient.os.openExternal.mutate({
-                url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
-              }),
+              void trpcClient.os.openExternal
+                .mutate({
+                  url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+                })
+                .catch((err) => log.error("Failed to open settings", err)),
           },
         });
       } else {

--- a/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
+++ b/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
@@ -1,0 +1,168 @@
+import { useSettingsStore } from "@features/settings/stores/settingsStore";
+import { trpcClient } from "@renderer/trpc";
+import { logger } from "@utils/logger";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+const log = logger.scope("useSoundRecorder");
+
+const MAX_RECORDING_MS = 10_000;
+
+function pickMimeType(): string | undefined {
+  if (typeof MediaRecorder === "undefined") return undefined;
+  const candidates = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"];
+  for (const mime of candidates) {
+    if (MediaRecorder.isTypeSupported(mime)) return mime;
+  }
+  return undefined;
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+export interface SoundRecorder {
+  isRecording: boolean;
+  hasRecording: boolean;
+  start: () => Promise<void>;
+  stop: () => void;
+  clear: () => void;
+}
+
+export function useSoundRecorder(): SoundRecorder {
+  const customCompletionSound = useSettingsStore(
+    (s) => s.customCompletionSound,
+  );
+  const setCustomCompletionSound = useSettingsStore(
+    (s) => s.setCustomCompletionSound,
+  );
+
+  const [isRecording, setIsRecording] = useState(false);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    for (const track of streamRef.current?.getTracks() ?? []) {
+      track.stop();
+    }
+    streamRef.current = null;
+    recorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  const start = useCallback(async () => {
+    if (recorderRef.current) return;
+    try {
+      // Trigger macOS prompt up front when status is unknown. In dev mode this
+      // can be flaky (adhoc-signed Electron); the getUserMedia call below will
+      // re-trigger the prompt if needed and the catch handles denial cleanly.
+      const status = await trpcClient.os.getMicrophoneAccessStatus.query();
+      log.info("Microphone status", { status });
+      if (status === "not-determined") {
+        await trpcClient.os.requestMicrophoneAccess.mutate();
+      }
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mimeType = pickMimeType();
+      const recorder = new MediaRecorder(
+        stream,
+        mimeType ? { mimeType } : undefined,
+      );
+      streamRef.current = stream;
+      recorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) chunksRef.current.push(event.data);
+      };
+
+      recorder.onstop = async () => {
+        const blob = new Blob(chunksRef.current, {
+          type: recorder.mimeType || "audio/webm",
+        });
+        log.info("Recording stopped", {
+          blobSize: blob.size,
+          blobType: blob.type,
+          chunkCount: chunksRef.current.length,
+        });
+        cleanup();
+        setIsRecording(false);
+        if (blob.size === 0) {
+          toast.error("Recording was empty");
+          return;
+        }
+        try {
+          const dataUrl = await blobToDataUrl(blob);
+          log.info("Recording saved", { dataUrlLength: dataUrl.length });
+          setCustomCompletionSound(dataUrl);
+        } catch (error) {
+          log.error("Failed to encode recording", error);
+          toast.error("Could not save recording");
+        }
+      };
+
+      recorder.start();
+      setIsRecording(true);
+      timeoutRef.current = setTimeout(() => {
+        if (recorderRef.current?.state === "recording") {
+          recorderRef.current.stop();
+          toast.error(`Recording capped at ${MAX_RECORDING_MS / 1000} seconds`);
+        }
+      }, MAX_RECORDING_MS);
+    } catch (error) {
+      log.error("Failed to start recording", error);
+      cleanup();
+      setIsRecording(false);
+      const isPermissionError =
+        error instanceof Error &&
+        (error.name === "NotAllowedError" ||
+          error.name === "SecurityError" ||
+          error.message.toLowerCase().includes("permission"));
+      if (isPermissionError) {
+        toast.error("Microphone access denied", {
+          description:
+            "Enable microphone access for PostHog Code in System Settings.",
+          action: {
+            label: "Open Settings",
+            onClick: () =>
+              trpcClient.os.openExternal.mutate({
+                url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+              }),
+          },
+        });
+      } else {
+        toast.error("Could not start recording");
+      }
+    }
+  }, [cleanup, setCustomCompletionSound]);
+
+  const stop = useCallback(() => {
+    if (recorderRef.current?.state === "recording") {
+      recorderRef.current.stop();
+    }
+  }, []);
+
+  const clear = useCallback(() => {
+    setCustomCompletionSound(null);
+  }, [setCustomCompletionSound]);
+
+  return {
+    isRecording,
+    hasRecording: customCompletionSound !== null,
+    start,
+    stop,
+    clear,
+  };
+}

--- a/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
+++ b/apps/code/src/renderer/features/settings/hooks/useSoundRecorder.ts
@@ -1,6 +1,7 @@
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { trpcClient } from "@renderer/trpc";
 import { logger } from "@utils/logger";
+import { isMac } from "@utils/platform";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -139,15 +140,17 @@ export function useSoundRecorder(): SoundRecorder {
         toast.error("Microphone access denied", {
           description:
             "Enable microphone access for PostHog Code in System Settings.",
-          action: {
-            label: "Open Settings",
-            onClick: () =>
-              void trpcClient.os.openExternal
-                .mutate({
-                  url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
-                })
-                .catch((err) => log.error("Failed to open settings", err)),
-          },
+          ...(isMac && {
+            action: {
+              label: "Open Settings",
+              onClick: () =>
+                void trpcClient.os.openExternal
+                  .mutate({
+                    url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+                  })
+                  .catch((err) => log.error("Failed to open settings", err)),
+            },
+          }),
         });
       } else {
         toast.error("Could not start recording");

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.ts
@@ -20,7 +20,8 @@ export type CompletionSound =
   | "shoot"
   | "slide"
   | "switch"
-  | "wilhelm";
+  | "wilhelm"
+  | "custom";
 export type AgentAdapter = "claude" | "codex";
 export type AutoConvertLongText = "off" | "1000" | "2500" | "5000" | "10000";
 export type DefaultInitialTaskMode = "plan" | "last_used";
@@ -47,6 +48,7 @@ interface SettingsStore {
 
   autoConvertLongText: AutoConvertLongText;
   completionSound: CompletionSound;
+  customCompletionSound: string | null;
   completionVolume: number;
   sendMessagesWith: SendMessagesWith;
   allowBypassPermissions: boolean;
@@ -65,6 +67,7 @@ interface SettingsStore {
   markHintLearned: (key: string) => void;
 
   setCompletionSound: (sound: CompletionSound) => void;
+  setCustomCompletionSound: (dataUrl: string | null) => void;
   setCompletionVolume: (volume: number) => void;
   setDefaultRunMode: (mode: DefaultRunMode) => void;
   setLastUsedRunMode: (mode: "local" | "cloud") => void;
@@ -112,6 +115,7 @@ export const useSettingsStore = create<SettingsStore>()(
       dockBadgeNotifications: true,
       dockBounceNotifications: false,
       completionSound: "none",
+      customCompletionSound: null,
       completionVolume: 80,
 
       autoConvertLongText: "2500",
@@ -154,6 +158,8 @@ export const useSettingsStore = create<SettingsStore>()(
         }),
 
       setCompletionSound: (sound) => set({ completionSound: sound }),
+      setCustomCompletionSound: (dataUrl) =>
+        set({ customCompletionSound: dataUrl }),
       setCompletionVolume: (volume) => set({ completionVolume: volume }),
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
       setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
@@ -222,6 +228,7 @@ export const useSettingsStore = create<SettingsStore>()(
 
         autoConvertLongText: state.autoConvertLongText,
         completionSound: state.completionSound,
+        customCompletionSound: state.customCompletionSound,
         completionVolume: state.completionVolume,
         sendMessagesWith: state.sendMessagesWith,
         allowBypassPermissions: state.allowBypassPermissions,

--- a/apps/code/src/renderer/utils/sounds.ts
+++ b/apps/code/src/renderer/utils/sounds.ts
@@ -1,4 +1,7 @@
-import type { CompletionSound } from "@features/settings/stores/settingsStore";
+import {
+  type CompletionSound,
+  useSettingsStore,
+} from "@features/settings/stores/settingsStore";
 import bubblesUrl from "@renderer/assets/sounds/bubbles.mp3";
 import daniloUrl from "@renderer/assets/sounds/danilo.mp3";
 import dropUrl from "@renderer/assets/sounds/drop.mp3";
@@ -11,8 +14,12 @@ import shootUrl from "@renderer/assets/sounds/shoot.mp3";
 import slideUrl from "@renderer/assets/sounds/slide.mp3";
 import switchUrl from "@renderer/assets/sounds/switch.mp3";
 import wilhelmUrl from "@renderer/assets/sounds/wilhelm.mp3";
+import { logger } from "@utils/logger";
 
-const SOUND_URLS: Record<Exclude<CompletionSound, "none">, string> = {
+const SOUND_URLS: Record<
+  Exclude<CompletionSound, "none" | "custom">,
+  string
+> = {
   guitar: guitarUrl,
   danilo: daniloUrl,
   revi: reviUrl,
@@ -27,13 +34,21 @@ const SOUND_URLS: Record<Exclude<CompletionSound, "none">, string> = {
   wilhelm: wilhelmUrl,
 };
 
+const log = logger.scope("sounds");
+
 let currentAudio: HTMLAudioElement | null = null;
 
 export function playCompletionSound(sound: CompletionSound, volume = 80): void {
   if (sound === "none") return;
 
-  const url = SOUND_URLS[sound];
-  if (!url) return;
+  const url =
+    sound === "custom"
+      ? useSettingsStore.getState().customCompletionSound
+      : SOUND_URLS[sound];
+  if (!url) {
+    log.warn("No URL for completion sound", { sound });
+    return;
+  }
 
   if (currentAudio) {
     currentAudio.pause();
@@ -42,9 +57,16 @@ export function playCompletionSound(sound: CompletionSound, volume = 80): void {
 
   const audio = new Audio(url);
   audio.volume = Math.max(0, Math.min(100, volume)) / 100;
+  audio.addEventListener("error", () => {
+    log.error("Audio element error", {
+      sound,
+      code: audio.error?.code,
+      message: audio.error?.message,
+    });
+  });
   currentAudio = audio;
-  audio.play().catch(() => {
-    // Audio play can fail if user hasn't interacted with the page yet
+  audio.play().catch((error) => {
+    log.error("audio.play() rejected", { sound, error: String(error) });
   });
   audio.addEventListener("ended", () => {
     if (currentAudio === audio) {

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -63,6 +63,10 @@
     "./image-processor": {
       "types": "./dist/image-processor.d.ts",
       "import": "./dist/image-processor.js"
+    },
+    "./media-access": {
+      "types": "./dist/media-access.d.ts",
+      "import": "./dist/media-access.js"
     }
   },
   "scripts": {

--- a/packages/platform/src/media-access.ts
+++ b/packages/platform/src/media-access.ts
@@ -1,0 +1,11 @@
+export type MediaAccessStatus =
+  | "not-determined"
+  | "granted"
+  | "denied"
+  | "restricted"
+  | "unknown";
+
+export interface IMediaAccess {
+  getMicrophoneStatus(): MediaAccessStatus;
+  requestMicrophoneAccess(): Promise<boolean>;
+}

--- a/packages/platform/tsup.config.ts
+++ b/packages/platform/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     "src/context-menu.ts",
     "src/bundled-resources.ts",
     "src/image-processor.ts",
+    "src/media-access.ts",
   ],
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
Note - you need to _build_ this to test it so mac permissions work...

## Summary
- Adds a "Custom recording" option to **Settings → General → Sound effect** so users can record a short clip from their microphone and play it when an agent finishes a task or needs input.
- New `IMediaAccess` platform port + `ElectronMediaAccess` adapter wrapping `systemPreferences.getMediaAccessStatus` / `askForMediaAccess`, exposed via two `os.*` tRPC procedures.
- `useSoundRecorder` hook wraps `MediaRecorder`, caps recordings at 10 seconds (with a toast on auto-stop), persists the result as a data URL in the existing settings store, and triggers the macOS permission flow up front.
- Mic-permission denial shows a toast with an "Open Settings" action that deep-links to System Settings → Privacy → Microphone on macOS.
- Adds `NSMicrophoneUsageDescription` to the packaged Info.plist via `extendInfo` and `com.apple.security.device.audio-input` to the hardened-runtime entitlements file.
- Drive-by: fixes a duplicate `isOnline` declaration in `SessionView.tsx` that was blocking typecheck on main.

## Test plan
- [ ] On macOS: Settings → General → Sound effect → "Custom recording" → Record → native mic permission prompt appears with our usage string → Allow → speak → Stop → Test plays back the recording.
- [ ] Denial path: at the prompt click "Don't Allow" → toast with "Open Settings" appears → clicking it opens System Settings → Privacy & Security → Microphone.
- [ ] Auto-stop: start a recording and let it run past 10 seconds → recording auto-stops and "Recording capped at 10 seconds" toast appears.
- [ ] Clear: with a saved recording, click the trash → recording is removed; Test button becomes disabled.
- [ ] Packaged build (`pnpm --filter code package`) launches cleanly and the app appears in Privacy & Security → Microphone after the first prompt.
- [ ] Non-macOS smoke (Linux/Windows): `requestMicrophoneAccess` returns true without prompting; recording works via the standard Chromium `getUserMedia` flow.

## Known follow-ups (not blocking)
- Storing the recording as a base64 data URL inside the encrypted `settings-storage` blob means every settings save re-encrypts the audio. Moving the bytes to `userData/custom-sounds/` and persisting just a filename is a worthwhile cleanup once this lands.
- `getMicrophoneAccessStatus` returns `z.string()`; could be tightened to `z.enum([...])` for a typed union end-to-end.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*