### PR TITLE
fix(inbox): break signal summary sections onto separate lines

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/utils/SignalReportSummaryMarkdown.tsx
+++ b/apps/code/src/renderer/features/inbox/components/utils/SignalReportSummaryMarkdown.tsx
@@ -1,4 +1,5 @@
 import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
+import { formatSignalReportSummaryMarkdown } from "@features/inbox/utils/formatSignalReportSummaryMarkdown";
 import { Box } from "@radix-ui/themes";
 
 interface SignalReportSummaryMarkdownProps {
@@ -23,7 +24,9 @@ export function SignalReportSummaryMarkdown({
   variant,
   pending,
 }: SignalReportSummaryMarkdownProps) {
-  const raw = content?.trim() ? content : fallback;
+  const raw = formatSignalReportSummaryMarkdown(
+    content?.trim() ? content : fallback,
+  );
 
   /** List rows: only the first line (before first newline); CSS still caps visual lines. */
   const listMarkdown = raw.split(/\r?\n/)[0] ?? "";

--- a/apps/code/src/renderer/features/inbox/components/utils/SignalReportSummaryMarkdown.tsx
+++ b/apps/code/src/renderer/features/inbox/components/utils/SignalReportSummaryMarkdown.tsx
@@ -24,12 +24,11 @@ export function SignalReportSummaryMarkdown({
   variant,
   pending,
 }: SignalReportSummaryMarkdownProps) {
-  const raw = formatSignalReportSummaryMarkdown(
-    content?.trim() ? content : fallback,
-  );
+  const rawContent = content?.trim() ? content : fallback;
+  const raw = formatSignalReportSummaryMarkdown(rawContent);
 
   /** List rows: only the first line (before first newline); CSS still caps visual lines. */
-  const listMarkdown = raw.split(/\r?\n/)[0] ?? "";
+  const listMarkdown = rawContent.split(/\r?\n/)[0] ?? "";
 
   const italicStyle = pending ? { fontStyle: "italic" as const } : undefined;
 

--- a/apps/code/src/renderer/features/inbox/utils/formatSignalReportSummaryMarkdown.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/formatSignalReportSummaryMarkdown.test.ts
@@ -2,32 +2,34 @@ import { describe, expect, it } from "vitest";
 import { formatSignalReportSummaryMarkdown } from "./formatSignalReportSummaryMarkdown";
 
 describe("formatSignalReportSummaryMarkdown", () => {
-  it("puts section body text on a new line after the header", () => {
-    const input =
-      "**What's happening:** Error tracking issue keyed on `app:dashboard_query`.";
-    expect(formatSignalReportSummaryMarkdown(input)).toBe(
-      "**What's happening:**\n\nError tracking issue keyed on `app:dashboard_query`.",
-    );
-  });
-
-  it("separates consecutive section headers onto their own lines", () => {
-    const input =
-      "**What's happening:** Users hit rate limits. **Root cause:** All four rate limiters are contended. **How to resolve:** Reduce blocking.";
-    expect(formatSignalReportSummaryMarkdown(input)).toBe(
-      "**What's happening:**\n\nUsers hit rate limits.\n\n**Root cause:**\n\nAll four rate limiters are contended.\n\n**How to resolve:**\n\nReduce blocking.",
-    );
-  });
-
-  it("separates a section header from preceding intro text", () => {
-    const input =
-      "Users on busy orgs are hitting hard limits. **What's happening:** Error tracking issue.";
-    expect(formatSignalReportSummaryMarkdown(input)).toBe(
-      "Users on busy orgs are hitting hard limits.\n\n**What's happening:**\n\nError tracking issue.",
-    );
-  });
-
-  it("leaves content without section headers unchanged", () => {
-    const input = "Plain summary with no structured sections.";
-    expect(formatSignalReportSummaryMarkdown(input)).toBe(input);
+  it.each([
+    {
+      name: "puts section body text on a new line after the header",
+      input:
+        "**What's happening:** Error tracking issue keyed on `app:dashboard_query`.",
+      expected:
+        "**What's happening:**\n\nError tracking issue keyed on `app:dashboard_query`.",
+    },
+    {
+      name: "separates consecutive section headers onto their own lines",
+      input:
+        "**What's happening:** Users hit rate limits. **Root cause:** All four rate limiters are contended. **How to resolve:** Reduce blocking.",
+      expected:
+        "**What's happening:**\n\nUsers hit rate limits.\n\n**Root cause:**\n\nAll four rate limiters are contended.\n\n**How to resolve:**\n\nReduce blocking.",
+    },
+    {
+      name: "separates a section header from preceding intro text",
+      input:
+        "Users on busy orgs are hitting hard limits. **What's happening:** Error tracking issue.",
+      expected:
+        "Users on busy orgs are hitting hard limits.\n\n**What's happening:**\n\nError tracking issue.",
+    },
+    {
+      name: "leaves content without section headers unchanged",
+      input: "Plain summary with no structured sections.",
+      expected: "Plain summary with no structured sections.",
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(formatSignalReportSummaryMarkdown(input)).toBe(expected);
   });
 });

--- a/apps/code/src/renderer/features/inbox/utils/formatSignalReportSummaryMarkdown.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/formatSignalReportSummaryMarkdown.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatSignalReportSummaryMarkdown } from "./formatSignalReportSummaryMarkdown";
+
+describe("formatSignalReportSummaryMarkdown", () => {
+  it("puts section body text on a new line after the header", () => {
+    const input =
+      "**What's happening:** Error tracking issue keyed on `app:dashboard_query`.";
+    expect(formatSignalReportSummaryMarkdown(input)).toBe(
+      "**What's happening:**\n\nError tracking issue keyed on `app:dashboard_query`.",
+    );
+  });
+
+  it("separates consecutive section headers onto their own lines", () => {
+    const input =
+      "**What's happening:** Users hit rate limits. **Root cause:** All four rate limiters are contended. **How to resolve:** Reduce blocking.";
+    expect(formatSignalReportSummaryMarkdown(input)).toBe(
+      "**What's happening:**\n\nUsers hit rate limits.\n\n**Root cause:**\n\nAll four rate limiters are contended.\n\n**How to resolve:**\n\nReduce blocking.",
+    );
+  });
+
+  it("separates a section header from preceding intro text", () => {
+    const input =
+      "Users on busy orgs are hitting hard limits. **What's happening:** Error tracking issue.";
+    expect(formatSignalReportSummaryMarkdown(input)).toBe(
+      "Users on busy orgs are hitting hard limits.\n\n**What's happening:**\n\nError tracking issue.",
+    );
+  });
+
+  it("leaves content without section headers unchanged", () => {
+    const input = "Plain summary with no structured sections.";
+    expect(formatSignalReportSummaryMarkdown(input)).toBe(input);
+  });
+});

--- a/apps/code/src/renderer/features/inbox/utils/formatSignalReportSummaryMarkdown.ts
+++ b/apps/code/src/renderer/features/inbox/utils/formatSignalReportSummaryMarkdown.ts
@@ -1,0 +1,35 @@
+const SIGNAL_SUMMARY_SECTION_HEADERS = [
+  "What's happening",
+  "Root cause",
+  "How to resolve",
+] as const;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Inserts line breaks around signal report summary section headers so each
+ * label and its body render on separate lines (matches agent output like
+ * `**What's happening:** text`).
+ */
+export function formatSignalReportSummaryMarkdown(content: string): string {
+  let result = content;
+
+  for (const header of SIGNAL_SUMMARY_SECTION_HEADERS) {
+    const escaped = escapeRegExp(header);
+    const boldHeaderPattern = `\\*\\*${escaped}:\\*\\*`;
+
+    result = result.replace(
+      new RegExp(`([^\\n])\\s*(${boldHeaderPattern})`, "gi"),
+      "$1\n\n$2",
+    );
+
+    result = result.replace(
+      new RegExp(`(${boldHeaderPattern})\\s+`, "gi"),
+      "$1\n\n",
+    );
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Problem

Signals had sections in the same line, which means it can be difficult to skim through quickly.

<img width="326" height="1250" alt="CleanShot 2026-05-22 at 17 38 32@2x" src="https://github.com/user-attachments/assets/1b19b5e4-f3ae-4efb-ad53-9a0d779fe17e" />


## Changes

Insert line breaks around What's happening, Root cause, and How to resolve headers so report summaries are easier to scan.

<img width="692" height="684" alt="CleanShot 2026-05-22 at 17 38 44@2x" src="https://github.com/user-attachments/assets/39b5f367-951b-444d-9cb3-58cf7fcdb0f3" />


## How did you test this?
Locally.

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
