### PR TITLE
feat(code): add Visual Studio Code style UI zoom

### DIFF
--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -70,6 +70,9 @@ import { UpdatesService } from "../services/updates/service";
 import { UsageMonitorService } from "../services/usage-monitor/service";
 import { WatcherRegistryService } from "../services/watcher-registry/service";
 import { WorkspaceService } from "../services/workspace/service";
+import type { ZoomPersistence } from "../services/zoom/schemas";
+import { ZoomService } from "../services/zoom/service";
+import { windowStateStore } from "../utils/store";
 import { MAIN_TOKENS } from "./tokens";
 
 export const container = new Container({
@@ -147,6 +150,12 @@ container.bind(MAIN_TOKENS.SleepService).to(SleepService);
 container.bind(MAIN_TOKENS.ShellService).to(ShellService);
 container.bind(MAIN_TOKENS.SlackIntegrationService).to(SlackIntegrationService);
 container.bind(MAIN_TOKENS.UIService).to(UIService);
+const zoomPersistence: ZoomPersistence = {
+  getZoomLevel: () => windowStateStore.get("zoomLevel", 0),
+  setZoomLevel: (level: number) => windowStateStore.set("zoomLevel", level),
+};
+container.bind(MAIN_TOKENS.ZoomPersistence).toConstantValue(zoomPersistence);
+container.bind(MAIN_TOKENS.ZoomService).to(ZoomService);
 container.bind(MAIN_TOKENS.UpdatesService).to(UpdatesService);
 container.bind(MAIN_TOKENS.UsageMonitorService).to(UsageMonitorService);
 container.bind(MAIN_TOKENS.TaskLinkService).to(TaskLinkService);

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -74,6 +74,8 @@ export const MAIN_TOKENS = Object.freeze({
   ShellService: Symbol.for("Main.ShellService"),
   PosthogPluginService: Symbol.for("Main.PosthogPluginService"),
   UIService: Symbol.for("Main.UIService"),
+  ZoomService: Symbol.for("Main.ZoomService"),
+  ZoomPersistence: Symbol.for("Main.ZoomPersistence"),
   UpdatesService: Symbol.for("Main.UpdatesService"),
   TaskLinkService: Symbol.for("Main.TaskLinkService"),
   InboxLinkService: Symbol.for("Main.InboxLinkService"),

--- a/apps/code/src/main/menu.ts
+++ b/apps/code/src/main/menu.ts
@@ -16,6 +16,7 @@ import type { AuthService } from "./services/auth/service";
 import type { McpAppsService } from "./services/mcp-apps/service";
 import type { UIService } from "./services/ui/service";
 import type { UpdatesService } from "./services/updates/service";
+import type { ZoomService } from "./services/zoom/service";
 import { isDevBuild } from "./utils/env";
 import { getLogFilePath } from "./utils/logger";
 
@@ -308,9 +309,30 @@ function buildViewMenu(): MenuItemConstructorOptions {
       },
       { role: "toggleDevTools" },
       { type: "separator" },
-      { role: "resetZoom" },
-      { role: "zoomIn" },
-      { role: "zoomOut" },
+      // Accelerators are shown for discoverability but not registered here:
+      // the renderer owns the key handling (so it can preventDefault Chromium's
+      // built-in zoom and keep a single source of truth). Clicks still work.
+      {
+        label: "Zoom In",
+        accelerator: "CmdOrCtrl+Plus",
+        registerAccelerator: false,
+        click: () =>
+          container.get<ZoomService>(MAIN_TOKENS.ZoomService).zoomIn(),
+      },
+      {
+        label: "Zoom Out",
+        accelerator: "CmdOrCtrl+-",
+        registerAccelerator: false,
+        click: () =>
+          container.get<ZoomService>(MAIN_TOKENS.ZoomService).zoomOut(),
+      },
+      {
+        label: "Reset Zoom",
+        accelerator: "CmdOrCtrl+0",
+        registerAccelerator: false,
+        click: () =>
+          container.get<ZoomService>(MAIN_TOKENS.ZoomService).reset(),
+      },
       { type: "separator" },
       { role: "togglefullscreen" },
       { type: "separator" },

--- a/apps/code/src/main/platform-adapters/electron-main-window.ts
+++ b/apps/code/src/main/platform-adapters/electron-main-window.ts
@@ -35,4 +35,15 @@ export class ElectronMainWindow implements IMainWindow {
     app.on("browser-window-focus", listener);
     return () => app.off("browser-window-focus", listener);
   }
+
+  public getZoomLevel(): number {
+    return this.getBrowserWindow()?.webContents.getZoomLevel() ?? 0;
+  }
+
+  public setZoomLevel(level: number): void {
+    const webContents = this.getBrowserWindow()?.webContents;
+    if (webContents) {
+      webContents.setZoomLevel(level);
+    }
+  }
 }

--- a/apps/code/src/main/services/zoom/schemas.test.ts
+++ b/apps/code/src/main/services/zoom/schemas.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampZoomLevel,
+  MAX_ZOOM_LEVEL,
+  MIN_ZOOM_LEVEL,
+  zoomLevelToPercent,
+} from "./schemas";
+
+describe("clampZoomLevel", () => {
+  it("leaves in-range, on-step values untouched", () => {
+    expect(clampZoomLevel(0)).toBe(0);
+    expect(clampZoomLevel(0.5)).toBe(0.5);
+    expect(clampZoomLevel(-1.5)).toBe(-1.5);
+  });
+
+  it("snaps to the nearest 0.5 step", () => {
+    expect(clampZoomLevel(1.3)).toBe(1.5);
+    expect(clampZoomLevel(1.2)).toBe(1.0);
+    expect(clampZoomLevel(-1.3)).toBe(-1.5);
+    expect(clampZoomLevel(0.24)).toBe(0);
+  });
+
+  it("clamps above the maximum", () => {
+    expect(clampZoomLevel(10)).toBe(MAX_ZOOM_LEVEL);
+    expect(clampZoomLevel(MAX_ZOOM_LEVEL + 0.5)).toBe(MAX_ZOOM_LEVEL);
+  });
+
+  it("clamps below the minimum", () => {
+    expect(clampZoomLevel(-10)).toBe(MIN_ZOOM_LEVEL);
+    expect(clampZoomLevel(MIN_ZOOM_LEVEL - 0.5)).toBe(MIN_ZOOM_LEVEL);
+  });
+
+  it("handles boundary values exactly", () => {
+    expect(clampZoomLevel(MAX_ZOOM_LEVEL)).toBe(MAX_ZOOM_LEVEL);
+    expect(clampZoomLevel(MIN_ZOOM_LEVEL)).toBe(MIN_ZOOM_LEVEL);
+  });
+});
+
+describe("zoomLevelToPercent", () => {
+  it("returns 100% at level 0", () => {
+    expect(zoomLevelToPercent(0)).toBe(100);
+  });
+
+  it("computes the 1.2^level factor as a rounded percentage", () => {
+    expect(zoomLevelToPercent(1)).toBe(120);
+    expect(zoomLevelToPercent(2)).toBe(144);
+    expect(zoomLevelToPercent(0.5)).toBe(110);
+    expect(zoomLevelToPercent(-1)).toBe(83);
+    expect(zoomLevelToPercent(MAX_ZOOM_LEVEL)).toBe(249);
+    expect(zoomLevelToPercent(MIN_ZOOM_LEVEL)).toBe(58);
+  });
+});

--- a/apps/code/src/main/services/zoom/schemas.ts
+++ b/apps/code/src/main/services/zoom/schemas.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+/**
+ * Zoom is expressed as an Electron "zoom level": 0 means 100%, and each unit is
+ * a 1.2x factor (the same scale `webContents.setZoomLevel` uses). Steps of 0.5
+ * give roughly ~10% increments, matching Electron's built-in zoom roles.
+ */
+export const ZOOM_STEP = 0.5;
+export const MIN_ZOOM_LEVEL = -3;
+export const MAX_ZOOM_LEVEL = 5;
+
+export const zoomStateSchema = z.object({
+  /** Raw Electron zoom level (0 = 100%). */
+  level: z.number(),
+  /** Human-friendly percentage derived from the level (e.g. 110). */
+  percent: z.number(),
+  canZoomIn: z.boolean(),
+  canZoomOut: z.boolean(),
+});
+
+export type ZoomState = z.infer<typeof zoomStateSchema>;
+
+export const setZoomLevelInputSchema = z.object({
+  level: z.number(),
+});
+
+// Zoom events emitted from main to renderer.
+export const ZoomServiceEvent = {
+  Changed: "zoom-changed",
+} as const;
+
+export interface ZoomServiceEvents {
+  [ZoomServiceEvent.Changed]: ZoomState;
+}
+
+/** Narrow persistence port so the service stays unit-testable without disk. */
+export interface ZoomPersistence {
+  getZoomLevel(): number;
+  setZoomLevel(level: number): void;
+}
+
+/** Snap to the nearest step and clamp into the allowed range. */
+export function clampZoomLevel(level: number): number {
+  const stepped = Math.round(level / ZOOM_STEP) * ZOOM_STEP;
+  return Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, stepped));
+}
+
+export function zoomLevelToPercent(level: number): number {
+  return Math.round(1.2 ** level * 100);
+}

--- a/apps/code/src/main/services/zoom/service.test.ts
+++ b/apps/code/src/main/services/zoom/service.test.ts
@@ -1,0 +1,139 @@
+import type { IMainWindow } from "@posthog/platform/main-window";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MAX_ZOOM_LEVEL,
+  MIN_ZOOM_LEVEL,
+  type ZoomPersistence,
+  ZoomServiceEvent,
+} from "./schemas";
+import { ZoomService } from "./service";
+
+function createMockWindow() {
+  return {
+    focus: vi.fn(),
+    isFocused: vi.fn(() => true),
+    isMinimized: vi.fn(() => false),
+    restore: vi.fn(),
+    onFocus: vi.fn(() => () => {}),
+    getZoomLevel: vi.fn(() => 0),
+    setZoomLevel: vi.fn(),
+  } satisfies IMainWindow;
+}
+
+function createMockPersistence(initial = 0) {
+  let stored = initial;
+  return {
+    getZoomLevel: vi.fn(() => stored),
+    setZoomLevel: vi.fn((level: number) => {
+      stored = level;
+    }),
+  } satisfies ZoomPersistence;
+}
+
+describe("ZoomService", () => {
+  let window: ReturnType<typeof createMockWindow>;
+  let persistence: ReturnType<typeof createMockPersistence>;
+  let service: ZoomService;
+
+  beforeEach(() => {
+    window = createMockWindow();
+    persistence = createMockPersistence(0);
+    service = new ZoomService(window, persistence);
+  });
+
+  it("starts at 100% (level 0)", () => {
+    const state = service.getState();
+    expect(state.level).toBe(0);
+    expect(state.percent).toBe(100);
+  });
+
+  it("zooms in by one step and applies + persists", () => {
+    const state = service.zoomIn();
+    expect(state.level).toBe(0.5);
+    expect(window.setZoomLevel).toHaveBeenCalledWith(0.5);
+    expect(persistence.setZoomLevel).toHaveBeenCalledWith(0.5);
+  });
+
+  it("zooms out by one step", () => {
+    const state = service.zoomOut();
+    expect(state.level).toBe(-0.5);
+    expect(window.setZoomLevel).toHaveBeenCalledWith(-0.5);
+  });
+
+  it("resets to level 0", () => {
+    service.zoomIn();
+    service.zoomIn();
+    const state = service.reset();
+    expect(state.level).toBe(0);
+    expect(state.percent).toBe(100);
+  });
+
+  it("clamps at the maximum level", () => {
+    for (let i = 0; i < 100; i++) {
+      service.zoomIn();
+    }
+    const state = service.getState();
+    expect(state.level).toBe(MAX_ZOOM_LEVEL);
+    expect(state.canZoomIn).toBe(false);
+    expect(state.canZoomOut).toBe(true);
+  });
+
+  it("clamps at the minimum level", () => {
+    for (let i = 0; i < 100; i++) {
+      service.zoomOut();
+    }
+    const state = service.getState();
+    expect(state.level).toBe(MIN_ZOOM_LEVEL);
+    expect(state.canZoomOut).toBe(false);
+    expect(state.canZoomIn).toBe(true);
+  });
+
+  it("snaps arbitrary levels to the nearest step", () => {
+    const state = service.setLevel(1.3);
+    expect(state.level).toBe(1.5);
+  });
+
+  it("emits a change event with the new state", () => {
+    const listener = vi.fn();
+    service.on(ZoomServiceEvent.Changed, listener);
+    service.zoomIn();
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 0.5, percent: 110 }),
+    );
+  });
+
+  it("restores the persisted level onto the window", () => {
+    const persisted = createMockPersistence(1.5);
+    const restored = new ZoomService(window, persisted);
+    const state = restored.restore();
+    expect(state.level).toBe(1.5);
+    expect(window.setZoomLevel).toHaveBeenLastCalledWith(1.5);
+  });
+
+  it("reads the persisted level on construction (before restore)", () => {
+    const persisted = createMockPersistence(2);
+    const fresh = new ZoomService(window, persisted);
+    expect(fresh.getState().level).toBe(2);
+    expect(fresh.getState().percent).toBe(144);
+  });
+
+  it("clamps an out-of-range persisted level on restore", () => {
+    const persisted = createMockPersistence(99);
+    const restored = new ZoomService(window, persisted);
+    const state = restored.restore();
+    expect(state.level).toBe(MAX_ZOOM_LEVEL);
+    expect(window.setZoomLevel).toHaveBeenLastCalledWith(MAX_ZOOM_LEVEL);
+  });
+
+  it("persists the clamped level, not the raw requested one", () => {
+    service.setLevel(99);
+    expect(persistence.setZoomLevel).toHaveBeenLastCalledWith(MAX_ZOOM_LEVEL);
+  });
+
+  it("does not zoom in past the maximum once clamped", () => {
+    service.setLevel(MAX_ZOOM_LEVEL);
+    persistence.setZoomLevel.mockClear();
+    const state = service.zoomIn();
+    expect(state.level).toBe(MAX_ZOOM_LEVEL);
+  });
+});

--- a/apps/code/src/main/services/zoom/service.ts
+++ b/apps/code/src/main/services/zoom/service.ts
@@ -1,0 +1,78 @@
+import type { IMainWindow } from "@posthog/platform/main-window";
+import { inject, injectable } from "inversify";
+import { MAIN_TOKENS } from "../../di/tokens";
+import { TypedEventEmitter } from "../../utils/typed-event-emitter";
+import {
+  clampZoomLevel,
+  MAX_ZOOM_LEVEL,
+  MIN_ZOOM_LEVEL,
+  ZOOM_STEP,
+  type ZoomPersistence,
+  ZoomServiceEvent,
+  type ZoomServiceEvents,
+  type ZoomState,
+  zoomLevelToPercent,
+} from "./schemas";
+
+/**
+ * Owns the window zoom level: applies it to the host window, persists it, and
+ * broadcasts changes so the renderer can reflect the current percentage.
+ *
+ * The window's zoom resets to 0 on every web-contents reload, so {@link restore}
+ * must be called after each load to re-apply the persisted level.
+ */
+@injectable()
+export class ZoomService extends TypedEventEmitter<ZoomServiceEvents> {
+  private currentLevel: number;
+
+  constructor(
+    @inject(MAIN_TOKENS.MainWindow)
+    private readonly mainWindow: IMainWindow,
+    @inject(MAIN_TOKENS.ZoomPersistence)
+    private readonly persistence: ZoomPersistence,
+  ) {
+    super();
+    this.currentLevel = clampZoomLevel(this.persistence.getZoomLevel());
+  }
+
+  /** Re-apply the persisted zoom level to the window (call after each load). */
+  restore(): ZoomState {
+    this.currentLevel = clampZoomLevel(this.persistence.getZoomLevel());
+    this.mainWindow.setZoomLevel(this.currentLevel);
+    return this.emitChange();
+  }
+
+  zoomIn(): ZoomState {
+    return this.setLevel(this.currentLevel + ZOOM_STEP);
+  }
+
+  zoomOut(): ZoomState {
+    return this.setLevel(this.currentLevel - ZOOM_STEP);
+  }
+
+  reset(): ZoomState {
+    return this.setLevel(0);
+  }
+
+  setLevel(level: number): ZoomState {
+    this.currentLevel = clampZoomLevel(level);
+    this.mainWindow.setZoomLevel(this.currentLevel);
+    this.persistence.setZoomLevel(this.currentLevel);
+    return this.emitChange();
+  }
+
+  getState(): ZoomState {
+    return {
+      level: this.currentLevel,
+      percent: zoomLevelToPercent(this.currentLevel),
+      canZoomIn: this.currentLevel < MAX_ZOOM_LEVEL,
+      canZoomOut: this.currentLevel > MIN_ZOOM_LEVEL,
+    };
+  }
+
+  private emitChange(): ZoomState {
+    const state = this.getState();
+    this.emit(ZoomServiceEvent.Changed, state);
+    return state;
+  }
+}

--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -38,6 +38,7 @@ import { uiRouter } from "./routers/ui";
 import { updatesRouter } from "./routers/updates";
 import { usageMonitorRouter } from "./routers/usage-monitor";
 import { workspaceRouter } from "./routers/workspace";
+import { zoomRouter } from "./routers/zoom";
 import { router } from "./trpc";
 
 export const trpcRouter = router({
@@ -82,6 +83,7 @@ export const trpcRouter = router({
   usageMonitor: usageMonitorRouter,
   deepLink: deepLinkRouter,
   workspace: workspaceRouter,
+  zoom: zoomRouter,
 });
 
 export type TrpcRouter = typeof trpcRouter;

--- a/apps/code/src/main/trpc/routers/zoom.ts
+++ b/apps/code/src/main/trpc/routers/zoom.ts
@@ -1,0 +1,41 @@
+import { container } from "../../di/container";
+import { MAIN_TOKENS } from "../../di/tokens";
+import {
+  setZoomLevelInputSchema,
+  ZoomServiceEvent,
+  zoomStateSchema,
+} from "../../services/zoom/schemas";
+import type { ZoomService } from "../../services/zoom/service";
+import { publicProcedure, router } from "../trpc";
+
+const getService = () => container.get<ZoomService>(MAIN_TOKENS.ZoomService);
+
+export const zoomRouter = router({
+  getState: publicProcedure
+    .output(zoomStateSchema)
+    .query(() => getService().getState()),
+  zoomIn: publicProcedure
+    .output(zoomStateSchema)
+    .mutation(() => getService().zoomIn()),
+  zoomOut: publicProcedure
+    .output(zoomStateSchema)
+    .mutation(() => getService().zoomOut()),
+  reset: publicProcedure
+    .output(zoomStateSchema)
+    .mutation(() => getService().reset()),
+  setLevel: publicProcedure
+    .input(setZoomLevelInputSchema)
+    .output(zoomStateSchema)
+    .mutation(({ input }) => getService().setLevel(input.level)),
+  onChange: publicProcedure.subscription(async function* (opts) {
+    const service = getService();
+    // Emit the current state immediately so subscribers render the right value.
+    yield service.getState();
+    const iterable = service.toIterable(ZoomServiceEvent.Changed, {
+      signal: opts.signal,
+    });
+    for await (const data of iterable) {
+      yield data;
+    }
+  }),
+});

--- a/apps/code/src/main/utils/store.ts
+++ b/apps/code/src/main/utils/store.ts
@@ -24,6 +24,7 @@ export interface WindowStateSchema {
   width: number;
   height: number;
   isMaximized: boolean;
+  zoomLevel: number;
 }
 
 const userDataDir = getUserDataDir();
@@ -50,5 +51,6 @@ export const windowStateStore = new Store<WindowStateSchema>({
     width: 1200,
     height: 600,
     isMaximized: true,
+    zoomLevel: 0,
   },
 });

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -13,6 +13,7 @@ import { container } from "./di/container";
 import { MAIN_TOKENS } from "./di/tokens";
 import { buildApplicationMenu } from "./menu";
 import type { ElectronMainWindow } from "./platform-adapters/electron-main-window";
+import type { ZoomService } from "./services/zoom/service";
 import { trpcRouter } from "./trpc/router";
 import { isDevBuild } from "./utils/env";
 import { logger, readChromiumLogTail } from "./utils/logger";
@@ -41,6 +42,7 @@ function getSavedWindowState(): WindowStateSchema {
     width: windowStateStore.get("width", 1200),
     height: windowStateStore.get("height", 600),
     isMaximized: windowStateStore.get("isMaximized", true),
+    zoomLevel: windowStateStore.get("zoomLevel", 0),
   };
 
   // Validate position is still on a connected display
@@ -252,6 +254,12 @@ export function createWindow(): void {
   setupEditableContextMenu(mainWindow);
   setupCrashLogging(mainWindow);
   buildApplicationMenu();
+
+  // The web contents reset zoom to 0 on every load, so re-apply the persisted
+  // level once loading completes.
+  mainWindow.webContents.on("did-finish-load", () => {
+    container.get<ZoomService>(MAIN_TOKENS.ZoomService).restore();
+  });
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);

--- a/apps/code/src/renderer/components/GlobalEventHandlers.tsx
+++ b/apps/code/src/renderer/components/GlobalEventHandlers.tsx
@@ -9,6 +9,8 @@ import { useSidebarStore } from "@features/sidebar/stores/sidebarStore";
 import { useTasks } from "@features/tasks/hooks/useTasks";
 import { useFocusWorkspace } from "@features/workspace/hooks/useFocusWorkspace";
 import { useWorkspaces } from "@features/workspace/hooks/useWorkspace";
+import { useZoomActions } from "@features/zoom/hooks/useZoom";
+import { resolveZoomIntent } from "@features/zoom/zoomKeybinding";
 import { useAppView } from "@hooks/useAppView";
 import { openTask, openTaskInput } from "@hooks/useOpenTask";
 import { SHORTCUTS } from "@renderer/constants/keyboard-shortcuts";
@@ -53,6 +55,7 @@ export function GlobalEventHandlers({
   const getReviewMode = useReviewNavigationStore(
     (state) => state.getReviewMode,
   );
+  const { zoomIn, zoomOut, reset: resetZoom } = useZoomActions();
 
   const currentTaskId = view.type === "task-detail" ? view.taskId : undefined;
   const { workspace: currentWorkspace, handleToggleFocus } = useFocusWorkspace(
@@ -197,6 +200,23 @@ export function GlobalEventHandlers({
     globalOptions,
     [handleSwitchTask],
   );
+
+  // Zoom shortcuts (Ctrl/Cmd with +, -, 0). A raw keydown listener is used
+  // instead of react-hotkeys-hook because the latter mis-parses symbol keys.
+  // Key resolution lives in resolveZoomIntent (pure + unit-tested); the zoom is
+  // applied in the main process and preventDefault stops Chromium's native zoom.
+  useEffect(() => {
+    const handleZoomKey = (event: KeyboardEvent) => {
+      const intent = resolveZoomIntent(event);
+      if (!intent) return;
+      event.preventDefault();
+      if (intent === "in") zoomIn();
+      else if (intent === "out") zoomOut();
+      else resetZoom();
+    };
+    window.addEventListener("keydown", handleZoomKey);
+    return () => window.removeEventListener("keydown", handleZoomKey);
+  }, [zoomIn, zoomOut, resetZoom]);
 
   // Konami code confetti
   const konamiProgressRef = useRef(0);

--- a/apps/code/src/renderer/constants/keyboard-shortcuts.ts
+++ b/apps/code/src/renderer/constants/keyboard-shortcuts.ts
@@ -58,6 +58,25 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     category: "general",
   },
   {
+    id: "zoom-in",
+    keys: "mod+=",
+    description: "Zoom in",
+    category: "general",
+    alternateKeys: "mod+shift+=",
+  },
+  {
+    id: "zoom-out",
+    keys: "mod+-",
+    description: "Zoom out",
+    category: "general",
+  },
+  {
+    id: "zoom-reset",
+    keys: "mod+0",
+    description: "Reset zoom",
+    category: "general",
+  },
+  {
     id: "shortcuts",
     keys: SHORTCUTS.SHORTCUTS_SHEET,
     description: "Show keyboard shortcuts",

--- a/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
+++ b/apps/code/src/renderer/features/settings/components/sections/GeneralSettings.tsx
@@ -9,6 +9,7 @@ import {
   type SendMessagesWith,
   useSettingsStore,
 } from "@features/settings/stores/settingsStore";
+import { ZoomControl } from "@features/zoom/components/ZoomControl";
 import { ArrowSquareOut } from "@phosphor-icons/react";
 import {
   Button,
@@ -271,6 +272,14 @@ export function GeneralSettings() {
             <Select.Item value="system">System</Select.Item>
           </Select.Content>
         </Select.Root>
+      </SettingRow>
+
+      <SettingRow
+        label="Interface zoom"
+        description="Scale the entire interface. Use Ctrl/⌘ with +, -, or 0 to adjust"
+        noBorder
+      >
+        <ZoomControl />
       </SettingRow>
 
       {/* Notifications */}

--- a/apps/code/src/renderer/features/zoom/components/ZoomControl.tsx
+++ b/apps/code/src/renderer/features/zoom/components/ZoomControl.tsx
@@ -1,0 +1,42 @@
+import { useZoomActions, useZoomState } from "@features/zoom/hooks/useZoom";
+import { Minus, Plus } from "@phosphor-icons/react";
+import { Button, Flex, Text } from "@radix-ui/themes";
+
+export function ZoomControl() {
+  const state = useZoomState();
+  const { zoomIn, zoomOut, reset } = useZoomActions();
+
+  return (
+    <Flex align="center" gap="2">
+      <Button
+        size="1"
+        variant="soft"
+        onClick={zoomOut}
+        disabled={!state.canZoomOut}
+        aria-label="Zoom out"
+      >
+        <Minus size={12} />
+      </Button>
+      <Text color="gray" className="min-w-[44px] text-center text-[13px]">
+        {state.percent}%
+      </Text>
+      <Button
+        size="1"
+        variant="soft"
+        onClick={zoomIn}
+        disabled={!state.canZoomIn}
+        aria-label="Zoom in"
+      >
+        <Plus size={12} />
+      </Button>
+      <Button
+        size="1"
+        variant="outline"
+        onClick={reset}
+        disabled={state.level === 0}
+      >
+        Reset
+      </Button>
+    </Flex>
+  );
+}

--- a/apps/code/src/renderer/features/zoom/hooks/useZoom.ts
+++ b/apps/code/src/renderer/features/zoom/hooks/useZoom.ts
@@ -1,0 +1,51 @@
+import { useTRPC } from "@renderer/trpc";
+import { useMutation } from "@tanstack/react-query";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { useMemo, useState } from "react";
+
+export interface ZoomState {
+  level: number;
+  percent: number;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
+}
+
+const DEFAULT_ZOOM_STATE: ZoomState = {
+  level: 0,
+  percent: 100,
+  canZoomIn: true,
+  canZoomOut: true,
+};
+
+/** Thin wrappers over the zoom mutations. No subscription, so it's cheap to use
+ * from global keyboard handlers. */
+export function useZoomActions() {
+  const trpc = useTRPC();
+  const zoomIn = useMutation(trpc.zoom.zoomIn.mutationOptions());
+  const zoomOut = useMutation(trpc.zoom.zoomOut.mutationOptions());
+  const reset = useMutation(trpc.zoom.reset.mutationOptions());
+
+  return useMemo(
+    () => ({
+      zoomIn: () => zoomIn.mutate(),
+      zoomOut: () => zoomOut.mutate(),
+      reset: () => reset.mutate(),
+    }),
+    [zoomIn.mutate, zoomOut.mutate, reset.mutate],
+  );
+}
+
+/** Current zoom state, kept in sync via the main-process subscription (which
+ * emits the current value on connect). */
+export function useZoomState(): ZoomState {
+  const trpc = useTRPC();
+  const [state, setState] = useState<ZoomState>(DEFAULT_ZOOM_STATE);
+
+  useSubscription(
+    trpc.zoom.onChange.subscriptionOptions(undefined, {
+      onData: (data) => setState(data),
+    }),
+  );
+
+  return state;
+}

--- a/apps/code/src/renderer/features/zoom/zoomKeybinding.test.ts
+++ b/apps/code/src/renderer/features/zoom/zoomKeybinding.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveZoomIntent } from "./zoomKeybinding";
+
+function key(
+  k: string,
+  mods: { ctrlKey?: boolean; metaKey?: boolean } = { ctrlKey: true },
+) {
+  return { ctrlKey: false, metaKey: false, ...mods, key: k };
+}
+
+describe("resolveZoomIntent", () => {
+  it("returns null without a Ctrl/Cmd modifier", () => {
+    expect(
+      resolveZoomIntent({ ctrlKey: false, metaKey: false, key: "=" }),
+    ).toBe(null);
+    expect(
+      resolveZoomIntent({ ctrlKey: false, metaKey: false, key: "-" }),
+    ).toBe(null);
+    expect(
+      resolveZoomIntent({ ctrlKey: false, metaKey: false, key: "0" }),
+    ).toBe(null);
+  });
+
+  it("maps zoom-in keys (= , + , numpad +)", () => {
+    expect(resolveZoomIntent(key("="))).toBe("in");
+    expect(resolveZoomIntent(key("+"))).toBe("in"); // shift+= and numpad add
+  });
+
+  it("maps zoom-out keys (- , _ , numpad -)", () => {
+    expect(resolveZoomIntent(key("-"))).toBe("out");
+    expect(resolveZoomIntent(key("_"))).toBe("out"); // shift+-
+  });
+
+  it("maps reset (0)", () => {
+    expect(resolveZoomIntent(key("0"))).toBe("reset");
+  });
+
+  it("works with the Cmd modifier (macOS)", () => {
+    expect(resolveZoomIntent(key("=", { metaKey: true }))).toBe("in");
+    expect(resolveZoomIntent(key("-", { metaKey: true }))).toBe("out");
+    expect(resolveZoomIntent(key("0", { metaKey: true }))).toBe("reset");
+  });
+
+  it("ignores unrelated keys even with the modifier held", () => {
+    expect(resolveZoomIntent(key("a"))).toBe(null);
+    expect(resolveZoomIntent(key("1"))).toBe(null); // task-switch shortcut
+    expect(resolveZoomIntent(key(")"))).toBe(null); // shift+0
+    expect(resolveZoomIntent(key("Backspace"))).toBe(null);
+  });
+});

--- a/apps/code/src/renderer/features/zoom/zoomKeybinding.ts
+++ b/apps/code/src/renderer/features/zoom/zoomKeybinding.ts
@@ -1,0 +1,32 @@
+export type ZoomIntent = "in" | "out" | "reset";
+
+/**
+ * Maps a keydown event to a zoom intent (or null when it's not a zoom shortcut).
+ *
+ * Kept as a pure function — separate from the DOM listener — because
+ * react-hotkeys-hook mis-parses symbol keys, so we match `event.key` ourselves
+ * and need to cover every keyboard variant:
+ *   - Ctrl/Cmd + "="            -> in
+ *   - Ctrl/Cmd + Shift+"=" ("+") -> in   (and numpad "+")
+ *   - Ctrl/Cmd + "-"            -> out
+ *   - Ctrl/Cmd + Shift+"-" ("_") -> out  (and numpad "-")
+ *   - Ctrl/Cmd + "0"            -> reset (and numpad "0")
+ */
+export function resolveZoomIntent(
+  event: Pick<KeyboardEvent, "ctrlKey" | "metaKey" | "key">,
+): ZoomIntent | null {
+  if (!(event.ctrlKey || event.metaKey)) return null;
+
+  switch (event.key) {
+    case "=":
+    case "+":
+      return "in";
+    case "-":
+    case "_":
+      return "out";
+    case "0":
+      return "reset";
+    default:
+      return null;
+  }
+}

--- a/packages/platform/src/main-window.ts
+++ b/packages/platform/src/main-window.ts
@@ -4,4 +4,8 @@ export interface IMainWindow {
   isMinimized(): boolean;
   restore(): void;
   onFocus(handler: () => void): () => void;
+  /** Current zoom level (0 = 100%, each unit ~= a 1.2x factor). */
+  getZoomLevel(): number;
+  /** Set the window zoom level. Resets on every web-contents reload. */
+  setZoomLevel(level: number): void;
 }


### PR DESCRIPTION
Adds window-level zoom like VS Code: `Ctrl/⌘ +`, `-`, and `0`, the View menu (Zoom In/Out/Reset), and a control in Settings → Appearance with a live percentage.

The zoom level is owned by a main-process `ZoomService`, persists across restarts (stored alongside window state), and is re-applied after web-contents reloads (zoom resets on every load). Keyboard handling lives in a pure, unit-tested `resolveZoomIntent` helper instead of react-hotkeys-hook, which mis-parses the `=`/`-`/`0` symbol keys.

There is no OS-specific code, so the behavior is portable to macOS and Linux (the native window controls intentionally stay fixed, matching VS Code).

## Testing
- 26 unit tests: key-intent mapping, clamp/percent math, and `ZoomService` behavior (zoom in/out/reset, clamping, persistence, restore)
- `typecheck` and `biome` pass clean
- Manually verified in a packaged Windows build: keyboard shortcuts, View menu, Settings control with live %, and persistence across a restart

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
