### PR TITLE
fix: Render at-mentioned chips as @labels in task titles

### DIFF
--- a/apps/code/src/renderer/features/message-editor/utils/content.test.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/content.test.ts
@@ -4,6 +4,7 @@ import {
   type EditorContent,
   extractFilePaths,
   xmlToContent,
+  xmlToPlainText,
 } from "./content";
 
 describe("xmlToContent", () => {
@@ -194,6 +195,30 @@ describe("xmlToContent", () => {
       ],
     };
     expect(extractFilePaths(content)).toEqual(["src/sub", "src/a.ts"]);
+  });
+
+  it("xmlToPlainText renders folder mentions as @mentions", () => {
+    expect(
+      xmlToPlainText('look at <folder path="products/agentic_tests" /> please'),
+    ).toBe("look at @products/agentic_tests please");
+  });
+
+  it("xmlToPlainText renders file mentions as @mentions", () => {
+    expect(
+      xmlToPlainText('see <file path="src/foo/bar.ts" /> for details'),
+    ).toBe("see @foo/bar.ts for details");
+  });
+
+  it("xmlToPlainText renders structured chip types as @label", () => {
+    expect(
+      xmlToPlainText(
+        'investigate <error id="err-1" /> and <feature_flag id="flag-2" />',
+      ),
+    ).toBe("investigate @err-1 and @flag-2");
+  });
+
+  it("xmlToPlainText leaves plain text untouched", () => {
+    expect(xmlToPlainText("ship the fix")).toBe("ship the fix");
   });
 
   it("round-trips contentToXml for a mix of text and chips", () => {

--- a/apps/code/src/renderer/features/message-editor/utils/content.ts
+++ b/apps/code/src/renderer/features/message-editor/utils/content.ts
@@ -142,6 +142,10 @@ function chipFromTag(tag: string, rawAttrs: string): MentionChip | null {
   }
 }
 
+export function xmlToPlainText(xml: string): string {
+  return contentToPlainText(xmlToContent(xml));
+}
+
 export function xmlToContent(xml: string): EditorContent {
   const segments: EditorContent["segments"] = [];
   let lastIndex = 0;

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -1,6 +1,7 @@
 import { CHAT_CONTENT_MAX_WIDTH } from "@features/sessions/constants";
 import { useContextUsage } from "@features/sessions/hooks/useContextUsage";
 import { useConversationSearch } from "@features/sessions/hooks/useConversationSearch";
+import { SessionTaskIdProvider } from "@features/sessions/hooks/useSessionTaskId";
 import {
   sessionStoreSetters,
   useOptimisticItemsForTask,
@@ -267,37 +268,39 @@ export function ConversationView({
           />
         )}
 
-        <VirtualizedList
-          ref={listRef}
-          items={items}
-          getItemKey={getItemKey}
-          renderItem={renderItem}
-          onScrollStateChange={handleScrollStateChange}
-          keepMounted={mcpAppIndices}
-          className="absolute inset-0 bg-background"
-          itemClassName="mx-auto px-2 py-1.5"
-          itemStyle={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
-          footer={
-            <div className={compact ? "pb-1" : "pb-16"}>
-              <SessionFooter
-                task={task}
-                isPromptPending={isPromptPending}
-                promptStartedAt={promptStartedAt}
-                lastGenerationDuration={
-                  lastTurnInfo?.isComplete
-                    ? Math.max(0, lastTurnInfo.durationMs - pausedDurationMs)
-                    : null
-                }
-                lastStopReason={lastTurnInfo?.stopReason}
-                queuedCount={queuedMessages.length}
-                hasPendingPermission={pendingPermissionsCount > 0}
-                pausedDurationMs={pausedDurationMs}
-                isCompacting={isCompacting}
-                usage={contextUsage}
-              />
-            </div>
-          }
-        />
+        <SessionTaskIdProvider taskId={taskId}>
+          <VirtualizedList
+            ref={listRef}
+            items={items}
+            getItemKey={getItemKey}
+            renderItem={renderItem}
+            onScrollStateChange={handleScrollStateChange}
+            keepMounted={mcpAppIndices}
+            className="absolute inset-0 bg-background"
+            itemClassName="mx-auto px-2 py-1.5"
+            itemStyle={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
+            footer={
+              <div className={compact ? "pb-1" : "pb-16"}>
+                <SessionFooter
+                  task={task}
+                  isPromptPending={isPromptPending}
+                  promptStartedAt={promptStartedAt}
+                  lastGenerationDuration={
+                    lastTurnInfo?.isComplete
+                      ? Math.max(0, lastTurnInfo.durationMs - pausedDurationMs)
+                      : null
+                  }
+                  lastStopReason={lastTurnInfo?.stopReason}
+                  queuedCount={queuedMessages.length}
+                  hasPendingPermission={pendingPermissionsCount > 0}
+                  pausedDurationMs={pausedDurationMs}
+                  isCompacting={isCompacting}
+                  usage={contextUsage}
+                />
+              </div>
+            }
+          />
+        </SessionTaskIdProvider>
         {showScrollButton && (
           <Box className="absolute right-4 bottom-4 z-10">
             <Button size="1" variant="solid" onClick={scrollToBottom}>

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -3,8 +3,8 @@ import { Tooltip } from "@components/ui/Tooltip";
 import { usePendingScrollStore } from "@features/code-editor/stores/pendingScrollStore";
 import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
 import { usePanelLayoutStore } from "@features/panels";
+import { useSessionTaskId } from "@features/sessions/hooks/useSessionTaskId";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { useTaskStore } from "@features/tasks/stores/taskStore";
 import type { FileItem } from "@hooks/useRepoFiles";
 import { useRepoFiles } from "@hooks/useRepoFiles";
 import { Check, Copy } from "@phosphor-icons/react";
@@ -46,7 +46,7 @@ function InlineFileLink({
   const { filePath: rawPath, lineSuffix } = parseFilePath(text);
   const filePath = resolvedPath ?? rawPath;
   const filename = rawPath.split("/").pop() ?? rawPath;
-  const taskId = useTaskStore((s) => s.selectedTaskId);
+  const taskId = useSessionTaskId();
   const repoPath = useCwd(taskId ?? "");
   const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);
   const requestScroll = usePendingScrollStore((s) => s.requestScroll);
@@ -86,7 +86,7 @@ function InlineFileLink({
 
 function BareFileLink({ text }: { text: string }) {
   const { filePath: bareFilename } = parseFilePath(text);
-  const taskId = useTaskStore((s) => s.selectedTaskId);
+  const taskId = useSessionTaskId();
   const repoPath = useCwd(taskId ?? "");
   const { files } = useRepoFiles(repoPath ?? undefined);
   const resolved = useMemo(

--- a/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
@@ -1,7 +1,7 @@
 import { FileIcon } from "@components/ui/FileIcon";
 import { usePanelLayoutStore } from "@features/panels";
+import { useSessionTaskId } from "@features/sessions/hooks/useSessionTaskId";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { useTaskStore } from "@features/tasks/stores/taskStore";
 import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
 import { Flex, Text } from "@radix-ui/themes";
 import { trpcClient } from "@renderer/trpc/client";
@@ -32,7 +32,7 @@ function toRelativePath(absolutePath: string, repoPath: string | null): string {
 export const FileMentionChip = memo(function FileMentionChip({
   filePath,
 }: FileMentionChipProps) {
-  const taskId = useTaskStore((s) => s.selectedTaskId);
+  const taskId = useSessionTaskId();
   const repoPath = useCwd(taskId ?? "");
   const workspace = useWorkspace(taskId ?? undefined);
   const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);

--- a/apps/code/src/renderer/features/sessions/hooks/useSessionTaskId.tsx
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionTaskId.tsx
@@ -1,0 +1,21 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+const SessionTaskIdContext = createContext<string | null>(null);
+
+export function SessionTaskIdProvider({
+  taskId,
+  children,
+}: {
+  taskId: string | null | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <SessionTaskIdContext.Provider value={taskId ?? null}>
+      {children}
+    </SessionTaskIdContext.Provider>
+  );
+}
+
+export function useSessionTaskId(): string | null {
+  return useContext(SessionTaskIdContext);
+}

--- a/apps/code/src/renderer/sagas/task/task-creation.test.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.test.ts
@@ -51,10 +51,6 @@ vi.mock("@features/sessions/service/service", () => ({
   }),
 }));
 
-vi.mock("@renderer/utils/generateTitle", () => ({
-  createFileTagRegex: () => /<file\s+path="([^"]+)"\s*\/>/g,
-}));
-
 vi.mock("@utils/logger", () => ({
   logger: {
     scope: () => ({
@@ -409,7 +405,7 @@ describe("TaskCreationSaga", () => {
     );
   });
 
-  it("sets fallback title when description is attachment-only", async () => {
+  it("renders attachment-only description as @mention title", async () => {
     const createdTask = createTask();
     const startedTask = createTask({ latest_run: createRun() });
     const createTaskMock = vi.fn().mockResolvedValue(createdTask);
@@ -438,8 +434,42 @@ describe("TaskCreationSaga", () => {
 
     expect(createTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: "Reading attachment\u2026",
+        title: "@tmp/code.ts",
         description: '<file path="/tmp/code.ts" />',
+      }),
+    );
+  });
+
+  it("renders folder mentions as readable @mention in title", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: createTaskRunMock,
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: vi.fn(),
+      } as never,
+    });
+
+    await saga.run({
+      content:
+        'look at <folder path="products/agentic_tests" /> and tell me what you see',
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    expect(createTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "look at @products/agentic_tests and tell me what you see",
       }),
     );
   });

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -1,4 +1,5 @@
 import { buildPromptBlocks } from "@features/editor/utils/prompt-builder";
+import { xmlToPlainText } from "@features/message-editor/utils/content";
 import { DEFAULT_PANEL_IDS } from "@features/panels/constants/panelConstants";
 import { usePanelLayoutStore } from "@features/panels/store/panelLayoutStore";
 import { useProvisioningStore } from "@features/provisioning/stores/provisioningStore";
@@ -18,7 +19,6 @@ import type {
 import { Saga, type SagaLogger } from "@posthog/shared";
 import type { PostHogAPIClient } from "@renderer/api/posthogClient";
 import { trpcClient } from "@renderer/trpc";
-import { createFileTagRegex } from "@renderer/utils/generateTitle";
 import { getTaskRepository } from "@renderer/utils/repository";
 import {
   type ExecutionMode,
@@ -401,7 +401,7 @@ export class TaskCreationSaga extends Saga<
       name: "task_creation",
       execute: async () => {
         const description = input.taskDescription ?? input.content ?? "";
-        const plainText = description.replace(createFileTagRegex(), "").trim();
+        const plainText = xmlToPlainText(description).trim();
         const result = await this.deps.posthogClient.createTask({
           title: (plainText || "Reading attachment\u2026").slice(0, 255),
           description,


### PR DESCRIPTION
## Problem

At-mentioned directories (and other chip types) rendered as raw XML like `<folder path="products/agentic_tests" />` in task titles instead of human-readable text.

Closes #2172

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add `xmlToPlainText` helper composing `xmlToContent` + `contentToPlainText`
2. Use it in the task-creation saga so every chip type renders as `@label`
3. Drop unused `createFileTagRegex` import from the saga
4. Update attachment-only saga test (now shows `@tmp/code.ts` instead of "Reading attachment…")
5. Add folder-mention regression test plus `xmlToPlainText` unit tests

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->