### PR TITLE
fix(code): unblock main thread by decompressing skills zips off-thread

### DIFF
--- a/apps/code/src/main/services/posthog-plugin/service.test.ts
+++ b/apps/code/src/main/services/posthog-plugin/service.test.ts
@@ -37,14 +37,20 @@ vi.mock("node:fs/promises", async () => {
   return { ...fs.promises, default: fs.promises };
 });
 
-vi.mock("../../utils/extract-zip.js", () => ({
-  extractZip: mockExtractZip,
+const mockFflateUnzip = vi.hoisted(() => vi.fn());
+vi.mock("fflate", () => ({
+  unzip: mockFflateUnzip,
 }));
 
-const mockFflateUnzipSync = vi.hoisted(() => vi.fn());
-vi.mock("fflate", () => ({
-  unzipSync: mockFflateUnzipSync,
-}));
+vi.mock("../../utils/extract-zip.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../utils/extract-zip.js")
+  >("../../utils/extract-zip.js");
+  return {
+    ...actual,
+    extractZip: mockExtractZip,
+  };
+});
 
 vi.mock("node:os", () => ({
   homedir: () => "/mock/home",
@@ -97,7 +103,7 @@ function simulateExtractZip() {
   mockExtractZip.mockImplementation(
     async (zipPath: string, extractDir: string) => {
       if (zipPath.includes("context-mill")) {
-        // Context-mill outer zip: produce omnibus-*.zip files (dummy bytes — unzipSync is mocked)
+        // Inner zip bytes are dummy — fflate.unzip is mocked below.
         vol.mkdirSync(extractDir, { recursive: true });
         vol.writeFileSync(`${extractDir}/omnibus-test-skill.zip`, "dummy");
         vol.writeFileSync(`${extractDir}/manifest.json`, "{}");
@@ -116,12 +122,18 @@ function simulateExtractZip() {
     },
   );
 
-  // Mock fflate unzipSync for inner zip extraction
-  mockFflateUnzipSync.mockImplementation(() => ({
-    "SKILL.md": new TextEncoder().encode(
-      "---\nname: omnibus-test-skill\n---\n# Test Skill",
-    ),
-  }));
+  mockFflateUnzip.mockImplementation(
+    (
+      _data: Uint8Array,
+      cb: (err: Error | null, data: Record<string, Uint8Array>) => void,
+    ) => {
+      cb(null, {
+        "SKILL.md": new TextEncoder().encode(
+          "---\nname: omnibus-test-skill\n---\n# Test Skill",
+        ),
+      });
+    },
+  );
 }
 
 /** Create the bundled plugin directory in memfs */

--- a/apps/code/src/main/services/posthog-plugin/update-skills-saga.ts
+++ b/apps/code/src/main/services/posthog-plugin/update-skills-saga.ts
@@ -9,9 +9,8 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
-import { extractZip } from "@main/utils/extract-zip";
+import { extractZip, unzipAsync } from "@main/utils/extract-zip";
 import { Saga } from "@posthog/shared";
-import { unzipSync } from "fflate";
 
 /**
  * Overlays previously-downloaded skills on top of the runtime plugin dir.
@@ -292,7 +291,7 @@ export class UpdateSkillsSaga extends Saga<
       const strippedName = file.replace(/^omnibus-/, "").replace(/\.zip$/, "");
       const innerZipPath = join(extractDir, file);
       const innerZipData = await readFile(innerZipPath);
-      const innerEntries = unzipSync(new Uint8Array(innerZipData));
+      const innerEntries = await unzipAsync(new Uint8Array(innerZipData));
       const skillDestDir = join(destDir, strippedName);
       await mkdir(skillDestDir, { recursive: true });
 

--- a/apps/code/src/main/utils/extract-zip.ts
+++ b/apps/code/src/main/utils/extract-zip.ts
@@ -1,6 +1,17 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { unzipSync } from "fflate";
+import { type Unzipped, unzip } from "fflate";
+
+// fflate's async unzip yields the event loop so the Electron main thread
+// stays responsive on large archives. Do not switch back to unzipSync.
+export function unzipAsync(data: Uint8Array): Promise<Unzipped> {
+  return new Promise((resolve, reject) => {
+    unzip(data, (err, unzipped) => {
+      if (err) reject(err);
+      else resolve(unzipped);
+    });
+  });
+}
 
 /**
  * Extracts a ZIP file to a directory using fflate (cross-platform, no native dependencies).
@@ -10,7 +21,7 @@ export async function extractZip(
   extractDir: string,
 ): Promise<void> {
   const data = await readFile(zipPath);
-  const unzipped = unzipSync(new Uint8Array(data));
+  const unzipped = await unzipAsync(new Uint8Array(data));
   for (const [filename, content] of Object.entries(unzipped)) {
     const fullPath = join(extractDir, filename);
     if (filename.endsWith("/")) {


### PR DESCRIPTION
## Summary

- `PosthogPluginService.updateSkills()` runs during startup and calls `fflate.unzipSync` on the downloaded skills + context-mill archives. Pure-JS sync decompression on the Electron main thread pegged `CrBrowserMain` for tens of seconds on launch, surfacing as an app-hang for users on v0.52.0 (`Unresponsive for 81 seconds before sampling` in the crash log).
- Swap to fflate's async `unzip` via a small `unzipAsync` promisify helper in `extract-zip.ts`. Used by both `extractZip` and the inner omnibus-zip path in `update-skills-saga.ts`. Async unzip yields the event loop so the main thread stays responsive during extraction.
- Build-time scripts (`vite.main.config.mts`, `scripts/pull-skills.mjs`) keep `unzipSync` — they don't run in the Electron app.

## Root cause (from the crash log)

Main thread stuck at `node::fs::FileHandle::CloseReq::Resolve` → V8 → JIT'd JS for all 41/41 samples — the promise continuation right after `await readFile(zipPath)` resolves, which is exactly where `unzipSync` ran. All 4 `libuv-worker` threads parked in `uv_cond_wait`, confirming the hang was pure CPU on the main thread, not I/O. 1.3 GB footprint matched the fully-materialized decompressed zip held in memory.

## Test plan

- [x] `pnpm --filter code typecheck` clean
- [x] `pnpm --filter code test` — all 1348 tests pass (one mock updated from `unzipSync` to async `unzip`)
- [ ] Manual: launch packaged build on a clean profile and confirm the app reaches the renderer without hanging while skills download

Generated-By: PostHog Code
Task-Id: 0270afde-6140-4867-bd57-52ae8a767a4d