### PR TITLE
chore(code): add prompt sent event to cloud tasks

### DIFF
--- a/apps/code/src/renderer/sagas/task/task-creation.ts
+++ b/apps/code/src/renderer/sagas/task/task-creation.ts
@@ -24,7 +24,9 @@ import {
   SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP,
   type Task,
 } from "@shared/types";
+import { ANALYTICS_EVENTS } from "@shared/types/analytics";
 import type { CloudRunSource, PrAuthorshipMode } from "@shared/types/cloud";
+import { track } from "@utils/analytics";
 import { logger } from "@utils/logger";
 
 const log = logger.scope("task-creation-saga");
@@ -303,13 +305,28 @@ export class TaskCreationSaga extends Saga<
               )
             : [];
 
-          return this.deps.posthogClient.startTaskRun(task.id, taskRun.id, {
-            pendingUserMessage: transport?.messageText,
-            pendingUserArtifactIds:
-              pendingUserArtifactIds.length > 0
-                ? pendingUserArtifactIds
-                : undefined,
-          });
+          const startedRun = await this.deps.posthogClient.startTaskRun(
+            task.id,
+            taskRun.id,
+            {
+              pendingUserMessage: transport?.messageText,
+              pendingUserArtifactIds:
+                pendingUserArtifactIds.length > 0
+                  ? pendingUserArtifactIds
+                  : undefined,
+            },
+          );
+
+          if (transport) {
+            track(ANALYTICS_EVENTS.PROMPT_SENT, {
+              task_id: task.id,
+              is_initial: true,
+              execution_type: "cloud",
+              prompt_length_chars: transport.messageText?.length ?? 0,
+            });
+          }
+
+          return startedRun;
         },
         rollback: async () => {
           log.info("Rolling back: cloud run (no-op)", { taskId: task.id });


### PR DESCRIPTION
## Problem

this is not 100% accurate because we only track "prompt sent" for local tasks https://us.posthog.com/project/2/insights/9A5loOF4

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

adds "prompt sent" event to cloud tasks

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?