### PR TITLE
fix(analytics): resolve INBOX_VIEWED typecheck errors

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -493,6 +493,7 @@ export function InboxSignalsTab() {
       source_product_filter: sourceProductFilter,
       status_filter_count: statusFilter.length,
       is_empty: totalCount === 0,
+      is_gated_due_to_scale: false,
     });
   }, [
     isInboxView,

--- a/apps/code/src/renderer/features/inbox/components/InboxView.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxView.tsx
@@ -3,12 +3,38 @@ import { useSetHeaderContent } from "@hooks/useSetHeaderContent";
 import { EnvelopeSimpleIcon } from "@phosphor-icons/react";
 import { Flex, Text } from "@radix-ui/themes";
 import { INBOX_GATED_DUE_TO_SCALE_FLAG } from "@shared/constants";
-import { useMemo } from "react";
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
+import { track } from "@utils/analytics";
+import { useEffect, useMemo, useRef } from "react";
 import { GatedDueToScalePane } from "./InboxEmptyStates";
 import { InboxSignalsTab } from "./InboxSignalsTab";
 
 export function InboxView() {
   const isGatedDueToScale = useFeatureFlag(INBOX_GATED_DUE_TO_SCALE_FLAG);
+
+  // Scale-gated users see GatedDueToScalePane instead of InboxSignalsTab (where
+  // INBOX_VIEWED normally fires), and the inbox data isn't loaded while gated.
+  // Fire the event here, once per gated visit, so these visits are still
+  // measured — flagged so they're distinguishable from a genuinely empty inbox.
+  const gatedViewedFiredRef = useRef(false);
+  useEffect(() => {
+    if (!isGatedDueToScale) {
+      gatedViewedFiredRef.current = false;
+      return;
+    }
+    if (gatedViewedFiredRef.current) return;
+    gatedViewedFiredRef.current = true;
+    track(ANALYTICS_EVENTS.INBOX_VIEWED, {
+      report_count: 0,
+      total_count: 0,
+      ready_count: 0,
+      has_active_filters: false,
+      source_product_filter: [],
+      status_filter_count: 0,
+      is_empty: true,
+      is_gated_due_to_scale: true,
+    });
+  }, [isGatedDueToScale]);
 
   const headerContent = useMemo(
     () => (

--- a/apps/code/src/renderer/stores/navigationStore.ts
+++ b/apps/code/src/renderer/stores/navigationStore.ts
@@ -258,7 +258,6 @@ export const useNavigationStore = create<NavigationStore>()(
 
         navigateToInbox: () => {
           navigate({ type: "inbox" });
-          track(ANALYTICS_EVENTS.INBOX_VIEWED);
         },
 
         navigateToArchived: () => {

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -451,6 +451,8 @@ export interface InboxViewedProperties {
   source_product_filter: string[];
   status_filter_count: number;
   is_empty: boolean;
+  /** True when the inbox is scale-gated (GatedDueToScalePane shown, data not loaded). */
+  is_gated_due_to_scale: boolean;
 }
 
 export interface InboxReportOpenedProperties {

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -597,7 +597,6 @@ export const ANALYTICS_EVENTS = {
   ONBOARDING_ABANDONED: "Onboarding abandoned",
   AI_CONSENT_GATE_SHOWN: "Ai consent gate shown",
   AI_CONSENT_APPROVED: "Ai consent approved",
-  INBOX_VIEWED: "Inbox viewed",
 
   // Setup / onboarding events
   SETUP_DISCOVERY_STARTED: "Setup discovery started",
@@ -704,7 +703,6 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.ONBOARDING_ABANDONED]: OnboardingAbandonedProperties;
   [ANALYTICS_EVENTS.AI_CONSENT_GATE_SHOWN]: AiConsentGateShownProperties;
   [ANALYTICS_EVENTS.AI_CONSENT_APPROVED]: never;
-  [ANALYTICS_EVENTS.INBOX_VIEWED]: never;
 
   // Setup / onboarding events
   [ANALYTICS_EVENTS.SETUP_DISCOVERY_STARTED]: SetupDiscoveryStartedProperties;


### PR DESCRIPTION
## Problem

`typecheck` job fails on every PR: `INBOX_VIEWED` is declared twice in `ANALYTICS_EVENTS` and twice in the event-properties map
