### PR TITLE
feat(inbox): Capture "Signal source connected" analytics event

### DIFF
--- a/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
@@ -9,8 +9,10 @@ import type {
   SignalReportPriority,
   SignalUserAutonomyConfig,
 } from "@shared/types";
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { getCloudUrlFromRegion } from "@shared/utils/urls";
 import { useQueryClient } from "@tanstack/react-query";
+import { track } from "@utils/analytics";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useEvaluations } from "./useEvaluations";
@@ -330,6 +332,9 @@ export function useSignalSourceManager() {
 
       const label = SOURCE_LABELS[product];
 
+      const hadExistingConfig = configs?.some(
+        (c) => c.source_product === product,
+      );
       try {
         if (product === "error_tracking") {
           for (const sourceType of ERROR_TRACKING_SOURCE_TYPES) {
@@ -369,6 +374,14 @@ export function useSignalSourceManager() {
               enabled: true,
             });
           }
+        }
+
+        if (enabled) {
+          track(ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED, {
+            source_product: product,
+            is_first_connection: !hadExistingConfig,
+            via_setup_wizard: false,
+          });
         }
 
         await invalidateAfterToggle();
@@ -415,6 +428,11 @@ export function useSignalSourceManager() {
             enabled: true,
           });
         }
+        track(ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED, {
+          source_product: completedSource,
+          is_first_connection: !existing,
+          via_setup_wizard: true,
+        });
       } catch {
         toast.error(
           "Data source connected, but failed to enable signal source. Try toggling it on.",

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -562,6 +562,22 @@ export interface InboxReportActionProperties {
   question_text?: string;
 }
 
+export interface SignalSourceConnectedProperties {
+  source_product:
+    | "session_replay"
+    | "error_tracking"
+    | "github"
+    | "linear"
+    | "zendesk"
+    | "conversations"
+    | "pganalyze"
+    | "llm_analytics";
+  /** True when this is a brand-new createSignalSourceConfig, false for re-enable of an existing config. */
+  is_first_connection: boolean;
+  /** True when the connection went through the DataSourceSetup wizard (warehouse OAuth path). */
+  via_setup_wizard: boolean;
+}
+
 // Subscription / billing events
 export interface SubscriptionStartedProperties {
   plan_key: string;
@@ -681,6 +697,7 @@ export const ANALYTICS_EVENTS = {
   INBOX_REPORT_CLOSED: "Inbox report closed",
   INBOX_REPORT_ACTION: "Inbox report action",
   INBOX_REPORT_SCROLLED: "Inbox report scrolled",
+  SIGNAL_SOURCE_CONNECTED: "Signal source connected",
 
   // Prompt history events
   PROMPT_HISTORY_OPENED: "Prompt history opened",
@@ -793,6 +810,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.INBOX_REPORT_CLOSED]: InboxReportClosedProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_ACTION]: InboxReportActionProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED]: InboxReportScrolledProperties;
+  [ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED]: SignalSourceConnectedProperties;
 
   // Prompt history events
   [ANALYTICS_EVENTS.PROMPT_HISTORY_OPENED]: PromptHistoryOpenedProperties;


### PR DESCRIPTION
## Summary

- Adds a new `Signal source connected` analytics event, fired from both signal-source connection paths in `useSignalSourceManager`: the direct toggle (non-warehouse sources) and the post-`DataSourceSetup`-wizard completion (warehouse sources).
- Event carries `source_product`, `is_first_connection` (brand-new config vs. re-enable of an existing one), and `via_setup_wizard` (warehouse OAuth path vs. plain toggle).
- Closes a gap surfaced when trying to measure inbox onboarding — there was no event firing on the actual source-connected moment. Now we can build a first-time-for-user trend (e.g. "inbox users onboarded") and subscribe a team channel to a daily snapshot.

## Test plan

- [ ] Toggle on `error_tracking` from the Inbox sources settings → confirm `Signal source connected` fires once with `source_product: "error_tracking"`, `is_first_connection: true`, `via_setup_wizard: false`. Toggle off then on again → second firing has `is_first_connection: false`.
- [ ] Toggle on `session_replay` → same flow as above (non-warehouse path).
- [ ] Connect `github` (or any warehouse source) via the `DataSourceSetup` wizard end-to-end → confirm one firing on completion with `via_setup_wizard: true` and `is_first_connection: true`.
- [ ] Disable a previously enabled source → confirm **no** event fires (we only track connections, not disconnections).
- [ ] If the API call inside `handleSetupComplete` fails → confirm the event does not fire (it lives inside the `try` block, before the `catch`).