### PR TITLE
fix(agent-server): remove debug build-marker log on start

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -527,9 +527,6 @@ export class AgentServer {
   }
 
   async start(): Promise<void> {
-    this.logger.debug(
-      "🐷 PostHog Code agent build — vojtab/pr-footer-slack-thread-link",
-    );
     await new Promise<void>((resolve) => {
       this.server = serve(
         {


### PR DESCRIPTION
## Problem

The agent-server was emitting a leftover debug log on every start — `🐷 PostHog Code agent build — vojtab/pr-footer-slack-thread-link` — which showed up on the agent-server. It was a build marker accidentally left in from #2540.

## Changes

Removed the debug log statement at the top of `AgentServer.start()`.

## How did you test this?

Not separately tested — straightforward removal of a single log line.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781009920778669)*
