### PR TITLE
fix: resolve codex-acp binary path on Windows by appending .exe extension

### DIFF
--- a/apps/code/src/main/services/agent/service.ts
+++ b/apps/code/src/main/services/agent/service.ts
@@ -343,7 +343,8 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
   }
 
   private getCodexBinaryPath(): string {
-    return this.bundledResources.resolve(".vite/build/codex-acp/codex-acp");
+    const binary = process.platform === "win32" ? "codex-acp.exe" : "codex-acp";
+    return this.bundledResources.resolve(`.vite/build/codex-acp/${binary}`);
   }
 
   /**


### PR DESCRIPTION
## Problem
Closes #2445 

On Windows, `getCodexBinaryPath()` looks for the binary at `.vite/build/codex-acp/codex-acp` — without the `.exe` extension. The file on disk is `codex-acp.exe`, so the lookup always fails and the Codex adapter cannot start.

The error thrown is:
```
codex-acp binary not found at ...\apps\code\.vite\build\codex-acp\codex-acp.
Run "node apps/code/scripts/download-binaries.mjs" to download it.
```

This causes the session to fall back to Claude silently, even when the user has explicitly selected a Codex/OpenAI model and the binary is present.

Note: the Claude binary path (line 341) already handles this correctly with a platform check — this fix applies the same pattern to the Codex binary.

## Changes

Added a `process.platform === "win32"` check to `getCodexBinaryPath()`, matching the existing pattern in `getClaudeBinaryPath()`:

```ts
// Before
private getCodexBinaryPath(): string {
  return this.bundledResources.resolve(".vite/build/codex-acp/codex-acp");
}

// After
private getCodexBinaryPath(): string {
  const binary = process.platform === "win32" ? "codex-acp.exe" : "codex-acp";
  return this.bundledResources.resolve(`.vite/build/codex-acp/${binary}`);
}
```

## How did you test this?

Tested manually on Windows 11 (WSL2 dev environment) running the dev build (`pnpm start` from the worktree):

1. Downloaded `codex-acp.exe` via `node apps/code/scripts/download-binaries.mjs`
2. Before fix: selecting a Codex model (gpt-5.4) at task creation always fell back to Claude with the binary-not-found error in logs
3. After fix: `[CodexAcpAgent] Spawning codex-acp process` appears in logs, task runs successfully through OpenAI

## Publish to changelog?

no