### PR TITLE
fix: Correct broken "Manage in PostHog Web" link

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
@@ -19,7 +19,7 @@ export function SlackSettings() {
 
   const slackSettingsUrl = projectId
     ? getPostHogUrl(
-        `/project/${projectId}/settings/environment-posthog-code#integration-posthog-code-slack`,
+        `/project/${projectId}/settings/project-integrations#setting=integration-slack`,
         cloudRegion,
       )
     : null;


### PR DESCRIPTION
## Problem

The Slack settings "Manage in PostHog Web" button routed to a non-existent PostHog web URL, leaving users unable to manage their Slack integration.

Closes #2378.<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Point the link to /settings/project-integrations#setting=integration-slack
2. Drop the invalid environment-posthog-code path and #integration-posthog-code-slack anchor

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?