### PR TITLE
fix(agent): surface error for unsupported slash commands instead of hanging

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
@@ -1,0 +1,163 @@
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockQuery, type MockQuery } from "../../test/mocks/claude-sdk";
+import { Pushable } from "../../utils/streams";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("./mcp/tool-metadata", () => ({
+  fetchMcpToolMetadata: vi.fn().mockResolvedValue(undefined),
+  getConnectedMcpServerNames: vi.fn().mockReturnValue([]),
+  setMcpToolApprovalStates: vi.fn(),
+  isMcpToolReadOnly: vi.fn().mockReturnValue(false),
+  getMcpToolMetadata: vi.fn().mockReturnValue(undefined),
+  getMcpToolApprovalState: vi.fn().mockReturnValue(undefined),
+}));
+
+const { ClaudeAcpAgent } = await import("./claude-agent");
+type Agent = InstanceType<typeof ClaudeAcpAgent>;
+
+interface ClientMocks {
+  sessionUpdate: ReturnType<typeof vi.fn>;
+  extNotification: ReturnType<typeof vi.fn>;
+}
+
+function makeAgent(): { agent: Agent; client: ClientMocks } {
+  const client: ClientMocks = {
+    sessionUpdate: vi.fn().mockResolvedValue(undefined),
+    extNotification: vi.fn().mockResolvedValue(undefined),
+  };
+  const agent = new ClaudeAcpAgent(client as unknown as AgentSideConnection);
+  return { agent, client };
+}
+
+function installFakeSession(agent: Agent, sessionId: string): MockQuery {
+  const query = createMockQuery();
+  const input = new Pushable();
+  const abortController = new AbortController();
+
+  const session = {
+    query,
+    queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
+    input,
+    cancelled: false,
+    interruptReason: undefined,
+    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
+    permissionMode: "default" as const,
+    abortController,
+    accumulatedUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    },
+    configOptions: [],
+    promptRunning: false,
+    pendingMessages: new Map(),
+    nextPendingOrder: 0,
+    cwd: "/tmp/repo",
+    notificationHistory: [] as unknown[],
+    taskRunId: "run-1",
+    lastContextWindowSize: 200_000,
+    modelId: "claude-sonnet-4-6",
+  };
+
+  (agent as unknown as { session: typeof session }).session = session;
+  (agent as unknown as { sessionId: string }).sessionId = sessionId;
+
+  return query;
+}
+
+describe("ClaudeAcpAgent.prompt — unsupported slash command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits a clear error and ends the turn when SDK silently consumes an unsupported slash command", async () => {
+    const { agent, client } = makeAgent();
+    const query = installFakeSession(agent, "s-slash");
+
+    const promptPromise = agent.prompt({
+      sessionId: "s-slash",
+      prompt: [{ type: "text", text: "/plugin install slack" }],
+    });
+
+    // Let the prompt loop start awaiting the first SDK message.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Simulate the SDK going idle without echoing the user message back
+    // (the failure mode reported in #2158).
+    const idleMessage: SDKMessage = {
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    } as unknown as SDKMessage;
+    query._mockHelpers.sendMessage(idleMessage);
+    query._mockHelpers.complete();
+
+    const result = await promptPromise;
+
+    expect(result.stopReason).toBe("end_turn");
+
+    const errorChunk = client.sessionUpdate.mock.calls.find(
+      ([call]) =>
+        (call as { update?: { sessionUpdate?: string } }).update
+          ?.sessionUpdate === "agent_message_chunk",
+    );
+    expect(errorChunk).toBeDefined();
+    const errorText =
+      (
+        errorChunk?.[0] as {
+          update: { content: { text: string } };
+        }
+      ).update.content.text ?? "";
+    expect(errorText).toContain("/plugin");
+    expect(errorText.toLowerCase()).toContain("unsupported");
+  });
+
+  it("still skips a pre-prompt idle for non-slash-command prompts", async () => {
+    const { agent, client } = makeAgent();
+    const query = installFakeSession(agent, "s-regular");
+
+    const promptPromise = agent.prompt({
+      sessionId: "s-regular",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // First an unrelated idle (e.g. from a background task) before the prompt
+    // is replayed — should be skipped, not surfaced as an error.
+    query._mockHelpers.sendMessage({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    } as unknown as SDKMessage);
+
+    // Then the SDK is done with no further output. The existing loop exits via
+    // the "Session did not end in result" path.
+    query._mockHelpers.complete();
+
+    await expect(promptPromise).rejects.toThrow(
+      /Session did not end in result/,
+    );
+
+    // Most importantly: no agent_message_chunk with an "unsupported" error
+    // was emitted for the regular prompt.
+    const errorChunk = client.sessionUpdate.mock.calls.find(([call]) => {
+      const update = (
+        call as {
+          update?: { sessionUpdate?: string; content?: { text?: string } };
+        }
+      ).update;
+      return (
+        update?.sessionUpdate === "agent_message_chunk" &&
+        update?.content?.text?.toLowerCase().includes("unsupported")
+      );
+    });
+    expect(errorChunk).toBeUndefined();
+  });
+});

--- a/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
@@ -71,93 +71,83 @@ function installFakeSession(agent: Agent, sessionId: string): MockQuery {
   return query;
 }
 
-describe("ClaudeAcpAgent.prompt — unsupported slash command", () => {
+function findUnsupportedChunkText(
+  calls: ClientMocks["sessionUpdate"]["mock"]["calls"],
+): string | undefined {
+  const match = calls.find(([call]) => {
+    const update = (
+      call as {
+        update?: { sessionUpdate?: string; content?: { text?: string } };
+      }
+    ).update;
+    return (
+      update?.sessionUpdate === "agent_message_chunk" &&
+      update?.content?.text?.toLowerCase().includes("unsupported")
+    );
+  });
+  return (match?.[0] as { update: { content: { text: string } } } | undefined)
+    ?.update.content.text;
+}
+
+describe("ClaudeAcpAgent.prompt — early idle handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("emits a clear error and ends the turn when SDK silently consumes an unsupported slash command", async () => {
+  const cases = [
+    {
+      label: "unsupported slash command surfaces error and ends turn",
+      sessionId: "s-slash",
+      prompt: "/plugin install slack",
+      expectsUnsupportedChunk: true,
+      commandInMessage: "/plugin",
+    },
+    {
+      label: "non-slash prompt with early idle is silently skipped",
+      sessionId: "s-regular",
+      prompt: "hello",
+      expectsUnsupportedChunk: false,
+      commandInMessage: null,
+    },
+  ] as const;
+
+  it.each(cases)("$label", async (tc) => {
     const { agent, client } = makeAgent();
-    const query = installFakeSession(agent, "s-slash");
+    const query = installFakeSession(agent, tc.sessionId);
 
     const promptPromise = agent.prompt({
-      sessionId: "s-slash",
-      prompt: [{ type: "text", text: "/plugin install slack" }],
+      sessionId: tc.sessionId,
+      prompt: [{ type: "text", text: tc.prompt }],
     });
 
     // Let the prompt loop start awaiting the first SDK message.
     await new Promise((resolve) => setImmediate(resolve));
 
-    // Simulate the SDK going idle without echoing the user message back
-    // (the failure mode reported in #2158).
-    const idleMessage: SDKMessage = {
-      type: "system",
-      subtype: "session_state_changed",
-      state: "idle",
-    } as unknown as SDKMessage;
-    query._mockHelpers.sendMessage(idleMessage);
-    query._mockHelpers.complete();
-
-    const result = await promptPromise;
-
-    expect(result.stopReason).toBe("end_turn");
-
-    const errorChunk = client.sessionUpdate.mock.calls.find(
-      ([call]) =>
-        (call as { update?: { sessionUpdate?: string } }).update
-          ?.sessionUpdate === "agent_message_chunk",
-    );
-    expect(errorChunk).toBeDefined();
-    const errorText =
-      (
-        errorChunk?.[0] as {
-          update: { content: { text: string } };
-        }
-      ).update.content.text ?? "";
-    expect(errorText).toContain("/plugin");
-    expect(errorText.toLowerCase()).toContain("unsupported");
-  });
-
-  it("still skips a pre-prompt idle for non-slash-command prompts", async () => {
-    const { agent, client } = makeAgent();
-    const query = installFakeSession(agent, "s-regular");
-
-    const promptPromise = agent.prompt({
-      sessionId: "s-regular",
-      prompt: [{ type: "text", text: "hello" }],
-    });
-
-    await new Promise((resolve) => setImmediate(resolve));
-
-    // First an unrelated idle (e.g. from a background task) before the prompt
-    // is replayed — should be skipped, not surfaced as an error.
     query._mockHelpers.sendMessage({
       type: "system",
       subtype: "session_state_changed",
       state: "idle",
     } as unknown as SDKMessage);
-
-    // Then the SDK is done with no further output. The existing loop exits via
-    // the "Session did not end in result" path.
     query._mockHelpers.complete();
 
-    await expect(promptPromise).rejects.toThrow(
-      /Session did not end in result/,
-    );
+    if (tc.expectsUnsupportedChunk) {
+      const result = await promptPromise;
+      expect(result.stopReason).toBe("end_turn");
 
-    // Most importantly: no agent_message_chunk with an "unsupported" error
-    // was emitted for the regular prompt.
-    const errorChunk = client.sessionUpdate.mock.calls.find(([call]) => {
-      const update = (
-        call as {
-          update?: { sessionUpdate?: string; content?: { text?: string } };
-        }
-      ).update;
-      return (
-        update?.sessionUpdate === "agent_message_chunk" &&
-        update?.content?.text?.toLowerCase().includes("unsupported")
+      const text = findUnsupportedChunkText(client.sessionUpdate.mock.calls);
+      expect(text).toBeDefined();
+      if (tc.commandInMessage) {
+        expect(text).toContain(tc.commandInMessage);
+      }
+    } else {
+      // No unsupported chunk; loop falls through to the existing
+      // "Session did not end in result" failure path.
+      await expect(promptPromise).rejects.toThrow(
+        /Session did not end in result/,
       );
-    });
-    expect(errorChunk).toBeUndefined();
+      expect(
+        findUnsupportedChunkText(client.sessionUpdate.mock.calls),
+      ).toBeUndefined();
+    }
   });
 });

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -496,6 +496,28 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
               (message as Record<string, unknown>).state === "idle"
             ) {
               if (!promptReplayed) {
+                // The SDK consumed a slash command we do not handle locally
+                // and produced no output (e.g. /plugin in a non-interactive
+                // context). Without this branch we would loop forever waiting
+                // for an echo that never comes; surface a clear error instead.
+                if (commandMatch && !isLocalOnlyCommand) {
+                  const cmd = commandMatch[1];
+                  this.logger.warn(
+                    "Slash command produced no output; treating as unsupported",
+                    { sessionId: params.sessionId, command: cmd },
+                  );
+                  await this.client.sessionUpdate({
+                    sessionId: params.sessionId,
+                    update: {
+                      sessionUpdate: "agent_message_chunk",
+                      content: {
+                        type: "text",
+                        text: `Unsupported slash command: \`${cmd}\`. PostHog Code does not implement this command.`,
+                      },
+                    },
+                  });
+                  return { stopReason: "end_turn" };
+                }
                 this.logger.debug("Skipping idle state before prompt replay", {
                   sessionId: params.sessionId,
                 });

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -500,7 +500,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                 // and produced no output (e.g. /plugin in a non-interactive
                 // context). Without this branch we would loop forever waiting
                 // for an echo that never comes; surface a clear error instead.
-                if (commandMatch && !isLocalOnlyCommand) {
+                if (commandMatch) {
                   const cmd = commandMatch[1];
                   this.logger.warn(
                     "Slash command produced no output; treating as unsupported",


### PR DESCRIPTION
Closes #2158

## Summary

- When the user submits a Claude Code slash command that PostHog Code does not implement (e.g. `/plugin install slack`), the SDK consumes the input but emits no echo or `local_command_output`. The prompt loop in `ClaudeAcpAgent.prompt` then sits on the first `session_state_changed → idle` notification with `promptReplayed` still false, breaks out of the switch, and goes back to `query.next()` forever. The chat shows "Discombobulating…" indefinitely with no way to recover.
- This change detects the case specifically: when an idle arrives before any prompt replay AND the original user input was a slash command we did not handle locally, emit a clear agent message and return `end_turn` so the renderer can clear its spinner.
- Regular prompts keep the existing skip behavior, so background idles (the original purpose of the skip) do not get misclassified as failures.

## Behavior

| Input | Old behavior | New behavior |
|---|---|---|
| `/context`, `/heapdump`, `/extra-usage` (local-only commands) | Works (`isLocalOnlyCommand`, `promptReplayed=true`) | Unchanged |
| `/plugin install slack` and other SDK commands that silently consume | Loop hangs forever, "Discombobulating…" | Emits `agent_message_chunk` with `"Unsupported slash command: \`/plugin\`. PostHog Code does not implement this command."` and returns `end_turn` |
| Regular prompt where an unrelated background `idle` arrives before replay | Skipped, waits for prompt replay | Unchanged |

## Test plan

- [x] `pnpm --filter @posthog/agent test src/adapters/claude/claude-agent.slash-command.test.ts` — 2 new tests:
  - Slash command + early `idle` → emits the unsupported-command chunk and returns `end_turn`.
  - Regular prompt + unrelated early `idle` → does NOT emit the chunk; falls through to the existing `Session did not end in result` path.
- [x] `pnpm --filter @posthog/agent test` — all 446 tests pass, including the existing `claude-agent.refresh.test.ts`.
- [x] `pnpm --filter @posthog/agent typecheck` and `biome check` clean on changed files.
- [ ] Manual: open a new task in PostHog Code, type `/plugin install slack`, submit. The chat should show the "Unsupported slash command" message and stay responsive instead of spinning.

## Notes

- The detection reuses the existing `commandMatch` regex (`/^(\/\S+)/`) that the function already computes at line 350, so the diff is small and the matching rules stay consistent with the `LOCAL_ONLY_COMMANDS` check.
- The error is emitted as a regular `agent_message_chunk` (the same channel local-only commands use to forward their results), so it renders inline in the conversation rather than as a toast or error banner — matching the reporter's "surface a clear error in the chat" expectation.
- This does not enumerate which slash commands PostHog Code supports vs not (that depends on the SDK's `supportedCommands()` and on what each command needs at runtime). It just catches the "SDK swallowed it and produced nothing" failure mode, which is the actual user-visible bug.