### PR TITLE
chore(cloud-agent): local MCP tool rename

### DIFF
--- a/packages/agent/src/adapters/claude/mcp/local-tools.test.ts
+++ b/packages/agent/src/adapters/claude/mcp/local-tools.test.ts
@@ -34,7 +34,7 @@ describe("createLocalToolsMcpServer", () => {
     if (!server) {
       throw new Error("expected the local-tools server to be registered");
     }
-    expect(server.name).toBe("posthog-local");
+    expect(server.name).toBe("posthog-code-tools");
 
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();

--- a/packages/agent/src/adapters/local-tools/registry.ts
+++ b/packages/agent/src/adapters/local-tools/registry.ts
@@ -5,9 +5,9 @@ import type { z } from "zod";
  * for both adapters: the Claude in-process SDK server and the Codex stdio
  * server. Adding a tool means adding one entry to `LOCAL_TOOLS` (see
  * `./index.ts`) — no per-tool server file or adapter wiring. The name appears
- * in tool ids as `mcp__posthog-local__<tool>`.
+ * in tool ids as `mcp__posthog-code-tools__<tool>`.
  */
-export const LOCAL_TOOLS_MCP_NAME = "posthog-local";
+export const LOCAL_TOOLS_MCP_NAME = "posthog-code-tools";
 
 /** Runtime context handed to every local tool's handler and gate. */
 export interface LocalToolCtx {


### PR DESCRIPTION
## Problem

a name collision was preventing `git_signed_commit` to be found, let's fix that.

