### PR TITLE
chore: Add config with AGENTS.md context and opt-out label for greptile

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,6 @@
+{
+    "disabledLabels": ["No Greptile"],
+    "customContext": {
+        "files": ["AGENTS.md"]
+    }
+}

--- a/greptile.json
+++ b/greptile.json
@@ -1,6 +1,6 @@
 {
   "disabledLabels": ["No Greptile"],
   "customContext": {
-    "files": ["AGENTS.md"]
+    "files": [{ "path": "AGENTS.md" }]
   }
 }

--- a/greptile.json
+++ b/greptile.json
@@ -1,6 +1,6 @@
 {
-    "disabledLabels": ["No Greptile"],
-    "customContext": {
-        "files": ["AGENTS.md"]
-    }
+  "disabledLabels": ["No Greptile"],
+  "customContext": {
+    "files": ["AGENTS.md"]
+  }
 }


### PR DESCRIPTION
## Problem

Greptile reviews this repo with no per-repo config, so it ignores our architecture rules. I'm matching this with the monorepo.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add greptile.json at repo root
2. Feed [AGENTS.md](http://AGENTS.md) into every review via customContext.files
3. Opt out per PR by applying the "No Greptile" label

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->