### PR TITLE
feat(inbox): add feedback dropdown to Create PR button

### DIFF
--- a/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
+++ b/apps/code/src/renderer/features/inbox/components/detail/ReportDetailPane.tsx
@@ -189,6 +189,8 @@ export function ReportDetailPane({
 }: ReportDetailPaneProps) {
   const [discussQuestion, setDiscussQuestion] = useState("");
   const [discussQuestionOpen, setDiscussQuestionOpen] = useState(false);
+  const [prFeedback, setPrFeedback] = useState("");
+  const [prFeedbackOpen, setPrFeedbackOpen] = useState(false);
   const { data: me } = useMeQuery();
 
   // ── Report data ─────────────────────────────────────────────────────────
@@ -357,16 +359,29 @@ export function ReportDetailPane({
     cloudRepository: effectiveCloudRepository,
   });
 
-  const handleCreateImplementationTask = useCallback(async () => {
-    if (!canCreateImplementationPr || isCreatingPr) return;
-    fireDetailAction("create_pr");
-    await createPrReport();
-  }, [
-    canCreateImplementationPr,
-    isCreatingPr,
-    createPrReport,
-    fireDetailAction,
-  ]);
+  const handleCreateImplementationTask = useCallback(
+    async (feedback?: string) => {
+      if (!canCreateImplementationPr || isCreatingPr) return;
+      const trimmedFeedback = feedback?.trim();
+      fireDetailAction("create_pr", {
+        has_feedback: !!trimmedFeedback,
+        feedback_text: trimmedFeedback
+          ? trimmedFeedback.slice(0, 500)
+          : undefined,
+      });
+      setPrFeedbackOpen(false);
+      await createPrReport(trimmedFeedback);
+    },
+    [canCreateImplementationPr, isCreatingPr, createPrReport, fireDetailAction],
+  );
+
+  const handleCreatePrSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      handleCreateImplementationTask(prFeedback);
+    },
+    [prFeedback, handleCreateImplementationTask],
+  );
 
   const { discussReport, isDiscussing } = useDiscussReport({
     reportId: report.id,
@@ -594,24 +609,97 @@ export function ReportDetailPane({
               onLinkClick={() => fireDetailAction("open_pr")}
             />
           ) : canCreateImplementationPr ? (
-            <Tooltip
-              content={
-                <Flex align="center" gap="1">
-                  Create PR <Kbd>{isMac ? "⌘↵" : "Ctrl+↵"}</Kbd>
-                </Flex>
-              }
-            >
-              <Button
-                size="1"
-                variant="solid"
-                className="gap-1 text-[12px]"
-                disabled={isCreatingPr}
-                onClick={handleCreateImplementationTask}
+            <Flex align="center" gap="0">
+              <Tooltip
+                content={
+                  <Flex align="center" gap="1">
+                    Create PR <Kbd>{isMac ? "⌘↵" : "Ctrl+↵"}</Kbd>
+                  </Flex>
+                }
               >
-                {isCreatingPr ? <Spinner size="1" /> : <Plus size={12} />}
-                Create PR
-              </Button>
-            </Tooltip>
+                <Button
+                  size="1"
+                  variant="solid"
+                  className="gap-1 rounded-r-none text-[12px]"
+                  disabled={isCreatingPr}
+                  onClick={() => handleCreateImplementationTask()}
+                >
+                  {isCreatingPr ? <Spinner size="1" /> : <Plus size={12} />}
+                  Create PR
+                </Button>
+              </Tooltip>
+              <Popover.Root
+                open={prFeedbackOpen}
+                onOpenChange={setPrFeedbackOpen}
+              >
+                <Popover.Trigger>
+                  <Button
+                    size="1"
+                    variant="solid"
+                    className="rounded-l-none border-l border-l-(--gray-a5) px-1"
+                    aria-label="Add optional feedback for the PR"
+                    disabled={isCreatingPr}
+                  >
+                    <CaretDownIcon size={12} />
+                  </Button>
+                </Popover.Trigger>
+                <Popover.Content
+                  align="end"
+                  className="w-[420px] border border-(--gray-6) bg-(--color-panel-solid) p-3 shadow-6"
+                  side="bottom"
+                  sideOffset={6}
+                >
+                  <form
+                    className="flex flex-col gap-2"
+                    onSubmit={handleCreatePrSubmit}
+                  >
+                    <TextArea
+                      aria-label="Optional feedback for Create PR"
+                      autoFocus
+                      placeholder="Add any extra feedback, e.g. answers to questions raised in the report thread..."
+                      resize="vertical"
+                      rows={5}
+                      size="2"
+                      value={prFeedback}
+                      onChange={(event) => setPrFeedback(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (
+                          event.key === "Enter" &&
+                          (event.metaKey || event.ctrlKey)
+                        ) {
+                          event.preventDefault();
+                          handleCreateImplementationTask(prFeedback);
+                        }
+                      }}
+                    />
+                    <Flex justify="between" align="center" gap="2">
+                      <Text size="1" color="gray">
+                        <Kbd>{isMac ? "⌘↵" : "Ctrl+↵"}</Kbd> to create
+                      </Text>
+                      <Flex gap="2">
+                        <Button
+                          color="gray"
+                          size="1"
+                          type="button"
+                          variant="soft"
+                          onClick={() => setPrFeedbackOpen(false)}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          size="1"
+                          type="submit"
+                          variant="solid"
+                          disabled={isCreatingPr}
+                        >
+                          Create PR
+                        </Button>
+                      </Flex>
+                    </Flex>
+                  </form>
+                </Popover.Content>
+              </Popover.Root>
+            </Flex>
           ) : null}
           <button
             type="button"

--- a/apps/code/src/renderer/features/inbox/hooks/useCreatePrReport.ts
+++ b/apps/code/src/renderer/features/inbox/hooks/useCreatePrReport.ts
@@ -30,8 +30,12 @@ interface UseCreatePrReportOptions {
 }
 
 interface UseCreatePrReportReturn {
-  /** Create an auto-mode implementation task for the report and navigate to it on success. */
-  createPrReport: () => Promise<void>;
+  /**
+   * Create an auto-mode implementation task for the report and navigate to it on success.
+   * Optional `feedback` is folded into the agent prompt, e.g. to answer questions raised
+   * in the report thread.
+   */
+  createPrReport: (feedback?: string) => Promise<void>;
   /** True while the task is being created. */
   isCreatingPr: boolean;
 }
@@ -55,133 +59,137 @@ export function useCreatePrReport({
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const { data: teamConfig } = useSignalTeamConfig();
 
-  const createPrReport = useCallback(async () => {
-    if (isCreatingPr) return;
-    if (!cloudRepository) {
-      toast.error("Pick a cloud repository before creating a PR");
-      return;
-    }
-
-    const githubUserIntegrationId =
-      getUserIntegrationIdForRepo(cloudRepository);
-    if (!githubUserIntegrationId) {
-      toast.error("Connect a GitHub integration to create a PR");
-      return;
-    }
-
-    if (!cloudRegion) {
-      toast.error("Sign in to create a PR");
-      return;
-    }
-
-    setIsCreatingPr(true);
-    const toastId = toast.loading(
-      "Starting PR task...",
-      reportTitle ?? undefined,
-    );
-
-    const prompt = buildCreatePrReportPrompt({
-      reportId,
-      isDevBuild: import.meta.env.DEV,
-    });
-
-    const settings = useSettingsStore.getState();
-    const adapter = settings.lastUsedAdapter ?? "claude";
-    const apiHost = getCloudUrlFromRegion(cloudRegion);
-
-    const model =
-      settings.lastUsedModel ?? (await resolveDefaultModel(apiHost, adapter));
-
-    if (!model) {
-      sonnerToast.dismiss(toastId);
-      toast.error("Failed to start PR task", {
-        description:
-          "Couldn't resolve a default model. Open the task page once and pick a model, then try again.",
-      });
-      setIsCreatingPr(false);
-      return;
-    }
-
-    const baseBranchOverrides = teamConfig?.autostart_base_branches ?? {};
-    const targetRepo = cloudRepository.toLowerCase();
-    const baseBranch =
-      Object.entries(baseBranchOverrides).find(
-        ([repo]) => repo.toLowerCase() === targetRepo,
-      )?.[1] ?? null;
-
-    const input: TaskCreationInput = {
-      content: prompt,
-      taskDescription: prompt,
-      repository: cloudRepository,
-      githubUserIntegrationId,
-      workspaceMode: "cloud",
-      executionMode: "auto",
-      adapter,
-      model,
-      branch: baseBranch,
-      reasoningLevel: settings.lastUsedReasoningEffort ?? undefined,
-      cloudPrAuthorshipMode: "user",
-      cloudRunSource: "signal_report",
-      signalReportId: reportId,
-    };
-
-    try {
-      const taskService = get<TaskService>(RENDERER_TOKENS.TaskService);
-      const result = await taskService.createTask(input, (output) => {
-        invalidateTasks(output.task);
-        void openTask(output.task);
-      });
-
-      if (result.success) {
-        sonnerToast.dismiss(toastId);
-        track(ANALYTICS_EVENTS.TASK_CREATED, {
-          auto_run: true,
-          created_from: "command-menu",
-          repository_provider: "github",
-          workspace_mode: "cloud",
-          has_branch: baseBranch != null,
-          cloud_run_source: "signal_report",
-          cloud_pr_authorship_mode: "user",
-          signal_report_id: reportId,
-          adapter,
-        });
-      } else {
-        sonnerToast.dismiss(toastId);
-        // Usage-limit blocks already show the upgrade modal; don't also toast an error.
-        if (!isUsageLimitResult(result)) {
-          toast.error("Failed to start PR task", {
-            description: result.error,
-          });
-          log.error("Create PR task creation failed", {
-            failedStep: result.failedStep,
-            error: result.error,
-            reportId,
-            reportTitle,
-          });
-        }
+  const createPrReport = useCallback(
+    async (feedback?: string) => {
+      if (isCreatingPr) return;
+      if (!cloudRepository) {
+        toast.error("Pick a cloud repository before creating a PR");
+        return;
       }
-    } catch (error) {
-      sonnerToast.dismiss(toastId);
-      const description =
-        error instanceof Error ? error.message : "Unknown error";
-      toast.error("Failed to start PR task", { description });
-      log.error("Unexpected error during Create PR task creation", {
-        error,
+
+      const githubUserIntegrationId =
+        getUserIntegrationIdForRepo(cloudRepository);
+      if (!githubUserIntegrationId) {
+        toast.error("Connect a GitHub integration to create a PR");
+        return;
+      }
+
+      if (!cloudRegion) {
+        toast.error("Sign in to create a PR");
+        return;
+      }
+
+      setIsCreatingPr(true);
+      const toastId = toast.loading(
+        "Starting PR task...",
+        reportTitle ?? undefined,
+      );
+
+      const prompt = buildCreatePrReportPrompt({
         reportId,
+        isDevBuild: import.meta.env.DEV,
+        feedback,
       });
-    } finally {
-      setIsCreatingPr(false);
-    }
-  }, [
-    isCreatingPr,
-    cloudRepository,
-    cloudRegion,
-    reportId,
-    reportTitle,
-    getUserIntegrationIdForRepo,
-    invalidateTasks,
-    teamConfig,
-  ]);
+
+      const settings = useSettingsStore.getState();
+      const adapter = settings.lastUsedAdapter ?? "claude";
+      const apiHost = getCloudUrlFromRegion(cloudRegion);
+
+      const model =
+        settings.lastUsedModel ?? (await resolveDefaultModel(apiHost, adapter));
+
+      if (!model) {
+        sonnerToast.dismiss(toastId);
+        toast.error("Failed to start PR task", {
+          description:
+            "Couldn't resolve a default model. Open the task page once and pick a model, then try again.",
+        });
+        setIsCreatingPr(false);
+        return;
+      }
+
+      const baseBranchOverrides = teamConfig?.autostart_base_branches ?? {};
+      const targetRepo = cloudRepository.toLowerCase();
+      const baseBranch =
+        Object.entries(baseBranchOverrides).find(
+          ([repo]) => repo.toLowerCase() === targetRepo,
+        )?.[1] ?? null;
+
+      const input: TaskCreationInput = {
+        content: prompt,
+        taskDescription: prompt,
+        repository: cloudRepository,
+        githubUserIntegrationId,
+        workspaceMode: "cloud",
+        executionMode: "auto",
+        adapter,
+        model,
+        branch: baseBranch,
+        reasoningLevel: settings.lastUsedReasoningEffort ?? undefined,
+        cloudPrAuthorshipMode: "user",
+        cloudRunSource: "signal_report",
+        signalReportId: reportId,
+      };
+
+      try {
+        const taskService = get<TaskService>(RENDERER_TOKENS.TaskService);
+        const result = await taskService.createTask(input, (output) => {
+          invalidateTasks(output.task);
+          void openTask(output.task);
+        });
+
+        if (result.success) {
+          sonnerToast.dismiss(toastId);
+          track(ANALYTICS_EVENTS.TASK_CREATED, {
+            auto_run: true,
+            created_from: "command-menu",
+            repository_provider: "github",
+            workspace_mode: "cloud",
+            has_branch: baseBranch != null,
+            cloud_run_source: "signal_report",
+            cloud_pr_authorship_mode: "user",
+            signal_report_id: reportId,
+            adapter,
+          });
+        } else {
+          sonnerToast.dismiss(toastId);
+          // Usage-limit blocks already show the upgrade modal; don't also toast an error.
+          if (!isUsageLimitResult(result)) {
+            toast.error("Failed to start PR task", {
+              description: result.error,
+            });
+            log.error("Create PR task creation failed", {
+              failedStep: result.failedStep,
+              error: result.error,
+              reportId,
+              reportTitle,
+            });
+          }
+        }
+      } catch (error) {
+        sonnerToast.dismiss(toastId);
+        const description =
+          error instanceof Error ? error.message : "Unknown error";
+        toast.error("Failed to start PR task", { description });
+        log.error("Unexpected error during Create PR task creation", {
+          error,
+          reportId,
+        });
+      } finally {
+        setIsCreatingPr(false);
+      }
+    },
+    [
+      isCreatingPr,
+      cloudRepository,
+      cloudRegion,
+      reportId,
+      reportTitle,
+      getUserIntegrationIdForRepo,
+      invalidateTasks,
+      teamConfig,
+    ],
+  );
 
   return { createPrReport, isCreatingPr };
 }

--- a/apps/code/src/renderer/features/inbox/utils/buildCreatePrReportPrompt.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/buildCreatePrReportPrompt.test.ts
@@ -40,4 +40,28 @@ describe("buildCreatePrReportPrompt", () => {
     expect(prompt).toMatch(/can't fetch the report/i);
     expect(prompt).toMatch(/instead of guessing/i);
   });
+
+  it("appends user feedback when provided", () => {
+    const prompt = buildCreatePrReportPrompt({
+      reportId: "abc123",
+      isDevBuild: false,
+      feedback: "Use the v2 endpoint, not v1.",
+    });
+    expect(prompt).toMatch(/Additional feedback from the user/i);
+    expect(prompt).toContain("Use the v2 endpoint, not v1.");
+  });
+
+  it("trims feedback and omits the section when it's blank", () => {
+    const withWhitespace = buildCreatePrReportPrompt({
+      reportId: "abc123",
+      isDevBuild: false,
+      feedback: "   ",
+    });
+    const withoutFeedback = buildCreatePrReportPrompt({
+      reportId: "abc123",
+      isDevBuild: false,
+    });
+    expect(withWhitespace).toBe(withoutFeedback);
+    expect(withWhitespace).not.toMatch(/Additional feedback/i);
+  });
 });

--- a/apps/code/src/renderer/features/inbox/utils/buildCreatePrReportPrompt.test.ts
+++ b/apps/code/src/renderer/features/inbox/utils/buildCreatePrReportPrompt.test.ts
@@ -51,17 +51,21 @@ describe("buildCreatePrReportPrompt", () => {
     expect(prompt).toContain("Use the v2 endpoint, not v1.");
   });
 
-  it("trims feedback and omits the section when it's blank", () => {
-    const withWhitespace = buildCreatePrReportPrompt({
+  it.each([
+    { label: "undefined", feedback: undefined },
+    { label: "empty string", feedback: "" },
+    { label: "whitespace only", feedback: "   " },
+  ])("omits the feedback section when feedback is $label", ({ feedback }) => {
+    const base = buildCreatePrReportPrompt({
       reportId: "abc123",
       isDevBuild: false,
-      feedback: "   ",
     });
-    const withoutFeedback = buildCreatePrReportPrompt({
+    const prompt = buildCreatePrReportPrompt({
       reportId: "abc123",
       isDevBuild: false,
+      feedback,
     });
-    expect(withWhitespace).toBe(withoutFeedback);
-    expect(withWhitespace).not.toMatch(/Additional feedback/i);
+    expect(prompt).toBe(base);
+    expect(prompt).not.toMatch(/Additional feedback/i);
   });
 });

--- a/apps/code/src/renderer/features/inbox/utils/buildCreatePrReportPrompt.ts
+++ b/apps/code/src/renderer/features/inbox/utils/buildCreatePrReportPrompt.ts
@@ -3,12 +3,18 @@ import { getDeeplinkProtocol } from "@shared/deeplink";
 interface BuildCreatePrReportPromptOptions {
   reportId: string;
   isDevBuild: boolean;
+  /** Optional extra feedback from the user, e.g. answers to questions raised in the report thread. */
+  feedback?: string;
 }
 
 export function buildCreatePrReportPrompt({
   reportId,
   isDevBuild,
+  feedback,
 }: BuildCreatePrReportPromptOptions): string {
   const reportLink = `${getDeeplinkProtocol(isDevBuild)}://inbox/${reportId}`;
-  return `Act on PostHog inbox report ${reportId} ([inbox item](${reportLink})). Use the inbox MCP tools to fetch the report, its signals, and any suggested reviewers; investigate the root cause; implement the fix; and open a PR. If you can't fetch the report, stop and report that instead of guessing what it contains.`;
+  const base = `Act on PostHog inbox report ${reportId} ([inbox item](${reportLink})). Use the inbox MCP tools to fetch the report, its signals, and any suggested reviewers; investigate the root cause; implement the fix; and open a PR. If you can't fetch the report, stop and report that instead of guessing what it contains.`;
+  const trimmedFeedback = feedback?.trim();
+  if (!trimmedFeedback) return base;
+  return `${base}\n\nAdditional feedback from the user (take this into account, including any questions raised in the report thread):\n${trimmedFeedback}`;
 }

--- a/apps/code/src/shared/types/analytics.ts
+++ b/apps/code/src/shared/types/analytics.ts
@@ -624,6 +624,11 @@ export interface InboxReportActionProperties {
   // The first question text the user typed before hitting Discuss. Truncated to
   // 500 chars to keep event payloads bounded.
   question_text?: string;
+  // True when the user submitted Create PR with extra feedback via the popover.
+  has_feedback?: boolean;
+  // The feedback text the user typed before hitting Create PR. Truncated to
+  // 500 chars to keep event payloads bounded.
+  feedback_text?: string;
 }
 
 export interface SignalSourceConnectedProperties {


### PR DESCRIPTION
## Summary

When clicking **Create PR** on an inbox report, you can now open a dropdown to add extra feedback before the PR task is created. This lets you answer questions that were raised in the body of the report thread (or give any other steering) without having to wait for the task, jump in, and re-prompt the agent.

The new control mirrors the existing **Discuss** split button right next to it: a primary button that fires immediately, plus a caret that opens a popover with a feedback text area.

## What changed

- **`ReportDetailPane.tsx`** — the Create PR button is now a split button. The caret opens a `Popover` with a `TextArea`; submitting (button or ⌘/Ctrl+↵) creates the PR task with the typed feedback. The primary button still creates a PR with no feedback, and the existing global ⌘/Ctrl+↵ shortcut is unchanged.
- **`buildCreatePrReportPrompt.ts`** — accepts optional `feedback`, trims it, and appends an "Additional feedback from the user" section to the agent prompt when present.
- **`useCreatePrReport.ts`** — `createPrReport` now takes an optional `feedback` argument and threads it into the prompt builder.
- **`analytics.ts`** — added `has_feedback` / `feedback_text` to `InboxReportActionProperties` (mirrors the existing `has_question` / `question_text` from Discuss), populated truncated to 500 chars.
- **`buildCreatePrReportPrompt.test.ts`** — added coverage for the feedback being appended, trimmed, and omitted when blank.

## Testing

- \`pnpm --filter code typecheck\` ✅
- \`pnpm --filter code test run src/renderer/features/inbox/utils/buildCreatePrReportPrompt.test.ts\` ✅ (7 passed)
- biome check ✅