### PR TITLE
feat: Add switch to org button on plan usage screen

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -54,15 +54,15 @@ export function PlanUsageSettings() {
   const switchOrgMutation = useSwitchOrgMutation();
   const billingUrl = getBillingUrl(cloudRegion);
 
-  const [billingSwitch, setBillingSwitch] = useState<{
-    pending: boolean;
-    error: boolean;
-  }>({ pending: false, error: false });
+  async function switchOrgAndRefreshSeat(orgId: string): Promise<void> {
+    await switchOrgMutation.mutateAsync(orgId);
+    await fetchSeat({ autoProvision: true });
+  }
 
   async function openBillingPage(orgId: string | null): Promise<void> {
     if (orgId && orgId !== currentOrgId) {
       try {
-        await switchOrgMutation.mutateAsync(orgId);
+        await switchOrgAndRefreshSeat(orgId);
       } catch (err) {
         log.warn("Failed to switch org before opening billing", err);
         return;
@@ -72,14 +72,10 @@ export function PlanUsageSettings() {
   }
 
   async function switchToBillingOrg(orgId: string): Promise<void> {
-    setBillingSwitch({ pending: true, error: false });
     try {
-      await switchOrgMutation.mutateAsync(orgId);
-      await fetchSeat({ autoProvision: true });
-      setBillingSwitch({ pending: false, error: false });
+      await switchOrgAndRefreshSeat(orgId);
     } catch (err) {
       log.warn("Failed to switch to billing org", err);
-      setBillingSwitch({ pending: false, error: true });
     }
   }
   const redirectFullUrl = redirectUrl
@@ -205,18 +201,18 @@ export function PlanUsageSettings() {
                   <Button
                     size="1"
                     variant="outline"
-                    disabled={billingSwitch.pending}
+                    disabled={switchOrgMutation.isPending}
                     onClick={() => {
                       void switchToBillingOrg(billingOrgId);
                     }}
                   >
-                    {billingSwitch.pending ? (
+                    {switchOrgMutation.isPending ? (
                       <Spinner size="1" />
                     ) : (
                       `Switch to ${seat.organization_name ?? "Pro org"}`
                     )}
                   </Button>
-                  {billingSwitch.error && (
+                  {switchOrgMutation.isError && (
                     <Text className="text-(--red-11) text-[12px]">
                       Switching failed. Try again or switch from the sidebar.
                     </Text>

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -60,19 +60,15 @@ export function PlanUsageSettings() {
         await switchOrgMutation.mutateAsync(orgId);
       } catch (err) {
         log.warn("Failed to switch org before opening billing", err);
+        return;
       }
     }
-    const url = getBillingUrl();
-    if (url) window.open(url, "_blank");
+    if (billingUrl) window.open(billingUrl, "_blank");
   }
 
   async function switchToBillingOrg(orgId: string): Promise<void> {
-    try {
-      await switchOrgMutation.mutateAsync(orgId);
-      await fetchSeat({ autoProvision: true });
-    } catch (err) {
-      log.warn("Failed to switch to billing org", err);
-    }
+    await switchOrgMutation.mutateAsync(orgId);
+    await fetchSeat({ autoProvision: true });
   }
   const redirectFullUrl = redirectUrl
     ? (getPostHogUrl(redirectUrl, cloudRegion) ?? billingUrl)
@@ -193,21 +189,27 @@ export function PlanUsageSettings() {
                 this page reflects your current organization.
               </Text>
               {billingOrgId && (
-                <Button
-                  size="1"
-                  variant="outline"
-                  disabled={switchOrgMutation.isPending}
-                  onClick={() => {
-                    void switchToBillingOrg(billingOrgId);
-                  }}
-                  className="self-start"
-                >
-                  {switchOrgMutation.isPending ? (
-                    <Spinner size="1" />
-                  ) : (
-                    `Switch to ${seat.organization_name}`
+                <Flex direction="column" gap="1" className="self-start">
+                  <Button
+                    size="1"
+                    variant="outline"
+                    disabled={switchOrgMutation.isPending}
+                    onClick={() => {
+                      void switchToBillingOrg(billingOrgId);
+                    }}
+                  >
+                    {switchOrgMutation.isPending ? (
+                      <Spinner size="1" />
+                    ) : (
+                      `Switch to ${seat.organization_name ?? "Pro org"}`
+                    )}
+                  </Button>
+                  {switchOrgMutation.isError && (
+                    <Text className="text-(--red-11) text-[12px]">
+                      Switching failed. Try again or switch from the sidebar.
+                    </Text>
                   )}
-                </Button>
+                </Flex>
               )}
             </Flex>
           </Callout.Text>

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -1,4 +1,4 @@
-import { getAuthenticatedClient } from "@features/auth/hooks/authClient";
+import { useSwitchOrgMutation } from "@features/auth/hooks/authMutations";
 import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { TokenSpendAnalysisBanner } from "@features/billing/components/TokenSpendAnalysisBanner";
 import { useUsage } from "@features/billing/hooks/useUsage";
@@ -34,21 +34,6 @@ const log = logger.scope("plan-usage");
 
 const SPEND_ANALYSIS_FLAG = "posthog-code-spend-analysis";
 
-async function openBillingPage(orgId: string | null): Promise<void> {
-  if (orgId) {
-    try {
-      const client = await getAuthenticatedClient();
-      if (client) {
-        await client.switchOrganization(orgId);
-      }
-    } catch (err) {
-      log.warn("Failed to switch org before opening billing", err);
-    }
-  }
-  const url = getBillingUrl();
-  if (url) window.open(url, "_blank");
-}
-
 export function PlanUsageSettings() {
   const {
     seat,
@@ -65,7 +50,30 @@ export function PlanUsageSettings() {
   const { fetchSeat, upgradeToPro, cancelSeat, reactivateSeat, clearError } =
     useSeatStore();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const currentOrgId = useAuthStateValue((state) => state.currentOrgId);
+  const switchOrgMutation = useSwitchOrgMutation();
   const billingUrl = getBillingUrl(cloudRegion);
+
+  async function openBillingPage(orgId: string | null): Promise<void> {
+    if (orgId && orgId !== currentOrgId) {
+      try {
+        await switchOrgMutation.mutateAsync(orgId);
+      } catch (err) {
+        log.warn("Failed to switch org before opening billing", err);
+      }
+    }
+    const url = getBillingUrl();
+    if (url) window.open(url, "_blank");
+  }
+
+  async function switchToBillingOrg(orgId: string): Promise<void> {
+    try {
+      await switchOrgMutation.mutateAsync(orgId);
+      await fetchSeat({ autoProvision: true });
+    } catch (err) {
+      log.warn("Failed to switch to billing org", err);
+    }
+  }
   const redirectFullUrl = redirectUrl
     ? (getPostHogUrl(redirectUrl, cloudRegion) ?? billingUrl)
     : null;
@@ -177,10 +185,31 @@ export function PlanUsageSettings() {
           <Callout.Icon>
             <Info size={16} />
           </Callout.Icon>
-          <Callout.Text className="text-sm">
-            You have a Pro plan on{" "}
-            <Text weight="medium">{seat.organization_name}</Text>. Usage on this
-            page reflects your current organization.
+          <Callout.Text>
+            <Flex direction="column" gap="2">
+              <Text className="text-sm">
+                You have a Pro plan on{" "}
+                <Text weight="medium">{seat.organization_name}</Text>. Usage on
+                this page reflects your current organization.
+              </Text>
+              {billingOrgId && (
+                <Button
+                  size="1"
+                  variant="outline"
+                  disabled={switchOrgMutation.isPending}
+                  onClick={() => {
+                    void switchToBillingOrg(billingOrgId);
+                  }}
+                  className="self-start"
+                >
+                  {switchOrgMutation.isPending ? (
+                    <Spinner size="1" />
+                  ) : (
+                    `Switch to ${seat.organization_name}`
+                  )}
+                </Button>
+              )}
+            </Flex>
           </Callout.Text>
         </Callout.Root>
       )}

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -54,6 +54,11 @@ export function PlanUsageSettings() {
   const switchOrgMutation = useSwitchOrgMutation();
   const billingUrl = getBillingUrl(cloudRegion);
 
+  const [billingSwitch, setBillingSwitch] = useState<{
+    pending: boolean;
+    error: boolean;
+  }>({ pending: false, error: false });
+
   async function openBillingPage(orgId: string | null): Promise<void> {
     if (orgId && orgId !== currentOrgId) {
       try {
@@ -67,8 +72,15 @@ export function PlanUsageSettings() {
   }
 
   async function switchToBillingOrg(orgId: string): Promise<void> {
-    await switchOrgMutation.mutateAsync(orgId);
-    await fetchSeat({ autoProvision: true });
+    setBillingSwitch({ pending: true, error: false });
+    try {
+      await switchOrgMutation.mutateAsync(orgId);
+      await fetchSeat({ autoProvision: true });
+      setBillingSwitch({ pending: false, error: false });
+    } catch (err) {
+      log.warn("Failed to switch to billing org", err);
+      setBillingSwitch({ pending: false, error: true });
+    }
   }
   const redirectFullUrl = redirectUrl
     ? (getPostHogUrl(redirectUrl, cloudRegion) ?? billingUrl)
@@ -193,18 +205,18 @@ export function PlanUsageSettings() {
                   <Button
                     size="1"
                     variant="outline"
-                    disabled={switchOrgMutation.isPending}
+                    disabled={billingSwitch.pending}
                     onClick={() => {
                       void switchToBillingOrg(billingOrgId);
                     }}
                   >
-                    {switchOrgMutation.isPending ? (
+                    {billingSwitch.pending ? (
                       <Spinner size="1" />
                     ) : (
                       `Switch to ${seat.organization_name ?? "Pro org"}`
                     )}
                   </Button>
-                  {switchOrgMutation.isError && (
+                  {billingSwitch.error && (
                     <Text className="text-(--red-11) text-[12px]">
                       Switching failed. Try again or switch from the sidebar.
                     </Text>


### PR DESCRIPTION
## Problem

`PlanUsageSettings` detected `hasBetterPlanElsewhere` and showed a callout but offered no way to actually switch to the org with the better plan. The page also called `client.switchOrganization` directly from the renderer, bypassing the main-process auth service.

## Changes

1. Add a "Switch to {org}" button to the `hasBetterPlanElsewhere` callout
2. Route every renderer org switch through `useSwitchOrgMutation` so `AuthService.switchOrg` is the single canonical path
3. Refetch the seat with `autoProvision: true` after the switch so the Pro card reflects the new active org
4. Show a red error callout when the switch fails, with a `?? "Pro org"` fallback when the API omits the org name

## How did you test this?

manually

## Publish to changelog?

no