### PR TITLE
feat: Add nightly cleanup of stale draft releases

### DIFF
--- a/.github/workflows/cleanup-draft-releases.yml
+++ b/.github/workflows/cleanup-draft-releases.yml
@@ -1,0 +1,31 @@
+name: Cleanup Draft Releases
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: cleanup-draft-releases
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete draft releases older than 1 hour
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          CUTOFF=$(date -u -d "1 hour ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Cutoff (UTC): $CUTOFF"
+          gh api --paginate "repos/$REPO/releases" \
+            --jq ".[] | select(.draft == true) | select(.created_at < \"$CUTOFF\") | .id" \
+          | while read -r release_id; do
+              [ -z "$release_id" ] && continue
+              echo "Deleting draft release $release_id"
+              gh api -X DELETE "repos/$REPO/releases/$release_id"
+            done

--- a/.github/workflows/cleanup-draft-releases.yml
+++ b/.github/workflows/cleanup-draft-releases.yml
@@ -15,12 +15,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Delete draft releases older than 1 hour
+      - name: Delete draft releases older than 24 hours
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          CUTOFF=$(date -u -d "1 hour ago" +%Y-%m-%dT%H:%M:%SZ)
+          set -o pipefail
+          CUTOFF=$(date -u -d "24 hours ago" +%Y-%m-%dT%H:%M:%SZ)
           echo "Cutoff (UTC): $CUTOFF"
           gh api --paginate "repos/$REPO/releases" \
             --jq ".[] | select(.draft == true) | select(.created_at < \"$CUTOFF\") | .id" \


### PR DESCRIPTION
## Problem

Draft releases left behind by failed or aborted release runs accumulate over time and clutter the releases page.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add cleanup-draft-releases.yml workflow
2. Schedule nightly at 00:00 UTC plus workflow_dispatch for manual runs
3. List releases via gh api --paginate and filter drafts with created_at older than 24 hours
4. Delete each match via DELETE /releases/{id}
5. Use default GITHUB_TOKEN with contents: write, no extra secrets required

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

I did not

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->