### PR TITLE
feat(billing): single-source usage via main-process relay

### DIFF
--- a/apps/code/src/main/services/usage-monitor/schemas.ts
+++ b/apps/code/src/main/services/usage-monitor/schemas.ts
@@ -1,3 +1,5 @@
+import type { UsageOutput } from "@main/services/llm-gateway/schemas";
+import { usageOutput } from "@main/services/llm-gateway/schemas";
 import { z } from "zod";
 
 export const USAGE_THRESHOLDS = [50, 75, 90, 100] as const;
@@ -19,10 +21,15 @@ export const thresholdCrossedEvent = z.object({
 
 export type ThresholdCrossedEvent = z.infer<typeof thresholdCrossedEvent>;
 
+export const usageSnapshotOutput = usageOutput.nullable();
+export type UsageSnapshot = UsageOutput | null;
+
 export const UsageMonitorEvent = {
   ThresholdCrossed: "threshold-crossed",
+  UsageUpdated: "usage-updated",
 } as const;
 
 export interface UsageMonitorEvents {
   [UsageMonitorEvent.ThresholdCrossed]: ThresholdCrossedEvent;
+  [UsageMonitorEvent.UsageUpdated]: UsageOutput;
 }

--- a/apps/code/src/main/services/usage-monitor/service.test.ts
+++ b/apps/code/src/main/services/usage-monitor/service.test.ts
@@ -23,7 +23,7 @@ vi.mock("../../utils/logger.js", () => ({
   },
 }));
 
-import { LlmGatewayService } from "../llm-gateway/service";
+import type { LlmGatewayService } from "../llm-gateway/service";
 import { UsageMonitorService } from "./service";
 
 function makeUsage(overrides?: {
@@ -178,5 +178,42 @@ describe("UsageMonitorService", () => {
 
     await expect(service.pollOnce()).resolves.toBeNull();
     expect(events).toHaveLength(0);
+  });
+
+  it("emits UsageUpdated and caches the snapshot on every successful poll", async () => {
+    const updates: UsageOutput[] = [];
+    const gateway = mockGateway(makeUsage({ burstPercent: 20 }));
+    service = new UsageMonitorService(gateway);
+    service.on(UsageMonitorEvent.UsageUpdated, (u) => updates.push(u));
+
+    expect(service.getLatest()).toBeNull();
+    await service.pollOnce();
+    expect(updates).toHaveLength(1);
+    expect(service.getLatest()?.burst.used_percent).toBe(20);
+
+    await service.pollOnce();
+    expect(updates).toHaveLength(2);
+  });
+
+  it("does not emit UsageUpdated when the gateway throws", async () => {
+    const updates: UsageOutput[] = [];
+    const gateway = {
+      fetchUsage: vi.fn().mockRejectedValue(new Error("offline")),
+    } as unknown as LlmGatewayService;
+    service = new UsageMonitorService(gateway);
+    service.on(UsageMonitorEvent.UsageUpdated, (u) => updates.push(u));
+
+    await service.pollOnce();
+    expect(updates).toHaveLength(0);
+    expect(service.getLatest()).toBeNull();
+  });
+
+  it("refreshNow triggers a fresh poll and returns the snapshot", async () => {
+    const gateway = mockGateway(makeUsage({ burstPercent: 42 }));
+    service = new UsageMonitorService(gateway);
+
+    const result = await service.refreshNow();
+    expect(result?.burst.used_percent).toBe(42);
+    expect(service.getLatest()?.burst.used_percent).toBe(42);
   });
 });

--- a/apps/code/src/main/services/usage-monitor/service.ts
+++ b/apps/code/src/main/services/usage-monitor/service.ts
@@ -25,6 +25,7 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
   // Snapshot of the most recent thresholdsSeen map so we hit electron-store
   // only when we actually persist a new threshold.
   private thresholdsSeen: Record<string, string>;
+  private latestUsage: UsageOutput | null = null;
 
   constructor(
     @inject(MAIN_TOKENS.LlmGatewayService)
@@ -32,6 +33,16 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
   ) {
     super();
     this.thresholdsSeen = { ...usageMonitorStore.get("thresholdsSeen", {}) };
+  }
+
+  /** Last successful usage snapshot; null until the first poll succeeds. */
+  getLatest(): UsageOutput | null {
+    return this.latestUsage;
+  }
+
+  /** Trigger an immediate refresh, returning the resulting snapshot. */
+  async refreshNow(): Promise<UsageOutput | null> {
+    return this.pollOnce();
   }
 
   @postConstruct()
@@ -54,7 +65,11 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     this.isPolling = true;
     try {
       const usage = await this.fetchUsageQuietly();
-      if (usage) this.processUsage(usage);
+      if (usage) {
+        this.latestUsage = usage;
+        this.emit(UsageMonitorEvent.UsageUpdated, usage);
+        this.processUsage(usage);
+      }
       return usage;
     } finally {
       this.isPolling = false;

--- a/apps/code/src/main/trpc/routers/llm-gateway.ts
+++ b/apps/code/src/main/trpc/routers/llm-gateway.ts
@@ -1,10 +1,6 @@
 import { container } from "../../di/container";
 import { MAIN_TOKENS } from "../../di/tokens";
-import {
-  promptInput,
-  promptOutput,
-  usageOutput,
-} from "../../services/llm-gateway/schemas";
+import { promptInput, promptOutput } from "../../services/llm-gateway/schemas";
 import type { LlmGatewayService } from "../../services/llm-gateway/service";
 import { publicProcedure, router } from "../trpc";
 
@@ -22,10 +18,6 @@ export const llmGatewayRouter = router({
         model: input.model,
       }),
     ),
-
-  usage: publicProcedure
-    .output(usageOutput)
-    .query(() => getService().fetchUsage()),
 
   invalidatePlanCache: publicProcedure.mutation(() =>
     getService().invalidatePlanCache(),

--- a/apps/code/src/main/trpc/routers/usage-monitor.ts
+++ b/apps/code/src/main/trpc/routers/usage-monitor.ts
@@ -3,6 +3,7 @@ import { MAIN_TOKENS } from "../../di/tokens";
 import {
   UsageMonitorEvent,
   type UsageMonitorEvents,
+  usageSnapshotOutput,
 } from "../../services/usage-monitor/schemas";
 import type { UsageMonitorService } from "../../services/usage-monitor/service";
 import { publicProcedure, router } from "../trpc";
@@ -22,4 +23,14 @@ function subscribe<K extends keyof UsageMonitorEvents>(event: K) {
 
 export const usageMonitorRouter = router({
   onThresholdCrossed: subscribe(UsageMonitorEvent.ThresholdCrossed),
+  // Stream of full usage snapshots — replaces the renderer's 30s poll.
+  onUsageUpdated: subscribe(UsageMonitorEvent.UsageUpdated),
+  // Cached snapshot for the renderer to bootstrap before the first event
+  // arrives. Null until the first poll completes.
+  getLatest: publicProcedure
+    .output(usageSnapshotOutput)
+    .query(() => getService().getLatest()),
+  refresh: publicProcedure
+    .output(usageSnapshotOutput)
+    .mutation(() => getService().refreshNow()),
 });

--- a/apps/code/src/renderer/features/billing/hooks/useUsage.ts
+++ b/apps/code/src/renderer/features/billing/hooks/useUsage.ts
@@ -1,21 +1,44 @@
 import { useTRPC } from "@renderer/trpc";
-import { useRendererWindowFocusStore } from "@stores/rendererWindowFocusStore";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { useCallback } from "react";
 
-const USAGE_REFETCH_INTERVAL_MS = 30_000;
-
+/**
+ * Subscribe to usage snapshots pushed by the main-process `UsageMonitorService`.
+ * Avoids the renderer doing its own gateway polling — the service is the single
+ * source of truth and we just consume what it broadcasts every ~30s.
+ */
 export function useUsage({ enabled = true }: { enabled?: boolean } = {}) {
   const trpc = useTRPC();
-  const focused = useRendererWindowFocusStore((s) => s.focused);
-  const {
-    data: usage,
-    isLoading,
-    refetch,
-  } = useQuery({
-    ...trpc.llmGateway.usage.queryOptions(),
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    ...trpc.usageMonitor.getLatest.queryOptions(),
     enabled,
-    refetchInterval: focused && enabled ? USAGE_REFETCH_INTERVAL_MS : false,
-    refetchIntervalInBackground: false,
   });
-  return { usage: usage ?? null, isLoading, refetch };
+  const refreshMutation = useMutation(
+    trpc.usageMonitor.refresh.mutationOptions(),
+  );
+
+  useSubscription(
+    trpc.usageMonitor.onUsageUpdated.subscriptionOptions(undefined, {
+      enabled,
+      onData: (data) => {
+        queryClient.setQueryData(trpc.usageMonitor.getLatest.queryKey(), data);
+      },
+    }),
+  );
+
+  const refetch = useCallback(async () => {
+    const fresh = await refreshMutation.mutateAsync();
+    if (fresh) {
+      queryClient.setQueryData(trpc.usageMonitor.getLatest.queryKey(), fresh);
+    }
+    return fresh;
+  }, [refreshMutation, queryClient, trpc.usageMonitor.getLatest]);
+
+  return {
+    usage: query.data ?? null,
+    isLoading: query.isLoading,
+    refetch,
+  };
 }


### PR DESCRIPTION
## Problem

The renderer was polling the LLM gateway directly every 30 seconds to fetch usage data, coupling the renderer to the gateway and duplicating polling logic that the `UsageMonitorService` already handles.

## Changes

The `UsageMonitorService` now caches the most recent usage snapshot (`latestUsage`) and emits a `UsageUpdated` event after every successful poll. Two new methods are exposed: `getLatest()` to retrieve the cached snapshot synchronously, and `refreshNow()` to trigger an immediate poll.

The `usageMonitorRouter` exposes these via three new tRPC endpoints: `onUsageUpdated` (a subscription that streams snapshots as they arrive), `getLatest` (a query to bootstrap the renderer before the first event), and `refresh` (a mutation to force an immediate poll). The `llmGateway.usage` query endpoint has been removed since it is no longer needed.

The `useUsage` hook in the renderer now subscribes to `onUsageUpdated` instead of polling on an interval. It bootstraps from `getLatest` on mount and exposes a `refetch` that calls the `refresh` mutation. The window-focus-based refetch interval logic has been removed entirely.

## How did you test this?

Three new unit tests were added to `service.test.ts`:
- Verifies that `UsageUpdated` is emitted and the snapshot is cached on every successful poll.
- Verifies that `UsageUpdated` is not emitted and the snapshot remains `null` when the gateway throws.
- Verifies that `refreshNow` triggers a fresh poll and returns the resulting snapshot.

## Publish to changelog?

No