### PR TITLE
fix(sessions): strip remote workspace prefix from file paths in chat

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
@@ -1,6 +1,6 @@
 import { FileIcon } from "@components/ui/FileIcon";
 import { usePanelLayoutStore } from "@features/panels";
-import { useCwd } from "@features/sidebar/hooks/useCwd";
+import { useDisplayRepoPath } from "@features/sessions/hooks/useDisplayRepoPath";
 import { useTaskStore } from "@features/tasks/stores/taskStore";
 import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
 import { Flex, Text } from "@radix-ui/themes";
@@ -33,7 +33,7 @@ export const FileMentionChip = memo(function FileMentionChip({
   filePath,
 }: FileMentionChipProps) {
   const taskId = useTaskStore((s) => s.selectedTaskId);
-  const repoPath = useCwd(taskId ?? "");
+  const repoPath = useDisplayRepoPath(taskId ?? undefined);
   const workspace = useWorkspace(taskId ?? undefined);
   const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);
 

--- a/apps/code/src/renderer/features/sessions/hooks/useDisplayRepoPath.test.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useDisplayRepoPath.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseCwd = vi.hoisted(() => vi.fn((): string | undefined => undefined));
+const mockUseTasks = vi.hoisted(() =>
+  vi.fn((): { data: Array<{ id: string; repository?: string | null }> } => ({
+    data: [],
+  })),
+);
+
+vi.mock("@features/sidebar/hooks/useCwd", () => ({ useCwd: mockUseCwd }));
+vi.mock("@features/tasks/hooks/useTasks", () => ({ useTasks: mockUseTasks }));
+
+import { useDisplayRepoPath } from "./useDisplayRepoPath";
+
+describe("useDisplayRepoPath", () => {
+  beforeEach(() => {
+    mockUseCwd.mockReturnValue(undefined);
+    mockUseTasks.mockReturnValue({ data: [] });
+  });
+
+  it("returns local cwd when available (local task)", () => {
+    mockUseCwd.mockReturnValue("/Users/me/code/posthog");
+    const { result } = renderHook(() => useDisplayRepoPath("task-1"));
+    expect(result.current).toBe("/Users/me/code/posthog");
+  });
+
+  it("derives remote workspace path from task.repository when cwd is missing", () => {
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "task-1", repository: "posthog/posthog.com" }],
+    });
+    const { result } = renderHook(() => useDisplayRepoPath("task-1"));
+    expect(result.current).toBe("/tmp/workspace/repos/posthog/posthog.com");
+  });
+
+  it("prefers local cwd over derived remote path when both could resolve", () => {
+    mockUseCwd.mockReturnValue("/Users/me/code/posthog");
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "task-1", repository: "posthog/posthog.com" }],
+    });
+    const { result } = renderHook(() => useDisplayRepoPath("task-1"));
+    expect(result.current).toBe("/Users/me/code/posthog");
+  });
+
+  it("returns undefined when task has no repository", () => {
+    mockUseTasks.mockReturnValue({ data: [{ id: "task-1" }] });
+    const { result } = renderHook(() => useDisplayRepoPath("task-1"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined when repository is malformed", () => {
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "task-1", repository: "not-a-valid-repo-string" }],
+    });
+    const { result } = renderHook(() => useDisplayRepoPath("task-1"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined when task is not found", () => {
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "other-task", repository: "posthog/posthog.com" }],
+    });
+    const { result } = renderHook(() => useDisplayRepoPath("task-1"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined when taskId is undefined", () => {
+    mockUseTasks.mockReturnValue({
+      data: [{ id: "task-1", repository: "posthog/posthog.com" }],
+    });
+    const { result } = renderHook(() => useDisplayRepoPath(undefined));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/apps/code/src/renderer/features/sessions/hooks/useDisplayRepoPath.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useDisplayRepoPath.ts
@@ -1,0 +1,21 @@
+import { useCwd } from "@features/sidebar/hooks/useCwd";
+import { useTasks } from "@features/tasks/hooks/useTasks";
+import { parseRepository } from "@utils/repository";
+
+const REMOTE_WORKSPACE_PREFIX = "/tmp/workspace/repos";
+
+export function useDisplayRepoPath(
+  taskId: string | undefined,
+): string | undefined {
+  const localCwd = useCwd(taskId ?? "");
+  const { data: tasks = [] } = useTasks();
+
+  if (localCwd) return localCwd;
+  if (!taskId) return undefined;
+
+  const task = tasks.find((t) => t.id === taskId);
+  const parsed = task?.repository ? parseRepository(task.repository) : null;
+  if (!parsed) return undefined;
+
+  return `${REMOTE_WORKSPACE_PREFIX}/${parsed.organization}/${parsed.repoName}`;
+}

--- a/apps/code/src/renderer/features/sessions/hooks/useDisplayRepoPath.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useDisplayRepoPath.ts
@@ -4,6 +4,12 @@ import { parseRepository } from "@utils/repository";
 
 const REMOTE_WORKSPACE_PREFIX = "/tmp/workspace/repos";
 
+/**
+ * Returns the repo root to strip when displaying file paths in tool calls.
+ * Cloud tasks have no local cwd, so we derive the conventional sandbox
+ * clone location from `task.repository` — otherwise chips would render
+ * the full `/tmp/workspace/repos/<owner>/<repo>/...` sandbox path.
+ */
 export function useDisplayRepoPath(
   taskId: string | undefined,
 ): string | undefined {


### PR DESCRIPTION
## Summary

When viewing a cloud task, file chips in the chat rendered the full sandbox path (e.g. `/tmp/workspace/repos/posthog/posthog.com/src/c`). For cloud tasks the local workspace cwd is empty (`folderPath: ""`, `worktreePath: null`), so `useCwd()` returned `undefined` and `FileMentionChip`'s `toRelativePath` had nothing to strip.

This adds a small `useDisplayRepoPath(taskId)` hook that prefers the local cwd, and falls back to the conventional sandbox root `/tmp/workspace/repos/<owner>/<repo>` derived from `task.repository` when there isn't one. `FileMentionChip` uses it instead of `useCwd` so the chip shows just the repo-relative directory on cloud tasks.

- `Read`/`Edit` views are unchanged structurally — they already use `FileMentionChip`; the chip just gets a correct prefix to strip now.
- Local tasks keep the existing behavior (cwd takes precedence).
- The `ToolCallView` fallback (`Glob`/`Grep`/etc. via `compactHomePath(title)`) is unchanged — out of scope for this fix.

## Test plan

- [x] `pnpm vitest run src/renderer/features/sessions` — 161 tests pass, including 7 new tests for `useDisplayRepoPath` covering local cwd, derived remote path, missing/malformed repository, and missing task.
- [x] `pnpm exec tsc -p tsconfig.web.json --noEmit` — clean.
- [x] `biome check` — clean (auto-formatted on commit via lint-staged).
- [ ] Manually: open a cloud task that has performed a `Read`, verify the chip shows `src/...` rather than `/tmp/workspace/repos/<owner>/<repo>/src/...`.
- [ ] Manually: open a local task and verify nothing regresses.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*