### PR TITLE
feat: allow using typed branch name directly

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -5,6 +5,7 @@ import { invalidateGitBranchQueries } from "@features/git-interaction/utils/gitC
 import {
   ArrowClockwise,
   CaretDown,
+  Check,
   GitBranch,
   Plus,
   Spinner,
@@ -175,6 +176,16 @@ export function BranchSelector({
 
   const isDisabled = !!(disabled || !repoPath || cloudStillLoading);
   const inputValue = isCloudMode ? (cloudSearchQuery ?? "") : searchQuery;
+  const trimmedInputValue = inputValue.trim();
+  const canUseInputBranch =
+    !isDisabled &&
+    trimmedInputValue.length > 0 &&
+    trimmedInputValue !== displayedBranch;
+
+  const handleUseInputBranch = () => {
+    if (!canUseInputBranch) return;
+    handleBranchChange(trimmedInputValue);
+  };
 
   return (
     <Combobox
@@ -237,8 +248,40 @@ export function BranchSelector({
             <ComboboxInput
               placeholder="Search branches..."
               showTrigger={false}
+              onKeyDownCapture={(event) => {
+                if (
+                  event.key !== "Enter" ||
+                  event.nativeEvent.isComposing ||
+                  !canUseInputBranch
+                ) {
+                  return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+                handleUseInputBranch();
+              }}
             />
           </div>
+          <Tooltip content="Use this branch name" side="bottom">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!canUseInputBranch}
+              aria-label="Use this branch name"
+              onMouseDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                handleUseInputBranch();
+              }}
+            >
+              <Check size={14} />
+            </Button>
+          </Tooltip>
           {onRefresh ? (
             <Button
               variant="outline"

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -270,6 +270,7 @@ export function BranchSelector({
               disabled={!canUseInputBranch}
               aria-label="Use this branch name"
               onMouseDown={(event) => {
+                // Keep focus inside the combobox so the popover doesn't close before click.
                 event.preventDefault();
                 event.stopPropagation();
               }}

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -257,6 +257,11 @@ export function BranchSelector({
                   return;
                 }
 
+                // If the combobox already has a highlighted item, let Base UI select it.
+                if (event.currentTarget.getAttribute("aria-activedescendant")) {
+                  return;
+                }
+
                 event.preventDefault();
                 event.stopPropagation();
                 handleUseInputBranch();


### PR DESCRIPTION
## Problem

the branch dropdown is slow as **** for large repos

## Changes

allows using a typed/pasted branch name through a check button, or by pressing enter

![Screenshot 2026-05-18 at 17.50.00.png](https://app.graphite.com/user-attachments/assets/6ffb0b0e-6c9a-4045-8300-52aa98e4364d.png)

## How did you test this?

tried locally