### PR TITLE
Fix review state render loop

### DIFF
--- a/apps/code/src/renderer/features/code-review/components/ReviewShell.test.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewShell.test.tsx
@@ -1,11 +1,19 @@
-import { render } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
+import { useEffect, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@renderer/features/code-review/stores/reviewNavigationStore", () => ({
   useReviewNavigationStore: vi.fn(),
 }));
 vi.mock("@features/code-editor/stores/diffViewerStore", () => ({
-  useDiffViewerStore: vi.fn(),
+  useDiffViewerStore: vi.fn((selector) =>
+    selector({
+      viewMode: "unified",
+      wordWrap: true,
+      loadFullFiles: false,
+      wordDiffs: false,
+    }),
+  ),
 }));
 vi.mock("@features/task-detail/components/ChangesPanel", () => ({
   ChangesPanel: () => null,
@@ -14,7 +22,7 @@ vi.mock("@features/git-interaction/utils/diffStats", () => ({
   computeDiffStats: () => ({ linesAdded: 0, linesRemoved: 0 }),
 }));
 vi.mock("@stores/themeStore", () => ({
-  useThemeStore: vi.fn(() => ({ isDarkMode: false })),
+  useThemeStore: vi.fn((selector) => selector({ isDarkMode: false })),
 }));
 vi.mock("@pierre/diffs/react", () => ({
   WorkerPoolContextProvider: ({ children }: { children: React.ReactNode }) =>
@@ -32,7 +40,11 @@ vi.mock("@features/sessions/service/service", () => ({
   getSessionService: vi.fn(),
 }));
 
-import { DeferredDiffPlaceholder, DiffFileHeader } from "./ReviewShell";
+import {
+  DeferredDiffPlaceholder,
+  DiffFileHeader,
+  useReviewState,
+} from "./ReviewShell";
 
 type FileDiffMetadata = import("@pierre/diffs/react").FileDiffMetadata;
 
@@ -74,6 +86,29 @@ function renderHeader(path: string) {
   );
   return { diff, deferred };
 }
+
+describe("useReviewState", () => {
+  it("does not loop when changedFiles is recreated during render", () => {
+    function useUnstableChangedFiles() {
+      const [_tick, setTick] = useState(0);
+      useEffect(() => setTick(1), []);
+
+      return useReviewState(
+        [
+          {
+            path: "dist/bundle.js",
+            status: "modified",
+            linesAdded: 600,
+            linesRemoved: 0,
+          },
+        ],
+        ["dist/bundle.js"],
+      );
+    }
+
+    expect(() => renderHook(() => useUnstableChangedFiles())).not.toThrow();
+  });
+});
 
 describe.each([
   ["DiffFileHeader", "diff" as const],

--- a/apps/code/src/renderer/features/code-review/components/ReviewShell.tsx
+++ b/apps/code/src/renderer/features/code-review/components/ReviewShell.tsx
@@ -81,6 +81,13 @@ const AUTO_COLLAPSE_PATTERNS = [
 
 export type DeferredReason = "deleted" | "large" | "generated" | "unavailable";
 
+function getDeferredPathsKey(paths: Map<string, DeferredReason>): string {
+  return Array.from(paths.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([path, reason]) => `${path}:${reason}`)
+    .join("\n");
+}
+
 export function computeAutoDeferred(
   files: {
     path: string;
@@ -158,11 +165,17 @@ function useCollapseState(
     () => new Set(),
   );
 
-  const [lastDeferred, setLastDeferred] = useState(deferredPaths);
-  if (deferredPaths !== lastDeferred) {
-    setLastDeferred(deferredPaths);
+  const deferredPathsKey = useMemo(
+    () => getDeferredPathsKey(deferredPaths),
+    [deferredPaths],
+  );
+
+  const lastDeferredPathsKey = useRef(deferredPathsKey);
+  useEffect(() => {
+    if (deferredPathsKey === lastDeferredPathsKey.current) return;
+    lastDeferredPathsKey.current = deferredPathsKey;
     setRevealedFiles(new Set());
-  }
+  }, [deferredPathsKey]);
 
   const revealFile = useCallback((filePath: string) => {
     setRevealedFiles((prev) => new Set(prev).add(filePath));


### PR DESCRIPTION
## Problem

The chat panel can hit React error #185 / maximum update depth. While investigating, I found a reproducible render loop in the code review/diff state path: `useCollapseState()` was synchronizing derived deferred-path state by calling React state setters during render when `deferredPaths` changed by object identity.

Closes #2165

## Changes

- Replace render-phase deferred-path state synchronization in `ReviewShell.useCollapseState()` with an effect guarded by a semantic deferred-path key.
- Preserve reveal state when equivalent deferred paths are recreated with new object identity.
- Add a focused regression test that recreates `changedFiles` across renders and verifies the hook no longer hits React's re-render limit.

### Follow-up note

While investigating this, I also noticed a similar render-phase prop/state synchronization smell in `InteractiveFileDiff.tsx`. I’m not changing it in this PR because I don’t currently have a focused repro showing it triggers the reported crash, but it may be worth hardening separately.

## How did you test this?

I couldn’t manually test the exact scenario, but this PR includes a focused regression test that reproduces the React #185-shaped loop on main and verifies the fix.

- `pnpm lint`
- `pnpm --filter code typecheck`
- `pnpm --filter code exec vitest run src/renderer/features/code-review`
- `pnpm --filter code exec vitest run src/main/services/archive/service.integration.test.ts --testTimeout=30000 --reporter=verbose`

I also ran `pnpm test`; the full local suite hit unrelated 5s timeout failures in `src/main/services/archive/service.integration.test.ts` under full-suite load. That same file passes when run directly with a larger timeout, as listed above.

## Publish to changelog?

do not publish to changelog