### PR TITLE
fix(code): make PR diff source consistent with PR badge

### DIFF
--- a/apps/code/src/renderer/features/code-review/hooks/useEffectiveDiffSource.ts
+++ b/apps/code/src/renderer/features/code-review/hooks/useEffectiveDiffSource.ts
@@ -1,5 +1,5 @@
 import { useDiffViewerStore } from "@features/code-editor/stores/diffViewerStore";
-import { useLinkedBranchPrUrl } from "@features/git-interaction/hooks/useLinkedBranchPrUrl";
+import { useTaskPrUrl } from "@features/git-interaction/hooks/useTaskPrUrl";
 import type { DiffStats } from "@features/git-interaction/utils/diffStats";
 import { useCwd } from "@features/sidebar/hooks/useCwd";
 import { useWorkspace } from "@features/workspace/hooks/useWorkspace";
@@ -72,10 +72,7 @@ export function useEffectiveDiffSource(taskId: string): EffectiveDiffSource {
   const hasLocalChanges = diffStats.filesChanged > 0;
   const branchSourceAvailable = !!linkedBranch && aheadOfDefault > 0;
 
-  const prUrl = useLinkedBranchPrUrl({
-    linkedBranch,
-    folderPath: workspace?.folderPath ?? null,
-  });
+  const prUrl = useTaskPrUrl(taskId, workspace?.mode === "cloud");
   const prSourceAvailable = !!prUrl;
 
   const repoSlug = repoInfo


### PR DESCRIPTION
## Problem

sometimes, you'll see a PR badge in the top right, but then the diff panel shows no option to view the PR diff

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

updates diff panel to read PR URL from DB if we have it

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manally

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?