### PR TITLE
feat(code): Enrich renderer crash events for Error Tracking

### DIFF
--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -55,6 +55,7 @@ import {
   focusWorktreePaths,
 } from "./services/focus/desktop-adapters";
 import type { WorkspaceServerService } from "./services/workspace-server/service";
+import { collectMemorySnapshot } from "./utils/crash-diagnostics";
 import { ensureClaudeConfigDir } from "./utils/env";
 import {
   getChromiumLogFilePath,
@@ -130,6 +131,8 @@ function isCrashLoop(): boolean {
 }
 
 app.on("render-process-gone", (_event, webContents, details) => {
+  const memory = collectMemorySnapshot(() => app.getAppMetrics());
+  const chromiumLogTail = readChromiumLogTail();
   const props = {
     source: "main",
     type: "render-process-gone",
@@ -138,14 +141,22 @@ app.on("render-process-gone", (_event, webContents, details) => {
     url: webContents.getURL(),
     title: webContents.getTitle(),
     webContentsId: String(webContents.id),
+    appUptimeSeconds: Math.round(process.uptime()),
+    memoryTotalWorkingSetKb: memory?.totalWorkingSetKb,
+    memoryPeakWorkingSetKb: memory?.peakWorkingSetKb,
+    memoryProcessCount: memory?.processCount,
+    memoryByType: memory ? JSON.stringify(memory.byType) : undefined,
   };
-  log.error("Renderer process gone", {
-    ...props,
-    chromiumLogTail: readChromiumLogTail(),
-  });
+  log.error("Renderer process gone", { ...props, chromiumLogTail });
   posthogNodeAnalytics.captureException(
     new Error(`Renderer process gone: ${details.reason}`),
-    props,
+    {
+      ...props,
+      chromiumLogTail,
+      // Stack is always this handler, so default grouping collapses every
+      // renderer death into one issue. Split by reason instead.
+      $exception_fingerprint: ["render-process-gone", details.reason],
+    },
   );
   posthogNodeAnalytics.flush().catch(() => {});
 
@@ -177,6 +188,8 @@ app.on("render-process-gone", (_event, webContents, details) => {
 });
 
 app.on("child-process-gone", (_event, details) => {
+  const memory = collectMemorySnapshot(() => app.getAppMetrics());
+  const chromiumLogTail = readChromiumLogTail();
   const props = {
     source: "main",
     type: "child-process-gone",
@@ -185,14 +198,24 @@ app.on("child-process-gone", (_event, details) => {
     exitCode: String(details.exitCode),
     serviceName: details.serviceName ?? "",
     name: details.name ?? "",
+    appUptimeSeconds: Math.round(process.uptime()),
+    memoryTotalWorkingSetKb: memory?.totalWorkingSetKb,
+    memoryPeakWorkingSetKb: memory?.peakWorkingSetKb,
+    memoryProcessCount: memory?.processCount,
+    memoryByType: memory ? JSON.stringify(memory.byType) : undefined,
   };
-  log.error("Child process gone", {
-    ...props,
-    chromiumLogTail: readChromiumLogTail(),
-  });
+  log.error("Child process gone", { ...props, chromiumLogTail });
   posthogNodeAnalytics.captureException(
     new Error(`Child process gone (${details.type}): ${details.reason}`),
-    props,
+    {
+      ...props,
+      chromiumLogTail,
+      $exception_fingerprint: [
+        "child-process-gone",
+        details.type,
+        details.reason,
+      ],
+    },
   );
   posthogNodeAnalytics.flush().catch(() => {});
 });

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -55,7 +55,10 @@ import {
   focusWorktreePaths,
 } from "./services/focus/desktop-adapters";
 import type { WorkspaceServerService } from "./services/workspace-server/service";
-import { collectMemorySnapshot } from "./utils/crash-diagnostics";
+import {
+  collectMemorySnapshot,
+  flattenMemorySnapshot,
+} from "./utils/crash-diagnostics";
 import { ensureClaudeConfigDir } from "./utils/env";
 import {
   getChromiumLogFilePath,
@@ -130,9 +133,18 @@ function isCrashLoop(): boolean {
   return recentCrashTimestamps.length >= CRASH_LOOP_THRESHOLD;
 }
 
+// Shared diagnostics attached to every crash event: uptime, the native chromium
+// log tail, and flattened memory. A hard OOM kills the renderer before it can
+// log, so the memory snapshot is often the only signal of what happened.
+function crashDiagnostics() {
+  return {
+    appUptimeSeconds: Math.round(process.uptime()),
+    chromiumLogTail: readChromiumLogTail(),
+    ...flattenMemorySnapshot(collectMemorySnapshot(() => app.getAppMetrics())),
+  };
+}
+
 app.on("render-process-gone", (_event, webContents, details) => {
-  const memory = collectMemorySnapshot(() => app.getAppMetrics());
-  const chromiumLogTail = readChromiumLogTail();
   const props = {
     source: "main",
     type: "render-process-gone",
@@ -141,18 +153,13 @@ app.on("render-process-gone", (_event, webContents, details) => {
     url: webContents.getURL(),
     title: webContents.getTitle(),
     webContentsId: String(webContents.id),
-    appUptimeSeconds: Math.round(process.uptime()),
-    memoryTotalWorkingSetKb: memory?.totalWorkingSetKb,
-    memoryPeakWorkingSetKb: memory?.peakWorkingSetKb,
-    memoryProcessCount: memory?.processCount,
-    memoryByType: memory ? JSON.stringify(memory.byType) : undefined,
+    ...crashDiagnostics(),
   };
-  log.error("Renderer process gone", { ...props, chromiumLogTail });
+  log.error("Renderer process gone", props);
   posthogNodeAnalytics.captureException(
     new Error(`Renderer process gone: ${details.reason}`),
     {
       ...props,
-      chromiumLogTail,
       // Stack is always this handler, so default grouping collapses every
       // renderer death into one issue. Split by reason instead.
       $exception_fingerprint: ["render-process-gone", details.reason],
@@ -188,8 +195,6 @@ app.on("render-process-gone", (_event, webContents, details) => {
 });
 
 app.on("child-process-gone", (_event, details) => {
-  const memory = collectMemorySnapshot(() => app.getAppMetrics());
-  const chromiumLogTail = readChromiumLogTail();
   const props = {
     source: "main",
     type: "child-process-gone",
@@ -198,18 +203,13 @@ app.on("child-process-gone", (_event, details) => {
     exitCode: String(details.exitCode),
     serviceName: details.serviceName ?? "",
     name: details.name ?? "",
-    appUptimeSeconds: Math.round(process.uptime()),
-    memoryTotalWorkingSetKb: memory?.totalWorkingSetKb,
-    memoryPeakWorkingSetKb: memory?.peakWorkingSetKb,
-    memoryProcessCount: memory?.processCount,
-    memoryByType: memory ? JSON.stringify(memory.byType) : undefined,
+    ...crashDiagnostics(),
   };
-  log.error("Child process gone", { ...props, chromiumLogTail });
+  log.error("Child process gone", props);
   posthogNodeAnalytics.captureException(
     new Error(`Child process gone (${details.type}): ${details.reason}`),
     {
       ...props,
-      chromiumLogTail,
       $exception_fingerprint: [
         "child-process-gone",
         details.type,

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -133,9 +133,6 @@ function isCrashLoop(): boolean {
   return recentCrashTimestamps.length >= CRASH_LOOP_THRESHOLD;
 }
 
-// Shared diagnostics attached to every crash event: uptime, the native chromium
-// log tail, and flattened memory. A hard OOM kills the renderer before it can
-// log, so the memory snapshot is often the only signal of what happened.
 function crashDiagnostics() {
   return {
     appUptimeSeconds: Math.round(process.uptime()),
@@ -160,8 +157,6 @@ app.on("render-process-gone", (_event, webContents, details) => {
     new Error(`Renderer process gone: ${details.reason}`),
     {
       ...props,
-      // Stack is always this handler, so default grouping collapses every
-      // renderer death into one issue. Split by reason instead.
       $exception_fingerprint: ["render-process-gone", details.reason],
     },
   );

--- a/apps/code/src/main/platform-adapters/posthog-analytics.test.ts
+++ b/apps/code/src/main/platform-adapters/posthog-analytics.test.ts
@@ -99,8 +99,15 @@ describe("posthog-analytics", () => {
       $session_id: "spoofed",
     });
 
-    const props = mockCaptureException.mock.calls.at(-1)?.[2];
-    expect(props.$session_id).toMatch(
+    const [, , props] = mockCaptureException.mock.calls.at(-1) ?? [];
+    expect(props.$session_id).toBe(posthogNodeAnalytics.getOrCreateSessionId());
+  });
+
+  it("mints a stable valid uuidv7 session id", () => {
+    const first = posthogNodeAnalytics.getOrCreateSessionId();
+
+    expect(posthogNodeAnalytics.getOrCreateSessionId()).toBe(first);
+    expect(first).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
   });

--- a/apps/code/src/main/platform-adapters/posthog-analytics.test.ts
+++ b/apps/code/src/main/platform-adapters/posthog-analytics.test.ts
@@ -93,4 +93,15 @@ describe("posthog-analytics", () => {
       }),
     );
   });
+
+  it("stamps the main-owned session id and ignores a caller override", () => {
+    posthogNodeAnalytics.captureException(new Error("boom"), {
+      $session_id: "spoofed",
+    });
+
+    const props = mockCaptureException.mock.calls.at(-1)?.[2];
+    expect(props.$session_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
 });

--- a/apps/code/src/main/platform-adapters/posthog-analytics.ts
+++ b/apps/code/src/main/platform-adapters/posthog-analytics.ts
@@ -4,10 +4,12 @@ import type {
 } from "@posthog/platform/analytics";
 import { PostHog } from "posthog-node";
 import { getAppVersion } from "../utils/env";
+import { uuidv7 } from "../utils/uuidv7";
 
 export class PosthogNodeAnalytics implements IAnalytics {
   private client: PostHog | null = null;
   private currentUserId: string | null = null;
+  private sessionId: string | null = null;
 
   initialize(): void {
     if (this.client) {
@@ -33,6 +35,29 @@ export class PosthogNodeAnalytics implements IAnalytics {
 
   getCurrentUserId(): string | null {
     return this.currentUserId;
+  }
+
+  /**
+   * The PostHog session id is OWNED BY MAIN. Main mints one UUIDv7 and every
+   * renderer window bootstraps posthog-js with it (`bootstrap.sessionID`).
+   * Because main outlives the renderer, the id stays stable across a renderer
+   * crash + reload, so the replay is one continuous session spanning the crash
+   * and main-captured crash events (the renderer can't report its own OOM)
+   * always carry the right `$session_id` with no race or hand-off.
+   *
+   * Minted lazily on first request (a window asks at boot, before posthog-js
+   * init) so its UUIDv7 timestamp precedes the session's first event, as
+   * posthog-js requires.
+   */
+  getOrCreateSessionId(): string {
+    if (!this.sessionId) {
+      this.sessionId = uuidv7();
+    }
+    return this.sessionId;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
   }
 
   track(eventName: string, properties?: AnalyticsProperties): void {
@@ -82,6 +107,7 @@ export class PosthogNodeAnalytics implements IAnalytics {
     const distinctId = this.currentUserId || "anonymous-app-event";
     this.client.captureException(error, distinctId, {
       team: "posthog-code",
+      ...(this.sessionId ? { $session_id: this.sessionId } : {}),
       ...additionalProperties,
       app_version: getAppVersion(),
     });

--- a/apps/code/src/main/platform-adapters/posthog-analytics.ts
+++ b/apps/code/src/main/platform-adapters/posthog-analytics.ts
@@ -28,9 +28,6 @@ export class PosthogNodeAnalytics implements IAnalytics {
       enableExceptionAutocapture: true,
     });
 
-    // Mint the main-owned session id now, before the first window, so crash
-    // handlers can stamp $session_id even when the renderer crashes during
-    // startup (before it fetches the id to bootstrap posthog-js).
     this.getOrCreateSessionId();
   }
 
@@ -42,18 +39,6 @@ export class PosthogNodeAnalytics implements IAnalytics {
     return this.currentUserId;
   }
 
-  /**
-   * The PostHog session id is OWNED BY MAIN. Main mints one UUIDv7 and every
-   * renderer window bootstraps posthog-js with it (`bootstrap.sessionID`).
-   * Because main outlives the renderer, the id stays stable across a renderer
-   * crash + reload, so the replay is one continuous session spanning the crash
-   * and main-captured crash events (the renderer can't report its own OOM)
-   * always carry the right `$session_id` with no race or hand-off.
-   *
-   * Minted lazily on first request (a window asks at boot, before posthog-js
-   * init) so its UUIDv7 timestamp precedes the session's first event, as
-   * posthog-js requires.
-   */
   getOrCreateSessionId(): string {
     if (!this.sessionId) {
       this.sessionId = uuidv7();
@@ -109,8 +94,6 @@ export class PosthogNodeAnalytics implements IAnalytics {
     this.client.captureException(error, distinctId, {
       team: "posthog-code",
       ...additionalProperties,
-      // System-owned fields last so callers can't overwrite them: main owns
-      // the session id used for crash->replay linking.
       ...(this.sessionId ? { $session_id: this.sessionId } : {}),
       app_version: getAppVersion(),
     });

--- a/apps/code/src/main/platform-adapters/posthog-analytics.ts
+++ b/apps/code/src/main/platform-adapters/posthog-analytics.ts
@@ -27,6 +27,11 @@ export class PosthogNodeAnalytics implements IAnalytics {
       host: apiHost || "https://internal-c.posthog.com",
       enableExceptionAutocapture: true,
     });
+
+    // Mint the main-owned session id now, before the first window, so crash
+    // handlers can stamp $session_id even when the renderer crashes during
+    // startup (before it fetches the id to bootstrap posthog-js).
+    this.getOrCreateSessionId();
   }
 
   setCurrentUserId(userId: string | null): void {
@@ -107,8 +112,10 @@ export class PosthogNodeAnalytics implements IAnalytics {
     const distinctId = this.currentUserId || "anonymous-app-event";
     this.client.captureException(error, distinctId, {
       team: "posthog-code",
-      ...(this.sessionId ? { $session_id: this.sessionId } : {}),
       ...additionalProperties,
+      // System-owned fields last so callers can't overwrite them: main owns
+      // the session id used for crash->replay linking.
+      ...(this.sessionId ? { $session_id: this.sessionId } : {}),
       app_version: getAppVersion(),
     });
   }

--- a/apps/code/src/main/platform-adapters/posthog-analytics.ts
+++ b/apps/code/src/main/platform-adapters/posthog-analytics.ts
@@ -61,10 +61,6 @@ export class PosthogNodeAnalytics implements IAnalytics {
     return this.sessionId;
   }
 
-  getSessionId(): string | null {
-    return this.sessionId;
-  }
-
   track(eventName: string, properties?: AnalyticsProperties): void {
     if (!this.client) {
       return;

--- a/apps/code/src/main/utils/crash-diagnostics.test.ts
+++ b/apps/code/src/main/utils/crash-diagnostics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { collectMemorySnapshot } from "./crash-diagnostics";
+import {
+  collectMemorySnapshot,
+  flattenMemorySnapshot,
+} from "./crash-diagnostics";
 
 function metric(
   type: string,
@@ -44,5 +47,27 @@ describe("collectMemorySnapshot", () => {
         throw new Error("getAppMetrics unavailable");
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("flattenMemorySnapshot", () => {
+  it("flattens scalars and serializes byType for PostHog", () => {
+    expect(
+      flattenMemorySnapshot({
+        totalWorkingSetKb: 430,
+        peakWorkingSetKb: 500,
+        processCount: 4,
+        byType: { Browser: 100, Tab: 250, GPU: 80 },
+      }),
+    ).toEqual({
+      memoryTotalWorkingSetKb: 430,
+      memoryPeakWorkingSetKb: 500,
+      memoryProcessCount: 4,
+      memoryByType: '{"Browser":100,"Tab":250,"GPU":80}',
+    });
+  });
+
+  it("returns an empty object when no snapshot was collected", () => {
+    expect(flattenMemorySnapshot(undefined)).toEqual({});
   });
 });

--- a/apps/code/src/main/utils/crash-diagnostics.test.ts
+++ b/apps/code/src/main/utils/crash-diagnostics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { collectMemorySnapshot } from "./crash-diagnostics";
+
+function metric(
+  type: string,
+  workingSetSize: number,
+  peakWorkingSetSize: number,
+): Electron.ProcessMetric {
+  return {
+    type,
+    memory: { workingSetSize, peakWorkingSetSize, privateBytes: 0 },
+  } as unknown as Electron.ProcessMetric;
+}
+
+describe("collectMemorySnapshot", () => {
+  it("sums working set, tracks peak, and groups by process type", () => {
+    const snapshot = collectMemorySnapshot(() => [
+      metric("Browser", 100, 150),
+      metric("Tab", 200, 500),
+      metric("Tab", 50, 60),
+      metric("GPU", 80, 90),
+    ]);
+
+    expect(snapshot).toEqual({
+      totalWorkingSetKb: 430,
+      peakWorkingSetKb: 500,
+      processCount: 4,
+      byType: { Browser: 100, Tab: 250, GPU: 80 },
+    });
+  });
+
+  it("returns a zeroed snapshot for no processes", () => {
+    expect(collectMemorySnapshot(() => [])).toEqual({
+      totalWorkingSetKb: 0,
+      peakWorkingSetKb: 0,
+      processCount: 0,
+      byType: {},
+    });
+  });
+
+  it("returns undefined instead of throwing (crash handler must not fail)", () => {
+    expect(
+      collectMemorySnapshot(() => {
+        throw new Error("getAppMetrics unavailable");
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/code/src/main/utils/crash-diagnostics.ts
+++ b/apps/code/src/main/utils/crash-diagnostics.ts
@@ -5,21 +5,6 @@ export interface MemorySnapshot {
   byType: Record<string, number>;
 }
 
-/**
- * Summarize per-process memory (from `app.getAppMetrics()`, passed in by the
- * caller so this stays free of a direct `electron` import) for crash
- * diagnostics. Working-set sizes are in KB. Attached to renderer/child crash
- * events so PostHog Error Tracking can show whether the app was under memory
- * pressure: a hard OOM kills the renderer before it can log anything, so the
- * chromium log usually goes silent and this is the only reliable signal.
- *
- * Defensive on purpose: a throw here would run before the crash handler's
- * auto-recovery reload, so failures return `undefined` instead.
- *
- * Caveat: at `render-process-gone` time the dead renderer is already gone from
- * the metrics, so the `Tab` total understates the renderer's real peak. The
- * `unresponsive` sample (renderer still alive) is the more telling one.
- */
 export function collectMemorySnapshot(
   getMetrics: () => Electron.ProcessMetric[],
 ): MemorySnapshot | undefined {
@@ -48,11 +33,6 @@ export function collectMemorySnapshot(
   }
 }
 
-/**
- * Flatten a snapshot into scalar event properties for PostHog (which doesn't
- * accept nested objects, so `byType` is serialized). Returns `{}` when no
- * snapshot was collected, so it spreads cleanly into a crash event's props.
- */
 export function flattenMemorySnapshot(
   memory: MemorySnapshot | undefined,
 ): Record<string, number | string> {

--- a/apps/code/src/main/utils/crash-diagnostics.ts
+++ b/apps/code/src/main/utils/crash-diagnostics.ts
@@ -47,3 +47,22 @@ export function collectMemorySnapshot(
     return undefined;
   }
 }
+
+/**
+ * Flatten a snapshot into scalar event properties for PostHog (which doesn't
+ * accept nested objects, so `byType` is serialized). Returns `{}` when no
+ * snapshot was collected, so it spreads cleanly into a crash event's props.
+ */
+export function flattenMemorySnapshot(
+  memory: MemorySnapshot | undefined,
+): Record<string, number | string> {
+  if (!memory) {
+    return {};
+  }
+  return {
+    memoryTotalWorkingSetKb: memory.totalWorkingSetKb,
+    memoryPeakWorkingSetKb: memory.peakWorkingSetKb,
+    memoryProcessCount: memory.processCount,
+    memoryByType: JSON.stringify(memory.byType),
+  };
+}

--- a/apps/code/src/main/utils/crash-diagnostics.ts
+++ b/apps/code/src/main/utils/crash-diagnostics.ts
@@ -1,0 +1,49 @@
+export interface MemorySnapshot {
+  totalWorkingSetKb: number;
+  peakWorkingSetKb: number;
+  processCount: number;
+  byType: Record<string, number>;
+}
+
+/**
+ * Summarize per-process memory (from `app.getAppMetrics()`, passed in by the
+ * caller so this stays free of a direct `electron` import) for crash
+ * diagnostics. Working-set sizes are in KB. Attached to renderer/child crash
+ * events so PostHog Error Tracking can show whether the app was under memory
+ * pressure: a hard OOM kills the renderer before it can log anything, so the
+ * chromium log usually goes silent and this is the only reliable signal.
+ *
+ * Defensive on purpose: a throw here would run before the crash handler's
+ * auto-recovery reload, so failures return `undefined` instead.
+ *
+ * Caveat: at `render-process-gone` time the dead renderer is already gone from
+ * the metrics, so the `Tab` total understates the renderer's real peak. The
+ * `unresponsive` sample (renderer still alive) is the more telling one.
+ */
+export function collectMemorySnapshot(
+  getMetrics: () => Electron.ProcessMetric[],
+): MemorySnapshot | undefined {
+  try {
+    const metrics = getMetrics();
+    let totalWorkingSetKb = 0;
+    let peakWorkingSetKb = 0;
+    const byType: Record<string, number> = {};
+    for (const metric of metrics) {
+      const workingSet = metric.memory.workingSetSize;
+      totalWorkingSetKb += workingSet;
+      peakWorkingSetKb = Math.max(
+        peakWorkingSetKb,
+        metric.memory.peakWorkingSetSize,
+      );
+      byType[metric.type] = (byType[metric.type] ?? 0) + workingSet;
+    }
+    return {
+      totalWorkingSetKb,
+      peakWorkingSetKb,
+      processCount: metrics.length,
+      byType,
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/code/src/main/utils/uuidv7.test.ts
+++ b/apps/code/src/main/utils/uuidv7.test.ts
@@ -16,7 +16,6 @@ describe("uuidv7", () => {
     const id = uuidv7();
     const after = Date.now();
 
-    // First 48 bits (first 12 hex chars, minus the dash) are the unix-ms stamp.
     const stampMs = Number.parseInt(id.slice(0, 8) + id.slice(9, 13), 16);
     expect(stampMs).toBeGreaterThanOrEqual(before);
     expect(stampMs).toBeLessThanOrEqual(after);
@@ -31,7 +30,6 @@ describe("uuidv7", () => {
     vi.spyOn(Date, "now").mockReturnValue(0x0123456789ab);
     try {
       const id = uuidv7();
-      // bytes 0-5 of 0x0123456789ab -> "01234567" then "89ab"
       expect(id.slice(0, 8)).toBe("01234567");
       expect(id.slice(9, 13)).toBe("89ab");
     } finally {

--- a/apps/code/src/main/utils/uuidv7.test.ts
+++ b/apps/code/src/main/utils/uuidv7.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { uuidv7 } from "./uuidv7";
 
 const UUID_V7 =
@@ -25,5 +25,17 @@ describe("uuidv7", () => {
   it("is unique across rapid calls", () => {
     const ids = new Set(Array.from({ length: 1000 }, () => uuidv7()));
     expect(ids.size).toBe(1000);
+  });
+
+  it("writes the 48-bit millisecond timestamp big-endian into the first 6 bytes", () => {
+    vi.spyOn(Date, "now").mockReturnValue(0x0123456789ab);
+    try {
+      const id = uuidv7();
+      // bytes 0-5 of 0x0123456789ab -> "01234567" then "89ab"
+      expect(id.slice(0, 8)).toBe("01234567");
+      expect(id.slice(9, 13)).toBe("89ab");
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 });

--- a/apps/code/src/main/utils/uuidv7.test.ts
+++ b/apps/code/src/main/utils/uuidv7.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { uuidv7 } from "./uuidv7";
+
+const UUID_V7 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("uuidv7", () => {
+  it("produces a valid v7 string (version nibble 7, variant 10)", () => {
+    for (let i = 0; i < 100; i++) {
+      expect(uuidv7()).toMatch(UUID_V7);
+    }
+  });
+
+  it("encodes the current time so ids sort in creation order", () => {
+    const before = Date.now();
+    const id = uuidv7();
+    const after = Date.now();
+
+    // First 48 bits (first 12 hex chars, minus the dash) are the unix-ms stamp.
+    const stampMs = Number.parseInt(id.slice(0, 8) + id.slice(9, 13), 16);
+    expect(stampMs).toBeGreaterThanOrEqual(before);
+    expect(stampMs).toBeLessThanOrEqual(after);
+  });
+
+  it("is unique across rapid calls", () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => uuidv7()));
+    expect(ids.size).toBe(1000);
+  });
+});

--- a/apps/code/src/main/utils/uuidv7.ts
+++ b/apps/code/src/main/utils/uuidv7.ts
@@ -1,0 +1,29 @@
+import { randomBytes } from "node:crypto";
+
+/**
+ * Generate a UUIDv7 (time-ordered, RFC 9562). posthog-js requires this exact
+ * format for `bootstrap.sessionID`: a valid v7 whose 48-bit timestamp precedes
+ * the session's first event. Main mints it before any window starts posthog-js,
+ * so the ordering holds.
+ *
+ * Layout: 48-bit big-endian unix-ms timestamp, 4-bit version (7), 2-bit variant
+ * (10), 74 random bits. Hand-rolled to avoid a phantom dependency on `uuid`
+ * (transitive only, and several major versions resolve in the tree).
+ */
+export function uuidv7(): string {
+  const bytes = randomBytes(16);
+  const timestamp = Date.now();
+
+  bytes[0] = Math.floor(timestamp / 2 ** 40) & 0xff;
+  bytes[1] = Math.floor(timestamp / 2 ** 32) & 0xff;
+  bytes[2] = Math.floor(timestamp / 2 ** 24) & 0xff;
+  bytes[3] = Math.floor(timestamp / 2 ** 16) & 0xff;
+  bytes[4] = Math.floor(timestamp / 2 ** 8) & 0xff;
+  bytes[5] = timestamp & 0xff;
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x70; // version 7
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/apps/code/src/main/utils/uuidv7.ts
+++ b/apps/code/src/main/utils/uuidv7.ts
@@ -1,15 +1,5 @@
 import { randomBytes } from "node:crypto";
 
-/**
- * Generate a UUIDv7 (time-ordered, RFC 9562). posthog-js requires this exact
- * format for `bootstrap.sessionID`: a valid v7 whose 48-bit timestamp precedes
- * the session's first event. Main mints it before any window starts posthog-js,
- * so the ordering holds.
- *
- * Layout: 48-bit big-endian unix-ms timestamp, 4-bit version (7), 2-bit variant
- * (10), 74 random bits. Hand-rolled to avoid a phantom dependency on `uuid`
- * (transitive only, and several major versions resolve in the tree).
- */
 export function uuidv7(): string {
   const bytes = randomBytes(16);
   const timestamp = Date.now();

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -14,6 +14,7 @@ import { container } from "./di/container";
 import { buildApplicationMenu } from "./menu";
 import type { ElectronMainWindow } from "./platform-adapters/electron-main-window";
 import { trpcRouter } from "./trpc/router";
+import { collectMemorySnapshot } from "./utils/crash-diagnostics";
 import { isDevBuild } from "./utils/env";
 import { logger, readChromiumLogTail } from "./utils/logger";
 import { type WindowStateSchema, windowStateStore } from "./utils/store";
@@ -106,13 +107,17 @@ function setupCrashLogging(window: BrowserWindow): void {
       reason: details.reason,
       exitCode: details.exitCode,
       url: window.webContents.getURL(),
+      memory: collectMemorySnapshot(() => app.getAppMetrics()),
       chromiumLogTail: readChromiumLogTail(),
     });
   });
 
+  // Unresponsive often precedes an OOM kill, and here the renderer is still
+  // alive, so this memory sample reflects its real (bloated) footprint.
   window.on("unresponsive", () => {
     log.warn("Window unresponsive", {
       url: window.webContents.getURL(),
+      memory: collectMemorySnapshot(() => app.getAppMetrics()),
       chromiumLogTail: readChromiumLogTail(),
     });
   });

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -112,8 +112,6 @@ function setupCrashLogging(window: BrowserWindow): void {
     });
   });
 
-  // Unresponsive often precedes an OOM kill, and here the renderer is still
-  // alive, so this memory sample reflects its real (bloated) footprint.
   window.on("unresponsive", () => {
     log.warn("Window unresponsive", {
       url: window.webContents.getURL(),

--- a/apps/code/src/renderer/contributions/app-boot.contributions.ts
+++ b/apps/code/src/renderer/contributions/app-boot.contributions.ts
@@ -12,13 +12,25 @@ const log = logger.scope("app-boot");
 @injectable()
 export class AnalyticsBootContribution implements Contribution {
   start(): void {
-    initializePostHog();
-    trpcClient.os.getAppVersion
-      .query()
-      .then(registerAppVersion)
-      .catch((error) => {
-        log.warn("Failed to register app version super property", { error });
-      });
+    // Fetch the main-owned session id BEFORE initializing posthog-js so the
+    // recording shares the id main stamps on crash events. Init is gated on it
+    // so the id is set before the first event (posthog-js requires the
+    // bootstrap id's timestamp to precede the session's first event).
+    void (async () => {
+      let sessionId: string | undefined;
+      try {
+        ({ sessionId } = await trpcClient.analytics.getSessionId.query());
+      } catch (error) {
+        log.warn("Failed to fetch session id from main", { error });
+      }
+      initializePostHog(sessionId);
+      trpcClient.os.getAppVersion
+        .query()
+        .then(registerAppVersion)
+        .catch((error) => {
+          log.warn("Failed to register app version super property", { error });
+        });
+    })();
   }
 }
 

--- a/apps/code/src/renderer/contributions/app-boot.contributions.ts
+++ b/apps/code/src/renderer/contributions/app-boot.contributions.ts
@@ -12,10 +12,6 @@ const log = logger.scope("app-boot");
 @injectable()
 export class AnalyticsBootContribution implements Contribution {
   start(): void {
-    // Fetch the main-owned session id BEFORE initializing posthog-js so the
-    // recording shares the id main stamps on crash events. Init is gated on it
-    // so the id is set before the first event (posthog-js requires the
-    // bootstrap id's timestamp to precede the session's first event).
     void (async () => {
       let sessionId: string | undefined;
       try {

--- a/packages/host-router/src/routers/analytics.router.ts
+++ b/packages/host-router/src/routers/analytics.router.ts
@@ -24,6 +24,19 @@ export const analyticsRouter = router({
       }
     }),
 
+  /**
+   * Return the main-owned session id for a window to bootstrap posthog-js with
+   * (`bootstrap.sessionID`). Main owns it so crash events captured from main
+   * link to the right replay, and the id survives renderer crash+reload.
+   */
+  getSessionId: publicProcedure
+    .output(z.object({ sessionId: z.string() }))
+    .query(({ ctx }) => ({
+      sessionId: ctx.container
+        .get<IAnalytics>(ANALYTICS_SERVICE)
+        .getOrCreateSessionId(),
+    })),
+
   resetUser: publicProcedure.mutation(({ ctx }) => {
     ctx.container.get<IAnalytics>(ANALYTICS_SERVICE).resetUser();
   }),

--- a/packages/host-router/src/routers/analytics.router.ts
+++ b/packages/host-router/src/routers/analytics.router.ts
@@ -24,11 +24,6 @@ export const analyticsRouter = router({
       }
     }),
 
-  /**
-   * Return the main-owned session id for a window to bootstrap posthog-js with
-   * (`bootstrap.sessionID`). Main owns it so crash events captured from main
-   * link to the right replay, and the id survives renderer crash+reload.
-   */
   getSessionId: publicProcedure
     .output(z.object({ sessionId: z.string() }))
     .query(({ ctx }) => ({

--- a/packages/platform/src/analytics.ts
+++ b/packages/platform/src/analytics.ts
@@ -12,7 +12,6 @@ export interface IAnalytics {
    * host-captured crash events link to the same replay session.
    */
   getOrCreateSessionId(): string;
-  getSessionId(): string | null;
   resetUser(): void;
   captureException(
     error: unknown,

--- a/packages/platform/src/analytics.ts
+++ b/packages/platform/src/analytics.ts
@@ -6,6 +6,13 @@ export interface IAnalytics {
   identify(userId: string, properties?: AnalyticsProperties): void;
   setCurrentUserId(userId: string | null): void;
   getCurrentUserId(): string | null;
+  /**
+   * Stable analytics session id owned by the host process. Minted lazily on
+   * first request so renderer windows can bootstrap posthog-js with it and
+   * host-captured crash events link to the same replay session.
+   */
+  getOrCreateSessionId(): string;
+  getSessionId(): string | null;
   resetUser(): void;
   captureException(
     error: unknown,

--- a/packages/platform/src/analytics.ts
+++ b/packages/platform/src/analytics.ts
@@ -6,11 +6,7 @@ export interface IAnalytics {
   identify(userId: string, properties?: AnalyticsProperties): void;
   setCurrentUserId(userId: string | null): void;
   getCurrentUserId(): string | null;
-  /**
-   * Stable analytics session id owned by the host process. Minted lazily on
-   * first request so renderer windows can bootstrap posthog-js with it and
-   * host-captured crash events link to the same replay session.
-   */
+  /** Host-owned analytics session id, minted lazily on first request. */
   getOrCreateSessionId(): string;
   resetUser(): void;
   captureException(

--- a/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
@@ -148,4 +148,29 @@ describe("initializePostHog", () => {
     expect(mockPosthog.init).not.toHaveBeenCalled();
     expect(mockPosthog.onFeatureFlags).not.toHaveBeenCalled();
   });
+
+  it("bootstraps posthog with the main-owned session id", async () => {
+    const { initializePostHog } = await loadAnalytics();
+
+    initializePostHog("0190abcd-1234-7890-8abc-def012345678");
+
+    expect(mockPosthog.init).toHaveBeenCalledWith(
+      "test-key",
+      expect.objectContaining({
+        bootstrap: { sessionID: "0190abcd-1234-7890-8abc-def012345678" },
+        session_idle_timeout_seconds: 36_000,
+      }),
+    );
+  });
+
+  it("omits bootstrap when no session id is provided", async () => {
+    const { initializePostHog } = await loadAnalytics();
+
+    initializePostHog();
+
+    expect(mockPosthog.init).toHaveBeenCalledWith(
+      "test-key",
+      expect.not.objectContaining({ bootstrap: expect.anything() }),
+    );
+  });
 });

--- a/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -41,7 +41,12 @@ type PendingFlagListener = {
 // Subscribers added before initializePostHog runs.
 const pendingFlagListeners = new Set<PendingFlagListener>();
 
-export function initializePostHog() {
+/**
+ * @param sessionId Main-owned session id (UUIDv7) to bootstrap posthog-js with,
+ *   so the recording shares the id main stamps on crash events. Main owns it so
+ *   it survives a renderer crash+reload as one continuous session.
+ */
+export function initializePostHog(sessionId?: string) {
   const apiKey = import.meta.env.VITE_POSTHOG_API_KEY;
   const apiHost =
     import.meta.env.VITE_POSTHOG_API_HOST || "https://internal-c.posthog.com";
@@ -56,6 +61,12 @@ export function initializePostHog() {
     api_host: apiHost,
     ui_host: uiHost,
     disable_session_recording: false,
+    // Hold the session open through long idle (max posthog-js allows) so its
+    // own rotation doesn't replace main's bootstrapped id mid-run. This app
+    // sits idle for hours with background tasks, which is exactly when a
+    // shorter timeout would silently rotate and break crash->replay linking.
+    session_idle_timeout_seconds: 36000,
+    ...(sessionId ? { bootstrap: { sessionID: sessionId } } : {}),
     capture_exceptions: import.meta.env.DEV
       ? false
       : {

--- a/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -41,6 +41,11 @@ type PendingFlagListener = {
 // Subscribers added before initializePostHog runs.
 const pendingFlagListeners = new Set<PendingFlagListener>();
 
+// 10 h, the posthog-js maximum. The app sits idle for hours during background
+// tasks; a shorter timeout would rotate the session id and break the
+// main-owned crash->replay link.
+const SESSION_IDLE_TIMEOUT_SECONDS = 36_000;
+
 /**
  * @param sessionId Main-owned session id (UUIDv7) to bootstrap posthog-js with,
  *   so the recording shares the id main stamps on crash events. Main owns it so
@@ -61,11 +66,9 @@ export function initializePostHog(sessionId?: string) {
     api_host: apiHost,
     ui_host: uiHost,
     disable_session_recording: false,
-    // Hold the session open through long idle (max posthog-js allows) so its
-    // own rotation doesn't replace main's bootstrapped id mid-run. This app
-    // sits idle for hours with background tasks, which is exactly when a
-    // shorter timeout would silently rotate and break crash->replay linking.
-    session_idle_timeout_seconds: 36000,
+    // Hold the session open through long idle so posthog-js's own rotation
+    // doesn't replace main's bootstrapped id mid-run.
+    session_idle_timeout_seconds: SESSION_IDLE_TIMEOUT_SECONDS,
     ...(sessionId ? { bootstrap: { sessionID: sessionId } } : {}),
     capture_exceptions: import.meta.env.DEV
       ? false

--- a/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -41,16 +41,8 @@ type PendingFlagListener = {
 // Subscribers added before initializePostHog runs.
 const pendingFlagListeners = new Set<PendingFlagListener>();
 
-// 10 h, the posthog-js maximum. The app sits idle for hours during background
-// tasks; a shorter timeout would rotate the session id and break the
-// main-owned crash->replay link.
 const SESSION_IDLE_TIMEOUT_SECONDS = 36_000;
 
-/**
- * @param sessionId Main-owned session id (UUIDv7) to bootstrap posthog-js with,
- *   so the recording shares the id main stamps on crash events. Main owns it so
- *   it survives a renderer crash+reload as one continuous session.
- */
 export function initializePostHog(sessionId?: string) {
   const apiKey = import.meta.env.VITE_POSTHOG_API_KEY;
   const apiHost =
@@ -66,8 +58,6 @@ export function initializePostHog(sessionId?: string) {
     api_host: apiHost,
     ui_host: uiHost,
     disable_session_recording: false,
-    // Hold the session open through long idle so posthog-js's own rotation
-    // doesn't replace main's bootstrapped id mid-run.
     session_idle_timeout_seconds: SESSION_IDLE_TIMEOUT_SECONDS,
     ...(sessionId ? { bootstrap: { sessionID: sessionId } } : {}),
     capture_exceptions: import.meta.env.DEV


### PR DESCRIPTION
## Problem

Renderer OOM crashes landed in Error Tracking as one collapsed, undiagnosable issue: the stack pointed at the handler, with no memory, no native logs, and no linked replay.<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Attach chromium log tail and per-process memory (getAppMetrics) to render/child crash events
2. Fingerprint crashes per reason so crashed/killed/oom stop collapsing into one issue
3. Main owns a UUIDv7 session id; every window bootstraps posthog-js with it before the first event
4. Stamp $session_id on captured exceptions so crashes link the session replay
5. Hold the session open through long idle (10h) so the id survives background tasks and reload

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?