### PR TITLE
fix(code): Do not show empty Inbox to users no GitHub social integration

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -19,6 +19,7 @@ import {
   useInboxReportsInfinite,
   useInboxSignalProcessingState,
 } from "@features/inbox/hooks/useInboxReports";
+import { useSeedSuggestedReviewerFilter } from "@features/inbox/hooks/useSeedSuggestedReviewerFilter";
 import { useSignalSourceConfigs } from "@features/inbox/hooks/useSignalSourceConfigs";
 import { useInboxReportSelectionStore } from "@features/inbox/stores/inboxReportSelectionStore";
 import { useInboxSignalsFilterStore } from "@features/inbox/stores/inboxSignalsFilterStore";
@@ -36,6 +37,7 @@ import { setPendingInboxOpenMethod } from "@features/inbox/utils/pendingInboxOpe
 import { DiscoveredTaskDetailPane } from "@features/setup/components/DiscoveredTaskDetailPane";
 import { RecommendedSetupTasks } from "@features/setup/components/RecommendedSetupTasks";
 import { useSetupStore } from "@features/setup/stores/setupStore";
+import { useAuthenticatedQuery } from "@hooks/useAuthenticatedQuery";
 import {
   useIntegrations,
   useRepositoryIntegration,
@@ -72,21 +74,22 @@ export function InboxSignalsTab() {
   const suggestedReviewerFilter = useInboxSignalsFilterStore(
     (s) => s.suggestedReviewerFilter,
   );
-  const seedSuggestedReviewerFilterWithCurrentUser = useInboxSignalsFilterStore(
-    (s) => s.seedSuggestedReviewerFilterWithCurrentUser,
-  );
-
   // ── Current user (seeds reviewer filter on first inbox visit) ───────────
   const authClient = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({
     client: authClient,
     enabled: !!authClient,
   });
-
-  useEffect(() => {
-    if (!currentUser?.uuid) return;
-    seedSuggestedReviewerFilterWithCurrentUser(currentUser.uuid);
-  }, [currentUser?.uuid, seedSuggestedReviewerFilterWithCurrentUser]);
+  // Gates the seed below: backend filters reports by GitHub login, not UUID.
+  const { data: githubLogin } = useAuthenticatedQuery(
+    ["github_login"],
+    (client) => client.getGithubLogin(),
+    { staleTime: 5 * 60 * 1000 },
+  );
+  useSeedSuggestedReviewerFilter({
+    currentUserUuid: currentUser?.uuid,
+    githubLogin,
+  });
 
   // ── GitHub integration ───────────────────────────────────────────────
   const { hasGithubIntegration } = useRepositoryIntegration();

--- a/apps/code/src/renderer/features/inbox/hooks/useSeedSuggestedReviewerFilter.test.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSeedSuggestedReviewerFilter.test.ts
@@ -1,0 +1,58 @@
+import { useInboxSignalsFilterStore } from "@features/inbox/stores/inboxSignalsFilterStore";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSeedSuggestedReviewerFilter } from "./useSeedSuggestedReviewerFilter";
+
+describe("useSeedSuggestedReviewerFilter", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useInboxSignalsFilterStore.setState({
+      suggestedReviewerFilter: [],
+      hasInitializedSuggestedReviewerFilter: false,
+    });
+  });
+
+  it("skips seeding when the user has no GitHub login", () => {
+    renderHook(() =>
+      useSeedSuggestedReviewerFilter({
+        currentUserUuid: "user-uuid",
+        githubLogin: null,
+      }),
+    );
+    const state = useInboxSignalsFilterStore.getState();
+    expect(state.suggestedReviewerFilter).toEqual([]);
+    // Init flag stays false so a later visit can retry once GitHub is connected.
+    expect(state.hasInitializedSuggestedReviewerFilter).toBe(false);
+  });
+
+  it("seeds with the current user when both UUID and GitHub login are present", () => {
+    renderHook(() =>
+      useSeedSuggestedReviewerFilter({
+        currentUserUuid: "user-uuid",
+        githubLogin: "octocat",
+      }),
+    );
+    const state = useInboxSignalsFilterStore.getState();
+    expect(state.suggestedReviewerFilter).toEqual(["user-uuid"]);
+    expect(state.hasInitializedSuggestedReviewerFilter).toBe(true);
+  });
+
+  it("seeds on a later render once the GitHub login resolves", () => {
+    const { rerender } = renderHook(
+      ({ githubLogin }: { githubLogin: string | null }) =>
+        useSeedSuggestedReviewerFilter({
+          currentUserUuid: "user-uuid",
+          githubLogin,
+        }),
+      { initialProps: { githubLogin: null as string | null } },
+    );
+    expect(
+      useInboxSignalsFilterStore.getState().suggestedReviewerFilter,
+    ).toEqual([]);
+
+    rerender({ githubLogin: "octocat" });
+    const state = useInboxSignalsFilterStore.getState();
+    expect(state.suggestedReviewerFilter).toEqual(["user-uuid"]);
+    expect(state.hasInitializedSuggestedReviewerFilter).toBe(true);
+  });
+});

--- a/apps/code/src/renderer/features/inbox/hooks/useSeedSuggestedReviewerFilter.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSeedSuggestedReviewerFilter.ts
@@ -1,0 +1,24 @@
+import { useInboxSignalsFilterStore } from "@features/inbox/stores/inboxSignalsFilterStore";
+import { useEffect } from "react";
+
+/**
+ * Seeds the inbox suggested-reviewer filter with the current user on first
+ * visit. Skips when no GitHub login is available — the backend resolves the
+ * UUID through it, so the filter would return 0 reports. Skipping leaves the
+ * init flag false so we try again once the user connects GitHub.
+ */
+export function useSeedSuggestedReviewerFilter({
+  currentUserUuid,
+  githubLogin,
+}: {
+  currentUserUuid: string | null | undefined;
+  githubLogin: string | null | undefined;
+}) {
+  const seed = useInboxSignalsFilterStore(
+    (s) => s.seedSuggestedReviewerFilterWithCurrentUser,
+  );
+  useEffect(() => {
+    if (!currentUserUuid || !githubLogin) return;
+    seed(currentUserUuid);
+  }, [currentUserUuid, githubLogin, seed]);
+}


### PR DESCRIPTION
## Problem
- Inbox showed "Reports (0)" after a PostHog Code update; backend actually had 590 reports for the user (caught by @annikaschmid in Session Replay)
- PR #2151 (May 19, @joshsny) added an auto-filter to show only reports assigned to the user on the Inbox visit.
- If the user doesn't have GitHub social logic (or has conflicts) - user sees 0 reports

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes
- If problems with detecting GitHub login - show all reports. It's better to show too much than "nothing, Inbox doesn't work".
- When the user adds a proper GitHub login - the per-reviewer filter should reapply on the next Inbox visit


<!-- What did you change and why? -->
<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
