### PR TITLE
fix(mobile): break signal report summary sections onto separate lines (port #2317)

### DIFF
--- a/apps/mobile/src/app/inbox/[...id].tsx
+++ b/apps/mobile/src/app/inbox/[...id].tsx
@@ -51,7 +51,10 @@ import type {
   SignalReportStatus,
   SuggestedReviewersArtefact,
 } from "@/features/inbox/types";
-import { inboxStatusLabel } from "@/features/inbox/utils";
+import {
+  formatSignalReportSummaryMarkdown,
+  inboxStatusLabel,
+} from "@/features/inbox/utils";
 import {
   computeReportAgeHours,
   type InboxReportActionType,
@@ -492,7 +495,9 @@ export default function ReportDetailScreen() {
         {/* Summary */}
         {report.summary && (
           <View className="mb-4" style={{ opacity: isReady ? 1 : 0.7 }}>
-            <MarkdownText content={report.summary} />
+            <MarkdownText
+              content={formatSignalReportSummaryMarkdown(report.summary)}
+            />
           </View>
         )}
 

--- a/apps/mobile/src/features/inbox/components/TinderView.tsx
+++ b/apps/mobile/src/features/inbox/components/TinderView.tsx
@@ -37,7 +37,7 @@ import type {
   SignalReportPriority,
   SignalReportStatus,
 } from "../types";
-import { inboxStatusLabel } from "../utils";
+import { formatSignalReportSummaryMarkdown, inboxStatusLabel } from "../utils";
 import { SwipeableReportCard } from "./SwipeableReportCard";
 
 const log = logger.scope("tinder-view");
@@ -423,7 +423,11 @@ export function TinderView({
 
                 {/* Summary */}
                 {expandedReport.summary && (
-                  <MarkdownText content={expandedReport.summary} />
+                  <MarkdownText
+                    content={formatSignalReportSummaryMarkdown(
+                      expandedReport.summary,
+                    )}
+                  />
                 )}
 
                 {/* Signal count + time */}

--- a/apps/mobile/src/features/inbox/utils.test.ts
+++ b/apps/mobile/src/features/inbox/utils.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   buildInboxViewedProperties,
   buildReviewerOptions,
+  formatSignalReportSummaryMarkdown,
   reviewerMatchesAvailable,
   toSuggestedReviewerWriteContent,
 } from "./utils";
@@ -60,6 +61,44 @@ function makeReport(
     ...partial,
   };
 }
+
+describe("formatSignalReportSummaryMarkdown", () => {
+  it.each([
+    {
+      name: "puts section body on a new line after the header",
+      input:
+        "**What's happening:** Error tracking issue keyed on `app:dashboard_query`.",
+      expected:
+        "**What's happening:**\n\nError tracking issue keyed on `app:dashboard_query`.",
+    },
+    {
+      name: "splits consecutive headers packed on one line",
+      input:
+        "**What's happening:** Users hit rate limits. **Root cause:** Limiters are contended. **How to resolve:** Reduce blocking.",
+      expected:
+        "**What's happening:**\n\nUsers hit rate limits.\n\n**Root cause:**\n\nLimiters are contended.\n\n**How to resolve:**\n\nReduce blocking.",
+    },
+    {
+      name: "leaves already-separated headers sane",
+      input:
+        "**What's happening:**\n\nUsers hit rate limits.\n\n**Root cause:**\n\nLimiters are contended.",
+      expected:
+        "**What's happening:**\n\nUsers hit rate limits.\n\n**Root cause:**\n\nLimiters are contended.",
+    },
+    {
+      name: "leaves content without headers unchanged",
+      input: "Plain summary with no structured sections.",
+      expected: "Plain summary with no structured sections.",
+    },
+    {
+      name: "matches headers case-insensitively",
+      input: "**what's happening:** lowercase header body.",
+      expected: "**what's happening:**\n\nlowercase header body.",
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(formatSignalReportSummaryMarkdown(input)).toBe(expected);
+  });
+});
 
 describe("buildInboxViewedProperties", () => {
   it("emits zero counts for an empty list", () => {

--- a/apps/mobile/src/features/inbox/utils.ts
+++ b/apps/mobile/src/features/inbox/utils.ts
@@ -8,6 +8,32 @@ import type {
   SuggestedReviewerWriteEntry,
 } from "./types";
 
+const SIGNAL_SUMMARY_SECTION_HEADERS = [
+  "What's happening",
+  "Root cause",
+  "How to resolve",
+] as const;
+
+/**
+ * Inserts blank lines around signal report summary section headers so each
+ * label and its body render on their own line (agent output often packs them
+ * together, e.g. `**What's happening:** text **Root cause:** ...`).
+ */
+export function formatSignalReportSummaryMarkdown(content: string): string {
+  let result = content;
+
+  for (const header of SIGNAL_SUMMARY_SECTION_HEADERS) {
+    const boldHeader = `\\*\\*${header}:\\*\\*`;
+    result = result.replace(
+      new RegExp(`([^\\n])\\s*(${boldHeader})`, "gi"),
+      "$1\n\n$2",
+    );
+    result = result.replace(new RegExp(`(${boldHeader})\\s+`, "gi"), "$1\n\n");
+  }
+
+  return result;
+}
+
 export function inboxStatusLabel(status: SignalReportStatus): string {
   switch (status) {
     case "ready":


### PR DESCRIPTION
Ports #2317 to the mobile app.

## Problem
Agent-generated signal report summaries often pack the labelled sections onto a single line, e.g.:

> **What's happening:** text **Root cause:** more text **How to resolve:** ...

which renders as one run-on paragraph in `MarkdownText`.

## Change
- Adds `formatSignalReportSummaryMarkdown` to `apps/mobile/src/features/inbox/utils.ts`. It inserts blank lines before each bold section header (`**What's happening:**`, `**Root cause:**`, `**How to resolve:**`) and after the header label, so each section and its body render on their own line. Matching is case-insensitive.
- Applies it to the summary passed into `MarkdownText` in both render sites:
  - the report detail screen (`apps/mobile/src/app/inbox/[...id].tsx`)
  - the expanded report card in `TinderView.tsx`
- Adds unit tests covering packed headers, already-separated headers, header-free content, and case-insensitive matching.

Pure presentation formatting in the renderer layer — no main-process or business-logic changes.

## Testing
- `pnpm --filter mobile test` — 202 passed
- `pnpm --filter mobile lint` — clean