### PR TITLE
feat: Polish git step to improve conversion 

### DIFF
--- a/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
@@ -14,21 +14,64 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
+import { Flex, Text } from "@radix-ui/themes";
 import { trpcClient } from "@renderer/trpc";
+import { logger } from "@utils/logger";
 import type { RefObject } from "react";
+
+const log = logger.scope("folder-picker");
+
+const FIELD_TRIGGER_CLASS =
+  "box-border flex w-full cursor-pointer appearance-none items-center justify-between gap-3 rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]";
 
 interface FolderPickerProps {
   value: string;
   onChange: (path: string) => void;
   placeholder?: string;
-  size?: "1" | "2";
+  variant?: "compact" | "field";
   anchor?: RefObject<HTMLElement | null>;
+}
+
+interface TriggerProps {
+  displayValue: string | null;
+  placeholder: string;
+  onClick?: () => void;
+}
+
+function CompactTrigger({ displayValue, placeholder, onClick }: TriggerProps) {
+  return (
+    <Button variant="outline" size="sm" aria-label="Folder" onClick={onClick}>
+      <FolderIcon size={14} weight="regular" className="shrink-0" />
+      <span className="max-w-[120px] truncate">
+        {displayValue || placeholder}
+      </span>
+      <CaretDown size={10} weight="bold" className="text-muted-foreground" />
+    </Button>
+  );
+}
+
+function FieldTrigger({ displayValue, placeholder, onClick }: TriggerProps) {
+  return (
+    <button type="button" onClick={onClick} className={FIELD_TRIGGER_CLASS}>
+      <Flex align="center" gap="2" className="min-w-0 flex-1">
+        <FolderIcon size={16} className="shrink-0 text-(--gray-12)" />
+        <Text
+          className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12) text-sm"
+          title={displayValue ?? undefined}
+        >
+          {displayValue || placeholder}
+        </Text>
+      </Flex>
+      <CaretDown size={14} className="shrink-0 text-(--gray-9)" />
+    </button>
+  );
 }
 
 export function FolderPicker({
   value,
   onChange,
   placeholder = "Select folder...",
+  variant = "compact",
   anchor,
 }: FolderPickerProps) {
   const {
@@ -42,31 +85,32 @@ export function FolderPicker({
   const recentFolders = getRecentFolders();
   const displayValue = getFolderDisplayName(value);
 
-  const handleSelect = async (path: string) => {
+  const handleSelect = (path: string) => {
     onChange(path);
     const folder = getFolderByPath(path);
-    if (folder) {
-      updateLastAccessed(folder.id);
-    }
+    if (folder) updateLastAccessed(folder.id);
   };
 
   const handleOpenFilePicker = async () => {
-    const selectedPath = await trpcClient.os.selectDirectory.query();
-    if (selectedPath) {
+    try {
+      const selectedPath = await trpcClient.os.selectDirectory.query();
+      if (!selectedPath) return;
       await addFolder(selectedPath);
       onChange(selectedPath);
+    } catch (error) {
+      log.error("Failed to open folder picker", { error });
     }
   };
 
+  const Trigger = variant === "field" ? FieldTrigger : CompactTrigger;
+
   if (recentFolders.length === 0) {
     return (
-      <Button variant="outline" size="sm" onClick={handleOpenFilePicker}>
-        <FolderIcon size={14} weight="regular" className="shrink-0" />
-        <span className="max-w-[120px] truncate">
-          {displayValue || placeholder}
-        </span>
-        <CaretDown size={10} weight="bold" className="text-muted-foreground" />
-      </Button>
+      <Trigger
+        displayValue={displayValue}
+        placeholder={placeholder}
+        onClick={handleOpenFilePicker}
+      />
     );
   }
 
@@ -74,42 +118,35 @@ export function FolderPicker({
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <Button variant="outline" size="sm" aria-label="Folder">
-            <FolderIcon size={14} weight="regular" className="shrink-0" />
-            <span className="max-w-[120px] truncate">
-              {displayValue || placeholder}
-            </span>
-            <CaretDown
-              size={10}
-              weight="bold"
-              className="text-muted-foreground"
-            />
-          </Button>
+          <Trigger displayValue={displayValue} placeholder={placeholder} />
         }
       />
       <DropdownMenuContent
         anchor={anchor}
         align="start"
         side="bottom"
-        sideOffset={6}
-        className="min-w-[200px]"
+        sideOffset={variant === "field" ? 4 : 6}
+        className={
+          variant === "field"
+            ? "w-(--anchor-width) min-w-(--anchor-width) max-w-(--anchor-width)"
+            : "min-w-[200px]"
+        }
       >
         <MenuLabel>Recent</MenuLabel>
-
         {recentFolders.map((folder) => (
           <DropdownMenuItem
             key={folder.id}
             onClick={() => handleSelect(folder.path)}
           >
-            <GitBranch size={12} />
-            <span className="whitespace-nowrap">{folder.name}</span>
+            <GitBranch size={12} className="shrink-0" />
+            <span className="min-w-0 flex-1 truncate" title={folder.path}>
+              {folder.name}
+            </span>
           </DropdownMenuItem>
         ))}
-
         <DropdownMenuSeparator />
-
         <DropdownMenuItem onClick={handleOpenFilePicker}>
-          <FolderOpen size={12} />
+          <FolderOpen size={12} className="shrink-0" />
           <span className="whitespace-nowrap">Open folder...</span>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
@@ -18,7 +18,7 @@ import { Flex, Text } from "@radix-ui/themes";
 import { FIELD_TRIGGER_CLASS } from "@renderer/styles/fieldTrigger";
 import { trpcClient } from "@renderer/trpc";
 import { logger } from "@utils/logger";
-import type { Ref, RefObject } from "react";
+import type { RefObject } from "react";
 
 const log = logger.scope("folder-picker");
 
@@ -28,63 +28,6 @@ interface FolderPickerProps {
   placeholder?: string;
   variant?: "compact" | "field";
   anchor?: RefObject<HTMLElement | null>;
-}
-
-interface TriggerProps {
-  ref?: Ref<HTMLButtonElement>;
-  displayValue: string | null;
-  placeholder: string;
-  onClick?: () => void;
-}
-
-function CompactTrigger({
-  ref,
-  displayValue,
-  placeholder,
-  onClick,
-}: TriggerProps) {
-  return (
-    <Button
-      ref={ref}
-      variant="outline"
-      size="sm"
-      aria-label="Folder"
-      onClick={onClick}
-    >
-      <FolderIcon size={14} weight="regular" className="shrink-0" />
-      <span className="max-w-[120px] truncate">
-        {displayValue || placeholder}
-      </span>
-      <CaretDown size={10} weight="bold" className="text-muted-foreground" />
-    </Button>
-  );
-}
-
-function FieldTrigger({
-  ref,
-  displayValue,
-  placeholder,
-  onClick,
-}: TriggerProps) {
-  return (
-    <button
-      ref={ref}
-      type="button"
-      onClick={onClick}
-      className={FIELD_TRIGGER_CLASS}
-    >
-      <Flex align="center" gap="2" className="min-w-0 flex-1">
-        <FolderIcon size={16} className="shrink-0 text-(--gray-12)" />
-        <Text
-          className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12)"
-          title={displayValue || undefined}
-        >
-          {displayValue || placeholder}
-        </Text>
-      </Flex>
-      <CaretDown size={14} className="shrink-0 text-(--gray-9)" />
-    </button>
-  );
 }
 
 export function FolderPicker({
@@ -104,6 +47,7 @@ export function FolderPicker({
 
   const recentFolders = getRecentFolders();
   const displayValue = getFolderDisplayName(value);
+  const isField = variant === "field";
 
   const handleSelect = (path: string) => {
     onChange(path);
@@ -122,15 +66,49 @@ export function FolderPicker({
     }
   };
 
-  const Trigger = variant === "field" ? FieldTrigger : CompactTrigger;
+  const fieldContent = (
+    <>
+      <Flex align="center" gap="2" className="min-w-0 flex-1">
+        <FolderIcon size={16} className="shrink-0 text-(--gray-12)" />
+        <Text
+          className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12)"
+          title={displayValue || undefined}
+        >
+          {displayValue || placeholder}
+        </Text>
+      </Flex>
+      <CaretDown size={14} className="shrink-0 text-(--gray-9)" />
+    </>
+  );
+
+  const compactContent = (
+    <>
+      <FolderIcon size={14} weight="regular" className="shrink-0" />
+      <span className="max-w-[120px] truncate">
+        {displayValue || placeholder}
+      </span>
+      <CaretDown size={10} weight="bold" className="text-muted-foreground" />
+    </>
+  );
 
   if (recentFolders.length === 0) {
-    return (
-      <Trigger
-        displayValue={displayValue}
-        placeholder={placeholder}
+    return isField ? (
+      <button
+        type="button"
         onClick={handleOpenFilePicker}
-      />
+        className={FIELD_TRIGGER_CLASS}
+      >
+        {fieldContent}
+      </button>
+    ) : (
+      <Button
+        variant="outline"
+        size="sm"
+        aria-label="Folder"
+        onClick={handleOpenFilePicker}
+      >
+        {compactContent}
+      </Button>
     );
   }
 
@@ -138,16 +116,24 @@ export function FolderPicker({
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <Trigger displayValue={displayValue} placeholder={placeholder} />
+          isField ? (
+            <button type="button" className={FIELD_TRIGGER_CLASS}>
+              {fieldContent}
+            </button>
+          ) : (
+            <Button variant="outline" size="sm" aria-label="Folder">
+              {compactContent}
+            </Button>
+          )
         }
       />
       <DropdownMenuContent
         anchor={anchor}
         align="start"
         side="bottom"
-        sideOffset={variant === "field" ? 4 : 6}
+        sideOffset={isField ? 4 : 6}
         className={
-          variant === "field"
+          isField
             ? "w-(--anchor-width) min-w-(--anchor-width) max-w-(--anchor-width)"
             : "min-w-[200px]"
         }

--- a/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/FolderPicker.tsx
@@ -15,14 +15,12 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { Flex, Text } from "@radix-ui/themes";
+import { FIELD_TRIGGER_CLASS } from "@renderer/styles/fieldTrigger";
 import { trpcClient } from "@renderer/trpc";
 import { logger } from "@utils/logger";
-import type { RefObject } from "react";
+import type { Ref, RefObject } from "react";
 
 const log = logger.scope("folder-picker");
-
-const FIELD_TRIGGER_CLASS =
-  "box-border flex w-full cursor-pointer appearance-none items-center justify-between gap-3 rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]";
 
 interface FolderPickerProps {
   value: string;
@@ -33,14 +31,26 @@ interface FolderPickerProps {
 }
 
 interface TriggerProps {
+  ref?: Ref<HTMLButtonElement>;
   displayValue: string | null;
   placeholder: string;
   onClick?: () => void;
 }
 
-function CompactTrigger({ displayValue, placeholder, onClick }: TriggerProps) {
+function CompactTrigger({
+  ref,
+  displayValue,
+  placeholder,
+  onClick,
+}: TriggerProps) {
   return (
-    <Button variant="outline" size="sm" aria-label="Folder" onClick={onClick}>
+    <Button
+      ref={ref}
+      variant="outline"
+      size="sm"
+      aria-label="Folder"
+      onClick={onClick}
+    >
       <FolderIcon size={14} weight="regular" className="shrink-0" />
       <span className="max-w-[120px] truncate">
         {displayValue || placeholder}
@@ -50,14 +60,24 @@ function CompactTrigger({ displayValue, placeholder, onClick }: TriggerProps) {
   );
 }
 
-function FieldTrigger({ displayValue, placeholder, onClick }: TriggerProps) {
+function FieldTrigger({
+  ref,
+  displayValue,
+  placeholder,
+  onClick,
+}: TriggerProps) {
   return (
-    <button type="button" onClick={onClick} className={FIELD_TRIGGER_CLASS}>
+    <button
+      ref={ref}
+      type="button"
+      onClick={onClick}
+      className={FIELD_TRIGGER_CLASS}
+    >
       <Flex align="center" gap="2" className="min-w-0 flex-1">
         <FolderIcon size={16} className="shrink-0 text-(--gray-12)" />
         <Text
-          className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12) text-sm"
-          title={displayValue ?? undefined}
+          className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12)"
+          title={displayValue || undefined}
         >
           {displayValue || placeholder}
         </Text>
@@ -139,7 +159,10 @@ export function FolderPicker({
             onClick={() => handleSelect(folder.path)}
           >
             <GitBranch size={12} className="shrink-0" />
-            <span className="min-w-0 flex-1 truncate" title={folder.path}>
+            <span
+              className="min-w-0 flex-1 truncate text-left"
+              title={folder.path}
+            >
               {folder.name}
             </span>
           </DropdownMenuItem>

--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -1,7 +1,7 @@
 import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
 import { useSelectProjectMutation } from "@features/auth/hooks/authMutations";
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
-import { useFolders } from "@features/folders/hooks/useFolders";
+import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
 import {
   describeGithubConnectError,
   invalidateGithubQueries,
@@ -17,23 +17,13 @@ import {
   ArrowRight,
   ArrowSquareOut,
   ArrowsClockwise,
-  CaretDown,
   CheckCircle,
   CircleNotch,
-  Folder as FolderIcon,
   FolderOpen,
   GearSix,
   GitBranch,
   Plus,
 } from "@phosphor-icons/react";
-import {
-  DropdownMenu as QuillDropdownMenu,
-  DropdownMenuContent as QuillDropdownMenuContent,
-  DropdownMenuItem as QuillDropdownMenuItem,
-  DropdownMenuSeparator as QuillDropdownMenuSeparator,
-  DropdownMenuTrigger as QuillDropdownMenuTrigger,
-  MenuLabel as QuillMenuLabel,
-} from "@posthog/quill";
 import {
   AlertDialog,
   Box,
@@ -48,7 +38,7 @@ import builderHog from "@renderer/assets/images/hedgehogs/builder-hog-03.png";
 import { trpcClient } from "@renderer/trpc/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import type { DetectedRepo } from "../hooks/useOnboardingFlow";
 import { useProjectsWithIntegrations } from "../hooks/useProjectsWithIntegrations";
@@ -64,9 +54,6 @@ interface GitIntegrationStepProps {
   onDirectoryChange: (path: string) => void;
 }
 
-const FOLDER_TRIGGER_CLASS =
-  "box-border flex w-full cursor-pointer appearance-none items-center justify-between gap-3 rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]";
-
 export function GitIntegrationStep({
   onNext,
   onBack,
@@ -77,31 +64,6 @@ export function GitIntegrationStep({
 }: GitIntegrationStepProps) {
   const currentProjectId = useAuthStateValue((state) => state.projectId);
   const selectProjectMutation = useSelectProjectMutation();
-
-  const {
-    getRecentFolders,
-    getFolderDisplayName,
-    addFolder,
-    updateLastAccessed,
-    getFolderByPath,
-  } = useFolders();
-  const recentFolders = getRecentFolders();
-  const folderDisplayValue = getFolderDisplayName(selectedDirectory);
-  const folderAnchorRef = useRef<HTMLButtonElement>(null);
-
-  const handleFolderSelect = (path: string) => {
-    onDirectoryChange(path);
-    const folder = getFolderByPath(path);
-    if (folder) updateLastAccessed(folder.id);
-  };
-
-  const handleOpenFilePicker = async () => {
-    const path = await trpcClient.os.selectDirectory.query();
-    if (path) {
-      await addFolder(path);
-      onDirectoryChange(path);
-    }
-  };
 
   const queryClient = useQueryClient();
   const { projects, projectsWithGithub, isLoading } =
@@ -277,85 +239,12 @@ export function GitIntegrationStep({
                         that contains multiple repos.
                       </Text>
                     </Flex>
-                    {recentFolders.length === 0 ? (
-                      <button
-                        ref={folderAnchorRef}
-                        type="button"
-                        onClick={handleOpenFilePicker}
-                        className={FOLDER_TRIGGER_CLASS}
-                      >
-                        <Flex align="center" gap="2" className="min-w-0 flex-1">
-                          <FolderIcon
-                            size={16}
-                            className="shrink-0 text-(--gray-12)"
-                          />
-                          <Text className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12) text-sm">
-                            {folderDisplayValue || "Select repository..."}
-                          </Text>
-                        </Flex>
-                        <CaretDown
-                          size={14}
-                          className="shrink-0 text-(--gray-9)"
-                        />
-                      </button>
-                    ) : (
-                      <QuillDropdownMenu>
-                        <QuillDropdownMenuTrigger
-                          render={
-                            <button
-                              ref={folderAnchorRef}
-                              type="button"
-                              className={FOLDER_TRIGGER_CLASS}
-                            >
-                              <Flex
-                                align="center"
-                                gap="2"
-                                className="min-w-0 flex-1"
-                              >
-                                <FolderIcon
-                                  size={16}
-                                  className="shrink-0 text-(--gray-12)"
-                                />
-                                <Text className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12) text-sm">
-                                  {folderDisplayValue || "Select repository..."}
-                                </Text>
-                              </Flex>
-                              <CaretDown
-                                size={14}
-                                className="shrink-0 text-(--gray-9)"
-                              />
-                            </button>
-                          }
-                        />
-                        <QuillDropdownMenuContent
-                          anchor={folderAnchorRef}
-                          align="start"
-                          side="bottom"
-                          sideOffset={4}
-                          className="w-(--anchor-width) min-w-(--anchor-width) max-w-(--anchor-width)"
-                        >
-                          <QuillMenuLabel>Recent</QuillMenuLabel>
-                          {recentFolders.map((folder) => (
-                            <QuillDropdownMenuItem
-                              key={folder.id}
-                              onClick={() => handleFolderSelect(folder.path)}
-                            >
-                              <GitBranch size={12} />
-                              <span className="whitespace-nowrap">
-                                {folder.name}
-                              </span>
-                            </QuillDropdownMenuItem>
-                          ))}
-                          <QuillDropdownMenuSeparator />
-                          <QuillDropdownMenuItem onClick={handleOpenFilePicker}>
-                            <FolderOpen size={12} />
-                            <span className="whitespace-nowrap">
-                              Open folder...
-                            </span>
-                          </QuillDropdownMenuItem>
-                        </QuillDropdownMenuContent>
-                      </QuillDropdownMenu>
-                    )}
+                    <FolderPicker
+                      variant="field"
+                      value={selectedDirectory}
+                      onChange={onDirectoryChange}
+                      placeholder="Select repository..."
+                    />
                     <AnimatePresence mode="wait">
                       {isDetectingRepo && (
                         <motion.div
@@ -432,362 +321,349 @@ export function GitIntegrationStep({
               </motion.div>
 
               {/* GitHub integration */}
-              <AnimatePresence>
-                {selectedDirectory && (
-                  <motion.div
-                    key="github-panel"
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 8 }}
-                    transition={{ duration: 0.25, delay: 0.05 }}
+              {selectedDirectory && (
+                <motion.div
+                  key="github-panel"
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.25, delay: 0.05 }}
+                >
+                  <Box
+                    p="5"
+                    style={{
+                      boxShadow:
+                        "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
+                    }}
+                    className="rounded-[12px] border border-(--gray-a3) bg-(--color-panel-solid)"
                   >
-                    <Box
-                      p="5"
-                      style={{
-                        boxShadow:
-                          "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
-                      }}
-                      className="rounded-[12px] border border-(--gray-a3) bg-(--color-panel-solid)"
-                    >
-                      <Flex direction="column" gap="4">
-                        <Flex direction="column" gap="1">
-                          <Flex align="center" justify="between" gap="2">
-                            <Flex align="center" gap="2">
-                              <GitBranch
-                                size={18}
-                                className="text-(--gray-12)"
-                              />
-                              <Text className="font-bold text-(--gray-12) text-base">
-                                Connect GitHub
-                              </Text>
-                            </Flex>
-                            {isLoading || githubUserIntegrationsLoading ? (
-                              <Skeleton className="h-[16px] w-[80px]" />
-                            ) : hasGitIntegration ? (
-                              anyIntegrationStale ? (
-                                <Text className="text-(--amber-11) text-[13px]">
-                                  Reconnect needed
-                                </Text>
-                              ) : (
-                                <Flex align="center" gap="1">
-                                  <CheckCircle
-                                    size={14}
-                                    weight="fill"
-                                    className="text-(--green-9)"
-                                  />
-                                  <Text className="text-(--green-11) text-[13px]">
-                                    {githubUserIntegrations.length > 1
-                                      ? `Connected (${githubUserIntegrations.length})`
-                                      : "Connected"}
-                                  </Text>
-                                </Flex>
-                              )
-                            ) : (
-                              <span className="inline-flex items-center rounded-[6px] bg-(--gray-a3) px-[6px] py-px font-medium text-(--gray-11) text-[11px]">
-                                Optional
-                              </span>
-                            )}
+                    <Flex direction="column" gap="4">
+                      <Flex direction="column" gap="1">
+                        <Flex align="center" justify="between" gap="2">
+                          <Flex align="center" gap="2">
+                            <GitBranch size={18} className="text-(--gray-12)" />
+                            <Text className="font-bold text-(--gray-12) text-base">
+                              Connect GitHub
+                            </Text>
                           </Flex>
-                          {!hasGitIntegration &&
-                            !isLoading &&
-                            !githubUserIntegrationsLoading &&
-                            (selectedProject?.hasGithubIntegration &&
-                            canTakeAction ? (
-                              <Text className="text-(--gray-11) text-sm">
-                                GitHub is already set up on{" "}
-                                <Text className="font-bold">
-                                  {selectedProject.name}
-                                </Text>
-                                . Sign in with one click to link your account,
-                                no admin approval needed.
-                              </Text>
-                            ) : selectedAlternative &&
-                              selectedProject &&
-                              canTakeAction ? (
-                              <Text className="text-(--gray-11) text-sm">
-                                GitHub is already connected on{" "}
-                                {alternativeConnectedProjects.length > 1 ? (
-                                  <DropdownMenu.Root>
-                                    <DropdownMenu.Trigger>
-                                      <button
-                                        type="button"
-                                        className="cursor-pointer border-0 bg-transparent p-0 font-bold text-(--gray-12) underline"
-                                      >
-                                        {selectedAlternative.name} +{" "}
-                                        {alternativeConnectedProjects.length -
-                                          1}{" "}
-                                        more
-                                      </button>
-                                    </DropdownMenu.Trigger>
-                                    <DropdownMenu.Content
-                                      size="1"
-                                      align="start"
-                                    >
-                                      {alternativeConnectedProjects.map((p) => (
-                                        <DropdownMenu.Item
-                                          key={p.id}
-                                          onSelect={() =>
-                                            setSelectedAlternativeId(p.id)
-                                          }
-                                        >
-                                          <Text className="text-[13px]">
-                                            {p.name}
-                                          </Text>
-                                          <Text className="ml-2 text-(--gray-10) text-[13px]">
-                                            {p.organization.name}
-                                          </Text>
-                                        </DropdownMenu.Item>
-                                      ))}
-                                    </DropdownMenu.Content>
-                                  </DropdownMenu.Root>
-                                ) : (
-                                  <>
-                                    <Text className="font-bold">
-                                      {selectedAlternative.name}
-                                    </Text>{" "}
-                                    ({selectedAlternative.organization.name})
-                                  </>
-                                )}
-                                .
+                          {isLoading || githubUserIntegrationsLoading ? (
+                            <Skeleton className="h-[16px] w-[80px]" />
+                          ) : hasGitIntegration ? (
+                            anyIntegrationStale ? (
+                              <Text className="text-(--amber-11) text-[13px]">
+                                Reconnect needed
                               </Text>
                             ) : (
-                              <Text
-                                className={
-                                  hasConnectError
-                                    ? "text-(--red-11) text-sm"
-                                    : "text-(--gray-11) text-sm"
-                                }
-                              >
-                                {defaultPanelMessage}
-                              </Text>
-                            ))}
+                              <Flex align="center" gap="1">
+                                <CheckCircle
+                                  size={14}
+                                  weight="fill"
+                                  className="text-(--green-9)"
+                                />
+                                <Text className="text-(--green-11) text-[13px]">
+                                  {githubUserIntegrations.length > 1
+                                    ? `Connected (${githubUserIntegrations.length})`
+                                    : "Connected"}
+                                </Text>
+                              </Flex>
+                            )
+                          ) : (
+                            <span className="inline-flex items-center rounded-[6px] bg-(--gray-a3) px-[6px] py-px font-medium text-(--gray-11) text-[11px]">
+                              Optional
+                            </span>
+                          )}
                         </Flex>
-                        {hasGitIntegration ? (
-                          <Flex direction="column" gap="3">
-                            {githubUserIntegrations.map((integration) => {
-                              const installationId =
-                                integration.installation_id;
-                              const accountName =
-                                integration.account?.name ?? "GitHub";
-                              const installRepos =
-                                reposByInstallationId[installationId];
-                              const isLoadingInstallRepos =
-                                installRepos === undefined;
-                              const isStale =
-                                failedInstallationIds.includes(installationId);
-                              const isReconnecting =
-                                reconnectingInstallationId === installationId;
-                              return (
-                                <Flex
-                                  key={integration.id}
-                                  direction="column"
-                                  gap="2"
-                                  p="3"
-                                  className="rounded-[8px] border border-(--gray-a3)"
-                                >
-                                  <Flex
-                                    align="center"
-                                    justify="between"
-                                    gap="2"
-                                    wrap="wrap"
-                                  >
-                                    <Flex align="center" gap="2">
-                                      <Text className="font-bold text-(--gray-12) text-sm">
-                                        {accountName}
-                                      </Text>
-                                      <Text className="text-(--gray-10) text-[12px]">
-                                        {integration.account?.type ===
-                                        "Organization"
-                                          ? "org"
-                                          : "personal"}
-                                      </Text>
-                                    </Flex>
-                                    {isStale ? (
-                                      <Text className="text-(--amber-11) text-[12px]">
-                                        Reconnect needed
-                                      </Text>
-                                    ) : (
-                                      <Text className="text-(--gray-10) text-[12px]">
-                                        {isLoadingInstallRepos
-                                          ? "Loading…"
-                                          : installRepos.length === 1
-                                            ? "1 repo"
-                                            : `${installRepos.length} repos`}
-                                      </Text>
-                                    )}
-                                  </Flex>
-                                  <Flex align="center" gap="3" wrap="wrap">
-                                    {isStale && (
-                                      <Button
-                                        size="1"
-                                        variant="solid"
-                                        loading={isReconnecting}
-                                        disabled={
-                                          reconnectingInstallationId !== null &&
-                                          !isReconnecting
+                        {!hasGitIntegration &&
+                          !isLoading &&
+                          !githubUserIntegrationsLoading &&
+                          (selectedProject?.hasGithubIntegration &&
+                          canTakeAction ? (
+                            <Text className="text-(--gray-11) text-sm">
+                              GitHub is already set up on{" "}
+                              <Text className="font-bold">
+                                {selectedProject.name}
+                              </Text>
+                              . Sign in with one click to link your account, no
+                              admin approval needed.
+                            </Text>
+                          ) : selectedAlternative &&
+                            selectedProject &&
+                            canTakeAction ? (
+                            <Text className="text-(--gray-11) text-sm">
+                              GitHub is already connected on{" "}
+                              {alternativeConnectedProjects.length > 1 ? (
+                                <DropdownMenu.Root>
+                                  <DropdownMenu.Trigger>
+                                    <button
+                                      type="button"
+                                      className="cursor-pointer border-0 bg-transparent p-0 font-bold text-(--gray-12) underline"
+                                    >
+                                      {selectedAlternative.name} +{" "}
+                                      {alternativeConnectedProjects.length - 1}{" "}
+                                      more
+                                    </button>
+                                  </DropdownMenu.Trigger>
+                                  <DropdownMenu.Content size="1" align="start">
+                                    {alternativeConnectedProjects.map((p) => (
+                                      <DropdownMenu.Item
+                                        key={p.id}
+                                        onSelect={() =>
+                                          setSelectedAlternativeId(p.id)
                                         }
-                                        onClick={async () => {
-                                          setReconnectingInstallationId(
-                                            installationId,
-                                          );
-                                          try {
-                                            await disconnectMutation.mutateAsync(
-                                              {
-                                                installationId,
-                                                silent: true,
-                                              },
-                                            );
-                                          } catch {
-                                            setReconnectingInstallationId(null);
-                                            return;
-                                          }
-                                          try {
-                                            await handleConnectGitHub();
-                                          } finally {
-                                            setReconnectingInstallationId(null);
-                                          }
-                                        }}
                                       >
-                                        Reconnect
-                                        <ArrowSquareOut size={12} />
-                                      </Button>
-                                    )}
+                                        <Text className="text-[13px]">
+                                          {p.name}
+                                        </Text>
+                                        <Text className="ml-2 text-(--gray-10) text-[13px]">
+                                          {p.organization.name}
+                                        </Text>
+                                      </DropdownMenu.Item>
+                                    ))}
+                                  </DropdownMenu.Content>
+                                </DropdownMenu.Root>
+                              ) : (
+                                <>
+                                  <Text className="font-bold">
+                                    {selectedAlternative.name}
+                                  </Text>{" "}
+                                  ({selectedAlternative.organization.name})
+                                </>
+                              )}
+                              .
+                            </Text>
+                          ) : (
+                            <Text
+                              className={
+                                hasConnectError
+                                  ? "text-(--red-11) text-sm"
+                                  : "text-(--gray-11) text-sm"
+                              }
+                            >
+                              {defaultPanelMessage}
+                            </Text>
+                          ))}
+                      </Flex>
+                      {hasGitIntegration ? (
+                        <Flex direction="column" gap="3">
+                          {githubUserIntegrations.map((integration) => {
+                            const installationId = integration.installation_id;
+                            const accountName =
+                              integration.account?.name ?? "GitHub";
+                            const installRepos =
+                              reposByInstallationId[installationId];
+                            const isLoadingInstallRepos =
+                              installRepos === undefined;
+                            const isStale =
+                              failedInstallationIds.includes(installationId);
+                            const isReconnecting =
+                              reconnectingInstallationId === installationId;
+                            return (
+                              <Flex
+                                key={integration.id}
+                                direction="column"
+                                gap="2"
+                                p="3"
+                                className="rounded-[8px] border border-(--gray-a3)"
+                              >
+                                <Flex
+                                  align="center"
+                                  justify="between"
+                                  gap="2"
+                                  wrap="wrap"
+                                >
+                                  <Flex align="center" gap="2">
+                                    <Text className="font-bold text-(--gray-12) text-sm">
+                                      {accountName}
+                                    </Text>
+                                    <Text className="text-(--gray-10) text-[12px]">
+                                      {integration.account?.type ===
+                                      "Organization"
+                                        ? "org"
+                                        : "personal"}
+                                    </Text>
+                                  </Flex>
+                                  {isStale ? (
+                                    <Text className="text-(--amber-11) text-[12px]">
+                                      Reconnect needed
+                                    </Text>
+                                  ) : (
+                                    <Text className="text-(--gray-10) text-[12px]">
+                                      {isLoadingInstallRepos
+                                        ? "Loading…"
+                                        : installRepos.length === 1
+                                          ? "1 repo"
+                                          : `${installRepos.length} repos`}
+                                    </Text>
+                                  )}
+                                </Flex>
+                                <Flex align="center" gap="3" wrap="wrap">
+                                  {isStale && (
                                     <Button
                                       size="1"
-                                      variant="soft"
-                                      color="gray"
-                                      onClick={() => {
-                                        const account = integration.account;
-                                        const url =
-                                          account?.type === "Organization" &&
-                                          account.name
-                                            ? `https://github.com/organizations/${account.name}/settings/installations/${installationId}`
-                                            : `https://github.com/settings/installations/${installationId}`;
-                                        trpcClient.os.openExternal.mutate({
-                                          url,
-                                        });
+                                      variant="solid"
+                                      loading={isReconnecting}
+                                      disabled={
+                                        reconnectingInstallationId !== null &&
+                                        !isReconnecting
+                                      }
+                                      onClick={async () => {
+                                        setReconnectingInstallationId(
+                                          installationId,
+                                        );
+                                        try {
+                                          await disconnectMutation.mutateAsync({
+                                            installationId,
+                                            silent: true,
+                                          });
+                                        } catch {
+                                          setReconnectingInstallationId(null);
+                                          return;
+                                        }
+                                        try {
+                                          await handleConnectGitHub();
+                                        } finally {
+                                          setReconnectingInstallationId(null);
+                                        }
                                       }}
                                     >
-                                      <GearSix size={12} />
-                                      Settings
+                                      Reconnect
+                                      <ArrowSquareOut size={12} />
                                     </Button>
-                                    <Button
-                                      size="1"
-                                      variant="soft"
-                                      color="red"
-                                      onClick={() =>
-                                        setDisconnectTarget({
-                                          installationId,
-                                          accountName,
-                                        })
-                                      }
-                                    >
-                                      Disconnect
-                                    </Button>
-                                  </Flex>
+                                  )}
+                                  <Button
+                                    size="1"
+                                    variant="soft"
+                                    color="gray"
+                                    onClick={() => {
+                                      const account = integration.account;
+                                      const url =
+                                        account?.type === "Organization" &&
+                                        account.name
+                                          ? `https://github.com/organizations/${account.name}/settings/installations/${installationId}`
+                                          : `https://github.com/settings/installations/${installationId}`;
+                                      trpcClient.os.openExternal.mutate({
+                                        url,
+                                      });
+                                    }}
+                                  >
+                                    <GearSix size={12} />
+                                    Settings
+                                  </Button>
+                                  <Button
+                                    size="1"
+                                    variant="soft"
+                                    color="red"
+                                    onClick={() =>
+                                      setDisconnectTarget({
+                                        installationId,
+                                        accountName,
+                                      })
+                                    }
+                                  >
+                                    Disconnect
+                                  </Button>
                                 </Flex>
-                              );
-                            })}
-                            <Flex align="center" gap="3" wrap="wrap">
-                              <Button
-                                size="1"
-                                variant="soft"
-                                color="gray"
-                                onClick={() => {
-                                  queryClient.invalidateQueries({
-                                    queryKey: ["integrations"],
-                                  });
-                                  queryClient.invalidateQueries({
-                                    queryKey: ["user-github-integrations"],
-                                  });
-                                }}
-                              >
-                                <ArrowsClockwise size={12} />
-                                Refresh
-                              </Button>
-                              <Button
-                                size="1"
-                                variant="ghost"
-                                color="gray"
-                                onClick={() => void handleConnectGitHub()}
-                                loading={isConnecting}
-                              >
-                                <Plus size={12} />
-                                Add another GitHub org
-                              </Button>
-                            </Flex>
+                              </Flex>
+                            );
+                          })}
+                          <Flex align="center" gap="3" wrap="wrap">
+                            <Button
+                              size="1"
+                              variant="soft"
+                              color="gray"
+                              onClick={() => {
+                                queryClient.invalidateQueries({
+                                  queryKey: ["integrations"],
+                                });
+                                queryClient.invalidateQueries({
+                                  queryKey: ["user-github-integrations"],
+                                });
+                              }}
+                            >
+                              <ArrowsClockwise size={12} />
+                              Refresh
+                            </Button>
+                            <Button
+                              size="1"
+                              variant="ghost"
+                              color="gray"
+                              onClick={() => void handleConnectGitHub()}
+                              loading={isConnecting}
+                            >
+                              <Plus size={12} />
+                              Add another GitHub org
+                            </Button>
                           </Flex>
-                        ) : !isLoading && !githubUserIntegrationsLoading ? (
-                          selectedProject?.hasGithubIntegration &&
+                        </Flex>
+                      ) : !isLoading && !githubUserIntegrationsLoading ? (
+                        selectedProject?.hasGithubIntegration &&
+                        canTakeAction ? (
+                          <Button
+                            size="2"
+                            variant="solid"
+                            onClick={() => void handleConnectGitHub()}
+                            className="self-start"
+                          >
+                            Sign in with GitHub
+                            <ArrowSquareOut size={12} />
+                          </Button>
+                        ) : selectedAlternative &&
+                          selectedProject &&
                           canTakeAction ? (
+                          <Flex direction="column" gap="2" align="start">
                             <Button
                               size="2"
                               variant="solid"
                               onClick={() => void handleConnectGitHub()}
-                              className="self-start"
                             >
-                              Sign in with GitHub
+                              Connect GitHub on {selectedProject.name}
                               <ArrowSquareOut size={12} />
                             </Button>
-                          ) : selectedAlternative &&
-                            selectedProject &&
-                            canTakeAction ? (
-                            <Flex direction="column" gap="2" align="start">
+                            <Button
+                              size="1"
+                              variant="ghost"
+                              color="gray"
+                              onClick={() =>
+                                setSelectedProjectId(selectedAlternative.id)
+                              }
+                            >
+                              Switch to {selectedAlternative.name}
+                            </Button>
+                          </Flex>
+                        ) : (
+                          <Flex gap="2" align="center">
+                            <Button
+                              size="2"
+                              variant="solid"
+                              onClick={() => {
+                                if (hasConnectError) resetConnect();
+                                void handleConnectGitHub();
+                              }}
+                              loading={isConnecting}
+                            >
+                              {isConnecting
+                                ? "Retry connection"
+                                : hasConnectError || timedOut
+                                  ? "Try again"
+                                  : "Connect GitHub"}
+                              <ArrowSquareOut size={12} />
+                            </Button>
+                            {hasConnectError && (
                               <Button
                                 size="2"
-                                variant="solid"
-                                onClick={() => void handleConnectGitHub()}
-                              >
-                                Connect GitHub on {selectedProject.name}
-                                <ArrowSquareOut size={12} />
-                              </Button>
-                              <Button
-                                size="1"
                                 variant="ghost"
                                 color="gray"
-                                onClick={() =>
-                                  setSelectedProjectId(selectedAlternative.id)
-                                }
+                                onClick={resetConnect}
                               >
-                                Switch to {selectedAlternative.name}
+                                Dismiss
                               </Button>
-                            </Flex>
-                          ) : (
-                            <Flex gap="2" align="center">
-                              <Button
-                                size="2"
-                                variant="solid"
-                                onClick={() => {
-                                  if (hasConnectError) resetConnect();
-                                  void handleConnectGitHub();
-                                }}
-                                loading={isConnecting}
-                              >
-                                {isConnecting
-                                  ? "Retry connection"
-                                  : hasConnectError || timedOut
-                                    ? "Try again"
-                                    : "Connect GitHub"}
-                                <ArrowSquareOut size={12} />
-                              </Button>
-                              {hasConnectError && (
-                                <Button
-                                  size="2"
-                                  variant="ghost"
-                                  color="gray"
-                                  onClick={resetConnect}
-                                >
-                                  Dismiss
-                                </Button>
-                              )}
-                            </Flex>
-                          )
-                        ) : null}
-                      </Flex>
-                    </Box>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+                            )}
+                          </Flex>
+                        )
+                      ) : null}
+                    </Flex>
+                  </Box>
+                </motion.div>
+              )}
             </Flex>
 
             {/* Hog tip */}

--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -24,6 +24,7 @@ import {
   GitBranch,
   Plus,
 } from "@phosphor-icons/react";
+import { cn } from "@posthog/quill";
 import {
   AlertDialog,
   Box,
@@ -44,6 +45,23 @@ import type { DetectedRepo } from "../hooks/useOnboardingFlow";
 import { useProjectsWithIntegrations } from "../hooks/useProjectsWithIntegrations";
 import { OnboardingHogTip } from "./OnboardingHogTip";
 import { StepActions } from "./StepActions";
+
+const PANEL_SHADOW = "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)";
+
+function getPanelMessage(opts: {
+  hasConnectError: boolean;
+  connectError: Parameters<typeof describeGithubConnectError>[0];
+  timedOut: boolean;
+  isConnecting: boolean;
+}): string {
+  if (opts.hasConnectError)
+    return describeGithubConnectError(opts.connectError);
+  if (opts.timedOut) {
+    return "We didn't hear back from GitHub. If the browser tab was closed, click Connect again.";
+  }
+  if (opts.isConnecting) return "Waiting for GitHub...";
+  return "Optional. Lets cloud agents work on this repo and open pull requests for you.";
+}
 
 interface GitIntegrationStepProps {
   onNext: () => void;
@@ -100,13 +118,12 @@ export function GitIntegrationStep({
     projectHasTeamIntegration: selectedProject?.hasGithubIntegration ?? null,
   });
   const canTakeAction = !isConnecting && !timedOut && !hasConnectError;
-  const defaultPanelMessage = hasConnectError
-    ? describeGithubConnectError(connectError)
-    : timedOut
-      ? "We didn't hear back from GitHub. If the browser tab was closed, click Connect again."
-      : isConnecting
-        ? "Waiting for GitHub..."
-        : "Optional. Lets cloud agents work on this repo and open pull requests for you.";
+  const defaultPanelMessage = getPanelMessage({
+    hasConnectError,
+    connectError,
+    timedOut,
+    isConnecting,
+  });
 
   const {
     data: githubUserIntegrations = [],
@@ -191,8 +208,7 @@ export function GitIntegrationStep({
           <Flex
             direction="column"
             gap="5"
-            style={{ margin: "auto auto" }}
-            className="w-full max-w-[560px]"
+            className="m-auto w-full max-w-[560px]"
           >
             {/* Header + content */}
             <Flex direction="column" gap="5" className="w-full">
@@ -220,10 +236,7 @@ export function GitIntegrationStep({
               >
                 <Box
                   p="5"
-                  style={{
-                    boxShadow:
-                      "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
-                  }}
+                  style={{ boxShadow: PANEL_SHADOW }}
                   className="rounded-[12px] border border-(--gray-a3) bg-(--color-panel-solid)"
                 >
                   <Flex direction="column" gap="4">
@@ -286,11 +299,12 @@ export function GitIntegrationStep({
                                 }
                               />
                               <Text
-                                className={`text-[13px] ${
+                                className={cn(
+                                  "text-[13px]",
                                   repoMatchesGitHub
                                     ? "text-(--green-11)"
-                                    : "text-(--gray-11)"
-                                }`}
+                                    : "text-(--gray-11)",
+                                )}
                               >
                                 {repoMatchesGitHub
                                   ? `Linked to ${detectedRepo.fullName} on GitHub`
@@ -329,10 +343,7 @@ export function GitIntegrationStep({
                 >
                   <Box
                     p="5"
-                    style={{
-                      boxShadow:
-                        "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
-                    }}
+                    style={{ boxShadow: PANEL_SHADOW }}
                     className="rounded-[12px] border border-(--gray-a3) bg-(--color-panel-solid)"
                   >
                     <Flex direction="column" gap="4">

--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -279,19 +279,18 @@ export function GitIntegrationStep({
                               <CheckCircle
                                 size={14}
                                 weight="fill"
-                                style={{
-                                  color: repoMatchesGitHub
-                                    ? "var(--green-9)"
-                                    : "var(--gray-9)",
-                                }}
+                                className={
+                                  repoMatchesGitHub
+                                    ? "text-(--green-9)"
+                                    : "text-(--gray-9)"
+                                }
                               />
                               <Text
-                                style={{
-                                  color: repoMatchesGitHub
-                                    ? "var(--green-11)"
-                                    : "var(--gray-11)",
-                                }}
-                                className="text-[13px]"
+                                className={`text-[13px] ${
+                                  repoMatchesGitHub
+                                    ? "text-(--green-11)"
+                                    : "text-(--gray-11)"
+                                }`}
                               >
                                 {repoMatchesGitHub
                                   ? `Linked to ${detectedRepo.fullName} on GitHub`
@@ -311,7 +310,7 @@ export function GitIntegrationStep({
                             transition={{ duration: 0.2 }}
                           >
                             <Text className="text-(--gray-9) text-[13px]">
-                              No git remote detected -- you can still continue.
+                              No git remote detected. You can still continue.
                             </Text>
                           </motion.div>
                         )}

--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -26,6 +26,7 @@ import {
 } from "@phosphor-icons/react";
 import {
   AlertDialog,
+  Badge,
   Box,
   Button,
   DropdownMenu,
@@ -206,7 +207,7 @@ export function GitIntegrationStep({
                     Give your agents access to code
                   </Text>
                   <Text className="text-(--gray-11) text-sm">
-                    Point to a local codebase and optionally connect GitHub.
+                    Select a folder to continue. Connecting GitHub is optional.
                   </Text>
                 </Flex>
               </motion.div>
@@ -227,11 +228,18 @@ export function GitIntegrationStep({
                 >
                   <Flex direction="column" gap="4">
                     <Flex direction="column" gap="1">
-                      <Flex align="center" gap="2">
-                        <FolderOpen size={18} className="text-(--gray-12)" />
-                        <Text className="font-bold text-(--gray-12) text-base">
-                          Choose your codebase
-                        </Text>
+                      <Flex align="center" justify="between" gap="2">
+                        <Flex align="center" gap="2">
+                          <FolderOpen size={18} className="text-(--gray-12)" />
+                          <Text className="font-bold text-(--gray-12) text-base">
+                            Choose your codebase
+                          </Text>
+                        </Flex>
+                        {selectedDirectory ? (
+                          <Badge color="green">Selected</Badge>
+                        ) : (
+                          <Badge color="red">Required</Badge>
+                        )}
                       </Flex>
                       <Text className="text-(--gray-11) text-sm">
                         Select the local folder for your project so we can
@@ -334,7 +342,7 @@ export function GitIntegrationStep({
                   className="rounded-[12px] border border-(--gray-a3) bg-(--color-panel-solid)"
                 >
                   <Flex direction="column" gap="3">
-                    <Flex align="center" justify="between">
+                    <Flex align="center" justify="between" gap="2">
                       <Flex align="center" gap="2">
                         <GitBranch size={18} className="text-(--gray-12)" />
                         <Text className="font-bold text-(--gray-12) text-base">
@@ -362,7 +370,9 @@ export function GitIntegrationStep({
                             </Text>
                           </Flex>
                         )
-                      ) : null}
+                      ) : (
+                        <Badge color="gray">Optional</Badge>
+                      )}
                     </Flex>
                     {hasGitIntegration ? (
                       <Flex direction="column" gap="3">
@@ -522,7 +532,7 @@ export function GitIntegrationStep({
                             <Text className="font-bold">
                               {selectedProject.name}
                             </Text>
-                            . Sign in with one click to link your account — no
+                            . Sign in with one click to link your account, no
                             admin approval needed.
                           </Text>
                           <Button

--- a/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/GitIntegrationStep.tsx
@@ -1,7 +1,7 @@
 import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
 import { useSelectProjectMutation } from "@features/auth/hooks/authMutations";
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
-import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
+import { useFolders } from "@features/folders/hooks/useFolders";
 import {
   describeGithubConnectError,
   invalidateGithubQueries,
@@ -17,16 +17,25 @@ import {
   ArrowRight,
   ArrowSquareOut,
   ArrowsClockwise,
+  CaretDown,
   CheckCircle,
   CircleNotch,
+  Folder as FolderIcon,
   FolderOpen,
   GearSix,
   GitBranch,
   Plus,
 } from "@phosphor-icons/react";
 import {
+  DropdownMenu as QuillDropdownMenu,
+  DropdownMenuContent as QuillDropdownMenuContent,
+  DropdownMenuItem as QuillDropdownMenuItem,
+  DropdownMenuSeparator as QuillDropdownMenuSeparator,
+  DropdownMenuTrigger as QuillDropdownMenuTrigger,
+  MenuLabel as QuillMenuLabel,
+} from "@posthog/quill";
+import {
   AlertDialog,
-  Badge,
   Box,
   Button,
   DropdownMenu,
@@ -39,7 +48,7 @@ import builderHog from "@renderer/assets/images/hedgehogs/builder-hog-03.png";
 import { trpcClient } from "@renderer/trpc/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { DetectedRepo } from "../hooks/useOnboardingFlow";
 import { useProjectsWithIntegrations } from "../hooks/useProjectsWithIntegrations";
@@ -55,6 +64,9 @@ interface GitIntegrationStepProps {
   onDirectoryChange: (path: string) => void;
 }
 
+const FOLDER_TRIGGER_CLASS =
+  "box-border flex w-full cursor-pointer appearance-none items-center justify-between gap-3 rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]";
+
 export function GitIntegrationStep({
   onNext,
   onBack,
@@ -65,6 +77,31 @@ export function GitIntegrationStep({
 }: GitIntegrationStepProps) {
   const currentProjectId = useAuthStateValue((state) => state.projectId);
   const selectProjectMutation = useSelectProjectMutation();
+
+  const {
+    getRecentFolders,
+    getFolderDisplayName,
+    addFolder,
+    updateLastAccessed,
+    getFolderByPath,
+  } = useFolders();
+  const recentFolders = getRecentFolders();
+  const folderDisplayValue = getFolderDisplayName(selectedDirectory);
+  const folderAnchorRef = useRef<HTMLButtonElement>(null);
+
+  const handleFolderSelect = (path: string) => {
+    onDirectoryChange(path);
+    const folder = getFolderByPath(path);
+    if (folder) updateLastAccessed(folder.id);
+  };
+
+  const handleOpenFilePicker = async () => {
+    const path = await trpcClient.os.selectDirectory.query();
+    if (path) {
+      await addFolder(path);
+      onDirectoryChange(path);
+    }
+  };
 
   const queryClient = useQueryClient();
   const { projects, projectsWithGithub, isLoading } =
@@ -107,7 +144,7 @@ export function GitIntegrationStep({
       ? "We didn't hear back from GitHub. If the browser tab was closed, click Connect again."
       : isConnecting
         ? "Waiting for GitHub..."
-        : "Optional. Unlocks cloud agents and pull request workflows.";
+        : "Optional. Lets cloud agents work on this repo and open pull requests for you.";
 
   const {
     data: githubUserIntegrations = [],
@@ -207,7 +244,8 @@ export function GitIntegrationStep({
                     Give your agents access to code
                   </Text>
                   <Text className="text-(--gray-11) text-sm">
-                    Select a folder to continue. Connecting GitHub is optional.
+                    Pick a repository to run local tasks on this machine.
+                    Connect GitHub to send tasks to cloud agents.
                   </Text>
                 </Flex>
               </motion.div>
@@ -228,30 +266,96 @@ export function GitIntegrationStep({
                 >
                   <Flex direction="column" gap="4">
                     <Flex direction="column" gap="1">
-                      <Flex align="center" justify="between" gap="2">
-                        <Flex align="center" gap="2">
-                          <FolderOpen size={18} className="text-(--gray-12)" />
-                          <Text className="font-bold text-(--gray-12) text-base">
-                            Choose your codebase
-                          </Text>
-                        </Flex>
-                        {selectedDirectory ? (
-                          <Badge color="green">Selected</Badge>
-                        ) : (
-                          <Badge color="red">Required</Badge>
-                        )}
+                      <Flex align="center" gap="2">
+                        <FolderOpen size={18} className="text-(--gray-12)" />
+                        <Text className="font-bold text-(--gray-12) text-base">
+                          Choose your repository
+                        </Text>
                       </Flex>
                       <Text className="text-(--gray-11) text-sm">
-                        Select the local folder for your project so we can
-                        analyze it.
+                        Select a single repository folder, not a parent folder
+                        that contains multiple repos.
                       </Text>
                     </Flex>
-                    <FolderPicker
-                      value={selectedDirectory}
-                      onChange={onDirectoryChange}
-                      placeholder="Select folder..."
-                      size="2"
-                    />
+                    {recentFolders.length === 0 ? (
+                      <button
+                        ref={folderAnchorRef}
+                        type="button"
+                        onClick={handleOpenFilePicker}
+                        className={FOLDER_TRIGGER_CLASS}
+                      >
+                        <Flex align="center" gap="2" className="min-w-0 flex-1">
+                          <FolderIcon
+                            size={16}
+                            className="shrink-0 text-(--gray-12)"
+                          />
+                          <Text className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12) text-sm">
+                            {folderDisplayValue || "Select repository..."}
+                          </Text>
+                        </Flex>
+                        <CaretDown
+                          size={14}
+                          className="shrink-0 text-(--gray-9)"
+                        />
+                      </button>
+                    ) : (
+                      <QuillDropdownMenu>
+                        <QuillDropdownMenuTrigger
+                          render={
+                            <button
+                              ref={folderAnchorRef}
+                              type="button"
+                              className={FOLDER_TRIGGER_CLASS}
+                            >
+                              <Flex
+                                align="center"
+                                gap="2"
+                                className="min-w-0 flex-1"
+                              >
+                                <FolderIcon
+                                  size={16}
+                                  className="shrink-0 text-(--gray-12)"
+                                />
+                                <Text className="min-w-0 max-w-full truncate text-left font-medium text-(--gray-12) text-sm">
+                                  {folderDisplayValue || "Select repository..."}
+                                </Text>
+                              </Flex>
+                              <CaretDown
+                                size={14}
+                                className="shrink-0 text-(--gray-9)"
+                              />
+                            </button>
+                          }
+                        />
+                        <QuillDropdownMenuContent
+                          anchor={folderAnchorRef}
+                          align="start"
+                          side="bottom"
+                          sideOffset={4}
+                          className="w-(--anchor-width) min-w-(--anchor-width) max-w-(--anchor-width)"
+                        >
+                          <QuillMenuLabel>Recent</QuillMenuLabel>
+                          {recentFolders.map((folder) => (
+                            <QuillDropdownMenuItem
+                              key={folder.id}
+                              onClick={() => handleFolderSelect(folder.path)}
+                            >
+                              <GitBranch size={12} />
+                              <span className="whitespace-nowrap">
+                                {folder.name}
+                              </span>
+                            </QuillDropdownMenuItem>
+                          ))}
+                          <QuillDropdownMenuSeparator />
+                          <QuillDropdownMenuItem onClick={handleOpenFilePicker}>
+                            <FolderOpen size={12} />
+                            <span className="whitespace-nowrap">
+                              Open folder...
+                            </span>
+                          </QuillDropdownMenuItem>
+                        </QuillDropdownMenuContent>
+                      </QuillDropdownMenu>
+                    )}
                     <AnimatePresence mode="wait">
                       {isDetectingRepo && (
                         <motion.div
@@ -328,341 +432,368 @@ export function GitIntegrationStep({
               </motion.div>
 
               {/* GitHub integration */}
-              <motion.div
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3, delay: 0.1 }}
-              >
-                <Box
-                  p="5"
-                  style={{
-                    boxShadow:
-                      "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
-                  }}
-                  className="rounded-[12px] border border-(--gray-a3) bg-(--color-panel-solid)"
-                >
-                  <Flex direction="column" gap="3">
-                    <Flex align="center" justify="between" gap="2">
-                      <Flex align="center" gap="2">
-                        <GitBranch size={18} className="text-(--gray-12)" />
-                        <Text className="font-bold text-(--gray-12) text-base">
-                          Connect GitHub
-                        </Text>
-                      </Flex>
-                      {isLoading || githubUserIntegrationsLoading ? (
-                        <Skeleton className="h-[16px] w-[80px]" />
-                      ) : hasGitIntegration ? (
-                        anyIntegrationStale ? (
-                          <Text className="text-(--amber-11) text-[13px]">
-                            Reconnect needed
-                          </Text>
-                        ) : (
-                          <Flex align="center" gap="1">
-                            <CheckCircle
-                              size={14}
-                              weight="fill"
-                              className="text-(--green-9)"
-                            />
-                            <Text className="text-(--green-11) text-[13px]">
-                              {githubUserIntegrations.length > 1
-                                ? `Connected (${githubUserIntegrations.length})`
-                                : "Connected"}
-                            </Text>
-                          </Flex>
-                        )
-                      ) : (
-                        <Badge color="gray">Optional</Badge>
-                      )}
-                    </Flex>
-                    {hasGitIntegration ? (
-                      <Flex direction="column" gap="3">
-                        {githubUserIntegrations.map((integration) => {
-                          const installationId = integration.installation_id;
-                          const accountName =
-                            integration.account?.name ?? "GitHub";
-                          const installRepos =
-                            reposByInstallationId[installationId];
-                          const isLoadingInstallRepos =
-                            installRepos === undefined;
-                          const isStale =
-                            failedInstallationIds.includes(installationId);
-                          const isReconnecting =
-                            reconnectingInstallationId === installationId;
-                          return (
-                            <Flex
-                              key={integration.id}
-                              direction="column"
-                              gap="2"
-                              p="3"
-                              className="rounded-[8px] border border-(--gray-a3)"
-                            >
-                              <Flex
-                                align="center"
-                                justify="between"
-                                gap="2"
-                                wrap="wrap"
-                              >
-                                <Flex align="center" gap="2">
-                                  <Text className="font-bold text-(--gray-12) text-sm">
-                                    {accountName}
-                                  </Text>
-                                  <Text className="text-(--gray-10) text-[12px]">
-                                    {integration.account?.type ===
-                                    "Organization"
-                                      ? "org"
-                                      : "personal"}
+              <AnimatePresence>
+                {selectedDirectory && (
+                  <motion.div
+                    key="github-panel"
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 8 }}
+                    transition={{ duration: 0.25, delay: 0.05 }}
+                  >
+                    <Box
+                      p="5"
+                      style={{
+                        boxShadow:
+                          "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
+                      }}
+                      className="rounded-[12px] border border-(--gray-a3) bg-(--color-panel-solid)"
+                    >
+                      <Flex direction="column" gap="4">
+                        <Flex direction="column" gap="1">
+                          <Flex align="center" justify="between" gap="2">
+                            <Flex align="center" gap="2">
+                              <GitBranch
+                                size={18}
+                                className="text-(--gray-12)"
+                              />
+                              <Text className="font-bold text-(--gray-12) text-base">
+                                Connect GitHub
+                              </Text>
+                            </Flex>
+                            {isLoading || githubUserIntegrationsLoading ? (
+                              <Skeleton className="h-[16px] w-[80px]" />
+                            ) : hasGitIntegration ? (
+                              anyIntegrationStale ? (
+                                <Text className="text-(--amber-11) text-[13px]">
+                                  Reconnect needed
+                                </Text>
+                              ) : (
+                                <Flex align="center" gap="1">
+                                  <CheckCircle
+                                    size={14}
+                                    weight="fill"
+                                    className="text-(--green-9)"
+                                  />
+                                  <Text className="text-(--green-11) text-[13px]">
+                                    {githubUserIntegrations.length > 1
+                                      ? `Connected (${githubUserIntegrations.length})`
+                                      : "Connected"}
                                   </Text>
                                 </Flex>
-                                {isStale ? (
-                                  <Text className="text-(--amber-11) text-[12px]">
-                                    Reconnect needed
-                                  </Text>
+                              )
+                            ) : (
+                              <span className="inline-flex items-center rounded-[6px] bg-(--gray-a3) px-[6px] py-px font-medium text-(--gray-11) text-[11px]">
+                                Optional
+                              </span>
+                            )}
+                          </Flex>
+                          {!hasGitIntegration &&
+                            !isLoading &&
+                            !githubUserIntegrationsLoading &&
+                            (selectedProject?.hasGithubIntegration &&
+                            canTakeAction ? (
+                              <Text className="text-(--gray-11) text-sm">
+                                GitHub is already set up on{" "}
+                                <Text className="font-bold">
+                                  {selectedProject.name}
+                                </Text>
+                                . Sign in with one click to link your account,
+                                no admin approval needed.
+                              </Text>
+                            ) : selectedAlternative &&
+                              selectedProject &&
+                              canTakeAction ? (
+                              <Text className="text-(--gray-11) text-sm">
+                                GitHub is already connected on{" "}
+                                {alternativeConnectedProjects.length > 1 ? (
+                                  <DropdownMenu.Root>
+                                    <DropdownMenu.Trigger>
+                                      <button
+                                        type="button"
+                                        className="cursor-pointer border-0 bg-transparent p-0 font-bold text-(--gray-12) underline"
+                                      >
+                                        {selectedAlternative.name} +{" "}
+                                        {alternativeConnectedProjects.length -
+                                          1}{" "}
+                                        more
+                                      </button>
+                                    </DropdownMenu.Trigger>
+                                    <DropdownMenu.Content
+                                      size="1"
+                                      align="start"
+                                    >
+                                      {alternativeConnectedProjects.map((p) => (
+                                        <DropdownMenu.Item
+                                          key={p.id}
+                                          onSelect={() =>
+                                            setSelectedAlternativeId(p.id)
+                                          }
+                                        >
+                                          <Text className="text-[13px]">
+                                            {p.name}
+                                          </Text>
+                                          <Text className="ml-2 text-(--gray-10) text-[13px]">
+                                            {p.organization.name}
+                                          </Text>
+                                        </DropdownMenu.Item>
+                                      ))}
+                                    </DropdownMenu.Content>
+                                  </DropdownMenu.Root>
                                 ) : (
-                                  <Text className="text-(--gray-10) text-[12px]">
-                                    {isLoadingInstallRepos
-                                      ? "Loading…"
-                                      : installRepos.length === 1
-                                        ? "1 repo"
-                                        : `${installRepos.length} repos`}
-                                  </Text>
+                                  <>
+                                    <Text className="font-bold">
+                                      {selectedAlternative.name}
+                                    </Text>{" "}
+                                    ({selectedAlternative.organization.name})
+                                  </>
                                 )}
-                              </Flex>
-                              <Flex align="center" gap="3" wrap="wrap">
-                                {isStale && (
-                                  <Button
-                                    size="1"
-                                    variant="solid"
-                                    loading={isReconnecting}
-                                    disabled={
-                                      reconnectingInstallationId !== null &&
-                                      !isReconnecting
-                                    }
-                                    onClick={async () => {
-                                      setReconnectingInstallationId(
-                                        installationId,
-                                      );
-                                      try {
-                                        await disconnectMutation.mutateAsync({
-                                          installationId,
-                                          silent: true,
+                                .
+                              </Text>
+                            ) : (
+                              <Text
+                                className={
+                                  hasConnectError
+                                    ? "text-(--red-11) text-sm"
+                                    : "text-(--gray-11) text-sm"
+                                }
+                              >
+                                {defaultPanelMessage}
+                              </Text>
+                            ))}
+                        </Flex>
+                        {hasGitIntegration ? (
+                          <Flex direction="column" gap="3">
+                            {githubUserIntegrations.map((integration) => {
+                              const installationId =
+                                integration.installation_id;
+                              const accountName =
+                                integration.account?.name ?? "GitHub";
+                              const installRepos =
+                                reposByInstallationId[installationId];
+                              const isLoadingInstallRepos =
+                                installRepos === undefined;
+                              const isStale =
+                                failedInstallationIds.includes(installationId);
+                              const isReconnecting =
+                                reconnectingInstallationId === installationId;
+                              return (
+                                <Flex
+                                  key={integration.id}
+                                  direction="column"
+                                  gap="2"
+                                  p="3"
+                                  className="rounded-[8px] border border-(--gray-a3)"
+                                >
+                                  <Flex
+                                    align="center"
+                                    justify="between"
+                                    gap="2"
+                                    wrap="wrap"
+                                  >
+                                    <Flex align="center" gap="2">
+                                      <Text className="font-bold text-(--gray-12) text-sm">
+                                        {accountName}
+                                      </Text>
+                                      <Text className="text-(--gray-10) text-[12px]">
+                                        {integration.account?.type ===
+                                        "Organization"
+                                          ? "org"
+                                          : "personal"}
+                                      </Text>
+                                    </Flex>
+                                    {isStale ? (
+                                      <Text className="text-(--amber-11) text-[12px]">
+                                        Reconnect needed
+                                      </Text>
+                                    ) : (
+                                      <Text className="text-(--gray-10) text-[12px]">
+                                        {isLoadingInstallRepos
+                                          ? "Loading…"
+                                          : installRepos.length === 1
+                                            ? "1 repo"
+                                            : `${installRepos.length} repos`}
+                                      </Text>
+                                    )}
+                                  </Flex>
+                                  <Flex align="center" gap="3" wrap="wrap">
+                                    {isStale && (
+                                      <Button
+                                        size="1"
+                                        variant="solid"
+                                        loading={isReconnecting}
+                                        disabled={
+                                          reconnectingInstallationId !== null &&
+                                          !isReconnecting
+                                        }
+                                        onClick={async () => {
+                                          setReconnectingInstallationId(
+                                            installationId,
+                                          );
+                                          try {
+                                            await disconnectMutation.mutateAsync(
+                                              {
+                                                installationId,
+                                                silent: true,
+                                              },
+                                            );
+                                          } catch {
+                                            setReconnectingInstallationId(null);
+                                            return;
+                                          }
+                                          try {
+                                            await handleConnectGitHub();
+                                          } finally {
+                                            setReconnectingInstallationId(null);
+                                          }
+                                        }}
+                                      >
+                                        Reconnect
+                                        <ArrowSquareOut size={12} />
+                                      </Button>
+                                    )}
+                                    <Button
+                                      size="1"
+                                      variant="soft"
+                                      color="gray"
+                                      onClick={() => {
+                                        const account = integration.account;
+                                        const url =
+                                          account?.type === "Organization" &&
+                                          account.name
+                                            ? `https://github.com/organizations/${account.name}/settings/installations/${installationId}`
+                                            : `https://github.com/settings/installations/${installationId}`;
+                                        trpcClient.os.openExternal.mutate({
+                                          url,
                                         });
-                                      } catch {
-                                        setReconnectingInstallationId(null);
-                                        return;
-                                      }
-                                      try {
-                                        await handleConnectGitHub();
-                                      } finally {
-                                        setReconnectingInstallationId(null);
-                                      }
-                                    }}
-                                  >
-                                    Reconnect
-                                    <ArrowSquareOut size={12} />
-                                  </Button>
-                                )}
-                                <Button
-                                  size="1"
-                                  variant="soft"
-                                  color="gray"
-                                  onClick={() => {
-                                    const account = integration.account;
-                                    const url =
-                                      account?.type === "Organization" &&
-                                      account.name
-                                        ? `https://github.com/organizations/${account.name}/settings/installations/${installationId}`
-                                        : `https://github.com/settings/installations/${installationId}`;
-                                    trpcClient.os.openExternal.mutate({ url });
-                                  }}
-                                >
-                                  <GearSix size={12} />
-                                  Settings
-                                </Button>
-                                <Button
-                                  size="1"
-                                  variant="soft"
-                                  color="red"
-                                  onClick={() =>
-                                    setDisconnectTarget({
-                                      installationId,
-                                      accountName,
-                                    })
-                                  }
-                                >
-                                  Disconnect
-                                </Button>
-                              </Flex>
-                            </Flex>
-                          );
-                        })}
-                        <Flex align="center" gap="3" wrap="wrap">
-                          <Button
-                            size="1"
-                            variant="soft"
-                            color="gray"
-                            onClick={() => {
-                              queryClient.invalidateQueries({
-                                queryKey: ["integrations"],
-                              });
-                              queryClient.invalidateQueries({
-                                queryKey: ["user-github-integrations"],
-                              });
-                            }}
-                          >
-                            <ArrowsClockwise size={12} />
-                            Refresh
-                          </Button>
-                          <Button
-                            size="1"
-                            variant="ghost"
-                            color="gray"
-                            onClick={() => void handleConnectGitHub()}
-                            loading={isConnecting}
-                          >
-                            <Plus size={12} />
-                            Add another GitHub org
-                          </Button>
-                        </Flex>
-                      </Flex>
-                    ) : !isLoading && !githubUserIntegrationsLoading ? (
-                      selectedProject?.hasGithubIntegration && canTakeAction ? (
-                        <Flex direction="column" gap="3">
-                          <Text className="text-(--gray-11) text-sm">
-                            GitHub is already set up on{" "}
-                            <Text className="font-bold">
-                              {selectedProject.name}
-                            </Text>
-                            . Sign in with one click to link your account, no
-                            admin approval needed.
-                          </Text>
-                          <Button
-                            size="1"
-                            variant="solid"
-                            onClick={() => void handleConnectGitHub()}
-                            className="self-start"
-                          >
-                            Sign in with GitHub
-                            <ArrowSquareOut size={12} />
-                          </Button>
-                        </Flex>
-                      ) : selectedAlternative &&
-                        selectedProject &&
-                        canTakeAction ? (
-                        <Flex direction="column" gap="3">
-                          <Text className="text-(--gray-11) text-sm">
-                            GitHub is already connected on{" "}
-                            {alternativeConnectedProjects.length > 1 ? (
-                              <DropdownMenu.Root>
-                                <DropdownMenu.Trigger>
-                                  <button
-                                    type="button"
-                                    className="cursor-pointer border-0 bg-transparent p-0 font-bold text-(--gray-12) underline"
-                                  >
-                                    {selectedAlternative.name} +{" "}
-                                    {alternativeConnectedProjects.length - 1}{" "}
-                                    more
-                                  </button>
-                                </DropdownMenu.Trigger>
-                                <DropdownMenu.Content size="1" align="start">
-                                  {alternativeConnectedProjects.map((p) => (
-                                    <DropdownMenu.Item
-                                      key={p.id}
-                                      onSelect={() =>
-                                        setSelectedAlternativeId(p.id)
+                                      }}
+                                    >
+                                      <GearSix size={12} />
+                                      Settings
+                                    </Button>
+                                    <Button
+                                      size="1"
+                                      variant="soft"
+                                      color="red"
+                                      onClick={() =>
+                                        setDisconnectTarget({
+                                          installationId,
+                                          accountName,
+                                        })
                                       }
                                     >
-                                      <Text className="text-[13px]">
-                                        {p.name}
-                                      </Text>
-                                      <Text className="ml-2 text-(--gray-10) text-[13px]">
-                                        {p.organization.name}
-                                      </Text>
-                                    </DropdownMenu.Item>
-                                  ))}
-                                </DropdownMenu.Content>
-                              </DropdownMenu.Root>
-                            ) : (
-                              <>
-                                <Text className="font-bold">
-                                  {selectedAlternative.name}
-                                </Text>{" "}
-                                ({selectedAlternative.organization.name})
-                              </>
-                            )}
-                            .
-                          </Text>
-                          <Flex direction="column" gap="2" align="start">
-                            <Button
-                              size="1"
-                              variant="solid"
-                              onClick={() => void handleConnectGitHub()}
-                            >
-                              Connect GitHub on {selectedProject.name}
-                              <ArrowSquareOut size={12} />
-                            </Button>
-                            <Button
-                              size="1"
-                              variant="ghost"
-                              color="gray"
-                              onClick={() =>
-                                setSelectedProjectId(selectedAlternative.id)
-                              }
-                            >
-                              Switch to {selectedAlternative.name}
-                            </Button>
-                          </Flex>
-                        </Flex>
-                      ) : (
-                        <Flex direction="column" gap="3">
-                          <Text
-                            className={
-                              hasConnectError
-                                ? "text-(--red-11) text-sm"
-                                : "text-(--gray-11) text-sm"
-                            }
-                          >
-                            {defaultPanelMessage}
-                          </Text>
-                          <Flex gap="2">
-                            <Button
-                              size="1"
-                              variant="soft"
-                              onClick={() => {
-                                if (hasConnectError) resetConnect();
-                                void handleConnectGitHub();
-                              }}
-                              loading={isConnecting}
-                            >
-                              {isConnecting
-                                ? "Retry connection"
-                                : hasConnectError || timedOut
-                                  ? "Try again"
-                                  : "Connect GitHub"}
-                              <ArrowSquareOut size={12} />
-                            </Button>
-                            {hasConnectError && (
+                                      Disconnect
+                                    </Button>
+                                  </Flex>
+                                </Flex>
+                              );
+                            })}
+                            <Flex align="center" gap="3" wrap="wrap">
+                              <Button
+                                size="1"
+                                variant="soft"
+                                color="gray"
+                                onClick={() => {
+                                  queryClient.invalidateQueries({
+                                    queryKey: ["integrations"],
+                                  });
+                                  queryClient.invalidateQueries({
+                                    queryKey: ["user-github-integrations"],
+                                  });
+                                }}
+                              >
+                                <ArrowsClockwise size={12} />
+                                Refresh
+                              </Button>
                               <Button
                                 size="1"
                                 variant="ghost"
                                 color="gray"
-                                onClick={resetConnect}
+                                onClick={() => void handleConnectGitHub()}
+                                loading={isConnecting}
                               >
-                                Dismiss
+                                <Plus size={12} />
+                                Add another GitHub org
                               </Button>
-                            )}
+                            </Flex>
                           </Flex>
-                        </Flex>
-                      )
-                    ) : null}
-                  </Flex>
-                </Box>
-              </motion.div>
+                        ) : !isLoading && !githubUserIntegrationsLoading ? (
+                          selectedProject?.hasGithubIntegration &&
+                          canTakeAction ? (
+                            <Button
+                              size="2"
+                              variant="solid"
+                              onClick={() => void handleConnectGitHub()}
+                              className="self-start"
+                            >
+                              Sign in with GitHub
+                              <ArrowSquareOut size={12} />
+                            </Button>
+                          ) : selectedAlternative &&
+                            selectedProject &&
+                            canTakeAction ? (
+                            <Flex direction="column" gap="2" align="start">
+                              <Button
+                                size="2"
+                                variant="solid"
+                                onClick={() => void handleConnectGitHub()}
+                              >
+                                Connect GitHub on {selectedProject.name}
+                                <ArrowSquareOut size={12} />
+                              </Button>
+                              <Button
+                                size="1"
+                                variant="ghost"
+                                color="gray"
+                                onClick={() =>
+                                  setSelectedProjectId(selectedAlternative.id)
+                                }
+                              >
+                                Switch to {selectedAlternative.name}
+                              </Button>
+                            </Flex>
+                          ) : (
+                            <Flex gap="2" align="center">
+                              <Button
+                                size="2"
+                                variant="solid"
+                                onClick={() => {
+                                  if (hasConnectError) resetConnect();
+                                  void handleConnectGitHub();
+                                }}
+                                loading={isConnecting}
+                              >
+                                {isConnecting
+                                  ? "Retry connection"
+                                  : hasConnectError || timedOut
+                                    ? "Try again"
+                                    : "Connect GitHub"}
+                                <ArrowSquareOut size={12} />
+                              </Button>
+                              {hasConnectError && (
+                                <Button
+                                  size="2"
+                                  variant="ghost"
+                                  color="gray"
+                                  onClick={resetConnect}
+                                >
+                                  Dismiss
+                                </Button>
+                              )}
+                            </Flex>
+                          )
+                        ) : null}
+                      </Flex>
+                    </Box>
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </Flex>
 
             {/* Hog tip */}
             <OnboardingHogTip
               hogSrc={builderHog}
-              message="GitHub access lets agents read issues and open pull requests for you."
+              message="Local tasks run on this machine. Cloud tasks need GitHub so agents can push branches and open PRs."
               delay={0.15}
             />
           </Flex>

--- a/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
@@ -255,7 +255,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                               value={org}
                               title={org.name}
                             >
-                              <Text className="text-sm">{org.name}</Text>
+                              <Text>{org.name}</Text>
                             </ComboboxItem>
                           )}
                         </ComboboxList>
@@ -340,7 +340,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                               value={project}
                               title={project.name}
                             >
-                              <Text className="text-sm">{project.name}</Text>
+                              <Text>{project.name}</Text>
                             </ComboboxItem>
                           )}
                         </ComboboxList>

--- a/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/ProjectSelectStep.tsx
@@ -17,7 +17,6 @@ import {
   ArrowLeft,
   ArrowRight,
   CaretDown,
-  Check,
   CheckCircle,
 } from "@phosphor-icons/react";
 import {
@@ -31,6 +30,10 @@ import {
 } from "@posthog/quill";
 import { Button, Flex, Spinner, Text } from "@radix-ui/themes";
 import happyHog from "@renderer/assets/images/hedgehogs/happy-hog.png";
+import {
+  FIELD_CONTENT_CLASS,
+  FIELD_TRIGGER_CLASS,
+} from "@renderer/styles/fieldTrigger";
 import { BILLING_FLAG } from "@shared/constants";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { logger } from "@utils/logger";
@@ -51,12 +54,6 @@ interface ProjectSelectStepProps {
   onNext: () => void;
   onBack: () => void;
 }
-
-const TRIGGER_CLASS =
-  "box-border flex w-full cursor-pointer appearance-none items-center justify-between gap-3 rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]";
-
-const CONTENT_CLASS =
-  "w-(--anchor-width) max-w-(--anchor-width) min-w-(--anchor-width) p-0";
 
 export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
   const authFetched = useAuthStateFetched();
@@ -227,9 +224,9 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                           <button
                             ref={orgAnchorRef}
                             type="button"
-                            className={TRIGGER_CLASS}
+                            className={FIELD_TRIGGER_CLASS}
                           >
-                            <Text className="min-w-0 flex-1 truncate text-left font-medium text-(--gray-12) text-sm">
+                            <Text className="min-w-0 flex-1 truncate text-left font-medium text-(--gray-12)">
                               {currentOrg?.name ?? "Select organization..."}
                             </Text>
                             <CaretDown
@@ -244,7 +241,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                         side="bottom"
                         align="start"
                         sideOffset={4}
-                        className={CONTENT_CLASS}
+                        className={FIELD_CONTENT_CLASS}
                       >
                         <ComboboxInput
                           placeholder="Search organizations..."
@@ -258,19 +255,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                               value={org}
                               title={org.name}
                             >
-                              <Flex
-                                align="center"
-                                justify="between"
-                                width="100%"
-                              >
-                                <Text className="text-sm">{org.name}</Text>
-                                {org.id === currentOrg?.id && (
-                                  <Check
-                                    size={14}
-                                    className="text-(--accent-11)"
-                                  />
-                                )}
-                              </Flex>
+                              <Text className="text-sm">{org.name}</Text>
                             </ComboboxItem>
                           )}
                         </ComboboxList>
@@ -312,7 +297,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                           <button
                             ref={projectAnchorRef}
                             type="button"
-                            className={TRIGGER_CLASS}
+                            className={FIELD_TRIGGER_CLASS}
                           >
                             <Flex
                               direction="column"
@@ -320,7 +305,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                               align="start"
                               className="min-w-0 flex-1 text-left"
                             >
-                              <Text className="min-w-0 max-w-full truncate font-medium text-(--gray-12) text-sm">
+                              <Text className="min-w-0 max-w-full truncate font-medium text-(--gray-12)">
                                 {currentProject?.name ?? "Select a project..."}
                               </Text>
                               {currentProject && !hasMultipleOrgs && (
@@ -341,7 +326,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                         side="bottom"
                         align="start"
                         sideOffset={4}
-                        className={CONTENT_CLASS}
+                        className={FIELD_CONTENT_CLASS}
                       >
                         <ComboboxInput
                           placeholder="Search projects..."
@@ -355,19 +340,7 @@ export function ProjectSelectStep({ onNext, onBack }: ProjectSelectStepProps) {
                               value={project}
                               title={project.name}
                             >
-                              <Flex
-                                align="center"
-                                justify="between"
-                                width="100%"
-                              >
-                                <Text className="text-sm">{project.name}</Text>
-                                {project.id === currentProjectId && (
-                                  <Check
-                                    size={14}
-                                    className="text-(--accent-11)"
-                                  />
-                                )}
-                              </Flex>
+                              <Text className="text-sm">{project.name}</Text>
                             </ComboboxItem>
                           )}
                         </ComboboxList>

--- a/apps/code/src/renderer/features/settings/components/sections/WorkspacesSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/WorkspacesSettings.tsx
@@ -50,7 +50,6 @@ export function WorkspacesSettings() {
             value={localWorktreeLocation}
             onChange={handleWorktreeLocationChange}
             placeholder="~/.posthog-code"
-            size="1"
           />
         </div>
       </SettingRow>

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -681,7 +681,6 @@ export function TaskInput({
                   value={selectedDirectory}
                   onChange={setSelectedDirectory}
                   placeholder="Select repository..."
-                  size="1"
                   anchor={buttonGroupRef}
                 />
               )}

--- a/apps/code/src/renderer/features/task-detail/components/WorkspaceSetupPrompt.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/WorkspaceSetupPrompt.tsx
@@ -139,7 +139,6 @@ export function WorkspaceSetupPrompt({
               value={selectedPath}
               onChange={handleFolderSelect}
               placeholder="Select folder..."
-              size="2"
             />
           </Box>
         </>

--- a/apps/code/src/renderer/styles/fieldTrigger.ts
+++ b/apps/code/src/renderer/styles/fieldTrigger.ts
@@ -1,0 +1,5 @@
+export const FIELD_TRIGGER_CLASS =
+  "box-border flex w-full cursor-pointer appearance-none items-center justify-between gap-3 rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]";
+
+export const FIELD_CONTENT_CLASS =
+  "w-(--anchor-width) max-w-(--anchor-width) min-w-(--anchor-width) p-0";

--- a/apps/code/src/renderer/styles/fieldTrigger.ts
+++ b/apps/code/src/renderer/styles/fieldTrigger.ts
@@ -1,3 +1,6 @@
+// Shared select-style trigger for the onboarding folder picker and combobox fields.
+// Apply directly to a DOM <button> or a forwardRef component that spreads props,
+// not to a function-component wrapper (Base UI's render prop clones the element).
 export const FIELD_TRIGGER_CLASS =
   "box-border flex w-full cursor-pointer appearance-none items-center justify-between gap-3 rounded-[10px] border border-(--gray-a3) bg-(--color-panel-solid) px-[14px] py-[10px] font-[inherit] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]";
 


### PR DESCRIPTION
## Problem

  The git onboarding step buried GitHub's optionality and used a small inline folder picker that didn't match the rest of the form.

## Changes

  1. Add "Optional" badge to the GitHub panel and clarify required vs optional steps
  2. Hide the GitHub panel until a repository is selected
  3. Add a `field` variant to FolderPicker matching other form field triggers
  4. Extract shared `FIELD_TRIGGER_CLASS` / `FIELD_CONTENT_CLASS` styles
  5. Rewrite copy to distinguish local tasks from cloud agents
  6. Fix folder picker ref forwarding and drop redundant combobox check icons

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->