### PR TITLE
fix(worktree): fetch trunk before creating worktree to avoid stale base

### DIFF
--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -590,9 +590,6 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         worktree = await worktreeManager.createWorktree({
           baseBranch: defaultBranch,
           onOutput,
-          // Fetch the remote tip first so the worktree isn't started from a
-          // stale local trunk — common when the harness provisions a clone
-          // whose local default branch hasn't been refreshed.
           fetchBeforeCreate: true,
         });
         log.info(

--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -590,6 +590,10 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         worktree = await worktreeManager.createWorktree({
           baseBranch: defaultBranch,
           onOutput,
+          // Fetch the remote tip first so the worktree isn't started from a
+          // stale local trunk — common when the harness provisions a clone
+          // whose local default branch hasn't been refreshed.
+          fetchBeforeCreate: true,
         });
         log.info(
           `Created detached worktree from trunk: ${worktree.worktreeName} at ${worktree.worktreePath}`,

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -1023,6 +1023,28 @@ export async function fetch(
   );
 }
 
+export async function hasRef(git: GitLike, ref: string): Promise<boolean> {
+  try {
+    await git.revparse(["--verify", "--quiet", `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function fetchRef(
+  git: GitLike,
+  remote: string,
+  ref: string,
+): Promise<boolean> {
+  try {
+    await git.raw(["fetch", "--quiet", "--no-tags", remote, ref]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function listFiles(
   baseDir: string,
   options?: CreateGitClientOptions,

--- a/packages/git/src/sagas/worktree.ts
+++ b/packages/git/src/sagas/worktree.ts
@@ -1,7 +1,13 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { GitSaga, type GitSagaInput } from "../git-saga";
-import { addToLocalExclude, branchExists, getDefaultBranch } from "../queries";
+import {
+  addToLocalExclude,
+  branchExists,
+  fetchRef,
+  getDefaultBranch,
+  hasRef,
+} from "../queries";
 import { forceRemove, safeSymlink } from "../utils";
 import { processWorktreeInclude, runPostCheckoutHook } from "../worktree";
 
@@ -9,6 +15,12 @@ export interface CreateWorktreeInput extends GitSagaInput {
   worktreePath: string;
   branchName: string;
   baseBranch?: string;
+  /**
+   * When true, fetch `origin/<baseBranch>` before creating the worktree and
+   * base the new branch on the remote tip when reachable. Falls back to the
+   * local base ref if the fetch fails.
+   */
+  fetchBeforeCreate?: boolean;
 }
 
 export interface CreateWorktreeOutput {
@@ -26,12 +38,34 @@ export class CreateWorktreeSaga extends GitSaga<
   protected async executeGitOperations(
     input: CreateWorktreeInput,
   ): Promise<CreateWorktreeOutput> {
-    const { baseDir, worktreePath, branchName, baseBranch, signal } = input;
+    const {
+      baseDir,
+      worktreePath,
+      branchName,
+      baseBranch,
+      fetchBeforeCreate,
+      signal,
+    } = input;
 
     const base = await this.readOnlyStep("get-base-branch", async () => {
       if (baseBranch) return baseBranch;
       return getDefaultBranch(baseDir, { abortSignal: signal });
     });
+
+    // Best-effort fetch the remote tip before creating the worktree so the
+    // new branch starts from `origin/<base>` rather than a stale local ref.
+    // Uses `this.git` directly (rather than the `fetch` query helper) to
+    // avoid re-entering the per-repo write lock the saga already holds.
+    const baseRef = fetchBeforeCreate
+      ? await this.readOnlyStep("resolve-fresh-base-ref", async () => {
+          const remote = "origin";
+          const remoteRef = `${remote}/${base}`;
+          const fetched = await fetchRef(this.git, remote, base);
+          if (!fetched) return base;
+          const exists = await hasRef(this.git, remoteRef);
+          return exists ? remoteRef : base;
+        })
+      : base;
 
     await this.step({
       name: "create-worktree",
@@ -44,7 +78,7 @@ export class CreateWorktreeSaga extends GitSaga<
           "-b",
           branchName,
           worktreePath,
-          base,
+          baseRef,
         ]),
       rollback: async () => {
         try {

--- a/packages/git/src/sagas/worktree.ts
+++ b/packages/git/src/sagas/worktree.ts
@@ -15,11 +15,7 @@ export interface CreateWorktreeInput extends GitSagaInput {
   worktreePath: string;
   branchName: string;
   baseBranch?: string;
-  /**
-   * When true, fetch `origin/<baseBranch>` before creating the worktree and
-   * base the new branch on the remote tip when reachable. Falls back to the
-   * local base ref if the fetch fails.
-   */
+  /** Base the worktree on `origin/<baseBranch>` after fetching; falls back to the local ref if the fetch fails. */
   fetchBeforeCreate?: boolean;
 }
 
@@ -52,10 +48,7 @@ export class CreateWorktreeSaga extends GitSaga<
       return getDefaultBranch(baseDir, { abortSignal: signal });
     });
 
-    // Best-effort fetch the remote tip before creating the worktree so the
-    // new branch starts from `origin/<base>` rather than a stale local ref.
-    // Uses `this.git` directly (rather than the `fetch` query helper) to
-    // avoid re-entering the per-repo write lock the saga already holds.
+    // Use `this.git` directly to avoid re-entering the write lock the saga already holds.
     const baseRef = fetchBeforeCreate
       ? await this.readOnlyStep("resolve-fresh-base-ref", async () => {
           const remote = "origin";

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -65,30 +65,19 @@ describe("WorktreeManager.createWorktree fetchBeforeCreate", () => {
     }
   });
 
-  it("without fetchBeforeCreate, worktree is based on the stale local ref", async () => {
+  it.each([
+    {
+      name: "without fetchBeforeCreate, worktree is based on the stale local ref",
+      fetchBeforeCreate: false,
+      expectRemoteTip: false,
+    },
+    {
+      name: "with fetchBeforeCreate, worktree starts at the remote tip",
+      fetchBeforeCreate: true,
+      expectRemoteTip: true,
+    },
+  ])("$name", async ({ fetchBeforeCreate, expectRemoteTip }) => {
     // Advance the remote: push a new commit from a separate clone.
-    const otherDir = await initLocalClone(remoteDir);
-    await commit(otherDir, "remote-new.txt", "remote-new\n");
-    const otherGit = createGitClient(otherDir);
-    await otherGit.push(["origin", "main"]);
-    const remoteTip = await shaOfBranch(otherDir, "main");
-    await rm(otherDir, { recursive: true, force: true });
-
-    const localTipBefore = await shaOfBranch(localDir, "main");
-    expect(localTipBefore).not.toBe(remoteTip);
-
-    const manager = new WorktreeManager({
-      mainRepoPath: localDir,
-      worktreeBasePath: worktreeBaseDir,
-    });
-    const info = await manager.createWorktree({ baseBranch: "main" });
-
-    const worktreeHead = await shaOfBranch(info.worktreePath, "HEAD");
-    expect(worktreeHead).toBe(localTipBefore);
-    expect(worktreeHead).not.toBe(remoteTip);
-  });
-
-  it("with fetchBeforeCreate, worktree starts at the remote tip", async () => {
     const otherDir = await initLocalClone(remoteDir);
     await commit(otherDir, "remote-new.txt", "remote-new\n");
     const otherGit = createGitClient(otherDir);
@@ -105,13 +94,18 @@ describe("WorktreeManager.createWorktree fetchBeforeCreate", () => {
     });
     const info = await manager.createWorktree({
       baseBranch: "main",
-      fetchBeforeCreate: true,
+      fetchBeforeCreate,
     });
 
     const worktreeHead = await shaOfBranch(info.worktreePath, "HEAD");
-    expect(worktreeHead).toBe(remoteTip);
+    if (expectRemoteTip) {
+      expect(worktreeHead).toBe(remoteTip);
+    } else {
+      expect(worktreeHead).toBe(localTipBefore);
+      expect(worktreeHead).not.toBe(remoteTip);
+    }
 
-    // Local `main` should NOT be mutated — only `origin/main` advances.
+    // Local `main` should never be mutated — only `origin/main` advances on fetch.
     const localMainAfter = await shaOfBranch(localDir, "main");
     expect(localMainAfter).toBe(localTipBefore);
   });

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createGitClient } from "./client";
+import { WorktreeManager } from "./worktree";
+
+async function initBareRemote(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "posthog-code-remote-"));
+  const git = createGitClient(dir);
+  await git.init(["--bare", "--initial-branch", "main"]);
+  return dir;
+}
+
+async function initLocalClone(remoteDir: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "posthog-code-local-"));
+  const git = createGitClient(dir);
+  await git.clone(remoteDir, dir);
+  await git.addConfig("user.name", "Test");
+  await git.addConfig("user.email", "test@example.com");
+  await git.addConfig("commit.gpgsign", "false");
+  return dir;
+}
+
+async function commit(repoDir: string, file: string, content: string) {
+  await writeFile(path.join(repoDir, file), content);
+  const git = createGitClient(repoDir);
+  await git.add([file]);
+  await git.commit(`add ${file}`);
+}
+
+async function shaOfBranch(repoDir: string, ref: string): Promise<string> {
+  const git = createGitClient(repoDir);
+  return (await git.revparse([ref])).trim();
+}
+
+describe("WorktreeManager.createWorktree fetchBeforeCreate", () => {
+  let remoteDir: string;
+  let localDir: string;
+  let worktreeBaseDir: string;
+
+  beforeEach(async () => {
+    remoteDir = await initBareRemote();
+
+    // Seed the remote with an initial commit on `main` so other clones can
+    // fetch a real tip.
+    const seedDir = await mkdtemp(path.join(tmpdir(), "posthog-code-seed-"));
+    const seedGit = createGitClient(seedDir);
+    await seedGit.init(["--initial-branch", "main"]);
+    await seedGit.addConfig("user.name", "Test");
+    await seedGit.addConfig("user.email", "test@example.com");
+    await seedGit.addConfig("commit.gpgsign", "false");
+    await commit(seedDir, "initial.txt", "initial\n");
+    await seedGit.addRemote("origin", remoteDir);
+    await seedGit.push(["origin", "main"]);
+    await rm(seedDir, { recursive: true, force: true });
+
+    localDir = await initLocalClone(remoteDir);
+    worktreeBaseDir = await mkdtemp(path.join(tmpdir(), "posthog-code-wts-"));
+  });
+
+  afterEach(async () => {
+    for (const d of [remoteDir, localDir, worktreeBaseDir]) {
+      await rm(d, { recursive: true, force: true });
+    }
+  });
+
+  it("without fetchBeforeCreate, worktree is based on the stale local ref", async () => {
+    // Advance the remote: push a new commit from a separate clone.
+    const otherDir = await initLocalClone(remoteDir);
+    await commit(otherDir, "remote-new.txt", "remote-new\n");
+    const otherGit = createGitClient(otherDir);
+    await otherGit.push(["origin", "main"]);
+    const remoteTip = await shaOfBranch(otherDir, "main");
+    await rm(otherDir, { recursive: true, force: true });
+
+    const localTipBefore = await shaOfBranch(localDir, "main");
+    expect(localTipBefore).not.toBe(remoteTip);
+
+    const manager = new WorktreeManager({
+      mainRepoPath: localDir,
+      worktreeBasePath: worktreeBaseDir,
+    });
+    const info = await manager.createWorktree({ baseBranch: "main" });
+
+    const worktreeHead = await shaOfBranch(info.worktreePath, "HEAD");
+    expect(worktreeHead).toBe(localTipBefore);
+    expect(worktreeHead).not.toBe(remoteTip);
+  });
+
+  it("with fetchBeforeCreate, worktree starts at the remote tip", async () => {
+    const otherDir = await initLocalClone(remoteDir);
+    await commit(otherDir, "remote-new.txt", "remote-new\n");
+    const otherGit = createGitClient(otherDir);
+    await otherGit.push(["origin", "main"]);
+    const remoteTip = await shaOfBranch(otherDir, "main");
+    await rm(otherDir, { recursive: true, force: true });
+
+    const localTipBefore = await shaOfBranch(localDir, "main");
+    expect(localTipBefore).not.toBe(remoteTip);
+
+    const manager = new WorktreeManager({
+      mainRepoPath: localDir,
+      worktreeBasePath: worktreeBaseDir,
+    });
+    const info = await manager.createWorktree({
+      baseBranch: "main",
+      fetchBeforeCreate: true,
+    });
+
+    const worktreeHead = await shaOfBranch(info.worktreePath, "HEAD");
+    expect(worktreeHead).toBe(remoteTip);
+
+    // Local `main` should NOT be mutated — only `origin/main` advances.
+    const localMainAfter = await shaOfBranch(localDir, "main");
+    expect(localMainAfter).toBe(localTipBefore);
+  });
+
+  it("with fetchBeforeCreate and an unreachable remote, falls back to local base", async () => {
+    // Point origin at a directory that doesn't exist so the fetch fails.
+    const git = createGitClient(localDir);
+    await git.remote(["set-url", "origin", "/nonexistent/path/to/remote"]);
+
+    const localTipBefore = await shaOfBranch(localDir, "main");
+
+    const manager = new WorktreeManager({
+      mainRepoPath: localDir,
+      worktreeBasePath: worktreeBaseDir,
+    });
+    const info = await manager.createWorktree({
+      baseBranch: "main",
+      fetchBeforeCreate: true,
+    });
+
+    const worktreeHead = await shaOfBranch(info.worktreePath, "HEAD");
+    expect(worktreeHead).toBe(localTipBefore);
+  });
+});

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -6,8 +6,10 @@ import { getCleanEnv, getGitOperationManager } from "./operation-manager";
 import {
   addToLocalExclude,
   branchExists,
+  fetchRef,
   getDefaultBranch,
   getHeadSha,
+  hasRef,
   listWorktrees as listWorktreesRaw,
 } from "./queries";
 import { clonePath, forceRemove, safeSymlink } from "./utils";
@@ -125,6 +127,16 @@ export class WorktreeManager {
   async createWorktree(options?: {
     baseBranch?: string;
     onOutput?: (data: string) => void;
+    /**
+     * When true, fetch `origin/<baseBranch>` before creating the worktree and
+     * base the new worktree on the remote tip when reachable. This avoids
+     * spawning a worktree off a stale local ref (e.g. when the cloud harness
+     * provisions a clone whose local trunk has fallen behind `origin`).
+     *
+     * Falls back to the local base ref if the fetch fails (offline / no remote
+     * configured / network blip), so existing local-only setups still work.
+     */
+    fetchBeforeCreate?: boolean;
   }): Promise<WorktreeInfo> {
     const manager = getGitOperationManager();
 
@@ -155,9 +167,13 @@ export class WorktreeManager {
       ? worktreePath
       : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
 
-    options?.onOutput?.(`Creating worktree from ${baseBranch}...\n`);
+    const baseRef = options?.fetchBeforeCreate
+      ? await this.resolveFreshBaseRef(baseBranch, options?.onOutput)
+      : baseBranch;
+
+    options?.onOutput?.(`Creating worktree from ${baseRef}...\n`);
     const output = await manager.executeWrite(this.mainRepoPath, async () => {
-      return this.spawnWorktreeAdd(["--detach", targetPath, baseBranch], {
+      return this.spawnWorktreeAdd(["--detach", targetPath, baseRef], {
         onOutput: options?.onOutput,
       });
     });
@@ -313,6 +329,52 @@ export class WorktreeManager {
       createdAt: new Date().toISOString(),
       output: output.trim() || undefined,
     };
+  }
+
+  /**
+   * Best-effort resolve a fresh base ref for a new worktree.
+   *
+   * Tries to `git fetch origin <baseBranch>` and return `origin/<baseBranch>`
+   * if the remote tip is reachable. Falls back to the local branch name when
+   * the fetch fails or the remote ref isn't present afterwards (offline,
+   * no `origin` remote, ref doesn't exist on the remote, etc.).
+   *
+   * We base off `origin/<branch>` rather than fast-forwarding the local
+   * branch so the user's local checkout is untouched — the worktree gets
+   * the current remote tip without mutating any local refs.
+   */
+  private async resolveFreshBaseRef(
+    baseBranch: string,
+    onOutput?: (data: string) => void,
+  ): Promise<string> {
+    const manager = getGitOperationManager();
+    const remote = "origin";
+    const remoteRef = `${remote}/${baseBranch}`;
+
+    onOutput?.(`Fetching ${remoteRef}...\n`);
+    const fetched = await manager.executeWrite(this.mainRepoPath, (git) =>
+      fetchRef(git, remote, baseBranch),
+    );
+
+    if (!fetched) {
+      onOutput?.(
+        `Fetch failed for ${remoteRef}, falling back to local ${baseBranch}.\n`,
+      );
+      return baseBranch;
+    }
+
+    const remoteRefExists = await manager.executeRead(
+      this.mainRepoPath,
+      (git) => hasRef(git, remoteRef),
+    );
+    if (!remoteRefExists) {
+      onOutput?.(
+        `Remote ref ${remoteRef} not found after fetch, falling back to local ${baseBranch}.\n`,
+      );
+      return baseBranch;
+    }
+
+    return remoteRef;
   }
 
   private spawnWorktreeAdd(

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -127,15 +127,7 @@ export class WorktreeManager {
   async createWorktree(options?: {
     baseBranch?: string;
     onOutput?: (data: string) => void;
-    /**
-     * When true, fetch `origin/<baseBranch>` before creating the worktree and
-     * base the new worktree on the remote tip when reachable. This avoids
-     * spawning a worktree off a stale local ref (e.g. when the cloud harness
-     * provisions a clone whose local trunk has fallen behind `origin`).
-     *
-     * Falls back to the local base ref if the fetch fails (offline / no remote
-     * configured / network blip), so existing local-only setups still work.
-     */
+    /** Base the worktree on `origin/<baseBranch>` after fetching; falls back to the local ref if the fetch fails. */
     fetchBeforeCreate?: boolean;
   }): Promise<WorktreeInfo> {
     const manager = getGitOperationManager();
@@ -332,16 +324,8 @@ export class WorktreeManager {
   }
 
   /**
-   * Best-effort resolve a fresh base ref for a new worktree.
-   *
-   * Tries to `git fetch origin <baseBranch>` and return `origin/<baseBranch>`
-   * if the remote tip is reachable. Falls back to the local branch name when
-   * the fetch fails or the remote ref isn't present afterwards (offline,
-   * no `origin` remote, ref doesn't exist on the remote, etc.).
-   *
-   * We base off `origin/<branch>` rather than fast-forwarding the local
-   * branch so the user's local checkout is untouched — the worktree gets
-   * the current remote tip without mutating any local refs.
+   * Returns `origin/<baseBranch>` after fetching, or the local branch name as a fallback.
+   * Bases off `origin/<branch>` rather than fast-forwarding so local refs stay untouched.
    */
   private async resolveFreshBaseRef(
     baseBranch: string,


### PR DESCRIPTION
## Problem

Local worktree tasks in the desktop app can start off a stale local trunk. When the user's local `main` hasn't been refreshed, `WorktreeManager.createWorktree` bases the new detached worktree on the local ref — so the agent begins iterating on code that's already behind `origin/main`, surfacing user-visible "worktree starts behind master" reports.

This only affects `mode === "worktree"` tasks. `mode === "local"` reuses the user's existing folder (no worktree), and `mode === "cloud"` returns from `doCreateWorkspace` before any worktree is created (the cloud runner provisions its workspace separately).

## Changes

Add an opt-in `fetchBeforeCreate` option on the trunk path:

- `WorktreeManager.createWorktree({ fetchBeforeCreate: true })` calls a new `resolveFreshBaseRef` helper that does a best-effort `git fetch origin <baseBranch>` and bases the worktree on `origin/<base>` when reachable. Falls back to the local base ref if the fetch fails (offline, no `origin`, ref doesn't exist on the remote) so existing local-only setups still work.
- `CreateWorktreeSaga` gets the same option for parity, using `this.git` directly inside the existing write lock (the `fetch` query helper would re-enter the lock and deadlock).
- `apps/code/src/main/services/workspace/service.ts` passes `fetchBeforeCreate: true` on the trunk path only. The occupied-branch fallback (which bases off a user-local branch they may have committed to) is intentionally left as-is — fetching there would silently bypass their local commits.

We base off `origin/<base>` rather than fast-forwarding the local branch so the user's local checkout is never mutated; only the worktree picks up the remote tip.

Two small helpers (`hasRef`, `fetchRef`) added to `packages/git/src/queries.ts` to keep the saga and `WorktreeManager` symmetric.

## How did you test this?

- `pnpm --filter @posthog/git test src/worktree.test.ts` — 3 new tests pass:
  - Without `fetchBeforeCreate`, worktree is based on the stale local ref (baseline that proves the bug).
  - With `fetchBeforeCreate`, worktree starts at the remote tip and local `main` is not mutated.
  - With `fetchBeforeCreate` and an unreachable remote, falls back to the local base.
- `pnpm --filter @posthog/git typecheck`, `pnpm --filter code typecheck`, `pnpm lint` — all clean.
- The 2 pre-existing failures in the git test suite (`forceRemove` EACCES, `detectDefaultBranch > prefers remote HEAD`) reproduce on `main` and are unrelated.

## Publish to changelog?

no