### PR TITLE
feat(cloud): auto-retry errored cloud streams on window focus

### DIFF
--- a/apps/code/src/renderer/components/GlobalEventHandlers.tsx
+++ b/apps/code/src/renderer/components/GlobalEventHandlers.tsx
@@ -1,6 +1,7 @@
 import { useReviewNavigationStore } from "@features/code-review/stores/reviewNavigationStore";
 import { useFolders } from "@features/folders/hooks/useFolders";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
+import { getSessionService } from "@features/sessions/service/service";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
 import { useSidebarData } from "@features/sidebar/hooks/useSidebarData";
 import { useVisualTaskOrder } from "@features/sidebar/hooks/useVisualTaskOrder";
@@ -231,6 +232,14 @@ export function GlobalEventHandlers({
     window.addEventListener("focus", handleFocus);
     return () => window.removeEventListener("focus", handleFocus);
   }, [loadFolders]);
+
+  useEffect(() => {
+    const handleFocus = () => {
+      getSessionService().retryUnhealthyCloudSessions();
+    };
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
+  }, []);
 
   // Check if current task's folder became invalid (e.g., moved while app was open)
   useEffect(() => {

--- a/apps/code/src/renderer/components/GlobalEventHandlers.tsx
+++ b/apps/code/src/renderer/components/GlobalEventHandlers.tsx
@@ -228,18 +228,11 @@ export function GlobalEventHandlers({
   useEffect(() => {
     const handleFocus = () => {
       loadFolders();
-    };
-    window.addEventListener("focus", handleFocus);
-    return () => window.removeEventListener("focus", handleFocus);
-  }, [loadFolders]);
-
-  useEffect(() => {
-    const handleFocus = () => {
       getSessionService().retryUnhealthyCloudSessions();
     };
     window.addEventListener("focus", handleFocus);
     return () => window.removeEventListener("focus", handleFocus);
-  }, []);
+  }, [loadFolders]);
 
   // Check if current task's folder became invalid (e.g., moved while app was open)
   useEffect(() => {

--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -2181,6 +2181,107 @@ describe("SessionService", () => {
     });
   });
 
+  describe("retryUnhealthyCloudSessions", () => {
+    it("retries every cloud session in `error` state and skips the rest", async () => {
+      const service = getSessionService();
+
+      const erroredCloudA: AgentSession = {
+        ...createMockSession({
+          taskId: "task-a",
+          taskRunId: "run-a",
+          status: "error",
+        }),
+        isCloud: true,
+      };
+      const erroredCloudB: AgentSession = {
+        ...createMockSession({
+          taskId: "task-b",
+          taskRunId: "run-b",
+          status: "error",
+        }),
+        isCloud: true,
+      };
+      const connectedCloud: AgentSession = {
+        ...createMockSession({
+          taskId: "task-c",
+          taskRunId: "run-c",
+          status: "connected",
+        }),
+        isCloud: true,
+      };
+      const erroredLocal: AgentSession = createMockSession({
+        taskId: "task-d",
+        taskRunId: "run-d",
+        status: "error",
+      });
+
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-a": erroredCloudA,
+        "run-b": erroredCloudB,
+        "run-c": connectedCloud,
+        "run-d": erroredLocal,
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockImplementation(
+        (taskId: string) => {
+          if (taskId === "task-a") return erroredCloudA;
+          if (taskId === "task-b") return erroredCloudB;
+          return undefined;
+        },
+      );
+
+      service.retryUnhealthyCloudSessions();
+
+      await vi.waitFor(() => {
+        expect(mockTrpcCloudTask.retry.mutate).toHaveBeenCalledTimes(2);
+      });
+      expect(mockTrpcCloudTask.retry.mutate).toHaveBeenCalledWith({
+        taskId: "task-a",
+        runId: "run-a",
+      });
+      expect(mockTrpcCloudTask.retry.mutate).toHaveBeenCalledWith({
+        taskId: "task-b",
+        runId: "run-b",
+      });
+    });
+
+    it("is a no-op when no sessions are errored", () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-c": {
+          ...createMockSession({ status: "connected" }),
+          isCloud: true,
+        },
+      });
+
+      service.retryUnhealthyCloudSessions();
+
+      expect(mockTrpcCloudTask.retry.mutate).not.toHaveBeenCalled();
+    });
+
+    it("swallows failures so one bad retry doesn't block the rest", async () => {
+      const service = getSessionService();
+      const errored: AgentSession = {
+        ...createMockSession({
+          taskId: "task-a",
+          taskRunId: "run-a",
+          status: "error",
+        }),
+        isCloud: true,
+      };
+
+      mockSessionStoreSetters.getSessions.mockReturnValue({ "run-a": errored });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(errored);
+      mockTrpcCloudTask.retry.mutate.mockRejectedValueOnce(
+        new Error("network down"),
+      );
+
+      expect(() => service.retryUnhealthyCloudSessions()).not.toThrow();
+      await vi.waitFor(() => {
+        expect(mockTrpcCloudTask.retry.mutate).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("reset", () => {
     it("clears connecting tasks", () => {
       const service = getSessionService();

--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -2182,7 +2182,7 @@ describe("SessionService", () => {
   });
 
   describe("retryUnhealthyCloudSessions", () => {
-    it("retries every cloud session in `error` state and skips the rest", async () => {
+    it("retries every errored cloud session", async () => {
       const service = getSessionService();
 
       const erroredCloudA: AgentSession = {
@@ -2201,25 +2201,10 @@ describe("SessionService", () => {
         }),
         isCloud: true,
       };
-      const connectedCloud: AgentSession = {
-        ...createMockSession({
-          taskId: "task-c",
-          taskRunId: "run-c",
-          status: "connected",
-        }),
-        isCloud: true,
-      };
-      const erroredLocal: AgentSession = createMockSession({
-        taskId: "task-d",
-        taskRunId: "run-d",
-        status: "error",
-      });
 
       mockSessionStoreSetters.getSessions.mockReturnValue({
         "run-a": erroredCloudA,
         "run-b": erroredCloudB,
-        "run-c": connectedCloud,
-        "run-d": erroredLocal,
       });
       mockSessionStoreSetters.getSessionByTaskId.mockImplementation(
         (taskId: string) => {
@@ -2244,13 +2229,41 @@ describe("SessionService", () => {
       });
     });
 
-    it("is a no-op when no sessions are errored", () => {
+    it.each([
+      [
+        "non-error cloud session (status=connected)",
+        {
+          ...createMockSession({
+            taskId: "task-skip",
+            taskRunId: "run-skip",
+            status: "connected",
+          }),
+          isCloud: true,
+        } as AgentSession,
+      ],
+      [
+        "non-error cloud session (status=disconnected)",
+        {
+          ...createMockSession({
+            taskId: "task-skip",
+            taskRunId: "run-skip",
+            status: "disconnected",
+          }),
+          isCloud: true,
+        } as AgentSession,
+      ],
+      [
+        "errored local session (isCloud=false)",
+        createMockSession({
+          taskId: "task-skip",
+          taskRunId: "run-skip",
+          status: "error",
+        }),
+      ],
+    ])("skips %s", (_label, session) => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessions.mockReturnValue({
-        "run-c": {
-          ...createMockSession({ status: "connected" }),
-          isCloud: true,
-        },
+        "run-skip": session,
       });
 
       service.retryUnhealthyCloudSessions();

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -3150,6 +3150,30 @@ export class SessionService {
     }
   }
 
+  /**
+   * Retries every cloud session whose stream is in the `error` state, i.e. the
+   * main process exhausted its SSE reconnect budget and surfaced the manual
+   * Retry button. Invoked on window focus so users coming back to the app
+   * after a Django deploy, laptop sleep, or network blip don't have to click
+   * Retry themselves.
+   */
+  public retryUnhealthyCloudSessions(): void {
+    const sessions = sessionStoreSetters.getSessions();
+    for (const session of Object.values(sessions)) {
+      if (!session.isCloud) continue;
+      if (session.status !== "error") continue;
+      log.info("Auto-retrying errored cloud session on focus", {
+        taskId: session.taskId,
+      });
+      this.retryCloudTaskWatch(session.taskId).catch((error) => {
+        log.warn("Auto-retry of errored cloud session failed", {
+          taskId: session.taskId,
+          error,
+        });
+      });
+    }
+  }
+
   public updateSessionTaskTitle(taskId: string, taskTitle: string): void {
     const session = sessionStoreSetters.getSessionByTaskId(taskId);
     if (!session) return;


### PR DESCRIPTION
## Summary

- The main process gives up on the cloud SSE stream after 5 reconnect attempts (~60s total with exponential backoff, capped at 30s). Anything longer than that — a Django deploy, a laptop sleep, a network blip — surfaces the manual "Retry" button.
- This change adds a `focus` listener that calls `SessionService.retryUnhealthyCloudSessions()` whenever the renderer regains focus. The method enumerates every session in `error` state where `isCloud === true` and kicks off the same `cloudTask.retry` mutation the manual button uses.
- Idempotent by construction: `retryCloudTaskWatch` flips status to `disconnected` before issuing the mutation, so a second focus event in the same tick is a no-op. Failures are caught + logged so one bad retry doesn't block others.

## Files

- `apps/code/src/renderer/features/sessions/service/service.ts` — adds `retryUnhealthyCloudSessions()` after the existing `retryCloudTaskWatch`.
- `apps/code/src/renderer/components/GlobalEventHandlers.tsx` — new `useEffect` mirroring the existing `loadFolders`-on-focus pattern.
- `apps/code/src/renderer/features/sessions/service/service.test.ts` — three new tests (retries only errored cloud sessions, no-op when none are errored, swallows per-session failures).

## Test plan

- [ ] `pnpm --filter code typecheck`
- [ ] `pnpm vitest run src/renderer/features/sessions/service/service.test.ts`
- [ ] Manual: start a cloud task → kill Django (or yank wifi for >60s) → wait for the "Cloud stream disconnected" Retry button → cmd-tab away → cmd-tab back → confirm the stream reconnects without clicking Retry.
- [ ] Manual: confirm local sessions and already-connected cloud sessions are not affected by focus events.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*