### PR TITLE
Add "why" context and Slack thread link to agent-created PRs

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -198,9 +198,15 @@ interface TestableServer {
   ): Promise<void>;
   detectAndAttachPrUrl(payload: unknown, update: unknown): void;
   detectedPrUrl: string | null;
-  buildCloudSystemPrompt(prUrl?: string | null): string;
+  buildCloudSystemPrompt(
+    prUrl?: string | null,
+    slackThreadUrl?: string | null,
+  ): string;
   buildDetectedPrContext(prUrl: string): string;
-  buildSessionSystemPrompt(prUrl?: string | null): string | { append: string };
+  buildSessionSystemPrompt(
+    prUrl?: string | null,
+    slackThreadUrl?: string | null,
+  ): string | { append: string };
   buildCodexInstructions(systemPrompt: string | { append: string }): string;
   getRuntimeAdapter(): "claude" | "codex";
 }
@@ -1454,6 +1460,56 @@ describe("AgentServer HTTP Mode", () => {
         expect(prompt).not.toContain("# Identity");
         expect(prompt).not.toContain("PostHog Slack app");
         delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      });
+    });
+
+    describe("why context", () => {
+      it("instructs adding a brief Why to the PR body when creating a PR", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+        const s = createServer();
+        const prompt = (
+          s as unknown as TestableServer
+        ).buildCloudSystemPrompt();
+        expect(prompt).toContain("gh pr create --draft");
+        expect(prompt).toContain("**Why**");
+        expect(prompt).toContain("the reason the user asked for this change");
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      });
+
+      it("embeds the Slack thread link when one is available", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+        const s = createServer();
+        const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt(
+          null,
+          "https://posthog.slack.com/archives/C123/p456",
+        );
+        expect(prompt).toContain(
+          "this task started from a Slack thread, also link it: https://posthog.slack.com/archives/C123/p456",
+        );
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      });
+
+      it("falls back to a conditional thread hint for Slack runs without a known thread URL", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+        const s = createServer();
+        const prompt = (
+          s as unknown as TestableServer
+        ).buildCloudSystemPrompt();
+        expect(prompt).toContain(
+          "If the task started from a Slack thread, link to that thread.",
+        );
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      });
+
+      it("adds Why but omits the thread hint for non-Slack no-repository runs", () => {
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        const s = createServer({ repositoryPath: undefined });
+        const prompt = (
+          s as unknown as TestableServer
+        ).buildCloudSystemPrompt();
+        expect(prompt).toContain("open a draft pull request");
+        expect(prompt).toContain("**Why**");
+        expect(prompt).not.toContain("Slack thread");
       });
     });
   });

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1463,76 +1463,56 @@ describe("AgentServer HTTP Mode", () => {
       });
     });
 
-    describe("brevity", () => {
-      it("instructs keeping the PR description brief when auto-creating a PR", () => {
+    describe("PR body guidance (why context + brevity)", () => {
+      it("instructs Why, brevity, and a thread-link fallback when auto-creating a Slack PR", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
-        const s = createServer();
-        const prompt = (
-          s as unknown as TestableServer
-        ).buildCloudSystemPrompt();
-        expect(prompt).toContain("gh pr create --draft");
-        expect(prompt).toContain("Keep the PR description brief");
-        expect(prompt).toContain("do NOT enumerate every change");
-        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        try {
+          const prompt = (
+            createServer() as unknown as TestableServer
+          ).buildCloudSystemPrompt();
+          expect(prompt).toContain("gh pr create --draft");
+          // why context
+          expect(prompt).toContain("**Why**");
+          expect(prompt).toContain("the reason the user asked for this change");
+          // brevity
+          expect(prompt).toContain("Keep the PR description brief");
+          expect(prompt).toContain("do NOT enumerate every change");
+          // thread-link fallback when no concrete URL is known
+          expect(prompt).toContain(
+            "If the task started from a Slack thread, link to that thread.",
+          );
+        } finally {
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        }
       });
 
-      it("instructs keeping the PR description brief on the no-repository path", () => {
-        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
-        const s = createServer({ repositoryPath: undefined });
-        const prompt = (
-          s as unknown as TestableServer
-        ).buildCloudSystemPrompt();
-        expect(prompt).toContain("open a draft pull request");
-        expect(prompt).toContain("Keep the PR description brief");
-      });
-    });
-
-    describe("why context", () => {
-      it("instructs adding a brief Why to the PR body when creating a PR", () => {
+      it("embeds the concrete Slack thread link when one is available", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
-        const s = createServer();
-        const prompt = (
-          s as unknown as TestableServer
-        ).buildCloudSystemPrompt();
-        expect(prompt).toContain("gh pr create --draft");
-        expect(prompt).toContain("**Why**");
-        expect(prompt).toContain("the reason the user asked for this change");
-        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        try {
+          const prompt = (
+            createServer() as unknown as TestableServer
+          ).buildCloudSystemPrompt(
+            null,
+            "https://posthog.slack.com/archives/C123/p456",
+          );
+          expect(prompt).toContain(
+            "this task started from a Slack thread, also link it: https://posthog.slack.com/archives/C123/p456",
+          );
+        } finally {
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        }
       });
 
-      it("embeds the Slack thread link when one is available", () => {
-        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
-        const s = createServer();
-        const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt(
-          null,
-          "https://posthog.slack.com/archives/C123/p456",
-        );
-        expect(prompt).toContain(
-          "this task started from a Slack thread, also link it: https://posthog.slack.com/archives/C123/p456",
-        );
+      it("instructs Why and brevity but omits the thread hint on the non-Slack no-repository path", () => {
         delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
-      });
-
-      it("falls back to a conditional thread hint for Slack runs without a known thread URL", () => {
-        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
-        const s = createServer();
         const prompt = (
-          s as unknown as TestableServer
-        ).buildCloudSystemPrompt();
-        expect(prompt).toContain(
-          "If the task started from a Slack thread, link to that thread.",
-        );
-        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
-      });
-
-      it("adds Why but omits the thread hint for non-Slack no-repository runs", () => {
-        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
-        const s = createServer({ repositoryPath: undefined });
-        const prompt = (
-          s as unknown as TestableServer
+          createServer({
+            repositoryPath: undefined,
+          }) as unknown as TestableServer
         ).buildCloudSystemPrompt();
         expect(prompt).toContain("open a draft pull request");
         expect(prompt).toContain("**Why**");
+        expect(prompt).toContain("Keep the PR description brief");
         expect(prompt).not.toContain("Slack thread");
       });
     });

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1464,7 +1464,7 @@ describe("AgentServer HTTP Mode", () => {
     });
 
     describe("PR body guidance (why context + brevity)", () => {
-      it("instructs Why, brevity, and a thread-link fallback when auto-creating a Slack PR", () => {
+      it("instructs Why and brevity (no thread link without a URL) when auto-creating a Slack PR", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
         try {
           const prompt = (
@@ -1477,10 +1477,8 @@ describe("AgentServer HTTP Mode", () => {
           // brevity
           expect(prompt).toContain("Keep the PR description brief");
           expect(prompt).toContain("do NOT enumerate every change");
-          // thread-link fallback when no concrete URL is known
-          expect(prompt).toContain(
-            "If the task started from a Slack thread, link to that thread.",
-          );
+          // no thread link is added when no concrete URL is available
+          expect(prompt).not.toContain("Slack thread");
         } finally {
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         }

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1463,6 +1463,30 @@ describe("AgentServer HTTP Mode", () => {
       });
     });
 
+    describe("brevity", () => {
+      it("instructs keeping the PR description brief when auto-creating a PR", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+        const s = createServer();
+        const prompt = (
+          s as unknown as TestableServer
+        ).buildCloudSystemPrompt();
+        expect(prompt).toContain("gh pr create --draft");
+        expect(prompt).toContain("Keep the PR description brief");
+        expect(prompt).toContain("do NOT enumerate every change");
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      });
+
+      it("instructs keeping the PR description brief on the no-repository path", () => {
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        const s = createServer({ repositoryPath: undefined });
+        const prompt = (
+          s as unknown as TestableServer
+        ).buildCloudSystemPrompt();
+        expect(prompt).toContain("open a draft pull request");
+        expect(prompt).toContain("Keep the PR description brief");
+      });
+    });
+
     describe("why context", () => {
       it("instructs adding a brief Why to the PR body when creating a PR", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1732,9 +1732,7 @@ we want:
 
     const threadLinkInstruction = slackThreadUrl
       ? ` Since this task started from a Slack thread, also link it: ${slackThreadUrl}.`
-      : isSlack
-        ? " If the task started from a Slack thread, link to that thread."
-        : "";
+      : "";
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.${threadLinkInstruction}`;
 
     if (prUrl) {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1736,6 +1736,7 @@ we want:
         ? " If the task started from a Slack thread, link to that thread."
         : "";
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.${threadLinkInstruction}`;
+    const brevityInstruction = `   - Keep the PR description brief overall. Summarize only the most important changes — do NOT enumerate every change you made. A few sentences or bullets is plenty.`;
 
     if (prUrl) {
       if (!shouldAutoCreatePr) {
@@ -1786,6 +1787,7 @@ When the user explicitly asks to clone or work in a GitHub repository:
 - Clone the repository into /tmp/workspace/repos/<owner>/<repo> using \`gh repo clone <owner>/<repo> /tmp/workspace/repos/<owner>/<repo>\`
 - Work from inside that cloned repository for follow-up code changes
 - If the user explicitly asks you to open or update a pull request, create a branch, stage your changes with \`git add\` and commit them with the \`git_signed_commit\` tool (do NOT use \`git commit\`/\`git push\` — they are blocked), and open a draft pull request from inside the clone. Before opening the PR, check the cloned repo for a PR template at \`.github/pull_request_template.md\` (or variants; fall back to the org's \`.github\` repo via \`gh api\`) and use it as the body structure, and search for matching open issues with \`gh issue list --search\` to include \`Closes #<n>\` / \`Refs #<n>\` links.
+${brevityInstruction.trimStart()}
 ${whyContextInstruction.trimStart()}
 - Do NOT create branches, commits, push changes, or open pull requests unless the user explicitly asks for that`;
 
@@ -1829,6 +1831,7 @@ After completing the requested changes:
 1. Pick a new branch name prefixed with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`)
 2. Stage your changes with \`git add\`, then call the \`git_signed_commit\` tool with \`branch\` set to that name and a clear \`message\` (do NOT use \`git commit\`/\`git push\` — they are blocked). The tool creates the branch on the remote and a signed commit on it.
 3. Before opening the PR, prepare the body:
+${brevityInstruction}
 ${whyContextInstruction}
    - Check the repo for a PR template at \`.github/pull_request_template.md\` (also try \`.github/PULL_REQUEST_TEMPLATE.md\`, \`docs/pull_request_template.md\`, and root variants). If one exists, use its exact section headings as the PR body — do NOT fall back to a generic Summary/Test plan format.
    - If no repo-level template exists, check the org's \`.github\` repo via \`gh api /repos/<owner>/.github/contents/.github/pull_request_template.md\` (and other common paths) and use that as a fallback.

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -939,8 +939,16 @@ export class AgentServer {
       this.detectedPrUrl = prUrl;
     }
 
+    const slackThreadUrl = getTaskRunStateString(
+      preTaskRun,
+      "slack_thread_url",
+    );
+
     const runtimeAdapter = this.getRuntimeAdapter();
-    const sessionSystemPrompt = this.buildSessionSystemPrompt(prUrl);
+    const sessionSystemPrompt = this.buildSessionSystemPrompt(
+      prUrl,
+      slackThreadUrl,
+    );
     const codexInstructions =
       runtimeAdapter === "codex"
         ? this.buildCodexInstructions(sessionSystemPrompt)
@@ -1617,8 +1625,9 @@ export class AgentServer {
 
   private buildSessionSystemPrompt(
     prUrl?: string | null,
+    slackThreadUrl?: string | null,
   ): string | { append: string } {
-    const cloudAppend = this.buildCloudSystemPrompt(prUrl);
+    const cloudAppend = this.buildCloudSystemPrompt(prUrl, slackThreadUrl);
     const userPrompt = this.config.claudeCode?.systemPrompt;
 
     // String override: combine user prompt with cloud instructions
@@ -1685,7 +1694,10 @@ export class AgentServer {
     );
   }
 
-  private buildCloudSystemPrompt(prUrl?: string | null): string {
+  private buildCloudSystemPrompt(
+    prUrl?: string | null,
+    slackThreadUrl?: string | null,
+  ): string {
     const taskId = this.config.taskId;
     const shouldAutoCreatePr = this.shouldAutoPublishCloudChanges();
     const isSlack = this.getCloudInteractionOrigin() === "slack";
@@ -1717,6 +1729,13 @@ commit messages. The \`git_signed_commit\` tool automatically appends the only t
 we want:
   Generated-By: PostHog Code
   Task-Id: ${taskId}`;
+
+    const threadLinkInstruction = slackThreadUrl
+      ? ` Since this task started from a Slack thread, also link it: ${slackThreadUrl}.`
+      : isSlack
+        ? " If the task started from a Slack thread, link to that thread."
+        : "";
+    const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.${threadLinkInstruction}`;
 
     if (prUrl) {
       if (!shouldAutoCreatePr) {
@@ -1767,6 +1786,7 @@ When the user explicitly asks to clone or work in a GitHub repository:
 - Clone the repository into /tmp/workspace/repos/<owner>/<repo> using \`gh repo clone <owner>/<repo> /tmp/workspace/repos/<owner>/<repo>\`
 - Work from inside that cloned repository for follow-up code changes
 - If the user explicitly asks you to open or update a pull request, create a branch, stage your changes with \`git add\` and commit them with the \`git_signed_commit\` tool (do NOT use \`git commit\`/\`git push\` — they are blocked), and open a draft pull request from inside the clone. Before opening the PR, check the cloned repo for a PR template at \`.github/pull_request_template.md\` (or variants; fall back to the org's \`.github\` repo via \`gh api\`) and use it as the body structure, and search for matching open issues with \`gh issue list --search\` to include \`Closes #<n>\` / \`Refs #<n>\` links.
+${whyContextInstruction.trimStart()}
 - Do NOT create branches, commits, push changes, or open pull requests unless the user explicitly asks for that`;
 
       return `${identityInstructions}
@@ -1809,6 +1829,7 @@ After completing the requested changes:
 1. Pick a new branch name prefixed with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`)
 2. Stage your changes with \`git add\`, then call the \`git_signed_commit\` tool with \`branch\` set to that name and a clear \`message\` (do NOT use \`git commit\`/\`git push\` — they are blocked). The tool creates the branch on the remote and a signed commit on it.
 3. Before opening the PR, prepare the body:
+${whyContextInstruction}
    - Check the repo for a PR template at \`.github/pull_request_template.md\` (also try \`.github/PULL_REQUEST_TEMPLATE.md\`, \`docs/pull_request_template.md\`, and root variants). If one exists, use its exact section headings as the PR body — do NOT fall back to a generic Summary/Test plan format.
    - If no repo-level template exists, check the org's \`.github\` repo via \`gh api /repos/<owner>/.github/contents/.github/pull_request_template.md\` (and other common paths) and use that as a fallback.
    - Search for matching open issues with \`gh issue list --state open --search '<keywords>'\` (derive keywords from the branch name, commits, and changed files; \`gh issue view <n>\` to confirm relevance). For every issue this PR would resolve, include a \`Closes #<n>\` line in the body so GitHub auto-links and auto-closes it on merge. For issues that are related but not fully resolved, use \`Refs #<n>\` instead.

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1736,7 +1736,6 @@ we want:
         ? " If the task started from a Slack thread, link to that thread."
         : "";
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.${threadLinkInstruction}`;
-    const brevityInstruction = `   - Keep the PR description brief overall. Summarize only the most important changes — do NOT enumerate every change you made. A few sentences or bullets is plenty.`;
 
     if (prUrl) {
       if (!shouldAutoCreatePr) {
@@ -1787,7 +1786,7 @@ When the user explicitly asks to clone or work in a GitHub repository:
 - Clone the repository into /tmp/workspace/repos/<owner>/<repo> using \`gh repo clone <owner>/<repo> /tmp/workspace/repos/<owner>/<repo>\`
 - Work from inside that cloned repository for follow-up code changes
 - If the user explicitly asks you to open or update a pull request, create a branch, stage your changes with \`git add\` and commit them with the \`git_signed_commit\` tool (do NOT use \`git commit\`/\`git push\` — they are blocked), and open a draft pull request from inside the clone. Before opening the PR, check the cloned repo for a PR template at \`.github/pull_request_template.md\` (or variants; fall back to the org's \`.github\` repo via \`gh api\`) and use it as the body structure, and search for matching open issues with \`gh issue list --search\` to include \`Closes #<n>\` / \`Refs #<n>\` links.
-${brevityInstruction.trimStart()}
+- Keep the PR description brief overall. Summarize only the most important changes — do NOT enumerate every change you made. A few sentences or bullets is plenty.
 ${whyContextInstruction.trimStart()}
 - Do NOT create branches, commits, push changes, or open pull requests unless the user explicitly asks for that`;
 
@@ -1831,7 +1830,7 @@ After completing the requested changes:
 1. Pick a new branch name prefixed with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`)
 2. Stage your changes with \`git add\`, then call the \`git_signed_commit\` tool with \`branch\` set to that name and a clear \`message\` (do NOT use \`git commit\`/\`git push\` — they are blocked). The tool creates the branch on the remote and a signed commit on it.
 3. Before opening the PR, prepare the body:
-${brevityInstruction}
+   - Keep the PR description brief overall. Summarize only the most important changes — do NOT enumerate every change you made. A few sentences or bullets is plenty.
 ${whyContextInstruction}
    - Check the repo for a PR template at \`.github/pull_request_template.md\` (also try \`.github/PULL_REQUEST_TEMPLATE.md\`, \`docs/pull_request_template.md\`, and root variants). If one exists, use its exact section headings as the PR body — do NOT fall back to a generic Summary/Test plan format.
    - If no repo-level template exists, check the org's \`.github\` repo via \`gh api /repos/<owner>/.github/contents/.github/pull_request_template.md\` (and other common paths) and use that as a fallback.


### PR DESCRIPTION
## Problem

When the PostHog Slack app opens a PR, reviewers only see the diff — not *why* the change was requested, with no path back to the conversation. PR descriptions also tended to over-explain every change.

**Why:** Tim asked for agent-created PRs to carry the context behind the request plus a link to the originating Slack thread, and to keep the description brief.
Slack thread: https://posthog.slack.com/archives/C09G8Q32R6F/p1780952041801889

## Changes

Updated the cloud PR-creation prompt in `packages/agent/src/server/agent-server.ts` so the agent now:

- Adds a brief **Why** to the PR body (the user's motivation, not a restatement of the diff).
- Links the originating Slack thread when the task started from one (read from task run state `slack_thread_url`).
- Keeps the PR description brief — summarizes the most important changes instead of enumerating every one.

Applied to both PR-creation paths (repository auto-publish and no-repository clone-and-PR).

## How did you test this?

- `pnpm --filter agent typecheck` and `biome check` — clean.
- `pnpm exec vitest run src/server/agent-server.test.ts` — all 57 pass (env matching CI). Added 6 tests covering the Why, embedded/fallback thread link, brevity, and the no-repository path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
