### PR TITLE
feat(agent): add claude-fable-5 model support

### DIFF
--- a/apps/mobile/src/features/tasks/composer/options.ts
+++ b/apps/mobile/src/features/tasks/composer/options.ts
@@ -37,6 +37,12 @@ export interface ModelOption {
 
 export const MODELS: ModelOption[] = [
   {
+    value: "claude-fable-5",
+    label: "Claude Fable 5",
+    description: "Newest, most capable",
+    supportsReasoning: true,
+  },
+  {
     value: "claude-opus-4-8",
     label: "Claude Opus 4.8",
     description: "Most capable, slower",

--- a/packages/agent/src/adapters/claude/session/models.test.ts
+++ b/packages/agent/src/adapters/claude/session/models.test.ts
@@ -20,6 +20,10 @@ describe("toSdkModelId", () => {
     expect(toSdkModelId("custom-model")).toBe("custom-model");
   });
 
+  it("passes claude-fable-5 through unchanged (no SDK alias)", () => {
+    expect(toSdkModelId("claude-fable-5")).toBe("claude-fable-5");
+  });
+
   it("passes deprecated gateway IDs through unchanged", () => {
     expect(toSdkModelId("claude-opus-4-6")).toBe("claude-opus-4-6");
     expect(toSdkModelId("claude-sonnet-4-5")).toBe("claude-sonnet-4-5");
@@ -41,6 +45,13 @@ describe("model capability flags", () => {
     expect(supportsXhighEffort("claude-opus-4-7")).toBe(true);
     expect(supportsXhighEffort("claude-opus-4-6")).toBe(false);
     expect(supportsEffort("claude-haiku-4-5")).toBe(false);
+  });
+
+  it("flags claude-fable-5 as a flagship model", () => {
+    expect(supports1MContext("claude-fable-5")).toBe(true);
+    expect(supportsEffort("claude-fable-5")).toBe(true);
+    expect(supportsXhighEffort("claude-fable-5")).toBe(true);
+    expect(supportsMcpInjection("claude-fable-5")).toBe(true);
   });
 
   it("allows MCP injection for supported Claude models", () => {

--- a/packages/agent/src/adapters/claude/session/models.ts
+++ b/packages/agent/src/adapters/claude/session/models.ts
@@ -14,6 +14,7 @@ const MODELS_WITH_1M_CONTEXT = new Set([
   "claude-opus-4-7",
   "claude-opus-4-8",
   "claude-sonnet-4-6",
+  "claude-fable-5",
 ]);
 
 export function supports1MContext(modelId: string): boolean {
@@ -24,11 +25,13 @@ const MODELS_WITH_EFFORT = new Set([
   "claude-opus-4-7",
   "claude-opus-4-8",
   "claude-sonnet-4-6",
+  "claude-fable-5",
 ]);
 
 const MODELS_WITH_XHIGH_EFFORT = new Set([
   "claude-opus-4-7",
   "claude-opus-4-8",
+  "claude-fable-5",
 ]);
 
 export function supportsEffort(modelId: string): boolean {


### PR DESCRIPTION
## Summary
Adds the new **claude-fable-5** model to PostHog Code as a flagship (Opus-class) model. The default model remains **claude-opus-4-8**.

Pairs with the LLM gateway change in posthog/posthog: https://github.com/PostHog/posthog/pull/62497 (the gateway must allow the model id for it to appear in the picker).

## Changes
- Flag `claude-fable-5` for **1M context**, **reasoning effort**, and **xhigh/max effort** in the Claude session capability sets (`models.ts`).
- No `GATEWAY_TO_SDK_MODEL` entry — it has no opus/sonnet/haiku SDK alias, so it passes through to the gateway as its full id (the intended fallback).
- Add it to the **mobile composer** model list (listed first as newest); default stays Opus 4.8.
- Unit tests for the new capability flags and pass-through behaviour.

The desktop model picker is fed dynamically from the gateway's `/v1/models`, and the display name auto-derives to "Claude Fable 5" via `formatModelId`, so no hardcoded desktop list change is needed.

## Testing
- `vitest run packages/agent/src/adapters/claude/session/models.test.ts` — 20/20 pass.
