### PR TITLE
feat(code): show scout name on signal cards

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx
@@ -30,9 +30,21 @@ const ERROR_TRACKING_TYPE_LABELS: Record<string, string> = {
   issue_spiking: "Volume spike",
 };
 
+// Turn a scout's skill_name (e.g. "signals-scout-error-tracking") into a
+// human-friendly label (e.g. "Error tracking").
+function prettifyScoutName(skillName: string): string {
+  const cleaned = skillName
+    .replace(/^signals-scout-/, "")
+    .replace(/[-_]/g, " ")
+    .trim();
+  if (!cleaned) return "";
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
 function signalCardSourceLine(signal: {
   source_product: string;
   source_type: string;
+  extra?: Record<string, unknown>;
 }): string {
   const { source_product, source_type } = signal;
 
@@ -78,7 +90,11 @@ function signalCardSourceLine(signal: {
     source_product === "signals_scout" &&
     source_type === "cross_source_issue"
   ) {
-    return "Scout · Cross-source issue";
+    const skillName =
+      typeof signal.extra?.skill_name === "string"
+        ? prettifyScoutName(signal.extra.skill_name)
+        : "";
+    return skillName ? `Scout · ${skillName}` : "Scout · Cross-source issue";
   }
 
   const productLabel = source_product.replace(/_/g, " ");
@@ -271,7 +287,7 @@ function SignalCardHeader({
         )}
       </span>
       <Text className="font-medium text-(--gray-10) text-[13px]">
-        {signalCardSourceLine(signal)}
+        {signalCardSourceLine({ ...signal, extra: parseExtra(signal.extra) })}
       </Text>
       <span className="flex-1" />
       <RelativeTimestamp timestamp={signal.timestamp} />


### PR DESCRIPTION
## Problem

Scout-emitted signals on a report all rendered the same generic source line — `Scout · Cross-source issue` — so there was no way to tell *which* scout produced a given finding. Every scout (error tracking, logs, revenue, LLM analytics, etc.) emits with the same `source_product`/`source_type` pair, so the taxonomy alone can't distinguish them.

## Changes

Surface the emitting scout's name on each signal card. The scout's `skill_name` already reaches the frontend inside the signal's `extra` payload (`SignalsScoutSignalExtra`), so this is a display-only change — no backend, API, or type plumbing needed.

- Added `prettifyScoutName()` — strips the `signals-scout-` prefix and sentence-cases the rest (e.g. `signals-scout-error-tracking` → `Error tracking`).
- The scout branch of `signalCardSourceLine()` now renders `Scout · <name>`, falling back to the previous `Scout · Cross-source issue` label when `skill_name` is absent.
- Normalized `extra` at the call site (`parseExtra`) since it can arrive as a raw JSON string.

Single file touched: `apps/code/src/renderer/features/inbox/components/detail/SignalCard.tsx`.

## How did you test this?

- `tsc` typecheck — no errors in `SignalCard.tsx`.
- Manual reasoning over the source-line logic; fallback preserves prior behavior for signals without `skill_name`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
