### PR TITLE
feat(agent): move Slack thread link to PR footer

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1463,8 +1463,8 @@ describe("AgentServer HTTP Mode", () => {
       });
     });
 
-    describe("PR body guidance (why context + brevity)", () => {
-      it("instructs Why and brevity (no thread link without a URL) when auto-creating a Slack PR", () => {
+    describe("PR body guidance (why context + brevity + footer)", () => {
+      it("instructs Why, brevity, and the plain footer (no Slack link) when auto-creating a Slack PR without a thread URL", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
         try {
           const prompt = (
@@ -1477,14 +1477,17 @@ describe("AgentServer HTTP Mode", () => {
           // brevity
           expect(prompt).toContain("Keep the PR description brief");
           expect(prompt).toContain("do NOT enumerate every change");
-          // no thread link is added when no concrete URL is available
+          // plain footer, no Slack link
+          expect(prompt).toContain(
+            "*Created with [PostHog Code](https://posthog.com/code?ref=pr)*",
+          );
           expect(prompt).not.toContain("Slack thread");
         } finally {
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         }
       });
 
-      it("embeds the concrete Slack thread link when one is available", () => {
+      it("embeds the Slack thread link in the footer when one is available", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
         try {
           const prompt = (
@@ -1494,14 +1497,18 @@ describe("AgentServer HTTP Mode", () => {
             "https://posthog.slack.com/archives/C123/p456",
           );
           expect(prompt).toContain(
-            "this task started from a Slack thread, also link it: https://posthog.slack.com/archives/C123/p456",
+            "*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C123/p456)*",
+          );
+          // The Why bullet no longer carries the thread link.
+          expect(prompt).not.toContain(
+            "this task started from a Slack thread, also link it",
           );
         } finally {
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         }
       });
 
-      it("instructs Why and brevity but omits the thread hint on the non-Slack no-repository path", () => {
+      it("instructs Why, brevity, and the plain footer on the non-Slack no-repository path", () => {
         delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         const prompt = (
           createServer({
@@ -1511,7 +1518,29 @@ describe("AgentServer HTTP Mode", () => {
         expect(prompt).toContain("open a draft pull request");
         expect(prompt).toContain("**Why**");
         expect(prompt).toContain("Keep the PR description brief");
+        expect(prompt).toContain(
+          "*Created with [PostHog Code](https://posthog.com/code?ref=pr)*",
+        );
         expect(prompt).not.toContain("Slack thread");
+      });
+
+      it("embeds the Slack thread link in the footer on the no-repository path when one is available", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+        try {
+          const prompt = (
+            createServer({
+              repositoryPath: undefined,
+            }) as unknown as TestableServer
+          ).buildCloudSystemPrompt(
+            null,
+            "https://posthog.slack.com/archives/C123/p456",
+          );
+          expect(prompt).toContain(
+            "*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C123/p456)*",
+          );
+        } finally {
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        }
       });
     });
   });

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1730,10 +1730,10 @@ we want:
   Generated-By: PostHog Code
   Task-Id: ${taskId}`;
 
-    const threadLinkInstruction = slackThreadUrl
-      ? ` Since this task started from a Slack thread, also link it: ${slackThreadUrl}.`
-      : "";
-    const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.${threadLinkInstruction}`;
+    const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.`;
+    const prFooter = slackThreadUrl
+      ? `*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](${slackThreadUrl})*`
+      : `*Created with [PostHog Code](https://posthog.com/code?ref=pr)*`;
 
     if (prUrl) {
       if (!shouldAutoCreatePr) {
@@ -1786,6 +1786,7 @@ When the user explicitly asks to clone or work in a GitHub repository:
 - If the user explicitly asks you to open or update a pull request, create a branch, stage your changes with \`git add\` and commit them with the \`git_signed_commit\` tool (do NOT use \`git commit\`/\`git push\` — they are blocked), and open a draft pull request from inside the clone. Before opening the PR, check the cloned repo for a PR template at \`.github/pull_request_template.md\` (or variants; fall back to the org's \`.github\` repo via \`gh api\`) and use it as the body structure, and search for matching open issues with \`gh issue list --search\` to include \`Closes #<n>\` / \`Refs #<n>\` links.
 - Keep the PR description brief overall. Summarize only the most important changes — do NOT enumerate every change you made. A few sentences or bullets is plenty.
 ${whyContextInstruction.trimStart()}
+- End the PR description with a horizontal rule followed by this footer line: ${prFooter}
 - Do NOT create branches, commits, push changes, or open pull requests unless the user explicitly asks for that`;
 
       return `${identityInstructions}
@@ -1836,7 +1837,7 @@ ${whyContextInstruction}
 4. Create a draft pull request using \`gh pr create --draft${this.config.baseBranch ? ` --base ${this.config.baseBranch}` : ""}\` with a descriptive title and the body prepared above. Add the following footer at the end of the PR description:
 \`\`\`
 ---
-*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
+${prFooter}
 \`\`\`
 
 Important:

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -527,6 +527,9 @@ export class AgentServer {
   }
 
   async start(): Promise<void> {
+    this.logger.debug(
+      "🐷 PostHog Code agent build — vojtab/pr-footer-slack-thread-link",
+    );
     await new Promise<void>((resolve) => {
       this.server = serve(
         {


### PR DESCRIPTION
## Problem

When a PR is opened by a task run that originated from a Slack thread, reviewers want a quick path back to the conversation that produced it. #2534 plumbed the `slack_thread_url` through and asked the agent to include it inline in the **Why** bullet — but that buried the link inside the PR's prose and made the Why bullet awkward when both pieces of context were present.

## Changes

Moved the Slack thread link from the **Why** bullet into the standard PR footer the agent already writes:

- When `slack_thread_url` is present on the task run state, the footer renders as:

  ```
  ---
  *Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/…)*
  ```

- When it's absent, the footer is unchanged from today's single-link version.

Applied to both PR-creation paths in `buildCloudSystemPrompt`: the auto-create-with-repo path and the no-repository clone-and-PR path.

## How did you test this?

- `pnpm --filter agent typecheck` — clean (after `pnpm install` to pick up workspace deps).
- `pnpm exec biome check` on the two touched files — clean.
- `pnpm --filter agent exec vitest run src/server/agent-server.test.ts` — all 55 tests pass.
- Updated the four existing PR-body-guidance tests to assert the new footer behavior (plain footer, Slack-link footer on auto-create path, plain footer on non-Slack no-repo path, Slack-link footer on no-repo path).
- Manual local test

## Showcase

<img width="899" height="280" alt="Screenshot 2026-06-09 at 11 47 12" src="https://github.com/user-attachments/assets/881d8dd1-6b74-4e8a-a434-7c539f0ed2fe" />


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?