### PR TITLE
fix: show logs not repo picker for inbox research tasks

### DIFF
--- a/apps/code/src/renderer/features/sessions/hooks/useSessionViewState.ts
+++ b/apps/code/src/renderer/features/sessions/hooks/useSessionViewState.ts
@@ -8,7 +8,7 @@ export function useSessionViewState(taskId: string, task: Task) {
   const session = useSessionForTask(taskId);
   const repoPath = useCwd(taskId) ?? null;
   const workspace = useWorkspace(taskId);
-  const isCloud = useIsCloudTask(taskId);
+  const isCloud = useIsCloudTask(taskId, task);
 
   const cloudStatus = session?.cloudStatus ?? null;
   const isCloudRunNotTerminal =

--- a/apps/code/src/renderer/features/workspace/hooks/useIsCloudTask.ts
+++ b/apps/code/src/renderer/features/workspace/hooks/useIsCloudTask.ts
@@ -1,6 +1,8 @@
+import type { Task } from "@shared/types";
 import { useWorkspace } from "./useWorkspace";
 
-export function useIsCloudTask(taskId: string): boolean {
+export function useIsCloudTask(taskId: string, task?: Task): boolean {
   const workspace = useWorkspace(taskId);
-  return workspace?.mode === "cloud";
+  if (workspace?.mode === "cloud") return true;
+  return task?.latest_run?.environment === "cloud";
 }


### PR DESCRIPTION
## Problem

On a report detail page in the inbox, expanding the **Research** (or Implementation) bar in the research task popover showed a **"Select a repository folder"** picker instead of the task's logs.

## Root cause

The report's tasks come from `useReportTasks`, which fetches them from the PostHog **cloud API** (`client.getTask`). These are server-created cloud tasks with **no local SQLite workspace record**.

`TaskLogsPanel` renders `WorkspaceSetupPrompt` when `!repoPath && !isCloud && ...`. But `isCloud` (`useIsCloudTask`) and `repoPath` (`useCwd`) were both derived **only** from the absent local workspace record, so `isCloud` was wrongly `false` and the folder-picker branch won.

## Fix

Make `useIsCloudTask` also honor the canonical task-level signal `task.latest_run?.environment === "cloud"` — the same `workspace?.mode === "cloud" || task.latest_run?.environment === "cloud"` combination already used in `TaskDetail.tsx` and `useTaskDiffSummaryStats.ts`. Thread `task` through from `useSessionViewState`.

With `isCloud` correct for these remote tasks:
- The `WorkspaceSetupPrompt` gate no longer matches → renders `SessionView` (logs).
- `useSessionConnection` routes through `watchCloudTask` (live cloud log stream) instead of the static `loadLogsOnly` fallback.

The optional `task` arg keeps the other `useIsCloudTask` call sites (`FileTreePanel`, `ChangesPanel`) unchanged.

## Verification

- `pnpm --filter code typecheck` passes.
- Manual (not run headlessly): inbox report → expand Research bar shows logs, not the picker; a local task with no workspace still shows the setup prompt (regression check).