### PR TITLE
fix(code): stop false "No internet connection" from a single failed probe

### DIFF
--- a/apps/code/src/main/services/connectivity/service.test.ts
+++ b/apps/code/src/main/services/connectivity/service.test.ts
@@ -54,12 +54,24 @@ describe("ConnectivityService", () => {
       );
     });
 
-    it("goes offline when the HEAD check throws", async () => {
+    it("stays online after a single failed check (requires confirmation)", async () => {
       mockFetch.mockImplementation(offline);
 
       service.init();
       await vi.advanceTimersByTimeAsync(0);
 
+      // One dropped probe is a transient blip, not an outage.
+      expect(service.getStatus()).toEqual({ isOnline: true });
+    });
+
+    it("goes offline only after consecutive failed checks", async () => {
+      mockFetch.mockImplementation(offline);
+
+      service.init();
+      await vi.advanceTimersByTimeAsync(0); // 1st failure
+      expect(service.getStatus()).toEqual({ isOnline: true });
+
+      await vi.advanceTimersByTimeAsync(3000); // 2nd failure -> confirmed offline
       expect(service.getStatus()).toEqual({ isOnline: false });
     });
   });
@@ -74,27 +86,28 @@ describe("ConnectivityService", () => {
       expect(result).toEqual({ isOnline: true });
     });
 
-    it("returns offline when HEAD rejects", async () => {
-      mockFetch.mockRejectedValue(new Error("Network error"));
+    it("does not flip offline on a single failed check", async () => {
+      mockFetch.mockResolvedValue(ok(204));
       service.init();
       await vi.advanceTimersByTimeAsync(0);
 
+      mockFetch.mockRejectedValue(new Error("Network error"));
       const result = await service.checkNow();
-      expect(result).toEqual({ isOnline: false });
+      expect(result).toEqual({ isOnline: true });
     });
 
-    it("returns offline when HEAD returns a non-ok non-204 response", async () => {
-      mockFetch.mockResolvedValue(notOk(500));
+    it("returns offline once failures reach the threshold", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
       service.init();
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0); // 1st failure
 
-      const result = await service.checkNow();
+      const result = await service.checkNow(); // 2nd failure -> offline
       expect(result).toEqual({ isOnline: false });
     });
   });
 
   describe("status change events", () => {
-    it("emits when going offline", async () => {
+    it("emits when going offline after confirmation", async () => {
       mockFetch.mockResolvedValue(ok(204));
       service.init();
       await vi.advanceTimersByTimeAsync(0);
@@ -103,21 +116,38 @@ describe("ConnectivityService", () => {
       service.on(ConnectivityEvent.StatusChange, handler);
 
       mockFetch.mockRejectedValue(new Error("offline"));
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(6000); // two failed polls
 
       expect(handler).toHaveBeenCalledWith({ isOnline: false });
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not emit on a single transient failure", async () => {
+      mockFetch.mockResolvedValue(ok(204));
+      service.init();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const handler = vi.fn();
+      service.on(ConnectivityEvent.StatusChange, handler);
+
+      mockFetch.mockRejectedValue(new Error("offline"));
+      await vi.advanceTimersByTimeAsync(3000); // one failed poll only
+
+      expect(handler).not.toHaveBeenCalled();
     });
 
     it("emits when coming back online", async () => {
       mockFetch.mockRejectedValue(new Error("offline"));
       service.init();
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0); // 1st failure
+      await vi.advanceTimersByTimeAsync(3000); // 2nd failure -> offline
+      expect(service.getStatus()).toEqual({ isOnline: false });
 
       const handler = vi.fn();
       service.on(ConnectivityEvent.StatusChange, handler);
 
       mockFetch.mockResolvedValue(ok(204));
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(3000); // recovery is instant
 
       expect(handler).toHaveBeenCalledWith({ isOnline: true });
     });
@@ -153,6 +183,43 @@ describe("ConnectivityService", () => {
 
       const result = await service.checkNow();
       expect(result).toEqual({ isOnline: true });
+    });
+
+    it("treats a non-ok non-204 response as a failed probe", async () => {
+      mockFetch.mockResolvedValue(notOk(500));
+      service.init();
+      await vi.advanceTimersByTimeAsync(0); // 1st failure
+
+      const result = await service.checkNow(); // 2nd failure -> offline
+      expect(result).toEqual({ isOnline: false });
+    });
+  });
+
+  describe("multi-endpoint probing", () => {
+    it("stays online when at least one host is reachable", async () => {
+      // Google is blocked, Cloudflare answers.
+      mockFetch.mockImplementation((url: string) =>
+        url.includes("google")
+          ? Promise.reject(new Error("blocked"))
+          : Promise.resolve(ok(204)),
+      );
+
+      service.init();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3000);
+
+      const result = await service.checkNow();
+      expect(result).toEqual({ isOnline: true });
+    });
+
+    it("goes offline only when every host fails", async () => {
+      mockFetch.mockRejectedValue(new Error("blocked"));
+
+      service.init();
+      await vi.advanceTimersByTimeAsync(0); // 1st failure
+      await vi.advanceTimersByTimeAsync(3000); // 2nd failure -> offline
+
+      expect(service.getStatus()).toEqual({ isOnline: false });
     });
   });
 

--- a/apps/code/src/main/services/connectivity/service.ts
+++ b/apps/code/src/main/services/connectivity/service.ts
@@ -10,8 +10,12 @@ import {
 
 const log = logger.scope("connectivity");
 
-const CHECK_URL = "https://www.google.com/generate_204";
+const CHECK_URLS = [
+  "https://www.google.com/generate_204",
+  "https://www.cloudflare.com/cdn-cgi/trace",
+];
 const CHECK_TIMEOUT_MS = 5_000;
+const OFFLINE_CONFIRM_THRESHOLD = 2;
 const MIN_POLL_INTERVAL_MS = 3_000;
 const MAX_POLL_INTERVAL_MS = 10_000;
 const ONLINE_POLL_INTERVAL_MS = 3_000;
@@ -21,6 +25,7 @@ export class ConnectivityService extends TypedEventEmitter<ConnectivityEvents> {
   private isOnline = false;
   private pollTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private offlinePollAttempt = 0;
+  private consecutiveFailures = 0;
 
   @postConstruct()
   init(): void {
@@ -54,19 +59,38 @@ export class ConnectivityService extends TypedEventEmitter<ConnectivityEvents> {
 
   private async checkConnectivity(): Promise<void> {
     const verified = await this.verifyWithHttp();
-    this.setOnline(verified);
+
+    if (verified) {
+      this.consecutiveFailures = 0;
+      this.setOnline(true);
+      return;
+    }
+
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= OFFLINE_CONFIRM_THRESHOLD) {
+      this.setOnline(false);
+    }
   }
 
   private async verifyWithHttp(): Promise<boolean> {
     try {
-      const response = await fetch(CHECK_URL, {
-        method: "HEAD",
-        signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
-      });
-      return response.ok || response.status === 204;
+      // Resolves as soon as the first host responds reachably; rejects only
+      // when every host fails.
+      await Promise.any(CHECK_URLS.map((url) => this.probe(url)));
+      return true;
     } catch (error) {
       log.debug("HTTP connectivity check failed", { error });
       return false;
+    }
+  }
+
+  private async probe(url: string): Promise<void> {
+    const response = await fetch(url, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+    });
+    if (!(response.ok || response.status === 204)) {
+      throw new Error(`Unexpected status ${response.status} from ${url}`);
     }
   }
 


### PR DESCRIPTION
## Context

"No internet connection" toast appearing while they users were connected pointed to a false-offline detection bug, not a real outage.

`ConnectivityService` decided online/offline from a single `HEAD` probe to `google.com` and flipped offline immediately on any single failure with no retry, no second host, no confirmation. So a momentary inability to reach it declared the whole app offline even when "real" internet was fine. That state then tripped the auth gate (`auth/service.ts:496` throws `Offline`), making every authenticated tRPC call fail with `TRPCClientError: Offline`.

### Log evidence

- Dozens of ~3-second `false→true` flaps w/ each one failed poll followed by the next poll succeeding (poll interval is 3s), i.e. a single dropped probe, not an outage
- A ~7-minute "offline" window whose only errors were self-inflicted `TRPCClientError: Offline`, immediately followed by a good request to `mcp.posthog.com`, proof the network was actually working
- downstream cascades: title generation and session reconnect failing with `Offline`

## Fix

All in `connectivity/service.ts`:

1. Multi-endpoint probe: `verifyWithHttp()` races `HEAD` checks against multiple independent hosts (Google + Cloudflare) via `Promise.any`, returning online as soon as any is reachable
2. Confirmation before going offline, flipping offline after `OFFLINE_CONFIRM_THRESHOLD` (2) failures (`consecutiveFailures` counter). Recovery stays instant (online on first success). This eliminates the single-blip flaps and stops them cascading into the auth gate that we experienced