### PR TITLE
fix: correct PostHog Slack settings URL path from project to environment

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
@@ -18,7 +18,7 @@ export function SlackSettings() {
 
   const slackSettingsUrl = projectId
     ? getPostHogUrl(
-        `/project/${projectId}/settings/project-posthog-code#integration-posthog-code-slack`,
+        `/project/${projectId}/settings/environment-posthog-code#integration-posthog-code-slack`,
         cloudRegion,
       )
     : null;


### PR DESCRIPTION
## Problem

Clicking "Manage in PostHog Web" under Settings > Slack was redirecting to an incorrect URL path, resulting in a "Setting not found" error in PostHog Web.

## Changes

- Updated the Slack settings redirect URL in `SlackSettings.tsx` to use the correct path segment
- Changed URL path from `/project/{projectId}/settings/project-posthog-code` to `/project/{projectId}/settings/environment-posthog-code`
- This ensures the link correctly directs users to the Slack integration settings page in PostHog Web

## How did you test this?

Manual verification that the "Manage in PostHog Web" link now generates the correct URL path that resolves properly in PostHog Web.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*