### PR TITLE
feat(agent): route signal_report tasks to signals gateway product

### DIFF
--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentServer } from "./agent-server";
 
 interface TestableServer {
-  configureEnvironment(args?: { isInternal?: boolean }): void;
+  configureEnvironment(args?: {
+    isInternal?: boolean;
+    originProduct?: string | null;
+  }): void;
 }
 
 const ENV_KEYS_UNDER_TEST = [
@@ -83,6 +86,34 @@ describe("AgentServer.configureEnvironment", () => {
 
     expect(fromBackground).toBe(fromInteractive);
     expect(fromBackground).toBe("https://gateway.us.posthog.com/posthog_code");
+  });
+
+  it("tags as signals when an internal task has origin_product 'signal_report'", () => {
+    buildServer("background").configureEnvironment({
+      isInternal: true,
+      originProduct: "signal_report",
+    });
+
+    expect(process.env.LLM_GATEWAY_URL).toBe(
+      "https://gateway.us.posthog.com/signals",
+    );
+    expect(process.env.ANTHROPIC_BASE_URL).toBe(
+      "https://gateway.us.posthog.com/signals",
+    );
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      "https://gateway.us.posthog.com/signals/v1",
+    );
+  });
+
+  it("does not tag as signals when origin_product is 'signal_report' but the task is not internal", () => {
+    buildServer("background").configureEnvironment({
+      isInternal: false,
+      originProduct: "signal_report",
+    });
+
+    expect(process.env.LLM_GATEWAY_URL).toBe(
+      "https://gateway.us.posthog.com/posthog_code",
+    );
   });
 
   it("respects the LLM_GATEWAY_URL override regardless of internal flag", () => {

--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -12,6 +12,7 @@ const ENV_KEYS_UNDER_TEST = [
   "LLM_GATEWAY_URL",
   "ANTHROPIC_BASE_URL",
   "OPENAI_BASE_URL",
+  "ANTHROPIC_CUSTOM_HEADERS",
 ] as const;
 
 describe("AgentServer.configureEnvironment", () => {
@@ -113,6 +114,25 @@ describe("AgentServer.configureEnvironment", () => {
 
     expect(process.env.LLM_GATEWAY_URL).toBe(
       "https://gateway.us.posthog.com/posthog_code",
+    );
+  });
+
+  it("forwards task_internal and task_origin_product as ANTHROPIC_CUSTOM_HEADERS", () => {
+    buildServer("background").configureEnvironment({
+      isInternal: true,
+      originProduct: "signal_report",
+    });
+
+    expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      "x-posthog-property-task_origin_product: signal_report\nx-posthog-property-task_internal: true",
+    );
+  });
+
+  it("omits task_origin_product from ANTHROPIC_CUSTOM_HEADERS when not provided", () => {
+    buildServer("background").configureEnvironment({ isInternal: false });
+
+    expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      "x-posthog-property-task_internal: false",
     );
   });
 

--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -5,6 +5,9 @@ interface TestableServer {
   configureEnvironment(args?: {
     isInternal?: boolean;
     originProduct?: string | null;
+    taskId?: string | null;
+    taskRunId?: string | null;
+    taskUserId?: number | null;
   }): void;
 }
 
@@ -117,18 +120,27 @@ describe("AgentServer.configureEnvironment", () => {
     );
   });
 
-  it("forwards task_internal and task_origin_product as ANTHROPIC_CUSTOM_HEADERS", () => {
+  it("forwards task metadata as ANTHROPIC_CUSTOM_HEADERS", () => {
     buildServer("background").configureEnvironment({
       isInternal: true,
       originProduct: "signal_report",
+      taskId: "task-abc",
+      taskRunId: "run-xyz",
+      taskUserId: 42,
     });
 
     expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toBe(
-      "x-posthog-property-task_origin_product: signal_report\nx-posthog-property-task_internal: true",
+      [
+        "x-posthog-property-task_origin_product: signal_report",
+        "x-posthog-property-task_internal: true",
+        "x-posthog-property-task_id: task-abc",
+        "x-posthog-property-task_run_id: run-xyz",
+        "x-posthog-property-task_user_id: 42",
+      ].join("\n"),
     );
   });
 
-  it("omits task_origin_product from ANTHROPIC_CUSTOM_HEADERS when not provided", () => {
+  it("omits optional task metadata from ANTHROPIC_CUSTOM_HEADERS when not provided", () => {
     buildServer("background").configureEnvironment({ isInternal: false });
 
     expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toBe(

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -47,7 +47,11 @@ import type {
 } from "../types";
 import { resourceLink } from "../utils/acp-content";
 import { AsyncMutex } from "../utils/async-mutex";
-import { getLlmGatewayUrl, resolveGatewayProduct } from "../utils/gateway";
+import {
+  buildGatewayPropertyHeaders,
+  getLlmGatewayUrl,
+  resolveGatewayProduct,
+} from "../utils/gateway";
 import { Logger } from "../utils/logger";
 import { logAgentshRuntimeInfo } from "./agentsh-runtime";
 import {
@@ -1819,6 +1823,14 @@ ${attributionInstructions}
     const openaiBaseUrl = gatewayUrl.endsWith("/v1")
       ? gatewayUrl
       : `${gatewayUrl}/v1`;
+    // Forward task metadata as `x-posthog-property-*` headers so the gateway
+    // lifts them onto the $ai_generation event. Routes through the Anthropic
+    // SDK's ANTHROPIC_CUSTOM_HEADERS env var; the OpenAI/codex path has no
+    // equivalent today.
+    const customHeaders = buildGatewayPropertyHeaders({
+      task_origin_product: originProduct,
+      task_internal: isInternal,
+    });
 
     Object.assign(process.env, {
       // PostHog
@@ -1831,6 +1843,7 @@ ${attributionInstructions}
       ANTHROPIC_API_KEY: apiKey,
       ANTHROPIC_AUTH_TOKEN: apiKey,
       ANTHROPIC_BASE_URL: gatewayUrl,
+      ANTHROPIC_CUSTOM_HEADERS: customHeaders,
       // OpenAI (for models like GPT-4, o1, etc.)
       OPENAI_API_KEY: apiKey,
       OPENAI_BASE_URL: openaiBaseUrl,

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -47,7 +47,7 @@ import type {
 } from "../types";
 import { resourceLink } from "../utils/acp-content";
 import { AsyncMutex } from "../utils/async-mutex";
-import { type GatewayProduct, getLlmGatewayUrl } from "../utils/gateway";
+import { getLlmGatewayUrl, resolveGatewayProduct } from "../utils/gateway";
 import { Logger } from "../utils/logger";
 import { logAgentshRuntimeInfo } from "./agentsh-runtime";
 import {
@@ -844,7 +844,10 @@ export class AgentServer {
       }),
     ]);
 
-    this.configureEnvironment({ isInternal: preTask?.internal === true });
+    this.configureEnvironment({
+      isInternal: preTask?.internal === true,
+      originProduct: preTask?.origin_product,
+    });
 
     const prUrl = getTaskRunStateString(preTaskRun, "slack_notified_pr_url");
 
@@ -1804,13 +1807,13 @@ ${attributionInstructions}
 
   private configureEnvironment({
     isInternal = false,
+    originProduct,
   }: {
     isInternal?: boolean;
+    originProduct?: string | null;
   } = {}): void {
     const { apiKey, apiUrl, projectId } = this.config;
-    const product: GatewayProduct = isInternal
-      ? "background_agents"
-      : "posthog_code";
+    const product = resolveGatewayProduct({ isInternal, originProduct });
     const gatewayUrl =
       process.env.LLM_GATEWAY_URL || getLlmGatewayUrl(apiUrl, product);
     const openaiBaseUrl = gatewayUrl.endsWith("/v1")

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -851,6 +851,9 @@ export class AgentServer {
     this.configureEnvironment({
       isInternal: preTask?.internal === true,
       originProduct: preTask?.origin_product,
+      taskId: payload.task_id,
+      taskRunId: payload.run_id,
+      taskUserId: payload.user_id,
     });
 
     const prUrl = getTaskRunStateString(preTaskRun, "slack_notified_pr_url");
@@ -1812,9 +1815,15 @@ ${attributionInstructions}
   private configureEnvironment({
     isInternal = false,
     originProduct,
+    taskId,
+    taskRunId,
+    taskUserId,
   }: {
     isInternal?: boolean;
     originProduct?: string | null;
+    taskId?: string | null;
+    taskRunId?: string | null;
+    taskUserId?: number | null;
   } = {}): void {
     const { apiKey, apiUrl, projectId } = this.config;
     const product = resolveGatewayProduct({ isInternal, originProduct });
@@ -1830,6 +1839,9 @@ ${attributionInstructions}
     const customHeaders = buildGatewayPropertyHeaders({
       task_origin_product: originProduct,
       task_internal: isInternal,
+      task_id: taskId,
+      task_run_id: taskRunId,
+      task_user_id: taskUserId,
     });
 
     Object.assign(process.env, {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -37,7 +37,8 @@ export interface Task {
     | "eval_clusters"
     | "user_created"
     | "support_queue"
-    | "session_summaries";
+    | "session_summaries"
+    | "signal_report";
   github_integration?: number | null;
   repository: string; // Format: "organization/repository" (e.g., "posthog/posthog-js")
   json_schema?: Record<string, unknown> | null; // JSON schema for task output validation

--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { resolveGatewayProduct } from "./gateway";
+
+describe("resolveGatewayProduct", () => {
+  it("returns posthog_code for non-internal tasks", () => {
+    expect(resolveGatewayProduct({ isInternal: false })).toBe("posthog_code");
+    expect(resolveGatewayProduct()).toBe("posthog_code");
+  });
+
+  it("returns posthog_code for non-internal tasks even when origin_product is signal_report", () => {
+    expect(
+      resolveGatewayProduct({
+        isInternal: false,
+        originProduct: "signal_report",
+      }),
+    ).toBe("posthog_code");
+  });
+
+  it("returns background_agents for internal tasks without origin_product", () => {
+    expect(resolveGatewayProduct({ isInternal: true })).toBe(
+      "background_agents",
+    );
+  });
+
+  it("returns background_agents for internal tasks with a non-signal origin_product", () => {
+    expect(
+      resolveGatewayProduct({
+        isInternal: true,
+        originProduct: "session_summaries",
+      }),
+    ).toBe("background_agents");
+  });
+
+  it("returns signals for internal tasks with origin_product 'signal_report'", () => {
+    expect(
+      resolveGatewayProduct({
+        isInternal: true,
+        originProduct: "signal_report",
+      }),
+    ).toBe("signals");
+  });
+});

--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveGatewayProduct } from "./gateway";
+import { buildGatewayPropertyHeaders, resolveGatewayProduct } from "./gateway";
 
 describe("resolveGatewayProduct", () => {
   it("returns posthog_code for non-internal tasks", () => {
@@ -38,5 +38,39 @@ describe("resolveGatewayProduct", () => {
         originProduct: "signal_report",
       }),
     ).toBe("signals");
+  });
+});
+
+describe("buildGatewayPropertyHeaders", () => {
+  it("renders each property as an x-posthog-property header line", () => {
+    expect(
+      buildGatewayPropertyHeaders({
+        task_origin_product: "signal_report",
+        task_internal: true,
+      }),
+    ).toBe(
+      "x-posthog-property-task_origin_product: signal_report\nx-posthog-property-task_internal: true",
+    );
+  });
+
+  it("drops null and undefined values but keeps falsy primitives", () => {
+    expect(
+      buildGatewayPropertyHeaders({
+        task_origin_product: null,
+        task_internal: false,
+        task_count: 0,
+      }),
+    ).toBe(
+      "x-posthog-property-task_internal: false\nx-posthog-property-task_count: 0",
+    );
+  });
+
+  it("returns an empty string when no usable properties remain", () => {
+    expect(
+      buildGatewayPropertyHeaders({
+        task_origin_product: null,
+        task_internal: undefined,
+      }),
+    ).toBe("");
   });
 });

--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -2,43 +2,37 @@ import { describe, expect, it } from "vitest";
 import { buildGatewayPropertyHeaders, resolveGatewayProduct } from "./gateway";
 
 describe("resolveGatewayProduct", () => {
-  it("returns posthog_code for non-internal tasks", () => {
-    expect(resolveGatewayProduct({ isInternal: false })).toBe("posthog_code");
-    expect(resolveGatewayProduct()).toBe("posthog_code");
-  });
-
-  it("returns posthog_code for non-internal tasks even when origin_product is signal_report", () => {
-    expect(
-      resolveGatewayProduct({
-        isInternal: false,
-        originProduct: "signal_report",
-      }),
-    ).toBe("posthog_code");
-  });
-
-  it("returns background_agents for internal tasks without origin_product", () => {
-    expect(resolveGatewayProduct({ isInternal: true })).toBe(
-      "background_agents",
-    );
-  });
-
-  it("returns background_agents for internal tasks with a non-signal origin_product", () => {
-    expect(
-      resolveGatewayProduct({
-        isInternal: true,
-        originProduct: "session_summaries",
-      }),
-    ).toBe("background_agents");
-  });
-
-  it("returns signals for internal tasks with origin_product 'signal_report'", () => {
-    expect(
-      resolveGatewayProduct({
-        isInternal: true,
-        originProduct: "signal_report",
-      }),
-    ).toBe("signals");
-  });
+  it.each([
+    { isInternal: false, originProduct: undefined, expected: "posthog_code" },
+    {
+      isInternal: undefined,
+      originProduct: undefined,
+      expected: "posthog_code",
+    },
+    {
+      isInternal: false,
+      originProduct: "signal_report",
+      expected: "posthog_code",
+    },
+    {
+      isInternal: true,
+      originProduct: undefined,
+      expected: "background_agents",
+    },
+    {
+      isInternal: true,
+      originProduct: "session_summaries",
+      expected: "background_agents",
+    },
+    { isInternal: true, originProduct: "signal_report", expected: "signals" },
+  ] as const)(
+    "isInternal=$isInternal originProduct=$originProduct -> $expected",
+    ({ isInternal, originProduct, expected }) => {
+      expect(resolveGatewayProduct({ isInternal, originProduct })).toBe(
+        expected,
+      );
+    },
+  );
 });
 
 describe("buildGatewayPropertyHeaders", () => {

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -1,4 +1,21 @@
-export type GatewayProduct = "posthog_code" | "background_agents";
+export type GatewayProduct = "posthog_code" | "background_agents" | "signals";
+
+const SIGNAL_REPORT_ORIGIN_PRODUCT = "signal_report";
+
+export function resolveGatewayProduct({
+  isInternal,
+  originProduct,
+}: {
+  isInternal?: boolean;
+  originProduct?: string | null;
+} = {}): GatewayProduct {
+  if (isInternal) {
+    return originProduct === SIGNAL_REPORT_ORIGIN_PRODUCT
+      ? "signals"
+      : "background_agents";
+  }
+  return "posthog_code";
+}
 
 function getGatewayBaseUrl(posthogHost: string): string {
   const url = new URL(posthogHost);

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -1,7 +1,5 @@
 export type GatewayProduct = "posthog_code" | "background_agents" | "signals";
 
-const SIGNAL_REPORT_ORIGIN_PRODUCT = "signal_report";
-
 export function resolveGatewayProduct({
   isInternal,
   originProduct,
@@ -10,11 +8,26 @@ export function resolveGatewayProduct({
   originProduct?: string | null;
 } = {}): GatewayProduct {
   if (isInternal) {
-    return originProduct === SIGNAL_REPORT_ORIGIN_PRODUCT
-      ? "signals"
-      : "background_agents";
+    return originProduct === "signal_report" ? "signals" : "background_agents";
   }
   return "posthog_code";
+}
+
+/**
+ * Build `x-posthog-property-<name>: <value>` header lines that the LLM
+ * gateway lifts onto the `$ai_generation` event it captures for each call
+ * (see `services/llm-gateway/src/llm_gateway/request_context.py`).
+ *
+ * Returns a newline-joined string ready for `ANTHROPIC_CUSTOM_HEADERS`.
+ * `null`/`undefined` property values are dropped.
+ */
+export function buildGatewayPropertyHeaders(
+  properties: Record<string, string | number | boolean | null | undefined>,
+): string {
+  return Object.entries(properties)
+    .filter(([, value]) => value !== null && value !== undefined)
+    .map(([key, value]) => `x-posthog-property-${key}: ${value}`)
+    .join("\n");
 }
 
 function getGatewayBaseUrl(posthogHost: string): string {


### PR DESCRIPTION
## Problem

Signals/report-generation traffic currently bills to the `background_agents` LLM gateway product, sharing a cost pool with every other internal task (Slack-triggered runs, session-summary work, etc.). This makes it hard to track signals spend separately and apply a dedicated budget.

## Changes

Route LLM gateway calls so each task type lands in the right product bucket:

- **internal** task with `origin_product = \"signal_report\"` → `signals`
- any other **internal** task → `background_agents`
- any other task → `posthog_code`

The decision was pulled out of `AgentServer.configureEnvironment` into a small pure helper, `resolveGatewayProduct`, exported from `@posthog/agent` next to the `GatewayProduct` type so the rule is independently testable and easy to reuse.

Files touched:

- \`packages/agent/src/utils/gateway.ts\` — add \`signals\` to \`GatewayProduct\`, add \`resolveGatewayProduct\` helper.
- \`packages/agent/src/utils/gateway.test.ts\` — unit tests for every branch of the helper.
- \`packages/agent/src/server/agent-server.ts\` — pass \`origin_product\` into \`configureEnvironment\` and delegate to \`resolveGatewayProduct\`.
- \`packages/agent/src/server/agent-server.configure-environment.test.ts\` — add coverage for the new signals branch and the non-internal + signal_report carve-out.
- \`packages/agent/src/types.ts\` — add \`signal_report\` to the \`Task.origin_product\` union.

Pairs with the gateway-side change [posthog/posthog#59433](https://github.com/PostHog/posthog/pull/59433) which adds the per-user cost limit for the `signals` product (\$500/7d burst, \$1000/30d sustained).

## How did you test this?

I'm an agent. I ran:

- \`pnpm --filter @posthog/agent test src/utils/gateway.test.ts src/server/agent-server.configure-environment.test.ts\` → 12/12 passing
- biome + tsc via the pre-commit hook on the staged changes

I did not run the full test suite or any manual / end-to-end testing.

## Publish to changelog?

no