### PR TITLE
fix(code): select task title text when entering rename mode

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/items/TaskItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/TaskItem.tsx
@@ -232,7 +232,7 @@ function InlineEditInput({
     const input = inputRef.current;
     if (input) {
       input.focus();
-      input.setSelectionRange(input.value.length, input.value.length);
+      input.select();
     }
   }, []);
 

--- a/apps/code/src/renderer/features/task-detail/components/HeaderTitleEditor.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/HeaderTitleEditor.tsx
@@ -19,7 +19,7 @@ export function HeaderTitleEditor({
     const input = inputRef.current;
     if (input) {
       input.focus();
-      input.setSelectionRange(input.value.length, input.value.length);
+      input.select();
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Both the sidebar inline rename and the task detail header rename were placing the cursor at the end of the existing title, so typing appended characters instead of replacing the name.
- Replace `setSelectionRange(length, length)` with `input.select()` so the full title is highlighted on focus and typing immediately overwrites it.

## Test plan
- [ ] Double-click a task in the sidebar → existing title is highlighted; typing replaces it.
- [ ] Use the sidebar context menu "Rename" → existing title is highlighted; typing replaces it.
- [ ] Double-click the task title in the task detail header → existing title is highlighted; typing replaces it.
- [ ] Pressing arrow keys before typing still lets you edit without replacing.