### PR TITLE
fix: push updated config options to renderer after mid-task model change

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1023,6 +1023,14 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         : o,
     );
 
+    await this.client.sessionUpdate({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: this.session.configOptions,
+      },
+    });
+
     return { configOptions: this.session.configOptions };
   }
 


### PR DESCRIPTION
## Problem

When switching from one thinking effort to another that isn't supported by the currently selected Claude model, the app throws an error and falls back. Two related issues:

1. **Incompatible efforts are shown** — The effort selector displays options that aren't valid for the selected model (e.g. Extra High/Max for Sonnet 4.6)
2. **Selector visible when it shouldn't be** — For models like Haiku 4.5 and Sonnet 4.5 that don't support any thinking effort, the selector stays visible after switching to them mid-task

The new-task flow already handles this correctly — but the mid-task flow didn't.

Closes https://github.com/PostHog/code/issues/2323

## Changes

The server-side `rebuildEffortConfigOption` was already correctly rebuilding/removing the effort config when the model changes. The problem was that the updated `configOptions` were never pushed to the renderer.

`setSessionConfigOption` now emits a `config_option_update` session event after any config change, so the renderer receives the fully rebuilt config options (including removed/filtered effort entries). The renderer already handles this event — it just wasn't being sent.

One-liner in `packages/agent/src/adapters/claude/claude-agent.ts`.

## How did you test this?

### Manual testing

I ran through each model tier since they have different effort support:

**Models with no effort support (selector should hide):**
- Switch to Haiku 4.5 or Sonnet 4.5 mid-task → effort selector disappears, no error

**Models with partial effort support (Low/Medium/High only):**
- Switch to Sonnet 4.6 or Opus 4.5 → dropdown shows only Low, Medium, High
- Cycling through each one works without errors

**Models with full effort support (all five levels):**
- Switch to Opus 4.6 or Opus 4.7 → dropdown shows Low, Medium, High, Extra High, Max
- Cycling through each one works without errors

**Effort clamping on model downgrade:**
- Set effort to Extra High on Opus 4.7, switch to Sonnet 4.6 → clamps to High
- Set effort to Max on Opus 4.6, switch to Opus 4.5 → clamps to High
- Set effort to anything on Sonnet 4.6, switch to Haiku 4.5 → selector disappears

**Effort restoration on model upgrade:**
- Start on Haiku 4.5 (no selector), switch to Sonnet 4.6 → selector reappears with High default
- From Sonnet 4.6, switch to Opus 4.7 → Extra High and Max now appear in dropdown

**New task creation (regression check):**
- New task with Haiku 4.5 → no selector shown
- New task with Sonnet 4.6 → Low/Medium/High only
- New task with Opus 4.7 → all five options

Across all scenarios: no error toasts, no console errors, selector label always matches the selected value.

## Publish to changelog?

no