### PR TITLE
fix(code-review): refresh staged/unstaged diffs on index changes

### DIFF
--- a/apps/code/src/renderer/features/code-review/hooks/useReviewDiffs.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/useReviewDiffs.ts
@@ -31,7 +31,7 @@ export function useReviewDiffs(
     trpc.git.getDiffCached.queryOptions(
       { directoryPath: repoPath as string, ignoreWhitespace: hideWhitespace },
       {
-        enabled: isActive && !!repoPath && hasStagedFiles,
+        enabled: isActive && !!repoPath,
         staleTime: 30_000,
         gcTime: 0,
         refetchOnMount: "always",
@@ -55,8 +55,7 @@ export function useReviewDiffs(
     ),
   );
 
-  const diffLoading =
-    diffUnstagedLoading || (hasStagedFiles && diffCachedLoading);
+  const diffLoading = diffUnstagedLoading || diffCachedLoading;
 
   const stagedParsedFiles = useMemo(
     () =>
@@ -106,8 +105,8 @@ export function useReviewDiffs(
   const refetch = useCallback(() => {
     if (repoPath) invalidateGitWorkingTreeQueries(repoPath);
     refetchDiffUnstaged();
-    if (hasStagedFiles) refetchDiffCached();
-  }, [repoPath, hasStagedFiles, refetchDiffCached, refetchDiffUnstaged]);
+    refetchDiffCached();
+  }, [repoPath, refetchDiffCached, refetchDiffUnstaged]);
 
   return {
     changedFiles,

--- a/apps/code/src/renderer/hooks/useFileWatcher.ts
+++ b/apps/code/src/renderer/hooks/useFileWatcher.ts
@@ -71,6 +71,7 @@ export function useFileWatcher(repoPath: string | null, taskId?: string) {
       onData: ({ repoPath: rp }) => {
         if (rp !== repoPath) return;
         invalidateGitBranchQueries(repoPath);
+        invalidateGitWorkingTreeQueries(repoPath);
       },
     }),
   );


### PR DESCRIPTION
## Summary

- External git operations (terminal `git add`, commits, etc.) write `.git/index` but the file watcher's `onGitStateChanged` handler only invalidated branch queries, so cached `getDiffCached` and `getDiffUnstaged` results stayed stale. The Local Review viewer kept showing the previous staged version after staging through the terminal.
- Dropped the `hasStagedFiles` gate on `getDiffCached` so the staged section appears/disappears in lockstep with the query result rather than racing the changed-files query (which is itself gated by `isActive` since #2113).

## Repro before fix

1. Edit `fileX`, `git add fileX`, then edit `fileX` again so it has both staged and unstaged changes.
2. Open the Review tab — only the staged version shows; the unstaged entry is missing or stale.
3. Run `git add fileX` from the terminal — viewer keeps showing the prior split instead of collapsing into a single combined staged diff.

## Test plan

- [ ] `pnpm dev`, open a local repo task
- [ ] Make staged + unstaged changes to the same file via terminal — both sections render with that file
- [ ] Run `git add <file>` in the terminal while the Review tab is open — the "Changes" section drops the file and "Staged Changes" updates to include the combined diff
- [ ] In-app stage/unstage button (`+` in Changes panel) still works
- [ ] `pnpm --filter code typecheck` passes
- [ ] `pnpm --filter code test` passes

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*