### PR TITLE
chore(code): bump Pro tier usage banners from 20x to 40x

### DIFF
--- a/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
+++ b/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
@@ -62,7 +62,7 @@ export function UsageLimitModal() {
     ? `Your Pro plan has ${proCapLabel}.${resetLabel ? ` ${resetLabel}.` : ""}`
     : `You've hit your Free ${
         isDaily ? "daily" : isMonthly ? "monthly" : "usage"
-      } limit. Upgrade to Pro for 20x more usage.`;
+      } limit. Upgrade to Pro for 40x more usage.`;
 
   return (
     <Dialog.Root open={isOpen}>

--- a/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
+++ b/apps/code/src/renderer/features/billing/components/UsageLimitModal.tsx
@@ -1,5 +1,5 @@
 import { useUsageLimitStore } from "@features/billing/stores/usageLimitStore";
-import { formatResetTime } from "@features/billing/utils";
+import { formatResetTime, PRO_USAGE_MULTIPLIER } from "@features/billing/utils";
 import { openSettings } from "@features/settings/hooks/useOpenSettings";
 import { useSeat } from "@hooks/useSeat";
 import { WarningCircle } from "@phosphor-icons/react";
@@ -62,7 +62,7 @@ export function UsageLimitModal() {
     ? `Your Pro plan has ${proCapLabel}.${resetLabel ? ` ${resetLabel}.` : ""}`
     : `You've hit your Free ${
         isDaily ? "daily" : isMonthly ? "monthly" : "usage"
-      } limit. Upgrade to Pro for 40x more usage.`;
+      } limit. Upgrade to Pro for ${PRO_USAGE_MULTIPLIER}× more usage.`;
 
   return (
     <Dialog.Root open={isOpen}>

--- a/apps/code/src/renderer/features/billing/utils.ts
+++ b/apps/code/src/renderer/features/billing/utils.ts
@@ -1,5 +1,8 @@
 import type { UsageOutput } from "@main/services/llm-gateway/schemas";
 
+/** How much more usage the Pro plan offers relative to the Free plan. */
+export const PRO_USAGE_MULTIPLIER = 40;
+
 export function isUsageExceeded(usage: UsageOutput): boolean {
   return (
     usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -237,7 +237,7 @@ export function PlanUsageSettings() {
               name="Pro"
               price="$200"
               period="/mo"
-              badge="20× Free usage"
+              badge="40× Free usage"
               isCurrent={isOrgPro && !isAlpha}
               resetLabel={
                 isOrgPro && !isAlpha && isCanceling && formattedActiveUntil
@@ -403,7 +403,7 @@ export function PlanUsageSettings() {
             ) : (
               "Your organization"
             )}{" "}
-            will be charged $200/month for 20× the Free usage limit.
+            will be charged $200/month for 40× the Free usage limit.
           </Dialog.Description>
           <Flex
             align="start"

--- a/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/PlanUsageSettings.tsx
@@ -3,7 +3,7 @@ import { useAuthStateValue } from "@features/auth/hooks/authQueries";
 import { TokenSpendAnalysisBanner } from "@features/billing/components/TokenSpendAnalysisBanner";
 import { useUsage } from "@features/billing/hooks/useUsage";
 import { useSeatStore } from "@features/billing/stores/seatStore";
-import { formatResetTime } from "@features/billing/utils";
+import { formatResetTime, PRO_USAGE_MULTIPLIER } from "@features/billing/utils";
 import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSeat } from "@hooks/useSeat";
 import type { UsageBucket } from "@main/services/llm-gateway/schemas";
@@ -237,7 +237,7 @@ export function PlanUsageSettings() {
               name="Pro"
               price="$200"
               period="/mo"
-              badge="40× Free usage"
+              badge={`${PRO_USAGE_MULTIPLIER}× Free usage`}
               isCurrent={isOrgPro && !isAlpha}
               resetLabel={
                 isOrgPro && !isAlpha && isCanceling && formattedActiveUntil
@@ -403,7 +403,8 @@ export function PlanUsageSettings() {
             ) : (
               "Your organization"
             )}{" "}
-            will be charged $200/month for 40× the Free usage limit.
+            will be charged $200/month for {PRO_USAGE_MULTIPLIER}× the Free
+            usage limit.
           </Dialog.Description>
           <Flex
             align="start"


### PR DESCRIPTION
## Problem

We bumped the Code plan limits to test proper usage on a smaller number of users:

- Free plan: $50 → $75
- Pro plan: $1000 → $3000

This makes the Pro plan 40× the Free usage limit, but the user-facing banners still said 20×.

## Changes

Updated the Pro-tier usage multiplier from 20× to 40× in three user-facing spots:

- `UsageLimitModal` — "Upgrade to Pro for 40x more usage."
- `PlanUsageSettings` Pro plan card badge — "40× Free usage"
- `PlanUsageSettings` upgrade dialog copy — "...for 40× the Free usage limit."

## How did you test this?

No automated tests run — copy-only change. Verified all three updated strings via grep.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
