### PR TITLE
feat(design): fullscreen plan should have same background as inline

### DIFF
--- a/apps/code/src/renderer/components/permissions/PlanContent.tsx
+++ b/apps/code/src/renderer/components/permissions/PlanContent.tsx
@@ -69,15 +69,15 @@ export function PlanContent({ id, plan }: PlanContentProps) {
           </Flex>
 
           {createPortal(
-            <Box className="pointer-events-auto absolute inset-0 flex flex-col bg-gray-1">
+            <Box className="pointer-events-auto absolute inset-0 flex flex-col bg-blue-2">
               <Flex
                 align="center"
                 justify="between"
-                className="border-gray-6 border-b px-4 py-2"
+                className="border-blue-6 border-b px-4 py-2"
               >
                 <Flex align="center" gap="2">
-                  <ListChecks size={14} className="text-gray-11" />
-                  <Text className="text-gray-11 text-sm">Plan</Text>
+                  <ListChecks size={14} className="text-blue-11" />
+                  <Text className="text-blue-11 text-sm">Plan</Text>
                 </Flex>
                 <IconButton
                   size="1"
@@ -92,7 +92,7 @@ export function PlanContent({ id, plan }: PlanContentProps) {
 
               <Box
                 ref={scrollRef}
-                className="plan-markdown flex-1 overflow-y-auto p-6"
+                className="plan-markdown flex-1 overflow-y-auto p-6 text-blue-12"
               >
                 {markdown}
               </Box>


### PR DESCRIPTION
## Problem

inline plans have a nice blue background

![Screenshot 2026-05-18 at 17.31.40.png](https://app.graphite.com/user-attachments/assets/d2b1eae4-fe84-4e5e-9a48-9b38d1eaf849.png)

## Changes

fullscreen ones didn't, but now they do

![Screenshot 2026-05-18 at 17.29.24.png](https://app.graphite.com/user-attachments/assets/d846c705-9a46-4224-aee2-bc541c79a4ef.png)

## How did you test this?

tried locally