### PR TITLE
feat(mobile): show relative timestamp on inbox signal cards

### DIFF
--- a/apps/mobile/src/features/inbox/components/SignalCard.tsx
+++ b/apps/mobile/src/features/inbox/components/SignalCard.tsx
@@ -209,7 +209,7 @@ export function SignalCard({ signal, finding }: SignalCardProps) {
   const externalUrl = issueUrl ?? ticketUrl ?? null;
 
   const timestampMs = signal.timestamp ? Date.parse(signal.timestamp) : NaN;
-  const hasTimestamp = !Number.isNaN(timestampMs);
+  const hasTimestamp = !Number.isNaN(timestampMs) && timestampMs <= Date.now();
 
   return (
     <View className="overflow-hidden rounded-xl border border-gray-6 bg-gray-1 p-3">

--- a/apps/mobile/src/features/inbox/components/SignalCard.tsx
+++ b/apps/mobile/src/features/inbox/components/SignalCard.tsx
@@ -16,6 +16,7 @@ import {
 import { useState } from "react";
 import { Linking, Pressable, View } from "react-native";
 import { MarkdownText } from "@/features/chat/components/MarkdownText";
+import { formatRelativeTime } from "@/lib/format";
 import { useThemeColors } from "@/lib/theme";
 import type { Signal, SignalFindingContent } from "../types";
 
@@ -207,6 +208,9 @@ export function SignalCard({ signal, finding }: SignalCardProps) {
 
   const externalUrl = issueUrl ?? ticketUrl ?? null;
 
+  const timestampMs = signal.timestamp ? Date.parse(signal.timestamp) : NaN;
+  const hasTimestamp = !Number.isNaN(timestampMs);
+
   return (
     <View className="overflow-hidden rounded-xl border border-gray-6 bg-gray-1 p-3">
       {/* Header */}
@@ -215,9 +219,18 @@ export function SignalCard({ signal, finding }: SignalCardProps) {
           product={signal.source_product}
           color={themeColors.gray[10]}
         />
-        <Text className="flex-1 font-medium text-[13px] text-gray-10">
+        <Text
+          className="min-w-0 shrink font-medium text-[13px] text-gray-10"
+          numberOfLines={1}
+        >
           {sourceLine(signal)}
         </Text>
+        <View className="flex-1" />
+        {hasTimestamp && (
+          <Text className="shrink-0 text-[11px] text-gray-10">
+            {formatRelativeTime(timestampMs)}
+          </Text>
+        )}
         {verified !== undefined && <VerifiedBadge verified={verified} />}
       </View>
 


### PR DESCRIPTION
## Summary

Ports PostHog/code#2240 ("feat(inbox): show relative timestamp on signal cards") to the mobile app. Each signal card on the report detail screen now shows a short relative timestamp (e.g. `2h ago`, `3d ago`) in the header, derived from the signal's own `timestamp`.

Reuses the existing `formatRelativeTime` util from `@/lib/format` instead of introducing a new component — the desktop's `<RelativeTimestamp />` wrapper exists primarily to add a tooltip with the full date, which has no native equivalent on mobile.

## Test plan

- [ ] Open a signal report on the mobile app and expand the **Signals** section
- [ ] Confirm each signal card shows a relative timestamp (e.g. `5m ago`, `2h ago`) on the right side of the header
- [ ] Confirm the timestamp wraps cleanly alongside the source-line label and the verified badge (no overflow)
- [ ] Confirm cards with a missing/invalid `signal.timestamp` simply omit the timestamp (no crash, no `NaN`)