### PR TITLE
feat(worktree): use human-readable names for worktree branches

### DIFF
--- a/packages/git/src/worktree-name.test.ts
+++ b/packages/git/src/worktree-name.test.ts
@@ -7,7 +7,7 @@ describe("generateHumanReadableName", () => {
     expect(name).toMatch(/^[a-z]+-[a-z]+-\d{2}$/);
   });
 
-  it("produces varied names over multiple calls", () => {
+  it("produces varied names over many calls", () => {
     const names = new Set<string>();
     for (let i = 0; i < 50; i++) {
       names.add(generateHumanReadableName());
@@ -17,16 +17,13 @@ describe("generateHumanReadableName", () => {
     expect(names.size).toBeGreaterThan(20);
   });
 
-  it("uses only filesystem-safe characters", () => {
-    for (let i = 0; i < 25; i++) {
-      const name = generateHumanReadableName();
-      expect(name).toMatch(/^[a-z0-9-]+$/);
-    }
+  const samples = Array.from({ length: 25 }, () => generateHumanReadableName());
+
+  it.each(samples)("uses only filesystem-safe characters: %s", (name) => {
+    expect(name).toMatch(/^[a-z0-9-]+$/);
   });
 
-  it("stays compact (under 32 chars)", () => {
-    for (let i = 0; i < 25; i++) {
-      expect(generateHumanReadableName().length).toBeLessThanOrEqual(32);
-    }
+  it.each(samples)("stays compact (≤32 chars): %s", (name) => {
+    expect(name.length).toBeLessThanOrEqual(32);
   });
 });

--- a/packages/git/src/worktree-name.test.ts
+++ b/packages/git/src/worktree-name.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { generateHumanReadableName } from "./worktree-name";
+
+describe("generateHumanReadableName", () => {
+  it("returns a string matching adjective-noun-NN", () => {
+    const name = generateHumanReadableName();
+    expect(name).toMatch(/^[a-z]+-[a-z]+-\d{2}$/);
+  });
+
+  it("produces varied names over multiple calls", () => {
+    const names = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      names.add(generateHumanReadableName());
+    }
+    // With 36 * 36 * 90 = ~116k combinations, 50 draws should yield
+    // many unique values. Allow generous slack for randomness.
+    expect(names.size).toBeGreaterThan(20);
+  });
+
+  it("uses only filesystem-safe characters", () => {
+    for (let i = 0; i < 25; i++) {
+      const name = generateHumanReadableName();
+      expect(name).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("stays compact (under 32 chars)", () => {
+    for (let i = 0; i < 25; i++) {
+      expect(generateHumanReadableName().length).toBeLessThanOrEqual(32);
+    }
+  });
+});

--- a/packages/git/src/worktree-name.ts
+++ b/packages/git/src/worktree-name.ts
@@ -1,0 +1,34 @@
+import * as crypto from "node:crypto";
+
+/**
+ * Curated adjective-noun word list used to label worktrees. Words are short,
+ * filesystem-safe (lowercase a-z only), and chosen to be inoffensive.
+ */
+// biome-ignore format: keep word lists compact
+const ADJECTIVES = [
+  "amber", "brave", "calm", "clever", "cosmic", "crisp", "dapper", "dusty",
+  "eager", "fancy", "fluffy", "gentle", "happy", "jolly", "lively", "lucky",
+  "merry", "mighty", "nimble", "plucky", "proud", "quick", "quiet", "rapid",
+  "shiny", "silver", "smooth", "snappy", "spry", "sturdy", "sunny", "swift",
+  "tidy", "vivid", "witty", "zesty",
+];
+
+// biome-ignore format: keep word lists compact
+const NOUNS = [
+  "badger", "beetle", "bison", "cedar", "comet", "cricket", "delta", "ember",
+  "falcon", "ferret", "finch", "fjord", "glade", "harbor", "heron", "ibex",
+  "lemur", "lynx", "marlin", "meadow", "mountain", "otter", "panda", "petal",
+  "pebble", "puffin", "quokka", "raven", "river", "robin", "sparrow", "summit",
+  "tiger", "valley", "willow", "wombat",
+];
+
+/**
+ * Generates a short, human-readable random name (e.g. "swift-otter-42").
+ * Suffix is a 2-digit number to reduce collisions while keeping names compact.
+ */
+export function generateHumanReadableName(): string {
+  const adjective = ADJECTIVES[crypto.randomInt(0, ADJECTIVES.length)];
+  const noun = NOUNS[crypto.randomInt(0, NOUNS.length)];
+  const suffix = crypto.randomInt(10, 100).toString();
+  return `${adjective}-${noun}-${suffix}`;
+}

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -1,5 +1,4 @@
 import { execFile, spawn } from "node:child_process";
-import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getCleanEnv, getGitOperationManager } from "./operation-manager";
@@ -13,6 +12,7 @@ import {
   listWorktrees as listWorktreesRaw,
 } from "./queries";
 import { clonePath, forceRemove, safeSymlink } from "./utils";
+import { generateHumanReadableName } from "./worktree-name";
 
 export interface WorktreeInfo {
   worktreePath: string;
@@ -46,7 +46,7 @@ export class WorktreeManager {
   }
 
   generateWorktreeName(): string {
-    return crypto.randomInt(1000, 10000).toString();
+    return generateHumanReadableName();
   }
 
   private getWorktreeBaseFolderPath(): string {


### PR DESCRIPTION
## Problem

Closes #1844

New worktrees were labeled with random 4-digit numbers (`crypto.randomInt(1000, 10000)`), which read like short SHA snippets and made it momentarily unclear which worktree you were on.

## Changes

- Added `packages/git/src/worktree-name.ts` with a small curated adjective-noun word list and a `generateHumanReadableName()` helper that returns names like `swift-otter-42`.
- `WorktreeManager.generateWorktreeName()` now delegates to this helper. All existing collision-handling paths and the `${name}${Date.now()}` defensive fallback are unchanged.
- Names stay lowercase, filesystem-safe (a-z, 0-9, `-`), and short (under 32 chars).
- The `~116k` combinations from 36 adjectives x 36 nouns x 90 suffix values keep collisions rare in practice.

## How did you test this?

- Added `packages/git/src/worktree-name.test.ts` covering the name shape, character safety, length bound, and rough uniqueness over 50 draws.
- `pnpm --filter @posthog/git test` -> 159 passed (8 files), including the 4 new ones.
- `pnpm --filter @posthog/git typecheck` -> clean.
- `biome check` on the touched files -> clean.

## Publish to changelog?

no