### PR TITLE
feat(mobile): add Scout as an inbox signal source (port #2505)

### DIFF
--- a/apps/mobile/src/features/inbox/components/FilterSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/FilterSheet.tsx
@@ -76,6 +76,7 @@ const SOURCE_PRODUCT_OPTIONS: { value: SourceProduct; label: string }[] = [
   { value: "linear", label: "Linear" },
   { value: "zendesk", label: "Zendesk" },
   { value: "conversations", label: "Conversations" },
+  { value: "signals_scout", label: "Scout" },
 ];
 
 function SectionHeader({ title }: { title: string }) {

--- a/apps/mobile/src/features/inbox/components/SignalCard.tsx
+++ b/apps/mobile/src/features/inbox/components/SignalCard.tsx
@@ -7,6 +7,7 @@ import {
   ChatCircle,
   CheckCircle,
   Code,
+  Compass,
   GithubLogo,
   LinkSimple,
   Question,
@@ -46,6 +47,12 @@ function sourceLine(signal: Signal): string {
     return "GitHub · Issue";
   if (source_product === "linear" && source_type === "issue")
     return "Linear · Issue";
+  if (
+    source_product === "signals_scout" &&
+    source_type === "cross_source_issue"
+  )
+    return "Scout · Cross-source issue";
+  if (source_product === "signals_scout") return "Scout";
   const product = source_product.replace(/_/g, " ");
   const type = source_type.replace(/_/g, " ");
   return `${product} · ${type}`;
@@ -73,6 +80,8 @@ function SourceIcon({
       return <ChatCircle size={size} color={color} />;
     case "linear":
       return <LinkSimple size={size} color={color} />;
+    case "signals_scout":
+      return <Compass size={size} color={color} />;
     default:
       return <WarningCircle size={size} color={color} />;
   }

--- a/apps/mobile/src/features/inbox/stores/inboxFilterStore.test.ts
+++ b/apps/mobile/src/features/inbox/stores/inboxFilterStore.test.ts
@@ -1,14 +1,40 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
 
 import { useInboxFilterStore } from "./inboxFilterStore";
 
-const INITIAL_STATE = useInboxFilterStore.getState();
+describe("inboxFilterStore", () => {
+  beforeEach(() => {
+    useInboxFilterStore.getState().resetFilters();
+  });
 
-beforeEach(() => {
-  useInboxFilterStore.setState(INITIAL_STATE, true);
+  it("toggles signals_scout in and out of the source filter", () => {
+    const { toggleSourceProduct } = useInboxFilterStore.getState();
+
+    toggleSourceProduct("signals_scout");
+    expect(useInboxFilterStore.getState().sourceProductFilter).toEqual([
+      "signals_scout",
+    ]);
+
+    toggleSourceProduct("signals_scout");
+    expect(useInboxFilterStore.getState().sourceProductFilter).toEqual([]);
+  });
 });
 
+const INITIAL_STATE = useInboxFilterStore.getState();
+
 describe("inboxFilterStore priority filter", () => {
+  beforeEach(() => {
+    useInboxFilterStore.setState(INITIAL_STATE, true);
+  });
+
   it("starts empty (no priority filter)", () => {
     expect(useInboxFilterStore.getState().priorityFilter).toEqual([]);
   });

--- a/apps/mobile/src/features/inbox/stores/inboxFilterStore.test.ts
+++ b/apps/mobile/src/features/inbox/stores/inboxFilterStore.test.ts
@@ -8,24 +8,27 @@ vi.mock("@react-native-async-storage/async-storage", () => ({
   },
 }));
 
-import { useInboxFilterStore } from "./inboxFilterStore";
+import { type SourceProduct, useInboxFilterStore } from "./inboxFilterStore";
 
 describe("inboxFilterStore", () => {
   beforeEach(() => {
     useInboxFilterStore.getState().resetFilters();
   });
 
-  it("toggles signals_scout in and out of the source filter", () => {
-    const { toggleSourceProduct } = useInboxFilterStore.getState();
+  it.each<SourceProduct>(["signals_scout", "error_tracking", "github"])(
+    "toggles %s in and out of the source filter",
+    (source) => {
+      const { toggleSourceProduct } = useInboxFilterStore.getState();
 
-    toggleSourceProduct("signals_scout");
-    expect(useInboxFilterStore.getState().sourceProductFilter).toEqual([
-      "signals_scout",
-    ]);
+      toggleSourceProduct(source);
+      expect(useInboxFilterStore.getState().sourceProductFilter).toEqual([
+        source,
+      ]);
 
-    toggleSourceProduct("signals_scout");
-    expect(useInboxFilterStore.getState().sourceProductFilter).toEqual([]);
-  });
+      toggleSourceProduct(source);
+      expect(useInboxFilterStore.getState().sourceProductFilter).toEqual([]);
+    },
+  );
 });
 
 const INITIAL_STATE = useInboxFilterStore.getState();

--- a/apps/mobile/src/features/inbox/stores/inboxFilterStore.ts
+++ b/apps/mobile/src/features/inbox/stores/inboxFilterStore.ts
@@ -21,7 +21,8 @@ export type SourceProduct =
   | "github"
   | "linear"
   | "zendesk"
-  | "conversations";
+  | "conversations"
+  | "signals_scout";
 
 export const DEFAULT_STATUS_FILTER: SignalReportStatus[] = [
   "ready",


### PR DESCRIPTION
## Summary

Ports PostHog/code#2505 ("feat(signals): add Scouts as a signal source in the inbox") to the mobile app.

Makes the mobile inbox aware of the `signals_scout` source product (displayed as **"Scout"**, with a Compass icon) so Scout-sourced signal reports display and filter correctly.

## Changes (`apps/mobile`)

- `features/inbox/stores/inboxFilterStore.ts` — add `"signals_scout"` to the `SourceProduct` union.
- `features/inbox/components/FilterSheet.tsx` — add `{ value: "signals_scout", label: "Scout" }` to the source options.
- `features/inbox/components/SignalCard.tsx` — add a `signals_scout` case to the `SourceIcon` switch (Compass icon, consistent with the other phosphor icons) and render a "Scout · Cross-source issue" / "Scout" label in `sourceLine()`.
- `features/inbox/stores/inboxFilterStore.test.ts` — test toggling the new source on/off.

Pure renderer/UI surface — no main-process or business-logic changes. Desktop (`apps/code`) code is untouched.

## Testing

- `pnpm --filter mobile test src/features/inbox/stores/inboxFilterStore.test.ts` passes.
- Biome formatting/lint clean on the changed files.