### PR TITLE
Clarify Discuss button tooltip in inbox reports

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -515,7 +515,7 @@ export function ReportDetailPane({
               size="1"
               variant="soft"
               className="gap-1 rounded-r-none text-[12px]"
-              tooltipContent="Open a chat session about this report"
+              tooltipContent="Discuss this report in a task with your agent"
               disabled={isDiscussing}
               onClick={() => handleDiscussReport()}
             >


### PR DESCRIPTION
## Problem

Users hovering over the "Discuss" button on an inbox report expected it would let them discuss the report with colleagues (Slack-style). It actually opens a task with the agent. The previous tooltip ("Open a chat session about this report") didn't make that distinction clear.

## Changes

Updated the tooltip on the Discuss button in `ReportDetailPane` from "Open a chat session about this report" to "Discuss this report in a task with your agent" so it's obvious the action is agent-facing, not human-facing.

## How did you test this?

Visual-only copy change in a button tooltip — verified the updated string in the source. No automated tests run.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*