### PR TITLE
feat(sidebar): add "By status" organize mode

### DIFF
--- a/apps/code/src/main/services/context-menu/schemas.ts
+++ b/apps/code/src/main/services/context-menu/schemas.ts
@@ -10,6 +10,10 @@ export const taskContextMenuInput = z.object({
   hasEmptyCommandCenterCell: z.boolean().optional(),
 });
 
+export const bulkTaskContextMenuInput = z.object({
+  taskCount: z.number().int().min(2),
+});
+
 export const archivedTaskContextMenuInput = z.object({
   taskTitle: z.string(),
 });
@@ -45,6 +49,10 @@ const taskAction = z.discriminatedUnion("type", [
   z.object({ type: z.literal("external-app"), action: externalAppAction }),
 ]);
 
+const bulkTaskAction = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("archive") }),
+]);
+
 const archivedTaskAction = z.discriminatedUnion("type", [
   z.object({ type: z.literal("restore") }),
   z.object({ type: z.literal("delete") }),
@@ -72,6 +80,9 @@ const splitDirection = z.enum(["left", "right", "up", "down"]);
 export const taskContextMenuOutput = z.object({
   action: taskAction.nullable(),
 });
+export const bulkTaskContextMenuOutput = z.object({
+  action: bulkTaskAction.nullable(),
+});
 export const archivedTaskContextMenuOutput = z.object({
   action: archivedTaskAction.nullable(),
 });
@@ -87,6 +98,7 @@ export const splitContextMenuOutput = z.object({
 });
 
 export type TaskContextMenuInput = z.infer<typeof taskContextMenuInput>;
+export type BulkTaskContextMenuInput = z.infer<typeof bulkTaskContextMenuInput>;
 export type ArchivedTaskContextMenuInput = z.infer<
   typeof archivedTaskContextMenuInput
 >;
@@ -96,6 +108,7 @@ export type FileContextMenuInput = z.infer<typeof fileContextMenuInput>;
 
 export type ExternalAppAction = z.infer<typeof externalAppAction>;
 export type TaskAction = z.infer<typeof taskAction>;
+export type BulkTaskAction = z.infer<typeof bulkTaskAction>;
 export type ArchivedTaskAction = z.infer<typeof archivedTaskAction>;
 export type FolderAction = z.infer<typeof folderAction>;
 export type TabAction = z.infer<typeof tabAction>;

--- a/apps/code/src/main/services/context-menu/service.ts
+++ b/apps/code/src/main/services/context-menu/service.ts
@@ -11,6 +11,8 @@ import type {
   ArchivedTaskAction,
   ArchivedTaskContextMenuInput,
   ArchivedTaskContextMenuResult,
+  BulkTaskAction,
+  BulkTaskContextMenuInput,
   ConfirmDeleteArchivedTaskInput,
   ConfirmDeleteArchivedTaskResult,
   ConfirmDeleteTaskInput,
@@ -153,6 +155,27 @@ export class ContextMenuService {
             message: "Archive all tasks older than this one?",
             detail:
               "This will archive every task created before this one. You can unarchive them later.",
+            confirmLabel: "Archive",
+          },
+        },
+      ),
+    ]);
+  }
+
+  async showBulkTaskContextMenu(
+    input: BulkTaskContextMenuInput,
+  ): Promise<{ action: BulkTaskAction | null }> {
+    const { taskCount } = input;
+    const label = `Archive ${taskCount} tasks`;
+    return this.showMenu<BulkTaskAction>([
+      this.item(
+        label,
+        { type: "archive" },
+        {
+          confirm: {
+            title: "Archive Tasks",
+            message: `Archive ${taskCount} tasks?`,
+            detail: "You can unarchive them later.",
             confirmLabel: "Archive",
           },
         },

--- a/apps/code/src/main/trpc/routers/context-menu.ts
+++ b/apps/code/src/main/trpc/routers/context-menu.ts
@@ -3,6 +3,8 @@ import { MAIN_TOKENS } from "../../di/tokens";
 import {
   archivedTaskContextMenuInput,
   archivedTaskContextMenuOutput,
+  bulkTaskContextMenuInput,
+  bulkTaskContextMenuOutput,
   confirmDeleteArchivedTaskInput,
   confirmDeleteArchivedTaskOutput,
   confirmDeleteTaskInput,
@@ -45,6 +47,11 @@ export const contextMenuRouter = router({
     .input(taskContextMenuInput)
     .output(taskContextMenuOutput)
     .mutation(({ input }) => getService().showTaskContextMenu(input)),
+
+  showBulkTaskContextMenu: publicProcedure
+    .input(bulkTaskContextMenuInput)
+    .output(bulkTaskContextMenuOutput)
+    .mutation(({ input }) => getService().showBulkTaskContextMenu(input)),
 
   showArchivedTaskContextMenu: publicProcedure
     .input(archivedTaskContextMenuInput)

--- a/apps/code/src/renderer/features/sidebar/components/MainSidebar.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/MainSidebar.tsx
@@ -3,7 +3,15 @@ import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import { Box } from "@radix-ui/themes";
 import { useEffect } from "react";
 import { useSidebarStore } from "../stores/sidebarStore";
+import { useTaskSelectionStore } from "../stores/taskSelectionStore";
 import { Sidebar, SidebarContent } from "./index";
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
 
 export function MainSidebar() {
   const { data: workspaces = {}, isFetched } = useWorkspaces();
@@ -18,6 +26,19 @@ export function MainSidebar() {
       setOpenAuto(hasCompletedOnboarding || workspaceCount > 0);
     }
   }, [isFetched, workspaces, hasCompletedOnboarding, setOpenAuto]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (isEditableTarget(e.target)) return;
+      const { selectedTaskIds, clearSelection } =
+        useTaskSelectionStore.getState();
+      if (selectedTaskIds.length === 0) return;
+      clearSelection();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
 
   return (
     <Box flexShrink="0" className="shrink-0">

--- a/apps/code/src/renderer/features/sidebar/components/SidebarItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarItem.tsx
@@ -17,10 +17,11 @@ interface SidebarItemProps {
   label: React.ReactNode;
   subtitle?: React.ReactNode;
   isActive?: boolean;
+  isSelected?: boolean;
   isDimmed?: boolean;
   draggable?: boolean;
   onDragStart?: (e: React.DragEvent) => void;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent) => void;
   onDoubleClick?: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
   action?: SidebarItemAction;
@@ -68,6 +69,7 @@ export function SidebarItem({
   label,
   subtitle,
   isActive,
+  isSelected,
   draggable,
   onDragStart,
   onClick,
@@ -82,9 +84,10 @@ export function SidebarItem({
       className={cn(
         "group flex w-full cursor-default text-left text-[13px] leading-snug transition-colors",
         "focus-visible:-outline-offset-2 focus-visible:outline-2 focus-visible:outline-accent-8",
-        "disabled:opacity-100 data-active:bg-fill-selected",
+        "disabled:opacity-100 data-active:bg-fill-selected data-selected:bg-(--gray-3)",
       )}
       data-active={isActive || undefined}
+      data-selected={(isSelected && !isActive) || undefined}
       draggable={draggable}
       onDragStart={onDragStart}
       style={{

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -8,7 +8,7 @@ import {
 } from "@features/inbox/utils/inboxConstants";
 import { getSessionService } from "@features/sessions/service/service";
 import {
-  archiveTaskImperative,
+  archiveTasksImperative,
   useArchiveTask,
 } from "@features/tasks/hooks/useArchiveTask";
 import { useTasks, useUpdateTask } from "@features/tasks/hooks/useTasks";
@@ -17,6 +17,7 @@ import { useTaskContextMenu } from "@hooks/useTaskContextMenu";
 import { ScrollArea, Separator } from "@posthog/quill";
 import { Box, Flex } from "@radix-ui/themes";
 import type { Schemas } from "@renderer/api/generated";
+import { trpcClient } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
 import { useCommandMenuStore } from "@stores/commandMenuStore";
 import { useNavigationStore } from "@stores/navigationStore";
@@ -24,11 +25,12 @@ import { useRendererWindowFocusStore } from "@stores/rendererWindowFocusStore";
 import { useQueryClient } from "@tanstack/react-query";
 import { logger } from "@utils/logger";
 import { toast } from "@utils/toast";
-import { memo, useCallback, useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { usePinnedTasks } from "../hooks/usePinnedTasks";
 import { useSidebarData } from "../hooks/useSidebarData";
 import { useTaskViewed } from "../hooks/useTaskViewed";
 import { useSidebarStore } from "../stores/sidebarStore";
+import { useTaskSelectionStore } from "../stores/taskSelectionStore";
 import { CommandCenterItem } from "./items/CommandCenterItem";
 import { InboxItem, NewTaskItem } from "./items/HomeItem";
 import { McpServersItem } from "./items/McpServersItem";
@@ -133,23 +135,133 @@ function SidebarMenuComponent() {
     openCommandMenu();
   };
 
-  const handleTaskClick = (taskId: string) => {
+  const queryClient = useQueryClient();
+
+  const selectedTaskIds = useTaskSelectionStore((s) => s.selectedTaskIds);
+  const toggleTaskSelection = useTaskSelectionStore(
+    (s) => s.toggleTaskSelection,
+  );
+  const selectRange = useTaskSelectionStore((s) => s.selectRange);
+  const clearSelection = useTaskSelectionStore((s) => s.clearSelection);
+  const pruneSelection = useTaskSelectionStore((s) => s.pruneSelection);
+
+  const organizeMode = useSidebarStore((s) => s.organizeMode);
+  const collapsedSections = useSidebarStore((s) => s.collapsedSections);
+
+  const allSidebarTasks = useMemo(
+    () => [...sidebarData.pinnedTasks, ...sidebarData.flatTasks],
+    [sidebarData.pinnedTasks, sidebarData.flatTasks],
+  );
+
+  const allSidebarTaskIds = useMemo(
+    () => allSidebarTasks.map((t) => t.id),
+    [allSidebarTasks],
+  );
+
+  // Ordered list of currently visible task IDs in display order. Used as the
+  // index for shift-click range selection so it matches what the user sees —
+  // in by-project mode the chronological flat order would span across project
+  // groups and pull in unrelated tasks.
+  const orderedVisibleTaskIds = useMemo(() => {
+    const ids: string[] = sidebarData.pinnedTasks.map((t) => t.id);
+    if (organizeMode === "by-project") {
+      for (const group of sidebarData.groupedTasks) {
+        if (collapsedSections.has(group.id)) continue;
+        for (const t of group.tasks) ids.push(t.id);
+      }
+    } else {
+      for (const t of sidebarData.flatTasks) ids.push(t.id);
+    }
+    return ids;
+  }, [
+    sidebarData.pinnedTasks,
+    sidebarData.flatTasks,
+    sidebarData.groupedTasks,
+    organizeMode,
+    collapsedSections,
+  ]);
+
+  useEffect(() => {
+    pruneSelection(allSidebarTaskIds);
+  }, [allSidebarTaskIds, pruneSelection]);
+
+  // The active (routed) task is implicitly part of any bulk selection — the
+  // user expects to see and act on it together with cmd/shift-clicked tasks.
+  const activeTaskId = sidebarData.activeTaskId;
+  const effectiveBulkIds = useMemo(() => {
+    if (selectedTaskIds.length === 0) return [];
+    if (!activeTaskId) return selectedTaskIds;
+    if (selectedTaskIds.includes(activeTaskId)) return selectedTaskIds;
+    return [activeTaskId, ...selectedTaskIds];
+  }, [activeTaskId, selectedTaskIds]);
+
+  const handleTaskClick = (taskId: string, e: React.MouseEvent) => {
+    if (e.shiftKey) {
+      e.preventDefault();
+      selectRange(taskId, orderedVisibleTaskIds, activeTaskId);
+      return;
+    }
+    if (e.metaKey || e.ctrlKey) {
+      e.preventDefault();
+      toggleTaskSelection(taskId);
+      return;
+    }
+
+    clearSelection();
     const task = taskMap.get(taskId);
     if (task) {
       navigateToTask(task);
     }
   };
 
-  const allSidebarTasks = [
-    ...sidebarData.pinnedTasks,
-    ...sidebarData.flatTasks,
-  ];
+  const handleBulkContextMenu = useCallback(
+    async (e: React.MouseEvent, taskIds: string[]) => {
+      e.preventDefault();
+      e.stopPropagation();
+      try {
+        const result =
+          await trpcClient.contextMenu.showBulkTaskContextMenu.mutate({
+            taskCount: taskIds.length,
+          });
+        if (!result.action) return;
+        if (result.action.type === "archive") {
+          const { archived, failed } = await archiveTasksImperative(
+            taskIds,
+            queryClient,
+          );
+          clearSelection();
+          if (failed === 0) {
+            toast.success(
+              `${archived} ${archived === 1 ? "task" : "tasks"} archived`,
+            );
+          } else {
+            toast.error(`${archived} archived, ${failed} failed`);
+          }
+        }
+      } catch (error) {
+        logger
+          .scope("sidebar-menu")
+          .error("Failed to show bulk context menu", error);
+      }
+    },
+    [queryClient, clearSelection],
+  );
 
   const handleTaskContextMenu = (
     taskId: string,
     e: React.MouseEvent,
     isPinned: boolean,
   ) => {
+    // Bulk menu when 2+ tasks are in the effective selection (active + cmd/shift-clicked)
+    // and the right-clicked task is one of them. Otherwise clear and fall through.
+    if (effectiveBulkIds.length > 1) {
+      if (effectiveBulkIds.includes(taskId)) {
+        handleBulkContextMenu(e, effectiveBulkIds);
+        return;
+      }
+      clearSelection();
+    }
+
     const task = taskMap.get(taskId);
     if (task) {
       const workspace = workspaces[taskId];
@@ -189,7 +301,6 @@ function SidebarMenuComponent() {
   };
 
   const updateTask = useUpdateTask();
-  const queryClient = useQueryClient();
 
   const handleArchivePrior = useCallback(
     async (taskId: string) => {
@@ -197,10 +308,9 @@ function SidebarMenuComponent() {
       const clickedTask = allVisible.find((t) => t.id === taskId);
       if (!clickedTask) return;
 
-      const sortKey = "createdAt" as const;
-      const threshold = clickedTask[sortKey];
+      const threshold = clickedTask.createdAt;
       const priorTaskIds = allVisible
-        .filter((t) => t.id !== taskId && t[sortKey] < threshold)
+        .filter((t) => t.id !== taskId && t.createdAt < threshold)
         .map((t) => t.id);
 
       if (priorTaskIds.length === 0) {
@@ -208,33 +318,17 @@ function SidebarMenuComponent() {
         return;
       }
 
-      const nav = useNavigationStore.getState();
-      const priorSet = new Set(priorTaskIds);
-      if (
-        nav.view.type === "task-detail" &&
-        nav.view.data &&
-        priorSet.has(nav.view.data.id)
-      ) {
-        nav.navigateToTaskInput();
-      }
-
-      let done = 0;
-      let failed = 0;
-      for (const id of priorTaskIds) {
-        try {
-          await archiveTaskImperative(id, queryClient, {
-            skipNavigate: true,
-          });
-          done++;
-        } catch {
-          failed++;
-        }
-      }
+      const { archived, failed } = await archiveTasksImperative(
+        priorTaskIds,
+        queryClient,
+      );
 
       if (failed === 0) {
-        toast.success(`${done} ${done === 1 ? "task" : "tasks"} archived`);
+        toast.success(
+          `${archived} ${archived === 1 ? "task" : "tasks"} archived`,
+        );
       } else {
-        toast.error(`${done} archived, ${failed} failed`);
+        toast.error(`${archived} archived, ${failed} failed`);
       }
     },
     [sidebarData.pinnedTasks, sidebarData.flatTasks, queryClient],
@@ -355,6 +449,7 @@ function SidebarMenuComponent() {
               statusGroupedTasks={sidebarData.statusGroupedTasks}
               activeTaskId={sidebarData.activeTaskId}
               editingTaskId={editingTaskId}
+              selectedTaskIds={effectiveBulkIds}
               onTaskClick={handleTaskClick}
               onTaskDoubleClick={handleTaskDoubleClick}
               onTaskContextMenu={handleTaskContextMenu}

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -352,6 +352,7 @@ function SidebarMenuComponent() {
               pinnedTasks={sidebarData.pinnedTasks}
               flatTasks={sidebarData.flatTasks}
               groupedTasks={sidebarData.groupedTasks}
+              statusGroupedTasks={sidebarData.statusGroupedTasks}
               activeTaskId={sidebarData.activeTaskId}
               editingTaskId={editingTaskId}
               onTaskClick={handleTaskClick}

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -42,7 +42,8 @@ interface TaskListViewProps {
   statusGroupedTasks: StatusGroup[];
   activeTaskId: string | null;
   editingTaskId: string | null;
-  onTaskClick: (taskId: string) => void;
+  selectedTaskIds: string[];
+  onTaskClick: (taskId: string, e: React.MouseEvent) => void;
   onTaskDoubleClick: (taskId: string) => void;
   onTaskContextMenu: (
     taskId: string,
@@ -77,6 +78,8 @@ function SectionLabel({
 function TaskRow({
   task,
   isActive,
+  isSelected,
+  hideHoverActions,
   isEditing,
   onClick,
   onDoubleClick,
@@ -90,8 +93,10 @@ function TaskRow({
 }: {
   task: TaskData;
   isActive: boolean;
+  isSelected: boolean;
+  hideHoverActions: boolean;
   isEditing: boolean;
-  onClick: () => void;
+  onClick: (e: React.MouseEvent) => void;
   onDoubleClick: () => void;
   onContextMenu: (e: React.MouseEvent, isPinned: boolean) => void;
   onArchive: () => void;
@@ -113,6 +118,8 @@ function TaskRow({
       taskId={task.id}
       label={task.title}
       isActive={isActive}
+      isSelected={isSelected}
+      hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}
       worktreePath={workspace?.worktreePath ?? undefined}
@@ -257,6 +264,7 @@ export function TaskListView({
   statusGroupedTasks,
   activeTaskId,
   editingTaskId,
+  selectedTaskIds,
   onTaskClick,
   onTaskDoubleClick,
   onTaskContextMenu,
@@ -266,6 +274,11 @@ export function TaskListView({
   onTaskEditCancel,
   hasMore,
 }: TaskListViewProps) {
+  const selectedIdSet = useMemo(
+    () => new Set(selectedTaskIds),
+    [selectedTaskIds],
+  );
+  const hasMultiSelection = selectedTaskIds.length > 1;
   const organizeMode = useSidebarStore((state) => state.organizeMode);
   const sortMode = useSidebarStore((state) => state.sortMode);
   const collapsedSections = useSidebarStore((state) => state.collapsedSections);
@@ -318,29 +331,32 @@ export function TaskListView({
     return groups;
   }, [flatTasks, timestampKey]);
 
+  const renderTaskRow = (task: TaskData, opts?: { depth?: number }) => (
+    <TaskRow
+      key={task.id}
+      task={task}
+      isActive={activeTaskId === task.id}
+      isSelected={selectedIdSet.has(task.id)}
+      hideHoverActions={hasMultiSelection}
+      isEditing={editingTaskId === task.id}
+      onClick={(e) => onTaskClick(task.id, e)}
+      onDoubleClick={() => onTaskDoubleClick(task.id)}
+      onContextMenu={(e, isPinned) => onTaskContextMenu(task.id, e, isPinned)}
+      onArchive={() => onTaskArchive(task.id)}
+      onTogglePin={() => onTaskTogglePin(task.id)}
+      onEditSubmit={(newTitle) => onTaskEditSubmit(task.id, newTitle)}
+      onEditCancel={onTaskEditCancel}
+      timestamp={task[timestampKey]}
+      depth={opts?.depth ?? 0}
+    />
+  );
+
   return (
     <Flex direction="column">
       {pinnedTasks.length > 0 && (
         <>
           <SectionLabel label="Pinned" />
-          {pinnedTasks.map((task) => (
-            <TaskRow
-              key={task.id}
-              task={task}
-              isActive={activeTaskId === task.id}
-              isEditing={editingTaskId === task.id}
-              onClick={() => onTaskClick(task.id)}
-              onDoubleClick={() => onTaskDoubleClick(task.id)}
-              onContextMenu={(e, isPinned) =>
-                onTaskContextMenu(task.id, e, isPinned)
-              }
-              onArchive={() => onTaskArchive(task.id)}
-              onTogglePin={() => onTaskTogglePin(task.id)}
-              onEditSubmit={(newTitle) => onTaskEditSubmit(task.id, newTitle)}
-              onEditCancel={onTaskEditCancel}
-              timestamp={task[timestampKey]}
-            />
-          ))}
+          {pinnedTasks.map((task) => renderTaskRow(task))}
         </>
       )}
 
@@ -407,27 +423,7 @@ export function TaskListView({
                 addSpacingBefore={false}
                 tooltipContent={meta.description}
               >
-                {group.tasks.map((task) => (
-                  <TaskRow
-                    key={task.id}
-                    task={task}
-                    isActive={activeTaskId === task.id}
-                    isEditing={editingTaskId === task.id}
-                    onClick={() => onTaskClick(task.id)}
-                    onDoubleClick={() => onTaskDoubleClick(task.id)}
-                    onContextMenu={(e, isPinned) =>
-                      onTaskContextMenu(task.id, e, isPinned)
-                    }
-                    onArchive={() => onTaskArchive(task.id)}
-                    onTogglePin={() => onTaskTogglePin(task.id)}
-                    onEditSubmit={(newTitle) =>
-                      onTaskEditSubmit(task.id, newTitle)
-                    }
-                    onEditCancel={onTaskEditCancel}
-                    timestamp={task[timestampKey]}
-                    depth={1}
-                  />
-                ))}
+                {group.tasks.map((task) => renderTaskRow(task, { depth: 1 }))}
               </SidebarSection>
             );
           })}
@@ -476,27 +472,9 @@ export function TaskListView({
                     }}
                     newTaskTooltip={`Start new task in ${folder?.name ?? group.name}`}
                   >
-                    {group.tasks.map((task) => (
-                      <TaskRow
-                        key={task.id}
-                        task={task}
-                        isActive={activeTaskId === task.id}
-                        isEditing={editingTaskId === task.id}
-                        onClick={() => onTaskClick(task.id)}
-                        onDoubleClick={() => onTaskDoubleClick(task.id)}
-                        onContextMenu={(e, isPinned) =>
-                          onTaskContextMenu(task.id, e, isPinned)
-                        }
-                        onArchive={() => onTaskArchive(task.id)}
-                        onTogglePin={() => onTaskTogglePin(task.id)}
-                        onEditSubmit={(newTitle) =>
-                          onTaskEditSubmit(task.id, newTitle)
-                        }
-                        onEditCancel={onTaskEditCancel}
-                        timestamp={task[timestampKey]}
-                        depth={1}
-                      />
-                    ))}
+                    {group.tasks.map((task) =>
+                      renderTaskRow(task, { depth: 1 }),
+                    )}
                   </SidebarSection>
                 </DraggableFolder>
               );
@@ -508,26 +486,7 @@ export function TaskListView({
           {dateGroupedTasks.map((group, groupIndex) => (
             <Fragment key={`${group.label ?? "today"}-${groupIndex}`}>
               {group.label && <SectionLabel label={group.label} />}
-              {group.tasks.map((task) => (
-                <TaskRow
-                  key={task.id}
-                  task={task}
-                  isActive={activeTaskId === task.id}
-                  isEditing={editingTaskId === task.id}
-                  onClick={() => onTaskClick(task.id)}
-                  onDoubleClick={() => onTaskDoubleClick(task.id)}
-                  onContextMenu={(e, isPinned) =>
-                    onTaskContextMenu(task.id, e, isPinned)
-                  }
-                  onArchive={() => onTaskArchive(task.id)}
-                  onTogglePin={() => onTaskTogglePin(task.id)}
-                  onEditSubmit={(newTitle) =>
-                    onTaskEditSubmit(task.id, newTitle)
-                  }
-                  onEditCancel={onTaskEditCancel}
-                  timestamp={task[timestampKey]}
-                />
-              ))}
+              {group.tasks.map((task) => renderTaskRow(task))}
             </Fragment>
           ))}
           {hasMore && (

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -27,11 +27,7 @@ import { useNavigationStore } from "@stores/navigationStore";
 import { getRelativeDateGroup } from "@utils/time";
 import { motion } from "framer-motion";
 import { Fragment, useCallback, useEffect, useMemo } from "react";
-import type {
-  StatusGroup,
-  TaskData,
-  TaskGroup,
-} from "../hooks/useSidebarData";
+import type { StatusGroup, TaskData, TaskGroup } from "../hooks/useSidebarData";
 import { useTaskPrStatus } from "../hooks/useTaskPrStatus";
 import { useSidebarStore } from "../stores/sidebarStore";
 import { STATUS_GROUP_META } from "../utils/groupByStatus";

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -27,9 +27,14 @@ import { useNavigationStore } from "@stores/navigationStore";
 import { getRelativeDateGroup } from "@utils/time";
 import { motion } from "framer-motion";
 import { Fragment, useCallback, useEffect, useMemo } from "react";
-import type { TaskData, TaskGroup } from "../hooks/useSidebarData";
+import type {
+  StatusGroup,
+  TaskData,
+  TaskGroup,
+} from "../hooks/useSidebarData";
 import { useTaskPrStatus } from "../hooks/useTaskPrStatus";
 import { useSidebarStore } from "../stores/sidebarStore";
+import { STATUS_GROUP_META } from "../utils/groupByStatus";
 import { DraggableFolder } from "./DraggableFolder";
 import { TaskItem } from "./items/TaskItem";
 import { SidebarSection } from "./SidebarSection";
@@ -38,6 +43,7 @@ interface TaskListViewProps {
   pinnedTasks: TaskData[];
   flatTasks: TaskData[];
   groupedTasks: TaskGroup[];
+  statusGroupedTasks: StatusGroup[];
   activeTaskId: string | null;
   editingTaskId: string | null;
   onTaskClick: (taskId: string) => void;
@@ -187,6 +193,9 @@ function TaskFilterMenu() {
           <DropdownMenuRadioItem value="by-project">
             By project
           </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="by-status">
+            By status
+          </DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="chronological">
             Chronological list
           </DropdownMenuRadioItem>
@@ -249,6 +258,7 @@ export function TaskListView({
   pinnedTasks,
   flatTasks,
   groupedTasks,
+  statusGroupedTasks,
   activeTaskId,
   editingTaskId,
   onTaskClick,
@@ -384,6 +394,48 @@ export function TaskListView({
             </motion.button>
           )}
         </div>
+      ) : organizeMode === "by-status" ? (
+        <Flex direction="column">
+          {statusGroupedTasks.map((group) => {
+            const isExpanded = !collapsedSections.has(group.id);
+            const meta = STATUS_GROUP_META[group.id];
+            const Icon = meta.icon;
+            return (
+              <SidebarSection
+                key={group.id}
+                id={group.id}
+                label={group.name}
+                icon={<Icon size={14} color={meta.color} />}
+                isExpanded={isExpanded}
+                onToggle={() => toggleSection(group.id)}
+                addSpacingBefore={false}
+                tooltipContent={meta.description}
+              >
+                {group.tasks.map((task) => (
+                  <TaskRow
+                    key={task.id}
+                    task={task}
+                    isActive={activeTaskId === task.id}
+                    isEditing={editingTaskId === task.id}
+                    onClick={() => onTaskClick(task.id)}
+                    onDoubleClick={() => onTaskDoubleClick(task.id)}
+                    onContextMenu={(e, isPinned) =>
+                      onTaskContextMenu(task.id, e, isPinned)
+                    }
+                    onArchive={() => onTaskArchive(task.id)}
+                    onTogglePin={() => onTaskTogglePin(task.id)}
+                    onEditSubmit={(newTitle) =>
+                      onTaskEditSubmit(task.id, newTitle)
+                    }
+                    onEditCancel={onTaskEditCancel}
+                    timestamp={task[timestampKey]}
+                    depth={1}
+                  />
+                ))}
+              </SidebarSection>
+            );
+          })}
+        </Flex>
       ) : organizeMode === "by-project" ? (
         <DragDropProvider
           onDragOver={handleDragOver}

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -331,32 +331,31 @@ export function TaskListView({
     return groups;
   }, [flatTasks, timestampKey]);
 
-  const renderTaskRow = (task: TaskData, opts?: { depth?: number }) => (
-    <TaskRow
-      key={task.id}
-      task={task}
-      isActive={activeTaskId === task.id}
-      isSelected={selectedIdSet.has(task.id)}
-      hideHoverActions={hasMultiSelection}
-      isEditing={editingTaskId === task.id}
-      onClick={(e) => onTaskClick(task.id, e)}
-      onDoubleClick={() => onTaskDoubleClick(task.id)}
-      onContextMenu={(e, isPinned) => onTaskContextMenu(task.id, e, isPinned)}
-      onArchive={() => onTaskArchive(task.id)}
-      onTogglePin={() => onTaskTogglePin(task.id)}
-      onEditSubmit={(newTitle) => onTaskEditSubmit(task.id, newTitle)}
-      onEditCancel={onTaskEditCancel}
-      timestamp={task[timestampKey]}
-      depth={opts?.depth ?? 0}
-    />
-  );
-
   return (
     <Flex direction="column">
       {pinnedTasks.length > 0 && (
         <>
           <SectionLabel label="Pinned" />
-          {pinnedTasks.map((task) => renderTaskRow(task))}
+          {pinnedTasks.map((task) => (
+            <TaskRow
+              key={task.id}
+              task={task}
+              isActive={activeTaskId === task.id}
+              isSelected={selectedIdSet.has(task.id)}
+              hideHoverActions={hasMultiSelection}
+              isEditing={editingTaskId === task.id}
+              onClick={(e) => onTaskClick(task.id, e)}
+              onDoubleClick={() => onTaskDoubleClick(task.id)}
+              onContextMenu={(e, isPinned) =>
+                onTaskContextMenu(task.id, e, isPinned)
+              }
+              onArchive={() => onTaskArchive(task.id)}
+              onTogglePin={() => onTaskTogglePin(task.id)}
+              onEditSubmit={(newTitle) => onTaskEditSubmit(task.id, newTitle)}
+              onEditCancel={onTaskEditCancel}
+              timestamp={task[timestampKey]}
+            />
+          ))}
         </>
       )}
 
@@ -423,7 +422,29 @@ export function TaskListView({
                 addSpacingBefore={false}
                 tooltipContent={meta.description}
               >
-                {group.tasks.map((task) => renderTaskRow(task, { depth: 1 }))}
+                {group.tasks.map((task) => (
+                  <TaskRow
+                    key={task.id}
+                    task={task}
+                    isActive={activeTaskId === task.id}
+                    isSelected={selectedIdSet.has(task.id)}
+                    hideHoverActions={hasMultiSelection}
+                    isEditing={editingTaskId === task.id}
+                    onClick={(e) => onTaskClick(task.id, e)}
+                    onDoubleClick={() => onTaskDoubleClick(task.id)}
+                    onContextMenu={(e, isPinned) =>
+                      onTaskContextMenu(task.id, e, isPinned)
+                    }
+                    onArchive={() => onTaskArchive(task.id)}
+                    onTogglePin={() => onTaskTogglePin(task.id)}
+                    onEditSubmit={(newTitle) =>
+                      onTaskEditSubmit(task.id, newTitle)
+                    }
+                    onEditCancel={onTaskEditCancel}
+                    timestamp={task[timestampKey]}
+                    depth={1}
+                  />
+                ))}
               </SidebarSection>
             );
           })}
@@ -472,9 +493,29 @@ export function TaskListView({
                     }}
                     newTaskTooltip={`Start new task in ${folder?.name ?? group.name}`}
                   >
-                    {group.tasks.map((task) =>
-                      renderTaskRow(task, { depth: 1 }),
-                    )}
+                    {group.tasks.map((task) => (
+                      <TaskRow
+                        key={task.id}
+                        task={task}
+                        isActive={activeTaskId === task.id}
+                        isSelected={selectedIdSet.has(task.id)}
+                        hideHoverActions={hasMultiSelection}
+                        isEditing={editingTaskId === task.id}
+                        onClick={(e) => onTaskClick(task.id, e)}
+                        onDoubleClick={() => onTaskDoubleClick(task.id)}
+                        onContextMenu={(e, isPinned) =>
+                          onTaskContextMenu(task.id, e, isPinned)
+                        }
+                        onArchive={() => onTaskArchive(task.id)}
+                        onTogglePin={() => onTaskTogglePin(task.id)}
+                        onEditSubmit={(newTitle) =>
+                          onTaskEditSubmit(task.id, newTitle)
+                        }
+                        onEditCancel={onTaskEditCancel}
+                        timestamp={task[timestampKey]}
+                        depth={1}
+                      />
+                    ))}
                   </SidebarSection>
                 </DraggableFolder>
               );
@@ -486,7 +527,28 @@ export function TaskListView({
           {dateGroupedTasks.map((group, groupIndex) => (
             <Fragment key={`${group.label ?? "today"}-${groupIndex}`}>
               {group.label && <SectionLabel label={group.label} />}
-              {group.tasks.map((task) => renderTaskRow(task))}
+              {group.tasks.map((task) => (
+                <TaskRow
+                  key={task.id}
+                  task={task}
+                  isActive={activeTaskId === task.id}
+                  isSelected={selectedIdSet.has(task.id)}
+                  hideHoverActions={hasMultiSelection}
+                  isEditing={editingTaskId === task.id}
+                  onClick={(e) => onTaskClick(task.id, e)}
+                  onDoubleClick={() => onTaskDoubleClick(task.id)}
+                  onContextMenu={(e, isPinned) =>
+                    onTaskContextMenu(task.id, e, isPinned)
+                  }
+                  onArchive={() => onTaskArchive(task.id)}
+                  onTogglePin={() => onTaskTogglePin(task.id)}
+                  onEditSubmit={(newTitle) =>
+                    onTaskEditSubmit(task.id, newTitle)
+                  }
+                  onEditCancel={onTaskEditCancel}
+                  timestamp={task[timestampKey]}
+                />
+              ))}
             </Fragment>
           ))}
           {hasMore && (

--- a/apps/code/src/renderer/features/sidebar/components/items/TaskItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/TaskItem.tsx
@@ -13,6 +13,8 @@ interface TaskItemProps {
   taskId: string;
   label: string;
   isActive: boolean;
+  isSelected?: boolean;
+  hideHoverActions?: boolean;
   workspaceMode?: WorkspaceMode;
   worktreePath?: string;
   isGenerating?: boolean;
@@ -27,7 +29,7 @@ interface TaskItemProps {
   hasDiff?: boolean;
   timestamp?: number;
   isEditing?: boolean;
-  onClick: () => void;
+  onClick: (e: React.MouseEvent) => void;
   onDoubleClick?: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
   onArchive?: () => void;
@@ -108,6 +110,8 @@ export function TaskItem({
   taskId,
   label,
   isActive,
+  isSelected = false,
+  hideHoverActions = false,
   workspaceMode,
   isSuspended = false,
   isGenerating,
@@ -152,7 +156,7 @@ export function TaskItem({
   ) : null;
 
   const toolbar =
-    onArchive || onTogglePin ? (
+    !hideHoverActions && (onArchive || onTogglePin) ? (
       <TaskHoverToolbar
         isPinned={isPinned}
         onTogglePin={onTogglePin}
@@ -195,6 +199,7 @@ export function TaskItem({
       icon={icon}
       label={label}
       isActive={isActive}
+      isSelected={isSelected}
       draggable
       onDragStart={handleDragStart}
       onClick={onClick}

--- a/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
+++ b/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
@@ -19,6 +19,10 @@ import {
   groupByRepository,
   type TaskRepositoryInfo,
 } from "../utils/groupTasks";
+import {
+  groupByStatus,
+  type StatusTaskGroup,
+} from "../utils/groupByStatus";
 import { computeSummaryIds } from "../utils/summaryIds";
 import { usePinnedTasks } from "./usePinnedTasks";
 import { useTaskViewed } from "./useTaskViewed";
@@ -46,6 +50,7 @@ export interface TaskData {
 }
 
 export type TaskGroup = GenericTaskGroup<TaskData>;
+export type StatusGroup = StatusTaskGroup<TaskData>;
 
 export interface SidebarData {
   isHomeActive: boolean;
@@ -58,6 +63,7 @@ export interface SidebarData {
   pinnedTasks: TaskData[];
   flatTasks: TaskData[];
   groupedTasks: TaskGroup[];
+  statusGroupedTasks: StatusGroup[];
   totalCount: number;
   hasMore: boolean;
 }
@@ -331,6 +337,11 @@ export function useSidebarData({
     [sortedUnpinnedTasks, folderOrder],
   );
 
+  const statusGroupedTasks = useMemo(
+    () => groupByStatus(sortedUnpinnedTasks),
+    [sortedUnpinnedTasks],
+  );
+
   const groupIdsRef = useRef<string[]>([]);
   useEffect(() => {
     if (groupedTasks.length === 0) return;
@@ -357,6 +368,7 @@ export function useSidebarData({
     pinnedTasks,
     flatTasks,
     groupedTasks,
+    statusGroupedTasks,
     totalCount,
     hasMore,
   };

--- a/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
+++ b/apps/code/src/renderer/features/sidebar/hooks/useSidebarData.ts
@@ -13,16 +13,13 @@ import type { Task, TaskRunStatus } from "@shared/types";
 import { useEffect, useMemo, useRef } from "react";
 import { useSidebarStore } from "../stores/sidebarStore";
 import type { SortMode } from "../types";
+import { groupByStatus, type StatusTaskGroup } from "../utils/groupByStatus";
 import {
   type TaskGroup as GenericTaskGroup,
   getRepositoryInfo,
   groupByRepository,
   type TaskRepositoryInfo,
 } from "../utils/groupTasks";
-import {
-  groupByStatus,
-  type StatusTaskGroup,
-} from "../utils/groupByStatus";
 import { computeSummaryIds } from "../utils/summaryIds";
 import { usePinnedTasks } from "./usePinnedTasks";
 import { useTaskViewed } from "./useTaskViewed";

--- a/apps/code/src/renderer/features/sidebar/stores/sidebarStore.ts
+++ b/apps/code/src/renderer/features/sidebar/stores/sidebarStore.ts
@@ -10,7 +10,7 @@ interface SidebarStoreState {
   collapsedSections: Set<string>;
   folderOrder: string[];
   historyVisibleCount: number;
-  organizeMode: "by-project" | "chronological";
+  organizeMode: "by-project" | "chronological" | "by-status";
   sortMode: "updated" | "created";
   showAllUsers: boolean;
   showInternal: boolean;

--- a/apps/code/src/renderer/features/sidebar/stores/taskSelectionStore.test.ts
+++ b/apps/code/src/renderer/features/sidebar/stores/taskSelectionStore.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTaskSelectionStore } from "./taskSelectionStore";
+
+describe("taskSelectionStore", () => {
+  beforeEach(() => {
+    useTaskSelectionStore.setState({
+      selectedTaskIds: [],
+      lastClickedId: null,
+    });
+  });
+
+  it("starts empty", () => {
+    expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual([]);
+    expect(useTaskSelectionStore.getState().lastClickedId).toBeNull();
+  });
+
+  it("setSelectedTaskIds de-duplicates ids", () => {
+    useTaskSelectionStore
+      .getState()
+      .setSelectedTaskIds(["t1", "t2", "t1", "t3", "t2"]);
+
+    expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual([
+      "t1",
+      "t2",
+      "t3",
+    ]);
+  });
+
+  it("setSelectedTaskIds with a single id sets lastClickedId", () => {
+    useTaskSelectionStore.getState().setSelectedTaskIds(["t1"]);
+
+    expect(useTaskSelectionStore.getState().lastClickedId).toBe("t1");
+  });
+
+  it("setSelectedTaskIds with multiple ids preserves existing lastClickedId", () => {
+    useTaskSelectionStore.setState({ lastClickedId: "t1" });
+    useTaskSelectionStore.getState().setSelectedTaskIds(["t2", "t3"]);
+
+    expect(useTaskSelectionStore.getState().lastClickedId).toBe("t1");
+  });
+
+  it("toggleTaskSelection adds an unselected task", () => {
+    useTaskSelectionStore.getState().toggleTaskSelection("t1");
+
+    expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual(["t1"]);
+    expect(useTaskSelectionStore.getState().lastClickedId).toBe("t1");
+  });
+
+  it("toggleTaskSelection removes a selected task", () => {
+    useTaskSelectionStore.setState({ selectedTaskIds: ["t1", "t2"] });
+
+    useTaskSelectionStore.getState().toggleTaskSelection("t1");
+
+    expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual(["t2"]);
+    expect(useTaskSelectionStore.getState().lastClickedId).toBe("t1");
+  });
+
+  it("isTaskSelected reflects selection state", () => {
+    useTaskSelectionStore.setState({ selectedTaskIds: ["t2"] });
+
+    expect(useTaskSelectionStore.getState().isTaskSelected("t1")).toBe(false);
+    expect(useTaskSelectionStore.getState().isTaskSelected("t2")).toBe(true);
+  });
+
+  it("clearSelection clears all selected tasks and lastClickedId", () => {
+    useTaskSelectionStore.setState({
+      selectedTaskIds: ["t1", "t2"],
+      lastClickedId: "t2",
+    });
+
+    useTaskSelectionStore.getState().clearSelection();
+
+    expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual([]);
+    expect(useTaskSelectionStore.getState().lastClickedId).toBeNull();
+  });
+
+  it("pruneSelection keeps only visible task ids", () => {
+    useTaskSelectionStore.setState({
+      selectedTaskIds: ["t1", "t2", "t3"],
+    });
+
+    useTaskSelectionStore.getState().pruneSelection(["t2", "t4"]);
+
+    expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual(["t2"]);
+  });
+
+  it("pruneSelection preserves array reference when nothing is pruned", () => {
+    useTaskSelectionStore.setState({ selectedTaskIds: ["t1", "t2"] });
+    const before = useTaskSelectionStore.getState().selectedTaskIds;
+
+    useTaskSelectionStore.getState().pruneSelection(["t1", "t2", "t3"]);
+
+    expect(useTaskSelectionStore.getState().selectedTaskIds).toBe(before);
+  });
+
+  describe("selectRange", () => {
+    const orderedIds = ["t1", "t2", "t3", "t4", "t5"];
+
+    it.each([
+      { direction: "forward", anchor: "t2", target: "t4" },
+      { direction: "backward", anchor: "t4", target: "t2" },
+    ])(
+      "selects a $direction range from anchor to target",
+      ({ anchor, target }) => {
+        useTaskSelectionStore.setState({ lastClickedId: anchor });
+
+        useTaskSelectionStore.getState().selectRange(target, orderedIds);
+
+        expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual([
+          "t2",
+          "t3",
+          "t4",
+        ]);
+      },
+    );
+
+    it("merges range with existing selection", () => {
+      useTaskSelectionStore.setState({
+        selectedTaskIds: ["t1"],
+        lastClickedId: "t3",
+      });
+
+      useTaskSelectionStore.getState().selectRange("t5", orderedIds);
+
+      expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual([
+        "t1",
+        "t3",
+        "t4",
+        "t5",
+      ]);
+    });
+
+    it.each([
+      { case: "no anchor", lastClickedId: null },
+      { case: "anchor not in ordered list", lastClickedId: "t99" },
+    ])("selects just the target when $case", ({ lastClickedId }) => {
+      if (lastClickedId) {
+        useTaskSelectionStore.setState({ lastClickedId });
+      }
+
+      useTaskSelectionStore.getState().selectRange("t3", orderedIds);
+
+      expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual(["t3"]);
+    });
+
+    it("uses fallbackAnchorId when there is no last-clicked anchor", () => {
+      useTaskSelectionStore.getState().selectRange("t4", orderedIds, "t2");
+
+      expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual([
+        "t2",
+        "t3",
+        "t4",
+      ]);
+      expect(useTaskSelectionStore.getState().lastClickedId).toBe("t4");
+    });
+
+    it("prefers lastClickedId over fallbackAnchorId when both are set", () => {
+      useTaskSelectionStore.setState({ lastClickedId: "t3" });
+
+      useTaskSelectionStore.getState().selectRange("t5", orderedIds, "t1");
+
+      expect(useTaskSelectionStore.getState().selectedTaskIds).toEqual([
+        "t3",
+        "t4",
+        "t5",
+      ]);
+    });
+
+    it("updates lastClickedId to the target", () => {
+      useTaskSelectionStore.setState({ lastClickedId: "t1" });
+
+      useTaskSelectionStore.getState().selectRange("t3", orderedIds);
+
+      expect(useTaskSelectionStore.getState().lastClickedId).toBe("t3");
+    });
+  });
+});

--- a/apps/code/src/renderer/features/sidebar/stores/taskSelectionStore.ts
+++ b/apps/code/src/renderer/features/sidebar/stores/taskSelectionStore.ts
@@ -1,0 +1,89 @@
+import { create } from "zustand";
+
+interface TaskSelectionState {
+  selectedTaskIds: string[];
+  /** The last task ID that was clicked — used as the anchor for shift-click range selection. */
+  lastClickedId: string | null;
+}
+
+interface TaskSelectionActions {
+  /** Replace the entire selection (plain click). */
+  setSelectedTaskIds: (taskIds: string[]) => void;
+  /** Toggle a single task in/out of the selection (cmd-click). */
+  toggleTaskSelection: (taskId: string) => void;
+  /** Select a contiguous range from the last-clicked task to `toId` within the given ordered list.
+   *  Existing selection outside the range is preserved (shift-click behavior).
+   *  If there is no last-clicked anchor (e.g. the user just navigated via a plain click),
+   *  `fallbackAnchorId` is used — typically the currently active/routed task. */
+  selectRange: (
+    toId: string,
+    orderedIds: string[],
+    fallbackAnchorId?: string | null,
+  ) => void;
+  isTaskSelected: (taskId: string) => boolean;
+  clearSelection: () => void;
+  pruneSelection: (visibleTaskIds: string[]) => void;
+}
+
+type TaskSelectionStore = TaskSelectionState & TaskSelectionActions;
+
+export const useTaskSelectionStore = create<TaskSelectionStore>()(
+  (set, get) => ({
+    selectedTaskIds: [],
+    lastClickedId: null,
+
+    setSelectedTaskIds: (taskIds) =>
+      set({
+        selectedTaskIds: Array.from(new Set(taskIds)),
+        lastClickedId: taskIds.length === 1 ? taskIds[0] : get().lastClickedId,
+      }),
+
+    toggleTaskSelection: (taskId) =>
+      set((state) => {
+        const isRemoving = state.selectedTaskIds.includes(taskId);
+        return {
+          selectedTaskIds: isRemoving
+            ? state.selectedTaskIds.filter((id) => id !== taskId)
+            : [...state.selectedTaskIds, taskId],
+          lastClickedId: taskId,
+        };
+      }),
+
+    selectRange: (toId, orderedIds, fallbackAnchorId) =>
+      set((state) => {
+        const anchorId = state.lastClickedId ?? fallbackAnchorId ?? null;
+        if (!anchorId) {
+          return { selectedTaskIds: [toId], lastClickedId: toId };
+        }
+        const anchorIndex = orderedIds.indexOf(anchorId);
+        const toIndex = orderedIds.indexOf(toId);
+        if (anchorIndex === -1 || toIndex === -1) {
+          return { selectedTaskIds: [toId], lastClickedId: toId };
+        }
+        const start = Math.min(anchorIndex, toIndex);
+        const end = Math.max(anchorIndex, toIndex);
+        const rangeIds = orderedIds.slice(start, end + 1);
+        const merged = Array.from(
+          new Set([...state.selectedTaskIds, ...rangeIds]),
+        );
+        return { selectedTaskIds: merged, lastClickedId: toId };
+      }),
+
+    isTaskSelected: (taskId) => get().selectedTaskIds.includes(taskId),
+
+    clearSelection: () => set({ selectedTaskIds: [], lastClickedId: null }),
+
+    pruneSelection: (visibleTaskIds) => {
+      const visibleIds = new Set(visibleTaskIds);
+      set((state) => {
+        const filtered = state.selectedTaskIds.filter((id) =>
+          visibleIds.has(id),
+        );
+        if (filtered.length === state.selectedTaskIds.length) {
+          return state;
+        }
+        return { selectedTaskIds: filtered };
+      });
+    },
+  }),
+);

--- a/apps/code/src/renderer/features/sidebar/utils/groupByStatus.test.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupByStatus.test.ts
@@ -14,52 +14,75 @@ function task(id: string, overrides: StatusGroupableTask = {}): TestTask {
 }
 
 describe("groupByStatus", () => {
-  it("buckets tasks by their status into the expected groups", () => {
-    const tasks: TestTask[] = [
-      task("idle-1"),
-      task("idle-2", { taskRunStatus: "not_started" }),
-      task("active-1", { isGenerating: true }),
-      task("active-2", { taskRunStatus: "in_progress" }),
-      task("active-3", { taskRunStatus: "queued" }),
-      task("done-1", { taskRunStatus: "completed" }),
-      task("failed-1", { taskRunStatus: "failed" }),
-      task("failed-2", { taskRunStatus: "cancelled" }),
-      task("needs-1", { needsPermission: true }),
-    ];
-
-    const groups = groupByStatus(tasks);
-    const byId = new Map(groups.map((g) => [g.id, g] as const));
-
-    expect(byId.get(STATUS_GROUP_IDS.needsYou)?.tasks.map((t) => t.id)).toEqual(
-      ["needs-1"],
-    );
-    expect(byId.get(STATUS_GROUP_IDS.active)?.tasks.map((t) => t.id)).toEqual([
-      "active-1",
-      "active-2",
-      "active-3",
-    ]);
-    expect(byId.get(STATUS_GROUP_IDS.done)?.tasks.map((t) => t.id)).toEqual([
-      "done-1",
-    ]);
-    expect(byId.get(STATUS_GROUP_IDS.failed)?.tasks.map((t) => t.id)).toEqual([
-      "failed-1",
-      "failed-2",
-    ]);
-    expect(byId.get(STATUS_GROUP_IDS.idle)?.tasks.map((t) => t.id)).toEqual([
-      "idle-1",
-      "idle-2",
-    ]);
+  describe("bucket assignment", () => {
+    it.each<[string, StatusGroupableTask, string]>([
+      ["needsPermission", { needsPermission: true }, STATUS_GROUP_IDS.needsYou],
+      ["isGenerating", { isGenerating: true }, STATUS_GROUP_IDS.active],
+      [
+        "taskRunStatus=queued",
+        { taskRunStatus: "queued" },
+        STATUS_GROUP_IDS.active,
+      ],
+      [
+        "taskRunStatus=in_progress",
+        { taskRunStatus: "in_progress" },
+        STATUS_GROUP_IDS.active,
+      ],
+      [
+        "taskRunStatus=completed",
+        { taskRunStatus: "completed" },
+        STATUS_GROUP_IDS.done,
+      ],
+      [
+        "taskRunStatus=failed",
+        { taskRunStatus: "failed" },
+        STATUS_GROUP_IDS.failed,
+      ],
+      [
+        "taskRunStatus=cancelled",
+        { taskRunStatus: "cancelled" },
+        STATUS_GROUP_IDS.failed,
+      ],
+      [
+        "taskRunStatus=not_started",
+        { taskRunStatus: "not_started" },
+        STATUS_GROUP_IDS.idle,
+      ],
+      ["no signals", {}, STATUS_GROUP_IDS.idle],
+    ])("routes a task with %s to the %s bucket", (_label, props, expected) => {
+      const groups = groupByStatus([task("t", props)]);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].id).toBe(expected);
+      expect(groups[0].tasks.map((t) => t.id)).toEqual(["t"]);
+    });
   });
 
-  it("prefers 'Needs you' over 'Active' when both predicates match", () => {
-    const tasks: TestTask[] = [
-      task("both", { needsPermission: true, taskRunStatus: "in_progress" }),
-    ];
-
-    const groups = groupByStatus(tasks);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].id).toBe(STATUS_GROUP_IDS.needsYou);
-    expect(groups[0].tasks).toHaveLength(1);
+  describe("predicate precedence", () => {
+    it.each<[string, StatusGroupableTask, string]>([
+      [
+        "needsPermission vs in_progress → needs-you",
+        { needsPermission: true, taskRunStatus: "in_progress" },
+        STATUS_GROUP_IDS.needsYou,
+      ],
+      [
+        "needsPermission vs isGenerating → needs-you",
+        { needsPermission: true, isGenerating: true },
+        STATUS_GROUP_IDS.needsYou,
+      ],
+      [
+        "needsPermission vs completed → needs-you",
+        { needsPermission: true, taskRunStatus: "completed" },
+        STATUS_GROUP_IDS.needsYou,
+      ],
+      [
+        "isGenerating vs completed → active",
+        { isGenerating: true, taskRunStatus: "completed" },
+        STATUS_GROUP_IDS.active,
+      ],
+    ])("resolves %s", (_label, props, expected) => {
+      const groups = groupByStatus([task("t", props)]);
+      expect(groups[0].id).toBe(expected);
+    });
   });
 
   it("returns groups in the fixed display order and omits empty buckets", () => {
@@ -81,13 +104,21 @@ describe("groupByStatus", () => {
     expect(groupByStatus([])).toEqual([]);
   });
 
-  it("preserves the input order of tasks within a bucket", () => {
-    const tasks: TestTask[] = [
-      task("a", { taskRunStatus: "completed" }),
-      task("b", { taskRunStatus: "completed" }),
-      task("c", { taskRunStatus: "completed" }),
-    ];
-    const groups = groupByStatus(tasks);
-    expect(groups[0].tasks.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  describe("preserves input order within each bucket", () => {
+    it.each<[string, StatusGroupableTask]>([
+      ["needs-you", { needsPermission: true }],
+      ["active", { taskRunStatus: "in_progress" }],
+      ["done", { taskRunStatus: "completed" }],
+      ["failed", { taskRunStatus: "failed" }],
+      ["idle", {}],
+    ])("for the %s bucket", (_label, props) => {
+      const tasks: TestTask[] = [
+        task("a", props),
+        task("b", props),
+        task("c", props),
+      ];
+      const groups = groupByStatus(tasks);
+      expect(groups[0].tasks.map((t) => t.id)).toEqual(["a", "b", "c"]);
+    });
   });
 });

--- a/apps/code/src/renderer/features/sidebar/utils/groupByStatus.test.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupByStatus.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupByStatus,
+  STATUS_GROUP_IDS,
+  type StatusGroupableTask,
+} from "./groupByStatus";
+
+interface TestTask extends StatusGroupableTask {
+  id: string;
+}
+
+function task(id: string, overrides: StatusGroupableTask = {}): TestTask {
+  return { id, ...overrides };
+}
+
+describe("groupByStatus", () => {
+  it("buckets tasks by their status into the expected groups", () => {
+    const tasks: TestTask[] = [
+      task("idle-1"),
+      task("idle-2", { taskRunStatus: "not_started" }),
+      task("active-1", { isGenerating: true }),
+      task("active-2", { taskRunStatus: "in_progress" }),
+      task("active-3", { taskRunStatus: "queued" }),
+      task("done-1", { taskRunStatus: "completed" }),
+      task("failed-1", { taskRunStatus: "failed" }),
+      task("failed-2", { taskRunStatus: "cancelled" }),
+      task("needs-1", { needsPermission: true }),
+    ];
+
+    const groups = groupByStatus(tasks);
+    const byId = new Map(groups.map((g) => [g.id, g] as const));
+
+    expect(byId.get(STATUS_GROUP_IDS.needsYou)?.tasks.map((t) => t.id)).toEqual(
+      ["needs-1"],
+    );
+    expect(byId.get(STATUS_GROUP_IDS.active)?.tasks.map((t) => t.id)).toEqual([
+      "active-1",
+      "active-2",
+      "active-3",
+    ]);
+    expect(byId.get(STATUS_GROUP_IDS.done)?.tasks.map((t) => t.id)).toEqual([
+      "done-1",
+    ]);
+    expect(byId.get(STATUS_GROUP_IDS.failed)?.tasks.map((t) => t.id)).toEqual([
+      "failed-1",
+      "failed-2",
+    ]);
+    expect(byId.get(STATUS_GROUP_IDS.idle)?.tasks.map((t) => t.id)).toEqual([
+      "idle-1",
+      "idle-2",
+    ]);
+  });
+
+  it("prefers 'Needs you' over 'Active' when both predicates match", () => {
+    const tasks: TestTask[] = [
+      task("both", { needsPermission: true, taskRunStatus: "in_progress" }),
+    ];
+
+    const groups = groupByStatus(tasks);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe(STATUS_GROUP_IDS.needsYou);
+    expect(groups[0].tasks).toHaveLength(1);
+  });
+
+  it("returns groups in the fixed display order and omits empty buckets", () => {
+    const tasks: TestTask[] = [
+      task("c", { taskRunStatus: "completed" }),
+      task("f", { taskRunStatus: "failed" }),
+      task("a", { taskRunStatus: "in_progress" }),
+    ];
+
+    const ids = groupByStatus(tasks).map((g) => g.id);
+    expect(ids).toEqual([
+      STATUS_GROUP_IDS.active,
+      STATUS_GROUP_IDS.done,
+      STATUS_GROUP_IDS.failed,
+    ]);
+  });
+
+  it("returns an empty array when there are no tasks", () => {
+    expect(groupByStatus([])).toEqual([]);
+  });
+
+  it("preserves the input order of tasks within a bucket", () => {
+    const tasks: TestTask[] = [
+      task("a", { taskRunStatus: "completed" }),
+      task("b", { taskRunStatus: "completed" }),
+      task("c", { taskRunStatus: "completed" }),
+    ];
+    const groups = groupByStatus(tasks);
+    expect(groups[0].tasks.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/apps/code/src/renderer/features/sidebar/utils/groupByStatus.ts
+++ b/apps/code/src/renderer/features/sidebar/utils/groupByStatus.ts
@@ -1,0 +1,124 @@
+import {
+  CheckCircle,
+  Circle,
+  HandPalm,
+  Lightning,
+  XCircle,
+} from "@phosphor-icons/react";
+import type { TaskRunStatus } from "@shared/types";
+
+export const STATUS_GROUP_IDS = {
+  active: "status-active",
+  needsYou: "status-needs-you",
+  idle: "status-idle",
+  done: "status-done",
+  failed: "status-failed",
+} as const;
+
+export type StatusGroupId =
+  (typeof STATUS_GROUP_IDS)[keyof typeof STATUS_GROUP_IDS];
+
+export interface StatusGroupableTask {
+  isGenerating?: boolean;
+  needsPermission?: boolean;
+  taskRunStatus?: TaskRunStatus;
+}
+
+export interface StatusTaskGroup<T> {
+  id: StatusGroupId;
+  name: string;
+  tasks: T[];
+}
+
+interface StatusBucket {
+  id: StatusGroupId;
+  name: string;
+  predicate: (task: StatusGroupableTask) => boolean;
+}
+
+// Order here is the display order AND the matching precedence — a task lands
+// in the first bucket whose predicate matches. So a task that's both
+// in_progress AND needs permission shows up under "Needs you".
+const STATUS_BUCKETS: StatusBucket[] = [
+  {
+    id: STATUS_GROUP_IDS.needsYou,
+    name: "Needs you",
+    predicate: (task) => Boolean(task.needsPermission),
+  },
+  {
+    id: STATUS_GROUP_IDS.active,
+    name: "Active",
+    predicate: (task) =>
+      Boolean(task.isGenerating) ||
+      task.taskRunStatus === "queued" ||
+      task.taskRunStatus === "in_progress",
+  },
+  {
+    id: STATUS_GROUP_IDS.done,
+    name: "Done",
+    predicate: (task) => task.taskRunStatus === "completed",
+  },
+  {
+    id: STATUS_GROUP_IDS.failed,
+    name: "Failed",
+    predicate: (task) =>
+      task.taskRunStatus === "failed" || task.taskRunStatus === "cancelled",
+  },
+  {
+    id: STATUS_GROUP_IDS.idle,
+    name: "Idle",
+    predicate: () => true,
+  },
+];
+
+export const STATUS_GROUP_META: Record<
+  StatusGroupId,
+  { icon: typeof Lightning; color: string; description: string }
+> = {
+  [STATUS_GROUP_IDS.active]: {
+    icon: Lightning,
+    color: "var(--accent-11)",
+    description: "Running now",
+  },
+  [STATUS_GROUP_IDS.needsYou]: {
+    icon: HandPalm,
+    color: "var(--blue-11)",
+    description: "Tasks waiting on your input",
+  },
+  [STATUS_GROUP_IDS.idle]: {
+    icon: Circle,
+    color: "var(--gray-10)",
+    description: "Not started",
+  },
+  [STATUS_GROUP_IDS.done]: {
+    icon: CheckCircle,
+    color: "var(--green-11)",
+    description: "Completed runs",
+  },
+  [STATUS_GROUP_IDS.failed]: {
+    icon: XCircle,
+    color: "var(--red-11)",
+    description: "Failed or cancelled runs",
+  },
+};
+
+export function groupByStatus<T extends StatusGroupableTask>(
+  tasks: T[],
+): StatusTaskGroup<T>[] {
+  const groupMap = new Map<StatusGroupId, StatusTaskGroup<T>>();
+
+  for (const task of tasks) {
+    const bucket = STATUS_BUCKETS.find((b) => b.predicate(task));
+    if (!bucket) continue;
+    let group = groupMap.get(bucket.id);
+    if (!group) {
+      group = { id: bucket.id, name: bucket.name, tasks: [] };
+      groupMap.set(bucket.id, group);
+    }
+    group.tasks.push(task);
+  }
+
+  return STATUS_BUCKETS.map((bucket) => groupMap.get(bucket.id)).filter(
+    (group): group is StatusTaskGroup<T> => group !== undefined,
+  );
+}

--- a/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
+++ b/apps/code/src/renderer/features/tasks/hooks/useArchiveTask.ts
@@ -92,6 +92,35 @@ export async function archiveTaskImperative(
   }
 }
 
+export async function archiveTasksImperative(
+  taskIds: string[],
+  queryClient: QueryClient,
+): Promise<{ archived: number; failed: number }> {
+  if (taskIds.length === 0) return { archived: 0, failed: 0 };
+
+  const nav = useNavigationStore.getState();
+  const idSet = new Set(taskIds);
+  if (
+    nav.view.type === "task-detail" &&
+    nav.view.data &&
+    idSet.has(nav.view.data.id)
+  ) {
+    nav.navigateToTaskInput();
+  }
+
+  let archived = 0;
+  let failed = 0;
+  for (const id of taskIds) {
+    try {
+      await archiveTaskImperative(id, queryClient, { skipNavigate: true });
+      archived++;
+    } catch {
+      failed++;
+    }
+  }
+  return { archived, failed };
+}
+
 export function useArchiveTask() {
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Summary

Adds a third **By status** option to the sidebar's organize menu (alongside *By project* and *Chronological list*). Tasks are bucketed into kanban-like collapsible sections by their lifecycle state — narrow enough to fit in the sidebar, but conceptually a vertical kanban.

Buckets in fixed precedence + display order:

1. **Needs you** — `needsPermission`
2. **Active** — `isGenerating` OR `taskRunStatus ∈ {queued, in_progress}`
3. **Done** — `taskRunStatus === "completed"`
4. **Failed** — `taskRunStatus ∈ {failed, cancelled}`
5. **Idle** — everything else (no run, `not_started`, etc.)

<img width="569" height="318" alt="Screenshot 2026-05-22 at 16 07 06" src="https://github.com/user-attachments/assets/a9a7f82d-84f5-49b3-b21c-db1bd0fe2104" />

A task lands in the first bucket whose predicate matches, so e.g. an in-progress run that needs permission shows under "Needs you", not "Active".

Empty buckets are hidden. Each section reuses the existing `collapsedSections` persistence in `sidebarStore`, so collapse state survives reloads.

## Test plan

- [x] `pnpm --filter code typecheck` clean
- [x] New unit tests in `groupByStatus.test.ts` cover bucket assignment, precedence (Needs-you > Active), display ordering, empty input, and intra-bucket order — all 5 pass
- [x] All existing sidebar tests still pass (36/36)
- [ ] Open the funnel menu, pick **By status** — verify sections render in the fixed order with status-colored icons
- [ ] Confirm sections collapse/expand independently and state persists after reload
- [ ] Switch between By project / By status / Chronological and back — verify no layout glitches
- [ ] Verify pinned tasks still appear in the top "Pinned" section across all modes
- [ ] With no tasks, the empty-state hedgehog still renders