### PR TITLE
feat: Update usage limit modal for Pro users

### DIFF
--- a/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
+++ b/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
@@ -1,14 +1,23 @@
 import { useUsageLimitStore } from "@features/billing/stores/usageLimitStore";
+import { formatResetTime } from "@features/billing/utils";
 import { useSettingsDialogStore } from "@features/settings/stores/settingsDialogStore";
+import { useSeat } from "@hooks/useSeat";
 import { WarningCircle } from "@phosphor-icons/react";
 import { Button, Dialog, Flex, Text } from "@radix-ui/themes";
+import { trpcClient } from "@renderer/trpc/client";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { track } from "@utils/analytics";
 import { useEffect } from "react";
 
+const SUPPORT_MAILTO =
+  "mailto:charles@posthog.com?subject=PostHog%20Code%20%E2%80%94%20Pro%20usage%20limit";
+
 export function UsageLimitModal() {
   const isOpen = useUsageLimitStore((s) => s.isOpen);
+  const bucket = useUsageLimitStore((s) => s.bucket);
+  const resetAt = useUsageLimitStore((s) => s.resetAt);
   const hide = useUsageLimitStore((s) => s.hide);
+  const { isPro } = useSeat();
 
   useEffect(() => {
     if (isOpen) {
@@ -26,6 +35,33 @@ export function UsageLimitModal() {
     useSettingsDialogStore.getState().open("plan-usage");
   };
 
+  const handleSupport = () => {
+    trpcClient.os.openExternal.mutate({ url: SUPPORT_MAILTO });
+  };
+
+  const isDaily = bucket === "burst";
+  const isMonthly = bucket === "sustained";
+  const resetLabel = resetAt ? formatResetTime(resetAt) : null;
+
+  const title = isDaily
+    ? "Daily limit reached"
+    : isMonthly && !isPro
+      ? "You're out of usage for this month"
+      : isMonthly
+        ? "Monthly limit reached"
+        : "Usage limit reached";
+
+  const proCapLabel = isDaily
+    ? "a daily usage cap"
+    : isMonthly
+      ? "a monthly usage cap"
+      : "usage caps";
+  const description = isPro
+    ? `Your Pro plan has ${proCapLabel}.${resetLabel ? ` ${resetLabel}.` : ""}`
+    : `You've hit your Free ${
+        isDaily ? "daily" : "usage"
+      } limit. Upgrade to Pro for 20x more usage.`;
+
   return (
     <Dialog.Root open={isOpen}>
       <Dialog.Content
@@ -36,23 +72,44 @@ export function UsageLimitModal() {
         <Flex direction="column" gap="3">
           <Flex align="center" gap="2">
             <WarningCircle size={20} weight="bold" color="var(--red-9)" />
-            <Dialog.Title className="mb-0">
-              You're out of usage for this month
-            </Dialog.Title>
+            <Dialog.Title className="mb-0">{title}</Dialog.Title>
           </Flex>
           <Dialog.Description>
             <Text color="gray" className="text-sm">
-              You've hit your Free usage limit. Upgrade to Pro for 20× more
-              usage.
+              {description}
             </Text>
           </Dialog.Description>
           <Flex justify="end" gap="3" mt="2">
-            <Button type="button" variant="soft" color="gray" onClick={hide}>
-              Not now
-            </Button>
-            <Button type="button" onClick={handleUpgrade}>
-              See Pro
-            </Button>
+            {isPro ? (
+              <>
+                <Button
+                  type="button"
+                  variant="soft"
+                  color="gray"
+                  onClick={handleSupport}
+                  mr="auto"
+                >
+                  Get support
+                </Button>
+                <Button type="button" onClick={hide}>
+                  Got it
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  variant="soft"
+                  color="gray"
+                  onClick={hide}
+                >
+                  Not now
+                </Button>
+                <Button type="button" onClick={handleUpgrade}>
+                  See Pro
+                </Button>
+              </>
+            )}
           </Flex>
         </Flex>
       </Dialog.Content>

--- a/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
+++ b/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
@@ -16,8 +16,10 @@ export function UsageLimitModal() {
   const isOpen = useUsageLimitStore((s) => s.isOpen);
   const bucket = useUsageLimitStore((s) => s.bucket);
   const resetAt = useUsageLimitStore((s) => s.resetAt);
+  const eventIsPro = useUsageLimitStore((s) => s.isPro);
   const hide = useUsageLimitStore((s) => s.hide);
-  const { isPro } = useSeat();
+  const { isPro: seatIsPro } = useSeat();
+  const isPro = eventIsPro ?? seatIsPro;
 
   useEffect(() => {
     if (isOpen) {
@@ -36,7 +38,7 @@ export function UsageLimitModal() {
   };
 
   const handleSupport = () => {
-    trpcClient.os.openExternal.mutate({ url: SUPPORT_MAILTO });
+    void trpcClient.os.openExternal.mutate({ url: SUPPORT_MAILTO });
   };
 
   const isDaily = bucket === "burst";
@@ -59,7 +61,7 @@ export function UsageLimitModal() {
   const description = isPro
     ? `Your Pro plan has ${proCapLabel}.${resetLabel ? ` ${resetLabel}.` : ""}`
     : `You've hit your Free ${
-        isDaily ? "daily" : "usage"
+        isDaily ? "daily" : isMonthly ? "monthly" : "usage"
       } limit. Upgrade to Pro for 20x more usage.`;
 
   return (

--- a/apps/code/src/renderer/features/billing/stores/usageLimitStore.test.ts
+++ b/apps/code/src/renderer/features/billing/stores/usageLimitStore.test.ts
@@ -3,7 +3,11 @@ import { useUsageLimitStore } from "./usageLimitStore";
 
 describe("usageLimitStore", () => {
   beforeEach(() => {
-    useUsageLimitStore.setState({ isOpen: false });
+    useUsageLimitStore.setState({
+      isOpen: false,
+      bucket: null,
+      resetAt: null,
+    });
   });
 
   it("starts closed", () => {
@@ -11,9 +15,23 @@ describe("usageLimitStore", () => {
     expect(state.isOpen).toBe(false);
   });
 
-  it("show opens the modal", () => {
+  it("show opens the modal with no context", () => {
     useUsageLimitStore.getState().show();
-    expect(useUsageLimitStore.getState().isOpen).toBe(true);
+    const state = useUsageLimitStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.bucket).toBeNull();
+    expect(state.resetAt).toBeNull();
+  });
+
+  it("show stores bucket and resetAt when provided", () => {
+    useUsageLimitStore.getState().show({
+      bucket: "burst",
+      resetAt: "2026-01-02T03:04:05Z",
+    });
+    const state = useUsageLimitStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.bucket).toBe("burst");
+    expect(state.resetAt).toBe("2026-01-02T03:04:05Z");
   });
 
   it("hide closes the modal", () => {

--- a/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
@@ -1,11 +1,15 @@
 import { create } from "zustand";
 
+export type UsageLimitBucket = "burst" | "sustained";
+
 interface UsageLimitState {
   isOpen: boolean;
+  bucket: UsageLimitBucket | null;
+  resetAt: string | null;
 }
 
 interface UsageLimitActions {
-  show: () => void;
+  show: (args?: { bucket: UsageLimitBucket; resetAt: string }) => void;
   hide: () => void;
 }
 
@@ -13,7 +17,14 @@ type UsageLimitStore = UsageLimitState & UsageLimitActions;
 
 export const useUsageLimitStore = create<UsageLimitStore>()((set) => ({
   isOpen: false,
+  bucket: null,
+  resetAt: null,
 
-  show: () => set({ isOpen: true }),
+  show: (args) =>
+    set({
+      isOpen: true,
+      bucket: args?.bucket ?? null,
+      resetAt: args?.resetAt ?? null,
+    }),
   hide: () => set({ isOpen: false }),
 }));

--- a/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
+++ b/apps/code/src/renderer/features/billing/stores/usageLimitStore.ts
@@ -6,10 +6,15 @@ interface UsageLimitState {
   isOpen: boolean;
   bucket: UsageLimitBucket | null;
   resetAt: string | null;
+  isPro: boolean | null;
 }
 
 interface UsageLimitActions {
-  show: (args?: { bucket: UsageLimitBucket; resetAt: string }) => void;
+  show: (args?: {
+    bucket: UsageLimitBucket;
+    resetAt: string;
+    isPro?: boolean;
+  }) => void;
   hide: () => void;
 }
 
@@ -19,12 +24,14 @@ export const useUsageLimitStore = create<UsageLimitStore>()((set) => ({
   isOpen: false,
   bucket: null,
   resetAt: null,
+  isPro: null,
 
   show: (args) =>
     set({
       isOpen: true,
       bucket: args?.bucket ?? null,
       resetAt: args?.resetAt ?? null,
+      isPro: args?.isPro ?? null,
     }),
   hide: () => set({ isOpen: false }),
 }));

--- a/apps/code/src/renderer/features/billing/subscriptions.ts
+++ b/apps/code/src/renderer/features/billing/subscriptions.ts
@@ -20,7 +20,10 @@ export function registerBillingSubscriptions() {
 
         if (event.threshold === 100) {
           if (event.userIsActive) {
-            useUsageLimitStore.getState().show();
+            useUsageLimitStore.getState().show({
+              bucket: event.bucket,
+              resetAt: event.resetAt,
+            });
             return;
           }
           toast.error("Usage limit reached", {

--- a/apps/code/src/renderer/features/billing/subscriptions.ts
+++ b/apps/code/src/renderer/features/billing/subscriptions.ts
@@ -23,6 +23,7 @@ export function registerBillingSubscriptions() {
             useUsageLimitStore.getState().show({
               bucket: event.bucket,
               resetAt: event.resetAt,
+              isPro: event.isPro,
             });
             return;
           }


### PR DESCRIPTION
## Problem

Pro users hitting the daily cap saw the same "upgrade to Pro" pitch as Free users, treating a normal reset window like a paywall.<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Branch modal title and copy on plan and bucket (daily vs monthly)
2. Drop the upgrade CTA for Pro users; show a single "Got it" button
3. Add "Get support" button on the left that opens mailto:charles@posthog.com (Pro only)
4. Pass bucket and resetAt from the threshold event through to the store
5. Read isPro from useSeat so the rate-limit fallback path also branches correctly

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->