### PR TITLE
refactor(mobile): centralize safe-area spacing in useScreenInsets

### DIFF
--- a/apps/mobile/src/app/automation/create.tsx
+++ b/apps/mobile/src/app/automation/create.tsx
@@ -9,13 +9,13 @@ import {
   ScrollView,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/text";
 import { TaskAutomationValidationError } from "@/features/tasks/api";
 import { AutomationForm } from "@/features/tasks/components/AutomationForm";
 import { useCreateTaskAutomation } from "@/features/tasks/hooks/useAutomations";
 import { useSkillStoreSkill } from "@/features/tasks/skills/hooks";
 import { formatSkillTemplateId } from "@/features/tasks/skills/skillTemplateIds";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 
 // Reserved space below the scrolling form content. Tall enough that the
@@ -35,7 +35,7 @@ export default function CreateAutomationScreen() {
     : skillNameParam;
   const router = useRouter();
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { insets, bottom } = useScreenInsets();
   const createAutomation = useCreateTaskAutomation();
   const defaultTimezone = useMemo(
     () => getCalendars()[0]?.timeZone ?? "UTC",
@@ -209,7 +209,7 @@ export default function CreateAutomationScreen() {
         {formMounted && (
           <View
             className="absolute inset-x-0 bottom-0 border-gray-6 border-t bg-background px-4 pt-3"
-            style={{ paddingBottom: insets.bottom + 12 }}
+            style={{ paddingBottom: bottom("compact") }}
           >
             <Pressable
               onPress={handleCreate}

--- a/apps/mobile/src/app/mcp-servers/add-custom.tsx
+++ b/apps/mobile/src/app/mcp-servers/add-custom.tsx
@@ -11,11 +11,11 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FloatingMcpHeader } from "@/features/mcp/components/FloatingMcpHeader";
 import { useMcpInstallations } from "@/features/mcp/hooks";
 import { installCustomWithOAuth } from "@/features/mcp/oauth";
 import type { McpAuthType } from "@/features/mcp/types";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
@@ -29,7 +29,7 @@ const AUTH_OPTIONS: { value: McpAuthType; label: string }[] = [
 
 export default function AddCustomMcpServerScreen() {
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { insets, bottom } = useScreenInsets();
   const installations = useMcpInstallations();
 
   const [name, setName] = useState("");
@@ -85,7 +85,7 @@ export default function AddCustomMcpServerScreen() {
           className="flex-1"
           contentContainerStyle={{
             paddingTop: insets.top + 60,
-            paddingBottom: insets.bottom + 24,
+            paddingBottom: bottom("default"),
             paddingHorizontal: 16,
           }}
           keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/app/mcp-servers/index.tsx
+++ b/apps/mobile/src/app/mcp-servers/index.tsx
@@ -10,7 +10,6 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FloatingMcpHeader } from "@/features/mcp/components/FloatingMcpHeader";
 import {
   installationToRowProps,
@@ -22,13 +21,14 @@ import type {
   McpRecommendedServer,
   McpServerInstallation,
 } from "@/features/mcp/types";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 
 type Tab = "installed" | "marketplace";
 
 export default function McpServersScreen() {
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { insets, bottom } = useScreenInsets();
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("installed");
   const [search, setSearch] = useState("");
@@ -149,7 +149,7 @@ export default function McpServersScreen() {
                 tintColor={themeColors.accent[9]}
               />
             }
-            contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+            contentContainerStyle={{ paddingBottom: bottom("default") }}
           />
         ) : (
           <FlatList
@@ -172,7 +172,7 @@ export default function McpServersScreen() {
                 tintColor={themeColors.accent[9]}
               />
             }
-            contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+            contentContainerStyle={{ paddingBottom: bottom("default") }}
           />
         )}
       </View>

--- a/apps/mobile/src/app/mcp-servers/installation/[id].tsx
+++ b/apps/mobile/src/app/mcp-servers/installation/[id].tsx
@@ -16,7 +16,6 @@ import {
   Switch,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FloatingMcpHeader } from "@/features/mcp/components/FloatingMcpHeader";
 import { ServerIcon } from "@/features/mcp/components/ServerIcon";
 import {
@@ -31,6 +30,7 @@ import { reauthorizeInstallation } from "@/features/mcp/oauth";
 import { getMcpConnectionManager } from "@/features/mcp/service";
 import type { McpApprovalState } from "@/features/mcp/types";
 import { isStdioServer } from "@/features/mcp/types";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
@@ -39,7 +39,7 @@ const log = logger.scope("mcp-installation-detail");
 export default function McpInstallationDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { insets, bottom } = useScreenInsets();
 
   const installations = useMcpInstallations();
   const installation = useMemo(
@@ -142,7 +142,7 @@ export default function McpInstallationDetailScreen() {
         className="flex-1"
         contentContainerStyle={{
           paddingTop: insets.top + 60,
-          paddingBottom: insets.bottom + 24,
+          paddingBottom: bottom("default"),
           paddingHorizontal: 16,
         }}
         refreshControl={

--- a/apps/mobile/src/app/mcp-servers/template/[id].tsx
+++ b/apps/mobile/src/app/mcp-servers/template/[id].tsx
@@ -10,7 +10,6 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FloatingMcpHeader } from "@/features/mcp/components/FloatingMcpHeader";
 import { ServerIcon } from "@/features/mcp/components/ServerIcon";
 import {
@@ -20,6 +19,7 @@ import {
 } from "@/features/mcp/hooks";
 import { installTemplateWithOAuth } from "@/features/mcp/oauth";
 import { isStdioServer } from "@/features/mcp/types";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
@@ -28,7 +28,7 @@ const log = logger.scope("mcp-template-detail");
 export default function McpTemplateDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { insets, bottom } = useScreenInsets();
 
   const marketplace = useMcpMarketplace();
   const installations = useMcpInstallations();
@@ -116,7 +116,7 @@ export default function McpTemplateDetailScreen() {
         className="flex-1"
         contentContainerStyle={{
           paddingTop: insets.top + 60,
-          paddingBottom: insets.bottom + 24,
+          paddingBottom: bottom("default"),
           paddingHorizontal: 16,
         }}
       >

--- a/apps/mobile/src/app/pr-diff.tsx
+++ b/apps/mobile/src/app/pr-diff.tsx
@@ -1,18 +1,18 @@
 import { Text } from "@components/text";
 import { useLocalSearchParams } from "expo-router";
 import { ActivityIndicator, FlatList, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FileDiff } from "@/features/tasks/components/FileDiff";
 import {
   type ChangedFile,
   usePrChangedFiles,
 } from "@/features/tasks/hooks/usePrChangedFiles";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 
 export default function PrDiffScreen() {
   const { prUrl } = useLocalSearchParams<{ prUrl?: string }>();
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { bottom } = useScreenInsets();
 
   const { data: files, isLoading } = usePrChangedFiles(prUrl ?? null);
 
@@ -47,7 +47,7 @@ export default function PrDiffScreen() {
       contentContainerStyle={{
         paddingHorizontal: 12,
         paddingTop: 8,
-        paddingBottom: insets.bottom + 16,
+        paddingBottom: bottom("default"),
       }}
       ListHeaderComponent={
         <View className="mb-2 flex-row items-center justify-between px-1 py-1">

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -3,7 +3,6 @@ import { router } from "expo-router";
 import { ArrowSquareOut, CaretRight, SpeakerHigh } from "phosphor-react-native";
 import { useState } from "react";
 import { Linking, Pressable, ScrollView, Switch, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuthStore, useProjectsQuery, useUserQuery } from "@/features/auth";
 import { useDismissedReportsStore } from "@/features/inbox/stores/dismissedReportsStore";
 import { usePushTokenStore } from "@/features/notifications/stores/pushTokenStore";
@@ -19,6 +18,7 @@ import { SettingsRow } from "@/features/settings/components/SettingsRow";
 import { SettingsSection } from "@/features/settings/components/SettingsSection";
 import { SelectSheet } from "@/features/tasks/composer/SelectSheet";
 import { playCompletionSound } from "@/features/tasks/utils/sounds";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
@@ -79,7 +79,7 @@ function taskModeLabel(mode: InitialTaskMode): string {
 
 export default function SettingsScreen() {
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { insets, bottom } = useScreenInsets();
 
   const {
     logout,
@@ -170,7 +170,7 @@ export default function SettingsScreen() {
   // padding clears the home indicator and gives breathing room past the last
   // row so it never hides behind it.
   const contentPaddingTop = insets.top + 60;
-  const contentPaddingBottom = insets.bottom + 32;
+  const contentPaddingBottom = bottom("default");
 
   return (
     <View className="flex-1 bg-background">

--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -60,6 +60,10 @@ export default function TaskDetailScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { insets, composerBottom } = useScreenInsets();
+  // Pre-compute outside the worklet: useAnimatedStyle runs on the UI thread and
+  // can't call the non-worklet getter. Capturing the primitive keeps the worklet
+  // closure stable (matches the pattern in task/index.tsx).
+  const composerBottomValue = composerBottom();
   const themeColors = useThemeColors();
   const [task, setTask] = useState<Task | null>(null);
   const [loading, setLoading] = useState(true);
@@ -123,9 +127,9 @@ export default function TaskDetailScreen() {
     // height, so the composer sits at the keyboard top — no extra gap needed
     // when open. Closed state keeps a comfortable bottom inset.
     return {
-      marginBottom: height.value < 0 ? 0 : composerBottom(),
+      marginBottom: height.value < 0 ? 0 : composerBottomValue,
     };
-  }, [composerBottom]);
+  }, [composerBottomValue]);
 
   useEffect(() => {
     if (!taskId) return;

--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -12,7 +12,6 @@ import {
 } from "react-native";
 import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FloatingBackButton } from "@/components/FloatingBackButton";
 import { getTask, runTaskInCloud } from "@/features/tasks/api";
 import { FloatingTaskHeader } from "@/features/tasks/components/FloatingTaskHeader";
@@ -36,6 +35,7 @@ import { useTaskSessionStore } from "@/features/tasks/stores/taskSessionStore";
 import { useTaskStore } from "@/features/tasks/stores/taskStore";
 import type { Task } from "@/features/tasks/types";
 import { getSessionActivityPhase } from "@/features/tasks/utils/sessionActivity";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
@@ -59,7 +59,7 @@ export default function TaskDetailScreen() {
   }>();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const insets = useSafeAreaInsets();
+  const { insets, composerBottom } = useScreenInsets();
   const themeColors = useThemeColors();
   const [task, setTask] = useState<Task | null>(null);
   const [loading, setLoading] = useState(true);
@@ -123,9 +123,9 @@ export default function TaskDetailScreen() {
     // height, so the composer sits at the keyboard top — no extra gap needed
     // when open. Closed state keeps a comfortable bottom inset.
     return {
-      marginBottom: height.value < 0 ? 0 : Math.max(insets.bottom, 50),
+      marginBottom: height.value < 0 ? 0 : composerBottom(),
     };
-  }, [insets.bottom]);
+  }, [composerBottom]);
 
   useEffect(() => {
     if (!taskId) return;

--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -28,8 +28,6 @@ import {
   useReanimatedKeyboardAnimation,
 } from "react-native-keyboard-controller";
 import Animated, { runOnJS, useAnimatedStyle } from "react-native-reanimated";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-
 import { useVoiceRecording } from "@/features/chat";
 import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
 import { createTask, runTaskInCloud } from "@/features/tasks/api";
@@ -74,6 +72,7 @@ import {
   isRepositorySelectionComplete,
   toRepositorySelection,
 } from "@/features/tasks/utils/repositorySelection";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { logger } from "@/lib/logger";
 import { toRgba, useThemeColors } from "@/lib/theme";
 
@@ -110,9 +109,9 @@ export default function NewTaskScreen() {
   }>();
   const router = useRouter();
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
+  const { insets, bottom } = useScreenInsets();
   const keyboard = useReanimatedKeyboardAnimation();
-  const restingBottom = insets.bottom + 12;
+  const restingBottom = bottom("compact");
   const {
     error,
     hasGithubIntegration,

--- a/apps/mobile/src/components/SheetContainer.tsx
+++ b/apps/mobile/src/components/SheetContainer.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Modal, Pressable, View } from "react-native";
+import { Modal, Pressable, View, type ViewStyle } from "react-native";
 import {
   type BottomGapVariant,
   useScreenInsets,
@@ -17,10 +17,17 @@ interface SheetContainerProps {
   open: boolean;
   onClose: () => void;
   children: ReactNode;
-  /** Bottom padding gap above the safe-area inset. Defaults to "compact". */
+  /**
+   * Bottom padding gap above the safe-area inset. Defaults to "compact"
+   * because that is the gap both legacy sheets (SelectSheet, AttachmentSheet)
+   * inherited — deliberately not BOTTOM_GAP's own "default" (24). Pass
+   * "default"/"roomy" when a sheet wants more breathing room.
+   */
   bottomGap?: BottomGapVariant;
   /** Extra classes for the sheet panel. */
   className?: string;
+  /** Extra inline styles for the sheet panel (e.g. a measured maxHeight). */
+  style?: ViewStyle;
 }
 
 /**
@@ -37,6 +44,7 @@ export function SheetContainer({
   children,
   bottomGap = "compact",
   className = "",
+  style,
 }: SheetContainerProps) {
   const { bottom } = useScreenInsets();
 
@@ -52,7 +60,11 @@ export function SheetContainer({
         <Pressable
           onPress={() => {}}
           className={`mt-auto rounded-t-2xl border-gray-6 border-t bg-background ${className}`}
-          style={{ paddingBottom: bottom(bottomGap), ...SHEET_SHADOW }}
+          style={{
+            paddingBottom: bottom(bottomGap),
+            ...SHEET_SHADOW,
+            ...style,
+          }}
         >
           {/* Drag handle */}
           <View className="items-center pt-2 pb-1">

--- a/apps/mobile/src/components/SheetContainer.tsx
+++ b/apps/mobile/src/components/SheetContainer.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { Modal, Pressable, View } from "react-native";
+import {
+  type BottomGapVariant,
+  useScreenInsets,
+} from "@/hooks/useScreenInsets";
+
+const SHEET_SHADOW = {
+  shadowColor: "#000",
+  shadowOpacity: 0.15,
+  shadowRadius: 20,
+  shadowOffset: { width: 0, height: -4 },
+  elevation: 12,
+} as const;
+
+interface SheetContainerProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  /** Bottom padding gap above the safe-area inset. Defaults to "compact". */
+  bottomGap?: BottomGapVariant;
+  /** Extra classes for the sheet panel. */
+  className?: string;
+}
+
+/**
+ * Bottom-sheet shell: a dimmed backdrop, a panel pinned to the bottom edge with
+ * the standard rounded top, border, shadow, drag handle, and safe-area-aware
+ * bottom padding. Tapping the backdrop closes; taps inside the panel don't.
+ *
+ * Use this instead of re-implementing the `mt-auto rounded-t-2xl …` markup so
+ * every sheet shares one shape and one inset policy.
+ */
+export function SheetContainer({
+  open,
+  onClose,
+  children,
+  bottomGap = "compact",
+  className = "",
+}: SheetContainerProps) {
+  const { bottom } = useScreenInsets();
+
+  return (
+    <Modal
+      visible={open}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <Pressable className="flex-1 bg-black/40" onPress={onClose}>
+        <Pressable
+          onPress={() => {}}
+          className={`mt-auto rounded-t-2xl border-gray-6 border-t bg-background ${className}`}
+          style={{ paddingBottom: bottom(bottomGap), ...SHEET_SHADOW }}
+        >
+          {/* Drag handle */}
+          <View className="items-center pt-2 pb-1">
+            <View className="h-1 w-10 rounded-full bg-gray-6" />
+          </View>
+          {children}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/features/inbox/components/DismissReportSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/DismissReportSheet.tsx
@@ -35,7 +35,7 @@ export function DismissReportSheet({
   onClose,
   onDismissed,
 }: DismissReportSheetProps) {
-  const { insets, bottom, contentTop } = useScreenInsets();
+  const { insets, bottom, sheetContentTop } = useScreenInsets();
   const themeColors = useThemeColors();
   const [reason, setReason] = useState<DismissalReasonOptionValue | null>(null);
   const [note, setNote] = useState("");
@@ -83,7 +83,7 @@ export function DismissReportSheet({
       >
         <View
           className="flex-1 bg-background"
-          style={{ paddingTop: contentTop() }}
+          style={{ paddingTop: sheetContentTop() }}
         >
           {/* Header */}
           <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">

--- a/apps/mobile/src/features/inbox/components/DismissReportSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/DismissReportSheet.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 import {
   DISMISSAL_REASON_OPTIONS,
@@ -35,7 +35,7 @@ export function DismissReportSheet({
   onClose,
   onDismissed,
 }: DismissReportSheetProps) {
-  const insets = useSafeAreaInsets();
+  const { insets, bottom, contentTop } = useScreenInsets();
   const themeColors = useThemeColors();
   const [reason, setReason] = useState<DismissalReasonOptionValue | null>(null);
   const [note, setNote] = useState("");
@@ -83,7 +83,7 @@ export function DismissReportSheet({
       >
         <View
           className="flex-1 bg-background"
-          style={{ paddingTop: insets.top + 8 }}
+          style={{ paddingTop: contentTop() }}
         >
           {/* Header */}
           <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">
@@ -163,7 +163,7 @@ export function DismissReportSheet({
           {/* Sticky submit */}
           <View
             className="border-gray-6 border-t bg-background px-4 pt-3"
-            style={{ paddingBottom: insets.bottom + 12 }}
+            style={{ paddingBottom: bottom("compact") }}
           >
             <Pressable
               onPress={handleConfirm}

--- a/apps/mobile/src/features/inbox/components/FilterSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/FilterSheet.tsx
@@ -94,7 +94,7 @@ function OptionRow({
 }
 
 export function FilterSheet({ visible, onClose }: FilterSheetProps) {
-  const { bottom, contentTop } = useScreenInsets();
+  const { bottom, sheetContentTop } = useScreenInsets();
   const themeColors = useThemeColors();
   const statusDotColors = useStatusDotColors();
 
@@ -120,7 +120,7 @@ export function FilterSheet({ visible, onClose }: FilterSheetProps) {
     >
       <View
         className="flex-1 bg-background"
-        style={{ paddingTop: contentTop() }}
+        style={{ paddingTop: sheetContentTop() }}
       >
         {/* Header */}
         <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">

--- a/apps/mobile/src/features/inbox/components/FilterSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/FilterSheet.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@components/text";
 import { Check } from "phosphor-react-native";
 import { Modal, Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 import {
   type SourceProduct,
@@ -94,7 +94,7 @@ function OptionRow({
 }
 
 export function FilterSheet({ visible, onClose }: FilterSheetProps) {
-  const insets = useSafeAreaInsets();
+  const { bottom, contentTop } = useScreenInsets();
   const themeColors = useThemeColors();
   const statusDotColors = useStatusDotColors();
 
@@ -120,7 +120,7 @@ export function FilterSheet({ visible, onClose }: FilterSheetProps) {
     >
       <View
         className="flex-1 bg-background"
-        style={{ paddingTop: insets.top + 8 }}
+        style={{ paddingTop: contentTop() }}
       >
         {/* Header */}
         <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">
@@ -145,7 +145,7 @@ export function FilterSheet({ visible, onClose }: FilterSheetProps) {
           contentContainerStyle={{
             paddingHorizontal: 16,
             paddingTop: 16,
-            paddingBottom: insets.bottom + 40,
+            paddingBottom: bottom("roomy"),
           }}
         >
           {/* Sort */}

--- a/apps/mobile/src/features/inbox/components/ReviewerFilterSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/ReviewerFilterSheet.tsx
@@ -67,7 +67,7 @@ export function ReviewerFilterSheet({
   visible,
   onClose,
 }: ReviewerFilterSheetProps) {
-  const { bottom, contentTop } = useScreenInsets();
+  const { bottom, sheetContentTop } = useScreenInsets();
   const themeColors = useThemeColors();
   const { data: currentUser } = useUserQuery();
   const { data: available, isLoading } = useAvailableSuggestedReviewers();
@@ -98,7 +98,7 @@ export function ReviewerFilterSheet({
     >
       <View
         className="flex-1 bg-background"
-        style={{ paddingTop: contentTop() }}
+        style={{ paddingTop: sheetContentTop() }}
       >
         {/* Header */}
         <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">

--- a/apps/mobile/src/features/inbox/components/ReviewerFilterSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/ReviewerFilterSheet.tsx
@@ -9,8 +9,8 @@ import {
   ScrollView,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useUserQuery } from "@/features/auth";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 import { useAvailableSuggestedReviewers } from "../hooks/useInboxReports";
 import { useInboxFilterStore } from "../stores/inboxFilterStore";
@@ -67,7 +67,7 @@ export function ReviewerFilterSheet({
   visible,
   onClose,
 }: ReviewerFilterSheetProps) {
-  const insets = useSafeAreaInsets();
+  const { bottom, contentTop } = useScreenInsets();
   const themeColors = useThemeColors();
   const { data: currentUser } = useUserQuery();
   const { data: available, isLoading } = useAvailableSuggestedReviewers();
@@ -98,7 +98,7 @@ export function ReviewerFilterSheet({
     >
       <View
         className="flex-1 bg-background"
-        style={{ paddingTop: insets.top + 8 }}
+        style={{ paddingTop: contentTop() }}
       >
         {/* Header */}
         <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">
@@ -132,7 +132,7 @@ export function ReviewerFilterSheet({
             contentContainerStyle={{
               paddingHorizontal: 16,
               paddingTop: 12,
-              paddingBottom: insets.bottom + 40,
+              paddingBottom: bottom("roomy"),
             }}
           >
             {options.map((reviewer, index) => {

--- a/apps/mobile/src/features/tasks/components/FloatingNewAutomationButton.tsx
+++ b/apps/mobile/src/features/tasks/components/FloatingNewAutomationButton.tsx
@@ -1,7 +1,7 @@
 import { Plus } from "phosphor-react-native";
 import { Pressable } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/text";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 
 interface FloatingNewAutomationButtonProps {
@@ -15,7 +15,7 @@ interface FloatingNewAutomationButtonProps {
 export function FloatingNewAutomationButton({
   onPress,
 }: FloatingNewAutomationButtonProps) {
-  const insets = useSafeAreaInsets();
+  const { fabBottom } = useScreenInsets();
   const themeColors = useThemeColors();
 
   return (
@@ -26,7 +26,7 @@ export function FloatingNewAutomationButton({
       accessibilityRole="button"
       className="absolute right-5 z-10 h-14 flex-row items-center justify-center gap-2 rounded-full bg-accent-9 pr-5 pl-4 active:opacity-85"
       style={{
-        bottom: insets.bottom + 20,
+        bottom: fabBottom(),
         shadowColor: "#000",
         shadowOpacity: 0.22,
         shadowRadius: 12,

--- a/apps/mobile/src/features/tasks/components/FloatingNewTaskButton.tsx
+++ b/apps/mobile/src/features/tasks/components/FloatingNewTaskButton.tsx
@@ -1,7 +1,7 @@
 import { Plus } from "phosphor-react-native";
 import { Pressable } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/text";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 
 interface FloatingNewTaskButtonProps {
@@ -13,7 +13,7 @@ interface FloatingNewTaskButtonProps {
  * on phones of any size and respects the home indicator inset.
  */
 export function FloatingNewTaskButton({ onPress }: FloatingNewTaskButtonProps) {
-  const insets = useSafeAreaInsets();
+  const { fabBottom } = useScreenInsets();
   const themeColors = useThemeColors();
 
   return (
@@ -24,7 +24,7 @@ export function FloatingNewTaskButton({ onPress }: FloatingNewTaskButtonProps) {
       accessibilityRole="button"
       className="absolute right-5 z-10 h-14 flex-row items-center justify-center gap-2 rounded-full bg-accent-9 pr-5 pl-4 active:opacity-85"
       style={{
-        bottom: insets.bottom + 20,
+        bottom: fabBottom(),
         shadowColor: "#000",
         shadowOpacity: 0.22,
         shadowRadius: 12,

--- a/apps/mobile/src/features/tasks/components/TaskFilterMenu.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskFilterMenu.tsx
@@ -2,8 +2,8 @@ import { Text } from "@components/text";
 import { Check, FunnelSimple } from "phosphor-react-native";
 import { useState } from "react";
 import { Modal, Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useUserQuery } from "@/features/auth";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { useThemeColors } from "@/lib/theme";
 import {
   type OrganizeMode,
@@ -44,7 +44,7 @@ function OptionRow({ label, selected, onPress }: OptionRowProps) {
 }
 
 export function TaskFilterMenu({ open, onClose }: TaskFilterMenuProps) {
-  const insets = useSafeAreaInsets();
+  const { bottom, contentTop } = useScreenInsets();
   const organizeMode = useTaskStore((s) => s.organizeMode);
   const setOrganizeMode = useTaskStore((s) => s.setOrganizeMode);
   const sortMode = useTaskStore((s) => s.sortMode);
@@ -70,7 +70,7 @@ export function TaskFilterMenu({ open, onClose }: TaskFilterMenuProps) {
     >
       <View
         className="flex-1 bg-background"
-        style={{ paddingTop: insets.top + 8 }}
+        style={{ paddingTop: contentTop() }}
       >
         {/* Header */}
         <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">
@@ -88,7 +88,7 @@ export function TaskFilterMenu({ open, onClose }: TaskFilterMenuProps) {
           contentContainerStyle={{
             paddingHorizontal: 16,
             paddingTop: 16,
-            paddingBottom: insets.bottom + 40,
+            paddingBottom: bottom("roomy"),
           }}
         >
           {/* Organize */}

--- a/apps/mobile/src/features/tasks/components/TaskFilterMenu.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskFilterMenu.tsx
@@ -44,7 +44,7 @@ function OptionRow({ label, selected, onPress }: OptionRowProps) {
 }
 
 export function TaskFilterMenu({ open, onClose }: TaskFilterMenuProps) {
-  const { bottom, contentTop } = useScreenInsets();
+  const { bottom, sheetContentTop } = useScreenInsets();
   const organizeMode = useTaskStore((s) => s.organizeMode);
   const setOrganizeMode = useTaskStore((s) => s.setOrganizeMode);
   const sortMode = useTaskStore((s) => s.sortMode);
@@ -70,7 +70,7 @@ export function TaskFilterMenu({ open, onClose }: TaskFilterMenuProps) {
     >
       <View
         className="flex-1 bg-background"
-        style={{ paddingTop: contentTop() }}
+        style={{ paddingTop: sheetContentTop() }}
       >
         {/* Header */}
         <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">

--- a/apps/mobile/src/features/tasks/composer/SelectSheet.tsx
+++ b/apps/mobile/src/features/tasks/composer/SelectSheet.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@components/text";
 import { Check } from "phosphor-react-native";
 import type { ReactNode } from "react";
-import { Modal, Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Pressable, ScrollView, View } from "react-native";
+import { SheetContainer } from "@/components/SheetContainer";
 import { useThemeColors } from "@/lib/theme";
 
 export interface SelectOption<T extends string> {
@@ -31,84 +31,51 @@ export function SelectSheet<T extends string>({
   onClose,
 }: SelectSheetProps<T>) {
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
 
   return (
-    <Modal
-      visible={open}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-      statusBarTranslucent
-    >
-      <Pressable className="flex-1 bg-black/40" onPress={onClose}>
-        <Pressable
-          onPress={() => {}}
-          className="mt-auto rounded-t-2xl border-gray-6 border-t bg-background"
-          style={{
-            paddingBottom: insets.bottom + 12,
-            shadowColor: "#000",
-            shadowOpacity: 0.15,
-            shadowRadius: 20,
-            shadowOffset: { width: 0, height: -4 },
-            elevation: 12,
-          }}
-        >
-          {/* Drag handle */}
-          <View className="items-center pt-2 pb-1">
-            <View className="h-1 w-10 rounded-full bg-gray-6" />
-          </View>
+    <SheetContainer open={open} onClose={onClose}>
+      <View className="px-4 pt-2 pb-2">
+        <Text className="font-semibold text-[16px] text-gray-12">{title}</Text>
+      </View>
 
-          <View className="px-4 pt-2 pb-2">
-            <Text className="font-semibold text-[16px] text-gray-12">
-              {title}
-            </Text>
-          </View>
-
-          <ScrollView className="max-h-96">
-            {options.map((option) => {
-              const selected = option.value === value;
-              return (
-                <Pressable
-                  key={option.value}
-                  onPress={() => {
-                    if (option.disabled) return;
-                    onChange(option.value);
-                    onClose();
-                  }}
-                  disabled={option.disabled}
-                  className={`flex-row items-center gap-3 px-4 py-3 ${
-                    option.disabled ? "opacity-40" : "active:bg-gray-2"
-                  }`}
-                >
-                  {option.icon ? (
-                    <View className="h-5 w-5 shrink-0 items-center justify-center">
-                      {option.icon}
-                    </View>
-                  ) : null}
-                  <View className="min-w-0 flex-1">
-                    <Text className="font-medium text-[15px] text-gray-12">
-                      {option.label}
-                    </Text>
-                    {option.description ? (
-                      <Text className="mt-0.5 text-[12px] text-gray-10">
-                        {option.description}
-                      </Text>
-                    ) : null}
-                  </View>
-                  {selected ? (
-                    <Check
-                      size={16}
-                      color={themeColors.accent[9]}
-                      weight="bold"
-                    />
-                  ) : null}
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-        </Pressable>
-      </Pressable>
-    </Modal>
+      <ScrollView className="max-h-96">
+        {options.map((option) => {
+          const selected = option.value === value;
+          return (
+            <Pressable
+              key={option.value}
+              onPress={() => {
+                if (option.disabled) return;
+                onChange(option.value);
+                onClose();
+              }}
+              disabled={option.disabled}
+              className={`flex-row items-center gap-3 px-4 py-3 ${
+                option.disabled ? "opacity-40" : "active:bg-gray-2"
+              }`}
+            >
+              {option.icon ? (
+                <View className="h-5 w-5 shrink-0 items-center justify-center">
+                  {option.icon}
+                </View>
+              ) : null}
+              <View className="min-w-0 flex-1">
+                <Text className="font-medium text-[15px] text-gray-12">
+                  {option.label}
+                </Text>
+                {option.description ? (
+                  <Text className="mt-0.5 text-[12px] text-gray-10">
+                    {option.description}
+                  </Text>
+                ) : null}
+              </View>
+              {selected ? (
+                <Check size={16} color={themeColors.accent[9]} weight="bold" />
+              ) : null}
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </SheetContainer>
   );
 }

--- a/apps/mobile/src/features/tasks/composer/attachments/AttachmentSheet.tsx
+++ b/apps/mobile/src/features/tasks/composer/attachments/AttachmentSheet.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@components/text";
 import { Camera, FileText, Image as ImageIcon } from "phosphor-react-native";
-import { Modal, Pressable, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Pressable, View } from "react-native";
+import { SheetContainer } from "@/components/SheetContainer";
 import { useThemeColors } from "@/lib/theme";
 
 interface AttachmentSheetProps {
@@ -44,74 +44,44 @@ export function AttachmentSheet({
   onPickDocument,
 }: AttachmentSheetProps) {
   const themeColors = useThemeColors();
-  const insets = useSafeAreaInsets();
 
   return (
-    <Modal
-      visible={open}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-      statusBarTranslucent
-    >
-      <Pressable className="flex-1 bg-black/40" onPress={onClose}>
-        <Pressable
-          onPress={() => {}}
-          className="mt-auto rounded-t-2xl border-gray-6 border-t bg-background"
-          style={{
-            paddingBottom: insets.bottom + 12,
-            shadowColor: "#000",
-            shadowOpacity: 0.15,
-            shadowRadius: 20,
-            shadowOffset: { width: 0, height: -4 },
-            elevation: 12,
-          }}
-        >
-          <View className="items-center pt-2 pb-1">
-            <View className="h-1 w-10 rounded-full bg-gray-6" />
-          </View>
+    <SheetContainer open={open} onClose={onClose}>
+      <View className="px-4 pt-2 pb-2">
+        <Text className="font-semibold text-[16px] text-gray-12">
+          Add attachment
+        </Text>
+      </View>
 
-          <View className="px-4 pt-2 pb-2">
-            <Text className="font-semibold text-[16px] text-gray-12">
-              Add attachment
-            </Text>
-          </View>
-
-          <Row
-            icon={
-              <ImageIcon size={18} color={themeColors.gray[12]} weight="bold" />
-            }
-            label="Photo library"
-            description="Pick a photo to share with the agent"
-            onPress={() => {
-              onClose();
-              onPickPhoto();
-            }}
-          />
-          <Row
-            icon={
-              <Camera size={18} color={themeColors.gray[12]} weight="bold" />
-            }
-            label="Take photo"
-            description="Capture a new photo from the camera"
-            onPress={() => {
-              onClose();
-              onPickCamera();
-            }}
-          />
-          <Row
-            icon={
-              <FileText size={18} color={themeColors.gray[12]} weight="bold" />
-            }
-            label="File"
-            description="Attach a text or code file from your device"
-            onPress={() => {
-              onClose();
-              onPickDocument();
-            }}
-          />
-        </Pressable>
-      </Pressable>
-    </Modal>
+      <Row
+        icon={
+          <ImageIcon size={18} color={themeColors.gray[12]} weight="bold" />
+        }
+        label="Photo library"
+        description="Pick a photo to share with the agent"
+        onPress={() => {
+          onClose();
+          onPickPhoto();
+        }}
+      />
+      <Row
+        icon={<Camera size={18} color={themeColors.gray[12]} weight="bold" />}
+        label="Take photo"
+        description="Capture a new photo from the camera"
+        onPress={() => {
+          onClose();
+          onPickCamera();
+        }}
+      />
+      <Row
+        icon={<FileText size={18} color={themeColors.gray[12]} weight="bold" />}
+        label="File"
+        description="Attach a text or code file from your device"
+        onPress={() => {
+          onClose();
+          onPickDocument();
+        }}
+      />
+    </SheetContainer>
   );
 }

--- a/apps/mobile/src/hooks/useScreenInsets.test.ts
+++ b/apps/mobile/src/hooks/useScreenInsets.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockInsets = { top: 47, bottom: 34, left: 0, right: 0 };
+
+vi.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
+
+// useMemo just needs to invoke its factory; we don't need a renderer to pin the
+// numeric scale, so stub it to call through.
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return { ...actual, useMemo: (factory: () => unknown) => factory() };
+});
+
+import { BOTTOM_GAP, useScreenInsets } from "./useScreenInsets";
+
+describe("useScreenInsets", () => {
+  it("pins the bottom gap scale onto the device inset", () => {
+    const { bottom } = useScreenInsets();
+    expect(bottom("compact")).toBe(mockInsets.bottom + 12);
+    expect(bottom("default")).toBe(mockInsets.bottom + 24);
+    expect(bottom("roomy")).toBe(mockInsets.bottom + 40);
+    // default variant matches "default"
+    expect(bottom()).toBe(bottom("default"));
+  });
+
+  it("keeps BOTTOM_GAP values frozen at 12 / 24 / 40", () => {
+    expect(BOTTOM_GAP).toEqual({ compact: 12, default: 24, roomy: 40 });
+  });
+
+  it("computes the sheet top, fab, and composer offsets", () => {
+    const { sheetContentTop, fabBottom, composerBottom } = useScreenInsets();
+    expect(sheetContentTop()).toBe(mockInsets.top + 8);
+    expect(fabBottom()).toBe(mockInsets.bottom + 20);
+    // composer floor is above the inset here, so it tracks the inset
+    expect(composerBottom()).toBe(Math.max(mockInsets.bottom, 50));
+  });
+
+  it("floors the composer bottom at COMPOSER_MIN_BOTTOM on zero-inset devices", () => {
+    mockInsets.bottom = 0;
+    const { composerBottom } = useScreenInsets();
+    expect(composerBottom()).toBe(50);
+    mockInsets.bottom = 34;
+  });
+});

--- a/apps/mobile/src/hooks/useScreenInsets.ts
+++ b/apps/mobile/src/hooks/useScreenInsets.ts
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+/**
+ * Single source of truth for screen spacing policy.
+ *
+ * The device safe-area insets (notch, home indicator, Android soft buttons)
+ * come from `useSafeAreaInsets()` and vary per device — we never hardcode
+ * those. What this hook centralizes is the *gap we add on top of the inset*,
+ * which was previously hand-written per screen with a scatter of magic numbers
+ * (12 / 16 / 20 / 24 / 32 / 40 / 50). Those are rationalized into one small
+ * scale so spacing is consistent across surfaces and tunable in one place.
+ */
+
+/**
+ * Standard content gaps layered ON TOP of the bottom safe-area inset.
+ * Pick by intent, not by pixel value.
+ */
+export const BOTTOM_GAP = {
+  /** Bottom sheets, sticky footers, tight composers. */
+  compact: 12,
+  /** Scrollable form / list content in modals and detail screens. */
+  default: 24,
+  /** Filter sheets and sections that want extra breathing room. */
+  roomy: 40,
+} as const;
+
+/** Standard gap above the top safe-area inset for page-sheet content. */
+const TOP_GAP = 8;
+
+/** Bottom-right floating action buttons sit this far above the inset. */
+const FAB_GAP = 20;
+
+/**
+ * The chat composer keeps at least this much bottom space when the keyboard
+ * is closed, even on devices that report a zero bottom inset (e.g. older
+ * Android with hardware buttons).
+ */
+export const COMPOSER_MIN_BOTTOM = 50;
+
+export type BottomGapVariant = keyof typeof BOTTOM_GAP;
+
+export function useScreenInsets() {
+  const insets = useSafeAreaInsets();
+
+  return useMemo(() => {
+    return {
+      /** Raw device insets, for cases the helpers below don't cover. */
+      insets,
+      /** Bottom padding = device inset + the standard gap for this surface. */
+      bottom: (variant: BottomGapVariant = "default") =>
+        insets.bottom + BOTTOM_GAP[variant],
+      /** Top padding for page-sheet content (inset + standard top gap). */
+      contentTop: () => insets.top + TOP_GAP,
+      /** Bottom offset for a floating action button. */
+      fabBottom: () => insets.bottom + FAB_GAP,
+      /** Composer bottom margin floor (never smaller than the min). */
+      composerBottom: () => Math.max(insets.bottom, COMPOSER_MIN_BOTTOM),
+    };
+  }, [insets]);
+}

--- a/apps/mobile/src/hooks/useScreenInsets.ts
+++ b/apps/mobile/src/hooks/useScreenInsets.ts
@@ -50,11 +50,24 @@ export function useScreenInsets() {
       /** Bottom padding = device inset + the standard gap for this surface. */
       bottom: (variant: BottomGapVariant = "default") =>
         insets.bottom + BOTTOM_GAP[variant],
-      /** Top padding for page-sheet content (inset + standard top gap). */
-      contentTop: () => insets.top + TOP_GAP,
-      /** Bottom offset for a floating action button. */
+      /**
+       * Top padding for bottom-sheet / filter-menu content (inset + the fixed
+       * sheet top gap). Scoped to sheets on purpose — full screens that need a
+       * measured header height should compute `insets.top + <headerHeight>`
+       * directly rather than reaching for this.
+       */
+      sheetContentTop: () => insets.top + TOP_GAP,
+      /**
+       * Bottom offset for a floating action button. The `+FAB_GAP` is a
+       * frozen domain-specific choice, not a `BOTTOM_GAP` variant — there is
+       * no `fabBottom("roomy")`. Tune `FAB_GAP` if every FAB should move.
+       */
       fabBottom: () => insets.bottom + FAB_GAP,
-      /** Composer bottom margin floor (never smaller than the min). */
+      /**
+       * Chat composer bottom margin floor. The `COMPOSER_MIN_BOTTOM` floor is
+       * a frozen domain-specific choice, not a `BOTTOM_GAP` variant — there is
+       * no `composerBottom("compact")`.
+       */
       composerBottom: () => Math.max(insets.bottom, COMPOSER_MIN_BOTTOM),
     };
   }, [insets]);


### PR DESCRIPTION
## Why

On mobile, screens each called `useSafeAreaInsets()` and then hand-added their own magic offset for top/bottom spacing (`12 / 16 / 20 / 24 / 32 / 40 / 50`). The device insets are the correct cross-platform/cross-device primitive — and they're used — but the *policy layered on top* was duplicated and inconsistent per screen. (Originated from a question about the gap under the task-screen composer: `Math.max(insets.bottom, 50)`, correct for that screen but not shared anywhere.)

## What

- **`useScreenInsets` hook** — single source of truth for spacing policy. Wraps `useSafeAreaInsets()` and exposes a rationalized **12/24/40** scale via `bottom("compact" | "default" | "roomy")`, plus `composerBottom()`, `fabBottom()`, `contentTop()`, and raw `insets`.
- **`SheetContainer` component** — extracts the duplicated bottom-sheet shell (backdrop, pinned panel, rounded top, border, shadow, drag handle, inset-aware padding). `SelectSheet` and `AttachmentSheet` now render through it.
- **Migrated 17 call sites** — FABs, composers, page sheets, and the mcp/settings/pr-diff/automation-create screens.

## Rationalization (intentional)

Two values snap onto the scale; everything else maps exactly:
- `settings` bottom: **32 → 24**
- `pr-diff` bottom: **16 → 24**

## Left bespoke on purpose

Functional clearances that aren't safe-area policy: DismissReportSheet's `+120` (clears its sticky footer), automation/create's computed floating-button clearance, inbox/[id]'s `+100`/`+16`, and measured floating-header heights (`insets.top + 60/64`).

## Testing

- `biome check`: clean
- `tsc --noEmit`: no new errors (pre-existing test-file errors unchanged vs. `main`)
- ⚠️ Not visually verified on a simulator — the two 8px shifts (settings, pr-diff) are low-risk but worth an eyeball in light/dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)