### PR TITLE
Simplify cloud environment dropdown when only one environment exists

### DIFF
--- a/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -163,21 +163,41 @@ export function WorkspaceModeSelect({
           ))}
         </DropdownMenuGroup>
 
-        {showCloud && (
+        {showCloud && environments.length === 0 && (
+          <DropdownMenuItem
+            onClick={() => {
+              onChange("cloud");
+              onCloudEnvironmentChange?.(null);
+            }}
+            render={
+              <ItemMenuItem size="xs" className="w-full">
+                <ItemMedia variant="icon" className="mt-2 ml-2">
+                  <span>{CLOUD_ICON}</span>
+                </ItemMedia>
+                <ItemContent variant="menuItem">
+                  <ItemTitle>Cloud</ItemTitle>
+                  <ItemDescription className="whitespace-nowrap leading-none">
+                    Run in a cloud sandbox
+                  </ItemDescription>
+                </ItemContent>
+              </ItemMenuItem>
+            }
+          />
+        )}
+
+        {showCloud && environments.length > 0 && (
           <>
             <DropdownMenuSeparator />
             <div className="flex items-center justify-between px-2 py-1">
               <MenuLabel className="p-0">Cloud environments</MenuLabel>
-              {environments.length > 0 && (
-                <button
-                  type="button"
-                  onClick={handleAddEnvironment}
-                  aria-label="Add cloud environment"
-                  className="flex cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0.5 text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
-                >
-                  <Plus size={12} />
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={handleAddEnvironment}
+                aria-label="Add cloud environment"
+                className="flex cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0.5 text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
+              >
+                <Plus size={12} />
+              </button>
             </div>
 
             <DropdownMenuGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a user has only one cloud environment (the built-in Default), the workspace mode dropdown shows a "Cloud environments" section header with a single "Default" item underneath. This is confusing — "Cloud environment: default" doesn't clearly communicate what it means.

## Changes

Modified `WorkspaceModeSelect` to detect when there are no custom sandbox environments and render a simple "Cloud" option inline with the other workspace modes (Worktree, Local) instead of the full "Cloud environments" section.

- **0 custom environments**: Shows a single "Cloud" item with description "Run in a cloud sandbox", no separator or section header
- **1+ custom environments**: Preserves the existing behavior with the "Cloud environments" section, "Default" entry, and all custom environments listed

## How did you test this?

Verified the component typechecks and that the lint-staged pre-commit hooks pass. No existing tests for this component.

## Publish to changelog?

no
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1779471077615439?thread_ts=1779471077.615439&cid=C09G8Q32R6F)

<div><a href="https://cursor.com/agents/bc-cd15c54b-f88e-50b3-a10f-8b5572c42004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd15c54b-f88e-50b3-a10f-8b5572c42004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

