### PR TITLE
Load file content from GitHub for cloud runs

### DIFF
--- a/apps/code/src/main/services/git/schemas.ts
+++ b/apps/code/src/main/services/git/schemas.ts
@@ -615,6 +615,15 @@ export const getGithubPullRequestInput = getGithubIssueInput;
 
 export const getGithubPullRequestOutput = getGithubIssueOutput;
 
+export const getGithubFileContentInput = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  filePath: z.string(),
+  ref: z.string(),
+});
+
+export const getGithubFileContentOutput = z.string().nullable();
+
 export const createPrProgressPayload = z.object({
   flowId: z.string(),
   step: createPrStep,

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -1957,6 +1957,35 @@ ${truncatedDiff || "(no diff available)"}${contextSection}`;
     return refs[0] ?? null;
   }
 
+  public async getGithubFileContent(
+    owner: string,
+    repo: string,
+    filePath: string,
+    ref: string,
+  ): Promise<string | null> {
+    const encodedPath = filePath
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+    const result = await execGh([
+      "api",
+      `/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`,
+      "-H",
+      "Accept: application/vnd.github.raw",
+    ]);
+    if (result.exitCode !== 0) {
+      log.info("Failed to fetch file from GitHub", {
+        owner,
+        repo,
+        filePath,
+        ref,
+        stderr: result.stderr,
+      });
+      return null;
+    }
+    return result.stdout;
+  }
+
   private async fetchGhRefs(
     args: string[],
     repo: string,

--- a/apps/code/src/main/trpc/routers/git.ts
+++ b/apps/code/src/main/trpc/routers/git.ts
@@ -37,6 +37,8 @@ import {
   getFileAtHeadOutput,
   getGitBusyStateInput,
   getGitBusyStateOutput,
+  getGithubFileContentInput,
+  getGithubFileContentOutput,
   getGithubIssueInput,
   getGithubIssueOutput,
   getGithubPullRequestInput,
@@ -461,6 +463,18 @@ export const gitRouter = router({
     .output(getGithubPullRequestOutput)
     .query(({ input }) =>
       getService().getGithubPullRequest(input.owner, input.repo, input.number),
+    ),
+
+  getGithubFileContent: publicProcedure
+    .input(getGithubFileContentInput)
+    .output(getGithubFileContentOutput)
+    .query(({ input }) =>
+      getService().getGithubFileContent(
+        input.owner,
+        input.repo,
+        input.filePath,
+        input.ref,
+      ),
     ),
 
   onCreatePrProgress: publicProcedure.subscription(async function* (opts) {

--- a/apps/code/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
+++ b/apps/code/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
@@ -68,16 +68,21 @@ function FilePanelImagePreview({
   );
 }
 
+const CLOUD_SANDBOX_REPOS_ROOT = "/tmp/workspace/repos";
+
 function toRepoRelativePath(
-  repoShortName: string | null,
+  owner: string,
+  name: string,
   path: string,
 ): string | null {
   if (!path.startsWith("/")) return path;
-  if (!repoShortName) return null;
-  const marker = `/${repoShortName}/`;
-  const idx = path.lastIndexOf(marker);
-  if (idx < 0) return null;
-  return path.slice(idx + marker.length);
+  const prefix = `${CLOUD_SANDBOX_REPOS_ROOT}/${owner}/${name}/`;
+  if (!path.startsWith(prefix)) return null;
+  return path.slice(prefix.length);
+}
+
+function encodePathSegments(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
 }
 
 export function CodeEditorPanel({
@@ -146,14 +151,14 @@ export function CodeEditorPanel({
     if (!repo || !branch) return null;
     const [owner, name] = repo.split("/");
     if (!owner || !name) return null;
-    const repoRelativePath = toRepoRelativePath(name, filePath);
+    const repoRelativePath = toRepoRelativePath(owner, name, filePath);
     if (!repoRelativePath) return null;
     return {
       owner,
       name,
       branch,
       repoRelativePath,
-      blobUrl: `https://github.com/${owner}/${name}/blob/${branch}/${repoRelativePath}`,
+      blobUrl: `https://github.com/${owner}/${name}/blob/${encodeURIComponent(branch)}/${encodePathSegments(repoRelativePath)}`,
     };
   }, [isCloudRun, task, cloudSession, filePath]);
 

--- a/apps/code/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
+++ b/apps/code/src/renderer/features/code-editor/components/CodeEditorPanel.tsx
@@ -9,6 +9,7 @@ import { isMarkdownFile } from "@features/code-editor/utils/markdownUtils";
 import { getRelativePath } from "@features/code-editor/utils/pathUtils";
 import { usePanelLayoutStore } from "@features/panels";
 import { useFileTreeStore } from "@features/right-sidebar/stores/fileTreeStore";
+import { useSessionForTask } from "@features/sessions/hooks/useSession";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
 import { useIsWorkspaceCloudRun } from "@features/workspace/hooks/useWorkspace";
 import { Check, Copy } from "@phosphor-icons/react";
@@ -17,7 +18,7 @@ import {
   isRasterImageFile,
   parseImageDataUrl,
 } from "@posthog/shared";
-import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
+import { Box, Button, Flex, IconButton, Text } from "@radix-ui/themes";
 import { trpcClient, useTRPC } from "@renderer/trpc/client";
 import type { Task } from "@shared/types";
 
@@ -67,9 +68,21 @@ function FilePanelImagePreview({
   );
 }
 
+function toRepoRelativePath(
+  repoShortName: string | null,
+  path: string,
+): string | null {
+  if (!path.startsWith("/")) return path;
+  if (!repoShortName) return null;
+  const marker = `/${repoShortName}/`;
+  const idx = path.lastIndexOf(marker);
+  if (idx < 0) return null;
+  return path.slice(idx + marker.length);
+}
+
 export function CodeEditorPanel({
   taskId,
-  task: _task,
+  task,
   absolutePath,
 }: CodeEditorPanelProps) {
   const trpcReact = useTRPC();
@@ -125,6 +138,38 @@ export function CodeEditorPanel({
     filePath,
     isCloudRun && !isImage,
   );
+  const cloudSession = useSessionForTask(isCloudRun ? taskId : undefined);
+  const cloudFileMeta = useMemo(() => {
+    if (!isCloudRun) return null;
+    const repo = task.repository ?? null;
+    const branch = task.latest_run?.branch ?? cloudSession?.cloudBranch ?? null;
+    if (!repo || !branch) return null;
+    const [owner, name] = repo.split("/");
+    if (!owner || !name) return null;
+    const repoRelativePath = toRepoRelativePath(name, filePath);
+    if (!repoRelativePath) return null;
+    return {
+      owner,
+      name,
+      branch,
+      repoRelativePath,
+      blobUrl: `https://github.com/${owner}/${name}/blob/${branch}/${repoRelativePath}`,
+    };
+  }, [isCloudRun, task, cloudSession, filePath]);
+
+  const shouldFetchFromGithub =
+    isCloudRun && !isImage && !cloudFile.touched && cloudFileMeta != null;
+  const githubFileQuery = useQuery(
+    trpcReact.git.getGithubFileContent.queryOptions(
+      {
+        owner: cloudFileMeta?.owner ?? "",
+        repo: cloudFileMeta?.name ?? "",
+        filePath: cloudFileMeta?.repoRelativePath ?? "",
+        ref: cloudFileMeta?.branch ?? "",
+      },
+      { enabled: shouldFetchFromGithub, staleTime: 5 * 60 * 1000 },
+    ),
+  );
 
   const repoQuery = useQuery(
     trpcReact.fs.readRepoFile.queryOptions(
@@ -151,8 +196,16 @@ export function CodeEditorPanel({
   );
 
   const localQuery = isInsideRepo ? repoQuery : absoluteQuery;
-  const fileContent = isCloudRun ? cloudFile.content : localQuery.data;
-  const isLoading = isCloudRun ? cloudFile.isLoading : localQuery.isLoading;
+  const cloudContentQuery = shouldFetchFromGithub
+    ? {
+        content: githubFileQuery.data ?? null,
+        isLoading: githubFileQuery.isLoading,
+      }
+    : { content: cloudFile.content, isLoading: cloudFile.isLoading };
+  const fileContent = isCloudRun ? cloudContentQuery.content : localQuery.data;
+  const isLoading = isCloudRun
+    ? cloudContentQuery.isLoading
+    : localQuery.isLoading;
   const error = isCloudRun ? null : localQuery.error;
 
   const enrichment = useFileEnrichment({
@@ -198,10 +251,42 @@ export function CodeEditorPanel({
     return <PanelMessage>Loading file...</PanelMessage>;
   }
 
-  if (isCloudRun && !cloudFile.touched) {
+  if (isCloudRun && !cloudFile.touched && !shouldFetchFromGithub) {
     return (
       <PanelMessage detail={filePath}>
-        File content not available — the agent did not read or write this file
+        File content not available — the agent did not read or write this file,
+        and the cloud run's branch could not be resolved
+      </PanelMessage>
+    );
+  }
+
+  if (
+    isCloudRun &&
+    !cloudFile.touched &&
+    shouldFetchFromGithub &&
+    fileContent == null
+  ) {
+    return (
+      <PanelMessage detail={filePath}>
+        <Flex direction="column" align="center" gap="2">
+          <Text className="text-sm">
+            Couldn't load file from GitHub — the agent did not read or write
+            this file
+          </Text>
+          {cloudFileMeta && (
+            <Button
+              size="1"
+              variant="soft"
+              onClick={() =>
+                trpcClient.os.openExternal.mutate({
+                  url: cloudFileMeta.blobUrl,
+                })
+              }
+            >
+              View on GitHub
+            </Button>
+          )}
+        </Flex>
       </PanelMessage>
     );
   }


### PR DESCRIPTION
## Summary

Closes PostHog/posthog#76230. In cloud runs, clicking a file reference in the chat showed "File content not available" when the agent only ran `grep`/`find` (never `Read`/`Edit`/`Write`) against it — leaving no way to see the file.

Now, when the file isn't in the agent's tool calls but we know the repo and branch, fetch the content from GitHub at that branch and render it in the same CodeMirror/markdown editor. Falls back to a "View on GitHub" button if the fetch returns null (404, private without `gh` auth, etc.).

## Implementation

- New `GitService.getGithubFileContent(owner, repo, filePath, ref)` using `gh api /repos/{owner}/{repo}/contents/{path}?ref=...` with `Accept: application/vnd.github.raw` and URL-encoded path segments.
- New Zod-validated tRPC procedure `git.getGithubFileContent`.
- `CodeEditorPanel` resolves `owner/repo/branch/path` from the task + cloud session, strips the sandbox prefix by locating the last `/<repo-short-name>/` segment, and renders the fetched content via the same editor used for local files.

## Test plan

- [ ] Open a cloud run task where the agent only `grep`-ed a file (didn't `Read` it). Click the file mention — the file content loads in the editor.
- [ ] Click a file the agent did `Read`/`Edit` — still uses the existing in-memory tool-call content (no GitHub round-trip).
- [ ] Private repo without `gh` auth → "View on GitHub" fallback button appears and opens the blob URL.
- [ ] Path with spaces or special characters loads correctly.
- [ ] Local (non-cloud) runs unaffected.