### PR TITLE
fix(agent): tell Slack app not to wrap links in bold

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1422,6 +1422,10 @@ describe("AgentServer HTTP Mode", () => {
           expect(prompt).toContain("# Identity");
           expect(prompt).toContain("PostHog Slack app");
           expect(prompt).toContain("Do NOT refer to yourself as Claude");
+          expect(prompt).toContain("# Slack formatting");
+          expect(prompt).toContain(
+            "NEVER wrap a URL or link in bold or any other formatting",
+          );
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         },
       );

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1692,6 +1692,12 @@ export class AgentServer {
       ? `
 # Identity
 You are the PostHog Slack app, PostHog's agent for helping users with their product data and coding tasks from Slack. When introducing yourself or referring to yourself in messages to the user, identify as "PostHog Slack app". Do NOT refer to yourself as Claude, an Anthropic assistant, or any underlying model name.
+
+# Slack formatting
+Your messages are rendered as Slack mrkdwn, not GitHub Markdown.
+- NEVER wrap a URL or link in bold or any other formatting. Bold uses single asterisks in Slack (\`*bold*\`), so a URL inside \`*...*\` puts an asterisk directly against the link and breaks it (e.g. \`*https://example.com*\` opens as \`https://example.com*\`). Always write bare URLs with no surrounding \`*\`, \`_\`, or backticks — e.g. write \`https://github.com/org/repo/pull/1\`, never \`*https://github.com/org/repo/pull/1*\`.
+- For a labeled link use Slack's \`<url|text>\` syntax, again with no formatting wrapped around it.
+- Bold is a single asterisk pair (\`*text*\`), not double (\`**text**\`). Use it for short labels only, never around links.
 `
       : "";
     const signedCommitInstructions = `


### PR DESCRIPTION
## Problem

The PostHog Slack app frequently emits messages where a URL is wrapped in bold, e.g. `*<https://github.com/PostHog/posthog/pull/61933*>`. In Slack mrkdwn, bold is a single asterisk pair, so the trailing `*` ends up attached to the URL — when opened in a browser the link includes the stray `*` and 404s.

## Changes

Added a **Slack formatting** section to the Slack-origin identity system prompt in `agent-server.ts` (`buildCloudSystemPrompt`). It tells the agent:

- Never wrap a URL or link in bold (or any) formatting, with a concrete example of how `*https://...*` breaks.
- Use Slack's `<url|text>` syntax for labeled links, again with no surrounding formatting.
- Bold is a single asterisk pair (`*text*`), not double (`**text**`), and should only be used for short labels — never around links.

This guidance is only injected for Slack-origin runs, alongside the existing identity block.

## How did you test this?

- `pnpm --filter agent typecheck` — passes.
- Added assertions to the existing identity-instructions tests in `agent-server.test.ts` verifying the new `# Slack formatting` section is present for Slack-origin prompts. Note: the `agent-server.test.ts` suite could not be executed in the sandbox because its `beforeEach` calls `createTestRepo` (git/env dependency) which fails here independently of this change; the added assertions are plain substring checks against the generated prompt string.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*