### PR TITLE
fix(code): respect manually-renamed task titles

### DIFF
--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -103,7 +103,7 @@ describe("useChatTitleGenerator", () => {
     });
   });
 
-  it("skips first generation when title_manually_set", async () => {
+  it("skips title update when title_manually_set", async () => {
     mockGetCachedTask.mockReturnValue({
       id: TASK_ID,
       title_manually_set: true,

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -103,46 +103,45 @@ describe("useChatTitleGenerator", () => {
     });
   });
 
-  it("skips title update when title_manually_set", async () => {
-    mockGetCachedTask.mockReturnValue({
-      id: TASK_ID,
-      title_manually_set: true,
-    });
-    mockGenerateTitle.mockResolvedValue({
-      title: "Auto title",
-      summary: "",
-    });
-    mockPrompts.value = ["some prompt"];
-
-    renderHook(() => useChatTitleGenerator(TASK_ID));
-
-    await waitFor(() => {
-      expect(mockGenerateTitle).toHaveBeenCalled();
-    });
-    expect(mockUpdateTask).not.toHaveBeenCalled();
-  });
-
-  it("still updates summary when title is skipped due to manual rename", async () => {
-    mockGetCachedTask.mockReturnValue({
-      id: TASK_ID,
-      title_manually_set: true,
-    });
-    mockGenerateTitle.mockResolvedValue({
-      title: "Auto title",
+  it.each([
+    { name: "no summary", summary: "", expectsSummaryUpdate: false },
+    {
+      name: "with summary",
       summary: "User wants to fix auth",
-    });
-    mockPrompts.value = ["fix auth"];
+      expectsSummaryUpdate: true,
+    },
+  ])(
+    "skips title update when title_manually_set ($name)",
+    async ({ summary, expectsSummaryUpdate }) => {
+      mockGetCachedTask.mockReturnValue({
+        id: TASK_ID,
+        title_manually_set: true,
+      });
+      mockGenerateTitle.mockResolvedValue({
+        title: "Auto title",
+        summary,
+      });
+      mockPrompts.value = ["fix auth"];
 
-    renderHook(() => useChatTitleGenerator(TASK_ID));
+      renderHook(() => useChatTitleGenerator(TASK_ID));
 
-    await waitFor(() => {
-      expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
-        "run-1",
-        { conversationSummary: "User wants to fix auth" },
-      );
-    });
-    expect(mockUpdateTask).not.toHaveBeenCalled();
-  });
+      await waitFor(() => {
+        expect(mockGenerateTitle).toHaveBeenCalled();
+      });
+      expect(mockUpdateTask).not.toHaveBeenCalled();
+
+      if (expectsSummaryUpdate) {
+        await waitFor(() => {
+          expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+            "run-1",
+            { conversationSummary: summary },
+          );
+        });
+      } else {
+        expect(mockSessionStoreSetters.updateSession).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("calls enrichDescriptionWithFileContent before generating", async () => {
     mockEnrichDescription.mockResolvedValue("enriched content");

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -103,7 +103,7 @@ describe("useChatTitleGenerator", () => {
     });
   });
 
-  it("allows first generation even when title_manually_set", async () => {
+  it("skips first generation when title_manually_set", async () => {
     mockGetCachedTask.mockReturnValue({
       id: TASK_ID,
       title_manually_set: true,
@@ -117,10 +117,31 @@ describe("useChatTitleGenerator", () => {
     renderHook(() => useChatTitleGenerator(TASK_ID));
 
     await waitFor(() => {
-      expect(mockUpdateTask).toHaveBeenCalledWith(TASK_ID, {
-        title: "Auto title",
-      });
+      expect(mockGenerateTitle).toHaveBeenCalled();
     });
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it("still updates summary when title is skipped due to manual rename", async () => {
+    mockGetCachedTask.mockReturnValue({
+      id: TASK_ID,
+      title_manually_set: true,
+    });
+    mockGenerateTitle.mockResolvedValue({
+      title: "Auto title",
+      summary: "User wants to fix auth",
+    });
+    mockPrompts.value = ["fix auth"];
+
+    renderHook(() => useChatTitleGenerator(TASK_ID));
+
+    await waitFor(() => {
+      expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+        "run-1",
+        { conversationSummary: "User wants to fix auth" },
+      );
+    });
+    expect(mockUpdateTask).not.toHaveBeenCalled();
   });
 
   it("calls enrichDescriptionWithFileContent before generating", async () => {

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
@@ -73,27 +73,26 @@ export function useChatTitleGenerator(taskId: string): void {
         const result = await generateTitleAndSummary(content);
         if (result) {
           const { title, summary } = result;
-          if (title) {
-            if (getCachedTask(taskId)?.title_manually_set) {
-              log.debug("Skipping auto-title, user renamed task", { taskId });
-            } else {
-              const client = await getAuthenticatedClient();
-              if (client) {
-                await client.updateTask(taskId, { title });
-                queryClient.setQueriesData<Task[]>(
-                  { queryKey: ["tasks", "list"] },
-                  (old) =>
-                    old?.map((task) =>
-                      task.id === taskId ? { ...task, title } : task,
-                    ),
-                );
-                getSessionService().updateSessionTaskTitle(taskId, title);
-                log.debug("Updated task title from conversation", {
-                  taskId,
-                  title,
-                  promptCount,
-                });
-              }
+          const titleLocked = !!getCachedTask(taskId)?.title_manually_set;
+
+          if (title && titleLocked) {
+            log.debug("Skipping auto-title, user renamed task", { taskId });
+          } else if (title) {
+            const client = await getAuthenticatedClient();
+            if (client) {
+              await client.updateTask(taskId, { title });
+              queryClient.setQueriesData<Task[]>(
+                { queryKey: ["tasks", "list"] },
+                (old) =>
+                  old?.map((task) =>
+                    task.id === taskId ? { ...task, title } : task,
+                  ),
+              );
+              getSessionService().updateSessionTaskTitle(taskId, title);
+              log.debug("Updated task title from conversation", {
+                taskId,
+                promptCount,
+              });
             }
           }
 
@@ -104,7 +103,6 @@ export function useChatTitleGenerator(taskId: string): void {
 
             log.debug("Updated task summary from conversation", {
               taskId,
-              summary,
               promptCount,
             });
           }

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
@@ -74,30 +74,26 @@ export function useChatTitleGenerator(taskId: string): void {
         if (result) {
           const { title, summary } = result;
           if (title) {
-            const isFirstGeneration = lastGeneratedAtCount.current === 0;
-            if (
-              !isFirstGeneration &&
-              getCachedTask(taskId)?.title_manually_set
-            ) {
+            if (getCachedTask(taskId)?.title_manually_set) {
               log.debug("Skipping auto-title, user renamed task", { taskId });
-              return;
-            }
-            const client = await getAuthenticatedClient();
-            if (client) {
-              await client.updateTask(taskId, { title });
-              queryClient.setQueriesData<Task[]>(
-                { queryKey: ["tasks", "list"] },
-                (old) =>
-                  old?.map((task) =>
-                    task.id === taskId ? { ...task, title } : task,
-                  ),
-              );
-              getSessionService().updateSessionTaskTitle(taskId, title);
-              log.debug("Updated task title from conversation", {
-                taskId,
-                title,
-                promptCount,
-              });
+            } else {
+              const client = await getAuthenticatedClient();
+              if (client) {
+                await client.updateTask(taskId, { title });
+                queryClient.setQueriesData<Task[]>(
+                  { queryKey: ["tasks", "list"] },
+                  (old) =>
+                    old?.map((task) =>
+                      task.id === taskId ? { ...task, title } : task,
+                    ),
+                );
+                getSessionService().updateSessionTaskTitle(taskId, title);
+                log.debug("Updated task title from conversation", {
+                  taskId,
+                  title,
+                  promptCount,
+                });
+              }
             }
           }
 


### PR DESCRIPTION
## Problem

If a user manually renamed a task and then sent their first prompt, the auto-title generator would still overwrite their title with an LLM-generated one. The guard against this only ran on *subsequent* generations — first-generation runs were exempted, so the user's rename got clobbered immediately.

A secondary bug: when the guard *did* fire, it `return`ed out of the whole run, also skipping the unrelated conversation-summary update.

## Changes

- Drop the `isFirstGeneration` exemption in `useChatTitleGenerator` so a manual rename is respected from prompt #1 onward.
- Move the `title_manually_set` guard into an `if/else` around just the title update, so the summary still gets written when the title is skipped.

## How did you test this?

- `pnpm --filter code typecheck` — clean.
- `pnpm --filter code test useChatTitleGenerator` — 7 tests pass, including two new ones:
  - skips first generation when `title_manually_set` is true
  - still updates the conversation summary when the title is skipped due to a manual rename
- All CI checks pass (build, unit-test, integration-test, typecheck, semgrep, CodeQL, Wiz).
- The new unit tests exercise the same scenario as the manual repro (rename → first prompt → title held), so the manual repro is covered by automation rather than required by hand.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*