### PR TITLE
feat(agent): route slack-originated tasks to slack_app gateway product

### DIFF
--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Task } from "../types";
 import { AgentServer } from "./agent-server";
 
 interface TestableServer {
   configureEnvironment(args?: {
     isInternal?: boolean;
-    originProduct?: string | null;
+    originProduct?: Task["origin_product"] | null;
     signalReportId?: string | null;
     taskId?: string | null;
     taskRunId?: string | null;
@@ -159,6 +160,43 @@ describe("AgentServer.configureEnvironment", () => {
 
     expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toBe(
       "x-posthog-property-task_internal: false",
+    );
+  });
+
+  it("tags as slack_app when the task was initiated from Slack", () => {
+    buildServer("interactive").configureEnvironment({
+      originProduct: "slack",
+    });
+
+    expect(process.env.LLM_GATEWAY_URL).toBe(
+      "https://gateway.us.posthog.com/slack_app",
+    );
+    expect(process.env.ANTHROPIC_BASE_URL).toBe(
+      "https://gateway.us.posthog.com/slack_app",
+    );
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      "https://gateway.us.posthog.com/slack_app/v1",
+    );
+  });
+
+  it("prefers slack_app over background_agents when both signals are present", () => {
+    buildServer("interactive").configureEnvironment({
+      isInternal: true,
+      originProduct: "slack",
+    });
+
+    expect(process.env.LLM_GATEWAY_URL).toBe(
+      "https://gateway.us.posthog.com/slack_app",
+    );
+  });
+
+  it("falls back to posthog_code for non-slack origin products", () => {
+    buildServer("background").configureEnvironment({
+      originProduct: "user_created",
+    });
+
+    expect(process.env.LLM_GATEWAY_URL).toBe(
+      "https://gateway.us.posthog.com/posthog_code",
     );
   });
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -43,6 +43,7 @@ import type {
   GitCheckpointEvent,
   HandoffLocalGitState,
   LogLevel,
+  Task,
   TaskRun,
   TaskRunArtifact,
 } from "../types";
@@ -1860,7 +1861,7 @@ ${signedCommitInstructions}
     taskUserId,
   }: {
     isInternal?: boolean;
-    originProduct?: string | null;
+    originProduct?: Task["origin_product"] | null;
     signalReportId?: string | null;
     taskId?: string | null;
     taskRunId?: string | null;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -38,7 +38,8 @@ export interface Task {
     | "user_created"
     | "support_queue"
     | "session_summaries"
-    | "signal_report";
+    | "signal_report"
+    | "slack";
   signal_report?: string | null; // Inbox report UUID when origin_product is "signal_report"
   github_integration?: number | null;
   repository: string; // Format: "organization/repository" (e.g., "posthog/posthog-js")

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -1,4 +1,8 @@
-export type GatewayProduct = "posthog_code" | "background_agents" | "signals";
+export type GatewayProduct =
+  | "posthog_code"
+  | "background_agents"
+  | "signals"
+  | "slack_app";
 
 export function resolveGatewayProduct({
   isInternal,
@@ -7,6 +11,9 @@ export function resolveGatewayProduct({
   isInternal?: boolean;
   originProduct?: string | null;
 } = {}): GatewayProduct {
+  if (originProduct === "slack") {
+    return "slack_app";
+  }
   if (isInternal) {
     return originProduct === "signal_report" ? "signals" : "background_agents";
   }


### PR DESCRIPTION
## Problem

The agent in the sandbox calls the LLM gateway as `posthog_code` regardless of how the task started. Slack-bot mentions are now billed differently from desktop tasks (gateway tags `slack_app` traffic with `\$ai_billable=true`), so the agent needs to send the correct product per task.

## Changes

- Add `"slack_app"` to the `GatewayProduct` type union (`packages/agent/src/utils/gateway.ts`).
- Add `"slack"` to the `Task.origin_product` union (`packages/agent/src/types.ts`) to mirror the Python `Task.OriginProduct.SLACK` value already set on the backend.
- `configureEnvironment` now accepts `originProduct?: Task["origin_product"] | null`. Mapping: `"slack"` → `slack_app`, `internal=true` → `background_agents`, else → `posthog_code`. Call site reads `preTask?.origin_product` from the Task fetched at session init.
- Three new unit tests covering the slack → slack_app mapping, slack-over-internal precedence, and non-slack fallback.

Pairs with PostHog/posthog#59040 (gateway-side product registration + per-turn quota gate). Both ship behind the existing `posthog-code-slack-availability` flag — neither side has user-visible effect until the flag is enabled.

## How did you test this?

I'm an agent. No manual testing.

- `pnpm --filter @posthog/agent test src/server/agent-server.configure-environment.test.ts` → **8 passed** (5 pre-existing + 3 new).
- Typecheck error count unchanged from clean main (pre-existing module-resolution noise unrelated to this change).
- `biome format --write` clean on touched files.

## Publish to changelog?

no