### PR TITLE
fix: Validate external URL schemes before opening

### DIFF
--- a/apps/code/src/main/trpc/routers/os.ts
+++ b/apps/code/src/main/trpc/routers/os.ts
@@ -9,6 +9,7 @@ import {
   ALLOWED_IMAGE_MIME_TYPES,
   IMAGE_MIME_TYPES,
   isRasterImageFile,
+  isSafeExternalUrl,
 } from "@posthog/shared";
 import { z } from "zod";
 import { container } from "../../di/container";
@@ -223,7 +224,16 @@ export const osRouter = router({
    * Open URL in external browser
    */
   openExternal: publicProcedure
-    .input(z.object({ url: z.string() }))
+    .input(
+      z.object({
+        url: z
+          .string()
+          .refine(
+            isSafeExternalUrl,
+            "Only http(s) and mailto URLs may be opened externally",
+          ),
+      }),
+    )
     .mutation(async ({ input }) => {
       await getUrlLauncher().launch(input.url);
     }),

--- a/apps/code/src/renderer/utils/browser.ts
+++ b/apps/code/src/renderer/utils/browser.ts
@@ -1,6 +1,8 @@
+import { isSafeExternalUrl } from "@posthog/shared";
 import { trpcClient } from "@renderer/trpc/client";
 
 export async function openUrlInBrowser(url: string): Promise<void> {
+  if (!isSafeExternalUrl(url)) return;
   try {
     await trpcClient.os.openExternal.mutate({ url });
   } catch {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,3 +37,4 @@ export {
   type SagaResult,
   type SagaStep,
 } from "./saga";
+export { isSafeExternalUrl } from "./url";

--- a/packages/shared/src/url.test.ts
+++ b/packages/shared/src/url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isSafeExternalUrl } from "./url";
+
+describe("isSafeExternalUrl", () => {
+  it.each([
+    "https://github.com/PostHog/code/pull/42",
+    "http://example.com",
+    "https://example.com/path?q=1#frag",
+    "HTTPS://EXAMPLE.COM",
+    "mailto:hi@posthog.com",
+  ])("allows %s", (url) => {
+    expect(isSafeExternalUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "file:///etc/passwd",
+    "data:text/html,<script>alert(1)</script>",
+    "smb://server/share",
+    "ms-msdt:/id",
+    "vscode://extension",
+    "//evil.com",
+    "/relative/path",
+    "not a url",
+    "",
+    "   ",
+  ])("blocks %s", (url) => {
+    expect(isSafeExternalUrl(url)).toBe(false);
+  });
+});

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -1,0 +1,22 @@
+const SAFE_EXTERNAL_URL_SCHEMES: ReadonlySet<string> = new Set([
+  "http:",
+  "https:",
+  "mailto:",
+]);
+
+/**
+ * Whether a URL is safe to hand to the host's "open externally" capability,
+ * which ultimately reaches `shell.openExternal` and dispatches to whatever app
+ * the OS has registered for the scheme. Restricting to web and mail schemes
+ * stops a tampered or attacker-supplied value from triggering `file:`, `smb:`,
+ * `data:`, `javascript:`, `ms-msdt:`, or custom app deep-link schemes.
+ */
+export function isSafeExternalUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return SAFE_EXTERNAL_URL_SCHEMES.has(parsed.protocol);
+}


### PR DESCRIPTION
## Problem

URLs were passed straight to the main openExternal handler with no scheme check, so a tampered value could launch file://, smb://, or custom app-handler schemes via shell.openExternal.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add isSafeExternalUrl (http/https/mailto allowlist) to @posthog/shared
2. Reject disallowed schemes in the os.openExternal tRPC input
3. Short-circuit openUrlInBrowser on unsafe URLs so the window.open fallback can't bypass the guard
4. Add unit tests covering allowed and blocked schemes

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?