### PR TITLE
fix(code): make toast close button clickable

### DIFF
--- a/apps/code/src/renderer/utils/toast.tsx
+++ b/apps/code/src/renderer/utils/toast.tsx
@@ -61,7 +61,7 @@ function ToastComponent(props: ToastProps) {
                   color="gray"
                   onClick={() => sonnerToast.dismiss(id)}
                 >
-                  <XIcon size={12} />
+                  <XIcon size={12} className="pointer-events-none" />
                 </IconButton>
               )}
             </Flex>


### PR DESCRIPTION
## Summary
- The X (close) button on toasts was unresponsive — clicking it did nothing.
- Root cause: sonner's pointerdown handler on the toast `<li>` only short-circuits when `event.target.tagName === 'BUTTON'`. Clicking the X made the SVG icon the event target, so sonner called `setPointerCapture` on the SVG and engaged its swipe logic, swallowing the click before the IconButton's `onClick` could fire `sonnerToast.dismiss(id)`.
- Fix: add `pointer-events-none` to the `<XIcon>` so the click target is always the button itself, which hits sonner's BUTTON early-return.
- Applies to every toast type (success / error / info / warning), not just "You're on the latest version" — that one was just easy to reproduce because it's a sticky non-loading toast.

## Test plan
- [ ] Trigger "You're on the latest version" toast (Check for updates → already up to date) and click the X — toast dismisses.
- [ ] Trigger any error/success/info/warning toast and click the X — toast dismisses.
- [ ] Toasts with an action label still dismiss when the action is clicked.