### PR TITLE
fix(code-review): support resolving GitHub PR review threads

### DIFF
--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -418,6 +418,7 @@ export const getPrReviewCommentsOutput = z.array(prReviewThreadSchema);
 export const resolveReviewThreadInput = z.object({
   prUrl: z.string(),
   threadNodeId: z.string(),
+  resolved: z.boolean(),
 });
 export const resolveReviewThreadOutput = z.object({
   success: z.boolean(),

--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -400,10 +400,32 @@ export const prReviewCommentSchema = z.object({
 
 export type PrReviewComment = z.infer<typeof prReviewCommentSchema>;
 
+export const prReviewThreadSchema = z.object({
+  nodeId: z.string(),
+  isResolved: z.boolean(),
+  rootId: z.number(),
+  filePath: z.string(),
+  comments: z.array(prReviewCommentSchema),
+});
+export type PrReviewThread = z.infer<typeof prReviewThreadSchema>;
+
 export const getPrReviewCommentsInput = z.object({
   prUrl: z.string(),
 });
-export const getPrReviewCommentsOutput = z.array(prReviewCommentSchema);
+export const getPrReviewCommentsOutput = z.array(prReviewThreadSchema);
+
+// resolveReviewThread schemas
+export const resolveReviewThreadInput = z.object({
+  prUrl: z.string(),
+  threadNodeId: z.string(),
+});
+export const resolveReviewThreadOutput = z.object({
+  success: z.boolean(),
+  isResolved: z.boolean(),
+});
+export type ResolveReviewThreadOutput = z.infer<
+  typeof resolveReviewThreadOutput
+>;
 
 // replyToPrComment schemas
 export const replyToPrCommentInput = z.object({

--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -319,3 +319,207 @@ describe("mapPrState", () => {
     expect(mapPrState("something", false, false)).toBeNull();
   });
 });
+
+describe("GitService.getPrReviewComments", () => {
+  let service: GitService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitService(
+      {} as LlmGatewayService,
+      {} as WorkspaceService,
+      { getSessionEnvForTask: async () => ({}) } as unknown as AgentService,
+    );
+  });
+
+  const makeThread = (id: string, commentId: number) => ({
+    id,
+    isResolved: false,
+    isOutdated: false,
+    path: "src/foo.ts",
+    diffSide: "RIGHT",
+    line: 10,
+    originalLine: 10,
+    startLine: null,
+    startDiffSide: null,
+    subjectType: "LINE",
+    comments: {
+      nodes: [
+        {
+          databaseId: commentId,
+          body: "looks good",
+          path: "src/foo.ts",
+          diffHunk: "@@ -1,3 +1,4 @@",
+          replyTo: null,
+          author: {
+            login: "alice",
+            avatarUrl: "https://example.com/alice.png",
+          },
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    },
+  });
+
+  const makePage = (
+    threads: object[],
+    hasNextPage: boolean,
+    endCursor: string | null,
+  ) => ({
+    exitCode: 0,
+    stdout: JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage, endCursor },
+              nodes: threads,
+            },
+          },
+        },
+      },
+    }),
+  });
+
+  it("returns empty array for non-PR URL", async () => {
+    const result = await service.getPrReviewComments(
+      "https://github.com/owner/repo",
+    );
+    expect(result).toEqual([]);
+    expect(mockExecGh).not.toHaveBeenCalled();
+  });
+
+  it("maps a single-page response to PrReviewThread[]", async () => {
+    mockExecGh.mockResolvedValueOnce(
+      makePage([makeThread("T_1", 101)], false, null),
+    );
+
+    const result = await service.getPrReviewComments(
+      "https://github.com/owner/repo/pull/1",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      nodeId: "T_1",
+      isResolved: false,
+      rootId: 101,
+      filePath: "src/foo.ts",
+    });
+    expect(result[0].comments[0]).toMatchObject({
+      id: 101,
+      body: "looks good",
+      side: "RIGHT",
+      line: 10,
+      subject_type: "line",
+    });
+  });
+
+  it("fetches all pages when hasNextPage is true", async () => {
+    mockExecGh
+      .mockResolvedValueOnce(
+        makePage([makeThread("T_1", 101)], true, "cursor-abc"),
+      )
+      .mockResolvedValueOnce(makePage([makeThread("T_2", 102)], false, null));
+
+    const result = await service.getPrReviewComments(
+      "https://github.com/owner/repo/pull/1",
+    );
+
+    expect(mockExecGh).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.nodeId)).toEqual(["T_1", "T_2"]);
+
+    const secondCall = JSON.parse(mockExecGh.mock.calls[1][1].input);
+    expect(secondCall.variables.cursor).toBe("cursor-abc");
+  });
+
+  it("returns partial results when MAX_THREAD_PAGES is exceeded", async () => {
+    let n = 0;
+    mockExecGh.mockImplementation(async () => {
+      n += 1;
+      return makePage([makeThread(`T_${n}`, 100 + n)], true, `cursor-${n}`);
+    });
+
+    const result = await service.getPrReviewComments(
+      "https://github.com/owner/repo/pull/1",
+    );
+
+    expect(mockExecGh).toHaveBeenCalledTimes(50);
+    expect(result).toHaveLength(50);
+    expect(result[0]?.nodeId).toBe("T_1");
+    expect(result[49]?.nodeId).toBe("T_50");
+  });
+
+  it("throws when gh exits with non-zero", async () => {
+    mockExecGh.mockResolvedValueOnce({
+      exitCode: 1,
+      stderr: "auth error",
+      stdout: "",
+    });
+
+    await expect(
+      service.getPrReviewComments("https://github.com/owner/repo/pull/1"),
+    ).rejects.toThrow("Failed to fetch PR review threads");
+  });
+});
+
+describe("GitService.resolveReviewThread", () => {
+  let service: GitService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GitService(
+      {} as LlmGatewayService,
+      {} as WorkspaceService,
+      { getSessionEnvForTask: async () => ({}) } as unknown as AgentService,
+    );
+  });
+
+  it("resolves a thread and returns isResolved: true", async () => {
+    mockExecGh.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        data: {
+          resolveReviewThread: { thread: { id: "T_1", isResolved: true } },
+        },
+      }),
+    });
+
+    const result = await service.resolveReviewThread("T_1", true);
+
+    expect(result).toEqual({ success: true, isResolved: true });
+    const body = JSON.parse(mockExecGh.mock.calls[0][1].input);
+    expect(body.query).toContain("resolveReviewThread");
+    expect(body.variables.threadId).toBe("T_1");
+  });
+
+  it("unresolves a thread and returns isResolved: false", async () => {
+    mockExecGh.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        data: {
+          unresolveReviewThread: { thread: { id: "T_1", isResolved: false } },
+        },
+      }),
+    });
+
+    const result = await service.resolveReviewThread("T_1", false);
+
+    expect(result).toEqual({ success: true, isResolved: false });
+    const body = JSON.parse(mockExecGh.mock.calls[0][1].input);
+    expect(body.query).toContain("unresolveReviewThread");
+  });
+
+  it("returns success: false when gh exits with non-zero", async () => {
+    mockExecGh.mockResolvedValueOnce({
+      exitCode: 1,
+      stderr: "network error",
+      stdout: "",
+    });
+
+    const result = await service.resolveReviewThread("T_1", true);
+
+    expect(result).toEqual({ success: false, isResolved: false });
+  });
+});

--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -462,6 +462,20 @@ describe("GitService.getPrReviewComments", () => {
       service.getPrReviewComments("https://github.com/owner/repo/pull/1"),
     ).rejects.toThrow("Failed to fetch PR review threads");
   });
+
+  it("throws with the GraphQL error message when GitHub returns 200 with errors", async () => {
+    mockExecGh.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        data: null,
+        errors: [{ message: "Resource not accessible by integration" }],
+      }),
+    });
+
+    await expect(
+      service.getPrReviewComments("https://github.com/owner/repo/pull/1"),
+    ).rejects.toThrow("Resource not accessible by integration");
+  });
 });
 
 describe("GitService.resolveReviewThread", () => {

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -1297,6 +1297,7 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
           };
         };
       };
+      errors?: Array<{ message: string }>;
     };
 
     const MAX_THREAD_PAGES = 50; // 50 × 100 = 5 000 threads max
@@ -1321,6 +1322,11 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
         }
 
         const data = JSON.parse(result.stdout) as PageResponse;
+        if (data.errors?.length) {
+          throw new Error(
+            `GraphQL error: ${data.errors.map((e) => e.message).join("; ")}`,
+          );
+        }
         const reviewThreads = data.data.repository.pullRequest.reviewThreads;
         allNodes.push(...reviewThreads.nodes);
         if (!reviewThreads.pageInfo.hasNextPage) {
@@ -1404,7 +1410,16 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
           resolveReviewThread?: { thread: { isResolved: boolean } };
           unresolveReviewThread?: { thread: { isResolved: boolean } };
         };
+        errors?: Array<{ message: string }>;
       };
+      if (data.errors?.length) {
+        log.warn("Failed to resolve/unresolve review thread", {
+          threadNodeId,
+          resolved,
+          error: data.errors.map((e) => e.message).join("; "),
+        });
+        return { success: false, isResolved: !resolved };
+      }
       const thread =
         data.data.resolveReviewThread?.thread ??
         data.data.unresolveReviewThread?.thread;

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -72,11 +72,13 @@ import type {
   PrActionType,
   PrDetailsByUrlOutput,
   PrReviewComment,
+  PrReviewThread,
   PrStatusOutput,
   PublishOutput,
   PullOutput,
   PushOutput,
   ReplyToPrCommentOutput,
+  ResolveReviewThreadOutput,
   SyncOutput,
   UpdatePrByUrlOutput,
 } from "./schemas";
@@ -1216,31 +1218,204 @@ export class GitService extends TypedEventEmitter<GitServiceEvents> {
     }
   }
 
-  public async getPrReviewComments(prUrl: string): Promise<PrReviewComment[]> {
+  public async getPrReviewComments(prUrl: string): Promise<PrReviewThread[]> {
     const pr = parseGithubUrl(prUrl);
     if (pr?.kind !== "pr") return [];
 
     const { owner, repo, number } = pr;
 
-    try {
-      const result = await execGh([
-        "api",
-        `repos/${owner}/${repo}/pulls/${number}/comments`,
-        "--paginate",
-        "--slurp",
-      ]);
+    // Position fields (line, side, etc.) live on the thread, not on individual comments.
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                isResolved
+                isOutdated
+                path
+                diffSide
+                line
+                originalLine
+                startLine
+                startDiffSide
+                subjectType
+                comments(first: 100) {
+                  nodes {
+                    databaseId
+                    body
+                    path
+                    diffHunk
+                    replyTo { databaseId }
+                    author { login avatarUrl }
+                    createdAt
+                    updatedAt
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
 
-      if (result.exitCode !== 0) {
-        throw new Error(
-          `Failed to fetch PR review comments: ${result.stderr || result.error || "Unknown error"}`,
+    type ThreadNode = {
+      id: string;
+      isResolved: boolean;
+      isOutdated: boolean;
+      path: string;
+      diffSide: "LEFT" | "RIGHT";
+      line: number | null;
+      originalLine: number | null;
+      startLine: number | null;
+      startDiffSide: "LEFT" | "RIGHT" | null;
+      subjectType: "LINE" | "FILE" | null;
+      comments: {
+        nodes: Array<{
+          databaseId: number;
+          body: string;
+          path: string;
+          diffHunk: string;
+          replyTo: { databaseId: number } | null;
+          author: { login: string; avatarUrl: string };
+          createdAt: string;
+          updatedAt: string;
+        }>;
+      };
+    };
+
+    type PageResponse = {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: boolean; endCursor: string | null };
+              nodes: ThreadNode[];
+            };
+          };
+        };
+      };
+    };
+
+    const MAX_THREAD_PAGES = 50; // 50 × 100 = 5 000 threads max
+
+    try {
+      const allNodes: ThreadNode[] = [];
+      let cursor: string | null = null;
+      let completed = false;
+
+      for (let page = 0; page < MAX_THREAD_PAGES; page++) {
+        const result = await execGh(["api", "graphql", "--input", "-"], {
+          input: JSON.stringify({
+            query,
+            variables: { owner, repo, number, cursor },
+          }),
+        });
+
+        if (result.exitCode !== 0) {
+          throw new Error(
+            `Failed to fetch PR review threads: ${result.stderr || result.error || "Unknown error"}`,
+          );
+        }
+
+        const data = JSON.parse(result.stdout) as PageResponse;
+        const reviewThreads = data.data.repository.pullRequest.reviewThreads;
+        allNodes.push(...reviewThreads.nodes);
+        if (!reviewThreads.pageInfo.hasNextPage) {
+          completed = true;
+          break;
+        }
+        cursor = reviewThreads.pageInfo.endCursor;
+      }
+
+      if (!completed) {
+        log.warn(
+          "getPrReviewComments hit MAX_THREAD_PAGES; returning partial results",
+          {
+            prUrl,
+            returned: allNodes.length,
+          },
         );
       }
 
-      const pages = JSON.parse(result.stdout) as PrReviewComment[][];
-      return pages.flat();
+      return allNodes.map((thread) => {
+        const comments: PrReviewComment[] = thread.comments.nodes.map((c) => ({
+          id: c.databaseId,
+          body: c.body,
+          path: c.path,
+          diff_hunk: c.diffHunk,
+          line: thread.line,
+          original_line: thread.originalLine,
+          side: thread.diffSide,
+          start_line: thread.startLine,
+          start_side: thread.startDiffSide,
+          in_reply_to_id: c.replyTo?.databaseId ?? null,
+          user: { login: c.author.login, avatar_url: c.author.avatarUrl },
+          created_at: c.createdAt,
+          updated_at: c.updatedAt,
+          subject_type: thread.subjectType
+            ? (thread.subjectType.toLowerCase() as "line" | "file")
+            : null,
+        }));
+
+        return {
+          nodeId: thread.id,
+          isResolved: thread.isResolved,
+          rootId: comments[0]?.id ?? 0,
+          filePath: thread.path,
+          comments,
+        };
+      });
     } catch (error) {
-      log.warn("Failed to fetch PR review comments", { prUrl, error });
+      log.warn("Failed to fetch PR review threads", { prUrl, error });
       throw error;
+    }
+  }
+
+  public async resolveReviewThread(
+    threadNodeId: string,
+    resolved: boolean,
+  ): Promise<ResolveReviewThreadOutput> {
+    const mutation = resolved
+      ? `mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { id isResolved } } }`
+      : `mutation($threadId: ID!) { unresolveReviewThread(input: { threadId: $threadId }) { thread { id isResolved } } }`;
+
+    try {
+      const result = await execGh(["api", "graphql", "--input", "-"], {
+        input: JSON.stringify({
+          query: mutation,
+          variables: { threadId: threadNodeId },
+        }),
+      });
+
+      if (result.exitCode !== 0) {
+        log.warn("Failed to resolve/unresolve review thread", {
+          threadNodeId,
+          resolved,
+          error: result.stderr || result.error,
+        });
+        return { success: false, isResolved: !resolved };
+      }
+
+      const data = JSON.parse(result.stdout) as {
+        data: {
+          resolveReviewThread?: { thread: { isResolved: boolean } };
+          unresolveReviewThread?: { thread: { isResolved: boolean } };
+        };
+      };
+      const thread =
+        data.data.resolveReviewThread?.thread ??
+        data.data.unresolveReviewThread?.thread;
+
+      return { success: true, isResolved: thread?.isResolved ?? resolved };
+    } catch (error) {
+      log.warn("Failed to resolve/unresolve review thread", {
+        threadNodeId,
+        error,
+      });
+      return { success: false, isResolved: !resolved };
     }
   }
 

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -74,6 +74,8 @@ import {
   pushOutput,
   replyToPrCommentInput,
   replyToPrCommentOutput,
+  resolveReviewThreadInput,
+  resolveReviewThreadOutput,
   searchGithubRefsInput,
   searchGithubRefsOutput,
   stageFilesInput,
@@ -389,6 +391,20 @@ export const gitRouter = router({
     .output(replyToPrCommentOutput)
     .mutation(({ input }) =>
       getService().replyToPrComment(input.prUrl, input.commentId, input.body),
+    ),
+
+  resolveReviewThread: publicProcedure
+    .input(resolveReviewThreadInput)
+    .output(resolveReviewThreadOutput)
+    .mutation(({ input }) =>
+      getService().resolveReviewThread(input.threadNodeId, true),
+    ),
+
+  unresolveReviewThread: publicProcedure
+    .input(resolveReviewThreadInput)
+    .output(resolveReviewThreadOutput)
+    .mutation(({ input }) =>
+      getService().resolveReviewThread(input.threadNodeId, false),
     ),
 
   getBranchChangedFiles: publicProcedure

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -397,14 +397,7 @@ export const gitRouter = router({
     .input(resolveReviewThreadInput)
     .output(resolveReviewThreadOutput)
     .mutation(({ input }) =>
-      getService().resolveReviewThread(input.threadNodeId, true),
-    ),
-
-  unresolveReviewThread: publicProcedure
-    .input(resolveReviewThreadInput)
-    .output(resolveReviewThreadOutput)
-    .mutation(({ input }) =>
-      getService().resolveReviewThread(input.threadNodeId, false),
+      getService().resolveReviewThread(input.threadNodeId, input.resolved),
     ),
 
   getBranchChangedFiles: publicProcedure

--- a/apps/code/src/renderer/features/code-review/components/PrCommentThread.tsx
+++ b/apps/code/src/renderer/features/code-review/components/PrCommentThread.tsx
@@ -2,9 +2,11 @@ import { MarkdownRenderer } from "@features/editor/components/MarkdownRenderer";
 import { sendPromptToAgent } from "@features/sessions/utils/sendPromptToAgent";
 import type { PrReviewComment } from "@main/services/git/schemas";
 import {
+  ArrowCounterClockwise,
   CaretDown,
   CaretUp,
   ChatCircle,
+  CheckCircle,
   File,
   Robot,
   WarningCircle,
@@ -39,6 +41,8 @@ interface ThreadActionBarProps {
   endLine: number;
   side: "old" | "new";
   comments: PrReviewComment[];
+  isResolved: boolean;
+  onResolveToggle: () => void;
   showReplyBox: boolean;
   pendingReply: string | null;
   onShowReplyBox: () => void;
@@ -55,6 +59,8 @@ function ThreadActionBar({
   endLine,
   side,
   comments,
+  isResolved,
+  onResolveToggle,
   showReplyBox,
   pendingReply,
   onShowReplyBox,
@@ -100,6 +106,22 @@ function ThreadActionBar({
         <Button size="sm" onClick={onShowReplyBox}>
           <ChatCircle />
           Reply
+        </Button>
+      )}
+
+      {prUrl && (
+        <Button size="sm" onClick={onResolveToggle}>
+          {isResolved ? (
+            <>
+              <ArrowCounterClockwise />
+              Unresolve
+            </>
+          ) : (
+            <>
+              <CheckCircle />
+              Resolve
+            </>
+          )}
         </Button>
       )}
 
@@ -243,6 +265,8 @@ export function PrCommentThread({
 }: PrCommentThreadProps) {
   const {
     threadId,
+    nodeId,
+    isResolved: initialIsResolved,
     comments,
     isOutdated,
     isFileLevel,
@@ -250,10 +274,15 @@ export function PrCommentThread({
     side: annotationSide,
   } = metadata;
   const side = annotationSide === "deletions" ? "old" : "new";
-  const { reply } = usePrCommentActions(prUrl);
+  const { reply, resolve } = usePrCommentActions(prUrl);
   const [showReplyBox, setShowReplyBox] = useState(false);
   const [pendingReply, setPendingReply] = useState<string | null>(null);
+  const [isResolved, setIsResolved] = useState(initialIsResolved);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    setIsResolved(initialIsResolved);
+  }, [initialIsResolved]);
 
   // Clear pending reply once the real comments list includes it
   const lastCommentId = comments[comments.length - 1]?.id;
@@ -301,14 +330,27 @@ export function PrCommentThread({
     [],
   );
 
+  const handleResolveToggle = useCallback(async () => {
+    const next = !isResolved;
+    setIsResolved(next);
+    const success = await resolve(nodeId, next);
+    if (!success) setIsResolved(!next);
+  }, [isResolved, nodeId, resolve]);
+
   return (
     <div className="px-3 py-1.5" style={{ contain: "inline-size" }}>
       <div
         data-pr-comment-thread=""
-        className="overflow-hidden whitespace-normal rounded-md border border-[var(--gray-5)] bg-[var(--gray-2)] px-2.5 py-2 font-sans"
+        className={`overflow-hidden whitespace-normal rounded-md border border-[var(--gray-5)] bg-[var(--gray-2)] px-2.5 py-2 font-sans ${isResolved ? "opacity-60" : ""}`}
       >
-        {(isOutdated || isFileLevel) && (
+        {(isResolved || isOutdated || isFileLevel) && (
           <Flex align="center" gap="1" className="mb-1.5">
+            {isResolved && (
+              <Badge color="green" size="1" variant="soft">
+                <CheckCircle size={12} weight="fill" />
+                Resolved
+              </Badge>
+            )}
             {isFileLevel && (
               <Badge color="gray" size="1" variant="soft">
                 <File size={12} />
@@ -362,6 +404,8 @@ export function PrCommentThread({
           endLine={endLine}
           side={side}
           comments={comments}
+          isResolved={isResolved}
+          onResolveToggle={handleResolveToggle}
           showReplyBox={showReplyBox}
           pendingReply={pendingReply}
           onShowReplyBox={() => setShowReplyBox(true)}

--- a/apps/code/src/renderer/features/code-review/components/PrCommentThread.tsx
+++ b/apps/code/src/renderer/features/code-review/components/PrCommentThread.tsx
@@ -135,7 +135,7 @@ function ThreadActionBar({
         }
       >
         <Robot />
-        Fix with agent
+        Fix
       </Button>
 
       <Button
@@ -148,7 +148,7 @@ function ThreadActionBar({
         }
       >
         <Robot />
-        Ask agent
+        Ask
       </Button>
     </Flex>
   );

--- a/apps/code/src/renderer/features/code-review/hooks/usePrCommentActions.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/usePrCommentActions.ts
@@ -36,17 +36,17 @@ export function usePrCommentActions(prUrl: string | null) {
   const resolve = useCallback(
     async (threadNodeId: string, resolved: boolean): Promise<boolean> => {
       if (!prUrl) return false;
-      const mutation = resolved
-        ? trpcClient.git.resolveReviewThread
-        : trpcClient.git.unresolveReviewThread;
+      const errorMessage = resolved
+        ? "Failed to resolve thread"
+        : "Failed to unresolve thread";
       try {
-        const result = await mutation.mutate({ prUrl, threadNodeId });
+        const result = await trpcClient.git.resolveReviewThread.mutate({
+          prUrl,
+          threadNodeId,
+          resolved,
+        });
         if (!result.success) {
-          toast.error(
-            resolved
-              ? "Failed to resolve thread"
-              : "Failed to unresolve thread",
-          );
+          toast.error(errorMessage);
           return false;
         }
         await queryClient.invalidateQueries(
@@ -54,9 +54,7 @@ export function usePrCommentActions(prUrl: string | null) {
         );
         return true;
       } catch {
-        toast.error(
-          resolved ? "Failed to resolve thread" : "Failed to unresolve thread",
-        );
+        toast.error(errorMessage);
         return false;
       }
     },

--- a/apps/code/src/renderer/features/code-review/hooks/usePrCommentActions.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/usePrCommentActions.ts
@@ -33,5 +33,35 @@ export function usePrCommentActions(prUrl: string | null) {
     [prUrl, queryClient, trpc],
   );
 
-  return { reply };
+  const resolve = useCallback(
+    async (threadNodeId: string, resolved: boolean): Promise<boolean> => {
+      if (!prUrl) return false;
+      const mutation = resolved
+        ? trpcClient.git.resolveReviewThread
+        : trpcClient.git.unresolveReviewThread;
+      try {
+        const result = await mutation.mutate({ prUrl, threadNodeId });
+        if (!result.success) {
+          toast.error(
+            resolved
+              ? "Failed to resolve thread"
+              : "Failed to unresolve thread",
+          );
+          return false;
+        }
+        await queryClient.invalidateQueries(
+          trpc.git.getPrReviewComments.queryFilter({ prUrl }),
+        );
+        return true;
+      } catch {
+        toast.error(
+          resolved ? "Failed to resolve thread" : "Failed to unresolve thread",
+        );
+        return false;
+      }
+    },
+    [prUrl, queryClient, trpc],
+  );
+
+  return { reply, resolve };
 }

--- a/apps/code/src/renderer/features/code-review/types.ts
+++ b/apps/code/src/renderer/features/code-review/types.ts
@@ -26,6 +26,8 @@ export interface DraftCommentMetadata {
 export interface PrCommentMetadata {
   kind: "pr-comment";
   threadId: number;
+  nodeId: string;
+  isResolved: boolean;
   comments: PrReviewComment[];
   isOutdated: boolean;
   isFileLevel: boolean;

--- a/apps/code/src/renderer/features/code-review/utils/prCommentAnnotations.ts
+++ b/apps/code/src/renderer/features/code-review/utils/prCommentAnnotations.ts
@@ -4,6 +4,8 @@ import type { AnnotationMetadata } from "../types";
 
 export interface PrCommentThread {
   rootId: number;
+  nodeId: string;
+  isResolved: boolean;
   comments: PrReviewComment[];
   filePath: string;
 }
@@ -31,6 +33,8 @@ function buildAnnotation(
     metadata: {
       kind: "pr-comment",
       threadId: thread.rootId,
+      nodeId: thread.nodeId,
+      isResolved: thread.isResolved,
       comments: thread.comments,
       isOutdated,
       isFileLevel,

--- a/apps/code/src/renderer/features/git-interaction/hooks/usePrDetails.ts
+++ b/apps/code/src/renderer/features/git-interaction/hooks/usePrDetails.ts
@@ -1,4 +1,4 @@
-import type { PrReviewComment } from "@main/services/git/schemas";
+import type { PrReviewThread } from "@main/services/git/schemas";
 import type { PrCommentThread } from "@renderer/features/code-review/utils/prCommentAnnotations";
 import { useTRPC } from "@renderer/trpc";
 import { useQuery } from "@tanstack/react-query";
@@ -8,30 +8,18 @@ interface UsePrDetailsOptions {
   includeComments?: boolean;
 }
 
-function groupCommentsIntoThreads(
-  comments: PrReviewComment[],
-): Map<number, PrCommentThread> {
-  const threads = new Map<number, PrCommentThread>();
-
-  for (const comment of comments) {
-    const rootId = comment.in_reply_to_id ?? comment.id;
-    const existing = threads.get(rootId);
-    if (existing) {
-      existing.comments.push(comment);
-    } else {
-      threads.set(rootId, {
-        rootId,
-        comments: [comment],
-        filePath: comment.path,
-      });
-    }
+function threadsToMap(threads: PrReviewThread[]): Map<number, PrCommentThread> {
+  const map = new Map<number, PrCommentThread>();
+  for (const thread of threads) {
+    map.set(thread.rootId, {
+      rootId: thread.rootId,
+      nodeId: thread.nodeId,
+      isResolved: thread.isResolved,
+      comments: thread.comments,
+      filePath: thread.filePath,
+    });
   }
-
-  for (const thread of threads.values()) {
-    thread.comments.sort((a, b) => a.created_at.localeCompare(b.created_at));
-  }
-
-  return threads;
+  return map;
 }
 
 export function usePrDetails(
@@ -66,7 +54,7 @@ export function usePrDetails(
   );
 
   const commentThreads = useMemo(
-    () => groupCommentsIntoThreads(commentsQuery.data ?? []),
+    () => threadsToMap(commentsQuery.data ?? []),
     [commentsQuery.data],
   );
 


### PR DESCRIPTION
## Problem

GitHub PR comments in Code only supported replying. There was no way to resolve or unresolve review threads from the app.

## Changes

- fetch PR review threads with the metadata needed for thread actions
- add resolve / unresolve tRPC mutations
- wire thread resolved state into code review annotations and UI
- add Resolve / Unresolve actions in `PrCommentThread`
- add bounded pagination safeguards for review thread fetching
- add service tests for pagination and resolve / unresolve behavior

## Notes

- Review thread pagination is capped at 50 pages.
- GitHub returns up to 100 threads per page, so this still allows up to 5,000 review threads on a single PR.
- We chose this to avoid an unbounded pagination loop while keeping the limit far above any normal PR size.
- If the cap is ever hit, we return partial results and log a warning.

## How did you test this?
<img width="605" height="226" alt="image" src="https://github.com/user-attachments/assets/69256e41-191c-4007-9d95-d90d7c9a133f" />

- Verified in the app against a live PR thread that Resolve / Unresolve shows up and works.
- `pnpm --filter code typecheck`
- `pnpm exec biome check apps/code/src/main/services/git/schemas.ts apps/code/src/main/services/git/service.test.ts apps/code/src/main/services/git/service.ts apps/code/src/main/trpc/routers/git.ts apps/code/src/renderer/features/code-review/components/PrCommentThread.tsx apps/code/src/renderer/features/code-review/hooks/usePrCommentActions.ts apps/code/src/renderer/features/code-review/types.ts apps/code/src/renderer/features/code-review/utils/prCommentAnnotations.ts apps/code/src/renderer/features/git-interaction/hooks/usePrDetails.ts`
- `cd apps/code && pnpm exec vitest run src/main/services/git/service.test.ts`

## Publish to changelog?

no

Closes #2248
