### PR TITLE
feat(task-input): cache cloud repositories so picker renders instantly

### DIFF
--- a/apps/code/src/renderer/features/settings/stores/settingsStore.test.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.test.ts
@@ -30,6 +30,7 @@ describe("feature settingsStore cloud selections", () => {
     useSettingsStore.setState({
       allowBypassPermissions: false,
       lastUsedCloudRepository: null,
+      cachedCloudRepositoryMap: {},
     });
   });
 
@@ -65,6 +66,56 @@ describe("feature settingsStore cloud selections", () => {
     expect(useSettingsStore.getState().lastUsedCloudRepository).toBe(
       "posthog/posthog",
     );
+  });
+
+  it("persists the cached cloud repository map", async () => {
+    useSettingsStore.getState().setCachedCloudRepositoryMap({
+      "posthog/posthog": {
+        userIntegrationId: "user-1",
+        installationId: "install-1",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(setItem).toHaveBeenCalled();
+    });
+
+    const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
+    const persisted = JSON.parse(lastCall[0].value);
+
+    expect(persisted.state.cachedCloudRepositoryMap).toEqual({
+      "posthog/posthog": {
+        userIntegrationId: "user-1",
+        installationId: "install-1",
+      },
+    });
+  });
+
+  it("rehydrates the cached cloud repository map", async () => {
+    getItem.mockResolvedValue(
+      JSON.stringify({
+        state: {
+          cachedCloudRepositoryMap: {
+            "posthog/code": {
+              userIntegrationId: "user-2",
+              installationId: "install-2",
+            },
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    useSettingsStore.setState({ cachedCloudRepositoryMap: {} });
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().cachedCloudRepositoryMap).toEqual({
+      "posthog/code": {
+        userIntegrationId: "user-2",
+        installationId: "install-2",
+      },
+    });
   });
 
   it("rehydrates the unsafe mode toggle", async () => {

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.ts
@@ -25,6 +25,11 @@ export type AgentAdapter = "claude" | "codex";
 export type AutoConvertLongText = "off" | "1000" | "2500" | "5000" | "10000";
 export type DefaultInitialTaskMode = "plan" | "last_used";
 
+export interface CachedCloudRepositoryRef {
+  userIntegrationId: string;
+  installationId: string;
+}
+
 export interface HintState {
   count: number;
   learned: boolean;
@@ -40,6 +45,7 @@ interface SettingsStore {
   lastUsedModel: string | null;
   lastUsedReasoningEffort: string | null;
   lastUsedCloudRepository: string | null;
+  cachedCloudRepositoryMap: Record<string, CachedCloudRepositoryRef>;
   lastUsedEnvironments: Record<string, string>;
   desktopNotifications: boolean;
   dockBadgeNotifications: boolean;
@@ -74,6 +80,9 @@ interface SettingsStore {
   setLastUsedModel: (model: string) => void;
   setLastUsedReasoningEffort: (effort: string) => void;
   setLastUsedCloudRepository: (repo: string | null) => void;
+  setCachedCloudRepositoryMap: (
+    map: Record<string, CachedCloudRepositoryRef>,
+  ) => void;
   setLastUsedEnvironment: (
     repoPath: string,
     environmentId: string | null,
@@ -107,6 +116,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedModel: null,
       lastUsedReasoningEffort: null,
       lastUsedCloudRepository: null,
+      cachedCloudRepositoryMap: {},
       lastUsedEnvironments: {},
       desktopNotifications: true,
       dockBadgeNotifications: true,
@@ -166,6 +176,8 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ lastUsedReasoningEffort: effort }),
       setLastUsedCloudRepository: (repo) =>
         set({ lastUsedCloudRepository: repo }),
+      setCachedCloudRepositoryMap: (map) =>
+        set({ cachedCloudRepositoryMap: map }),
       setLastUsedEnvironment: (repoPath, environmentId) =>
         set((state) => {
           const next = { ...state.lastUsedEnvironments };
@@ -215,6 +227,7 @@ export const useSettingsStore = create<SettingsStore>()(
         lastUsedModel: state.lastUsedModel,
         lastUsedReasoningEffort: state.lastUsedReasoningEffort,
         lastUsedCloudRepository: state.lastUsedCloudRepository,
+        cachedCloudRepositoryMap: state.cachedCloudRepositoryMap,
         lastUsedEnvironments: state.lastUsedEnvironments,
         desktopNotifications: state.desktopNotifications,
         dockBadgeNotifications: state.dockBadgeNotifications,

--- a/apps/code/src/renderer/hooks/useIntegrations.ts
+++ b/apps/code/src/renderer/hooks/useIntegrations.ts
@@ -5,6 +5,7 @@ import {
   useIntegrationSelectors,
   useIntegrationStore,
 } from "@features/integrations/stores/integrationStore";
+import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import type { UserGitHubIntegration } from "@renderer/api/posthogClient";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import {
@@ -503,6 +504,13 @@ export function useUserRepositoryIntegration() {
     useUserGithubIntegrations();
   const [isRefreshingRepos, setIsRefreshingRepos] = useState(false);
 
+  const cachedCloudRepositoryMap = useSettingsStore(
+    (s) => s.cachedCloudRepositoryMap,
+  );
+  const setCachedCloudRepositoryMap = useSettingsStore(
+    (s) => s.setCachedCloudRepositoryMap,
+  );
+
   const {
     repositoryMap,
     reposByInstallationId,
@@ -510,25 +518,68 @@ export function useUserRepositoryIntegration() {
     failedInstallationIds,
   } = useAllUserGithubRepositories(githubIntegrations);
 
+  // Keep the persisted cache in sync with the freshly fetched map so that the
+  // next cold start can render the picker without waiting on the network.
+  // Clear the cache when the user has no integrations; otherwise only write
+  // once everything has loaded so we don't blow it away with partial data.
+  useEffect(() => {
+    if (integrationsPending) return;
+    if (githubIntegrations.length === 0) {
+      if (Object.keys(cachedCloudRepositoryMap).length > 0) {
+        setCachedCloudRepositoryMap({});
+      }
+      return;
+    }
+    if (reposPending) return;
+    if (Object.keys(repositoryMap).length === 0) return;
+    setCachedCloudRepositoryMap(repositoryMap);
+  }, [
+    integrationsPending,
+    reposPending,
+    githubIntegrations.length,
+    repositoryMap,
+    cachedCloudRepositoryMap,
+    setCachedCloudRepositoryMap,
+  ]);
+
+  // Use the cached map as a stand-in while the live queries are loading so
+  // the picker can render the last-used repo immediately on a cold start.
+  const effectiveRepositoryMap = useMemo(() => {
+    const liveLoading = integrationsPending || reposPending;
+    const hasLiveData = Object.keys(repositoryMap).length > 0;
+    if (hasLiveData) return repositoryMap;
+    if (liveLoading && Object.keys(cachedCloudRepositoryMap).length > 0) {
+      return cachedCloudRepositoryMap;
+    }
+    return repositoryMap;
+  }, [
+    integrationsPending,
+    reposPending,
+    repositoryMap,
+    cachedCloudRepositoryMap,
+  ]);
+
   const repositories = useMemo(
-    () => Object.keys(repositoryMap),
-    [repositoryMap],
+    () => Object.keys(effectiveRepositoryMap),
+    [effectiveRepositoryMap],
   );
 
   const getUserIntegrationIdForRepo = useCallback(
     (repoKey: string) =>
-      repositoryMap[repoKey?.toLowerCase()]?.userIntegrationId,
-    [repositoryMap],
+      effectiveRepositoryMap[repoKey?.toLowerCase()]?.userIntegrationId,
+    [effectiveRepositoryMap],
   );
 
   const getInstallationIdForRepo = useCallback(
-    (repoKey: string) => repositoryMap[repoKey?.toLowerCase()]?.installationId,
-    [repositoryMap],
+    (repoKey: string) =>
+      effectiveRepositoryMap[repoKey?.toLowerCase()]?.installationId,
+    [effectiveRepositoryMap],
   );
 
   const isRepoInIntegration = useCallback(
-    (repoKey: string) => !repoKey || repoKey.toLowerCase() in repositoryMap,
-    [repositoryMap],
+    (repoKey: string) =>
+      !repoKey || repoKey.toLowerCase() in effectiveRepositoryMap,
+    [effectiveRepositoryMap],
   );
 
   const refreshRepositories = useCallback(async () => {
@@ -564,15 +615,23 @@ export function useUserRepositoryIntegration() {
     }
   }, [client, githubIntegrations, queryClient]);
 
+  const liveLoading = integrationsPending || reposPending;
+  const servingFromCache =
+    liveLoading &&
+    Object.keys(repositoryMap).length === 0 &&
+    Object.keys(cachedCloudRepositoryMap).length > 0;
+
   return {
     repositories,
     getUserIntegrationIdForRepo,
     getInstallationIdForRepo,
     isRepoInIntegration,
-    isLoadingRepos: integrationsPending || reposPending,
-    isRefreshingRepos,
+    isLoadingRepos: liveLoading && !servingFromCache,
+    isRefreshingRepos: isRefreshingRepos || servingFromCache,
     refreshRepositories,
-    hasGithubIntegration: githubIntegrations.length > 0,
+    hasGithubIntegration:
+      githubIntegrations.length > 0 ||
+      (integrationsPending && Object.keys(cachedCloudRepositoryMap).length > 0),
     failedInstallationIds,
     reposByInstallationId,
   };


### PR DESCRIPTION
## Summary

Clicking **New task** next to a repo in the sidebar would show a "Loading repos..." spinner in the GitHub repo picker, even though the answer was almost always the same repo the user picked last time. The picker waited on a full integrations + per-installation repo fetch from PostHog every mount, and only then could it validate the selection against the live list.

This change persists the user repository map in `settingsStore` and uses it as a stand-in while the live data loads, so the picker renders the last-used repo immediately. The network request still fires in the background and replaces the cache when it returns; the existing cleanup effect will still clear the selection if the repo turns out to be gone.

### Changes

- `settingsStore`: new persisted field `cachedCloudRepositoryMap` (repo name → `{ userIntegrationId, installationId }`) + setter.
- `useUserRepositoryIntegration`:
  - Writes fresh repo map to cache once everything has loaded.
  - Clears the cache when the user has no integrations.
  - Substitutes the cached map for `repositoryMap` while live queries are pending and `repositoryMap` is still empty.
  - Treats `hasGithubIntegration` as true while integrations are loading if cache is non-empty, so the picker doesn't briefly collapse to local mode on cold start.

No changes to `TaskInput` are required — the existing `selectedCloudRepository` validation and the cleanup effect both already work against whatever the hook returns.

## Test plan

- [ ] Unit: settingsStore persists and rehydrates cachedCloudRepositoryMap (added tests).
- [ ] Cold start with a cached repo: clicking **New task** in the sidebar shows the previously selected repo immediately, no "Loading repos..." spinner.
- [ ] First-ever launch (empty cache): behavior is unchanged — shows the loading state until repos load.
- [ ] User removes a GitHub integration that contains the cached repo: after live data loads, the selection clears (existing cleanup effect).
- [ ] User has zero GitHub integrations: cache gets cleared, picker shows "No GitHub repos".
- [ ] Refreshing repos via the picker's refresh button still works; cache gets updated to the fresh data.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*