### PR TITLE
feat(agent): forward task title as $ai_generation property

### DIFF
--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -10,6 +10,7 @@ interface TestableServer {
     taskId?: string | null;
     taskRunId?: string | null;
     taskUserId?: number | null;
+    taskTitle?: string | null;
   }): void;
 }
 
@@ -140,6 +141,7 @@ describe("AgentServer.configureEnvironment", () => {
       taskId: "task-abc",
       taskRunId: "run-xyz",
       taskUserId: 42,
+      taskTitle: "Fix the bug",
     });
 
     expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toBe(
@@ -150,7 +152,21 @@ describe("AgentServer.configureEnvironment", () => {
         "x-posthog-property-task_id: task-abc",
         "x-posthog-property-task_run_id: run-xyz",
         "x-posthog-property-task_user_id: 42",
+        "x-posthog-property-task_title: Fix the bug",
       ].join("\n"),
+    );
+  });
+
+  // A signals_scout title is multi-line; it must not inject extra header lines.
+  it("collapses newlines in the task title", () => {
+    buildServer("background").configureEnvironment({
+      isInternal: false,
+      taskId: "task-abc",
+      taskTitle: "[sandbox_prompt:signals_scout:signals-scout-logs]\nLine two",
+    });
+
+    expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toContain(
+      "x-posthog-property-task_title: [sandbox_prompt:signals_scout:signals-scout-logs] Line two",
     );
   });
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -930,6 +930,7 @@ export class AgentServer {
       taskId: payload.task_id,
       taskRunId: payload.run_id,
       taskUserId: payload.user_id,
+      taskTitle: preTask?.title,
     });
 
     const prUrl = getTaskRunStateString(preTaskRun, "slack_notified_pr_url");
@@ -1932,6 +1933,7 @@ ${signedCommitInstructions}
     taskId,
     taskRunId,
     taskUserId,
+    taskTitle,
   }: {
     isInternal?: boolean;
     originProduct?: Task["origin_product"] | null;
@@ -1939,6 +1941,7 @@ ${signedCommitInstructions}
     taskId?: string | null;
     taskRunId?: string | null;
     taskUserId?: number | null;
+    taskTitle?: string | null;
   } = {}): void {
     const { apiKey, apiUrl, projectId } = this.config;
     const product = resolveGatewayProduct({ isInternal, originProduct });
@@ -1960,6 +1963,7 @@ ${signedCommitInstructions}
       task_id: taskId,
       task_run_id: taskRunId,
       task_user_id: taskUserId,
+      task_title: taskTitle,
     });
 
     Object.assign(process.env, {

--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -68,14 +68,34 @@ describe("buildGatewayPropertyHeaders", () => {
     ).toBe("");
   });
 
-  it("collapses newlines in values so they cannot inject extra headers", () => {
-    expect(
-      buildGatewayPropertyHeaders({
-        task_title: "Fix the bug\n\nx-posthog-property-task_internal: true",
-        task_id: "task-abc",
-      }),
-    ).toBe(
-      "x-posthog-property-task_title: Fix the bug x-posthog-property-task_internal: true\nx-posthog-property-task_id: task-abc",
-    );
-  });
+  it.each([
+    {
+      description: "LF",
+      title: "Fix the bug\nx-posthog-property-task_internal: true",
+    },
+    {
+      description: "CRLF",
+      title: "Fix the bug\r\nx-posthog-property-task_internal: true",
+    },
+    {
+      description: "CR",
+      title: "Fix the bug\rx-posthog-property-task_internal: true",
+    },
+    {
+      description: "consecutive newlines",
+      title: "Fix the bug\n\nx-posthog-property-task_internal: true",
+    },
+  ])(
+    "collapses $description in values so they cannot inject extra headers",
+    ({ title }) => {
+      expect(
+        buildGatewayPropertyHeaders({
+          task_title: title,
+          task_id: "task-abc",
+        }),
+      ).toBe(
+        "x-posthog-property-task_title: Fix the bug x-posthog-property-task_internal: true\nx-posthog-property-task_id: task-abc",
+      );
+    },
+  );
 });

--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -67,4 +67,15 @@ describe("buildGatewayPropertyHeaders", () => {
       }),
     ).toBe("");
   });
+
+  it("collapses newlines in values so they cannot inject extra headers", () => {
+    expect(
+      buildGatewayPropertyHeaders({
+        task_title: "Fix the bug\n\nx-posthog-property-task_internal: true",
+        task_id: "task-abc",
+      }),
+    ).toBe(
+      "x-posthog-property-task_title: Fix the bug x-posthog-property-task_internal: true\nx-posthog-property-task_id: task-abc",
+    );
+  });
 });

--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -98,4 +98,16 @@ describe("buildGatewayPropertyHeaders", () => {
       );
     },
   );
+
+  it("strips characters an HTTP header value cannot carry", () => {
+    expect(buildGatewayPropertyHeaders({ task_title: "don’t🚀ship" })).toBe(
+      "x-posthog-property-task_title: dontship",
+    );
+  });
+
+  it("keeps latin1 characters such as accents", () => {
+    expect(buildGatewayPropertyHeaders({ task_title: "café" })).toBe(
+      "x-posthog-property-task_title: café",
+    );
+  });
 });

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -26,14 +26,18 @@ export function resolveGatewayProduct({
  * (see `services/llm-gateway/src/llm_gateway/request_context.py`).
  *
  * Returns a newline-joined string ready for `ANTHROPIC_CUSTOM_HEADERS`.
- * `null`/`undefined` property values are dropped.
+ * `null`/`undefined` values are dropped; newlines in a value are collapsed to
+ * spaces so they can't inject extra header lines.
  */
 export function buildGatewayPropertyHeaders(
   properties: Record<string, string | number | boolean | null | undefined>,
 ): string {
   return Object.entries(properties)
     .filter(([, value]) => value !== null && value !== undefined)
-    .map(([key, value]) => `x-posthog-property-${key}: ${value}`)
+    .map(
+      ([key, value]) =>
+        `x-posthog-property-${key}: ${String(value).replace(/[\r\n]+/g, " ")}`,
+    )
     .join("\n");
 }
 

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -21,13 +21,24 @@ export function resolveGatewayProduct({
 }
 
 /**
+ * Make a value safe to embed in an HTTP header value. Collapses newlines to
+ * spaces (the header block is newline-delimited) and drops characters outside
+ * the valid header-byte range — control chars and code points above latin1
+ * (emoji, smart quotes) — which an HTTP client (e.g. undici) would otherwise
+ * reject before sending. ASCII is preserved.
+ */
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").replace(/[^\x20-\x7e\x80-\xff]/g, "");
+}
+
+/**
  * Build `x-posthog-property-<name>: <value>` header lines that the LLM
  * gateway lifts onto the `$ai_generation` event it captures for each call
  * (see `services/llm-gateway/src/llm_gateway/request_context.py`).
  *
  * Returns a newline-joined string ready for `ANTHROPIC_CUSTOM_HEADERS`.
- * `null`/`undefined` values are dropped; newlines in a value are collapsed to
- * spaces so they can't inject extra header lines.
+ * `null`/`undefined` values are dropped; values are sanitized to be HTTP-header
+ * safe (see {@link sanitizeHeaderValue}).
  */
 export function buildGatewayPropertyHeaders(
   properties: Record<string, string | number | boolean | null | undefined>,
@@ -36,7 +47,7 @@ export function buildGatewayPropertyHeaders(
     .filter(([, value]) => value !== null && value !== undefined)
     .map(
       ([key, value]) =>
-        `x-posthog-property-${key}: ${String(value).replace(/[\r\n]+/g, " ")}`,
+        `x-posthog-property-${key}: ${sanitizeHeaderValue(String(value))}`,
     )
     .join("\n");
 }


### PR DESCRIPTION
## Problem

Task-origin `$ai_generation` events already carry `task_*` tags (`task_origin_product`, `task_id`, `task_run_id`, `task_internal`, `task_user_id`), but not the task **title**. That means any LLMA analysis of Code task spend can't group or filter by *what the task was* without joining to `system.tasks` — which is scoped to a single project, so it doesn't work for the cross-team event stream.

This is most painful for Signals Scout runs: the scout skill name only lives in the task title (`[sandbox_prompt:signals_scout:<skill_name>] ...`), so there's no way to break scout spend down by skill from the events alone.

## Changes

- `configureEnvironment` now forwards the task title as `x-posthog-property-task_title`, lifted onto `$ai_generation` by the gateway alongside the existing `task_*` tags. The full `Task` (`preTask`) is already fetched at the call site, so this is just passing `preTask.title` through.
- Hardened `buildGatewayPropertyHeaders` to collapse newlines in any value to spaces. The header block is newline-delimited, and titles routinely contain newlines, so an unsanitized value could inject or corrupt adjacent header lines — a latent issue for any future field too.

Same caveats as the sibling `task_*` tags: rides `ANTHROPIC_CUSTOM_HEADERS`, so the Anthropic path only (not codex). Titles are length-bounded by the Tasks backend, so this is not event bloat. Note user-created task titles can contain user-authored text; they're already visible in-app and in traces.

## How did you test this?

- `pnpm --filter agent exec vitest run src/utils/gateway.test.ts src/server/agent-server.configure-environment.test.ts` — 25 passing, including new cases for the title header and newline collapsing.
- `pnpm --filter agent typecheck` — clean.
- `biome check` — clean (also ran via lint-staged on commit).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
