### PR TITLE
fix cloud queue idle recovery

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/cloudRunIdleTracker.ts
+++ b/apps/code/src/renderer/features/sessions/service/cloudRunIdleTracker.ts
@@ -1,0 +1,161 @@
+import type { AgentSession } from "@features/sessions/stores/sessionStore";
+import { isNotification, POSTHOG_NOTIFICATIONS } from "@posthog/agent";
+import { isJsonRpcRequest } from "@shared/types/session-events";
+
+interface CloudRunIdleScanState {
+  nextEventIndex: number;
+  seenCurrentRunStart: boolean;
+  idle: boolean;
+}
+
+export interface CloudRunIdleEvidenceSnapshot {
+  taskRunId: string;
+  eventCount: number;
+  agentIdleForRunId: string | undefined;
+  scanState?: CloudRunIdleScanState;
+}
+
+export interface CloudRunIdleRestoreResult {
+  agentIdleForRunId: string | undefined;
+}
+
+export interface CloudRunIdleScanResult {
+  idle: boolean;
+  /** True when the scan path proved idle and the store can cache it. */
+  shouldCacheToStore: boolean;
+}
+
+/**
+ * Tracks idleness for cloud runs incrementally so repeated `in_progress`
+ * updates don't re-scan the full event list each time.
+ */
+export class CloudRunIdleTracker {
+  private scanStates = new Map<string, CloudRunIdleScanState>();
+
+  clear(): void {
+    this.scanStates.clear();
+  }
+
+  delete(taskRunId: string): void {
+    this.scanStates.delete(taskRunId);
+  }
+
+  /**
+   * Marks the run as busy. Sets `seenCurrentRunStart: true` even if a
+   * `RUN_STARTED` notification was never observed because a prompt is
+   * proof the run started.
+   */
+  markBusy(session: AgentSession): void {
+    this.scanStates.set(session.taskRunId, {
+      nextEventIndex: session.events.length,
+      seenCurrentRunStart: true,
+      idle: false,
+    });
+  }
+
+  markIdle(session: AgentSession): void {
+    this.scanStates.set(session.taskRunId, {
+      nextEventIndex: session.events.length,
+      seenCurrentRunStart: true,
+      idle: true,
+    });
+  }
+
+  capture(session: AgentSession): CloudRunIdleEvidenceSnapshot {
+    const scanState = this.scanStates.get(session.taskRunId);
+    return {
+      taskRunId: session.taskRunId,
+      eventCount: session.events.length,
+      agentIdleForRunId: session.agentIdleForRunId,
+      scanState: scanState ? { ...scanState } : undefined,
+    };
+  }
+
+  restoreAfterFailedSend(
+    snapshot: CloudRunIdleEvidenceSnapshot,
+    session: AgentSession,
+  ): CloudRunIdleRestoreResult | undefined {
+    for (let i = snapshot.eventCount; i < session.events.length; i += 1) {
+      const acpMsg = session.events[i];
+      if (
+        acpMsg &&
+        isJsonRpcRequest(acpMsg.message) &&
+        acpMsg.message.method === "session/prompt"
+      ) {
+        return undefined;
+      }
+    }
+
+    const currentScanState = this.scanStates.get(snapshot.taskRunId);
+    const stillAtFailedSendMarker =
+      currentScanState?.nextEventIndex === snapshot.eventCount &&
+      currentScanState.seenCurrentRunStart &&
+      !currentScanState.idle;
+    if (!stillAtFailedSendMarker) {
+      return undefined;
+    }
+
+    if (snapshot.scanState) {
+      this.scanStates.set(snapshot.taskRunId, { ...snapshot.scanState });
+    } else {
+      this.scanStates.delete(snapshot.taskRunId);
+    }
+
+    return { agentIdleForRunId: snapshot.agentIdleForRunId };
+  }
+
+  /**
+   * Returns idleness for this run, scanning only events added since the
+   * previous call. `shouldCacheToStore` is true when the scan path proved
+   * idle instead of the `agentIdleForRunId` fast path.
+   */
+  evaluateIdle(session: AgentSession): CloudRunIdleScanResult {
+    if (session.agentIdleForRunId === session.taskRunId) {
+      return { idle: true, shouldCacheToStore: false };
+    }
+
+    let scanState = this.scanStates.get(session.taskRunId);
+    if (!scanState || scanState.nextEventIndex > session.events.length) {
+      scanState = {
+        nextEventIndex: 0,
+        seenCurrentRunStart: false,
+        idle: false,
+      };
+    }
+
+    for (let i = scanState.nextEventIndex; i < session.events.length; i += 1) {
+      const acpMsg = session.events[i];
+      if (!acpMsg) continue;
+      const msg = acpMsg.message;
+      if (
+        "method" in msg &&
+        isNotification(msg.method, POSTHOG_NOTIFICATIONS.RUN_STARTED)
+      ) {
+        const params = (msg as { params?: { runId?: unknown } }).params;
+        if (params?.runId === session.taskRunId) {
+          scanState.seenCurrentRunStart = true;
+          scanState.idle = false;
+        }
+        continue;
+      }
+      if (!scanState.seenCurrentRunStart) {
+        continue;
+      }
+      if (isJsonRpcRequest(msg) && msg.method === "session/prompt") {
+        scanState.idle = false;
+        continue;
+      }
+      if (
+        "method" in msg &&
+        isNotification(msg.method, POSTHOG_NOTIFICATIONS.TURN_COMPLETE)
+      ) {
+        scanState.idle = true;
+      }
+    }
+
+    scanState.nextEventIndex = session.events.length;
+    this.scanStates.set(session.taskRunId, scanState);
+
+    return { idle: scanState.idle, shouldCacheToStore: scanState.idle };
+  }
+}

--- a/apps/code/src/renderer/features/sessions/service/service.test.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.test.ts
@@ -1,6 +1,7 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import type { AgentSession } from "@features/sessions/stores/sessionStore";
 import type { Task } from "@shared/types";
+import type { AcpMessage } from "@shared/types/session-events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Hoisted Mocks ---
@@ -1232,6 +1233,101 @@ describe("SessionService", () => {
       });
     });
 
+    it("coalesces repeated idle recovery status updates before the queued flush runs", () => {
+      const service = getSessionService();
+      const queuedMessage = {
+        id: "q-1",
+        content: "follow up",
+        queuedAt: 1700000000,
+      };
+      let messageReads = 0;
+      const runStartedEvent = {
+        type: "acp_message" as const,
+        ts: 1700000000,
+        get message() {
+          messageReads += 1;
+          return {
+            jsonrpc: "2.0" as const,
+            method: "_posthog/run_started",
+            params: { runId: "run-123", taskId: "task-123" },
+          };
+        },
+      } as AcpMessage;
+      const turnCompleteEvent = {
+        type: "acp_message" as const,
+        ts: 1700000001,
+        get message() {
+          messageReads += 1;
+          return {
+            jsonrpc: "2.0" as const,
+            method: "_posthog/turn_complete",
+            params: { sessionId: "acp-session", stopReason: "end_turn" },
+          };
+        },
+      } as AcpMessage;
+      const sessionWithQueue = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "connected",
+        isCloud: true,
+        cloudStatus: "in_progress",
+        agentIdleForRunId: undefined,
+        events: [runStartedEvent, turnCompleteEvent],
+        messageQueue: [queuedMessage],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        sessionWithQueue,
+      );
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": sessionWithQueue,
+      });
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue("");
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue("{}");
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run-123",
+      );
+
+      const subscribeOptions = mockTrpcCloudTask.onUpdate.subscribe.mock
+        .calls[0][1] as {
+        onData: (update: {
+          kind: "status";
+          taskId: string;
+          runId: string;
+          status: "in_progress";
+        }) => void;
+      };
+
+      vi.useFakeTimers();
+      try {
+        for (let i = 0; i < 100; i += 1) {
+          subscribeOptions.onData({
+            kind: "status",
+            taskId: "task-123",
+            runId: "run-123",
+            status: "in_progress",
+          });
+        }
+
+        // The two reads are the initial incremental scan over
+        // run_started/turn_complete; repeated in_progress updates must not
+        // re-read the same historical events.
+        expect(messageReads).toBe(2);
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          { agentIdleForRunId: "run-123" },
+        );
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    });
+
     it("does not flush queued cloud messages when cloudStatus flips to in_progress while still connecting", async () => {
       const service = getSessionService();
       mockBuildAuthenticatedClient.mockReturnValue(mockAuthenticatedClient);
@@ -1612,6 +1708,114 @@ describe("SessionService", () => {
             params: expect.objectContaining({ content: "follow up" }),
           }),
         );
+      });
+    });
+
+    it("restores idle evidence after a failed queued dispatch so recovery can retry", async () => {
+      const service = getSessionService();
+      mockBuildAuthenticatedClient.mockReturnValue(mockAuthenticatedClient);
+      const queuedMessage = {
+        id: "q-1",
+        content: "follow up",
+        queuedAt: 1700000000,
+      };
+      const runStartedEvent = {
+        type: "acp_message" as const,
+        ts: 1700000000,
+        message: {
+          jsonrpc: "2.0" as const,
+          method: "_posthog/run_started",
+          params: {
+            sessionId: "acp-session",
+            runId: "run-123",
+            taskId: "task-123",
+          },
+        },
+      };
+      const turnCompleteEvent = {
+        type: "acp_message" as const,
+        ts: 1700000001,
+        message: {
+          jsonrpc: "2.0" as const,
+          method: "_posthog/turn_complete",
+          params: { sessionId: "acp-session", stopReason: "end_turn" },
+        },
+      };
+      const disconnectedSession = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "disconnected",
+        isCloud: true,
+        cloudStatus: "in_progress",
+        isPromptPending: false,
+        agentIdleForRunId: undefined,
+        events: [runStartedEvent, turnCompleteEvent],
+        messageQueue: [queuedMessage],
+      });
+      const connectedSession = createMockSession({
+        ...disconnectedSession,
+        status: "connected",
+      });
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": disconnectedSession,
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        connectedSession,
+      );
+      mockSessionStoreSetters.dequeueMessages.mockReturnValue([queuedMessage]);
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue("");
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue("{}");
+      mockTrpcLogs.writeLocalLogs.mutate.mockResolvedValue(undefined);
+      mockTrpcCloudTask.sendCommand.mutate
+        .mockRejectedValueOnce(new Error("transient backend failure"))
+        .mockResolvedValueOnce({
+          success: true,
+          result: { stopReason: "end_turn" },
+        });
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run-123",
+      );
+
+      const subscribeOptions = mockTrpcCloudTask.onUpdate.subscribe.mock
+        .calls[0][1] as {
+        onData: (update: {
+          kind: "status";
+          taskId: string;
+          runId: string;
+          status: "in_progress";
+        }) => void;
+      };
+      subscribeOptions.onData({
+        kind: "status",
+        taskId: "task-123",
+        runId: "run-123",
+        status: "in_progress",
+      });
+
+      await vi.waitFor(() => {
+        expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledTimes(1);
+      });
+      await vi.waitFor(() => {
+        expect(
+          mockSessionStoreSetters.prependQueuedMessages,
+        ).toHaveBeenCalledWith("task-123", [queuedMessage]);
+      });
+
+      subscribeOptions.onData({
+        kind: "status",
+        taskId: "task-123",
+        runId: "run-123",
+        status: "in_progress",
+      });
+
+      await vi.waitFor(() => {
+        expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -81,6 +81,7 @@ import {
   uploadRunAttachments,
   uploadTaskStagedAttachments,
 } from "../utils/cloudArtifacts";
+import { CloudRunIdleTracker } from "./cloudRunIdleTracker";
 
 const log = logger.scope("session-service");
 const LOCAL_SESSION_RECONNECT_ATTEMPTS = 3;
@@ -254,6 +255,9 @@ export class SessionService {
   private localRecoveryAttempts = new Map<string, Promise<boolean>>();
   /** Re-entrance guard for cloud queue dispatch (per taskId). */
   private dispatchingCloudQueues = new Set<string>();
+  /** Coalesces deferred cloud queue flush timers (per taskId). */
+  private scheduledCloudQueueFlushes = new Set<string>();
+  private cloudRunIdleTracker = new CloudRunIdleTracker();
   private nextCloudTaskWatchToken = 0;
   private subscriptions = new Map<
     string,
@@ -700,6 +704,7 @@ export class SessionService {
 
     this.unsubscribeFromChannel(taskRunId);
     sessionStoreSetters.removeSession(taskRunId);
+    this.cloudRunIdleTracker.delete(taskRunId);
     if (session) {
       this.localRepoPaths.delete(session.taskId);
       this.localRecoveryAttempts.delete(session.taskId);
@@ -1080,6 +1085,8 @@ export class SessionService {
     this.cloudPermissionRequestIds.clear();
     this.cloudLogGapReconciles.clear();
     this.dispatchingCloudQueues.clear();
+    this.scheduledCloudQueueFlushes.clear();
+    this.cloudRunIdleTracker.clear();
     this.idleKilledSubscription?.unsubscribe();
     this.idleKilledSubscription = null;
   }
@@ -1098,10 +1105,13 @@ export class SessionService {
           currentPromptId: msg.id,
         });
         const promptSession = sessionStoreSetters.getSessions()[taskRunId];
-        if (promptSession?.isCloud && promptSession.agentIdleForRunId) {
-          sessionStoreSetters.updateSession(taskRunId, {
-            agentIdleForRunId: undefined,
-          });
+        if (promptSession?.isCloud) {
+          this.cloudRunIdleTracker.markBusy(promptSession);
+          if (promptSession.agentIdleForRunId) {
+            sessionStoreSetters.updateSession(taskRunId, {
+              agentIdleForRunId: undefined,
+            });
+          }
         }
       }
       if (
@@ -1190,6 +1200,7 @@ export class SessionService {
           if (Object.keys(updates).length > 0) {
             sessionStoreSetters.updateSession(taskRunId, updates);
           }
+          this.cloudRunIdleTracker.markIdle(session);
           if (session.messageQueue.length > 0) {
             this.scheduleCloudQueueFlush(session.taskId, "turn_complete");
           }
@@ -1791,12 +1802,18 @@ export class SessionService {
       params.artifact_ids = artifactIds;
     }
 
+    const currentSessionBeforeSend =
+      this.getSessionByRunId(session.taskRunId) ?? session;
+    const idleEvidenceBeforeSend = this.cloudRunIdleTracker.capture(
+      currentSessionBeforeSend,
+    );
     sessionStoreSetters.updateSession(session.taskRunId, {
       isPromptPending: true,
       promptStartedAt: Date.now(),
       pausedDurationMs: 0,
       agentIdleForRunId: undefined,
     });
+    this.cloudRunIdleTracker.markBusy(currentSessionBeforeSend);
     sessionStoreSetters.appendOptimisticItem(session.taskRunId, {
       type: "user_message",
       content: transport.promptText,
@@ -1839,6 +1856,29 @@ export class SessionService {
         promptStartedAt: null,
       });
       sessionStoreSetters.clearTailOptimisticItems(session.taskRunId);
+      const currentSessionAfterFailure = this.getSessionByRunId(
+        session.taskRunId,
+      );
+      if (currentSessionAfterFailure) {
+        const restoreResult = this.cloudRunIdleTracker.restoreAfterFailedSend(
+          idleEvidenceBeforeSend,
+          currentSessionAfterFailure,
+        );
+        if (restoreResult) {
+          log.warn("Restored idle evidence after failed cloud send", {
+            taskId: session.taskId,
+            taskRunId: session.taskRunId,
+          });
+          if (
+            currentSessionAfterFailure.agentIdleForRunId !==
+            restoreResult.agentIdleForRunId
+          ) {
+            sessionStoreSetters.updateSession(session.taskRunId, {
+              agentIdleForRunId: restoreResult.agentIdleForRunId,
+            });
+          }
+        }
+      }
       throw error;
     }
   }
@@ -3231,56 +3271,20 @@ export class SessionService {
    * schedules from multiple triggers collapse to one.
    */
   private scheduleCloudQueueFlush(taskId: string, reason: string): void {
+    if (
+      this.scheduledCloudQueueFlushes.has(taskId) ||
+      this.dispatchingCloudQueues.has(taskId)
+    ) {
+      return;
+    }
+
+    this.scheduledCloudQueueFlushes.add(taskId);
     setTimeout(() => {
+      this.scheduledCloudQueueFlushes.delete(taskId);
       this.sendQueuedCloudMessages(taskId).catch((err) =>
         log.error("cloud queue flush failed", { taskId, reason, error: err }),
       );
     }, 0);
-  }
-
-  /**
-   * True when the agent for this exact run is idle: it has completed at
-   * least one turn for this run and is not mid-turn. Tracked live via
-   * `agentIdleForRunId` (set only on `_posthog/turn_complete`), with a
-   * fallback that replays events for the case where a session was recreated
-   * from logs and the live flag was never set (no-delta dedup guard skipped
-   * reprocessing).
-   *
-   * Deliberately independent of `isPromptPending`: `retryCloudTaskWatch()`
-   * forcibly clears it on reconnect, so trusting it would let recovery
-   * dispatch a queued follow-up while a remote turn is still running.
-   */
-  private isAgentIdleForRun(session: AgentSession): boolean {
-    if (session.agentIdleForRunId === session.taskRunId) {
-      return true;
-    }
-    let seenCurrentRunStart = false;
-    let idle = false;
-    for (const acpMsg of session.events) {
-      const msg = acpMsg.message;
-      if (
-        "method" in msg &&
-        isNotification(msg.method, POSTHOG_NOTIFICATIONS.RUN_STARTED)
-      ) {
-        const params = (msg as { params?: { runId?: unknown } }).params;
-        if (params?.runId === session.taskRunId) {
-          seenCurrentRunStart = true;
-          idle = false;
-        }
-        continue;
-      }
-      if (!seenCurrentRunStart) {
-        continue;
-      }
-      if (isJsonRpcRequest(msg) && msg.method === "session/prompt") {
-        idle = false;
-        continue;
-      }
-      if (isTurnCompleteEvent(acpMsg)) {
-        idle = true;
-      }
-    }
-    return idle;
   }
 
   /**
@@ -3307,16 +3311,10 @@ export class SessionService {
     if (session.cloudStatus !== "in_progress") {
       return;
     }
-
-    // The agent must be provably idle for this run, the
-    // connected path included. `status: "connected"` alone is NOT proof of
-    // idleness: the `_posthog/run_started` handler flips status to
-    // "connected" before the initial/resume turn even starts, so a
-    // connected-but-not-idle session is mid-boot. Draining now would race
-    // with `sendInitialTaskMessage`/`sendResumeMessage` and one prompt
-    // would be cancelled. Only `_posthog/turn_complete` makes the agent
-    // idle for the run (`isAgentIdleForRun`).
-    if (!this.isAgentIdleForRun(session)) {
+    if (
+      this.scheduledCloudQueueFlushes.has(session.taskId) ||
+      this.dispatchingCloudQueues.has(session.taskId)
+    ) {
       return;
     }
 
@@ -3326,6 +3324,30 @@ export class SessionService {
 
     if (session.status !== "connected" && !recoverableAfterTransportDrop) {
       return;
+    }
+
+    // A local prompt in flight means a queued follow-up would double-send.
+    // The idle scan below is still the real safety check after reconnect.
+    if (session.isPromptPending) {
+      return;
+    }
+
+    // The agent must be provably idle for this run, the
+    // connected path included. `status: "connected"` alone is NOT proof of
+    // idleness: the `_posthog/run_started` handler flips status to
+    // "connected" before the initial/resume turn even starts, so a
+    // connected-but-not-idle session is mid-boot. Draining now would race
+    // with `sendInitialTaskMessage`/`sendResumeMessage` and one prompt
+    // would be cancelled. Only `_posthog/turn_complete` makes the agent
+    // idle for the run.
+    const idleResult = this.cloudRunIdleTracker.evaluateIdle(session);
+    if (!idleResult.idle) {
+      return;
+    }
+    if (idleResult.shouldCacheToStore) {
+      sessionStoreSetters.updateSession(taskRunId, {
+        agentIdleForRunId: taskRunId,
+      });
     }
 
     if (recoverableAfterTransportDrop) {
@@ -3723,6 +3745,7 @@ export class SessionService {
       if (hasSessionPromptEvent(events)) {
         sessionStoreSetters.clearTailOptimisticItems(taskRunId);
       }
+      this.cloudRunIdleTracker.delete(taskRunId);
       sessionStoreSetters.updateSession(taskRunId, {
         events,
         isCloud: true,


### PR DESCRIPTION
## Problem

defensive hardening of the idle-recovery path

## Changes

- coalesce deferred cloud queue flushes and skip idle recovery while a flush is already scheduled or dispatching