### PR TITLE
fix(code): Restore named leading-* utilities to fix oversized badges

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -250,7 +250,6 @@ export function SessionView({
     [onSendPrompt],
   );
 
-  const { isOnline } = useConnectivity();
   const handleBeforeSubmit = useCallback(
     (text: string, clearEditor: () => void): boolean => {
       if (!isOnline) {

--- a/apps/code/tailwind.config.js
+++ b/apps/code/tailwind.config.js
@@ -33,6 +33,17 @@ module.exports = {
           900: "#7f1d1d",
         },
       },
+      // radix-themes-tw replaces Tailwind's lineHeight scale with `{ 1: var(--line-height-1), … 9: var(--line-height-9) }`,
+      // which silently drops the named utilities (`leading-tight`, `leading-snug`, `leading-normal`, …). Re-add them so
+      // utilities written against the standard Tailwind names continue to apply.
+      lineHeight: {
+        none: "1",
+        tight: "1.25",
+        snug: "1.375",
+        normal: "1.5",
+        relaxed: "1.625",
+        loose: "2",
+      },
       // fontFamily lives in globals.css `@theme` (--font-sans / --font-mono)
       // — the Tailwind v4 source of truth. Don't re-declare here.
     },


### PR DESCRIPTION
## What

Tag badges (`[Alpha]`, `P1`, etc.) ballooned from ~17px to ~26px tall.

## Why

`radix-themes-tw`'s preset *replaces* (not extends) Tailwind's `lineHeight` scale, so `leading-tight` / `leading-snug` / `leading-normal` / `leading-relaxed` / `leading-loose` silently stopped compiling. `Badge`'s `!leading-tight` override became a no-op, and Radix's `--line-height-1` (overridden to 20px in `globals.css`) took over.

## Fix

Re-add the named tokens via `theme.extend.lineHeight` so they merge with the Radix scale instead of replacing it.

Also: one-line `SessionView` cleanup to unblock `pnpm typecheck` (TS2451 on `main` from #1971).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*