### PR TITLE
fix: prevent copy code and copy message buttons from overlapping

### DIFF
--- a/apps/code/src/renderer/components/CodeBlock.tsx
+++ b/apps/code/src/renderer/components/CodeBlock.tsx
@@ -53,10 +53,7 @@ export function CodeBlock({ children, size = "1" }: CodeBlockProps) {
         variant="ghost"
         color="gray"
         onClick={handleCopy}
-        style={{
-          transition: "opacity 0.15s",
-        }}
-        className="group-hover:!opacity-100 [&]:hover:!opacity-100 absolute top-1 right-1 cursor-pointer opacity-0"
+        className="absolute top-1 right-1 cursor-pointer"
         aria-label="Copy code"
       >
         {copied ? <Check size={14} /> : <Copy size={14} />}

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -163,6 +163,7 @@ export const AgentMessage = memo(function AgentMessage({
             variant="ghost"
             color={copied ? "green" : "gray"}
             onClick={handleCopy}
+            aria-label="Copy message"
           >
             {copied ? <Check size={12} /> : <Copy size={12} />}
           </IconButton>

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -149,12 +149,14 @@ export const AgentMessage = memo(function AgentMessage({
   }, [content]);
 
   return (
-    <Box className="group/msg relative py-1 pl-3 text-[13px] [&>*:last-child]:mb-0">
-      <MarkdownRenderer
-        content={content}
-        componentsOverride={agentComponents}
-      />
-      <Box className="absolute top-1 right-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
+    <Box className="py-1 pl-3 text-[13px]">
+      <div className="[&>*:last-child]:mb-0">
+        <MarkdownRenderer
+          content={content}
+          componentsOverride={agentComponents}
+        />
+      </div>
+      <Box className="flex justify-end pt-1">
         <Tooltip content={copied ? "Copied!" : "Copy message"}>
           <IconButton
             size="1"

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -154,7 +154,7 @@ export const AgentMessage = memo(function AgentMessage({
         content={content}
         componentsOverride={agentComponents}
       />
-      <Box className="-top-3 absolute right-1 z-10 rounded-(--radius-2) border border-(--gray-5) bg-(--gray-1) opacity-0 shadow-sm transition-opacity group-hover/msg:opacity-100">
+      <Box className="absolute top-1 left-full ml-2 opacity-0 transition-opacity group-hover/msg:opacity-100">
         <Tooltip content={copied ? "Copied!" : "Copy message"}>
           <IconButton
             size="1"
@@ -163,7 +163,7 @@ export const AgentMessage = memo(function AgentMessage({
             onClick={handleCopy}
             aria-label="Copy message"
           >
-            {copied ? <Check size={12} /> : <Copy size={12} />}
+            {copied ? <Check size={14} /> : <Copy size={14} />}
           </IconButton>
         </Tooltip>
       </Box>

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -149,14 +149,14 @@ export const AgentMessage = memo(function AgentMessage({
   }, [content]);
 
   return (
-    <Box className="py-1 pl-3 text-[13px]">
+    <Box className="group/msg py-1 pl-3 text-[13px]">
       <div className="[&>*:last-child]:mb-0">
         <MarkdownRenderer
           content={content}
           componentsOverride={agentComponents}
         />
       </div>
-      <Box className="flex justify-end pt-1">
+      <Box className="flex justify-end pt-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
         <Tooltip content={copied ? "Copied!" : "Copy message"}>
           <IconButton
             size="1"

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -149,14 +149,12 @@ export const AgentMessage = memo(function AgentMessage({
   }, [content]);
 
   return (
-    <Box className="group/msg py-1 pl-3 text-[13px]">
-      <div className="[&>*:last-child]:mb-0">
-        <MarkdownRenderer
-          content={content}
-          componentsOverride={agentComponents}
-        />
-      </div>
-      <Box className="flex justify-end pt-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
+    <Box className="group/msg relative py-1 pl-3 text-[13px] [&>*:last-child]:mb-0">
+      <MarkdownRenderer
+        content={content}
+        componentsOverride={agentComponents}
+      />
+      <Box className="-top-3 absolute right-1 z-10 rounded-(--radius-2) border border-(--gray-5) bg-(--gray-1) opacity-0 shadow-sm transition-opacity group-hover/msg:opacity-100">
         <Tooltip content={copied ? "Copied!" : "Copy message"}>
           <IconButton
             size="1"


### PR DESCRIPTION

## Problem

The copy button on a code block and the copy button on the surrounding message sit in overlapping hit areas. Clicking the code block's copy button can land on the message-level copy button, copying the entire message instead of just the code.

 Closes #2155

## Changes

 - Moved the message-level copy button from an absolute top-right overlay into the document flow below the content, so it no longer overlaps with the per-code-block copy button
  - Made both copy buttons always visible for better discoverability

## How did you test this?

- Tested messages with text only, code block only, and text + code block combinations
- Verified both copy buttons work independently and copy the correct content
- Confirmed no visual overlap in any scenario

## Publish to changelog?

no

