### PR TITLE
feat(mobile): add configurable default effort level

### DIFF
--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -8,6 +8,7 @@ import { useDismissedReportsStore } from "@/features/inbox/stores/dismissedRepor
 import { usePushTokenStore } from "@/features/notifications/stores/pushTokenStore";
 import {
   type CompletionSound,
+  type DefaultReasoningEffort,
   type InitialTaskMode,
   type ThemePreference,
   usePreferencesStore,
@@ -59,6 +60,23 @@ const TASK_MODE_OPTIONS = [
   },
 ] as const;
 
+const REASONING_EFFORT_OPTIONS: ReadonlyArray<{
+  value: DefaultReasoningEffort;
+  label: string;
+  description?: string;
+}> = [
+  {
+    value: "last_used",
+    label: "Last used",
+    description: "Remember the effort level you picked last time",
+  },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra High" },
+  { value: "max", label: "Max" },
+];
+
 function themeLabel(theme: ThemePreference): string {
   return THEME_OPTIONS.find((o) => o.value === theme)?.label ?? "Match system";
 }
@@ -76,6 +94,13 @@ function volumeLabel(volume: number): string {
 
 function taskModeLabel(mode: InitialTaskMode): string {
   return TASK_MODE_OPTIONS.find((o) => o.value === mode)?.label ?? "Plan";
+}
+
+function reasoningEffortLabel(effort: DefaultReasoningEffort): string {
+  return (
+    REASONING_EFFORT_OPTIONS.find((o) => o.value === effort)?.label ??
+    "Last used"
+  );
 }
 
 export default function SettingsScreen() {
@@ -113,6 +138,12 @@ export default function SettingsScreen() {
   const setDefaultInitialTaskMode = usePreferencesStore(
     (s) => s.setDefaultInitialTaskMode,
   );
+  const defaultReasoningEffort = usePreferencesStore(
+    (s) => s.defaultReasoningEffort,
+  );
+  const setDefaultReasoningEffort = usePreferencesStore(
+    (s) => s.setDefaultReasoningEffort,
+  );
   const decidedCount = useDismissedReportsStore(
     (s) => s.dismissedIds.length + s.acceptedIds.length,
   );
@@ -122,6 +153,8 @@ export default function SettingsScreen() {
   const [soundSheetOpen, setSoundSheetOpen] = useState(false);
   const [volumeSheetOpen, setVolumeSheetOpen] = useState(false);
   const [taskModeSheetOpen, setTaskModeSheetOpen] = useState(false);
+  const [reasoningEffortSheetOpen, setReasoningEffortSheetOpen] =
+    useState(false);
   const [projectSheetOpen, setProjectSheetOpen] = useState(false);
 
   // The selected project's name. Prefer the names fetched for the scoped teams
@@ -272,11 +305,24 @@ export default function SettingsScreen() {
             label="Initial task mode"
             description="What mode new tasks start in"
             onPress={() => setTaskModeSheetOpen(true)}
-            showDivider={false}
             rightSlot={
               <>
                 <Text className="text-[14px] text-gray-11">
                   {taskModeLabel(defaultInitialTaskMode)}
+                </Text>
+                <CaretRight size={14} color={themeColors.gray[10]} />
+              </>
+            }
+          />
+          <SettingsRow
+            label="Default effort level"
+            description="Reasoning effort to pre-fill on new tasks"
+            onPress={() => setReasoningEffortSheetOpen(true)}
+            showDivider={false}
+            rightSlot={
+              <>
+                <Text className="text-[14px] text-gray-11">
+                  {reasoningEffortLabel(defaultReasoningEffort)}
                 </Text>
                 <CaretRight size={14} color={themeColors.gray[10]} />
               </>
@@ -502,6 +548,21 @@ export default function SettingsScreen() {
         }
         onClose={() => setTaskModeSheetOpen(false)}
         options={TASK_MODE_OPTIONS.map((option) => ({
+          value: option.value,
+          label: option.label,
+          description: option.description,
+        }))}
+      />
+
+      <SelectSheet
+        open={reasoningEffortSheetOpen}
+        title="Default effort level"
+        value={defaultReasoningEffort}
+        onChange={(value) =>
+          setDefaultReasoningEffort(value as DefaultReasoningEffort)
+        }
+        onClose={() => setReasoningEffortSheetOpen(false)}
+        options={REASONING_EFFORT_OPTIONS.map((option) => ({
           value: option.value,
           label: option.label,
           description: option.description,

--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -13,6 +13,7 @@ import {
 import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
 import { FloatingBackButton } from "@/components/FloatingBackButton";
+import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
 import { getTask, runTaskInCloud } from "@/features/tasks/api";
 import { FloatingTaskHeader } from "@/features/tasks/components/FloatingTaskHeader";
 import { PrDiffStatsBadge } from "@/features/tasks/components/PrDiffStatsBadge";
@@ -307,6 +308,7 @@ export default function TaskDetailScreen() {
       if (!taskId) return;
       setComposerConfig(taskId, { reasoning: value });
       setConfigOption(taskId, "effort", value).catch(() => {});
+      usePreferencesStore.getState().setLastUsedReasoningEffort(value);
     },
     [taskId, setComposerConfig, setConfigOption],
   );

--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -180,8 +180,16 @@ export default function NewTaskScreen() {
     return DEFAULT_EXECUTION_MODE;
   });
   const [model, setModel] = useState<string>(DEFAULT_MODEL);
-  const [reasoning, setReasoning] =
-    useState<ReasoningEffort>(DEFAULT_REASONING);
+  const [reasoning, setReasoning] = useState<ReasoningEffort>(() => {
+    const prefs = usePreferencesStore.getState();
+    const isValidReasoning = (v: string): v is ReasoningEffort =>
+      REASONING_LEVELS.some((r) => r.value === v);
+    const desired =
+      prefs.defaultReasoningEffort === "last_used"
+        ? prefs.lastUsedReasoningEffort
+        : prefs.defaultReasoningEffort;
+    return isValidReasoning(desired) ? desired : DEFAULT_REASONING;
+  });
   const [creating, setCreating] = useState(false);
   const [repoSheetOpen, setRepoSheetOpen] = useState(false);
   const [modeSheetOpen, setModeSheetOpen] = useState(false);
@@ -681,7 +689,11 @@ export default function NewTaskScreen() {
         open={reasoningSheetOpen}
         title="Reasoning"
         value={reasoning}
-        onChange={(value) => setReasoning(value as ReasoningEffort)}
+        onChange={(value) => {
+          const next = value as ReasoningEffort;
+          setReasoning(next);
+          usePreferencesStore.getState().setLastUsedReasoningEffort(next);
+        }}
         onClose={() => setReasoningSheetOpen(false)}
         options={REASONING_LEVELS.map((reasoningLevel) => ({
           value: reasoningLevel.value,

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { usePreferencesStore } from "./preferencesStore";
+
+const INITIAL_STATE = usePreferencesStore.getState();
+
+beforeEach(() => {
+  // Reset to the store's defined defaults between tests so persisted state from
+  // earlier cases doesn't leak in.
+  usePreferencesStore.setState(INITIAL_STATE, true);
+});
+
+describe("preferencesStore reasoning effort", () => {
+  it("defaults defaultReasoningEffort to last_used", () => {
+    expect(usePreferencesStore.getState().defaultReasoningEffort).toBe(
+      "last_used",
+    );
+  });
+
+  it("defaults lastUsedReasoningEffort to high", () => {
+    expect(usePreferencesStore.getState().lastUsedReasoningEffort).toBe("high");
+  });
+
+  it("updates defaultReasoningEffort via setter", () => {
+    usePreferencesStore.getState().setDefaultReasoningEffort("max");
+    expect(usePreferencesStore.getState().defaultReasoningEffort).toBe("max");
+
+    usePreferencesStore.getState().setDefaultReasoningEffort("last_used");
+    expect(usePreferencesStore.getState().defaultReasoningEffort).toBe(
+      "last_used",
+    );
+  });
+
+  it("updates lastUsedReasoningEffort via setter", () => {
+    usePreferencesStore.getState().setLastUsedReasoningEffort("xhigh");
+    expect(usePreferencesStore.getState().lastUsedReasoningEffort).toBe(
+      "xhigh",
+    );
+  });
+
+  it("keeps lastUsedReasoningEffort independent of defaultReasoningEffort", () => {
+    usePreferencesStore.getState().setDefaultReasoningEffort("low");
+    usePreferencesStore.getState().setLastUsedReasoningEffort("max");
+
+    const state = usePreferencesStore.getState();
+    expect(state.defaultReasoningEffort).toBe("low");
+    expect(state.lastUsedReasoningEffort).toBe("max");
+  });
+});

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
@@ -21,22 +21,25 @@ describe("preferencesStore reasoning effort", () => {
     expect(usePreferencesStore.getState().lastUsedReasoningEffort).toBe("high");
   });
 
-  it("updates defaultReasoningEffort via setter", () => {
-    usePreferencesStore.getState().setDefaultReasoningEffort("max");
-    expect(usePreferencesStore.getState().defaultReasoningEffort).toBe("max");
+  it.each(["low", "medium", "high", "xhigh", "max", "last_used"] as const)(
+    "updates defaultReasoningEffort to %s via setter",
+    (effort) => {
+      usePreferencesStore.getState().setDefaultReasoningEffort(effort);
+      expect(usePreferencesStore.getState().defaultReasoningEffort).toBe(
+        effort,
+      );
+    },
+  );
 
-    usePreferencesStore.getState().setDefaultReasoningEffort("last_used");
-    expect(usePreferencesStore.getState().defaultReasoningEffort).toBe(
-      "last_used",
-    );
-  });
-
-  it("updates lastUsedReasoningEffort via setter", () => {
-    usePreferencesStore.getState().setLastUsedReasoningEffort("xhigh");
-    expect(usePreferencesStore.getState().lastUsedReasoningEffort).toBe(
-      "xhigh",
-    );
-  });
+  it.each(["low", "medium", "high", "xhigh", "max"] as const)(
+    "updates lastUsedReasoningEffort to %s via setter",
+    (effort) => {
+      usePreferencesStore.getState().setLastUsedReasoningEffort(effort);
+      expect(usePreferencesStore.getState().lastUsedReasoningEffort).toBe(
+        effort,
+      );
+    },
+  );
 
   it("keeps lastUsedReasoningEffort independent of defaultReasoningEffort", () => {
     usePreferencesStore.getState().setDefaultReasoningEffort("low");

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.ts
@@ -15,6 +15,14 @@ export type CompletionSound =
 
 export type InitialTaskMode = "plan" | "last_used";
 
+export type DefaultReasoningEffort =
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "last_used";
+
 interface PreferencesState {
   pingsEnabled: boolean;
   setPingsEnabled: (enabled: boolean) => void;
@@ -35,6 +43,13 @@ interface PreferencesState {
    *  `defaultInitialTaskMode === "last_used"` can pre-fill it next time. */
   lastNewTaskMode: string;
   setLastNewTaskMode: (mode: string) => void;
+
+  defaultReasoningEffort: DefaultReasoningEffort;
+  setDefaultReasoningEffort: (effort: DefaultReasoningEffort) => void;
+  /** Most recent reasoning effort the user picked. Persisted so
+   *  `defaultReasoningEffort === "last_used"` can pre-fill it next time. */
+  lastUsedReasoningEffort: string;
+  setLastUsedReasoningEffort: (effort: string) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -62,6 +77,13 @@ export const usePreferencesStore = create<PreferencesState>()(
         set({ defaultInitialTaskMode: mode }),
       lastNewTaskMode: "plan",
       setLastNewTaskMode: (mode) => set({ lastNewTaskMode: mode }),
+
+      defaultReasoningEffort: "last_used",
+      setDefaultReasoningEffort: (effort) =>
+        set({ defaultReasoningEffort: effort }),
+      lastUsedReasoningEffort: "high",
+      setLastUsedReasoningEffort: (effort) =>
+        set({ lastUsedReasoningEffort: effort }),
     }),
     {
       name: "posthog-preferences",
@@ -74,6 +96,8 @@ export const usePreferencesStore = create<PreferencesState>()(
         completionVolume: state.completionVolume,
         defaultInitialTaskMode: state.defaultInitialTaskMode,
         lastNewTaskMode: state.lastNewTaskMode,
+        defaultReasoningEffort: state.defaultReasoningEffort,
+        lastUsedReasoningEffort: state.lastUsedReasoningEffort,
       }),
     },
   ),


### PR DESCRIPTION
## Summary
- Ports desktop PR #2116 to the mobile app: adds a "Default effort level" preference that pre-fills the reasoning pill on the new-task composer.
- The setting accepts the five effort levels mobile's composer already supports (low/medium/high/xhigh/max) plus `last_used`, which remembers the user's most recent pick.
- New `lastUsedReasoningEffort` is updated whenever the user picks a reasoning level in either composer, so the `last_used` default has something to fall back on.
- All persisted in the existing `preferencesStore`. UI added under Settings > Input below "Initial task mode".

## Test plan
- [ ] `pnpm --filter @posthog/mobile test` (preferences store unit tests + existing suite)
- [ ] Manually verify in the app: pick "Max" as default, open the new-task screen, confirm reasoning pill shows "Max"
- [ ] Switch the setting to "Last used", change the pill to "Low" while composing, reopen the new-task screen, confirm it remembers "Low"
- [ ] Setting persists across app restart