### PR TITLE
feat(mobile): warn before archiving a running task (port #2530)

### DIFF
--- a/apps/mobile/src/features/tasks/components/SwipeableTaskItem.tsx
+++ b/apps/mobile/src/features/tasks/components/SwipeableTaskItem.tsx
@@ -11,9 +11,22 @@ import {
 } from "react-native";
 import { useThemeColors } from "@/lib/theme";
 import type { Task } from "../types";
+import {
+  confirmArchiveRunningTask,
+  isTaskRunning,
+} from "../utils/archiveGuard";
 import { TaskItem } from "./TaskItem";
 
 const SWIPE_THRESHOLD = 60;
+
+function springToRest(value: Animated.Value): void {
+  Animated.spring(value, {
+    toValue: 0,
+    useNativeDriver: true,
+    tension: 40,
+    friction: 8,
+  }).start();
+}
 
 interface SwipeableTaskItemProps {
   task: Task;
@@ -104,6 +117,17 @@ export function SwipeableTaskItem({
         if (gesture.dx < -SWIPE_THRESHOLD && !actionTriggeredRef.current) {
           actionTriggeredRef.current = true;
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+
+          // Archiving a running task stops its agent, so spring the row back
+          // and confirm first — only archive once the user agrees.
+          if (!p.isArchived && isTaskRunning(p.task)) {
+            springToRest(translateX);
+            confirmArchiveRunningTask(p.task.title, () =>
+              p.onArchive(p.task.id),
+            );
+            return;
+          }
+
           Animated.timing(translateX, {
             toValue: -400,
             duration: 150,
@@ -120,12 +144,7 @@ export function SwipeableTaskItem({
             }
           });
         } else {
-          Animated.spring(translateX, {
-            toValue: 0,
-            useNativeDriver: true,
-            tension: 40,
-            friction: 8,
-          }).start();
+          springToRest(translateX);
         }
       },
       onPanResponderTerminate: () => {

--- a/apps/mobile/src/features/tasks/components/SwipeableTaskItem.tsx
+++ b/apps/mobile/src/features/tasks/components/SwipeableTaskItem.tsx
@@ -28,6 +28,20 @@ function springToRest(value: Animated.Value): void {
   }).start();
 }
 
+// Slide the row off-screen, then smooth the list-height change before running
+// the archive/unarchive side effect.
+function slideOut(value: Animated.Value, onDone: () => void): void {
+  Animated.timing(value, {
+    toValue: -400,
+    duration: 150,
+    easing: Easing.in(Easing.ease),
+    useNativeDriver: true,
+  }).start(() => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    onDone();
+  });
+}
+
 interface SwipeableTaskItemProps {
   task: Task;
   isArchived: boolean;
@@ -119,24 +133,17 @@ export function SwipeableTaskItem({
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
           // Archiving a running task stops its agent, so spring the row back
-          // and confirm first — only archive once the user agrees.
+          // and confirm first — only slide out and archive once the user
+          // agrees, matching the animation of every other archive action.
           if (!p.isArchived && isTaskRunning(p.task)) {
             springToRest(translateX);
             confirmArchiveRunningTask(p.task.title, () =>
-              p.onArchive(p.task.id),
+              slideOut(translateX, () => p.onArchive(p.task.id)),
             );
             return;
           }
 
-          Animated.timing(translateX, {
-            toValue: -400,
-            duration: 150,
-            easing: Easing.in(Easing.ease),
-            useNativeDriver: true,
-          }).start(() => {
-            LayoutAnimation.configureNext(
-              LayoutAnimation.Presets.easeInEaseOut,
-            );
+          slideOut(translateX, () => {
             if (p.isArchived) {
               p.onUnarchive(p.task.id);
             } else {

--- a/apps/mobile/src/features/tasks/utils/archiveGuard.test.ts
+++ b/apps/mobile/src/features/tasks/utils/archiveGuard.test.ts
@@ -1,0 +1,80 @@
+import { Alert } from "react-native";
+import { describe, expect, it, vi } from "vitest";
+import type { Task, TaskRunStatus } from "../types";
+import { confirmArchiveRunningTask, isTaskRunning } from "./archiveGuard";
+
+function makeTask(status?: TaskRunStatus): Task {
+  return {
+    id: "task-1",
+    task_number: 1,
+    slug: "task-1",
+    title: "Test task",
+    description: "",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    origin_product: "code",
+    latest_run: status
+      ? {
+          id: "run-1",
+          task: "task-1",
+          team: 1,
+          branch: null,
+          stage: null,
+          environment: "cloud",
+          status,
+          log_url: "",
+          error_message: null,
+          output: null,
+          state: {},
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          completed_at: null,
+        }
+      : undefined,
+  };
+}
+
+describe("isTaskRunning", () => {
+  it("treats a task with no run as not running", () => {
+    expect(isTaskRunning(makeTask())).toBe(false);
+  });
+
+  it("treats non-terminal run statuses as running", () => {
+    for (const status of [
+      "not_started",
+      "queued",
+      "started",
+      "in_progress",
+    ] as const) {
+      expect(isTaskRunning(makeTask(status))).toBe(true);
+    }
+  });
+
+  it("treats terminal run statuses as not running", () => {
+    for (const status of ["completed", "failed", "cancelled"] as const) {
+      expect(isTaskRunning(makeTask(status))).toBe(false);
+    }
+  });
+});
+
+describe("confirmArchiveRunningTask", () => {
+  it("archives only when the user confirms", () => {
+    const onConfirm = vi.fn();
+    confirmArchiveRunningTask("My task", onConfirm);
+
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    const [title, message, buttons] = vi.mocked(Alert.alert).mock.calls[0];
+    expect(title).toBe("Archive running task?");
+    expect(message).toContain("My task");
+    expect(message).toContain("stop the agent");
+
+    const cancelButton = buttons?.find((b) => b.text === "Cancel");
+    const archiveButton = buttons?.find((b) => b.text === "Archive");
+
+    cancelButton?.onPress?.();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    archiveButton?.onPress?.();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/features/tasks/utils/archiveGuard.test.ts
+++ b/apps/mobile/src/features/tasks/utils/archiveGuard.test.ts
@@ -39,22 +39,19 @@ describe("isTaskRunning", () => {
     expect(isTaskRunning(makeTask())).toBe(false);
   });
 
-  it("treats non-terminal run statuses as running", () => {
-    for (const status of [
-      "not_started",
-      "queued",
-      "started",
-      "in_progress",
-    ] as const) {
+  it.each(["not_started", "queued", "started", "in_progress"] as const)(
+    "treats %s as running",
+    (status) => {
       expect(isTaskRunning(makeTask(status))).toBe(true);
-    }
-  });
+    },
+  );
 
-  it("treats terminal run statuses as not running", () => {
-    for (const status of ["completed", "failed", "cancelled"] as const) {
+  it.each(["completed", "failed", "cancelled"] as const)(
+    "treats %s as not running",
+    (status) => {
       expect(isTaskRunning(makeTask(status))).toBe(false);
-    }
-  });
+    },
+  );
 });
 
 describe("confirmArchiveRunningTask", () => {

--- a/apps/mobile/src/features/tasks/utils/archiveGuard.ts
+++ b/apps/mobile/src/features/tasks/utils/archiveGuard.ts
@@ -1,0 +1,21 @@
+import { Alert } from "react-native";
+import { isTerminalStatus, type Task } from "../types";
+
+export function isTaskRunning(task: Task): boolean {
+  const status = task.latest_run?.status;
+  return status !== undefined && !isTerminalStatus(status);
+}
+
+export function confirmArchiveRunningTask(
+  taskTitle: string,
+  onConfirm: () => void,
+): void {
+  Alert.alert(
+    "Archive running task?",
+    `"${taskTitle}" is still running. Archiving it now will stop the agent. You can unarchive it later.`,
+    [
+      { text: "Cancel", style: "cancel" },
+      { text: "Archive", style: "destructive", onPress: onConfirm },
+    ],
+  );
+}


### PR DESCRIPTION
## What

Ports desktop PR #2530 (_add warning dialog for archiving running tasks_) to the mobile app.

On desktop, choosing **Archive** on a still-running task shows a confirmation dialog before stopping the agent. Mobile archives tasks via swipe, so this adds the equivalent guard to the swipe-to-archive flow.

- Swiping to archive a task whose latest run is **non-terminal** (still running) now shows a native `Alert.alert` confirm — title `Archive running task?`, message `"<task title>" is still running. Archiving it now will stop the agent. You can unarchive it later.`, with **Cancel** / **Archive** buttons. The row springs back so a cancel leaves it visibly un-archived; it only archives on confirm.
- Archiving a **terminal** task (completed / failed / cancelled) or one with no run proceeds immediately with no prompt — unchanged behaviour.

## How

- New renderer-layer util `features/tasks/utils/archiveGuard.ts`:
  - `isTaskRunning(task)` — true when `latest_run.status` is non-terminal (reuses the existing `isTerminalStatus`).
  - `confirmArchiveRunningTask(taskTitle, onConfirm)` — thin `Alert.alert` wrapper.
- `SwipeableTaskItem` calls the guard in its swipe-release handler before sliding the row off.

Matches the mobile convention of native `Alert.alert` confirms (as used for delete-automation, attachment permissions, etc.). The running-vs-terminal decision uses the existing task status field — no new business logic in stores.

## Scope

Like the desktop original (which only guarded its single-task menu archive, not bulk operations), this guards the single-task swipe path. The bulk selection-mode archive is intentionally left unchanged.

## Tests

Added `archiveGuard.test.ts` covering `isTaskRunning` (running for non-terminal statuses, not running for terminal / no run) and `confirmArchiveRunningTask` (confirm archives, cancel does not). Full mobile tasks suite passes (74 tests); lint clean; typecheck introduces no new errors.