### PR TITLE
fix(code): route all markdown link clicks through openExternal

### DIFF
--- a/apps/code/src/renderer/features/editor/components/MarkdownRenderer.tsx
+++ b/apps/code/src/renderer/features/editor/components/MarkdownRenderer.tsx
@@ -99,12 +99,11 @@ export const baseComponents: Components = {
         </GithubRefChip>
       );
     }
-    const isDeeplink = isPostHogCodeDeeplink(href);
     return (
       <a
         href={href}
         onClick={(event) => {
-          if (!isDeeplink || !href) return;
+          if (!href) return;
           event.preventDefault();
           void trpcClient.os.openExternal.mutate({ url: href });
         }}


### PR DESCRIPTION
## Summary

External `https://` links rendered inside chat / agent messages were inert when clicked — they appeared correctly (with the external-link glyph), but did nothing. The regression was introduced in #2241, which added an `onClick` handler to the markdown `<a>` renderer for `posthog-code://` deeplinks and short-circuited every other URL:

```ts
onClick={(event) => {
  if (!isDeeplink || !href) return;   // ← bails for normal http(s) URLs
  event.preventDefault();
  void trpcClient.os.openExternal.mutate({ url: href });
}}
```

For non-deeplink URLs the click was left to `target="_blank"` + the main process's `setWindowOpenHandler` fallback, which on at least some setups was not actually opening the URL in the system browser.

This change drops the `isDeeplink` guard so **every** link with a real `href` is routed through `trpcClient.os.openExternal` — the same path the deeplink branch already uses. `setupExternalLinkHandlers` in `apps/code/src/main/window.ts` remains as a defensive safety net for any stray navigations from elsewhere in the renderer.

The `isPostHogCodeDeeplink` import is still in use for `markdownUrlTransform` (so `defaultUrlTransform` doesn't strip the custom scheme); only the unused local in the `a` renderer was removed.

## Test plan

- [ ] In a session, send a prompt that yields a markdown message containing a plain `https://` link (e.g. ask the agent for a PostHog insight URL). Click the link → opens in the default system browser.
- [ ] Click a `posthog-code://` deeplink (e.g. via Inbox → Discuss). Deeplink still routes correctly.
- [ ] Click a GitHub issue/PR URL in chat. `GithubRefChip` path is unaffected (returns before the modified onClick).
- [ ] Right-click a link → "Open link in new window" still does not spawn an Electron child window (`setWindowOpenHandler` returns `action: "deny"`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*