### PR TITLE
fix(enricher): stop warning on expected query compilation failures

### DIFF
--- a/packages/enricher/src/parser-manager.ts
+++ b/packages/enricher/src/parser-manager.ts
@@ -132,8 +132,7 @@ export class ParserManager {
       }
       this.queryCache.set(cacheKey, query);
       return query;
-    } catch (err) {
-      warn("Query compilation failed", err);
+    } catch {
       this.failedQueries.add(cacheKey);
       return null;
     }


### PR DESCRIPTION
possibly the noisiest logs ive ever seen in phc yet, query compilation failures can happen, and should not be logged