### PR TITLE
fix(ci): pre-create release so parallel publishers don't race

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -10,7 +10,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Get app token
+        id: app-token
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+        with:
+          app_id: ${{ secrets.GH_APP_ARRAY_RELEASER_APP_ID }}
+          private_key: ${{ secrets.GH_APP_ARRAY_RELEASER_PRIVATE_KEY }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create draft release if absent
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Pre-create a single draft release so every parallel publish job uploads
+          # into the same release. Without this, electron-forge's GitHub publisher
+          # creates-if-missing from each job at once, producing multiple releases for
+          # one tag and scattering assets (the orphans get left as drafts).
+          if gh release view "v$APP_VERSION" --repo PostHog/code >/dev/null 2>&1; then
+            echo "Release v$APP_VERSION already exists — reusing it"
+          else
+            gh release create "v$APP_VERSION" --repo PostHog/code --draft \
+              --title "v$APP_VERSION" --notes "Release v$APP_VERSION (build in progress)"
+          fi
+
   publish-macos:
+    needs: [prepare-release]
     strategy:
       fail-fast: false
       matrix:
@@ -164,6 +199,7 @@ jobs:
         run: pnpm --filter code exec electron-forge publish --from-dry-run
 
   publish-windows:
+    needs: [prepare-release]
     runs-on: windows-latest
     permissions:
       id-token: write
@@ -245,6 +281,7 @@ jobs:
         run: pnpm --filter code run publish
 
   publish-linux:
+    needs: [prepare-release]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The release workflow fans out into 5 parallel publish jobs (macOS arm64, macOS x64, Windows, Linux x64, Linux arm64). Each runs `electron-forge publish` independently, and electron-forge's GitHub publisher creates the release if it can't find one for the tag

When the jobs start together and no release exists yet, two or more of them each create a *separate* release for the same tag (GitHub allows multiple releases per tag, at most one published). Each job then uploads only its own artifacts into the release it created. `finalize-release` un-drafts whichever single release `gh release edit` resolves, stranding the others and heir artifacts as orphan draft releases.

`v0.53.105` had Intel macOS + ARM Linux + Windows, while the macOS arm64 and x64 Linux artifacts were left in an orphan draft. 

The existing `cleanup-draft-releases.yml` cron (deletes drafts >24h) is a band-aid for this same symptom — and would soon delete the stranded artifacts entirely.

## Fix

Add a `prepare-release` job that creates a single draft release for the tag up front (idempotent). All three publish jobs now `needs: [prepare-release]`, so every `electron-forge publish` finds that one release and only uploads into it, there's nothing to race. `finalize-release` continues to un-draft the single release