### PR TITLE
fix(code): bound cloud session reconnect attempts with cumulative cap

### DIFF
--- a/apps/code/src/main/services/cloud-task/service.test.ts
+++ b/apps/code/src/main/services/cloud-task/service.test.ts
@@ -604,6 +604,72 @@ describe("CloudTaskService", () => {
     ).toBe(true);
   });
 
+  it("fails the watcher after exhausting the cumulative reconnect budget on clean-EOF loops", async () => {
+    vi.useFakeTimers();
+
+    const updates: unknown[] = [];
+    service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));
+
+    const makeInProgressRun = () =>
+      createJsonResponse({
+        id: "run-1",
+        status: "in_progress",
+        stage: null,
+        output: null,
+        error_message: null,
+        branch: "main",
+        updated_at: "2026-01-01T00:00:00Z",
+      });
+
+    mockNetFetch.mockImplementation((input: string | Request) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.includes("/session_logs/")) {
+        return Promise.resolve(
+          createJsonResponse([], 200, { "X-Has-More": "false" }),
+        );
+      }
+      return Promise.resolve(makeInProgressRun());
+    });
+
+    // Every stream closes cleanly with no events. Under the previous
+    // implementation reconnectAttempts was reset to 0 on each clean EOF
+    // and the watcher would loop forever.
+    mockStreamFetch.mockImplementation(() =>
+      Promise.resolve(createSseResponse("")),
+    );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => mockStreamFetch.mock.calls.length === 1);
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    await waitFor(
+      () =>
+        updates.some(
+          (u) =>
+            typeof u === "object" &&
+            u !== null &&
+            (u as { kind?: string }).kind === "error",
+        ),
+      10_000,
+    );
+
+    expect(updates).toContainEqual({
+      taskId: "task-1",
+      runId: "run-1",
+      kind: "error",
+      errorTitle: "Cloud run unreachable",
+      errorMessage:
+        "Could not maintain a connection to the cloud run after many attempts. Click retry once the issue is resolved.",
+      retryable: true,
+    });
+  });
+
   it("emits a retryable cloud error after repeated stream failures", async () => {
     vi.useFakeTimers();
 

--- a/apps/code/src/main/services/cloud-task/service.test.ts
+++ b/apps/code/src/main/services/cloud-task/service.test.ts
@@ -631,9 +631,6 @@ describe("CloudTaskService", () => {
       return Promise.resolve(makeInProgressRun());
     });
 
-    // Every stream closes cleanly with no events. Under the previous
-    // implementation reconnectAttempts was reset to 0 on each clean EOF
-    // and the watcher would loop forever.
     mockStreamFetch.mockImplementation(() =>
       Promise.resolve(createSseResponse("")),
     );

--- a/apps/code/src/main/services/cloud-task/service.ts
+++ b/apps/code/src/main/services/cloud-task/service.ts
@@ -1131,7 +1131,8 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
     if (!isTerminalStatus(watcher.lastStatus) && reconnectIfNonTerminal) {
       if (stateChanged) {
-        // Polled progress proves the run is alive — don't burn cumulative budget.
+        // Polled progress proves the run is alive — reset both budgets.
+        watcher.reconnectAttempts = 0;
         watcher.cumulativeReconnectAttempts = 0;
         this.emit(CloudTaskEvent.Update, {
           taskId: watcher.taskId,

--- a/apps/code/src/main/services/cloud-task/service.ts
+++ b/apps/code/src/main/services/cloud-task/service.ts
@@ -1021,9 +1021,8 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       clearTimeout(watcher.reconnectTimeoutId);
     }
 
-    // Every scheduled reconnect burns cumulative budget — clean EOF loops
-    // would otherwise dodge the per-burst counter (`reconnectAttempts`)
-    // by setting countAttempt=false and silently retrying forever.
+    // Cumulative counter bounds runaway loops that clean-EOF (countAttempt=false)
+    // and would otherwise dodge `reconnectAttempts`.
     watcher.cumulativeReconnectAttempts += 1;
     const countAttempt = options.countAttempt ?? true;
     if (countAttempt) {
@@ -1132,9 +1131,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
     if (!isTerminalStatus(watcher.lastStatus) && reconnectIfNonTerminal) {
       if (stateChanged) {
-        // Server-side progress observed via polling — the run is alive even
-        // if the SSE stream keeps closing without events. Don't burn the
-        // cumulative budget while progress is happening.
+        // Polled progress proves the run is alive — don't burn cumulative budget.
         watcher.cumulativeReconnectAttempts = 0;
         this.emit(CloudTaskEvent.Update, {
           taskId: watcher.taskId,

--- a/apps/code/src/main/services/cloud-task/service.ts
+++ b/apps/code/src/main/services/cloud-task/service.ts
@@ -764,8 +764,9 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     }
 
     // A real data event proves the stream materialized; clear the backend-error
-    // budget too.
+    // and cumulative budgets too.
     watcher.streamErrorAttempts = 0;
+    watcher.cumulativeReconnectAttempts = 0;
 
     if (isTaskRunStateEvent(event.data)) {
       if (this.applyTaskRunState(watcher, event.data)) {
@@ -1131,6 +1132,10 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
     if (!isTerminalStatus(watcher.lastStatus) && reconnectIfNonTerminal) {
       if (stateChanged) {
+        // Server-side progress observed via polling — the run is alive even
+        // if the SSE stream keeps closing without events. Don't burn the
+        // cumulative budget while progress is happening.
+        watcher.cumulativeReconnectAttempts = 0;
         this.emit(CloudTaskEvent.Update, {
           taskId: watcher.taskId,
           runId: watcher.runId,

--- a/apps/code/src/main/services/cloud-task/service.ts
+++ b/apps/code/src/main/services/cloud-task/service.ts
@@ -19,6 +19,7 @@ import { type SseEvent, SseEventParser } from "./sse-parser";
 const log = logger.scope("cloud-task");
 
 const MAX_SSE_RECONNECT_ATTEMPTS = 5;
+const MAX_CUMULATIVE_RECONNECT_ATTEMPTS = 30;
 const SSE_RECONNECT_BASE_DELAY_MS = 2_000;
 const SSE_RECONNECT_MAX_DELAY_MS = 30_000;
 const SSE_HEALTHY_CONNECTION_MS = 60_000;
@@ -91,6 +92,7 @@ interface WatcherState {
   totalEntryCount: number;
   reconnectAttempts: number;
   streamErrorAttempts: number;
+  cumulativeReconnectAttempts: number;
   lastEventId: string | null;
   lastStatus: TaskRunStatus | null;
   lastStage: string | null;
@@ -283,6 +285,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
     watcher.reconnectAttempts = 0;
     watcher.streamErrorAttempts = 0;
+    watcher.cumulativeReconnectAttempts = 0;
     watcher.failed = false;
     watcher.pendingLogEntries = [];
     watcher.bufferedLogBatches = [];
@@ -406,6 +409,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       totalEntryCount: 0,
       reconnectAttempts: 0,
       streamErrorAttempts: 0,
+      cumulativeReconnectAttempts: 0,
       lastEventId: null,
       lastStatus: null,
       lastStage: null,
@@ -1016,12 +1020,27 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       clearTimeout(watcher.reconnectTimeoutId);
     }
 
+    // Every scheduled reconnect burns cumulative budget — clean EOF loops
+    // would otherwise dodge the per-burst counter (`reconnectAttempts`)
+    // by setting countAttempt=false and silently retrying forever.
+    watcher.cumulativeReconnectAttempts += 1;
     const countAttempt = options.countAttempt ?? true;
     if (countAttempt) {
       watcher.reconnectAttempts += 1;
-    } else {
-      watcher.reconnectAttempts = 0;
     }
+
+    if (
+      watcher.cumulativeReconnectAttempts > MAX_CUMULATIVE_RECONNECT_ATTEMPTS
+    ) {
+      this.failWatcher(key, {
+        title: "Cloud run unreachable",
+        message:
+          "Could not maintain a connection to the cloud run after many attempts. Click retry once the issue is resolved.",
+        retryable: true,
+      });
+      return;
+    }
+
     // The watcher fails once either budget is exhausted: transport reconnect
     // failures or backend stream-error frames.
     const attemptCount = Math.max(


### PR DESCRIPTION
## Problem

When a cloud run stream repeatedly closes with a clean EOF (no error), the per-attempt reconnect counter was being reset to zero on each clean disconnect. This allowed the watcher to loop indefinitely without ever hitting the `MAX_SSE_RECONNECT_ATTEMPTS` limit, leaving users stuck watching a run that can never be reached.

## Changes

A new `cumulativeReconnectAttempts` counter was added to the watcher state that increments on every reconnect attempt regardless of whether the disconnect was clean or errored. Unlike `reconnectAttempts`, it is never reset by a clean EOF — only by a successful SSE event or confirmed in-progress poll response. If the cumulative count exceeds `MAX_CUMULATIVE_RECONNECT_ATTEMPTS` (30), the watcher is failed with a retryable "Cloud run unreachable" error.

The previous behavior of resetting `reconnectAttempts` to zero on clean EOF was removed, since the cumulative counter now handles the runaway loop case independently.

## How did you test this?

A new automated test was added that mocks the stream to always return a clean empty SSE response and verifies that after exhausting the cumulative reconnect budget, the watcher emits an error update with `kind: "error"` and the expected `"Cloud run unreachable"` message.

## Publish to changelog?

No