### PR TITLE
fix(code): reduce window minWidth from 1200 to 800

### DIFF
--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -182,7 +182,7 @@ export function createWindow(): void {
     ...(savedState.y !== undefined && { y: savedState.y }),
     width: savedState.width,
     height: savedState.height,
-    minWidth: 1200,
+    minWidth: 800,
     minHeight: 600,
     backgroundColor: "#0a0a0a",
     ...platformWindowConfig,


### PR DESCRIPTION
## Summary
- The main `BrowserWindow` enforced a `minWidth: 1200`, preventing users on common laptop displays (e.g. 1440–1600px wide) from tiling the app to half a screen.
- Drop the floor to `800px`. `minHeight: 600` is unchanged — already low enough.
- No other constraints fight this: no root-level CSS `min-width`, and internal `min-w-*` usages are scoped to components that already handle narrower widths.

## Test plan
- [ ] `pnpm dev:code` and drag the window inward; confirm it now resizes down to ~800px wide
- [ ] Tile the window to half a 1600px display; confirm tiling succeeds
- [ ] Sanity-check the header, sidebar, and task detail panels at ~800px for clipping