### PR TITLE
fix: Fix sidebar task scroll layout

### DIFF
--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -15,7 +15,7 @@ import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import { useAppView } from "@hooks/useAppView";
 import { openTask, openTaskInput } from "@hooks/useOpenTask";
 import { useTaskContextMenu } from "@hooks/useTaskContextMenu";
-import { MenuLabel, Separator } from "@posthog/quill";
+import { Separator } from "@posthog/quill";
 import { Box, Flex } from "@radix-ui/themes";
 import {
   navigateToCommandCenter,
@@ -43,7 +43,8 @@ import { McpServersItem } from "./items/McpServersItem";
 import { SearchItem } from "./items/SearchItem";
 import { SkillsItem } from "./items/SkillsItem";
 import { SidebarItem } from "./SidebarItem";
-import { TaskFilterMenu, TaskListView, TaskSearchButton } from "./TaskListView";
+import { TaskListView } from "./TaskListView";
+import { TasksHeader } from "./TasksHeader";
 
 const log = logger.scope("sidebar-menu");
 
@@ -370,7 +371,7 @@ function SidebarMenuComponent() {
       id="side-bar-menu"
       className="flex min-h-0 flex-col"
     >
-      <Flex direction="column" className="shrink-0 px-2 py-2" gap="1px">
+      <Flex direction="column" className="shrink-0 gap-px px-2 py-2">
         <Box mb="2">
           <NewTaskItem
             isActive={sidebarData.isHomeActive}
@@ -416,21 +417,10 @@ function SidebarMenuComponent() {
 
       <Separator className="mx-2 my-2 shrink-0" />
 
-      <div className="shrink-0 px-2">
-        <MenuLabel
-          className="flex items-center justify-between pt-0 pr-0 pb-[2px]"
-          htmlFor="null"
-        >
-          Tasks
-          <span className="flex items-center">
-            <TaskSearchButton />
-            <TaskFilterMenu />
-          </span>
-        </MenuLabel>
-      </div>
+      <TasksHeader />
 
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
-        <Flex direction="column" gap="1px" px="2" pb="2">
+        <Flex direction="column" className="gap-px px-2 pb-2">
           {sidebarData.isLoading ? (
             <SidebarItem
               depth={0}

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -364,80 +364,89 @@ function SidebarMenuComponent() {
   }, [setEditingTaskId]);
 
   return (
-    <Box height="100%" position="relative" id="side-bar-menu">
-      <ScrollArea className="h-full overflow-y-auto overflow-x-hidden">
-        <Flex direction="column" py="2" px="2" gap="1px">
-          <Box mb="2">
-            <NewTaskItem
-              isActive={sidebarData.isHomeActive}
-              onClick={handleNewTaskClick}
-              variant="primary"
-            />
-          </Box>
+    <Box
+      height="100%"
+      position="relative"
+      id="side-bar-menu"
+      className="flex min-h-0 flex-col"
+    >
+      <Flex direction="column" className="shrink-0 px-2 py-2" gap="1px">
+        <Box mb="2">
+          <NewTaskItem
+            isActive={sidebarData.isHomeActive}
+            onClick={handleNewTaskClick}
+            variant="primary"
+          />
+        </Box>
 
-          <Box>
-            <SearchItem onClick={handleSearchClick} />
-          </Box>
+        <Box>
+          <SearchItem onClick={handleSearchClick} />
+        </Box>
 
-          <Box>
-            <InboxItem
-              isActive={sidebarData.isInboxActive}
-              onClick={handleInboxClick}
-              signalCount={inboxSignalCount}
-            />
-          </Box>
+        <Box>
+          <InboxItem
+            isActive={sidebarData.isInboxActive}
+            onClick={handleInboxClick}
+            signalCount={inboxSignalCount}
+          />
+        </Box>
 
-          <Box>
-            <SkillsItem
-              isActive={sidebarData.isSkillsActive}
-              onClick={handleSkillsClick}
-            />
-          </Box>
+        <Box>
+          <SkillsItem
+            isActive={sidebarData.isSkillsActive}
+            onClick={handleSkillsClick}
+          />
+        </Box>
 
-          <Box>
-            <McpServersItem
-              isActive={sidebarData.isMcpServersActive}
-              onClick={handleMcpServersClick}
-            />
-          </Box>
+        <Box>
+          <McpServersItem
+            isActive={sidebarData.isMcpServersActive}
+            onClick={handleMcpServersClick}
+          />
+        </Box>
 
-          <Box mb="2">
-            <CommandCenterItem
-              isActive={sidebarData.isCommandCenterActive}
-              onClick={handleCommandCenterClick}
-              activeCount={commandCenterActiveCount}
-            />
-          </Box>
+        <Box mb="2">
+          <CommandCenterItem
+            isActive={sidebarData.isCommandCenterActive}
+            onClick={handleCommandCenterClick}
+            activeCount={commandCenterActiveCount}
+          />
+        </Box>
+      </Flex>
 
-          <Separator className="mx-2 my-2" />
+      <Separator className="mx-2 my-2 shrink-0" />
 
-          {sidebarData.isLoading ? (
-            <SidebarItem
-              depth={0}
-              icon={<DotsCircleSpinner size={12} className="text-gray-10" />}
-              label="Loading tasks..."
-              disabled
-            />
-          ) : (
-            <TaskListView
-              pinnedTasks={sidebarData.pinnedTasks}
-              flatTasks={sidebarData.flatTasks}
-              groupedTasks={sidebarData.groupedTasks}
-              activeTaskId={sidebarData.activeTaskId}
-              editingTaskId={editingTaskId}
-              selectedTaskIds={effectiveBulkIds}
-              onTaskClick={handleTaskClick}
-              onTaskDoubleClick={handleTaskDoubleClick}
-              onTaskContextMenu={handleTaskContextMenu}
-              onTaskArchive={handleTaskArchive}
-              onTaskTogglePin={togglePin}
-              onTaskEditSubmit={handleTaskEditSubmit}
-              onTaskEditCancel={handleTaskEditCancel}
-              hasMore={sidebarData.hasMore}
-            />
-          )}
-        </Flex>
-      </ScrollArea>
+      <Box className="min-h-0 flex-1">
+        <ScrollArea className="h-full overflow-y-auto overflow-x-hidden">
+          <Flex direction="column" gap="1px" px="2" pb="2">
+            {sidebarData.isLoading ? (
+              <SidebarItem
+                depth={0}
+                icon={<DotsCircleSpinner size={12} className="text-gray-10" />}
+                label="Loading tasks..."
+                disabled
+              />
+            ) : (
+              <TaskListView
+                pinnedTasks={sidebarData.pinnedTasks}
+                flatTasks={sidebarData.flatTasks}
+                groupedTasks={sidebarData.groupedTasks}
+                activeTaskId={sidebarData.activeTaskId}
+                editingTaskId={editingTaskId}
+                selectedTaskIds={effectiveBulkIds}
+                onTaskClick={handleTaskClick}
+                onTaskDoubleClick={handleTaskDoubleClick}
+                onTaskContextMenu={handleTaskContextMenu}
+                onTaskArchive={handleTaskArchive}
+                onTaskTogglePin={togglePin}
+                onTaskEditSubmit={handleTaskEditSubmit}
+                onTaskEditCancel={handleTaskEditCancel}
+                hasMore={sidebarData.hasMore}
+              />
+            )}
+          </Flex>
+        </ScrollArea>
+      </Box>
     </Box>
   );
 }

--- a/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/SidebarMenu.tsx
@@ -15,7 +15,7 @@ import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import { useAppView } from "@hooks/useAppView";
 import { openTask, openTaskInput } from "@hooks/useOpenTask";
 import { useTaskContextMenu } from "@hooks/useTaskContextMenu";
-import { ScrollArea, Separator } from "@posthog/quill";
+import { MenuLabel, Separator } from "@posthog/quill";
 import { Box, Flex } from "@radix-ui/themes";
 import {
   navigateToCommandCenter,
@@ -43,7 +43,7 @@ import { McpServersItem } from "./items/McpServersItem";
 import { SearchItem } from "./items/SearchItem";
 import { SkillsItem } from "./items/SkillsItem";
 import { SidebarItem } from "./SidebarItem";
-import { TaskListView } from "./TaskListView";
+import { TaskFilterMenu, TaskListView, TaskSearchButton } from "./TaskListView";
 
 const log = logger.scope("sidebar-menu");
 
@@ -416,37 +416,48 @@ function SidebarMenuComponent() {
 
       <Separator className="mx-2 my-2 shrink-0" />
 
-      <Box className="min-h-0 flex-1">
-        <ScrollArea className="h-full overflow-y-auto overflow-x-hidden">
-          <Flex direction="column" gap="1px" px="2" pb="2">
-            {sidebarData.isLoading ? (
-              <SidebarItem
-                depth={0}
-                icon={<DotsCircleSpinner size={12} className="text-gray-10" />}
-                label="Loading tasks..."
-                disabled
-              />
-            ) : (
-              <TaskListView
-                pinnedTasks={sidebarData.pinnedTasks}
-                flatTasks={sidebarData.flatTasks}
-                groupedTasks={sidebarData.groupedTasks}
-                activeTaskId={sidebarData.activeTaskId}
-                editingTaskId={editingTaskId}
-                selectedTaskIds={effectiveBulkIds}
-                onTaskClick={handleTaskClick}
-                onTaskDoubleClick={handleTaskDoubleClick}
-                onTaskContextMenu={handleTaskContextMenu}
-                onTaskArchive={handleTaskArchive}
-                onTaskTogglePin={togglePin}
-                onTaskEditSubmit={handleTaskEditSubmit}
-                onTaskEditCancel={handleTaskEditCancel}
-                hasMore={sidebarData.hasMore}
-              />
-            )}
-          </Flex>
-        </ScrollArea>
-      </Box>
+      <div className="shrink-0 px-2">
+        <MenuLabel
+          className="flex items-center justify-between pt-0 pr-0 pb-[2px]"
+          htmlFor="null"
+        >
+          Tasks
+          <span className="flex items-center">
+            <TaskSearchButton />
+            <TaskFilterMenu />
+          </span>
+        </MenuLabel>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+        <Flex direction="column" gap="1px" px="2" pb="2">
+          {sidebarData.isLoading ? (
+            <SidebarItem
+              depth={0}
+              icon={<DotsCircleSpinner size={12} className="text-gray-10" />}
+              label="Loading tasks..."
+              disabled
+            />
+          ) : (
+            <TaskListView
+              pinnedTasks={sidebarData.pinnedTasks}
+              flatTasks={sidebarData.flatTasks}
+              groupedTasks={sidebarData.groupedTasks}
+              activeTaskId={sidebarData.activeTaskId}
+              editingTaskId={editingTaskId}
+              selectedTaskIds={effectiveBulkIds}
+              onTaskClick={handleTaskClick}
+              onTaskDoubleClick={handleTaskDoubleClick}
+              onTaskContextMenu={handleTaskContextMenu}
+              onTaskArchive={handleTaskArchive}
+              onTaskTogglePin={togglePin}
+              onTaskEditSubmit={handleTaskEditSubmit}
+              onTaskEditCancel={handleTaskEditCancel}
+              hasMore={sidebarData.hasMore}
+            />
+          )}
+        </Flex>
+      </div>
     </Box>
   );
 }

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -3,28 +3,13 @@ import type { DragDropEvents } from "@dnd-kit/react";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useFolders } from "@features/folders/hooks/useFolders";
 import { useAppView } from "@hooks/useAppView";
-import { useMeQuery } from "@hooks/useMeQuery";
 import { openTaskInput } from "@hooks/useOpenTask";
-import {
-  FunnelSimple as FunnelSimpleIcon,
-  GitBranch,
-  MagnifyingGlass,
-} from "@phosphor-icons/react";
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-  MenuLabel,
-} from "@posthog/quill";
+import { GitBranch } from "@phosphor-icons/react";
+import { MenuLabel } from "@posthog/quill";
 import { Flex, Text } from "@radix-ui/themes";
 import builderHog from "@renderer/assets/images/hedgehogs/builder-hog-03.png";
 import { useWorkspace } from "@renderer/features/workspace/hooks/useWorkspace";
 import { normalizeRepoKey } from "@shared/utils/repo";
-import { useCommandMenuStore } from "@stores/commandMenuStore";
 import { getRelativeDateGroup } from "@utils/time";
 import { motion } from "framer-motion";
 import { Fragment, useCallback, useEffect, useMemo } from "react";
@@ -60,22 +45,8 @@ interface TaskListViewProps {
   hasMore: boolean;
 }
 
-function SectionLabel({
-  label,
-  endContent,
-}: {
-  label: string;
-  endContent?: React.ReactNode;
-}) {
-  return (
-    <MenuLabel
-      className="flex items-center justify-between py-0 pr-0"
-      htmlFor="null"
-    >
-      {label}
-      {endContent ? <span>{endContent}</span> : null}
-    </MenuLabel>
-  );
+function SectionLabel({ label }: { label: string }) {
+  return <MenuLabel className="flex items-center py-0">{label}</MenuLabel>;
 }
 
 function TaskRow({
@@ -145,115 +116,6 @@ function TaskRow({
       onEditSubmit={onEditSubmit}
       onEditCancel={onEditCancel}
     />
-  );
-}
-
-export function TaskSearchButton() {
-  const openCommandMenu = useCommandMenuStore((state) => state.open);
-  return (
-    <Button
-      type="button"
-      aria-label="Search tasks"
-      size="icon-sm"
-      onClick={() => openCommandMenu()}
-    >
-      <MagnifyingGlass size={14} />
-    </Button>
-  );
-}
-
-export function TaskFilterMenu() {
-  const organizeMode = useSidebarStore((state) => state.organizeMode);
-  const sortMode = useSidebarStore((state) => state.sortMode);
-  const showAllUsers = useSidebarStore((state) => state.showAllUsers);
-  const showInternal = useSidebarStore((state) => state.showInternal);
-  const setOrganizeMode = useSidebarStore((state) => state.setOrganizeMode);
-  const setSortMode = useSidebarStore((state) => state.setSortMode);
-  const setShowAllUsers = useSidebarStore((state) => state.setShowAllUsers);
-  const setShowInternal = useSidebarStore((state) => state.setShowInternal);
-  const { data: currentUser } = useMeQuery();
-  const isStaff = currentUser?.is_staff === true;
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button type="button" aria-label="Filter tasks" size="icon-sm">
-            <FunnelSimpleIcon size={14} />
-          </Button>
-        }
-      />
-      <DropdownMenuContent
-        align="start"
-        side="bottom"
-        sideOffset={6}
-        className="min-w-fit"
-      >
-        <MenuLabel>Organize</MenuLabel>
-        <DropdownMenuRadioGroup
-          value={organizeMode}
-          onValueChange={(value) =>
-            setOrganizeMode(value as typeof organizeMode)
-          }
-        >
-          <DropdownMenuRadioItem value="by-project">
-            By project
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="chronological">
-            Chronological list
-          </DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
-
-        <DropdownMenuSeparator />
-
-        <MenuLabel>Sort by</MenuLabel>
-        <DropdownMenuRadioGroup
-          value={sortMode}
-          onValueChange={(value) => setSortMode(value as typeof sortMode)}
-        >
-          <DropdownMenuRadioItem value="created">Created</DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="updated">Updated</DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
-
-        {import.meta.env.DEV && (
-          <>
-            <DropdownMenuSeparator />
-
-            <MenuLabel>Show</MenuLabel>
-            <DropdownMenuRadioGroup
-              value={showAllUsers ? "all" : "mine"}
-              onValueChange={(value) => setShowAllUsers(value === "all")}
-            >
-              <DropdownMenuRadioItem value="mine">
-                My tasks
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="all">
-                All tasks
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
-          </>
-        )}
-
-        {isStaff && (
-          <>
-            <DropdownMenuSeparator />
-
-            <MenuLabel>Task visibility</MenuLabel>
-            <DropdownMenuRadioGroup
-              value={showInternal ? "internal" : "external"}
-              onValueChange={(value) => setShowInternal(value === "internal")}
-            >
-              <DropdownMenuRadioItem value="external">
-                External
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="internal">
-                Internal
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }
 

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -148,7 +148,7 @@ function TaskRow({
   );
 }
 
-function TaskSearchButton() {
+export function TaskSearchButton() {
   const openCommandMenu = useCommandMenuStore((state) => state.open);
   return (
     <Button
@@ -162,7 +162,7 @@ function TaskSearchButton() {
   );
 }
 
-function TaskFilterMenu() {
+export function TaskFilterMenu() {
   const organizeMode = useSidebarStore((state) => state.organizeMode);
   const sortMode = useSidebarStore((state) => state.sortMode);
   const showAllUsers = useSidebarStore((state) => state.showAllUsers);
@@ -356,18 +356,6 @@ export function TaskListView({
           ))}
         </>
       )}
-
-      <div className="sticky top-0 z-10 bg-(--color-background) pt-2 pb-1">
-        <SectionLabel
-          label="Tasks"
-          endContent={
-            <span className="flex items-center">
-              <TaskSearchButton />
-              <TaskFilterMenu />
-            </span>
-          }
-        />
-      </div>
 
       {pinnedTasks.length === 0 &&
       flatTasks.length === 0 &&

--- a/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TaskListView.tsx
@@ -357,15 +357,17 @@ export function TaskListView({
         </>
       )}
 
-      <SectionLabel
-        label="Tasks"
-        endContent={
-          <span className="flex items-center">
-            <TaskSearchButton />
-            <TaskFilterMenu />
-          </span>
-        }
-      />
+      <div className="sticky top-0 z-10 bg-(--color-background) pt-2 pb-1">
+        <SectionLabel
+          label="Tasks"
+          endContent={
+            <span className="flex items-center">
+              <TaskSearchButton />
+              <TaskFilterMenu />
+            </span>
+          }
+        />
+      </div>
 
       {pinnedTasks.length === 0 &&
       flatTasks.length === 0 &&

--- a/apps/code/src/renderer/features/sidebar/components/TasksHeader.tsx
+++ b/apps/code/src/renderer/features/sidebar/components/TasksHeader.tsx
@@ -1,0 +1,140 @@
+import { useMeQuery } from "@hooks/useMeQuery";
+import {
+  FunnelSimple as FunnelSimpleIcon,
+  MagnifyingGlass,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  MenuLabel,
+} from "@posthog/quill";
+import { useCommandMenuStore } from "@stores/commandMenuStore";
+import { useSidebarStore } from "../stores/sidebarStore";
+
+function TaskSearchButton() {
+  const openCommandMenu = useCommandMenuStore((state) => state.open);
+  return (
+    <Button
+      type="button"
+      aria-label="Search tasks"
+      size="icon-sm"
+      onClick={() => openCommandMenu()}
+    >
+      <MagnifyingGlass size={14} />
+    </Button>
+  );
+}
+
+function TaskFilterMenu() {
+  const organizeMode = useSidebarStore((state) => state.organizeMode);
+  const sortMode = useSidebarStore((state) => state.sortMode);
+  const showAllUsers = useSidebarStore((state) => state.showAllUsers);
+  const showInternal = useSidebarStore((state) => state.showInternal);
+  const setOrganizeMode = useSidebarStore((state) => state.setOrganizeMode);
+  const setSortMode = useSidebarStore((state) => state.setSortMode);
+  const setShowAllUsers = useSidebarStore((state) => state.setShowAllUsers);
+  const setShowInternal = useSidebarStore((state) => state.setShowInternal);
+  const { data: currentUser } = useMeQuery();
+  const isStaff = currentUser?.is_staff === true;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button type="button" aria-label="Filter tasks" size="icon-sm">
+            <FunnelSimpleIcon size={14} />
+          </Button>
+        }
+      />
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="min-w-fit"
+      >
+        <MenuLabel>Organize</MenuLabel>
+        <DropdownMenuRadioGroup
+          value={organizeMode}
+          onValueChange={(value) =>
+            setOrganizeMode(value as typeof organizeMode)
+          }
+        >
+          <DropdownMenuRadioItem value="by-project">
+            By project
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="chronological">
+            Chronological list
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+
+        <DropdownMenuSeparator />
+
+        <MenuLabel>Sort by</MenuLabel>
+        <DropdownMenuRadioGroup
+          value={sortMode}
+          onValueChange={(value) => setSortMode(value as typeof sortMode)}
+        >
+          <DropdownMenuRadioItem value="created">Created</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="updated">Updated</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+
+        {import.meta.env.DEV && (
+          <>
+            <DropdownMenuSeparator />
+
+            <MenuLabel>Show</MenuLabel>
+            <DropdownMenuRadioGroup
+              value={showAllUsers ? "all" : "mine"}
+              onValueChange={(value) => setShowAllUsers(value === "all")}
+            >
+              <DropdownMenuRadioItem value="mine">
+                My tasks
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="all">
+                All tasks
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </>
+        )}
+
+        {isStaff && (
+          <>
+            <DropdownMenuSeparator />
+
+            <MenuLabel>Task visibility</MenuLabel>
+            <DropdownMenuRadioGroup
+              value={showInternal ? "internal" : "external"}
+              onValueChange={(value) => setShowInternal(value === "internal")}
+            >
+              <DropdownMenuRadioItem value="external">
+                External
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="internal">
+                Internal
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function TasksHeader() {
+  return (
+    <div className="shrink-0 px-2">
+      <MenuLabel className="flex items-center justify-between pt-0 pr-0 pb-0.5">
+        Tasks
+        <span className="flex items-center">
+          <TaskSearchButton />
+          <TaskFilterMenu />
+        </span>
+      </MenuLabel>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

The Tasks section in the sidebar was not height-constrained, so scrolling let it expand over the fixed controls instead of staying inside its intended area.

Closes #2359

## Changes

Split the sidebar into a fixed controls block and a bounded task scroll region with a sticky task section header (section title "TASKS", search and filter icons)

## How did you test this?

Verified the edited files and manually reviewed the layout change.

## Demo
[sidebar-tasks-section-overflow-scroll-fixed-with-sticky-controls-block-and-tasks-section-header.webm](https://github.com/user-attachments/assets/d3c47ba7-2f06-4505-a561-b58308f0b281)

## Publish to changelog?

Do not publish to changelog.
