### PR TITLE
fix: Unblock cloud branch picker during slow remote load

### DIFF
--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.test.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.test.tsx
@@ -1,0 +1,153 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@features/git-interaction/state/gitInteractionStore", () => ({
+  useGitInteractionStore: () => ({ actions: { openBranch: vi.fn() } }),
+}));
+
+vi.mock("@features/git-interaction/utils/getSuggestedBranchName", () => ({
+  getSuggestedBranchName: vi.fn(() => null),
+}));
+
+vi.mock("@features/git-interaction/utils/gitCacheKeys", () => ({
+  invalidateGitBranchQueries: vi.fn(),
+}));
+
+vi.mock("@renderer/trpc", () => ({
+  useTRPC: () => ({
+    git: {
+      getAllBranches: { queryOptions: () => ({ queryKey: ["mock"] }) },
+      checkoutBranch: { mutationOptions: () => ({}) },
+    },
+  }),
+}));
+
+vi.mock("@renderer/utils/toast", () => ({
+  toast: { error: vi.fn() },
+}));
+
+const mutateMock = vi.fn();
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [], isLoading: false }),
+  useMutation: () => ({ mutate: mutateMock }),
+}));
+
+import { BranchSelector } from "./BranchSelector";
+
+function renderInTheme(children: React.ReactElement) {
+  return render(<Theme>{children}</Theme>);
+}
+
+describe("BranchSelector cloud mode", () => {
+  it("keeps the trigger enabled while the initial cloud load is in flight", () => {
+    renderInTheme(
+      <BranchSelector
+        repoPath="owner/repo"
+        currentBranch={null}
+        workspaceMode="cloud"
+        cloudBranches={[]}
+        cloudBranchesLoading={true}
+        cloudSearchQuery=""
+        onBranchSelect={vi.fn()}
+        onCloudSearchChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Branch" })).toBeEnabled();
+  });
+
+  it("surfaces the 'Use input as branch name' action when the typed value is new", async () => {
+    const user = userEvent.setup();
+    renderInTheme(
+      <BranchSelector
+        repoPath="owner/repo"
+        currentBranch={null}
+        workspaceMode="cloud"
+        cloudBranches={["main", "feature-a"]}
+        cloudBranchesLoading={false}
+        cloudSearchQuery="brand-new-branch"
+        onBranchSelect={vi.fn()}
+        onCloudSearchChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Branch" }));
+
+    expect(
+      await screen.findByText('Use "brand-new-branch" as branch name'),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the typed-name action when the input exactly matches an existing branch", async () => {
+    const user = userEvent.setup();
+    renderInTheme(
+      <BranchSelector
+        repoPath="owner/repo"
+        currentBranch={null}
+        workspaceMode="cloud"
+        cloudBranches={["main", "feature-a"]}
+        cloudBranchesLoading={false}
+        cloudSearchQuery="main"
+        onBranchSelect={vi.fn()}
+        onCloudSearchChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Branch" }));
+
+    expect(
+      screen.queryByText(/Use "main" as branch name/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("commits the typed value via onBranchSelect when the sentinel action is selected", async () => {
+    const user = userEvent.setup();
+    const onBranchSelect = vi.fn();
+    renderInTheme(
+      <BranchSelector
+        repoPath="owner/repo"
+        currentBranch={null}
+        workspaceMode="cloud"
+        cloudBranches={[]}
+        cloudBranchesLoading={true}
+        cloudSearchQuery="brand-new-branch"
+        onBranchSelect={onBranchSelect}
+        onCloudSearchChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Branch" }));
+    await user.click(
+      await screen.findByText('Use "brand-new-branch" as branch name'),
+    );
+
+    expect(onBranchSelect).toHaveBeenCalledWith("brand-new-branch");
+  });
+
+  it("invokes onCloudBranchCommit when the typed value is committed (so the parent can reset the search)", async () => {
+    const user = userEvent.setup();
+    const onCloudBranchCommit = vi.fn();
+    renderInTheme(
+      <BranchSelector
+        repoPath="owner/repo"
+        currentBranch={null}
+        workspaceMode="cloud"
+        cloudBranches={[]}
+        cloudBranchesLoading={true}
+        cloudSearchQuery="brand-new-branch"
+        onBranchSelect={vi.fn()}
+        onCloudSearchChange={vi.fn()}
+        onCloudBranchCommit={onCloudBranchCommit}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Branch" }));
+    await user.click(
+      await screen.findByText('Use "brand-new-branch" as branch name'),
+    );
+
+    expect(onCloudBranchCommit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -37,8 +37,10 @@ const COMBOBOX_LIMIT = 50;
 const CREATE_BRANCH_ACTION = "__create_branch__";
 
 // Sentinel for the "Use '<input>' as branch name" action in cloud mode.
-// Surfaced as the first list item so it's keyboard-reachable and
-// auto-highlighted while the (slow) remote search is still running.
+// Positioned first when the list is empty so it's auto-highlighted while the
+// (slow) remote search is still running; pushed into the footer once branches
+// have loaded so auto-highlight lands on a real branch (typed names that match
+// a server-returned prefix would otherwise be shadowed by the literal input).
 const USE_INPUT_BRANCH_ACTION = "__use_input_branch__";
 
 function LoadingRow({ label }: { label: string }) {
@@ -243,10 +245,18 @@ export function BranchSelector({
     handleBranchChange(trimmedInputValue);
   };
 
+  const useInputBranchPosition: "leading" | "trailing" | null =
+    showUseInputBranchAction
+      ? branches.length === 0
+        ? "leading"
+        : "trailing"
+      : null;
   const comboboxItems = isCloudMode
-    ? showUseInputBranchAction
+    ? useInputBranchPosition === "leading"
       ? [USE_INPUT_BRANCH_ACTION, ...branches]
-      : branches
+      : useInputBranchPosition === "trailing"
+        ? [...branches, USE_INPUT_BRANCH_ACTION]
+        : branches
     : [...branches, CREATE_BRANCH_ACTION];
 
   return (
@@ -405,7 +415,7 @@ export function BranchSelector({
               );
             }
             if (item === USE_INPUT_BRANCH_ACTION) {
-              return (
+              const useInputItem = (
                 <ComboboxItem
                   key={USE_INPUT_BRANCH_ACTION}
                   value={USE_INPUT_BRANCH_ACTION}
@@ -416,6 +426,14 @@ export function BranchSelector({
                   Use "{trimmedInputValue}" as branch name
                 </ComboboxItem>
               );
+              if (useInputBranchPosition === "trailing") {
+                return (
+                  <ComboboxListFooter key="use-input-footer">
+                    {useInputItem}
+                  </ComboboxListFooter>
+                );
+              }
+              return useInputItem;
             }
             return (
               <ComboboxItem

--- a/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
+++ b/apps/code/src/renderer/features/git-interaction/components/BranchSelector.tsx
@@ -36,6 +36,11 @@ const COMBOBOX_LIMIT = 50;
 // plain button the combobox's roving focus skips over.
 const CREATE_BRANCH_ACTION = "__create_branch__";
 
+// Sentinel for the "Use '<input>' as branch name" action in cloud mode.
+// Surfaced as the first list item so it's keyboard-reachable and
+// auto-highlighted while the (slow) remote search is still running.
+const USE_INPUT_BRANCH_ACTION = "__use_input_branch__";
+
 function LoadingRow({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-1 px-2 py-1.5 text-muted-foreground text-xs">
@@ -136,8 +141,6 @@ export function BranchSelector({
 
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
-  const cloudStillLoading =
-    isCloudMode && cloudBranchesLoading && branches.length === 0 && !open;
   const branchListLoading = isCloudMode
     ? !!cloudBranchesLoading
     : localBranchesLoading;
@@ -164,40 +167,6 @@ export function BranchSelector({
     }),
   );
 
-  const handleBranchChange = (value: string | null) => {
-    if (!value) return;
-    if (value === CREATE_BRANCH_ACTION) {
-      setOpen(false);
-      actions.openBranch(
-        taskId
-          ? getSuggestedBranchName(taskId, repoPath ?? undefined)
-          : undefined,
-      );
-      return;
-    }
-    if (isSelectionOnly) {
-      onBranchSelect?.(value);
-    } else if (value !== currentBranch) {
-      checkoutMutation.mutate({
-        directoryPath: repoPath as string,
-        branchName: value,
-      });
-    }
-    if (isCloudMode) {
-      onCloudBranchCommit?.();
-    }
-    setOpen(false);
-  };
-
-  const handleOpenChange = (next: boolean) => {
-    setOpen(next);
-    if (isCloudMode && next) {
-      onCloudPickerOpen?.();
-    } else if (isCloudMode && !next) {
-      onCloudPickerClose?.();
-    }
-  };
-
   // In local mode, surface in-progress git operations (rebase/merge/etc.) so the
   // user understands why there's no current branch and why we won't let them
   // checkout a different one — checkout would fail with a hard-to-read git error.
@@ -216,12 +185,7 @@ export function BranchSelector({
   const showSpinner =
     effectiveLoading || (isCloudMode && open && cloudBranchesFetchingMore);
 
-  const isDisabled = !!(
-    disabled ||
-    !repoPath ||
-    cloudStillLoading ||
-    localBusy
-  );
+  const isDisabled = !!(disabled || !repoPath || localBusy);
   const disabledReason =
     localBusy && busyOperationLabel
       ? `${busyOperationLabel} in progress — finish or abort it to switch branches.`
@@ -232,15 +196,62 @@ export function BranchSelector({
     !isDisabled &&
     trimmedInputValue.length > 0 &&
     trimmedInputValue !== displayedBranch;
+  const showUseInputBranchAction =
+    isCloudMode &&
+    canUseInputBranch &&
+    !branches.some((branch) => branch === trimmedInputValue);
+
+  const handleBranchChange = (value: string | null) => {
+    if (!value) return;
+    if (value === CREATE_BRANCH_ACTION) {
+      setOpen(false);
+      actions.openBranch(
+        taskId
+          ? getSuggestedBranchName(taskId, repoPath ?? undefined)
+          : undefined,
+      );
+      return;
+    }
+    const branchName =
+      value === USE_INPUT_BRANCH_ACTION ? trimmedInputValue : value;
+    if (!branchName) return;
+    if (isSelectionOnly) {
+      onBranchSelect?.(branchName);
+    } else if (branchName !== currentBranch) {
+      checkoutMutation.mutate({
+        directoryPath: repoPath as string,
+        branchName,
+      });
+    }
+    if (isCloudMode) {
+      onCloudBranchCommit?.();
+    }
+    setOpen(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (isCloudMode && next) {
+      onCloudPickerOpen?.();
+    } else if (isCloudMode && !next) {
+      onCloudPickerClose?.();
+    }
+  };
 
   const handleUseInputBranch = () => {
     if (!canUseInputBranch) return;
     handleBranchChange(trimmedInputValue);
   };
 
+  const comboboxItems = isCloudMode
+    ? showUseInputBranchAction
+      ? [USE_INPUT_BRANCH_ACTION, ...branches]
+      : branches
+    : [...branches, CREATE_BRANCH_ACTION];
+
   return (
     <Combobox
-      items={isCloudMode ? branches : [...branches, CREATE_BRANCH_ACTION]}
+      items={comboboxItems}
       limit={COMBOBOX_LIMIT}
       autoHighlight
       value={displayedBranch}
@@ -378,19 +389,35 @@ export function BranchSelector({
         )}
 
         <ComboboxList className="max-h-[min(14rem,calc(var(--available-height,14rem)-5rem))]">
-          {(item: string) =>
-            item === CREATE_BRANCH_ACTION ? (
-              <ComboboxListFooter key="footer">
+          {(item: string) => {
+            if (item === CREATE_BRANCH_ACTION) {
+              return (
+                <ComboboxListFooter key="footer">
+                  <ComboboxItem
+                    value={CREATE_BRANCH_ACTION}
+                    title="Create new branch"
+                    className="text-accent-foreground"
+                  >
+                    <Plus size={11} weight="bold" />
+                    Create new branch
+                  </ComboboxItem>
+                </ComboboxListFooter>
+              );
+            }
+            if (item === USE_INPUT_BRANCH_ACTION) {
+              return (
                 <ComboboxItem
-                  value={CREATE_BRANCH_ACTION}
-                  title="Create new branch"
+                  key={USE_INPUT_BRANCH_ACTION}
+                  value={USE_INPUT_BRANCH_ACTION}
+                  title={`Use "${trimmedInputValue}" as branch name`}
                   className="text-accent-foreground"
                 >
                   <Plus size={11} weight="bold" />
-                  Create new branch
+                  Use "{trimmedInputValue}" as branch name
                 </ComboboxItem>
-              </ComboboxListFooter>
-            ) : (
+              );
+            }
+            return (
               <ComboboxItem
                 key={item}
                 value={item}
@@ -399,8 +426,8 @@ export function BranchSelector({
               >
                 {item}
               </ComboboxItem>
-            )
-          }
+            );
+          }}
         </ComboboxList>
 
         {isCloudMode && cloudBranchesHasMore ? (

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -728,6 +728,7 @@ export function TaskInput({
                   cloudSearchQuery={cloudBranchSearchQuery}
                   onCloudPickerClose={handleCloudBranchPickerClose}
                   onCloudSearchChange={handleCloudBranchSearchChange}
+                  onCloudBranchCommit={handleCloudBranchPickerClose}
                   onCloudLoadMore={handleLoadMoreCloudBranches}
                   onRefresh={
                     workspaceMode === "cloud"

--- a/apps/code/src/renderer/hooks/useIntegrations.ts
+++ b/apps/code/src/renderer/hooks/useIntegrations.ts
@@ -5,6 +5,7 @@ import {
   useIntegrationSelectors,
   useIntegrationStore,
 } from "@features/integrations/stores/integrationStore";
+import { useDebounce } from "@hooks/useDebounce";
 import type { UserGitHubIntegration } from "@renderer/api/posthogClient";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import {
@@ -16,6 +17,12 @@ import {
 } from "react";
 import { useAuthenticatedInfiniteQuery } from "./useAuthenticatedInfiniteQuery";
 import { useAuthenticatedQuery } from "./useAuthenticatedQuery";
+
+// Branch search hits a slow remote endpoint (GitHub via PostHog proxy). Debounce
+// keystrokes so we fire at most one request per typing burst. Empty searches
+// skip the debounce so closing the picker (which resets search to "") clears
+// stale results immediately.
+const BRANCH_SEARCH_DEBOUNCE_MS = 300;
 
 const integrationKeys = {
   all: ["integrations"] as const,
@@ -366,11 +373,15 @@ export function useGithubBranches(
   search?: string,
   enabled: boolean = true,
 ) {
-  const deferredSearch = useDeferredValue(search?.trim() ?? "");
+  const trimmedSearch = search?.trim() ?? "";
+  const debouncedSearch = useDebounce(
+    trimmedSearch,
+    trimmedSearch ? BRANCH_SEARCH_DEBOUNCE_MS : 0,
+  );
   const queryEnabled = enabled && !!integrationId && !!repo;
 
   const query = useAuthenticatedInfiniteQuery<GithubBranchesPage, number>(
-    integrationKeys.branches(integrationId, repo, deferredSearch),
+    integrationKeys.branches(integrationId, repo, debouncedSearch),
     async (client, offset) => {
       if (!integrationId || !repo) {
         return { branches: [], defaultBranch: null, hasMore: false };
@@ -382,7 +393,7 @@ export function useGithubBranches(
         repo,
         offset,
         pageSize,
-        deferredSearch,
+        debouncedSearch,
       );
     },
     {
@@ -435,11 +446,15 @@ export function useUserGithubBranches(
   search?: string,
   enabled: boolean = true,
 ) {
-  const deferredSearch = useDeferredValue(search?.trim() ?? "");
+  const trimmedSearch = search?.trim() ?? "";
+  const debouncedSearch = useDebounce(
+    trimmedSearch,
+    trimmedSearch ? BRANCH_SEARCH_DEBOUNCE_MS : 0,
+  );
   const queryEnabled = enabled && !!installationId && !!repo;
 
   const query = useAuthenticatedInfiniteQuery<GithubBranchesPage, number>(
-    userGithubIntegrationKeys.branches(installationId, repo, deferredSearch),
+    userGithubIntegrationKeys.branches(installationId, repo, debouncedSearch),
     async (client, offset) => {
       if (!installationId || !repo) {
         return { branches: [], defaultBranch: null, hasMore: false };
@@ -451,7 +466,7 @@ export function useUserGithubBranches(
         repo,
         offset,
         pageSize,
-        deferredSearch,
+        debouncedSearch,
       );
     },
     {


### PR DESCRIPTION
## Problem

Cloud branch picker was disabled while the slow GitHub remote was loading, blocking users from typing a known branch name and forcing them to wait on a request that often takes seconds.

Closes https://github.com/PostHog/code/issues/1984

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Stop disabling the picker while cloud branches are still loading
2. Add "Use 'input' as branch name" action as the auto-highlighted first item so it is keyboard-reachable during the slow fetch
3. Debounce branch search at 300ms instead of useDeferredValue to coalesce keystrokes into one request
4. Skip debounce on empty search so closing the picker clears stale results immediately
5. Refactor Combobox item rendering to handle the new sentinel action

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->