### PR TITLE
feat(mac): expose native window options in menu bar

### DIFF
--- a/apps/code/src/main/menu.ts
+++ b/apps/code/src/main/menu.ts
@@ -325,13 +325,5 @@ function buildViewMenu(): MenuItemConstructorOptions {
 }
 
 function buildWindowMenu(): MenuItemConstructorOptions {
-  return {
-    label: "Window",
-    submenu: [
-      { role: "minimize" },
-      { role: "zoom" },
-      { type: "separator" },
-      { role: "front" },
-    ],
-  };
+  return { role: "windowMenu" };
 }


### PR DESCRIPTION
## Problem

can't use the mac window manager with posthog code

![Bildschirmfoto 2026-05-18 um 12.35.59.png](https://app.graphite.com/user-attachments/assets/2785d2b6-d1ab-4234-9557-1a155e35abb0.png)

## Changes

now i can

![Screenshot 2026-05-18 at 16.53.50.png](https://app.graphite.com/user-attachments/assets/77b0d358-698d-4abf-b721-94e770e019b0.png)

## How did you test this?

tried locally