### PR TITLE
fix(ci): harden react-doctor workflow and comment renderer

### DIFF
--- a/.github/scripts/react-doctor-comment.mjs
+++ b/.github/scripts/react-doctor-comment.mjs
@@ -13,10 +13,12 @@ const head = (
   ""
 ).trim();
 
+const MAX_LISTED = 50;
 const plural = (n, word) => `${n} ${word}${n === 1 ? "" : "s"}`;
 const inline = (value) =>
   String(value ?? "")
     .replace(/\s+/g, " ")
+    .replace(/[`<>]/g, "")
     .trim();
 const byFileThenLine = (a, b) =>
   a.filePath === b.filePath
@@ -26,8 +28,8 @@ const byFileThenLine = (a, b) =>
       : 1;
 const fileLink = (file, line) =>
   slug && head
-    ? `[\`${file}:${line}\`](${server}/${slug}/blob/${head}/${file}#L${line})`
-    : `\`${file}:${line}\``;
+    ? `[\`${inline(file)}:${line}\`](${server}/${slug}/blob/${head}/${file}#L${line})`
+    : `\`${inline(file)}:${line}\``;
 
 let report;
 try {
@@ -70,12 +72,17 @@ if (!report) {
       .sort(byFileThenLine);
     if (errors.length) {
       lines.push("", "**Errors**", "");
-      for (const error of errors) {
+      for (const error of errors.slice(0, MAX_LISTED)) {
         const title = inline(error.title);
         lines.push(
-          `- ❌ ${fileLink(error.filePath, error.line)}${title ? ` ${title}` : ""} \`${error.rule}\``,
+          `- ❌ ${fileLink(error.filePath, error.line)}${title ? ` ${title}` : ""} \`${inline(error.rule)}\``,
         );
       }
+      if (errors.length > MAX_LISTED)
+        lines.push(
+          "",
+          `${plural(errors.length - MAX_LISTED, "more error")} not shown.`,
+        );
     }
 
     const warnings = diagnostics
@@ -88,21 +95,21 @@ if (!report) {
         "",
       );
       let currentFile = null;
-      for (const warning of warnings.slice(0, 50)) {
+      for (const warning of warnings.slice(0, MAX_LISTED)) {
         if (warning.filePath !== currentFile) {
           if (currentFile !== null) lines.push("");
-          lines.push(`**\`${warning.filePath}\`**`);
+          lines.push(`**\`${inline(warning.filePath)}\`**`);
           currentFile = warning.filePath;
         }
         const title = inline(warning.title);
         lines.push(
-          `- ⚠️ ${fileLink(warning.filePath, warning.line)}${title ? ` ${title}` : ""} \`${warning.rule}\``,
+          `- ⚠️ ${fileLink(warning.filePath, warning.line)}${title ? ` ${title}` : ""} \`${inline(warning.rule)}\``,
         );
       }
-      if (warnings.length > 50)
+      if (warnings.length > MAX_LISTED)
         lines.push(
           "",
-          `${plural(warnings.length - 50, "more warning")} not shown.`,
+          `${plural(warnings.length - MAX_LISTED, "more warning")} not shown.`,
         );
       lines.push("", "</details>");
     }

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -37,7 +37,11 @@ jobs:
         run: |
           set -uo pipefail
           CHANGED="${RUNNER_TEMP}/react-doctor-changed-files.txt"
-          git diff --name-only --diff-filter=ACMR "${REACT_DOCTOR_BASE_SHA}...${HEAD_SHA}" > "$CHANGED"
+          if ! git diff --name-only --diff-filter=ACMR "${REACT_DOCTOR_BASE_SHA}...${HEAD_SHA}" > "$CHANGED"; then
+            echo "Could not diff ${REACT_DOCTOR_BASE_SHA}...${HEAD_SHA}; failing rather than skipping the scan." >&2
+            echo "exit-code=1" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           if [ ! -s "$CHANGED" ]; then
             echo "No changed files; nothing for react-doctor to scan."
             echo "exit-code=0" >> "$GITHUB_OUTPUT"
@@ -45,7 +49,8 @@ jobs:
           fi
           REPORT="${RUNNER_TEMP}/react-doctor-report.json"
           npx --yes react-doctor@0.4.2 . --blocking error --changed-files-from "$CHANGED" --json --json-compact > "$REPORT"
-          echo "exit-code=$?" >> "$GITHUB_OUTPUT"
+          status=$?
+          echo "exit-code=$status" >> "$GITHUB_OUTPUT"
           echo "report=$REPORT" >> "$GITHUB_OUTPUT"
 
       - name: Upsert sticky PR comment


### PR DESCRIPTION
## Problem

#2520 added the react-doctor CI action. A multi-perspective review of the equivalent change on posthog/posthog (PostHog/posthog#62084) surfaced a few reliability and robustness issues in the same workflow + renderer that were already merged here. This is the catch-up hardening.

## Changes

`react-doctor.yml`:
- **Fail closed on `git diff` failure.** The scan step runs `set -uo pipefail` without `-e`, so previously if `git diff base...head` failed (e.g. the base SHA was missing), the redirect left an empty changed-files list — indistinguishable from "no changes" — and the gate passed green **without scanning anything**. Now a failed diff exits 1.
- **Edit-safe exit-code capture.** `npx ... > "$REPORT"; status=$?` on adjacent lines instead of `echo "exit-code=$?"`, so the gate can't be silently broken by inserting a command between the run and the capture.

`react-doctor-comment.mjs`:
- **Cap the errors list** at `MAX_LISTED` (50) like warnings already were, so a large error set can't exceed GitHub's 65536-char comment limit (which would 422 and post no comment). Named the shared cap.
- **Neutralise PR-controlled strings.** Strip backticks and angle brackets from file paths, rule names, and titles so a crafted filename can't spoof the comment layout (e.g. inject a stray `</details>` or a fake "no issues" line). GitHub already sanitises for XSS; this prevents cosmetic spoofing.

No behaviour change for the normal (clean / has-findings) path.

## How did you test this?

I'm an agent. Validated the workflow YAML parses, ran the renderer locally against synthetic reports including a malicious-input case (backtick/angle-bracket file path and `</details><script>` title) to confirm they're stripped, and ran Biome (`biome ci`) on the renderer. The workflow exercises itself on this PR.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
