### PR TITLE
refactor(rename): use "AI observability" for renamed LLM analytics product

### DIFF
--- a/apps/code/src/renderer/features/billing/components/TokenSpendAnalysisBanner.tsx
+++ b/apps/code/src/renderer/features/billing/components/TokenSpendAnalysisBanner.tsx
@@ -24,7 +24,7 @@ import { Button, Callout, Flex, Spinner, Table, Text } from "@radix-ui/themes";
 import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import { track } from "@utils/analytics";
 
-const DOCS_URL = "https://posthog.com/docs/llm-analytics";
+const DOCS_URL = "https://posthog.com/docs/ai-observability";
 
 function generateSuggestions(data: SpendAnalysisResponse): string[] {
   const suggestions: string[] = [];
@@ -254,7 +254,7 @@ function FooterLinks({ data }: { data: SpendAnalysisResponse }) {
           rel="noreferrer"
           className="text-(--accent-11) underline"
         >
-          PostHog AI Observability
+          PostHog AI observability
         </a>{" "}
         in your own project for the full slice-and-dice experience.
       </Text>
@@ -363,7 +363,7 @@ export function TokenSpendAnalysisBanner() {
       <Callout.Text>
         <Flex direction="column" gap="2">
           <Text className="font-medium text-sm">
-            Analyse your token usage with PostHog AI Observability
+            Analyse your token usage with PostHog AI observability
           </Text>
           <Text className="text-(--gray-11) text-[13px]">
             See where your spend goes — by product, tool, and model — over the

--- a/apps/code/src/renderer/features/billing/utils/spendAnalysisPrompt.test.ts
+++ b/apps/code/src/renderer/features/billing/utils/spendAnalysisPrompt.test.ts
@@ -188,7 +188,7 @@ describe("buildAnalysisPrompt", () => {
   it("instructs the agent not to query external data", () => {
     const prompt = buildAnalysisPrompt(makeResponse());
     expect(prompt).toContain(
-      "do **not** try to query PostHog LLM analytics or any external data source",
+      "do **not** try to query PostHog AI observability or any external data source",
     );
   });
 });

--- a/apps/code/src/renderer/features/billing/utils/spendAnalysisPrompt.ts
+++ b/apps/code/src/renderer/features/billing/utils/spendAnalysisPrompt.ts
@@ -93,7 +93,7 @@ export function buildAnalysisPrompt(data: SpendAnalysisResponse): string {
 
   return `Here is my PostHog Code LLM spend for the last ${windowDays}. Help me understand what's driving the cost and what concrete changes I should make to reduce it.
 
-Work only from the tables below — do **not** try to query PostHog LLM analytics or any external data source. The numbers here are everything you have. Rank advice by impact, lead with the biggest lever, and keep each suggestion concrete and actionable.
+Work only from the tables below — do **not** try to query PostHog AI observability or any external data source. The numbers here are everything you have. Rank advice by impact, lead with the biggest lever, and keep each suggestion concrete and actionable.
 
 ## My spend
 

--- a/apps/code/src/renderer/features/inbox/components/SignalSourceToggles.tsx
+++ b/apps/code/src/renderer/features/inbox/components/SignalSourceToggles.tsx
@@ -178,7 +178,7 @@ export const EvaluationsSection = memo(function EvaluationsSection({
           <Flex direction="column" gap="1">
             <Flex align="center" gap="2">
               <Text className="font-medium text-(--gray-12) text-sm">
-                LLM Analytics
+                AI observability
               </Text>
               <Tooltip content="This is only visible to staff users of PostHog">
                 <Badge color="blue">Internal</Badge>
@@ -189,21 +189,21 @@ export const EvaluationsSection = memo(function EvaluationsSection({
             </Text>
             <Text className="text-(--gray-11) text-[13px]">
               <a
-                href="https://posthog.com/docs/llm-analytics"
+                href="https://posthog.com/docs/ai-observability"
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
                   window.open(
-                    "https://posthog.com/docs/llm-analytics",
+                    "https://posthog.com/docs/ai-observability",
                     "_blank",
                     "noopener",
                   );
                 }}
                 className="inline-flex items-center gap-[4px] text-(--accent-11) no-underline"
               >
-                Learn about LLM Analytics
+                Learn about AI observability
                 <ArrowSquareOutIcon size={11} />
               </a>
             </Text>

--- a/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
@@ -60,7 +60,7 @@ function signalCardSourceLine(signal: {
     return "Session replay · Session analysis cluster";
   }
   if (source_product === "llm_analytics" && source_type === "evaluation") {
-    return "LLM analytics · Evaluation";
+    return "AI observability · Evaluation";
   }
   if (source_product === "zendesk" && source_type === "ticket") {
     return "Zendesk · Ticket";

--- a/apps/code/src/renderer/features/inbox/components/list/FilterSortMenu.tsx
+++ b/apps/code/src/renderer/features/inbox/components/list/FilterSortMenu.tsx
@@ -103,7 +103,7 @@ const SOURCE_PRODUCT_OPTIONS: {
   },
   {
     value: "llm_analytics",
-    label: "LLM analytics",
+    label: "AI observability",
     icon: <BrainIcon size={14} />,
   },
   { value: "github", label: "GitHub", icon: <GithubLogoIcon size={14} /> },

--- a/apps/code/src/renderer/features/inbox/components/utils/source-product-icons.tsx
+++ b/apps/code/src/renderer/features/inbox/components/utils/source-product-icons.tsx
@@ -33,7 +33,7 @@ export const SOURCE_PRODUCT_META: Record<
   llm_analytics: {
     Icon: BrainIcon,
     color: "var(--purple-9)",
-    label: "LLM analytics",
+    label: "AI observability",
   },
   github: {
     Icon: GithubLogoIcon,

--- a/apps/mobile/src/features/inbox/components/FilterSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/FilterSheet.tsx
@@ -52,7 +52,7 @@ function useStatusDotColors(): Record<string, string> {
 const SOURCE_PRODUCT_OPTIONS: { value: SourceProduct; label: string }[] = [
   { value: "session_replay", label: "Session replay" },
   { value: "error_tracking", label: "Error tracking" },
-  { value: "llm_analytics", label: "LLM analytics" },
+  { value: "llm_analytics", label: "AI observability" },
   { value: "github", label: "GitHub" },
   { value: "linear", label: "Linear" },
   { value: "zendesk", label: "Zendesk" },

--- a/apps/mobile/src/features/inbox/components/SignalCard.tsx
+++ b/apps/mobile/src/features/inbox/components/SignalCard.tsx
@@ -38,7 +38,7 @@ function sourceLine(signal: Signal): string {
   if (source_product === "session_replay" && source_type === "session_problem")
     return "Session replay · Session problem";
   if (source_product === "llm_analytics" && source_type === "evaluation")
-    return "LLM analytics · Evaluation";
+    return "AI observability · Evaluation";
   if (source_product === "zendesk" && source_type === "ticket")
     return "Zendesk · Ticket";
   if (source_product === "github" && source_type === "issue")

--- a/packages/agent/src/posthog-products.ts
+++ b/packages/agent/src/posthog-products.ts
@@ -22,7 +22,7 @@ export const POSTHOG_PRODUCTS = {
   error_tracking: "Error tracking",
   session_replay: "Session replay",
   surveys: "Surveys",
-  llm_analytics: "LLM analytics",
+  llm_analytics: "AI observability",
   data_warehouse: "Data warehouse",
   cdp: "Data pipelines",
   logs: "Logs",


### PR DESCRIPTION
## Problem

PostHog renamed the **LLM analytics** product to **AI observability**. PostHog Code still showed the old name in several places in the UI, so the copy is now out of date.

## Changes

Renamed all user-facing references from "LLM analytics" to "AI observability" (sentence case, matching the other product labels like "Web analytics" / "Session replay"):

- **Canonical product label** in `POSTHOG_PRODUCTS` (`packages/agent/src/posthog-products.ts`) — drives the session "PostHog resources used" product chip.
- **Desktop inbox**: signal-source label/icon badge, filter dropdown, signal card source line, and the signal-source toggles section header + "Learn about…" link.
- **Mobile inbox**: signal card source line and filter sheet label.
- **Billing**: token-spend banner copy (normalized the pre-existing "AI Observability" to sentence case) and the spend-analysis agent prompt.
- **Docs URLs** updated from `/docs/llm-analytics` to `/docs/ai-observability` (the session resources bar already used the new path).

Internal identifiers are intentionally left unchanged: the `llm_analytics` product id, type unions, API paths (`/api/llm_analytics/...`), cloud-nav URLs, the `/instrument-llm-analytics` slash command, and the auto-generated API types in `generated.ts`.

## How did you test this?

- `pnpm --filter agent typecheck` — clean
- `posthog-products.test.ts` — 59/59 passing
- `spendAnalysisPrompt.test.ts` — 21/21 passing (assertion updated to match new prompt text)
- Inbox renderer tests — 84/84 passing
- Verified pre-existing agent/renderer test failures are unrelated (reproduced on a clean tree via `git stash`)
- Grep confirms no remaining user-facing "LLM analytics" strings (only two intentionally-skipped code comments)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
