### PR TITLE
fix(code): fire completion notifications for cloud tasks

### DIFF
--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -1180,18 +1180,22 @@ export class SessionService {
             promptStartedAt: null,
             currentPromptId: null,
           });
-          // Mirror local sessions, where `notifyPromptComplete` fires when
-          // the JSON-RPC response carries `stopReason: "end_turn"`. Gate on
-          // `isLive` so hydration/gap-fill replays of historical logs don't
-          // re-fire notifications for turns that completed in past app runs,
-          // and skip when the queue still has messages — those will start a
-          // new turn, matching the local `!hasQueuedMessages` check.
-          if (isLive && session.messageQueue.length === 0) {
-            notifyPromptComplete(
-              session.taskTitle,
-              "end_turn",
-              session.taskId,
-            );
+          // Mirror the local `stopReason: "end_turn"` path: notify on turn
+          // completion and bump task activity for sidebar ordering / unread
+          // badges. Gate on `isLive` so hydration/gap-fill replays of
+          // historical logs don't re-fire notifications or stamp activity
+          // for turns that completed in past app runs. Skip the notification
+          // (but not the activity bump, matching local) when the queue still
+          // has messages — those will start a new turn.
+          if (isLive) {
+            if (session.messageQueue.length === 0) {
+              notifyPromptComplete(
+                session.taskTitle,
+                "end_turn",
+                session.taskId,
+              );
+            }
+            taskViewedApi.markActivity(session.taskId);
           }
         }
       }

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -1128,6 +1128,7 @@ export class SessionService {
   private updatePromptStateFromEvents(
     taskRunId: string,
     events: AcpMessage[],
+    isLive = false,
   ): void {
     for (const acpMsg of events) {
       const msg = acpMsg.message;
@@ -1179,6 +1180,19 @@ export class SessionService {
             promptStartedAt: null,
             currentPromptId: null,
           });
+          // Mirror local sessions, where `notifyPromptComplete` fires when
+          // the JSON-RPC response carries `stopReason: "end_turn"`. Gate on
+          // `isLive` so hydration/gap-fill replays of historical logs don't
+          // re-fire notifications for turns that completed in past app runs,
+          // and skip when the queue still has messages — those will start a
+          // new turn, matching the local `!hasQueuedMessages` check.
+          if (isLive && session.messageQueue.length === 0) {
+            notifyPromptComplete(
+              session.taskTitle,
+              "end_turn",
+              session.taskId,
+            );
+          }
         }
       }
       // Lifecycle handshake from the agent — flip status to "connected"
@@ -1264,7 +1278,7 @@ export class SessionService {
     } else {
       sessionStoreSetters.appendEvents(taskRunId, [acpMsg]);
     }
-    this.updatePromptStateFromEvents(taskRunId, [acpMsg]);
+    this.updatePromptStateFromEvents(taskRunId, [acpMsg], true);
 
     const msg = acpMsg.message;
 
@@ -3511,7 +3525,7 @@ export class SessionService {
           sessionStoreSetters.clearTailOptimisticItems(taskRunId);
         }
         sessionStoreSetters.appendEvents(taskRunId, newEvents, expectedCount);
-        this.updatePromptStateFromEvents(taskRunId, newEvents);
+        this.updatePromptStateFromEvents(taskRunId, newEvents, true);
       } else {
         this.reconcileCloudLogGap({
           taskId: update.taskId,

--- a/apps/code/src/renderer/features/sessions/service/service.ts
+++ b/apps/code/src/renderer/features/sessions/service/service.ts
@@ -1128,7 +1128,7 @@ export class SessionService {
   private updatePromptStateFromEvents(
     taskRunId: string,
     events: AcpMessage[],
-    isLive = false,
+    { isLive = false }: { isLive?: boolean } = {},
   ): void {
     for (const acpMsg of events) {
       const msg = acpMsg.message;
@@ -1180,14 +1180,8 @@ export class SessionService {
             promptStartedAt: null,
             currentPromptId: null,
           });
-          // Mirror the local `stopReason: "end_turn"` path: notify on turn
-          // completion and bump task activity for sidebar ordering / unread
-          // badges. Gate on `isLive` so hydration/gap-fill replays of
-          // historical logs don't re-fire notifications or stamp activity
-          // for turns that completed in past app runs. Skip the notification
-          // (but not the activity bump, matching local) when the queue still
-          // has messages — those will start a new turn.
           if (isLive) {
+            // Queued messages will start a new turn — suppress the "done" notification in that case.
             if (session.messageQueue.length === 0) {
               notifyPromptComplete(
                 session.taskTitle,
@@ -1282,7 +1276,7 @@ export class SessionService {
     } else {
       sessionStoreSetters.appendEvents(taskRunId, [acpMsg]);
     }
-    this.updatePromptStateFromEvents(taskRunId, [acpMsg], true);
+    this.updatePromptStateFromEvents(taskRunId, [acpMsg], { isLive: true });
 
     const msg = acpMsg.message;
 
@@ -3529,7 +3523,9 @@ export class SessionService {
           sessionStoreSetters.clearTailOptimisticItems(taskRunId);
         }
         sessionStoreSetters.appendEvents(taskRunId, newEvents, expectedCount);
-        this.updatePromptStateFromEvents(taskRunId, newEvents, true);
+        this.updatePromptStateFromEvents(taskRunId, newEvents, {
+          isLive: true,
+        });
       } else {
         this.reconcileCloudLogGap({
           taskId: update.taskId,


### PR DESCRIPTION
## Problem

Cloud tasks never fired completion notifications (desktop notification, dock badge, completion sound) when a turn finished. Local sessions worked because they listen for the JSON-RPC `stopReason: "end_turn"` response in `handleSessionEvent` and call `notifyPromptComplete` from there. Cloud sessions never see that response — their canonical "turn done" signal is the `_posthog/turn_complete` event, and the cloud branch of `updatePromptStateFromEvents` was clearing `isPromptPending` on `turn_complete` but never calling `notifyPromptComplete` or `taskViewedApi.markActivity`.

Permission-request notifications already worked for cloud tasks (via `handleCloudPermissionRequest`), so the infrastructure was wired — completion just got missed.

## Changes

- Add an `isLive` parameter (default `false`) to `updatePromptStateFromEvents`.
- In the cloud `turn_complete` branch, when `isLive`:
  - Fire `notifyPromptComplete(taskTitle, "end_turn", taskId)` when the message queue is empty (mirrors the local `!hasQueuedMessages` gate — queued messages will start a new turn).
  - Call `taskViewedApi.markActivity(taskId)` unconditionally so sidebar ordering and unread badges stay consistent with local sessions.
- Pass `isLive: true` from the two live entry points: `handleSessionEvent` (local) and `handleCloudTaskUpdate` (cloud delta updates).
- Leave hydration (`hydrateCloudTaskSession`) and gap-fill (`reconcileCloudLogGap`) call sites on the default `false`, so replaying historical logs after app restart doesn't re-notify or re-stamp activity for turns that completed in past app runs.

## How did you test this?

- Typecheck (`pnpm --filter code typecheck`) — clean.
- Biome (`pnpm exec biome ci apps/code/src/renderer/features/sessions/service/service.ts`) — clean.
- Unit tests (`pnpm --filter code test`) — all 1436 non-environmental tests pass; the only failures are pre-existing `archive/service.integration.test.ts` cases that fail because the sandbox blocks unsigned `git commit`, unrelated to this change.
- Did NOT exercise the full Electron app end-to-end. Worth a manual smoke test before merging: run a cloud task to completion and confirm desktop notification, dock badge, completion sound, and sidebar activity bump all fire.

## Publish to changelog?

no