### PR TITLE
fix(task-input): respect folderId when pre-selecting directory

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -37,6 +37,7 @@ import { useAuthStore } from "@renderer/features/auth/stores/authStore";
 import { useDraftStore } from "@renderer/features/message-editor/stores/draftStore";
 import { trpcClient, useTRPC } from "@renderer/trpc/client";
 import { toast } from "@renderer/utils/toast";
+import { normalizeRepoKey } from "@shared/utils/repo";
 import {
   type TaskInputReportAssociation,
   useNavigationStore,
@@ -405,13 +406,16 @@ export function TaskInput({
   ]);
 
   useEffect(() => {
-    if (view.folderId) {
-      const folder = folders.find((f) => f.id === view.folderId);
-      if (folder) {
-        setSelectedDirectory(folder.path);
-      }
+    if (!view.folderId) return;
+    const folder = folders.find((f) => f.id === view.folderId);
+    if (!folder) return;
+    setSelectedDirectory(folder.path);
+    if (folder.remoteUrl) {
+      const repoKey = normalizeRepoKey(folder.remoteUrl).toLowerCase();
+      setSelectedRepository(repoKey);
+      setLastUsedCloudRepository(repoKey);
     }
-  }, [view.folderId, folders]);
+  }, [view.folderId, folders, setLastUsedCloudRepository]);
 
   useEffect(() => {
     setCloudBranchSearchQuery("");

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -164,10 +164,11 @@ export function TaskInput({
   }, [activeReportAssociation, navigateToInbox, setSelectedReportIds]);
 
   useEffect(() => {
+    if (view.folderId) return;
     if (!selectedDirectory && mostRecentRepo?.path) {
       setSelectedDirectory(mostRecentRepo.path);
     }
-  }, [mostRecentRepo?.path, selectedDirectory]);
+  }, [view.folderId, mostRecentRepo?.path, selectedDirectory]);
 
   const setAdapter = (newAdapter: AgentAdapter) =>
     setLastUsedAdapter(newAdapter);


### PR DESCRIPTION
## Summary

- Clicking the **+** beside a project in the task sidebar passes that project's `folderId` to the new-task view, but the directory was still being pre-filled with the most-recently-accessed repo.
- Two effects in `TaskInput` raced to initialize `selectedDirectory`: a fallback to `mostRecentRepo.path` and a lookup driven by `view.folderId`. When `folders` hadn't loaded yet on first render, the fallback fired first and the folderId lookup never overrode it.
- Skip the fallback when `view.folderId` is set so the folder lookup is the sole source of truth in that case. Behavior is unchanged when no folder context is provided.

## Test plan

- [ ] Start a task in Project A so it becomes the most-recently-accessed repo.
- [ ] Click the **+** beside Project B in the sidebar — the new-task UI should pre-select Project B's directory, not Project A's.
- [ ] Reverse the roles and repeat to confirm.
- [ ] Open the new-task UI from a global entry point (no folder context) — it should still pre-select the most-recent repo.