### PR TITLE
fix(tasks): only reconcile cloud tasks into workspace registry

### DIFF
--- a/apps/code/src/renderer/components/MainLayout.tsx
+++ b/apps/code/src/renderer/components/MainLayout.tsx
@@ -98,7 +98,10 @@ export function MainLayout() {
     if (!syncCloudTasksEnabled) return;
     if (!tasks || !workspaces || !workspacesFetched) return;
     const missing = tasks.filter(
-      (t) => !workspaces[t.id] && !reconcilingTaskIds.current.has(t.id),
+      (t) =>
+        t.latest_run?.environment === "cloud" &&
+        !workspaces[t.id] &&
+        !reconcilingTaskIds.current.has(t.id),
     );
     if (missing.length === 0) return;
     for (const t of missing) reconcilingTaskIds.current.add(t.id);


### PR DESCRIPTION
## Problem

When the `posthog-code-sync-cloud-tasks` flag is enabled, creating a new local worktree task ends up registered as a cloud task. Paul hit this and confirmed it goes away after he removes himself from the flag.

The reconciliation effect added in #2146 (apps/code/src/renderer/components/MainLayout.tsx) creates a `cloud` workspace for every task without a local workspace, regardless of the task's actual environment. The `TaskCreationSaga` calls `onTaskReady` (which invalidates `useTasks`) **before** `workspace.create.mutate({ mode: "worktree" })`, so a freshly-created worktree task briefly appears in `tasks` with no workspace and races the reconciliation effect — which wins and registers it as `cloud`.

## Changes

Filter reconciliation to only tasks whose `latest_run?.environment === "cloud"`. Local-worktree tasks mid-creation no longer match, so the saga's workspace.create runs uncontested.

## How did you test this?

- Typecheck passes locally (pre-commit hook).
- Manual repro requires the flag, which I don't have; reviewers on the flag can verify worktree creation works again.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*