### PR TITLE
feat(code): show Draft badge on New task when input is unsubmitted

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/items/HomeItem.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/items/HomeItem.tsx
@@ -2,6 +2,8 @@ import { Tooltip } from "@components/ui/Tooltip";
 import { EnvelopeSimple, Plus } from "@phosphor-icons/react";
 import { Badge, type ButtonProps } from "@posthog/quill";
 import { SHORTCUTS } from "@renderer/constants/keyboard-shortcuts";
+import { useDraftStore } from "@renderer/features/message-editor/stores/draftStore";
+import { isContentEmpty } from "@renderer/features/message-editor/utils/content";
 import { SidebarItem } from "../SidebarItem";
 import { SidebarKbdHint } from "./SidebarKbdHint";
 
@@ -12,6 +14,9 @@ interface NewTaskItemProps {
 }
 
 export function NewTaskItem({ isActive, onClick }: NewTaskItemProps) {
+  const hasDraft = useDraftStore(
+    (s) => !isContentEmpty(s.drafts["task-input"]),
+  );
   return (
     <SidebarItem
       depth={0}
@@ -19,7 +24,16 @@ export function NewTaskItem({ isActive, onClick }: NewTaskItemProps) {
       label="New task"
       isActive={isActive}
       onClick={onClick}
-      endContent={<SidebarKbdHint keys={SHORTCUTS.NEW_TASK} />}
+      endContent={
+        <>
+          {hasDraft ? (
+            <Badge variant="default" title="You have unsubmitted changes">
+              Draft
+            </Badge>
+          ) : null}
+          <SidebarKbdHint keys={SHORTCUTS.NEW_TASK} />
+        </>
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary
- Adds a small **Draft** badge on the "New task" sidebar item when the user has typed into the new-task input but not submitted it
- Reuses the existing persisted draft state (`useDraftStore` keyed on `"task-input"`) — no new state machinery; the badge automatically disappears on submit because `clearDraft` already runs in the submit flow

<img width="1436" height="766" alt="Screenshot 2026-05-25 at 12 28 34" src="https://github.com/user-attachments/assets/a1e3fd82-1d52-4252-9843-0d41b76d790f" />

## Test plan
- [ ] Open the app — "New task" shows no badge
- [ ] Click "New task", type something into the editor, then navigate away (e.g. click a task or the Inbox) — "New task" now shows a **Draft** badge
- [ ] Reopen "New task" — the draft text is still in the editor, badge stays visible
- [ ] Submit the task — badge disappears, draft cleared
- [ ] Clear the editor manually (delete all text) — badge disappears
- [ ] Restart the app with a draft present — badge re-appears after the draft store hydrates from `electronStorage`