### PR TITLE
feat(code): add claude code import page to onboarding

### DIFF
--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -25,6 +25,7 @@ import { mcpAppsRouter } from "./routers/mcp-apps";
 import { mcpCallbackRouter } from "./routers/mcp-callback";
 import { notificationRouter } from "./routers/notification";
 import { oauthRouter } from "./routers/oauth";
+import { onboardingImportRouter } from "./routers/onboarding-import";
 import { osRouter } from "./routers/os";
 import { processTrackingRouter } from "./routers/process-tracking";
 import { provisioningRouter } from "./routers/provisioning";
@@ -67,6 +68,7 @@ export const trpcRouter = router({
   mcpCallback: mcpCallbackRouter,
   notification: notificationRouter,
   oauth: oauthRouter,
+  onboardingImport: onboardingImportRouter,
   logs: logsRouter,
   os: osRouter,
   processTracking: processTrackingRouter,

--- a/apps/code/src/main/trpc/routers/onboarding-import.ts
+++ b/apps/code/src/main/trpc/routers/onboarding-import.ts
@@ -1,0 +1,130 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { z } from "zod";
+import { container } from "../../di/container";
+import { MAIN_TOKENS } from "../../di/tokens";
+import {
+  getMarketplaceInstallPaths,
+  readSkillMetadataFromDir,
+} from "../../services/agent/discover-plugins";
+import type { FoldersService } from "../../services/folders/service";
+import { publicProcedure, router } from "../trpc";
+
+const getFoldersService = () =>
+  container.get<FoldersService>(MAIN_TOKENS.FoldersService);
+
+const category = z.object({
+  count: z.number(),
+  paths: z.array(z.string()),
+});
+
+const summaryOutput = z.object({
+  total: z.number(),
+  skills: category,
+  plugins: category,
+  mcpServers: category,
+  permissions: category,
+});
+
+function toDisplayPath(absolutePath: string): string {
+  const home = os.homedir();
+  return absolutePath.startsWith(home)
+    ? absolutePath.replace(home, "~")
+    : absolutePath;
+}
+
+function readClaudeMcpServers(): { count: number; paths: string[] } {
+  const file = path.join(os.homedir(), ".claude.json");
+  try {
+    const cfg = JSON.parse(fs.readFileSync(file, "utf-8")) as {
+      mcpServers?: Record<string, unknown>;
+    };
+    const count =
+      cfg.mcpServers && typeof cfg.mcpServers === "object"
+        ? Object.keys(cfg.mcpServers).length
+        : 0;
+    return { count, paths: count > 0 ? [toDisplayPath(file)] : [] };
+  } catch {
+    return { count: 0, paths: [] };
+  }
+}
+
+function readClaudePermissions(): { count: number; paths: string[] } {
+  const file = path.join(os.homedir(), ".claude", "settings.json");
+  try {
+    const settings = JSON.parse(fs.readFileSync(file, "utf-8")) as {
+      permissions?: { allow?: unknown; deny?: unknown };
+    };
+    const allow = Array.isArray(settings?.permissions?.allow)
+      ? settings.permissions.allow.length
+      : 0;
+    const deny = Array.isArray(settings?.permissions?.deny)
+      ? settings.permissions.deny.length
+      : 0;
+    const count = allow + deny;
+    return { count, paths: count > 0 ? [toDisplayPath(file)] : [] };
+  } catch {
+    return { count: 0, paths: [] };
+  }
+}
+
+export const onboardingImportRouter = router({
+  getSummary: publicProcedure.output(summaryOutput).query(async () => {
+    const folders = await getFoldersService().getFolders();
+    const marketplacePaths = await getMarketplaceInstallPaths();
+
+    const userSkillsDir = path.join(os.homedir(), ".claude", "skills");
+    const repoSkillDirs = folders.map((f) => ({
+      dir: path.join(f.path, ".claude", "skills"),
+      name: f.name,
+    }));
+    const marketplaceSkillDirs = marketplacePaths.map((p) =>
+      path.join(p, "skills"),
+    );
+
+    const [userSkills, repoResults, marketplaceResults] = await Promise.all([
+      readSkillMetadataFromDir(userSkillsDir, "user"),
+      Promise.all(
+        repoSkillDirs.map(async (d) => ({
+          dir: d.dir,
+          skills: await readSkillMetadataFromDir(d.dir, "repo", d.name),
+        })),
+      ),
+      Promise.all(
+        marketplaceSkillDirs.map(async (dir) => ({
+          dir,
+          skills: await readSkillMetadataFromDir(dir, "marketplace"),
+        })),
+      ),
+    ]);
+
+    const skillsPaths = [
+      ...(userSkills.length > 0 ? [userSkillsDir] : []),
+      ...repoResults.filter((r) => r.skills.length > 0).map((r) => r.dir),
+      ...marketplaceResults
+        .filter((r) => r.skills.length > 0)
+        .map((r) => r.dir),
+    ].map(toDisplayPath);
+
+    const skillsCount =
+      userSkills.length +
+      repoResults.reduce((sum, r) => sum + r.skills.length, 0) +
+      marketplaceResults.reduce((sum, r) => sum + r.skills.length, 0);
+
+    const plugins = {
+      count: marketplacePaths.length,
+      paths: marketplacePaths.map(toDisplayPath),
+    };
+    const mcpServers = readClaudeMcpServers();
+    const permissions = readClaudePermissions();
+
+    return {
+      total: skillsCount + plugins.count + mcpServers.count + permissions.count,
+      skills: { count: skillsCount, paths: skillsPaths },
+      plugins,
+      mcpServers,
+      permissions,
+    };
+  }),
+});

--- a/apps/code/src/renderer/features/onboarding/components/ImportConfigStep.css
+++ b/apps/code/src/renderer/features/onboarding/components/ImportConfigStep.css
@@ -1,0 +1,155 @@
+.import-stat-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border-radius: var(--radius-4);
+  border: 1px solid var(--gray-a4);
+  background: var(--color-panel-solid);
+  overflow: hidden;
+  cursor: default;
+  user-select: none;
+  transition:
+    border-color 0.25s ease,
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.import-stat-card:hover {
+  border-color: var(--accent-a7);
+  transform: translateY(-2px);
+  box-shadow:
+    0 1px 0 0 var(--gray-a3) inset,
+    0 8px 24px -12px var(--accent-a4);
+}
+
+.import-stat-card__grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, var(--gray-a3) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--gray-a3) 1px, transparent 1px);
+  background-size: 16px 16px;
+  background-position: -1px -1px;
+  mask-image: radial-gradient(110% 90% at 100% 0%, black 0%, transparent 65%);
+  opacity: 0.35;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.import-stat-card:hover .import-stat-card__grid {
+  opacity: 0.7;
+}
+
+.import-stat-card__glow {
+  position: absolute;
+  top: -30%;
+  right: -30%;
+  width: 65%;
+  height: 65%;
+  background: radial-gradient(closest-side, var(--accent-a3), transparent 70%);
+  opacity: 0.55;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.import-stat-card:hover .import-stat-card__glow {
+  opacity: 1;
+}
+
+.import-stat-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-3);
+  background: var(--color-panel-solid);
+  border: 1px solid var(--accent-a5);
+  color: var(--accent-11);
+  box-shadow: 0 1px 0 0 var(--gray-a3) inset;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.import-stat-card:hover .import-stat-card__icon {
+  transform: scale(1.06);
+  border-color: var(--accent-a8);
+}
+
+.import-stat-card__count {
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--gray-12);
+  font-variant-numeric: tabular-nums;
+}
+
+.import-stat-card--empty {
+  background: var(--gray-2);
+}
+
+.import-stat-card--empty:hover {
+  border-color: var(--gray-a5);
+  transform: none;
+  box-shadow: none;
+}
+
+.import-stat-card--empty .import-stat-card__glow {
+  display: none;
+}
+
+.import-stat-card--empty:hover .import-stat-card__grid {
+  opacity: 0.35;
+}
+
+.import-stat-card--empty .import-stat-card__icon {
+  border-color: var(--gray-a4);
+  color: var(--gray-9);
+}
+
+.import-stat-card--empty:hover .import-stat-card__icon {
+  transform: none;
+  border-color: var(--gray-a4);
+}
+
+.import-stat-card--empty .import-stat-card__count {
+  color: var(--gray-8);
+}
+
+.import-stat-card__path {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 2px 7px;
+  border-radius: var(--radius-2);
+  border: 1px solid var(--gray-a4);
+  background: var(--gray-a2);
+  color: var(--gray-11);
+  font-family: var(--code-font-family);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.import-stat-card__path svg {
+  flex-shrink: 0;
+  color: var(--gray-9);
+}
+
+.import-stat-card__path-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-stat-card__path-more {
+  flex-shrink: 0;
+  font-weight: 600;
+  color: var(--gray-9);
+}

--- a/apps/code/src/renderer/features/onboarding/components/ImportConfigStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/ImportConfigStep.tsx
@@ -1,0 +1,247 @@
+import { Tooltip } from "@components/ui/Tooltip";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Folder,
+  type Icon,
+  PlugsConnected,
+  PuzzlePiece,
+  ShieldCheck,
+  Sparkle,
+} from "@phosphor-icons/react";
+import { Button, Flex, Spinner, Text } from "@radix-ui/themes";
+import happyHog from "@renderer/assets/images/hedgehogs/happy-hog.png";
+import { useTRPC } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import "./ImportConfigStep.css";
+import { OnboardingHogTip } from "./OnboardingHogTip";
+import { StepActions } from "./StepActions";
+
+interface ImportConfigStepProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+interface StatCard {
+  key: string;
+  label: string;
+  count: number;
+  paths: string[];
+  icon: Icon;
+}
+
+function PathChip({ paths }: { paths: string[] }) {
+  const [primary, ...rest] = paths ?? [];
+  if (!primary) return null;
+
+  const chip = (
+    <span className="import-stat-card__path">
+      <Folder size={11} weight="duotone" />
+      <span className="import-stat-card__path-text">{primary}</span>
+      {rest.length > 0 && (
+        <span className="import-stat-card__path-more">+{rest.length}</span>
+      )}
+    </span>
+  );
+
+  if (rest.length === 0) return chip;
+
+  return (
+    <Tooltip
+      side="bottom"
+      content={
+        <Flex direction="column" gap="1">
+          {paths.map((p) => (
+            <span key={p} className="font-[var(--code-font-family)] text-xs">
+              {p}
+            </span>
+          ))}
+        </Flex>
+      }
+    >
+      {chip}
+    </Tooltip>
+  );
+}
+
+const prefersReducedMotion = () =>
+  window?.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+function useCountUp(target: number, durationMs = 850, delayMs = 0): number {
+  const [value, setValue] = useState(() =>
+    prefersReducedMotion() ? target : 0,
+  );
+
+  useEffect(() => {
+    if (prefersReducedMotion() || target === 0) {
+      setValue(target);
+      return;
+    }
+    let raf = 0;
+    let startTs = 0;
+    const step = (now: number) => {
+      if (!startTs) startTs = now;
+      const t = Math.min(1, (now - startTs) / durationMs);
+      const eased = 1 - (1 - t) ** 3;
+      setValue(Math.round(eased * target));
+      if (t < 1) raf = requestAnimationFrame(step);
+    };
+    const timer = setTimeout(() => {
+      raf = requestAnimationFrame(step);
+    }, delayMs);
+    return () => {
+      clearTimeout(timer);
+      cancelAnimationFrame(raf);
+    };
+  }, [target, durationMs, delayMs]);
+
+  return value;
+}
+
+function StatCardView({ card, index }: { card: StatCard; index: number }) {
+  const IconComponent = card.icon;
+  const isEmpty = card.count === 0;
+  const entryDelay = 0.06 + index * 0.07;
+  const count = useCountUp(card.count, 850, (entryDelay + 0.18) * 1000);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        duration: 0.35,
+        delay: entryDelay,
+        ease: [0.16, 1, 0.3, 1],
+      }}
+      className={
+        isEmpty
+          ? "import-stat-card import-stat-card--empty"
+          : "import-stat-card"
+      }
+    >
+      <div className="import-stat-card__grid" aria-hidden="true" />
+      <div className="import-stat-card__glow" aria-hidden="true" />
+      <Flex direction="column" gap="3" className="relative z-10">
+        <span className="import-stat-card__icon">
+          <IconComponent size={17} weight="duotone" />
+        </span>
+        <Flex direction="column" gap="2">
+          <Flex align="baseline" gap="2" wrap="wrap">
+            <span className="import-stat-card__count">{count}</span>
+            <Text className="font-semibold text-(--gray-12) text-base leading-tight">
+              {card.label}
+            </Text>
+          </Flex>
+          <PathChip paths={card.paths} />
+        </Flex>
+      </Flex>
+    </motion.div>
+  );
+}
+
+export function ImportConfigStep({ onNext, onBack }: ImportConfigStepProps) {
+  const trpc = useTRPC();
+  const { data: summary, isLoading } = useQuery(
+    trpc.onboardingImport.getSummary.queryOptions(undefined, {
+      staleTime: 60_000,
+    }),
+  );
+
+  const cards: StatCard[] = summary
+    ? [
+        {
+          key: "skills",
+          label: summary.skills.count === 1 ? "Skill" : "Skills",
+          count: summary.skills.count,
+          paths: summary.skills.paths,
+          icon: Sparkle,
+        },
+        {
+          key: "plugins",
+          label: summary.plugins.count === 1 ? "Plugin" : "Plugins",
+          count: summary.plugins.count,
+          paths: summary.plugins.paths,
+          icon: PuzzlePiece,
+        },
+        {
+          key: "mcp",
+          label: summary.mcpServers.count === 1 ? "MCP server" : "MCP servers",
+          count: summary.mcpServers.count,
+          paths: summary.mcpServers.paths,
+          icon: PlugsConnected,
+        },
+        {
+          key: "permissions",
+          label: "Permission rules",
+          count: summary.permissions.count,
+          paths: summary.permissions.paths,
+          icon: ShieldCheck,
+        },
+      ]
+    : [];
+
+  return (
+    <Flex align="center" height="100%" px="8">
+      <Flex
+        direction="column"
+        align="center"
+        className="h-full w-full pt-[24px] pb-[40px]"
+      >
+        <Flex direction="column" className="min-h-0 flex-1 overflow-y-auto">
+          <Flex
+            direction="column"
+            gap="5"
+            className="m-auto w-full max-w-[560px]"
+          >
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Flex direction="column" gap="2">
+                <Text className="font-bold text-(--gray-12) text-2xl tracking-[-0.02em]">
+                  Your Claude Code environment is ready
+                </Text>
+                <Text className="text-(--gray-11) text-sm leading-relaxed">
+                  Same workflow, now in PostHog Code.
+                </Text>
+              </Flex>
+            </motion.div>
+
+            {isLoading ? (
+              <Flex align="center" justify="center" className="py-12">
+                <Spinner size="3" />
+              </Flex>
+            ) : (
+              <>
+                <div className="grid w-full grid-cols-2 gap-3">
+                  {cards.map((card, index) => (
+                    <StatCardView key={card.key} card={card} index={index} />
+                  ))}
+                </div>
+                <OnboardingHogTip
+                  hogSrc={happyHog}
+                  message="All your favorite skills, plugins, and MCP servers are ready to use."
+                  delay={0.2 + cards.length * 0.07}
+                />
+              </>
+            )}
+          </Flex>
+        </Flex>
+
+        <StepActions>
+          <Button size="3" variant="outline" color="gray" onClick={onBack}>
+            <ArrowLeft size={16} weight="bold" />
+            Back
+          </Button>
+          <Button size="3" onClick={onNext}>
+            Continue
+            <ArrowRight size={16} weight="bold" />
+          </Button>
+        </StepActions>
+      </Flex>
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/onboarding/components/OnboardingFlow.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/OnboardingFlow.tsx
@@ -19,6 +19,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { useOnboardingFlow } from "../hooks/useOnboardingFlow";
 import { ConnectGitHubStep } from "./ConnectGitHubStep";
+import { ImportConfigStep } from "./ImportConfigStep";
 import { InstallCliStep } from "./InstallCliStep";
 import { InviteCodeStep } from "./InviteCodeStep";
 import { ProjectSelectStep } from "./ProjectSelectStep";
@@ -273,6 +274,21 @@ export function OnboardingFlow() {
               className="min-h-0 w-full flex-1"
             >
               <InstallCliStep onNext={handleNext} onBack={handleBack} />
+            </motion.div>
+          )}
+
+          {currentStep === "import-config" && (
+            <motion.div
+              key="import-config"
+              custom={direction}
+              initial="enter"
+              animate="center"
+              exit="exit"
+              variants={stepVariants}
+              transition={{ duration: 0.3 }}
+              className="min-h-0 w-full flex-1"
+            >
+              <ImportConfigStep onNext={handleNext} onBack={handleBack} />
             </motion.div>
           )}
 

--- a/apps/code/src/renderer/features/onboarding/hooks/useHasImportableConfig.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useHasImportableConfig.ts
@@ -1,0 +1,13 @@
+import { useTRPC } from "@renderer/trpc/client";
+import { useQuery } from "@tanstack/react-query";
+
+export function useHasImportableConfig(): boolean {
+  const trpc = useTRPC();
+  const { data, isError } = useQuery(
+    trpc.onboardingImport.getSummary.queryOptions(undefined, {
+      staleTime: 60_000,
+    }),
+  );
+  if (isError) return false;
+  return data?.total !== 0;
+}

--- a/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/apps/code/src/renderer/features/onboarding/hooks/useOnboardingFlow.ts
@@ -9,6 +9,7 @@ import { useActiveRepoStore } from "@stores/activeRepoStore";
 import { track } from "@utils/analytics";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ONBOARDING_STEPS, type OnboardingStep } from "../types";
+import { useHasImportableConfig } from "./useHasImportableConfig";
 
 function inferRepositoryProvider(
   remote: string | undefined,
@@ -106,13 +107,15 @@ export function useOnboardingFlow() {
   );
 
   const hasCodeAccess = useAuthStateValue((state) => state.hasCodeAccess);
+  const hasImportableConfig = useHasImportableConfig();
 
   const activeSteps = useMemo(() => {
-    if (hasCodeAccess === true) {
-      return ONBOARDING_STEPS.filter((s) => s !== "invite-code");
-    }
-    return ONBOARDING_STEPS;
-  }, [hasCodeAccess]);
+    return ONBOARDING_STEPS.filter((step) => {
+      if (step === "invite-code" && hasCodeAccess === true) return false;
+      if (step === "import-config" && !hasImportableConfig) return false;
+      return true;
+    });
+  }, [hasCodeAccess, hasImportableConfig]);
 
   useEffect(() => {
     if (!activeSteps.includes(currentStep)) {

--- a/apps/code/src/renderer/features/onboarding/types.ts
+++ b/apps/code/src/renderer/features/onboarding/types.ts
@@ -4,6 +4,7 @@ export type OnboardingStep =
   | "invite-code"
   | "connect-github"
   | "install-cli"
+  | "import-config"
   | "select-repo";
 
 export const ONBOARDING_STEPS: OnboardingStep[] = [
@@ -12,5 +13,6 @@ export const ONBOARDING_STEPS: OnboardingStep[] = [
   "invite-code",
   "connect-github",
   "install-cli",
+  "import-config",
   "select-repo",
 ];

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -343,6 +343,7 @@ export type OnboardingStepId =
   | "invite-code"
   | "connect-github"
   | "install-cli"
+  | "import-config"
   | "select-repo";
 
 type OnboardingSkipReason = "no_repo_selected" | "dev_skip";


### PR DESCRIPTION
## Problem

- users are often dropping befoe submitting their first prompt
- i often hear things like "why would i want to set up X when i already have everything i like configured in Y?"

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds an informational-only screen to onboarding that shows what was important from claude code. i wonder if this will ease some user concerns, and do a better job communicating "hey you can just use this like claude code"

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## ![Screenshot 2026-06-05 at 2.47.03 PM.png](https://app.graphite.com/user-attachments/assets/8e53b9da-25ad-4347-9e25-e1e11e8b71ad.png)



## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?