### PR TITLE
feat(analytics): attach app version to all custom events

### DIFF
--- a/apps/code/src/main/services/posthog-analytics.test.ts
+++ b/apps/code/src/main/services/posthog-analytics.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCapture = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockIdentify = vi.hoisted(() => vi.fn());
+const mockShutdown = vi.hoisted(() => vi.fn());
+const MockPostHog = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-node", () => ({ PostHog: MockPostHog }));
+
+import {
+  captureException,
+  initializePostHog,
+  resetUser,
+  shutdownPostHog,
+  trackAppEvent,
+} from "./posthog-analytics";
+
+describe("posthog-analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockPostHog.mockImplementation(function (this: Record<string, unknown>) {
+      this.capture = mockCapture;
+      this.captureException = mockCaptureException;
+      this.identify = mockIdentify;
+      this.shutdown = mockShutdown;
+    });
+    process.env.VITE_POSTHOG_API_KEY = "test-key";
+    resetUser();
+    initializePostHog();
+  });
+
+  afterEach(async () => {
+    await shutdownPostHog();
+  });
+
+  it("includes the app version on every tracked event", () => {
+    trackAppEvent("app_started");
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "app_started",
+        properties: expect.objectContaining({
+          team: "posthog-code",
+          app_version: "0.0.0-test",
+        }),
+      }),
+    );
+  });
+
+  it("lets caller-supplied properties coexist with the app version", () => {
+    trackAppEvent("app_quit", { reason: "user-initiated" });
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          reason: "user-initiated",
+          app_version: "0.0.0-test",
+        }),
+      }),
+    );
+  });
+
+  it("includes the app version on captured exceptions", () => {
+    captureException(new Error("boom"));
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.any(String),
+      expect.objectContaining({
+        team: "posthog-code",
+        app_version: "0.0.0-test",
+      }),
+    );
+  });
+});

--- a/apps/code/src/main/services/posthog-analytics.test.ts
+++ b/apps/code/src/main/services/posthog-analytics.test.ts
@@ -61,6 +61,18 @@ describe("posthog-analytics", () => {
     );
   });
 
+  it("does not let caller-supplied app_version override the system value", () => {
+    trackAppEvent("app_quit", { app_version: "spoofed" });
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          app_version: "0.0.0-test",
+        }),
+      }),
+    );
+  });
+
   it("includes the app version on captured exceptions", () => {
     captureException(new Error("boom"));
 
@@ -69,6 +81,18 @@ describe("posthog-analytics", () => {
       expect.any(String),
       expect.objectContaining({
         team: "posthog-code",
+        app_version: "0.0.0-test",
+      }),
+    );
+  });
+
+  it("does not let additionalProperties override app_version on exceptions", () => {
+    captureException(new Error("boom"), { app_version: "spoofed" });
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.any(String),
+      expect.objectContaining({
         app_version: "0.0.0-test",
       }),
     );

--- a/apps/code/src/main/services/posthog-analytics.ts
+++ b/apps/code/src/main/services/posthog-analytics.ts
@@ -47,8 +47,8 @@ export function trackAppEvent(
     event: eventName,
     properties: {
       team: "posthog-code",
-      app_version: getAppVersion(),
       ...properties,
+      app_version: getAppVersion(),
       $process_person_profile: !!currentUserId,
     },
   });
@@ -96,7 +96,7 @@ export function captureException(
   const distinctId = currentUserId || "anonymous-app-event";
   posthogClient.captureException(error, distinctId, {
     team: "posthog-code",
-    app_version: getAppVersion(),
     ...additionalProperties,
+    app_version: getAppVersion(),
   });
 }

--- a/apps/code/src/main/services/posthog-analytics.ts
+++ b/apps/code/src/main/services/posthog-analytics.ts
@@ -1,4 +1,5 @@
 import { PostHog } from "posthog-node";
+import { getAppVersion } from "../utils/env";
 
 let posthogClient: PostHog | null = null;
 let currentUserId: string | null = null;
@@ -46,6 +47,7 @@ export function trackAppEvent(
     event: eventName,
     properties: {
       team: "posthog-code",
+      app_version: getAppVersion(),
       ...properties,
       $process_person_profile: !!currentUserId,
     },
@@ -94,6 +96,7 @@ export function captureException(
   const distinctId = currentUserId || "anonymous-app-event";
   posthogClient.captureException(error, distinctId, {
     team: "posthog-code",
+    app_version: getAppVersion(),
     ...additionalProperties,
   });
 }

--- a/apps/code/src/renderer/App.tsx
+++ b/apps/code/src/renderer/App.tsx
@@ -48,8 +48,7 @@ function App() {
   const [showTransition, setShowTransition] = useState(false);
   const wasInMainApp = useRef(isAuthenticated && hasCompletedOnboarding);
 
-  // Initialize PostHog analytics and attach the app version as a super
-  // property so every event is sliceable by PostHog Code version.
+  // Initialize PostHog analytics and register the app version super property.
   useEffect(() => {
     initializePostHog();
     trpcClient.os.getAppVersion

--- a/apps/code/src/renderer/App.tsx
+++ b/apps/code/src/renderer/App.tsx
@@ -26,7 +26,7 @@ import { isNotAuthenticatedError } from "@shared/errors";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSubscription } from "@trpc/tanstack-react-query";
-import { initializePostHog, track } from "@utils/analytics";
+import { initializePostHog, registerAppVersion, track } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { toast } from "@utils/toast";
 import { AnimatePresence, motion } from "framer-motion";
@@ -48,9 +48,16 @@ function App() {
   const [showTransition, setShowTransition] = useState(false);
   const wasInMainApp = useRef(isAuthenticated && hasCompletedOnboarding);
 
-  // Initialize PostHog analytics
+  // Initialize PostHog analytics and attach the app version as a super
+  // property so every event is sliceable by PostHog Code version.
   useEffect(() => {
     initializePostHog();
+    trpcClient.os.getAppVersion
+      .query()
+      .then(registerAppVersion)
+      .catch((error) => {
+        log.warn("Failed to register app version super property", { error });
+      });
   }, []);
 
   // Initialize connectivity monitoring

--- a/apps/code/src/renderer/utils/analytics.test.ts
+++ b/apps/code/src/renderer/utils/analytics.test.ts
@@ -108,6 +108,22 @@ describe("registerAppVersion", () => {
 
     expect(mockPosthog.register).not.toHaveBeenCalled();
   });
+
+  it("re-registers app_version after resetUser clears super properties", async () => {
+    const { initializePostHog, registerAppVersion, resetUser } =
+      await loadAnalytics();
+
+    initializePostHog();
+    registerAppVersion("1.2.3");
+
+    resetUser();
+
+    expect(mockPosthog.reset).toHaveBeenCalledTimes(1);
+    expect(mockPosthog.register).toHaveBeenLastCalledWith({
+      team: "posthog-code",
+      app_version: "1.2.3",
+    });
+  });
 });
 
 describe("initializePostHog", () => {

--- a/apps/code/src/renderer/utils/analytics.test.ts
+++ b/apps/code/src/renderer/utils/analytics.test.ts
@@ -91,6 +91,25 @@ describe("onFeatureFlagsLoaded", () => {
   });
 });
 
+describe("registerAppVersion", () => {
+  it("registers app_version as a super property after init", async () => {
+    const { initializePostHog, registerAppVersion } = await loadAnalytics();
+
+    initializePostHog();
+    registerAppVersion("1.2.3");
+
+    expect(mockPosthog.register).toHaveBeenCalledWith({ app_version: "1.2.3" });
+  });
+
+  it("does nothing before init", async () => {
+    const { registerAppVersion } = await loadAnalytics();
+
+    registerAppVersion("1.2.3");
+
+    expect(mockPosthog.register).not.toHaveBeenCalled();
+  });
+});
+
 describe("initializePostHog", () => {
   it("is idempotent across repeat calls", async () => {
     const { initializePostHog } = await loadAnalytics();

--- a/apps/code/src/renderer/utils/analytics.ts
+++ b/apps/code/src/renderer/utils/analytics.ts
@@ -14,6 +14,23 @@ const log = logger.scope("analytics");
 
 let isInitialized = false;
 
+// The app version fetched from the main process at startup. Cached so it can be
+// re-applied after `posthog.reset()` (logout), which clears all super
+// properties — see registerPersistentSuperProperties / resetUser.
+let registeredAppVersion: string | null = null;
+
+// Super properties that must ride along on every event for the lifetime of the
+// app, including across logout/login cycles. `posthog.reset()` wipes all super
+// properties, so these are re-registered after each reset.
+function registerPersistentSuperProperties() {
+  posthog.register({
+    team: "posthog-code",
+    ...(registeredAppVersion !== null
+      ? { app_version: registeredAppVersion }
+      : {}),
+  });
+}
+
 type PendingFlagListener = {
   callback: () => void;
   unsubscribe: (() => void) | null;
@@ -49,9 +66,9 @@ export function initializePostHog() {
     },
   });
 
-  posthog.register({ team: "posthog-code" });
-
   isInitialized = true;
+
+  registerPersistentSuperProperties();
 
   for (const listener of pendingFlagListeners) {
     listener.unsubscribe = posthog.onFeatureFlags(listener.callback);
@@ -109,6 +126,10 @@ export function startSessionRecording() {
  * The version is fetched from the main process at startup (see App.tsx).
  */
 export function registerAppVersion(appVersion: string) {
+  // Cache regardless of init state so it survives a later reset and gets
+  // re-applied by registerPersistentSuperProperties.
+  registeredAppVersion = appVersion;
+
   if (!isInitialized) {
     return;
   }
@@ -160,6 +181,10 @@ export function resetUser() {
   }
 
   posthog.reset();
+
+  // reset() clears all super properties; re-apply the ones that must persist
+  // across logout/login cycles (team + app_version).
+  registerPersistentSuperProperties();
 }
 
 export function track<K extends keyof EventPropertyMap>(

--- a/apps/code/src/renderer/utils/analytics.ts
+++ b/apps/code/src/renderer/utils/analytics.ts
@@ -14,14 +14,10 @@ const log = logger.scope("analytics");
 
 let isInitialized = false;
 
-// The app version fetched from the main process at startup. Cached so it can be
-// re-applied after `posthog.reset()` (logout), which clears all super
-// properties — see registerPersistentSuperProperties / resetUser.
+// Cached so it can be re-applied after posthog.reset() clears super properties.
 let registeredAppVersion: string | null = null;
 
-// Super properties that must ride along on every event for the lifetime of the
-// app, including across logout/login cycles. `posthog.reset()` wipes all super
-// properties, so these are re-registered after each reset.
+// posthog.reset() wipes super properties, so these are re-registered after each reset.
 function registerPersistentSuperProperties() {
   posthog.register({
     team: "posthog-code",
@@ -119,15 +115,8 @@ export function startSessionRecording() {
   }, 1000);
 }
 
-/**
- * Register the PostHog Code version as a super property so it is attached to
- * every subsequently captured event. This lets us slice analytics by app
- * version — e.g. to spot users stuck on old versions or failing auto-updates.
- * The version is fetched from the main process at startup (see App.tsx).
- */
+// Register the app version as a super property so it rides along on every event.
 export function registerAppVersion(appVersion: string) {
-  // Cache regardless of init state so it survives a later reset and gets
-  // re-applied by registerPersistentSuperProperties.
   registeredAppVersion = appVersion;
 
   if (!isInitialized) {
@@ -182,8 +171,7 @@ export function resetUser() {
 
   posthog.reset();
 
-  // reset() clears all super properties; re-apply the ones that must persist
-  // across logout/login cycles (team + app_version).
+  // reset() clears super properties; re-apply the persistent ones.
   registerPersistentSuperProperties();
 }
 

--- a/apps/code/src/renderer/utils/analytics.ts
+++ b/apps/code/src/renderer/utils/analytics.ts
@@ -102,6 +102,20 @@ export function startSessionRecording() {
   }, 1000);
 }
 
+/**
+ * Register the PostHog Code version as a super property so it is attached to
+ * every subsequently captured event. This lets us slice analytics by app
+ * version — e.g. to spot users stuck on old versions or failing auto-updates.
+ * The version is fetched from the main process at startup (see App.tsx).
+ */
+export function registerAppVersion(appVersion: string) {
+  if (!isInitialized) {
+    return;
+  }
+
+  posthog.register({ app_version: appVersion });
+}
+
 export function identifyUser(
   userId: string,
   properties?: UserIdentifyProperties,

--- a/apps/code/vite-plugin-auto-services.ts
+++ b/apps/code/vite-plugin-auto-services.ts
@@ -14,6 +14,8 @@ export function autoServicesPlugin(servicesDir: string): Plugin {
       (f) =>
         f.endsWith(".ts") &&
         !f.endsWith(".types.ts") &&
+        !f.endsWith(".test.ts") &&
+        !f.endsWith(".spec.ts") &&
         f !== "index.ts" &&
         f !== "types.ts",
     );


### PR DESCRIPTION
## Problem

We send custom events to PostHog from the Code app, but none of them carry the PostHog Code version. That makes it impossible to answer version-related questions from product analytics — e.g. "are users stuck on old versions?" or "did auto-updates stop landing?" (see the auto-update reports in Slack). The version was only available in OTel logs as `service.version`, not on events.

## Changes

Attach the app version (`getAppVersion()` / `POSTHOG_CODE_VERSION`, sourced from `app.getVersion()`) to every custom event:

- **Main process** (`posthog-analytics.ts`): merge `app_version` into the properties of every `trackAppEvent(...)` capture and every `captureException(...)`.
- **Renderer**: add a focused `registerAppVersion(version)` that registers `app_version` as a PostHog super property (so it rides along on all subsequent events, including exceptions). `App.tsx` fetches the version via the existing `os.getAppVersion` tRPC query at startup and registers it.

Kept `analytics.ts` free of any `trpcClient` import (the fetch lives in `App.tsx`) to avoid a module-load-time tRPC/ipcLink dependency that would otherwise break renderer unit tests.

No UI changes.

## How did you test this?

- Added `posthog-analytics.test.ts` (main): asserts `app_version` is on tracked events, on captured exceptions, and coexists with caller-supplied props.
- Extended `analytics.test.ts` (renderer): `registerAppVersion` registers the super property after init and no-ops before init.
- Ran the full code app suite: `pnpm --filter code test` → 1516 passed.
- `npx biome check` and `tsc -p tsconfig.web.json` clean on touched files; pre-commit typecheck hook passed.

## Publish to changelog?

no
