### PR TITLE
fix: Make file references in agent messages clickable in command center

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -1,6 +1,7 @@
 import { CHAT_CONTENT_MAX_WIDTH } from "@features/sessions/constants";
 import { useContextUsage } from "@features/sessions/hooks/useContextUsage";
 import { useConversationSearch } from "@features/sessions/hooks/useConversationSearch";
+import { SessionTaskIdProvider } from "@features/sessions/hooks/useSessionTaskId";
 import {
   sessionStoreSetters,
   useOptimisticItemsForTask,
@@ -267,37 +268,39 @@ export function ConversationView({
           />
         )}
 
-        <VirtualizedList
-          ref={listRef}
-          items={items}
-          getItemKey={getItemKey}
-          renderItem={renderItem}
-          onScrollStateChange={handleScrollStateChange}
-          keepMounted={mcpAppIndices}
-          className="absolute inset-0 bg-background"
-          itemClassName="mx-auto px-2 py-1.5"
-          itemStyle={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
-          footer={
-            <div className={compact ? "pb-1" : "pb-16"}>
-              <SessionFooter
-                task={task}
-                isPromptPending={isPromptPending}
-                promptStartedAt={promptStartedAt}
-                lastGenerationDuration={
-                  lastTurnInfo?.isComplete
-                    ? Math.max(0, lastTurnInfo.durationMs - pausedDurationMs)
-                    : null
-                }
-                lastStopReason={lastTurnInfo?.stopReason}
-                queuedCount={queuedMessages.length}
-                hasPendingPermission={pendingPermissionsCount > 0}
-                pausedDurationMs={pausedDurationMs}
-                isCompacting={isCompacting}
-                usage={contextUsage}
-              />
-            </div>
-          }
-        />
+        <SessionTaskIdProvider taskId={taskId}>
+          <VirtualizedList
+            ref={listRef}
+            items={items}
+            getItemKey={getItemKey}
+            renderItem={renderItem}
+            onScrollStateChange={handleScrollStateChange}
+            keepMounted={mcpAppIndices}
+            className="absolute inset-0 bg-background"
+            itemClassName="mx-auto px-2 py-1.5"
+            itemStyle={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
+            footer={
+              <div className={compact ? "pb-1" : "pb-16"}>
+                <SessionFooter
+                  task={task}
+                  isPromptPending={isPromptPending}
+                  promptStartedAt={promptStartedAt}
+                  lastGenerationDuration={
+                    lastTurnInfo?.isComplete
+                      ? Math.max(0, lastTurnInfo.durationMs - pausedDurationMs)
+                      : null
+                  }
+                  lastStopReason={lastTurnInfo?.stopReason}
+                  queuedCount={queuedMessages.length}
+                  hasPendingPermission={pendingPermissionsCount > 0}
+                  pausedDurationMs={pausedDurationMs}
+                  isCompacting={isCompacting}
+                  usage={contextUsage}
+                />
+              </div>
+            }
+          />
+        </SessionTaskIdProvider>
         {showScrollButton && (
           <Box className="absolute right-4 bottom-4 z-10">
             <Button size="1" variant="solid" onClick={scrollToBottom}>

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -3,8 +3,8 @@ import { Tooltip } from "@components/ui/Tooltip";
 import { usePendingScrollStore } from "@features/code-editor/stores/pendingScrollStore";
 import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
 import { usePanelLayoutStore } from "@features/panels";
+import { useSessionTaskId } from "@features/sessions/hooks/useSessionTaskId";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { useTaskStore } from "@features/tasks/stores/taskStore";
 import type { FileItem } from "@hooks/useRepoFiles";
 import { useRepoFiles } from "@hooks/useRepoFiles";
 import { Check, Copy } from "@phosphor-icons/react";
@@ -46,7 +46,7 @@ function InlineFileLink({
   const { filePath: rawPath, lineSuffix } = parseFilePath(text);
   const filePath = resolvedPath ?? rawPath;
   const filename = rawPath.split("/").pop() ?? rawPath;
-  const taskId = useTaskStore((s) => s.selectedTaskId);
+  const taskId = useSessionTaskId();
   const repoPath = useCwd(taskId ?? "");
   const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);
   const requestScroll = usePendingScrollStore((s) => s.requestScroll);
@@ -86,7 +86,7 @@ function InlineFileLink({
 
 function BareFileLink({ text }: { text: string }) {
   const { filePath: bareFilename } = parseFilePath(text);
-  const taskId = useTaskStore((s) => s.selectedTaskId);
+  const taskId = useSessionTaskId();
   const repoPath = useCwd(taskId ?? "");
   const { files } = useRepoFiles(repoPath ?? undefined);
   const resolved = useMemo(

--- a/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/FileMentionChip.tsx
@@ -1,7 +1,7 @@
 import { FileIcon } from "@components/ui/FileIcon";
 import { usePanelLayoutStore } from "@features/panels";
+import { useSessionTaskId } from "@features/sessions/hooks/useSessionTaskId";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
-import { useTaskStore } from "@features/tasks/stores/taskStore";
 import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
 import { Flex, Text } from "@radix-ui/themes";
 import { trpcClient } from "@renderer/trpc/client";
@@ -32,7 +32,7 @@ function toRelativePath(absolutePath: string, repoPath: string | null): string {
 export const FileMentionChip = memo(function FileMentionChip({
   filePath,
 }: FileMentionChipProps) {
-  const taskId = useTaskStore((s) => s.selectedTaskId);
+  const taskId = useSessionTaskId();
   const repoPath = useCwd(taskId ?? "");
   const workspace = useWorkspace(taskId ?? undefined);
   const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);

--- a/apps/code/src/renderer/features/sessions/hooks/useSessionTaskId.tsx
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionTaskId.tsx
@@ -1,0 +1,21 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+const SessionTaskIdContext = createContext<string | null>(null);
+
+export function SessionTaskIdProvider({
+  taskId,
+  children,
+}: {
+  taskId: string | null | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <SessionTaskIdContext.Provider value={taskId ?? null}>
+      {children}
+    </SessionTaskIdContext.Provider>
+  );
+}
+
+export function useSessionTaskId(): string | null {
+  return useContext(SessionTaskIdContext);
+}

--- a/apps/code/src/renderer/features/sessions/hooks/useSessionTaskId.tsx
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionTaskId.tsx
@@ -6,7 +6,7 @@ export function SessionTaskIdProvider({
   taskId,
   children,
 }: {
-  taskId: string | null | undefined;
+  taskId: string | undefined;
   children: ReactNode;
 }) {
   return (

--- a/apps/code/src/renderer/features/task-detail/components/TaskDetail.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskDetail.tsx
@@ -14,7 +14,6 @@ import { getSessionService } from "@features/sessions/service/service";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
 import { useTaskData } from "@features/task-detail/hooks/useTaskData";
 import { useUpdateTask } from "@features/tasks/hooks/useTasks";
-import { useTaskStore } from "@features/tasks/stores/taskStore";
 import { useWorkspaceEvents } from "@features/workspace/hooks";
 import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
 import { useBlurOnEscape } from "@hooks/useBlurOnEscape";
@@ -39,12 +38,6 @@ interface TaskDetailProps {
 
 export function TaskDetail({ task: initialTask }: TaskDetailProps) {
   const taskId = initialTask.id;
-  const selectTask = useTaskStore((s) => s.selectTask);
-
-  useEffect(() => {
-    selectTask(taskId);
-    return () => selectTask(null);
-  }, [taskId, selectTask]);
 
   const { task } = useTaskData({ taskId, initialTask });
 

--- a/apps/code/src/renderer/features/tasks/stores/taskStore.ts
+++ b/apps/code/src/renderer/features/tasks/stores/taskStore.ts
@@ -23,7 +23,6 @@ function toggleOperator(
 export const useTaskStore = create<TaskState>()(
   persist(
     (set) => ({
-      selectedTaskId: null,
       selectedIndex: null,
       hoveredIndex: null,
       contextMenuIndex: null,
@@ -39,7 +38,6 @@ export const useTaskStore = create<TaskState>()(
       isFilterDropdownOpen: false,
       editingFilterBadgeKey: null,
 
-      selectTask: (taskId) => set({ selectedTaskId: taskId }),
       setSelectedIndex: (index) => set({ selectedIndex: index }),
       setHoveredIndex: (index) => set({ hoveredIndex: index }),
       setContextMenuIndex: (index) => set({ contextMenuIndex: index }),

--- a/apps/code/src/renderer/features/tasks/stores/taskStore.types.ts
+++ b/apps/code/src/renderer/features/tasks/stores/taskStore.types.ts
@@ -42,7 +42,6 @@ export const TASK_STATUS_ORDER: string[] = [
 ];
 
 export interface TaskState {
-  selectedTaskId: string | null;
   selectedIndex: number | null;
   hoveredIndex: number | null;
   contextMenuIndex: number | null;
@@ -58,7 +57,6 @@ export interface TaskState {
   isFilterDropdownOpen: boolean;
   editingFilterBadgeKey: string | null;
 
-  selectTask: (taskId: string | null) => void;
   setSelectedIndex: (index: number | null) => void;
   setHoveredIndex: (index: number | null) => void;
   setContextMenuIndex: (index: number | null) => void;


### PR DESCRIPTION
## Problem

In Command Center cells, file references in agent messages (e.g. `resources.md`) were silently disabled because the link components read `useTaskStore.selectedTaskId`, which is null when notask is selected from the sidebar.

Closes https://github.com/PostHog/code/issues/2170<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add `SessionTaskIdContext` exposing the active conversation's taskId
2. Provide it from `ConversationView` so every message renders against its own task
3. Read taskId from the context in `InlineFileLink` and `BareFileLink`
4. Read taskId from the context in `FileMentionChip`

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->