### PR TITLE
fix(sessions): show inline banner on cloud stream disconnect

### DIFF
--- a/apps/code/src/renderer/features/command-center/components/CommandCenterSessionView.tsx
+++ b/apps/code/src/renderer/features/command-center/components/CommandCenterSessionView.tsx
@@ -34,6 +34,7 @@ export function CommandCenterSessionView({
     cloudStatus,
     errorTitle,
     errorMessage,
+    errorRetryable,
   } = useSessionViewState(taskId, task);
 
   useSessionConnection({ taskId, task, session, repoPath, isCloud });
@@ -67,6 +68,7 @@ export function CommandCenterSessionView({
         hasError={hasError}
         errorTitle={errorTitle}
         errorMessage={errorMessage ?? undefined}
+        errorRetryable={errorRetryable}
         onRetry={handleRetry}
         onNewSession={isCloud ? undefined : handleNewSession}
         isInitializing={isInitializing}

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -68,6 +68,7 @@ interface SessionViewProps {
   hasError?: boolean;
   errorTitle?: string;
   errorMessage?: string;
+  errorRetryable?: boolean;
   onRetry?: () => void;
   onNewSession?: () => void;
   isInitializing?: boolean;
@@ -82,6 +83,48 @@ interface SessionViewProps {
 
 const DEFAULT_ERROR_MESSAGE =
   "Failed to resume this session. The working directory may have been deleted. Please start a new session.";
+
+interface CloudStreamDisconnectedBannerProps {
+  errorTitle?: string;
+  errorMessage?: string;
+  onRetry?: () => void;
+}
+
+function CloudStreamDisconnectedBanner({
+  errorTitle,
+  errorMessage,
+  onRetry,
+}: CloudStreamDisconnectedBannerProps) {
+  return (
+    <Flex
+      align="center"
+      justify="between"
+      gap="3"
+      py="2"
+      px="3"
+      className="shrink-0 border-(--red-5) border-b bg-(--red-2)"
+    >
+      <Flex align="center" gap="2" className="min-w-0">
+        <Warning size={14} weight="duotone" color="var(--red-9)" />
+        {errorTitle && (
+          <Text className="shrink-0 font-medium text-(--red-12) text-[13px]">
+            {errorTitle}
+          </Text>
+        )}
+        {errorMessage && (
+          <Text color="gray" className="truncate text-[13px]">
+            {errorMessage}
+          </Text>
+        )}
+      </Flex>
+      {onRetry && (
+        <Button variant="soft" size="1" color="red" onClick={onRetry}>
+          Retry
+        </Button>
+      )}
+    </Flex>
+  );
+}
 
 /**
  * When an allow_always permission is granted outside a mode-switch prompt,
@@ -121,6 +164,7 @@ export function SessionView({
   hasError = false,
   errorTitle,
   errorMessage = DEFAULT_ERROR_MESSAGE,
+  errorRetryable = false,
   onRetry,
   onNewSession,
   isInitializing = false,
@@ -143,6 +187,7 @@ export function SessionView({
   const currentModeId = modeOption?.currentValue;
   const handoffInProgress =
     useSessionForTask(taskId)?.handoffInProgress ?? false;
+  const showInlineBanner = hasError && errorRetryable && events.length > 0;
 
   useEffect(() => {
     if (!taskId) return;
@@ -541,6 +586,13 @@ export function SessionView({
             ) : (
               <>
                 <DropZoneOverlay isVisible={isDraggingFile} />
+                {showInlineBanner && (
+                  <CloudStreamDisconnectedBanner
+                    errorTitle={errorTitle}
+                    errorMessage={errorMessage}
+                    onRetry={onRetry}
+                  />
+                )}
                 <ConversationView
                   events={events}
                   isPromptPending={isPromptPending}
@@ -554,7 +606,7 @@ export function SessionView({
 
                 <PlanStatusBar plan={latestPlan} />
 
-                {hasError ? (
+                {hasError && !showInlineBanner ? (
                   <Flex
                     align="center"
                     justify="center"

--- a/apps/code/src/renderer/features/sessions/hooks/useSessionViewState.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionViewState.ts
@@ -67,5 +67,6 @@ export function useSessionViewState(taskId: string, task: Task) {
     errorMessage:
       session?.errorMessage ??
       (isCloud ? session?.cloudErrorMessage : undefined),
+    errorRetryable: session?.errorRetryable,
   };
 }

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -3311,11 +3311,13 @@ export class SessionService {
 
     const previousErrorTitle = session.errorTitle;
     const previousErrorMessage = session.errorMessage;
+    const previousErrorRetryable = session.errorRetryable;
 
     sessionStoreSetters.updateSession(session.taskRunId, {
       status: "disconnected",
       errorTitle: undefined,
       errorMessage: undefined,
+      errorRetryable: undefined,
       isPromptPending: false,
     });
 
@@ -3329,6 +3331,7 @@ export class SessionService {
         status: "error",
         errorTitle: previousErrorTitle,
         errorMessage: previousErrorMessage,
+        errorRetryable: previousErrorRetryable,
       });
       throw error;
     }
@@ -3488,6 +3491,7 @@ export class SessionService {
         errorMessage:
           update.errorMessage ??
           "Lost connection to the cloud run. Retry to reconnect.",
+        errorRetryable: update.retryable,
         isPromptPending: false,
       });
       return;

--- a/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/sessionStore.ts
@@ -50,6 +50,7 @@ export interface AgentSession {
   status: "connecting" | "connected" | "disconnected" | "error";
   errorTitle?: string;
   errorMessage?: string;
+  errorRetryable?: boolean;
   isPromptPending: boolean;
   isCompacting: boolean;
   promptStartedAt: number | null;

--- a/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskLogsPanel.tsx
@@ -60,6 +60,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
     cloudStatus,
     errorTitle,
     errorMessage,
+    errorRetryable,
   } = useSessionViewState(taskId, task);
 
   useSessionConnection({
@@ -145,6 +146,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
               hasError={hasError}
               errorTitle={errorTitle}
               errorMessage={errorMessage ?? undefined}
+              errorRetryable={errorRetryable}
               hideInput={hideInput}
               onRetry={handleRetry}
               onNewSession={isCloud ? undefined : handleNewSession}


### PR DESCRIPTION
## Summary

- When the cloud SSE stream gives up after exhausted reconnects, `SessionView` was painting a fullscreen `absolute inset-0` error overlay on top of an already-rendered `ConversationView` — hiding all the cached events even though session data is still in memory and logs are on disk.
- Plumb the existing `retryable` flag from `CloudTaskErrorUpdate` through `service.ts` → `sessionStore` → `useSessionViewState` → `SessionView`.
- When `hasError && errorRetryable && events.length > 0`, render a small red `CloudStreamDisconnectedBanner` above the conversation with title, message, and Retry button. Otherwise (hard errors, no events yet, non-retryable failures), keep the existing fullscreen overlay.

## Testing

tried locally (just wait 15+ min with any task selected and then click into another cloud task)

![Screenshot 2026-05-18 at 21.04.55.png](https://app.graphite.com/user-attachments/assets/0e26635c-4cf7-4e53-83ee-a9b4124f1dcb.png)

