### PR TITLE
fix(task-input): preserve picked folder when adding to recents

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -48,6 +48,7 @@ import { useQuery } from "@tanstack/react-query";
 import { FOCUSABLE_SELECTOR } from "@utils/overlay";
 import { LayoutGroup, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useInitialDirectoryFromFolderId } from "../hooks/useInitialDirectoryFromFolderId";
 import { usePreviewConfig } from "../hooks/usePreviewConfig";
 import { useTaskCreation } from "../hooks/useTaskCreation";
 import { CloudGithubMissingNotice } from "./CloudGithubMissingNotice";
@@ -401,19 +402,7 @@ export function TaskInput({
     setLastUsedCloudRepository,
   ]);
 
-  const lastInitializedFolderIdRef = useRef<string | undefined>(undefined);
-  useEffect(() => {
-    if (!view.folderId) {
-      lastInitializedFolderIdRef.current = undefined;
-      return;
-    }
-    if (lastInitializedFolderIdRef.current === view.folderId) return;
-    const folder = folders.find((f) => f.id === view.folderId);
-    if (folder) {
-      setSelectedDirectory(folder.path);
-      lastInitializedFolderIdRef.current = view.folderId;
-    }
-  }, [view.folderId, folders]);
+  useInitialDirectoryFromFolderId(view.folderId, folders, setSelectedDirectory);
 
   useEffect(() => {
     setCloudBranchSearchQuery("");

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -401,12 +401,17 @@ export function TaskInput({
     setLastUsedCloudRepository,
   ]);
 
+  const lastInitializedFolderIdRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    if (view.folderId) {
-      const folder = folders.find((f) => f.id === view.folderId);
-      if (folder) {
-        setSelectedDirectory(folder.path);
-      }
+    if (!view.folderId) {
+      lastInitializedFolderIdRef.current = undefined;
+      return;
+    }
+    if (lastInitializedFolderIdRef.current === view.folderId) return;
+    const folder = folders.find((f) => f.id === view.folderId);
+    if (folder) {
+      setSelectedDirectory(folder.path);
+      lastInitializedFolderIdRef.current = view.folderId;
     }
   }, [view.folderId, folders]);
 

--- a/apps/code/src/renderer/features/task-detail/hooks/useInitialDirectoryFromFolderId.test.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useInitialDirectoryFromFolderId.test.ts
@@ -1,0 +1,89 @@
+import type { RegisteredFolder } from "@main/services/folders/schemas";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useInitialDirectoryFromFolderId } from "./useInitialDirectoryFromFolderId";
+
+const folder = (id: string, path: string): RegisteredFolder => ({
+  id,
+  path,
+  name: id,
+  remoteUrl: null,
+  lastAccessed: "2026-05-21T00:00:00Z",
+  createdAt: "2026-05-21T00:00:00Z",
+});
+
+describe("useInitialDirectoryFromFolderId", () => {
+  it("syncs the directory to the folder matching folderId on first render", () => {
+    const setSelectedDirectory = vi.fn();
+    renderHook(() =>
+      useInitialDirectoryFromFolderId(
+        "a",
+        [folder("a", "/repos/a")],
+        setSelectedDirectory,
+      ),
+    );
+    expect(setSelectedDirectory).toHaveBeenCalledExactlyOnceWith("/repos/a");
+  });
+
+  it("waits for folders to load before syncing", () => {
+    const setSelectedDirectory = vi.fn();
+    const { rerender } = renderHook(
+      ({ folders }: { folders: RegisteredFolder[] }) =>
+        useInitialDirectoryFromFolderId("a", folders, setSelectedDirectory),
+      { initialProps: { folders: [] as RegisteredFolder[] } },
+    );
+    expect(setSelectedDirectory).not.toHaveBeenCalled();
+
+    rerender({ folders: [folder("a", "/repos/a")] });
+    expect(setSelectedDirectory).toHaveBeenCalledExactlyOnceWith("/repos/a");
+  });
+
+  it("does not re-sync when folders changes but folderId stays the same", () => {
+    const setSelectedDirectory = vi.fn();
+    const { rerender } = renderHook(
+      ({ folders }: { folders: RegisteredFolder[] }) =>
+        useInitialDirectoryFromFolderId("a", folders, setSelectedDirectory),
+      { initialProps: { folders: [folder("a", "/repos/a")] } },
+    );
+    expect(setSelectedDirectory).toHaveBeenCalledExactlyOnceWith("/repos/a");
+
+    // Simulate adding a folder (e.g. after the user picks one via "Open
+    // folder..."). The folders list changes but the user's pick must not be
+    // clobbered by re-syncing from the original folderId.
+    rerender({
+      folders: [folder("a", "/repos/a"), folder("b", "/repos/picked")],
+    });
+    expect(setSelectedDirectory).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-syncs when folderId changes", () => {
+    const setSelectedDirectory = vi.fn();
+    const folders = [folder("a", "/repos/a"), folder("b", "/repos/b")];
+    const { rerender } = renderHook(
+      ({ folderId }: { folderId: string }) =>
+        useInitialDirectoryFromFolderId(
+          folderId,
+          folders,
+          setSelectedDirectory,
+        ),
+      { initialProps: { folderId: "a" } },
+    );
+    expect(setSelectedDirectory).toHaveBeenLastCalledWith("/repos/a");
+
+    rerender({ folderId: "b" });
+    expect(setSelectedDirectory).toHaveBeenLastCalledWith("/repos/b");
+    expect(setSelectedDirectory).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing when folderId is undefined", () => {
+    const setSelectedDirectory = vi.fn();
+    renderHook(() =>
+      useInitialDirectoryFromFolderId(
+        undefined,
+        [folder("a", "/repos/a")],
+        setSelectedDirectory,
+      ),
+    );
+    expect(setSelectedDirectory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/code/src/renderer/features/task-detail/hooks/useInitialDirectoryFromFolderId.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useInitialDirectoryFromFolderId.ts
@@ -1,0 +1,29 @@
+import type { RegisteredFolder } from "@main/services/folders/schemas";
+import { useEffect, useRef } from "react";
+
+/**
+ * Syncs `selectedDirectory` to the path of `folders[view.folderId]` once per
+ * folderId. The dependency on `folders` is required so the sync still fires
+ * when the folder list hasn't loaded yet on initial mount, but we must not
+ * re-sync on later `folders` refetches (e.g. after `addFolder`) — that would
+ * clobber a folder the user just picked via the file dialog.
+ */
+export function useInitialDirectoryFromFolderId(
+  folderId: string | undefined,
+  folders: RegisteredFolder[],
+  setSelectedDirectory: (path: string) => void,
+) {
+  const lastInitializedRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (!folderId) {
+      lastInitializedRef.current = undefined;
+      return;
+    }
+    if (lastInitializedRef.current === folderId) return;
+    const folder = folders.find((f) => f.id === folderId);
+    if (folder) {
+      setSelectedDirectory(folder.path);
+      lastInitializedRef.current = folderId;
+    }
+  }, [folderId, folders, setSelectedDirectory]);
+}


### PR DESCRIPTION
## Problem

When creating a new task and clicking **Open folder...** in local/worktree mode, the selected folder is added to the **Recent** list but isn't actually selected as the task's folder.

## Changes

The `useEffect` in `TaskInput.tsx` that syncs `selectedDirectory` from `view.folderId` had `folders` in its dependency array and re-ran every time `folders` changed. Picking a new folder via the file dialog triggers `addFolder`, which invalidates `getFolders`, which refetches and updates `folders` — causing the effect to fire and revert `selectedDirectory` back to the original `view.folderId` folder, overwriting the user's pick.

Track the last applied `folderId` in a ref so the effect only syncs when `view.folderId` actually changes, not on every folders refetch. The dependency on `folders` is preserved so the initial sync still works when the folder list hasn't loaded yet on mount.

## How did you test this?

- Typecheck (`pnpm --filter code typecheck`) passes.
- Build (`pnpm build`) succeeds.
- `pnpm --filter code test` — all TaskInput-related tests pass; the 2 failing tests are pre-existing archive service integration timeouts unrelated to this change.
- Did not manually verify in the running app — no display available in this environment.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*