### PR TITLE
feat(inbox): render expandable inbox report card under initial prompt

### DIFF
--- a/packages/ui/src/features/inbox/components/InboxReportCard.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportCard.tsx
@@ -1,0 +1,120 @@
+import {
+  ArrowSquareOut,
+  CaretDown,
+  CaretUp,
+  Tray,
+} from "@phosphor-icons/react";
+import { useInboxReportById } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useInboxReportSelectionStore } from "@posthog/ui/features/inbox/stores/inboxReportSelectionStore";
+import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
+import { navigateToInbox } from "@posthog/ui/router/navigationBridge";
+import { Box, Flex, Spinner, Text } from "@radix-ui/themes";
+import { useCallback, useState } from "react";
+import { SignalReportActionabilityBadge } from "./utils/SignalReportActionabilityBadge";
+import { SignalReportPriorityBadge } from "./utils/SignalReportPriorityBadge";
+import { SignalReportStatusBadge } from "./utils/SignalReportStatusBadge";
+import { SignalReportSummaryMarkdown } from "./utils/SignalReportSummaryMarkdown";
+
+interface InboxReportCardProps {
+  reportId: string;
+}
+
+/**
+ * Compact, expandable card for the inbox report a task is associated with.
+ * Rendered under the initial prompt so the report can be read inline instead
+ * of navigating away to the inbox view. Reads the report from the same query
+ * cache the inbox uses (`useInboxReportById`), so it stays in sync and an
+ * "Open in inbox" action can reuse the warmed cache for the detail pane.
+ */
+export function InboxReportCard({ reportId }: InboxReportCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { data: report, isLoading } = useInboxReportById(reportId, {
+    staleTime: 60_000,
+  });
+
+  const setSelectedReportIds = useInboxReportSelectionStore(
+    (s) => s.setSelectedReportIds,
+  );
+  const resetFilters = useInboxSignalsFilterStore((s) => s.resetFilters);
+
+  const handleOpenInInbox = useCallback(() => {
+    // Reset inbox-local filters first so the report isn't hidden by an active
+    // filter, then navigate and select it (mirrors the deep-link open path).
+    resetFilters();
+    navigateToInbox();
+    setSelectedReportIds([reportId]);
+  }, [reportId, resetFilters, setSelectedReportIds]);
+
+  if (isLoading && !report) {
+    return (
+      <Flex
+        align="center"
+        gap="2"
+        className="mt-2 rounded-md border border-gray-5 bg-gray-1 px-2.5 py-2"
+      >
+        <Spinner size="1" />
+        <Text color="gray" className="text-[12px]">
+          Loading inbox report...
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (!report) return null;
+
+  return (
+    <Box className="mt-2 overflow-hidden rounded-md border border-gray-5 bg-gray-1">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 px-2.5 py-2 text-left hover:bg-gray-2"
+      >
+        <Tray size={14} weight="duotone" className="shrink-0 text-gray-10" />
+        <Text className="min-w-0 flex-1 truncate font-medium text-[13px]">
+          {report.title ?? "Inbox report"}
+        </Text>
+        <Box className="shrink-0">
+          <SignalReportStatusBadge status={report.status} />
+        </Box>
+        {expanded ? (
+          <CaretUp size={12} className="shrink-0 text-gray-10" />
+        ) : (
+          <CaretDown size={12} className="shrink-0 text-gray-10" />
+        )}
+      </button>
+
+      {expanded && (
+        <Flex
+          direction="column"
+          gap="2"
+          className="border-gray-5 border-t px-2.5 py-2"
+        >
+          <SignalReportSummaryMarkdown
+            content={report.summary}
+            fallback="No summary available."
+            variant="detail"
+          />
+
+          {(report.priority || report.actionability) && (
+            <Flex align="center" gap="1" wrap="wrap">
+              <SignalReportPriorityBadge priority={report.priority} />
+              <SignalReportActionabilityBadge
+                actionability={report.actionability}
+              />
+            </Flex>
+          )}
+
+          <button
+            type="button"
+            onClick={handleOpenInInbox}
+            className="inline-flex items-center gap-1 self-start text-[12px] text-accent-11 hover:text-accent-12"
+          >
+            <ArrowSquareOut size={12} />
+            <span>Open in inbox</span>
+          </button>
+        </Flex>
+      )}
+    </Box>
+  );
+}

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -258,6 +258,11 @@ export function ConversationView({
                   ? slackThreadUrl
                   : undefined
               }
+              signalReportId={
+                item.id === firstUserMessageId
+                  ? (task?.signal_report ?? undefined)
+                  : undefined
+              }
             />
           );
         case "git_action":
@@ -286,7 +291,14 @@ export function ConversationView({
           return <UserShellExecuteView item={item} />;
       }
     },
-    [repoPath, taskId, slackThreadUrl, firstUserMessageId, initialItemIds],
+    [
+      repoPath,
+      taskId,
+      slackThreadUrl,
+      firstUserMessageId,
+      initialItemIds,
+      task?.signal_report,
+    ],
   );
 
   const getRowKey = useCallback((row: ThreadRow) => row.id, []);

--- a/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -15,6 +15,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Tooltip } from "../../../../primitives/Tooltip";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import { useFeatureFlag } from "../../../feature-flags/useFeatureFlag";
+import { InboxReportCard } from "../../../inbox/components/InboxReportCard";
 import { usePanelLayoutStore } from "../../../panels/panelLayoutStore";
 import type { UserMessageAttachment } from "../../userMessageTypes";
 import { extractCanvasInstructions } from "./canvasInstructions";
@@ -32,6 +33,9 @@ interface UserMessageProps {
   content: string;
   timestamp?: number;
   sourceUrl?: string;
+  /** Inbox report this message's task is associated with — rendered as an
+   * expandable card under the message (first user message only). */
+  signalReportId?: string;
   attachments?: UserMessageAttachment[];
   animate?: boolean;
   /** Task the message belongs to — needed to open the context file tab. */
@@ -58,6 +62,7 @@ export const UserMessage = memo(function UserMessage({
   content,
   timestamp,
   sourceUrl,
+  signalReportId,
   attachments = [],
   animate = true,
   taskId,
@@ -251,6 +256,7 @@ export const UserMessage = memo(function UserMessage({
             <span>View Slack thread</span>
           </a>
         )}
+        {signalReportId && <InboxReportCard reportId={signalReportId} />}
         <Box className="absolute top-1 right-1 flex select-none items-center gap-1.5 rounded-md bg-gray-2 py-0.5 pr-1 pl-2 opacity-0 shadow-sm transition-opacity group-hover/msg:opacity-100">
           {timestamp != null && (
             <span aria-hidden className="text-[11px] text-gray-10">


### PR DESCRIPTION
## Summary

When a task is associated with a PostHog inbox report (`task.signal_report`), the conversation now renders an **expandable inbox-report card directly under the initial prompt**. You can read the report inline — title, status, summary, priority/actionability — instead of jumping out to the inbox view to read more about it.

## What changed

**New component — `InboxReportCard.tsx`**
- Fetches the report via the existing `useInboxReportById` hook (same TanStack Query cache the inbox uses, so it stays in sync — no new data plumbing).
- **Collapsed:** compact card with a tray icon, report title, and status badge.
- **Expanded:** the researched summary (`SignalReportSummaryMarkdown`), priority + actionability badges, and an "Open in inbox" link that resets filters, navigates to the inbox, and selects the report (mirrors the deep-link open path, reusing the warm cache for the detail pane).
- Shows a subtle loading row while fetching; renders nothing if the report isn't accessible.

**Wiring (mirrors the existing `slackThreadUrl` pattern)**
- `UserMessage.tsx` — added an optional `signalReportId` prop; when present it renders `<InboxReportCard>` below the message body.
- `ConversationView.tsx` — passes `task.signal_report` to `UserMessage` for the **first user message only**.

## Notes
- The existing `[inbox item](posthog-code://…)` deep link inside the agent's prompt text is **kept** — it's part of the prompt the agent reads; the card is an additive UI affordance.
- The card appears on the live/suspended conversation view, not the transient pre-connection `PendingChatView`.

## Verification
- `pnpm --filter code typecheck` passes clean.
- `biome check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)