### PR TITLE
fix(tasks): sync cloud-started tasks into local workspace registry

### DIFF
--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -33,7 +33,7 @@ import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useIntegrations } from "@hooks/useIntegrations";
 import { Box, Flex } from "@radix-ui/themes";
 import { useTRPC } from "@renderer/trpc/client";
-import { BILLING_FLAG } from "@shared/constants";
+import { BILLING_FLAG, SYNC_CLOUD_TASKS_FLAG } from "@shared/constants";
 import { useCommandMenuStore } from "@stores/commandMenuStore";
 import { useNavigationStore } from "@stores/navigationStore";
 import { useShortcutsSheetStore } from "@stores/shortcutsSheetStore";
@@ -70,6 +70,7 @@ export function MainLayout() {
   const queryClient = useQueryClient();
   const reconcilingTaskIds = useRef<Set<string>>(new Set());
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
+  const syncCloudTasksEnabled = useFeatureFlag(SYNC_CLOUD_TASKS_FLAG);
 
   // Space switcher data
   const sidebarData = useSidebarData({ activeView: view });
@@ -94,6 +95,7 @@ export function MainLayout() {
   }, [tasks, hydrateTask]);
 
   useEffect(() => {
+    if (!syncCloudTasksEnabled) return;
     if (!tasks || !workspaces || !workspacesFetched) return;
     const missing = tasks.filter(
       (t) => !workspaces[t.id] && !reconcilingTaskIds.current.has(t.id),
@@ -127,7 +129,14 @@ export function MainLayout() {
         );
       }
     });
-  }, [tasks, workspaces, workspacesFetched, queryClient, trpcReact]);
+  }, [
+    syncCloudTasksEnabled,
+    tasks,
+    workspaces,
+    workspacesFetched,
+    queryClient,
+    trpcReact,
+  ]);
 
   useEffect(() => {
     if (view.type === "task-detail" && !view.data && !view.taskId) {

--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -25,16 +25,22 @@ import { useTasks } from "@features/tasks/hooks/useTasks";
 import { TourOverlay } from "@features/tour/components/TourOverlay";
 import { useTourStore } from "@features/tour/stores/tourStore";
 import { createFirstTaskTour } from "@features/tour/tours/createFirstTaskTour";
+import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useIntegrations } from "@hooks/useIntegrations";
 import { Box, Flex } from "@radix-ui/themes";
+import { trpcClient, useTRPC } from "@renderer/trpc/client";
 import { BILLING_FLAG } from "@shared/constants";
 import { useCommandMenuStore } from "@stores/commandMenuStore";
 import { useNavigationStore } from "@stores/navigationStore";
 import { useShortcutsSheetStore } from "@stores/shortcutsSheetStore";
-import { useCallback, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { logger } from "@utils/logger";
+import { useCallback, useEffect, useRef } from "react";
 import { useTaskDeepLink } from "../hooks/useTaskDeepLink";
 import { GlobalEventHandlers } from "./GlobalEventHandlers";
+
+const log = logger.scope("main-layout");
 
 export function MainLayout() {
   const {
@@ -56,6 +62,10 @@ export function MainLayout() {
     close: closeShortcutsSheet,
   } = useShortcutsSheetStore();
   const { data: tasks } = useTasks();
+  const { data: workspaces, isFetched: workspacesFetched } = useWorkspaces();
+  const trpcReact = useTRPC();
+  const queryClient = useQueryClient();
+  const reconcilingTaskIds = useRef<Set<string>>(new Set());
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
 
   // Space switcher data
@@ -79,6 +89,37 @@ export function MainLayout() {
       hydrateTask(tasks);
     }
   }, [tasks, hydrateTask]);
+
+  useEffect(() => {
+    if (!tasks || !workspaces || !workspacesFetched) return;
+    const missing = tasks.filter(
+      (t) => !workspaces[t.id] && !reconcilingTaskIds.current.has(t.id),
+    );
+    if (missing.length === 0) return;
+    for (const t of missing) reconcilingTaskIds.current.add(t.id);
+    void Promise.allSettled(
+      missing.map((t) =>
+        trpcClient.workspace.create.mutate({
+          taskId: t.id,
+          mainRepoPath: "",
+          folderId: "",
+          folderPath: "",
+          mode: "cloud",
+        }),
+      ),
+    ).then((results) => {
+      for (const [i, r] of results.entries()) {
+        const id = missing[i].id;
+        reconcilingTaskIds.current.delete(id);
+        if (r.status === "rejected") {
+          log.warn(`Failed to reconcile workspace for task ${id}`, r.reason);
+        }
+      }
+      void queryClient.invalidateQueries(
+        trpcReact.workspace.getAll.pathFilter(),
+      );
+    });
+  }, [tasks, workspaces, workspacesFetched, queryClient, trpcReact]);
 
   useEffect(() => {
     if (view.type === "task-detail" && !view.data && !view.taskId) {

--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -25,11 +25,14 @@ import { useTasks } from "@features/tasks/hooks/useTasks";
 import { TourOverlay } from "@features/tour/components/TourOverlay";
 import { useTourStore } from "@features/tour/stores/tourStore";
 import { createFirstTaskTour } from "@features/tour/tours/createFirstTaskTour";
-import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
+import {
+  useWorkspaces,
+  workspaceApi,
+} from "@features/workspace/hooks/useWorkspace";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useIntegrations } from "@hooks/useIntegrations";
 import { Box, Flex } from "@radix-ui/themes";
-import { trpcClient, useTRPC } from "@renderer/trpc/client";
+import { useTRPC } from "@renderer/trpc/client";
 import { BILLING_FLAG } from "@shared/constants";
 import { useCommandMenuStore } from "@stores/commandMenuStore";
 import { useNavigationStore } from "@stores/navigationStore";
@@ -99,7 +102,7 @@ export function MainLayout() {
     for (const t of missing) reconcilingTaskIds.current.add(t.id);
     void Promise.allSettled(
       missing.map((t) =>
-        trpcClient.workspace.create.mutate({
+        workspaceApi.create({
           taskId: t.id,
           mainRepoPath: "",
           folderId: "",
@@ -108,16 +111,21 @@ export function MainLayout() {
         }),
       ),
     ).then((results) => {
+      let anySucceeded = false;
       for (const [i, r] of results.entries()) {
         const id = missing[i].id;
         reconcilingTaskIds.current.delete(id);
         if (r.status === "rejected") {
           log.warn(`Failed to reconcile workspace for task ${id}`, r.reason);
+        } else {
+          anySucceeded = true;
         }
       }
-      void queryClient.invalidateQueries(
-        trpcReact.workspace.getAll.pathFilter(),
-      );
+      if (anySucceeded) {
+        void queryClient.invalidateQueries(
+          trpcReact.workspace.getAll.pathFilter(),
+        );
+      }
     });
   }, [tasks, workspaces, workspacesFetched, queryClient, trpcReact]);
 

--- a/apps/code/src/shared/constants.ts
+++ b/apps/code/src/shared/constants.ts
@@ -1,5 +1,6 @@
 export const BILLING_FLAG = "posthog-code-billing";
 export const INBOX_GATED_DUE_TO_SCALE_FLAG = "inbox-gated-due-to-scale";
+export const SYNC_CLOUD_TASKS_FLAG = "posthog-code-sync-cloud-tasks";
 export const BRANCH_PREFIX = "posthog-code/";
 export const DATA_DIR = ".posthog-code";
 export const WORKTREES_DIR = ".posthog-code/worktrees";


### PR DESCRIPTION
## Summary

- Tasks started outside the desktop app (web, CLI, another machine — same user) were already returned by the `/api/projects/{id}/tasks/` poll, but the sidebar filter in `useSidebarData.ts` hides any task without a matching local SQLite workspace row, so they never appeared.
- Mirror the API task list into the local workspace registry: when `useTasks()` yields a new list, create an idempotent `mode: "cloud"` workspace row for each missing task, then invalidate the workspaces query so the existing filter passes them through. `WorkspaceService.doCreateWorkspace` already short-circuits when a row exists, and `createWorkspaceInput` permits empty paths for cloud mode (same shape `task-creation.ts` uses for pure cloud tasks today).
- Reconciliation runs from `MainLayout.tsx` where `useTasks()` already lives; a `useRef<Set>` prevents duplicate in-flight calls between polls.

## Test plan

- [ ] `pnpm --filter code typecheck` passes
- [ ] `pnpm --filter code test` passes (one pre-existing unrelated git integration timeout)
- [ ] Manual: start a task via the web app or CLI as the same user, wait <30s, confirm the task appears in the desktop sidebar with the correct title and that clicking it opens `TaskDetail` without errors
- [ ] Restart the app and confirm the cloud workspace row persists (SQLite-backed)
- [ ] Spot-check logs for `Workspace already exists for task ...` on subsequent polls — no duplicate row creation