### PR TITLE
feat(inbox): summarize many repos by owner in the GitHub tooltip

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/GitHubIntegrationSection.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GitHubIntegrationSection.tsx
@@ -11,6 +11,26 @@ import {
   InfoIcon,
 } from "@phosphor-icons/react";
 import { Box, Button, Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
+import { useMemo } from "react";
+
+/**
+ * Past this count, the tooltip would become an unreadable wall of `owner/name`
+ * rows, so we collapse to owner-level summaries instead.
+ */
+const REPO_LIST_TOOLTIP_THRESHOLD = 10;
+
+function summarizeReposByOwner(
+  repositories: readonly string[],
+): { owner: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const repo of repositories) {
+    const owner = repo.includes("/") ? (repo.split("/", 1)[0] ?? repo) : repo;
+    counts.set(owner, (counts.get(owner) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([owner, count]) => ({ owner, count }))
+    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+}
 
 export function GitHubIntegrationSection({
   hasGithubIntegration,
@@ -18,6 +38,13 @@ export function GitHubIntegrationSection({
   hasGithubIntegration: boolean;
 }) {
   const { repositories, isLoadingRepos } = useRepositoryIntegration();
+  const ownerSummary = useMemo(
+    () =>
+      repositories.length > REPO_LIST_TOOLTIP_THRESHOLD
+        ? summarizeReposByOwner(repositories)
+        : null,
+    [repositories],
+  );
   const projectId = useAuthStateValue((state) => state.projectId);
   const {
     error: connectError,
@@ -51,13 +78,27 @@ export function GitHubIntegrationSection({
           repositories.length > 0 ? (
             <Tooltip
               content={
-                <Flex direction="column" gap="1">
-                  {repositories.map((repo) => (
-                    <Text key={repo} className="text-[13px]">
-                      {repo}
+                ownerSummary ? (
+                  <Flex direction="column" gap="1">
+                    <Text className="text-(--gray-10) text-[13px]">
+                      {repositories.length} repos across {ownerSummary.length}{" "}
+                      {ownerSummary.length === 1 ? "owner" : "owners"}
                     </Text>
-                  ))}
-                </Flex>
+                    {ownerSummary.map(({ owner, count }) => (
+                      <Text key={owner} className="text-[13px]">
+                        {owner} ({count})
+                      </Text>
+                    ))}
+                  </Flex>
+                ) : (
+                  <Flex direction="column" gap="1">
+                    {repositories.map((repo) => (
+                      <Text key={repo} className="text-[13px]">
+                        {repo}
+                      </Text>
+                    ))}
+                  </Flex>
+                )
               }
               side="bottom"
             >


### PR DESCRIPTION
## Problem

When a PostHog project's GitHub integration covers many repositories, the connected-repos tooltip on the inbox configuration dialog renders every `owner/name` as its own row. Past a handful of repos, the tooltip becomes a long wall of text that's harder to scan than the trigger label itself.

## Changes

- `GitHubIntegrationSection`: when there are more than 10 repos, group them by owner and render `owner (count)` rows with a leading `N repos across M owners` summary line. Small sets (≤10) keep the existing flat list.
- Pulls the grouping into a small `summarizeReposByOwner` helper sorted by count, then owner name, so the most-used owner sits at the top.

## How did you test this?

- `pnpm --filter code typecheck`
- `pnpm exec biome check apps/code/src/renderer/features/settings/components/sections/GitHubIntegrationSection.tsx`
- Manual UI verification deferred — no screenshot yet; reviewer can sanity-check by hovering the "Connected and active (N repos)" label in Inbox configuration with an account that has >10 connected repos.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*