### PR TITLE
fix(ci): url-encode file paths in react-doctor comment links

### DIFF
--- a/.github/scripts/react-doctor-comment.mjs
+++ b/.github/scripts/react-doctor-comment.mjs
@@ -26,9 +26,18 @@ const byFileThenLine = (a, b) =>
     : a.filePath < b.filePath
       ? -1
       : 1;
+const encodedPath = (file) =>
+  String(file ?? "")
+    .split("/")
+    .map((segment) =>
+      encodeURIComponent(segment).replace(/[()]/g, (c) =>
+        c === "(" ? "%28" : "%29",
+      ),
+    )
+    .join("/");
 const fileLink = (file, line) =>
   slug && head
-    ? `[\`${inline(file)}:${line}\`](${server}/${slug}/blob/${head}/${file}#L${line})`
+    ? `[\`${inline(file)}:${line}\`](${server}/${slug}/blob/${head}/${encodedPath(file)}#L${line})`
     : `\`${inline(file)}:${line}\``;
 
 let report;


### PR DESCRIPTION
## Problem

Follow-up to the markdown hardening in #2525 (merged before this could be folded in). Two PR review bots (chatgpt-codex, greptile) correctly flagged a gap: the comment renderer's `fileLink` sanitizes the link **display text** via `inline(file)`, but the link **URL target** still interpolated the raw `file` path. A path containing an unbalanced `)` — reasonably common in React codebases (e.g. `Button(deprecated).tsx`, or worse `weird)name.tsx`) — closes the GFM link early and leaks the remainder as visible text, which defeats the spoofing protection the hardening added.

## Changes

`react-doctor-comment.mjs`: percent-encode each path segment in the markdown link target (`encodedPath`), including parens and spaces (`encodeURIComponent` leaves `(`/`)` literal, so they're encoded explicitly to `%28`/`%29`). Slashes are preserved as path separators. Display text is unchanged (still the readable, backtick/angle-bracket-stripped path).

## How did you test this?

I'm an agent. Ran the renderer against a synthetic report with a path containing an unbalanced `)` and a space (`src/weird)name (x).tsx`) and confirmed the URL renders as `.../src/weird%29name%20%28x%29.tsx#L7` (link intact, nothing leaks), and ran Biome (`biome ci`) on the file.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
