### PR TITLE
feat: Add stale PR auto-close workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: stale-prs
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: stale
+          stale-pr-message: "This PR has had no activity for 30 days and has been marked stale. It will be closed in 7 days if no further activity occurs."
+          close-pr-message: "Closing this PR due to inactivity. Feel free to reopen if you'd like to continue the work."
+          exempt-pr-labels: "no stale,security"
+          exempt-draft-pr: false


### PR DESCRIPTION
## Problem

I remember a time when we could regularly hit 0 open PR's on this repo, that seems unlikely to ever happen again (which is a good thing!). The other side of that means we need some automation here so inactivate PRs don't accumulate and clutter the PR list.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add daily workflow using actions/stale@v9
2. Mark PRs stale after 30 days of inactivity
3. Close stale PRs 7 days later (37 days total)
4. Exempt PRs labeled no stale or security
5. Issues are disabled for now (PR-only), can be enabled later

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

I did not

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->