### PR TITLE
feat(tasks): add cloud hogland runtime option to workspace picker

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -171,6 +171,7 @@ interface CloudRunOptions {
   model?: string;
   reasoningLevel?: string;
   sandboxEnvironmentId?: string;
+  sandboxRuntime?: string;
   prAuthorshipMode?: PrAuthorshipMode;
   runSource?: CloudRunSource;
   signalReportId?: string;
@@ -240,6 +241,9 @@ function buildCloudRunRequestBody(
   }
   if (options?.sandboxEnvironmentId) {
     body.sandbox_environment_id = options.sandboxEnvironmentId;
+  }
+  if (options?.sandboxRuntime) {
+    body.sandbox_runtime = options.sandboxRuntime;
   }
   if (options?.prAuthorshipMode) {
     body.pr_authorship_mode = options.prAuthorshipMode;

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -122,6 +122,9 @@ export function TaskInput({
   const [selectedCloudEnvId, setSelectedCloudEnvId] = useState<string | null>(
     null,
   );
+  const [selectedSandboxRuntime, setSelectedSandboxRuntime] = useState<
+    string | null
+  >(null);
   const [activeReportAssociation, setActiveReportAssociation] = useState(
     reportAssociation ?? null,
   );
@@ -489,6 +492,10 @@ export function TaskInput({
       effectiveWorkspaceMode === "cloud" && selectedCloudEnvId
         ? selectedCloudEnvId
         : undefined,
+    sandboxRuntime:
+      effectiveWorkspaceMode === "cloud" && selectedSandboxRuntime
+        ? selectedSandboxRuntime
+        : undefined,
     signalReportId: activeReportAssociation?.reportId,
   });
 
@@ -654,6 +661,8 @@ export function TaskInput({
                 onChange={setWorkspaceMode}
                 selectedCloudEnvironmentId={selectedCloudEnvId}
                 onCloudEnvironmentChange={setSelectedCloudEnvId}
+                selectedSandboxRuntime={selectedSandboxRuntime}
+                onSandboxRuntimeChange={setSelectedSandboxRuntime}
                 size="1"
               />
               {workspaceMode === "worktree" && (

--- a/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -36,7 +36,11 @@ interface WorkspaceModeSelectProps {
   overrideModes?: WorkspaceMode[];
   selectedCloudEnvironmentId?: string | null;
   onCloudEnvironmentChange?: (envId: string | null) => void;
+  selectedSandboxRuntime?: string | null;
+  onSandboxRuntimeChange?: (runtime: string | null) => void;
 }
+
+const HOGLAND_RUNTIME = "posthog";
 
 const LOCAL_MODES: {
   mode: WorkspaceMode;
@@ -67,9 +71,13 @@ export function WorkspaceModeSelect({
   overrideModes,
   selectedCloudEnvironmentId,
   onCloudEnvironmentChange,
+  selectedSandboxRuntime,
+  onSandboxRuntimeChange,
 }: WorkspaceModeSelectProps) {
   const cloudModeEnabled =
     useFeatureFlag("twig-cloud-mode-toggle") || import.meta.env.DEV;
+  const hoglandRuntimeEnabled =
+    useFeatureFlag("tasks-hogland-runtime") || import.meta.env.DEV;
 
   const { environments } = useSandboxEnvironments();
   const openSettings = useSettingsDialogStore((s) => s.open);
@@ -97,12 +105,17 @@ export function WorkspaceModeSelect({
     return environments.find((e) => e.id === selectedCloudEnvironmentId)?.name;
   }, [value, selectedCloudEnvironmentId, environments]);
 
+  const isHoglandActive =
+    value === "cloud" && selectedSandboxRuntime === HOGLAND_RUNTIME;
+
   const triggerLabel = useMemo(() => {
     if (value === "cloud") {
-      return selectedEnvName ? `Cloud · ${selectedEnvName}` : "Cloud";
+      if (selectedEnvName) return `Cloud · ${selectedEnvName}`;
+      if (isHoglandActive) return "Cloud · Hogland";
+      return "Cloud";
     }
     return LOCAL_MODES.find((m) => m.mode === value)?.label ?? "Worktree";
-  }, [value, selectedEnvName]);
+  }, [value, selectedEnvName, isHoglandActive]);
 
   const triggerIcon = useMemo(() => {
     if (value === "cloud") return CLOUD_ICON;
@@ -145,6 +158,7 @@ export function WorkspaceModeSelect({
               onClick={() => {
                 onChange(item.mode);
                 onCloudEnvironmentChange?.(null);
+                onSandboxRuntimeChange?.(null);
               }}
               render={
                 <ItemMenuItem size="xs" className="w-full">
@@ -164,25 +178,50 @@ export function WorkspaceModeSelect({
         </DropdownMenuGroup>
 
         {showCloud && environments.length === 0 && (
-          <DropdownMenuItem
-            onClick={() => {
-              onChange("cloud");
-              onCloudEnvironmentChange?.(null);
-            }}
-            render={
-              <ItemMenuItem size="xs" className="w-full">
-                <ItemMedia variant="icon" className="mt-2 ml-2">
-                  <span>{CLOUD_ICON}</span>
-                </ItemMedia>
-                <ItemContent variant="menuItem">
-                  <ItemTitle>Cloud</ItemTitle>
-                  <ItemDescription className="whitespace-nowrap leading-none">
-                    Run in a cloud sandbox
-                  </ItemDescription>
-                </ItemContent>
-              </ItemMenuItem>
-            }
-          />
+          <>
+            <DropdownMenuItem
+              onClick={() => {
+                onChange("cloud");
+                onCloudEnvironmentChange?.(null);
+                onSandboxRuntimeChange?.(null);
+              }}
+              render={
+                <ItemMenuItem size="xs" className="w-full">
+                  <ItemMedia variant="icon" className="mt-2 ml-2">
+                    <span>{CLOUD_ICON}</span>
+                  </ItemMedia>
+                  <ItemContent variant="menuItem">
+                    <ItemTitle>Cloud</ItemTitle>
+                    <ItemDescription className="whitespace-nowrap leading-none">
+                      Run in a cloud sandbox
+                    </ItemDescription>
+                  </ItemContent>
+                </ItemMenuItem>
+              }
+            />
+            {hoglandRuntimeEnabled && (
+              <DropdownMenuItem
+                onClick={() => {
+                  onChange("cloud");
+                  onCloudEnvironmentChange?.(null);
+                  onSandboxRuntimeChange?.(HOGLAND_RUNTIME);
+                }}
+                render={
+                  <ItemMenuItem size="xs" className="w-full">
+                    <ItemMedia variant="icon" className="mt-2 ml-2">
+                      <span>{CLOUD_ICON}</span>
+                    </ItemMedia>
+                    <ItemContent variant="menuItem">
+                      <ItemTitle>Cloud · Hogland</ItemTitle>
+                      <ItemDescription className="whitespace-nowrap leading-none">
+                        Run on the PostHog sandbox backend
+                      </ItemDescription>
+                    </ItemContent>
+                  </ItemMenuItem>
+                }
+              />
+            )}
+          </>
         )}
 
         {showCloud && environments.length > 0 && (
@@ -205,6 +244,7 @@ export function WorkspaceModeSelect({
                 onClick={() => {
                   onChange("cloud");
                   onCloudEnvironmentChange?.(null);
+                  onSandboxRuntimeChange?.(null);
                 }}
                 render={
                   <ItemMenuItem size="xs" className="w-full">
@@ -221,12 +261,36 @@ export function WorkspaceModeSelect({
                 }
               />
 
+              {hoglandRuntimeEnabled && (
+                <DropdownMenuItem
+                  onClick={() => {
+                    onChange("cloud");
+                    onCloudEnvironmentChange?.(null);
+                    onSandboxRuntimeChange?.(HOGLAND_RUNTIME);
+                  }}
+                  render={
+                    <ItemMenuItem size="xs" className="w-full">
+                      <ItemMedia variant="icon" className="mt-2 ml-2">
+                        <span>{CLOUD_ICON}</span>
+                      </ItemMedia>
+                      <ItemContent variant="menuItem">
+                        <ItemTitle>Hogland</ItemTitle>
+                        <ItemDescription className="whitespace-nowrap leading-none">
+                          PostHog sandbox backend
+                        </ItemDescription>
+                      </ItemContent>
+                    </ItemMenuItem>
+                  }
+                />
+              )}
+
               {environments.map((env) => (
                 <DropdownMenuItem
                   key={`cloud-env-${env.id}`}
                   onClick={() => {
                     onChange("cloud");
                     onCloudEnvironmentChange?.(env.id);
+                    onSandboxRuntimeChange?.(null);
                   }}
                   render={
                     <ItemMenuItem size="xs" className="w-full">

--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -44,6 +44,7 @@ interface UseTaskCreationOptions {
   reasoningLevel?: string;
   environmentId?: string | null;
   sandboxEnvironmentId?: string;
+  sandboxRuntime?: string;
   signalReportId?: string;
   onTaskCreated?: (task: Task) => void;
 }
@@ -69,6 +70,7 @@ function prepareTaskInput(
     reasoningLevel?: string;
     environmentId?: string | null;
     sandboxEnvironmentId?: string;
+    sandboxRuntime?: string;
     signalReportId?: string;
   },
 ): TaskCreationInput {
@@ -98,6 +100,7 @@ function prepareTaskInput(
     reasoningLevel: options.reasoningLevel,
     environmentId: options.environmentId ?? undefined,
     sandboxEnvironmentId: options.sandboxEnvironmentId,
+    sandboxRuntime: options.sandboxRuntime,
     cloudPrAuthorshipMode:
       options.signalReportId && options.workspaceMode === "cloud"
         ? "user"
@@ -185,6 +188,7 @@ export function useTaskCreation({
   reasoningLevel,
   environmentId,
   sandboxEnvironmentId,
+  sandboxRuntime,
   signalReportId,
   onTaskCreated,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
@@ -258,6 +262,7 @@ export function useTaskCreation({
           reasoningLevel,
           environmentId,
           sandboxEnvironmentId,
+          sandboxRuntime,
           signalReportId,
         });
 
@@ -332,6 +337,7 @@ export function useTaskCreation({
       reasoningLevel,
       environmentId,
       sandboxEnvironmentId,
+      sandboxRuntime,
       signalReportId,
       clearTaskInputReportAssociation,
       invalidateTasks,

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -57,6 +57,7 @@ export interface TaskCreationInput {
   reasoningLevel?: string;
   environmentId?: string;
   sandboxEnvironmentId?: string;
+  sandboxRuntime?: string;
   cloudPrAuthorshipMode?: PrAuthorshipMode;
   cloudRunSource?: CloudRunSource;
   signalReportId?: string;
@@ -248,6 +249,7 @@ export class TaskCreationSaga extends Saga<
             model: input.model,
             reasoningLevel: input.reasoningLevel,
             sandboxEnvironmentId: input.sandboxEnvironmentId,
+            sandboxRuntime: input.sandboxRuntime,
             prAuthorshipMode,
             runSource: input.cloudRunSource ?? "manual",
             signalReportId: input.signalReportId,


### PR DESCRIPTION
## Problem

Adds a "Cloud · Hogland" entry to the workspace picker so we can dark-launch the new hogland sandbox backend (see [posthog/posthog#60042](https://github.com/PostHog/posthog/pull/60042)) end-to-end without committing to it as the default. Lets us A/B against the current Modal cloud runtime per-run.

## Changes

- `WorkspaceModeSelect`: new "Cloud · Hogland" row alongside the existing "Default", gated by feature flag `tasks-hogland-runtime` (on in dev). Picking Hogland clears the cloud environment selection; picking Default or a user env clears the runtime. Trigger label reflects the active choice.
- Plumbs an optional `sandboxRuntime` through `TaskInput` → `useTaskCreation` → `TaskCreationSaga` → `createTaskRun`, where it's serialized as the existing backend field `sandbox_runtime`.
- `sandbox_runtime` and `sandbox_environment_id` are orthogonal: runtime picks the backend infra, environment picks the network policy. Mutually exclusive in this PR by design — if we ever want a per-env default runtime, that's a separate column on `SandboxEnvironment`.

Handoff is intentionally not touched. New cloud runs only.

## How did you test this?

Local diff review against the existing `sandboxEnvironmentId` plumbing — same pattern, parallel field. Did not run typecheck (no `pnpm install` yet); the changes follow the existing patterns 1:1 so I'd be surprised if anything breaks, but worth running `pnpm --filter @posthog/code typecheck` before merging.

## Publish to changelog?

no
