### PR TITLE
fix(tasks): show renames instantly in sidebar and never overwrite them

### DIFF
--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -101,6 +101,14 @@ describe("useChatTitleGenerator", () => {
         title: "Fix login bug",
       });
     });
+    expect(mockSetQueriesData).toHaveBeenCalledWith(
+      { queryKey: ["tasks", "list"] },
+      expect.any(Function),
+    );
+    expect(mockSetQueriesData).toHaveBeenCalledWith(
+      { queryKey: ["tasks", "summaries"] },
+      expect.any(Function),
+    );
   });
 
   it.each([

--- a/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts
@@ -4,6 +4,7 @@ import {
   sessionStoreSetters,
   useSessionStore,
 } from "@features/sessions/stores/sessionStore";
+import type { Schemas } from "@renderer/api/generated";
 import type { Task } from "@shared/types";
 import {
   enrichDescriptionWithFileContent,
@@ -83,6 +84,13 @@ export function useChatTitleGenerator(taskId: string): void {
               await client.updateTask(taskId, { title });
               queryClient.setQueriesData<Task[]>(
                 { queryKey: ["tasks", "list"] },
+                (old) =>
+                  old?.map((task) =>
+                    task.id === taskId ? { ...task, title } : task,
+                  ),
+              );
+              queryClient.setQueriesData<Schemas.TaskSummary[]>(
+                { queryKey: ["tasks", "summaries"] },
                 (old) =>
                   old?.map((task) =>
                     task.id === taskId ? { ...task, title } : task,

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -18,6 +18,7 @@ import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import { useTaskContextMenu } from "@hooks/useTaskContextMenu";
 import { ScrollArea, Separator } from "@posthog/quill";
 import { Box, Flex } from "@radix-ui/themes";
+import type { Schemas } from "@renderer/api/generated";
 import type { Task } from "@shared/types";
 import { useNavigationStore } from "@stores/navigationStore";
 import { useRendererWindowFocusStore } from "@stores/rendererWindowFocusStore";
@@ -273,6 +274,13 @@ function SidebarMenuComponent() {
               : task,
           ),
       );
+      queryClient.setQueriesData<Schemas.TaskSummary[]>(
+        { queryKey: ["tasks", "summaries"] },
+        (old) =>
+          old?.map((task) =>
+            task.id === taskId ? { ...task, title: newTitle } : task,
+          ),
+      );
 
       // Sync to session store so notifications use the updated title
       getSessionService().updateSessionTaskTitle(taskId, newTitle);
@@ -286,6 +294,7 @@ function SidebarMenuComponent() {
         log.error("Failed to rename task", error);
         // Refetch to revert optimistic update on failure
         queryClient.invalidateQueries({ queryKey: ["tasks", "list"] });
+        queryClient.invalidateQueries({ queryKey: ["tasks", "summaries"] });
       }
     },
     [setEditingTaskId, updateTask, queryClient, log],

--- a/apps/code/src/renderer/features/tasks/hooks/useTasks.ts
+++ b/apps/code/src/renderer/features/tasks/hooks/useTasks.ts
@@ -136,6 +136,9 @@ export function useUpdateTask() {
       onSuccess: (_, { taskId }) => {
         queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
         queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) });
+        queryClient.invalidateQueries({
+          queryKey: [...taskKeys.all, "summaries"],
+        });
       },
     },
   );


### PR DESCRIPTION
## Summary

Two related bugs with manual task renames:

1. **Sidebar list lagged by up to 30s.** The sidebar reads task names from the `["tasks", "summaries"]` query cache (via `useTaskSummaries`), but the rename flow only touched `["tasks", "list"]`. So the header updated instantly while the sidebar waited for the next poll. Now both caches are written optimistically in `SidebarMenu.handleTaskEditSubmit`, invalidated in `useUpdateTask.onSuccess`, and rolled back in the catch branch.
2. **Auto-title clobbered manual renames on first generation.** `useChatTitleGenerator` had a `!isFirstGeneration` carve-out that bypassed the `title_manually_set` guard. If the user renamed a task before the first prompt's auto-title finished, their rename was overwritten. The carve-out is removed — `title_manually_set` is now respected unconditionally.

## Files changed

- `apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx` — optimistic write + rollback for the summaries cache.
- `apps/code/src/renderer/features/tasks/hooks/useTasks.ts` — invalidate summaries in `useUpdateTask.onSuccess`.
- `apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.ts` — drop the first-generation carve-out.
- `apps/code/src/renderer/features/sessions/hooks/useChatTitleGenerator.test.ts` — flipped the test that documented the old behavior.

## Test plan

- [x] `pnpm --filter code typecheck`
- [x] `pnpm --filter code test` — 1224 tests pass
- [x] Lint passes on touched files
- [ ] Manual: right-click rename a task in the sidebar → new title appears instantly in both header and sidebar list
- [ ] Manual: double-click rename a task → same instant-update behavior
- [ ] Manual: rename a freshly-created task before the first prompt's auto-title generates → rename is preserved (not overwritten)
- [ ] Manual: rename failure path (force the PATCH to fail) → sidebar reverts to the old title