### PR TITLE
Remove "Stop All" button from command center toolbar

### DIFF
--- a/apps/code/src/renderer/features/command-center/components/CommandCenterToolbar.tsx
+++ b/apps/code/src/renderer/features/command-center/components/CommandCenterToolbar.tsx
@@ -1,15 +1,10 @@
-import { getSessionService } from "@features/sessions/service/service";
 import {
   MagnifyingGlassMinus,
   MagnifyingGlassPlus,
-  Stop,
   Trash,
 } from "@phosphor-icons/react";
 import { Flex, Select, Text } from "@radix-ui/themes";
-import type {
-  CommandCenterCellData,
-  StatusSummary,
-} from "../hooks/useCommandCenterData";
+import type { StatusSummary } from "../hooks/useCommandCenterData";
 import {
   type LayoutPreset,
   useCommandCenterStore,
@@ -68,7 +63,6 @@ const LAYOUT_OPTIONS: {
 
 interface CommandCenterToolbarProps {
   summary: StatusSummary;
-  cells: CommandCenterCellData[];
 }
 
 function StatusSummaryText({ summary }: { summary: StatusSummary }) {
@@ -85,30 +79,13 @@ function StatusSummaryText({ summary }: { summary: StatusSummary }) {
   );
 }
 
-export function CommandCenterToolbar({
-  summary,
-  cells,
-}: CommandCenterToolbarProps) {
+export function CommandCenterToolbar({ summary }: CommandCenterToolbarProps) {
   const layout = useCommandCenterStore((s) => s.layout);
   const setLayout = useCommandCenterStore((s) => s.setLayout);
   const clearAll = useCommandCenterStore((s) => s.clearAll);
   const zoom = useCommandCenterStore((s) => s.zoom);
   const zoomIn = useCommandCenterStore((s) => s.zoomIn);
   const zoomOut = useCommandCenterStore((s) => s.zoomOut);
-
-  const hasActiveAgents = summary.running > 0 || summary.waiting > 0;
-
-  const stopAll = () => {
-    const service = getSessionService();
-    for (const cell of cells) {
-      if (
-        cell.taskId &&
-        (cell.status === "running" || cell.status === "waiting")
-      ) {
-        service.cancelPrompt(cell.taskId);
-      }
-    }
-  };
 
   return (
     <Flex
@@ -162,17 +139,6 @@ export function CommandCenterToolbar({
       </Flex>
 
       <div className="flex-1" />
-
-      <button
-        type="button"
-        onClick={stopAll}
-        disabled={!hasActiveAgents}
-        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[12px] text-red-10 transition-colors hover:bg-red-3 hover:text-red-11 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-red-10"
-        title="Stop all agents"
-      >
-        <Stop size={12} weight="fill" />
-        Stop All
-      </button>
 
       <button
         type="button"

--- a/apps/code/src/renderer/features/command-center/components/CommandCenterView.tsx
+++ b/apps/code/src/renderer/features/command-center/components/CommandCenterView.tsx
@@ -47,7 +47,7 @@ export function CommandCenterView() {
 
   return (
     <Flex direction="column" height="100%">
-      <CommandCenterToolbar summary={summary} cells={cells} />
+      <CommandCenterToolbar summary={summary} />
       <Box className="min-h-0 flex-1">
         <CommandCenterGrid layout={layout} cells={cells} />
       </Box>

--- a/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.test.ts
+++ b/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.test.ts
@@ -324,4 +324,41 @@ describe("useAutofillCommandCenter", () => {
       null,
     ]);
   });
+
+  it("leaves hasAutofilled unset when there are no candidates yet", () => {
+    setQueries({ tasks: [], workspaces: {} });
+    renderHook(() => useAutofillCommandCenter());
+    expect(useCommandCenterStore.getState().hasAutofilled).toBe(false);
+  });
+
+  it("does not top up empty cells once the grid has been autofilled", () => {
+    useCommandCenterStore.setState({
+      cells: ["existing", null, null, null],
+      hasAutofilled: true,
+    });
+    setQueries({
+      tasks: [
+        makeTask({ id: "t1", updated_at: new Date(NOW - 100).toISOString() }),
+        makeTask({ id: "t2", updated_at: new Date(NOW - 200).toISOString() }),
+      ],
+      workspaces: { t1: makeWorkspace("t1"), t2: makeWorkspace("t2") },
+    });
+    renderHook(() => useAutofillCommandCenter());
+    expect(useCommandCenterStore.getState().cells).toEqual([
+      "existing",
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it("marks autofilled when the grid is already full so removals do not refill", () => {
+    useCommandCenterStore.setState({ cells: ["a", "b", "c", "d"] });
+    setQueries({
+      tasks: [makeTask({ id: "t1" })],
+      workspaces: { t1: makeWorkspace("t1") },
+    });
+    renderHook(() => useAutofillCommandCenter());
+    expect(useCommandCenterStore.getState().hasAutofilled).toBe(true);
+  });
 });

--- a/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.ts
+++ b/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.ts
@@ -26,7 +26,6 @@ export function useAutofillCommandCenter(): void {
   const cells = useCommandCenterStore((s) => s.cells);
   const hasAutofilled = useCommandCenterStore((s) => s.hasAutofilled);
   const autofillCells = useCommandCenterStore((s) => s.autofillCells);
-  const markAutofilled = useCommandCenterStore((s) => s.markAutofilled);
 
   useEffect(() => {
     // Autofill is a one-time convenience to bootstrap an empty grid. Once it
@@ -39,11 +38,6 @@ export function useAutofillCommandCenter(): void {
     if (!tasksFetched) return;
 
     const emptySlots = cells.filter((id) => id == null).length;
-    if (emptySlots === 0) {
-      markAutofilled();
-      return;
-    }
-
     const assignedIds = new Set(cells.filter((id): id is string => id != null));
     const cutoff = Date.now() - RECENT_WINDOW_MS;
     const candidates = tasks
@@ -58,10 +52,10 @@ export function useAutofillCommandCenter(): void {
       .slice(0, emptySlots)
       .map((task) => task.id);
 
-    // No eligible tasks yet — leave the flag unset so autofill can still
-    // bootstrap the grid once recent tasks exist.
-    if (candidates.length === 0) return;
-
+    // Hand the candidates to the store, which records the one-time bootstrap
+    // — including when the grid is already full and there is nothing to place.
+    // With no eligible tasks yet on a partial grid the flag stays unset, so
+    // autofill can still bootstrap once recent tasks exist.
     autofillCells(candidates);
   }, [
     cells,
@@ -72,6 +66,5 @@ export function useAutofillCommandCenter(): void {
     tasksFetched,
     archivedTaskIds,
     autofillCells,
-    markAutofilled,
   ]);
 }

--- a/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.ts
+++ b/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.ts
@@ -28,11 +28,8 @@ export function useAutofillCommandCenter(): void {
   const autofillCells = useCommandCenterStore((s) => s.autofillCells);
 
   useEffect(() => {
-    // Autofill is a one-time convenience to bootstrap an empty grid. Once it
-    // has populated the grid (or the user has curated it), the persisted
-    // `hasAutofilled` flag stops it from re-topping-up empty cells every time
-    // the Command Center remounts — opening a task full-screen and coming back
-    // no longer wipes out a deliberately trimmed layout.
+    // One-time bootstrap: the persisted `hasAutofilled` flag stops empty cells
+    // from being re-filled every time the Command Center remounts.
     if (hasAutofilled) return;
     if (!workspacesFetched || !workspaces) return;
     if (!tasksFetched) return;
@@ -52,10 +49,6 @@ export function useAutofillCommandCenter(): void {
       .slice(0, emptySlots)
       .map((task) => task.id);
 
-    // Hand the candidates to the store, which records the one-time bootstrap
-    // — including when the grid is already full and there is nothing to place.
-    // With no eligible tasks yet on a partial grid the flag stays unset, so
-    // autofill can still bootstrap once recent tasks exist.
     autofillCells(candidates);
   }, [
     cells,

--- a/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.ts
+++ b/apps/code/src/renderer/features/command-center/hooks/useAutofillCommandCenter.ts
@@ -2,7 +2,7 @@ import { useArchivedTaskIds } from "@features/archive/hooks/useArchivedTaskIds";
 import { useTasks } from "@features/tasks/hooks/useTasks";
 import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
 import type { Task } from "@shared/types";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useCommandCenterStore } from "../stores/commandCenterStore";
 
 // Window for "still in the current working session". Tasks last touched
@@ -24,21 +24,23 @@ export function useAutofillCommandCenter(): void {
   const archivedTaskIds = useArchivedTaskIds();
 
   const cells = useCommandCenterStore((s) => s.cells);
+  const hasAutofilled = useCommandCenterStore((s) => s.hasAutofilled);
   const autofillCells = useCommandCenterStore((s) => s.autofillCells);
-
-  // Fires at most once per mount so clearing cells in-place doesn't
-  // immediately re-populate them. Navigating away and back remounts the
-  // view and lets autofill run again with the latest recent tasks.
-  const hasRunRef = useRef(false);
+  const markAutofilled = useCommandCenterStore((s) => s.markAutofilled);
 
   useEffect(() => {
-    if (hasRunRef.current) return;
+    // Autofill is a one-time convenience to bootstrap an empty grid. Once it
+    // has populated the grid (or the user has curated it), the persisted
+    // `hasAutofilled` flag stops it from re-topping-up empty cells every time
+    // the Command Center remounts — opening a task full-screen and coming back
+    // no longer wipes out a deliberately trimmed layout.
+    if (hasAutofilled) return;
     if (!workspacesFetched || !workspaces) return;
     if (!tasksFetched) return;
 
     const emptySlots = cells.filter((id) => id == null).length;
     if (emptySlots === 0) {
-      hasRunRef.current = true;
+      markAutofilled();
       return;
     }
 
@@ -56,17 +58,20 @@ export function useAutofillCommandCenter(): void {
       .slice(0, emptySlots)
       .map((task) => task.id);
 
-    if (candidates.length > 0) {
-      autofillCells(candidates);
-    }
-    hasRunRef.current = true;
+    // No eligible tasks yet — leave the flag unset so autofill can still
+    // bootstrap the grid once recent tasks exist.
+    if (candidates.length === 0) return;
+
+    autofillCells(candidates);
   }, [
     cells,
+    hasAutofilled,
     workspaces,
     workspacesFetched,
     tasks,
     tasksFetched,
     archivedTaskIds,
     autofillCells,
+    markAutofilled,
   ]);
 }

--- a/apps/code/src/renderer/features/command-center/stores/commandCenterStore.test.ts
+++ b/apps/code/src/renderer/features/command-center/stores/commandCenterStore.test.ts
@@ -75,5 +75,27 @@ describe("commandCenterStore", () => {
         null,
       ]);
     });
+
+    it("sets hasAutofilled when it populates cells", () => {
+      useCommandCenterStore.getState().autofillCells(["t1"]);
+      expect(useCommandCenterStore.getState().hasAutofilled).toBe(true);
+    });
+
+    it("leaves hasAutofilled unset when there is nothing to fill", () => {
+      useCommandCenterStore.getState().autofillCells([]);
+      expect(useCommandCenterStore.getState().hasAutofilled).toBe(false);
+    });
+  });
+
+  describe("hasAutofilled", () => {
+    it("assigning a task marks the grid as curated", () => {
+      useCommandCenterStore.getState().assignTask(0, "t1");
+      expect(useCommandCenterStore.getState().hasAutofilled).toBe(true);
+    });
+
+    it("markAutofilled sets the flag", () => {
+      useCommandCenterStore.getState().markAutofilled();
+      expect(useCommandCenterStore.getState().hasAutofilled).toBe(true);
+    });
   });
 });

--- a/apps/code/src/renderer/features/command-center/stores/commandCenterStore.test.ts
+++ b/apps/code/src/renderer/features/command-center/stores/commandCenterStore.test.ts
@@ -93,8 +93,9 @@ describe("commandCenterStore", () => {
       expect(useCommandCenterStore.getState().hasAutofilled).toBe(true);
     });
 
-    it("markAutofilled sets the flag", () => {
-      useCommandCenterStore.getState().markAutofilled();
+    it("marks the grid as autofilled when it is already full", () => {
+      useCommandCenterStore.setState({ cells: ["a", "b", "c", "d"] });
+      useCommandCenterStore.getState().autofillCells([]);
       expect(useCommandCenterStore.getState().hasAutofilled).toBe(true);
     });
   });

--- a/apps/code/src/renderer/features/command-center/stores/commandCenterStore.ts
+++ b/apps/code/src/renderer/features/command-center/stores/commandCenterStore.ts
@@ -38,7 +38,6 @@ interface CommandCenterStoreActions {
   setActiveCell: (cellIndex: number | null) => void;
   assignTask: (cellIndex: number, taskId: string) => void;
   autofillCells: (taskIds: string[]) => void;
-  markAutofilled: () => void;
   removeTask: (cellIndex: number) => void;
   removeTaskById: (taskId: string) => void;
   clearAll: () => void;
@@ -131,8 +130,12 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
 
       autofillCells: (taskIds) =>
         set((state) => {
+          // Grid is already full — nothing to place, but the one-time
+          // bootstrap is done, so record it and stop autofill from re-running.
+          if (state.cells.every((id) => id != null)) {
+            return { hasAutofilled: true };
+          }
           if (taskIds.length === 0) return state;
-          if (state.cells.every((id) => id != null)) return state;
           const cells: (string | null)[] = [...state.cells];
           const queue = [...taskIds];
           for (let i = 0; i < cells.length && queue.length > 0; i++) {
@@ -142,8 +145,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
           }
           return { cells, hasAutofilled: true };
         }),
-
-      markAutofilled: () => set({ hasAutofilled: true }),
 
       removeTask: (cellIndex) =>
         set((state) => {

--- a/apps/code/src/renderer/features/command-center/stores/commandCenterStore.ts
+++ b/apps/code/src/renderer/features/command-center/stores/commandCenterStore.ts
@@ -26,6 +26,10 @@ interface CommandCenterStoreState {
   activeCellIndex: number | null;
   zoom: number;
   creatingCells: number[];
+  // True once autofill has bootstrapped the grid (or the user has curated it
+  // by assigning a task). Persisted so autofill never repopulates cells the
+  // user deliberately left empty when the Command Center remounts.
+  hasAutofilled: boolean;
 }
 
 interface CommandCenterStoreActions {
@@ -34,6 +38,7 @@ interface CommandCenterStoreActions {
   setActiveCell: (cellIndex: number | null) => void;
   assignTask: (cellIndex: number, taskId: string) => void;
   autofillCells: (taskIds: string[]) => void;
+  markAutofilled: () => void;
   removeTask: (cellIndex: number) => void;
   removeTaskById: (taskId: string) => void;
   clearAll: () => void;
@@ -51,6 +56,7 @@ export const COMMAND_CENTER_INITIAL_STATE: CommandCenterStoreState = {
   activeCellIndex: null,
   zoom: 1,
   creatingCells: [],
+  hasAutofilled: false,
 };
 
 type CommandCenterStore = CommandCenterStoreState & CommandCenterStoreActions;
@@ -117,6 +123,9 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
             cells,
             activeTaskId: taskId,
             creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
+            // Manually placing a task counts as curating the grid, so autofill
+            // should never top up the remaining empty cells.
+            hasAutofilled: true,
           };
         }),
 
@@ -131,8 +140,10 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
               cells[i] = queue.shift() as string;
             }
           }
-          return { cells };
+          return { cells, hasAutofilled: true };
         }),
+
+      markAutofilled: () => set({ hasAutofilled: true }),
 
       removeTask: (cellIndex) =>
         set((state) => {
@@ -197,6 +208,7 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
         activeCellIndex: state.activeCellIndex,
         zoom: state.zoom,
         creatingCells: state.creatingCells,
+        hasAutofilled: state.hasAutofilled,
       }),
     },
   ),

--- a/apps/code/src/renderer/features/command-center/stores/commandCenterStore.ts
+++ b/apps/code/src/renderer/features/command-center/stores/commandCenterStore.ts
@@ -26,9 +26,7 @@ interface CommandCenterStoreState {
   activeCellIndex: number | null;
   zoom: number;
   creatingCells: number[];
-  // True once autofill has bootstrapped the grid (or the user has curated it
-  // by assigning a task). Persisted so autofill never repopulates cells the
-  // user deliberately left empty when the Command Center remounts.
+  // Persisted so autofill bootstraps the grid only once, not on every remount.
   hasAutofilled: boolean;
 }
 
@@ -122,16 +120,14 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
             cells,
             activeTaskId: taskId,
             creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
-            // Manually placing a task counts as curating the grid, so autofill
-            // should never top up the remaining empty cells.
+            // Manually placing a task counts as curating the grid.
             hasAutofilled: true,
           };
         }),
 
       autofillCells: (taskIds) =>
         set((state) => {
-          // Grid is already full — nothing to place, but the one-time
-          // bootstrap is done, so record it and stop autofill from re-running.
+          // Grid already full: nothing to place, but the bootstrap is done.
           if (state.cells.every((id) => id != null)) {
             return { hasAutofilled: true };
           }


### PR DESCRIPTION
## Problem

Two pieces of Command Center feedback from the thread:

1. The toolbar had a **"Stop All"** button that cancels every running/waiting agent at once — an easy-to-hit, broad action whose value was questioned.
2. After trimming the grid down to a couple of tasks, opening a task **full-screen and coming back re-filled all the empty cells** with recent tasks, so the curated layout was lost every time.

## Changes

**Remove "Stop All"**
- Removed the button from `CommandCenterToolbar`, plus the now-unused `stopAll` handler, `hasActiveAgents` check, `cells` prop, and the `getSessionService` / `Stop` icon / `CommandCenterCellData` imports.
- `CommandCenterView` no longer passes `cells` to the toolbar.

**Stop autofill from clobbering a curated grid**
- Autofill re-ran on every mount (its guard was a per-mount `useRef`), so navigating away and back re-topped-up empty cells. It's now a one-time bootstrap gated on a **persisted `hasAutofilled` flag**.
- The flag is set once autofill populates the grid, when the grid is already full, or when the user manually assigns a task — so a curated layout (including deliberately empty cells) survives navigation.
- The flag stays unset when there are no eligible tasks yet, so autofill can still bootstrap the grid once recent tasks exist.
- The existing "top up empty slots on first open" behaviour is preserved.

## How did you test this?

- `vitest run` on `commandCenterStore.test.ts` and `useAutofillCommandCenter.test.ts` — 26 tests pass, including new cases: autofill no longer tops up once `hasAutofilled` is set, the flag is set on fill / full grid / manual assign, and it stays unset when there are no candidates.
- `tsc -p tsconfig.web.json` reports no errors in the command-center files; `biome check` is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*