### PR TITLE
fix(agent): detect feature flags product across tool-name variants

### DIFF
--- a/packages/agent/src/posthog-products.test.ts
+++ b/packages/agent/src/posthog-products.test.ts
@@ -197,6 +197,13 @@ describe("classifyPostHogExecCall", () => {
         'call activity-log-list {"scope":"FeatureFlag"}',
       ),
     ).toEqual(["feature_flags"]);
+    // Web analytics is only reachable from the activity log via this scope.
+    expect(
+      classifyPostHogExecCall(
+        "activity-log-list",
+        'call activity-log-list {"scope":"WebAnalyticsFilterPreset"}',
+      ),
+    ).toEqual(["web_analytics"]);
   });
 
   it("attributes advanced-activity-logs to every recognized scope, deduped", () => {

--- a/packages/agent/src/posthog-products.test.ts
+++ b/packages/agent/src/posthog-products.test.ts
@@ -46,6 +46,21 @@ describe("classifyPostHogSubTool", () => {
     },
   );
 
+  // Plural and verb-first tool names resolve to the same domain product as the
+  // canonical singular form — no per-variant entry required.
+  it.each([
+    ["feature-flags-activity-retrieve", "feature_flags"],
+    ["feature-flags-status-retrieve", "feature_flags"],
+    ["create-feature-flag", "feature_flags"],
+    ["update-feature-flag", "feature_flags"],
+    ["delete-feature-flag", "feature_flags"],
+    // The fix is general, not flag-specific.
+    ["create-survey", "surveys"],
+    ["create-experiment", "experiments"],
+  ])("matches plural/verb-first variant %s to %s", (subTool, product) => {
+    expect(classifyPostHogSubTool(subTool)).toBe(product);
+  });
+
   it.each(["project-get", "activity-log-list", "docs-search", "tasks-list"])(
     "returns null for admin/meta/introspection domain %s",
     (subTool) => {
@@ -164,5 +179,52 @@ describe("classifyPostHogExecCall", () => {
 
   it("returns an empty array for admin/meta sub-tools", () => {
     expect(classifyPostHogExecCall("project-get")).toEqual([]);
+  });
+
+  it("attributes a plural feature-flag tool to feature_flags", () => {
+    expect(
+      classifyPostHogExecCall(
+        "feature-flags-activity-retrieve",
+        'call feature-flags-activity-retrieve {"id":1}',
+      ),
+    ).toEqual(["feature_flags"]);
+  });
+
+  it("attributes an activity-log read to the product of its scope", () => {
+    expect(
+      classifyPostHogExecCall(
+        "activity-log-list",
+        'call activity-log-list {"scope":"FeatureFlag"}',
+      ),
+    ).toEqual(["feature_flags"]);
+  });
+
+  it("attributes advanced-activity-logs to every recognized scope, deduped", () => {
+    expect(
+      classifyPostHogExecCall(
+        "advanced-activity-logs-list",
+        'call advanced-activity-logs-list {"scopes":["FeatureFlag","Insight"]}',
+      ),
+    ).toEqual(["feature_flags", "product_analytics"]);
+  });
+
+  it.each([
+    // No scope / empty scopes → nothing, as before.
+    ["activity-log-list", 'call activity-log-list {"page":1}'],
+    [
+      "advanced-activity-logs-list",
+      'call advanced-activity-logs-list {"scopes":[]}',
+    ],
+    // Admin/meta scope is not surfaced.
+    ["activity-log-list", 'call activity-log-list {"scope":"Team"}'],
+  ])(
+    "returns nothing for unscoped/admin activity-log read: %s",
+    (subTool, cmd) => {
+      expect(classifyPostHogExecCall(subTool, cmd)).toEqual([]);
+    },
+  );
+
+  it("returns nothing for an activity-log read with no command text", () => {
+    expect(classifyPostHogExecCall("activity-log-list")).toEqual([]);
   });
 });

--- a/packages/agent/src/posthog-products.test.ts
+++ b/packages/agent/src/posthog-products.test.ts
@@ -4,6 +4,7 @@ import {
   classifyPostHogSqlQuery,
   classifyPostHogSubTool,
   POSTHOG_PRODUCTS,
+  type PostHogProductId,
 } from "./posthog-products";
 
 describe("classifyPostHogSubTool", () => {
@@ -177,46 +178,39 @@ describe("classifyPostHogExecCall", () => {
     expect(classifyPostHogExecCall("experiment-get")).toEqual(["experiments"]);
   });
 
-  it("returns an empty array for admin/meta sub-tools", () => {
-    expect(classifyPostHogExecCall("project-get")).toEqual([]);
+  it.each<[string, string | undefined, PostHogProductId[]]>([
+    // Plural tool name resolves via the pattern matcher.
+    [
+      "feature-flags-activity-retrieve",
+      'call feature-flags-activity-retrieve {"id":1}',
+      ["feature_flags"],
+    ],
+    // Activity-log reads are attributed by their scope...
+    [
+      "activity-log-list",
+      'call activity-log-list {"scope":"FeatureFlag"}',
+      ["feature_flags"],
+    ],
+    // ...including web analytics, only reachable from the log via this scope.
+    [
+      "activity-log-list",
+      'call activity-log-list {"scope":"WebAnalyticsFilterPreset"}',
+      ["web_analytics"],
+    ],
+    // Multiple scopes are collected and deduped.
+    [
+      "advanced-activity-logs-list",
+      'call advanced-activity-logs-list {"scopes":["FeatureFlag","Insight"]}',
+      ["feature_flags", "product_analytics"],
+    ],
+  ])("attributes %s to its scope/domain product", (subTool, cmd, expected) => {
+    expect(classifyPostHogExecCall(subTool, cmd)).toEqual(expected);
   });
 
-  it("attributes a plural feature-flag tool to feature_flags", () => {
-    expect(
-      classifyPostHogExecCall(
-        "feature-flags-activity-retrieve",
-        'call feature-flags-activity-retrieve {"id":1}',
-      ),
-    ).toEqual(["feature_flags"]);
-  });
-
-  it("attributes an activity-log read to the product of its scope", () => {
-    expect(
-      classifyPostHogExecCall(
-        "activity-log-list",
-        'call activity-log-list {"scope":"FeatureFlag"}',
-      ),
-    ).toEqual(["feature_flags"]);
-    // Web analytics is only reachable from the activity log via this scope.
-    expect(
-      classifyPostHogExecCall(
-        "activity-log-list",
-        'call activity-log-list {"scope":"WebAnalyticsFilterPreset"}',
-      ),
-    ).toEqual(["web_analytics"]);
-  });
-
-  it("attributes advanced-activity-logs to every recognized scope, deduped", () => {
-    expect(
-      classifyPostHogExecCall(
-        "advanced-activity-logs-list",
-        'call advanced-activity-logs-list {"scopes":["FeatureFlag","Insight"]}',
-      ),
-    ).toEqual(["feature_flags", "product_analytics"]);
-  });
-
-  it.each([
-    // No scope / empty scopes → nothing, as before.
+  it.each<[string, string | undefined]>([
+    // Admin/meta sub-tool.
+    ["project-get", undefined],
+    // Unscoped or empty-scope activity-log reads.
     ["activity-log-list", 'call activity-log-list {"page":1}'],
     [
       "advanced-activity-logs-list",
@@ -224,14 +218,9 @@ describe("classifyPostHogExecCall", () => {
     ],
     // Admin/meta scope is not surfaced.
     ["activity-log-list", 'call activity-log-list {"scope":"Team"}'],
-  ])(
-    "returns nothing for unscoped/admin activity-log read: %s",
-    (subTool, cmd) => {
-      expect(classifyPostHogExecCall(subTool, cmd)).toEqual([]);
-    },
-  );
-
-  it("returns nothing for an activity-log read with no command text", () => {
-    expect(classifyPostHogExecCall("activity-log-list")).toEqual([]);
+    // No command text to read a scope from.
+    ["activity-log-list", undefined],
+  ])("returns nothing for %s", (subTool, cmd) => {
+    expect(classifyPostHogExecCall(subTool, cmd)).toEqual([]);
   });
 });

--- a/packages/agent/src/posthog-products.ts
+++ b/packages/agent/src/posthog-products.ts
@@ -245,6 +245,7 @@ const ACTIVITY_SCOPE_PRODUCT: Record<string, PostHogProductId> = {
   Log: "logs",
   LogsAlertConfiguration: "logs",
   LogsExclusionRule: "logs",
+  WebAnalyticsFilterPreset: "web_analytics",
   Insight: "product_analytics",
   Dashboard: "product_analytics",
   DashboardWidget: "product_analytics",
@@ -257,8 +258,11 @@ const ACTIVITY_SCOPE_PRODUCT: Record<string, PostHogProductId> = {
   PropertyDefinition: "product_analytics",
   Annotation: "product_analytics",
   Endpoint: "product_analytics",
+  EndpointVersion: "product_analytics",
   Subscription: "product_analytics",
   AlertConfiguration: "product_analytics",
+  Threshold: "product_analytics",
+  AlertSubscription: "product_analytics",
 };
 
 /**

--- a/packages/agent/src/posthog-products.ts
+++ b/packages/agent/src/posthog-products.ts
@@ -118,6 +118,23 @@ const DOMAIN_PRODUCT: Record<string, PostHogProductId | null> = {
 
 const KNOWN_DOMAINS = Object.keys(DOMAIN_PRODUCT);
 
+const escapeRe = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * One regex per domain: the domain must appear as a complete hyphen-delimited
+ * token run anywhere in the sub-tool name, tolerating a plural trailing "s".
+ * A single pattern covers `feature-flag-get` (prefix), `create-feature-flag`
+ * (verb-first) and `feature-flags-status-retrieve` (plural) — so a new
+ * `feature-flags-*` tool needs no entry here. The `(^|-)…($|-)` boundaries keep
+ * a domain from matching a partial token, and `s?` matches zero for
+ * already-plural domains like `external-data-sources`.
+ */
+const DOMAIN_PATTERNS: ReadonlyArray<readonly [string, RegExp]> =
+  KNOWN_DOMAINS.map(
+    (d) => [d, new RegExp(`(^|-)${escapeRe(d)}s?($|-)`)] as const,
+  );
+
 /**
  * HogQL/PostHog table name → product. Lets an `execute-sql` call be attributed
  * to the product whose data it reads (e.g. `SELECT count() FROM feature_flags`
@@ -199,13 +216,92 @@ export function classifyPostHogSqlQuery(sql: string): PostHogProductId[] {
 }
 
 /**
+ * Activity-log `scope` value → product. The activity-log tools are generic
+ * audit readers (their own domain is suppressed), but a call scoped to a
+ * specific entity type is really about that entity's product. Keys are the
+ * PascalCase scope enum values; only scopes that map to a surfaced product are
+ * listed — admin/meta scopes (Team, Project, User, Role, Comment, Tag, …) are
+ * omitted so a scoped audit read of them surfaces nothing, as before.
+ */
+const ACTIVITY_SCOPE_PRODUCT: Record<string, PostHogProductId> = {
+  FeatureFlag: "feature_flags",
+  EarlyAccessFeature: "feature_flags",
+  Experiment: "experiments",
+  ExperimentHoldout: "experiments",
+  ExperimentSavedMetric: "experiments",
+  ErrorTrackingIssue: "error_tracking",
+  Replay: "session_replay",
+  SessionRecordingPlaylist: "session_replay",
+  Survey: "surveys",
+  LLMTrace: "llm_analytics",
+  Evaluation: "llm_analytics",
+  DataWarehouseSavedQuery: "data_warehouse",
+  ExternalDataSource: "data_warehouse",
+  ExternalDataSchema: "data_warehouse",
+  BatchExport: "data_warehouse",
+  BatchImport: "data_warehouse",
+  HogFunction: "cdp",
+  HogFlow: "cdp",
+  Log: "logs",
+  LogsAlertConfiguration: "logs",
+  LogsExclusionRule: "logs",
+  Insight: "product_analytics",
+  Dashboard: "product_analytics",
+  DashboardWidget: "product_analytics",
+  Cohort: "product_analytics",
+  Person: "product_analytics",
+  Group: "product_analytics",
+  Notebook: "product_analytics",
+  Action: "product_analytics",
+  EventDefinition: "product_analytics",
+  PropertyDefinition: "product_analytics",
+  Annotation: "product_analytics",
+  Endpoint: "product_analytics",
+  Subscription: "product_analytics",
+  AlertConfiguration: "product_analytics",
+};
+
+/**
+ * Attribute an activity-log call to the product(s) of its `scope`/`scopes`
+ * argument. Returns an empty array when the body has no recognized scope (so an
+ * unscoped or admin-scoped audit read still surfaces nothing).
+ */
+function classifyPostHogActivityLog(commandText: string): PostHogProductId[] {
+  const start = commandText.indexOf("{");
+  const end = commandText.lastIndexOf("}");
+  if (start === -1 || end <= start) return [];
+  let body: unknown;
+  try {
+    body = JSON.parse(commandText.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+  if (!body || typeof body !== "object") return [];
+  const scopesField = (body as { scopes?: unknown }).scopes;
+  const raw: unknown[] = [
+    (body as { scope?: unknown }).scope,
+    ...(Array.isArray(scopesField) ? scopesField : []),
+  ];
+  const products = new Set<PostHogProductId>();
+  for (const s of raw) {
+    if (typeof s === "string") {
+      const product = ACTIVITY_SCOPE_PRODUCT[s];
+      if (product) products.add(product);
+    }
+  }
+  return [...products];
+}
+
+/**
  * Classify an executed MCP exec `call` into the products it touched. For
  * `execute-sql` the query text is inspected so the call is attributed to the
  * product whose tables it reads (e.g. Feature flags), falling back to the
- * generic "sql" product only when no table maps. All other sub-tools resolve
- * to their single domain product (or none, for admin/meta domains).
+ * generic "sql" product only when no table maps. Activity-log reads are
+ * attributed by their `scope` argument. All other sub-tools resolve to their
+ * single domain product (or none, for admin/meta domains).
  *
- * `commandText` is the raw exec command (which embeds the SQL for execute-sql).
+ * `commandText` is the raw exec command (which embeds the SQL for execute-sql
+ * and the scope JSON for activity-log reads).
  */
 export function classifyPostHogExecCall(
   subTool: string,
@@ -215,6 +311,13 @@ export function classifyPostHogExecCall(
   if (name === "execute-sql" || name === "execute_sql") {
     const fromTables = commandText ? classifyPostHogSqlQuery(commandText) : [];
     return fromTables.length > 0 ? fromTables : ["sql"];
+  }
+  if (
+    name === "activity-log" ||
+    name.startsWith("activity-log-") ||
+    name.startsWith("advanced-activity-logs")
+  ) {
+    return commandText ? classifyPostHogActivityLog(commandText) : [];
   }
   const product = classifyPostHogSubTool(subTool);
   return product ? [product] : [];
@@ -249,8 +352,8 @@ export function classifyPostHogSubTool(
   // Longest matching domain wins so `feature-flag` beats a hypothetical
   // `feature` and multi-word domains aren't shadowed by shorter prefixes.
   let best: string | null = null;
-  for (const domain of KNOWN_DOMAINS) {
-    if (name === domain || name.startsWith(`${domain}-`)) {
+  for (const [domain, re] of DOMAIN_PATTERNS) {
+    if (re.test(name)) {
       if (best === null || domain.length > best.length) best = domain;
     }
   }


### PR DESCRIPTION
## human desc

The "Products used: Feature flags" chip never showed when I asked the agent to tell me how many flags were rolled out this week. that's because it didn't check for plurals, nor did it parse activity log queries for product names.

This PR does those two things.

## Problem

The session resources bar above the chat input shows which PostHog products a turn touched. During a session that investigated feature-flag rollouts, the **Feature flags** chip never appeared. Two gaps in the `exec`-call classifier (`packages/agent/src/posthog-products.ts`) caused it:

1. **Naming mismatch.** Matching was an exact domain *prefix* (`name === domain || name.startsWith(`${domain}-`)`) against the singular key `feature-flag`. The live MCP also ships:
   - plural `feature-flags-*` (e.g. `feature-flags-activity-retrieve`) — `startsWith("feature-flag-")` is false (char after `feature-flag` is `s`).
   - verb-first `create-feature-flag` / `update-feature-flag` / `delete-feature-flag` — don't start with `feature-flag-`.

   All fell through to the generic `posthog` fallback, showing a plain "PostHog" chip.

2. **Activity-log scope ignored.** The natural way to answer "what flags changed this week" is `activity-log-list` / `advanced-activity-logs-list` with `scope: "FeatureFlag"`. Those domains map to `null` (generic audit readers) and the classifier never inspected the `scope` argument, so the calls surfaced nothing.

## Changes

- **Pattern-based domain matcher.** Kept the single canonical domain keys and replaced the prefix check with a precompiled per-domain regex `(^|-)<domain>s?($|-)` — the domain matches as a complete hyphen-delimited token run anywhere in the sub-tool name, tolerating a plural `s`. One pattern covers prefix, verb-first, and plural forms for **every** product, so it can't drift out of date as tools are added.
- **Activity-log scope attribution.** Added `ACTIVITY_SCOPE_PRODUCT` (PascalCase scope → product; admin/meta scopes intentionally omitted) and `classifyPostHogActivityLog()`, and branched `classifyPostHogExecCall` for `activity-log*` / `advanced-activity-logs*`. The name-only `classifyPostHogSubTool` still returns `null` for those domains, so existing behavior is unchanged.

## How did you test this?

- `vitest run src/posthog-products.test.ts` — 58 passed. Added cases for plural/verb-first variants (incl. non-flag `create-survey` / `create-experiment` to prove generality) and for activity-log scope (single, multiple-deduped, empty/unscoped, admin scope, no command text).
- Biome clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Diagnosed from a real session: feature-flag rollout data was pulled via `activity-log-list {scope: FeatureFlag}` and `feature-flags-activity-retrieve`, neither of which the classifier attributed to Feature flags. Fix targets the matcher (generalizes naming) and adds scope-aware activity-log attribution.
