### PR TITLE
perf(agent-server): cut redundant calls from boot critical path

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1516,30 +1516,61 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       ? withTimeout(q.initializationResult(), SESSION_VALIDATION_TIMEOUT_MS)
       : undefined;
 
-    const [rawModelOptions] = await Promise.all([
-      this.getModelConfigOptions(
-        settingsManager.getSettings().model || meta?.model || undefined,
-      ),
-      ...(meta?.taskRunId
-        ? [
-            this.client.extNotification(POSTHOG_NOTIFICATIONS.SDK_SESSION, {
-              taskRunId: meta.taskRunId,
-              sessionId,
-              adapter: "claude",
-            }),
-          ]
-        : []),
-    ]);
+    // When the caller already pinned a model (cloud always does), the awaited
+    // gateway /v1/models call is only used to populate the UI's available-models
+    // dropdown — kicking it off in the background lets us return the session
+    // sooner. With no pinned model we still wait, since we need the gateway
+    // list to choose a default.
+    const knownModelId =
+      settingsManager.getSettings().model || meta?.model || undefined;
+
+    const sdkSessionNotification = meta?.taskRunId
+      ? this.client.extNotification(POSTHOG_NOTIFICATIONS.SDK_SESSION, {
+          taskRunId: meta.taskRunId,
+          sessionId,
+          adapter: "claude",
+        })
+      : Promise.resolve();
+
+    let modelOptions: {
+      currentModelId: string;
+      options: SessionConfigSelectOption[];
+    };
+    if (knownModelId) {
+      // Synthesize a minimal options list; the real list arrives via
+      // deferBackgroundFetches below.
+      modelOptions = {
+        currentModelId: knownModelId,
+        options: [
+          {
+            value: knownModelId,
+            name: knownModelId,
+            description: "",
+          },
+        ],
+      };
+      void sdkSessionNotification;
+    } else {
+      [modelOptions] = await Promise.all([
+        this.getModelConfigOptions(undefined),
+        sdkSessionNotification,
+      ]);
+    }
 
     // Restrict the model list to the user's `availableModels` allowlist
     // from settings.json so config UI and downstream resolution stay
     // consistent with what the user configured. The Default option is
-    // always preserved per the Claude Code docs.
+    // always preserved per the Claude Code docs. In the pinned-model case
+    // the synthesized single-entry list is left untouched (the allowlist
+    // falls back to it when nothing matches).
     const settingsAvailableModels =
       settingsManager.getSettings().availableModels;
-    const modelOptions = Array.isArray(settingsAvailableModels)
-      ? applyAvailableModelsAllowlist(rawModelOptions, settingsAvailableModels)
-      : rawModelOptions;
+    if (Array.isArray(settingsAvailableModels)) {
+      modelOptions = applyAvailableModelsAllowlist(
+        modelOptions,
+        settingsAvailableModels,
+      );
+    }
 
     if (initPromise) {
       try {
@@ -1943,8 +1974,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   // ================================
 
   /**
-   * Fire-and-forget: fetch slash commands and MCP tool metadata in parallel.
-   * Both populate caches used later — neither is needed to return configOptions.
+   * Fire-and-forget: fetch slash commands, MCP tool metadata, and prime the
+   * gateway models cache in parallel. None of these are needed to return
+   * configOptions — priming the gateway cache here keeps `getContextWindowForModel`
+   * accurate by the time the first prompt fires.
    */
   private deferBackgroundFetches(q: Query): void {
     Promise.all([
@@ -1960,6 +1993,12 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         if (serverNames.length > 0) {
           this.options?.onMcpServersReady?.(serverNames);
         }
+      }),
+      // Warm the gateway models cache so subsequent context-window lookups
+      // don't fall back to the 200k default. Result is stored on the
+      // agent instance via fetchGatewayModels' internal cache.
+      this.getModelConfigOptions(this.session?.modelId).catch(() => {
+        // Best-effort: failures here just leave the default in place.
       }),
     ]).catch((err) =>
       this.logger.error("Background fetch failed", { error: err }),

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1125,7 +1125,7 @@ export class AgentServer {
         this.logger.debug("Failed to set task run to in_progress", err),
       );
 
-    await this.sendInitialTaskMessage(payload, preTaskRun);
+    await this.sendInitialTaskMessage(payload, preTaskRun, preTask);
   }
 
   private extractErrorClassification(error: unknown): {
@@ -1165,6 +1165,7 @@ export class AgentServer {
   private async sendInitialTaskMessage(
     payload: JwtPayload,
     prefetchedRun?: TaskRun | null,
+    prefetchedTask?: Task | null,
   ): Promise<void> {
     if (!this.session) return;
 
@@ -1203,7 +1204,11 @@ export class AgentServer {
     }
 
     try {
-      const task = await this.posthogAPI.getTask(payload.task_id);
+      // Reuse the task fetched during session init when available; it was
+      // fetched milliseconds ago in the same boot path, so re-fetching it
+      // here is a redundant sandbox->PostHog round trip on the hot path.
+      const task =
+        prefetchedTask ?? (await this.posthogAPI.getTask(payload.task_id));
 
       const initialPromptOverride = taskRun
         ? this.getInitialPromptOverride(taskRun)


### PR DESCRIPTION
## Problem

The cloud `start_agent_server` activity gates on the agent-server's `/health` returning `hasSession:true`, which only happens after `_doInitializeSession` finishes. Two things on that path do avoidable network work that sits directly on the boot critical path:

1. `createSession` awaits a synchronous gateway call
2. `getTask()` is called twice during boot and each call is a sandbox→PostHog round trip through the egress path

## Changes

- when `meta.model` / settings model is set, `createSession` returns a minimal single-entry options list immediately and warms the real gateway models cache in `deferBackgroundFetches`
- `sendInitialTaskMessage` now takes the already-fetched `preTask` and only falls back to `getTask()` when it is absent