### PR TITLE
fix(integrations): Fix "Update in GitHub" flow

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -665,7 +665,7 @@ export class PostHogAPIClient {
         body: JSON.stringify({ next }),
       },
     });
-    if (!response.ok && response.status !== 204) {
+    if (!response.ok) {
       const err = (await response.json().catch(() => ({}))) as {
         detail?: unknown;
       };

--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -650,6 +650,33 @@ export class PostHogAPIClient {
     };
   }
 
+  /** Seed team GitHub setup callback state before opening github.com installation settings. */
+  async prepareGithubTeamIntegrationCallback(
+    teamId: number,
+    next: string,
+  ): Promise<void> {
+    const urlPath = `/api/environments/${teamId}/integrations/github/prepare_callback/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path: urlPath,
+      overrides: {
+        body: JSON.stringify({ next }),
+      },
+    });
+    if (!response.ok && response.status !== 204) {
+      const err = (await response.json().catch(() => ({}))) as {
+        detail?: unknown;
+      };
+      const detail =
+        typeof err.detail === "string"
+          ? err.detail
+          : "Failed to prepare GitHub callback";
+      throw new Error(detail);
+    }
+  }
+
   async getGithubUserIntegrations(): Promise<UserGitHubIntegration[]> {
     const urlPath = `/api/users/@me/integrations/`;
     const url = new URL(`${this.api.baseUrl}${urlPath}`);

--- a/apps/code/src/renderer/features/integrations/stores/integrationStore.ts
+++ b/apps/code/src/renderer/features/integrations/stores/integrationStore.ts
@@ -7,6 +7,7 @@ export interface IntegrationAccount {
 
 export interface IntegrationConfig {
   account?: IntegrationAccount;
+  installation_id?: string | number | null;
   [key: string]: unknown;
 }
 

--- a/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
+++ b/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import type { Integration } from "../stores/integrationStore";
 import {
   githubInstallationSettingsUrl,
   resolveGithubInstallationId,

--- a/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
+++ b/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
@@ -27,7 +27,12 @@ describe("resolveGithubInstallationId", () => {
   it.each([
     [
       "prefers top-level installation_id over integration_id and config",
-      { id: 99, kind: "github", installation_id: "a", config: { installation_id: "c" } },
+      {
+        id: 99,
+        kind: "github",
+        installation_id: "a",
+        config: { installation_id: "c" },
+      },
       "a",
     ],
     [
@@ -41,10 +46,10 @@ describe("resolveGithubInstallationId", () => {
       "c",
     ],
   ])("%s", (_label, input, expected) => {
-    expect(resolveGithubInstallationId(input as Parameters<typeof resolveGithubInstallationId>[0])).toBe(expected);
+    expect(
+      resolveGithubInstallationId(
+        input as Parameters<typeof resolveGithubInstallationId>[0],
+      ),
+    ).toBe(expected);
   });
-});
-      expect(resolveGithubInstallationId(input)).toBe(expected);
-    },
-  );
 });

--- a/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
+++ b/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Integration } from "../stores/integrationStore";
 import {
   githubInstallationSettingsUrl,
   resolveGithubInstallationId,
@@ -24,28 +25,31 @@ describe("githubInstallationSettingsUrl", () => {
 });
 
 describe("resolveGithubInstallationId", () => {
-  it("prefers top-level installation_id then id then config", () => {
-    expect(
-      resolveGithubInstallationId({
+  it.each([
+    [
+      "prefers top-level installation_id over integration_id and config",
+      {
         id: 99,
         kind: "github",
         installation_id: "a",
         config: { installation_id: "c" },
-      }),
-    ).toBe("a");
-    expect(
-      resolveGithubInstallationId({
-        id: 1,
-        kind: "github",
-        integration_id: 12345,
-      }),
-    ).toBe("12345");
-    expect(
-      resolveGithubInstallationId({
-        id: 1,
-        kind: "github",
-        config: { installation_id: "c" },
-      }),
-    ).toBe("c");
-  });
+      },
+      "a",
+    ],
+    [
+      "falls back to integration_id when installation_id is absent",
+      { id: 1, kind: "github", integration_id: 12345 },
+      "12345",
+    ],
+    [
+      "falls back to config.installation_id as last resort",
+      { id: 1, kind: "github", config: { installation_id: "c" } },
+      "c",
+    ],
+  ] satisfies [string, Integration, string][])(
+    "%s",
+    (_label, input, expected) => {
+      expect(resolveGithubInstallationId(input)).toBe(expected);
+    },
+  );
 });

--- a/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
+++ b/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  githubInstallationSettingsUrl,
+  resolveGithubInstallationId,
+} from "./githubInstallationSettingsUrl";
+
+describe("githubInstallationSettingsUrl", () => {
+  it("uses org settings for organization accounts", () => {
+    expect(
+      githubInstallationSettingsUrl("99", {
+        type: "Organization",
+        name: "posthog",
+      }),
+    ).toBe(
+      "https://github.com/organizations/posthog/settings/installations/99",
+    );
+  });
+
+  it("uses user settings for personal accounts", () => {
+    expect(
+      githubInstallationSettingsUrl("42", { type: "User", name: "octocat" }),
+    ).toBe("https://github.com/settings/installations/42");
+  });
+});
+
+describe("resolveGithubInstallationId", () => {
+  it("prefers top-level installation_id then id then config", () => {
+    expect(
+      resolveGithubInstallationId({
+        id: 99,
+        kind: "github",
+        installation_id: "a",
+        config: { installation_id: "c" },
+      }),
+    ).toBe("a");
+    expect(
+      resolveGithubInstallationId({
+        id: 1,
+        kind: "github",
+        integration_id: 12345,
+      }),
+    ).toBe("12345");
+    expect(
+      resolveGithubInstallationId({
+        id: 1,
+        kind: "github",
+        config: { installation_id: "c" },
+      }),
+    ).toBe("c");
+  });
+});

--- a/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
+++ b/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.test.ts
@@ -23,17 +23,11 @@ describe("githubInstallationSettingsUrl", () => {
     ).toBe("https://github.com/settings/installations/42");
   });
 });
-
 describe("resolveGithubInstallationId", () => {
   it.each([
     [
       "prefers top-level installation_id over integration_id and config",
-      {
-        id: 99,
-        kind: "github",
-        installation_id: "a",
-        config: { installation_id: "c" },
-      },
+      { id: 99, kind: "github", installation_id: "a", config: { installation_id: "c" } },
       "a",
     ],
     [
@@ -46,9 +40,10 @@ describe("resolveGithubInstallationId", () => {
       { id: 1, kind: "github", config: { installation_id: "c" } },
       "c",
     ],
-  ] satisfies [string, Integration, string][])(
-    "%s",
-    (_label, input, expected) => {
+  ])("%s", (_label, input, expected) => {
+    expect(resolveGithubInstallationId(input as Parameters<typeof resolveGithubInstallationId>[0])).toBe(expected);
+  });
+});
       expect(resolveGithubInstallationId(input)).toBe(expected);
     },
   );

--- a/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.ts
+++ b/apps/code/src/renderer/features/integrations/utils/githubInstallationSettingsUrl.ts
@@ -1,0 +1,44 @@
+import type { Integration } from "../stores/integrationStore";
+
+interface GithubInstallationAccount {
+  type?: string | null;
+  name?: string | null;
+}
+
+export function githubInstallationSettingsUrl(
+  installationId: string,
+  account?: GithubInstallationAccount | null,
+): string {
+  const accountType = account?.type;
+  const accountName = account?.name;
+  if (
+    typeof accountType === "string" &&
+    accountType.toLowerCase() === "organization" &&
+    typeof accountName === "string" &&
+    accountName
+  ) {
+    return `https://github.com/organizations/${accountName}/settings/installations/${installationId}`;
+  }
+  return `https://github.com/settings/installations/${installationId}`;
+}
+
+/** Resolves a GitHub App installation id from team or user integration payloads. */
+export function resolveGithubInstallationId(
+  integration: Integration,
+): string | null {
+  const legacy = integration as {
+    installation_id?: string | null;
+    integration_id?: string | number | null;
+  };
+  const candidates = [
+    legacy.installation_id,
+    legacy.integration_id,
+    integration.config?.installation_id,
+  ];
+  for (const value of candidates) {
+    if (value === null || value === undefined) continue;
+    const id = String(value).trim();
+    if (id) return id;
+  }
+  return null;
+}

--- a/apps/code/src/renderer/features/settings/components/sections/GitHubIntegrationSection.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GitHubIntegrationSection.tsx
@@ -20,6 +20,7 @@ import { Button } from "@posthog/quill";
 import { Box, Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
 import { openUrlInBrowser } from "@utils/browser";
 import { useMemo } from "react";
+import { toast } from "sonner";
 
 /**
  * Past this count, the tooltip would become an unreadable wall of `owner/name`
@@ -73,11 +74,17 @@ export function GitHubIntegrationSection({
     const integration = githubIntegrations[0];
     if (!integration || projectId === null || !client) return;
     const installationId = resolveGithubInstallationId(integration);
-    if (!installationId) return;
+    if (!installationId) {
+      toast.error("Couldn't find GitHub installation details");
+      return;
+    }
     const nextPath = `/account-connected/github-integration?provider=github&project_id=${projectId}&connect_from=posthog_code`;
     try {
       await client.prepareGithubTeamIntegrationCallback(projectId, nextPath);
-    } catch {
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to open GitHub settings",
+      );
       return;
     }
     void openUrlInBrowser(

--- a/apps/code/src/renderer/features/settings/components/sections/GitHubIntegrationSection.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GitHubIntegrationSection.tsx
@@ -1,8 +1,14 @@
+import { useOptionalAuthenticatedClient } from "@features/auth/hooks/authClient";
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import {
   describeGithubConnectError,
   useGithubConnect,
 } from "@features/integrations/hooks/useGithubUserConnect";
+import { useIntegrationSelectors } from "@features/integrations/stores/integrationStore";
+import {
+  githubInstallationSettingsUrl,
+  resolveGithubInstallationId,
+} from "@features/integrations/utils/githubInstallationSettingsUrl";
 import { useRepositoryIntegration } from "@hooks/useIntegrations";
 import {
   ArrowSquareOutIcon,
@@ -12,6 +18,7 @@ import {
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import { Box, Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
+import { openUrlInBrowser } from "@utils/browser";
 import { useMemo } from "react";
 
 /**
@@ -48,6 +55,8 @@ export function GitHubIntegrationSection({
         : null,
     [repositories],
   );
+  const { githubIntegrations } = useIntegrationSelectors();
+  const client = useOptionalAuthenticatedClient();
   const projectId = useAuthStateValue((state) => state.projectId);
   const {
     error: connectError,
@@ -59,6 +68,25 @@ export function GitHubIntegrationSection({
     projectId,
     projectHasTeamIntegration: hasGithubIntegration,
   });
+
+  const handleUpdateInGitHub = async () => {
+    const integration = githubIntegrations[0];
+    if (!integration || projectId === null || !client) return;
+    const installationId = resolveGithubInstallationId(integration);
+    if (!installationId) return;
+    const nextPath = `/account-connected/github-integration?provider=github&project_id=${projectId}&connect_from=posthog_code`;
+    try {
+      await client.prepareGithubTeamIntegrationCallback(projectId, nextPath);
+    } catch {
+      return;
+    }
+    void openUrlInBrowser(
+      githubInstallationSettingsUrl(
+        installationId,
+        integration.config?.account,
+      ),
+    );
+  };
 
   if (isLoading) {
     return (
@@ -168,7 +196,11 @@ export function GitHubIntegrationSection({
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => void handleConnect()}
+            onClick={() =>
+              hasGithubIntegration
+                ? void handleUpdateInGitHub()
+                : void handleConnect()
+            }
           >
             {hasGithubIntegration
               ? "Update in GitHub"


### PR DESCRIPTION
## What's broken

If you already have GitHub connected and hit "Update in GitHub" in Code settings, it wasn't doing the right thing. It kicked off a fresh connect flow instead of taking you to your existing app installation. And when you came back after changing repo access on GitHub, Code didn't reliably pick up the update (esp. the `setup_action=update` path where GitHub doesn't send `state`).

## What this fixes

"Update in GitHub" now opens the correct GitHub installation settings page (org installs vs personal installs are different URLs), and sets up the callback so PostHog knows to finish setup when you return. You land back in Code with refreshed integration state. Initial "Connect GitHub" is unchanged..

Needs [PostHog/posthog#58951](https://github.com/PostHog/posthog/pull/58951) on the backend for the return trip to actually work end-to-end.