### PR TITLE
fix: Pin actions/stale to full SHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-pr-stale: 30
           days-before-pr-close: 7


### PR DESCRIPTION
## Problem

The workflow is failing to run because the action is not pinned.
https://github.com/PostHog/code/actions/runs/26611117555/job/78417017648

## Changes

- Pinned actions/stale to the full sha

## How did you test this?

I did not

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
