### PR TITLE
revert(integrations): remove server-side kind filter (#1954)

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -1477,18 +1477,15 @@ export class PostHogAPIClient {
     }
   }
 
-  async getIntegrations(kind?: string) {
+  async getIntegrations() {
     const teamId = await this.getTeamId();
-    return this.getIntegrationsForProject(teamId, kind);
+    return this.getIntegrationsForProject(teamId);
   }
 
-  async getIntegrationsForProject(projectId: number, kind?: string) {
+  async getIntegrationsForProject(projectId: number) {
     const url = new URL(
       `${this.api.baseUrl}/api/environments/${projectId}/integrations/`,
     );
-    if (kind) {
-      url.searchParams.set("kind", kind);
-    }
     const response = await this.api.fetcher.fetch({
       method: "get",
       url,

--- a/apps/code/src/renderer/hooks/useIntegrations.ts
+++ b/apps/code/src/renderer/hooks/useIntegrations.ts
@@ -78,7 +78,7 @@ export function useIntegrations() {
 
   const query = useAuthenticatedQuery(
     integrationKeys.list(),
-    (client) => client.getIntegrations("github") as Promise<Integration[]>,
+    (client) => client.getIntegrations() as Promise<Integration[]>,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Reverts #1954, which filtered integration API calls to GitHub only via a server-side `?kind=github` query param.

That filtering broke Slack connection for inbox notifications (added in #2174) - PostHog Code no longer saw Slack integrations configured on the project because they were excluded from the API response.

Client-side filtering in `integrationStore` already handles per-kind selectors (`githubIntegrations`, `slackIntegrations`), so fetching all integrations is safe and restores Slack (and other) integration visibility.