### PR TITLE
fix(agent): guard permission auto-approve against empty options

### DIFF
--- a/apps/code/src/main/services/agent/service.test.ts
+++ b/apps/code/src/main/services/agent/service.test.ts
@@ -121,7 +121,7 @@ vi.mock("node:fs", async (importOriginal) => {
 });
 
 // --- Import after mocks ---
-import { AgentService } from "./service";
+import { AgentService, buildAutoApproveOutcome } from "./service";
 
 // --- Test helpers ---
 
@@ -459,5 +459,38 @@ describe("AgentService", () => {
         expect.anything(),
       );
     });
+  });
+});
+
+describe("buildAutoApproveOutcome", () => {
+  it("prefers an allow_once option", () => {
+    expect(
+      buildAutoApproveOutcome([
+        { optionId: "reject", kind: "reject_once", name: "Reject" },
+        { optionId: "allow", kind: "allow_once", name: "Allow" },
+      ]),
+    ).toEqual({ outcome: "selected", optionId: "allow" });
+  });
+
+  it("prefers an allow_always option", () => {
+    expect(
+      buildAutoApproveOutcome([
+        { optionId: "reject", kind: "reject_once", name: "Reject" },
+        { optionId: "allow_always", kind: "allow_always", name: "Always" },
+      ]),
+    ).toEqual({ outcome: "selected", optionId: "allow_always" });
+  });
+
+  it("falls back to the first option when no allow option exists", () => {
+    expect(
+      buildAutoApproveOutcome([
+        { optionId: "first", kind: "reject_once", name: "First" },
+        { optionId: "second", kind: "reject_always", name: "Second" },
+      ]),
+    ).toEqual({ outcome: "selected", optionId: "first" });
+  });
+
+  it("returns a cancelled outcome when options is empty", () => {
+    expect(buildAutoApproveOutcome([])).toEqual({ outcome: "cancelled" });
   });
 });

--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -260,6 +260,19 @@ function getAgentSessionId(session: ManagedSession): string {
   return sessionId;
 }
 
+export function buildAutoApproveOutcome(
+  options: RequestPermissionRequest["options"],
+): RequestPermissionResponse["outcome"] {
+  const allowOption = options.find(
+    (o) => o.kind === "allow_once" || o.kind === "allow_always",
+  );
+  const optionId = allowOption?.optionId ?? options[0]?.optionId;
+  if (!optionId) {
+    return { outcome: "cancelled" };
+  }
+  return { outcome: "selected", optionId };
+}
+
 interface PendingPermission {
   resolve: (response: RequestPermissionResponse) => void;
   reject: (error: Error) => void;
@@ -1258,15 +1271,7 @@ For git operations while detached:
               taskRunId,
               toolName,
             });
-            const allowOption = params.options.find(
-              (o) => o.kind === "allow_once" || o.kind === "allow_always",
-            );
-            return {
-              outcome: {
-                outcome: "selected",
-                optionId: allowOption?.optionId ?? params.options[0].optionId,
-              },
-            };
+            return { outcome: buildAutoApproveOutcome(params.options) };
           }
         }
 
@@ -1341,15 +1346,7 @@ For git operations while detached:
           taskRunId,
           toolName,
         });
-        const allowOption = params.options.find(
-          (o) => o.kind === "allow_once" || o.kind === "allow_always",
-        );
-        return {
-          outcome: {
-            outcome: "selected",
-            optionId: allowOption?.optionId ?? params.options[0].optionId,
-          },
-        };
+        return { outcome: buildAutoApproveOutcome(params.options) };
       },
 
       async readTextFile(params) {


### PR DESCRIPTION
## Summary

Both auto-approve fallbacks in `requestPermission` (the MCP-trusted-tool branch and the no-`toolCallId` fallback) indexed `params.options[0].optionId` without checking length. If the SDK sent a permission request with an empty `options` array, the `.optionId` access threw a `TypeError` out of the `requestPermission` callback, crashing the in-flight tool call and taking the agent session with it.

## Fix

- Extract `buildAutoApproveOutcome(options)` next to the other top-level helpers in `service.ts`.
- It prefers `allow_once`/`allow_always`, falls back to the first option, and returns `{ outcome: "cancelled" }` (a valid ACP outcome) when `options` is empty.
- Both call sites now use the helper, so the empty case is handled in one place.

## Test plan

- [x] `pnpm --filter code typecheck`
- [x] `pnpm --filter code test` (1352 tests, all passing — includes 4 new tests for `buildAutoApproveOutcome` covering the allow / first-fallback / empty-options paths)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*