### PR TITLE
Close mode/model/effort dropdowns on selection

### DIFF
--- a/apps/code/src/renderer/features/message-editor/components/ModeSelector.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/ModeSelector.tsx
@@ -19,6 +19,7 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { flattenSelectOptions } from "@renderer/features/sessions/stores/sessionStore";
+import { useState } from "react";
 
 interface ModeStyle {
   icon: React.ReactNode;
@@ -78,6 +79,8 @@ export function ModeSelector({
   allowBypassPermissions,
   disabled,
 }: ModeSelectorProps) {
+  const [open, setOpen] = useState(false);
+
   if (!modeOption || modeOption.type !== "select") return null;
 
   const allOptions = flattenSelectOptions(modeOption.options);
@@ -95,7 +98,7 @@ export function ModeSelector({
     allOptions.find((opt) => opt.value === currentValue)?.name ?? currentValue;
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
         render={
           <Button
@@ -122,7 +125,13 @@ export function ModeSelector({
         className={allowBypassPermissions ? "min-w-[220px]" : "min-w-[200px]"}
       >
         <MenuLabel>Mode</MenuLabel>
-        <DropdownMenuRadioGroup value={currentValue} onValueChange={onChange}>
+        <DropdownMenuRadioGroup
+          value={currentValue}
+          onValueChange={(value) => {
+            onChange(value);
+            setOpen(false);
+          }}
+        >
           {options.map((option) => {
             const style = getStyle(option.value);
             return (

--- a/apps/code/src/renderer/features/message-editor/components/ModeSelector.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/ModeSelector.tsx
@@ -19,7 +19,7 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { flattenSelectOptions } from "@renderer/features/sessions/stores/sessionStore";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 interface ModeStyle {
   icon: React.ReactNode;
@@ -80,6 +80,7 @@ export function ModeSelector({
   disabled,
 }: ModeSelectorProps) {
   const [open, setOpen] = useState(false);
+  const pendingValueRef = useRef<string | null>(null);
 
   if (!modeOption || modeOption.type !== "select") return null;
 
@@ -98,7 +99,16 @@ export function ModeSelector({
     allOptions.find((opt) => opt.value === currentValue)?.name ?? currentValue;
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu
+      open={open}
+      onOpenChange={setOpen}
+      onOpenChangeComplete={(isOpen) => {
+        if (!isOpen && pendingValueRef.current !== null) {
+          onChange(pendingValueRef.current);
+          pendingValueRef.current = null;
+        }
+      }}
+    >
       <DropdownMenuTrigger
         render={
           <Button
@@ -128,7 +138,7 @@ export function ModeSelector({
         <DropdownMenuRadioGroup
           value={currentValue}
           onValueChange={(value) => {
-            onChange(value);
+            pendingValueRef.current = value;
             setOpen(false);
           }}
         >

--- a/apps/code/src/renderer/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ReasoningLevelSelector.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { flattenSelectOptions } from "../stores/sessionStore";
 
 interface ReasoningLevelSelectorProps {
@@ -26,6 +26,7 @@ export function ReasoningLevelSelector({
   disabled,
 }: ReasoningLevelSelectorProps) {
   const [open, setOpen] = useState(false);
+  const pendingValueRef = useRef<string | null>(null);
 
   if (!thoughtOption || thoughtOption.type !== "select") {
     return null;
@@ -39,7 +40,16 @@ export function ReasoningLevelSelector({
   const prefix = adapter === "codex" ? "Reasoning" : "Effort";
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu
+      open={open}
+      onOpenChange={setOpen}
+      onOpenChangeComplete={(isOpen) => {
+        if (!isOpen && pendingValueRef.current !== null) {
+          onChange?.(pendingValueRef.current);
+          pendingValueRef.current = null;
+        }
+      }}
+    >
       <DropdownMenuTrigger
         render={
           <Button
@@ -69,7 +79,7 @@ export function ReasoningLevelSelector({
         <DropdownMenuRadioGroup
           value={activeLevel}
           onValueChange={(value) => {
-            onChange?.(value);
+            pendingValueRef.current = value;
             setOpen(false);
           }}
         >

--- a/apps/code/src/renderer/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ReasoningLevelSelector.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
+import { useState } from "react";
 import { flattenSelectOptions } from "../stores/sessionStore";
 
 interface ReasoningLevelSelectorProps {
@@ -24,6 +25,8 @@ export function ReasoningLevelSelector({
   onChange,
   disabled,
 }: ReasoningLevelSelectorProps) {
+  const [open, setOpen] = useState(false);
+
   if (!thoughtOption || thoughtOption.type !== "select") {
     return null;
   }
@@ -36,7 +39,7 @@ export function ReasoningLevelSelector({
   const prefix = adapter === "codex" ? "Reasoning" : "Effort";
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
         render={
           <Button
@@ -65,7 +68,10 @@ export function ReasoningLevelSelector({
         <MenuLabel>{adapter === "codex" ? "Reasoning" : "Effort"}</MenuLabel>
         <DropdownMenuRadioGroup
           value={activeLevel}
-          onValueChange={(value) => onChange?.(value)}
+          onValueChange={(value) => {
+            onChange?.(value);
+            setOpen(false);
+          }}
         >
           {options.map((level) => (
             <DropdownMenuRadioItem key={level.value} value={level.value}>

--- a/apps/code/src/renderer/features/sessions/components/UnifiedModelSelector.tsx
+++ b/apps/code/src/renderer/features/sessions/components/UnifiedModelSelector.tsx
@@ -21,7 +21,7 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useMemo, useRef, useState } from "react";
 import { flattenSelectOptions } from "../stores/sessionStore";
 
 const ADAPTER_ICONS: Record<AgentAdapter, React.ReactNode> = {
@@ -56,6 +56,7 @@ export function UnifiedModelSelector({
   isConnecting,
 }: UnifiedModelSelectorProps) {
   const [open, setOpen] = useState(false);
+  const pendingValueRef = useRef<string | null>(null);
   const selectOption = modelOption?.type === "select" ? modelOption : undefined;
   const options = selectOption
     ? flattenSelectOptions(selectOption.options)
@@ -84,7 +85,16 @@ export function UnifiedModelSelector({
   }
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu
+      open={open}
+      onOpenChange={setOpen}
+      onOpenChangeComplete={(isOpen) => {
+        if (!isOpen && pendingValueRef.current !== null) {
+          onModelChange?.(pendingValueRef.current);
+          pendingValueRef.current = null;
+        }
+      }}
+    >
       <DropdownMenuTrigger
         render={
           <Button
@@ -116,7 +126,7 @@ export function UnifiedModelSelector({
         <DropdownMenuRadioGroup
           value={currentValue ?? ""}
           onValueChange={(value) => {
-            onModelChange?.(value);
+            pendingValueRef.current = value;
             setOpen(false);
           }}
         >

--- a/apps/code/src/renderer/features/sessions/components/UnifiedModelSelector.tsx
+++ b/apps/code/src/renderer/features/sessions/components/UnifiedModelSelector.tsx
@@ -21,7 +21,7 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
-import { Fragment, useMemo } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { flattenSelectOptions } from "../stores/sessionStore";
 
 const ADAPTER_ICONS: Record<AgentAdapter, React.ReactNode> = {
@@ -55,6 +55,7 @@ export function UnifiedModelSelector({
   disabled,
   isConnecting,
 }: UnifiedModelSelectorProps) {
+  const [open, setOpen] = useState(false);
   const selectOption = modelOption?.type === "select" ? modelOption : undefined;
   const options = selectOption
     ? flattenSelectOptions(selectOption.options)
@@ -83,7 +84,7 @@ export function UnifiedModelSelector({
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
         render={
           <Button
@@ -114,7 +115,10 @@ export function UnifiedModelSelector({
         <MenuLabel>{ADAPTER_LABELS[adapter]}</MenuLabel>
         <DropdownMenuRadioGroup
           value={currentValue ?? ""}
-          onValueChange={(value) => onModelChange?.(value)}
+          onValueChange={(value) => {
+            onModelChange?.(value);
+            setOpen(false);
+          }}
         >
           {groupedOptions.length > 0
             ? groupedOptions.map((group, index) => (


### PR DESCRIPTION
## Summary
- The mode (auto/plan), model, and effort/reasoning dropdowns in the composer use Radix's `DropdownMenuRadioItem`, which doesn't auto-close the menu after a selection — picking a value left the dropdown hanging open
- Control the open state in `ModeSelector`, `UnifiedModelSelector`, and `ReasoningLevelSelector` and close the menu after `onValueChange` fires

## Test plan
- [ ] Open composer, click the mode dropdown, pick a mode → dropdown closes
- [ ] Same for the model dropdown
- [ ] Same for the effort/reasoning dropdown
- [ ] "Switch to <other adapter>" item in the model dropdown still closes (uses `DropdownMenuItem`, already auto-closes)