### PR TITLE
fix(agent): show server name and exec context in MCP permission dialog

### DIFF
--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -104,6 +104,35 @@ describe("canUseTool MCP approval enforcement", () => {
     expect(context.client.requestPermission).toHaveBeenCalled();
   });
 
+  it("tags MCP tools in the default permission flow with claudeCode.toolName so the renderer can show the server name and unwrap exec dispatch args", async () => {
+    setMcpToolApprovalStates({ mcp__posthog__exec: "approved" });
+
+    const context = createContext("mcp__posthog__exec", {
+      toolInput: { command: "call experiment-get-all {}" },
+    });
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("allow");
+    expect(context.client.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({
+          _meta: { claudeCode: { toolName: "mcp__posthog__exec" } },
+        }),
+      }),
+    );
+  });
+
+  it("does not set claudeCode._meta on non-MCP tools in the default permission flow", async () => {
+    const context = createContext("WebFetch", {
+      toolInput: { url: "https://example.com" },
+    });
+    await canUseTool(context);
+
+    const call = (context.client.requestPermission as ReturnType<typeof vi.fn>)
+      .mock.calls[0]?.[0];
+    expect(call?.toolCall?._meta).toBeUndefined();
+  });
+
   it("blocks do_not_use even on read-only MCP tools", async () => {
     setMcpToolApprovalStates({
       mcp__server__readonly_blocked: "do_not_use",

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -364,6 +364,12 @@ async function handleDefaultPermissionFlow(
     suggestions,
   );
 
+  // Tag MCP tool calls so the renderer routes them through McpPermission,
+  // which knows how to show `serverName - toolName (MCP)` plus the unwrapped
+  // PostHog exec body. Without this, the dialog falls back to DefaultPermission
+  // and just shows the bare tool name (e.g. "exec") with no context.
+  const isMcpTool = toolName.startsWith("mcp__");
+
   const response = await client.requestPermission({
     options,
     sessionId,
@@ -374,6 +380,7 @@ async function handleDefaultPermissionFlow(
       content: toolInfo.content,
       locations: toolInfo.locations,
       rawInput: { ...(toolInput as Record<string, unknown>), toolName },
+      ...(isMcpTool ? { _meta: { claudeCode: { toolName } } } : {}),
     },
   });
 


### PR DESCRIPTION
## Problem

Closes #2177

The permission dialog for the PostHog `exec` toolcall (and any other MCP tool that falls into the default permission flow) shows only the bare tool name — e.g. just `exec` with no server prefix, no unwrapped sub-tool name, and no dispatch args. The user has no way to tell what the agent is about to do before approving.

The `needs_approval` MCP flow and the PostHog destructive-subtool flow both already tag their requestPermission payload with `_meta.claudeCode.toolName`, which is the signal `PermissionSelector` uses to route through `McpPermission` (renders `posthog - <subtool> (MCP)` + the formatted exec body). The default permission flow was missing that tag, so MCP tools fell through to `DefaultPermission` and lost all that context.

## Changes

- In `handleDefaultPermissionFlow`, add `_meta: { claudeCode: { toolName } }` to the toolCall payload when `toolName.startsWith("mcp__")`. Non-MCP tools are unchanged.
- Add two unit tests:
  - MCP tools in the default flow are tagged with `claudeCode.toolName`.
  - Non-MCP tools are not tagged.

Net change: 36 lines (7 production, 29 test).

## How did you test this?

- `pnpm vitest run src/adapters/claude/permissions/` in `packages/agent`: 33/33 pass (including the 2 new tests).
- `tsc --noEmit` in `packages/agent`: clean.
- biome + typecheck pre-commit hooks: clean.

## Publish to changelog?

no