### PR TITLE
feat: Render PostHog URLs as rich preview chips

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -1365,7 +1365,9 @@ export class PostHogAPIClient {
     throw new Error("No team found for user");
   }
 
-  async getDefaultProjectId(): Promise<number> {
+  // Public alias for the private getTeamId(), used when resolving PostHog
+  // resource URLs. Not async — it just forwards the already-Promise result.
+  getDefaultProjectId(): Promise<number> {
     return this.getTeamId();
   }
 
@@ -6153,11 +6155,18 @@ export class PostHogAPIClient {
     );
   }
 
-  async getFeatureFlag(
+  /**
+   * Fetch a single PostHog resource by id from a project-scoped REST endpoint
+   * (`/api/projects/{projectId}/{resourcePath}/{resourceId}/`) and return its
+   * parsed JSON, or null on a non-ok response. Shared by the by-id resource
+   * getters below so the fetch/error/JSON boilerplate lives in one place.
+   */
+  private async fetchProjectResourceById(
+    resourcePath: string,
     projectId: string,
-    flagId: string,
-  ): Promise<{ name: string; key: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/feature_flags/${encodeURIComponent(flagId)}/`;
+    resourceId: string,
+  ): Promise<Record<string, unknown> | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/${resourcePath}/${encodeURIComponent(resourceId)}/`;
     const url = new URL(`${this.api.baseUrl}${urlPath}`);
     const response = await this.api.fetcher.fetch({
       method: "get",
@@ -6165,168 +6174,153 @@ export class PostHogAPIClient {
       path: urlPath,
     });
     if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string; key?: string };
-    return { name: data.name ?? "", key: data.key ?? "" };
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  async getFeatureFlag(
+    projectId: string,
+    flagId: string,
+  ): Promise<{ name: string; key: string } | null> {
+    const data = await this.fetchProjectResourceById(
+      "feature_flags",
+      projectId,
+      flagId,
+    );
+    if (!data) return null;
+    return {
+      name: (data.name as string) ?? "",
+      key: (data.key as string) ?? "",
+    };
   }
 
   async getExperiment(
     projectId: string,
     experimentId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/experiments/${encodeURIComponent(experimentId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "experiments",
+      projectId,
+      experimentId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getInsight(
     projectId: string,
     insightId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/insights/${encodeURIComponent(insightId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "insights",
+      projectId,
+      insightId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getDashboard(
     projectId: string,
     dashboardId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/dashboards/${encodeURIComponent(dashboardId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "dashboards",
+      projectId,
+      dashboardId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getErrorTrackingGroup(
     projectId: string,
     groupId: string,
   ): Promise<{ title: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/error_tracking/${encodeURIComponent(groupId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { title?: string };
-    return { title: data.title ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "error_tracking",
+      projectId,
+      groupId,
+    );
+    if (!data) return null;
+    return { title: (data.title as string) ?? "" };
   }
 
   async getRecording(
     projectId: string,
     recordingId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/session_recordings/${encodeURIComponent(recordingId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "session_recordings",
+      projectId,
+      recordingId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getSurvey(
     projectId: string,
     surveyId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/surveys/${encodeURIComponent(surveyId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "surveys",
+      projectId,
+      surveyId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getNotebook(
     projectId: string,
     notebookId: string,
   ): Promise<{ title: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/notebooks/${encodeURIComponent(notebookId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { title?: string };
-    return { title: data.title ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "notebooks",
+      projectId,
+      notebookId,
+    );
+    if (!data) return null;
+    return { title: (data.title as string) ?? "" };
   }
 
   async getCohort(
     projectId: string,
     cohortId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/cohorts/${encodeURIComponent(cohortId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "cohorts",
+      projectId,
+      cohortId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getAction(
     projectId: string,
     actionId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/actions/${encodeURIComponent(actionId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "actions",
+      projectId,
+      actionId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getEarlyAccessFeature(
     projectId: string,
     featureId: string,
   ): Promise<{ name: string } | null> {
-    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/early_access_feature/${encodeURIComponent(featureId)}/`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as { name?: string };
-    return { name: data.name ?? "" };
+    const data = await this.fetchProjectResourceById(
+      "early_access_feature",
+      projectId,
+      featureId,
+    );
+    if (!data) return null;
+    return { name: (data.name as string) ?? "" };
   }
 
   async getPerson(

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -1365,6 +1365,10 @@ export class PostHogAPIClient {
     throw new Error("No team found for user");
   }
 
+  async getDefaultProjectId(): Promise<number> {
+    return this.getTeamId();
+  }
+
   async getCurrentUser() {
     const data = await this.api.get("/api/users/{uuid}/", {
       path: { uuid: "@me" },
@@ -6147,5 +6151,225 @@ export class PostHogAPIClient {
       { kpi, daily, perAgent, byModel, toolErrors },
       nameById,
     );
+  }
+
+  async getFeatureFlag(
+    projectId: string,
+    flagId: string,
+  ): Promise<{ name: string; key: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/feature_flags/${encodeURIComponent(flagId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string; key?: string };
+    return { name: data.name ?? "", key: data.key ?? "" };
+  }
+
+  async getExperiment(
+    projectId: string,
+    experimentId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/experiments/${encodeURIComponent(experimentId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getInsight(
+    projectId: string,
+    insightId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/insights/${encodeURIComponent(insightId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getDashboard(
+    projectId: string,
+    dashboardId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/dashboards/${encodeURIComponent(dashboardId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getErrorTrackingGroup(
+    projectId: string,
+    groupId: string,
+  ): Promise<{ title: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/error_tracking/${encodeURIComponent(groupId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { title?: string };
+    return { title: data.title ?? "" };
+  }
+
+  async getRecording(
+    projectId: string,
+    recordingId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/session_recordings/${encodeURIComponent(recordingId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getSurvey(
+    projectId: string,
+    surveyId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/surveys/${encodeURIComponent(surveyId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getNotebook(
+    projectId: string,
+    notebookId: string,
+  ): Promise<{ title: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/notebooks/${encodeURIComponent(notebookId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { title?: string };
+    return { title: data.title ?? "" };
+  }
+
+  async getCohort(
+    projectId: string,
+    cohortId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/cohorts/${encodeURIComponent(cohortId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getAction(
+    projectId: string,
+    actionId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/actions/${encodeURIComponent(actionId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getEarlyAccessFeature(
+    projectId: string,
+    featureId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/early_access_feature/${encodeURIComponent(featureId)}/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { name?: string };
+    return { name: data.name ?? "" };
+  }
+
+  async getPerson(
+    projectId: string,
+    distinctId: string,
+  ): Promise<{ name: string } | null> {
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/persons/?distinct_id=${encodeURIComponent(distinctId)}`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as {
+      results?: Array<{ properties?: { email?: string; name?: string } }>;
+    };
+    const person = data.results?.[0];
+    return {
+      name: person?.properties?.email || person?.properties?.name || "",
+    };
+  }
+
+  async getGroup(
+    projectId: string,
+    groupCompoundId: string,
+  ): Promise<{ name: string } | null> {
+    const slashIndex = groupCompoundId.indexOf("/");
+    if (slashIndex === -1) return null;
+    const typeIndex = groupCompoundId.slice(0, slashIndex);
+    const groupKey = groupCompoundId.slice(slashIndex + 1);
+    const urlPath = `/api/projects/${encodeURIComponent(projectId)}/groups/?group_type_index=${encodeURIComponent(typeIndex)}&group_key=${encodeURIComponent(groupKey)}`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as {
+      results?: Array<{ group_properties?: { name?: string } }>;
+    };
+    const group = data.results?.[0];
+    return { name: group?.group_properties?.name || "" };
   }
 }

--- a/packages/core/src/message-editor/content.test.ts
+++ b/packages/core/src/message-editor/content.test.ts
@@ -305,3 +305,51 @@ describe("xmlToContent", () => {
     ]);
   });
 });
+
+describe("contentToXml — PostHog chip labels", () => {
+  it("strips the transient '- Loading...' suffix so it is never persisted", () => {
+    const content: EditorContent = {
+      segments: [
+        {
+          type: "chip",
+          chip: {
+            type: "feature_flag",
+            id: "https://us.posthog.com/project/1/feature_flags/42",
+            // Message submitted before resolvePostHogRefChip finished.
+            label: "Feature Flag #42 - Loading...",
+          },
+        },
+      ],
+    };
+
+    const xml = contentToXml(content);
+    expect(xml).not.toContain("Loading...");
+    expect(xml).toContain('label="Feature Flag #42"');
+
+    // Re-hydrating from history shows the clean base label, not "Loading...".
+    const segment = xmlToContent(xml).segments[0];
+    expect(segment.type).toBe("chip");
+    if (segment.type === "chip") {
+      expect(segment.chip.label).toBe("Feature Flag #42");
+    }
+  });
+
+  it("persists a fully resolved label verbatim", () => {
+    const content: EditorContent = {
+      segments: [
+        {
+          type: "chip",
+          chip: {
+            type: "feature_flag",
+            id: "https://us.posthog.com/project/1/feature_flags/42",
+            label: "Feature Flag #42 - My cool flag",
+          },
+        },
+      ],
+    };
+
+    expect(contentToXml(content)).toContain(
+      'label="Feature Flag #42 - My cool flag"',
+    );
+  });
+});

--- a/packages/core/src/message-editor/content.ts
+++ b/packages/core/src/message-editor/content.ts
@@ -1,4 +1,5 @@
 import { escapeXmlAttr, type UploadableSkillSource } from "@posthog/shared";
+import { stripPlaceholderLabelSuffix } from "./posthogChip";
 import { parsePostHogUrl } from "./posthogUrl";
 import { isUploadableSkillSource, parseXmlAttrs } from "./skillTags";
 
@@ -97,7 +98,7 @@ export function contentToXml(content: EditorContent): string {
       case "early_access_feature":
       case "person":
       case "group":
-        return `<${chip.type} id="${escapedId}" label="${escapeXmlAttr(chip.label)}" />`;
+        return `<${chip.type} id="${escapedId}" label="${escapeXmlAttr(stripPlaceholderLabelSuffix(chip.label))}" />`;
       case "github_issue":
       case "github_pr": {
         const labelMatch = chip.label.match(/^#(\d+)(?:\s*-\s*(.*))?$/);

--- a/packages/core/src/message-editor/content.ts
+++ b/packages/core/src/message-editor/content.ts
@@ -1,4 +1,5 @@
 import { escapeXmlAttr, type UploadableSkillSource } from "@posthog/shared";
+import { parsePostHogUrl } from "./posthogUrl";
 import { isUploadableSkillSource, parseXmlAttrs } from "./skillTags";
 
 export interface MentionChip {
@@ -10,6 +11,16 @@ export interface MentionChip {
     | "experiment"
     | "insight"
     | "feature_flag"
+    | "dashboard"
+    | "recording"
+    | "error_tracking"
+    | "survey"
+    | "notebook"
+    | "cohort"
+    | "action"
+    | "early_access_feature"
+    | "person"
+    | "group"
     | "github_issue"
     | "github_pr";
   id: string;
@@ -74,11 +85,19 @@ export function contentToXml(content: EditorContent): string {
       case "error":
         return `<error id="${escapedId}" />`;
       case "experiment":
-        return `<experiment id="${escapedId}" />`;
       case "insight":
-        return `<insight id="${escapedId}" />`;
       case "feature_flag":
-        return `<feature_flag id="${escapedId}" />`;
+      case "dashboard":
+      case "recording":
+      case "error_tracking":
+      case "survey":
+      case "notebook":
+      case "cohort":
+      case "action":
+      case "early_access_feature":
+      case "person":
+      case "group":
+        return `<${chip.type} id="${escapedId}" label="${escapeXmlAttr(chip.label)}" />`;
       case "github_issue":
       case "github_pr": {
         const labelMatch = chip.label.match(/^#(\d+)(?:\s*-\s*(.*))?$/);
@@ -104,7 +123,7 @@ export function contentToXml(content: EditorContent): string {
 }
 
 const CHIP_TAG_REGEX =
-  /<(file|folder|skill|error|experiment|insight|feature_flag|github_issue|github_pr)\b([^>]*?)\s*\/>/g;
+  /<(file|folder|skill|error|experiment|insight|feature_flag|dashboard|recording|error_tracking|survey|notebook|cohort|action|early_access_feature|person|group|github_issue|github_pr)\b([^>]*?)\s*\/>/g;
 
 export function deriveFileLabel(filePath: string): string {
   const segments = filePath.split("/").filter(Boolean);
@@ -142,13 +161,28 @@ function chipFromTag(tag: string, rawAttrs: string): MentionChip | null {
         skillName: name,
       };
     }
-    case "error":
-    case "experiment":
-    case "insight":
-    case "feature_flag": {
+    case "error": {
       const id = attrs.id;
       if (!id) return null;
       return { type: tag, id, label: id };
+    }
+    case "experiment":
+    case "insight":
+    case "feature_flag":
+    case "dashboard":
+    case "recording":
+    case "error_tracking":
+    case "survey":
+    case "notebook":
+    case "cohort":
+    case "action":
+    case "early_access_feature":
+    case "person":
+    case "group": {
+      const id = attrs.id;
+      if (!id) return null;
+      const label = attrs.label || parsePostHogUrl(id)?.label || id;
+      return { type: tag, id, label };
     }
     case "github_issue":
     case "github_pr": {

--- a/packages/core/src/message-editor/posthogChip.ts
+++ b/packages/core/src/message-editor/posthogChip.ts
@@ -33,8 +33,28 @@ function formatDisplayId(resourceId: string, prefix: string): string {
   return `${prefix} ${displayId}`;
 }
 
+/**
+ * Suffix appended to a PostHog chip's label while its title is still being
+ * fetched. Kept as a shared constant so serialization can strip it (see
+ * stripPlaceholderLabelSuffix) and never persist "Loading..." into the XML.
+ */
+export const PLACEHOLDER_LABEL_SUFFIX = " - Loading...";
+
 export function buildPostHogPlaceholderLabel(parsed: ParsedPostHogUrl): string {
-  return `${formatDisplayId(parsed.resourceId, LABEL_PREFIXES[parsed.resourceType])} - Loading...`;
+  return `${formatDisplayId(parsed.resourceId, LABEL_PREFIXES[parsed.resourceType])}${PLACEHOLDER_LABEL_SUFFIX}`;
+}
+
+/**
+ * Strip the transient "- Loading..." suffix from a chip label. Used at
+ * serialization time so that a message submitted before resolvePostHogRefChip
+ * finishes persists the clean base label (e.g. "Feature Flag #42") rather than
+ * the placeholder — which would otherwise render "Loading..." forever when the
+ * message is re-hydrated from history.
+ */
+export function stripPlaceholderLabelSuffix(label: string): string {
+  return label.endsWith(PLACEHOLDER_LABEL_SUFFIX)
+    ? label.slice(0, -PLACEHOLDER_LABEL_SUFFIX.length)
+    : label;
 }
 
 export function buildResolvedLabel(

--- a/packages/core/src/message-editor/posthogChip.ts
+++ b/packages/core/src/message-editor/posthogChip.ts
@@ -1,0 +1,126 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import type { MentionChip } from "./content";
+import type { ParsedPostHogUrl, PostHogResourceType } from "./posthogUrl";
+
+export function posthogResourceToMentionChip(
+  parsed: ParsedPostHogUrl,
+): MentionChip {
+  return {
+    type: parsed.resourceType,
+    id: parsed.normalizedUrl,
+    label: parsed.label,
+  };
+}
+
+const LABEL_PREFIXES: Record<PostHogResourceType, string> = {
+  feature_flag: "Feature Flag",
+  experiment: "Experiment",
+  insight: "Insight",
+  dashboard: "Dashboard",
+  error_tracking: "Error",
+  recording: "Recording",
+  survey: "Survey",
+  notebook: "Notebook",
+  cohort: "Cohort",
+  action: "Action",
+  early_access_feature: "Early Access Feature",
+  person: "Person",
+  group: "Group",
+};
+
+function formatDisplayId(resourceId: string, prefix: string): string {
+  const displayId = /^\d+$/.test(resourceId) ? `#${resourceId}` : resourceId;
+  return `${prefix} ${displayId}`;
+}
+
+export function buildPostHogPlaceholderLabel(parsed: ParsedPostHogUrl): string {
+  return `${formatDisplayId(parsed.resourceId, LABEL_PREFIXES[parsed.resourceType])} - Loading...`;
+}
+
+export function buildResolvedLabel(
+  parsed: ParsedPostHogUrl,
+  title: string | null,
+): string {
+  const base = formatDisplayId(
+    parsed.resourceId,
+    LABEL_PREFIXES[parsed.resourceType],
+  );
+  return title ? `${base} - ${title}` : base;
+}
+
+async function resolveProjectId(client: PostHogAPIClient): Promise<string> {
+  return String(await client.getDefaultProjectId());
+}
+
+export async function fetchPostHogResourceTitle(
+  client: PostHogAPIClient,
+  parsed: ParsedPostHogUrl,
+): Promise<string | null> {
+  try {
+    const projectId = await resolveProjectId(client);
+    switch (parsed.resourceType) {
+      case "feature_flag": {
+        const flag = await client.getFeatureFlag(projectId, parsed.resourceId);
+        return flag?.name || flag?.key || null;
+      }
+      case "experiment": {
+        const exp = await client.getExperiment(projectId, parsed.resourceId);
+        return exp?.name || null;
+      }
+      case "insight": {
+        const insight = await client.getInsight(projectId, parsed.resourceId);
+        return insight?.name || null;
+      }
+      case "dashboard": {
+        const dash = await client.getDashboard(projectId, parsed.resourceId);
+        return dash?.name || null;
+      }
+      case "error_tracking": {
+        const group = await client.getErrorTrackingGroup(
+          projectId,
+          parsed.resourceId,
+        );
+        return group?.title || null;
+      }
+      case "recording": {
+        const rec = await client.getRecording(projectId, parsed.resourceId);
+        return rec?.name || null;
+      }
+      case "survey": {
+        const survey = await client.getSurvey(projectId, parsed.resourceId);
+        return survey?.name || null;
+      }
+      case "notebook": {
+        const nb = await client.getNotebook(projectId, parsed.resourceId);
+        return nb?.title || null;
+      }
+      case "cohort": {
+        const cohort = await client.getCohort(projectId, parsed.resourceId);
+        return cohort?.name || null;
+      }
+      case "action": {
+        const action = await client.getAction(projectId, parsed.resourceId);
+        return action?.name || null;
+      }
+      case "early_access_feature": {
+        const eaf = await client.getEarlyAccessFeature(
+          projectId,
+          parsed.resourceId,
+        );
+        return eaf?.name || null;
+      }
+      case "person": {
+        const person = await client.getPerson(projectId, parsed.resourceId);
+        return person?.name || null;
+      }
+      case "group": {
+        const group = await client.getGroup(projectId, parsed.resourceId);
+        return group?.name || null;
+      }
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/message-editor/posthogUrl.test.ts
+++ b/packages/core/src/message-editor/posthogUrl.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import { type ParsedPostHogUrl, parsePostHogUrl } from "./posthogUrl";
+
+describe("parsePostHogUrl", () => {
+  const accepts: Array<{
+    name: string;
+    input: string;
+    expected: ParsedPostHogUrl;
+  }> = [
+    // --- Long format: /project/{id}/... ---
+    {
+      name: "US cloud feature flag (long)",
+      input: "https://us.posthog.com/project/1/feature_flags/42",
+      expected: {
+        resourceType: "feature_flag",
+        projectId: "1",
+        resourceId: "42",
+        normalizedUrl: "https://us.posthog.com/project/1/feature_flags/42",
+        label: "Feature Flag #42",
+      },
+    },
+    {
+      name: "EU cloud experiment (long)",
+      input: "https://eu.posthog.com/project/99/experiments/7",
+      expected: {
+        resourceType: "experiment",
+        projectId: "99",
+        resourceId: "7",
+        normalizedUrl: "https://eu.posthog.com/project/99/experiments/7",
+        label: "Experiment #7",
+      },
+    },
+    {
+      name: "localhost insight with alphanumeric ID",
+      input: "http://localhost:8010/project/1/insights/abc123",
+      expected: {
+        resourceType: "insight",
+        projectId: "1",
+        resourceId: "abc123",
+        normalizedUrl: "http://localhost:8010/project/1/insights/abc123",
+        label: "Insight abc123",
+      },
+    },
+    {
+      name: "dashboard (long)",
+      input: "https://us.posthog.com/project/5/dashboard/10",
+      expected: {
+        resourceType: "dashboard",
+        projectId: "5",
+        resourceId: "10",
+        normalizedUrl: "https://us.posthog.com/project/5/dashboard/10",
+        label: "Dashboard #10",
+      },
+    },
+    {
+      name: "error tracking (long)",
+      input: "https://us.posthog.com/project/1/error_tracking/abc-def-123",
+      expected: {
+        resourceType: "error_tracking",
+        projectId: "1",
+        resourceId: "abc-def-123",
+        normalizedUrl:
+          "https://us.posthog.com/project/1/error_tracking/abc-def-123",
+        label: "Error abc-def-123",
+      },
+    },
+    {
+      name: "recording (replay, long)",
+      input: "https://eu.posthog.com/project/2/replay/019012ab-cd34-ef56",
+      expected: {
+        resourceType: "recording",
+        projectId: "2",
+        resourceId: "019012ab-cd34-ef56",
+        normalizedUrl:
+          "https://eu.posthog.com/project/2/replay/019012ab-cd34-ef56",
+        label: "Recording 019012ab-cd34-ef56",
+      },
+    },
+    {
+      name: "trailing slash is stripped",
+      input: "https://us.posthog.com/project/1/feature_flags/42/",
+      expected: {
+        resourceType: "feature_flag",
+        projectId: "1",
+        resourceId: "42",
+        normalizedUrl: "https://us.posthog.com/project/1/feature_flags/42",
+        label: "Feature Flag #42",
+      },
+    },
+    {
+      name: "query params are stripped",
+      input: "https://us.posthog.com/project/1/experiments/3?tab=results",
+      expected: {
+        resourceType: "experiment",
+        projectId: "1",
+        resourceId: "3",
+        normalizedUrl: "https://us.posthog.com/project/1/experiments/3",
+        label: "Experiment #3",
+      },
+    },
+    {
+      name: "fragment is stripped",
+      input: "https://us.posthog.com/project/1/dashboard/5#section",
+      expected: {
+        resourceType: "dashboard",
+        projectId: "1",
+        resourceId: "5",
+        normalizedUrl: "https://us.posthog.com/project/1/dashboard/5",
+        label: "Dashboard #5",
+      },
+    },
+    {
+      name: "surrounding whitespace",
+      input: "  https://us.posthog.com/project/1/feature_flags/42  \n",
+      expected: {
+        resourceType: "feature_flag",
+        projectId: "1",
+        resourceId: "42",
+        normalizedUrl: "https://us.posthog.com/project/1/feature_flags/42",
+        label: "Feature Flag #42",
+      },
+    },
+
+    // --- Short format (no /project/{id}/) ---
+    {
+      name: "short feature flag",
+      input: "https://us.posthog.com/feature_flags/619272",
+      expected: {
+        resourceType: "feature_flag",
+        projectId: "",
+        resourceId: "619272",
+        normalizedUrl: "https://us.posthog.com/feature_flags/619272",
+        label: "Feature Flag #619272",
+      },
+    },
+    {
+      name: "short experiment",
+      input: "https://us.posthog.com/experiments/373424",
+      expected: {
+        resourceType: "experiment",
+        projectId: "",
+        resourceId: "373424",
+        normalizedUrl: "https://us.posthog.com/experiments/373424",
+        label: "Experiment #373424",
+      },
+    },
+    {
+      name: "short insight (alphanumeric ID)",
+      input: "https://us.posthog.com/insights/KP8iqi6E",
+      expected: {
+        resourceType: "insight",
+        projectId: "",
+        resourceId: "KP8iqi6E",
+        normalizedUrl: "https://us.posthog.com/insights/KP8iqi6E",
+        label: "Insight KP8iqi6E",
+      },
+    },
+    {
+      name: "short dashboard",
+      input: "https://us.posthog.com/dashboard/944836",
+      expected: {
+        resourceType: "dashboard",
+        projectId: "",
+        resourceId: "944836",
+        normalizedUrl: "https://us.posthog.com/dashboard/944836",
+        label: "Dashboard #944836",
+      },
+    },
+
+    // --- New resource types ---
+    {
+      name: "survey (short, UUID)",
+      input:
+        "https://us.posthog.com/surveys/019d1c79-170c-0000-b8dc-6880403ecae9",
+      expected: {
+        resourceType: "survey",
+        projectId: "",
+        resourceId: "019d1c79-170c-0000-b8dc-6880403ecae9",
+        normalizedUrl:
+          "https://us.posthog.com/surveys/019d1c79-170c-0000-b8dc-6880403ecae9",
+        label: "Survey 019d1c79-170c-0000-b8dc-6880403ecae9",
+      },
+    },
+    {
+      name: "notebook (short)",
+      input: "https://us.posthog.com/notebooks/wkGd",
+      expected: {
+        resourceType: "notebook",
+        projectId: "",
+        resourceId: "wkGd",
+        normalizedUrl: "https://us.posthog.com/notebooks/wkGd",
+        label: "Notebook wkGd",
+      },
+    },
+    {
+      name: "cohort (long)",
+      input: "https://us.posthog.com/project/1/cohorts/55",
+      expected: {
+        resourceType: "cohort",
+        projectId: "1",
+        resourceId: "55",
+        normalizedUrl: "https://us.posthog.com/project/1/cohorts/55",
+        label: "Cohort #55",
+      },
+    },
+    {
+      name: "action (nested path, long)",
+      input: "https://us.posthog.com/project/1/data-management/actions/99",
+      expected: {
+        resourceType: "action",
+        projectId: "1",
+        resourceId: "99",
+        normalizedUrl:
+          "https://us.posthog.com/project/1/data-management/actions/99",
+        label: "Action #99",
+      },
+    },
+    {
+      name: "action (nested path, short)",
+      input: "https://us.posthog.com/data-management/actions/99",
+      expected: {
+        resourceType: "action",
+        projectId: "",
+        resourceId: "99",
+        normalizedUrl: "https://us.posthog.com/data-management/actions/99",
+        label: "Action #99",
+      },
+    },
+    {
+      name: "early access feature (long)",
+      input:
+        "https://us.posthog.com/project/1/early_access_features/abc-123-def",
+      expected: {
+        resourceType: "early_access_feature",
+        projectId: "1",
+        resourceId: "abc-123-def",
+        normalizedUrl:
+          "https://us.posthog.com/project/1/early_access_features/abc-123-def",
+        label: "Early Access Feature abc-123-def",
+      },
+    },
+    {
+      name: "survey (long)",
+      input:
+        "https://us.posthog.com/project/1/surveys/019d1c79-170c-0000-b8dc-6880403ecae9",
+      expected: {
+        resourceType: "survey",
+        projectId: "1",
+        resourceId: "019d1c79-170c-0000-b8dc-6880403ecae9",
+        normalizedUrl:
+          "https://us.posthog.com/project/1/surveys/019d1c79-170c-0000-b8dc-6880403ecae9",
+        label: "Survey 019d1c79-170c-0000-b8dc-6880403ecae9",
+      },
+    },
+
+    // --- Person ---
+    {
+      name: "person (short)",
+      input: "https://us.posthog.com/persons/user_abc123",
+      expected: {
+        resourceType: "person",
+        projectId: "",
+        resourceId: "user_abc123",
+        normalizedUrl: "https://us.posthog.com/persons/user_abc123",
+        label: "Person user_abc123",
+      },
+    },
+    {
+      name: "person (long)",
+      input: "https://us.posthog.com/project/1/persons/user_abc123",
+      expected: {
+        resourceType: "person",
+        projectId: "1",
+        resourceId: "user_abc123",
+        normalizedUrl: "https://us.posthog.com/project/1/persons/user_abc123",
+        label: "Person user_abc123",
+      },
+    },
+
+    // --- Group (compound ID: type-index/group-key) ---
+    {
+      name: "group (short)",
+      input: "https://us.posthog.com/groups/0/my-company-name",
+      expected: {
+        resourceType: "group",
+        projectId: "",
+        resourceId: "0/my-company-name",
+        normalizedUrl: "https://us.posthog.com/groups/0/my-company-name",
+        label: "Group 0/my-company-name",
+      },
+    },
+    {
+      name: "group (long)",
+      input: "https://us.posthog.com/project/1/groups/0/my-company-name",
+      expected: {
+        resourceType: "group",
+        projectId: "1",
+        resourceId: "0/my-company-name",
+        normalizedUrl:
+          "https://us.posthog.com/project/1/groups/0/my-company-name",
+        label: "Group 0/my-company-name",
+      },
+    },
+    {
+      name: "group with numeric key",
+      input: "https://eu.posthog.com/groups/1/12345",
+      expected: {
+        resourceType: "group",
+        projectId: "",
+        resourceId: "1/12345",
+        normalizedUrl: "https://eu.posthog.com/groups/1/12345",
+        label: "Group 1/12345",
+      },
+    },
+  ];
+
+  it.each(accepts)("accepts $name", ({ input, expected }) => {
+    expect(parsePostHogUrl(input)).toEqual(expected);
+  });
+
+  const rejects: Array<{ name: string; input: string }> = [
+    {
+      name: "non-PostHog host",
+      input: "https://example.com/project/1/feature_flags/42",
+    },
+    { name: "github URL", input: "https://github.com/PostHog/code/issues/1" },
+    { name: "non-URL text", input: "not a url" },
+    { name: "empty string", input: "" },
+    {
+      name: "search/filter URL without resource ID",
+      input: "https://us.posthog.com/project/1/feature_flags?search=my-flag",
+    },
+    {
+      name: "org-level billing URL",
+      input: "https://us.posthog.com/organization/billing/overview",
+    },
+    {
+      name: "feature flags index without ID (long)",
+      input: "https://us.posthog.com/project/1/feature_flags",
+    },
+    {
+      name: "unknown resource type",
+      input: "https://us.posthog.com/project/1/unknown_thing/42",
+    },
+    {
+      name: "bare host with no path",
+      input: "https://us.posthog.com/",
+    },
+    {
+      name: "single segment (not a resource detail)",
+      input: "https://us.posthog.com/feature_flags",
+    },
+    {
+      name: "groups with only type index (missing group key)",
+      input: "https://us.posthog.com/groups/0",
+    },
+  ];
+
+  it.each(rejects)("rejects $name", ({ input }) => {
+    expect(parsePostHogUrl(input)).toBeNull();
+  });
+});

--- a/packages/core/src/message-editor/posthogUrl.ts
+++ b/packages/core/src/message-editor/posthogUrl.ts
@@ -1,0 +1,132 @@
+export type PostHogResourceType =
+  | "feature_flag"
+  | "experiment"
+  | "insight"
+  | "dashboard"
+  | "error_tracking"
+  | "recording"
+  | "survey"
+  | "notebook"
+  | "cohort"
+  | "action"
+  | "early_access_feature"
+  | "person"
+  | "group";
+
+export interface ParsedPostHogUrl {
+  resourceType: PostHogResourceType;
+  projectId: string;
+  resourceId: string;
+  normalizedUrl: string;
+  label: string;
+}
+
+const POSTHOG_HOSTS = new Set([
+  "us.posthog.com",
+  "eu.posthog.com",
+  "localhost:8010",
+]);
+
+const RESOURCE_PATTERNS: Array<{
+  pathSegments: string[];
+  type: PostHogResourceType;
+  labelPrefix: string;
+  idSegmentCount?: number;
+}> = [
+  {
+    pathSegments: ["feature_flags"],
+    type: "feature_flag",
+    labelPrefix: "Feature Flag",
+  },
+  {
+    pathSegments: ["experiments"],
+    type: "experiment",
+    labelPrefix: "Experiment",
+  },
+  { pathSegments: ["insights"], type: "insight", labelPrefix: "Insight" },
+  { pathSegments: ["dashboard"], type: "dashboard", labelPrefix: "Dashboard" },
+  {
+    pathSegments: ["error_tracking"],
+    type: "error_tracking",
+    labelPrefix: "Error",
+  },
+  { pathSegments: ["replay"], type: "recording", labelPrefix: "Recording" },
+  { pathSegments: ["surveys"], type: "survey", labelPrefix: "Survey" },
+  { pathSegments: ["notebooks"], type: "notebook", labelPrefix: "Notebook" },
+  { pathSegments: ["cohorts"], type: "cohort", labelPrefix: "Cohort" },
+  {
+    pathSegments: ["data-management", "actions"],
+    type: "action",
+    labelPrefix: "Action",
+  },
+  {
+    pathSegments: ["early_access_features"],
+    type: "early_access_feature",
+    labelPrefix: "Early Access Feature",
+  },
+  { pathSegments: ["persons"], type: "person", labelPrefix: "Person" },
+  {
+    pathSegments: ["groups"],
+    type: "group",
+    labelPrefix: "Group",
+    idSegmentCount: 2,
+  },
+];
+
+export function parsePostHogUrl(text: string): ParsedPostHogUrl | null {
+  const trimmed = text.trim();
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!POSTHOG_HOSTS.has(url.host)) return null;
+
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  let projectId = "";
+  let resourceSegments: string[];
+
+  // Long format: /project/{projectId}/{resourcePath}/{resourceId}
+  if (segments.length >= 2 && segments[0] === "project") {
+    projectId = segments[1];
+    resourceSegments = segments.slice(2);
+  } else {
+    // Short format: /{resourcePath}/{resourceId}
+    resourceSegments = segments;
+  }
+
+  if (resourceSegments.length < 2) return null;
+
+  const match = RESOURCE_PATTERNS.find((p) => {
+    const idCount = p.idSegmentCount ?? 1;
+    const expectedLength = p.pathSegments.length + idCount;
+    if (resourceSegments.length !== expectedLength) return false;
+    return p.pathSegments.every((seg, i) => seg === resourceSegments[i]);
+  });
+
+  if (!match) return null;
+
+  const idSegments = resourceSegments.slice(match.pathSegments.length);
+  const resourceId = idSegments.join("/");
+
+  if (!resourceId) return null;
+
+  const projectPrefix = projectId ? `/project/${projectId}` : "";
+  const resourcePath = match.pathSegments.join("/");
+  const normalizedUrl = `${url.protocol}//${url.host}${projectPrefix}/${resourcePath}/${resourceId}`;
+
+  const displayId = /^\d+$/.test(resourceId) ? `#${resourceId}` : resourceId;
+  const label = `${match.labelPrefix} ${displayId}`;
+
+  return {
+    resourceType: match.type,
+    projectId,
+    resourceId,
+    normalizedUrl,
+    label,
+  };
+}

--- a/packages/core/src/message-editor/posthogUrl.ts
+++ b/packages/core/src/message-editor/posthogUrl.ts
@@ -1,17 +1,35 @@
-export type PostHogResourceType =
-  | "feature_flag"
-  | "experiment"
-  | "insight"
-  | "dashboard"
-  | "error_tracking"
-  | "recording"
-  | "survey"
-  | "notebook"
-  | "cohort"
-  | "action"
-  | "early_access_feature"
-  | "person"
-  | "group";
+// Single source of truth for PostHog resource chip types. The union type is
+// derived from this array so the two can never drift, and consumers can do a
+// positive runtime membership check (e.g. isPostHogRef) instead of defining
+// PostHog chips by exclusion.
+export const POSTHOG_RESOURCE_TYPES = [
+  "feature_flag",
+  "experiment",
+  "insight",
+  "dashboard",
+  "error_tracking",
+  "recording",
+  "survey",
+  "notebook",
+  "cohort",
+  "action",
+  "early_access_feature",
+  "person",
+  "group",
+] as const;
+
+export type PostHogResourceType = (typeof POSTHOG_RESOURCE_TYPES)[number];
+
+const POSTHOG_RESOURCE_TYPE_SET: ReadonlySet<string> = new Set(
+  POSTHOG_RESOURCE_TYPES,
+);
+
+/** True when `type` is one of the PostHog resource chip types. */
+export function isPostHogResourceType(
+  type: string,
+): type is PostHogResourceType {
+  return POSTHOG_RESOURCE_TYPE_SET.has(type);
+}
 
 export interface ParsedPostHogUrl {
   resourceType: PostHogResourceType;

--- a/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -1,17 +1,32 @@
-import { isPostHogCodeDeeplink } from "@posthog/shared";
+import {
+  buildResolvedLabel,
+  fetchPostHogResourceTitle,
+} from "@posthog/core/message-editor/posthogChip";
+import {
+  type ParsedPostHogUrl,
+  parsePostHogUrl,
+} from "@posthog/core/message-editor/posthogUrl";
+import { useHostTRPC } from "@posthog/host-router/react";
+import { isPostHogCodeDeeplink, unescapeXmlAttr } from "@posthog/shared";
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
-import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
+import {
+  type ParsedGithubIssueUrl,
+  parseGithubIssueUrl,
+} from "@posthog/ui/features/message-editor/githubIssueUrl";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
 import { Divider } from "@posthog/ui/primitives/Divider";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
 import { List, ListItem } from "@posthog/ui/primitives/List";
 import { Blockquote, Checkbox, Code, Kbd, Text } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
 import { memo, useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { PluggableList } from "unified";
 import { openExternalUrl } from "../../../shell/openExternal";
+import { PostHogRefChip } from "./PostHogRefChip";
 
 interface MarkdownRendererProps {
   content: string;
@@ -20,10 +35,21 @@ interface MarkdownRendererProps {
   rehypePlugins?: PluggableList;
 }
 
+const POSTHOG_CHIP_TAG_REGEX =
+  /<(feature_flag|experiment|insight|dashboard|recording|error_tracking|survey|notebook|cohort|action|early_access_feature|person|group)\s+id="([^"]+)"(?:\s+label="([^"]*)")?\s*\/>/g;
+
 // Preprocessor to prevent setext heading interpretation of horizontal rules
-// Ensures `---`, `***`, `___` are preceded by a blank line
+// Ensures `---`, `***`, `___` are preceded by a blank line.
+// Also converts PostHog XML chip tags to markdown links so the `a` component
+// handler can render them as PostHogRefChip.
 function preprocessMarkdown(content: string): string {
-  return content.replace(/\n([^\n].*)\n(---+|___+|\*\*\*+)\n/g, "\n$1\n\n$2\n");
+  return content
+    .replace(/\n([^\n].*)\n(---+|___+|\*\*\*+)\n/g, "\n$1\n\n$2\n")
+    .replace(POSTHOG_CHIP_TAG_REGEX, (_, _type, id, label) => {
+      const url = unescapeXmlAttr(id);
+      const text = label ? unescapeXmlAttr(label) : url;
+      return `[${text}](${url})`;
+    });
 }
 
 function markdownUrlTransform(value: string): string {
@@ -36,6 +62,49 @@ const HeadingText = ({ children }: { children: React.ReactNode }) => (
     <strong>{children}</strong>
   </Text>
 );
+
+function SmartGithubRefChip({ parsed }: { parsed: ParsedGithubIssueUrl }) {
+  const trpc = useHostTRPC();
+  const input = {
+    owner: parsed.owner,
+    repo: parsed.repo,
+    number: parsed.number,
+  };
+  const options =
+    parsed.kind === "pr"
+      ? trpc.git.getGithubPullRequest.queryOptions(input)
+      : trpc.git.getGithubIssue.queryOptions(input);
+  const { data } = useQuery({ ...options, staleTime: 60_000 });
+
+  const label = data?.title
+    ? `#${parsed.number} - ${data.title}`
+    : `${parsed.owner}/${parsed.repo}#${parsed.number}`;
+
+  return (
+    <GithubRefChip href={parsed.normalizedUrl} kind={parsed.kind}>
+      {label}
+    </GithubRefChip>
+  );
+}
+
+function SmartPostHogRefChip({ parsed }: { parsed: ParsedPostHogUrl }) {
+  const { data: title } = useAuthenticatedQuery(
+    ["posthog-resource", parsed.normalizedUrl],
+    (client) => fetchPostHogResourceTitle(client, parsed),
+    { staleTime: 60_000 },
+  );
+
+  const label = buildResolvedLabel(parsed, title ?? null);
+
+  return (
+    <PostHogRefChip
+      href={parsed.normalizedUrl}
+      resourceType={parsed.resourceType}
+    >
+      {label}
+    </PostHogRefChip>
+  );
+}
 
 export const baseComponents: Components = {
   h1: ({ children }) => <HeadingText>{children}</HeadingText>,
@@ -77,13 +146,28 @@ export const baseComponents: Components = {
     const githubRef = href ? parseGithubIssueUrl(href) : null;
     if (githubRef) {
       const isAutoLink = typeof children === "string" && children === href;
-      const label = isAutoLink
-        ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
-        : children;
+      if (isAutoLink) {
+        return <SmartGithubRefChip parsed={githubRef} />;
+      }
       return (
         <GithubRefChip href={githubRef.normalizedUrl} kind={githubRef.kind}>
-          {label}
+          {children}
         </GithubRefChip>
+      );
+    }
+    const posthogRef = href ? parsePostHogUrl(href) : null;
+    if (posthogRef) {
+      const isAutoLink = typeof children === "string" && children === href;
+      if (isAutoLink) {
+        return <SmartPostHogRefChip parsed={posthogRef} />;
+      }
+      return (
+        <PostHogRefChip
+          href={posthogRef.normalizedUrl}
+          resourceType={posthogRef.resourceType}
+        >
+          {children}
+        </PostHogRefChip>
       );
     }
     const isDeeplink = isPostHogCodeDeeplink(href);

--- a/packages/ui/src/features/editor/components/PostHogRefChip.tsx
+++ b/packages/ui/src/features/editor/components/PostHogRefChip.tsx
@@ -1,0 +1,59 @@
+import {
+  BugIcon,
+  BuildingsIcon,
+  ChartLineIcon,
+  ClipboardTextIcon,
+  FlagIcon,
+  FlaskIcon,
+  LightningIcon,
+  NotebookIcon,
+  RocketLaunchIcon,
+  SquaresFourIcon,
+  UserIcon,
+  UsersThreeIcon,
+  VideoIcon,
+} from "@phosphor-icons/react";
+import type { PostHogResourceType } from "@posthog/core/message-editor/posthogUrl";
+import { Chip } from "@posthog/quill";
+import type { ComponentType, ReactNode } from "react";
+
+const resourceIconMap: Record<
+  PostHogResourceType,
+  ComponentType<{ size: number }>
+> = {
+  feature_flag: FlagIcon,
+  experiment: FlaskIcon,
+  insight: ChartLineIcon,
+  dashboard: SquaresFourIcon,
+  error_tracking: BugIcon,
+  recording: VideoIcon,
+  survey: ClipboardTextIcon,
+  notebook: NotebookIcon,
+  cohort: UsersThreeIcon,
+  action: LightningIcon,
+  early_access_feature: RocketLaunchIcon,
+  person: UserIcon,
+  group: BuildingsIcon,
+};
+
+export function PostHogRefChip({
+  href,
+  resourceType,
+  children,
+}: {
+  href: string;
+  resourceType: PostHogResourceType;
+  children: ReactNode;
+}) {
+  const Icon = resourceIconMap[resourceType];
+  return (
+    <Chip
+      size="xs"
+      onClick={() => window.open(href, "_blank")}
+      className="cli-file-mention mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1 align-middle active:translate-y-0"
+    >
+      <Icon size={10} />
+      <span className="min-w-0 truncate">{children}</span>
+    </Chip>
+  );
+}

--- a/packages/ui/src/features/message-editor/tiptap/MentionChipNode.ts
+++ b/packages/ui/src/features/message-editor/tiptap/MentionChipNode.ts
@@ -11,6 +11,16 @@ export type ChipType =
   | "experiment"
   | "insight"
   | "feature_flag"
+  | "dashboard"
+  | "recording"
+  | "error_tracking"
+  | "survey"
+  | "notebook"
+  | "cohort"
+  | "action"
+  | "early_access_feature"
+  | "person"
+  | "group"
   | "github_issue"
   | "github_pr";
 

--- a/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
+++ b/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
@@ -1,12 +1,22 @@
 import {
+  BugIcon,
+  BuildingsIcon,
   ChartLineIcon,
+  ClipboardTextIcon,
   FileTextIcon,
   FlagIcon,
   FlaskIcon,
   FolderIcon,
   GithubLogoIcon,
   GitPullRequestIcon,
+  LightningIcon,
+  NotebookIcon,
+  RocketLaunchIcon,
+  SquaresFourIcon,
   TerminalIcon,
+  UserIcon,
+  UsersThreeIcon,
+  VideoIcon,
   WarningIcon,
   XIcon,
 } from "@phosphor-icons/react";
@@ -33,6 +43,16 @@ const typeIconMap: Record<ChipType, React.ComponentType<{ size: number }>> = {
   experiment: FlaskIcon,
   insight: ChartLineIcon,
   feature_flag: FlagIcon,
+  dashboard: SquaresFourIcon,
+  recording: VideoIcon,
+  error_tracking: BugIcon,
+  survey: ClipboardTextIcon,
+  notebook: NotebookIcon,
+  cohort: UsersThreeIcon,
+  action: LightningIcon,
+  early_access_feature: RocketLaunchIcon,
+  person: UserIcon,
+  group: BuildingsIcon,
 };
 
 function IconCloseButton({
@@ -82,17 +102,24 @@ function DefaultChip({
   const isFile = type === "file";
   const isFolder = type === "folder";
   const isGithubRef = type === "github_issue" || type === "github_pr";
-  const canOpenUrl = isGithubRef && /^https:\/\//.test(id);
+  const isPostHogRef =
+    type !== "file" &&
+    type !== "folder" &&
+    type !== "command" &&
+    type !== "error" &&
+    !isGithubRef;
+  const isUrlChip = isGithubRef || isPostHogRef;
+  const canOpenUrl = isUrlChip && /^https?:\/\//.test(id);
 
   const chipContent = (
     <Chip
       size="xs"
       contentEditable={false}
       onClick={canOpenUrl ? () => window.open(id, "_blank") : undefined}
-      className={`${chipBase} max-w-full whitespace-nowrap ${isGithubRef ? "cursor-pointer!" : "cursor-default! active:translate-y-0!"} ${isCommand ? "cli-slash-command" : "cli-file-mention"} ${selected ? selectedRing : ""}`}
+      className={`${chipBase} max-w-full whitespace-nowrap ${isUrlChip ? "cursor-pointer!" : "cursor-default! active:translate-y-0!"} ${isCommand ? "cli-slash-command" : "cli-file-mention"} ${selected ? selectedRing : ""}`}
     >
       <IconCloseButton type={type as ChipType} onRemove={onRemove} />
-      {isGithubRef ? (
+      {isUrlChip ? (
         <span className="min-w-0 truncate">{label}</span>
       ) : (
         `${prefix}${label}`

--- a/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
+++ b/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
@@ -21,6 +21,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { Chip } from "@posthog/quill";
+import { isPostHogResourceType } from "@posthog/core/message-editor/posthogUrl";
 import { useSettingsStore as useFeatureSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import type { Node as PmNode } from "@tiptap/pm/model";
@@ -102,12 +103,9 @@ function DefaultChip({
   const isFile = type === "file";
   const isFolder = type === "folder";
   const isGithubRef = type === "github_issue" || type === "github_pr";
-  const isPostHogRef =
-    type !== "file" &&
-    type !== "folder" &&
-    type !== "command" &&
-    type !== "error" &&
-    !isGithubRef;
+  // Positive membership check against the known PostHog resource types, so a
+  // future chip type is never silently treated as a clickable PostHog chip.
+  const isPostHogRef = isPostHogResourceType(type);
   const isUrlChip = isGithubRef || isPostHogRef;
   const canOpenUrl = isUrlChip && /^https?:\/\//.test(id);
 

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -18,10 +18,22 @@ import {
   isUrlOnly,
   shouldAutoConvertLongText,
 } from "@posthog/core/message-editor/paste";
+import {
+  buildPostHogPlaceholderLabel,
+  buildResolvedLabel,
+  fetchPostHogResourceTitle,
+  posthogResourceToMentionChip,
+} from "@posthog/core/message-editor/posthogChip";
+import {
+  type ParsedPostHogUrl,
+  parsePostHogUrl,
+} from "@posthog/core/message-editor/posthogUrl";
+import { getAuthenticatedClient } from "@posthog/ui/features/auth/authClientImperative";
 import { sessionStoreSetters } from "@posthog/ui/features/sessions/sessionStore";
 import { useSettingsStore as useFeatureSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { toast } from "@posthog/ui/primitives/toast";
 import { isSendMessageSubmitKey } from "@posthog/ui/utils/sendMessageKey";
+import { Fragment, type Node as PmNode, Slice } from "@tiptap/pm/model";
 import type { EditorView } from "@tiptap/pm/view";
 import { useEditor } from "@tiptap/react";
 import type React from "react";
@@ -105,6 +117,77 @@ async function pasteTextAsFile(
   view.focus();
 }
 
+interface MixedPasteResult {
+  fragment: Fragment;
+  githubRefs: ParsedGithubIssueUrl[];
+  posthogRefs: ParsedPostHogUrl[];
+}
+
+const URL_INLINE_REGEX = /https?:\/\/\S+/g;
+
+function buildMixedPasteContent(
+  view: EditorView,
+  text: string,
+): MixedPasteResult | null {
+  const schema = view.state.schema;
+  const nodes: PmNode[] = [];
+  const githubRefs: ParsedGithubIssueUrl[] = [];
+  const posthogRefs: ParsedPostHogUrl[] = [];
+  let lastIndex = 0;
+  let hasChip = false;
+
+  for (const match of text.matchAll(URL_INLINE_REGEX)) {
+    const url = match[0];
+    const matchIndex = match.index;
+
+    const githubRef = parseGithubIssueUrl(url);
+    const posthogRef = parsePostHogUrl(url);
+
+    if (!githubRef && !posthogRef) continue;
+
+    hasChip = true;
+
+    if (matchIndex > lastIndex) {
+      nodes.push(schema.text(text.slice(lastIndex, matchIndex)));
+    }
+
+    if (githubRef) {
+      const chip = buildGithubRefPlaceholderChip(githubRef);
+      nodes.push(
+        schema.nodes.mentionChip.create({
+          pastedText: false,
+          ...chip,
+        }),
+      );
+      githubRefs.push(githubRef);
+    } else if (posthogRef) {
+      const chip = posthogResourceToMentionChip(posthogRef);
+      chip.label = buildPostHogPlaceholderLabel(posthogRef);
+      nodes.push(
+        schema.nodes.mentionChip.create({
+          pastedText: false,
+          ...chip,
+        }),
+      );
+      posthogRefs.push(posthogRef);
+    }
+
+    lastIndex = matchIndex + url.length;
+  }
+
+  if (!hasChip) return null;
+
+  if (lastIndex < text.length) {
+    nodes.push(schema.text(text.slice(lastIndex)));
+  }
+
+  return {
+    fragment: Fragment.from(nodes),
+    githubRefs,
+    posthogRefs,
+  };
+}
+
 function insertGithubRefPlaceholder(
   view: EditorView,
   parsed: ParsedGithubIssueUrl,
@@ -150,6 +233,48 @@ async function resolveGithubRefChip(
     if (
       node.type.name !== "mentionChip" ||
       node.attrs.type !== chipType ||
+      node.attrs.id !== parsed.normalizedUrl ||
+      node.attrs.label !== placeholderLabel
+    ) {
+      return true;
+    }
+    tr.setNodeMarkup(pos, undefined, {
+      ...node.attrs,
+      label: resolvedLabel,
+    });
+    updated = true;
+    return false;
+  });
+
+  if (updated) view.dispatch(tr);
+}
+
+function insertPostHogRefPlaceholder(
+  view: EditorView,
+  parsed: ParsedPostHogUrl,
+): void {
+  const chip = posthogResourceToMentionChip(parsed);
+  chip.label = buildPostHogPlaceholderLabel(parsed);
+  insertChipWithTrailingSpace(view, chip);
+}
+
+async function resolvePostHogRefChip(
+  view: EditorView,
+  parsed: ParsedPostHogUrl,
+): Promise<void> {
+  const placeholderLabel = buildPostHogPlaceholderLabel(parsed);
+  const client = await getAuthenticatedClient();
+  const title = client ? await fetchPostHogResourceTitle(client, parsed) : null;
+  const resolvedLabel = buildResolvedLabel(parsed, title);
+
+  if (view.isDestroyed) return;
+
+  const { doc, tr } = view.state;
+  let updated = false;
+  doc.descendants((node, pos) => {
+    if (
+      node.type.name !== "mentionChip" ||
+      node.attrs.type !== parsed.resourceType ||
       node.attrs.id !== parsed.normalizedUrl ||
       node.attrs.label !== placeholderLabel
     ) {
@@ -405,6 +530,29 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               event.preventDefault();
               insertGithubRefPlaceholder(view, parsedRef);
               void resolveGithubRefChip(view, parsedRef);
+              return true;
+            }
+
+            const parsedPostHog = parsePostHogUrl(trimmedClipboardText);
+            if (parsedPostHog) {
+              event.preventDefault();
+              insertPostHogRefPlaceholder(view, parsedPostHog);
+              void resolvePostHogRefChip(view, parsedPostHog);
+              return true;
+            }
+
+            const mixed = buildMixedPasteContent(view, trimmedClipboardText);
+            if (mixed) {
+              event.preventDefault();
+              const { tr } = view.state;
+              tr.replaceSelection(new Slice(mixed.fragment, 0, 0));
+              view.dispatch(tr);
+              for (const ref of mixed.githubRefs) {
+                void resolveGithubRefChip(view, ref);
+              }
+              for (const ref of mixed.posthogRefs) {
+                void resolvePostHogRefChip(view, ref);
+              }
               return true;
             }
           }

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
@@ -1,5 +1,14 @@
 import { Check, Copy } from "@phosphor-icons/react";
 import {
+  buildResolvedLabel,
+  fetchPostHogResourceTitle,
+} from "@posthog/core/message-editor/posthogChip";
+import {
+  type ParsedPostHogUrl,
+  parsePostHogUrl,
+} from "@posthog/core/message-editor/posthogUrl";
+import { useHostTRPC } from "@posthog/host-router/react";
+import {
   Heading,
   Separator,
   Table,
@@ -10,23 +19,91 @@ import {
   TableRow,
   Text,
 } from "@posthog/quill";
+import { unescapeXmlAttr } from "@posthog/shared";
+import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { PostHogRefChip } from "@posthog/ui/features/editor/components/PostHogRefChip";
 import {
   parseOpenFence,
   splitMarkdownBlocks,
 } from "@posthog/ui/features/editor/components/splitMarkdownBlocks";
+import {
+  type ParsedGithubIssueUrl,
+  parseGithubIssueUrl,
+} from "@posthog/ui/features/message-editor/githubIssueUrl";
 import {
   BareFileLink,
   hasDirectoryPath,
   InlineFileLink,
   looksLikeBareFilename,
 } from "@posthog/ui/features/sessions/components/session-update/fileLinkChips";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
 import { useCopy } from "@posthog/ui/primitives/useCopy";
 import { IconButton } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
 import { memo, type ReactNode, useMemo } from "react";
 import Markdown, { type Components } from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
+
+const POSTHOG_CHIP_TAG_REGEX =
+  /<(feature_flag|experiment|insight|dashboard|recording|error_tracking|survey|notebook|cohort|action|early_access_feature|person|group)\s+id="([^"]+)"(?:\s+label="([^"]*)")?\s*\/>/g;
+
+/** Converts persisted PostHog XML chip tags (see `content.ts`) into markdown links so the `a`
+ * component below can render them as {@link SmartPostHogRefChip}. */
+function preprocessChipTags(content: string): string {
+  return content.replace(POSTHOG_CHIP_TAG_REGEX, (_, _type, id, label) => {
+    const url = unescapeXmlAttr(id);
+    const text = label ? unescapeXmlAttr(label) : url;
+    return `[${text}](${url})`;
+  });
+}
+
+/** Mirrors `MarkdownRenderer`'s `SmartGithubRefChip` — resolves the issue/PR title via tRPC. */
+function SmartGithubRefChip({ parsed }: { parsed: ParsedGithubIssueUrl }) {
+  const trpc = useHostTRPC();
+  const input = {
+    owner: parsed.owner,
+    repo: parsed.repo,
+    number: parsed.number,
+  };
+  const options =
+    parsed.kind === "pr"
+      ? trpc.git.getGithubPullRequest.queryOptions(input)
+      : trpc.git.getGithubIssue.queryOptions(input);
+  const { data } = useQuery({ ...options, staleTime: 60_000 });
+
+  const label = data?.title
+    ? `#${parsed.number} - ${data.title}`
+    : `${parsed.owner}/${parsed.repo}#${parsed.number}`;
+
+  return (
+    <GithubRefChip href={parsed.normalizedUrl} kind={parsed.kind}>
+      {label}
+    </GithubRefChip>
+  );
+}
+
+/** Mirrors `MarkdownRenderer`'s `SmartPostHogRefChip` — resolves the resource title via the
+ * authenticated PostHog API client. */
+function SmartPostHogRefChip({ parsed }: { parsed: ParsedPostHogUrl }) {
+  const { data: title } = useAuthenticatedQuery(
+    ["posthog-resource", parsed.normalizedUrl],
+    (client) => fetchPostHogResourceTitle(client, parsed),
+    { staleTime: 60_000 },
+  );
+
+  const label = buildResolvedLabel(parsed, title ?? null);
+
+  return (
+    <PostHogRefChip
+      href={parsed.normalizedUrl}
+      resourceType={parsed.resourceType}
+    >
+      {label}
+    </PostHogRefChip>
+  );
+}
 
 function ChatCodeBlock({
   code,
@@ -66,16 +143,45 @@ const components: Components = {
   p: ({ children }) => (
     <Text className="text-sm leading-[1.5]">{children}</Text>
   ),
-  a: ({ children, href }) => (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      className="text-primary underline underline-offset-2"
-    >
-      {children}
-    </a>
-  ),
+  a: ({ children, href }) => {
+    const githubRef = href ? parseGithubIssueUrl(href) : null;
+    if (githubRef) {
+      const isAutoLink = typeof children === "string" && children === href;
+      if (isAutoLink) {
+        return <SmartGithubRefChip parsed={githubRef} />;
+      }
+      return (
+        <GithubRefChip href={githubRef.normalizedUrl} kind={githubRef.kind}>
+          {children}
+        </GithubRefChip>
+      );
+    }
+    const posthogRef = href ? parsePostHogUrl(href) : null;
+    if (posthogRef) {
+      const isAutoLink = typeof children === "string" && children === href;
+      if (isAutoLink) {
+        return <SmartPostHogRefChip parsed={posthogRef} />;
+      }
+      return (
+        <PostHogRefChip
+          href={posthogRef.normalizedUrl}
+          resourceType={posthogRef.resourceType}
+        >
+          {children}
+        </PostHogRefChip>
+      );
+    }
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className="text-primary underline underline-offset-2"
+      >
+        {children}
+      </a>
+    );
+  },
   ul: ({ children }) => (
     <ul className="list-disc space-y-0.5 ps-4">{children}</ul>
   ),
@@ -159,6 +265,10 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 }: {
   content: string;
 }) {
+  const processedContent = useMemo(
+    () => preprocessChipTags(content),
+    [content],
+  );
   return (
     <div className="flex flex-col gap-3 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
       <Markdown
@@ -166,7 +276,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
         rehypePlugins={rehypePlugins}
         components={components}
       >
-        {content}
+        {processedContent}
       </Markdown>
     </div>
   );

--- a/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
@@ -1,4 +1,5 @@
 import { File, Folder, Warning } from "@phosphor-icons/react";
+import type { PostHogResourceType } from "@posthog/core/message-editor/posthogUrl";
 import { unescapeXmlAttr } from "@posthog/shared";
 import { Text } from "@radix-ui/themes";
 import type { ReactNode } from "react";
@@ -10,11 +11,12 @@ import {
   baseComponents,
   defaultRemarkPlugins,
 } from "../../../editor/components/MarkdownRenderer";
+import { PostHogRefChip } from "../../../editor/components/PostHogRefChip";
 
 const MENTION_TAG_REGEX =
-  /<file\s+path="([^"]+)"\s*\/>|<(github_issue|github_pr)\s+number="([^"]+)"(?:\s+title="([^"]*)")?(?:\s+url="([^"]*)")?\s*\/>|<error_context\s+label="([^"]*)">[\s\S]*?<\/error_context>|<folder\s+path="([^"]+)"\s*\/>/g;
+  /<file\s+path="([^"]+)"\s*\/>|<(github_issue|github_pr)\s+number="([^"]+)"(?:\s+title="([^"]*)")?(?:\s+url="([^"]*)")?\s*\/>|<error_context\s+label="([^"]*)">[\s\S]*?<\/error_context>|<folder\s+path="([^"]+)"\s*\/>|<(feature_flag|experiment|insight|dashboard|recording|error_tracking|survey|notebook|cohort|action|early_access_feature|person|group)\s+id="([^"]+)"(?:\s+label="([^"]*)")?\s*\/>/g;
 const MENTION_TAG_TEST =
-  /<(?:file\s+path|folder\s+path|github_issue\s+number|github_pr\s+number|error_context\s+label)="[^"]+"/;
+  /<(?:file\s+path|folder\s+path|github_issue\s+number|github_pr\s+number|error_context\s+label|(?:feature_flag|experiment|insight|dashboard|recording|error_tracking|survey|notebook|cohort|action|early_access_feature|person|group)\s+id)="[^"]+"/;
 const SLASH_COMMAND_START = /^\/([a-zA-Z][\w-]*)(?=\s|$)/;
 
 const inlineComponents: Components = {
@@ -161,6 +163,19 @@ export function parseMentionTags(content: string): ReactNode[] {
           icon={<Folder size={12} />}
           label={folderName}
         />,
+      );
+    } else if (match[8]) {
+      const resourceType = match[8] as PostHogResourceType;
+      const id = unescapeXmlAttr(match[9]);
+      const label = match[10] ? unescapeXmlAttr(match[10]) : id;
+      parts.push(
+        <PostHogRefChip
+          key={`posthog-${matchIndex}`}
+          href={id}
+          resourceType={resourceType}
+        >
+          {label}
+        </PostHogRefChip>,
       );
     }
 


### PR DESCRIPTION
## Problem

When PostHog resource URLs (dashboards, feature flags, insights, experiments, etc.) appear in agent responses or are pasted into the editor, they render as plain text links — unlike GitHub URLs which already get rich chip rendering with icons and resolved titles. This makes it harder to quickly identify and interact with referenced PostHog resources.

Closes PostHog/posthog#76253

## Changes

Mirrors the GitHub URL → chip pipeline for PostHog Cloud URLs across both the MarkdownRenderer (agent messages) and the Tiptap editor (paste handling).

**New files:**
- `posthogUrl.ts` — URL parser supporting both long (`/project/{id}/...`) and short (no project prefix) URL formats. Handles `us.posthog.com`, `eu.posthog.com`, and `localhost:8010`.
- `posthogUrl.test.ts` — 37 tests covering all 13 resource types, both URL formats, edge cases (trailing slashes, query params, fragments), and rejection cases.
- `PostHogRefChip.tsx` — Read-only chip component for agent messages with per-type Phosphor icons.
- `posthogChip.ts` — Chip builder + async title resolution via PostHog API (feature flag names, experiment names, dashboard titles, etc.)

**Modified files:**
- `MarkdownRenderer.tsx` — Adds `SmartPostHogRefChip` that resolves resource titles via `useAuthenticatedQuery`, same pattern as `SmartGithubRefChip`.
- `useTiptapEditor.ts` — Paste-time title resolution with "Loading..." placeholder → resolved label. Works for single URLs, multi-URL pastes, and mixed GitHub + PostHog URL pastes.
- `content.ts` — Persists chip labels in XML (`<feature_flag id="..." label="..." />`) so they survive the user message round-trip. Old messages without a `label` attr gracefully fall back to URL-derived labels.
- `MentionChipNode.ts`, `MentionChipView.tsx` — Extended `ChipType` union and icon map for all new resource types.
- `posthogClient.ts` — 13 new API methods for fetching resource metadata, plus `getDefaultProjectId()` for short URL support.

### Supported resource types

| Resource | URL path segment | Icon | Example |
|----------|-----------------|------|---------|
| Feature Flag | `/feature_flags/{id}` | 🚩 FlagIcon | `Feature Flag #619272 - beta-rollout` |
| Experiment | `/experiments/{id}` | 🧪 FlaskIcon | `Experiment #373424 - signup-test` |
| Insight | `/insights/{id}` | 📈 ChartLineIcon | `Insight KP8iqi6E - Weekly DAU` |
| Dashboard | `/dashboard/{id}` | ◻️ SquaresFourIcon | `Dashboard #944836 - Product KPIs` |
| Error Tracking | `/error_tracking/{id}` | 🐛 BugIcon | `Error abc-def-123 - TypeError...` |
| Recording | `/replay/{id}` | 🎬 VideoIcon | `Recording 019012ab...` |
| Survey | `/surveys/{id}` | 📋 ClipboardTextIcon | `Survey 019d1c79... - NPS Q2` |
| Notebook | `/notebooks/{id}` | 📓 NotebookIcon | `Notebook wkGd - Sprint retro` |
| Cohort | `/cohorts/{id}` | 👥 UsersThreeIcon | `Cohort PostHog/code#55 - Power users` |
| Action | `/data-management/actions/{id}` | ⚡ LightningIcon | `Action PostHog/code#99 - Signed up` |
| Early Access Feature | `/early_access_features/{id}` | 🚀 RocketLaunchIcon | `Early Access Feature abc-123...` |
| Person | `/persons/{id}` | 👤 UserIcon | `Person user_abc123 - jane@example.com` |
| Group | `/groups/{type-index}/{group-key}` | 🏢 BuildingsIcon | `Group 0/my-company-name - Acme Corp` |

All 13 resource types support both long (`/project/{id}/...`) and short (no project prefix) URL formats. Groups use a compound 2-segment ID (`type-index/group-key`).

### What's NOT matched

Org-level and non-resource PostHog URLs render as normal clickable links — no chip, no icon, no metadata resolution:
- `/organization/billing/overview`
- `/settings/...`
- `/feature_flags` (index/list page, no specific resource ID)
- `/project/{id}/feature_flags?search=my-flag` (search/filter page)
- Any URL that doesn't resolve to a specific resource detail page with an ID

These are intentionally excluded — chips are only shown when we can identify a discrete resource to link to.

## How did you test this?

**Automated:**
- 37 new unit tests for the URL parser (all pass)
- 25 existing content.ts round-trip tests (all pass)
- Full typecheck passes
- Biome lint passes

**Manual testing steps**

**Demo 1 — Resource chip rendering & title resolution**

Pasted/referenced all 13 supported resource types (Feature Flag → Group) covering both long (`/project/{id}/...`) and short (no project prefix) URL formats.

- URLs with real, valid resource IDs belonging to the authenticated org resolve and display the resource title in the chip (e.g. `Feature Flag #619272 - beta-rollout`)
- URLs with fake/test IDs, or IDs belonging to orgs the user doesn't have access to, render the chip with the ID only — no title — which is the expected graceful fallback behavior

[valid-posthog-resource-urls-rendering-posthog-code.webm](https://github.com/user-attachments/assets/155ef9d1-b07a-4eef-a097-63102f264377)

**Demo 2 — Non-resource URLs & GitHub interop**

Verified that org-level and list/index PostHog URLs are intentionally excluded from chip rendering and fall back to plain clickable links:

- `https://us.posthog.com/feature_flags` → plain link
- `https://us.posthog.com/organization/billing/overview` → plain link
- `https://us.posthog.com/data-warehouse` → plain link
- `https://us.posthog.com/project/99271/feature_flags?search=my-flag` → plain link

Also confirmed that existing GitHub URL chip rendering is unaffected:

- `https://github.com/PostHog/code/issues/2360` → renders as GitHub chip as before

[org-level-and-non-resource-urls-shouldnt-render-as-chips-posthog-code.webm](https://github.com/user-attachments/assets/6e2288a5-87fb-4a0b-bdc5-1eef948ff8cc)

## Publish to changelog?

no
