### PR TITLE
feat(agent): exclude Code from the "PostHog resources used" bar

### DIFF
--- a/apps/code/src/renderer/features/sessions/components/SessionResourcesBar.tsx
+++ b/apps/code/src/renderer/features/sessions/components/SessionResourcesBar.tsx
@@ -5,7 +5,6 @@ import {
   BugIcon,
   ChartLineIcon,
   ClipboardTextIcon,
-  CodeIcon,
   DatabaseIcon,
   FileTextIcon,
   FlagIcon,
@@ -42,7 +41,6 @@ const PRODUCT_ICON: Record<PostHogProductId, ComponentType<IconProps>> = {
   logs: FileTextIcon,
   apm: GaugeIcon,
   sql: TableIcon,
-  code: CodeIcon,
   posthog: SparkleIcon,
 };
 
@@ -65,7 +63,6 @@ const PRODUCT_DOC_URL: Partial<Record<PostHogProductId, string>> = {
   cdp: "https://posthog.com/docs/cdp",
   logs: "https://posthog.com/docs/logs",
   sql: "https://posthog.com/docs/sql",
-  code: "https://posthog.com/code",
   posthog: "https://posthog.com/docs",
 };
 

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1413,7 +1413,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       settingsManager,
       onModeChange: this.createOnModeChange(),
       onPostHogResourceUsed: this.createOnPostHogResourceUsed(),
-      onCodeFileRead: this.createOnCodeFileRead(),
       onProcessSpawned: this.options?.onProcessSpawned,
       onProcessExited: this.options?.onProcessExited,
       effort,
@@ -1662,12 +1661,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         classifyPostHogExecCall(subTool, commandText),
       );
     };
-  }
-
-  /** Records the `code` product the first time the agent reads a file from the
-   *  codebase, so working with code surfaces a chip just like an MCP call does. */
-  private createOnCodeFileRead() {
-    return () => this.recordSessionResources(["code"]);
   }
 
   /** Adds products to the session-wide set and emits any newly-seen ones.

--- a/packages/agent/src/adapters/claude/hooks.test.ts
+++ b/packages/agent/src/adapters/claude/hooks.test.ts
@@ -10,7 +10,6 @@ vi.mock("../../enrichment/file-enricher", () => ({
 import { Logger } from "../../utils/logger";
 import type { TaskState } from "./conversion/task-state";
 import {
-  createPostToolUseHook,
   createPreToolUseHook,
   createReadEnrichmentHook,
   createSignedCommitGuardHook,
@@ -198,38 +197,6 @@ describe("createReadEnrichmentHook", () => {
 
     const [, , content] = enrichFileMock.mock.calls[0];
     expect(content).toBe("foo");
-  });
-});
-
-describe("createPostToolUseHook onCodeFileRead", () => {
-  const signal = { signal: new AbortController().signal };
-
-  test("fires onCodeFileRead when a file is read", async () => {
-    const onCodeFileRead = vi.fn();
-    const hook = createPostToolUseHook({ onCodeFileRead });
-    await hook(buildReadHookInput({ tool_name: "Read" }), "toolu_1", signal);
-
-    expect(onCodeFileRead).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not fire onCodeFileRead for non-Read tools", async () => {
-    const onCodeFileRead = vi.fn();
-    const hook = createPostToolUseHook({ onCodeFileRead });
-    await hook(buildReadHookInput({ tool_name: "Bash" }), "toolu_1", signal);
-
-    expect(onCodeFileRead).not.toHaveBeenCalled();
-  });
-
-  test("does not fire onCodeFileRead for non-PostToolUse events", async () => {
-    const onCodeFileRead = vi.fn();
-    const hook = createPostToolUseHook({ onCodeFileRead });
-    await hook(
-      { hook_event_name: "PreToolUse", tool_name: "Read" } as HookInput,
-      "toolu_1",
-      signal,
-    );
-
-    expect(onCodeFileRead).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/agent/src/adapters/claude/hooks.ts
+++ b/packages/agent/src/adapters/claude/hooks.ts
@@ -179,16 +179,12 @@ interface CreatePostToolUseHookParams {
   /** Called after a PostHog MCP `call` exec executes, with the sub-tool name
    *  and the raw command (the command embeds the SQL for execute-sql). */
   onPostHogResourceUsed?: (subTool: string, commandText?: string) => void;
-  /** Called after the agent reads a file from the codebase, to surface the
-   *  "Code" resource chip. */
-  onCodeFileRead?: () => void;
 }
 
 export const createPostToolUseHook =
   ({
     onModeChange,
     onPostHogResourceUsed,
-    onCodeFileRead,
   }: CreatePostToolUseHookParams): HookCallback =>
   async (
     input: HookInput,
@@ -199,11 +195,6 @@ export const createPostToolUseHook =
 
       if (onModeChange && toolName === "EnterPlanMode") {
         await onModeChange("plan");
-      }
-
-      // Any file read counts as "used PostHog Code" — surface the Code chip.
-      if (onCodeFileRead && toolName === "Read") {
-        onCodeFileRead();
       }
 
       // Record PostHog product usage from the MCP exec dispatcher. Only the

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -60,9 +60,6 @@ export interface BuildOptionsParams {
   enrichedReadCache?: EnrichedReadCache;
   /** Records PostHog product usage from MCP exec calls (deduped, session-wide). */
   onPostHogResourceUsed?: (subTool: string, commandText?: string) => void;
-  /** Records the `code` product when the agent reads a file from the codebase
-   *  (deduped, session-wide). */
-  onCodeFileRead?: () => void;
   /** Cloud task session — enables the signed-commit guard. */
   cloudMode?: boolean;
   /** Per-session task state populated by createTaskHook from SDK Task* events. */
@@ -168,7 +165,6 @@ function buildHooks(
   onPostHogResourceUsed:
     | ((subTool: string, commandText?: string) => void)
     | undefined,
-  onCodeFileRead: (() => void) | undefined,
   settingsManager: SettingsManager,
   logger: Logger,
   enrichmentDeps: FileEnrichmentDeps | undefined,
@@ -182,7 +178,6 @@ function buildHooks(
     createPostToolUseHook({
       onModeChange,
       onPostHogResourceUsed,
-      onCodeFileRead,
     }),
   ];
   if (enrichmentDeps && enrichedReadCache) {
@@ -409,7 +404,6 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
       params.userProvidedOptions?.hooks,
       params.onModeChange,
       params.onPostHogResourceUsed,
-      params.onCodeFileRead,
       params.settingsManager,
       params.logger,
       params.enrichmentDeps,

--- a/packages/agent/src/posthog-products.ts
+++ b/packages/agent/src/posthog-products.ts
@@ -28,9 +28,6 @@ export const POSTHOG_PRODUCTS = {
   logs: "Logs",
   apm: "APM",
   sql: "SQL",
-  /** Sourced from the agent reading a file in the user's codebase, not from an
-   *  MCP sub-tool — see the PostToolUse hook's Read handling. */
-  code: "Code",
   /** Generic fallback for a recognized-PostHog call we don't classify yet. */
   posthog: "PostHog",
 } as const;


### PR DESCRIPTION
## Problem

The "PostHog resources used" bar above the composer surfaced a **Code** chip on essentially every task — it was added on any file read. Since a user driving PostHog Code is already, by definition, using Code, the chip carried no information, and its link to the `posthog.com/code` landing page left people confused about what it was telling them (per the Slack thread that prompted this).

## Changes

Removes the `code` product from the resources-used display entirely:

- Drops the `onCodeFileRead` PostToolUse hook and its plumbing through `claude-agent.ts` and `session/options.ts`.
- Removes the `code` entry from `POSTHOG_PRODUCTS` and the corresponding icon / doc-URL entries in `SessionResourcesBar`.

Other PostHog product chips (Experiments, Feature flags, SQL, …) are unaffected.

## How did you test this?

- `pnpm --filter agent typecheck` and `pnpm --filter code typecheck` — clean.
- `pnpm --filter agent exec vitest run` on `hooks.test.ts` and `posthog-products.test.ts` (91 tests) — pass.
- `pnpm --filter code exec vitest run` on `accumulateSessionResources.test.ts` (3 tests) — pass.
- Biome check on changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781004567121189?thread_ts=1781004567.121189&cid=C09G8Q32R6F)*