### PR TITLE
Highlight current user in signal suggested reviewers

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -17,6 +17,7 @@ import {
   CaretRightIcon,
   ChatCircleIcon,
   EyeIcon,
+  InfoIcon,
   LinkSimpleIcon,
   Plus,
   ThumbsDownIcon,
@@ -211,8 +212,12 @@ export function ReportDetailPane({
     const reviewerArtefact = allArtefacts.find(
       (a): a is SuggestedReviewersArtefact => a.type === "suggested_reviewers",
     );
-    return reviewerArtefact?.content ?? [];
-  }, [allArtefacts]);
+    const reviewers = reviewerArtefact?.content ?? [];
+    if (!me?.uuid) return reviewers;
+    const meIndex = reviewers.findIndex((r) => r.user?.uuid === me.uuid);
+    if (meIndex <= 0) return reviewers;
+    return [reviewers[meIndex], ...reviewers.filter((_, i) => i !== meIndex)];
+  }, [allArtefacts, me?.uuid]);
 
   const signalFindings = useMemo(() => {
     const map = new Map<string, SignalFindingArtefact["content"]>();
@@ -818,16 +823,47 @@ export function ReportDetailPane({
                           {reviewer.relevant_commits.map((commit, i) => (
                             <span key={commit.sha}>
                               {i > 0 && ", "}
-                              <Tooltip content={commit.reason || undefined}>
-                                <a
-                                  href={commit.url}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="font-mono text-gray-9 hover:text-gray-11"
-                                >
-                                  {commit.sha.slice(0, 7)}
-                                </a>
-                              </Tooltip>
+                              {isMe ? (
+                                <>
+                                  <a
+                                    href={commit.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="font-mono text-gray-9 hover:text-gray-11"
+                                  >
+                                    {commit.sha.slice(0, 7)}
+                                  </a>
+                                  {commit.reason && (
+                                    <Tooltip
+                                      content={
+                                        <Flex direction="column" gap="1">
+                                          <Text as="div" size="1" weight="bold">
+                                            Why was I assigned?
+                                          </Text>
+                                          <Text as="div" size="1">
+                                            {commit.reason}
+                                          </Text>
+                                        </Flex>
+                                      }
+                                    >
+                                      <span className="ml-0.5 inline-flex cursor-help align-middle text-gray-9 hover:text-gray-11">
+                                        <InfoIcon size={11} />
+                                      </span>
+                                    </Tooltip>
+                                  )}
+                                </>
+                              ) : (
+                                <Tooltip content={commit.reason || undefined}>
+                                  <a
+                                    href={commit.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="font-mono text-gray-9 hover:text-gray-11"
+                                  >
+                                    {commit.sha.slice(0, 7)}
+                                  </a>
+                                </Tooltip>
+                              )}
                             </span>
                           ))}
                         </span>

--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -823,8 +823,23 @@ export function ReportDetailPane({
                           {reviewer.relevant_commits.map((commit, i) => (
                             <span key={commit.sha}>
                               {i > 0 && ", "}
-                              {isMe ? (
-                                <>
+                              <Tooltip
+                                content={
+                                  isMe ? (
+                                    <Flex direction="column" gap="1">
+                                      <Text as="div" size="1" weight="bold">
+                                        Why was I assigned?
+                                      </Text>
+                                      <Text as="div" size="1">
+                                        {commit.reason}
+                                      </Text>
+                                    </Flex>
+                                  ) : (
+                                    commit.reason || undefined
+                                  )
+                                }
+                              >
+                                <span className="inline-flex items-center gap-0.5">
                                   <a
                                     href={commit.url}
                                     target="_blank"
@@ -833,37 +848,14 @@ export function ReportDetailPane({
                                   >
                                     {commit.sha.slice(0, 7)}
                                   </a>
-                                  {commit.reason && (
-                                    <Tooltip
-                                      content={
-                                        <Flex direction="column" gap="1">
-                                          <Text as="div" size="1" weight="bold">
-                                            Why was I assigned?
-                                          </Text>
-                                          <Text as="div" size="1">
-                                            {commit.reason}
-                                          </Text>
-                                        </Flex>
-                                      }
-                                    >
-                                      <span className="ml-0.5 inline-flex cursor-help align-middle text-gray-9 hover:text-gray-11">
-                                        <InfoIcon size={11} />
-                                      </span>
-                                    </Tooltip>
+                                  {isMe && commit.reason && (
+                                    <InfoIcon
+                                      size={11}
+                                      className="cursor-help text-gray-9"
+                                    />
                                   )}
-                                </>
-                              ) : (
-                                <Tooltip content={commit.reason || undefined}>
-                                  <a
-                                    href={commit.url}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="font-mono text-gray-9 hover:text-gray-11"
-                                  >
-                                    {commit.sha.slice(0, 7)}
-                                  </a>
-                                </Tooltip>
-                              )}
+                                </span>
+                              </Tooltip>
                             </span>
                           ))}
                         </span>


### PR DESCRIPTION
## Problem

When a signal report assigns suggested reviewers, it can be hard to tell at a glance whether *you* are on the list, and why. The commit SHA-only tooltip explaining the rationale isn't obviously discoverable — you have to know to hover.

## Changes

In the Suggested reviewers section of the report detail pane:

- Sort the list so the current user appears first when present.
- For the current user, render a small info icon next to each commit SHA. The icon is the tooltip trigger, and the tooltip now has a "Why was I assigned?" title above the existing rationale, making the explanation discoverable.
- Other reviewers keep the existing behaviour (rationale tooltip on the SHA itself).

## How did you test this?

- `pnpm --filter code typecheck` (web tsconfig)
- `pnpm exec biome check` on the edited file

Did not run the desktop app in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*