### PR TITLE
UI thread cleanup + tanstack virtualized

### DIFF
--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -143,6 +143,7 @@
     "@radix-ui/themes": "^3.2.1",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.90.2",
+    "@tanstack/react-virtual": "^3.13.26",
     "@tiptap/core": "^3.13.0",
     "@tiptap/extension-mention": "^3.13.0",
     "@tiptap/extension-placeholder": "^3.13.0",

--- a/apps/code/src/renderer/features/message-editor/components/PromptInput.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/PromptInput.tsx
@@ -285,7 +285,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
         <InputGroup
           onClick={handleContainerClick}
           onContextMenu={handleContextMenu}
-          className={`h-auto cursor-text bg-card focus-within:ring-1 focus-within:ring-purple-9 ${isBashMode ? "ring-1 ring-blue-9" : ""}`}
+          className={`h-auto cursor-text bg-card ${isBashMode ? "ring-1 ring-blue-9" : "focus-within:ring-1 focus-within:ring-purple-9"}`}
           {...(tourTarget && {
             "data-tour": `${tourTarget}-editor`,
             "data-tour-ready": !isEmpty ? "true" : undefined,

--- a/apps/code/src/renderer/features/message-editor/components/PromptInput.tsx
+++ b/apps/code/src/renderer/features/message-editor/components/PromptInput.tsx
@@ -285,7 +285,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
         <InputGroup
           onClick={handleContainerClick}
           onContextMenu={handleContextMenu}
-          className={`h-auto cursor-text bg-card ${isBashMode ? "ring-1 ring-blue-9" : ""}`}
+          className={`h-auto cursor-text bg-card focus-within:ring-1 focus-within:ring-purple-9 ${isBashMode ? "ring-1 ring-blue-9" : ""}`}
           {...(tourTarget && {
             "data-tour": `${tourTarget}-editor`,
             "data-tour-ready": !isEmpty ? "true" : undefined,
@@ -307,7 +307,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
           >
             <EditorContent editor={editor} />
           </div>
-          <InputGroupAddon align="block-end">
+          <InputGroupAddon align="block-end" className="p-1">
             <AttachmentMenu
               disabled={disabled}
               repoPath={repoPath}

--- a/apps/code/src/renderer/features/sessions/components/ContextUsageIndicator.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ContextUsageIndicator.tsx
@@ -58,7 +58,7 @@ export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
                 strokeLinecap="round"
               />
             </svg>
-            <Text className="text-[13px] text-gray-10 tabular-nums">
+            <Text className="text-[13px] text-muted-foreground tabular-nums">
               {formatTokensCompact(used)}/{formatTokensCompact(size)} ·{" "}
               {percentage}%
             </Text>

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -14,7 +14,13 @@ import { SkillButtonActionMessage } from "@features/skill-buttons/components/Ski
 import { ArrowDown, XCircle } from "@phosphor-icons/react";
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import WorkerUrl from "@pierre/diffs/worker/worker.js?worker&url";
-import { Box, Button, Flex, Text } from "@radix-ui/themes";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import { Box, Flex, Text } from "@radix-ui/themes";
 import type { Task } from "@shared/types";
 import type { AcpMessage } from "@shared/types/session-events";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -250,7 +256,7 @@ export function ConversationView({
       poolOptions={DIFFS_POOL_OPTIONS}
       highlighterOptions={DIFFS_HIGHLIGHTER_OPTIONS}
     >
-      <div ref={containerRef} className="relative flex-1">
+      <div ref={containerRef} className="group/thread relative flex-1">
         <div
           id="fullscreen-portal"
           className="pointer-events-none absolute inset-0 z-20"
@@ -302,11 +308,19 @@ export function ConversationView({
           />
         </SessionTaskIdProvider>
         {showScrollButton && (
-          <Box className="absolute right-4 bottom-4 z-10">
-            <Button size="1" variant="solid" onClick={scrollToBottom}>
-              <ArrowDown size={14} weight="bold" />
-              Scroll to bottom
-            </Button>
+          <Box className="absolute right-6 bottom-4 z-10">
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  size="icon-lg"
+                  variant="outline"
+                  onClick={scrollToBottom}
+                >
+                  <ArrowDown size={14} weight="bold" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Scroll to bottom</TooltipContent>
+            </Tooltip>
           </Box>
         )}
       </div>

--- a/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/ConversationView.tsx
@@ -310,15 +310,17 @@ export function ConversationView({
         {showScrollButton && (
           <Box className="absolute right-6 bottom-4 z-10">
             <Tooltip>
-              <TooltipTrigger>
-                <Button
-                  size="icon-lg"
-                  variant="outline"
-                  onClick={scrollToBottom}
-                >
-                  <ArrowDown size={14} weight="bold" />
-                </Button>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="icon-lg"
+                    variant="outline"
+                    onClick={scrollToBottom}
+                  >
+                    <ArrowDown size={14} weight="bold" />
+                  </Button>
+                }
+              />
               <TooltipContent>Scroll to bottom</TooltipContent>
             </Tooltip>
           </Box>

--- a/apps/code/src/renderer/features/sessions/components/SessionFooter.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionFooter.tsx
@@ -33,7 +33,7 @@ export function SessionFooter({
   usage,
 }: SessionFooterProps) {
   const rightSide = (
-    <Flex align="center" gap="3" className="shrink-0">
+    <Flex align="center" gap="3" className="ml-auto shrink-0">
       {task && <DiffStatsChip task={task} />}
       <ContextUsageIndicator usage={usage ?? null} />
     </Flex>
@@ -41,16 +41,16 @@ export function SessionFooter({
   if (isPromptPending && !isCompacting) {
     if (hasPendingPermission) {
       return (
-        <Box className="pt-3 pb-1">
+        <Box className="pt-3 pb-1 opacity-50 transition-opacity group-hover/thread:opacity-100">
           <Flex align="center" justify="between" gap="2">
             <Flex
               align="center"
               gap="2"
-              className="min-w-0 select-none select-none text-gray-10"
+              className="min-w-0 select-none text-muted-foreground"
               style={{ WebkitUserSelect: "none" }}
             >
               <Pause size={14} weight="fill" className="shrink-0" />
-              <Text className="truncate text-[13px]">
+              <Text className="truncate text-[13px] text-muted-foreground">
                 Awaiting permission...
               </Text>
             </Flex>
@@ -61,7 +61,7 @@ export function SessionFooter({
     }
 
     return (
-      <Box className="pt-3 pb-1">
+      <Box className="pt-3 pb-1 opacity-50 transition-opacity group-hover/thread:opacity-100">
         <Flex align="center" justify="between" gap="2">
           <Flex align="center" gap="2" className="min-w-0">
             <GeneratingIndicator
@@ -69,7 +69,7 @@ export function SessionFooter({
               pausedDurationMs={pausedDurationMs}
             />
             {queuedCount > 0 && (
-              <Text color="gray" className="truncate text-[13px]">
+              <Text className="truncate text-[13px] text-muted-foreground">
                 ({queuedCount} queued)
               </Text>
             )}
@@ -89,19 +89,18 @@ export function SessionFooter({
     !wasCancelled;
 
   return (
-    <Box className="pb-1">
+    <Box className="pb-1 opacity-50 transition-opacity group-hover/thread:opacity-100">
       <Flex align="center" justify="between" gap="2">
         {showDuration && (
           <Flex
             align="center"
             gap="2"
-            className="min-w-0 select-none text-gray-10"
+            className="min-w-0 select-none text-muted-foreground"
           >
             <Brain size={12} className="shrink-0" />
             <Text
-              color="gray"
               style={{ fontVariantNumeric: "tabular-nums" }}
-              className="truncate text-[13px]"
+              className="truncate text-[13px] text-muted-foreground"
             >
               Generated in {formatDuration(lastGenerationDuration)}
             </Text>

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -598,7 +598,7 @@ export function SessionView({
                     </Flex>
                   </Flex>
                 ) : hideInput ? null : firstPendingPermission ? (
-                  <Box className="max-h-1/2 min-h-0 overflow-y-auto border-gray-4 border-t">
+                  <Box className="min-h-0 overflow-y-auto">
                     <Box
                       className={compact ? "p-1" : "mx-auto px-2 pb-2"}
                       style={

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -476,7 +476,7 @@ export function SessionView({
                 />
                 <Box className="border-gray-4 border-t">
                   <Box
-                    className="mx-auto p-2"
+                    className="mx-auto px-2 pb-2"
                     style={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
                   >
                     <Flex
@@ -600,7 +600,7 @@ export function SessionView({
                 ) : hideInput ? null : firstPendingPermission ? (
                   <Box className="max-h-1/2 min-h-0 overflow-y-auto border-gray-4 border-t">
                     <Box
-                      className={compact ? "p-1" : "mx-auto p-2"}
+                      className={compact ? "p-1" : "mx-auto px-2 pb-2"}
                       style={
                         compact
                           ? undefined
@@ -616,7 +616,7 @@ export function SessionView({
                     </Box>
                   </Box>
                 ) : (
-                  <Box className="relative border-gray-4 border-t">
+                  <Box className="relative">
                     <Box
                       className={`absolute inset-0 flex min-h-[66px] items-center justify-center gap-2 transition-opacity duration-200 ${
                         isRunning
@@ -637,7 +637,7 @@ export function SessionView({
                       }`}
                     >
                       <Box
-                        className={compact ? "p-1" : "mx-auto p-2"}
+                        className={compact ? "p-1" : "mx-auto px-2 pb-2"}
                         style={
                           compact
                             ? undefined

--- a/apps/code/src/renderer/features/sessions/components/SessionView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionView.tsx
@@ -476,7 +476,7 @@ export function SessionView({
                 />
                 <Box className="border-gray-4 border-t">
                   <Box
-                    className="mx-auto px-2 pb-2"
+                    className="mx-auto px-2 pb-3"
                     style={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
                   >
                     <Flex
@@ -600,7 +600,7 @@ export function SessionView({
                 ) : hideInput ? null : firstPendingPermission ? (
                   <Box className="min-h-0 overflow-y-auto">
                     <Box
-                      className={compact ? "p-1" : "mx-auto px-2 pb-2"}
+                      className={compact ? "p-1" : "mx-auto px-2 pb-3"}
                       style={
                         compact
                           ? undefined
@@ -637,7 +637,7 @@ export function SessionView({
                       }`}
                     >
                       <Box
-                        className={compact ? "p-1" : "mx-auto px-2 pb-2"}
+                        className={compact ? "p-1" : "mx-auto px-2 pb-3"}
                         style={
                           compact
                             ? undefined

--- a/apps/code/src/renderer/features/sessions/components/VirtualizedList.tsx
+++ b/apps/code/src/renderer/features/sessions/components/VirtualizedList.tsx
@@ -1,3 +1,4 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type CSSProperties,
   forwardRef,
@@ -6,9 +7,9 @@ import {
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
+  useMemo,
   useRef,
 } from "react";
-import { VList, type VListHandle } from "virtua";
 
 interface VirtualizedListProps<T> {
   items: T[];
@@ -28,6 +29,9 @@ export interface VirtualizedListHandle {
 }
 
 const AT_BOTTOM_THRESHOLD = 50;
+const ESTIMATED_ROW_SIZE = 80;
+const OVERSCAN = 6;
+const FOOTER_KEY = "__virtualized_footer__";
 
 function VirtualizedListInner<T>(
   {
@@ -43,106 +47,203 @@ function VirtualizedListInner<T>(
   }: VirtualizedListProps<T>,
   ref: React.ForwardedRef<VirtualizedListHandle>,
 ) {
-  const listRef = useRef<VListHandle>(null);
-  const isAtBottomRef = useRef(true);
+  const parentRef = useRef<HTMLDivElement>(null);
   const initializedRef = useRef(false);
+  const isAtBottomRef = useRef(true);
+  const settlingRef = useRef(false);
+  const settleRafRef = useRef<number | null>(null);
   const onScrollStateChangeRef = useRef(onScrollStateChange);
   onScrollStateChangeRef.current = onScrollStateChange;
-  const itemCountRef = useRef(items.length);
-  itemCountRef.current = items.length;
+
+  const hasFooter = footer != null;
+  const totalCount = items.length + (hasFooter ? 1 : 0);
+
+  const virtualizer = useVirtualizer({
+    count: totalCount,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ESTIMATED_ROW_SIZE,
+    overscan: OVERSCAN,
+    anchorTo: "end",
+    followOnAppend: true,
+    scrollEndThreshold: AT_BOTTOM_THRESHOLD,
+    getItemKey: (index) => {
+      if (hasFooter && index === items.length) return FOOTER_KEY;
+      const item = items[index];
+      return getItemKey ? getItemKey(item, index) : index;
+    },
+  });
+
+  const settleAtEnd = useCallback(() => {
+    if (settleRafRef.current !== null) {
+      cancelAnimationFrame(settleRafRef.current);
+      settleRafRef.current = null;
+    }
+    settlingRef.current = true;
+    isAtBottomRef.current = true;
+    let attempts = 0;
+    const step = () => {
+      virtualizer.scrollToEnd();
+      if (virtualizer.isAtEnd(AT_BOTTOM_THRESHOLD)) {
+        settlingRef.current = false;
+        settleRafRef.current = null;
+        if (initializedRef.current) {
+          onScrollStateChangeRef.current?.(true);
+        }
+        return;
+      }
+      if (++attempts > 12) {
+        settlingRef.current = false;
+        settleRafRef.current = null;
+        return;
+      }
+      settleRafRef.current = requestAnimationFrame(step);
+    };
+    step();
+  }, [virtualizer]);
 
   useImperativeHandle(
     ref,
     () => ({
-      scrollToBottom: () => {
-        const handle = listRef.current;
-        if (handle) {
-          handle.scrollTo(handle.scrollSize);
-          isAtBottomRef.current = true;
-        }
-      },
+      scrollToBottom: settleAtEnd,
       scrollToIndex: (index: number) => {
-        const handle = listRef.current;
-        if (handle) {
-          isAtBottomRef.current = false;
-          handle.scrollToIndex(index, { align: "center" });
+        if (settleRafRef.current !== null) {
+          cancelAnimationFrame(settleRafRef.current);
+          settleRafRef.current = null;
+          settlingRef.current = false;
         }
+        isAtBottomRef.current = false;
+        virtualizer.scrollToIndex(index, { align: "center" });
       },
     }),
-    [],
+    [virtualizer, settleAtEnd],
   );
 
-  useLayoutEffect(() => {
-    const handle = listRef.current;
-    if (!handle) return;
-
-    if (items.length > 0 && !initializedRef.current) {
-      handle.scrollToIndex(items.length - 1, { align: "end" });
-
-      requestAnimationFrame(() => {
-        initializedRef.current = true;
-      });
-    }
-  }, [items.length]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-run when items change for streaming scroll
   useEffect(() => {
-    if (isAtBottomRef.current) {
-      const handle = listRef.current;
-      if (handle) {
-        // Use scrollToIndex for reliable positioning after measurements settle
-        const totalChildren = itemCountRef.current + (footer ? 1 : 0);
-        if (totalChildren > 0) {
-          handle.scrollToIndex(totalChildren - 1, { align: "end" });
-        }
+    return () => {
+      if (settleRafRef.current !== null) {
+        cancelAnimationFrame(settleRafRef.current);
       }
-    }
-  }, [items, footer]);
-
-  const handleScroll = useCallback((offset: number) => {
-    const handle = listRef.current;
-    if (!handle) return;
-    const distanceFromBottom = handle.scrollSize - offset - handle.viewportSize;
-    const atBottom = distanceFromBottom < AT_BOTTOM_THRESHOLD;
-    if (isAtBottomRef.current !== atBottom) {
-      isAtBottomRef.current = atBottom;
-    }
-    // Skip reporting during initialization to avoid flashing the
-    // scroll-to-bottom button before measurements settle.
-    if (initializedRef.current) {
-      onScrollStateChangeRef.current?.(atBottom);
-    }
+    };
   }, []);
 
+  useLayoutEffect(() => {
+    if (initializedRef.current || totalCount === 0) return;
+    virtualizer.scrollToEnd();
+    requestAnimationFrame(() => {
+      initializedRef.current = true;
+    });
+  }, [totalCount, virtualizer]);
+
+  // Safety net: streaming tokens grow an existing row in place; neither
+  // followOnAppend (count-based) nor anchorTo='end' (above-viewport-resize)
+  // covers in-place growth of the last row. Re-pin to end when at-bottom.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on items mutation, including streaming text updates
+  useEffect(() => {
+    if (!initializedRef.current) return;
+    if (!isAtBottomRef.current) return;
+    virtualizer.scrollToEnd();
+  }, [items, virtualizer]);
+
+  const handleScroll = useCallback(() => {
+    const atBottom = virtualizer.isAtEnd(AT_BOTTOM_THRESHOLD);
+    isAtBottomRef.current = atBottom;
+    if (!initializedRef.current) return;
+    // Suppress intermediate "not at bottom" pings while a programmatic
+    // scrollToEnd is still settling after row remeasure.
+    if (settlingRef.current && !atBottom) return;
+    onScrollStateChangeRef.current?.(atBottom);
+  }, [virtualizer]);
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  const renderedIndices = useMemo(() => {
+    const set = new Set<number>();
+    for (const v of virtualItems) set.add(v.index);
+    return set;
+  }, [virtualItems]);
+
+  const orphanKeepIndices = useMemo(() => {
+    if (!keepMounted || keepMounted.length === 0) return [];
+    return keepMounted.filter(
+      (i) => i >= 0 && i < items.length && !renderedIndices.has(i),
+    );
+  }, [keepMounted, renderedIndices, items.length]);
+
   return (
-    <div className={`flex h-full flex-col ${className}`}>
-      <VList
-        ref={listRef}
-        shift={false}
-        style={{ scrollbarGutter: "stable" }}
+    <div className={`flex h-full flex-col ${className ?? ""}`}>
+      <div
+        ref={parentRef}
         onScroll={handleScroll}
-        keepMounted={keepMounted}
-        className="flex-1"
+        className="scroll-mask-8 flex-1 overflow-auto"
+        style={{ scrollbarGutter: "stable" }}
       >
-        {items.map((item, index) => {
-          const key = getItemKey ? getItemKey(item, index) : index;
-          return (
-            <div
-              key={key}
-              className={itemClassName}
-              style={itemStyle}
-              data-conversation-item-id={key}
-            >
-              {renderItem(item, index)}
-            </div>
-          );
-        })}
-        {footer && (
-          <div className={itemClassName} style={itemStyle}>
-            {footer}
-          </div>
-        )}
-      </VList>
+        <div
+          style={{
+            height: virtualizer.getTotalSize(),
+            position: "relative",
+            width: "100%",
+          }}
+        >
+          {virtualItems.map((virtualItem) => {
+            const isFooter = hasFooter && virtualItem.index === items.length;
+            const item = isFooter ? null : items[virtualItem.index];
+            const itemKey = isFooter
+              ? FOOTER_KEY
+              : getItemKey
+                ? getItemKey(item as T, virtualItem.index)
+                : virtualItem.index;
+            return (
+              <div
+                key={virtualItem.key}
+                ref={virtualizer.measureElement}
+                data-index={virtualItem.index}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualItem.start}px)`,
+                }}
+              >
+                <div
+                  className={itemClassName}
+                  style={itemStyle}
+                  data-conversation-item-id={itemKey}
+                >
+                  {isFooter ? footer : renderItem(item as T, virtualItem.index)}
+                </div>
+              </div>
+            );
+          })}
+          {orphanKeepIndices.map((index) => {
+            const item = items[index];
+            const k = getItemKey ? getItemKey(item, index) : index;
+            return (
+              <div
+                key={`keep-${k}`}
+                aria-hidden
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: "translateY(-99999px)",
+                  pointerEvents: "none",
+                  visibility: "hidden",
+                }}
+              >
+                <div
+                  className={itemClassName}
+                  style={itemStyle}
+                  data-conversation-item-id={k}
+                >
+                  {renderItem(item, index)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/AgentMessage.tsx
@@ -149,7 +149,7 @@ export const AgentMessage = memo(function AgentMessage({
   }, [content]);
 
   return (
-    <Box className="group/msg relative py-1 pl-3 text-[13px] [&>*:last-child]:mb-0">
+    <Box className="group/msg relative py-1 pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
       <MarkdownRenderer
         content={content}
         componentsOverride={agentComponents}

--- a/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/UserMessage.tsx
@@ -89,7 +89,7 @@ export function UserMessage({
       >
         <Box
           ref={contentRef}
-          className="relative overflow-hidden font-medium text-[13px] [&>*:last-child]:mb-0"
+          className="relative overflow-hidden font-medium text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]"
           style={
             !isExpanded && isOverflowing
               ? { maxHeight: COLLAPSED_MAX_HEIGHT }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.20(react@19.1.0)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.26
+        version: 3.13.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tiptap/core':
         specifier: ^3.13.0
         version: 3.19.0(@tiptap/pm@3.19.0)
@@ -5085,6 +5088,15 @@ packages:
     resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.13.26':
+    resolution: {integrity: sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.16.0':
+    resolution: {integrity: sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -17224,6 +17236,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.1.0
+
+  '@tanstack/react-virtual@3.13.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.16.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/virtual-core@3.16.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ minimumReleaseAgeExclude:
   - '@pierre/diffs'
   - '@posthog/quill'
   - '@posthog/quill-tokens'
+  - '@tanstack/react-virtual'
+  - '@tanstack/virtual-core'
 
 onlyBuiltDependencies:
   - '@parcel/watcher'


### PR DESCRIPTION
## Changelog

- virtua → @tanstack/react-virtual
- scroll-to-bottom: 2 clicks → 1 click
- streaming text drifts off bottom → safety-net keeps it pinned
- session footer text: gray-10 → text-muted-foreground
- session footer: always visible → opacity 50% until thread hover
- session footer context indicator: flowed left when alone → always right
- thread edges: hard cut → scroll-mask fade
- message paragraphs: tight leading → leading-[1.9]
- pending permission box: max-h-1/2 + top border → no cap, no border
- prompt input wrapper: top border → no border
- prompt input: no focus ring → purple-9 focus-within ring
- prompt input block-end addon: no padding → p-1 for visual alignment
- prompt input row bottom padding: pb-2 → pb-3

<img width="1626" height="1324" alt="2026-05-28 23 34 59" src="https://github.com/user-attachments/assets/f0ca1e34-c394-4af8-a568-2e1e2a6675de" />
---
<img width="1626" height="478" alt="2026-05-28 23 31 42" src="https://github.com/user-attachments/assets/e936e7e6-b21a-4d80-95ad-1542aa56ce42" />
---
<img width="924" height="650" alt="2026-05-28 23 30 46" src="https://github.com/user-attachments/assets/ebfba376-b167-41f7-9aa9-5338bc75da3b" />
---
<img width="2522" height="1198" alt="2026-05-28 23 29 13" src="https://github.com/user-attachments/assets/353e9c13-e630-4f61-8b3a-b4c849f813d2" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)