### PR TITLE
fix: Buffer feature-flag subscribers registered before init

### DIFF
--- a/apps/code/src/renderer/utils/analytics.test.ts
+++ b/apps/code/src/renderer/utils/analytics.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPosthog = {
+  init: vi.fn(),
+  register: vi.fn(),
+  onFeatureFlags: vi.fn(),
+  isFeatureEnabled: vi.fn(),
+  startSessionRecording: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  group: vi.fn(),
+  reset: vi.fn(),
+  captureException: vi.fn(),
+  reloadFeatureFlags: vi.fn(),
+};
+
+vi.mock("posthog-js/dist/module.full.no-external", () => ({
+  default: mockPosthog,
+}));
+
+vi.mock("posthog-js/dist/posthog-recorder", () => ({}));
+
+async function loadAnalytics() {
+  vi.resetModules();
+  return await import("./analytics");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("VITE_POSTHOG_API_KEY", "test-key");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("onFeatureFlagsLoaded", () => {
+  it("delivers pre-init subscribers when init runs", async () => {
+    const { initializePostHog, onFeatureFlagsLoaded } = await loadAnalytics();
+
+    const cb = vi.fn();
+    onFeatureFlagsLoaded(cb);
+
+    expect(mockPosthog.onFeatureFlags).not.toHaveBeenCalled();
+
+    initializePostHog();
+
+    expect(mockPosthog.onFeatureFlags).toHaveBeenCalledTimes(1);
+    expect(mockPosthog.onFeatureFlags).toHaveBeenCalledWith(cb);
+  });
+
+  it("does not register a buffered listener that unsubscribed before init", async () => {
+    const { initializePostHog, onFeatureFlagsLoaded } = await loadAnalytics();
+
+    const cb = vi.fn();
+    const off = onFeatureFlagsLoaded(cb);
+    off();
+
+    initializePostHog();
+
+    expect(mockPosthog.onFeatureFlags).not.toHaveBeenCalled();
+  });
+
+  it("propagates unsubscribe to PostHog when called after init", async () => {
+    const realUnsub = vi.fn();
+    mockPosthog.onFeatureFlags.mockReturnValue(realUnsub);
+
+    const { initializePostHog, onFeatureFlagsLoaded } = await loadAnalytics();
+
+    const off = onFeatureFlagsLoaded(vi.fn());
+    initializePostHog();
+    off();
+
+    expect(realUnsub).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes post-init subscribers directly to PostHog", async () => {
+    const realUnsub = vi.fn();
+    mockPosthog.onFeatureFlags.mockReturnValue(realUnsub);
+
+    const { initializePostHog, onFeatureFlagsLoaded } = await loadAnalytics();
+    initializePostHog();
+
+    const cb = vi.fn();
+    const off = onFeatureFlagsLoaded(cb);
+
+    expect(mockPosthog.onFeatureFlags).toHaveBeenCalledWith(cb);
+
+    off();
+    expect(realUnsub).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("initializePostHog", () => {
+  it("is idempotent across repeat calls", async () => {
+    const { initializePostHog } = await loadAnalytics();
+
+    initializePostHog();
+    initializePostHog();
+
+    expect(mockPosthog.init).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when no API key is set", async () => {
+    vi.stubEnv("VITE_POSTHOG_API_KEY", "");
+    const { initializePostHog, onFeatureFlagsLoaded } = await loadAnalytics();
+
+    const cb = vi.fn();
+    onFeatureFlagsLoaded(cb);
+    initializePostHog();
+
+    expect(mockPosthog.init).not.toHaveBeenCalled();
+    expect(mockPosthog.onFeatureFlags).not.toHaveBeenCalled();
+  });
+});

--- a/apps/code/src/renderer/utils/analytics.ts
+++ b/apps/code/src/renderer/utils/analytics.ts
@@ -16,10 +16,10 @@ let isInitialized = false;
 
 type PendingFlagListener = {
   callback: () => void;
-  unsubscribe?: () => void;
+  unsubscribe: (() => void) | null;
 };
 
-// Buffers subscribers that arrive before init (child useEffects run before parent's initializePostHog).
+// Subscribers added before initializePostHog runs.
 const pendingFlagListeners = new Set<PendingFlagListener>();
 
 export function initializePostHog() {
@@ -56,6 +56,7 @@ export function initializePostHog() {
   for (const listener of pendingFlagListeners) {
     listener.unsubscribe = posthog.onFeatureFlags(listener.callback);
   }
+  pendingFlagListeners.clear();
 }
 
 /**
@@ -228,11 +229,14 @@ export function onFeatureFlagsLoaded(callback: () => void): () => void {
     return posthog.onFeatureFlags(callback);
   }
 
-  const listener: PendingFlagListener = { callback };
+  const listener: PendingFlagListener = { callback, unsubscribe: null };
   pendingFlagListeners.add(listener);
   return () => {
-    pendingFlagListeners.delete(listener);
-    listener.unsubscribe?.();
+    if (listener.unsubscribe) {
+      listener.unsubscribe();
+    } else {
+      pendingFlagListeners.delete(listener);
+    }
   };
 }
 

--- a/apps/code/src/renderer/utils/analytics.ts
+++ b/apps/code/src/renderer/utils/analytics.ts
@@ -14,6 +14,14 @@ const log = logger.scope("analytics");
 
 let isInitialized = false;
 
+type PendingFlagListener = {
+  callback: () => void;
+  unsubscribe?: () => void;
+};
+
+// Buffers subscribers that arrive before init (child useEffects run before parent's initializePostHog).
+const pendingFlagListeners = new Set<PendingFlagListener>();
+
 export function initializePostHog() {
   const apiKey = import.meta.env.VITE_POSTHOG_API_KEY;
   const apiHost =
@@ -44,6 +52,10 @@ export function initializePostHog() {
   posthog.register({ team: "posthog-code" });
 
   isInitialized = true;
+
+  for (const listener of pendingFlagListeners) {
+    listener.unsubscribe = posthog.onFeatureFlags(listener.callback);
+  }
 }
 
 /**
@@ -212,11 +224,16 @@ export function isFeatureFlagEnabled(flagKey: string): boolean {
  * Returns unsubscribe function.
  */
 export function onFeatureFlagsLoaded(callback: () => void): () => void {
-  if (!isInitialized) {
-    return () => {};
+  if (isInitialized) {
+    return posthog.onFeatureFlags(callback);
   }
 
-  return posthog.onFeatureFlags(callback);
+  const listener: PendingFlagListener = { callback };
+  pendingFlagListeners.add(listener);
+  return () => {
+    pendingFlagListeners.delete(listener);
+    listener.unsubscribe?.();
+  };
 }
 
 /**


### PR DESCRIPTION
## Problem

`useFeatureFlag` callers that mount before App's init useEffect runs subscribe via `onFeatureFlagsLoaded` while PostHog is uninitialized, so the no-op return silently drops the subscription. When flags later resolve, nothing fires and the hook stays stuck on its initial value for the rest of the session.<!-- Who is this for and what problem does it solve? -->

Closes https://github.com/PostHog/code/issues/2123

<!-- Closes #ISSUE_ID -->

## Changes

1. Buffer onFeatureFlagsLoaded callbacks added before PostHog initializes
2. Drain the buffer into posthog.onFeatureFlags at the end of initializePostHog
3. Return a cleanup that unsubscribes from both the buffer and PostHog

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->