### PR TITLE
fix: Restore "Back to app" exit and rename spend banner

### DIFF
--- a/apps/code/src/renderer/features/billing/components/TokenSpendAnalysisBanner.tsx
+++ b/apps/code/src/renderer/features/billing/components/TokenSpendAnalysisBanner.tsx
@@ -254,7 +254,7 @@ function FooterLinks({ data }: { data: SpendAnalysisResponse }) {
           rel="noreferrer"
           className="text-(--accent-11) underline"
         >
-          PostHog LLM analytics
+          PostHog AI Observability
         </a>{" "}
         in your own project for the full slice-and-dice experience.
       </Text>
@@ -363,7 +363,7 @@ export function TokenSpendAnalysisBanner() {
       <Callout.Text>
         <Flex direction="column" gap="2">
           <Text className="font-medium text-sm">
-            Analyse your token usage with PostHog LLM analytics
+            Analyse your token usage with PostHog AI Observability
           </Text>
           <Text className="text-(--gray-11) text-[13px]">
             See where your spend goes — by product, tool, and model — over the

--- a/apps/code/src/renderer/features/settings/hooks/useOpenSettings.ts
+++ b/apps/code/src/renderer/features/settings/hooks/useOpenSettings.ts
@@ -36,8 +36,14 @@ export function openSettings(
  */
 export function closeSettings(): void {
   useSettingsPageStore.getState().reset();
-  if (nav.isOnSettingsRoute()) {
+  if (!nav.isOnSettingsRoute()) return;
+  // history.back() is a no-op when settings is the first history entry — e.g.
+  // the app was quit on the settings page and reopened restoring that route.
+  // There is nothing to go back to, so navigate to the app explicitly.
+  if (nav.canGoBackInHistory()) {
     nav.goBackInHistory();
+  } else {
+    nav.navigateToCode();
   }
 }
 

--- a/apps/code/src/renderer/features/settings/hooks/useOpenSettings.ts
+++ b/apps/code/src/renderer/features/settings/hooks/useOpenSettings.ts
@@ -37,9 +37,6 @@ export function openSettings(
 export function closeSettings(): void {
   useSettingsPageStore.getState().reset();
   if (!nav.isOnSettingsRoute()) return;
-  // history.back() is a no-op when settings is the first history entry — e.g.
-  // the app was quit on the settings page and reopened restoring that route.
-  // There is nothing to go back to, so navigate to the app explicitly.
   if (nav.canGoBackInHistory()) {
     nav.goBackInHistory();
   } else {

--- a/apps/code/src/renderer/navigationBridge.ts
+++ b/apps/code/src/renderer/navigationBridge.ts
@@ -88,6 +88,13 @@ export function goBackInHistory(): void {
   getRouterOrNull()?.history.back();
 }
 
+// False when the current entry is the first in the session history (index 0),
+// e.g. after a quit+reopen restores a deep route directly. In that case
+// `history.back()` is a no-op and callers should navigate to a fallback route.
+export function canGoBackInHistory(): boolean {
+  return getRouterOrNull()?.history.canGoBack() ?? false;
+}
+
 export function goForwardInHistory(): void {
   getRouterOrNull()?.history.forward();
 }


### PR DESCRIPTION
## Problem

Quitting on the settings page restores that route as the only history entry, so "Back to app" (and Escape) became dead no-ops until you used File > New task. Also corrects the spend banner product name.

## Changes

  1. Add `canGoBackInHistory()` wrapping router `history.canGoBack()`
  2. `closeSettings` navigates to `/code` when there is nothing to pop
  3. Restores "Back to app" and Escape after quit+reopen on settings
  4. Rename "PostHog LLM analytics" to "PostHog AI Observability" in the spend banner

## How did you test this?

Manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
