### PR TITLE
feat(mobile): add slug suffix to inbox report deep links

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -108,10 +108,12 @@ function RootLayoutNav({ isConnected }: RootLayoutNavProps) {
       />
 
       {/* Inbox report detail - modal presentation, no native header
-          (the in-content title block is the canonical header). Path mirrors
-          the desktop app's `posthog-code://inbox/<reportId>` deep-link shape. */}
+          (the in-content title block is the canonical header). Catch-all
+          segment so the route also tolerates the cosmetic slug suffix on
+          shared links: `posthog://inbox/<reportId>` and
+          `posthog://inbox/<reportId>/<slug>` both resolve here. */}
       <Stack.Screen
-        name="inbox/[id]"
+        name="inbox/[...id]"
         options={{ presentation: "modal", headerShown: false }}
       />
 

--- a/apps/mobile/src/app/inbox/[...id].tsx
+++ b/apps/mobile/src/app/inbox/[...id].tsx
@@ -108,7 +108,13 @@ function ActionabilityBadge({ value }: { value: string }) {
 }
 
 export default function ReportDetailScreen() {
-  const { id: reportId } = useLocalSearchParams<{ id: string }>();
+  // Catch-all route: `id` arrives as string[] for `/inbox/<uuid>/<slug>` and
+  // we only read the first segment (the UUID). The slug is purely cosmetic;
+  // receivers ignore everything past the UUID, matching the desktop contract
+  // in `apps/code/src/shared/deeplink.ts`. Expo-router can hand us either a
+  // string or string[] depending on the URL shape, so tolerate both.
+  const { id: idParam } = useLocalSearchParams<{ id: string | string[] }>();
+  const reportId = Array.isArray(idParam) ? idParam[0] : idParam;
   const router = useRouter();
   const themeColors = useThemeColors();
   const insets = useSafeAreaInsets();
@@ -455,6 +461,7 @@ export default function ReportDetailScreen() {
       <DiscussReportSheet
         visible={discussOpen}
         reportId={report.id}
+        reportTitle={report.title}
         onClose={() => setDiscussOpen(false)}
         onSubmit={handleDiscussSubmit}
       />

--- a/apps/mobile/src/features/inbox/components/DiscussReportSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/DiscussReportSheet.tsx
@@ -11,12 +11,13 @@ import {
   View,
 } from "react-native";
 import { SheetContainer } from "@/components/SheetContainer";
-import { customSchemeUrl, paths } from "@/lib/deep-links";
+import { inboxReportShareUrl } from "@/lib/deep-links";
 import { useThemeColors } from "@/lib/theme";
 
 interface DiscussReportSheetProps {
   visible: boolean;
   reportId: string;
+  reportTitle?: string | null;
   onClose: () => void;
   onSubmit: (params: { prompt: string; question: string }) => void;
 }
@@ -24,6 +25,7 @@ interface DiscussReportSheetProps {
 export function DiscussReportSheet({
   visible,
   reportId,
+  reportTitle,
   onClose,
   onSubmit,
 }: DiscussReportSheetProps) {
@@ -37,7 +39,7 @@ export function DiscussReportSheet({
   const handleSubmit = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     const trimmed = question.trim();
-    const reportLink = customSchemeUrl(paths.inboxReport(reportId));
+    const reportLink = inboxReportShareUrl(reportId, reportTitle);
     const prompt = buildDiscussReportPrompt({
       reportId,
       reportLink,

--- a/apps/mobile/src/lib/deep-links.test.ts
+++ b/apps/mobile/src/lib/deep-links.test.ts
@@ -6,12 +6,14 @@ import {
 } from "./deep-links";
 
 describe("slugifyTitle", () => {
-  it("returns an empty string when the title is missing or blank", () => {
-    expect(slugifyTitle(null)).toBe("");
-    expect(slugifyTitle(undefined)).toBe("");
-    expect(slugifyTitle("")).toBe("");
-    expect(slugifyTitle("   ")).toBe("");
-    expect(slugifyTitle(":::")).toBe("");
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+    ["whitespace only", "   "],
+    ["unsafe-only characters", ":::"],
+  ])("returns an empty string when the title is %s", (_label, input) => {
+    expect(slugifyTitle(input)).toBe("");
   });
 
   it("emits `--` for runs that mix a colon with other unsafe chars", () => {
@@ -44,16 +46,22 @@ describe("slugifyTitle", () => {
 });
 
 describe("inboxReportShareUrl", () => {
-  it("returns just the UUID when no title is given", () => {
+  it("returns just the UUID when no title argument is passed", () => {
     expect(inboxReportShareUrl("abc-123")).toBe("posthog://inbox/abc-123");
-    expect(inboxReportShareUrl("abc-123", null)).toBe(
-      "posthog://inbox/abc-123",
-    );
-    expect(inboxReportShareUrl("abc-123", undefined)).toBe(
-      "posthog://inbox/abc-123",
-    );
-    expect(inboxReportShareUrl("abc-123", "")).toBe("posthog://inbox/abc-123");
   });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+  ])(
+    "returns just the UUID when the title is %s",
+    (_label, input: string | null | undefined) => {
+      expect(inboxReportShareUrl("abc-123", input)).toBe(
+        "posthog://inbox/abc-123",
+      );
+    },
+  );
 
   it("appends a slug derived from the title", () => {
     expect(inboxReportShareUrl("abc-123", "Hello World")).toBe(
@@ -61,11 +69,11 @@ describe("inboxReportShareUrl", () => {
     );
   });
 
-  it("omits the slug when the title slugifies to empty", () => {
-    expect(inboxReportShareUrl("abc-123", ":::")).toBe(
-      "posthog://inbox/abc-123",
-    );
-    expect(inboxReportShareUrl("abc-123", "   ")).toBe(
+  it.each([
+    ["unsafe-only characters", ":::"],
+    ["whitespace only", "   "],
+  ])("omits the slug when the title is %s", (_label, input) => {
+    expect(inboxReportShareUrl("abc-123", input)).toBe(
       "posthog://inbox/abc-123",
     );
   });
@@ -122,8 +130,10 @@ describe("externalUrlToAppPath", () => {
     );
   });
 
-  it("ignores URLs from unrelated hosts/schemes", () => {
-    expect(externalUrlToAppPath("https://example.com/inbox/x")).toBe(null);
-    expect(externalUrlToAppPath("not a url")).toBe(null);
+  it.each([
+    ["unrelated https host", "https://example.com/inbox/x"],
+    ["unparseable string", "not a url"],
+  ])("ignores URLs from %s", (_label, input) => {
+    expect(externalUrlToAppPath(input)).toBe(null);
   });
 });

--- a/apps/mobile/src/lib/deep-links.test.ts
+++ b/apps/mobile/src/lib/deep-links.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  externalUrlToAppPath,
+  inboxReportShareUrl,
+  slugifyTitle,
+} from "./deep-links";
+
+describe("slugifyTitle", () => {
+  it("returns an empty string when the title is missing or blank", () => {
+    expect(slugifyTitle(null)).toBe("");
+    expect(slugifyTitle(undefined)).toBe("");
+    expect(slugifyTitle("")).toBe("");
+    expect(slugifyTitle("   ")).toBe("");
+    expect(slugifyTitle(":::")).toBe("");
+  });
+
+  it("emits `--` for runs that mix a colon with other unsafe chars", () => {
+    expect(slugifyTitle("fix(inbox): Add foo")).toBe("fix-inbox--Add-foo");
+  });
+
+  it("emits a single `-` for a colon-only run", () => {
+    expect(slugifyTitle("feat:bar")).toBe("feat-bar");
+  });
+
+  it("preserves URL-unreserved punctuation (- _ . ~)", () => {
+    expect(slugifyTitle("v1.2.3_final~ish")).toBe("v1.2.3_final~ish");
+  });
+
+  it("collapses runs of unsafe punctuation into a single hyphen", () => {
+    expect(slugifyTitle("Cost $5, 50% off!")).toBe("Cost-5-50-off");
+  });
+
+  it("folds accented Latin letters to their ASCII base", () => {
+    expect(slugifyTitle("café résumé naïve")).toBe("cafe-resume-naive");
+  });
+
+  it("hyphenizes non-Latin scripts that have no ASCII fold", () => {
+    expect(slugifyTitle("Hello Привет world")).toBe("Hello-world");
+  });
+
+  it("preserves case", () => {
+    expect(slugifyTitle("Hello World")).toBe("Hello-World");
+  });
+});
+
+describe("inboxReportShareUrl", () => {
+  it("returns just the UUID when no title is given", () => {
+    expect(inboxReportShareUrl("abc-123")).toBe("posthog://inbox/abc-123");
+    expect(inboxReportShareUrl("abc-123", null)).toBe(
+      "posthog://inbox/abc-123",
+    );
+    expect(inboxReportShareUrl("abc-123", undefined)).toBe(
+      "posthog://inbox/abc-123",
+    );
+    expect(inboxReportShareUrl("abc-123", "")).toBe("posthog://inbox/abc-123");
+  });
+
+  it("appends a slug derived from the title", () => {
+    expect(inboxReportShareUrl("abc-123", "Hello World")).toBe(
+      "posthog://inbox/abc-123/Hello-World",
+    );
+  });
+
+  it("omits the slug when the title slugifies to empty", () => {
+    expect(inboxReportShareUrl("abc-123", ":::")).toBe(
+      "posthog://inbox/abc-123",
+    );
+    expect(inboxReportShareUrl("abc-123", "   ")).toBe(
+      "posthog://inbox/abc-123",
+    );
+  });
+
+  it("preserves the desktop colon-run convention", () => {
+    expect(inboxReportShareUrl("abc-123", "fix(inbox): Add foo")).toBe(
+      "posthog://inbox/abc-123/fix-inbox--Add-foo",
+    );
+  });
+});
+
+describe("externalUrlToAppPath", () => {
+  it("returns the router path for a custom-scheme URL", () => {
+    expect(externalUrlToAppPath("posthog://task/task-123")).toBe(
+      "/task/task-123",
+    );
+  });
+
+  it("returns the router path for a universal-link URL", () => {
+    expect(externalUrlToAppPath("https://code.posthog.com/task/task-123")).toBe(
+      "/task/task-123",
+    );
+  });
+
+  it("preserves the query string", () => {
+    expect(externalUrlToAppPath("posthog://task/task-123?foo=bar")).toBe(
+      "/task/task-123?foo=bar",
+    );
+  });
+
+  it("strips a trailing slug segment from inbox custom-scheme URLs", () => {
+    expect(
+      externalUrlToAppPath("posthog://inbox/report-abc/fix-inbox--Add-foo"),
+    ).toBe("/inbox/report-abc");
+  });
+
+  it("strips a trailing slug segment from inbox universal links", () => {
+    expect(
+      externalUrlToAppPath(
+        "https://code.posthog.com/inbox/report-abc/Hello-World",
+      ),
+    ).toBe("/inbox/report-abc");
+  });
+
+  it("preserves the query string when stripping an inbox slug", () => {
+    expect(
+      externalUrlToAppPath("posthog://inbox/report-abc/Hello-World?x=1"),
+    ).toBe("/inbox/report-abc?x=1");
+  });
+
+  it("leaves a bare inbox URL untouched", () => {
+    expect(externalUrlToAppPath("posthog://inbox/report-abc")).toBe(
+      "/inbox/report-abc",
+    );
+  });
+
+  it("ignores URLs from unrelated hosts/schemes", () => {
+    expect(externalUrlToAppPath("https://example.com/inbox/x")).toBe(null);
+    expect(externalUrlToAppPath("not a url")).toBe(null);
+  });
+});

--- a/apps/mobile/src/lib/deep-links.ts
+++ b/apps/mobile/src/lib/deep-links.ts
@@ -7,6 +7,7 @@
  *   posthog://task/<taskId>
  *   posthog://task/<taskId>/run/<runId>
  *   posthog://inbox/<reportId>
+ *   posthog://inbox/<reportId>/<slug>   (slug is cosmetic, ignored on receive)
  *
  * Mobile uses the `posthog://` custom scheme (registered in app.json) and
  * https://code.posthog.com as the universal-link host. Both share the same
@@ -16,7 +17,8 @@
  * For in-app navigation, prefer the `paths.*` helpers — they return the
  * router-relative path that `router.push()` expects. For external/shareable
  * links (push notifications, Slack messages, copy-link buttons), use
- * `universalUrl()` or `customSchemeUrl()`.
+ * `universalUrl()` or `customSchemeUrl()`. To produce a human-readable share
+ * link for an inbox report, use `inboxReportShareUrl(reportId, title)`.
  */
 
 export const MOBILE_SCHEME = "posthog";
@@ -57,9 +59,59 @@ export function universalUrl(path: AppPath): string {
 }
 
 /**
+ * Slugify a free-form title for use as a trailing path segment on a shareable
+ * deep link. Mirrors `buildInboxDeeplink`'s slug rules in the desktop app
+ * (apps/code/src/shared/deeplink.ts) exactly:
+ *
+ * - Accented Latin letters are folded to their ASCII base (`café` → `cafe`)
+ *   via NFD decomposition + combining-mark stripping.
+ * - Letters, digits, and the URL-unreserved punctuation `_ . ~` are kept
+ *   verbatim (case preserved).
+ * - Any run of other characters collapses to a single `-`, except runs that
+ *   mix a colon with other unsafe chars collapse to `--`. This preserves the
+ *   title-like break in `fix(inbox): Add foo` → `fix-inbox--Add-foo` while
+ *   keeping standalone colons compact (`feat:bar` → `feat-bar`) and unrelated
+ *   runs single (`Cost $5, 50% off` → `Cost-5-50-off`).
+ * - Leading and trailing hyphens are stripped.
+ *
+ * Returns the empty string when the input is null/undefined/empty or
+ * slugifies to nothing.
+ */
+export function slugifyTitle(title: string | null | undefined): string {
+  if (!title) return "";
+  return title
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .replace(/[^a-zA-Z0-9_.~]+/g, (run) =>
+      run.includes(":") && /[^:]/.test(run) ? "--" : "-",
+    )
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build a shareable `posthog://inbox/<reportId>` URL, optionally with a
+ * cosmetic slug suffix derived from the title. The slug is purely cosmetic;
+ * receivers must ignore everything after the UUID. See
+ * `externalUrlToAppPath` for the corresponding inbound tolerance.
+ */
+export function inboxReportShareUrl(
+  reportId: string,
+  title?: string | null,
+): string {
+  const slug = slugifyTitle(title);
+  const path = slug ? `/inbox/${reportId}/${slug}` : `/inbox/${reportId}`;
+  return customSchemeUrl(path);
+}
+
+/**
  * Convert an incoming external URL (custom scheme or universal link) to the
  * router-relative path expo-router uses. Returns null if the URL doesn't
  * belong to us.
+ *
+ * A `posthog://inbox/<id>/<slug>` link (or the universal-link equivalent) is
+ * normalized to `/inbox/<id>` — the slug is decorative and the route only
+ * cares about the UUID. Mirrors the desktop receiver, which also ignores the
+ * slug.
  *
  * Used by the auth gate to round-trip the originally-requested URL through
  * the sign-in flow.
@@ -68,26 +120,41 @@ export function externalUrlToAppPath(url: string): AppPath | null {
   try {
     const parsed = new URL(url);
 
+    let path: AppPath | null = null;
     if (parsed.protocol === `${MOBILE_SCHEME}:`) {
       // posthog://task/abc → /task/abc
       const host = parsed.hostname;
       if (!host) return null;
       const rest = parsed.pathname || "";
       const search = parsed.search || "";
-      return `/${host}${rest}${search}`;
-    }
-
-    if (
+      path = `/${host}${rest}${search}`;
+    } else if (
       (parsed.protocol === "https:" || parsed.protocol === "http:") &&
       parsed.hostname === UNIVERSAL_LINK_HOST
     ) {
       // https://code.posthog.com/task/abc → /task/abc
-      const path = parsed.pathname || "/";
-      return `${path}${parsed.search || ""}`;
+      const pathname = parsed.pathname || "/";
+      path = `${pathname}${parsed.search || ""}`;
     }
 
-    return null;
+    if (path === null) return null;
+    return stripInboxSlugSuffix(path);
   } catch {
     return null;
   }
+}
+
+/**
+ * Collapse `/inbox/<id>/<slug>[?query]` to `/inbox/<id>[?query]`. No-op for
+ * any path that isn't an inbox-report deep link with a trailing segment.
+ */
+function stripInboxSlugSuffix(path: AppPath): AppPath {
+  const queryStart = path.indexOf("?");
+  const pathOnly = queryStart === -1 ? path : path.slice(0, queryStart);
+  const query = queryStart === -1 ? "" : path.slice(queryStart);
+  const segments = pathOnly.split("/").filter(Boolean);
+  if (segments.length >= 3 && segments[0] === "inbox") {
+    return `/inbox/${segments[1]}${query}`;
+  }
+  return path;
 }


### PR DESCRIPTION
## Summary

Port of the desktop PR [#2298](https://github.com/PostHog/code/pull/2298) to the mobile app: when the "Discuss this report" flow builds a link back to a report, append the slugified title as a trailing path segment so shared/copied links read like `posthog://inbox/<reportId>/fix-inbox--Add-foo` instead of just the UUID. The slug is purely cosmetic — receivers ignore everything past the UUID.

- `apps/mobile/src/lib/deep-links.ts`
  - Adds `slugifyTitle(title)` mirroring `buildInboxDeeplink`'s slug rules in `apps/code/src/shared/deeplink.ts` exactly (NFD-fold accented Latin, preserve URL-unreserved punctuation `_ . ~`, collapse colon-with-other-chars runs to `--`, single colon-only runs to `-`, strip leading/trailing hyphens).
  - Adds `inboxReportShareUrl(reportId, title?)` that produces the slug-suffixed `posthog://inbox/<id>/<slug>` custom-scheme URL (no slug when the title is empty / slugifies to empty).
  - Extends `externalUrlToAppPath` to strip a trailing slug from inbox custom-scheme and universal-link URLs so notification-tap navigation lands on the bare `/inbox/<id>` path. Mirrors the desktop receiver, which also ignores the slug.

- `apps/mobile/src/app/inbox/[id].tsx` → `apps/mobile/src/app/inbox/[...id].tsx`
  - Converts the route to a catch-all so expo-router resolves both `/inbox/<id>` and `/inbox/<id>/<slug>` to the same report screen (the OS-level deep-link entry doesn't go through `externalUrlToAppPath`, so route-level tolerance is the load-bearing fix).
  - Pulls `reportId` from the first catch-all segment and passes `report.title` into `DiscussReportSheet`.
  - `_layout.tsx` Stack.Screen registration updated to `inbox/[...id]`.

- `apps/mobile/src/features/inbox/components/DiscussReportSheet.tsx`
  - Accepts optional `reportTitle?: string | null` and builds the link via `inboxReportShareUrl(reportId, reportTitle)` (replacing the bare `customSchemeUrl(paths.inboxReport(reportId))`).
  - Still hands the resulting URL to `buildDiscussReportPrompt` from `@posthog/shared` unchanged.

- `apps/mobile/src/lib/deep-links.test.ts`
  - Covers the slug rules (accented-fold, colon-run `--` vs single `-`, URL-unreserved punctuation passthrough, punctuation-collapse, trim) mirroring `apps/code/src/shared/deeplink.test.ts`.
  - Covers `inboxReportShareUrl` (empty title, slug-empty title, colon-run convention).
  - Covers inbound path tolerance: a trailing slug segment is stripped from both `posthog://inbox/<id>/<slug>` and `https://code.posthog.com/inbox/<id>/<slug>`, including query-string preservation.

No changes to `apps/code` or shared-package code — `buildDiscussReportPrompt` from `@posthog/shared` is reused as-is.

## Test plan

- [x] `pnpm --filter @posthog/mobile test` — 156/156 passing including the new slug + inbound-path cases.
- [x] `pnpm --filter @posthog/mobile lint` — clean.
- [ ] Manual: tap `posthog://inbox/<id>` on a device → routes to the report.
- [ ] Manual: tap `posthog://inbox/<id>/some-slug` on a device → routes to the same report (slug ignored).
- [ ] Manual: tap `https://code.posthog.com/inbox/<id>/some-slug` (universal link) → routes to the same report.
- [ ] Manual: open a report, hit "Discuss" → confirm the prompt embeds a `posthog://inbox/<id>/<slug>` URL with the slugified title.