### PR TITLE
feat: add MCP apps sidebar to task threads

### DIFF
--- a/apps/code/src/renderer/App.tsx
+++ b/apps/code/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import {
 } from "@features/auth/hooks/authQueries";
 import { useAuthSession } from "@features/auth/hooks/useAuthSession";
 import { useIsOrgAdmin } from "@features/auth/hooks/useOrgRole";
+import { useMcpUiToolsSubscription } from "@features/mcp-apps/hooks/useMcpUiToolsSubscription";
 import { OnboardingFlow } from "@features/onboarding/components/OnboardingFlow";
 import { useOnboardingStore } from "@features/onboarding/stores/onboardingStore";
 import { Flex, Spinner, Text } from "@radix-ui/themes";
@@ -147,6 +148,9 @@ function App() {
       },
     }),
   );
+
+  // Keep the MCP UI tool registry up to date across all sessions.
+  useMcpUiToolsSubscription();
 
   // Auto-unfocus when user manually checks out to a different branch
   useSubscription(

--- a/apps/code/src/renderer/features/mcp-apps/hooks/useMcpUiToolsSubscription.ts
+++ b/apps/code/src/renderer/features/mcp-apps/hooks/useMcpUiToolsSubscription.ts
@@ -1,0 +1,16 @@
+import { useMcpUiToolsStore } from "@features/mcp-apps/stores/mcpUiToolsStore";
+import { useTRPC } from "@renderer/trpc/client";
+import { useSubscription } from "@trpc/tanstack-react-query";
+
+export function useMcpUiToolsSubscription(): void {
+  const trpcReact = useTRPC();
+  const setToolKeys = useMcpUiToolsStore((s) => s.setToolKeys);
+
+  useSubscription(
+    trpcReact.mcpApps.onDiscoveryComplete.subscriptionOptions(undefined, {
+      onData: (event) => {
+        setToolKeys(event.toolKeys);
+      },
+    }),
+  );
+}

--- a/apps/code/src/renderer/features/mcp-apps/stores/mcpUiToolsStore.ts
+++ b/apps/code/src/renderer/features/mcp-apps/stores/mcpUiToolsStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface McpUiToolsState {
+  toolKeys: Set<string>;
+  isReady: boolean;
+  setToolKeys: (keys: readonly string[]) => void;
+}
+
+export const useMcpUiToolsStore = create<McpUiToolsState>((set) => ({
+  toolKeys: new Set<string>(),
+  isReady: false,
+  setToolKeys: (keys) => set({ toolKeys: new Set(keys), isReady: true }),
+}));

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -168,6 +168,8 @@ export function ConversationView({
       // Only list tools that have a registered UI (true MCP apps).
       if (!mcpUiToolKeys.has(fullToolName)) continue;
 
+      const merged = item.turnContext.toolCalls?.get(update.toolCallId);
+      const toolCall = merged ?? update;
       const { serverName, toolName } = parseMcpToolKey(fullToolName);
       entries.push({
         itemIndex: i,
@@ -175,9 +177,9 @@ export function ConversationView({
         fullToolName,
         serverName,
         toolName,
-        title: update.title,
-        inputPreview: buildInputPreview(update.rawInput),
-        status: update.status ?? null,
+        title: toolCall.title,
+        status: toolCall.status ?? null,
+        toolCall,
       });
     }
     return { mcpAppIndices: indices, mcpEntries: entries };
@@ -347,22 +349,6 @@ export function ConversationView({
       </Flex>
     </WorkerPoolContextProvider>
   );
-}
-
-function buildInputPreview(rawInput: unknown): string | undefined {
-  if (rawInput == null || typeof rawInput !== "object") return undefined;
-  const entries = Object.entries(rawInput as Record<string, unknown>);
-  if (entries.length === 0) return undefined;
-  const [key, value] = entries[0];
-  const formatted =
-    typeof value === "string"
-      ? value
-      : typeof value === "number" || typeof value === "boolean"
-        ? String(value)
-        : JSON.stringify(value);
-  const compact = formatted.replace(/\s+/g, " ").trim();
-  const truncated = compact.length > 60 ? `${compact.slice(0, 60)}…` : compact;
-  return `${key}: ${truncated}`;
 }
 
 const SessionUpdateRow = memo(function SessionUpdateRow({

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -1,6 +1,13 @@
+import { useMcpUiToolsStore } from "@features/mcp-apps/stores/mcpUiToolsStore";
+import { parseMcpToolKey } from "@features/mcp-apps/utils/mcp-app-host-utils";
+import {
+  type McpAppEntry,
+  McpAppsSidebar,
+} from "@features/sessions/components/McpAppsSidebar";
 import { CHAT_CONTENT_MAX_WIDTH } from "@features/sessions/constants";
 import { useContextUsage } from "@features/sessions/hooks/useContextUsage";
 import { useConversationSearch } from "@features/sessions/hooks/useConversationSearch";
+import { useMcpAppsSidebarStore } from "@features/sessions/stores/mcpAppsSidebarStore";
 import {
   sessionStoreSetters,
   useOptimisticItemsForTask,
@@ -136,24 +143,45 @@ export function ConversationView({
     [conversationItems, optimisticItems, queuedItems, isCloud],
   );
 
-  // Keep MCP App tool call items mounted so their iframes and bridges
-  // survive scrolling out of the virtualized viewport.
-  const mcpAppIndices = useMemo(() => {
+  const mcpUiToolKeys = useMcpUiToolsStore((s) => s.toolKeys);
+
+  // Single pass over items: collect indices for keepMounted (so iframes
+  // survive scrolling out of the virtualized viewport) and structured
+  // entries for the MCP apps sidebar.
+  const { mcpAppIndices, mcpEntries } = useMemo(() => {
     const indices: number[] = [];
+    const entries: McpAppEntry[] = [];
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
       if (item.type !== "session_update") continue;
       const update = item.update;
+      if (update.sessionUpdate !== "tool_call") continue;
       if (!("_meta" in update)) continue;
       const meta = update._meta as
         | { claudeCode?: { toolName?: string } }
         | undefined;
-      if (meta?.claudeCode?.toolName?.startsWith("mcp__")) {
-        indices.push(i);
-      }
+      const fullToolName = meta?.claudeCode?.toolName;
+      if (!fullToolName?.startsWith("mcp__")) continue;
+
+      indices.push(i);
+
+      // Only list tools that have a registered UI (true MCP apps).
+      if (!mcpUiToolKeys.has(fullToolName)) continue;
+
+      const { serverName, toolName } = parseMcpToolKey(fullToolName);
+      entries.push({
+        itemIndex: i,
+        toolCallId: update.toolCallId,
+        fullToolName,
+        serverName,
+        toolName,
+        title: update.title,
+        inputPreview: buildInputPreview(update.rawInput),
+        status: update.status ?? null,
+      });
     }
-    return indices;
-  }, [items]);
+    return { mcpAppIndices: indices, mcpEntries: entries };
+  }, [items, mcpUiToolKeys]);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const search = useConversationSearch({ items, containerRef, listRef });
@@ -244,71 +272,97 @@ export function ConversationView({
 
   const getItemKey = useCallback((item: ConversationItem) => item.id, []);
 
+  const isMcpSidebarOpen = useMcpAppsSidebarStore((s) => s.open);
+  const scrollToMcpItem = useCallback((itemIndex: number) => {
+    listRef.current?.scrollToIndex(itemIndex);
+  }, []);
+
   return (
     <WorkerPoolContextProvider
       poolOptions={DIFFS_POOL_OPTIONS}
       highlighterOptions={DIFFS_HIGHLIGHTER_OPTIONS}
     >
-      <div ref={containerRef} className="relative flex-1">
-        <div
-          id="fullscreen-portal"
-          className="pointer-events-none absolute inset-0 z-20"
-        />
-        {search.open && (
-          <ConversationSearchBar
-            ref={search.searchBarRef}
-            query={search.query}
-            currentMatch={search.currentIndex}
-            totalMatches={search.totalMatches}
-            onQueryChange={search.setQuery}
-            onNext={search.next}
-            onPrev={search.prev}
-            onClose={search.close}
+      <Flex className="h-full min-h-0 flex-1">
+        <div ref={containerRef} className="relative min-w-0 flex-1">
+          <div
+            id="fullscreen-portal"
+            className="pointer-events-none absolute inset-0 z-20"
           />
-        )}
+          {search.open && (
+            <ConversationSearchBar
+              ref={search.searchBarRef}
+              query={search.query}
+              currentMatch={search.currentIndex}
+              totalMatches={search.totalMatches}
+              onQueryChange={search.setQuery}
+              onNext={search.next}
+              onPrev={search.prev}
+              onClose={search.close}
+            />
+          )}
 
-        <VirtualizedList
-          ref={listRef}
-          items={items}
-          getItemKey={getItemKey}
-          renderItem={renderItem}
-          onScrollStateChange={handleScrollStateChange}
-          keepMounted={mcpAppIndices}
-          className="absolute inset-0 bg-background"
-          itemClassName="mx-auto px-2 py-1.5"
-          itemStyle={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
-          footer={
-            <div className={compact ? "pb-1" : "pb-16"}>
-              <SessionFooter
-                task={task}
-                isPromptPending={isPromptPending}
-                promptStartedAt={promptStartedAt}
-                lastGenerationDuration={
-                  lastTurnInfo?.isComplete
-                    ? Math.max(0, lastTurnInfo.durationMs - pausedDurationMs)
-                    : null
-                }
-                lastStopReason={lastTurnInfo?.stopReason}
-                queuedCount={queuedMessages.length}
-                hasPendingPermission={pendingPermissionsCount > 0}
-                pausedDurationMs={pausedDurationMs}
-                isCompacting={isCompacting}
-                usage={contextUsage}
-              />
-            </div>
-          }
-        />
-        {showScrollButton && (
-          <Box className="absolute right-4 bottom-4 z-10">
-            <Button size="1" variant="solid" onClick={scrollToBottom}>
-              <ArrowDown size={14} weight="bold" />
-              Scroll to bottom
-            </Button>
-          </Box>
+          <VirtualizedList
+            ref={listRef}
+            items={items}
+            getItemKey={getItemKey}
+            renderItem={renderItem}
+            onScrollStateChange={handleScrollStateChange}
+            keepMounted={mcpAppIndices}
+            className="absolute inset-0 bg-background"
+            itemClassName="mx-auto px-2 py-1.5"
+            itemStyle={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
+            footer={
+              <div className={compact ? "pb-1" : "pb-16"}>
+                <SessionFooter
+                  task={task}
+                  isPromptPending={isPromptPending}
+                  promptStartedAt={promptStartedAt}
+                  lastGenerationDuration={
+                    lastTurnInfo?.isComplete
+                      ? Math.max(0, lastTurnInfo.durationMs - pausedDurationMs)
+                      : null
+                  }
+                  lastStopReason={lastTurnInfo?.stopReason}
+                  queuedCount={queuedMessages.length}
+                  hasPendingPermission={pendingPermissionsCount > 0}
+                  pausedDurationMs={pausedDurationMs}
+                  isCompacting={isCompacting}
+                  usage={contextUsage}
+                />
+              </div>
+            }
+          />
+          {showScrollButton && (
+            <Box className="absolute right-4 bottom-4 z-10">
+              <Button size="1" variant="solid" onClick={scrollToBottom}>
+                <ArrowDown size={14} weight="bold" />
+                Scroll to bottom
+              </Button>
+            </Box>
+          )}
+        </div>
+        {isMcpSidebarOpen && (
+          <McpAppsSidebar entries={mcpEntries} onSelect={scrollToMcpItem} />
         )}
-      </div>
+      </Flex>
     </WorkerPoolContextProvider>
   );
+}
+
+function buildInputPreview(rawInput: unknown): string | undefined {
+  if (rawInput == null || typeof rawInput !== "object") return undefined;
+  const entries = Object.entries(rawInput as Record<string, unknown>);
+  if (entries.length === 0) return undefined;
+  const [key, value] = entries[0];
+  const formatted =
+    typeof value === "string"
+      ? value
+      : typeof value === "number" || typeof value === "boolean"
+        ? String(value)
+        : JSON.stringify(value);
+  const compact = formatted.replace(/\s+/g, " ").trim();
+  const truncated = compact.length > 60 ? `${compact.slice(0, 60)}…` : compact;
+  return `${key}: ${truncated}`;
 }
 
 const SessionUpdateRow = memo(function SessionUpdateRow({

--- a/apps/code/src/renderer/features/sessions/components/McpAppsSidebar.tsx
+++ b/apps/code/src/renderer/features/sessions/components/McpAppsSidebar.tsx
@@ -1,7 +1,7 @@
-import { Tooltip } from "@components/ui/Tooltip";
+import { McpAppHost } from "@features/mcp-apps/components/McpAppHost";
 import { useMcpAppsSidebarStore } from "@features/sessions/stores/mcpAppsSidebarStore";
-import type { ToolCallStatus } from "@features/sessions/types";
-import { X } from "@phosphor-icons/react";
+import type { ToolCall, ToolCallStatus } from "@features/sessions/types";
+import { ArrowSquareOut, X } from "@phosphor-icons/react";
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { useCallback, useEffect, useRef } from "react";
 
@@ -12,8 +12,8 @@ export interface McpAppEntry {
   serverName: string;
   toolName: string;
   title?: string;
-  inputPreview?: string;
   status?: ToolCallStatus | null;
+  toolCall: ToolCall;
 }
 
 interface McpAppsSidebarProps {
@@ -21,8 +21,8 @@ interface McpAppsSidebarProps {
   onSelect: (itemIndex: number) => void;
 }
 
-const MIN_WIDTH = 200;
-const MAX_WIDTH = 480;
+const MIN_WIDTH = 280;
+const MAX_WIDTH = 720;
 
 export function McpAppsSidebar({ entries, onSelect }: McpAppsSidebarProps) {
   const width = useMcpAppsSidebarStore((s) => s.width);
@@ -117,12 +117,12 @@ export function McpAppsSidebar({ entries, onSelect }: McpAppsSidebarProps) {
               </Text>
             </Flex>
           ) : (
-            <Flex direction="column" className="py-1">
+            <Flex direction="column" gap="3" className="p-3">
               {entries.map((entry) => (
-                <McpAppRow
+                <McpAppCard
                   key={entry.toolCallId}
                   entry={entry}
-                  onClick={() => onSelect(entry.itemIndex)}
+                  onJump={() => onSelect(entry.itemIndex)}
                 />
               ))}
             </Flex>
@@ -133,32 +133,48 @@ export function McpAppsSidebar({ entries, onSelect }: McpAppsSidebarProps) {
   );
 }
 
-function McpAppRow({
+function McpAppCard({
   entry,
-  onClick,
+  onJump,
 }: {
   entry: McpAppEntry;
-  onClick: () => void;
+  onJump: () => void;
 }) {
   const label = entry.title?.trim() || entry.toolName || entry.fullToolName;
-  const subtitle = entry.inputPreview;
   return (
-    <Tooltip content={label} side="left" delayDuration={400}>
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-(--gray-12) text-[13px] transition-colors hover:bg-(--gray-3) focus:bg-(--gray-3) focus:outline-none"
+    <Box className="overflow-hidden rounded-(--radius-2) border border-(--gray-5) bg-(--gray-1)">
+      <Flex
+        align="center"
+        gap="2"
+        className="border-(--gray-5) border-b px-2 py-1.5"
       >
         <StatusDot status={entry.status ?? null} />
         <Flex direction="column" className="min-w-0 flex-1">
-          <Text className="truncate text-(--gray-12) text-[13px]">{label}</Text>
+          <Text className="truncate text-(--gray-12) text-[12px]">{label}</Text>
           <Text className="truncate text-(--gray-9) text-[11px]">
-            {entry.serverName}
-            {subtitle ? ` · ${subtitle}` : ""}
+            {entry.serverName} · {entry.toolName}
           </Text>
         </Flex>
-      </button>
-    </Tooltip>
+        <IconButton
+          size="1"
+          variant="ghost"
+          color="gray"
+          aria-label="Jump to in conversation"
+          title="Jump to in conversation"
+          onClick={onJump}
+        >
+          <ArrowSquareOut size={12} />
+        </IconButton>
+      </Flex>
+      <Box className="p-2">
+        <McpAppHost
+          toolCall={entry.toolCall}
+          mcpToolName={entry.fullToolName}
+          serverName={entry.serverName}
+          toolName={entry.toolName}
+        />
+      </Box>
+    </Box>
   );
 }
 

--- a/apps/code/src/renderer/features/sessions/components/McpAppsSidebar.tsx
+++ b/apps/code/src/renderer/features/sessions/components/McpAppsSidebar.tsx
@@ -1,0 +1,180 @@
+import { Tooltip } from "@components/ui/Tooltip";
+import { useMcpAppsSidebarStore } from "@features/sessions/stores/mcpAppsSidebarStore";
+import type { ToolCallStatus } from "@features/sessions/types";
+import { X } from "@phosphor-icons/react";
+import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
+import { useCallback, useEffect, useRef } from "react";
+
+export interface McpAppEntry {
+  itemIndex: number;
+  toolCallId: string;
+  fullToolName: string;
+  serverName: string;
+  toolName: string;
+  title?: string;
+  inputPreview?: string;
+  status?: ToolCallStatus | null;
+}
+
+interface McpAppsSidebarProps {
+  entries: readonly McpAppEntry[];
+  onSelect: (itemIndex: number) => void;
+}
+
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 480;
+
+export function McpAppsSidebar({ entries, onSelect }: McpAppsSidebarProps) {
+  const width = useMcpAppsSidebarStore((s) => s.width);
+  const setWidth = useMcpAppsSidebarStore((s) => s.setWidth);
+  const setOpen = useMcpAppsSidebarStore((s) => s.setOpen);
+  const isResizing = useMcpAppsSidebarStore((s) => s.isResizing);
+  const setIsResizing = useMcpAppsSidebarStore((s) => s.setIsResizing);
+
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(width);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      startXRef.current = e.clientX;
+      startWidthRef.current = width;
+      setIsResizing(true);
+    },
+    [width, setIsResizing],
+  );
+
+  useEffect(() => {
+    if (!isResizing) return;
+    const onMouseMove = (e: MouseEvent) => {
+      const delta = startXRef.current - e.clientX;
+      const next = Math.min(
+        MAX_WIDTH,
+        Math.max(MIN_WIDTH, startWidthRef.current + delta),
+      );
+      setWidth(next);
+    };
+    const onMouseUp = () => {
+      setIsResizing(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+  }, [isResizing, setIsResizing, setWidth]);
+
+  return (
+    <>
+      <Box
+        onMouseDown={handleResizeStart}
+        className="z-[1] w-[4px] shrink-0 cursor-col-resize border-l border-l-(--gray-6) bg-transparent transition-colors hover:bg-accent-6 active:bg-accent-8"
+      />
+      <Box
+        style={{ width: `${width}px` }}
+        className="flex h-full shrink-0 flex-col bg-background"
+      >
+        <Flex
+          align="center"
+          justify="between"
+          gap="2"
+          className="border-(--gray-5) border-b px-3 py-2"
+        >
+          <Flex align="center" gap="2" className="min-w-0">
+            <Text className="truncate font-medium text-(--gray-12) text-[13px]">
+              MCP apps
+            </Text>
+            {entries.length > 0 && (
+              <Text className="text-(--gray-9) text-[12px]">
+                {entries.length}
+              </Text>
+            )}
+          </Flex>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            aria-label="Close MCP apps sidebar"
+            onClick={() => setOpen(false)}
+          >
+            <X size={14} weight="bold" />
+          </IconButton>
+        </Flex>
+        <Box className="min-h-0 flex-1 overflow-y-auto">
+          {entries.length === 0 ? (
+            <Flex
+              align="center"
+              justify="center"
+              className="h-full px-4 text-center"
+            >
+              <Text className="text-(--gray-9) text-[12px]">
+                No MCP apps in this thread yet.
+              </Text>
+            </Flex>
+          ) : (
+            <Flex direction="column" className="py-1">
+              {entries.map((entry) => (
+                <McpAppRow
+                  key={entry.toolCallId}
+                  entry={entry}
+                  onClick={() => onSelect(entry.itemIndex)}
+                />
+              ))}
+            </Flex>
+          )}
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+function McpAppRow({
+  entry,
+  onClick,
+}: {
+  entry: McpAppEntry;
+  onClick: () => void;
+}) {
+  const label = entry.title?.trim() || entry.toolName || entry.fullToolName;
+  const subtitle = entry.inputPreview;
+  return (
+    <Tooltip content={label} side="left" delayDuration={400}>
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-(--gray-12) text-[13px] transition-colors hover:bg-(--gray-3) focus:bg-(--gray-3) focus:outline-none"
+      >
+        <StatusDot status={entry.status ?? null} />
+        <Flex direction="column" className="min-w-0 flex-1">
+          <Text className="truncate text-(--gray-12) text-[13px]">{label}</Text>
+          <Text className="truncate text-(--gray-9) text-[11px]">
+            {entry.serverName}
+            {subtitle ? ` · ${subtitle}` : ""}
+          </Text>
+        </Flex>
+      </button>
+    </Tooltip>
+  );
+}
+
+function StatusDot({ status }: { status: ToolCallStatus | null }) {
+  const color = (() => {
+    switch (status) {
+      case "in_progress":
+      case "pending":
+        return "bg-(--amber-9)";
+      case "failed":
+        return "bg-(--red-9)";
+      case "completed":
+        return "bg-(--green-9)";
+      default:
+        return "bg-(--gray-7)";
+    }
+  })();
+  return <span className={`block size-2 shrink-0 rounded-full ${color}`} />;
+}

--- a/apps/code/src/renderer/features/sessions/components/McpAppsSidebar.tsx
+++ b/apps/code/src/renderer/features/sessions/components/McpAppsSidebar.tsx
@@ -3,7 +3,7 @@ import { useMcpAppsSidebarStore } from "@features/sessions/stores/mcpAppsSidebar
 import type { ToolCall, ToolCallStatus } from "@features/sessions/types";
 import { ArrowSquareOut, X } from "@phosphor-icons/react";
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface McpAppEntry {
   itemIndex: number;
@@ -22,37 +22,69 @@ interface McpAppsSidebarProps {
 }
 
 const MIN_WIDTH = 280;
-const MAX_WIDTH = 720;
+const MIN_RATIO = 0.2;
+const MAX_RATIO = 0.8;
 
 export function McpAppsSidebar({ entries, onSelect }: McpAppsSidebarProps) {
-  const width = useMcpAppsSidebarStore((s) => s.width);
-  const setWidth = useMcpAppsSidebarStore((s) => s.setWidth);
+  const widthRatio = useMcpAppsSidebarStore((s) => s.widthRatio);
+  const setWidthRatio = useMcpAppsSidebarStore((s) => s.setWidthRatio);
   const setOpen = useMcpAppsSidebarStore((s) => s.setOpen);
   const isResizing = useMcpAppsSidebarStore((s) => s.isResizing);
   const setIsResizing = useMcpAppsSidebarStore((s) => s.setIsResizing);
 
+  const outerRef = useRef<HTMLDivElement>(null);
+  const [parentWidth, setParentWidth] = useState(0);
+
+  useEffect(() => {
+    const parent = outerRef.current?.parentElement;
+    if (!parent) return;
+    setParentWidth(parent.getBoundingClientRect().width);
+    const observer = new ResizeObserver((observed) => {
+      for (const entry of observed) {
+        setParentWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(parent);
+    return () => observer.disconnect();
+  }, []);
+
+  const ratioMin = parentWidth > 0 ? MIN_WIDTH / parentWidth : MIN_RATIO;
+  const effectiveRatio = Math.min(
+    MAX_RATIO,
+    Math.max(Math.min(ratioMin, MAX_RATIO), widthRatio),
+  );
+  const width =
+    parentWidth > 0
+      ? Math.round(parentWidth * effectiveRatio)
+      : Math.round(MIN_WIDTH);
+
   const startXRef = useRef(0);
   const startWidthRef = useRef(width);
+  const startParentWidthRef = useRef(parentWidth);
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       startXRef.current = e.clientX;
       startWidthRef.current = width;
+      startParentWidthRef.current = parentWidth;
       setIsResizing(true);
     },
-    [width, setIsResizing],
+    [width, parentWidth, setIsResizing],
   );
 
   useEffect(() => {
     if (!isResizing) return;
     const onMouseMove = (e: MouseEvent) => {
       const delta = startXRef.current - e.clientX;
-      const next = Math.min(
-        MAX_WIDTH,
-        Math.max(MIN_WIDTH, startWidthRef.current + delta),
+      const parent = startParentWidthRef.current;
+      if (parent <= 0) return;
+      const nextPx = startWidthRef.current + delta;
+      const nextRatio = Math.min(
+        MAX_RATIO,
+        Math.max(MIN_WIDTH / parent, nextPx / parent),
       );
-      setWidth(next);
+      setWidthRatio(nextRatio);
     };
     const onMouseUp = () => {
       setIsResizing(false);
@@ -67,7 +99,7 @@ export function McpAppsSidebar({ entries, onSelect }: McpAppsSidebarProps) {
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
     };
-  }, [isResizing, setIsResizing, setWidth]);
+  }, [isResizing, setIsResizing, setWidthRatio]);
 
   return (
     <>
@@ -76,6 +108,7 @@ export function McpAppsSidebar({ entries, onSelect }: McpAppsSidebarProps) {
         className="z-[1] w-[4px] shrink-0 cursor-col-resize border-l border-l-(--gray-6) bg-transparent transition-colors hover:bg-accent-6 active:bg-accent-8"
       />
       <Box
+        ref={outerRef}
         style={{ width: `${width}px` }}
         className="flex h-full shrink-0 flex-col bg-background"
       >

--- a/apps/code/src/renderer/features/sessions/stores/mcpAppsSidebarStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/mcpAppsSidebarStore.ts
@@ -2,6 +2,6 @@ import { createSidebarStore } from "@stores/createSidebarStore";
 
 export const useMcpAppsSidebarStore = createSidebarStore({
   name: "mcp-apps-sidebar-storage",
-  defaultWidth: 260,
+  defaultWidth: 380,
   defaultOpen: false,
 });

--- a/apps/code/src/renderer/features/sessions/stores/mcpAppsSidebarStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/mcpAppsSidebarStore.ts
@@ -1,0 +1,7 @@
+import { createSidebarStore } from "@stores/createSidebarStore";
+
+export const useMcpAppsSidebarStore = createSidebarStore({
+  name: "mcp-apps-sidebar-storage",
+  defaultWidth: 260,
+  defaultOpen: false,
+});

--- a/apps/code/src/renderer/features/sessions/stores/mcpAppsSidebarStore.ts
+++ b/apps/code/src/renderer/features/sessions/stores/mcpAppsSidebarStore.ts
@@ -1,7 +1,30 @@
-import { createSidebarStore } from "@stores/createSidebarStore";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
-export const useMcpAppsSidebarStore = createSidebarStore({
-  name: "mcp-apps-sidebar-storage",
-  defaultWidth: 380,
-  defaultOpen: false,
-});
+interface McpAppsSidebarState {
+  open: boolean;
+  widthRatio: number;
+  isResizing: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  setWidthRatio: (ratio: number) => void;
+  setIsResizing: (isResizing: boolean) => void;
+}
+
+export const useMcpAppsSidebarStore = create<McpAppsSidebarState>()(
+  persist(
+    (set) => ({
+      open: false,
+      widthRatio: 0.5,
+      isResizing: false,
+      setOpen: (open) => set({ open }),
+      toggle: () => set((s) => ({ open: !s.open })),
+      setWidthRatio: (widthRatio) => set({ widthRatio }),
+      setIsResizing: (isResizing) => set({ isResizing }),
+    }),
+    {
+      name: "mcp-apps-sidebar-storage-v2",
+      partialize: (s) => ({ open: s.open, widthRatio: s.widthRatio }),
+    },
+  ),
+);

--- a/apps/code/src/renderer/features/task-detail/components/McpAppsToggleButton.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/McpAppsToggleButton.tsx
@@ -1,0 +1,30 @@
+import { Tooltip } from "@components/ui/Tooltip";
+import { useMcpAppsSidebarStore } from "@features/sessions/stores/mcpAppsSidebarStore";
+import { SquaresFour } from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
+
+const ICON_SIZE = 18;
+
+export function McpAppsToggleButton() {
+  const open = useMcpAppsSidebarStore((s) => s.open);
+  const toggle = useMcpAppsSidebarStore((s) => s.toggle);
+
+  return (
+    <Tooltip
+      content={open ? "Hide MCP apps" : "Show MCP apps"}
+      side="bottom"
+      delayDuration={300}
+    >
+      <Button
+        size="icon-sm"
+        variant="outline"
+        aria-label={open ? "Hide MCP apps sidebar" : "Show MCP apps sidebar"}
+        aria-pressed={open}
+        onClick={toggle}
+        className="no-drag"
+      >
+        <SquaresFour size={ICON_SIZE} weight="regular" />
+      </Button>
+    </Tooltip>
+  );
+}

--- a/apps/code/src/renderer/features/task-detail/components/TaskDetail.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskDetail.tsx
@@ -27,8 +27,8 @@ import { logger } from "@utils/logger";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys, useHotkeysContext } from "react-hotkeys-hook";
 import { ExternalAppsOpener } from "./ExternalAppsOpener";
-
 import { HeaderTitleEditor } from "./HeaderTitleEditor";
+import { McpAppsToggleButton } from "./McpAppsToggleButton";
 
 const MIN_REVIEW_WIDTH = 300;
 const log = logger.scope("task-detail");
@@ -151,7 +151,10 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
             </Text>
           </Tooltip>
         )}
-        {openTargetPath && <ExternalAppsOpener targetPath={openTargetPath} />}
+        <Flex align="center" gap="1" className="no-drag">
+          <McpAppsToggleButton />
+          {openTargetPath && <ExternalAppsOpener targetPath={openTargetPath} />}
+        </Flex>
       </Flex>
     ),
     [


### PR DESCRIPTION
## Summary

- Adds a collapsible right-side sidebar inside the task conversation view that lists every MCP-app (UI-rendering) tool call in the thread.
- Clicking an entry scrolls the chat to that exact item via the existing `VirtualizedList.scrollToIndex` mechanism (same as conversation search).
- A toggle button lives in the task header next to `ExternalAppsOpener`.
- A single global subscription to `mcpApps.onDiscoveryComplete` maintains a `Set` of tool keys with registered UI, so the sidebar filters to true "apps" without firing N `hasUiForTool` queries.

https://github.com/user-attachments/assets/59879618-e1cd-4978-8086-8e28ecb0e1aa


## Files

**New**
- `mcp-apps/stores/mcpUiToolsStore.ts` — runtime registry of MCP tool keys with UI
- `mcp-apps/hooks/useMcpUiToolsSubscription.ts` — single global subscription that populates the registry
- `sessions/stores/mcpAppsSidebarStore.ts` — persisted open/width via `createSidebarStore`
- `sessions/components/McpAppsSidebar.tsx` — the panel with resize handle and clickable rows
- `task-detail/components/McpAppsToggleButton.tsx` — header icon button

**Modified**
- `App.tsx` — mounts the subscription once
- `ConversationView.tsx` — single pass derives both `mcpAppIndices` (for `keepMounted`) and `mcpEntries`; root wrapped in a Flex to host the sidebar
- `TaskDetail.tsx` — toggle button next to `ExternalAppsOpener` in the header

## Test plan

- [ ] `pnpm --filter code typecheck` passes
- [ ] `pnpm dev` — open a task, generate a couple of PostHog MCP apps (insights / dashboard)
- [ ] Click the SquaresFour icon in the task header → sidebar opens to 260px on the right
- [ ] Sidebar lists only UI-rendering MCP calls; non-UI MCP tools are absent
- [ ] Scroll the chat up; click an entry → conversation scrolls to that item centred, iframe state preserved
- [ ] Drag the resize handle; reload the app → width persisted
- [ ] Close the sidebar; reload → closed state persisted
- [ ] Empty thread → sidebar shows empty state