### PR TITLE
fix(cloud-agent): tolerate interrupt errors during claude session refresh

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -278,6 +278,29 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
     );
   });
 
+  it("recovers when interrupting the old query throws Operation aborted", async () => {
+    const agent = makeAgent();
+    const { session, oldQuery, endSpy } = installFakeSession(
+      agent,
+      "s-interrupt-throws",
+    );
+    oldQuery.interrupt.mockRejectedValue(new Error("Operation aborted"));
+
+    const result = await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
+      mcpServers: freshMcpServers,
+    });
+
+    expect(result).toEqual({ refreshed: true });
+    expect(endSpy).toHaveBeenCalledTimes(1);
+    const updated = session as unknown as {
+      query: SdkQueryHandle;
+      abortController: AbortController;
+    };
+    expect(updated.query).toBe(createdQueries[0]);
+    expect(updated.query).not.toBe(oldQuery);
+    expect(updated.abortController.signal.aborted).toBe(false);
+  });
+
   it("re-fetches MCP tool metadata for the new query", async () => {
     const agent = makeAgent();
     installFakeSession(agent, "s-metadata");

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1089,7 +1089,14 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // We allocate a fresh controller for the new Query below so aborting
     // the old one doesn't poison it.
     prev.abortController.abort();
-    await prev.query.interrupt();
+    try {
+      await prev.query.interrupt();
+    } catch (error) {
+      this.logger.debug("Ignoring interrupt error during session refresh", {
+        sessionId: this.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     prev.input.end();
 
     // Reuse every option from the running session; swap mcpServers, re-root


### PR DESCRIPTION
## Problem

recently observer that a follow-up message reached the agent-server but was instantly aborted ("Operation aborted"`), and every subsequent message failed the same way (surfacing in the client as a queue failure).

claude adapter's `refreshSession` aborts the live query's `AbortController`, then `await`s `prev.query.interrupt()` before installing the fresh controller/query

## Changes

- wrap `await prev.query.interrupt()` in try/catch so tearing down the old query can't abort the swap. Keeps the abort-first ordering; brings the claude adapter to parity with codex (which works with the guard already)
