### PR TITLE
feat(inbox): Add slug suffix to inbox report deep links

### DIFF
--- a/apps/code/src/main/services/inbox-link/service.test.ts
+++ b/apps/code/src/main/services/inbox-link/service.test.ts
@@ -91,6 +91,15 @@ describe("InboxLinkService", () => {
     expect(listener).toHaveBeenCalledWith({ reportId: "abc-123" });
   });
 
+  it("ignores a trailing slug segment after the report id", () => {
+    const listener = vi.fn();
+    service.on(InboxLinkEvent.OpenReport, listener);
+
+    deepLinkService.trigger("inbox", "abc-123/fix-inbox--Add-foo");
+
+    expect(listener).toHaveBeenCalledWith({ reportId: "abc-123" });
+  });
+
   it("returns false and does not emit when the path is empty", () => {
     const listener = vi.fn();
     service.on(InboxLinkEvent.OpenReport, listener);

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -36,7 +36,7 @@ import {
 } from "@radix-ui/themes";
 import { useTRPC } from "@renderer/trpc";
 import { EXTERNAL_LINKS } from "@renderer/utils/links";
-import { getDeeplinkProtocol } from "@shared/deeplink";
+import { buildInboxDeeplink } from "@shared/deeplink";
 import type {
   ActionabilityJudgmentArtefact,
   ActionabilityJudgmentContent,
@@ -477,7 +477,9 @@ export function ReportDetailPane({
               onClick={async () => {
                 try {
                   await navigator.clipboard.writeText(
-                    `${getDeeplinkProtocol(import.meta.env.DEV)}://inbox/${report.id}`,
+                    buildInboxDeeplink(report.id, report.title, {
+                      isDevBuild: import.meta.env.DEV,
+                    }),
                   );
                   fireDetailAction("copy_link");
                   toast.success("Link copied");

--- a/apps/code/src/renderer/features/inbox/hooks/useDiscussReport.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useDiscussReport.ts
@@ -80,6 +80,7 @@ export function useDiscussReport({
 
       const prompt = buildDiscussReportPrompt({
         reportId,
+        reportTitle,
         question,
         isDevBuild: import.meta.env.DEV,
       });

--- a/apps/code/src/renderer/features/inbox/utils/buildDiscussReportPrompt.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/buildDiscussReportPrompt.test.ts
@@ -45,6 +45,24 @@ describe("buildDiscussReportPrompt", () => {
     expect(prompt).toContain("brief readout");
   });
 
+  it("appends a slugified title suffix to the deep link", () => {
+    const prompt = buildDiscussReportPrompt({
+      reportId: "abc123",
+      reportTitle: "fix(inbox): Add foo",
+      isDevBuild: false,
+    });
+    expect(prompt).toContain("posthog-code://inbox/abc123/fix-inbox--Add-foo");
+  });
+
+  it("omits the slug suffix when the title is blank", () => {
+    const prompt = buildDiscussReportPrompt({
+      reportId: "abc123",
+      reportTitle: "   ",
+      isDevBuild: false,
+    });
+    expect(prompt).toContain("posthog-code://inbox/abc123)");
+  });
+
   it("tells the agent to say so rather than guess if the report can't be fetched", () => {
     const withQuestion = buildDiscussReportPrompt({
       reportId: "abc123",

--- a/apps/code/src/renderer/features/inbox/utils/buildDiscussReportPrompt.ts
+++ b/apps/code/src/renderer/features/inbox/utils/buildDiscussReportPrompt.ts
@@ -1,17 +1,19 @@
 import { buildDiscussReportPrompt as buildSharedDiscussReportPrompt } from "@posthog/shared";
-import { getDeeplinkProtocol } from "@shared/deeplink";
+import { buildInboxDeeplink } from "@shared/deeplink";
 
 interface BuildDiscussReportPromptOptions {
   reportId: string;
+  reportTitle?: string | null;
   question?: string;
   isDevBuild: boolean;
 }
 
 export function buildDiscussReportPrompt({
   reportId,
+  reportTitle,
   question,
   isDevBuild,
 }: BuildDiscussReportPromptOptions): string {
-  const reportLink = `${getDeeplinkProtocol(isDevBuild)}://inbox/${reportId}`;
+  const reportLink = buildInboxDeeplink(reportId, reportTitle, { isDevBuild });
   return buildSharedDiscussReportPrompt({ reportId, reportLink, question });
 }

--- a/apps/code/src/shared/deeplink.test.ts
+++ b/apps/code/src/shared/deeplink.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildInboxDeeplink } from "./deeplink";
+
+describe("buildInboxDeeplink", () => {
+  it("returns just the UUID when no title is given", () => {
+    expect(buildInboxDeeplink("abc-123", null, { isDevBuild: false })).toBe(
+      "posthog-code://inbox/abc-123",
+    );
+    expect(
+      buildInboxDeeplink("abc-123", undefined, { isDevBuild: false }),
+    ).toBe("posthog-code://inbox/abc-123");
+    expect(buildInboxDeeplink("abc-123", "", { isDevBuild: false })).toBe(
+      "posthog-code://inbox/abc-123",
+    );
+  });
+
+  it("emits `--` for runs that mix a colon with other unsafe chars", () => {
+    expect(
+      buildInboxDeeplink("abc-123", "fix(inbox): Add foo", {
+        isDevBuild: false,
+      }),
+    ).toBe("posthog-code://inbox/abc-123/fix-inbox--Add-foo");
+  });
+
+  it("emits a single `-` for a colon-only run", () => {
+    expect(
+      buildInboxDeeplink("abc-123", "feat:bar", { isDevBuild: false }),
+    ).toBe("posthog-code://inbox/abc-123/feat-bar");
+  });
+
+  it("omits the slug when the title slugifies to empty", () => {
+    expect(buildInboxDeeplink("abc-123", ":::", { isDevBuild: false })).toBe(
+      "posthog-code://inbox/abc-123",
+    );
+    expect(buildInboxDeeplink("abc-123", "   ", { isDevBuild: false })).toBe(
+      "posthog-code://inbox/abc-123",
+    );
+  });
+
+  it("uses the dev scheme when isDevBuild is true", () => {
+    expect(
+      buildInboxDeeplink("abc-123", "Hello World", { isDevBuild: true }),
+    ).toBe("posthog-code-dev://inbox/abc-123/Hello-World");
+  });
+
+  it("preserves URL-unreserved punctuation (- _ . ~)", () => {
+    expect(
+      buildInboxDeeplink("abc-123", "v1.2.3_final~ish", { isDevBuild: false }),
+    ).toBe("posthog-code://inbox/abc-123/v1.2.3_final~ish");
+  });
+
+  it("collapses runs of unsafe punctuation into a single hyphen", () => {
+    expect(
+      buildInboxDeeplink("abc-123", "Cost $5, 50% off!", { isDevBuild: false }),
+    ).toBe("posthog-code://inbox/abc-123/Cost-5-50-off");
+  });
+
+  it("folds accented Latin letters to their ASCII base", () => {
+    expect(
+      buildInboxDeeplink("abc-123", "café résumé naïve", { isDevBuild: false }),
+    ).toBe("posthog-code://inbox/abc-123/cafe-resume-naive");
+  });
+
+  it("hyphenizes non-Latin scripts that have no ASCII fold", () => {
+    expect(
+      buildInboxDeeplink("abc-123", "Hello Привет world", {
+        isDevBuild: false,
+      }),
+    ).toBe("posthog-code://inbox/abc-123/Hello-world");
+  });
+});

--- a/apps/code/src/shared/deeplink.ts
+++ b/apps/code/src/shared/deeplink.ts
@@ -23,3 +23,38 @@ export function isPostHogCodeDeeplink(
     return false;
   }
 }
+
+/**
+ * Build the deep link URL for an inbox report. The optional title is slugified
+ * and appended as a trailing path segment for human-readable sharing; the
+ * receiver only reads the UUID, so the slug is purely cosmetic.
+ *
+ * Slug rules:
+ * - Accented Latin letters are folded to their ASCII base (`café` → `cafe`)
+ *   via NFD decomposition + combining-mark stripping.
+ * - Letters, digits, and the URL-unreserved punctuation `_ . ~` are kept
+ *   verbatim (case preserved).
+ * - Any run of other characters collapses to a single `-`, except runs that
+ *   mix a colon with other unsafe chars collapse to `--`. This preserves the
+ *   title-like break in `fix(inbox): Add foo` → `fix-inbox--Add-foo` while
+ *   keeping standalone colons compact (`feat:bar` → `feat-bar`) and unrelated
+ *   runs single (`Cost $5, 50% off` → `Cost-5-50-off`).
+ * - Leading and trailing hyphens are stripped.
+ */
+export function buildInboxDeeplink(
+  reportId: string,
+  title: string | null | undefined,
+  { isDevBuild }: { isDevBuild: boolean },
+): string {
+  const base = `${getDeeplinkProtocol(isDevBuild)}://inbox/${reportId}`;
+  const slug = title
+    ? title
+        .normalize("NFD")
+        .replace(/\p{M}/gu, "")
+        .replace(/[^a-zA-Z0-9_.~]+/g, (run) =>
+          run.includes(":") && /[^:]/.test(run) ? "--" : "-",
+        )
+        .replace(/^-+|-+$/g, "")
+    : "";
+  return slug ? `${base}/${slug}` : base;
+}


### PR DESCRIPTION
## Problem

People are sharing PostHog Code inbox links like `posthog-code://inbox/01928f7a-…` - problem is the link tells you nothing about what's on the other side. When pasted into Slack, a PR, or a doc, the recipient has no _signal_ whether the link is worth clicking.

## Changes

Deep links now include a human-readable slug of the report title after the UUID, like Graphite PRs:

```
posthog-code://inbox/<uuid>/fix-inbox--Add-foo
```

The slug is cosmetic-only, and slug-less are links are supported as always. (Did not test if slugful links work on older PH Code, likely not).

Slugification rules:
- Accented Latin folded to ASCII (`café` → `cafe`) via NFD normalization
- Letters, digits, and URL-unreserved punctuation (`_ . ~`) kept verbatim, case preserved
- Runs of other characters collapse to a single `-`, except runs that mix a colon with other unsafe chars collapse to `--` (so the title-like break in `fix(inbox): Add foo` reads as `fix-inbox--Add-foo`)

Updated the "Copy link" button to use this. 

## How did you test this?

Very pleasant to unit-test the slugification, it's now in `apps/code/src/shared/deeplink.test.ts`. Also updated `buildDiscussReportPrompt.test.ts`. Finally, clicked around manually.

## Publish to changelog?

Yes - PostHog Inbox sharing links now include human-readable titles for easy sharing.