### PR TITLE
fix(git): cap and stream untracked-file line counting

### DIFF
--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -244,7 +244,12 @@ describe("getBranchDiffPatchesByPath", () => {
   });
 });
 
-describe("getChangedFilesDetailed", () => {
+// Picked to land well past the default 64KB highWaterMark of
+// `createReadStream` so the regression test actually exercises the
+// across-chunk path of the streaming line counter.
+const LINE_COUNT_LARGER_THAN_READ_STREAM_CHUNK = 800_000;
+
+describe("getChangedFilesDetailed > untracked line counts", () => {
   let repoDir: string;
 
   afterEach(async () => {
@@ -254,17 +259,33 @@ describe("getChangedFilesDetailed", () => {
     }
   });
 
-  it("reports line counts for small untracked files", async () => {
+  it.each([
+    { name: "trailing newline", content: "a\nb\nc\n", expected: 3 },
+    { name: "no trailing newline", content: "a\nb\nc", expected: 3 },
+    { name: "single byte, no newline", content: "a", expected: 1 },
+    { name: "lone newline", content: "\n", expected: 1 },
+    { name: "consecutive newlines", content: "\n\n", expected: 2 },
+    // CRLF: legacy `split("\n")` counted only `\n` separators, so
+    // `"a\r\nb\r\n"` -> 2 lines. Byte-counter matches.
+    { name: "CRLF endings", content: "a\r\nb\r\n", expected: 2 },
+  ])("counts $name as $expected line(s)", async ({ content, expected }) => {
     repoDir = await setupRepo();
-    await writeFile(path.join(repoDir, "small.txt"), "a\nb\nc\n");
-    await writeFile(path.join(repoDir, "no-trailing.txt"), "a\nb\nc");
+    await writeFile(path.join(repoDir, "f.txt"), content);
 
     const files = await getChangedFilesDetailed(repoDir);
-    const small = files.find((f) => f.path === "small.txt");
-    const noTrailing = files.find((f) => f.path === "no-trailing.txt");
+    const f = files.find((file) => file.path === "f.txt");
 
-    expect(small).toMatchObject({ status: "untracked", linesAdded: 3 });
-    expect(noTrailing).toMatchObject({ status: "untracked", linesAdded: 3 });
+    expect(f).toMatchObject({ status: "untracked", linesAdded: expected });
+  });
+
+  it("reports 0 lines for empty untracked files", async () => {
+    repoDir = await setupRepo();
+    await writeFile(path.join(repoDir, "empty.txt"), "");
+
+    const files = await getChangedFilesDetailed(repoDir);
+    const empty = files.find((f) => f.path === "empty.txt");
+
+    expect(empty).toMatchObject({ status: "untracked", linesAdded: 0 });
   });
 
   // Regression guard for the OOM in #2218. Before the fix `countFileLines`
@@ -279,8 +300,7 @@ describe("getChangedFilesDetailed", () => {
   // accurate line count.
   it("stream-counts untracked files larger than the streaming chunk size", async () => {
     repoDir = await setupRepo();
-    const lineCount = 800_000; // ~1.6MB at 2 bytes/line, well over default 64KB chunk
-    const content = "a\n".repeat(lineCount);
+    const content = "a\n".repeat(LINE_COUNT_LARGER_THAN_READ_STREAM_CHUNK);
     await writeFile(path.join(repoDir, "huge.txt"), content);
 
     const files = await getChangedFilesDetailed(repoDir);
@@ -288,7 +308,7 @@ describe("getChangedFilesDetailed", () => {
 
     expect(huge).toMatchObject({
       status: "untracked",
-      linesAdded: lineCount,
+      linesAdded: LINE_COUNT_LARGER_THAN_READ_STREAM_CHUNK,
     });
   });
 });

--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -267,22 +267,28 @@ describe("getChangedFilesDetailed", () => {
     expect(noTrailing).toMatchObject({ status: "untracked", linesAdded: 3 });
   });
 
-  // Regression guard for the OOM in https://github.com/PostHog/code/issues/...
-  // (introduced in c617988f). Before the fix `countFileLines` read each
-  // untracked file's full content into memory, 16-way concurrent, with no
-  // size cap. On a monorepo with multi-MB build artifacts / lockfiles this
-  // exhausted the main-process V8 heap (~3GB+) and froze the renderer
-  // waiting on the dead tRPC call. The fix bails on files larger than
-  // COUNT_FILE_LINES_MAX_BYTES (1MB) and stream-counts the rest, so peak
-  // memory stays ~16 * 64KB regardless of file size.
-  it("skips line counting for files over the size cap", async () => {
+  // Regression guard for the OOM in #2218. Before the fix `countFileLines`
+  // read each untracked file's full content into memory via
+  // `fs.readFile(..., "utf-8")`, 16-way concurrent against every untracked
+  // path returned by `streamGitStatus` (up to 50k). On a monorepo with
+  // multi-MB build artifacts this exhausted the main-process V8 heap
+  // (`16 * file_bytes * 2` for V8's UTF-16) and froze the renderer waiting
+  // on the dead tRPC call. The fix stream-counts via `createReadStream`,
+  // so peak per-stream memory is ~64KB regardless of file size — the
+  // multi-MB case below would have OOM'd pre-fix and must still report an
+  // accurate line count.
+  it("stream-counts untracked files larger than the streaming chunk size", async () => {
     repoDir = await setupRepo();
-    const oneAndAHalfMB = "a\n".repeat(800_000);
-    await writeFile(path.join(repoDir, "huge.txt"), oneAndAHalfMB);
+    const lineCount = 800_000; // ~1.6MB at 2 bytes/line, well over default 64KB chunk
+    const content = "a\n".repeat(lineCount);
+    await writeFile(path.join(repoDir, "huge.txt"), content);
 
     const files = await getChangedFilesDetailed(repoDir);
     const huge = files.find((f) => f.path === "huge.txt");
 
-    expect(huge).toMatchObject({ status: "untracked", linesAdded: 0 });
+    expect(huge).toMatchObject({
+      status: "untracked",
+      linesAdded: lineCount,
+    });
   });
 });

--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -6,6 +6,7 @@ import { createGitClient } from "./client";
 import {
   detectDefaultBranch,
   getBranchDiffPatchesByPath,
+  getChangedFilesDetailed,
   splitUnifiedDiffByFile,
 } from "./queries";
 
@@ -240,5 +241,48 @@ describe("getBranchDiffPatchesByPath", () => {
     } finally {
       await rm(remoteDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("getChangedFilesDetailed", () => {
+  let repoDir: string;
+
+  afterEach(async () => {
+    if (repoDir) {
+      await rm(repoDir, { recursive: true, force: true });
+      repoDir = "";
+    }
+  });
+
+  it("reports line counts for small untracked files", async () => {
+    repoDir = await setupRepo();
+    await writeFile(path.join(repoDir, "small.txt"), "a\nb\nc\n");
+    await writeFile(path.join(repoDir, "no-trailing.txt"), "a\nb\nc");
+
+    const files = await getChangedFilesDetailed(repoDir);
+    const small = files.find((f) => f.path === "small.txt");
+    const noTrailing = files.find((f) => f.path === "no-trailing.txt");
+
+    expect(small).toMatchObject({ status: "untracked", linesAdded: 3 });
+    expect(noTrailing).toMatchObject({ status: "untracked", linesAdded: 3 });
+  });
+
+  // Regression guard for the OOM in https://github.com/PostHog/code/issues/...
+  // (introduced in c617988f). Before the fix `countFileLines` read each
+  // untracked file's full content into memory, 16-way concurrent, with no
+  // size cap. On a monorepo with multi-MB build artifacts / lockfiles this
+  // exhausted the main-process V8 heap (~3GB+) and froze the renderer
+  // waiting on the dead tRPC call. The fix bails on files larger than
+  // COUNT_FILE_LINES_MAX_BYTES (1MB) and stream-counts the rest, so peak
+  // memory stays ~16 * 64KB regardless of file size.
+  it("skips line counting for files over the size cap", async () => {
+    repoDir = await setupRepo();
+    const oneAndAHalfMB = "a\n".repeat(800_000);
+    await writeFile(path.join(repoDir, "huge.txt"), oneAndAHalfMB);
+
+    const files = await getChangedFilesDetailed(repoDir);
+    const huge = files.find((f) => f.path === "huge.txt");
+
+    expect(huge).toMatchObject({ status: "untracked", linesAdded: 0 });
   });
 });

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -1,3 +1,4 @@
+import { createReadStream } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { CreateGitClientOptions } from "./client";
@@ -413,11 +414,33 @@ function matchesExcludePattern(filePath: string, patterns: string[]): boolean {
   });
 }
 
+const COUNT_FILE_LINES_MAX_BYTES = 1 * 1024 * 1024;
+
 async function countFileLines(filePath: string): Promise<number> {
   try {
-    const content = await fs.readFile(filePath, "utf-8");
-    if (!content) return 0;
-    return content.split("\n").length - (content.endsWith("\n") ? 1 : 0);
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile() || stat.size === 0) return 0;
+    if (stat.size > COUNT_FILE_LINES_MAX_BYTES) return 0;
+    return await new Promise<number>((resolve) => {
+      let newlines = 0;
+      let lastByte = -1;
+      const stream = createReadStream(filePath);
+      stream.on("data", (chunk) => {
+        const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+        for (let i = 0; i < buf.length; i++) {
+          if (buf[i] === 0x0a) newlines++;
+        }
+        if (buf.length > 0) lastByte = buf[buf.length - 1];
+      });
+      stream.on("end", () => {
+        if (lastByte === -1) {
+          resolve(0);
+          return;
+        }
+        resolve(lastByte === 0x0a ? newlines : newlines + 1);
+      });
+      stream.on("error", () => resolve(0));
+    });
   } catch {
     return 0;
   }

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -414,29 +414,54 @@ function matchesExcludePattern(filePath: string, patterns: string[]): boolean {
   });
 }
 
-async function countFileLines(filePath: string): Promise<number> {
+async function countFileLines(
+  filePath: string,
+  options?: { signal?: AbortSignal },
+): Promise<number> {
   try {
-    const stat = await fs.stat(filePath);
+    // `lstat` instead of `stat` so an untracked symlink (rare, but legal)
+    // pointing at /dev/zero or a path outside the workdir doesn't stream
+    // forever — symlinks fail `isFile()` and short-circuit to 0.
+    const stat = await fs.lstat(filePath);
     if (!stat.isFile() || stat.size === 0) return 0;
     return await new Promise<number>((resolve) => {
       let newlines = 0;
       let lastByte = -1;
-      const stream = createReadStream(filePath);
-      stream.on("data", (chunk) => {
-        const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
-        for (let i = 0; i < buf.length; i++) {
-          if (buf[i] === 0x0a) newlines++;
+      const stream = createReadStream(filePath, { signal: options?.signal });
+      stream.on("data", (rawChunk) => {
+        // Node types stream chunks as `string | Buffer`; without an
+        // `encoding` option `createReadStream` always emits `Buffer`,
+        // so the cast is for the type checker, not the runtime.
+        const chunk = rawChunk as Buffer;
+        // Native `Buffer.indexOf` — ~10x faster than a per-byte JS loop
+        // on multi-MB buffers, which is the workload this whole function
+        // exists to handle.
+        for (
+          let idx = chunk.indexOf(0x0a);
+          idx !== -1;
+          idx = chunk.indexOf(0x0a, idx + 1)
+        ) {
+          newlines++;
         }
-        if (buf.length > 0) lastByte = buf[buf.length - 1];
+        if (chunk.length > 0) lastByte = chunk[chunk.length - 1];
       });
       stream.on("end", () => {
+        // Guards against TOCTOU truncation between lstat and read —
+        // size > 0 at stat time, zero bytes by the time we open.
         if (lastByte === -1) {
           resolve(0);
           return;
         }
         resolve(lastByte === 0x0a ? newlines : newlines + 1);
       });
-      stream.on("error", () => resolve(0));
+      stream.on("error", (err) => {
+        // Don't propagate — caller already treats any failure as 0 lines.
+        // But log so the next time a "shows 0 lines" mystery shows up
+        // there's a breadcrumb (the original OOM in #2218 hid behind the
+        // same silent-zero return).
+        console.warn(`countFileLines failed for ${filePath}:`, err);
+        resolve(0);
+      });
     });
   } catch {
     return 0;
@@ -447,12 +472,14 @@ async function mapWithConcurrency<T, R>(
   items: readonly T[],
   concurrency: number,
   mapper: (item: T) => Promise<R>,
+  options?: { signal?: AbortSignal },
 ): Promise<R[]> {
   if (items.length === 0) return [];
   const results = new Array<R>(items.length);
   let index = 0;
   const worker = async () => {
     while (index < items.length) {
+      if (options?.signal?.aborted) return;
       const i = index++;
       results[i] = await mapper(items[i]);
     }
@@ -541,7 +568,11 @@ export async function getChangedFilesDetailed(
         const untrackedLineCounts = await mapWithConcurrency(
           untrackedToCount,
           16,
-          (file) => countFileLines(path.join(baseDir, file)),
+          (file) =>
+            countFileLines(path.join(baseDir, file), {
+              signal: gitOptions?.abortSignal,
+            }),
+          { signal: gitOptions?.abortSignal },
         );
         for (let i = 0; i < untrackedToCount.length; i++) {
           files.push({

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -414,13 +414,10 @@ function matchesExcludePattern(filePath: string, patterns: string[]): boolean {
   });
 }
 
-const COUNT_FILE_LINES_MAX_BYTES = 1 * 1024 * 1024;
-
 async function countFileLines(filePath: string): Promise<number> {
   try {
     const stat = await fs.stat(filePath);
     if (!stat.isFile() || stat.size === 0) return 0;
-    if (stat.size > COUNT_FILE_LINES_MAX_BYTES) return 0;
     return await new Promise<number>((resolve) => {
       let newlines = 0;
       let lastByte = -1;


### PR DESCRIPTION
Fixes an OOM in the main process that freezes the app a few seconds after the sidebar paints, on accounts whose selected directory is a monorepo with large untracked files (lockfiles, build artifacts, source maps). `countFileLines` was reading each file's full contents into V8 memory via `fs.readFile`, run 16-way concurrent against tens of thousands of paths — a single big file in any of the 16 in-flight reads could push the heap past 4 GB and crash main. Now we stream-count `\n` bytes with `createReadStream`, so peak per-stream memory is ~64 KB regardless of file size and the 16-way batch stays bounded around 1 MB total.

## Problem

- `countFileLines` in `packages/git/src/queries.ts` was reading each untracked file fully into memory via `fs.readFile(filePath, "utf-8")`, and the caller (`getChangedFilesDetailed`) runs it 16-way concurrent against up to 50k untracked paths from `streamGitStatus`.
- On a monorepo with multi-MB build artifacts, lockfiles, or other large untracked files, peak heap was `16 × file_bytes × 2` (V8's UTF-16 cost). That blew past Electron's 4 GB main-process heap on real-world repos and OOM'd the main process. The renderer appeared frozen ~2–3 s after the sidebar painted because all its in-flight tRPC calls were waiting on a dead main. Symptom in chromium.log was a silent `OOM error in V8: Scavenger: semi-space copy Allocation failed`, with no `[ipc-rate]` warning before it (no IPC storm — just main quietly running out of heap).
- Regression introduced by #2113 (c617988f), which removed the previous 10k-file cap and switched to concurrent reads when migrating to `streamGitStatus`. Bisected on a freshly-onboarded data dir pointed at this monorepo.

## Fix

- Stream the file with `createReadStream` (64 KB highWaterMark) and count `\n` bytes byte-by-byte. Per-stream memory stays at ~64 KB regardless of file size, so peak across 16 concurrent reads is ~1 MB total — well under any heap pressure threshold.
- Preserves the original return semantics: trailing-newline-aware count, 0 for empty / non-regular files / errors.
- No artificial file-size cap — every untracked file gets an accurate line count. (An earlier version of this PR gated at 1 MB, which silently returned `linesAdded: 0` for any larger file. That's a correctness regression and the streaming alone is already enough to fix the OOM, so the cap was dropped in the follow-up commit.)

## Test plan

- [x] `pnpm --filter @posthog/git test src/queries.test.ts` — new `getChangedFilesDetailed` tests pass (small-file accuracy + correct counting of a multi-MB untracked file that previously OOM'd)
- [x] `pnpm --filter code typecheck`
- [x] `pnpm dev` against a fresh data dir pointed at this monorepo — previously OOM'd within ~3 s of `MainSidebar` paint, now stays responsive
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)