### PR TITLE
feat(inbox): capture dismissal_note in dismiss analytics event

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -298,7 +298,14 @@ export function InboxSignalsTab() {
           bulk_size: 1,
           rank: preMutationRank,
           list_size: preMutationListSize,
-          ...(isSnooze ? {} : { dismissal_reason: result.reason }),
+          ...(isSnooze
+            ? {}
+            : {
+                dismissal_reason: result.reason,
+                ...(result.note.trim()
+                  ? { dismissal_note: result.note.slice(0, 1000) }
+                  : {}),
+              }),
         });
         setDismissReport(null);
       }

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -497,6 +497,7 @@ export interface InboxReportActionProperties {
   rank: number;
   list_size: number;
   dismissal_reason?: string;
+  dismissal_note?: string;
   signal_id?: string;
   signal_source_product?: string;
   signal_source_type?: string;


### PR DESCRIPTION
## Summary

- Adds `dismissal_note` to the `Inbox report action` event when `action_type = "dismiss"` and the user typed a note in the dismiss dialog
- Truncated to 1000 chars (postgres stores up to 4000) to keep event payloads bounded
- Only attached when the trimmed note is non-empty

## Why

Annika asked in [Slack](https://posthog.slack.com/archives/C09SK2PAGKF/p1779370788620269) for a dismiss event "including their feedback" so she can read why users are dismissing inbox reports directly in PostHog instead of querying `postgres_signals_signalreportartefact`. We were already sending the note to the API (stored in `content.note`) but it wasn't on the analytics event.

Matches the precedent set by the unmerged Discuss button PR (which captures `question_text` truncated to 500 chars on the `discuss` action).

## Test plan

- [ ] Dismiss a report with a reason picked but no note → event has `dismissal_reason` and **no** `dismissal_note` key
- [ ] Dismiss a report with a reason and a note → event has both, note value matches input, truncated at 1000 chars if longer
- [ ] Dismiss a report with whitespace-only note → no `dismissal_note` attached
- [ ] Snooze (i.e. reason resolves to snooze) → no dismissal-related props on the event