### PR TITLE
feat(signed-commit): accept an optional cwd so the tool works on any clone

### DIFF
--- a/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createSignedCommit = vi.fn();
+
+vi.mock("@posthog/git/signed-commit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@posthog/git/signed-commit")>();
+  return {
+    ...actual,
+    createSignedCommit: (...args: unknown[]) => createSignedCommit(...args),
+  };
+});
+
+// Importing the tool after the mock so its transitive `createSignedCommit`
+// reference resolves to the mock above.
+const { signedCommitTool } = await import("./signed-commit");
+
+describe("signed-commit tool handler", () => {
+  const savedSandbox = process.env.IS_SANDBOX;
+
+  beforeEach(() => {
+    createSignedCommit.mockReset();
+    createSignedCommit.mockResolvedValue({
+      branch: "posthog-code/feature",
+      commits: [
+        { sha: "deadbeef", url: "https://github.com/x/y/commit/deadbeef" },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    if (savedSandbox === undefined) {
+      delete process.env.IS_SANDBOX;
+    } else {
+      process.env.IS_SANDBOX = savedSandbox;
+    }
+  });
+
+  it("defaults to the session cwd when args.cwd is absent", async () => {
+    await signedCommitTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      { message: "chore: bump" },
+    );
+    const [ctx] = createSignedCommit.mock.calls[0];
+    expect(ctx.cwd).toBe("/tmp/workspace/repos/posthog/code");
+  });
+
+  it("uses an absolute args.cwd verbatim so a sibling clone is reachable", async () => {
+    await signedCommitTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      {
+        message: "chore: bump",
+        cwd: "/tmp/workspace/repos/posthog/posthog",
+      },
+    );
+    const [ctx] = createSignedCommit.mock.calls[0];
+    expect(ctx.cwd).toBe("/tmp/workspace/repos/posthog/posthog");
+  });
+
+  it("resolves a relative args.cwd against the session cwd", async () => {
+    await signedCommitTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      { message: "chore: bump", cwd: "../posthog" },
+    );
+    const [ctx] = createSignedCommit.mock.calls[0];
+    expect(ctx.cwd).toBe("/tmp/workspace/repos/posthog/posthog");
+  });
+
+  it("does not forward cwd to createSignedCommit input", async () => {
+    await signedCommitTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      { message: "chore: bump", cwd: "/elsewhere" },
+    );
+    const [, input] = createSignedCommit.mock.calls[0];
+    expect(input).not.toHaveProperty("cwd");
+    expect(input).toEqual({ message: "chore: bump" });
+  });
+
+  it("returns the no-token error without invoking createSignedCommit", async () => {
+    const savedGh = process.env.GH_TOKEN;
+    const savedGithub = process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    try {
+      const result = await signedCommitTool.handler(
+        { cwd: "/tmp/workspace/repos/posthog/code" },
+        { message: "chore: bump" },
+      );
+      expect(result.isError).toBe(true);
+      expect(createSignedCommit).not.toHaveBeenCalled();
+    } finally {
+      if (savedGh !== undefined) process.env.GH_TOKEN = savedGh;
+      if (savedGithub !== undefined) process.env.GITHUB_TOKEN = savedGithub;
+    }
+  });
+});

--- a/packages/agent/src/adapters/local-tools/tools/signed-commit.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-commit.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { isCloudRun } from "../../../utils/common";
 import { resolveGithubToken } from "../../../utils/github-token";
 import {
@@ -37,9 +38,12 @@ export const signedCommitTool = defineLocalTool({
         isError: true,
       });
     }
-    return runSignedCommitTool(
-      { cwd: ctx.cwd, token, taskId: ctx.taskId },
-      args,
-    );
+    // Resolve an explicit `cwd` arg against the session cwd so the agent can
+    // commit from any clone reachable in the sandbox, not just the one the
+    // session was rooted at. Absolute paths fall through `path.resolve`
+    // unchanged; relative paths join the session cwd.
+    const { cwd: argCwd, ...input } = args;
+    const cwd = argCwd ? path.resolve(ctx.cwd, argCwd) : ctx.cwd;
+    return runSignedCommitTool({ cwd, token, taskId: ctx.taskId }, input);
   },
 });

--- a/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/packages/agent/src/adapters/signed-commit-shared.ts
@@ -41,6 +41,14 @@ export const signedCommitToolSchema = {
     .describe(
       "Files to stage before committing; defaults to already-staged files.",
     ),
+  cwd: z
+    .string()
+    .optional()
+    .describe(
+      "Path to the git checkout to commit from; defaults to the session's working directory. " +
+        "Pass this when committing to a clone outside the session cwd (e.g. a sibling repo cloned during the run). " +
+        "Relative paths resolve against the session cwd.",
+    ),
 };
 
 export function formatSignedCommitResult(result: SignedCommitResult): string {


### PR DESCRIPTION
## Problem

The `git_signed_commit` MCP tool's `ctx.cwd` is bound once at session
creation: `agent-server.ts` passes `this.config.repositoryPath ?? "/tmp/workspace"`
into the new session and the local-tools MCP server captures that as
its `LocalToolCtx.cwd`. Every git invocation in `createSignedCommit`
runs against that bound cwd, so a task that clones a second repo (or
works in any checkout outside the original session cwd) can't commit
from it — `git remote get-url origin` runs from the wrong directory
and fails.

## Changes

- Add an optional `cwd` field to `signedCommitToolSchema`.
- In the local-tool handler, resolve it via `path.resolve(ctx.cwd, argCwd)`
  (absolute paths pass through, relative paths join the session cwd),
  override the ctx, and strip `cwd` from the input forwarded to
  `createSignedCommit` so the lower-level API surface is unchanged.
- Default behavior is preserved: omit `cwd` and the tool still runs
  against the session cwd.

## How did you test this?

- `pnpm --filter @posthog/agent typecheck` — clean.
- `pnpm exec vitest run src/adapters/local-tools src/adapters/claude/mcp/local-tools`
  passes. New `signed-commit.test.ts` covers: default-to-session-cwd,
  absolute override, relative resolution, that `cwd` isn't forwarded as
  a `SignedCommitInput` field, and the existing no-token error path.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*