### PR TITLE
feat(inbox): remove scale-gated rollout for signals inbox

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/InboxEmptyStates.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxEmptyStates.tsx
@@ -1,13 +1,8 @@
 import { AnimatedEllipsis } from "@features/inbox/components/utils/AnimatedEllipsis";
 import { SOURCE_PRODUCT_META } from "@features/inbox/components/utils/source-product-icons";
-import { CheckCircleIcon } from "@phosphor-icons/react";
 import { Box, Button, Flex, Text, Tooltip } from "@radix-ui/themes";
-import builderHog from "@renderer/assets/images/hedgehogs/builder-hog-03.png";
 import explorerHog from "@renderer/assets/images/hedgehogs/explorer-hog.png";
 import mailHog from "@renderer/assets/images/mail-hog.png";
-import { ANALYTICS_EVENTS } from "@shared/types/analytics";
-import { track } from "@utils/analytics";
-import { useState } from "react";
 
 // ── Full-width empty states ─────────────────────────────────────────────────
 
@@ -67,78 +62,6 @@ export function WarmingUpPane({
             Configure inbox
           </Button>
         </Flex>
-      </Flex>
-    </Flex>
-  );
-}
-
-export function GatedDueToScalePane() {
-  const [registered, setRegistered] = useState(false);
-
-  const handleRegisterInterest = () => {
-    track(ANALYTICS_EVENTS.INBOX_INTEREST_REGISTERED);
-    setRegistered(true);
-  };
-
-  return (
-    <Flex
-      direction="column"
-      align="center"
-      justify="center"
-      height="100%"
-      px="5"
-    >
-      <Flex direction="column" align="center" className="max-w-[420px]">
-        <img src={builderHog} alt="" className="mb-[16px] w-[120px]" />
-
-        <Text
-          align="center"
-          className="font-bold text-(--gray-12) text-lg leading-6.5"
-        >
-          We're rolling out self-driving gradually
-          <AnimatedEllipsis />
-        </Text>
-
-        <Flex
-          direction="column"
-          align="center"
-          gap="3"
-          mt="3"
-          className="max-w-[340px]"
-        >
-          <Text
-            align="center"
-            className="text-(--gray-11) text-[13px] leading-[1.35]"
-          >
-            Inbox watches your sessions, issues, and evals around the clock, and
-            surfaces ready-to-run fixes.
-            <br />
-            <Text className="font-medium text-(--gray-12)">
-              We're scaling it up carefully so every report stays high-signal.
-            </Text>
-          </Text>
-        </Flex>
-
-        {registered ? (
-          <Flex align="center" gap="2" className="mt-[20px]">
-            <CheckCircleIcon
-              size={16}
-              weight="fill"
-              className="text-(--grass-9)"
-            />
-            <Text className="text-(--gray-11) text-[13px]">
-              Got it — we'll let you know.
-            </Text>
-          </Flex>
-        ) : (
-          <Button
-            size="2"
-            onClick={handleRegisterInterest}
-            className="mt-[20px]"
-          >
-            Let me know when self-driving is available for my organization
-          </Button>
-        )}
       </Flex>
     </Flex>
   );

--- a/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxSignalsTab.tsx
@@ -539,7 +539,6 @@ export function InboxSignalsTab() {
       source_product_filter: sourceProductFilter,
       status_filter_count: statusFilter.length,
       is_empty: totalCount === 0,
-      is_gated_due_to_scale: false,
       priority_p0_count: priorityCounts.P0,
       priority_p1_count: priorityCounts.P1,
       priority_p2_count: priorityCounts.P2,

--- a/apps/code/src/renderer/features/inbox/components/InboxView.tsx
+++ b/apps/code/src/renderer/features/inbox/components/InboxView.tsx
@@ -1,51 +1,10 @@
-import { useFeatureFlag } from "@hooks/useFeatureFlag";
 import { useSetHeaderContent } from "@hooks/useSetHeaderContent";
 import { EnvelopeSimpleIcon } from "@phosphor-icons/react";
 import { Flex, Text } from "@radix-ui/themes";
-import { INBOX_GATED_DUE_TO_SCALE_FLAG } from "@shared/constants";
-import { ANALYTICS_EVENTS } from "@shared/types/analytics";
-import { track } from "@utils/analytics";
-import { useEffect, useMemo, useRef } from "react";
-import { GatedDueToScalePane } from "./InboxEmptyStates";
+import { useMemo } from "react";
 import { InboxSignalsTab } from "./InboxSignalsTab";
 
 export function InboxView() {
-  const isGatedDueToScale = useFeatureFlag(INBOX_GATED_DUE_TO_SCALE_FLAG);
-
-  // Scale-gated users see GatedDueToScalePane instead of InboxSignalsTab (where
-  // INBOX_VIEWED normally fires), and the inbox data isn't loaded while gated.
-  // Fire the event here, once per gated visit, so these visits are still
-  // measured — flagged so they're distinguishable from a genuinely empty inbox.
-  const gatedViewedFiredRef = useRef(false);
-  useEffect(() => {
-    if (!isGatedDueToScale) {
-      gatedViewedFiredRef.current = false;
-      return;
-    }
-    if (gatedViewedFiredRef.current) return;
-    gatedViewedFiredRef.current = true;
-    track(ANALYTICS_EVENTS.INBOX_VIEWED, {
-      report_count: 0,
-      total_count: 0,
-      ready_count: 0,
-      has_active_filters: false,
-      source_product_filter: [],
-      status_filter_count: 0,
-      is_empty: true,
-      is_gated_due_to_scale: true,
-      priority_p0_count: 0,
-      priority_p1_count: 0,
-      priority_p2_count: 0,
-      priority_p3_count: 0,
-      priority_p4_count: 0,
-      priority_unknown_count: 0,
-      actionability_immediately_actionable_count: 0,
-      actionability_requires_human_input_count: 0,
-      actionability_not_actionable_count: 0,
-      actionability_unknown_count: 0,
-    });
-  }, [isGatedDueToScale]);
-
   const headerContent = useMemo(
     () => (
       <Flex align="center" gap="2" className="w-full min-w-0">
@@ -65,7 +24,7 @@ export function InboxView() {
 
   return (
     <div className="h-full">
-      {isGatedDueToScale ? <GatedDueToScalePane /> : <InboxSignalsTab />}
+      <InboxSignalsTab />
     </div>
   );
 }

--- a/apps/code/src/shared/constants.ts
+++ b/apps/code/src/shared/constants.ts
@@ -1,5 +1,4 @@
 export const BILLING_FLAG = "posthog-code-billing";
-export const INBOX_GATED_DUE_TO_SCALE_FLAG = "inbox-gated-due-to-scale";
 export const EXPERIMENT_SUGGESTIONS_FLAG =
   "posthog-code-experiment-suggestions";
 export const SYNC_CLOUD_TASKS_FLAG = "posthog-code-sync-cloud-tasks";

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -523,8 +523,6 @@ export interface InboxViewedProperties {
   source_product_filter: string[];
   status_filter_count: number;
   is_empty: boolean;
-  /** True when the inbox is scale-gated (GatedDueToScalePane shown, data not loaded). */
-  is_gated_due_to_scale: boolean;
   /** Breakdown of the visible report_count by priority (P0–P4, or "unknown"). */
   priority_p0_count: number;
   priority_p1_count: number;
@@ -776,7 +774,6 @@ export const ANALYTICS_EVENTS = {
   CLOUD_STREAM_DISCONNECTED: "Cloud stream disconnected",
 
   // Inbox events
-  INBOX_INTEREST_REGISTERED: "Inbox interest registered",
   INBOX_VIEWED: "Inbox viewed",
   INBOX_REPORT_OPENED: "Inbox report opened",
   INBOX_REPORT_CLOSED: "Inbox report closed",
@@ -899,7 +896,6 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.CLOUD_STREAM_DISCONNECTED]: CloudStreamDisconnectedProperties;
 
   // Inbox events
-  [ANALYTICS_EVENTS.INBOX_INTEREST_REGISTERED]: never;
   [ANALYTICS_EVENTS.INBOX_VIEWED]: InboxViewedProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_OPENED]: InboxReportOpenedProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_CLOSED]: InboxReportClosedProperties;

--- a/apps/mobile/src/features/inbox/utils.test.ts
+++ b/apps/mobile/src/features/inbox/utils.test.ts
@@ -75,7 +75,6 @@ describe("buildInboxViewedProperties", () => {
       ready_count: 0,
       has_active_filters: false,
       is_empty: true,
-      is_gated_due_to_scale: false,
       priority_p0_count: 0,
       priority_p1_count: 0,
       priority_p2_count: 0,

--- a/apps/mobile/src/features/inbox/utils.ts
+++ b/apps/mobile/src/features/inbox/utils.ts
@@ -237,7 +237,6 @@ export function buildInboxViewedProperties(
     source_product_filter: filters.sourceProductFilter,
     status_filter_count: filters.statusFilter.length,
     is_empty: totalCount === 0,
-    is_gated_due_to_scale: false,
     priority_p0_count: priorityCounts.P0,
     priority_p1_count: priorityCounts.P1,
     priority_p2_count: priorityCounts.P2,

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -62,7 +62,6 @@ export interface InboxViewedProperties {
   source_product_filter: string[];
   status_filter_count: number;
   is_empty: boolean;
-  is_gated_due_to_scale: boolean;
   priority_p0_count: number;
   priority_p1_count: number;
   priority_p2_count: number;


### PR DESCRIPTION
## Problem

The signals Inbox was gated behind the `inbox-gated-due-to-scale` feature flag. Orgs flagged in were shown a "we're rolling out self-driving gradually" pane (`GatedDueToScalePane`) instead of their inbox, and the inbox data wasn't loaded for them. We no longer need this rollout gate — the inbox should be available to everyone.

## Changes

Removed the scale gate end to end:

- **`InboxView.tsx`** — dropped the `useFeatureFlag(INBOX_GATED_DUE_TO_SCALE_FLAG)` branch and the gate-only `INBOX_VIEWED` tracking effect; now always renders `<InboxSignalsTab />`.
- **`InboxEmptyStates.tsx`** — deleted the now-unused `GatedDueToScalePane` component and its dangling imports.
- **`constants.ts`** — removed the `INBOX_GATED_DUE_TO_SCALE_FLAG` constant.
- **Analytics** — removed the gate-only `is_gated_due_to_scale` property from `InboxViewedProperties` and the `INBOX_INTEREST_REGISTERED` event (desktop `analytics.ts`, `InboxSignalsTab.tsx`, and the mobile equivalents).

No backend changes are needed in `posthog/posthog` — that repo never referenced this flag (the flag was configured purely in PostHog). The web Inbox there is gated by a separate `product-autonomy` flag, which is unrelated to this scale gate and left untouched.

## How did you test this?

- `pnpm typecheck` in `apps/code` — 0 errors.
- `biome check` on all changed files — clean.
- `vitest run apps/mobile/src/features/inbox/utils.test.ts` — 11/11 passing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*