### PR TITLE
feat(signals): add option for default team channel for signals notifications

### DIFF
--- a/apps/code/src/renderer/api/posthogClient.ts
+++ b/apps/code/src/renderer/api/posthogClient.ts
@@ -2270,9 +2270,12 @@ export class PostHogAPIClient {
     return (await response.json()) as SignalTeamConfig;
   }
 
-  async updateSignalTeamConfig(updates: {
-    default_autostart_priority: string;
-  }): Promise<SignalTeamConfig> {
+  async updateSignalTeamConfig(
+    updates: Partial<{
+      default_autostart_priority: string;
+      default_slack_notification_channel: string | null;
+    }>,
+  ): Promise<SignalTeamConfig> {
     const teamId = await this.getTeamId();
     const url = new URL(
       `${this.api.baseUrl}/api/projects/${teamId}/signals/config/`,

--- a/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useSignalSourceManager.ts
@@ -477,6 +477,27 @@ export function useSignalSourceManager() {
     [client, queryClient],
   );
 
+  const handleUpdateTeamSlackChannel = useCallback(
+    async (channel: string | null) => {
+      if (!client) return;
+      try {
+        await client.updateSignalTeamConfig({
+          default_slack_notification_channel: channel,
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ["signals", "team-config"],
+        });
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to update default notification channel";
+        toast.error(message);
+      }
+    },
+    [client, queryClient],
+  );
+
   const handleUpdateUserAutonomyPriority = useCallback(
     async (priority: string | null) => {
       if (!client) return;
@@ -591,6 +612,7 @@ export function useSignalSourceManager() {
     handleToggleEvaluation,
     teamConfig,
     handleUpdateAutostartPriority,
+    handleUpdateTeamSlackChannel,
     userAutonomyConfig,
     userAutonomyConfigLoading,
     handleUpdateUserAutonomyPriority,

--- a/apps/code/src/renderer/features/settings/components/SettingsPanel.tsx
+++ b/apps/code/src/renderer/features/settings/components/SettingsPanel.tsx
@@ -108,7 +108,9 @@ const CATEGORY_COMPONENTS: Record<SettingsCategory, React.ComponentType> = {
   shortcuts: ShortcutsSettings,
   github: GitHubSettings,
   slack: SlackSettings,
-  signals: SignalSourcesSettings,
+  // Slack notification config lives in the dedicated Slack section; the Signals
+  // section links out to it rather than duplicating the controls.
+  signals: () => <SignalSourcesSettings showSlackNotifications={false} />,
   updates: UpdatesSettings,
   advanced: AdvancedSettings,
 };
@@ -162,6 +164,13 @@ export function SettingsPanel({
   });
 
   const ActiveComponent = CATEGORY_COMPONENTS[activeCategory];
+
+  const activeCategoryIcon = SIDEBAR_ITEMS.find(
+    (item) =>
+      item.id === activeCategory ||
+      (item.id === "environments" && activeCategory === "cloud-environments"),
+  )?.icon;
+
   const initials = getUserInitials(user);
 
   return (
@@ -274,9 +283,14 @@ export function SettingsPanel({
             <Box p="6" mx="auto" className="relative z-[1] max-w-[800px]">
               <Flex direction="column" gap="4">
                 {!formMode && (
-                  <Text className="font-medium text-lg leading-6.5">
-                    {CATEGORY_TITLES[activeCategory]}
-                  </Text>
+                  <Flex align="center" gap="2">
+                    {activeCategoryIcon && (
+                      <span className="text-gray-10">{activeCategoryIcon}</span>
+                    )}
+                    <Text className="font-medium text-lg leading-6.5">
+                      {CATEGORY_TITLES[activeCategory]}
+                    </Text>
+                  </Flex>
                 )}
                 <ActiveComponent />
               </Flex>

--- a/apps/code/src/renderer/features/settings/components/SlackChannelCombobox.tsx
+++ b/apps/code/src/renderer/features/settings/components/SlackChannelCombobox.tsx
@@ -1,0 +1,236 @@
+import { useSlackChannels } from "@features/inbox/hooks/useSlackChannels";
+import { ModalInlineComboboxContent } from "@features/settings/components/ModalInlineComboboxContent";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { CaretDown, Hash, Lock } from "@phosphor-icons/react";
+import {
+  Button,
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+} from "@posthog/quill";
+import type { SlackChannelOption } from "@shared/types";
+import { useMemo, useRef, useState } from "react";
+
+const OFF_VALUE = "__off__";
+const SLACK_CHANNEL_SEARCH_DEBOUNCE_MS = 300;
+const CONTROL_CLASS = "min-w-[200px] max-w-[240px]";
+
+export function buildChannelTargetValue(
+  channelId: string,
+  channelName: string,
+): string {
+  const display = channelName.startsWith("#") ? channelName : `#${channelName}`;
+  return `${channelId}|${display}`;
+}
+
+export function parseChannelIdFromTargetValue(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  return value.split("|")[0]?.trim() || null;
+}
+
+export function parseChannelNameFromTargetValue(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  const display = value.split("|")[1]?.trim();
+  if (!display) return null;
+  return display.startsWith("#") ? display.slice(1) : display;
+}
+
+function configuredSlackChannelOption(
+  id: string,
+  name: string,
+): SlackChannelOption {
+  return {
+    id,
+    name,
+    is_private: false,
+    is_member: true,
+    is_ext_shared: false,
+    is_private_without_access: false,
+  };
+}
+
+interface SlackChannelComboboxProps {
+  /** Workspace whose channels we list. Channels can't be picked without one. */
+  integrationId: number | null;
+  /** Current `channel_id|#channel-name` target, or null when nothing is set. */
+  value: string | null;
+  /** Fires with a new target, or null when "off" is chosen. */
+  onChange: (channelTarget: string | null) => void;
+  /** Label for the "off" item, e.g. "Off — don't notify me" or "No default channel". */
+  offLabel: string;
+  ariaLabel: string;
+  modal?: boolean;
+  disabled?: boolean;
+}
+
+export function SlackChannelCombobox({
+  integrationId,
+  value,
+  onChange,
+  offLabel,
+  ariaLabel,
+  modal = false,
+  disabled = false,
+}: SlackChannelComboboxProps) {
+  const selectedChannelId = parseChannelIdFromTargetValue(value);
+  const selectedChannelName = parseChannelNameFromTargetValue(value);
+  const hasChannel = !!value;
+
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const { debounced: debouncedSearch, isPending: searchDebouncing } =
+    useDebouncedValue(searchQuery.trim(), SLACK_CHANNEL_SEARCH_DEBOUNCE_MS);
+
+  const { data: channelsData, isFetching } = useSlackChannels(integrationId, {
+    search: debouncedSearch || undefined,
+    enabled: open,
+  });
+  const searchPending = open && (isFetching || searchDebouncing);
+
+  const visibleChannels = useMemo(() => {
+    const channels = [...(channelsData?.channels ?? [])];
+    if (
+      selectedChannelId &&
+      selectedChannelName &&
+      !channels.some((channel) => channel.id === selectedChannelId)
+    ) {
+      channels.unshift(
+        configuredSlackChannelOption(selectedChannelId, selectedChannelName),
+      );
+    }
+    return channels;
+  }, [channelsData?.channels, selectedChannelId, selectedChannelName]);
+
+  const comboboxItems = useMemo(
+    () => [OFF_VALUE, ...visibleChannels.map((c) => c.id)],
+    [visibleChannels],
+  );
+
+  const triggerLabel = (() => {
+    if (searchPending && !hasChannel) return "Loading channels…";
+    if (selectedChannelName) return selectedChannelName;
+    if (selectedChannelId) return selectedChannelId;
+    return "Pick a channel";
+  })();
+
+  const onComboboxChange = (rawValue: string | null) => {
+    setOpen(false);
+    setSearchQuery("");
+    if (rawValue === null) return;
+    if (rawValue === OFF_VALUE) {
+      onChange(null);
+      return;
+    }
+    if (!integrationId) return;
+    const channel = visibleChannels.find((c) => c.id === rawValue);
+    if (!channel) return;
+    onChange(buildChannelTargetValue(channel.id, channel.name));
+  };
+
+  const panel = (
+    <>
+      <ComboboxInput placeholder="Search channels…" showTrigger={false} />
+      <ComboboxEmpty>
+        {searchPending
+          ? "Loading channels…"
+          : "No channels match — make sure PostHog is in the channel."}
+      </ComboboxEmpty>
+      <ComboboxList className="max-h-[min(18rem,calc(var(--available-height,18rem)-5rem))]">
+        {(itemValue: string) => {
+          if (itemValue === OFF_VALUE) {
+            return (
+              <ComboboxItem key={OFF_VALUE} value={OFF_VALUE} title={offLabel}>
+                {offLabel}
+              </ComboboxItem>
+            );
+          }
+          const channel = visibleChannels.find((c) => c.id === itemValue);
+          if (!channel) return null;
+          const Icon = channel.is_private ? Lock : Hash;
+          return (
+            <ComboboxItem
+              key={channel.id}
+              value={channel.id}
+              title={channel.name}
+            >
+              <Icon size={12} weight="regular" className="shrink-0" />
+              <span className="min-w-0 truncate">{channel.name}</span>
+              {channel.is_ext_shared ? (
+                <span className="ms-1 shrink-0 text-muted-foreground text-xs">
+                  (shared)
+                </span>
+              ) : null}
+            </ComboboxItem>
+          );
+        }}
+      </ComboboxList>
+    </>
+  );
+
+  const popupProps = {
+    anchor: anchorRef,
+    side: "bottom" as const,
+    sideOffset: 4,
+    className: "min-w-[240px]",
+  };
+
+  return (
+    <div ref={anchorRef} className="inline-flex">
+      <Combobox
+        items={comboboxItems}
+        filter={null}
+        value={hasChannel && selectedChannelId ? selectedChannelId : OFF_VALUE}
+        onValueChange={(v) => onComboboxChange(v as string | null)}
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setSearchQuery("");
+        }}
+        inputValue={searchQuery}
+        onInputValueChange={(v) => setSearchQuery(v ?? "")}
+        disabled={disabled || !integrationId}
+        modal={false}
+      >
+        <ComboboxTrigger
+          render={
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={disabled || !integrationId}
+              aria-label={ariaLabel}
+              className={`${CONTROL_CLASS} justify-between`}
+            >
+              <span className="flex min-w-0 items-center gap-1">
+                {hasChannel && selectedChannelId ? (
+                  <Hash size={12} weight="regular" className="shrink-0" />
+                ) : null}
+                <span className="min-w-0 truncate">{triggerLabel}</span>
+              </span>
+              <CaretDown
+                size={10}
+                weight="bold"
+                className="shrink-0 text-muted-foreground"
+              />
+            </Button>
+          }
+        />
+        {modal ? (
+          <ModalInlineComboboxContent {...popupProps}>
+            {panel}
+          </ModalInlineComboboxContent>
+        ) : (
+          <ComboboxContent {...popupProps}>{panel}</ComboboxContent>
+        )}
+      </Combobox>
+    </div>
+  );
+}

--- a/apps/code/src/renderer/features/settings/components/sections/SignalDefaultChannelSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SignalDefaultChannelSettings.tsx
@@ -1,0 +1,84 @@
+import { useIsOrgAdmin } from "@features/auth/hooks/useOrgRole";
+import { useSignalSourceManager } from "@features/inbox/hooks/useSignalSourceManager";
+import { useIntegrationSelectors } from "@features/integrations/stores/integrationStore";
+import { SlackChannelCombobox } from "@features/settings/components/SlackChannelCombobox";
+import { Box, Flex, Text } from "@radix-ui/themes";
+
+interface SignalDefaultChannelSettingsProps {
+  channelComboboxModal?: boolean;
+  isLoading?: boolean;
+}
+
+export function SignalDefaultChannelSettings({
+  channelComboboxModal = false,
+  isLoading = false,
+}: SignalDefaultChannelSettingsProps) {
+  const { slackIntegrations, hasSlackIntegration } = useIntegrationSelectors();
+  const { teamConfig, handleUpdateTeamSlackChannel } = useSignalSourceManager();
+  const { isAdmin } = useIsOrgAdmin();
+
+  // The backend resolves the team's Slack integration dynamically (its first
+  // `slack` install), so we list channels from that same workspace.
+  const teamIntegrationId = slackIntegrations[0]?.id ?? null;
+  const channelTarget = teamConfig?.default_slack_notification_channel ?? null;
+  const canEdit = isAdmin === true;
+
+  if (isLoading) {
+    return (
+      <Flex
+        direction="column"
+        gap="2"
+        pt="3"
+        className="border-(--gray-5) border-t border-dashed"
+      >
+        <Flex direction="column" gap="1">
+          <Box className="h-[14px] w-[200px] animate-pulse rounded bg-gray-4" />
+          <Box className="h-[11px] w-[80%] animate-pulse rounded bg-gray-3" />
+        </Flex>
+        <Box className="mt-1 h-[28px] w-[200px] animate-pulse rounded bg-gray-3" />
+      </Flex>
+    );
+  }
+
+  // Connecting Slack is offered in the per-user section below; nothing to
+  // configure here until a workspace exists.
+  if (!hasSlackIntegration) return null;
+
+  return (
+    <Flex
+      direction="column"
+      gap="2"
+      pt="3"
+      style={{ borderTop: "1px dashed var(--gray-5)" }}
+    >
+      <Flex direction="column" gap="1">
+        <Text className="font-medium text-(--gray-12) text-sm">
+          Default notification channel
+        </Text>
+        <Text className="text-(--gray-11) text-[13px]">
+          Every new inbox report for the team is posted to this channel, with
+          the suggested reviewers @mentioned. Shared across the whole team.
+        </Text>
+      </Flex>
+
+      <Flex direction="column" gap="1" className="min-w-0">
+        <Text className="text-(--gray-11) text-[12px]">Channel</Text>
+        <SlackChannelCombobox
+          integrationId={teamIntegrationId}
+          value={channelTarget}
+          onChange={(channel) => void handleUpdateTeamSlackChannel(channel)}
+          offLabel="No default channel"
+          ariaLabel="Default notification channel"
+          modal={channelComboboxModal}
+          disabled={!canEdit || !teamIntegrationId}
+        />
+      </Flex>
+
+      <Text className="text-(--gray-10) text-[11px]">
+        {isAdmin === false
+          ? "Only organization admins can change the team's default channel."
+          : "PostHog must be in the channel — invite with /invite @PostHog."}
+      </Text>
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/settings/components/sections/SignalDefaultChannelSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SignalDefaultChannelSettings.tsx
@@ -5,32 +5,27 @@ import { SlackChannelCombobox } from "@features/settings/components/SlackChannel
 import { Box, Flex, Text } from "@radix-ui/themes";
 
 interface SignalDefaultChannelSettingsProps {
+  /** Workspace whose channels are listed — shared with the per-user section. */
+  integrationId: number | null;
   channelComboboxModal?: boolean;
   isLoading?: boolean;
 }
 
 export function SignalDefaultChannelSettings({
+  integrationId,
   channelComboboxModal = false,
   isLoading = false,
 }: SignalDefaultChannelSettingsProps) {
-  const { slackIntegrations, hasSlackIntegration } = useIntegrationSelectors();
+  const { hasSlackIntegration } = useIntegrationSelectors();
   const { teamConfig, handleUpdateTeamSlackChannel } = useSignalSourceManager();
   const { isAdmin } = useIsOrgAdmin();
 
-  // The backend resolves the team's Slack integration dynamically (its first
-  // `slack` install), so we list channels from that same workspace.
-  const teamIntegrationId = slackIntegrations[0]?.id ?? null;
   const channelTarget = teamConfig?.default_slack_notification_channel ?? null;
   const canEdit = isAdmin === true;
 
   if (isLoading) {
     return (
-      <Flex
-        direction="column"
-        gap="2"
-        pt="3"
-        className="border-(--gray-5) border-t border-dashed"
-      >
+      <Flex direction="column" gap="2" pt="2">
         <Flex direction="column" gap="1">
           <Box className="h-[14px] w-[200px] animate-pulse rounded bg-gray-4" />
           <Box className="h-[11px] w-[80%] animate-pulse rounded bg-gray-3" />
@@ -45,40 +40,35 @@ export function SignalDefaultChannelSettings({
   if (!hasSlackIntegration) return null;
 
   return (
-    <Flex
-      direction="column"
-      gap="2"
-      pt="3"
-      style={{ borderTop: "1px dashed var(--gray-5)" }}
-    >
+    <Flex direction="column" gap="2" pt="2">
       <Flex direction="column" gap="1">
         <Text className="font-medium text-(--gray-12) text-sm">
           Default notification channel
         </Text>
         <Text className="text-(--gray-11) text-[13px]">
-          Every new inbox report for the team is posted to this channel, with
-          the suggested reviewers @mentioned. Shared across the whole team.
+          Where every report is posted for the whole team. Reviewers who set
+          their own channel below are notified there instead.
         </Text>
       </Flex>
 
       <Flex direction="column" gap="1" className="min-w-0">
-        <Text className="text-(--gray-11) text-[12px]">Channel</Text>
+        <Text className="text-(--gray-11) text-[12px]">Default Channel</Text>
         <SlackChannelCombobox
-          integrationId={teamIntegrationId}
+          integrationId={integrationId}
           value={channelTarget}
           onChange={(channel) => void handleUpdateTeamSlackChannel(channel)}
           offLabel="No default channel"
           ariaLabel="Default notification channel"
           modal={channelComboboxModal}
-          disabled={!canEdit || !teamIntegrationId}
+          disabled={!canEdit || !integrationId}
         />
       </Flex>
 
-      <Text className="text-(--gray-10) text-[11px]">
-        {isAdmin === false
-          ? "Only organization admins can change the team's default channel."
-          : "PostHog must be in the channel — invite with /invite @PostHog."}
-      </Text>
+      {isAdmin === false ? (
+        <Text className="text-(--gray-10) text-[11px]">
+          Only organization admins can change the team's default channel.
+        </Text>
+      ) : null}
     </Flex>
   );
 }

--- a/apps/code/src/renderer/features/settings/components/sections/SignalSlackNotificationsSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SignalSlackNotificationsSettings.tsx
@@ -6,7 +6,6 @@ import { SlackChannelCombobox } from "@features/settings/components/SlackChannel
 import { Button } from "@posthog/quill";
 import { Box, Callout, Flex, Text } from "@radix-ui/themes";
 import type { SignalReportPriority } from "@shared/types";
-import { useMemo } from "react";
 
 const NOTIFY_ALL_VALUE = "__all__";
 
@@ -24,65 +23,33 @@ const MIN_PRIORITY_OPTIONS: {
 
 const SETTINGS_CONTROL_CLASS = "min-w-[200px] max-w-[240px]";
 
-function getSlackIntegrationLabel(integration: {
-  id: number;
-  display_name?: string;
-  config?: { account?: { name?: string } };
-}): string {
-  return (
-    integration.display_name ??
-    integration.config?.account?.name ??
-    `Slack workspace ${integration.id}`
-  );
-}
-
 interface SignalSlackNotificationsSettingsProps {
+  /** Workspace whose channels are listed — shared with the team default. */
+  integrationId: number | null;
   channelComboboxModal?: boolean;
   isLoading?: boolean;
 }
 
 export function SignalSlackNotificationsSettings({
+  integrationId,
   channelComboboxModal = false,
   isLoading = false,
 }: SignalSlackNotificationsSettingsProps) {
-  const { slackIntegrations, hasSlackIntegration } = useIntegrationSelectors();
+  const { hasSlackIntegration } = useIntegrationSelectors();
   const { userAutonomyConfig, handleUpdateSlackNotifications } =
     useSignalSourceManager();
   const slackConnect = useSlackConnect();
 
-  const selectedIntegrationId =
-    userAutonomyConfig?.slack_notification_integration_id ?? null;
   const selectedChannelTarget =
     userAutonomyConfig?.slack_notification_channel ?? null;
   const minPriority =
     userAutonomyConfig?.slack_notification_min_priority ?? null;
 
-  // Default the integration selection to the first one if there's only one
-  // available — we still require an explicit channel pick to enable delivery.
-  const effectiveIntegrationId =
-    selectedIntegrationId ??
-    (slackIntegrations.length === 1 ? slackIntegrations[0].id : null);
-
-  const notificationsEnabled =
-    !!selectedIntegrationId && !!selectedChannelTarget;
-
-  const integrationOptions = useMemo(
-    () =>
-      slackIntegrations.map((integration) => ({
-        value: String(integration.id),
-        label: getSlackIntegrationLabel(integration),
-      })),
-    [slackIntegrations],
-  );
+  const notificationsEnabled = !!integrationId && !!selectedChannelTarget;
 
   if (isLoading) {
     return (
-      <Flex
-        direction="column"
-        gap="2"
-        pt="3"
-        className="border-(--gray-5) border-t border-dashed"
-      >
+      <Flex direction="column" gap="2" pt="2">
         <Flex direction="column" gap="1">
           <Box className="h-[14px] w-[160px] animate-pulse rounded bg-gray-4" />
           <Box className="h-[11px] w-[80%] animate-pulse rounded bg-gray-3" />
@@ -94,12 +61,7 @@ export function SignalSlackNotificationsSettings({
 
   if (!hasSlackIntegration) {
     return (
-      <Flex
-        direction="column"
-        gap="2"
-        pt="3"
-        style={{ borderTop: "1px dashed var(--gray-5)" }}
-      >
+      <Flex direction="column" gap="2" pt="2">
         <Flex direction="column" gap="1">
           <Text className="font-medium text-(--gray-12) text-sm">
             Notify me directly
@@ -132,7 +94,7 @@ export function SignalSlackNotificationsSettings({
           <Callout.Root size="1" color="gray" variant="soft">
             <Callout.Text>
               We didn't hear back from PostHog. If you completed the connection
-              in your browser it should appear shortly — otherwise try again.
+              in your browser it should appear shortly, otherwise try again.
             </Callout.Text>
           </Callout.Root>
         ) : null}
@@ -145,19 +107,8 @@ export function SignalSlackNotificationsSettings({
       void handleUpdateSlackNotifications({ channel: null });
       return;
     }
-    if (!effectiveIntegrationId) return;
-    void handleUpdateSlackNotifications({
-      integrationId: effectiveIntegrationId,
-      channel,
-    });
-  };
-
-  const onIntegrationChange = (value: string) => {
-    const integrationId = Number(value);
-    if (!Number.isFinite(integrationId)) return;
-    // Switching workspaces clears the channel — the previously picked
-    // channel won't exist in the new workspace.
-    void handleUpdateSlackNotifications({ integrationId, channel: null });
+    if (!integrationId) return;
+    void handleUpdateSlackNotifications({ integrationId, channel });
   };
 
   const onMinPriorityChange = (value: string) => {
@@ -167,57 +118,28 @@ export function SignalSlackNotificationsSettings({
   };
 
   return (
-    <Flex
-      direction="column"
-      gap="2"
-      pt="3"
-      style={{ borderTop: "1px dashed var(--gray-5)" }}
-    >
+    <Flex direction="column" gap="2" pt="2">
       <Flex direction="column" gap="1">
         <Text className="font-medium text-(--gray-12) text-sm">
           Notify me directly
         </Text>
         <Text className="text-(--gray-11) text-[13px]">
-          Ping you in your own channel when you're a suggested reviewer — on top
-          of the team's default channel above.
+          When you're a suggested reviewer, get pinged in your own channel
+          instead of the team's default channel above.
         </Text>
-      </Flex>
-
-      <Flex align="center" justify="between" gap="2" wrap="wrap">
-        <Flex align="center" gap="2" className="min-w-0">
-          <Text className="shrink-0 text-(--gray-11) text-[12px]">
-            Workspace
-          </Text>
-          {slackIntegrations.length > 1 ? (
-            <SettingsOptionSelect
-              value={
-                effectiveIntegrationId ? String(effectiveIntegrationId) : ""
-              }
-              options={integrationOptions}
-              ariaLabel="Slack workspace"
-              placeholder="Select workspace"
-              className={`${SETTINGS_CONTROL_CLASS} min-w-[160px]`}
-              onValueChange={onIntegrationChange}
-            />
-          ) : slackIntegrations[0] ? (
-            <Text className="truncate font-medium text-(--gray-12) text-[13px]">
-              {getSlackIntegrationLabel(slackIntegrations[0])}
-            </Text>
-          ) : null}
-        </Flex>
       </Flex>
 
       <Flex gap="2" wrap="wrap" align="end">
         <Flex direction="column" gap="1" className="min-w-0">
           <Text className="text-(--gray-11) text-[12px]">Channel</Text>
           <SlackChannelCombobox
-            integrationId={effectiveIntegrationId}
+            integrationId={integrationId}
             value={selectedChannelTarget}
             onChange={onChannelChange}
-            offLabel="Off — don't notify me"
+            offLabel="Off, don't notify me"
             ariaLabel="Notification channel"
             modal={channelComboboxModal}
-            disabled={!effectiveIntegrationId}
+            disabled={!integrationId}
           />
         </Flex>
         <Flex direction="column" gap="1" className="min-w-0">
@@ -232,10 +154,6 @@ export function SignalSlackNotificationsSettings({
           />
         </Flex>
       </Flex>
-      <Text className="text-(--gray-10) text-[11px]">
-        PostHog must be in the channel — invite with{" "}
-        <code className="text-[11px]">/invite @PostHog</code>
-      </Text>
     </Flex>
   );
 }

--- a/apps/code/src/renderer/features/settings/components/sections/SignalSlackNotificationsSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SignalSlackNotificationsSettings.tsx
@@ -1,28 +1,14 @@
 import { useSignalSourceManager } from "@features/inbox/hooks/useSignalSourceManager";
-import { useSlackChannels } from "@features/inbox/hooks/useSlackChannels";
 import { useSlackConnect } from "@features/integrations/hooks/useSlackConnect";
 import { useIntegrationSelectors } from "@features/integrations/stores/integrationStore";
-import { ModalInlineComboboxContent } from "@features/settings/components/ModalInlineComboboxContent";
 import { SettingsOptionSelect } from "@features/settings/components/SettingsOptionSelect";
-import { useDebouncedValue } from "@hooks/useDebouncedValue";
-import { CaretDown, Hash, Lock } from "@phosphor-icons/react";
-import {
-  Button,
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxTrigger,
-} from "@posthog/quill";
+import { SlackChannelCombobox } from "@features/settings/components/SlackChannelCombobox";
+import { Button } from "@posthog/quill";
 import { Box, Callout, Flex, Text } from "@radix-ui/themes";
-import type { SignalReportPriority, SlackChannelOption } from "@shared/types";
-import { useMemo, useRef, useState } from "react";
+import type { SignalReportPriority } from "@shared/types";
+import { useMemo } from "react";
 
-const NOTIFY_OFF_VALUE = "__off__";
 const NOTIFY_ALL_VALUE = "__all__";
-const SLACK_CHANNEL_SEARCH_DEBOUNCE_MS = 300;
 
 const MIN_PRIORITY_OPTIONS: {
   value: SignalReportPriority | typeof NOTIFY_ALL_VALUE;
@@ -37,30 +23,6 @@ const MIN_PRIORITY_OPTIONS: {
 ];
 
 const SETTINGS_CONTROL_CLASS = "min-w-[200px] max-w-[240px]";
-
-function buildChannelTargetValue(
-  channelId: string,
-  channelName: string,
-): string {
-  const display = channelName.startsWith("#") ? channelName : `#${channelName}`;
-  return `${channelId}|${display}`;
-}
-
-function parseChannelIdFromTargetValue(
-  value: string | null | undefined,
-): string | null {
-  if (!value) return null;
-  return value.split("|")[0]?.trim() || null;
-}
-
-function parseChannelNameFromTargetValue(
-  value: string | null | undefined,
-): string | null {
-  if (!value) return null;
-  const display = value.split("|")[1]?.trim();
-  if (!display) return null;
-  return display.startsWith("#") ? display.slice(1) : display;
-}
 
 function getSlackIntegrationLabel(integration: {
   id: number;
@@ -92,12 +54,6 @@ export function SignalSlackNotificationsSettings({
     userAutonomyConfig?.slack_notification_integration_id ?? null;
   const selectedChannelTarget =
     userAutonomyConfig?.slack_notification_channel ?? null;
-  const selectedChannelId = parseChannelIdFromTargetValue(
-    selectedChannelTarget,
-  );
-  const selectedChannelName = parseChannelNameFromTargetValue(
-    selectedChannelTarget,
-  );
   const minPriority =
     userAutonomyConfig?.slack_notification_min_priority ?? null;
 
@@ -107,48 +63,8 @@ export function SignalSlackNotificationsSettings({
     selectedIntegrationId ??
     (slackIntegrations.length === 1 ? slackIntegrations[0].id : null);
 
-  const channelAnchorRef = useRef<HTMLDivElement>(null);
-  const [channelComboboxOpen, setChannelComboboxOpen] = useState(false);
-  const [channelSearchQuery, setChannelSearchQuery] = useState("");
-  const {
-    debounced: debouncedChannelSearch,
-    isPending: channelSearchDebouncing,
-  } = useDebouncedValue(
-    channelSearchQuery.trim(),
-    SLACK_CHANNEL_SEARCH_DEBOUNCE_MS,
-  );
-
-  const { data: channelsData, isFetching: channelsFetching } = useSlackChannels(
-    effectiveIntegrationId,
-    {
-      search: debouncedChannelSearch || undefined,
-      enabled: channelComboboxOpen,
-    },
-  );
-  const channelsSearchPending =
-    channelComboboxOpen && (channelsFetching || channelSearchDebouncing);
-
   const notificationsEnabled =
     !!selectedIntegrationId && !!selectedChannelTarget;
-
-  const visibleChannels = useMemo(() => {
-    const channels = [...(channelsData?.channels ?? [])];
-    if (
-      selectedChannelId &&
-      selectedChannelName &&
-      !channels.some((channel) => channel.id === selectedChannelId)
-    ) {
-      channels.unshift(
-        configuredSlackChannelOption(selectedChannelId, selectedChannelName),
-      );
-    }
-    return channels;
-  }, [channelsData?.channels, selectedChannelId, selectedChannelName]);
-
-  const channelComboboxItems = useMemo(
-    () => [NOTIFY_OFF_VALUE, ...visibleChannels.map((c) => c.id)],
-    [visibleChannels],
-  );
 
   const integrationOptions = useMemo(
     () =>
@@ -186,11 +102,11 @@ export function SignalSlackNotificationsSettings({
       >
         <Flex direction="column" gap="1">
           <Text className="font-medium text-(--gray-12) text-sm">
-            Slack notifications
+            Notify me directly
           </Text>
           <Text className="text-(--gray-11) text-[13px]">
-            Get pinged in Slack when you're a suggested reviewer on a new inbox
-            item.
+            Get pinged in your own channel when you're a suggested reviewer on a
+            new inbox item.
           </Text>
         </Flex>
         <Button
@@ -224,20 +140,15 @@ export function SignalSlackNotificationsSettings({
     );
   }
 
-  const onChannelComboboxChange = (rawValue: string | null) => {
-    setChannelComboboxOpen(false);
-    setChannelSearchQuery("");
-    if (rawValue === null) return;
-    if (rawValue === NOTIFY_OFF_VALUE) {
+  const onChannelChange = (channel: string | null) => {
+    if (channel === null) {
       void handleUpdateSlackNotifications({ channel: null });
       return;
     }
     if (!effectiveIntegrationId) return;
-    const channel = visibleChannels.find((c) => c.id === rawValue);
-    if (!channel) return;
     void handleUpdateSlackNotifications({
       integrationId: effectiveIntegrationId,
-      channel: buildChannelTargetValue(channel.id, channel.name),
+      channel,
     });
   };
 
@@ -246,10 +157,7 @@ export function SignalSlackNotificationsSettings({
     if (!Number.isFinite(integrationId)) return;
     // Switching workspaces clears the channel — the previously picked
     // channel won't exist in the new workspace.
-    void handleUpdateSlackNotifications({
-      integrationId,
-      channel: null,
-    });
+    void handleUpdateSlackNotifications({ integrationId, channel: null });
   };
 
   const onMinPriorityChange = (value: string) => {
@@ -257,82 +165,6 @@ export function SignalSlackNotificationsSettings({
       minPriority: value === NOTIFY_ALL_VALUE ? null : value,
     });
   };
-
-  const channelTriggerLabel = (() => {
-    if (channelsSearchPending && !notificationsEnabled) {
-      return "Loading channels…";
-    }
-    if (!notificationsEnabled) return "Pick a channel";
-    if (selectedChannelName) return selectedChannelName;
-    if (selectedChannelId) return selectedChannelId;
-    return "Pick a channel";
-  })();
-
-  const channelComboboxPanel = (
-    <>
-      <ComboboxInput placeholder="Search channels…" showTrigger={false} />
-      <ComboboxEmpty>
-        {channelsSearchPending
-          ? "Loading channels…"
-          : "No channels match — make sure PostHog is in the channel."}
-      </ComboboxEmpty>
-      <ComboboxList className="max-h-[min(18rem,calc(var(--available-height,18rem)-5rem))]">
-        {(itemValue: string) => {
-          if (itemValue === NOTIFY_OFF_VALUE) {
-            return (
-              <ComboboxItem
-                key={NOTIFY_OFF_VALUE}
-                value={NOTIFY_OFF_VALUE}
-                title="Off — don't notify me"
-              >
-                Off — don't notify me
-              </ComboboxItem>
-            );
-          }
-          const channel = visibleChannels.find((c) => c.id === itemValue);
-          if (!channel) return null;
-          const Icon = channel.is_private ? Lock : Hash;
-          return (
-            <ComboboxItem
-              key={channel.id}
-              value={channel.id}
-              title={channel.name}
-            >
-              <Icon size={12} weight="regular" className="shrink-0" />
-              <span className="min-w-0 truncate">{channel.name}</span>
-              {channel.is_ext_shared ? (
-                <span className="ms-1 shrink-0 text-muted-foreground text-xs">
-                  (shared)
-                </span>
-              ) : null}
-            </ComboboxItem>
-          );
-        }}
-      </ComboboxList>
-    </>
-  );
-
-  const channelComboboxPopupProps = {
-    anchor: channelAnchorRef,
-    side: "bottom" as const,
-    sideOffset: 4,
-    className: "min-w-[240px]",
-  };
-
-  const connectWorkspaceButton = (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      className="shrink-0"
-      disabled={slackConnect.isConnecting}
-      onClick={() => {
-        void slackConnect.connect();
-      }}
-    >
-      {slackConnect.isConnecting ? "Waiting…" : "Add workspace"}
-    </Button>
-  );
 
   return (
     <Flex
@@ -343,10 +175,11 @@ export function SignalSlackNotificationsSettings({
     >
       <Flex direction="column" gap="1">
         <Text className="font-medium text-(--gray-12) text-sm">
-          Slack notifications
+          Notify me directly
         </Text>
         <Text className="text-(--gray-11) text-[13px]">
-          Ping in Slack when you're a suggested reviewer on a new inbox item.
+          Ping you in your own channel when you're a suggested reviewer — on top
+          of the team's default channel above.
         </Text>
       </Flex>
 
@@ -372,68 +205,20 @@ export function SignalSlackNotificationsSettings({
             </Text>
           ) : null}
         </Flex>
-        {connectWorkspaceButton}
       </Flex>
 
       <Flex gap="2" wrap="wrap" align="end">
         <Flex direction="column" gap="1" className="min-w-0">
           <Text className="text-(--gray-11) text-[12px]">Channel</Text>
-          <div ref={channelAnchorRef} className="inline-flex">
-            <Combobox
-              items={channelComboboxItems}
-              filter={null}
-              value={
-                notificationsEnabled && selectedChannelId
-                  ? selectedChannelId
-                  : NOTIFY_OFF_VALUE
-              }
-              onValueChange={(v) => onChannelComboboxChange(v as string | null)}
-              open={channelComboboxOpen}
-              onOpenChange={(open) => {
-                setChannelComboboxOpen(open);
-                if (!open) setChannelSearchQuery("");
-              }}
-              inputValue={channelSearchQuery}
-              onInputValueChange={(v) => setChannelSearchQuery(v ?? "")}
-              disabled={!effectiveIntegrationId}
-              modal={false}
-            >
-              <ComboboxTrigger
-                render={
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!effectiveIntegrationId}
-                    aria-label="Notification channel"
-                    className={`${SETTINGS_CONTROL_CLASS} justify-between`}
-                  >
-                    <span className="flex min-w-0 items-center gap-1">
-                      {notificationsEnabled && selectedChannelId ? (
-                        <Hash size={12} weight="regular" className="shrink-0" />
-                      ) : null}
-                      <span className="min-w-0 truncate">
-                        {channelTriggerLabel}
-                      </span>
-                    </span>
-                    <CaretDown
-                      size={10}
-                      weight="bold"
-                      className="shrink-0 text-muted-foreground"
-                    />
-                  </Button>
-                }
-              />
-              {channelComboboxModal ? (
-                <ModalInlineComboboxContent {...channelComboboxPopupProps}>
-                  {channelComboboxPanel}
-                </ModalInlineComboboxContent>
-              ) : (
-                <ComboboxContent {...channelComboboxPopupProps}>
-                  {channelComboboxPanel}
-                </ComboboxContent>
-              )}
-            </Combobox>
-          </div>
+          <SlackChannelCombobox
+            integrationId={effectiveIntegrationId}
+            value={selectedChannelTarget}
+            onChange={onChannelChange}
+            offLabel="Off — don't notify me"
+            ariaLabel="Notification channel"
+            modal={channelComboboxModal}
+            disabled={!effectiveIntegrationId}
+          />
         </Flex>
         <Flex direction="column" gap="1" className="min-w-0">
           <Text className="text-(--gray-11) text-[12px]">Min. priority</Text>
@@ -453,18 +238,4 @@ export function SignalSlackNotificationsSettings({
       </Text>
     </Flex>
   );
-}
-
-function configuredSlackChannelOption(
-  id: string,
-  name: string,
-): SlackChannelOption {
-  return {
-    id,
-    name,
-    is_private: false,
-    is_member: true,
-    is_ext_shared: false,
-    is_private_without_access: false,
-  };
 }

--- a/apps/code/src/renderer/features/settings/components/sections/SignalSourcesSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SignalSourcesSettings.tsx
@@ -6,9 +6,10 @@ import {
 import { useSignalSourceManager } from "@features/inbox/hooks/useSignalSourceManager";
 import { SettingsOptionSelect } from "@features/settings/components/SettingsOptionSelect";
 import { GitHubIntegrationSection } from "@features/settings/components/sections/GitHubIntegrationSection";
-import { SignalDefaultChannelSettings } from "@features/settings/components/sections/SignalDefaultChannelSettings";
-import { SignalSlackNotificationsSettings } from "@features/settings/components/sections/SignalSlackNotificationsSettings";
+import { SlackInboxNotificationsSettings } from "@features/settings/components/sections/SlackInboxNotificationsSettings";
+import { openSettings } from "@features/settings/hooks/useOpenSettings";
 import { useRepositoryIntegration } from "@hooks/useIntegrations";
+import { ArrowRightIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import type { SignalReportPriority } from "@shared/types";
 
@@ -30,10 +31,17 @@ const USER_PRIORITY_OPTIONS: { value: string; label: string }[] = [
 interface SignalSourcesSettingsProps {
   /** Slack channel combobox is inside a Radix modal dialog (Inbox configuration). */
   slackNotificationsInModal?: boolean;
+  /**
+   * Render the Slack inbox-notification config inline. True in the inbox setup
+   * flow (where picking a channel is part of onboarding); false in the Settings
+   * dialog's Signals section, which links out to the dedicated Slack section.
+   */
+  showSlackNotifications?: boolean;
 }
 
 export function SignalSourcesSettings({
   slackNotificationsInModal = false,
+  showSlackNotifications = true,
 }: SignalSourcesSettingsProps) {
   const {
     displayValues,
@@ -111,9 +119,14 @@ export function SignalSourcesSettings({
         style={{ borderTop: "1px dashed var(--gray-5)" }}
       >
         <Flex direction="column" gap="1">
-          <Text className="font-medium text-(--gray-12) text-sm">
-            Your PR auto-start threshold
-          </Text>
+          <Flex align="center" gap="2">
+            <Box className="shrink-0 text-(--gray-11)">
+              <GithubLogoIcon size={16} />
+            </Box>
+            <Text className="font-medium text-(--gray-12) text-sm">
+              Your PR auto-start threshold
+            </Text>
+          </Flex>
           <Text className="text-(--gray-11) text-[13px]">
             Automatically start tasks assigned to you for reports at or above
             this priority. These count toward your usage. Choose
@@ -136,14 +149,38 @@ export function SignalSourcesSettings({
           />
         )}
       </Flex>
-      <SignalDefaultChannelSettings
-        channelComboboxModal={slackNotificationsInModal}
-        isLoading={isLoadingIntegrations}
-      />
-      <SignalSlackNotificationsSettings
-        channelComboboxModal={slackNotificationsInModal}
-        isLoading={isLoadingIntegrations}
-      />
+      {showSlackNotifications ? (
+        <SlackInboxNotificationsSettings
+          channelComboboxModal={slackNotificationsInModal}
+          isLoading={isLoadingIntegrations}
+        />
+      ) : (
+        <Flex
+          align="center"
+          justify="between"
+          gap="2"
+          pt="3"
+          wrap="wrap"
+          style={{ borderTop: "1px dashed var(--gray-5)" }}
+        >
+          <Flex direction="column" gap="1" className="min-w-0">
+            <Text className="font-medium text-(--gray-12) text-sm">
+              Slack notifications
+            </Text>
+            <Text className="text-(--gray-11) text-[13px]">
+              Choose where ready inbox reports are posted and who gets pinged.
+            </Text>
+          </Flex>
+          <button
+            type="button"
+            className="flex shrink-0 cursor-pointer items-center gap-1 border-0 bg-transparent text-[13px] text-accent-11 transition-colors hover:text-accent-12"
+            onClick={() => openSettings("slack")}
+          >
+            Manage in Slack settings
+            <ArrowRightIcon size={13} />
+          </button>
+        </Flex>
+      )}
     </Flex>
   );
 }

--- a/apps/code/src/renderer/features/settings/components/sections/SignalSourcesSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SignalSourcesSettings.tsx
@@ -6,6 +6,7 @@ import {
 import { useSignalSourceManager } from "@features/inbox/hooks/useSignalSourceManager";
 import { SettingsOptionSelect } from "@features/settings/components/SettingsOptionSelect";
 import { GitHubIntegrationSection } from "@features/settings/components/sections/GitHubIntegrationSection";
+import { SignalDefaultChannelSettings } from "@features/settings/components/sections/SignalDefaultChannelSettings";
 import { SignalSlackNotificationsSettings } from "@features/settings/components/sections/SignalSlackNotificationsSettings";
 import { useRepositoryIntegration } from "@hooks/useIntegrations";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
@@ -135,6 +136,10 @@ export function SignalSourcesSettings({
           />
         )}
       </Flex>
+      <SignalDefaultChannelSettings
+        channelComboboxModal={slackNotificationsInModal}
+        isLoading={isLoadingIntegrations}
+      />
       <SignalSlackNotificationsSettings
         channelComboboxModal={slackNotificationsInModal}
         isLoading={isLoadingIntegrations}

--- a/apps/code/src/renderer/features/settings/components/sections/SlackInboxNotificationsSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SlackInboxNotificationsSettings.tsx
@@ -1,0 +1,120 @@
+import { useSignalSourceManager } from "@features/inbox/hooks/useSignalSourceManager";
+import { useIntegrationSelectors } from "@features/integrations/stores/integrationStore";
+import { SettingsOptionSelect } from "@features/settings/components/SettingsOptionSelect";
+import { SignalDefaultChannelSettings } from "@features/settings/components/sections/SignalDefaultChannelSettings";
+import { SignalSlackNotificationsSettings } from "@features/settings/components/sections/SignalSlackNotificationsSettings";
+import { SlackLogoIcon } from "@phosphor-icons/react";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { useMemo } from "react";
+
+const WORKSPACE_CONTROL_CLASS = "min-w-[160px] max-w-[240px]";
+
+function getSlackIntegrationLabel(integration: {
+  id: number;
+  display_name?: string;
+  config?: { account?: { name?: string } };
+}): string {
+  return (
+    integration.display_name ??
+    integration.config?.account?.name ??
+    `Slack workspace ${integration.id}`
+  );
+}
+
+interface SlackInboxNotificationsSettingsProps {
+  channelComboboxModal?: boolean;
+  isLoading?: boolean;
+}
+
+export function SlackInboxNotificationsSettings({
+  channelComboboxModal = false,
+  isLoading = false,
+}: SlackInboxNotificationsSettingsProps) {
+  const { slackIntegrations, hasSlackIntegration } = useIntegrationSelectors();
+  const { userAutonomyConfig, handleUpdateSlackNotifications } =
+    useSignalSourceManager();
+
+  // Workspace is shared by both the team default and the per-user channel. We
+  // default to the only workspace when there's a single one; otherwise the user
+  // picks (which also persists their personal notification integration).
+  const selectedIntegrationId =
+    userAutonomyConfig?.slack_notification_integration_id ?? null;
+  const effectiveIntegrationId =
+    selectedIntegrationId ??
+    (slackIntegrations.length === 1 ? slackIntegrations[0].id : null);
+
+  const integrationOptions = useMemo(
+    () =>
+      slackIntegrations.map((integration) => ({
+        value: String(integration.id),
+        label: getSlackIntegrationLabel(integration),
+      })),
+    [slackIntegrations],
+  );
+
+  const onIntegrationChange = (value: string) => {
+    const integrationId = Number(value);
+    if (!Number.isFinite(integrationId)) return;
+    // Switching workspaces clears the personal channel — the previously picked
+    // channel won't exist in the new workspace.
+    void handleUpdateSlackNotifications({ integrationId, channel: null });
+  };
+
+  return (
+    <Flex
+      direction="column"
+      gap="1"
+      pt="3"
+      style={{ borderTop: "1px dashed var(--gray-5)" }}
+    >
+      <Flex align="center" gap="2">
+        <Box className="shrink-0 text-(--gray-11)">
+          <SlackLogoIcon size={16} />
+        </Box>
+        <Text className="font-medium text-(--gray-12) text-sm">
+          Inbox notifications
+        </Text>
+      </Flex>
+      <Text className="text-(--gray-11) text-[13px]">
+        New inbox reports are posted to Slack with the suggested reviewers
+        @mentioned. PostHog must be in the channel, so invite it with{" "}
+        <code className="text-[13px]">/invite @PostHog</code>.
+      </Text>
+
+      {!isLoading && hasSlackIntegration ? (
+        <Flex align="center" gap="2" pt="2" className="min-w-0">
+          <Text className="shrink-0 text-(--gray-11) text-[12px]">
+            Workspace
+          </Text>
+          {slackIntegrations.length > 1 ? (
+            <SettingsOptionSelect
+              value={
+                effectiveIntegrationId ? String(effectiveIntegrationId) : ""
+              }
+              options={integrationOptions}
+              ariaLabel="Slack workspace"
+              placeholder="Select workspace"
+              className={WORKSPACE_CONTROL_CLASS}
+              onValueChange={onIntegrationChange}
+            />
+          ) : slackIntegrations[0] ? (
+            <Text className="truncate font-medium text-(--gray-12) text-[13px]">
+              {getSlackIntegrationLabel(slackIntegrations[0])}
+            </Text>
+          ) : null}
+        </Flex>
+      ) : null}
+
+      <SignalDefaultChannelSettings
+        integrationId={effectiveIntegrationId}
+        channelComboboxModal={channelComboboxModal}
+        isLoading={isLoading}
+      />
+      <SignalSlackNotificationsSettings
+        integrationId={effectiveIntegrationId}
+        channelComboboxModal={channelComboboxModal}
+        isLoading={isLoading}
+      />
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/SlackSettings.tsx
@@ -9,7 +9,7 @@ import { Box, Button, Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
 import { formatRelativeTimeLong } from "@renderer/utils/time";
 import { openUrlInBrowser } from "@utils/browser";
 import { getPostHogUrl } from "@utils/urls";
-import { SignalSlackNotificationsSettings } from "./SignalSlackNotificationsSettings";
+import { SlackInboxNotificationsSettings } from "./SlackInboxNotificationsSettings";
 
 export function SlackSettings() {
   const projectId = useAuthStateValue((s) => s.currentProjectId);
@@ -79,7 +79,7 @@ export function SlackSettings() {
 
       <Flex>{manageButtonWithTooltip}</Flex>
 
-      <SignalSlackNotificationsSettings isLoading={isLoading} />
+      <SlackInboxNotificationsSettings isLoading={isLoading} />
     </Flex>
   );
 }

--- a/apps/code/src/shared/types.ts
+++ b/apps/code/src/shared/types.ts
@@ -539,6 +539,8 @@ export interface SignalReportTask {
 export interface SignalTeamConfig {
   id: string;
   default_autostart_priority: SignalReportPriority;
+  /** Team-wide default `channel_id|#channel-name` target for inbox notifications. `null` = no team default. */
+  default_slack_notification_channel?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
This adds a default channel for inbox notifications for your team to post all signal reports to. Users can override with their own channel for high priority notifications.

<img width="790" height="392" alt="Screenshot 2026-06-04 at 18 00 40" src="https://github.com/user-attachments/assets/7544028e-ab2a-4c13-8260-9f4085e112cd" />
