### PR TITLE
feat(code): add additional directories UI button

### DIFF
--- a/apps/code/src/main/db/migrations/0009_bake_default_directories.sql
+++ b/apps/code/src/main/db/migrations/0009_bake_default_directories.sql
@@ -1,0 +1,10 @@
+UPDATE workspaces
+SET additional_directories = (
+  SELECT json_group_array(path)
+  FROM (
+    SELECT value AS path FROM json_each(workspaces.additional_directories)
+    UNION
+    SELECT path FROM default_additional_directories
+  )
+)
+WHERE (SELECT COUNT(*) FROM default_additional_directories) > 0;

--- a/apps/code/src/main/db/migrations/meta/0009_snapshot.json
+++ b/apps/code/src/main/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,640 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6d99dc19-32d0-4955-afe3-a87c3f715375",
+  "prevId": "59b807ad-4cd5-4587-9b2b-a559039e97bb",
+  "tables": {
+    "archives": {
+      "name": "archives",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "archives_workspaceId_unique": {
+          "name": "archives_workspaceId_unique",
+          "columns": ["workspace_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "archives_workspace_id_workspaces_id_fk": {
+          "name": "archives_workspace_id_workspaces_id_fk",
+          "tableFrom": "archives",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_org_project_preferences": {
+      "name": "auth_org_project_preferences",
+      "columns": {
+        "account_key": {
+          "name": "account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_region": {
+          "name": "cloud_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_selected_project_id": {
+          "name": "last_selected_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "auth_org_project_account_region_org_idx": {
+          "name": "auth_org_project_account_region_org_idx",
+          "columns": ["account_key", "cloud_region", "org_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_preferences": {
+      "name": "auth_preferences",
+      "columns": {
+        "account_key": {
+          "name": "account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_region": {
+          "name": "cloud_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_selected_project_id": {
+          "name": "last_selected_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_selected_org_id": {
+          "name": "last_selected_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "auth_preferences_account_region_idx": {
+          "name": "auth_preferences_account_region_idx",
+          "columns": ["account_key", "cloud_region"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_sessions": {
+      "name": "auth_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cloud_region": {
+          "name": "cloud_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_project_id": {
+          "name": "selected_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_version": {
+          "name": "scope_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "default_additional_directories": {
+      "name": "default_additional_directories",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "repositories_path_unique": {
+          "name": "repositories_path_unique",
+          "columns": ["path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "suspensions": {
+      "name": "suspensions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "suspensions_workspaceId_unique": {
+          "name": "suspensions_workspaceId_unique",
+          "columns": ["workspace_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "suspensions_workspace_id_workspaces_id_fk": {
+          "name": "suspensions_workspace_id_workspaces_id_fk",
+          "tableFrom": "suspensions",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_branch": {
+          "name": "linked_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_directories": {
+          "name": "additional_directories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_state": {
+          "name": "pr_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_taskId_unique": {
+          "name": "workspaces_taskId_unique",
+          "columns": ["task_id"],
+          "isUnique": true
+        },
+        "workspaces_repository_id_idx": {
+          "name": "workspaces_repository_id_idx",
+          "columns": ["repository_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_repository_id_repositories_id_fk": {
+          "name": "workspaces_repository_id_repositories_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "worktrees_workspaceId_unique": {
+          "name": "worktrees_workspaceId_unique",
+          "columns": ["workspace_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "worktrees_workspace_id_workspaces_id_fk": {
+          "name": "worktrees_workspace_id_workspaces_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/code/src/main/db/migrations/meta/_journal.json
+++ b/apps/code/src/main/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1779747695688,
       "tag": "0008_stiff_reptil",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1779747695689,
+      "tag": "0009_bake_default_directories",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/code/src/main/services/agent/service.test.ts
+++ b/apps/code/src/main/services/agent/service.test.ts
@@ -191,11 +191,6 @@ function createMockDependencies() {
       appDataPath: "/mock/userData",
       logsPath: "/mock/logs",
     },
-    defaultAdditionalDirectoryRepository: {
-      list: vi.fn(() => [] as string[]),
-      add: vi.fn(),
-      remove: vi.fn(),
-    },
     workspaceRepository: {
       getAdditionalDirectories: vi.fn(() => [] as string[]),
       addAdditionalDirectory: vi.fn(),
@@ -231,7 +226,6 @@ describe("AgentService", () => {
       deps.bundledResources as never,
       deps.appMeta as never,
       deps.storagePaths as never,
-      deps.defaultAdditionalDirectoryRepository as never,
       deps.workspaceRepository as never,
     );
   });

--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -45,7 +45,6 @@ import type { IStoragePaths } from "@posthog/platform/storage-paths";
 import { isAuthError } from "@shared/errors";
 import type { AcpMessage } from "@shared/types/session-events";
 import { inject, injectable, preDestroy } from "inversify";
-import type { IDefaultAdditionalDirectoryRepository } from "../../db/repositories/default-additional-directory-repository";
 import type { IWorkspaceRepository } from "../../db/repositories/workspace-repository";
 import { MAIN_TOKENS } from "../../di/tokens";
 import { isDevBuild } from "../../utils/env";
@@ -319,8 +318,6 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     private readonly appMeta: IAppMeta,
     @inject(MAIN_TOKENS.StoragePaths)
     private readonly storagePaths: IStoragePaths,
-    @inject(MAIN_TOKENS.DefaultAdditionalDirectoryRepository)
-    private readonly defaultAdditionalDirectoryRepository: IDefaultAdditionalDirectoryRepository,
     @inject(MAIN_TOKENS.WorkspaceRepository)
     private readonly workspaceRepository: IWorkspaceRepository,
   ) {
@@ -526,20 +523,6 @@ When creating pull requests, add the following footer at the end of the PR descr
     return { append: prompt };
   }
 
-  private resolveAdditionalDirectories(taskId: string): string[] {
-    const defaults = this.defaultAdditionalDirectoryRepository.list();
-    const taskScoped =
-      this.workspaceRepository.getAdditionalDirectories(taskId);
-    const seen = new Set<string>();
-    const merged: string[] = [];
-    for (const path of [...defaults, ...taskScoped]) {
-      if (!path || seen.has(path)) continue;
-      seen.add(path);
-      merged.push(path);
-    }
-    return merged;
-  }
-
   async startSession(params: StartSessionInput): Promise<SessionResponse> {
     this.validateSessionParams(params);
     const config = this.toSessionConfig(params);
@@ -588,7 +571,9 @@ When creating pull requests, add the following footer at the end of the PR descr
     const repoPath = taskId === "__preview__" ? tmpdir() : rawRepoPath;
 
     const additionalDirectories =
-      taskId === "__preview__" ? [] : this.resolveAdditionalDirectories(taskId);
+      taskId === "__preview__"
+        ? []
+        : this.workspaceRepository.getAdditionalDirectories(taskId);
 
     if (!isRetry) {
       const existing = this.sessions.get(taskRunId);

--- a/apps/code/src/renderer/features/folder-picker/components/AdditionalDirectoriesButton.tsx
+++ b/apps/code/src/renderer/features/folder-picker/components/AdditionalDirectoriesButton.tsx
@@ -1,0 +1,135 @@
+import { useFolders } from "@features/folders/hooks/useFolders";
+import { Check, FolderOpen, FolderPlus } from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  MenuLabel,
+} from "@posthog/quill";
+import { trpcClient } from "@renderer/trpc";
+import { logger } from "@utils/logger";
+import { useMemo } from "react";
+
+const log = logger.scope("additional-directories-button");
+
+interface AdditionalDirectoriesButtonProps {
+  values: string[];
+  onChange: (values: string[]) => void;
+  primaryDirectory?: string | null;
+  disabled?: boolean;
+}
+
+export function AdditionalDirectoriesButton({
+  values,
+  onChange,
+  primaryDirectory,
+  disabled,
+}: AdditionalDirectoriesButtonProps) {
+  const { getFolderByPath, getRecentFolders, addFolder, updateLastAccessed } =
+    useFolders();
+  const count = values.length;
+  const selected = useMemo(() => new Set(values), [values]);
+
+  const folders = useMemo(() => {
+    const recent = getRecentFolders().filter(
+      (f) => f.path !== primaryDirectory,
+    );
+    const seen = new Set(recent.map((f) => f.path));
+    for (const path of values) {
+      if (seen.has(path)) continue;
+      const folder = getFolderByPath(path);
+      if (folder) {
+        recent.push(folder);
+        seen.add(path);
+      }
+    }
+    return recent;
+  }, [getRecentFolders, getFolderByPath, values, primaryDirectory]);
+
+  const toggle = (path: string) => {
+    if (selected.has(path)) {
+      onChange(values.filter((p) => p !== path));
+      return;
+    }
+    onChange([...values, path]);
+    const folder = getFolderByPath(path);
+    if (folder) updateLastAccessed(folder.id);
+  };
+
+  const handlePickNative = async () => {
+    try {
+      const selectedPath = await trpcClient.os.selectDirectory.query();
+      if (!selectedPath) return;
+      if (selectedPath === primaryDirectory) return;
+      await addFolder(selectedPath);
+      if (!selected.has(selectedPath)) {
+        onChange([...values, selectedPath]);
+      }
+    } catch (error) {
+      log.error("Failed to open directory picker", { error });
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Additional directories"
+            disabled={disabled}
+          >
+            <FolderPlus size={14} weight="regular" className="shrink-0" />
+            {count > 0 && (
+              <span className="font-medium tabular-nums">+{count}</span>
+            )}
+          </Button>
+        }
+      />
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="min-w-[260px]"
+      >
+        {folders.length > 0 && (
+          <>
+            <MenuLabel>Additional directories</MenuLabel>
+            {folders.map((folder) => {
+              const isSelected = selected.has(folder.path);
+              return (
+                <DropdownMenuItem
+                  key={folder.id}
+                  closeOnClick={false}
+                  onClick={() => toggle(folder.path)}
+                >
+                  <Check
+                    size={12}
+                    weight="bold"
+                    className={`shrink-0 ${isSelected ? "" : "invisible"}`}
+                  />
+                  <span
+                    className="min-w-0 flex-1 truncate text-left"
+                    title={folder.path}
+                  >
+                    {folder.name}
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+            <DropdownMenuSeparator />
+          </>
+        )}
+
+        <DropdownMenuItem onClick={handlePickNative}>
+          <FolderOpen size={12} className="shrink-0" />
+          <span className="whitespace-nowrap">Open folder...</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
+++ b/apps/code/src/renderer/features/task-detail/components/TaskInput.tsx
@@ -1,5 +1,6 @@
 import { DotPatternBackground } from "@components/DotPatternBackground";
 import { EnvironmentSelector } from "@features/environments/components/EnvironmentSelector";
+import { AdditionalDirectoriesButton } from "@features/folder-picker/components/AdditionalDirectoriesButton";
 import { FolderPicker } from "@features/folder-picker/components/FolderPicker";
 import { GitHubRepoPicker } from "@features/folder-picker/components/GitHubRepoPicker";
 import { useFolders } from "@features/folders/hooks/useFolders";
@@ -469,7 +470,13 @@ export function TaskInput({
       ? selectedBranch
       : null;
 
-  const { isCreatingTask, canSubmit, handleSubmit } = useTaskCreation({
+  const {
+    isCreatingTask,
+    canSubmit,
+    handleSubmit,
+    additionalDirectories,
+    setAdditionalDirectories,
+  } = useTaskCreation({
     editorRef,
     selectedDirectory,
     selectedRepository: selectedCloudRepository,
@@ -731,6 +738,14 @@ export function TaskInput({
                 anchor={buttonGroupRef}
               />
             </ButtonGroup>
+            {workspaceMode !== "cloud" && (
+              <AdditionalDirectoriesButton
+                values={additionalDirectories}
+                onChange={setAdditionalDirectories}
+                primaryDirectory={selectedDirectory}
+                disabled={isCreatingTask}
+              />
+            )}
             {cloudRegion === "dev" && (
               <Flex align="center" gap="1" className="shrink-0">
                 <span

--- a/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
+++ b/apps/code/src/renderer/features/task-detail/hooks/useTaskCreation.ts
@@ -16,12 +16,13 @@ import { useConnectivity } from "@hooks/useConnectivity";
 import type { WorkspaceMode } from "@main/services/workspace/schemas";
 import { get } from "@renderer/di/container";
 import { RENDERER_TOKENS } from "@renderer/di/tokens";
-import { trpcClient } from "@renderer/trpc/client";
+import { trpcClient, useTRPC } from "@renderer/trpc/client";
 import { toast } from "@renderer/utils/toast";
 import type { ExecutionMode, Task } from "@shared/types";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { useNavigationStore } from "@stores/navigationStore";
 import { pendingTaskPromptStoreApi } from "@stores/pendingTaskPromptStore";
+import { useQuery } from "@tanstack/react-query";
 import { track } from "@utils/analytics";
 import { logger } from "@utils/logger";
 import { useCallback, useState } from "react";
@@ -52,6 +53,8 @@ interface UseTaskCreationReturn {
   isCreatingTask: boolean;
   canSubmit: boolean;
   handleSubmit: (contentOverride?: EditorContent) => Promise<boolean>;
+  additionalDirectories: string[];
+  setAdditionalDirectories: (next: string[]) => void;
 }
 
 function prepareTaskInput(
@@ -70,6 +73,7 @@ function prepareTaskInput(
     environmentId?: string | null;
     sandboxEnvironmentId?: string;
     signalReportId?: string;
+    additionalDirectories?: string[];
   },
 ): TaskCreationInput {
   const serializedContent = contentToXml(content).trim();
@@ -107,6 +111,10 @@ function prepareTaskInput(
         ? "signal_report"
         : undefined,
     signalReportId: options.signalReportId,
+    additionalDirectories:
+      options.workspaceMode === "cloud"
+        ? undefined
+        : options.additionalDirectories,
   };
 }
 
@@ -190,6 +198,16 @@ export function useTaskCreation({
   onTaskCreated,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
   const [isCreatingTask, setIsCreatingTask] = useState(false);
+  const trpc = useTRPC();
+  const defaultAdditionalDirectoriesQuery = useQuery(
+    trpc.additionalDirectories.listDefaults.queryOptions(),
+  );
+  const defaultAdditionalDirectories =
+    defaultAdditionalDirectoriesQuery.data ?? [];
+  const [additionalDirectoriesOverride, setAdditionalDirectoriesOverride] =
+    useState<string[] | null>(null);
+  const additionalDirectories =
+    additionalDirectoriesOverride ?? defaultAdditionalDirectories;
   const {
     clearTaskInputReportAssociation,
     navigateToTask,
@@ -260,6 +278,7 @@ export function useTaskCreation({
           environmentId,
           sandboxEnvironmentId,
           signalReportId,
+          additionalDirectories,
         });
 
         if (executionMode) {
@@ -287,6 +306,7 @@ export function useTaskCreation({
         });
 
         if (result.success) {
+          setAdditionalDirectoriesOverride(null);
           void trackTaskCreated(input, selectedDirectory);
         }
 
@@ -334,6 +354,7 @@ export function useTaskCreation({
       environmentId,
       sandboxEnvironmentId,
       signalReportId,
+      additionalDirectories,
       clearTaskInputReportAssociation,
       invalidateTasks,
       navigateToTask,
@@ -347,5 +368,7 @@ export function useTaskCreation({
     isCreatingTask,
     canSubmit,
     handleSubmit,
+    additionalDirectories,
+    setAdditionalDirectories: setAdditionalDirectoriesOverride,
   };
 }

--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -59,6 +59,7 @@ export interface TaskCreationInput {
   cloudPrAuthorshipMode?: PrAuthorshipMode;
   cloudRunSource?: CloudRunSource;
   signalReportId?: string;
+  additionalDirectories?: string[];
 }
 
 export interface TaskCreationOutput {
@@ -201,6 +202,40 @@ export class TaskCreationSaga extends Saga<
         linkedBranch: null,
         createdAt: new Date().toISOString(),
       };
+    }
+
+    const extraDirectories = input.taskId
+      ? []
+      : (input.additionalDirectories ?? []).filter(
+          (path) => path && path !== repoPath,
+        );
+    if (extraDirectories.length > 0) {
+      await this.step({
+        name: "additional_directories",
+        execute: async () => {
+          await Promise.all(
+            extraDirectories.map((path) =>
+              trpcClient.additionalDirectories.addForTask.mutate({
+                taskId: task.id,
+                path,
+              }),
+            ),
+          );
+          return { taskId: task.id, paths: extraDirectories };
+        },
+        rollback: async ({ taskId, paths }) => {
+          log.info("Rolling back: removing additional directories", { taskId });
+          await Promise.all(
+            paths.map((path) =>
+              trpcClient.additionalDirectories.removeForTask
+                .mutate({ taskId, path })
+                .catch((error) => {
+                  log.warn("Failed to remove additional directory", { error });
+                }),
+            ),
+          );
+        },
+      });
     }
 
     const shouldStartCloudRun = workspaceMode === "cloud" && !task.latest_run;


### PR DESCRIPTION
## Problem

we have `/add-dir` but there's no way to _start_ a task with multiple dirs

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

- adds a button on the new task page to add more directories
- updated store so the source of truth is now the per-task `workspaces.additional_directories` table, not the defaults table
- defaults table is now used as a template for new tasks, new tasks start with the additional dirs UI pre-populated from this template
- migration to copy defaults into each workspace

[addl-dirs.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/37611354-42d9-4365-8384-62abfb8dadd7.mp4" />](https://app.graphite.com/user-attachments/video/37611354-42d9-4365-8384-62abfb8dadd7.mp4)

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

yes

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->