### PR TITLE
fix(auth): use scoped_teams when scoped_organizations is empty

### DIFF
--- a/apps/code/src/main/services/auth/service.ts
+++ b/apps/code/src/main/services/auth/service.ts
@@ -551,15 +551,23 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     options: TokenResponseOptions,
   ): Promise<InMemorySession> {
     const scopedOrgIds = tokenResponse.scoped_organizations ?? [];
+    const scopedTeamIds = tokenResponse.scoped_teams ?? [];
     const { accountKey, currentOrgId } = await this.fetchUserContext(
       tokenResponse.access_token,
       options.cloudRegion,
     );
-    const orgProjectsMap = await this.buildOrgProjectsMap(
-      tokenResponse.access_token,
-      options.cloudRegion,
-      scopedOrgIds,
-    );
+    const orgProjectsMap =
+      scopedOrgIds.length > 0
+        ? await this.buildOrgProjectsMap(
+            tokenResponse.access_token,
+            options.cloudRegion,
+            scopedOrgIds,
+          )
+        : await this.buildOrgProjectsMapFromTeams(
+            tokenResponse.access_token,
+            options.cloudRegion,
+            scopedTeamIds,
+          );
     const lastPrefs = accountKey
       ? this.authPreferenceRepository.get(accountKey, options.cloudRegion)
       : null;
@@ -601,6 +609,72 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     );
 
     return Object.fromEntries(entries);
+  }
+  private async buildOrgProjectsMapFromTeams(
+    accessToken: string,
+    cloudRegion: CloudRegion,
+    teamIds: number[],
+  ): Promise<OrgProjectsMap> {
+    if (teamIds.length === 0) return {};
+
+    const teamMetas = await Promise.all(
+      teamIds.map((id) => this.fetchProjectMeta(accessToken, cloudRegion, id)),
+    );
+
+    const projectsByOrg = new Map<string, { id: number; name: string }[]>();
+    for (const meta of teamMetas) {
+      if (!meta) continue;
+      const bucket = projectsByOrg.get(meta.organization) ?? [];
+      bucket.push({ id: meta.id, name: meta.name });
+      projectsByOrg.set(meta.organization, bucket);
+    }
+
+    const entries = await Promise.all(
+      Array.from(projectsByOrg.entries()).map(
+        async ([orgId, projects]): Promise<[string, OrgProjects]> => {
+          const org = await this.fetchOrgWithProjects(
+            accessToken,
+            cloudRegion,
+            orgId,
+          );
+          return [orgId, { orgName: org?.orgName ?? "(unknown)", projects }];
+        },
+      ),
+    );
+
+    return Object.fromEntries(entries);
+  }
+  private async fetchProjectMeta(
+    accessToken: string,
+    cloudRegion: CloudRegion,
+    teamId: number,
+  ): Promise<{ id: number; name: string; organization: string } | null> {
+    const apiHost = getCloudUrlFromRegion(cloudRegion);
+    try {
+      const res = await this.executeAuthenticatedFetch(
+        fetch,
+        `${apiHost}/api/projects/${teamId}/`,
+        {},
+        accessToken,
+      );
+      if (!res.ok) return null;
+      const raw = (await res.json().catch(() => null)) as {
+        id?: unknown;
+        name?: unknown;
+        organization?: unknown;
+      } | null;
+      if (
+        typeof raw?.id !== "number" ||
+        typeof raw?.name !== "string" ||
+        typeof raw?.organization !== "string"
+      ) {
+        return null;
+      }
+      return { id: raw.id, name: raw.name, organization: raw.organization };
+    } catch (error) {
+      log.warn("Failed to fetch project meta", { teamId, error });
+      return null;
+    }
   }
   private async fetchOrgProjects(
     accessToken: string,

--- a/apps/code/src/main/services/oauth/schemas.ts
+++ b/apps/code/src/main/services/oauth/schemas.ts
@@ -25,6 +25,7 @@ export const oAuthTokenResponse = z.object({
   scope: z.string().optional().default(""),
   refresh_token: z.string(),
   scoped_organizations: z.array(z.string()).optional(),
+  scoped_teams: z.array(z.number()).optional(),
 });
 export type OAuthTokenResponse = z.infer<typeof oAuthTokenResponse>;
 


### PR DESCRIPTION
## human description

I could not get an agent to run when using local PostHog. After an hour with claude it tells me this is the fix - and now it's working locally. 

## Summary
- `scoped_organizations` is empty when the OAuth grant is project-level — PostHog returns `scoped_teams` instead. The old code only consulted `scoped_organizations`, so project-scoped logins ended up with an empty `orgProjectsMap`, no `currentProjectId`, and "No projects available" in the switcher (downstream: `Missing auth credentials` and the agent failing to start a session).
- Add `scoped_teams` to the OAuth token Zod schema and, when `scoped_organizations` is empty, build the org/project map from `scoped_teams`: fetch each project via `/api/projects/<id>/`, group by `organization`, then fetch each org's name. Only the teams the user actually authorized are included.
- Org-level grants are unchanged — `scoped_organizations` path still wins when populated.

## Test plan
- [ ] Log out, log back in selecting **Dev** region, grant access to a single project on the PostHog consent screen.
- [ ] Verify the project switcher shows the org and the granted project, and a session starts (no `Missing auth credentials` in `~/.posthog-code/logs-dev/main.log`).
- [ ] Re-test with an org-level grant (e.g. against US/EU) to confirm the existing path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)