### PR TITLE
chore(code): add flag to discovery run

### DIFF
--- a/apps/code/src/renderer/features/setup/hooks/useSetupDiscovery.ts
+++ b/apps/code/src/renderer/features/setup/hooks/useSetupDiscovery.ts
@@ -1,12 +1,15 @@
 import type { SetupRunService } from "@features/setup/services/setupRunService";
 import { useSetupStore } from "@features/setup/stores/setupStore";
+import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { get } from "@renderer/di/container";
 import { RENDERER_TOKENS } from "@renderer/di/tokens";
+import { DISCOVERY_RUN_FLAG } from "@shared/constants";
 import { useActiveRepoStore } from "@stores/activeRepoStore";
 import { useEffect } from "react";
 
 export function useSetupDiscovery() {
   const selectedDirectory = useActiveRepoStore((s) => s.path);
+  const discoveryEnabled = useFeatureFlag(DISCOVERY_RUN_FLAG);
 
   // Discovery is a one-time-per-user agent run; once any repo has triggered
   // it we never auto-launch another one from this hook. Errored/interrupted
@@ -16,13 +19,13 @@ export function useSetupDiscovery() {
   useEffect(() => {
     if (!selectedDirectory) return;
     const service = get<SetupRunService>(RENDERER_TOKENS.SetupRunService);
+
+    service.startEnricherForRepo(selectedDirectory);
+
+    if (!discoveryEnabled) return;
     const discoveryEverStarted = Object.values(
       useSetupStore.getState().discoveryByRepo,
     ).some((d) => d.status !== "idle");
-    if (discoveryEverStarted) {
-      service.startEnricherForRepo(selectedDirectory);
-    } else {
-      service.startSetup(selectedDirectory);
-    }
-  }, [selectedDirectory]);
+    if (!discoveryEverStarted) service.startDiscovery(selectedDirectory);
+  }, [selectedDirectory, discoveryEnabled]);
 }

--- a/apps/code/src/renderer/features/setup/services/setupRunService.ts
+++ b/apps/code/src/renderer/features/setup/services/setupRunService.ts
@@ -237,21 +237,6 @@ export class SetupRunService {
   private discoveryStartingByRepo = new Set<string>();
   private enricherSuggestionsRunningByRepo = new Set<string>();
 
-  startSetup(directory: string): void {
-    // Defense in depth: never auto-run from a non-idle persisted state.
-    // The hook (useSetupDiscovery) is the primary gate, but a direct call
-    // path could otherwise re-enter the loop that wedged users on boot —
-    // creating fresh cloud tasks and a tree-sitter parse storm against the
-    // user's repo on every launch.
-    const status = selectRepoDiscovery(
-      useSetupStore.getState(),
-      directory,
-    ).status;
-    if (status !== "idle") return;
-    this.injectEnricherSuggestions(directory);
-    this.startDiscovery(directory);
-  }
-
   startEnricherForRepo(directory: string): void {
     this.injectEnricherSuggestions(directory);
   }

--- a/apps/code/src/shared/constants.ts
+++ b/apps/code/src/shared/constants.ts
@@ -3,6 +3,7 @@ export const INBOX_GATED_DUE_TO_SCALE_FLAG = "inbox-gated-due-to-scale";
 export const EXPERIMENT_SUGGESTIONS_FLAG =
   "posthog-code-experiment-suggestions";
 export const SYNC_CLOUD_TASKS_FLAG = "posthog-code-sync-cloud-tasks";
+export const DISCOVERY_RUN_FLAG = "posthog-code-discovery-run";
 export const BRANCH_PREFIX = "posthog-code/";
 export const DATA_DIR = ".posthog-code";
 export const WORKTREES_DIR = ".posthog-code/worktrees";


### PR DESCRIPTION
## Problem

users often wait around on the new task page for discovery to run, see the results, then stop and churn

hypothesis: discovery results are not very good, they leave a bad taste in users' mouths, and/or they are mentally blocking users from even trying their own task

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

gated discovery run behind a flag at 0% rollout

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?