### PR TITLE
fix: keep inline tool call open while selecting text

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/ExecuteToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ExecuteToolView.tsx
@@ -45,18 +45,18 @@ export function ExecuteToolView({
   const isExpandable = hasOutput;
 
   const handleClick = () => {
-    if (!isExpandable) return;
-    const selection = window.getSelection();
-    if (selection && selection.toString().length > 0) return;
-    setIsExpanded(!isExpanded);
+    if (isExpandable) {
+      setIsExpanded(!isExpanded);
+    }
   };
 
   return (
-    <Box
-      className={`group py-0.5 ${isExpandable ? "cursor-pointer" : ""}`}
-      onClick={handleClick}
-    >
-      <Flex gap="2" className="min-w-0">
+    <Box className="py-0.5">
+      <Flex
+        gap="2"
+        className={`group min-w-0 ${isExpandable ? "cursor-pointer" : ""}`}
+        onClick={handleClick}
+      >
         <Box className="shrink-0 pt-px">
           <ExpandableIcon
             icon={Terminal}

--- a/apps/code/src/renderer/features/sessions/components/session-update/ExecuteToolView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ExecuteToolView.tsx
@@ -45,9 +45,10 @@ export function ExecuteToolView({
   const isExpandable = hasOutput;
 
   const handleClick = () => {
-    if (isExpandable) {
-      setIsExpanded(!isExpanded);
-    }
+    if (!isExpandable) return;
+    const selection = window.getSelection();
+    if (selection && selection.toString().length > 0) return;
+    setIsExpanded(!isExpanded);
   };
 
   return (

--- a/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
@@ -88,9 +88,10 @@ export function ToolCallView({
   const isExpandable = !!fullInput || hasOutput;
 
   const handleClick = () => {
-    if (isExpandable) {
-      setIsExpanded(!isExpanded);
-    }
+    if (!isExpandable) return;
+    const selection = window.getSelection();
+    if (selection && selection.toString().length > 0) return;
+    setIsExpanded(!isExpanded);
   };
 
   return (

--- a/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
@@ -88,18 +88,18 @@ export function ToolCallView({
   const isExpandable = !!fullInput || hasOutput;
 
   const handleClick = () => {
-    if (!isExpandable) return;
-    const selection = window.getSelection();
-    if (selection && selection.toString().length > 0) return;
-    setIsExpanded(!isExpanded);
+    if (isExpandable) {
+      setIsExpanded(!isExpanded);
+    }
   };
 
   return (
-    <Box
-      className={`group py-0.5 ${isExpandable ? "cursor-pointer" : ""}`}
-      onClick={handleClick}
-    >
-      <Flex gap="2" className="min-w-0">
+    <Box className="py-0.5">
+      <Flex
+        gap="2"
+        className={`group min-w-0 ${isExpandable ? "cursor-pointer" : ""}`}
+        onClick={handleClick}
+      >
         <Box className="shrink-0 pt-px">
           <ExpandableIcon
             icon={KindIcon}


### PR DESCRIPTION
TL;DR: I want to be able to select text from AskUserQuestion, but can't because it toggles when i release the mouse button

## Summary

- Drag-selecting text inside an expanded `ToolCallView` or `ExecuteToolView` released on the outer `<Box>`, which fired the toggle's `onClick` and collapsed the card before the user could copy.
- Move the `onClick`, `cursor-pointer`, and `group` classes onto the header `<Flex>` so the expanded content is a sibling, not a child — matches the pattern already used by `ReadToolView`/`FetchToolView`/`SearchToolView`.
- Cursor is now an I-beam over selectable output (instead of a pointer), and selection just works without any `window.getSelection()` guard.
- Only these two views were affected; the other expandable tool views already used this layout, and `Edit`/`Think`/`Subagent` use dedicated `<button>` / `IconButton` for the toggle.

## Test plan

- [x] `pnpm --filter code typecheck`
- [x] `pnpm --filter code test` (1244 tests pass)
- [x] Manual: trigger an `ExecuteToolView` (any Bash) or `ToolCallView` (unrecognized agent tool, e.g. AskUserQuestion), expand it, drag-select text in the body — card stays open, cursor shows I-beam.
- [x] Manual: click on the header (no selection) — card still toggles as before, cursor shows pointer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*