### PR TITLE
fix(task-detail): Remove cloudAvailable check, allowing Cloud setup

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/CloudGithubMissingNotice.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/CloudGithubMissingNotice.tsx
@@ -29,7 +29,7 @@ export function CloudGithubMissingNotice() {
             <Text size="1">
               {hasError
                 ? describeGithubConnectError(error)
-                : "Connecting your personal GitHub is required to run cloud tasks."}
+                : "Connect GitHub to your PostHog account for cloud tasks."}
             </Text>
           </Callout.Text>
         </Flex>

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -82,7 +82,6 @@ export function TaskInput({
     trpcReact.folders.getMostRecentlyAccessedRepository.queryOptions(),
   );
   const {
-    lastUsedLocalWorkspaceMode,
     setLastUsedLocalWorkspaceMode,
     lastUsedWorkspaceMode,
     setLastUsedWorkspaceMode,
@@ -186,13 +185,8 @@ export function TaskInput({
     hasGithubIntegration,
   } = useUserRepositoryIntegration();
 
-  // Stay optimistic while the integration list resolves to avoid flicker.
-  const cloudAvailable = isLoadingRepos || hasGithubIntegration;
   const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() => {
     if (initialCloudRepository) return "cloud";
-    if (!cloudAvailable && lastUsedWorkspaceMode === "cloud") {
-      return lastUsedLocalWorkspaceMode;
-    }
     return lastUsedWorkspaceMode || "local";
   });
 
@@ -203,12 +197,6 @@ export function TaskInput({
       setLastUsedLocalWorkspaceMode(mode);
     }
   };
-
-  useEffect(() => {
-    if (workspaceMode === "cloud" && !cloudAvailable) {
-      setWorkspaceModeState(lastUsedLocalWorkspaceMode);
-    }
-  }, [workspaceMode, cloudAvailable, lastUsedLocalWorkspaceMode]);
   const {
     repositories: visibleCloudRepositories,
     isPending: cloudRepositoriesLoading,
@@ -642,7 +630,6 @@ export function TaskInput({
                 onChange={setWorkspaceMode}
                 selectedCloudEnvironmentId={selectedCloudEnvId}
                 onCloudEnvironmentChange={setSelectedCloudEnvId}
-                cloudAvailable={cloudAvailable}
                 size="1"
               />
               {workspaceMode === "worktree" && (

--- a/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -36,7 +36,6 @@ interface WorkspaceModeSelectProps {
   overrideModes?: WorkspaceMode[];
   selectedCloudEnvironmentId?: string | null;
   onCloudEnvironmentChange?: (envId: string | null) => void;
-  cloudAvailable?: boolean;
 }
 
 const LOCAL_MODES: {
@@ -68,7 +67,6 @@ export function WorkspaceModeSelect({
   overrideModes,
   selectedCloudEnvironmentId,
   onCloudEnvironmentChange,
-  cloudAvailable = true,
 }: WorkspaceModeSelectProps) {
   const cloudModeEnabled =
     useFeatureFlag("twig-cloud-mode-toggle") || import.meta.env.DEV;
@@ -82,9 +80,9 @@ export function WorkspaceModeSelect({
     openSettings("cloud-environments", "create");
   }, [openSettings]);
 
-  const showCloud =
-    cloudAvailable &&
-    (overrideModes ? overrideModes.includes("cloud") : cloudModeEnabled);
+  const showCloud = overrideModes
+    ? overrideModes.includes("cloud")
+    : cloudModeEnabled;
 
   const localModes = useMemo(
     () =>


### PR DESCRIPTION
## Problem

I removed my personal integration from my PostHog account, and then I just had no "Cloud" button in new task mode selector – only "Local" and "Worktree", not even a "Connect GitHub for Cloud agents" button. Leaving no way for me to see the error message or reconnect their account.

## Changes

Not hiding the "Cloud" option anymore when "Cloud is not available". Seem to have been introduced in https://github.com/PostHog/code/pull/2045, but I don't quite understand what was the intention of _this specific_ guard.

## How did you test this?

Ran this and indeed was able to connect GH.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*