### PR TITLE
fix(task-input): stop composer flicker on long multi-line prompts

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -620,7 +620,7 @@ export function TaskInput({
     >
       <DropZoneOverlay isVisible={isDraggingFile} />
       <Flex
-        align="start"
+        align="center"
         justify="center"
         height="100%"
         className="relative px-4 pt-[10vh]"

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -46,7 +46,6 @@ import {
 } from "@stores/navigationStore";
 import { useQuery } from "@tanstack/react-query";
 import { FOCUSABLE_SELECTOR } from "@utils/overlay";
-import { LayoutGroup, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePreviewConfig } from "../hooks/usePreviewConfig";
 import { useTaskCreation } from "../hooks/useTaskCreation";
@@ -627,220 +626,210 @@ export function TaskInput({
         className="relative px-4 pt-[10vh]"
       >
         <DotPatternBackground className="h-[100.333%]" />
-        <LayoutGroup>
-          <motion.div
-            layout
-            transition={{ duration: 0.25, ease: [0.4, 0, 0.2, 1] }}
-            style={{
-              zIndex: 1,
-            }}
-            className="relative flex w-full max-w-[600px] flex-col gap-2"
-          >
-            <Flex gap="2" align="center" className="min-w-0">
-              <WorkspaceModeSelect
-                value={workspaceMode}
-                onChange={setWorkspaceMode}
-                selectedCloudEnvironmentId={selectedCloudEnvId}
-                onCloudEnvironmentChange={setSelectedCloudEnvId}
-                cloudAvailable={cloudAvailable}
-                size="1"
+        <div
+          style={{
+            zIndex: 1,
+          }}
+          className="relative flex w-full max-w-[600px] flex-col gap-2"
+        >
+          <Flex gap="2" align="center" className="min-w-0">
+            <WorkspaceModeSelect
+              value={workspaceMode}
+              onChange={setWorkspaceMode}
+              selectedCloudEnvironmentId={selectedCloudEnvId}
+              onCloudEnvironmentChange={setSelectedCloudEnvId}
+              cloudAvailable={cloudAvailable}
+              size="1"
+            />
+            {workspaceMode === "worktree" && (
+              <EnvironmentSelector
+                repoPath={effectiveRepoPath ?? null}
+                value={selectedEnvironment}
+                onChange={setSelectedEnvironment}
+                disabled={isCreatingTask}
               />
-              {workspaceMode === "worktree" && (
-                <EnvironmentSelector
-                  repoPath={effectiveRepoPath ?? null}
-                  value={selectedEnvironment}
-                  onChange={setSelectedEnvironment}
+            )}
+            <ButtonGroup
+              ref={buttonGroupRef}
+              data-tour="folder-picker"
+              data-tour-ready={
+                (
+                  workspaceMode === "cloud"
+                    ? selectedRepository
+                    : selectedDirectory
+                )
+                  ? "true"
+                  : undefined
+              }
+            >
+              {workspaceMode === "cloud" ? (
+                <GitHubRepoPicker
+                  value={selectedRepository}
+                  onChange={handleRepositorySelect}
+                  repositories={
+                    isCloudRepoPickerOpen
+                      ? visibleCloudRepositories
+                      : repositories
+                  }
+                  isLoading={
+                    isLoadingRepos ||
+                    (isCloudRepoPickerOpen && cloudRepositoriesLoading)
+                  }
+                  isRefreshing={isRefreshingRepos}
+                  onRefresh={handleRefreshRepositories}
+                  open={isCloudRepoPickerOpen}
+                  onOpenChange={handleCloudRepoPickerOpenChange}
+                  searchQuery={cloudRepoSearchQuery}
+                  onSearchQueryChange={handleCloudRepoSearchChange}
+                  hasMore={cloudRepositoriesHasMore}
+                  onLoadMore={handleLoadMoreCloudRepositories}
+                  placeholder="Select repository..."
+                  size="1"
                   disabled={isCreatingTask}
                 />
-              )}
-              <ButtonGroup
-                ref={buttonGroupRef}
-                data-tour="folder-picker"
-                data-tour-ready={
-                  (
-                    workspaceMode === "cloud"
-                      ? selectedRepository
-                      : selectedDirectory
-                  )
-                    ? "true"
-                    : undefined
-                }
-              >
-                {workspaceMode === "cloud" ? (
-                  <GitHubRepoPicker
-                    value={selectedRepository}
-                    onChange={handleRepositorySelect}
-                    repositories={
-                      isCloudRepoPickerOpen
-                        ? visibleCloudRepositories
-                        : repositories
-                    }
-                    isLoading={
-                      isLoadingRepos ||
-                      (isCloudRepoPickerOpen && cloudRepositoriesLoading)
-                    }
-                    isRefreshing={isRefreshingRepos}
-                    onRefresh={handleRefreshRepositories}
-                    open={isCloudRepoPickerOpen}
-                    onOpenChange={handleCloudRepoPickerOpenChange}
-                    searchQuery={cloudRepoSearchQuery}
-                    onSearchQueryChange={handleCloudRepoSearchChange}
-                    hasMore={cloudRepositoriesHasMore}
-                    onLoadMore={handleLoadMoreCloudRepositories}
-                    placeholder="Select repository..."
-                    size="1"
-                    disabled={isCreatingTask}
-                  />
-                ) : (
-                  <FolderPicker
-                    value={selectedDirectory}
-                    onChange={setSelectedDirectory}
-                    placeholder="Select repository..."
-                    anchor={buttonGroupRef}
-                  />
-                )}
-                <BranchSelector
-                  repoPath={
-                    workspaceMode === "cloud"
-                      ? selectedCloudRepository
-                      : selectedDirectory
-                  }
-                  currentBranch={currentBranch}
-                  defaultBranch={
-                    workspaceMode === "cloud"
-                      ? cloudDefaultBranch
-                      : defaultBranch
-                  }
-                  disabled={
-                    isCreatingTask ||
-                    (workspaceMode === "cloud" && !selectedCloudRepository)
-                  }
-                  loading={workspaceMode === "cloud" ? false : branchLoading}
-                  workspaceMode={workspaceMode}
-                  selectedBranch={selectedBranch}
-                  onBranchSelect={setSelectedBranch}
-                  busyState={busyState}
-                  cloudBranches={cloudBranches}
-                  cloudBranchesLoading={cloudBranchesLoading}
-                  isRefreshing={cloudBranchesRefreshing}
-                  cloudBranchesFetchingMore={cloudBranchesFetchingMore}
-                  cloudBranchesHasMore={cloudBranchesHasMore}
-                  cloudSearchQuery={cloudBranchSearchQuery}
-                  onCloudPickerClose={handleCloudBranchPickerClose}
-                  onCloudSearchChange={handleCloudBranchSearchChange}
-                  onCloudLoadMore={handleLoadMoreCloudBranches}
-                  onRefresh={
-                    workspaceMode === "cloud"
-                      ? handleRefreshBranches
-                      : undefined
-                  }
+              ) : (
+                <FolderPicker
+                  value={selectedDirectory}
+                  onChange={setSelectedDirectory}
+                  placeholder="Select repository..."
                   anchor={buttonGroupRef}
                 />
-              </ButtonGroup>
-              {cloudRegion === "dev" && (
-                <Flex align="center" gap="1" className="shrink-0">
-                  <span
-                    className="inline-block h-2 w-2 rounded-full bg-orange-9"
-                    aria-hidden
-                  />
-                  <Text color="orange" className="font-medium text-[13px]">
-                    Dev
-                  </Text>
-                </Flex>
               )}
-            </Flex>
-
-            <Flex direction="column" gap="0">
-              <PromptInput
-                ref={editorRef}
-                sessionId={promptSessionId}
-                placeholder={`What do you want to ship? ${hints}`}
-                editorHeight="large"
-                disabled={isCreatingTask}
-                isLoading={isCreatingTask}
-                autoFocus
-                clearOnSubmit={false}
-                submitDisabledExternal={
-                  !canSubmit || isCreatingTask || !isOnline
+              <BranchSelector
+                repoPath={
+                  workspaceMode === "cloud"
+                    ? selectedCloudRepository
+                    : selectedDirectory
                 }
-                tourTarget="task-input"
-                repoPath={selectedDirectory}
-                modeOption={modeOption}
-                onModeChange={handleModeChange}
-                allowBypassPermissions={allowBypassPermissions}
-                enableCommands
-                enableBashMode={false}
-                modelSelector={
-                  <UnifiedModelSelector
-                    modelOption={modelOption}
-                    adapter={adapter ?? "claude"}
-                    onAdapterChange={setAdapter}
-                    disabled={isCreatingTask}
-                    isConnecting={isPreviewLoading}
-                    onModelChange={handleModelChange}
-                  />
+                currentBranch={currentBranch}
+                defaultBranch={
+                  workspaceMode === "cloud" ? cloudDefaultBranch : defaultBranch
                 }
-                historyButton={
-                  <PromptHistoryDialog
-                    onSelect={handleHistorySelect}
-                    hasPendingDraft={hasPendingDraft}
-                    disabled={isCreatingTask}
-                  />
+                disabled={
+                  isCreatingTask ||
+                  (workspaceMode === "cloud" && !selectedCloudRepository)
                 }
-                reasoningSelector={
-                  !isPreviewLoading && (
-                    <ReasoningLevelSelector
-                      thoughtOption={thoughtOption}
-                      adapter={adapter}
-                      onChange={handleThoughtChange}
-                      disabled={isCreatingTask}
-                    />
-                  )
+                loading={workspaceMode === "cloud" ? false : branchLoading}
+                workspaceMode={workspaceMode}
+                selectedBranch={selectedBranch}
+                onBranchSelect={setSelectedBranch}
+                busyState={busyState}
+                cloudBranches={cloudBranches}
+                cloudBranchesLoading={cloudBranchesLoading}
+                isRefreshing={cloudBranchesRefreshing}
+                cloudBranchesFetchingMore={cloudBranchesFetchingMore}
+                cloudBranchesHasMore={cloudBranchesHasMore}
+                cloudSearchQuery={cloudBranchSearchQuery}
+                onCloudPickerClose={handleCloudBranchPickerClose}
+                onCloudSearchChange={handleCloudBranchSearchChange}
+                onCloudLoadMore={handleLoadMoreCloudBranches}
+                onRefresh={
+                  workspaceMode === "cloud" ? handleRefreshBranches : undefined
                 }
-                getPromptHistory={getPromptHistory}
-                onEmptyChange={handleEditorEmptyChange}
-                onSubmitClick={handleSubmit}
-                onSubmit={() => {
-                  if (canSubmit) handleSubmit();
-                }}
+                anchor={buttonGroupRef}
               />
-              {activeReportAssociation && (
-                <div className="-mt-px mx-2 flex select-none items-center justify-between gap-2 rounded-b-md border border-blue-6 border-t-0 bg-blue-2 px-2 py-1 text-[12px] text-blue-11">
-                  <span className="flex min-w-0 flex-1 items-center gap-1">
-                    <span className="shrink-0">
-                      This task will be associated with report
-                    </span>
-                    <button
-                      type="button"
-                      onClick={handleOpenAssociatedReport}
-                      className="min-w-0 truncate text-left font-medium underline underline-offset-2 hover:text-blue-12"
-                    >
-                      {activeReportAssociation.title || "Untitled report"}
-                    </button>
+            </ButtonGroup>
+            {cloudRegion === "dev" && (
+              <Flex align="center" gap="1" className="shrink-0">
+                <span
+                  className="inline-block h-2 w-2 rounded-full bg-orange-9"
+                  aria-hidden
+                />
+                <Text color="orange" className="font-medium text-[13px]">
+                  Dev
+                </Text>
+              </Flex>
+            )}
+          </Flex>
+
+          <Flex direction="column" gap="0">
+            <PromptInput
+              ref={editorRef}
+              sessionId={promptSessionId}
+              placeholder={`What do you want to ship? ${hints}`}
+              editorHeight="large"
+              disabled={isCreatingTask}
+              isLoading={isCreatingTask}
+              autoFocus
+              clearOnSubmit={false}
+              submitDisabledExternal={!canSubmit || isCreatingTask || !isOnline}
+              tourTarget="task-input"
+              repoPath={selectedDirectory}
+              modeOption={modeOption}
+              onModeChange={handleModeChange}
+              allowBypassPermissions={allowBypassPermissions}
+              enableCommands
+              enableBashMode={false}
+              modelSelector={
+                <UnifiedModelSelector
+                  modelOption={modelOption}
+                  adapter={adapter ?? "claude"}
+                  onAdapterChange={setAdapter}
+                  disabled={isCreatingTask}
+                  isConnecting={isPreviewLoading}
+                  onModelChange={handleModelChange}
+                />
+              }
+              historyButton={
+                <PromptHistoryDialog
+                  onSelect={handleHistorySelect}
+                  hasPendingDraft={hasPendingDraft}
+                  disabled={isCreatingTask}
+                />
+              }
+              reasoningSelector={
+                !isPreviewLoading && (
+                  <ReasoningLevelSelector
+                    thoughtOption={thoughtOption}
+                    adapter={adapter}
+                    onChange={handleThoughtChange}
+                    disabled={isCreatingTask}
+                  />
+                )
+              }
+              getPromptHistory={getPromptHistory}
+              onEmptyChange={handleEditorEmptyChange}
+              onSubmitClick={handleSubmit}
+              onSubmit={() => {
+                if (canSubmit) handleSubmit();
+              }}
+            />
+            {activeReportAssociation && (
+              <div className="-mt-px mx-2 flex select-none items-center justify-between gap-2 rounded-b-md border border-blue-6 border-t-0 bg-blue-2 px-2 py-1 text-[12px] text-blue-11">
+                <span className="flex min-w-0 flex-1 items-center gap-1">
+                  <span className="shrink-0">
+                    This task will be associated with report
                   </span>
-                  <Tooltip content="Exit Inbox mode">
-                    <button
-                      type="button"
-                      onClick={handleDismissReportAssociation}
-                      aria-label="Exit Inbox mode"
-                      className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-blue-10 hover:bg-blue-4 hover:text-blue-12"
-                    >
-                      <X size={12} />
-                    </button>
-                  </Tooltip>
+                  <button
+                    type="button"
+                    onClick={handleOpenAssociatedReport}
+                    className="min-w-0 truncate text-left font-medium underline underline-offset-2 hover:text-blue-12"
+                  >
+                    {activeReportAssociation.title || "Untitled report"}
+                  </button>
+                </span>
+                <Tooltip content="Exit Inbox mode">
+                  <button
+                    type="button"
+                    onClick={handleDismissReportAssociation}
+                    aria-label="Exit Inbox mode"
+                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-blue-10 hover:bg-blue-4 hover:text-blue-12"
+                  >
+                    <X size={12} />
+                  </button>
+                </Tooltip>
+              </div>
+            )}
+            {effectiveWorkspaceMode === "cloud" &&
+              !isLoadingRepos &&
+              !hasGithubIntegration && (
+                <div className="mx-2 mt-2">
+                  <CloudGithubMissingNotice />
                 </div>
               )}
-              {effectiveWorkspaceMode === "cloud" &&
-                !isLoadingRepos &&
-                !hasGithubIntegration && (
-                  <div className="mx-2 mt-2">
-                    <CloudGithubMissingNotice />
-                  </div>
-                )}
-              <SuggestedTasksPanel onSelect={handleSelectSuggestion} />
-            </Flex>
-          </motion.div>
-        </LayoutGroup>
+            <SuggestedTasksPanel onSelect={handleSelectSuggestion} />
+          </Flex>
+        </div>
       </Flex>
 
       <GitBranchDialog

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -620,7 +620,7 @@ export function TaskInput({
     >
       <DropZoneOverlay isVisible={isDraggingFile} />
       <Flex
-        align="center"
+        align="start"
         justify="center"
         height="100%"
         className="relative px-4 pt-[10vh]"


### PR DESCRIPTION
## Summary

The "New task" composer flickered — bouncing up and down by one line — when typing a long, multi-line prompt. The column was wrapped in a framer-motion `<motion.div layout>` with a 250ms transition, so each new Tiptap line triggered a layout animation; rapid keystrokes interrupted each other and produced a visible one-line oscillation.

- Replace the `<LayoutGroup>` + `<motion.div layout>` wrapper with a plain `<div>` so the editor grows instantaneously.
- Drop the now-unused `framer-motion` import.
- The suggestions panel below already handles its own enter/exit transitions via its internal `AnimatePresence`, so no animation is lost.

https://github.com/user-attachments/assets/44f7fb06-1972-46e4-b9fe-eaf9b6a886be

## Test plan

- [ ] `pnpm dev:code`, open New task, type a prompt long enough to wrap to ~5 lines — composer grows smoothly with no flicker.
- [ ] Type past `max-h-[45vh]` — inner scroll engages cleanly.
- [ ] Delete content back to one line — composer shrinks smoothly.
- [ ] Trigger discovery so `SuggestedTasksPanel` shows entries below the editor, then type — suggestions don't flicker and don't push the editor around.