### PR TITLE
Update pull_request_template.md to match monorepo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,7 @@
 <!-- Describe what you tested -- manual steps, automated tests, or both. -->
 <!-- If you're an agent, only list tests you actually ran. -->
 
-## Publish to changelog?
+## Automatic notifications
 
-<!-- For features only -->
-
-<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->
-
-<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
+- [ ] Publish to changelog?
+- [ ] Alert Sales and Marketing teams?


### PR DESCRIPTION
## Problem

We updated the monorepo PR template to accommodate for marketing notifications. Updating here, too, for the same reason

## Changes

Adds these checkboxes that will trigger various workflows:

```
## Checklist

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
```

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->
<!-- If you're an agent, only list tests you actually ran. -->

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
