### PR TITLE
Introduce as PostHog Slack app in Slack-originated runs

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1403,6 +1403,59 @@ describe("AgentServer HTTP Mode", () => {
       expect(prompt).not.toContain("Push to the existing PR branch");
       delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
     });
+
+    describe("identity instructions", () => {
+      it.each([
+        {
+          label: "no repository, no PR",
+          config: { repositoryPath: undefined },
+        },
+        { label: "repository, no PR", config: {} },
+      ])(
+        "injects PostHog Slack app identity for Slack-origin runs ($label)",
+        ({ config }) => {
+          process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+          const s = createServer(config);
+          const prompt = (
+            s as unknown as TestableServer
+          ).buildCloudSystemPrompt();
+          expect(prompt).toContain("# Identity");
+          expect(prompt).toContain("PostHog Slack app");
+          expect(prompt).toContain("Do NOT refer to yourself as Claude");
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        },
+      );
+
+      it("injects identity for Slack-origin runs with an existing PR", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+        const s = createServer();
+        const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt(
+          "https://github.com/org/repo/pull/1",
+        );
+        expect(prompt).toContain("# Identity");
+        expect(prompt).toContain("PostHog Slack app");
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      });
+
+      it.each([
+        { label: "no origin set", origin: undefined },
+        { label: "signal_report origin", origin: "signal_report" },
+        { label: "posthog_code origin", origin: "posthog_code" },
+      ])("omits identity block for non-Slack runs ($label)", ({ origin }) => {
+        if (origin) {
+          process.env.POSTHOG_CODE_INTERACTION_ORIGIN = origin;
+        } else {
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        }
+        const s = createServer();
+        const prompt = (
+          s as unknown as TestableServer
+        ).buildCloudSystemPrompt();
+        expect(prompt).not.toContain("# Identity");
+        expect(prompt).not.toContain("PostHog Slack app");
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      });
+    });
   });
 
   describe("buildDetectedPrContext", () => {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1687,7 +1687,7 @@ export class AgentServer {
     const identityInstructions = isSlack
       ? `
 # Identity
-You are the PostHog Slack app, PostHog's agent for helping users with their product data and codebase from Slack. When introducing yourself or referring to yourself in messages to the user, identify as "PostHog Slack app". Do NOT refer to yourself as Claude, an Anthropic assistant, or any underlying model name.
+You are the PostHog Slack app, PostHog's agent for helping users with their product data and coding tasks from Slack. When introducing yourself or referring to yourself in messages to the user, identify as "PostHog Slack app". Do NOT refer to yourself as Claude, an Anthropic assistant, or any underlying model name.
 `
       : "";
     const signedCommitInstructions = `

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1687,11 +1687,7 @@ export class AgentServer {
     const identityInstructions = isSlack
       ? `
 # Identity
-You are the PostHog Slack app, PostHog's agent for helping users with their
-product data and codebase from Slack. When introducing yourself or referring
-to yourself in messages to the user, identify as "PostHog Slack app". Do NOT
-refer to yourself as Claude, an Anthropic assistant, or any underlying model
-name.
+You are the PostHog Slack app, PostHog's agent for helping users with their product data and codebase from Slack. When introducing yourself or referring to yourself in messages to the user, identify as "PostHog Slack app". Do NOT refer to yourself as Claude, an Anthropic assistant, or any underlying model name.
 `
       : "";
     const signedCommitInstructions = `

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1683,6 +1683,17 @@ export class AgentServer {
   private buildCloudSystemPrompt(prUrl?: string | null): string {
     const taskId = this.config.taskId;
     const shouldAutoCreatePr = this.shouldAutoPublishCloudChanges();
+    const isSlack = this.getCloudInteractionOrigin() === "slack";
+    const identityInstructions = isSlack
+      ? `
+# Identity
+You are the PostHog Slack app, PostHog's agent for helping users with their
+product data and codebase from Slack. When introducing yourself or referring
+to yourself in messages to the user, identify as "PostHog Slack app". Do NOT
+refer to yourself as Claude, an Anthropic assistant, or any underlying model
+name.
+`
+      : "";
     const signedCommitInstructions = `
 ## Committing (signed commits required)
 Commits MUST be signed. \`git commit\` and \`git push\` are blocked in this environment.
@@ -1701,7 +1712,7 @@ we want:
 
     if (prUrl) {
       if (!shouldAutoCreatePr) {
-        return `
+        return `${identityInstructions}
 # Cloud Task Execution
 
 This task already has an open pull request: ${prUrl}
@@ -1715,7 +1726,7 @@ ${signedCommitInstructions}
 `;
       }
 
-      return `
+      return `${identityInstructions}
 # Cloud Task Execution
 
 This task already has an open pull request: ${prUrl}
@@ -1749,7 +1760,7 @@ When the user explicitly asks to clone or work in a GitHub repository:
 - If the user explicitly asks you to open or update a pull request, create a branch, stage your changes with \`git add\` and commit them with the \`git_signed_commit\` tool (do NOT use \`git commit\`/\`git push\` — they are blocked), and open a draft pull request from inside the clone. Before opening the PR, check the cloned repo for a PR template at \`.github/pull_request_template.md\` (or variants; fall back to the org's \`.github\` repo via \`gh api\`) and use it as the body structure, and search for matching open issues with \`gh issue list --search\` to include \`Closes #<n>\` / \`Refs #<n>\` links.
 - Do NOT create branches, commits, push changes, or open pull requests unless the user explicitly asks for that`;
 
-      return `
+      return `${identityInstructions}
 # Cloud Task Execution — No Repository Mode
 
 You are a helpful assistant with access to PostHog via MCP tools. You can help with both code tasks and data/analytics questions.
@@ -1771,7 +1782,7 @@ ${signedCommitInstructions}
     }
 
     if (!shouldAutoCreatePr) {
-      return `
+      return `${identityInstructions}
 # Cloud Task Execution
 
 Do the requested work, but stop with local changes ready for review.
@@ -1782,7 +1793,7 @@ ${signedCommitInstructions}
 `;
     }
 
-    return `
+    return `${identityInstructions}
 # Cloud Task Execution
 
 After completing the requested changes:


### PR DESCRIPTION
Adds an identity block to the cloud system prompt so Slack-originated runs introduce themselves as "PostHog Slack app" instead of Claude. Scoped to `origin === "slack"` only.

## Showcase

<img width="593" height="667" alt="Screenshot 2026-06-02 at 22 56 12" src="https://github.com/user-attachments/assets/087bc3d2-9bd6-425b-b7de-4e4bee39c480" />
