### PR TITLE
feat(settings): add inbox Slack notifications to Slack settings

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
@@ -9,6 +9,7 @@ import { Box, Button, Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
 import { formatRelativeTimeLong } from "@renderer/utils/time";
 import { openUrlInBrowser } from "@utils/browser";
 import { getPostHogUrl } from "@utils/urls";
+import { SignalSlackNotificationsSettings } from "./SignalSlackNotificationsSettings";
 
 export function SlackSettings() {
   const projectId = useAuthStateValue((s) => s.projectId);
@@ -77,6 +78,8 @@ export function SlackSettings() {
       </Flex>
 
       <Flex>{manageButtonWithTooltip}</Flex>
+
+      <SignalSlackNotificationsSettings isLoading={isLoading} />
     </Flex>
   );
 }


### PR DESCRIPTION
## Problem

The Slack settings view previously only listed connected workspaces and a "Manage in PostHog Web" button. Inbox notification configuration (workspace, channel, min priority) lived only inside the inbox "Configure inbox" dialog — discoverable in roughly nobody's experience.

## Changes

Embed the existing self-contained `SignalSlackNotificationsSettings` component below the workspace list in `SlackSettings.tsx`. The component already handles loading, no-integration ("Connect Slack workspace" CTA), workspace selection, channel picking, and min-priority selection — so this is a one-import + one-render addition.

## How did you test this?

- `pnpm --filter code typecheck` passes
- `pnpm exec biome check` on the modified file passes
- Did not exercise the UI in a running app

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*