### PR TITLE
fix: Deep-link Slack settings to the correct anchor

### DIFF
--- a/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
@@ -19,7 +19,7 @@ export function SlackSettings() {
 
   const slackSettingsUrl = projectId
     ? getPostHogUrl(
-        `/project/${projectId}/settings/project-integrations#setting=integration-slack`,
+        `/project/${projectId}/settings/project-integrations#integration-slack`,
         cloudRegion,
       )
     : null;


### PR DESCRIPTION
## Problem

In PostHog Code's Slack settings, the **Manage in PostHog Web** button opened the PostHog Integrations settings page but did not scroll to or highlight the Slack integration — it just landed on the section.

The link used the hash `#setting=integration-slack`. The PostHog settings scene scrolls to a specific setting via the `useAnchor` hook, which matches `location.hash.slice(1)` against an element `id` directly (`<h2 id="integration-slack">`). `#setting=integration-slack` matches no element id, so no scroll/highlight happened. The full settings scene has no URL handler that reads a `setting=` hash param on load.

(For reference, the originally-reported 404 was a separate, earlier issue — the section path was already corrected to `project-integrations` in #2477; this PR fixes the remaining hash.)

## Changes

Changed the deep-link hash from `#setting=integration-slack` to the bare-anchor form `#integration-slack`.

This matches exactly what PostHog's own `urls.settings(section, settingId)` helper generates (via `combineUrl`, a value-less hash key) and what `useAnchor` resolves to the Slack integration heading. The section path stays `project-integrations`, the canonical alias of `environment-integrations` where the `integration-slack` setting lives.

## How did you test this?

- Verified against the PostHog web source (`SettingsMap.tsx`, `settingsSceneLogic.ts`, `settingsLogic.ts`, `Settings.tsx`, `useAnchor.ts`, `urls.ts`) that `integration-slack` is the real setting id, that `project-integrations` is the canonical section, and that `useAnchor` scrolls to the bare `#integration-slack` anchor while `#setting=...` does not resolve on load.
- No automated tests added — this is a one-line URL string change with no existing test coverage for the link.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
