### PR TITLE
fix(ci): match linux maker bin to executableName

### DIFF
--- a/apps/code/forge.config.ts
+++ b/apps/code/forge.config.ts
@@ -150,7 +150,8 @@ const sharedLinuxOptions = {
   productName: "PostHog Code",
   genericName: "Code Editor",
   description: "PostHog Code desktop app",
-  bin: "posthog-code",
+  // Must match packagerConfig.executableName — the maker locates the packaged binary by this name
+  bin: "PostHog Code",
   icon: "./build/app-icon.png",
   categories: ["Development"],
   homepage: "https://github.com/PostHog/code",


### PR DESCRIPTION
## Problem

The `code-release.yml` pipeline has failed on every release since #2466 (`v0.53.82`, `.95`, `.97`, `.98`). Both `publish-linux` jobs (`ubuntu-24.04` and `ubuntu-24.04-arm`) abort while building the `.deb` distributable:

```
✖ Making a deb distributable for linux/{arch} [FAILED: could not find the Electron app
  binary at ".../apps/code/out/PostHog Code-linux-{arch}/posthog-code".]
```

## Changes

Set `sharedLinuxOptions.bin` to `"PostHog Code"` so the deb/rpm makers match the packaged `executableName`