### PR TITLE
feat(code): top-level app nav rail (Home / Inbox / Code)

### DIFF
--- a/apps/code/src/renderer/components/AppNav.tsx
+++ b/apps/code/src/renderer/components/AppNav.tsx
@@ -3,12 +3,6 @@ import { CodeIcon, HouseIcon, TrayIcon } from "@phosphor-icons/react";
 import { Badge, Button } from "@posthog/quill";
 import { Box, Flex } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { isMac } from "@utils/platform";
-
-// macOS draws the traffic lights over the top-left of the window
-// (titleBarStyle: hiddenInset). Reserve space so the first rail button clears
-// them.
-const MAC_TRAFFIC_LIGHT_INSET = 28;
 
 type AppNavItem = {
   id: "home" | "inbox" | "code";
@@ -59,9 +53,7 @@ export function AppNav() {
       direction="column"
       align="center"
       gap="2"
-      p="2"
-      className="drag h-full shrink-0 border-gray-6 border-r bg-gray-2"
-      style={{ paddingTop: isMac ? MAC_TRAFFIC_LIGHT_INSET : undefined }}
+      className="drag h-full shrink-0 border-gray-6 border-r bg-gray-2 px-2 pt-10 pb-2"
     >
       {NAV_ITEMS.map((item) => {
         const active = item.isActive(pathname);

--- a/apps/code/src/renderer/components/AppNav.tsx
+++ b/apps/code/src/renderer/components/AppNav.tsx
@@ -1,0 +1,96 @@
+import { useInboxSignalCount } from "@features/inbox/hooks/useInboxSignalCount";
+import { CodeIcon, HouseIcon, TrayIcon } from "@phosphor-icons/react";
+import { Badge, Button } from "@posthog/quill";
+import { Box, Flex } from "@radix-ui/themes";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { isMac } from "@utils/platform";
+
+// macOS draws the traffic lights over the top-left of the window
+// (titleBarStyle: hiddenInset). Reserve space so the first rail button clears
+// them.
+const MAC_TRAFFIC_LIGHT_INSET = 28;
+
+type AppNavItem = {
+  id: "home" | "inbox" | "code";
+  label: string;
+  icon: typeof HouseIcon;
+  to: "/" | "/inbox" | "/code";
+  isActive: (pathname: string) => boolean;
+};
+
+// Slack-like app rail switching between top-level "spaces": Home (the / scene),
+// Inbox (the full-screen inbox), and Code (the existing /code app).
+const NAV_ITEMS: AppNavItem[] = [
+  {
+    id: "home",
+    label: "Home",
+    icon: HouseIcon,
+    to: "/",
+    isActive: (pathname) => pathname === "/",
+  },
+  {
+    id: "inbox",
+    label: "Inbox",
+    icon: TrayIcon,
+    to: "/inbox",
+    isActive: (pathname) => pathname === "/inbox",
+  },
+  {
+    id: "code",
+    label: "Code",
+    icon: CodeIcon,
+    to: "/code",
+    isActive: (pathname) =>
+      pathname === "/code" || pathname.startsWith("/code/"),
+  },
+];
+
+function formatBadgeCount(count: number): string {
+  return count > 99 ? "99+" : String(count);
+}
+
+export function AppNav() {
+  const navigate = useNavigate();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const inboxCount = useInboxSignalCount();
+
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      gap="2"
+      p="2"
+      className="drag h-full shrink-0 border-gray-6 border-r bg-gray-2"
+      style={{ paddingTop: isMac ? MAC_TRAFFIC_LIGHT_INSET : undefined }}
+    >
+      {NAV_ITEMS.map((item) => {
+        const active = item.isActive(pathname);
+        const Icon = item.icon;
+        const badgeCount = item.id === "inbox" ? inboxCount : 0;
+        return (
+          <Box key={item.id} position="relative" className="no-drag">
+            <Button
+              size="icon-lg"
+              variant="default"
+              aria-selected={active}
+              aria-label={item.label}
+              title={item.label}
+              onClick={() => navigate({ to: item.to })}
+            >
+              <Icon size={20} weight="regular" />
+            </Button>
+            {badgeCount > 0 && (
+              <Badge
+                variant="destructive"
+                className="-top-1 -right-1 pointer-events-none absolute min-w-4 justify-center rounded-full px-1 tabular-nums"
+                title={`${badgeCount} actionable report${badgeCount === 1 ? "" : "s"}`}
+              >
+                {formatBadgeCount(badgeCount)}
+              </Badge>
+            )}
+          </Box>
+        );
+      })}
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/inbox/hooks/useInboxSignalCount.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useInboxSignalCount.ts
@@ -1,0 +1,24 @@
+import { useInboxReports } from "@features/inbox/hooks/useInboxReports";
+import { isReportUpForReview } from "@features/inbox/utils/filterReports";
+import {
+  INBOX_PIPELINE_STATUS_FILTER,
+  INBOX_REFETCH_INTERVAL_MS,
+} from "@features/inbox/utils/inboxConstants";
+import { useRendererWindowFocusStore } from "@stores/rendererWindowFocusStore";
+
+/**
+ * Count of actionable inbox reports assigned to the user. Uses the same query
+ * args as the sidebar inbox probe, so they share one cache (no extra polling).
+ */
+export function useInboxSignalCount(): number {
+  const polling = useRendererWindowFocusStore((s) => s.focused);
+  const { data } = useInboxReports(
+    { status: INBOX_PIPELINE_STATUS_FILTER },
+    {
+      refetchInterval: polling ? INBOX_REFETCH_INTERVAL_MS : false,
+      refetchIntervalInBackground: false,
+      staleTime: polling ? INBOX_REFETCH_INTERVAL_MS : 15_000,
+    },
+  );
+  return (data?.results ?? []).filter(isReportUpForReview).length;
+}

--- a/apps/code/src/renderer/hooks/useFeatureFlag.ts
+++ b/apps/code/src/renderer/hooks/useFeatureFlag.ts
@@ -21,3 +21,19 @@ export function useFeatureFlag(
 
   return enabled;
 }
+
+/**
+ * True once PostHog has resolved feature flags at least once. Use this to defer
+ * flag-dependent redirects until a flag's value is trustworthy, rather than
+ * acting on the `false` default that every flag reports before load.
+ */
+export function useFeatureFlagsLoaded(): boolean {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    // onFeatureFlagsLoaded fires immediately if flags are already resolved.
+    return onFeatureFlagsLoaded(() => setLoaded(true));
+  }, []);
+
+  return loaded;
+}

--- a/apps/code/src/renderer/routeTree.gen.ts
+++ b/apps/code/src/renderer/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as McpServersRouteImport } from './routes/mcp-servers'
+import { Route as InboxRouteImport } from './routes/inbox'
 import { Route as CommandCenterRouteImport } from './routes/command-center'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
@@ -30,6 +31,11 @@ const SkillsRoute = SkillsRouteImport.update({
 const McpServersRoute = McpServersRouteImport.update({
   id: '/mcp-servers',
   path: '/mcp-servers',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InboxRoute = InboxRouteImport.update({
+  id: '/inbox',
+  path: '/inbox',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CommandCenterRoute = CommandCenterRouteImport.update({
@@ -86,6 +92,7 @@ const CodeTasksPendingKeyRoute = CodeTasksPendingKeyRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/command-center': typeof CommandCenterRoute
+  '/inbox': typeof InboxRoute
   '/mcp-servers': typeof McpServersRoute
   '/skills': typeof SkillsRoute
   '/code/archived': typeof CodeArchivedRoute
@@ -100,6 +107,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/command-center': typeof CommandCenterRoute
+  '/inbox': typeof InboxRoute
   '/mcp-servers': typeof McpServersRoute
   '/skills': typeof SkillsRoute
   '/code/archived': typeof CodeArchivedRoute
@@ -115,6 +123,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/command-center': typeof CommandCenterRoute
+  '/inbox': typeof InboxRoute
   '/mcp-servers': typeof McpServersRoute
   '/skills': typeof SkillsRoute
   '/code/archived': typeof CodeArchivedRoute
@@ -131,6 +140,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/command-center'
+    | '/inbox'
     | '/mcp-servers'
     | '/skills'
     | '/code/archived'
@@ -145,6 +155,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/command-center'
+    | '/inbox'
     | '/mcp-servers'
     | '/skills'
     | '/code/archived'
@@ -159,6 +170,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/command-center'
+    | '/inbox'
     | '/mcp-servers'
     | '/skills'
     | '/code/archived'
@@ -174,6 +186,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CommandCenterRoute: typeof CommandCenterRoute
+  InboxRoute: typeof InboxRoute
   McpServersRoute: typeof McpServersRoute
   SkillsRoute: typeof SkillsRoute
   CodeArchivedRoute: typeof CodeArchivedRoute
@@ -200,6 +213,13 @@ declare module '@tanstack/react-router' {
       path: '/mcp-servers'
       fullPath: '/mcp-servers'
       preLoaderRoute: typeof McpServersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/inbox': {
+      id: '/inbox'
+      path: '/inbox'
+      fullPath: '/inbox'
+      preLoaderRoute: typeof InboxRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/command-center': {
@@ -278,6 +298,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CommandCenterRoute: CommandCenterRoute,
+  InboxRoute: InboxRoute,
   McpServersRoute: McpServersRoute,
   SkillsRoute: SkillsRoute,
   CodeArchivedRoute: CodeArchivedRoute,

--- a/apps/code/src/renderer/routes/__root.tsx
+++ b/apps/code/src/renderer/routes/__root.tsx
@@ -1,3 +1,4 @@
+import { AppNav } from "@components/AppNav";
 import { HeaderRow } from "@components/HeaderRow";
 import { HedgehogMode } from "@components/HedgehogMode";
 import { KeyboardShortcutsSheet } from "@components/KeyboardShortcutsSheet";
@@ -16,12 +17,17 @@ import {
   workspaceApi,
 } from "@features/workspace/hooks/useWorkspace";
 import { useAppView } from "@hooks/useAppView";
-import { useFeatureFlag } from "@hooks/useFeatureFlag";
+import { useFeatureFlag, useFeatureFlagsLoaded } from "@hooks/useFeatureFlag";
 import { useIntegrations } from "@hooks/useIntegrations";
 import { openTask, openTaskInput } from "@hooks/useOpenTask";
 import { Box, Flex } from "@radix-ui/themes";
+import { navigateToCode } from "@renderer/navigationBridge";
 import { useTRPC } from "@renderer/trpc/client";
-import { BILLING_FLAG, SYNC_CLOUD_TASKS_FLAG } from "@shared/constants";
+import {
+  BILLING_FLAG,
+  PROJECT_BLUEBIRD_FLAG,
+  SYNC_CLOUD_TASKS_FLAG,
+} from "@shared/constants";
 import { useCommandMenuStore } from "@stores/commandMenuStore";
 import { useShortcutsSheetStore } from "@stores/shortcutsSheetStore";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
@@ -102,6 +108,11 @@ function RootLayout() {
   const reconcilingTaskIds = useRef<Set<string>>(new Set());
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const syncCloudTasksEnabled = useFeatureFlag(SYNC_CLOUD_TASKS_FLAG);
+  // Default on in dev so the rail shows locally without PostHog serving the flag.
+  const bluebirdEnabled = useFeatureFlag(
+    PROJECT_BLUEBIRD_FLAG,
+    import.meta.env.DEV,
+  );
 
   const sidebarData = useSidebarData({ activeView: view });
   const visualTaskOrder = useVisualTaskOrder(sidebarData);
@@ -159,11 +170,30 @@ function RootLayout() {
     toggleCommandMenu();
   }, [toggleCommandMenu]);
 
-  // Settings is a full-page route — drop the app chrome (header/sidebar/
+  // Settings is a full-page route — drop the app chrome (rail/header/sidebar/
   // space-switcher) so the panel occupies the full window.
   const isSettingsRoute = useRouterState({
     select: (s) => s.matches.some((m) => m.routeId.startsWith("/settings")),
   });
+
+  // The Home and Inbox spaces render full-screen (rail only, no code chrome).
+  const onHomePath = useRouterState({
+    select: (s) => s.location.pathname === "/",
+  });
+  const onInboxPath = useRouterState({
+    select: (s) => s.location.pathname === "/inbox",
+  });
+  const isHomeRoute = bluebirdEnabled && onHomePath;
+  const isInboxRoute = bluebirdEnabled && onInboxPath;
+
+  // With the rail hidden there's no way to leave a rail-only space, so a user
+  // stranded on / or /inbox (cold-boot restore, stale deep link) goes to /code
+  // — but only once flags resolve, so a flagged user isn't bounced mid-load.
+  const flagsLoaded = useFeatureFlagsLoaded();
+  useEffect(() => {
+    if (!flagsLoaded || bluebirdEnabled) return;
+    if (onHomePath || onInboxPath) navigateToCode();
+  }, [flagsLoaded, bluebirdEnabled, onHomePath, onInboxPath]);
 
   if (isSettingsRoute) {
     return (
@@ -188,24 +218,40 @@ function RootLayout() {
     );
   }
 
+  const isRailSpace = isHomeRoute || isInboxRoute;
+
   return (
-    <Flex direction="column" height="100vh">
-      <HeaderRow />
-      <Flex flexGrow="1" overflow="hidden">
-        <MainSidebar />
-        <Box flexGrow="1" overflow="hidden">
-          <Outlet />
-        </Box>
+    <Flex height="100vh" overflow="hidden">
+      {bluebirdEnabled && <AppNav />}
+      <Flex direction="column" flexGrow="1" overflow="hidden">
+        {isRailSpace ? (
+          <Box flexGrow="1" overflow="hidden">
+            <Outlet />
+          </Box>
+        ) : (
+          <>
+            <HeaderRow />
+            <Flex flexGrow="1" overflow="hidden">
+              <MainSidebar />
+              <Box flexGrow="1" overflow="hidden">
+                <Outlet />
+              </Box>
+            </Flex>
+
+            <SpaceSwitcher
+              tasks={visualTaskOrder}
+              activeTaskId={activeTaskId}
+              allTasks={tasks ?? []}
+              isOnNewTask={
+                view.type === "task-input" || view.type === "task-pending"
+              }
+              onNavigateToTask={openTask}
+              onNewTask={openTaskInput}
+            />
+          </>
+        )}
       </Flex>
 
-      <SpaceSwitcher
-        tasks={visualTaskOrder}
-        activeTaskId={activeTaskId}
-        allTasks={tasks ?? []}
-        isOnNewTask={view.type === "task-input" || view.type === "task-pending"}
-        onNavigateToTask={openTask}
-        onNewTask={openTaskInput}
-      />
       <CommandMenu open={commandMenuOpen} onOpenChange={setCommandMenuOpen} />
       <KeyboardShortcutsSheet
         open={shortcutsSheetOpen}

--- a/apps/code/src/renderer/routes/inbox.tsx
+++ b/apps/code/src/renderer/routes/inbox.tsx
@@ -1,0 +1,7 @@
+import { InboxView } from "@features/inbox/components/InboxView";
+import { createFileRoute } from "@tanstack/react-router";
+
+// Top-level Inbox space: the existing inbox, full-screen via the app rail.
+export const Route = createFileRoute("/inbox")({
+  component: InboxView,
+});

--- a/apps/code/src/renderer/routes/index.tsx
+++ b/apps/code/src/renderer/routes/index.tsx
@@ -1,7 +1,22 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { Flex, Heading, Text } from "@radix-ui/themes";
+import { createFileRoute } from "@tanstack/react-router";
 
+// Home space: empty for now. The app rail's Home button lands here.
 export const Route = createFileRoute("/")({
-  beforeLoad: () => {
-    throw redirect({ to: "/code" });
-  },
+  component: HomeRoute,
 });
+
+function HomeRoute() {
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      justify="center"
+      height="100%"
+      gap="2"
+    >
+      <Heading size="6">Home</Heading>
+      <Text className="text-gray-10">Nothing here yet.</Text>
+    </Flex>
+  );
+}

--- a/apps/code/src/shared/constants.ts
+++ b/apps/code/src/shared/constants.ts
@@ -3,6 +3,9 @@ export const INBOX_GATED_DUE_TO_SCALE_FLAG = "inbox-gated-due-to-scale";
 export const EXPERIMENT_SUGGESTIONS_FLAG =
   "posthog-code-experiment-suggestions";
 export const SYNC_CLOUD_TASKS_FLAG = "posthog-code-sync-cloud-tasks";
+// Gates the top-level app nav rail (Home / Inbox / Code spaces). When off, the
+// app is the code-only shell it is today.
+export const PROJECT_BLUEBIRD_FLAG = "project-bluebird";
 export const BRANCH_PREFIX = "posthog-code/";
 export const DATA_DIR = ".posthog-code";
 export const WORKTREES_DIR = ".posthog-code/worktrees";


### PR DESCRIPTION
## Dev-only for now

This is **gated behind the `project-bluebird` feature flag and is not enabled for any real users.** It only shows up for people who have the flag turned on — i.e. us, internally, while the Home space is built out.

- **Flag on** (default in dev builds, plus anyone we explicitly target): the app rail appears with Home / Inbox / Code.
- **Flag off** (every prod user today): the app is **byte-for-byte the current code-only shell** — no rail, `/` and `/inbox` redirect to `/code`, and the Code chrome is untouched.

So merging this is a no-op for users until we deliberately flip the flag. It's safe to land and iterate on behind the flag.

<img width="2124" height="1222" alt="2026-06-04 23 27 02" src="https://github.com/user-attachments/assets/6b2357ea-2636-4a3c-93de-a866e988d3e1" />


## What

Adds a Slack-like vertical **app nav rail** that switches between three top-level spaces:

- **Home** — empty placeholder for now (this is what we're still building).
- **Inbox** — the existing inbox, full-screen.
- **Code** — the existing app, unchanged.

This is the minimal top-nav extraction from the larger canvas branch — none of the canvas / dashboards / channels machinery comes along.

## Changes

- `components/AppNav.tsx` — the rail: active-space highlighting, the inbox actionable-report badge (`useInboxSignalCount`, reuses the inbox feature's existing query — no extra polling), and 2.5rem top padding to clear the titlebar.
- `routes/index.tsx` — `/` renders an empty Home space (was a `redirect → /code`).
- `routes/inbox.tsx` — new top-level route mounting the existing `InboxView`.
- `routes/__root.tsx` — renders the rail (only when the flag is on) and branches Home/Inbox to a chrome-less `Outlet`; Code keeps its existing chrome. Redirect guard sends stranded rail-only paths to `/code` once flags resolve when the flag is off.
- `shared/constants.ts` — `PROJECT_BLUEBIRD_FLAG`.
- `hooks/useFeatureFlag.ts` — `useFeatureFlagsLoaded()` so the redirect waits for a trustworthy flag value rather than the pre-load `false` default.

## Testing

- `pnpm --filter code typecheck` — clean.
- Biome — clean.
- Did not run the Electron app in this environment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*