### PR TITLE
fix(agent): run native Claude executable directly

### DIFF
--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -82,22 +82,24 @@ describe("buildSessionOptions", () => {
       }
     });
 
-    it("does not force node when Claude executable is a native binary", () => {
-      process.env.CLAUDE_CODE_EXECUTABLE = "/tmp/claude";
+    it.each([
+      {
+        executablePath: "/tmp/claude",
+        expectedExecutable: undefined,
+        name: "does not force node when Claude executable is a native binary",
+      },
+      {
+        executablePath: "/tmp/cli.js",
+        expectedExecutable: "node",
+        name: "uses node when Claude executable is the legacy JavaScript CLI",
+      },
+    ])("$name", ({ executablePath, expectedExecutable }) => {
+      process.env.CLAUDE_CODE_EXECUTABLE = executablePath;
 
       const options = buildSessionOptions(makeParams());
 
-      expect(options.pathToClaudeCodeExecutable).toBe("/tmp/claude");
-      expect(options.executable).toBeUndefined();
-    });
-
-    it("uses node when Claude executable is the legacy JavaScript CLI", () => {
-      process.env.CLAUDE_CODE_EXECUTABLE = "/tmp/cli.js";
-
-      const options = buildSessionOptions(makeParams());
-
-      expect(options.pathToClaudeCodeExecutable).toBe("/tmp/cli.js");
-      expect(options.executable).toBe("node");
+      expect(options.pathToClaudeCodeExecutable).toBe(executablePath);
+      expect(options.executable).toBe(expectedExecutable);
     });
   });
 

--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -74,6 +74,10 @@ describe("buildSessionOptions", () => {
   describe("CLAUDE_CODE_EXECUTABLE", () => {
     const originalClaudeExecutable = process.env.CLAUDE_CODE_EXECUTABLE;
 
+    beforeEach(() => {
+      delete process.env.CLAUDE_CODE_EXECUTABLE;
+    });
+
     afterEach(() => {
       if (originalClaudeExecutable === undefined) {
         delete process.env.CLAUDE_CODE_EXECUTABLE;
@@ -85,20 +89,36 @@ describe("buildSessionOptions", () => {
     it.each([
       {
         executablePath: "/tmp/claude",
+        expectedPath: "/tmp/claude",
         expectedExecutable: undefined,
         name: "does not force node when Claude executable is a native binary",
       },
       {
         executablePath: "/tmp/cli.js",
+        expectedPath: "/tmp/cli.js",
         expectedExecutable: "node",
         name: "uses node when Claude executable is the legacy JavaScript CLI",
       },
-    ])("$name", ({ executablePath, expectedExecutable }) => {
-      process.env.CLAUDE_CODE_EXECUTABLE = executablePath;
+      {
+        executablePath: undefined,
+        expectedPath: undefined,
+        expectedExecutable: undefined,
+        name: "leaves executable and path unset when CLAUDE_CODE_EXECUTABLE is missing",
+      },
+      {
+        executablePath: "",
+        expectedPath: undefined,
+        expectedExecutable: undefined,
+        name: "leaves executable and path unset when CLAUDE_CODE_EXECUTABLE is empty",
+      },
+    ])("$name", ({ executablePath, expectedPath, expectedExecutable }) => {
+      if (executablePath !== undefined) {
+        process.env.CLAUDE_CODE_EXECUTABLE = executablePath;
+      }
 
       const options = buildSessionOptions(makeParams());
 
-      expect(options.pathToClaudeCodeExecutable).toBe(executablePath);
+      expect(options.pathToClaudeCodeExecutable).toBe(expectedPath);
       expect(options.executable).toBe(expectedExecutable);
     });
   });

--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -71,6 +71,36 @@ describe("buildSessionOptions", () => {
     expect(options.agents?.["ph-explore"]).toEqual(override);
   });
 
+  describe("CLAUDE_CODE_EXECUTABLE", () => {
+    const originalClaudeExecutable = process.env.CLAUDE_CODE_EXECUTABLE;
+
+    afterEach(() => {
+      if (originalClaudeExecutable === undefined) {
+        delete process.env.CLAUDE_CODE_EXECUTABLE;
+      } else {
+        process.env.CLAUDE_CODE_EXECUTABLE = originalClaudeExecutable;
+      }
+    });
+
+    it("does not force node when Claude executable is a native binary", () => {
+      process.env.CLAUDE_CODE_EXECUTABLE = "/tmp/claude";
+
+      const options = buildSessionOptions(makeParams());
+
+      expect(options.pathToClaudeCodeExecutable).toBe("/tmp/claude");
+      expect(options.executable).toBeUndefined();
+    });
+
+    it("uses node when Claude executable is the legacy JavaScript CLI", () => {
+      process.env.CLAUDE_CODE_EXECUTABLE = "/tmp/cli.js";
+
+      const options = buildSessionOptions(makeParams());
+
+      expect(options.pathToClaudeCodeExecutable).toBe("/tmp/cli.js");
+      expect(options.executable).toBe("node");
+    });
+  });
+
   describe("ANTHROPIC_CUSTOM_HEADERS", () => {
     const originalProjectId = process.env.POSTHOG_PROJECT_ID;
     const originalCustomHeaders = process.env.ANTHROPIC_CUSTOM_HEADERS;

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -360,6 +360,7 @@ function ensureLocalSettings(cwd: string): void {
   }
 }
 
+// The legacy CLI ships as cli.js; native binaries have no file extension.
 function isLegacyJavaScriptClaudeExecutable(executablePath: string): boolean {
   return executablePath.endsWith(".js");
 }
@@ -392,10 +393,6 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     allowDangerouslySkipPermissions: !IS_ROOT || !!process.env.IS_SANDBOX,
     permissionMode: params.permissionMode,
     canUseTool: params.canUseTool,
-    ...(claudeCodeExecutable &&
-      isLegacyJavaScriptClaudeExecutable(claudeCodeExecutable) && {
-        executable: "node",
-      }),
     tools,
     agents,
     extraArgs: {
@@ -437,6 +434,9 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
 
   if (claudeCodeExecutable) {
     options.pathToClaudeCodeExecutable = claudeCodeExecutable;
+    if (isLegacyJavaScriptClaudeExecutable(claudeCodeExecutable)) {
+      options.executable = "node";
+    }
   }
 
   if (params.isResume) {

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -360,6 +360,10 @@ function ensureLocalSettings(cwd: string): void {
   }
 }
 
+function isLegacyJavaScriptClaudeExecutable(executablePath: string): boolean {
+  return executablePath.endsWith(".js");
+}
+
 export function buildSessionOptions(params: BuildOptionsParams): Options {
   ensureLocalSettings(params.cwd);
 
@@ -375,6 +379,7 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
 
   const agents = buildAgents(params.userProvidedOptions?.agents);
   const registeredAgentNames = new Set(Object.keys(agents));
+  const claudeCodeExecutable = process.env.CLAUDE_CODE_EXECUTABLE;
 
   const options: Options = {
     ...params.userProvidedOptions,
@@ -387,7 +392,10 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     allowDangerouslySkipPermissions: !IS_ROOT || !!process.env.IS_SANDBOX,
     permissionMode: params.permissionMode,
     canUseTool: params.canUseTool,
-    executable: "node",
+    ...(claudeCodeExecutable &&
+      isLegacyJavaScriptClaudeExecutable(claudeCodeExecutable) && {
+        executable: "node",
+      }),
     tools,
     agents,
     extraArgs: {
@@ -427,8 +435,8 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     }),
   };
 
-  if (process.env.CLAUDE_CODE_EXECUTABLE) {
-    options.pathToClaudeCodeExecutable = process.env.CLAUDE_CODE_EXECUTABLE;
+  if (claudeCodeExecutable) {
+    options.pathToClaudeCodeExecutable = claudeCodeExecutable;
   }
 
   if (params.isResume) {


### PR DESCRIPTION
## Problem

Packaged PostHog Code builds now bundle Claude as a platform-specific native executable via `@anthropic-ai/claude-agent-sdk` optional dependencies.

On Linux, for example Fedora, `CLAUDE_CODE_EXECUTABLE` points to the bundled native binary:

text
.vite/build/claude-cli/claude
However, the Claude session options still forced:

executable: "node"

This can cause the SDK to try to run the native binary through Node, effectively:

node /path/to/claude
instead of executing it directly:

/path/to/claude
That breaks because the native Claude binary is not JavaScript.

Changes
Make executable: "node" conditional in Claude session options.
Keep using Node only when CLAUDE_CODE_EXECUTABLE points to the legacy JavaScript CLI, e.g. cli.js.
For native Claude executables like claude or claude.exe, leave executable unset so the SDK can execute the binary directly.
Added tests covering both cases:
native binary path does not force Node
legacy .js CLI path still uses Node
How did you test this?

Automated tests run:

PATH=/home/kenayperez/code/node_modules/.bin:/usr/bin:/usr/local/bin:/home/kenayperez/.local/bin /usr/bin/node /usr/lib/node_modules/pnpm/bin/pnpm.cjs -C packages/agent exec vitest run src/adapters/claude/session/options.test.ts --reporter=verbose
Result:

Test Files  1 passed (1)
Tests       8 passed (8)
Also ran:

PATH=/home/kenayperez/code/node_modules/.bin:/usr/bin:/usr/local/bin:/home/kenayperez/.local/bin /usr/bin/node /usr/lib/node_modules/pnpm/bin/pnpm.cjs --filter @posthog/agent typecheck
Result: exited with code 0.