### PR TITLE
feat: Configurable terminal font setting and surrounding polish

### DIFF
--- a/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.test.ts
+++ b/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useComboboxFilter } from "./useComboboxFilter";
+
+describe("useComboboxFilter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const items = ["alpha", "beta", "gamma", "delta"];
+
+  it("returns all items unfiltered when query is empty", () => {
+    const { result } = renderHook(() =>
+      useComboboxFilter(items, { open: true }),
+    );
+    expect(result.current.filtered).toEqual(items);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("debounces the search before filtering", () => {
+    const { result } = renderHook(() =>
+      useComboboxFilter(items, { open: true }),
+    );
+
+    act(() => {
+      result.current.onSearchChange("alp");
+    });
+    expect(result.current.filtered).toEqual(items);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.filtered).toEqual(["alpha"]);
+  });
+
+  it("clears the query immediately when the popover closes so reopen starts clean", () => {
+    const { result, rerender } = renderHook(
+      ({ open }) => useComboboxFilter(items, { open }),
+      { initialProps: { open: true } },
+    );
+
+    act(() => {
+      result.current.onSearchChange("alp");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.filtered).toEqual(["alpha"]);
+
+    rerender({ open: false });
+    rerender({ open: true });
+    expect(result.current.filtered).toEqual(items);
+  });
+
+  it("respects the limit and reports hasMore", () => {
+    const many = Array.from({ length: 60 }, (_, i) => `item-${i}`);
+    const { result } = renderHook(() =>
+      useComboboxFilter(many, { open: true, limit: 10 }),
+    );
+    expect(result.current.filtered).toHaveLength(10);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.moreCount).toBe(50);
+  });
+
+  it("places pinned values first regardless of score", () => {
+    const { result } = renderHook(() =>
+      useComboboxFilter(items, { open: true, pinned: ["gamma"] }),
+    );
+    expect(result.current.filtered[0]).toBe("gamma");
+  });
+});

--- a/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
+++ b/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
@@ -1,5 +1,6 @@
+import { useDebounce } from "@hooks/useDebounce";
 import { defaultFilter } from "cmdk";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const DEFAULT_LIMIT = 50;
 const MIN_FUZZY_SCORE = 0.1;
@@ -33,25 +34,15 @@ export function useComboboxFilter<T>(
   options?: UseComboboxFilterOptions,
   getValue?: (item: T) => string,
 ): UseComboboxFilterResult<T> {
-  const [search, setSearch] = useState("");
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const [inputValue, setInputValue] = useState("");
+  const search = useDebounce(inputValue, DEBOUNCE_MS);
   const limit = options?.limit ?? DEFAULT_LIMIT;
   const pinned = options?.pinned;
   const open = options?.open;
 
-  const debouncedSetSearch = useCallback((value: string) => {
-    clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => setSearch(value), DEBOUNCE_MS);
-  }, []);
-
   useEffect(() => {
-    if (!open) {
-      clearTimeout(debounceRef.current);
-      setSearch("");
-    }
+    if (!open) setInputValue("");
   }, [open]);
-
-  useEffect(() => () => clearTimeout(debounceRef.current), []);
 
   const resolve = useCallback(
     (item: T): string => (getValue ? getValue(item) : String(item)),
@@ -105,7 +96,7 @@ export function useComboboxFilter<T>(
 
   return {
     filtered,
-    onSearchChange: debouncedSetSearch,
+    onSearchChange: setInputValue,
     hasMore: totalMatches > filtered.length,
     moreCount: Math.max(0, totalMatches - filtered.length),
   };

--- a/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
+++ b/apps/code/src/renderer/components/ui/combobox/useComboboxFilter.ts
@@ -34,11 +34,13 @@ export function useComboboxFilter<T>(
   options?: UseComboboxFilterOptions,
   getValue?: (item: T) => string,
 ): UseComboboxFilterResult<T> {
-  const [inputValue, setInputValue] = useState("");
-  const search = useDebounce(inputValue, DEBOUNCE_MS);
   const limit = options?.limit ?? DEFAULT_LIMIT;
   const pinned = options?.pinned;
   const open = options?.open;
+  const [inputValue, setInputValue] = useState("");
+  // delay=0 while closed so the next open starts on fresh empty-query results,
+  // not a flash of the previous filtered set.
+  const search = useDebounce(inputValue, open ? DEBOUNCE_MS : 0);
 
   useEffect(() => {
     if (!open) setInputValue("");

--- a/apps/code/src/renderer/constants/keyboard-shortcuts.ts
+++ b/apps/code/src/renderer/constants/keyboard-shortcuts.ts
@@ -2,7 +2,7 @@ import { isMac } from "@utils/platform";
 
 export const SHORTCUTS = {
   COMMAND_MENU: "mod+k",
-  NEW_TASK: "mod+n,mod+t,mod+0",
+  NEW_TASK: "mod+n,mod+t",
   SETTINGS: "mod+,",
   SHORTCUTS_SHEET: "mod+/",
   GO_BACK: "mod+[",
@@ -43,7 +43,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     keys: "mod+n",
     description: "New task",
     category: "general",
-    alternateKeys: "mod+t, mod+0",
+    alternateKeys: "mod+t",
   },
   {
     id: "command-menu",

--- a/apps/code/src/renderer/features/message-editor/components/IssuePicker.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/IssuePicker.tsx
@@ -47,7 +47,9 @@ export function IssuePicker({
 }: IssuePickerProps) {
   const trpc = useTRPC();
   const [query, setQuery] = useState("");
-  const debouncedQuery = useDebounce(query, 300);
+  // delay=0 while closed so debouncedQuery snaps back synchronously, otherwise
+  // reopening within 300ms briefly shows cached results from the previous search.
+  const debouncedQuery = useDebounce(query, open ? 300 : 0);
 
   useEffect(() => {
     if (!open) setQuery("");

--- a/apps/code/src/renderer/features/message-editor/components/IssuePicker.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/IssuePicker.tsx
@@ -1,3 +1,4 @@
+import { useDebounce } from "@hooks/useDebounce";
 import {
   Combobox,
   ComboboxContent,
@@ -8,7 +9,7 @@ import {
 } from "@posthog/quill";
 import { useTRPC } from "@renderer/trpc/client";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { GithubRefKind, GithubRefState } from "../types";
 import type { MentionChip } from "../utils/content";
 import {
@@ -46,24 +47,10 @@ export function IssuePicker({
 }: IssuePickerProps) {
   const trpc = useTRPC();
   const [query, setQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debouncedQuery = useDebounce(query, 300);
 
   useEffect(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      setDebouncedQuery(query);
-    }, 300);
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [query]);
-
-  useEffect(() => {
-    if (!open) {
-      setQuery("");
-      setDebouncedQuery("");
-    }
+    if (!open) setQuery("");
   }, [open]);
 
   const { data: refs = [], isFetching } = useQuery(

--- a/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
+++ b/apps/code/src/renderer/features/settings/components/SettingsDialog.tsx
@@ -25,6 +25,7 @@ import {
   Palette,
   SignOut,
   SlackLogo,
+  Terminal,
   TrafficSignal,
   TreeStructure,
   Wrench,
@@ -43,6 +44,7 @@ import { PlanUsageSettings } from "./sections/PlanUsageSettings";
 import { ShortcutsSettings } from "./sections/ShortcutsSettings";
 import { SignalSourcesSettings } from "./sections/SignalSourcesSettings";
 import { SlackSettings } from "./sections/SlackSettings";
+import { TerminalSettings } from "./sections/TerminalSettings";
 import { UpdatesSettings } from "./sections/UpdatesSettings";
 import { WorkspacesSettings } from "./sections/WorkspacesSettings";
 import { WorktreesSettings } from "./sections/worktrees/WorktreesSettings";
@@ -69,6 +71,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
     label: "Personalization",
     icon: <Palette size={16} />,
   },
+  { id: "terminal", label: "Terminal", icon: <Terminal size={16} /> },
   { id: "claude-code", label: "Claude Code", icon: <Code size={16} /> },
   { id: "shortcuts", label: "Shortcuts", icon: <Keyboard size={16} /> },
   { id: "github", label: "GitHub", icon: <GithubLogo size={16} /> },
@@ -91,6 +94,7 @@ const CATEGORY_TITLES: Record<SettingsCategory, string> = {
   environments: "Environments",
   "cloud-environments": "Environments",
   personalization: "Personalization",
+  terminal: "Terminal",
   "claude-code": "Claude Code",
   shortcuts: "Shortcuts",
   github: "GitHub",
@@ -109,6 +113,7 @@ const CATEGORY_COMPONENTS: Record<SettingsCategory, React.ComponentType> = {
   environments: EnvironmentsSettings,
   "cloud-environments": EnvironmentsSettings,
   personalization: PersonalizationSettings,
+  terminal: TerminalSettings,
   "claude-code": ClaudeCodeSettings,
   shortcuts: ShortcutsSettings,
   github: GitHubSettings,

--- a/apps/code/src/renderer/features/settings/components/sections/PersonalizationSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PersonalizationSettings.tsx
@@ -1,11 +1,11 @@
 import { useSettingsStore } from "@features/settings/stores/settingsStore";
+import { useDebounce } from "@hooks/useDebounce";
 import { Flex, Text, TextArea } from "@radix-ui/themes";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { track } from "@utils/analytics";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const MAX_INSTRUCTIONS_LENGTH = 2000;
-const DEBOUNCE_MS = 500;
 
 export function PersonalizationSettings() {
   const customInstructions = useSettingsStore((s) => s.customInstructions);
@@ -15,7 +15,7 @@ export function PersonalizationSettings() {
 
   const [localInstructions, setLocalInstructions] =
     useState(customInstructions);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debouncedInstructions = useDebounce(localInstructions, 500);
 
   // Sync local state when store changes externally
   useEffect(() => {
@@ -35,37 +35,13 @@ export function PersonalizationSettings() {
     [setCustomInstructions],
   );
 
-  const handleInstructionsChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const value = e.target.value;
-      setLocalInstructions(value);
-
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-      debounceRef.current = setTimeout(() => {
-        saveInstructions(value);
-      }, DEBOUNCE_MS);
-    },
-    [saveInstructions],
-  );
+  useEffect(() => {
+    saveInstructions(debouncedInstructions);
+  }, [debouncedInstructions, saveInstructions]);
 
   const handleInstructionsBlur = useCallback(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
-    }
     saveInstructions(localInstructions);
   }, [localInstructions, saveInstructions]);
-
-  // Cleanup debounce on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, []);
 
   return (
     <Flex direction="column" gap="1" py="4">
@@ -77,7 +53,7 @@ export function PersonalizationSettings() {
       </Flex>
       <TextArea
         value={localInstructions}
-        onChange={handleInstructionsChange}
+        onChange={(e) => setLocalInstructions(e.target.value)}
         onBlur={handleInstructionsBlur}
         maxLength={MAX_INSTRUCTIONS_LENGTH}
         placeholder="e.g. Always write tests for new code. Prefer functional patterns."

--- a/apps/code/src/renderer/features/settings/components/sections/TerminalSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/TerminalSettings.tsx
@@ -29,7 +29,9 @@ export function TerminalSettings() {
     setDraftCustomFont(terminalCustomFontFamily);
   }, [terminalCustomFontFamily]);
 
-  // Commit the debounced draft back to the store.
+  // Commit the debounced draft back to the store. The equality guard breaks
+  // the draft<->store loop: writing the store would re-fire the pull-in effect
+  // above, which would re-fire this one without it.
   useEffect(() => {
     if (debouncedCustomFont === terminalCustomFontFamily) return;
     setTerminalCustomFontFamily(debouncedCustomFont);

--- a/apps/code/src/renderer/features/settings/components/sections/TerminalSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/TerminalSettings.tsx
@@ -1,0 +1,101 @@
+import { SettingRow } from "@features/settings/components/SettingRow";
+import {
+  type TerminalFont,
+  useSettingsStore,
+} from "@features/settings/stores/settingsStore";
+import { useDebounce } from "@hooks/useDebounce";
+import { Flex, Select, Text, TextField } from "@radix-ui/themes";
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
+import { track } from "@utils/analytics";
+import { useEffect, useState } from "react";
+
+export function TerminalSettings() {
+  const terminalFont = useSettingsStore((s) => s.terminalFont);
+  const setTerminalFont = useSettingsStore((s) => s.setTerminalFont);
+  const terminalCustomFontFamily = useSettingsStore(
+    (s) => s.terminalCustomFontFamily,
+  );
+  const setTerminalCustomFontFamily = useSettingsStore(
+    (s) => s.setTerminalCustomFontFamily,
+  );
+
+  const [draftCustomFont, setDraftCustomFont] = useState(
+    terminalCustomFontFamily,
+  );
+  const debouncedCustomFont = useDebounce(draftCustomFont, 500);
+
+  // Pull external changes (hydration, devtools) into the draft.
+  useEffect(() => {
+    setDraftCustomFont(terminalCustomFontFamily);
+  }, [terminalCustomFontFamily]);
+
+  // Commit the debounced draft back to the store.
+  useEffect(() => {
+    if (debouncedCustomFont === terminalCustomFontFamily) return;
+    setTerminalCustomFontFamily(debouncedCustomFont);
+    track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+      setting_name: "terminal_custom_font_family",
+      new_value: debouncedCustomFont.length > 0,
+    });
+  }, [
+    debouncedCustomFont,
+    terminalCustomFontFamily,
+    setTerminalCustomFontFamily,
+  ]);
+
+  const handleFontChange = (value: TerminalFont) => {
+    track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+      setting_name: "terminal_font",
+      new_value: value,
+      old_value: terminalFont,
+    });
+    setTerminalFont(value);
+  };
+
+  const showCustomInput = terminalFont === "custom";
+
+  return (
+    <Flex direction="column" gap="1" py="4">
+      <SettingRow
+        label="Font"
+        description="Font used to render the terminal output"
+        noBorder={!showCustomInput}
+      >
+        <Select.Root
+          value={terminalFont}
+          onValueChange={(value) => handleFontChange(value as TerminalFont)}
+          size="1"
+        >
+          <Select.Trigger className="min-w-[160px]" />
+          <Select.Content>
+            <Select.Item value="berkeley-mono">Berkeley Mono</Select.Item>
+            <Select.Item value="jetbrains-mono">JetBrains Mono</Select.Item>
+            <Select.Item value="system">System monospace</Select.Item>
+            <Select.Item value="custom">Custom</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </SettingRow>
+
+      {showCustomInput && (
+        <SettingRow
+          label="Custom font family"
+          description="Any CSS font-family value. Example: Fira Code, Cascadia Code"
+          noBorder
+        >
+          <Flex direction="column" align="end" gap="1">
+            <TextField.Root
+              value={draftCustomFont}
+              onChange={(e) => setDraftCustomFont(e.target.value)}
+              placeholder="Fira Code"
+              size="1"
+              className="min-w-[240px]"
+            />
+            <Text color="gray" className="text-[12px]">
+              Falls back to Berkeley Mono if unavailable
+            </Text>
+          </Flex>
+        </SettingRow>
+      )}
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/settings/stores/settingsDialogStore.test.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsDialogStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSettingsDialogStore } from "./settingsDialogStore";
 
 describe("settingsDialogStore", () => {
@@ -12,6 +12,10 @@ describe("settingsDialogStore", () => {
       initialAction: null,
       formMode: false,
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("defaults the first open to general when no category is given", () => {

--- a/apps/code/src/renderer/features/settings/stores/settingsDialogStore.test.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsDialogStore.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsDialogStore } from "./settingsDialogStore";
+
+describe("settingsDialogStore", () => {
+  beforeEach(() => {
+    vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+    vi.spyOn(window.history, "back").mockImplementation(() => {});
+    useSettingsDialogStore.setState({
+      isOpen: false,
+      activeCategory: "general",
+      context: {},
+      initialAction: null,
+      formMode: false,
+    });
+  });
+
+  it("defaults the first open to general when no category is given", () => {
+    useSettingsDialogStore.getState().open();
+    expect(useSettingsDialogStore.getState().activeCategory).toBe("general");
+  });
+
+  it("remembers the last active category when reopened without a category", () => {
+    const { open, close, setCategory } = useSettingsDialogStore.getState();
+
+    open();
+    setCategory("terminal");
+    close();
+    open();
+
+    expect(useSettingsDialogStore.getState().activeCategory).toBe("terminal");
+  });
+
+  it("respects an explicit category over the remembered one", () => {
+    const { open, close, setCategory } = useSettingsDialogStore.getState();
+
+    open();
+    setCategory("terminal");
+    close();
+    open("plan-usage");
+
+    expect(useSettingsDialogStore.getState().activeCategory).toBe("plan-usage");
+  });
+
+  it("treats a string second argument as an initial action, not context", () => {
+    useSettingsDialogStore.getState().open("environments", "create-new");
+    const state = useSettingsDialogStore.getState();
+    expect(state.activeCategory).toBe("environments");
+    expect(state.initialAction).toBe("create-new");
+    expect(state.context).toEqual({});
+  });
+
+  it("consumeInitialAction returns and clears the pending action", () => {
+    useSettingsDialogStore.getState().open("environments", "create-new");
+    expect(useSettingsDialogStore.getState().consumeInitialAction()).toBe(
+      "create-new",
+    );
+    expect(useSettingsDialogStore.getState().initialAction).toBeNull();
+  });
+});

--- a/apps/code/src/renderer/features/settings/stores/settingsDialogStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsDialogStore.ts
@@ -8,6 +8,7 @@ export type SettingsCategory =
   | "environments"
   | "cloud-environments"
   | "personalization"
+  | "terminal"
   | "claude-code"
   | "shortcuts"
   | "github"

--- a/apps/code/src/renderer/features/settings/stores/settingsDialogStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsDialogStore.ts
@@ -58,7 +58,7 @@ export const useSettingsDialogStore = create<SettingsDialogStore>()(
       const isAction = typeof contextOrAction === "string";
       set({
         isOpen: true,
-        activeCategory: category ?? "general",
+        activeCategory: category ?? get().activeCategory,
         context: isAction ? {} : (contextOrAction ?? {}),
         initialAction: isAction ? contextOrAction : null,
         formMode: false,

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.test.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.test.ts
@@ -82,3 +82,58 @@ describe("feature settingsStore cloud selections", () => {
     expect(useSettingsStore.getState().allowBypassPermissions).toBe(true);
   });
 });
+
+describe("feature settingsStore terminal font", () => {
+  beforeEach(() => {
+    getItem.mockReset();
+    setItem.mockReset();
+    removeItem.mockReset();
+    getItem.mockResolvedValue(null);
+    setItem.mockResolvedValue(undefined);
+    removeItem.mockResolvedValue(undefined);
+
+    useSettingsStore.setState({
+      terminalFont: "berkeley-mono",
+      terminalCustomFontFamily: "",
+    });
+  });
+
+  it("defaults to berkeley-mono with no custom override", () => {
+    expect(useSettingsStore.getState().terminalFont).toBe("berkeley-mono");
+    expect(useSettingsStore.getState().terminalCustomFontFamily).toBe("");
+  });
+
+  it("persists terminal font selection and custom family", async () => {
+    useSettingsStore.getState().setTerminalFont("custom");
+    useSettingsStore.getState().setTerminalCustomFontFamily("Fira Code");
+
+    await vi.waitFor(() => {
+      expect(setItem).toHaveBeenCalled();
+    });
+
+    const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
+    const persisted = JSON.parse(lastCall[0].value);
+
+    expect(persisted.state.terminalFont).toBe("custom");
+    expect(persisted.state.terminalCustomFontFamily).toBe("Fira Code");
+  });
+
+  it("rehydrates terminal font selection and custom family", async () => {
+    getItem.mockResolvedValue(
+      JSON.stringify({
+        state: {
+          terminalFont: "jetbrains-mono",
+          terminalCustomFontFamily: "Cascadia Code",
+        },
+        version: 0,
+      }),
+    );
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().terminalFont).toBe("jetbrains-mono");
+    expect(useSettingsStore.getState().terminalCustomFontFamily).toBe(
+      "Cascadia Code",
+    );
+  });
+});

--- a/apps/code/src/renderer/features/settings/stores/settingsStore.ts
+++ b/apps/code/src/renderer/features/settings/stores/settingsStore.ts
@@ -4,9 +4,17 @@ import { electronStorage } from "@utils/electronStorage";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+// ---------- Types ----------
+
 export type DefaultRunMode = "local" | "cloud" | "last_used";
 export type LocalWorkspaceMode = "worktree" | "local";
+export type AgentAdapter = "claude" | "codex";
+export type DefaultInitialTaskMode = "plan" | "last_used";
+
 export type SendMessagesWith = "enter" | "cmd+enter";
+export type AutoConvertLongText = "off" | "1000" | "2500" | "5000" | "10000";
+export type DiffOpenMode = "auto" | "split" | "same-pane" | "last-active-pane";
+
 export type CompletionSound =
   | "none"
   | "guitar"
@@ -21,17 +29,22 @@ export type CompletionSound =
   | "slide"
   | "switch"
   | "wilhelm";
-export type AgentAdapter = "claude" | "codex";
-export type AutoConvertLongText = "off" | "1000" | "2500" | "5000" | "10000";
-export type DefaultInitialTaskMode = "plan" | "last_used";
+
+export type TerminalFont =
+  | "berkeley-mono"
+  | "jetbrains-mono"
+  | "system"
+  | "custom";
 
 export interface HintState {
   count: number;
   learned: boolean;
 }
-export type DiffOpenMode = "auto" | "split" | "same-pane" | "last-active-pane";
+
+// ---------- Store shape ----------
 
 interface SettingsStore {
+  // Run mode + last-used flow defaults
   defaultRunMode: DefaultRunMode;
   lastUsedRunMode: "local" | "cloud";
   lastUsedLocalWorkspaceMode: LocalWorkspaceMode;
@@ -41,31 +54,8 @@ interface SettingsStore {
   lastUsedReasoningEffort: string | null;
   lastUsedCloudRepository: string | null;
   lastUsedEnvironments: Record<string, string>;
-  desktopNotifications: boolean;
-  dockBadgeNotifications: boolean;
-  dockBounceNotifications: boolean;
-
-  autoConvertLongText: AutoConvertLongText;
-  completionSound: CompletionSound;
-  completionVolume: number;
-  sendMessagesWith: SendMessagesWith;
-  allowBypassPermissions: boolean;
-  preventSleepWhileRunning: boolean;
-  debugLogsCloudRuns: boolean;
-  customInstructions: string;
   defaultInitialTaskMode: DefaultInitialTaskMode;
   lastUsedInitialTaskMode: ExecutionMode;
-  diffOpenMode: DiffOpenMode;
-  hedgehogMode: boolean;
-  mcpAppsDisabledServers: string[];
-  hints: Record<string, HintState>;
-
-  shouldShowHint: (key: string, max?: number) => boolean;
-  recordHintShown: (key: string) => void;
-  markHintLearned: (key: string) => void;
-
-  setCompletionSound: (sound: CompletionSound) => void;
-  setCompletionVolume: (volume: number) => void;
   setDefaultRunMode: (mode: DefaultRunMode) => void;
   setLastUsedRunMode: (mode: "local" | "cloud") => void;
   setLastUsedLocalWorkspaceMode: (mode: LocalWorkspaceMode) => void;
@@ -79,26 +69,66 @@ interface SettingsStore {
     environmentId: string | null,
   ) => void;
   getLastUsedEnvironment: (repoPath: string) => string | null;
+  setDefaultInitialTaskMode: (mode: DefaultInitialTaskMode) => void;
+  setLastUsedInitialTaskMode: (mode: ExecutionMode) => void;
+
+  // Notifications
+  desktopNotifications: boolean;
+  dockBadgeNotifications: boolean;
+  dockBounceNotifications: boolean;
+  completionSound: CompletionSound;
+  completionVolume: number;
   setDesktopNotifications: (enabled: boolean) => void;
   setDockBadgeNotifications: (enabled: boolean) => void;
   setDockBounceNotifications: (enabled: boolean) => void;
+  setCompletionSound: (sound: CompletionSound) => void;
+  setCompletionVolume: (volume: number) => void;
 
+  // Composer / chat
+  autoConvertLongText: AutoConvertLongText;
+  sendMessagesWith: SendMessagesWith;
+  customInstructions: string;
   setAutoConvertLongText: (value: AutoConvertLongText) => void;
   setSendMessagesWith: (mode: SendMessagesWith) => void;
+  setCustomInstructions: (instructions: string) => void;
+
+  // Diff viewer
+  diffOpenMode: DiffOpenMode;
+  setDiffOpenMode: (mode: DiffOpenMode) => void;
+
+  // System / power / permissions
+  allowBypassPermissions: boolean;
+  preventSleepWhileRunning: boolean;
+  debugLogsCloudRuns: boolean;
   setAllowBypassPermissions: (enabled: boolean) => void;
   setPreventSleepWhileRunning: (enabled: boolean) => void;
   setDebugLogsCloudRuns: (enabled: boolean) => void;
-  setCustomInstructions: (instructions: string) => void;
-  setDefaultInitialTaskMode: (mode: DefaultInitialTaskMode) => void;
-  setLastUsedInitialTaskMode: (mode: ExecutionMode) => void;
-  setDiffOpenMode: (mode: DiffOpenMode) => void;
+
+  // Terminal
+  terminalFont: TerminalFont;
+  terminalCustomFontFamily: string;
+  setTerminalFont: (font: TerminalFont) => void;
+  setTerminalCustomFontFamily: (value: string) => void;
+
+  // Experimental / misc
+  hedgehogMode: boolean;
+  mcpAppsDisabledServers: string[];
   setHedgehogMode: (enabled: boolean) => void;
   setMcpAppsDisabledServers: (servers: string[]) => void;
+
+  // Onboarding hints
+  hints: Record<string, HintState>;
+  shouldShowHint: (key: string, max?: number) => boolean;
+  recordHintShown: (key: string) => void;
+  markHintLearned: (key: string) => void;
 }
+
+// ---------- Store ----------
 
 export const useSettingsStore = create<SettingsStore>()(
   persist(
     (set, get) => ({
+      // Run mode + last-used flow defaults
       defaultRunMode: "last_used",
       lastUsedRunMode: "local",
       lastUsedLocalWorkspaceMode: "local",
@@ -108,25 +138,90 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedReasoningEffort: null,
       lastUsedCloudRepository: null,
       lastUsedEnvironments: {},
+      defaultInitialTaskMode: "plan",
+      lastUsedInitialTaskMode: "plan",
+      setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
+      setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
+      setLastUsedLocalWorkspaceMode: (mode) =>
+        set({ lastUsedLocalWorkspaceMode: mode }),
+      setLastUsedWorkspaceMode: (mode) => set({ lastUsedWorkspaceMode: mode }),
+      setLastUsedAdapter: (adapter) => set({ lastUsedAdapter: adapter }),
+      setLastUsedModel: (model) => set({ lastUsedModel: model }),
+      setLastUsedReasoningEffort: (effort) =>
+        set({ lastUsedReasoningEffort: effort }),
+      setLastUsedCloudRepository: (repo) =>
+        set({ lastUsedCloudRepository: repo }),
+      setLastUsedEnvironment: (repoPath, environmentId) =>
+        set((state) => {
+          const next = { ...state.lastUsedEnvironments };
+          if (environmentId) {
+            next[repoPath] = environmentId;
+          } else {
+            delete next[repoPath];
+          }
+          return { lastUsedEnvironments: next };
+        }),
+      getLastUsedEnvironment: (repoPath) =>
+        get().lastUsedEnvironments[repoPath] ?? null,
+      setDefaultInitialTaskMode: (mode) =>
+        set({ defaultInitialTaskMode: mode }),
+      setLastUsedInitialTaskMode: (mode) =>
+        set({ lastUsedInitialTaskMode: mode }),
+
+      // Notifications
       desktopNotifications: true,
       dockBadgeNotifications: true,
       dockBounceNotifications: false,
       completionSound: "none",
       completionVolume: 80,
+      setDesktopNotifications: (enabled) =>
+        set({ desktopNotifications: enabled }),
+      setDockBadgeNotifications: (enabled) =>
+        set({ dockBadgeNotifications: enabled }),
+      setDockBounceNotifications: (enabled) =>
+        set({ dockBounceNotifications: enabled }),
+      setCompletionSound: (sound) => set({ completionSound: sound }),
+      setCompletionVolume: (volume) => set({ completionVolume: volume }),
 
+      // Composer / chat
       autoConvertLongText: "2500",
       sendMessagesWith: "enter",
+      customInstructions: "",
+      setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
+      setSendMessagesWith: (mode) => set({ sendMessagesWith: mode }),
+      setCustomInstructions: (instructions) =>
+        set({ customInstructions: instructions }),
+
+      // Diff viewer
+      diffOpenMode: "auto",
+      setDiffOpenMode: (mode) => set({ diffOpenMode: mode }),
+
+      // System / power / permissions
       allowBypassPermissions: false,
       preventSleepWhileRunning: false,
       debugLogsCloudRuns: false,
-      customInstructions: "",
-      defaultInitialTaskMode: "plan",
-      lastUsedInitialTaskMode: "plan",
-      diffOpenMode: "auto",
+      setAllowBypassPermissions: (enabled) =>
+        set({ allowBypassPermissions: enabled }),
+      setPreventSleepWhileRunning: (enabled) =>
+        set({ preventSleepWhileRunning: enabled }),
+      setDebugLogsCloudRuns: (enabled) => set({ debugLogsCloudRuns: enabled }),
+
+      // Terminal
+      terminalFont: "berkeley-mono",
+      terminalCustomFontFamily: "",
+      setTerminalFont: (font) => set({ terminalFont: font }),
+      setTerminalCustomFontFamily: (value) =>
+        set({ terminalCustomFontFamily: value }),
+
+      // Experimental / misc
       hedgehogMode: false,
       mcpAppsDisabledServers: [],
-      hints: {},
+      setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
+      setMcpAppsDisabledServers: (servers) =>
+        set({ mcpAppsDisabledServers: servers }),
 
+      // Onboarding hints
+      hints: {},
       shouldShowHint: (key, max = 3) => {
         const hint = get().hints[key];
         if (!hint) return true;
@@ -152,61 +247,12 @@ export const useSettingsStore = create<SettingsStore>()(
             },
           };
         }),
-
-      setCompletionSound: (sound) => set({ completionSound: sound }),
-      setCompletionVolume: (volume) => set({ completionVolume: volume }),
-      setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
-      setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
-      setLastUsedLocalWorkspaceMode: (mode) =>
-        set({ lastUsedLocalWorkspaceMode: mode }),
-      setLastUsedWorkspaceMode: (mode) => set({ lastUsedWorkspaceMode: mode }),
-      setLastUsedAdapter: (adapter) => set({ lastUsedAdapter: adapter }),
-      setLastUsedModel: (model) => set({ lastUsedModel: model }),
-      setLastUsedReasoningEffort: (effort) =>
-        set({ lastUsedReasoningEffort: effort }),
-      setLastUsedCloudRepository: (repo) =>
-        set({ lastUsedCloudRepository: repo }),
-      setLastUsedEnvironment: (repoPath, environmentId) =>
-        set((state) => {
-          const next = { ...state.lastUsedEnvironments };
-          if (environmentId) {
-            next[repoPath] = environmentId;
-          } else {
-            delete next[repoPath];
-          }
-          return { lastUsedEnvironments: next };
-        }),
-      getLastUsedEnvironment: (repoPath) =>
-        get().lastUsedEnvironments[repoPath] ?? null,
-      setDesktopNotifications: (enabled) =>
-        set({ desktopNotifications: enabled }),
-      setDockBadgeNotifications: (enabled) =>
-        set({ dockBadgeNotifications: enabled }),
-      setDockBounceNotifications: (enabled) =>
-        set({ dockBounceNotifications: enabled }),
-
-      setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
-      setSendMessagesWith: (mode) => set({ sendMessagesWith: mode }),
-      setAllowBypassPermissions: (enabled) =>
-        set({ allowBypassPermissions: enabled }),
-      setPreventSleepWhileRunning: (enabled) =>
-        set({ preventSleepWhileRunning: enabled }),
-      setDebugLogsCloudRuns: (enabled) => set({ debugLogsCloudRuns: enabled }),
-      setCustomInstructions: (instructions) =>
-        set({ customInstructions: instructions }),
-      setDefaultInitialTaskMode: (mode) =>
-        set({ defaultInitialTaskMode: mode }),
-      setLastUsedInitialTaskMode: (mode) =>
-        set({ lastUsedInitialTaskMode: mode }),
-      setDiffOpenMode: (mode) => set({ diffOpenMode: mode }),
-      setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
-      setMcpAppsDisabledServers: (servers) =>
-        set({ mcpAppsDisabledServers: servers }),
     }),
     {
       name: "settings-storage",
       storage: electronStorage,
       partialize: (state) => ({
+        // Run mode + last-used flow defaults
         defaultRunMode: state.defaultRunMode,
         lastUsedRunMode: state.lastUsedRunMode,
         lastUsedLocalWorkspaceMode: state.lastUsedLocalWorkspaceMode,
@@ -216,24 +262,39 @@ export const useSettingsStore = create<SettingsStore>()(
         lastUsedReasoningEffort: state.lastUsedReasoningEffort,
         lastUsedCloudRepository: state.lastUsedCloudRepository,
         lastUsedEnvironments: state.lastUsedEnvironments,
+        defaultInitialTaskMode: state.defaultInitialTaskMode,
+        lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,
+
+        // Notifications
         desktopNotifications: state.desktopNotifications,
         dockBadgeNotifications: state.dockBadgeNotifications,
         dockBounceNotifications: state.dockBounceNotifications,
-
-        autoConvertLongText: state.autoConvertLongText,
         completionSound: state.completionSound,
         completionVolume: state.completionVolume,
+
+        // Composer / chat
+        autoConvertLongText: state.autoConvertLongText,
         sendMessagesWith: state.sendMessagesWith,
+        customInstructions: state.customInstructions,
+
+        // Diff viewer
+        diffOpenMode: state.diffOpenMode,
+
+        // System / power / permissions
         allowBypassPermissions: state.allowBypassPermissions,
         preventSleepWhileRunning: state.preventSleepWhileRunning,
         debugLogsCloudRuns: state.debugLogsCloudRuns,
-        customInstructions: state.customInstructions,
-        defaultInitialTaskMode: state.defaultInitialTaskMode,
-        lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,
-        diffOpenMode: state.diffOpenMode,
+
+        // Terminal
+        terminalFont: state.terminalFont,
+        terminalCustomFontFamily: state.terminalCustomFontFamily,
+
+        // Experimental / misc
         hedgehogMode: state.hedgehogMode,
-        hints: state.hints,
         mcpAppsDisabledServers: state.mcpAppsDisabledServers,
+
+        // Onboarding hints
+        hints: state.hints,
       }),
       merge: (persisted, current) => {
         const merged = {

--- a/apps/code/src/renderer/features/terminal/components/Terminal.tsx
+++ b/apps/code/src/renderer/features/terminal/components/Terminal.tsx
@@ -1,3 +1,4 @@
+import { useSettingsStore } from "@features/settings/stores/settingsStore";
 import { Box } from "@radix-ui/themes";
 import { useTRPC } from "@renderer/trpc";
 import { useThemeStore } from "@stores/themeStore";
@@ -6,6 +7,7 @@ import "@xterm/xterm/css/xterm.css";
 import { useSubscription } from "@trpc/tanstack-react-query";
 import { useCallback, useEffect, useRef } from "react";
 import { terminalManager } from "../services/TerminalManager";
+import { resolveTerminalFontFamily } from "../utils/resolveTerminalFontFamily";
 
 export interface TerminalProps {
   sessionId: string;
@@ -31,6 +33,10 @@ export function Terminal({
   const trpcReact = useTRPC();
   const terminalRef = useRef<HTMLDivElement>(null);
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
+  const terminalFont = useSettingsStore((s) => s.terminalFont);
+  const terminalCustomFontFamily = useSettingsStore(
+    (s) => s.terminalCustomFontFamily,
+  );
 
   // Create instance (idempotent)
   useEffect(() => {
@@ -62,6 +68,13 @@ export function Terminal({
   useEffect(() => {
     terminalManager.setTheme(isDarkMode);
   }, [isDarkMode]);
+
+  // Font sync
+  useEffect(() => {
+    terminalManager.setFontFamily(
+      resolveTerminalFontFamily(terminalFont, terminalCustomFontFamily),
+    );
+  }, [terminalFont, terminalCustomFontFamily]);
 
   // Subscribe to shell data events
   useSubscription(

--- a/apps/code/src/renderer/features/terminal/services/TerminalManager.ts
+++ b/apps/code/src/renderer/features/terminal/services/TerminalManager.ts
@@ -449,6 +449,9 @@ class TerminalManagerImpl {
 
     for (const instance of this.instances.values()) {
       instance.term.options.fontFamily = fontFamily;
+      // Parked terminals live in a 0x0 container, so fit would compute garbage.
+      // attach() refits on reattachment, so skipping here is safe.
+      if (!instance.attachedElement) continue;
       try {
         instance.fitAddon.fit();
       } catch (error) {

--- a/apps/code/src/renderer/features/terminal/services/TerminalManager.ts
+++ b/apps/code/src/renderer/features/terminal/services/TerminalManager.ts
@@ -5,10 +5,9 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { DEFAULT_TERMINAL_FONT_FAMILY } from "../utils/resolveTerminalFontFamily";
 
 const log = logger.scope("terminal-manager");
-const TERMINAL_FONT_FAMILY =
-  'var(--code-font-family, "Berkeley Mono", "JetBrains Mono", "Consolas", "Monaco", monospace)';
 
 let parkingContainer: HTMLElement | null = null;
 
@@ -142,6 +141,7 @@ class TerminalManagerImpl {
   private instances = new Map<string, TerminalInstance>();
   private listeners = new Map<EventType, Set<Listener<EventType>>>();
   private isDarkMode = true;
+  private fontFamily: string = DEFAULT_TERMINAL_FONT_FAMILY;
 
   has(sessionId: string): boolean {
     return this.instances.has(sessionId);
@@ -163,7 +163,7 @@ class TerminalManagerImpl {
     const term = new XTerm({
       cursorBlink: true,
       fontSize: 12,
-      fontFamily: TERMINAL_FONT_FAMILY,
+      fontFamily: this.fontFamily,
       theme: getTerminalTheme(this.isDarkMode),
       cursorStyle: "block",
       cursorWidth: 8,
@@ -437,6 +437,23 @@ class TerminalManagerImpl {
 
     for (const instance of this.instances.values()) {
       instance.term.options.theme = theme;
+    }
+  }
+
+  setFontFamily(fontFamily: string): void {
+    if (this.fontFamily === fontFamily) {
+      return;
+    }
+
+    this.fontFamily = fontFamily;
+
+    for (const instance of this.instances.values()) {
+      instance.term.options.fontFamily = fontFamily;
+      try {
+        instance.fitAddon.fit();
+      } catch (error) {
+        log.error("Failed to refit after font change:", error);
+      }
     }
   }
 

--- a/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.test.ts
+++ b/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.test.ts
@@ -8,23 +8,28 @@ const FALLBACK =
   '"Berkeley Mono", "JetBrains Mono", "Consolas", "Monaco", monospace';
 
 describe("resolveTerminalFontFamily", () => {
-  it("uses Berkeley Mono as the default and matches the exported constant", () => {
-    expect(resolveTerminalFontFamily("berkeley-mono", "")).toBe(
-      `"Berkeley Mono", ${FALLBACK}`,
-    );
+  it("exports a default that matches the berkeley-mono stack", () => {
     expect(DEFAULT_TERMINAL_FONT_FAMILY).toBe(`"Berkeley Mono", ${FALLBACK}`);
   });
 
-  it("returns the JetBrains Mono stack", () => {
-    expect(resolveTerminalFontFamily("jetbrains-mono", "")).toBe(
-      `"JetBrains Mono", ${FALLBACK}`,
-    );
-  });
-
-  it("returns the system monospace stack and ignores the custom value", () => {
-    expect(resolveTerminalFontFamily("system", "Fira Code")).toBe(
-      "ui-monospace, Menlo, Monaco, Consolas, monospace",
-    );
+  it.each([
+    {
+      font: "berkeley-mono" as const,
+      custom: "",
+      expected: `"Berkeley Mono", ${FALLBACK}`,
+    },
+    {
+      font: "jetbrains-mono" as const,
+      custom: "",
+      expected: `"JetBrains Mono", ${FALLBACK}`,
+    },
+    {
+      font: "system" as const,
+      custom: "Fira Code",
+      expected: "ui-monospace, Menlo, Monaco, Consolas, monospace",
+    },
+  ])("resolves the $font preset", ({ font, custom, expected }) => {
+    expect(resolveTerminalFontFamily(font, custom)).toBe(expected);
   });
 
   it("falls back to the default stack when custom is empty or whitespace", () => {

--- a/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.test.ts
+++ b/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TERMINAL_FONT_FAMILY,
+  resolveTerminalFontFamily,
+} from "./resolveTerminalFontFamily";
+
+const FALLBACK =
+  '"Berkeley Mono", "JetBrains Mono", "Consolas", "Monaco", monospace';
+
+describe("resolveTerminalFontFamily", () => {
+  it("uses Berkeley Mono as the default and matches the exported constant", () => {
+    expect(resolveTerminalFontFamily("berkeley-mono", "")).toBe(
+      `"Berkeley Mono", ${FALLBACK}`,
+    );
+    expect(DEFAULT_TERMINAL_FONT_FAMILY).toBe(`"Berkeley Mono", ${FALLBACK}`);
+  });
+
+  it("returns the JetBrains Mono stack", () => {
+    expect(resolveTerminalFontFamily("jetbrains-mono", "")).toBe(
+      `"JetBrains Mono", ${FALLBACK}`,
+    );
+  });
+
+  it("returns the system monospace stack and ignores the custom value", () => {
+    expect(resolveTerminalFontFamily("system", "Fira Code")).toBe(
+      "ui-monospace, Menlo, Monaco, Consolas, monospace",
+    );
+  });
+
+  it("falls back to the default stack when custom is empty or whitespace", () => {
+    expect(resolveTerminalFontFamily("custom", "")).toBe(FALLBACK);
+    expect(resolveTerminalFontFamily("custom", "   ")).toBe(FALLBACK);
+  });
+
+  it("prepends a trimmed custom value to the fallback stack", () => {
+    expect(resolveTerminalFontFamily("custom", "Fira Code")).toBe(
+      `Fira Code, ${FALLBACK}`,
+    );
+    expect(resolveTerminalFontFamily("custom", "  Fira Code  ")).toBe(
+      `Fira Code, ${FALLBACK}`,
+    );
+  });
+
+  it("preserves multi-value font stacks the user types verbatim", () => {
+    expect(
+      resolveTerminalFontFamily("custom", '"Cascadia Code", "Fira Code"'),
+    ).toBe(`"Cascadia Code", "Fira Code", ${FALLBACK}`);
+  });
+});

--- a/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.ts
+++ b/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.ts
@@ -11,7 +11,7 @@ export function resolveTerminalFontFamily(
 ): string {
   switch (font) {
     case "berkeley-mono":
-      return `"Berkeley Mono", ${FALLBACK}`;
+      return DEFAULT_TERMINAL_FONT_FAMILY;
     case "jetbrains-mono":
       return `"JetBrains Mono", ${FALLBACK}`;
     case "system":

--- a/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.ts
+++ b/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.ts
@@ -5,20 +5,6 @@ const FALLBACK =
 
 export const DEFAULT_TERMINAL_FONT_FAMILY = `"Berkeley Mono", ${FALLBACK}`;
 
-function normalizeFontFamily(input: string): string {
-  return input
-    .split(",")
-    .map((piece) =>
-      piece
-        .trim()
-        .replace(/^['"]|['"]$/g, "")
-        .trim(),
-    )
-    .filter((piece) => piece.length > 0)
-    .map((piece) => `"${piece}"`)
-    .join(", ");
-}
-
 export function resolveTerminalFontFamily(
   font: TerminalFont,
   customFontFamily: string,
@@ -31,8 +17,8 @@ export function resolveTerminalFontFamily(
     case "system":
       return "ui-monospace, Menlo, Monaco, Consolas, monospace";
     case "custom": {
-      const normalized = normalizeFontFamily(customFontFamily);
-      return normalized.length > 0 ? `${normalized}, ${FALLBACK}` : FALLBACK;
+      const trimmed = customFontFamily.trim();
+      return trimmed.length > 0 ? `${trimmed}, ${FALLBACK}` : FALLBACK;
     }
   }
 }

--- a/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.ts
+++ b/apps/code/src/renderer/features/terminal/utils/resolveTerminalFontFamily.ts
@@ -1,0 +1,38 @@
+import type { TerminalFont } from "@features/settings/stores/settingsStore";
+
+const FALLBACK =
+  '"Berkeley Mono", "JetBrains Mono", "Consolas", "Monaco", monospace';
+
+export const DEFAULT_TERMINAL_FONT_FAMILY = `"Berkeley Mono", ${FALLBACK}`;
+
+function normalizeFontFamily(input: string): string {
+  return input
+    .split(",")
+    .map((piece) =>
+      piece
+        .trim()
+        .replace(/^['"]|['"]$/g, "")
+        .trim(),
+    )
+    .filter((piece) => piece.length > 0)
+    .map((piece) => `"${piece}"`)
+    .join(", ");
+}
+
+export function resolveTerminalFontFamily(
+  font: TerminalFont,
+  customFontFamily: string,
+): string {
+  switch (font) {
+    case "berkeley-mono":
+      return `"Berkeley Mono", ${FALLBACK}`;
+    case "jetbrains-mono":
+      return `"JetBrains Mono", ${FALLBACK}`;
+    case "system":
+      return "ui-monospace, Menlo, Monaco, Consolas, monospace";
+    case "custom": {
+      const normalized = normalizeFontFamily(customFontFamily);
+      return normalized.length > 0 ? `${normalized}, ${FALLBACK}` : FALLBACK;
+    }
+  }
+}

--- a/apps/code/src/renderer/hooks/useDebounce.test.ts
+++ b/apps/code/src/renderer/hooks/useDebounce.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDebounce } from "./useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value synchronously", () => {
+    const { result } = renderHook(() => useDebounce("initial", 200));
+    expect(result.current).toBe("initial");
+  });
+
+  it("updates the value after the delay elapses", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe("b");
+  });
+
+  it("restarts the timer when the value changes mid-window", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    rerender({ value: "c" });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe("c");
+  });
+
+  it("syncs immediately when delay is zero or negative", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: "a", delay: 200 } },
+    );
+
+    rerender({ value: "b", delay: 200 });
+    expect(result.current).toBe("a");
+
+    rerender({ value: "b", delay: 0 });
+    expect(result.current).toBe("b");
+
+    rerender({ value: "c", delay: -1 });
+    expect(result.current).toBe("c");
+  });
+
+  it("cancels the pending timer on unmount", () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ value }) => useDebounce(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current).toBe("a");
+  });
+});

--- a/apps/code/src/renderer/hooks/useDebounce.ts
+++ b/apps/code/src/renderer/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/apps/code/src/renderer/hooks/useDebounce.ts
+++ b/apps/code/src/renderer/hooks/useDebounce.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+// `delay <= 0` syncs synchronously and is the documented way to collapse the
+// window (e.g. flip to 0 when a popover closes so reopen starts clean).
 export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
 

--- a/apps/code/src/renderer/hooks/useDebounce.ts
+++ b/apps/code/src/renderer/hooks/useDebounce.ts
@@ -4,6 +4,10 @@ export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(() => {
+    if (delay <= 0) {
+      setDebouncedValue(value);
+      return;
+    }
     const handle = setTimeout(() => setDebouncedValue(value), delay);
     return () => clearTimeout(handle);
   }, [value, delay]);


### PR DESCRIPTION
## Problem

The terminal lacked a font override, and several adjacent rough edges (lost settings tab, scattered debounce timers, Cmd+0 hijacking zoom reset) made the area feel unpolished.

Closes https://github.com/PostHog/code/issues/2231

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes
1. Add configurable terminal font setting with custom-override input (TerminalSettings, resolveTerminalFontFamily, TerminalManager wiring)
2. Migrate manual setTimeout debounces to a shared useDebounce hook (combobox filter, issue picker)
3. Clean up the settings store and trim PersonalizationSettings
4. Remember the last-active settings tab when reopening the dialog
5. Free Cmd+0 so it resets zoom instead of opening the new-task input
<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->