### PR TITLE
ci: run smoke tests after build

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-15-arm64
+            runner: macos-15
           - arch: x64
             runner: macos-15-intel
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -134,11 +134,34 @@ jobs:
       - name: Build native modules
         run: pnpm --filter code run build-native
 
-      - name: Publish with Electron Forge
+      - name: Build release artifacts
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: pnpm --filter code exec electron-forge publish --arch=${{ matrix.arch }} --platform=darwin
+        run: pnpm --filter code exec electron-forge publish --dry-run --arch=${{ matrix.arch }} --platform=darwin
+
+      - name: Install Playwright
+        run: pnpm --filter code exec playwright install --with-deps chromium
+
+      - name: Smoke test packaged app
+        env:
+          CI: true
+          E2E_APP_ARCH: ${{ matrix.arch }}
+        run: pnpm --filter code exec playwright test --config=tests/e2e/playwright.config.ts tests/e2e/tests/smoke.spec.ts
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: release-playwright-report-macos-${{ matrix.arch }}
+          path: apps/code/playwright-report/
+          retention-days: 7
+
+      - name: Publish release artifacts
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: pnpm --filter code exec electron-forge publish --from-dry-run
 
   publish-windows:
     runs-on: windows-latest

--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -141,7 +141,7 @@ jobs:
         run: pnpm --filter code exec electron-forge publish --dry-run --arch=${{ matrix.arch }} --platform=darwin
 
       - name: Install Playwright
-        run: pnpm --filter code exec playwright install --with-deps chromium
+        run: pnpm --filter code exec playwright install
 
       - name: Smoke test packaged app
         env:

--- a/apps/code/tests/e2e/fixtures/electron.ts
+++ b/apps/code/tests/e2e/fixtures/electron.ts
@@ -9,6 +9,7 @@ import {
 
 function getAppPath(): string {
   const outDir = path.join(__dirname, "../../../out");
+  const requestedArch = process.env.E2E_APP_ARCH;
 
   if (process.platform === "darwin") {
     const arm64Path = path.join(
@@ -19,6 +20,16 @@ function getAppPath(): string {
       outDir,
       "PostHog Code-darwin-x64/PostHog Code.app/Contents/MacOS/PostHog Code",
     );
+
+    if (requestedArch === "arm64") {
+      if (existsSync(arm64Path)) return arm64Path;
+      throw new Error(`No darwin-arm64 packaged app found at ${arm64Path}.`);
+    }
+
+    if (requestedArch === "x64") {
+      if (existsSync(x64Path)) return x64Path;
+      throw new Error(`No darwin-x64 packaged app found at ${x64Path}.`);
+    }
 
     if (existsSync(arm64Path)) return arm64Path;
     if (existsSync(x64Path)) return x64Path;


### PR DESCRIPTION
We were not running E2E tests on the release artifacts, making it possible to release a build that would not boot at all. 

This is the same E2E test we run during the build step on a PR, but during release. See #2385 and #2433 for a scenario where CI passed, but the release would still not boot.