### PR TITLE
fix(mobile): fire completion notifications for cloud task turns

### DIFF
--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
@@ -152,6 +152,7 @@ interface BatchAnalysis {
   hasTurnEnd: boolean;
   hasAwaitingUserInput: boolean;
   hasTurnCompleted: boolean;
+  hasTurnFailed: boolean;
   hasVisibleAgentOutput: boolean;
   externalUserMessageCount: number;
   agentMessageFinalized: boolean;
@@ -164,6 +165,7 @@ function analyzeEntries(
   let hasTurnEnd = false;
   let hasAwaitingUserInput = false;
   let hasTurnCompleted = false;
+  let hasTurnFailed = false;
   let hasVisibleAgentOutput = false;
   let externalUserMessageCount = 0;
   let agentMessageFinalized = false;
@@ -180,6 +182,9 @@ function analyzeEntries(
         method === "_posthog/task_complete"
       ) {
         hasTurnCompleted = true;
+      }
+      if (method === "_posthog/error") {
+        hasTurnFailed = true;
       }
     }
 
@@ -209,6 +214,7 @@ function analyzeEntries(
     hasTurnEnd,
     hasAwaitingUserInput,
     hasTurnCompleted,
+    hasTurnFailed,
     hasVisibleAgentOutput,
     externalUserMessageCount,
     agentMessageFinalized,
@@ -906,13 +912,16 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
         };
       });
 
-      // Live `logs` deltas fire pings for two turn-boundary cases:
+      // Live `logs` deltas fire pings for three turn-boundary cases:
       //   * agent is blocked on the user (_posthog/awaiting_user_input)
       //   * agent finished its turn (_posthog/turn_complete / task_complete)
-      // The terminal-status block below only fires when the whole run goes
-      // terminal without first emitting a turn_complete (e.g. sandbox killed
-      // mid-turn). Normal completion flows now ping here. Snapshots are
-      // historical replay — never ping for those.
+      //   * agent errored out the turn (_posthog/error)
+      // The terminal-status block below can't be relied on for these: the
+      // turn-end log entry arrives first and clears `awaitingPing`, so by
+      // the time status terminal fires its `preState.awaitingPing` is
+      // already false. Status-only termination (sandbox killed without a
+      // turn-end log) still falls through to the status block. Snapshots
+      // are historical replay — never ping for those.
       const shouldPingForAwaitingInput =
         !isSnapshot && wasAwaitingPing && analysis.hasAwaitingUserInput;
       const shouldPingForTurnComplete =
@@ -920,8 +929,16 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
         wasAwaitingPing &&
         analysis.hasTurnCompleted &&
         !analysis.hasAwaitingUserInput;
+      const shouldPingForTurnFailed =
+        !isSnapshot &&
+        wasAwaitingPing &&
+        analysis.hasTurnFailed &&
+        !analysis.hasAwaitingUserInput &&
+        !analysis.hasTurnCompleted;
       const shouldPingNow =
-        shouldPingForAwaitingInput || shouldPingForTurnComplete;
+        shouldPingForAwaitingInput ||
+        shouldPingForTurnComplete ||
+        shouldPingForTurnFailed;
       if (shouldPingNow && usePreferencesStore.getState().pingsEnabled) {
         playMeepSound().catch(() => {});
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
@@ -935,6 +952,11 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
         maybePresentLocalNotification({
           taskRunId,
           kind: "turn_complete",
+        });
+      } else if (shouldPingForTurnFailed) {
+        maybePresentLocalNotification({
+          taskRunId,
+          kind: "task_failed",
         });
       }
     }

--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
@@ -151,6 +151,7 @@ const TURN_END_METHODS = new Set([
 interface BatchAnalysis {
   hasTurnEnd: boolean;
   hasAwaitingUserInput: boolean;
+  hasTurnCompleted: boolean;
   hasVisibleAgentOutput: boolean;
   externalUserMessageCount: number;
   agentMessageFinalized: boolean;
@@ -162,6 +163,7 @@ function analyzeEntries(
 ): BatchAnalysis {
   let hasTurnEnd = false;
   let hasAwaitingUserInput = false;
+  let hasTurnCompleted = false;
   let hasVisibleAgentOutput = false;
   let externalUserMessageCount = 0;
   let agentMessageFinalized = false;
@@ -172,6 +174,12 @@ function analyzeEntries(
       hasTurnEnd = true;
       if (method === "_posthog/awaiting_user_input") {
         hasAwaitingUserInput = true;
+      }
+      if (
+        method === "_posthog/turn_complete" ||
+        method === "_posthog/task_complete"
+      ) {
+        hasTurnCompleted = true;
       }
     }
 
@@ -200,6 +208,7 @@ function analyzeEntries(
   return {
     hasTurnEnd,
     hasAwaitingUserInput,
+    hasTurnCompleted,
     hasVisibleAgentOutput,
     externalUserMessageCount,
     agentMessageFinalized,
@@ -897,20 +906,35 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
         };
       });
 
-      // Live `logs` deltas only fire pings for the "agent is blocked on the
-      // user" case. Terminal completion / failure is handled by the status
-      // block below, so we don't double-fire on every intermediate turn.
-      // Snapshots are historical replay — never ping for those.
-      const shouldPingNow =
+      // Live `logs` deltas fire pings for two turn-boundary cases:
+      //   * agent is blocked on the user (_posthog/awaiting_user_input)
+      //   * agent finished its turn (_posthog/turn_complete / task_complete)
+      // The terminal-status block below only fires when the whole run goes
+      // terminal without first emitting a turn_complete (e.g. sandbox killed
+      // mid-turn). Normal completion flows now ping here. Snapshots are
+      // historical replay — never ping for those.
+      const shouldPingForAwaitingInput =
         !isSnapshot && wasAwaitingPing && analysis.hasAwaitingUserInput;
+      const shouldPingForTurnComplete =
+        !isSnapshot &&
+        wasAwaitingPing &&
+        analysis.hasTurnCompleted &&
+        !analysis.hasAwaitingUserInput;
+      const shouldPingNow =
+        shouldPingForAwaitingInput || shouldPingForTurnComplete;
       if (shouldPingNow && usePreferencesStore.getState().pingsEnabled) {
         playMeepSound().catch(() => {});
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       }
-      if (shouldPingNow) {
+      if (shouldPingForAwaitingInput) {
         maybePresentLocalNotification({
           taskRunId,
           kind: "awaiting_user_input",
+        });
+      } else if (shouldPingForTurnComplete) {
+        maybePresentLocalNotification({
+          taskRunId,
+          kind: "turn_complete",
         });
       }
     }


### PR DESCRIPTION
## Problem

Mobile cloud tasks never fired completion notifications for normal turn
endings. The user would send a prompt, background the app, and the agent
would finish without the device ringing — because mobile only had two
notification paths and both missed the common case:

1. The live `logs` path fired a notification only on
   `_posthog/awaiting_user_input` (agent blocking on the user). Plain
   `_posthog/turn_complete` (agent done, run still alive) was a no-op
   beyond clearing `isPromptPending`.
2. The terminal-status path fired when the run went
   `completed`/`failed`/`cancelled`. But the final `turn_complete` log
   entry arrives via the SSE stream before the status update, and the
   log batch already clears `awaitingPing` — so the status branch's
   `shouldPing = preState.awaitingPing` check always read `false` by the
   time it ran. Effectively dead for normal completions.

Same shape of gap as desktop PR #2344 ("fire completion notifications
for cloud tasks"), where the cloud branch of
`updatePromptStateFromEvents` was clearing `isPromptPending` on
`turn_complete` but never calling `notifyPromptComplete`.

## Changes

- `analyzeEntries` now surfaces a distinct `hasTurnCompleted` flag for
  `_posthog/turn_complete` / `_posthog/task_complete`, in addition to
  the existing `hasTurnEnd` (which covers all four turn-end methods
  including `awaiting_user_input` and `error`).
- The live `logs` branch of `_handleCloudUpdate` now fires the
  `turn_complete` local notification (plus the existing sound + haptic
  side effects, gated by `pingsEnabled`) when:
  - the batch isn't a historical snapshot, AND
  - the user was awaiting a ping (this-device-initiated action), AND
  - `hasTurnCompleted` is true, AND
  - `hasAwaitingUserInput` is false (which has its own dedicated banner).
- Snapshots and gap-fill replay paths stay unaffected — those are
  historical entries and would re-notify for turns that completed in
  past app runs.
- The dedup window in `maybePresentLocalNotification` (30s per task) and
  the `focusedTaskId` suppression continue to apply, so the new path
  doesn't double-fire when status terminal arrives shortly after
  turn_complete.

No desktop code changes; only the React Native app.

## Test plan

- [x] `pnpm --filter @posthog/mobile test` — 25 files / 105 tests pass.
- [x] `pnpm exec biome ci apps/mobile/src/features/tasks/stores/taskSessionStore.ts` — clean.
- [x] `npx tsc --noEmit` in `apps/mobile` — no new errors introduced by this change (the pre-existing test-file errors are untouched).
- [ ] Manual: send a prompt to a cloud task on a TestFlight build, background the app, confirm a \"<task> finished\" banner fires when the agent completes its turn.
- [ ] Manual: leave the task screen focused while the agent finishes — no notification (focused-task suppression).
- [ ] Manual: receive an `awaiting_user_input` turn end — still get the \"needs your input\" banner, not the generic \"finished\" one.