### PR TITLE
fix(inbox): make Discuss question input a resizable textarea

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -575,7 +575,7 @@ export function ReportDetailPane({
                   />
                   <Flex justify="between" align="center" gap="2">
                     <Text size="1" color="gray">
-                      <Kbd>⌘</Kbd> <Kbd>↵</Kbd> to send
+                      <Kbd>{isMac ? "⌘↵" : "Ctrl+↵"}</Kbd> to send
                     </Text>
                     <Flex gap="2">
                       <Button

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -31,7 +31,7 @@ import {
   ScrollArea,
   Spinner,
   Text,
-  TextField,
+  TextArea,
   Tooltip,
 } from "@radix-ui/themes";
 import { useTRPC } from "@renderer/trpc";
@@ -546,7 +546,7 @@ export function ReportDetailPane({
               </Popover.Trigger>
               <Popover.Content
                 align="end"
-                className="w-[320px] border border-(--gray-6) bg-(--color-panel-solid) p-3 shadow-6"
+                className="w-[420px] border border-(--gray-6) bg-(--color-panel-solid) p-3 shadow-6"
                 side="bottom"
                 sideOffset={6}
               >
@@ -554,27 +554,43 @@ export function ReportDetailPane({
                   className="flex flex-col gap-2"
                   onSubmit={handleDiscussSubmit}
                 >
-                  <TextField.Root
+                  <TextArea
                     aria-label="Optional first question for Discuss"
                     autoFocus
                     placeholder="Ask about this report..."
+                    resize="vertical"
+                    rows={5}
                     size="2"
                     value={discussQuestion}
                     onChange={(event) => setDiscussQuestion(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (
+                        event.key === "Enter" &&
+                        (event.metaKey || event.ctrlKey)
+                      ) {
+                        event.preventDefault();
+                        handleDiscussReport(discussQuestion);
+                      }
+                    }}
                   />
-                  <Flex justify="end" gap="2">
-                    <Button
-                      color="gray"
-                      size="1"
-                      type="button"
-                      variant="soft"
-                      onClick={() => setDiscussQuestionOpen(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button size="1" type="submit" variant="soft">
-                      Discuss
-                    </Button>
+                  <Flex justify="between" align="center" gap="2">
+                    <Text size="1" color="gray">
+                      <Kbd>⌘</Kbd> <Kbd>↵</Kbd> to send
+                    </Text>
+                    <Flex gap="2">
+                      <Button
+                        color="gray"
+                        size="1"
+                        type="button"
+                        variant="soft"
+                        onClick={() => setDiscussQuestionOpen(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button size="1" type="submit" variant="soft">
+                        Discuss
+                      </Button>
+                    </Flex>
                   </Flex>
                 </form>
               </Popover.Content>


### PR DESCRIPTION
## Problem

The optional "Discuss" question input on inbox report details is a single-line `TextField` cramped inside a 320px popover. Users have started using Discuss to ask longer questions (and even series of questions) and the tiny one-liner is awkward — most of what they type is hidden off-screen.

## Changes

<img width="1520" height="702" alt="image" src="https://github.com/user-attachments/assets/b1f909b4-16b4-45ea-83f1-d2f55ff31411" />


- Swap the `TextField.Root` for a Radix `TextArea` so it's multi-line by default.
- Set `rows={5}` for a noticeably taller default height.
- `resize="vertical"` so users can drag from the bottom-right to make it bigger when they want to type more.
- Widen the popover from 320px to 420px so the textarea isn't squeezed.
- Add Cmd/Ctrl+Enter to submit (with a small Kbd hint) since Enter now inserts a newline in the textarea.

## How did you test this?

- `pnpm --filter code typecheck` passes.
- `biome check` on the changed file passes.
- Did not manually run the Electron app in this environment, so the UI/drag behavior has not been visually verified — worth a quick local check before merge.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*