### PR TITLE
fix(notifications): retain Notification reference so click handler fires

### DIFF
--- a/apps/code/src/main/platform-adapters/electron-notifier.ts
+++ b/apps/code/src/main/platform-adapters/electron-notifier.ts
@@ -32,6 +32,7 @@ export class ElectronNotifier implements INotifier {
     const release = () => this.active.delete(notification);
     notification.once("close", release);
     notification.once("click", release);
+    notification.once("failed", release);
     if (options.onClick) {
       notification.on("click", options.onClick);
     }

--- a/apps/code/src/main/platform-adapters/electron-notifier.ts
+++ b/apps/code/src/main/platform-adapters/electron-notifier.ts
@@ -6,6 +6,13 @@ import type { ElectronMainWindow } from "./electron-main-window";
 
 @injectable()
 export class ElectronNotifier implements INotifier {
+  // Retain shown notifications so V8 doesn't GC the JS wrapper (and its
+  // `click` listener) before the user interacts. Without this, the OS still
+  // shows the notification and macOS will even focus the app on click, but
+  // the JS click handler never fires — so any in-app routing tied to it
+  // (e.g. switching to the task the notification was about) silently breaks.
+  private readonly active = new Set<Notification>();
+
   constructor(
     @inject(MAIN_TOKENS.MainWindow)
     private readonly mainWindow: ElectronMainWindow,
@@ -21,6 +28,10 @@ export class ElectronNotifier implements INotifier {
       body: options.body,
       silent: options.silent,
     });
+    this.active.add(notification);
+    const release = () => this.active.delete(notification);
+    notification.once("close", release);
+    notification.once("click", release);
     if (options.onClick) {
       notification.on("click", options.onClick);
     }


### PR DESCRIPTION
## Problem

After #2210, PostHog Code can fire notifications for a different task while you're already focused on another task in the app. Clicking those notifications was supposed to switch you to the task the notification was about (via `TaskLinkService` → `deepLink.onOpenTask` → `useTaskDeepLink` → `navigateToTask`), but the in-app view never changed. On macOS this surfaced as "the app comes to the foreground but stays on the wrong task" — because macOS raises the app on notification click as default OS behaviour, independent of whether the JS click handler runs.

Root cause: `ElectronNotifier.notify()` (`apps/code/src/main/platform-adapters/electron-notifier.ts`) created `new Notification(...)` in a local variable and let it fall out of scope right after `.show()`. With no retained reference, V8 was free to garbage-collect the JS wrapper before the user clicked, taking the `click` listener with it. The OS-level notification still rendered fine, but `onClick` (where `taskLinkService.emit(TaskLinkEvent.OpenTask, ...)` lives) never fired.

## Changes

Hold a reference to each shown `Notification` in an instance `Set<Notification>` on `ElectronNotifier`, and release it when the notification's `click` or `close` event fires. This keeps the JS wrapper alive long enough for its events to actually reach JS, with no behavioural change beyond that.

## How did you test this?

- `pnpm --filter code typecheck` — clean
- `pnpm lint` — clean
- Traced the click path end-to-end: `electron-notifier.ts` (now retains ref) → `notification/service.ts:38-49` (`onClick` emits `OpenTask`) → `deep-link.ts:27` (subscription yields) → `useTaskDeepLink.ts:113-123` (calls `handleOpenTask`) → `navigationStore.navigateToTask` (which uses `isSameView` task-id comparison, so it correctly switches between distinct task-detail views).
- Tested manually with desktop app and it works.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*