### PR TITLE
fix(code): sharper hedgehog rendering on Retina displays

### DIFF
--- a/patches/@posthog__hedgehog-mode.patch
+++ b/patches/@posthog__hedgehog-mode.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/index-BBpNRJEB.js b/dist/index-BBpNRJEB.js
+--- a/dist/index-BBpNRJEB.js
++++ b/dist/index-BBpNRJEB.js
+@@ -29183,7 +29183,7 @@
+     );
+   }
+   loadSpriteFrames(e) {
+-    this.sprite = new gh(e), this.loadRigidBody(), this.sprite.eventMode = "static", this.sprite.texture.source.scaleMode = "nearest", this.sprite.play(), this.sprite.anchor.set(0.5), this.sprite.x = this.rigidBody.position.x, this.sprite.y = this.rigidBody.position.y, this.game.app.stage.addChild(this.sprite), this.setupPointerEvents();
++    this.sprite = new gh(e), this.loadRigidBody(), this.sprite.eventMode = "static", this.sprite.texture.source.scaleMode = "linear", this.sprite.play(), this.sprite.anchor.set(0.5), this.sprite.x = this.rigidBody.position.x, this.sprite.y = this.rigidBody.position.y, this.game.app.stage.addChild(this.sprite), this.setupPointerEvents();
+   }
+   loadRigidBody(e = !1) {
+     let t = window.innerWidth / 2, r = window.innerHeight / 2;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  '@posthog/hedgehog-mode':
+    hash: 6218f5ec7306fd59ad8d5c0f66ca030d406197739da485953f6737e7911da148
+    path: patches/@posthog__hedgehog-mode.patch
   node-pty:
     hash: 4dfdf785f5ac51a03f5d6032371cebe89036381acd403621f250a896245647c5
     path: patches/node-pty.patch
@@ -171,7 +174,7 @@ importers:
         version: link:../../packages/git
       '@posthog/hedgehog-mode':
         specifier: ^0.0.48
-        version: 0.0.48(prop-types@15.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 0.0.48(patch_hash=6218f5ec7306fd59ad8d5c0f66ca030d406197739da485953f6737e7911da148)(prop-types@15.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@posthog/platform':
         specifier: workspace:*
         version: link:../../packages/platform
@@ -15269,7 +15272,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/hedgehog-mode@0.0.48(prop-types@15.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@posthog/hedgehog-mode@0.0.48(patch_hash=6218f5ec7306fd59ad8d5c0f66ca030d406197739da485953f6737e7911da148)(prop-types@15.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       gsap: 3.14.2
       lodash: 4.17.23

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,4 @@ onlyBuiltDependencies:
 
 patchedDependencies:
   node-pty: patches/node-pty.patch
+  '@posthog/hedgehog-mode': patches/@posthog__hedgehog-mode.patch


### PR DESCRIPTION
## Summary
- Patch `@posthog/hedgehog-mode` to use `linear` instead of `nearest` texture sampling on sprite sources.
- On Retina (DPR=2) displays, Pixi's backing buffer is 2x while the source sprites are 80x80, so `nearest` sampling rendered each texel as a chunky 2x2 block. Linear sampling interpolates, giving a smoother result.
- Registered under `patchedDependencies` in `pnpm-workspace.yaml`; verified the patch applies cleanly on `pnpm install`.

## Tradeoff
This trades the pixel-art crispness for slight softness. If we want to keep the pixel-art aesthetic, the alternative is shipping 2x source sprites upstream.

## Test plan
- [ ] On a MacBook Pro Retina display, enable hedgehog mode under Settings → Fun and confirm the hedgehog is no longer blocky.
- [ ] On a standard-DPI display, confirm rendering still looks reasonable.

Generated-By: PostHog Code
Task-Id: 9a2867a2-c109-474c-a88b-393a2023e9f3