### PR TITLE
feat(mobile): add Discuss button to inbox reports

### DIFF
--- a/apps/code/src/renderer/features/inbox/utils/buildDiscussReportPrompt.ts
+++ b/apps/code/src/renderer/features/inbox/utils/buildDiscussReportPrompt.ts
@@ -1,3 +1,4 @@
+import { buildDiscussReportPrompt as buildSharedDiscussReportPrompt } from "@posthog/shared";
 import { getDeeplinkProtocol } from "@shared/deeplink";
 
 interface BuildDiscussReportPromptOptions {
@@ -11,13 +12,6 @@ export function buildDiscussReportPrompt({
   question,
   isDevBuild,
 }: BuildDiscussReportPromptOptions): string {
-  const trimmedQuestion = question?.trim();
   const reportLink = `${getDeeplinkProtocol(isDevBuild)}://inbox/${reportId}`;
-  const intro = `Discuss PostHog inbox report ${reportId} ([inbox item](${reportLink})). Use the inbox MCP tools to fetch the report,`;
-  const guard =
-    " If you can't fetch the report, say so instead of guessing what it contains.";
-  const body = trimmedQuestion
-    ? `${intro} then answer this first: ${trimmedQuestion}`
-    : `${intro} then give me a brief readout and ask what I want to dig into.`;
-  return `${body}${guard}`;
+  return buildSharedDiscussReportPrompt({ reportId, reportLink, question });
 }

--- a/apps/mobile/src/app/inbox/[id].tsx
+++ b/apps/mobile/src/app/inbox/[id].tsx
@@ -5,17 +5,20 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import {
   CaretDown,
   CaretRight,
+  ChatCircle,
   Lightning,
   Play,
   Plus,
   ThumbsDown,
   Warning,
 } from "phosphor-react-native";
+import { usePostHog } from "posthog-react-native";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { MarkdownText } from "@/features/chat/components/MarkdownText";
 import { getReportRepository } from "@/features/inbox/api";
+import { DiscussReportSheet } from "@/features/inbox/components/DiscussReportSheet";
 import { DismissReportSheet } from "@/features/inbox/components/DismissReportSheet";
 import { SignalCard } from "@/features/inbox/components/SignalCard";
 import { SuggestedReviewers } from "@/features/inbox/components/SuggestedReviewers";
@@ -109,9 +112,11 @@ export default function ReportDetailScreen() {
   const router = useRouter();
   const themeColors = useThemeColors();
   const insets = useSafeAreaInsets();
+  const posthog = usePostHog();
   const { data: report, isLoading, error } = useInboxReport(reportId ?? null);
   const [reportRepo, setReportRepo] = useState<string | null>(null);
   const [dismissOpen, setDismissOpen] = useState(false);
+  const [discussOpen, setDiscussOpen] = useState(false);
   const [signalsExpanded, setSignalsExpanded] = useState(false);
 
   const artefactsQuery = useInboxReportArtefacts(reportId ?? null);
@@ -191,6 +196,34 @@ export default function ReportDetailScreen() {
     setDismissOpen(false);
     if (router.canGoBack()) router.back();
   }, [router]);
+
+  const handleDiscussSubmit = useCallback(
+    ({ prompt, question }: { prompt: string; question: string }) => {
+      setDiscussOpen(false);
+      if (!report) return;
+      posthog?.capture("Inbox report action", {
+        report_id: report.id,
+        report_title: report.title ?? null,
+        action_type: "discuss",
+        surface: "detail_pane",
+        is_bulk: false,
+        bulk_size: 1,
+        has_question: question.length > 0,
+        ...(question.length > 0
+          ? { question_text: question.slice(0, 500) }
+          : {}),
+      });
+      router.push({
+        pathname: "/task",
+        params: {
+          prompt,
+          ...(reportRepo ? { repo: reportRepo } : {}),
+          signalReport: report.id,
+        },
+      });
+    },
+    [report, router, reportRepo, posthog],
+  );
 
   if (error) {
     return (
@@ -365,14 +398,14 @@ export default function ReportDetailScreen() {
       </ScrollView>
 
       <View
-        className="absolute inset-x-0 flex-row items-center justify-center gap-3 px-4"
+        className="absolute inset-x-0 flex-row flex-wrap items-center justify-center gap-3 px-4"
         style={{ bottom: insets.bottom + 16 }}
         pointerEvents="box-none"
       >
         <Pressable
           onPress={() => setDismissOpen(true)}
           accessibilityLabel="Dismiss report"
-          className="flex-row items-center gap-2 rounded-full border border-gray-6 bg-background px-5 py-3.5 shadow-lg active:opacity-80"
+          className="flex-row items-center gap-2 rounded-full border border-gray-6 bg-background px-4 py-3.5 shadow-lg active:opacity-80"
         >
           <ThumbsDown size={16} color={themeColors.gray[11]} weight="fill" />
           <Text className="font-semibold text-[15px] text-gray-11">
@@ -380,10 +413,24 @@ export default function ReportDetailScreen() {
           </Text>
         </Pressable>
 
+        <Pressable
+          onPress={() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            setDiscussOpen(true);
+          }}
+          accessibilityLabel="Discuss report"
+          className="flex-row items-center gap-2 rounded-full border border-gray-6 bg-background px-4 py-3.5 shadow-lg active:opacity-80"
+        >
+          <ChatCircle size={16} color={themeColors.gray[11]} weight="fill" />
+          <Text className="font-semibold text-[15px] text-gray-11">
+            Discuss
+          </Text>
+        </Pressable>
+
         {canStartTask && (
           <Pressable
             onPress={handleStartTask}
-            className="flex-row items-center gap-2 rounded-full bg-accent-9 px-5 py-3.5 shadow-lg active:opacity-80"
+            className="flex-row items-center gap-2 rounded-full bg-accent-9 px-4 py-3.5 shadow-lg active:opacity-80"
           >
             {isAwaitingInput ? (
               <Plus size={18} color="#ffffff" weight="bold" />
@@ -403,6 +450,13 @@ export default function ReportDetailScreen() {
         reportTitle={report.title?.trim() ? report.title : "Untitled signal"}
         onClose={() => setDismissOpen(false)}
         onDismissed={handleDismissed}
+      />
+
+      <DiscussReportSheet
+        visible={discussOpen}
+        reportId={report.id}
+        onClose={() => setDiscussOpen(false)}
+        onSubmit={handleDiscussSubmit}
       />
     </>
   );

--- a/apps/mobile/src/features/inbox/components/DiscussReportSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/DiscussReportSheet.tsx
@@ -1,0 +1,97 @@
+import { Text } from "@components/text";
+import { buildDiscussReportPrompt } from "@posthog/shared";
+import * as Haptics from "expo-haptics";
+import { ChatCircle } from "phosphor-react-native";
+import { useEffect, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  TextInput,
+  View,
+} from "react-native";
+import { SheetContainer } from "@/components/SheetContainer";
+import { customSchemeUrl, paths } from "@/lib/deep-links";
+import { useThemeColors } from "@/lib/theme";
+
+interface DiscussReportSheetProps {
+  visible: boolean;
+  reportId: string;
+  onClose: () => void;
+  onSubmit: (params: { prompt: string; question: string }) => void;
+}
+
+export function DiscussReportSheet({
+  visible,
+  reportId,
+  onClose,
+  onSubmit,
+}: DiscussReportSheetProps) {
+  const themeColors = useThemeColors();
+  const [question, setQuestion] = useState("");
+
+  useEffect(() => {
+    if (visible) setQuestion("");
+  }, [visible]);
+
+  const handleSubmit = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    const trimmed = question.trim();
+    const reportLink = customSchemeUrl(paths.inboxReport(reportId));
+    const prompt = buildDiscussReportPrompt({
+      reportId,
+      reportLink,
+      question: trimmed || undefined,
+    });
+    onSubmit({ prompt, question: trimmed });
+  };
+
+  return (
+    <SheetContainer open={visible} onClose={onClose} bottomGap="default">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <View className="px-4 pt-2 pb-3">
+          <Text className="mb-1 font-semibold text-[16px] text-gray-12">
+            Discuss this report
+          </Text>
+          <Text className="mb-3 text-[13px] text-gray-11 leading-snug">
+            Ask a question, or leave it blank for a brief readout from the
+            agent.
+          </Text>
+          <TextInput
+            value={question}
+            onChangeText={setQuestion}
+            placeholder="What do you want to know?"
+            placeholderTextColor={themeColors.gray[9]}
+            multiline
+            maxLength={2000}
+            autoFocus
+            className="min-h-[96px] rounded-xl bg-gray-2 px-3 py-3 text-[14px] text-gray-12"
+            style={{ textAlignVertical: "top" }}
+          />
+          <View className="mt-3 flex-row items-center justify-end gap-2">
+            <Pressable
+              onPress={onClose}
+              hitSlop={6}
+              className="rounded-full px-4 py-2.5 active:opacity-60"
+            >
+              <Text className="text-[14px] text-gray-11">Cancel</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleSubmit}
+              accessibilityRole="button"
+              accessibilityLabel="Start discussion"
+              className="flex-row items-center gap-1.5 rounded-full bg-accent-9 px-4 py-2.5 active:opacity-80"
+            >
+              <ChatCircle size={16} color="#ffffff" weight="fill" />
+              <Text className="font-semibold text-[14px] text-white">
+                Discuss
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </SheetContainer>
+  );
+}

--- a/packages/shared/src/inbox-prompts.ts
+++ b/packages/shared/src/inbox-prompts.ts
@@ -1,0 +1,20 @@
+interface BuildDiscussReportPromptOptions {
+  reportId: string;
+  reportLink: string;
+  question?: string;
+}
+
+export function buildDiscussReportPrompt({
+  reportId,
+  reportLink,
+  question,
+}: BuildDiscussReportPromptOptions): string {
+  const trimmedQuestion = question?.trim();
+  const intro = `Discuss PostHog inbox report ${reportId} ([inbox item](${reportLink})). Use the inbox MCP tools to fetch the report,`;
+  const guard =
+    " If you can't fetch the report, say so instead of guessing what it contains.";
+  const body = trimmedQuestion
+    ? `${intro} then answer this first: ${trimmedQuestion}`
+    : `${intro} then give me a brief readout and ask what I want to dig into.`;
+  return `${body}${guard}`;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,7 @@ export {
   type ParsedImageDataUrl,
   parseImageDataUrl,
 } from "./image";
+export { buildDiscussReportPrompt } from "./inbox-prompts";
 export {
   Saga,
   type SagaLogger,


### PR DESCRIPTION
## Summary
- Ports the desktop "Discuss" affordance (PostHog/code#2241) to mobile: tapping Discuss on an inbox report opens a sheet where the user can optionally type a first question, then routes to the new-task composer with the agent-fetch-the-report prompt prefilled and the `signal_report` id attached.
- Moves `buildDiscussReportPrompt` into `@posthog/shared` and parameterises it on the deep-link URL so each host passes its own scheme (`posthog-code://` on desktop, `posthog://` on mobile) without forking the wording. The desktop wrapper keeps its previous `isDevBuild` signature so all existing callers stay unchanged.
- Fires the same `Inbox report action` analytics event desktop does with `action_type: "discuss"`, `surface: "detail_pane"`, `has_question`, and the report id, so the discuss surface shows up alongside the other inbox actions.

## Test plan
- [ ] Open an inbox report on mobile, tap **Discuss**: sheet appears with text input
- [ ] Submit empty → composer opens with the "brief readout" variant of the prompt and the repo + `signalReport` params prefilled
- [ ] Submit with a question → composer opens with the "answer this first" variant
- [ ] Confirm the new task is tagged with `origin_product: "signal_report"` and `signal_report_id` on the API side once sent
- [ ] On desktop, confirm the existing Discuss button still works (the wrapper now delegates to the shared util)
- [ ] `pnpm --filter code test buildDiscussReportPrompt` still passes