### PR TITLE
Show skill tool calls as "Reading `<name>` skill"

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
@@ -74,13 +74,19 @@ export function ToolCallView({
     Wrench;
 
   const filePath = kind === "read" && locations?.[0]?.path;
-  const displayText = filePath
-    ? `Read ${getFilename(filePath)}`
-    : title
-      ? compactHomePath(title)
+  const skillName =
+    agentToolName === "Skill"
+      ? (rawInput as { skill?: string } | undefined)?.skill
       : undefined;
+  const displayText = skillName
+    ? "Reading"
+    : filePath
+      ? `Read ${getFilename(filePath)}`
+      : title
+        ? compactHomePath(title)
+        : undefined;
 
-  const inputPreview = compactInput(rawInput);
+  const inputPreview = skillName ?? compactInput(rawInput);
   const fullInput = formatInput(rawInput);
 
   const output = stripCodeFences(getContentText(content) ?? "");
@@ -115,6 +121,7 @@ export function ToolCallView({
               <span className="font-mono text-accent-11">{inputPreview}</span>
             </ToolTitle>
           )}
+          {skillName && <ToolTitle>skill</ToolTitle>}
           <StatusIndicators isFailed={isFailed} wasCancelled={wasCancelled} />
         </Flex>
       </Flex>

--- a/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
+++ b/apps/code/src/renderer/features/sessions/components/session-update/ToolCallView.tsx
@@ -50,6 +50,16 @@ const toolNameIcons: Record<string, Icon> = {
   Skill: Command,
 };
 
+// Tools that render a friendly "<prefix> `<input>` <suffix>" line instead of
+// the raw JSON input preview. `inputKey` is the rawInput field to highlight.
+const toolNameDisplays: Record<
+  string,
+  { prefix: string; suffix: string; inputKey: string }
+> = {
+  Skill: { prefix: "Reading", suffix: "skill", inputKey: "skill" },
+  ToolSearch: { prefix: "Searching", suffix: "tools", inputKey: "query" },
+};
+
 interface ToolCallViewProps extends ToolViewProps {
   agentToolName?: string;
 }
@@ -74,19 +84,27 @@ export function ToolCallView({
     Wrench;
 
   const filePath = kind === "read" && locations?.[0]?.path;
-  const skillName =
-    agentToolName === "Skill"
-      ? (rawInput as { skill?: string } | undefined)?.skill
+  const toolDisplay = agentToolName
+    ? toolNameDisplays[agentToolName]
+    : undefined;
+  const highlightValue =
+    toolDisplay && rawInput && typeof rawInput === "object"
+      ? (rawInput as Record<string, unknown>)[toolDisplay.inputKey]
       : undefined;
-  const displayText = skillName
-    ? "Reading"
+  const specialDisplay =
+    toolDisplay && typeof highlightValue === "string"
+      ? { ...toolDisplay, value: highlightValue }
+      : undefined;
+
+  const displayText = specialDisplay
+    ? specialDisplay.prefix
     : filePath
       ? `Read ${getFilename(filePath)}`
       : title
         ? compactHomePath(title)
         : undefined;
 
-  const inputPreview = skillName ?? compactInput(rawInput);
+  const inputPreview = specialDisplay?.value ?? compactInput(rawInput);
   const fullInput = formatInput(rawInput);
 
   const output = stripCodeFences(getContentText(content) ?? "");
@@ -121,7 +139,7 @@ export function ToolCallView({
               <span className="font-mono text-accent-11">{inputPreview}</span>
             </ToolTitle>
           )}
-          {skillName && <ToolTitle>skill</ToolTitle>}
+          {specialDisplay && <ToolTitle>{specialDisplay.suffix}</ToolTitle>}
           <StatusIndicators isFailed={isFailed} wasCancelled={wasCancelled} />
         </Flex>
       </Flex>


### PR DESCRIPTION
## Summary
- The current display for Skill tool calls dumps the raw input as JSON, e.g. `Skill {"skill":"implementing-mcp-tools"}`.
- This change renders it as `Reading <skill-name> skill` with the skill name in the accent color, matching how we already style input previews.

## Test plan
- [ ] Trigger a session that invokes a skill (e.g. ask the agent to use the `implementing-mcp-tools` skill) and confirm the tool row reads `Reading implementing-mcp-tools skill` with the skill name highlighted.
- [ ] Confirm non-Skill tool calls (Read, Bash, Grep, MCP tools, etc.) are unchanged.
- [ ] Confirm the row is still expandable and the expanded view still shows the full raw input.