### PR TITLE
fix(code): prevent archived tasks from reappearing after archive

### DIFF
--- a/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
+++ b/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
@@ -34,9 +34,20 @@ export async function archiveTaskImperative(
     }
   }
 
+  const terminalStatesSnapshot = Object.fromEntries(
+    Object.entries(useTerminalStore.getState().terminalStates).filter(
+      ([key]) => key === taskId || key.startsWith(`${taskId}-`),
+    ),
+  );
+  const commandCenterIndex = useCommandCenterStore
+    .getState()
+    .cells.indexOf(taskId);
+
   pinnedTasksApi.unpin(taskId);
   useTerminalStore.getState().clearTerminalStatesForTask(taskId);
   useCommandCenterStore.getState().removeTaskById(taskId);
+
+  await queryClient.cancelQueries(trpc.archive.pathFilter());
 
   queryClient.setQueryData<string[]>(
     trpc.archive.archivedTaskIds.queryKey(),
@@ -86,6 +97,14 @@ export async function archiveTaskImperative(
     );
     if (wasPinned) {
       pinnedTasksApi.togglePin(taskId);
+    }
+    if (Object.keys(terminalStatesSnapshot).length > 0) {
+      useTerminalStore.setState((s) => ({
+        terminalStates: { ...s.terminalStates, ...terminalStatesSnapshot },
+      }));
+    }
+    if (commandCenterIndex !== -1) {
+      useCommandCenterStore.getState().assignTask(commandCenterIndex, taskId);
     }
 
     throw error;

--- a/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
+++ b/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
@@ -39,9 +39,9 @@ export async function archiveTaskImperative(
       ([key]) => key === taskId || key.startsWith(`${taskId}-`),
     ),
   );
-  const commandCenterIndex = useCommandCenterStore
-    .getState()
-    .cells.indexOf(taskId);
+  const commandCenterState = useCommandCenterStore.getState();
+  const commandCenterIndex = commandCenterState.cells.indexOf(taskId);
+  const wasActiveInCommandCenter = commandCenterState.activeTaskId === taskId;
 
   pinnedTasksApi.unpin(taskId);
   useTerminalStore.getState().clearTerminalStatesForTask(taskId);
@@ -104,7 +104,13 @@ export async function archiveTaskImperative(
       }));
     }
     if (commandCenterIndex !== -1) {
-      useCommandCenterStore.getState().assignTask(commandCenterIndex, taskId);
+      useCommandCenterStore.setState((s) => {
+        const cells = [...s.cells];
+        cells[commandCenterIndex] = taskId;
+        return wasActiveInCommandCenter
+          ? { cells, activeTaskId: taskId }
+          : { cells };
+      });
     }
 
     throw error;


### PR DESCRIPTION
## Problem

Archiving a task in the sidebar sometimes worked cleanly, sometimes silently re-listed the task a moment later, and sometimes appeared to fail outright. The behaviour was timing-dependent.

Root cause: `archiveTaskImperative` (`apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts`) wrote optimistic updates to the archive queries without first cancelling in-flight refetches. A background refetch (window-focus manager or the 30s task-summaries poll) could land between the optimistic write and the mutation completing, then overwrite the optimistic cache with the still-unarchived server snapshot — making the archived task reappear in the sidebar until the post-mutation `invalidateQueries` caught up. `useDeleteTask` already uses the correct `cancelQueries`-first pattern; archive did not.

Secondary issue: if the archive mutation threw after we'd already called `clearTerminalStatesForTask` and `removeTaskById`, the task came back in the sidebar but its terminal state and command-center slot were silently dropped.

## Changes

- Call `await queryClient.cancelQueries(trpc.archive.pathFilter())` immediately before the optimistic `setQueryData` calls in `archiveTaskImperative`. This kills any in-flight archive refetch so it can no longer overwrite the optimistic state. The same fix transitively covers the bulk "Archive prior tasks" loop in `SidebarMenu`, since every iteration calls `archiveTaskImperative` and therefore cancels the previous iteration's invalidate-triggered refetch.
- Snapshot the per-task terminal states (keyed by `taskId` and `${taskId}-*`) and the command-center cell index *before* clearing them. On mutation failure, restore both alongside the existing pin/cache rollbacks via `useTerminalStore.setState(...)` and `useCommandCenterStore.getState().assignTask(cellIndex, taskId)`.

No new dependencies, no new public API, no behaviour change on the success path beyond eliminating the race.

## How did you test this?

- Ran `pnpm --filter code typecheck` — only the pre-existing workspace-package errors remained (`@posthog/git/*`, `@posthog/platform/*`); the edited file is clean.
- Ran `npx biome check` on the edited file — passes.
- The pre-commit hook (`biome check --write` + `pnpm typecheck` on staged files) ran on the commit and passed.
- Did **not** manually repro in a built Electron app — the race is timing-dependent and easiest to confirm via the symptoms Richard described disappearing after the fix lands.

## Publish to changelog?

no