### PR TITLE
feat(mobile): highlight and surface current user in suggested reviewers (port #2435)

### DIFF
--- a/apps/mobile/src/features/inbox/components/SuggestedReviewers.tsx
+++ b/apps/mobile/src/features/inbox/components/SuggestedReviewers.tsx
@@ -21,6 +21,7 @@ import type {
   SuggestedReviewersArtefact,
 } from "../types";
 import {
+  orderSuggestedReviewers,
   reviewerMatchesAvailable,
   toSuggestedReviewerWriteContent,
 } from "../utils";
@@ -54,12 +55,10 @@ export function SuggestedReviewers({
 
   const reviewers = artefact.content;
 
-  const displayReviewers = useMemo(() => {
-    if (!meUuid) return reviewers;
-    const meIndex = reviewers.findIndex((r) => r.user?.uuid === meUuid);
-    if (meIndex <= 0) return reviewers;
-    return [reviewers[meIndex], ...reviewers.filter((_, i) => i !== meIndex)];
-  }, [reviewers, meUuid]);
+  const displayReviewers = useMemo(
+    () => orderSuggestedReviewers(reviewers, meUuid),
+    [reviewers, meUuid],
+  );
 
   const removeReviewer = (target: SuggestedReviewer) => {
     const next = reviewers.filter((r) => r !== target);

--- a/apps/mobile/src/features/inbox/utils.test.ts
+++ b/apps/mobile/src/features/inbox/utils.test.ts
@@ -10,9 +10,57 @@ import {
   buildPriorityFilterParam,
   buildReviewerOptions,
   formatSignalReportSummaryMarkdown,
+  orderSuggestedReviewers,
   reviewerMatchesAvailable,
   toSuggestedReviewerWriteContent,
 } from "./utils";
+
+function reviewer(login: string, uuid?: string): SuggestedReviewer {
+  return {
+    github_login: login,
+    github_name: login,
+    relevant_commits: [],
+    user: uuid
+      ? {
+          id: 1,
+          uuid,
+          email: `${login}@posthog.com`,
+          first_name: login,
+          last_name: "",
+        }
+      : null,
+  };
+}
+
+describe("orderSuggestedReviewers", () => {
+  it("moves the current user to the front", () => {
+    const reviewers = [
+      reviewer("a", "uuid-a"),
+      reviewer("me", "uuid-me"),
+      reviewer("c", "uuid-c"),
+    ];
+    const ordered = orderSuggestedReviewers(reviewers, "uuid-me");
+    expect(ordered.map((r) => r.github_login)).toEqual(["me", "a", "c"]);
+  });
+
+  it("is a no-op when the current user is already first", () => {
+    const reviewers = [reviewer("me", "uuid-me"), reviewer("a", "uuid-a")];
+    const ordered = orderSuggestedReviewers(reviewers, "uuid-me");
+    expect(ordered).toBe(reviewers);
+  });
+
+  it("is a no-op when the current user is absent", () => {
+    const reviewers = [reviewer("a", "uuid-a"), reviewer("b", "uuid-b")];
+    const ordered = orderSuggestedReviewers(reviewers, "uuid-me");
+    expect(ordered).toBe(reviewers);
+  });
+
+  it("is a no-op when meUuid is missing", () => {
+    const reviewers = [reviewer("a", "uuid-a"), reviewer("me", "uuid-me")];
+    expect(orderSuggestedReviewers(reviewers, null)).toBe(reviewers);
+    expect(orderSuggestedReviewers(reviewers, undefined)).toBe(reviewers);
+  });
+});
 
 function makeReviewer(
   partial: Partial<SuggestedReviewer> = {},

--- a/apps/mobile/src/features/inbox/utils.test.ts
+++ b/apps/mobile/src/features/inbox/utils.test.ts
@@ -43,22 +43,29 @@ describe("orderSuggestedReviewers", () => {
     expect(ordered.map((r) => r.github_login)).toEqual(["me", "a", "c"]);
   });
 
-  it("is a no-op when the current user is already first", () => {
-    const reviewers = [reviewer("me", "uuid-me"), reviewer("a", "uuid-a")];
-    const ordered = orderSuggestedReviewers(reviewers, "uuid-me");
-    expect(ordered).toBe(reviewers);
-  });
-
-  it("is a no-op when the current user is absent", () => {
-    const reviewers = [reviewer("a", "uuid-a"), reviewer("b", "uuid-b")];
-    const ordered = orderSuggestedReviewers(reviewers, "uuid-me");
-    expect(ordered).toBe(reviewers);
-  });
-
-  it("is a no-op when meUuid is missing", () => {
-    const reviewers = [reviewer("a", "uuid-a"), reviewer("me", "uuid-me")];
-    expect(orderSuggestedReviewers(reviewers, null)).toBe(reviewers);
-    expect(orderSuggestedReviewers(reviewers, undefined)).toBe(reviewers);
+  it.each([
+    {
+      label: "already first",
+      reviewers: [reviewer("me", "uuid-me"), reviewer("a", "uuid-a")],
+      meUuid: "uuid-me" as string | null | undefined,
+    },
+    {
+      label: "absent",
+      reviewers: [reviewer("a", "uuid-a"), reviewer("b", "uuid-b")],
+      meUuid: "uuid-me" as string | null | undefined,
+    },
+    {
+      label: "null meUuid",
+      reviewers: [reviewer("a", "uuid-a"), reviewer("me", "uuid-me")],
+      meUuid: null as string | null | undefined,
+    },
+    {
+      label: "undefined meUuid",
+      reviewers: [reviewer("a", "uuid-a"), reviewer("me", "uuid-me")],
+      meUuid: undefined as string | null | undefined,
+    },
+  ])("is a no-op when $label", ({ reviewers, meUuid }) => {
+    expect(orderSuggestedReviewers(reviewers, meUuid)).toBe(reviewers);
   });
 });
 

--- a/apps/mobile/src/features/inbox/utils.ts
+++ b/apps/mobile/src/features/inbox/utils.ts
@@ -126,6 +126,16 @@ export function getActionableReports(reports: SignalReport[]): SignalReport[] {
   );
 }
 
+export function orderSuggestedReviewers(
+  reviewers: SuggestedReviewer[],
+  meUuid: string | null | undefined,
+): SuggestedReviewer[] {
+  if (!meUuid) return reviewers;
+  const meIndex = reviewers.findIndex((r) => r.user?.uuid === meUuid);
+  if (meIndex <= 0) return reviewers;
+  return [reviewers[meIndex], ...reviewers.filter((_, i) => i !== meIndex)];
+}
+
 export interface ReviewerOption {
   uuid: string;
   name: string;


### PR DESCRIPTION
## Summary

Ports desktop PR #2435 ("Highlight current user in signal suggested reviewers") to the mobile app, bringing the inbox report detail to parity.

Two gaps were closed in the mobile "Suggested reviewers" list:

1. **Wire the current user through.** The detail screen now reads the logged-in user's uuid via `useUserQuery` and passes it as `meUuid` to `<SuggestedReviewers>`, so the component's existing `isMe` highlight badge actually shows.
2. **Reorder so the current user is first.** When the logged-in user appears in the list and isn't already first, they're moved to the front — mirroring the desktop behavior. The reorder lives in a pure, testable `orderSuggestedReviewers` util alongside the other inbox derivation helpers.

The "Why was I assigned?" commit-reason tooltip from desktop is intentionally **not** ported: mobile's `SuggestedReviewers` does not render `relevant_commits` at all, and inventing a new commits UI was out of scope.

## Changes

- `apps/mobile/src/features/inbox/utils.ts` — add `orderSuggestedReviewers(reviewers, meUuid)`.
- `apps/mobile/src/app/inbox/[id].tsx` — call `useUserQuery`, reorder in the `suggestedReviewers` memo, pass `meUuid` to the component.
- `apps/mobile/src/features/inbox/utils.test.ts` — unit tests for the reorder (moves to front, no-op when already first / absent / no uuid).

## Testing

- `pnpm --filter @posthog/mobile test src/features/inbox/` — passing.
- `tsc --noEmit` clean for the changed files.
- Desktop code under `apps/code` untouched.