### PR TITLE
feat(code): auto-run commands during onboarding

### DIFF
--- a/apps/code/src/renderer/features/onboarding/components/InstallCliStep.tsx
+++ b/apps/code/src/renderer/features/onboarding/components/InstallCliStep.tsx
@@ -1,4 +1,6 @@
 import { Tooltip } from "@components/ui/Tooltip";
+import { Terminal } from "@features/terminal/components/Terminal";
+import { terminalManager } from "@features/terminal/services/TerminalManager";
 import {
   ArrowLeft,
   ArrowRight,
@@ -8,9 +10,10 @@ import {
   Copy,
   GitBranch,
   GithubLogo,
+  Play,
   Warning,
 } from "@phosphor-icons/react";
-import { Button, Flex, IconButton, Text } from "@radix-ui/themes";
+import { Box, Button, Flex, IconButton, Text } from "@radix-ui/themes";
 import builderHog from "@renderer/assets/images/hedgehogs/builder-hog-03.png";
 import { trpcClient, useTRPC } from "@renderer/trpc/client";
 import {
@@ -20,6 +23,7 @@ import {
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { track } from "@utils/analytics";
 import { EXTERNAL_LINKS } from "@utils/links";
+import { isMac } from "@utils/platform";
 import { motion } from "framer-motion";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CliCheckPanel, InstalledBadge } from "./CliCheckPanel";
@@ -62,6 +66,129 @@ function CommandLine({ command }: { command: string }) {
           {copied ? <Check size={14} /> : <Copy size={14} />}
         </IconButton>
       </Tooltip>
+    </Flex>
+  );
+}
+
+/**
+ * A command the user can copy, or — on macOS — run directly in an embedded
+ * terminal. The run streams into an interactive xterm (so flows like
+ * `gh auth login` that prompt or open a browser work), and on a clean exit
+ * calls `onSuccess` so the parent can re-check install/auth status.
+ */
+function RunnableCommand({
+  displayCommand,
+  runCommand,
+  sessionPrefix,
+  analyticsCommand,
+  onSuccess,
+}: {
+  displayCommand: string;
+  runCommand?: string;
+  sessionPrefix: string;
+  analyticsCommand: "install_git" | "install_gh" | "auth_gh";
+  onSuccess?: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  // 0 = not started; each run bumps the generation for a fresh PTY/session.
+  const [generation, setGeneration] = useState(0);
+  const [exitCode, setExitCode] = useState<number | null>(null);
+
+  const sessionId = `${sessionPrefix}-${generation}`;
+  const isRunning = generation > 0 && exitCode === null;
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(displayCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [displayCommand]);
+
+  const handleRun = useCallback(() => {
+    setExitCode(null);
+    setGeneration((g) => g + 1);
+  }, []);
+
+  const handleExit = useCallback(
+    (code?: number) => {
+      const resolved = code ?? 0;
+      setExitCode(resolved);
+      track(ANALYTICS_EVENTS.ONBOARDING_CLI_RUN_COMPLETED, {
+        command: analyticsCommand,
+        exit_code: resolved,
+      });
+      if (resolved === 0) {
+        void onSuccess?.();
+      }
+    },
+    [analyticsCommand, onSuccess],
+  );
+
+  // Tear down the embedded terminal (and its PTY, if still alive) when the user
+  // re-runs or this command unmounts — onboarding shells shouldn't outlive it.
+  useEffect(() => {
+    if (generation === 0) return;
+    return () => {
+      terminalManager.destroy(sessionId);
+      void trpcClient.shell.destroy.mutate({ sessionId }).catch(() => {});
+    };
+  }, [sessionId, generation]);
+
+  return (
+    <Flex direction="column" gap="2">
+      <Flex
+        align="center"
+        justify="between"
+        gap="2"
+        className="rounded-(--radius-2) border border-(--gray-a3) bg-(--gray-2) py-[6px] pr-2 pl-3"
+      >
+        <Flex align="center" gap="2" className="min-w-0">
+          <Text className="select-none font-[var(--code-font-family)] text-(--gray-9) text-sm">
+            $
+          </Text>
+          <Text className="truncate font-[var(--code-font-family)] text-(--gray-12) text-sm">
+            {displayCommand}
+          </Text>
+        </Flex>
+        <Flex align="center" gap="2" className="shrink-0">
+          {isMac && (
+            <Button size="1" onClick={handleRun} loading={isRunning}>
+              <Play size={14} weight="fill" />
+              Run
+            </Button>
+          )}
+          <Tooltip content={copied ? "Copied!" : "Copy command"}>
+            <IconButton
+              size="1"
+              variant="ghost"
+              color="gray"
+              onClick={() => void handleCopy()}
+              aria-label="Copy command"
+            >
+              {copied ? <Check size={14} /> : <Copy size={14} />}
+            </IconButton>
+          </Tooltip>
+        </Flex>
+      </Flex>
+
+      {generation > 0 && (
+        <Box className="h-[220px] overflow-hidden rounded-(--radius-2) border border-(--gray-a3) bg-(--gray-2)">
+          <Terminal
+            key={sessionId}
+            sessionId={sessionId}
+            persistenceKey={sessionId}
+            cwd="~"
+            command={runCommand ?? displayCommand}
+            onExit={handleExit}
+          />
+        </Box>
+      )}
+
+      {exitCode !== null && exitCode !== 0 && (
+        <Text className="text-(--amber-11) text-xs">
+          Exited with code {exitCode}. Re-run it, or copy the command to run
+          manually.
+        </Text>
+      )}
     </Flex>
   );
 }
@@ -180,7 +307,12 @@ export function InstallCliStep({ onNext, onBack }: InstallCliStepProps) {
                         Install with Homebrew or Xcode Command Line Tools:
                       </Text>
                       <Flex direction="column" gap="2">
-                        <CommandLine command="brew install git" />
+                        <RunnableCommand
+                          displayCommand="brew install git"
+                          sessionPrefix="onboarding-git-install"
+                          analyticsCommand="install_git"
+                          onSuccess={() => void handleCheckGit()}
+                        />
                         <CommandLine command="xcode-select --install" />
                       </Flex>
                       <Flex align="center" justify="between" gap="3">
@@ -250,7 +382,12 @@ export function InstallCliStep({ onNext, onBack }: InstallCliStepProps) {
                       <Text className="text-(--gray-11) text-sm">
                         Install with Homebrew:
                       </Text>
-                      <CommandLine command="brew install gh" />
+                      <RunnableCommand
+                        displayCommand="brew install gh"
+                        sessionPrefix="onboarding-gh-install"
+                        analyticsCommand="install_gh"
+                        onSuccess={() => void handleCheckGh()}
+                      />
                       <Flex align="center" justify="between" gap="3">
                         <Button
                           size="1"
@@ -281,9 +418,15 @@ export function InstallCliStep({ onNext, onBack }: InstallCliStepProps) {
                   {!isLoadingGh && ghInstalled && !ghAuthenticated && (
                     <Flex direction="column" gap="3">
                       <Text className="text-(--gray-11) text-sm">
-                        Run this in your terminal to log in:
+                        Log in to the GitHub CLI
                       </Text>
-                      <CommandLine command="gh auth login" />
+                      <RunnableCommand
+                        displayCommand="gh auth login"
+                        runCommand="gh auth login --web --hostname github.com --git-protocol https"
+                        sessionPrefix="onboarding-gh-auth"
+                        analyticsCommand="auth_gh"
+                        onSuccess={() => void handleCheckGh()}
+                      />
                       <Flex justify="end">
                         <Button
                           size="1"

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -396,6 +396,11 @@ export interface OnboardingCliCheckCompletedProperties {
   gh_authenticated: boolean;
 }
 
+export interface OnboardingCliRunCompletedProperties {
+  command: "install_git" | "install_gh" | "auth_gh";
+  exit_code: number;
+}
+
 export interface OnboardingCompletedProperties {
   duration_seconds: number;
   github_connected: boolean;
@@ -751,6 +756,7 @@ export const ANALYTICS_EVENTS = {
   ONBOARDING_GITHUB_CONNECT_FAILED: "Onboarding github connect failed",
   ONBOARDING_GITHUB_CONNECTED: "Onboarding github connected",
   ONBOARDING_CLI_CHECK_COMPLETED: "Onboarding cli check completed",
+  ONBOARDING_CLI_RUN_COMPLETED: "Onboarding cli run completed",
   ONBOARDING_COMPLETED: "Onboarding completed",
   ONBOARDING_ABANDONED: "Onboarding abandoned",
   AI_CONSENT_GATE_SHOWN: "Ai consent gate shown",
@@ -874,6 +880,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECT_FAILED]: OnboardingGithubConnectFailedProperties;
   [ANALYTICS_EVENTS.ONBOARDING_GITHUB_CONNECTED]: never;
   [ANALYTICS_EVENTS.ONBOARDING_CLI_CHECK_COMPLETED]: OnboardingCliCheckCompletedProperties;
+  [ANALYTICS_EVENTS.ONBOARDING_CLI_RUN_COMPLETED]: OnboardingCliRunCompletedProperties;
   [ANALYTICS_EVENTS.ONBOARDING_COMPLETED]: OnboardingCompletedProperties;
   [ANALYTICS_EVENTS.ONBOARDING_ABANDONED]: OnboardingAbandonedProperties;
   [ANALYTICS_EVENTS.AI_CONSENT_GATE_SHOWN]: AiConsentGateShownProperties;


### PR DESCRIPTION
## Problem

i've seen a number of users without `gh` installed -- sometimes they're confused and don't know how to proceed, but either way, it's friction

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

for `brew install [git|gh] `and `gh auth login` commands, adds a "Run" button that runs the command in the onboarding step, with a mini terminal window

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## ![Screenshot 2026-06-08 at 3.57.18 PM.png](https://app.graphite.com/user-attachments/assets/bb5c2a84-0a5d-43da-b4a6-8ae1e95d7e3b.png)

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?