### PR TITLE
Fix MCP exec permission display metadata

### DIFF
--- a/apps/code/src/renderer/components/permissions/McpPermission.tsx
+++ b/apps/code/src/renderer/components/permissions/McpPermission.tsx
@@ -8,7 +8,24 @@ import {
 import { formatInput } from "@features/sessions/components/session-update/toolCallUtils";
 import { Box, Code } from "@radix-ui/themes";
 import { DefaultPermission } from "./DefaultPermission";
-import { type BasePermissionProps, toSelectorOptions } from "./types";
+import {
+  type BasePermissionProps,
+  type PermissionToolCall,
+  toSelectorOptions,
+} from "./types";
+
+export function getMcpPermissionToolName(
+  toolCall: PermissionToolCall,
+): string | undefined {
+  const metaToolName = (
+    toolCall._meta as { claudeCode?: { toolName?: unknown } } | undefined
+  )?.claudeCode?.toolName;
+  if (typeof metaToolName === "string") return metaToolName;
+
+  const rawToolName = (toolCall.rawInput as { toolName?: unknown } | undefined)
+    ?.toolName;
+  return typeof rawToolName === "string" ? rawToolName : undefined;
+}
 
 export function McpPermission({
   toolCall,
@@ -16,9 +33,7 @@ export function McpPermission({
   onSelect,
   onCancel,
 }: BasePermissionProps) {
-  const mcpToolName = (
-    toolCall._meta as { claudeCode?: { toolName?: string } } | undefined
-  )?.claudeCode?.toolName;
+  const mcpToolName = getMcpPermissionToolName(toolCall);
 
   if (!mcpToolName) {
     return (

--- a/apps/code/src/renderer/components/permissions/McpPermission.tsx
+++ b/apps/code/src/renderer/components/permissions/McpPermission.tsx
@@ -10,22 +10,9 @@ import { Box, Code } from "@radix-ui/themes";
 import { DefaultPermission } from "./DefaultPermission";
 import {
   type BasePermissionProps,
-  type PermissionToolCall,
+  getMcpPermissionToolName,
   toSelectorOptions,
 } from "./types";
-
-export function getMcpPermissionToolName(
-  toolCall: PermissionToolCall,
-): string | undefined {
-  const metaToolName = (
-    toolCall._meta as { claudeCode?: { toolName?: unknown } } | undefined
-  )?.claudeCode?.toolName;
-  if (typeof metaToolName === "string") return metaToolName;
-
-  const rawToolName = (toolCall.rawInput as { toolName?: unknown } | undefined)
-    ?.toolName;
-  return typeof rawToolName === "string" ? rawToolName : undefined;
-}
 
 export function McpPermission({
   toolCall,

--- a/apps/code/src/renderer/components/permissions/PermissionSelector.test.tsx
+++ b/apps/code/src/renderer/components/permissions/PermissionSelector.test.tsx
@@ -1,0 +1,42 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PermissionSelector } from "./PermissionSelector";
+
+describe("PermissionSelector", () => {
+  it("renders MCP permissions from rawInput toolName when metadata is missing", () => {
+    render(
+      <Theme>
+        <PermissionSelector
+          toolCall={{
+            toolCallId: "tool-1",
+            title: "exec",
+            kind: "other",
+            rawInput: {
+              command: "info execute-sql",
+              toolName: "mcp__posthog__exec",
+            },
+          }}
+          options={[
+            { kind: "allow_once", optionId: "allow", name: "Yes" },
+            {
+              kind: "allow_always",
+              optionId: "allow_always",
+              name: "Yes, always allow",
+            },
+          ]}
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      </Theme>,
+    );
+
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.textContent === "posthog - Read execute-sql (MCP)",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^exec$/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/code/src/renderer/components/permissions/PermissionSelector.test.tsx
+++ b/apps/code/src/renderer/components/permissions/PermissionSelector.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { PermissionSelector } from "./PermissionSelector";
 
 describe("PermissionSelector", () => {
-  it("renders MCP permissions from rawInput toolName when metadata is missing", () => {
+  it("renders MCP permissions using claudeCode.toolName metadata", () => {
     render(
       <Theme>
         <PermissionSelector
@@ -12,10 +12,8 @@ describe("PermissionSelector", () => {
             toolCallId: "tool-1",
             title: "exec",
             kind: "other",
-            rawInput: {
-              command: "info execute-sql",
-              toolName: "mcp__posthog__exec",
-            },
+            rawInput: { command: "info execute-sql" },
+            _meta: { claudeCode: { toolName: "mcp__posthog__exec" } },
           }}
           options={[
             { kind: "allow_once", optionId: "allow", name: "Yes" },

--- a/apps/code/src/renderer/components/permissions/PermissionSelector.tsx
+++ b/apps/code/src/renderer/components/permissions/PermissionSelector.tsx
@@ -4,7 +4,7 @@ import { DeletePermission } from "./DeletePermission";
 import { EditPermission } from "./EditPermission";
 import { ExecutePermission } from "./ExecutePermission";
 import { FetchPermission } from "./FetchPermission";
-import { McpPermission } from "./McpPermission";
+import { getMcpPermissionToolName, McpPermission } from "./McpPermission";
 import { MovePermission } from "./MovePermission";
 import { QuestionPermission } from "./QuestionPermission";
 import { ReadPermission } from "./ReadPermission";
@@ -34,7 +34,7 @@ export function PermissionSelector({
   const meta = toolCall._meta as
     | { codeToolKind?: string; claudeCode?: { toolName?: string } }
     | undefined;
-  const agentToolName = meta?.claudeCode?.toolName;
+  const agentToolName = getMcpPermissionToolName(toolCall);
   if (agentToolName?.startsWith("mcp__")) {
     return <McpPermission {...props} />;
   }

--- a/apps/code/src/renderer/components/permissions/PermissionSelector.tsx
+++ b/apps/code/src/renderer/components/permissions/PermissionSelector.tsx
@@ -4,14 +4,14 @@ import { DeletePermission } from "./DeletePermission";
 import { EditPermission } from "./EditPermission";
 import { ExecutePermission } from "./ExecutePermission";
 import { FetchPermission } from "./FetchPermission";
-import { getMcpPermissionToolName, McpPermission } from "./McpPermission";
+import { McpPermission } from "./McpPermission";
 import { MovePermission } from "./MovePermission";
 import { QuestionPermission } from "./QuestionPermission";
 import { ReadPermission } from "./ReadPermission";
 import { SearchPermission } from "./SearchPermission";
 import { SwitchModePermission } from "./SwitchModePermission";
 import { ThinkPermission } from "./ThinkPermission";
-import type { PermissionToolCall } from "./types";
+import { getMcpPermissionToolName, type PermissionToolCall } from "./types";
 
 interface PermissionSelectorProps {
   toolCall: PermissionToolCall;

--- a/apps/code/src/renderer/components/permissions/PermissionSelector.tsx
+++ b/apps/code/src/renderer/components/permissions/PermissionSelector.tsx
@@ -31,9 +31,7 @@ export function PermissionSelector({
   onCancel,
 }: PermissionSelectorProps) {
   const props = { toolCall, options, onSelect, onCancel };
-  const meta = toolCall._meta as
-    | { codeToolKind?: string; claudeCode?: { toolName?: string } }
-    | undefined;
+  const meta = toolCall._meta as { codeToolKind?: string } | undefined;
   const agentToolName = getMcpPermissionToolName(toolCall);
   if (agentToolName?.startsWith("mcp__")) {
     return <McpPermission {...props} />;

--- a/apps/code/src/renderer/components/permissions/types.ts
+++ b/apps/code/src/renderer/components/permissions/types.ts
@@ -22,6 +22,15 @@ export interface BasePermissionProps {
   onCancel: () => void;
 }
 
+export function getMcpPermissionToolName(
+  toolCall: PermissionToolCall,
+): string | undefined {
+  const toolName = (
+    toolCall._meta as { claudeCode?: { toolName?: unknown } } | undefined
+  )?.claudeCode?.toolName;
+  return typeof toolName === "string" ? toolName : undefined;
+}
+
 export function toSelectorOptions(
   options: PermissionOption[],
 ): SelectorOption[] {

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -74,6 +74,33 @@ describe("canUseTool MCP approval enforcement", () => {
       expect.objectContaining({
         toolCall: expect.objectContaining({
           title: "The agent wants to call search_crm_objects (HubSpot)",
+          _meta: {
+            claudeCode: { toolName: "mcp__HubSpot__search_crm_objects" },
+          },
+        }),
+      }),
+    );
+  });
+
+  it("passes metadata through generic PostHog exec approval requests", async () => {
+    setMcpToolApprovalStates({
+      mcp__posthog__exec: "needs_approval",
+    });
+
+    const context = createContext("mcp__posthog__exec", {
+      toolInput: { command: "info execute-sql" },
+    });
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("allow");
+    expect(context.client.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({
+          rawInput: expect.objectContaining({
+            command: "info execute-sql",
+            toolName: "mcp__posthog__exec",
+          }),
+          _meta: { claudeCode: { toolName: "mcp__posthog__exec" } },
         }),
       }),
     );

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -457,6 +457,7 @@ async function handleMcpApprovalFlow(
         ? [{ type: "content" as const, content: text(description) }]
         : [],
       rawInput: { ...(toolInput as Record<string, unknown>), toolName },
+      _meta: { claudeCode: { toolName } },
     },
   });
 


### PR DESCRIPTION
## Summary

- route MCP permission requests through the MCP renderer when the tool name is present on `rawInput`
- include Claude Code MCP tool metadata on generic MCP approval requests
- add regressions for PostHog `exec` permission cards rendering as `posthog - Read execute-sql (MCP)` instead of a generic `exec` title

Fixes #2177.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build:deps`
- `pnpm exec vitest run src/renderer/components/permissions/PermissionSelector.test.tsx src/renderer/features/posthog-mcp/utils/posthog-exec-display.test.ts` from `apps/code`
- `pnpm exec vitest run src/adapters/claude/permissions/permission-handlers.test.ts` from `packages/agent`
- `pnpm exec biome check apps/code/src/renderer/components/permissions/McpPermission.tsx apps/code/src/renderer/components/permissions/PermissionSelector.tsx apps/code/src/renderer/components/permissions/PermissionSelector.test.tsx packages/agent/src/adapters/claude/permissions/permission-handlers.ts packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts`
- `pnpm --filter @posthog/code typecheck`
- `pnpm --filter @posthog/agent typecheck`

No packaged app/manual UI smoke was run.
