### PR TITLE
fix(sessions): handle turn_complete event ordering for local sessions

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -73,7 +73,7 @@ const mockSessionStoreSetters = vi.hoisted(() => ({
   enqueueMessage: vi.fn(),
   removeQueuedMessage: vi.fn(),
   clearMessageQueue: vi.fn(),
-  dequeueMessagesAsText: vi.fn(() => null),
+  dequeueMessagesAsText: vi.fn((): string | null => null),
   dequeueMessages: vi.fn(
     () =>
       [] as Array<{
@@ -3024,6 +3024,95 @@ describe("SessionService", () => {
           errorMessage: expect.stringContaining("Reconnecting"),
         }),
       );
+    });
+  });
+
+  describe("local turn_complete + JSON-RPC response ordering", () => {
+    it("drains queued messages when turn_complete arrives before the JSON-RPC response (local Codex regression)", async () => {
+      const service = getSessionService();
+
+      let session: AgentSession | undefined;
+      mockSessionStoreSetters.getSessionByTaskId.mockImplementation(
+        () => session,
+      );
+      mockSessionStoreSetters.getSessions.mockImplementation(() =>
+        session ? { "run-123": session } : {},
+      );
+      mockSessionStoreSetters.updateSession.mockImplementation(
+        (_taskRunId, updates) => {
+          if (session) session = { ...session, ...updates };
+        },
+      );
+      mockSessionStoreSetters.setSession.mockImplementation((next) => {
+        session = next as AgentSession;
+      });
+      mockSessionStoreSetters.dequeueMessagesAsText.mockReturnValue(
+        "follow up",
+      );
+
+      mockBuildAuthenticatedClient.mockReturnValue({
+        ...mockAuthenticatedClient,
+        createTaskRun: vi.fn().mockResolvedValue({ id: "run-123" }),
+        appendTaskRunLog: vi.fn(),
+      });
+      mockTrpcAgent.start.mutate.mockResolvedValue({
+        channel: "agent-event:run-123",
+        configOptions: [],
+      });
+      mockTrpcAgent.prompt.mutate.mockResolvedValue({ stopReason: "end_turn" });
+
+      await service.connectToTask({
+        task: createMockTask(),
+        repoPath: "/repo",
+      });
+
+      const onData = mockTrpcAgent.onSessionEvent.subscribe.mock.calls.at(
+        -1,
+      )?.[1]?.onData as ((payload: unknown) => void) | undefined;
+      expect(onData).toBeDefined();
+
+      const queuedMessage = {
+        id: "q-1",
+        content: "follow up",
+        queuedAt: 1700000000,
+      };
+      session = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "connected",
+        isCloud: false,
+        currentPromptId: 42,
+        isPromptPending: true,
+        messageQueue: [queuedMessage],
+      });
+
+      onData?.({
+        type: "acp_message",
+        ts: 1700000001,
+        message: {
+          jsonrpc: "2.0",
+          method: "_posthog/turn_complete",
+          params: { sessionId: "acp-session", stopReason: "end_turn" },
+        },
+      });
+
+      expect(session?.currentPromptId).toBe(42);
+
+      onData?.({
+        type: "acp_message",
+        ts: 1700000002,
+        message: {
+          jsonrpc: "2.0",
+          id: 42,
+          result: { stopReason: "end_turn" },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(mockTrpcAgent.prompt.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({ sessionId: "run-123" }),
+        );
+      });
     });
   });
 

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -180,7 +180,7 @@ function buildCloudDefaultConfigOptions(
   ];
 }
 
-function isCloudTurnCompleteEvent(event: AcpMessage): boolean {
+function isTurnCompleteEvent(event: AcpMessage): boolean {
   const msg = event.message;
   return (
     "method" in msg &&
@@ -1111,12 +1111,18 @@ export class SessionService {
           currentPromptId: null,
         });
       }
-      if (isCloudTurnCompleteEvent(acpMsg)) {
-        sessionStoreSetters.updateSession(taskRunId, {
-          isPromptPending: false,
-          promptStartedAt: null,
-          currentPromptId: null,
-        });
+      if (isTurnCompleteEvent(acpMsg)) {
+        // Local sessions use the JSON-RPC response as the canonical turn-done
+        // signal; clearing currentPromptId here would race the id-match guard
+        // above. Cloud sessions never see that response.
+        const session = this.getSessionByRunId(taskRunId);
+        if (session?.isCloud) {
+          sessionStoreSetters.updateSession(taskRunId, {
+            isPromptPending: false,
+            promptStartedAt: null,
+            currentPromptId: null,
+          });
+        }
       }
       // Lifecycle handshake from the agent — flip status to "connected"
       // so the UI can release the queue-while-not-ready guard. This is


### PR DESCRIPTION
## TL;DR

This PR reapplies a critical fix for local session event ordering where `turn_complete` events arrive before JSON-RPC responses, causing race conditions. The fix ensures cloud and local sessions handle turn completion differently based on their canonical signal sources.

closes https://github.com/PostHog/code/issues/2182 to fix codex message queuing

## Problem

Local sessions with Codex agents experience a race condition where the `turn_complete` event arrives before the corresponding JSON-RPC response. The previous implementation cleared `currentPromptId` immediately on `turn_complete`, which interfered with the ID-match guard that relies on this value being present when the JSON-RPC response arrives. This caused prompts to hang or fail to complete properly.

Cloud sessions use `turn_complete` as their canonical turn-done signal, while local sessions use the JSON-RPC response. These require different handling to prevent race conditions.

## Changes

- **Type safety improvement**: Updated `dequeueMessagesAsText` mock return type annotation from implicit to explicit `(): string | null => null` for clarity
- **Event handling logic**: Renamed `isCloudTurnCompleteEvent()` to `isTurnCompleteEvent()` to better reflect its universal applicability
- **Conditional turn completion**: Modified `turn_complete` event handling to only clear session state (`isPromptPending`, `promptStartedAt`, `currentPromptId`) for cloud sessions, preventing the race condition in local sessions
- **Test coverage**: Added comprehensive test case "drains queued messages when turn_complete arrives before the JSON-RPC response (local Codex regression)" to verify proper ordering and message queue drainage for local sessions

## How did you test this?

The changes include a new integration test that reproduces the race condition scenario:
1. Creates a local session with a queued message
2. Sends a `turn_complete` event before the JSON-RPC response
3. Verifies that `currentPromptId` is preserved until the JSON-RPC response arrives
4. Confirms the subsequent prompt call is made with the correct session ID

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*