### PR TITLE
perf(code): make task composer repo/branch selectors feel instant

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -107,7 +107,7 @@ export function BranchSelector({
     useQuery(
       trpc.git.getAllBranches.queryOptions(
         { directoryPath: repoPath as string },
-        { enabled: !isCloudMode && !!repoPath && open, staleTime: 10_000 },
+        { enabled: !isCloudMode && !!repoPath, staleTime: 60_000 },
       ),
     );
 

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -106,7 +106,6 @@ export function TaskInput({
   const [cloudRepoSearchQuery, setCloudRepoSearchQuery] = useState("");
   const [isCloudRepoPickerOpen, setIsCloudRepoPickerOpen] = useState(false);
   const [cloudBranchSearchQuery, setCloudBranchSearchQuery] = useState("");
-  const [isCloudBranchPickerOpen, setIsCloudBranchPickerOpen] = useState(false);
   const [selectedEnvironment, setSelectedEnvironmentRaw] = useState<
     string | null
   >(null);
@@ -244,7 +243,6 @@ export function TaskInput({
     selectedInstallationId,
     selectedCloudRepository,
     cloudBranchSearchQuery,
-    isCloudBranchPickerOpen,
   );
   const cloudBranches = cloudBranchData?.branches;
   const cloudDefaultBranch = cloudBranchData?.defaultBranch ?? null;
@@ -324,10 +322,6 @@ export function TaskInput({
     });
   }, [refreshCloudBranches]);
 
-  const handleCloudBranchPickerOpen = useCallback(() => {
-    setIsCloudBranchPickerOpen(true);
-  }, []);
-
   const handleCloudRepoPickerOpenChange = useCallback((open: boolean) => {
     setIsCloudRepoPickerOpen(open);
     if (!open) {
@@ -344,7 +338,6 @@ export function TaskInput({
   }, [loadMoreCloudRepositories]);
 
   const handleCloudBranchPickerClose = useCallback(() => {
-    setIsCloudBranchPickerOpen(false);
     setCloudBranchSearchQuery("");
   }, []);
 
@@ -414,7 +407,6 @@ export function TaskInput({
 
   useEffect(() => {
     setCloudBranchSearchQuery("");
-    setIsCloudBranchPickerOpen(false);
   }, []);
 
   const effectiveRepoPath =
@@ -717,7 +709,6 @@ export function TaskInput({
                 cloudBranchesFetchingMore={cloudBranchesFetchingMore}
                 cloudBranchesHasMore={cloudBranchesHasMore}
                 cloudSearchQuery={cloudBranchSearchQuery}
-                onCloudPickerOpen={handleCloudBranchPickerOpen}
                 onCloudPickerClose={handleCloudBranchPickerClose}
                 onCloudSearchChange={handleCloudBranchSearchChange}
                 onCloudLoadMore={handleLoadMoreCloudBranches}

--- a/apps/code/src/renderer/hooks/useIntegrations.ts
+++ b/apps/code/src/renderer/hooks/useIntegrations.ts
@@ -392,6 +392,7 @@ export function useGithubBranches(
         if (!lastPage.hasMore) return undefined;
         return allPages.reduce((n, p) => n + p.branches.length, 0);
       },
+      staleTime: 5 * 60 * 1000,
     },
   );
 
@@ -460,6 +461,7 @@ export function useUserGithubBranches(
         if (!lastPage.hasMore) return undefined;
         return allPages.reduce((n, p) => n + p.branches.length, 0);
       },
+      staleTime: 5 * 60 * 1000,
     },
   );
 


### PR DESCRIPTION
## Summary

- Fetch cloud branches as soon as a repo is selected — first page contains `default_branch`, so the branch button shows `main`/`master` immediately and the dropdown opens against a warm cache.
- Add `staleTime: 5 min` to `useGithubBranches` and `useUserGithubBranches` so reopens within 5 min skip the network.
- Drop the `open` gate on the local-mode branches query in `BranchSelector` (it's a fast local git call) and bump `staleTime` to 60s.
- Remove the now-dead `isCloudBranchPickerOpen` state in `TaskInput`.

## Why

The branch dropdown was empty until the user clicked it, and the trigger button stayed blank until that round-trip returned. Reopening refetched from scratch because the infinite query had no `staleTime`.

## Test plan

- [ ] `pnpm --filter code typecheck` passes
- [ ] In cloud mode with a remembered repo, the branch button shows the default branch within one round-trip without clicking the dropdown
- [ ] Opening the branch dropdown a second time within 5 min shows results without a loading row (warm cache)
- [ ] Switching repos fires one branches request and updates the button when the new repo's first page returns
- [ ] In local/worktree mode, the branch button populates without opening the dropdown