### PR TITLE
feat(notifications): notify when focused on a different task

### DIFF
--- a/apps/code/src/renderer/utils/notifications.test.ts
+++ b/apps/code/src/renderer/utils/notifications.test.ts
@@ -40,11 +40,9 @@ import { notifyPermissionRequest, notifyPromptComplete } from "./notifications";
 const TASK_ID = "task-123";
 const OTHER_TASK_ID = "task-999";
 
-function setView(view: {
-  type: string;
-  data?: { id: string };
-  taskId?: string;
-}) {
+type View = { type: string; data?: { id: string }; taskId?: string };
+
+function setView(view: View) {
   useNavigationStore.setState({
     // biome-ignore lint/suspicious/noExplicitAny: test-only narrow cast
     view: view as any,
@@ -72,91 +70,106 @@ describe("notifications", () => {
   });
 
   describe("shouldNotifyForTask gating (via notifyPermissionRequest)", () => {
-    it("notifies when the window is unfocused", () => {
-      setFocus(false);
-      setView({ type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID });
+    const cases: ReadonlyArray<{
+      name: string;
+      focused: boolean;
+      view: View;
+      taskId?: string;
+      shouldNotify: boolean;
+    }> = [
+      {
+        name: "window unfocused → notifies",
+        focused: false,
+        view: { type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID },
+        taskId: TASK_ID,
+        shouldNotify: true,
+      },
+      {
+        name: "focused on the same task → does not notify",
+        focused: true,
+        view: { type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID },
+        taskId: TASK_ID,
+        shouldNotify: false,
+      },
+      {
+        name: "focused on a different task → notifies",
+        focused: true,
+        view: {
+          type: "task-detail",
+          data: { id: OTHER_TASK_ID },
+          taskId: OTHER_TASK_ID,
+        },
+        taskId: TASK_ID,
+        shouldNotify: true,
+      },
+      {
+        name: "focused but view is not task-detail → notifies",
+        focused: true,
+        view: { type: "inbox" },
+        taskId: TASK_ID,
+        shouldNotify: true,
+      },
+      {
+        name: "focused with no taskId supplied → does not notify",
+        focused: true,
+        view: { type: "inbox" },
+        taskId: undefined,
+        shouldNotify: false,
+      },
+      {
+        name: "focused, view.data missing, falls back to view.taskId → does not notify",
+        focused: true,
+        view: { type: "task-detail", taskId: TASK_ID },
+        taskId: TASK_ID,
+        shouldNotify: false,
+      },
+    ];
 
-      notifyPermissionRequest("My task", TASK_ID);
+    it.each(cases)("$name", ({ focused, view, taskId, shouldNotify }) => {
+      setFocus(focused);
+      setView(view);
 
-      expect(sendMutate).toHaveBeenCalledTimes(1);
-      expect(playSound).toHaveBeenCalledTimes(1);
-    });
+      notifyPermissionRequest("My task", taskId);
 
-    it("does NOT notify when focused on the same task", () => {
-      setFocus(true);
-      setView({ type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID });
-
-      notifyPermissionRequest("My task", TASK_ID);
-
-      expect(sendMutate).not.toHaveBeenCalled();
-      expect(playSound).not.toHaveBeenCalled();
-    });
-
-    it("notifies when focused but viewing a different task", () => {
-      setFocus(true);
-      setView({
-        type: "task-detail",
-        data: { id: OTHER_TASK_ID },
-        taskId: OTHER_TASK_ID,
-      });
-
-      notifyPermissionRequest("My task", TASK_ID);
-
-      expect(sendMutate).toHaveBeenCalledTimes(1);
-      expect(playSound).toHaveBeenCalledTimes(1);
-    });
-
-    it("notifies when focused but the view is not a task-detail", () => {
-      setFocus(true);
-      setView({ type: "inbox" });
-
-      notifyPermissionRequest("My task", TASK_ID);
-
-      expect(sendMutate).toHaveBeenCalledTimes(1);
-    });
-
-    it("does NOT notify when focused and no taskId is supplied", () => {
-      setFocus(true);
-      setView({ type: "inbox" });
-
-      notifyPermissionRequest("My task");
-
-      expect(sendMutate).not.toHaveBeenCalled();
-    });
-
-    it("falls back to view.taskId when view.data is missing", () => {
-      setFocus(true);
-      setView({ type: "task-detail", taskId: TASK_ID });
-
-      notifyPermissionRequest("My task", TASK_ID);
-
-      expect(sendMutate).not.toHaveBeenCalled();
+      expect(sendMutate).toHaveBeenCalledTimes(shouldNotify ? 1 : 0);
+      expect(playSound).toHaveBeenCalledTimes(shouldNotify ? 1 : 0);
     });
   });
 
   describe("notifyPromptComplete", () => {
-    it("only fires on end_turn", () => {
-      setFocus(false);
-      notifyPromptComplete("My task", "tool_use", TASK_ID);
-      expect(sendMutate).not.toHaveBeenCalled();
+    it.each([
+      { stopReason: "tool_use", shouldNotify: false },
+      { stopReason: "max_tokens", shouldNotify: false },
+      { stopReason: "end_turn", shouldNotify: true },
+    ])(
+      "stop reason '$stopReason' → notifies=$shouldNotify",
+      ({ stopReason, shouldNotify }) => {
+        setFocus(false);
+        notifyPromptComplete("My task", stopReason, TASK_ID);
+        expect(sendMutate).toHaveBeenCalledTimes(shouldNotify ? 1 : 0);
+      },
+    );
 
-      notifyPromptComplete("My task", "end_turn", TASK_ID);
-      expect(sendMutate).toHaveBeenCalledTimes(1);
-    });
-
-    it("applies the same task-aware gating", () => {
+    it.each([
+      {
+        name: "focused on same task → does not notify",
+        view: { type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID },
+        shouldNotify: false,
+      },
+      {
+        name: "focused on different task → notifies",
+        view: {
+          type: "task-detail",
+          data: { id: OTHER_TASK_ID },
+          taskId: OTHER_TASK_ID,
+        },
+        shouldNotify: true,
+      },
+    ])("$name", ({ view, shouldNotify }) => {
       setFocus(true);
-      setView({ type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID });
+      setView(view);
       notifyPromptComplete("My task", "end_turn", TASK_ID);
-      expect(sendMutate).not.toHaveBeenCalled();
-
-      setView({
-        type: "task-detail",
-        data: { id: OTHER_TASK_ID },
-        taskId: OTHER_TASK_ID,
-      });
-      notifyPromptComplete("My task", "end_turn", TASK_ID);
-      expect(sendMutate).toHaveBeenCalledTimes(1);
+      expect(sendMutate).toHaveBeenCalledTimes(shouldNotify ? 1 : 0);
     });
   });
 });

--- a/apps/code/src/renderer/utils/notifications.test.ts
+++ b/apps/code/src/renderer/utils/notifications.test.ts
@@ -1,0 +1,162 @@
+import { useSettingsStore } from "@features/settings/stores/settingsStore";
+import { useNavigationStore } from "@stores/navigationStore";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendMutate, showDockBadgeMutate, bounceDockMutate, playSound } =
+  vi.hoisted(() => ({
+    sendMutate: vi.fn().mockResolvedValue(undefined),
+    showDockBadgeMutate: vi.fn().mockResolvedValue(undefined),
+    bounceDockMutate: vi.fn().mockResolvedValue(undefined),
+    playSound: vi.fn(),
+  }));
+
+vi.mock("@renderer/trpc/client", () => ({
+  trpcClient: {
+    notification: {
+      send: { mutate: sendMutate },
+      showDockBadge: { mutate: showDockBadgeMutate },
+      bounceDock: { mutate: bounceDockMutate },
+    },
+    secureStore: {
+      getItem: { query: vi.fn().mockResolvedValue(null) },
+      setItem: { query: vi.fn().mockResolvedValue(undefined) },
+      removeItem: { query: vi.fn().mockResolvedValue(undefined) },
+    },
+  },
+}));
+
+vi.mock("@utils/logger", () => ({
+  logger: { scope: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+vi.mock("@utils/analytics", () => ({ track: vi.fn() }));
+
+vi.mock("@utils/sounds", () => ({
+  playCompletionSound: playSound,
+}));
+
+import { notifyPermissionRequest, notifyPromptComplete } from "./notifications";
+
+const TASK_ID = "task-123";
+const OTHER_TASK_ID = "task-999";
+
+function setView(view: {
+  type: string;
+  data?: { id: string };
+  taskId?: string;
+}) {
+  useNavigationStore.setState({
+    // biome-ignore lint/suspicious/noExplicitAny: test-only narrow cast
+    view: view as any,
+  });
+}
+
+function setFocus(focused: boolean) {
+  vi.spyOn(document, "hasFocus").mockReturnValue(focused);
+}
+
+describe("notifications", () => {
+  beforeEach(() => {
+    sendMutate.mockClear();
+    showDockBadgeMutate.mockClear();
+    bounceDockMutate.mockClear();
+    playSound.mockClear();
+    useSettingsStore.setState({
+      desktopNotifications: true,
+      dockBadgeNotifications: true,
+      dockBounceNotifications: true,
+      completionSound: "meep",
+      completionVolume: 80,
+    });
+    setView({ type: "task-input" });
+  });
+
+  describe("shouldNotifyForTask gating (via notifyPermissionRequest)", () => {
+    it("notifies when the window is unfocused", () => {
+      setFocus(false);
+      setView({ type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID });
+
+      notifyPermissionRequest("My task", TASK_ID);
+
+      expect(sendMutate).toHaveBeenCalledTimes(1);
+      expect(playSound).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT notify when focused on the same task", () => {
+      setFocus(true);
+      setView({ type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID });
+
+      notifyPermissionRequest("My task", TASK_ID);
+
+      expect(sendMutate).not.toHaveBeenCalled();
+      expect(playSound).not.toHaveBeenCalled();
+    });
+
+    it("notifies when focused but viewing a different task", () => {
+      setFocus(true);
+      setView({
+        type: "task-detail",
+        data: { id: OTHER_TASK_ID },
+        taskId: OTHER_TASK_ID,
+      });
+
+      notifyPermissionRequest("My task", TASK_ID);
+
+      expect(sendMutate).toHaveBeenCalledTimes(1);
+      expect(playSound).toHaveBeenCalledTimes(1);
+    });
+
+    it("notifies when focused but the view is not a task-detail", () => {
+      setFocus(true);
+      setView({ type: "inbox" });
+
+      notifyPermissionRequest("My task", TASK_ID);
+
+      expect(sendMutate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT notify when focused and no taskId is supplied", () => {
+      setFocus(true);
+      setView({ type: "inbox" });
+
+      notifyPermissionRequest("My task");
+
+      expect(sendMutate).not.toHaveBeenCalled();
+    });
+
+    it("falls back to view.taskId when view.data is missing", () => {
+      setFocus(true);
+      setView({ type: "task-detail", taskId: TASK_ID });
+
+      notifyPermissionRequest("My task", TASK_ID);
+
+      expect(sendMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("notifyPromptComplete", () => {
+    it("only fires on end_turn", () => {
+      setFocus(false);
+      notifyPromptComplete("My task", "tool_use", TASK_ID);
+      expect(sendMutate).not.toHaveBeenCalled();
+
+      notifyPromptComplete("My task", "end_turn", TASK_ID);
+      expect(sendMutate).toHaveBeenCalledTimes(1);
+    });
+
+    it("applies the same task-aware gating", () => {
+      setFocus(true);
+      setView({ type: "task-detail", data: { id: TASK_ID }, taskId: TASK_ID });
+      notifyPromptComplete("My task", "end_turn", TASK_ID);
+      expect(sendMutate).not.toHaveBeenCalled();
+
+      setView({
+        type: "task-detail",
+        data: { id: OTHER_TASK_ID },
+        taskId: OTHER_TASK_ID,
+      });
+      notifyPromptComplete("My task", "end_turn", TASK_ID);
+      expect(sendMutate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/code/src/renderer/utils/notifications.ts
+++ b/apps/code/src/renderer/utils/notifications.ts
@@ -1,5 +1,6 @@
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { trpcClient } from "@renderer/trpc/client";
+import { useNavigationStore } from "@stores/navigationStore";
 import { logger } from "@utils/logger";
 import { playCompletionSound } from "@utils/sounds";
 
@@ -10,6 +11,15 @@ const MAX_TITLE_LENGTH = 50;
 function truncateTitle(title: string): string {
   if (title.length <= MAX_TITLE_LENGTH) return title;
   return `${title.slice(0, MAX_TITLE_LENGTH)}...`;
+}
+
+function shouldNotifyForTask(taskId?: string): boolean {
+  if (!document.hasFocus()) return true;
+  if (!taskId) return false;
+  const view = useNavigationStore.getState().view;
+  const viewedTaskId =
+    view.type === "task-detail" ? (view.data?.id ?? view.taskId) : undefined;
+  return viewedTaskId !== taskId;
 }
 
 function sendDesktopNotification(
@@ -52,8 +62,7 @@ export function notifyPromptComplete(
     dockBounceNotifications,
   } = useSettingsStore.getState();
 
-  const isWindowFocused = document.hasFocus();
-  if (isWindowFocused) return;
+  if (!shouldNotifyForTask(taskId)) return;
 
   const willPlayCustomSound = completionSound !== "none";
   playCompletionSound(completionSound, completionVolume);
@@ -85,25 +94,24 @@ export function notifyPermissionRequest(
     dockBadgeNotifications,
     dockBounceNotifications,
   } = useSettingsStore.getState();
-  const isWindowFocused = document.hasFocus();
 
-  if (!isWindowFocused) {
-    const willPlayCustomSound = completionSound !== "none";
-    playCompletionSound(completionSound, completionVolume);
+  if (!shouldNotifyForTask(taskId)) return;
 
-    if (desktopNotifications) {
-      sendDesktopNotification(
-        "PostHog Code",
-        `"${truncateTitle(taskTitle)}" needs your input`,
-        willPlayCustomSound,
-        taskId,
-      );
-    }
-    if (dockBadgeNotifications) {
-      showDockBadge();
-    }
-    if (dockBounceNotifications) {
-      bounceDock();
-    }
+  const willPlayCustomSound = completionSound !== "none";
+  playCompletionSound(completionSound, completionVolume);
+
+  if (desktopNotifications) {
+    sendDesktopNotification(
+      "PostHog Code",
+      `"${truncateTitle(taskTitle)}" needs your input`,
+      willPlayCustomSound,
+      taskId,
+    );
+  }
+  if (dockBadgeNotifications) {
+    showDockBadge();
+  }
+  if (dockBounceNotifications) {
+    bounceDock();
   }
 }


### PR DESCRIPTION
## Problem

When you're focused on task A inside PostHog Code and task B asks for a permission or finishes its turn, nothing surfaces — the existing notification logic in `notifications.ts` only fires when the window is unfocused, so a same-window-but-different-task interrupt is silent. Reported as: "no meep when task need input while focus other task, sad".

## Changes

Added a `shouldNotifyForTask(taskId)` helper in `apps/code/src/renderer/utils/notifications.ts` that consults `useNavigationStore` for the currently viewed task. Both `notifyPromptComplete` and `notifyPermissionRequest` now fire (sound, desktop notification, dock badge, dock bounce) when:

- the window is unfocused (unchanged), **or**
- the window is focused but the user is viewing a different task (new).

| Window focused? | Viewing same task? | Notify? |
|---|---|---|
| No | — | Yes (unchanged) |
| Yes | Yes | No (unchanged) |
| Yes | No / different task | **Yes (new)** |

All existing settings (`desktopNotifications`, `dockBadgeNotifications`, `dockBounceNotifications`, `completionSound`, `completionVolume`) still gate the channels — no new preference. Falls back to "don't notify when focused" if `taskId` is unknown, so callers without a `taskId` keep their previous behaviour.

Clicking the desktop notification already routes to the right task via `TaskLinkService` → `deepLink.onOpenTask` → `useTaskDeepLink` → `navigateToTask`, so no extra wiring needed there.

## How did you test this?

- `pnpm --filter code typecheck` — clean
- `pnpm exec biome check apps/code/src/renderer/utils/notifications.ts` — clean
- Traced the click-to-navigate path end-to-end (`electron-notifier.ts:25` → `notification/service.ts:38` → `deep-link.ts:27` → `useTaskDeepLink.ts` → `navigationStore.navigateToTask`) to confirm clicking the notification still lands on the originating task.
- Did not run the app manually in this environment.

## Publish to changelog?

no
