### PR TITLE
fix(mobile): auto-refresh on PostHog 401/403 auth failures

### DIFF
--- a/apps/mobile/src/features/auth/hooks/useProjectsQuery.ts
+++ b/apps/mobile/src/features/auth/hooks/useProjectsQuery.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { authedFetch, getBaseUrl } from "@/lib/api";
 import { useAuthStore } from "../stores/authStore";
 
 export interface ProjectSummary {
@@ -14,21 +15,19 @@ export interface ProjectSummary {
  * rather than dropping the project from the list.
  */
 export function useProjectsQuery() {
-  const { cloudRegion, oauthAccessToken, scopedTeams, getCloudUrlFromRegion } =
-    useAuthStore();
+  const { cloudRegion, oauthAccessToken, scopedTeams } = useAuthStore();
 
   return useQuery({
     queryKey: ["projects", cloudRegion, scopedTeams],
     queryFn: async (): Promise<ProjectSummary[]> => {
-      if (!cloudRegion) throw new Error("No cloud region");
-      const baseUrl = getCloudUrlFromRegion(cloudRegion);
+      const baseUrl = getBaseUrl();
 
       return Promise.all(
         scopedTeams.map(async (id): Promise<ProjectSummary> => {
           try {
-            const response = await fetch(`${baseUrl}/api/projects/${id}/`, {
-              headers: { Authorization: `Bearer ${oauthAccessToken}` },
-            });
+            const response = await authedFetch(
+              `${baseUrl}/api/projects/${id}/`,
+            );
             if (!response.ok) return { id, name: `Project ${id}` };
             const data: { name?: string } = await response.json();
             return { id, name: data.name || `Project ${id}` };

--- a/apps/mobile/src/features/auth/hooks/useUserQuery.ts
+++ b/apps/mobile/src/features/auth/hooks/useUserQuery.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { authedFetch, getBaseUrl } from "@/lib/api";
 import { useAuthStore } from "../stores/authStore";
 
 export interface UserData {
@@ -19,19 +20,12 @@ export interface UserData {
 }
 
 export function useUserQuery() {
-  const { cloudRegion, oauthAccessToken, getCloudUrlFromRegion } =
-    useAuthStore();
+  const { cloudRegion, oauthAccessToken } = useAuthStore();
 
   return useQuery({
     queryKey: ["user", "me"],
     queryFn: async (): Promise<UserData> => {
-      if (!cloudRegion) throw new Error("No cloud region");
-      const baseUrl = getCloudUrlFromRegion(cloudRegion);
-      const response = await fetch(`${baseUrl}/api/users/@me/`, {
-        headers: {
-          Authorization: `Bearer ${oauthAccessToken}`,
-        },
-      });
+      const response = await authedFetch(`${getBaseUrl()}/api/users/@me/`);
 
       if (!response.ok) {
         throw new Error(`Failed to fetch user: ${response.statusText}`);

--- a/apps/mobile/src/features/inbox/api.ts
+++ b/apps/mobile/src/features/inbox/api.ts
@@ -1,6 +1,5 @@
-import { fetch } from "expo/fetch";
 import { HttpError } from "@/features/tasks/api";
-import { getBaseUrl, getHeaders, getProjectId } from "@/lib/api";
+import { authedFetch, getBaseUrl, getProjectId } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import type { DismissalReasonOptionValue } from "./constants";
 
@@ -24,7 +23,6 @@ export async function getSignalReports(
 ): Promise<SignalReportsResponse> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
   const url = new URL(`${baseUrl}/api/projects/${projectId}/signals/reports/`);
 
@@ -47,7 +45,7 @@ export async function getSignalReports(
     url.searchParams.set("suggested_reviewers", params.suggested_reviewers);
   }
 
-  const response = await fetch(url.toString(), { headers });
+  const response = await authedFetch(url.toString());
 
   if (!response.ok) {
     throw new HttpError(
@@ -69,11 +67,9 @@ export async function getSignalReport(
 ): Promise<SignalReport | null> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/`,
-    { headers },
   );
 
   if (response.status === 404 || response.status === 403) {
@@ -94,11 +90,9 @@ export async function getSignalReport(
 export async function getSignalProcessingState(): Promise<SignalProcessingStateResponse> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/signals/processing_state/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -117,7 +111,6 @@ export async function getAvailableSuggestedReviewers(
 ): Promise<AvailableSuggestedReviewersResponse> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
   const url = new URL(
     `${baseUrl}/api/projects/${projectId}/signals/reports/available_reviewers/`,
@@ -127,7 +120,7 @@ export async function getAvailableSuggestedReviewers(
     url.searchParams.set("query", query.trim());
   }
 
-  const response = await fetch(url.toString(), { headers });
+  const response = await authedFetch(url.toString());
 
   if (!response.ok) {
     throw new HttpError(
@@ -160,11 +153,9 @@ export async function getSignalReportTasks(
 ): Promise<SignalReportTask[]> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/tasks/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -184,11 +175,9 @@ export async function getSignalReportArtefacts(
 ): Promise<SignalReportArtefactsResponse> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/artefacts/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -211,11 +200,9 @@ export async function getSignalReportSignals(
 ): Promise<SignalReportSignalsResponse> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/signals/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -268,13 +255,11 @@ export async function dismissSignalReport(
 ): Promise<SignalReport> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/state/`,
     {
       method: "POST",
-      headers: { ...headers, "Content-Type": "application/json" },
       body: JSON.stringify({
         state: "suppressed",
         dismissal_reason: input.reason,

--- a/apps/mobile/src/features/mcp/api.ts
+++ b/apps/mobile/src/features/mcp/api.ts
@@ -1,5 +1,4 @@
-import { fetch } from "expo/fetch";
-import { getBaseUrl, getHeaders, getProjectId } from "@/lib/api";
+import { authedFetch, getBaseUrl, getProjectId } from "@/lib/api";
 import type {
   InstallCustomMcpServerOptions,
   InstallMcpTemplateOptions,
@@ -37,9 +36,8 @@ export async function getMcpRecommendedServers(): Promise<
 > {
   const base = getBaseUrl();
   const projectId = getProjectId();
-  const response = await fetch(
+  const response = await authedFetch(
     `${base}/api/environments/${projectId}/mcp_servers/`,
-    { headers: getHeaders() },
   );
   const data = await readJsonOrThrow<
     McpRecommendedServer[] | { results?: McpRecommendedServer[] }
@@ -51,7 +49,7 @@ export async function getMcpRecommendedServers(): Promise<
 export async function getMcpServerInstallations(): Promise<
   McpServerInstallation[]
 > {
-  const response = await fetch(`${mcpBaseUrl()}/`, { headers: getHeaders() });
+  const response = await authedFetch(`${mcpBaseUrl()}/`);
   const data = await readJsonOrThrow<
     McpServerInstallation[] | { results?: McpServerInstallation[] }
   >(response, "Failed to fetch MCP server installations");
@@ -62,9 +60,8 @@ export async function getMcpServerInstallations(): Promise<
 export async function installCustomMcpServer(
   options: InstallCustomMcpServerOptions,
 ): Promise<McpInstallResponse> {
-  const response = await fetch(`${mcpBaseUrl()}/install_custom/`, {
+  const response = await authedFetch(`${mcpBaseUrl()}/install_custom/`, {
     method: "POST",
-    headers: getHeaders(),
     body: JSON.stringify(options),
   });
   return readJsonOrThrow<McpInstallResponse>(
@@ -77,9 +74,8 @@ export async function installCustomMcpServer(
 export async function installMcpTemplate(
   options: InstallMcpTemplateOptions,
 ): Promise<McpInstallResponse> {
-  const response = await fetch(`${mcpBaseUrl()}/install_template/`, {
+  const response = await authedFetch(`${mcpBaseUrl()}/install_template/`, {
     method: "POST",
-    headers: getHeaders(),
     body: JSON.stringify(options),
   });
   return readJsonOrThrow<McpInstallResponse>(
@@ -93,9 +89,8 @@ export async function updateMcpServerInstallation(
   installationId: string,
   updates: UpdateMcpServerInstallationOptions,
 ): Promise<McpServerInstallation> {
-  const response = await fetch(`${mcpBaseUrl()}/${installationId}/`, {
+  const response = await authedFetch(`${mcpBaseUrl()}/${installationId}/`, {
     method: "PATCH",
-    headers: getHeaders(),
     body: JSON.stringify(updates),
   });
   return readJsonOrThrow<McpServerInstallation>(
@@ -108,9 +103,8 @@ export async function updateMcpServerInstallation(
 export async function uninstallMcpServer(
   installationId: string,
 ): Promise<void> {
-  const response = await fetch(`${mcpBaseUrl()}/${installationId}/`, {
+  const response = await authedFetch(`${mcpBaseUrl()}/${installationId}/`, {
     method: "DELETE",
-    headers: getHeaders(),
   });
   if (!response.ok && response.status !== 204) {
     throw new Error(`Failed to uninstall MCP server: ${response.statusText}`);
@@ -131,9 +125,8 @@ export async function authorizeMcpInstallation(options: {
   if (options.posthog_code_callback_url) {
     params.set("posthog_code_callback_url", options.posthog_code_callback_url);
   }
-  const response = await fetch(
+  const response = await authedFetch(
     `${mcpBaseUrl()}/authorize/?${params.toString()}`,
-    { headers: getHeaders() },
   );
   return readJsonOrThrow<McpOAuthRedirectResponse>(
     response,
@@ -149,9 +142,8 @@ export async function getMcpInstallationTools(
   const params = new URLSearchParams();
   if (options.includeRemoved) params.set("include_removed", "1");
   const query = params.toString();
-  const response = await fetch(
+  const response = await authedFetch(
     `${mcpBaseUrl()}/${installationId}/tools/${query ? `?${query}` : ""}`,
-    { headers: getHeaders() },
   );
   const data = await readJsonOrThrow<
     McpInstallationTool[] | { results?: McpInstallationTool[] }
@@ -165,11 +157,10 @@ export async function updateMcpToolApproval(
   toolName: string,
   approval_state: McpApprovalState,
 ): Promise<McpInstallationTool> {
-  const response = await fetch(
+  const response = await authedFetch(
     `${mcpBaseUrl()}/${installationId}/tools/${encodeURIComponent(toolName)}/`,
     {
       method: "PATCH",
-      headers: getHeaders(),
       body: JSON.stringify({ approval_state }),
     },
   );
@@ -183,9 +174,9 @@ export async function updateMcpToolApproval(
 export async function refreshMcpInstallationTools(
   installationId: string,
 ): Promise<McpInstallationTool[]> {
-  const response = await fetch(
+  const response = await authedFetch(
     `${mcpBaseUrl()}/${installationId}/tools/refresh/`,
-    { method: "POST", headers: getHeaders() },
+    { method: "POST" },
   );
   const data = await readJsonOrThrow<
     McpInstallationTool[] | { results?: McpInstallationTool[] }

--- a/apps/mobile/src/features/tasks/api.automations.test.ts
+++ b/apps/mobile/src/features/tasks/api.automations.test.ts
@@ -10,11 +10,16 @@ vi.mock("expo/fetch", () => ({
 
 vi.mock("@/lib/api", () => ({
   getBaseUrl: () => "https://app.posthog.test",
-  getHeaders: () => ({
-    Authorization: "Bearer token",
-    "Content-Type": "application/json",
-  }),
   getProjectId: () => 42,
+  authedFetch: (url: string, init?: RequestInit) =>
+    mockFetch(url, {
+      ...init,
+      headers: {
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
+        ...((init?.headers as Record<string, string> | undefined) ?? {}),
+      },
+    }),
 }));
 
 import {

--- a/apps/mobile/src/features/tasks/api.ts
+++ b/apps/mobile/src/features/tasks/api.ts
@@ -1,9 +1,9 @@
 import { fetch } from "expo/fetch";
 import {
+  authedFetch,
   createTimeoutSignal,
   getAccessToken,
   getBaseUrl,
-  getHeaders,
   getProjectId,
 } from "@/lib/api";
 import { logger } from "@/lib/logger";
@@ -127,7 +127,6 @@ export async function getTasks(filters?: {
 }): Promise<Task[]> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
   const params = new URLSearchParams({ limit: "500" });
   if (filters?.repository) {
@@ -140,9 +139,8 @@ export async function getTasks(filters?: {
     params.set("origin_product", filters.originProduct);
   }
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/tasks/?${params}`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -160,11 +158,9 @@ export async function getTasks(filters?: {
 export async function getTask(taskId: string): Promise<Task> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -181,11 +177,9 @@ export async function getTask(taskId: string): Promise<Task> {
 export async function getTaskAutomations(): Promise<TaskAutomation[]> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/task_automations/?limit=500`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -207,11 +201,9 @@ export async function getTaskAutomation(
 ): Promise<TaskAutomation> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/task_automations/${automationId}/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -230,13 +222,11 @@ export async function createTaskAutomation(
 ): Promise<TaskAutomation> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/task_automations/`,
     {
       method: "POST",
-      headers,
       body: JSON.stringify(options),
     },
   );
@@ -254,13 +244,11 @@ export async function updateTaskAutomation(
 ): Promise<TaskAutomation> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/task_automations/${automationId}/`,
     {
       method: "PATCH",
-      headers,
       body: JSON.stringify(updates),
     },
   );
@@ -277,14 +265,10 @@ export async function deleteTaskAutomation(
 ): Promise<void> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/task_automations/${automationId}/`,
-    {
-      method: "DELETE",
-      headers,
-    },
+    { method: "DELETE" },
   );
 
   if (!response.ok) {
@@ -301,14 +285,10 @@ export async function runTaskAutomation(
 ): Promise<TaskAutomation> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/task_automations/${automationId}/run/`,
-    {
-      method: "POST",
-      headers,
-    },
+    { method: "POST" },
   );
 
   if (!response.ok) {
@@ -325,16 +305,17 @@ export async function runTaskAutomation(
 export async function createTask(options: CreateTaskOptions): Promise<Task> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(`${baseUrl}/api/projects/${projectId}/tasks/`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      origin_product: "user_created",
-      ...options,
-    }),
-  });
+  const response = await authedFetch(
+    `${baseUrl}/api/projects/${projectId}/tasks/`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        origin_product: "user_created",
+        ...options,
+      }),
+    },
+  );
 
   if (!response.ok) {
     const errorText = await response.text();
@@ -355,13 +336,11 @@ export async function updateTask(
 ): Promise<Task> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/`,
     {
       method: "PATCH",
-      headers,
       body: JSON.stringify(updates),
     },
   );
@@ -380,14 +359,10 @@ export async function updateTask(
 export async function deleteTask(taskId: string): Promise<void> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/`,
-    {
-      method: "DELETE",
-      headers,
-    },
+    { method: "DELETE" },
   );
 
   if (!response.ok) {
@@ -424,7 +399,6 @@ export async function runTaskInCloud(
 ): Promise<Task> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
   // Only serialize a body when we have options to send. Sending an empty
   // or minimal body on the initial run historically changed backend
@@ -470,11 +444,10 @@ export async function runTaskInCloud(
     body = JSON.stringify(payload);
   }
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/run/`,
     {
       method: "POST",
-      headers,
       body,
     },
   );
@@ -496,11 +469,9 @@ export async function getTaskRun(
 ): Promise<TaskRun> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -523,13 +494,11 @@ export async function appendTaskRunLog(
     async () => {
       const baseUrl = getBaseUrl();
       const projectId = getProjectId();
-      const headers = getHeaders();
 
-      const response = await fetch(
+      const response = await authedFetch(
         `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/append_log/`,
         {
           method: "POST",
-          headers,
           body: JSON.stringify({ entries }),
         },
       );
@@ -593,7 +562,6 @@ export async function sendCloudCommand(
 ): Promise<unknown> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
   const body = {
     jsonrpc: "2.0",
@@ -602,11 +570,10 @@ export async function sendCloudCommand(
     id: `posthog-mobile-${Date.now()}`,
   };
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/command/`,
     {
       method: "POST",
-      headers,
       body: JSON.stringify(body),
     },
   );
@@ -661,16 +628,15 @@ export async function fetchSessionLogs(
     async () => {
       const baseUrl = getBaseUrl();
       const projectId = getProjectId();
-      const headers = getHeaders();
 
       const params = new URLSearchParams({
         limit: String(options.limit ?? 5000),
         offset: String(options.offset ?? 0),
       });
 
-      const response = await fetch(
+      const response = await authedFetch(
         `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/session_logs/?${params}`,
-        { headers, signal: createTimeoutSignal(10_000) },
+        { signal: createTimeoutSignal(10_000) },
       );
 
       if (!response.ok) {
@@ -731,11 +697,9 @@ export async function streamCloudTask(
 export async function getIntegrations(): Promise<Integration[]> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/environments/${projectId}/integrations/`,
-    { headers },
   );
 
   if (!response.ok) {
@@ -762,7 +726,6 @@ export async function getGithubRepositories(
 ): Promise<string[]> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
   const allRepos: string[] = [];
   let offset = 0;
@@ -772,9 +735,8 @@ export async function getGithubRepositories(
       limit: String(GITHUB_REPOS_PAGE_SIZE),
       offset: String(offset),
     });
-    const response = await fetch(
+    const response = await authedFetch(
       `${baseUrl}/api/environments/${projectId}/integrations/${integrationId}/github_repos/?${params}`,
-      { headers },
     );
 
     if (!response.ok) {
@@ -822,13 +784,11 @@ export interface GithubUserConnectResult {
 export async function startGithubUserIntegrationConnect(): Promise<GithubUserConnectResult> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
-  const headers = getHeaders();
 
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/users/@me/integrations/github/start/`,
     {
       method: "POST",
-      headers,
       body: JSON.stringify({
         team_id: projectId,
         connect_from: "posthog_mobile",
@@ -854,11 +814,8 @@ export async function getUserGithubIntegrations(): Promise<
   UserGithubIntegration[]
 > {
   const baseUrl = getBaseUrl();
-  const headers = getHeaders();
 
-  const response = await fetch(`${baseUrl}/api/users/@me/integrations/`, {
-    headers,
-  });
+  const response = await authedFetch(`${baseUrl}/api/users/@me/integrations/`);
 
   if (!response.ok) {
     throw new HttpError(
@@ -878,7 +835,6 @@ export async function getUserGithubRepositories(
   installationId: string,
 ): Promise<string[]> {
   const baseUrl = getBaseUrl();
-  const headers = getHeaders();
 
   const allRepos: string[] = [];
   let offset = 0;
@@ -888,9 +844,8 @@ export async function getUserGithubRepositories(
       limit: String(GITHUB_REPOS_PAGE_SIZE),
       offset: String(offset),
     });
-    const response = await fetch(
+    const response = await authedFetch(
       `${baseUrl}/api/users/@me/integrations/github/${installationId}/repos/?${params}`,
-      { headers },
     );
 
     if (!response.ok) {

--- a/apps/mobile/src/features/tasks/skills/api.test.ts
+++ b/apps/mobile/src/features/tasks/skills/api.test.ts
@@ -10,11 +10,16 @@ vi.mock("expo/fetch", () => ({
 
 vi.mock("@/lib/api", () => ({
   getBaseUrl: () => "https://app.posthog.test",
-  getHeaders: () => ({
-    Authorization: "Bearer token",
-    "Content-Type": "application/json",
-  }),
   getProjectId: () => 42,
+  authedFetch: (url: string, init?: RequestInit) =>
+    mockFetch(url, {
+      ...init,
+      headers: {
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
+        ...((init?.headers as Record<string, string> | undefined) ?? {}),
+      },
+    }),
 }));
 
 import { getSkillStoreSkill, getSkillStoreSkills } from "./api";

--- a/apps/mobile/src/features/tasks/skills/api.ts
+++ b/apps/mobile/src/features/tasks/skills/api.ts
@@ -1,5 +1,4 @@
-import { fetch } from "expo/fetch";
-import { getBaseUrl, getHeaders, getProjectId } from "@/lib/api";
+import { authedFetch, getBaseUrl, getProjectId } from "@/lib/api";
 import type { SkillStoreListEntry, SkillStoreSkill } from "./types";
 
 function skillStoreBaseUrl(): string {
@@ -23,9 +22,7 @@ async function readJsonOrThrow<T>(
 }
 
 export async function getSkillStoreSkills(): Promise<SkillStoreListEntry[]> {
-  const response = await fetch(`${skillStoreBaseUrl()}/`, {
-    headers: getHeaders(),
-  });
+  const response = await authedFetch(`${skillStoreBaseUrl()}/`);
 
   const data = await readJsonOrThrow<
     SkillStoreListEntry[] | { results?: SkillStoreListEntry[] }
@@ -37,11 +34,8 @@ export async function getSkillStoreSkills(): Promise<SkillStoreListEntry[]> {
 export async function getSkillStoreSkill(
   skillName: string,
 ): Promise<SkillStoreSkill> {
-  const response = await fetch(
+  const response = await authedFetch(
     `${skillStoreBaseUrl()}/name/${encodeURIComponent(skillName)}/`,
-    {
-      headers: getHeaders(),
-    },
   );
 
   return readJsonOrThrow<SkillStoreSkill>(response, "Failed to fetch skill");

--- a/apps/mobile/src/lib/api.test.ts
+++ b/apps/mobile/src/lib/api.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFetch, mockRefreshAccessToken, mockGetState } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockRefreshAccessToken: vi.fn(),
+  mockGetState: vi.fn(),
+}));
+
+vi.mock("expo/fetch", () => ({
+  fetch: mockFetch,
+}));
+
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { version: "0.0.0-test" } },
+}));
+
+vi.mock("@/features/auth", () => ({
+  useAuthStore: {
+    getState: mockGetState,
+  },
+}));
+
+import { authedFetch } from "./api";
+
+const url = "https://app.posthog.test/api/projects/1/tasks/";
+const ok = (data: unknown = {}) =>
+  new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+const err = (status: number, body: unknown = { error: status }) =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText: `Error ${status}`,
+    headers: { "Content-Type": "application/json" },
+  });
+
+function setupTokens(initial = "old-token", refreshed = "new-token") {
+  let current = initial;
+  mockRefreshAccessToken.mockImplementation(async () => {
+    current = refreshed;
+  });
+  mockGetState.mockImplementation(() => ({
+    oauthAccessToken: current,
+    refreshAccessToken: mockRefreshAccessToken,
+  }));
+}
+
+describe("authedFetch", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockRefreshAccessToken.mockReset();
+    mockGetState.mockReset();
+  });
+
+  it("attaches the bearer token from the auth store", async () => {
+    setupTokens("my-token");
+    mockFetch.mockResolvedValueOnce(ok());
+
+    await authedFetch(url);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe(
+      "Bearer my-token",
+    );
+  });
+
+  it("retries once with a freshly fetched token on 401", async () => {
+    setupTokens("old-token", "new-token");
+    mockFetch.mockResolvedValueOnce(err(401)).mockResolvedValueOnce(ok());
+
+    const response = await authedFetch(url);
+
+    expect(response.ok).toBe(true);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe(
+      "Bearer old-token",
+    );
+    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe(
+      "Bearer new-token",
+    );
+  });
+
+  it("does not retry on 403 without authentication_failed body", async () => {
+    setupTokens("token");
+    mockFetch.mockResolvedValueOnce(err(403, { detail: "Permission denied." }));
+
+    const response = await authedFetch(url);
+
+    expect(response.status).toBe(403);
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries with a fresh token on 403 with authentication_failed body", async () => {
+    setupTokens("stale-token", "fresh-token");
+    mockFetch
+      .mockResolvedValueOnce(
+        err(403, {
+          type: "authentication_error",
+          code: "authentication_failed",
+          detail: "Invalid access token.",
+        }),
+      )
+      .mockResolvedValueOnce(ok());
+
+    const response = await authedFetch(url);
+
+    expect(response.ok).toBe(true);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe(
+      "Bearer fresh-token",
+    );
+  });
+
+  it("does not retry on other 4xx errors", async () => {
+    setupTokens("token");
+    mockFetch.mockResolvedValueOnce(err(400, { detail: "Bad request." }));
+
+    const response = await authedFetch(url);
+
+    expect(response.status).toBe(400);
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("returns the failed response when the retry still 401s", async () => {
+    setupTokens("token-1", "token-2");
+    mockFetch.mockResolvedValueOnce(err(401)).mockResolvedValueOnce(err(401));
+
+    const response = await authedFetch(url);
+
+    expect(response.status).toBe(401);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls through with the original 401 when token refresh itself fails", async () => {
+    mockGetState.mockReturnValue({
+      oauthAccessToken: "token",
+      refreshAccessToken: mockRefreshAccessToken,
+    });
+    mockRefreshAccessToken.mockRejectedValueOnce(new Error("refresh failed"));
+    mockFetch.mockResolvedValueOnce(err(401));
+
+    const response = await authedFetch(url);
+
+    expect(response.status).toBe(401);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates network errors from the underlying fetch", async () => {
+    setupTokens("token");
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+
+    await expect(authedFetch(url)).rejects.toThrow("Network failure");
+  });
+
+  it("merges caller-provided headers with the auth headers", async () => {
+    setupTokens("my-token");
+    mockFetch.mockResolvedValueOnce(ok());
+
+    await authedFetch(url, {
+      method: "POST",
+      headers: { "X-Custom": "value" },
+      body: "{}",
+    });
+
+    const init = mockFetch.mock.calls[0][1];
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe("{}");
+    expect(init.headers.Authorization).toBe("Bearer my-token");
+    expect(init.headers["X-Custom"]).toBe("value");
+  });
+
+  it("dedups concurrent refreshes so only one fires on a 401 stampede", async () => {
+    let current = "old-token";
+    let resolveRefresh: () => void = () => {};
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = () => {
+        current = "new-token";
+        resolve();
+      };
+    });
+    mockRefreshAccessToken.mockImplementation(() => refreshPromise);
+    mockGetState.mockImplementation(() => ({
+      oauthAccessToken: current,
+      refreshAccessToken: mockRefreshAccessToken,
+    }));
+
+    mockFetch
+      .mockResolvedValueOnce(err(401))
+      .mockResolvedValueOnce(err(401))
+      .mockResolvedValueOnce(err(401))
+      .mockResolvedValueOnce(ok({ n: 1 }))
+      .mockResolvedValueOnce(ok({ n: 2 }))
+      .mockResolvedValueOnce(ok({ n: 3 }));
+
+    const pending = Promise.all([
+      authedFetch(url),
+      authedFetch(url),
+      authedFetch(url),
+    ]);
+
+    // Drain microtasks until all three callers have parked on the shared
+    // refresh, then release it and let the retries complete.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    resolveRefresh();
+    const responses = await pending;
+
+    expect(responses.every((r) => r.ok)).toBe(true);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/lib/api.test.ts
+++ b/apps/mobile/src/lib/api.test.ts
@@ -66,64 +66,64 @@ describe("authedFetch", () => {
     );
   });
 
-  it("retries once with a freshly fetched token on 401", async () => {
-    setupTokens("old-token", "new-token");
-    mockFetch.mockResolvedValueOnce(err(401)).mockResolvedValueOnce(ok());
-
-    const response = await authedFetch(url);
-
-    expect(response.ok).toBe(true);
-    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe(
-      "Bearer old-token",
-    );
-    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe(
-      "Bearer new-token",
-    );
-  });
-
-  it("does not retry on 403 without authentication_failed body", async () => {
-    setupTokens("token");
-    mockFetch.mockResolvedValueOnce(err(403, { detail: "Permission denied." }));
-
-    const response = await authedFetch(url);
-
-    expect(response.status).toBe(403);
-    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries with a fresh token on 403 with authentication_failed body", async () => {
-    setupTokens("stale-token", "fresh-token");
-    mockFetch
-      .mockResolvedValueOnce(
+  it.each([
+    {
+      name: "401",
+      failure: () => err(401),
+    },
+    {
+      name: "403 with authentication_failed body",
+      failure: () =>
         err(403, {
           type: "authentication_error",
           code: "authentication_failed",
           detail: "Invalid access token.",
         }),
-      )
-      .mockResolvedValueOnce(ok());
+    },
+  ])(
+    "retries once with a freshly fetched token on $name",
+    async ({ failure }) => {
+      setupTokens("old-token", "new-token");
+      mockFetch.mockResolvedValueOnce(failure()).mockResolvedValueOnce(ok());
 
-    const response = await authedFetch(url);
+      const response = await authedFetch(url);
 
-    expect(response.ok).toBe(true);
-    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe(
-      "Bearer fresh-token",
-    );
-  });
+      expect(response.ok).toBe(true);
+      expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe(
+        "Bearer old-token",
+      );
+      expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe(
+        "Bearer new-token",
+      );
+    },
+  );
 
-  it("does not retry on other 4xx errors", async () => {
-    setupTokens("token");
-    mockFetch.mockResolvedValueOnce(err(400, { detail: "Bad request." }));
+  it.each([
+    {
+      name: "403 without authentication_failed body",
+      response: () => err(403, { detail: "Permission denied." }),
+      expectedStatus: 403,
+    },
+    {
+      name: "400 bad request",
+      response: () => err(400, { detail: "Bad request." }),
+      expectedStatus: 400,
+    },
+  ])(
+    "does not retry on $name",
+    async ({ response: makeResponse, expectedStatus }) => {
+      setupTokens("token");
+      mockFetch.mockResolvedValueOnce(makeResponse());
 
-    const response = await authedFetch(url);
+      const response = await authedFetch(url);
 
-    expect(response.status).toBe(400);
-    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(expectedStatus);
+      expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("returns the failed response when the retry still 401s", async () => {
     setupTokens("token-1", "token-2");

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,3 +1,4 @@
+import type { FetchRequestInit } from "expo/build/winter/fetch/fetch.types";
 import { fetch } from "expo/fetch";
 import Constants from "expo-constants";
 import { useAuthStore } from "@/features/auth";
@@ -57,19 +58,112 @@ export function createTimeoutSignal(ms: number): AbortSignal {
   return controller.signal;
 }
 
+// Concurrent 401s would otherwise stampede the refresh endpoint and have the
+// in-flight responses invalidate each other's new tokens. Share a single
+// pending refresh across all callers and reset it once it settles.
+let pendingRefresh: Promise<void> | null = null;
+
+async function refreshAccessTokenOnce(): Promise<void> {
+  if (pendingRefresh) return pendingRefresh;
+  const promise = useAuthStore
+    .getState()
+    .refreshAccessToken()
+    .finally(() => {
+      if (pendingRefresh === promise) {
+        pendingRefresh = null;
+      }
+    });
+  pendingRefresh = promise;
+  return promise;
+}
+
+async function isAuthFailureResponse(response: Response): Promise<boolean> {
+  if (response.status === 401) return true;
+  if (response.status !== 403) return false;
+  try {
+    const body = await response.clone().json();
+    return (
+      body?.code === "authentication_failed" ||
+      body?.type === "authentication_error"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function mergeHeaders(
+  base: Record<string, string>,
+  override: HeadersInit | undefined,
+): Record<string, string> {
+  if (!override) return base;
+  const merged: Record<string, string> = { ...base };
+  if (override instanceof Headers) {
+    override.forEach((value, key) => {
+      merged[key] = value;
+    });
+    return merged;
+  }
+  if (Array.isArray(override)) {
+    for (const [key, value] of override) {
+      merged[key] = value;
+    }
+    return merged;
+  }
+  for (const [key, value] of Object.entries(override)) {
+    merged[key] = value;
+  }
+  return merged;
+}
+
+/**
+ * `fetch` against the PostHog API with automatic token refresh on auth
+ * failure. On a 401 — or a 403 whose JSON body looks like an authentication
+ * failure (`code: "authentication_failed"` / `type: "authentication_error"`) —
+ * triggers a single shared token refresh and retries the request once. If the
+ * refresh itself fails, the original response is returned so callers fall
+ * through to their existing error-handling and sign-out flows.
+ *
+ * Mirrors the desktop fetcher's retry semantics
+ * (apps/code/src/renderer/api/fetcher.ts).
+ */
+export async function authedFetch(
+  url: string,
+  init: FetchRequestInit = {},
+): Promise<Response> {
+  const headers = mergeHeaders(getHeaders(), init.headers);
+  let response: Response = await fetch(url, { ...init, headers });
+
+  if (response.ok || !(await isAuthFailureResponse(response))) {
+    return response;
+  }
+
+  try {
+    await refreshAccessTokenOnce();
+  } catch (err) {
+    log.warn("Token refresh on auth failure failed", {
+      url,
+      status: response.status,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return response;
+  }
+
+  const retryHeaders = mergeHeaders(getHeaders(), init.headers);
+  response = await fetch(url, { ...init, headers: retryHeaders });
+  return response;
+}
+
 export async function registerPushToken(args: {
   token: string;
   platform: string;
 }): Promise<void> {
   const baseUrl = getBaseUrl();
-  const headers = getHeaders();
 
   // Push tokens are per-user, not per-project — endpoint lives under
   // /api/users/@me/ alongside the other user-scoped APIs.
   const url = `${baseUrl}/api/users/@me/push_tokens/`;
-  const response = await fetch(url, {
+  const response = await authedFetch(url, {
     method: "POST",
-    headers,
     body: JSON.stringify(args),
   });
 
@@ -89,15 +183,13 @@ export async function registerPushToken(args: {
 
 export async function deletePushToken(args: { token: string }): Promise<void> {
   const baseUrl = getBaseUrl();
-  const headers = getHeaders();
 
   // Unregister is a POST sub-action (not DELETE) because some clients and
   // proxies strip request bodies on DELETE.
-  const response = await fetch(
+  const response = await authedFetch(
     `${baseUrl}/api/users/@me/push_tokens/unregister/`,
     {
       method: "POST",
-      headers,
       body: JSON.stringify(args),
     },
   );

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,8 +1,11 @@
-import type { FetchRequestInit } from "expo/build/winter/fetch/fetch.types";
 import { fetch } from "expo/fetch";
 import Constants from "expo-constants";
 import { useAuthStore } from "@/features/auth";
 import { logger } from "@/lib/logger";
+
+// Derive the init shape directly from expo/fetch so we don't import from
+// expo's internal build output (which can move between versions).
+type FetchInit = NonNullable<Parameters<typeof fetch>[1]>;
 
 const log = logger.scope("api");
 
@@ -128,7 +131,7 @@ function mergeHeaders(
  */
 export async function authedFetch(
   url: string,
-  init: FetchRequestInit = {},
+  init: FetchInit = {},
 ): Promise<Response> {
   const headers = mergeHeaders(getHeaders(), init.headers);
   let response: Response = await fetch(url, { ...init, headers });


### PR DESCRIPTION
## Summary

- Ports the desktop fix from #2186 to the React Native mobile app.
- Adds `authedFetch(url, init)` in `apps/mobile/src/lib/api.ts` that transparently refreshes the OAuth token and retries once when a PostHog request returns 401, or 403 with an authentication-error body (`code: "authentication_failed"` / `type: "authentication_error"`). If refresh fails, the original response is returned so callers stay on their existing error / sign-out paths.
- Threads `authedFetch` through every PostHog request site (`tasks`, `inbox`, `mcp`, `skills`, push tokens, `useUserQuery`, `useProjectsQuery`). A module-level in-flight promise dedups concurrent 401s so a stampede only triggers one refresh.

## Scope notes

- `streamCloudTask` (the SSE endpoint) keeps its raw `fetch` — it has its own resumption flow via `Last-Event-ID` / abort signal and can't simply be replayed with a fresh token after the body has started streaming.
- The mobile MCP transport (`features/mcp/service.ts`) bakes the token into the transport at construction time. That's the mobile analogue of the desktop MCP proxy fix, but rebuilding the long-lived `Client` on auth failure is meaningfully more invasive than the API layer change and is left for a follow-up.

## Test plan

- [x] `pnpm --filter @posthog/mobile test` — 115 tests pass (including the new `src/lib/api.test.ts`, which mirrors `apps/code/src/renderer/api/fetcher.test.ts` plus a dedup test for concurrent 401s).
- [x] `pnpm --filter @posthog/mobile lint` clean.
- [x] `tsc --noEmit` clean for the touched files (pre-existing unrelated errors in `*.test.tsx` component renderer tests remain).
- [ ] Smoke test on a build: expire the access token, kick off a task action, confirm the request retries silently instead of bubbling a hard 401.