### PR TITLE
docs(code): add troubleshooting note for missing Plan & usage tab

### DIFF
--- a/apps/code/README.md
+++ b/apps/code/README.md
@@ -278,3 +278,9 @@ Reference the workspace path:
 echo "Working in: $POSTHOG_CODE_WORKSPACE_NAME"
 echo "Root repo: $POSTHOG_CODE_ROOT_PATH"
 ```
+
+## Troubleshooting
+
+### "Plan & usage" tab is missing
+
+The app couldn't reach PostHog, usually because of a restrictive network, firewall, or tracker blocker. Connect to a VPN (or fix the network) and restart the app.


### PR DESCRIPTION
## Summary

Adds a **Troubleshooting** section to the Code app README documenting why the "Plan & usage" settings tab sometimes goes missing and how to fix it.

A user reported the tab missing (on Windows); it turned out their network was blocking the app from reaching PostHog, so the billing feature flag never loaded and the tab stayed hidden. Connecting through a VPN restored it. This note saves the next person the debugging round-trip.