### PR TITLE
chore: upgrade codex-acp to 0.14.0 and @agentclientprotocol/sdk to 0.19.0

### DIFF
--- a/apps/code/scripts/download-binaries.mjs
+++ b/apps/code/scripts/download-binaries.mjs
@@ -19,7 +19,7 @@ const DEST_DIR = join(__dirname, "..", "resources", "codex-acp");
 const BINARIES = [
   {
     name: "codex-acp",
-    version: "0.12.0",
+    version: "0.14.0",
     getUrl: (version, target) => {
       const ext = target.includes("windows") ? "zip" : "tar.gz";
       return `https://github.com/zed-industries/codex-acp/releases/download/v${version}/codex-acp-${version}-${target}.${ext}`;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,7 @@
     "clean": "node ../../scripts/rimraf.mjs dist .turbo"
   },
   "devDependencies": {
-    "@agentclientprotocol/sdk": "0.16.1",
+    "@agentclientprotocol/sdk": "0.19.0",
     "tsup": "^8.5.1",
     "typescript": "^5.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -835,8 +835,8 @@ importers:
   packages/shared:
     devDependencies:
       '@agentclientprotocol/sdk':
-        specifier: 0.16.1
-        version: 0.16.1(zod@4.3.6)
+        specifier: 0.19.0
+        version: 0.19.0(zod@4.3.6)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -856,11 +856,6 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
-
-  '@agentclientprotocol/sdk@0.16.1':
-    resolution: {integrity: sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   '@agentclientprotocol/sdk@0.19.0':
     resolution: {integrity: sha512-U9I8ws9WTOk6jCBAWpXefGSDgVXn14/kV6HFzwWGcstQ02mOQgClMAROHmoIn9GqZbDBDEOkdIbP4P4TEMQdug==}
@@ -11886,10 +11881,6 @@ snapshots:
       graphql: 16.12.0
 
   '@adobe/css-tools@4.4.4': {}
-
-  '@agentclientprotocol/sdk@0.16.1(zod@4.3.6)':
-    dependencies:
-      zod: 4.3.6
 
   '@agentclientprotocol/sdk@0.19.0(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## TL;DR

Upgrades two key dependencies: `codex-acp` from 0.12.0 to 0.14.0 and `@agentclientprotocol/sdk` from 0.16.1 to 0.19.0 to incorporate the latest improvements and bug fixes from both packages.

## Problem

<!-- Who is this for and what problem does it solve? -->

Keeping dependencies up-to-date ensures access to latest features, performance improvements, and bug fixes.

closes https://github.com/PostHog/code/issues/2180
bunch of other improvements included less memory leak with codex

## Changes

- Updated `codex-acp` binary version from 0.12.0 to 0.14.0 in `apps/code/scripts/download-binaries.mjs`
- Updated `@agentclientprotocol/sdk` dev dependency from 0.16.1 to 0.19.0 in `packages/shared/package.json`
- Updated pnpm lock file to reflect the new dependency versions

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

Verify that the application builds successfully and that the upgraded dependencies are correctly resolved.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*