### PR TITLE
fix(sidebar): show PR state on cloud task icons, stop constant pulse

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/items/TaskIcon.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/TaskIcon.tsx
@@ -104,7 +104,23 @@ function CloudStatusIcon({
   const link = meta && threadUrl ? threadUrl : undefined;
   const ariaLabel = link ? `Open ${sourceLabel} thread` : undefined;
 
-  if (taskRunStatus === "queued" || taskRunStatus === "in_progress") {
+  if (taskRunStatus === "queued") {
+    return (
+      <Tooltip
+        content={
+          link ? `Open ${sourceLabel} thread` : `${sourceLabel} (queued)`
+        }
+        side="right"
+      >
+        {renderIconSpan({
+          icon: <Icon size={size} className="ph-pulse" />,
+          link,
+          ariaLabel,
+        })}
+      </Tooltip>
+    );
+  }
+  if (taskRunStatus === "in_progress") {
     return (
       <Tooltip
         content={
@@ -113,7 +129,7 @@ function CloudStatusIcon({
         side="right"
       >
         {renderIconSpan({
-          icon: <Icon size={size} className="ph-pulse" />,
+          icon: <Icon size={size} weight="fill" color="var(--accent-11)" />,
           link,
           ariaLabel,
         })}
@@ -288,16 +304,6 @@ export function TaskIcon({
   if (isGenerating) {
     return <DotsCircleSpinner size={size} className="text-accent-11" />;
   }
-  if (isCloudTask) {
-    return (
-      <CloudStatusIcon
-        taskRunStatus={taskRunStatus}
-        originProduct={originProduct}
-        threadUrl={slackThreadUrl}
-        size={size}
-      />
-    );
-  }
   if (isSuspended) {
     return (
       <Tooltip content="Suspended" side="right">
@@ -319,6 +325,16 @@ export function TaskIcon({
   }
   if (isPinned) {
     return <PushPin size={size} color="var(--accent-11)" />;
+  }
+  if (isCloudTask) {
+    return (
+      <CloudStatusIcon
+        taskRunStatus={taskRunStatus}
+        originProduct={originProduct}
+        threadUrl={slackThreadUrl}
+        size={size}
+      />
+    );
   }
   if (originProductMeta) {
     const { Icon, label } = originProductMeta;


### PR DESCRIPTION
## Problem

The `ph-pulse` animation ran for the whole `in_progress` window, so every active cloud task looked permanently busy. And the `isCloudTask` short-circuit in `TaskIcon` hid PR, diff, suspended, unread, and pinned state on non-terminal cloud tasks, so a cloud task with an open PR did not get the green PR icon a local task would.

## Changes

- Pulse only on `queued`. `in_progress` renders as a steady filled accent icon.
- Drop the early `isCloudTask` return so PR/diff/suspended/unread/pinned state takes precedence over the cloud icon.
- Cloud tasks with a `cloudPrUrl` now show the same green/purple `GitPullRequest`/`GitMerge` icon as local tasks (`hasDiff` amber branch still requires a local worktree).

## How did you test this?

`pnpm --filter code typecheck` and `pnpm lint` pass. I did not run the desktop app, so the new icons are not visually verified.

## Publish to changelog?

no