### PR TITLE
feat(inbox): render the signal report artefact log

### DIFF
--- a/apps/mobile/src/features/inbox/api.ts
+++ b/apps/mobile/src/features/inbox/api.ts
@@ -15,7 +15,6 @@ import type {
   SignalReportSignalsResponse,
   SignalReportsQueryParams,
   SignalReportsResponse,
-  SignalReportTask,
   SuggestedReviewerWriteEntry,
 } from "./types";
 
@@ -150,28 +149,6 @@ export async function getAvailableSuggestedReviewers(
     .filter((r): r is AvailableSuggestedReviewer => r !== null);
 
   return { results, count: results.length };
-}
-
-export async function getSignalReportTasks(
-  reportId: string,
-): Promise<SignalReportTask[]> {
-  const baseUrl = getBaseUrl();
-  const projectId = getProjectId();
-
-  const response = await authedFetch(
-    `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/tasks/`,
-  );
-
-  if (!response.ok) {
-    throw new HttpError(
-      response.status,
-      response.statusText,
-      "Failed to fetch signal report tasks",
-    );
-  }
-
-  const data = await response.json();
-  return data.results ?? [];
 }
 
 export async function getSignalReportArtefacts(

--- a/apps/mobile/src/features/inbox/types.ts
+++ b/apps/mobile/src/features/inbox/types.ts
@@ -76,13 +76,6 @@ export interface AvailableSuggestedReviewersResponse {
   count: number;
 }
 
-export interface SignalReportTask {
-  id: string;
-  relationship: string;
-  task_id: string;
-  created_at: string;
-}
-
 export interface Signal {
   signal_id: string;
   content: string;

--- a/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
@@ -22,6 +22,7 @@ describe("signed-commit tool handler", () => {
     createSignedCommit.mockReset();
     createSignedCommit.mockResolvedValue({
       branch: "posthog-code/feature",
+      repository: "x/y",
       commits: [
         { sha: "deadbeef", url: "https://github.com/x/y/commit/deadbeef" },
       ],

--- a/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/packages/agent/src/adapters/signed-commit-shared.ts
@@ -9,6 +9,7 @@ import {
   type SignedRewriteInput,
 } from "@posthog/git/signed-commit";
 import { z } from "zod";
+import { reportCommitArtefacts } from "../signed-commit-artefacts";
 import { qualifiedLocalToolName } from "./local-tools/registry";
 
 /**
@@ -168,7 +169,20 @@ export function runSignedCommitTool(
 ): Promise<SignedCommitToolResult> {
   return runSignedTool(
     SIGNED_COMMIT_TOOL_NAME,
-    createSignedCommit,
+    async (c, a: SignedCommitInput) => {
+      const result = await createSignedCommit(c, a);
+      // The "commit hook": every pushed commit becomes a `commit` artefact on the signal
+      // reports this task is associated with. Best-effort and awaited inside the tool's
+      // try/catch-free success path — reportCommitArtefacts never throws, so a failed
+      // artefact post can't fail a commit that already landed. git_signed_rewrite is
+      // intentionally not hooked (it republishes existing history).
+      await reportCommitArtefacts({
+        taskId: c.taskId,
+        result,
+        message: a.message,
+      });
+      return result;
+    },
     (r) => `Created ${r.commits.length} signed commit(s) on ${r.branch}`,
     ctx,
     args,

--- a/packages/agent/src/posthog-api.ts
+++ b/packages/agent/src/posthog-api.ts
@@ -245,6 +245,35 @@ export class PostHogAPIClient {
     return manifest.slice(-artifacts.length);
   }
 
+  /** Signal reports the given task is associated with (via report task associations). */
+  async getSignalReportIdsForTask(taskId: string): Promise<string[]> {
+    const teamId = this.getTeamId();
+    const response = await this.apiRequest<{ results?: { id: string }[] }>(
+      `/api/projects/${teamId}/signals/reports/?task_id=${encodeURIComponent(taskId)}&limit=100`,
+    );
+    return (response.results ?? []).map((r) => r.id);
+  }
+
+  /**
+   * Append a log artefact to a signal report, attributed to `taskId` via the
+   * `X-PostHog-Task-Id` header (the server validates it against the token's team).
+   */
+  async createSignalReportArtefact(
+    reportId: string,
+    taskId: string,
+    body: { artefact_type: string; content: Record<string, unknown> },
+  ): Promise<void> {
+    const teamId = this.getTeamId();
+    await this.apiRequest(
+      `/api/projects/${teamId}/signals/reports/${reportId}/artefacts/`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "X-PostHog-Task-Id": taskId },
+      },
+    );
+  }
+
   /**
    * Download artifact content by storage path
    * Streams the file through the PostHog backend so the sandbox does not need

--- a/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/packages/agent/src/signed-commit-artefacts.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { reportCommitArtefacts } from "./signed-commit-artefacts";
+
+const ENV = {
+  POSTHOG_API_URL: "https://us.posthog.com",
+  POSTHOG_PERSONAL_API_KEY: "pha_test",
+  POSTHOG_PROJECT_ID: "7",
+};
+
+// Point the env-file read at a path that never exists so only `env` is used.
+const NO_ENV_FILE = "/nonexistent/agent-env";
+
+const RESULT = {
+  branch: "posthog-code/fix-foo",
+  repository: "posthog/posthog",
+  commits: [
+    { sha: "aaa111", url: "https://github.com/posthog/posthog/commit/aaa111" },
+    { sha: "bbb222", url: "https://github.com/posthog/posthog/commit/bbb222" },
+  ],
+};
+
+describe("reportCommitArtefacts", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("posts one commit artefact per commit per associated report, attributed via header", async () => {
+    fetchMock.mockImplementation(async (url: string | URL) => {
+      if (String(url).includes("/signals/reports/?")) {
+        return jsonResponse({
+          results: [{ id: "report-1" }, { id: "report-2" }],
+        });
+      }
+      return jsonResponse({ id: "artefact" });
+    });
+
+    await reportCommitArtefacts({
+      taskId: "task-1",
+      result: RESULT,
+      message: "fix: foo",
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+    });
+
+    const lookupCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("/signals/reports/?task_id=task-1"),
+    );
+    expect(lookupCalls).toHaveLength(1);
+
+    const postCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("/artefacts/"),
+    );
+    // 2 commits × 2 reports.
+    expect(postCalls).toHaveLength(4);
+    for (const [url, init] of postCalls) {
+      expect(String(url)).toMatch(
+        /\/api\/projects\/7\/signals\/reports\/report-[12]\/artefacts\/$/,
+      );
+      const headers = new Headers((init as RequestInit).headers);
+      expect(headers.get("X-PostHog-Task-Id")).toBe("task-1");
+      const body = JSON.parse(String((init as RequestInit).body));
+      expect(body.artefact_type).toBe("commit");
+      expect(body.content.repository).toBe("posthog/posthog");
+      expect(body.content.branch).toBe("posthog-code/fix-foo");
+      expect(["aaa111", "bbb222"]).toContain(body.content.commit_sha);
+      expect(body.content.message).toBe("fix: foo");
+    }
+  });
+
+  it("is a no-op without a task id", async () => {
+    await reportCommitArtefacts({
+      taskId: undefined,
+      result: RESULT,
+      message: "fix: foo",
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op without sandbox PostHog credentials", async () => {
+    await reportCommitArtefacts({
+      taskId: "task-1",
+      result: RESULT,
+      message: "fix: foo",
+      env: {},
+      envFilePath: NO_ENV_FILE,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the report lookup fails", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    await expect(
+      reportCommitArtefacts({
+        taskId: "task-1",
+        result: RESULT,
+        message: "fix: foo",
+        env: ENV,
+        envFilePath: NO_ENV_FILE,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps posting remaining artefacts when one post fails", async () => {
+    let postCount = 0;
+    fetchMock.mockImplementation(async (url: string | URL) => {
+      if (String(url).includes("/signals/reports/?")) {
+        return jsonResponse({ results: [{ id: "report-1" }] });
+      }
+      postCount += 1;
+      if (postCount === 1) {
+        return new Response("{}", { status: 500 });
+      }
+      return jsonResponse({ id: "artefact" });
+    });
+
+    await reportCommitArtefacts({
+      taskId: "task-1",
+      result: RESULT,
+      message: "fix: foo",
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+    });
+
+    // Both commits attempted despite the first failing.
+    expect(postCount).toBe(2);
+  });
+});

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import type { SignedCommitResult } from "@posthog/git/signed-commit";
+import { PostHogAPIClient } from "./posthog-api";
+import { SANDBOX_ENV_FILE } from "./utils/github-token";
+
+/**
+ * Best-effort "commit hook": after a successful signed-commit push, record one `commit`
+ * artefact per pushed commit on every signal report the task is associated with, so the
+ * report's work log shows exactly what landed. Attribution is deterministic — the artefact
+ * endpoint reads the `X-PostHog-Task-Id` header, never the model.
+ *
+ * Credentials come from the sandbox environment (`POSTHOG_API_URL` /
+ * `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID`), preferring the live agentsh env file
+ * for the key so a mid-session token refresh is picked up — the same pattern as
+ * `resolveGithubToken`. Works identically from the Claude in-process server and the Codex
+ * stdio child (both inherit the sandbox env). Never throws: a failed artefact post must not
+ * fail the commit that already landed.
+ */
+
+interface SandboxPosthogApi {
+  apiUrl: string;
+  apiKey: string;
+  projectId: number;
+}
+
+function readSandboxEnvFile(envFilePath: string): Record<string, string> {
+  try {
+    const raw = readFileSync(envFilePath, "utf8");
+    const env: Record<string, string> = {};
+    for (const entry of raw.split("\0")) {
+      const eq = entry.indexOf("=");
+      if (eq > 0) {
+        env[entry.slice(0, eq)] = entry.slice(eq + 1);
+      }
+    }
+    return env;
+  } catch {
+    // No env file (local/desktop or test) — fall back to the process env only.
+    return {};
+  }
+}
+
+export function resolveSandboxPosthogApi(
+  env: Record<string, string | undefined> = process.env,
+  envFilePath: string = SANDBOX_ENV_FILE,
+): SandboxPosthogApi | undefined {
+  const fileEnv = readSandboxEnvFile(envFilePath);
+  const apiUrl = fileEnv.POSTHOG_API_URL ?? env.POSTHOG_API_URL;
+  const apiKey =
+    fileEnv.POSTHOG_PERSONAL_API_KEY ?? env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = Number(
+    fileEnv.POSTHOG_PROJECT_ID ?? env.POSTHOG_PROJECT_ID,
+  );
+  if (!apiUrl || !apiKey || !Number.isFinite(projectId) || projectId <= 0) {
+    return undefined;
+  }
+  return { apiUrl, apiKey, projectId };
+}
+
+export async function reportCommitArtefacts(opts: {
+  taskId: string | undefined;
+  result: SignedCommitResult;
+  /** Commit headline — the same for every chunk of a split payload. */
+  message: string;
+  env?: Record<string, string | undefined>;
+  envFilePath?: string;
+}): Promise<void> {
+  const { taskId, result, message } = opts;
+  if (!taskId) {
+    return; // Local/desktop run — no task to attribute or associate through.
+  }
+  try {
+    const api = resolveSandboxPosthogApi(opts.env, opts.envFilePath);
+    if (!api) {
+      return; // No sandbox PostHog credentials — nothing to report to.
+    }
+    const client = new PostHogAPIClient({
+      apiUrl: api.apiUrl,
+      projectId: api.projectId,
+      getApiKey: () => api.apiKey,
+    });
+    const reportIds = await client.getSignalReportIdsForTask(taskId);
+    for (const reportId of reportIds) {
+      for (const commit of result.commits) {
+        try {
+          await client.createSignalReportArtefact(reportId, taskId, {
+            artefact_type: "commit",
+            content: {
+              repository: result.repository,
+              branch: result.branch,
+              commit_sha: commit.sha,
+              message,
+            },
+          });
+        } catch (err) {
+          warn(
+            `failed to record commit ${commit.sha} on report ${reportId}: ${err}`,
+          );
+        }
+      }
+    }
+  } catch (err) {
+    warn(`failed to record commit artefacts: ${err}`);
+  }
+}
+
+// stderr directly (not console) — this also runs inside the Codex stdio MCP child,
+// where stdout is the protocol channel.
+function warn(message: string): void {
+  process.stderr.write(`[signed-commit-artefacts] ${message}\n`);
+}

--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -499,16 +499,6 @@ describe("PostHogAPIClient", () => {
         created_at: "2026-06-01T00:00:08Z",
       },
       {
-        id: "a10",
-        type: "code_diff",
-        content: {
-          file_path: "src/a.ts",
-          diff: "--- a\n+++ b",
-          relevance_note: "proposed fix",
-        },
-        created_at: "2026-06-01T00:00:09Z",
-      },
-      {
         id: "a11",
         type: "line_reference",
         content: {

--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -386,6 +386,228 @@ describe("PostHogAPIClient", () => {
     });
   });
 
+  describe("getSignalReportArtefacts", () => {
+    function makeClient(fetch: ReturnType<typeof vi.fn>) {
+      const client = new PostHogAPIClient(
+        "http://localhost:8000",
+        async () => "token",
+        async () => "token",
+        123,
+      );
+      (
+        client as unknown as {
+          api: { baseUrl: string; fetcher: { fetch: typeof fetch } };
+        }
+      ).api = {
+        baseUrl: "http://localhost:8000",
+        fetcher: { fetch },
+      };
+      return client;
+    }
+
+    // One row per backend ArtefactType (products/signals/backend/models.py),
+    // content shapes mirroring artefact_schemas.py / real API payloads.
+    const ROWS = [
+      {
+        id: "a1",
+        type: "video_segment",
+        content: {
+          session_id: "s1",
+          start_time: "2026-06-01T00:00:00Z",
+          end_time: "2026-06-01T00:01:00Z",
+          distinct_id: "d1",
+          content: "user rage-clicked the save button",
+          distance_to_centroid: 0.1,
+        },
+        created_at: "2026-06-01T00:00:00Z",
+      },
+      {
+        id: "a2",
+        type: "safety_judgment",
+        content: { choice: true, explanation: "No prompt injection found." },
+        created_at: "2026-06-01T00:00:01Z",
+        task_id: "t1",
+      },
+      {
+        id: "a3",
+        type: "actionability_judgment",
+        content: {
+          explanation: "Clear repro and code path.",
+          actionability: "immediately_actionable",
+          already_addressed: false,
+        },
+        created_at: "2026-06-01T00:00:02Z",
+      },
+      {
+        id: "a4",
+        type: "priority_judgment",
+        content: { explanation: "Cosmetic race.", priority: "P3" },
+        created_at: "2026-06-01T00:00:03Z",
+      },
+      {
+        id: "a5",
+        type: "signal_finding",
+        content: {
+          signal_id: "sig-1",
+          relevant_code_paths: ["a.ts"],
+          relevant_commit_hashes: { abc1234: "introduced the bug" },
+          data_queried: "execute-sql",
+          verified: true,
+        },
+        created_at: "2026-06-01T00:00:04Z",
+      },
+      {
+        id: "a6",
+        type: "repo_selection",
+        content: { repository: "posthog/posthog", reason: "Caller provided." },
+        created_at: "2026-06-01T00:00:05Z",
+      },
+      {
+        id: "a7",
+        type: "suggested_reviewers",
+        content: [
+          {
+            github_login: "octocat",
+            github_name: "Octo Cat",
+            relevant_commits: [],
+            user: null,
+          },
+        ],
+        created_at: "2026-06-01T00:00:06Z",
+      },
+      {
+        id: "a8",
+        type: "dismissal",
+        content: {
+          reason: "already_fixed",
+          note: "",
+          user_id: 1,
+          user_uuid: null,
+        },
+        created_at: "2026-06-01T00:00:07Z",
+      },
+      {
+        id: "a9",
+        type: "code_reference",
+        content: {
+          file_path: "src/a.ts",
+          start_line: 1,
+          end_line: 3,
+          contents: "let x = 1",
+          relevance_note: "origin",
+        },
+        created_at: "2026-06-01T00:00:08Z",
+      },
+      {
+        id: "a10",
+        type: "code_diff",
+        content: {
+          file_path: "src/a.ts",
+          diff: "--- a\n+++ b",
+          relevance_note: "proposed fix",
+        },
+        created_at: "2026-06-01T00:00:09Z",
+      },
+      {
+        id: "a11",
+        type: "line_reference",
+        content: {
+          file_path: "src/a.ts",
+          line: 2,
+          note: "here",
+          contents: "x++",
+        },
+        created_at: "2026-06-01T00:00:10Z",
+      },
+      {
+        id: "a12",
+        type: "commit",
+        content: {
+          repository: "posthog/posthog",
+          branch: "main",
+          commit_sha: "abc1234",
+          message: "fix",
+          note: null,
+        },
+        created_at: "2026-06-01T00:00:11Z",
+      },
+      {
+        id: "a13",
+        type: "task_run",
+        content: { task_id: "t1", product: "tasks", type: "agent_run" },
+        created_at: "2026-06-01T00:00:12Z",
+        task_id: "t1",
+      },
+      {
+        id: "a14",
+        type: "note",
+        content: { note: "Guinea-pig probe note." },
+        created_at: "2026-06-01T00:00:13Z",
+        task_id: "t1",
+        created_by: null,
+      },
+    ];
+
+    it("normalizes every backend artefact type without dropping rows", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ count: ROWS.length, results: ROWS }),
+      });
+      const client = makeClient(fetch);
+
+      const { results, unavailableReason } =
+        await client.getSignalReportArtefacts("r1");
+
+      expect(unavailableReason).toBeUndefined();
+      expect(results.map((a) => a.id)).toEqual(ROWS.map((r) => r.id));
+      expect(results.map((a) => a.type)).toEqual(ROWS.map((r) => r.type));
+      expect(results.every((a) => !a.degraded)).toBe(true);
+    });
+
+    it("keeps rows whose content does not match the type's shape as degraded previews", async () => {
+      const rows = [
+        // commit missing branch/sha — must not vanish
+        {
+          id: "bad1",
+          type: "commit",
+          content: { repository: "posthog/posthog", message: "where am I" },
+          created_at: "2026-06-01T00:00:00Z",
+          task_id: "t1",
+        },
+        // unknown future type with arbitrary object content
+        {
+          id: "bad2",
+          type: "deploy_event",
+          content: { reason: "rolled back v2" },
+          created_at: "2026-06-01T00:00:01Z",
+        },
+        // empty content
+        {
+          id: "bad3",
+          type: "note",
+          content: {},
+          created_at: "2026-06-01T00:00:02Z",
+        },
+      ];
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ count: rows.length, results: rows }),
+      });
+      const client = makeClient(fetch);
+
+      const { results } = await client.getSignalReportArtefacts("r1");
+
+      expect(results.map((a) => a.id)).toEqual(["bad1", "bad2", "bad3"]);
+      expect(results.every((a) => a.degraded)).toBe(true);
+      expect(results[0].type).toBe("commit");
+      expect((results[1].content as { content: string }).content).toBe(
+        "rolled back v2",
+      );
+      // attribution survives the fallback path
+      expect(results[0].task_id).toBe("t1");
+    });
+  });
+
   describe("updateSignalReportArtefact", () => {
     const ARTEFACT_PATH =
       "/api/projects/123/signals/reports/report-1/artefacts/art-1/";

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -16,7 +16,13 @@ import type {
   ActionabilityJudgmentArtefact,
   AvailableSuggestedReviewer,
   AvailableSuggestedReviewersResponse,
+  CodeDiffArtefact,
+  CodeReferenceArtefact,
+  CommitArtefact,
+  CommitDiffResponse,
   DismissalArtefact,
+  LineReferenceArtefact,
+  NoteArtefact,
   PriorityJudgmentArtefact,
   RepoSelectionArtefact,
   SandboxEnvironment,
@@ -32,7 +38,6 @@ import type {
   SignalReportsQueryParams,
   SignalReportsResponse,
   SignalReportTask,
-  SignalReportTaskRelationship,
   SignalTeamConfig,
   SignalUserAutonomyConfig,
   SlackChannelsQueryParams,
@@ -41,6 +46,7 @@ import type {
   SuggestedReviewerWriteEntry,
   Task,
   TaskRun,
+  TaskRunArtefact,
 } from "@posthog/shared/domain-types";
 import { buildApiFetcher } from "./fetcher";
 import { createApiClient, type Schemas } from "./generated";
@@ -522,6 +528,25 @@ function optionalString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+/** Unwrap the shared fetcher's `Failed request: [<status>] <json>` into the endpoint's clean message. */
+function extractRequestErrorMessage(error: unknown, fallback: string): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const match = raw.match(/^Failed request: \[(\d+)\] (.*)$/s);
+  if (!match) {
+    return fallback;
+  }
+  try {
+    const body = JSON.parse(match[2]) as { error?: unknown; detail?: unknown };
+    const message = body.error ?? body.detail;
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  } catch {
+    // Non-JSON body — fall through to the status-based fallback.
+  }
+  return `${fallback} (HTTP ${match[1]})`;
+}
+
 type AnyArtefact =
   | SignalReportArtefact
   | PriorityJudgmentArtefact
@@ -529,7 +554,13 @@ type AnyArtefact =
   | SignalFindingArtefact
   | RepoSelectionArtefact
   | SuggestedReviewersArtefact
-  | DismissalArtefact;
+  | DismissalArtefact
+  | CodeReferenceArtefact
+  | CodeDiffArtefact
+  | LineReferenceArtefact
+  | CommitArtefact
+  | TaskRunArtefact
+  | NoteArtefact;
 
 const DISMISSAL_REASONS = new Set<DismissalReasonOptionValue>(
   DISMISSAL_REASON_OPTIONS.map((o) => o.value),
@@ -691,6 +722,164 @@ function normalizeDismissalArtefact(
   };
 }
 
+// ── Log artefact normalizers ──────────────────────────────────────────────
+// The backend stores log-artefact content as a JSON object (not the string-or-
+// session_id shape the generic fallback expects), so each type needs an explicit
+// normalizer — otherwise it falls through and gets dropped.
+
+function logArtefactBase(value: Record<string, unknown>): {
+  created_at: string;
+  updated_at: string | null;
+} {
+  return {
+    created_at: optionalString(value.created_at) ?? new Date(0).toISOString(),
+    updated_at: optionalString(value.updated_at),
+  };
+}
+
+function normalizeCodeReferenceArtefact(
+  value: Record<string, unknown>,
+): CodeReferenceArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+  const c = isObjectRecord(value.content) ? value.content : null;
+  if (!c) return null;
+  const file_path = optionalString(c.file_path);
+  if (!file_path) return null;
+
+  return {
+    id,
+    type: "code_reference",
+    ...logArtefactBase(value),
+    content: {
+      file_path,
+      start_line: typeof c.start_line === "number" ? c.start_line : 0,
+      end_line: typeof c.end_line === "number" ? c.end_line : 0,
+      contents: optionalString(c.contents) ?? "",
+      relevance_note: optionalString(c.relevance_note) ?? "",
+    },
+  };
+}
+
+function normalizeCodeDiffArtefact(
+  value: Record<string, unknown>,
+): CodeDiffArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+  const c = isObjectRecord(value.content) ? value.content : null;
+  if (!c) return null;
+  const file_path = optionalString(c.file_path);
+  if (!file_path) return null;
+
+  return {
+    id,
+    type: "code_diff",
+    ...logArtefactBase(value),
+    content: {
+      file_path,
+      diff: optionalString(c.diff) ?? "",
+      relevance_note: optionalString(c.relevance_note) ?? "",
+    },
+  };
+}
+
+function normalizeLineReferenceArtefact(
+  value: Record<string, unknown>,
+): LineReferenceArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+  const c = isObjectRecord(value.content) ? value.content : null;
+  if (!c) return null;
+  const file_path = optionalString(c.file_path);
+  if (!file_path) return null;
+
+  return {
+    id,
+    type: "line_reference",
+    ...logArtefactBase(value),
+    content: {
+      file_path,
+      line: typeof c.line === "number" ? c.line : 0,
+      note: optionalString(c.note) ?? "",
+      contents: optionalString(c.contents),
+    },
+  };
+}
+
+function normalizeCommitArtefact(
+  value: Record<string, unknown>,
+): CommitArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+  const c = isObjectRecord(value.content) ? value.content : null;
+  if (!c) return null;
+  const repository = optionalString(c.repository);
+  const branch = optionalString(c.branch);
+  const commit_sha = optionalString(c.commit_sha);
+  if (!repository || !branch || !commit_sha) return null;
+
+  return {
+    id,
+    type: "commit",
+    ...logArtefactBase(value),
+    task_id: optionalString(value.task_id),
+    content: {
+      repository,
+      branch,
+      commit_sha,
+      message: optionalString(c.message) ?? "",
+      note: optionalString(c.note),
+    },
+  };
+}
+
+function normalizeTaskRunArtefact(
+  value: Record<string, unknown>,
+): TaskRunArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+  const c = isObjectRecord(value.content) ? value.content : null;
+  if (!c) return null;
+  const task_id = optionalString(c.task_id);
+  if (!task_id) return null;
+  const product = optionalString(c.product);
+  const type = optionalString(c.type);
+  if (!product || !type) return null;
+
+  return {
+    id,
+    type: "task_run",
+    ...logArtefactBase(value),
+    content: {
+      task_id,
+      run_id: optionalString(c.run_id),
+      product,
+      type,
+    },
+  };
+}
+
+function normalizeNoteArtefact(
+  value: Record<string, unknown>,
+): NoteArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+  const c = isObjectRecord(value.content) ? value.content : null;
+  if (!c) return null;
+  const note = optionalString(c.note);
+  if (!note) return null;
+
+  return {
+    id,
+    type: "note",
+    ...logArtefactBase(value),
+    content: {
+      note,
+      author: optionalString(c.author),
+    },
+  };
+}
+
 function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
   if (!isObjectRecord(value)) {
     return null;
@@ -711,6 +900,24 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
   }
   if (dispatchType === "dismissal") {
     return normalizeDismissalArtefact(value);
+  }
+  if (dispatchType === "code_reference") {
+    return normalizeCodeReferenceArtefact(value);
+  }
+  if (dispatchType === "code_diff") {
+    return normalizeCodeDiffArtefact(value);
+  }
+  if (dispatchType === "line_reference") {
+    return normalizeLineReferenceArtefact(value);
+  }
+  if (dispatchType === "commit") {
+    return normalizeCommitArtefact(value);
+  }
+  if (dispatchType === "task_run") {
+    return normalizeTaskRunArtefact(value);
+  }
+  if (dispatchType === "note") {
+    return normalizeNoteArtefact(value);
   }
 
   const id = optionalString(value.id);
@@ -1804,8 +2011,6 @@ export class PostHogAPIClient {
       > & {
         github_integration?: number | null;
         github_user_integration?: string | null;
-        /** POST-only: `SignalReportTask.relationship` to create when linking to `signal_report`. */
-        signal_report_task_relationship?: SignalReportTaskRelationship;
       },
   ) {
     const teamId = await this.getTeamId();
@@ -2943,6 +3148,32 @@ export class PostHogAPIClient {
     }
   }
 
+  async getCommitDiff(
+    reportId: string,
+    artefactId: string,
+  ): Promise<CommitDiffResponse> {
+    const teamId = await this.getTeamId();
+    const path = `/api/projects/${teamId}/signals/reports/${reportId}/artefacts/${artefactId}/diff/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+
+    // The shared fetcher throws `Failed request: [<status>] <json-body>` for any non-2xx, so
+    // unwrap that into the endpoint's clean `error` message rather than surfacing the raw string.
+    let response: Response;
+    try {
+      response = await this.api.fetcher.fetch({ method: "get", url, path });
+    } catch (error) {
+      throw new Error(
+        extractRequestErrorMessage(error, "Couldn\u2019t load the diff."),
+      );
+    }
+
+    const data = (await response.json()) as Partial<CommitDiffResponse>;
+    return {
+      diff: typeof data.diff === "string" ? data.diff : "",
+      truncated: data.truncated === true,
+    };
+  }
+
   async updateSignalReportState(
     reportId: string,
     input:
@@ -2984,6 +3215,12 @@ export class PostHogAPIClient {
     return (await response.json()) as SignalReport;
   }
 
+  /**
+   * Edit a report's suggested reviewers. The server appends a new `suggested_reviewers` status
+   * artefact (latest-wins), canonicalizes each entry to a lowercase `github_login`, and carries
+   * `relevant_commits` / `github_name` forward from the current reviewers for surviving logins.
+   * Returns the newly-appended artefact (a fresh id), not the one addressed by `artefactId`.
+   */
   async updateSignalReportArtefact(
     reportId: string,
     artefactId: string,
@@ -3070,17 +3307,11 @@ export class PostHogAPIClient {
     };
   }
 
-  async getSignalReportTasks(
-    reportId: string,
-    options?: { relationship?: SignalReportTask["relationship"] },
-  ): Promise<SignalReportTask[]> {
+  async getSignalReportTasks(reportId: string): Promise<SignalReportTask[]> {
     const teamId = await this.getTeamId();
     const url = new URL(
       `${this.api.baseUrl}/api/projects/${teamId}/signals/reports/${reportId}/tasks/`,
     );
-    if (options?.relationship) {
-      url.searchParams.set("relationship", options.relationship);
-    }
     const path = `/api/projects/${teamId}/signals/reports/${reportId}/tasks/`;
 
     const response = await this.api.fetcher.fetch({

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -25,6 +25,7 @@ import type {
   NoteArtefact,
   PriorityJudgmentArtefact,
   RepoSelectionArtefact,
+  SafetyJudgmentArtefact,
   SandboxEnvironment,
   SandboxEnvironmentInput,
   Signal,
@@ -551,6 +552,7 @@ type AnyArtefact =
   | SignalReportArtefact
   | PriorityJudgmentArtefact
   | ActionabilityJudgmentArtefact
+  | SafetyJudgmentArtefact
   | SignalFindingArtefact
   | RepoSelectionArtefact
   | SuggestedReviewersArtefact
@@ -624,6 +626,26 @@ function normalizeActionabilityJudgmentArtefact(
         typeof contentValue.already_addressed === "boolean"
           ? contentValue.already_addressed
           : false,
+    },
+  };
+}
+
+function normalizeSafetyJudgmentArtefact(
+  value: Record<string, unknown>,
+): SafetyJudgmentArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+
+  const contentValue = isObjectRecord(value.content) ? value.content : null;
+  if (!contentValue || typeof contentValue.choice !== "boolean") return null;
+
+  return {
+    id,
+    type: "safety_judgment",
+    ...artefactBase(value),
+    content: {
+      choice: contentValue.choice,
+      explanation: optionalString(contentValue.explanation),
     },
   };
 }
@@ -911,6 +933,9 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
   }
   if (dispatchType === "actionability_judgment") {
     return normalizeActionabilityJudgmentArtefact(value);
+  }
+  if (dispatchType === "safety_judgment") {
+    return normalizeSafetyJudgmentArtefact(value);
   }
   if (dispatchType === "priority_judgment") {
     return normalizePriorityJudgmentArtefact(value);

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -37,7 +37,6 @@ import type {
   SignalReportStatus,
   SignalReportsQueryParams,
   SignalReportsResponse,
-  SignalReportTask,
   SignalTeamConfig,
   SignalUserAutonomyConfig,
   SlackChannelsQueryParams,
@@ -3305,29 +3304,6 @@ export class PostHogAPIClient {
       status: "reingestion_started" | "already_running";
       report_id: string;
     };
-  }
-
-  async getSignalReportTasks(reportId: string): Promise<SignalReportTask[]> {
-    const teamId = await this.getTeamId();
-    const url = new URL(
-      `${this.api.baseUrl}/api/projects/${teamId}/signals/reports/${reportId}/tasks/`,
-    );
-    const path = `/api/projects/${teamId}/signals/reports/${reportId}/tasks/`;
-
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path,
-    });
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch signal report tasks: ${response.statusText}`,
-      );
-    }
-
-    const data = (await response.json()) as { results?: SignalReportTask[] };
-    return data.results ?? [];
   }
 
   async getSignalTeamConfig(): Promise<SignalTeamConfig> {

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -46,6 +46,7 @@ import type {
   Task,
   TaskRun,
   TaskRunArtefact,
+  UserBasic,
 } from "@posthog/shared/domain-types";
 import { buildApiFetcher } from "./fetcher";
 import { createApiClient, type Schemas } from "./generated";
@@ -582,7 +583,7 @@ function normalizePriorityJudgmentArtefact(
   return {
     id,
     type: "priority_judgment",
-    created_at: optionalString(value.created_at) ?? new Date(0).toISOString(),
+    ...artefactBase(value),
     content: {
       explanation: optionalString(contentValue.explanation) ?? "",
       priority: priority as PriorityJudgmentArtefact["content"]["priority"],
@@ -614,7 +615,7 @@ function normalizeActionabilityJudgmentArtefact(
   return {
     id,
     type: "actionability_judgment",
-    created_at: optionalString(value.created_at) ?? new Date(0).toISOString(),
+    ...artefactBase(value),
     content: {
       explanation: optionalString(contentValue.explanation) ?? "",
       actionability:
@@ -642,7 +643,7 @@ function normalizeSignalFindingArtefact(
   return {
     id,
     type: "signal_finding",
-    created_at: optionalString(value.created_at) ?? new Date(0).toISOString(),
+    ...artefactBase(value),
     content: {
       signal_id: signalId,
       relevant_code_paths: Array.isArray(contentValue.relevant_code_paths)
@@ -680,7 +681,7 @@ function normalizeRepoSelectionArtefact(
   return {
     id,
     type: "repo_selection",
-    created_at: optionalString(value.created_at) ?? new Date(0).toISOString(),
+    ...artefactBase(value),
     content: {
       repository: optionalString(contentValue.repository),
       reason: optionalString(contentValue.reason) ?? "",
@@ -710,7 +711,7 @@ function normalizeDismissalArtefact(
   return {
     id,
     type: "dismissal",
-    created_at: optionalString(value.created_at) ?? new Date(0).toISOString(),
+    ...artefactBase(value),
     content: {
       reason,
       note: optionalString(contentValue.note) ?? "",
@@ -726,13 +727,34 @@ function normalizeDismissalArtefact(
 // session_id shape the generic fallback expects), so each type needs an explicit
 // normalizer — otherwise it falls through and gets dropped.
 
-function logArtefactBase(value: Record<string, unknown>): {
+/** User the artefact is attributed to, when the row carries a valid `created_by`. */
+function normalizeArtefactUser(value: unknown): UserBasic | null {
+  if (!isObjectRecord(value)) return null;
+  const id = value.id;
+  const uuid = optionalString(value.uuid);
+  const email = optionalString(value.email);
+  if (typeof id !== "number" || !uuid || !email) return null;
+  return {
+    id,
+    uuid,
+    email,
+    first_name: optionalString(value.first_name) ?? undefined,
+    last_name: optionalString(value.last_name) ?? undefined,
+  };
+}
+
+/** Row-level fields shared by every artefact: timestamps plus user/task attribution. */
+function artefactBase(value: Record<string, unknown>): {
   created_at: string;
   updated_at: string | null;
+  created_by: UserBasic | null;
+  task_id: string | null;
 } {
   return {
     created_at: optionalString(value.created_at) ?? new Date(0).toISOString(),
     updated_at: optionalString(value.updated_at),
+    created_by: normalizeArtefactUser(value.created_by),
+    task_id: optionalString(value.task_id),
   };
 }
 
@@ -749,7 +771,7 @@ function normalizeCodeReferenceArtefact(
   return {
     id,
     type: "code_reference",
-    ...logArtefactBase(value),
+    ...artefactBase(value),
     content: {
       file_path,
       start_line: typeof c.start_line === "number" ? c.start_line : 0,
@@ -773,7 +795,7 @@ function normalizeCodeDiffArtefact(
   return {
     id,
     type: "code_diff",
-    ...logArtefactBase(value),
+    ...artefactBase(value),
     content: {
       file_path,
       diff: optionalString(c.diff) ?? "",
@@ -795,7 +817,7 @@ function normalizeLineReferenceArtefact(
   return {
     id,
     type: "line_reference",
-    ...logArtefactBase(value),
+    ...artefactBase(value),
     content: {
       file_path,
       line: typeof c.line === "number" ? c.line : 0,
@@ -820,8 +842,7 @@ function normalizeCommitArtefact(
   return {
     id,
     type: "commit",
-    ...logArtefactBase(value),
-    task_id: optionalString(value.task_id),
+    ...artefactBase(value),
     content: {
       repository,
       branch,
@@ -848,7 +869,7 @@ function normalizeTaskRunArtefact(
   return {
     id,
     type: "task_run",
-    ...logArtefactBase(value),
+    ...artefactBase(value),
     content: {
       task_id,
       run_id: optionalString(c.run_id),
@@ -871,7 +892,7 @@ function normalizeNoteArtefact(
   return {
     id,
     type: "note",
-    ...logArtefactBase(value),
+    ...artefactBase(value),
     content: {
       note,
       author: optionalString(c.author),
@@ -925,15 +946,13 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
   }
 
   const type = dispatchType ?? "unknown";
-  const created_at =
-    optionalString(value.created_at) ?? new Date(0).toISOString();
 
   // suggested_reviewers: content is an array of reviewer objects
   if (type === "suggested_reviewers" && Array.isArray(value.content)) {
     return {
       id,
       type: "suggested_reviewers" as const,
-      created_at,
+      ...artefactBase(value),
       content: value.content as SuggestedReviewersArtefact["content"],
     };
   }
@@ -955,7 +974,7 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
   return {
     id,
     type,
-    created_at,
+    ...artefactBase(value),
     content: {
       session_id: sessionId ?? "",
       start_time: optionalString(contentValue.start_time) ?? "",

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -16,7 +16,6 @@ import type {
   ActionabilityJudgmentArtefact,
   AvailableSuggestedReviewer,
   AvailableSuggestedReviewersResponse,
-  CodeDiffArtefact,
   CodeReferenceArtefact,
   CommitArtefact,
   CommitDiffResponse,
@@ -558,7 +557,6 @@ type AnyArtefact =
   | SuggestedReviewersArtefact
   | DismissalArtefact
   | CodeReferenceArtefact
-  | CodeDiffArtefact
   | LineReferenceArtefact
   | CommitArtefact
   | TaskRunArtefact
@@ -804,28 +802,6 @@ function normalizeCodeReferenceArtefact(
   };
 }
 
-function normalizeCodeDiffArtefact(
-  value: Record<string, unknown>,
-): CodeDiffArtefact | null {
-  const id = optionalString(value.id);
-  if (!id) return null;
-  const c = isObjectRecord(value.content) ? value.content : null;
-  if (!c) return null;
-  const file_path = optionalString(c.file_path);
-  if (!file_path) return null;
-
-  return {
-    id,
-    type: "code_diff",
-    ...artefactBase(value),
-    content: {
-      file_path,
-      diff: optionalString(c.diff) ?? "",
-      relevance_note: optionalString(c.relevance_note) ?? "",
-    },
-  };
-}
-
 function normalizeLineReferenceArtefact(
   value: Record<string, unknown>,
 ): LineReferenceArtefact | null {
@@ -1007,9 +983,6 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
     return (
       normalizeCodeReferenceArtefact(value) ?? normalizeFallbackArtefact(value)
     );
-  }
-  if (dispatchType === "code_diff") {
-    return normalizeCodeDiffArtefact(value) ?? normalizeFallbackArtefact(value);
   }
   if (dispatchType === "line_reference") {
     return (

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -922,6 +922,49 @@ function normalizeNoteArtefact(
   };
 }
 
+/** Best human-readable one-liner from arbitrary artefact content. */
+function contentPreview(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (isObjectRecord(content)) {
+    for (const key of ["note", "explanation", "reason", "message", "content"]) {
+      const v = content[key];
+      if (typeof v === "string" && v.trim()) return v;
+    }
+  }
+  try {
+    const text = JSON.stringify(content);
+    return text && text !== "{}" && text !== "null" ? text.slice(0, 300) : "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Last-resort normalizer: keeps the row (type, timestamps, attribution, a text
+ * preview) when its content doesn't match the type's expected shape, so an
+ * artefact never silently vanishes from the activity log.
+ */
+function normalizeFallbackArtefact(
+  value: Record<string, unknown>,
+): SignalReportArtefact | null {
+  const id = optionalString(value.id);
+  if (!id) return null;
+  return {
+    id,
+    type: optionalString(value.type) ?? "unknown",
+    degraded: true,
+    ...artefactBase(value),
+    content: {
+      session_id: "",
+      start_time: "",
+      end_time: "",
+      distinct_id: "",
+      content: contentPreview(value.content),
+      distance_to_centroid: null,
+    },
+  };
+}
+
 function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
   if (!isObjectRecord(value)) {
     return null;
@@ -929,40 +972,58 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
 
   const dispatchType = optionalString(value.type);
   if (dispatchType === "signal_finding") {
-    return normalizeSignalFindingArtefact(value);
+    return (
+      normalizeSignalFindingArtefact(value) ?? normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "actionability_judgment") {
-    return normalizeActionabilityJudgmentArtefact(value);
+    return (
+      normalizeActionabilityJudgmentArtefact(value) ??
+      normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "safety_judgment") {
-    return normalizeSafetyJudgmentArtefact(value);
+    return (
+      normalizeSafetyJudgmentArtefact(value) ?? normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "priority_judgment") {
-    return normalizePriorityJudgmentArtefact(value);
+    return (
+      normalizePriorityJudgmentArtefact(value) ??
+      normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "repo_selection") {
-    return normalizeRepoSelectionArtefact(value);
+    return (
+      normalizeRepoSelectionArtefact(value) ?? normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "dismissal") {
-    return normalizeDismissalArtefact(value);
+    return (
+      normalizeDismissalArtefact(value) ?? normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "code_reference") {
-    return normalizeCodeReferenceArtefact(value);
+    return (
+      normalizeCodeReferenceArtefact(value) ?? normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "code_diff") {
-    return normalizeCodeDiffArtefact(value);
+    return normalizeCodeDiffArtefact(value) ?? normalizeFallbackArtefact(value);
   }
   if (dispatchType === "line_reference") {
-    return normalizeLineReferenceArtefact(value);
+    return (
+      normalizeLineReferenceArtefact(value) ?? normalizeFallbackArtefact(value)
+    );
   }
   if (dispatchType === "commit") {
-    return normalizeCommitArtefact(value);
+    return normalizeCommitArtefact(value) ?? normalizeFallbackArtefact(value);
   }
   if (dispatchType === "task_run") {
-    return normalizeTaskRunArtefact(value);
+    return normalizeTaskRunArtefact(value) ?? normalizeFallbackArtefact(value);
   }
   if (dispatchType === "note") {
-    return normalizeNoteArtefact(value);
+    return normalizeNoteArtefact(value) ?? normalizeFallbackArtefact(value);
   }
 
   const id = optionalString(value.id);
@@ -985,7 +1046,7 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
   // video_segment and other artefacts with object content
   const contentValue = isObjectRecord(value.content) ? value.content : null;
   if (!contentValue) {
-    return null;
+    return normalizeFallbackArtefact(value);
   }
 
   const content = optionalString(contentValue.content);
@@ -993,7 +1054,7 @@ function normalizeSignalReportArtefact(value: unknown): AnyArtefact | null {
 
   // The backend may return empty content objects when binary decode fails.
   if (!content && !sessionId) {
-    return null;
+    return normalizeFallbackArtefact(value);
   }
 
   return {

--- a/packages/core/src/inbox/reportArtefacts.ts
+++ b/packages/core/src/inbox/reportArtefacts.ts
@@ -10,12 +10,31 @@ import type {
 
 type ReportArtefact = SignalReportArtefactsResponse["results"][number];
 
+// Artefacts are an append-only history: status types (judgments, reviewers) are
+// latest-wins, and `signal_finding` is keyed by signal_id with the latest version
+// per signal winning. ISO-8601 `created_at` strings compare lexicographically in
+// chronological order, so selection is order-independent rather than relying on
+// the API's `-created_at` response ordering.
+function latestOfType<T extends ReportArtefact>(
+  artefacts: ReportArtefact[],
+  type: T["type"],
+): T | null {
+  let latest: T | null = null;
+  for (const a of artefacts) {
+    if (a.type === type && (!latest || a.created_at > latest.created_at)) {
+      latest = a as T;
+    }
+  }
+  return latest;
+}
+
 export function selectSuggestedReviewers(
   artefacts: ReportArtefact[],
   meUuid?: string,
 ): SuggestedReviewer[] {
-  const artefact = artefacts.find(
-    (a): a is SuggestedReviewersArtefact => a.type === "suggested_reviewers",
+  const artefact = latestOfType<SuggestedReviewersArtefact>(
+    artefacts,
+    "suggested_reviewers",
   );
   const reviewers = artefact?.content ?? [];
   if (!meUuid) return reviewers;
@@ -27,12 +46,18 @@ export function selectSuggestedReviewers(
 export function buildSignalFindingMap(
   artefacts: ReportArtefact[],
 ): Map<string, SignalFindingArtefact["content"]> {
-  const map = new Map<string, SignalFindingArtefact["content"]>();
+  const latestBySignal = new Map<string, SignalFindingArtefact>();
   for (const a of artefacts) {
-    if (a.type === "signal_finding") {
-      const finding = a as SignalFindingArtefact;
-      map.set(finding.content.signal_id, finding.content);
+    if (a.type !== "signal_finding") continue;
+    const finding = a as SignalFindingArtefact;
+    const existing = latestBySignal.get(finding.content.signal_id);
+    if (!existing || finding.created_at > existing.created_at) {
+      latestBySignal.set(finding.content.signal_id, finding);
     }
+  }
+  const map = new Map<string, SignalFindingArtefact["content"]>();
+  for (const [signalId, finding] of latestBySignal) {
+    map.set(signalId, finding.content);
   }
   return map;
 }
@@ -40,21 +65,19 @@ export function buildSignalFindingMap(
 export function selectActionabilityJudgment(
   artefacts: ReportArtefact[],
 ): ActionabilityJudgmentContent | null {
-  for (const a of artefacts) {
-    if (a.type === "actionability_judgment") {
-      return (a as ActionabilityJudgmentArtefact).content;
-    }
-  }
-  return null;
+  return (
+    latestOfType<ActionabilityJudgmentArtefact>(
+      artefacts,
+      "actionability_judgment",
+    )?.content ?? null
+  );
 }
 
 export function selectPriorityExplanation(
   artefacts: ReportArtefact[],
 ): string | null {
-  for (const a of artefacts) {
-    if (a.type === "priority_judgment") {
-      return (a as PriorityJudgmentArtefact).content.explanation || null;
-    }
-  }
-  return null;
+  return (
+    latestOfType<PriorityJudgmentArtefact>(artefacts, "priority_judgment")
+      ?.content.explanation || null
+  );
 }

--- a/packages/core/src/inbox/reportRepository.ts
+++ b/packages/core/src/inbox/reportRepository.ts
@@ -1,20 +1,20 @@
-import type { SignalReportTask, Task } from "@posthog/shared/domain-types";
+import type { Task } from "@posthog/shared/domain-types";
 
 /**
- * Resolve the repository a report's work happened in. Associations are
- * unlabelled — the repository is simply the first one any associated task
- * carries, walking oldest-first (repo selection / research precede
- * implementation).
+ * Resolve the repository a report's work happened in. Association is derived
+ * from `task_run` artefacts — the repository is simply the first one any
+ * associated task carries, walking oldest-first (repo selection / research
+ * precede implementation).
  */
 export async function resolveReportRepository(
-  reportTasks: SignalReportTask[],
+  associatedTasks: Array<{ taskId: string; startedAt: string }>,
   getTask: (taskId: string) => Promise<Task | null>,
 ): Promise<string | null> {
-  const ordered = [...reportTasks].sort((a, b) =>
-    a.created_at.localeCompare(b.created_at),
+  const ordered = [...associatedTasks].sort((a, b) =>
+    a.startedAt.localeCompare(b.startedAt),
   );
-  for (const reportTask of ordered) {
-    const task = await getTask(reportTask.task_id);
+  for (const entry of ordered) {
+    const task = await getTask(entry.taskId);
     if (task?.repository) {
       return task.repository.toLowerCase();
     }

--- a/packages/core/src/inbox/reportRepository.ts
+++ b/packages/core/src/inbox/reportRepository.ts
@@ -1,19 +1,19 @@
 import type { SignalReportTask, Task } from "@posthog/shared/domain-types";
 
-export const REPOSITORY_SOURCE_RELATIONSHIPS: SignalReportTask["relationship"][] =
-  ["repo_selection", "research", "implementation"];
-
+/**
+ * Resolve the repository a report's work happened in. Associations are
+ * unlabelled — the repository is simply the first one any associated task
+ * carries, walking oldest-first (repo selection / research precede
+ * implementation).
+ */
 export async function resolveReportRepository(
   reportTasks: SignalReportTask[],
   getTask: (taskId: string) => Promise<Task | null>,
 ): Promise<string | null> {
-  for (const relationship of REPOSITORY_SOURCE_RELATIONSHIPS) {
-    const reportTask = reportTasks.find(
-      (task) => task.relationship === relationship,
-    );
-    if (!reportTask) {
-      continue;
-    }
+  const ordered = [...reportTasks].sort((a, b) =>
+    a.created_at.localeCompare(b.created_at),
+  );
+  for (const reportTask of ordered) {
     const task = await getTask(reportTask.task_id);
     if (task?.repository) {
       return task.repository.toLowerCase();

--- a/packages/core/src/inbox/reportTasks.ts
+++ b/packages/core/src/inbox/reportTasks.ts
@@ -1,35 +1,4 @@
-import type { SignalReportTask, Task } from "@posthog/shared/domain-types";
-
-export type ReportTaskRelationship = SignalReportTask["relationship"];
-
-export const DISPLAYED_RELATIONSHIPS: ReportTaskRelationship[] = [
-  "implementation",
-  "research",
-];
-
-export interface ReportTaskData {
-  task: Task;
-  relationship: ReportTaskRelationship;
-  startedAt: string;
-}
-
-/** Keep only report-task relationships that the detail pane renders. */
-export function selectDisplayedReportTasks(
-  reportTasks: SignalReportTask[],
-): SignalReportTask[] {
-  return reportTasks.filter((rt) =>
-    DISPLAYED_RELATIONSHIPS.includes(rt.relationship),
-  );
-}
-
-/** Sort report tasks by their relationship's display rank. */
-export function sortByRelationship(tasks: ReportTaskData[]): ReportTaskData[] {
-  return [...tasks].sort(
-    (a, b) =>
-      DISPLAYED_RELATIONSHIPS.indexOf(a.relationship) -
-      DISPLAYED_RELATIONSHIPS.indexOf(b.relationship),
-  );
-}
+import type { Task } from "@posthog/shared/domain-types";
 
 /** Extract the PR url from a task's latest run output, if present. */
 export function getTaskPrUrl(task: Task): string | null {

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -16,10 +16,7 @@ import {
   type Workspace,
 } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
-import {
-  SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP,
-  type Task,
-} from "@posthog/shared/domain-types";
+import type { Task } from "@posthog/shared/domain-types";
 import type { TaskCreationApiClient } from "./taskCreationApiClient";
 import type { ITaskCreationHost } from "./taskCreationHost";
 
@@ -478,10 +475,9 @@ export class TaskCreationSaga extends Saga<
           origin_product: input.signalReportId
             ? "signal_report"
             : "user_created",
+          // The server associates the task with the report and records the implementation
+          // task_run artefact — no relationship label is sent (associations are unlabelled).
           signal_report: input.signalReportId ?? undefined,
-          signal_report_task_relationship: input.signalReportId
-            ? SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP
-            : undefined,
         });
         return result as unknown as Task;
       },

--- a/packages/git/src/signed-commit.ts
+++ b/packages/git/src/signed-commit.ts
@@ -55,6 +55,8 @@ export interface SignedCommitInput {
 
 export interface SignedCommitResult {
   branch: string;
+  /** Repository the commits were pushed to, as `owner/repo` (from the origin remote). */
+  repository: string;
   /** One entry per chunk; >1 only when the payload was split. */
   commits: { sha: string; url: string }[];
 }
@@ -871,7 +873,7 @@ export async function createSignedCommit(
       (await runGit(["diff", "--cached", "--quiet", "HEAD"], ctx.cwd))
         .exitCode !== 0;
     if (hasStagedChanges) {
-      return { branch, commits: [] };
+      return { branch, repository: repo, commits: [] };
     }
     throw new Error(
       "No staged changes to commit. Stage files with `git add` first (or pass `paths`).",
@@ -895,7 +897,7 @@ export async function createSignedCommit(
   );
 
   await syncLocalCheckout(ctx, branch, newTip);
-  return { branch, commits };
+  return { branch, repository: repo, commits };
 }
 
 /** Splits a raw commit message into a headline and the remaining body */
@@ -1039,7 +1041,7 @@ export async function createSignedRewrite(
     }
     await forceUpdateRef(ctx, repo, branch, expectedHeadOid);
     await syncLocalCheckout(ctx, branch, expectedHeadOid);
-    return { branch, commits };
+    return { branch, repository: repo, commits };
   } finally {
     // The history is already published via the ref move; the scratch ref is just
     // bookkeeping, so a delete failure is non-fatal.

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -438,18 +438,6 @@ export interface CodeReferenceContent {
   relevance_note: string;
 }
 
-/** Artefact with `type: "code_diff"` — a unified diff for a single file. */
-export interface CodeDiffArtefact extends SignalReportArtefactBase {
-  type: "code_diff";
-  content: CodeDiffContent;
-}
-
-export interface CodeDiffContent {
-  file_path: string;
-  diff: string;
-  relevance_note: string;
-}
-
 /** Artefact with `type: "line_reference"` — a single source line callout (a point). */
 export interface LineReferenceArtefact extends SignalReportArtefactBase {
   type: "line_reference";
@@ -603,7 +591,6 @@ export type AnySignalReportArtefact =
   | SuggestedReviewersArtefact
   | DismissalArtefact
   | CodeReferenceArtefact
-  | CodeDiffArtefact
   | LineReferenceArtefact
   | CommitArtefact
   | TaskRunArtefact

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -643,17 +643,6 @@ export interface SignalReportsQueryParams {
   has_implementation_pr?: boolean;
 }
 
-/**
- * An unlabelled task↔report association. A task's purpose (research / implementation / …)
- * is derived from the report's `task_run` artefacts, not stored on the link.
- */
-export interface SignalReportTask {
-  id: string;
-  report_id: string;
-  task_id: string;
-  created_at: string;
-}
-
 export interface SignalTeamConfig {
   id: string;
   default_autostart_priority: SignalReportPriority;

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -26,7 +26,7 @@ export const effortLevelSchema = z.enum([
 ]);
 export type EffortLevel = z.infer<typeof effortLevelSchema>;
 
-interface UserBasic {
+export interface UserBasic {
   id: number;
   uuid: string;
   distinct_id?: string | null;
@@ -309,19 +309,30 @@ export interface SignalReportArtefactContent {
   distance_to_centroid: number | null;
 }
 
-export interface SignalReportArtefact {
+/**
+ * Fields shared by every artefact row. `created_by` / `task_id` carry attribution:
+ * at most one is set — `created_by` for user writes, `task_id` for agent writes,
+ * neither for system (pipeline) writes.
+ */
+export interface SignalReportArtefactBase {
   id: string;
+  created_at: string;
+  updated_at?: string | null;
+  /** User the artefact is attributed to, when a user produced it. */
+  created_by?: UserBasic | null;
+  /** Task the artefact is attributed to, when an agent produced it. */
+  task_id?: string | null;
+}
+
+export interface SignalReportArtefact extends SignalReportArtefactBase {
   type: string;
   content: SignalReportArtefactContent;
-  created_at: string;
 }
 
 /** Artefact with `type: "priority_judgment"` — priority assessment from the agentic report. */
-export interface PriorityJudgmentArtefact {
-  id: string;
+export interface PriorityJudgmentArtefact extends SignalReportArtefactBase {
   type: "priority_judgment";
   content: PriorityJudgmentContent;
-  created_at: string;
 }
 
 export interface PriorityJudgmentContent {
@@ -330,11 +341,10 @@ export interface PriorityJudgmentContent {
 }
 
 /** Artefact with `type: "actionability_judgment"` — actionability assessment from the agentic report. */
-export interface ActionabilityJudgmentArtefact {
-  id: string;
+export interface ActionabilityJudgmentArtefact
+  extends SignalReportArtefactBase {
   type: "actionability_judgment";
   content: ActionabilityJudgmentContent;
-  created_at: string;
 }
 
 export interface ActionabilityJudgmentContent {
@@ -344,11 +354,9 @@ export interface ActionabilityJudgmentContent {
 }
 
 /** Artefact with `type: "signal_finding"` — per-signal research finding from the agentic report. */
-export interface SignalFindingArtefact {
-  id: string;
+export interface SignalFindingArtefact extends SignalReportArtefactBase {
   type: "signal_finding";
   content: SignalFindingContent;
-  created_at: string;
 }
 
 export interface SignalFindingContent {
@@ -360,11 +368,9 @@ export interface SignalFindingContent {
 }
 
 /** Artefact with `type: "repo_selection"` - selected repository for the report run. */
-export interface RepoSelectionArtefact {
-  id: string;
+export interface RepoSelectionArtefact extends SignalReportArtefactBase {
   type: "repo_selection";
   content: RepoSelectionContent;
-  created_at: string;
 }
 
 export interface RepoSelectionContent {
@@ -373,19 +379,15 @@ export interface RepoSelectionContent {
 }
 
 /** Artefact with `type: "suggested_reviewers"` — content is an enriched reviewer list. */
-export interface SuggestedReviewersArtefact {
-  id: string;
+export interface SuggestedReviewersArtefact extends SignalReportArtefactBase {
   type: "suggested_reviewers";
   content: SuggestedReviewer[];
-  created_at: string;
 }
 
 /** Artefact with `type: "dismissal"` — captures the user's rationale when suppressing a report. */
-export interface DismissalArtefact {
-  id: string;
+export interface DismissalArtefact extends SignalReportArtefactBase {
   type: "dismissal";
   content: DismissalContent;
-  created_at: string;
 }
 
 export interface DismissalContent {
@@ -404,12 +406,9 @@ export interface DismissalContent {
 // Content shapes mirror products/signals/backend/artefact_schemas.py.
 
 /** Artefact with `type: "code_reference"` — a contiguous span of source lines. */
-export interface CodeReferenceArtefact {
-  id: string;
+export interface CodeReferenceArtefact extends SignalReportArtefactBase {
   type: "code_reference";
   content: CodeReferenceContent;
-  created_at: string;
-  updated_at?: string | null;
 }
 
 export interface CodeReferenceContent {
@@ -421,12 +420,9 @@ export interface CodeReferenceContent {
 }
 
 /** Artefact with `type: "code_diff"` — a unified diff for a single file. */
-export interface CodeDiffArtefact {
-  id: string;
+export interface CodeDiffArtefact extends SignalReportArtefactBase {
   type: "code_diff";
   content: CodeDiffContent;
-  created_at: string;
-  updated_at?: string | null;
 }
 
 export interface CodeDiffContent {
@@ -436,12 +432,9 @@ export interface CodeDiffContent {
 }
 
 /** Artefact with `type: "line_reference"` — a single source line callout (a point). */
-export interface LineReferenceArtefact {
-  id: string;
+export interface LineReferenceArtefact extends SignalReportArtefactBase {
   type: "line_reference";
   content: LineReferenceContent;
-  created_at: string;
-  updated_at?: string | null;
 }
 
 export interface LineReferenceContent {
@@ -453,14 +446,9 @@ export interface LineReferenceContent {
 }
 
 /** Artefact with `type: "commit"` — one commit pushed in relation to the report. */
-export interface CommitArtefact {
-  id: string;
+export interface CommitArtefact extends SignalReportArtefactBase {
   type: "commit";
   content: CommitContent;
-  created_at: string;
-  updated_at?: string | null;
-  /** Task the artefact is attributed to (the agent session that pushed it), when known. */
-  task_id?: string | null;
 }
 
 export interface CommitContent {
@@ -472,12 +460,9 @@ export interface CommitContent {
 }
 
 /** Artefact with `type: "task_run"` — a reference to a `tasks.Task` run for the report. */
-export interface TaskRunArtefact {
-  id: string;
+export interface TaskRunArtefact extends SignalReportArtefactBase {
   type: "task_run";
   content: TaskRunArtefactContent;
-  created_at: string;
-  updated_at?: string | null;
 }
 
 export interface TaskRunArtefactContent {
@@ -496,12 +481,9 @@ export interface TaskRunArtefactContent {
 }
 
 /** Artefact with `type: "note"` — a free-form note authored by an agent or by code. */
-export interface NoteArtefact {
-  id: string;
+export interface NoteArtefact extends SignalReportArtefactBase {
   type: "note";
   content: NoteContent;
-  created_at: string;
-  updated_at?: string | null;
 }
 
 export interface NoteContent {

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -398,6 +398,125 @@ export interface DismissalContent {
   user_uuid: string | null;
 }
 
+// ── Log artefacts ────────────────────────────────────────────────────────────
+// Append-but-deletable "work log" entries that accumulate on a report. Distinct
+// from the status artefacts above (judgments, reviewers) which are latest-wins.
+// Content shapes mirror products/signals/backend/artefact_schemas.py.
+
+/** Artefact with `type: "code_reference"` — a contiguous span of source lines. */
+export interface CodeReferenceArtefact {
+  id: string;
+  type: "code_reference";
+  content: CodeReferenceContent;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface CodeReferenceContent {
+  file_path: string;
+  start_line: number;
+  end_line: number;
+  contents: string;
+  relevance_note: string;
+}
+
+/** Artefact with `type: "code_diff"` — a unified diff for a single file. */
+export interface CodeDiffArtefact {
+  id: string;
+  type: "code_diff";
+  content: CodeDiffContent;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface CodeDiffContent {
+  file_path: string;
+  diff: string;
+  relevance_note: string;
+}
+
+/** Artefact with `type: "line_reference"` — a single source line callout (a point). */
+export interface LineReferenceArtefact {
+  id: string;
+  type: "line_reference";
+  content: LineReferenceContent;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface LineReferenceContent {
+  file_path: string;
+  line: number;
+  note: string;
+  /** The exact source text of the referenced line, if available. */
+  contents?: string | null;
+}
+
+/** Artefact with `type: "commit"` — one commit pushed in relation to the report. */
+export interface CommitArtefact {
+  id: string;
+  type: "commit";
+  content: CommitContent;
+  created_at: string;
+  updated_at?: string | null;
+  /** Task the artefact is attributed to (the agent session that pushed it), when known. */
+  task_id?: string | null;
+}
+
+export interface CommitContent {
+  repository: string;
+  branch: string;
+  commit_sha: string;
+  message: string;
+  note?: string | null;
+}
+
+/** Artefact with `type: "task_run"` — a reference to a `tasks.Task` run for the report. */
+export interface TaskRunArtefact {
+  id: string;
+  type: "task_run";
+  content: TaskRunArtefactContent;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface TaskRunArtefactContent {
+  task_id: string;
+  run_id?: string | null;
+  /**
+   * Product that ran the task — `signals` for the built-in pipeline, or a custom agent's
+   * product identifier (mirrors backend TaskRunArtefact).
+   */
+  product: string;
+  /**
+   * Task type within the product — e.g. `research` / `implementation` / `repo_selection` for the
+   * signals pipeline, or a custom agent's type identifier.
+   */
+  type: string;
+}
+
+/** Artefact with `type: "note"` — a free-form note authored by an agent or by code. */
+export interface NoteArtefact {
+  id: string;
+  type: "note";
+  content: NoteContent;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+export interface NoteContent {
+  note: string;
+  author?: string | null;
+}
+
+/** Response from the `commit` artefact diff endpoint — the commit rendered against its parent. */
+export interface CommitDiffResponse {
+  /** Unified diff (patch) text introduced by the commit. */
+  diff: string;
+  /** True when the diff was too large to return in full and has been truncated. */
+  truncated: boolean;
+}
+
 export interface SuggestedReviewerCommit {
   sha: string;
   url: string;
@@ -472,16 +591,24 @@ export interface SignalReportSignalsResponse {
   signals: Signal[];
 }
 
+/** Any artefact returned by the report `artefacts/` endpoint, discriminated on `type`. */
+export type AnySignalReportArtefact =
+  | SignalReportArtefact
+  | PriorityJudgmentArtefact
+  | ActionabilityJudgmentArtefact
+  | SignalFindingArtefact
+  | RepoSelectionArtefact
+  | SuggestedReviewersArtefact
+  | DismissalArtefact
+  | CodeReferenceArtefact
+  | CodeDiffArtefact
+  | LineReferenceArtefact
+  | CommitArtefact
+  | TaskRunArtefact
+  | NoteArtefact;
+
 export interface SignalReportArtefactsResponse {
-  results: (
-    | SignalReportArtefact
-    | PriorityJudgmentArtefact
-    | ActionabilityJudgmentArtefact
-    | SignalFindingArtefact
-    | RepoSelectionArtefact
-    | SuggestedReviewersArtefact
-    | DismissalArtefact
-  )[];
+  results: AnySignalReportArtefact[];
   count: number;
   unavailableReason?:
     | "forbidden"
@@ -516,23 +643,13 @@ export interface SignalReportsQueryParams {
   has_implementation_pr?: boolean;
 }
 
-/** Values match `SignalReportTask.Relationship` on the PostHog API. */
-export const SIGNAL_REPORT_TASK_RELATIONSHIPS = [
-  "repo_selection",
-  "research",
-  "implementation",
-] as const;
-
-export type SignalReportTaskRelationship =
-  (typeof SIGNAL_REPORT_TASK_RELATIONSHIPS)[number];
-
-/** Inbox / cloud PR tasks must use this when creating the `SignalReportTask` link. */
-export const SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP: SignalReportTaskRelationship =
-  "implementation";
-
+/**
+ * An unlabelled task↔report association. A task's purpose (research / implementation / …)
+ * is derived from the report's `task_run` artefacts, not stored on the link.
+ */
 export interface SignalReportTask {
   id: string;
-  relationship: SignalReportTaskRelationship;
+  report_id: string;
   task_id: string;
   created_at: string;
 }

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -353,6 +353,19 @@ export interface ActionabilityJudgmentContent {
   already_addressed: boolean;
 }
 
+/** Artefact with `type: "safety_judgment"` — the prompt-injection safety verdict for the report. */
+export interface SafetyJudgmentArtefact extends SignalReportArtefactBase {
+  type: "safety_judgment";
+  content: SafetyJudgmentContent;
+}
+
+export interface SafetyJudgmentContent {
+  /** True when the report's signals are judged safe to act on. */
+  choice: boolean;
+  /** Why the report was judged unsafe; null when safe. */
+  explanation: string | null;
+}
+
 /** Artefact with `type: "signal_finding"` — per-signal research finding from the agentic report. */
 export interface SignalFindingArtefact extends SignalReportArtefactBase {
   type: "signal_finding";
@@ -578,6 +591,7 @@ export type AnySignalReportArtefact =
   | SignalReportArtefact
   | PriorityJudgmentArtefact
   | ActionabilityJudgmentArtefact
+  | SafetyJudgmentArtefact
   | SignalFindingArtefact
   | RepoSelectionArtefact
   | SuggestedReviewersArtefact

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -322,6 +322,12 @@ export interface SignalReportArtefactBase {
   created_by?: UserBasic | null;
   /** Task the artefact is attributed to, when an agent produced it. */
   task_id?: string | null;
+  /**
+   * True when the row's content did not match its type's expected shape and was
+   * normalized to a plain text preview instead — the entry still renders rather
+   * than silently vanishing from the activity log.
+   */
+  degraded?: boolean;
 }
 
 export interface SignalReportArtefact extends SignalReportArtefactBase {

--- a/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
+++ b/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
@@ -23,6 +23,7 @@ import {
   resolveRunVariant,
 } from "@posthog/ui/features/inbox/components/AgentRunCard";
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { ReportActivitySection } from "@posthog/ui/features/inbox/components/detail/ReportActivitySection";
 import { InboxDetailPageHeader } from "@posthog/ui/features/inbox/components/InboxDetailPageHeader";
 import {
   InboxMetaSeparator,
@@ -423,6 +424,7 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
                 )}
               </RightColumnSection>
             )}
+            <ReportActivitySection reportId={report.id} />
           </Flex>
         </div>
       </div>

--- a/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
+++ b/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
@@ -16,8 +16,6 @@ import { Button } from "@posthog/quill";
 import {
   isTerminalStatus,
   type SignalReport,
-  type SignalReportTaskRelationship,
-  type Task,
   type TaskRunStatus,
 } from "@posthog/shared/types";
 import {
@@ -47,7 +45,10 @@ import {
   hasKnownSourceProduct,
 } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { useInboxReportSignals } from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import { useReportTasks } from "@posthog/ui/features/inbox/hooks/useReportTasks";
+import {
+  type ReportTaskData,
+  useReportTasks,
+} from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 import { TaskLogsPanel } from "@posthog/ui/features/task-detail/components/TaskLogsPanel";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
@@ -72,21 +73,8 @@ export function TaskRunStatusDot({ status }: { status: TaskRunStatus }) {
   );
 }
 
-export const RELATIONSHIP_LABEL: Record<SignalReportTaskRelationship, string> =
-  {
-    research: "Research",
-    implementation: "Implementation",
-    repo_selection: "Repo selection",
-  };
-
-interface RelevantTask {
-  task: Task;
-  relationship: SignalReportTaskRelationship;
-  startedAt: string;
-}
-
 /** Prefer in-motion tasks; tie-break by most-recently-created. */
-function pickPrimaryTask(tasks: RelevantTask[]): RelevantTask | null {
+function pickPrimaryTask(tasks: ReportTaskData[]): ReportTaskData | null {
   if (tasks.length === 0) return null;
   return [...tasks].sort((a, b) => {
     const aInMotion = !isTerminalStatus(a.task.latest_run?.status ?? "");
@@ -261,9 +249,7 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
   // regardless of how the first attempt ended.
   const isReResearch = useMemo(() => {
     if (!reportTasks) return false;
-    const researchTasks = reportTasks.filter(
-      (rt) => rt.relationship === "research",
-    );
+    const researchTasks = reportTasks.filter((rt) => rt.purpose === "research");
     if (researchTasks.length < 2) return false;
     const hasInFlight = researchTasks.some(
       (rt) =>
@@ -449,8 +435,8 @@ function TaskLogRightSlot({
   selectedEntry,
   onSelect,
 }: {
-  entries: RelevantTask[];
-  selectedEntry: RelevantTask | null | undefined;
+  entries: ReportTaskData[];
+  selectedEntry: ReportTaskData | null | undefined;
   onSelect: (id: string) => void;
 }) {
   if (!selectedEntry) return null;
@@ -472,7 +458,7 @@ function TaskLogRightSlot({
           <TaskRunStatusDot
             status={selectedEntry.task.latest_run?.status ?? "not_started"}
           />
-          {RELATIONSHIP_LABEL[selectedEntry.relationship]}
+          {selectedEntry.purposeLabel}
           <CaretDownIcon size={12} className="text-gray-10" />
         </button>
       </DropdownMenu.Trigger>
@@ -487,7 +473,7 @@ function TaskLogRightSlot({
               <Flex align="center" gap="2" className="min-w-[200px]">
                 <TaskRunStatusDot status={status} />
                 <Text className="font-medium text-[12.5px]">
-                  {RELATIONSHIP_LABEL[entry.relationship]}
+                  {entry.purposeLabel}
                 </Text>
                 <Text className="ml-auto font-mono text-[11px] text-gray-10">
                   {entry.task.id.slice(0, 8)}

--- a/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -54,6 +54,8 @@ interface InboxDetailFrameProps {
     Icon: ComponentType<IconProps>;
     title: string;
   } | null;
+  /** Optional section(s) rendered below the summary in the left column (e.g. the activity log). */
+  belowSummary?: ReactNode;
   /** Sections rendered alongside the summary (Tasks, Suggested reviewers, …). */
   children?: ReactNode;
 }
@@ -78,6 +80,7 @@ export function InboxDetailFrame({
   summarySection,
   evidenceSection,
   showDismiss = true,
+  belowSummary,
   children,
 }: InboxDetailFrameProps) {
   const { data: signalsResp } = useInboxReportSignals(report.id);
@@ -173,7 +176,7 @@ export function InboxDetailFrame({
         */}
       <div className="@container mx-auto w-full max-w-[calc(160ch+5rem)] px-6 py-5 text-[13px]">
         <div className="grid @4xl:grid-cols-[minmax(0,80ch)_minmax(0,1fr)] grid-cols-1 gap-5">
-          <div className="min-w-0">
+          <div className="flex min-w-0 flex-col gap-5">
             <DetailSection Icon={SummaryIcon} title={summarySection.title}>
               <SignalReportSummaryMarkdown
                 content={report.summary}
@@ -182,6 +185,7 @@ export function InboxDetailFrame({
                 pending={report.status === "in_progress"}
               />
             </DetailSection>
+            {belowSummary}
           </div>
 
           <div className="flex min-w-0 flex-col gap-5">

--- a/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -54,8 +54,6 @@ interface InboxDetailFrameProps {
     Icon: ComponentType<IconProps>;
     title: string;
   } | null;
-  /** Optional section(s) rendered below the summary in the left column (e.g. the activity log). */
-  belowSummary?: ReactNode;
   /** Sections rendered alongside the summary (Tasks, Suggested reviewers, …). */
   children?: ReactNode;
 }
@@ -80,7 +78,6 @@ export function InboxDetailFrame({
   summarySection,
   evidenceSection,
   showDismiss = true,
-  belowSummary,
   children,
 }: InboxDetailFrameProps) {
   const { data: signalsResp } = useInboxReportSignals(report.id);
@@ -176,7 +173,7 @@ export function InboxDetailFrame({
         */}
       <div className="@container mx-auto w-full max-w-[calc(160ch+5rem)] px-6 py-5 text-[13px]">
         <div className="grid @4xl:grid-cols-[minmax(0,80ch)_minmax(0,1fr)] grid-cols-1 gap-5">
-          <div className="flex min-w-0 flex-col gap-5">
+          <div className="min-w-0">
             <DetailSection Icon={SummaryIcon} title={summarySection.title}>
               <SignalReportSummaryMarkdown
                 content={report.summary}
@@ -185,7 +182,6 @@ export function InboxDetailFrame({
                 pending={report.status === "in_progress"}
               />
             </DetailSection>
-            {belowSummary}
           </div>
 
           <div className="flex min-w-0 flex-col gap-5">

--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -7,6 +7,7 @@ import {
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
+import { ReportActivitySection } from "@posthog/ui/features/inbox/components/detail/ReportActivitySection";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxMetaSeparator } from "@posthog/ui/features/inbox/components/InboxMetaRow";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
@@ -114,6 +115,7 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
     >
       <ReportTasksSection report={report} />
       <SuggestedReviewersSection report={report} />
+      <ReportActivitySection reportId={report.id} />
     </InboxDetailFrame>
   );
 }

--- a/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -1,21 +1,17 @@
 import {
-  ClockCounterClockwiseIcon,
   CopyIcon,
   FileTextIcon,
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
-import { ArtefactLogList } from "@posthog/ui/features/inbox/components/detail/ArtefactLogList";
+import { ReportActivitySection } from "@posthog/ui/features/inbox/components/detail/ReportActivitySection";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
 import { ReportTasksSection } from "@posthog/ui/features/inbox/components/ReportTasksSection";
-import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
-import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
-import { Text } from "@radix-ui/themes";
 
 interface ReportDetailProps {
   reportId: string;
@@ -40,9 +36,6 @@ export function ReportDetail({
 }
 
 function ReportDetailContent({ report }: { report: SignalReport }) {
-  const { data: artefactsResp } = useInboxReportArtefacts(report.id);
-  const artefacts = artefactsResp?.results ?? [];
-
   return (
     <InboxDetailFrame
       report={report}
@@ -68,19 +61,7 @@ function ReportDetailContent({ report }: { report: SignalReport }) {
     >
       <ReportTasksSection report={report} />
       <SuggestedReviewersSection report={report} />
-      {artefacts.length > 0 ? (
-        <RightColumnSection
-          Icon={ClockCounterClockwiseIcon}
-          title="Activity"
-          rightSlot={
-            <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
-              {artefacts.length} entr{artefacts.length === 1 ? "y" : "ies"}
-            </Text>
-          }
-        >
-          <ArtefactLogList reportId={report.id} artefacts={artefacts} />
-        </RightColumnSection>
-      ) : null}
+      <ReportActivitySection reportId={report.id} />
     </InboxDetailFrame>
   );
 }

--- a/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -1,16 +1,21 @@
 import {
+  ClockCounterClockwiseIcon,
   CopyIcon,
   FileTextIcon,
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { ArtefactLogList } from "@posthog/ui/features/inbox/components/detail/ArtefactLogList";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
 import { ReportTasksSection } from "@posthog/ui/features/inbox/components/ReportTasksSection";
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
+import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
+import { Text } from "@radix-ui/themes";
 
 interface ReportDetailProps {
   reportId: string;
@@ -35,6 +40,9 @@ export function ReportDetail({
 }
 
 function ReportDetailContent({ report }: { report: SignalReport }) {
+  const { data: artefactsResp } = useInboxReportArtefacts(report.id);
+  const artefacts = artefactsResp?.results ?? [];
+
   return (
     <InboxDetailFrame
       report={report}
@@ -57,6 +65,21 @@ function ReportDetailContent({ report }: { report: SignalReport }) {
       }
       summarySection={{ Icon: FileTextIcon, title: "Summary" }}
       evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
+      belowSummary={
+        artefacts.length > 0 ? (
+          <DetailSection
+            Icon={ClockCounterClockwiseIcon}
+            title="Activity"
+            rightSlot={
+              <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
+                {artefacts.length} entr{artefacts.length === 1 ? "y" : "ies"}
+              </Text>
+            }
+          >
+            <ArtefactLogList reportId={report.id} artefacts={artefacts} />
+          </DetailSection>
+        ) : null
+      }
     >
       <ReportTasksSection report={report} />
       <SuggestedReviewersSection report={report} />

--- a/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -6,12 +6,12 @@ import {
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
-import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
 import { ArtefactLogList } from "@posthog/ui/features/inbox/components/detail/ArtefactLogList";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
 import { ReportTasksSection } from "@posthog/ui/features/inbox/components/ReportTasksSection";
+import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
 import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
@@ -65,24 +65,22 @@ function ReportDetailContent({ report }: { report: SignalReport }) {
       }
       summarySection={{ Icon: FileTextIcon, title: "Summary" }}
       evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
-      belowSummary={
-        artefacts.length > 0 ? (
-          <DetailSection
-            Icon={ClockCounterClockwiseIcon}
-            title="Activity"
-            rightSlot={
-              <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
-                {artefacts.length} entr{artefacts.length === 1 ? "y" : "ies"}
-              </Text>
-            }
-          >
-            <ArtefactLogList reportId={report.id} artefacts={artefacts} />
-          </DetailSection>
-        ) : null
-      }
     >
       <ReportTasksSection report={report} />
       <SuggestedReviewersSection report={report} />
+      {artefacts.length > 0 ? (
+        <RightColumnSection
+          Icon={ClockCounterClockwiseIcon}
+          title="Activity"
+          rightSlot={
+            <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
+              {artefacts.length} entr{artefacts.length === 1 ? "y" : "ies"}
+            </Text>
+          }
+        >
+          <ArtefactLogList reportId={report.id} artefacts={artefacts} />
+        </RightColumnSection>
+      ) : null}
     </InboxDetailFrame>
   );
 }

--- a/packages/ui/src/features/inbox/components/ReportTasksSection.tsx
+++ b/packages/ui/src/features/inbox/components/ReportTasksSection.tsx
@@ -1,13 +1,6 @@
 import { ArrowSquareOutIcon, TerminalIcon } from "@phosphor-icons/react";
-import type {
-  SignalReport,
-  SignalReportTaskRelationship,
-  Task,
-} from "@posthog/shared/types";
-import {
-  RELATIONSHIP_LABEL,
-  TaskRunStatusDot,
-} from "@posthog/ui/features/inbox/components/AgentRunDetail";
+import type { SignalReport, Task } from "@posthog/shared/types";
+import { TaskRunStatusDot } from "@posthog/ui/features/inbox/components/AgentRunDetail";
 import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
 import { useReportTasks } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { Flex, Text } from "@radix-ui/themes";
@@ -30,11 +23,11 @@ export function ReportTasksSection({ report }: ReportTasksSectionProps) {
   return (
     <RightColumnSection Icon={TerminalIcon} title="Runs">
       <Flex direction="column" gap="0.5">
-        {reportTasks.map(({ task, relationship }) => (
+        {reportTasks.map(({ task, purposeLabel }) => (
           <TaskRow
             key={task.id}
             task={task}
-            relationship={relationship}
+            purposeLabel={purposeLabel}
             onOpen={() =>
               navigate({
                 to: "/code/inbox/runs/$reportId",
@@ -50,11 +43,11 @@ export function ReportTasksSection({ report }: ReportTasksSectionProps) {
 
 function TaskRow({
   task,
-  relationship,
+  purposeLabel,
   onOpen,
 }: {
   task: Task;
-  relationship: SignalReportTaskRelationship;
+  purposeLabel: string;
   onOpen: () => void;
 }) {
   const status = task.latest_run?.status ?? "not_started";
@@ -65,9 +58,7 @@ function TaskRow({
       className="group flex cursor-default select-none items-center gap-2 rounded-(--radius-1) px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-(--gray-3)"
     >
       <TaskRunStatusDot status={status} />
-      <Text className="shrink-0 text-gray-11">
-        {RELATIONSHIP_LABEL[relationship]}
-      </Text>
+      <Text className="shrink-0 text-gray-11">{purposeLabel}</Text>
       <Text className="ml-auto truncate text-(--gray-9)">
         {task.title || "Untitled"}
       </Text>

--- a/packages/ui/src/features/inbox/components/detail/ArtefactCommit.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactCommit.tsx
@@ -1,0 +1,95 @@
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { inboxReportKeys } from "@posthog/core/inbox/inboxQuery";
+import type { CommitContent } from "@posthog/shared/types";
+import { DiffBlock } from "@posthog/ui/features/inbox/components/detail/DiffBlock";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { Box, Flex, Spinner, Text } from "@radix-ui/themes";
+import { useState } from "react";
+
+/**
+ * Renders a `commit` artefact: commit metadata plus a collapsible diff of the commit against
+ * its parent, fetched lazily (on first expand) from the team's GitHub integration.
+ */
+export function ArtefactCommit({
+  reportId,
+  artefactId,
+  content,
+}: {
+  reportId: string;
+  artefactId: string;
+  content: CommitContent;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const diffQuery = useAuthenticatedQuery(
+    [...inboxReportKeys.artefacts(reportId), artefactId, "diff"],
+    (client) => client.getCommitDiff(reportId, artefactId),
+    // Only fetch once expanded; a commit's diff is immutable.
+    { enabled: expanded, staleTime: 5 * 60_000, retry: false },
+  );
+
+  return (
+    <Box>
+      <Text className="block text-(--gray-12) text-[12px]">
+        {content.message}
+      </Text>
+      <Text className="block font-mono text-(--gray-10) text-[11px]">
+        {content.commit_sha.slice(0, 12)} · {content.repository}@
+        {content.branch}
+      </Text>
+      {content.note?.trim() ? (
+        <Text className="block text-(--gray-11) text-[12px]">
+          {content.note}
+        </Text>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="-mx-1 mt-1.5 flex items-center gap-1 rounded-md px-1 py-0.5 text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
+      >
+        {expanded ? (
+          <CaretDownIcon size={12} className="shrink-0" />
+        ) : (
+          <CaretRightIcon size={12} className="shrink-0" />
+        )}
+        {expanded ? "Hide diff" : "View diff"}
+      </button>
+
+      {expanded ? (
+        <Box className="mt-1.5">
+          {diffQuery.isLoading ? (
+            <Flex
+              align="center"
+              gap="2"
+              className="text-(--gray-10) text-[12px]"
+            >
+              <Spinner size="1" />
+              Fetching diff…
+            </Flex>
+          ) : diffQuery.isError ? (
+            <Text className="block text-(--red-11) text-[12px]">
+              {diffQuery.error instanceof Error
+                ? diffQuery.error.message
+                : "Couldn’t load the diff."}
+            </Text>
+          ) : diffQuery.data?.diff.trim() ? (
+            <>
+              <DiffBlock diff={diffQuery.data.diff} />
+              {diffQuery.data.truncated ? (
+                <Text className="mt-1 block text-(--gray-10) text-[11px]">
+                  Diff truncated — too large to display in full.
+                </Text>
+              ) : null}
+            </>
+          ) : (
+            <Text className="block text-(--gray-10) text-[12px]">
+              No changes recorded for this commit.
+            </Text>
+          )}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -6,7 +6,6 @@ import {
 import type {
   ActionabilityJudgmentContent,
   AnySignalReportArtefact,
-  CodeDiffContent,
   CodeReferenceContent,
   CommitContent,
   DismissalContent,
@@ -22,7 +21,6 @@ import type {
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { ArtefactCommit } from "@posthog/ui/features/inbox/components/detail/ArtefactCommit";
 import { ArtefactTaskRun } from "@posthog/ui/features/inbox/components/detail/ArtefactTaskRun";
-import { DiffBlock } from "@posthog/ui/features/inbox/components/detail/DiffBlock";
 import { SignalReportActionabilityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportActionabilityBadge";
 import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
 import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
@@ -40,7 +38,6 @@ import { useState } from "react";
 // append-only history of changes — the current status lives at the top of the report.
 const TYPE_LABELS: Record<string, string> = {
   code_reference: "Code referenced",
-  code_diff: "Diff proposed",
   line_reference: "Line highlighted",
   commit: "Commit pushed",
   task_run: "Task run",
@@ -95,8 +92,6 @@ function locationLabel(artefact: AnySignalReportArtefact): string | null {
       const c = artefact.content as CodeReferenceContent;
       return `${c.file_path}:${c.start_line}-${c.end_line}`;
     }
-    case "code_diff":
-      return (artefact.content as CodeDiffContent).file_path;
     case "line_reference": {
       const c = artefact.content as LineReferenceContent;
       return `${c.file_path}:${c.line}`;
@@ -271,17 +266,6 @@ function ArtefactBody({
             code={c.contents}
             language={languageFromPath(c.file_path)}
           />
-        </Box>
-      );
-    }
-    case "code_diff": {
-      const c = artefact.content as CodeDiffContent;
-      return (
-        <Box>
-          <RelevanceNote note={c.relevance_note} />
-          <Box className="mt-1.5">
-            <DiffBlock diff={c.diff} />
-          </Box>
         </Box>
       );
     }

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -250,6 +250,17 @@ function ArtefactBody({
   reportId: string;
   artefact: AnySignalReportArtefact;
 }) {
+  // Degraded rows carry a plain text preview instead of their type's content
+  // shape — render that rather than feeding mismatched content to a typed body.
+  if (artefact.degraded) {
+    const text = (artefact.content as SignalReportArtefactContent | null)
+      ?.content;
+    return (
+      <Text className="block text-(--gray-10) text-[12px]">
+        {text || "No preview available."}
+      </Text>
+    );
+  }
   switch (artefact.type) {
     case "code_reference": {
       const c = artefact.content as CodeReferenceContent;

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -1,4 +1,8 @@
-import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import {
+  ArrowSquareOutIcon,
+  CaretDownIcon,
+  CaretRightIcon,
+} from "@phosphor-icons/react";
 import type {
   ActionabilityJudgmentContent,
   AnySignalReportArtefact,
@@ -100,6 +104,32 @@ function CodeRefBlock({ code, language }: { code: string; language: string }) {
 function RelevanceNote({ note }: { note: string }) {
   if (!note.trim()) return null;
   return <Text className="block text-(--gray-11) text-[12px]">{note}</Text>;
+}
+
+/** Judgment explanations are often paragraphs — collapsed by default behind a toggle. */
+function CollapsibleReasoning({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  if (!text.trim()) return null;
+  return (
+    <Box>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="-mx-1 flex items-center gap-1 rounded-md px-1 py-0.5 text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
+      >
+        {expanded ? (
+          <CaretDownIcon size={12} className="shrink-0" />
+        ) : (
+          <CaretRightIcon size={12} className="shrink-0" />
+        )}
+        {expanded ? "Hide reasoning" : "Show reasoning"}
+      </button>
+      {expanded ? (
+        <Text className="block text-(--gray-11) text-[12px]">{text}</Text>
+      ) : null}
+    </Box>
+  );
 }
 
 function ReviewersBody({ reviewers }: { reviewers: SuggestedReviewer[] }) {
@@ -224,7 +254,7 @@ function ArtefactBody({
       return (
         <Flex direction="column" gap="1">
           <SignalReportPriorityBadge priority={c.priority} />
-          {c.explanation ? <RelevanceNote note={c.explanation} /> : null}
+          {c.explanation ? <CollapsibleReasoning text={c.explanation} /> : null}
         </Flex>
       );
     }
@@ -240,7 +270,7 @@ function ArtefactBody({
               </Badge>
             ) : null}
           </Flex>
-          {c.explanation ? <RelevanceNote note={c.explanation} /> : null}
+          {c.explanation ? <CollapsibleReasoning text={c.explanation} /> : null}
         </Flex>
       );
     }

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -132,6 +132,55 @@ function CollapsibleReasoning({ text }: { text: string }) {
   );
 }
 
+/**
+ * Notes are free-form markdown and can run long — collapsed to a one-line
+ * preview (the first non-empty line) that expands to the rendered note.
+ */
+function CollapsibleNote({
+  note,
+  author,
+}: {
+  note: string;
+  author?: string | null;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const preview = note
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return (
+    <Box>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="-mx-1 flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-left text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
+      >
+        {expanded ? (
+          <CaretDownIcon size={12} className="shrink-0" />
+        ) : (
+          <CaretRightIcon size={12} className="shrink-0" />
+        )}
+        {expanded ? (
+          "Hide note"
+        ) : (
+          <Text className="min-w-0 flex-1 truncate">{preview ?? "Note"}</Text>
+        )}
+      </button>
+      {expanded ? (
+        <Box className="text-[12px]">
+          <MarkdownRenderer content={note} />
+          {author ? (
+            <Text className="block text-(--gray-10) text-[11px]">
+              — {author}
+            </Text>
+          ) : null}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
 function ReviewersBody({ reviewers }: { reviewers: SuggestedReviewer[] }) {
   if (reviewers.length === 0) {
     return (
@@ -238,16 +287,7 @@ function ArtefactBody({
       );
     case "note": {
       const c = artefact.content as NoteContent;
-      return (
-        <Box className="text-[12px]">
-          <MarkdownRenderer content={c.note} />
-          {c.author ? (
-            <Text className="block text-(--gray-10) text-[11px]">
-              — {c.author}
-            </Text>
-          ) : null}
-        </Box>
-      );
+      return <CollapsibleNote note={c.note} author={c.author} />;
     }
     case "priority_judgment": {
       const c = artefact.content as PriorityJudgmentContent;

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -68,6 +68,20 @@ function languageFromPath(filePath: string): string {
   return filePath.split(".").pop()?.toLowerCase() ?? "";
 }
 
+/**
+ * Who produced the artefact: a user's name, "agent" for task-attributed writes,
+ * or null for system (pipeline) writes and pre-attribution rows.
+ */
+function attributionLabel(artefact: AnySignalReportArtefact): string | null {
+  if (artefact.created_by) {
+    return artefact.created_by.first_name?.trim() || artefact.created_by.email;
+  }
+  if (artefact.task_id) {
+    return "agent";
+  }
+  return null;
+}
+
 // The generic `SignalReportArtefact` fallback carries `type: string`, so it stays
 // in every narrowed branch and breaks discriminated-union narrowing — the runtime
 // `type` dispatch is authoritative (content is set alongside type in the
@@ -377,6 +391,7 @@ function ArtefactRow({
 }) {
   const [showRaw, setShowRaw] = useState(false);
   const location = locationLabel(artefact);
+  const attribution = attributionLabel(artefact);
 
   return (
     <Box className="rounded-lg border border-gray-6 bg-gray-1 p-3">
@@ -392,6 +407,11 @@ function ArtefactRow({
           ) : null}
         </Flex>
         <Flex align="center" gap="2" className="shrink-0">
+          {attribution ? (
+            <Text className="text-(--gray-10) text-[11px]">
+              by {attribution}
+            </Text>
+          ) : null}
           {/* Dev-only escape hatch for inspecting the raw artefact payload. */}
           {import.meta.env.DEV ? (
             <button

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -13,6 +13,7 @@ import type {
   LineReferenceContent,
   NoteContent,
   PriorityJudgmentContent,
+  SafetyJudgmentContent,
   SignalFindingContent,
   SignalReportArtefactContent,
   SuggestedReviewer,
@@ -324,6 +325,17 @@ function ArtefactBody({
               </Badge>
             ) : null}
           </Flex>
+          {c.explanation ? <CollapsibleReasoning text={c.explanation} /> : null}
+        </Flex>
+      );
+    }
+    case "safety_judgment": {
+      const c = artefact.content as SafetyJudgmentContent;
+      return (
+        <Flex direction="column" gap="1">
+          <Badge color={c.choice ? "green" : "red"} variant="soft">
+            {c.choice ? "Safe to act on" : "Unsafe"}
+          </Badge>
           {c.explanation ? <CollapsibleReasoning text={c.explanation} /> : null}
         </Flex>
       );

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -1,0 +1,379 @@
+import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import type {
+  ActionabilityJudgmentContent,
+  AnySignalReportArtefact,
+  CodeDiffContent,
+  CodeReferenceContent,
+  CommitContent,
+  DismissalContent,
+  LineReferenceContent,
+  NoteContent,
+  PriorityJudgmentContent,
+  SignalFindingContent,
+  SignalReportArtefactContent,
+  SuggestedReviewer,
+  TaskRunArtefactContent,
+} from "@posthog/shared/types";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { ArtefactCommit } from "@posthog/ui/features/inbox/components/detail/ArtefactCommit";
+import { ArtefactTaskRun } from "@posthog/ui/features/inbox/components/detail/ArtefactTaskRun";
+import { DiffBlock } from "@posthog/ui/features/inbox/components/detail/DiffBlock";
+import { SignalReportActionabilityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportActionabilityBadge";
+import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
+import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
+import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+import { useState } from "react";
+
+// A chronological log of every artefact on a report. Each known type renders a
+// tailored body; unrecognized types fall back to a plain text preview (never raw
+// JSON). Timeline chrome (rails, grouping) is a follow-up — this is the polished
+// content layer.
+
+// Each entry is framed as a point-in-time action ("what happened"), since the log is an
+// append-only history of changes — the current status lives at the top of the report.
+const TYPE_LABELS: Record<string, string> = {
+  code_reference: "Code referenced",
+  code_diff: "Diff proposed",
+  line_reference: "Line highlighted",
+  commit: "Commit pushed",
+  task_run: "Task run",
+  note: "Note added",
+  priority_judgment: "Priority assessed",
+  actionability_judgment: "Actionability assessed",
+  safety_judgment: "Safety assessed",
+  signal_finding: "Signal investigated",
+  suggested_reviewers: "Reviewers suggested",
+  repo_selection: "Repo selected",
+  dismissal: "Report dismissed",
+  video_segment: "Video segment",
+};
+
+function typeLabel(type: string): string {
+  return TYPE_LABELS[type] ?? type;
+}
+
+function prettify(value: string): string {
+  const cleaned = value.replace(/[-_]/g, " ").trim();
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/** Map a file path to a syntax-highlight language key (extension-based). */
+function languageFromPath(filePath: string): string {
+  return filePath.split(".").pop()?.toLowerCase() ?? "";
+}
+
+// The generic `SignalReportArtefact` fallback carries `type: string`, so it stays
+// in every narrowed branch and breaks discriminated-union narrowing — the runtime
+// `type` dispatch is authoritative (content is set alongside type in the
+// normalizers), so we read `content` through the matching content type.
+
+/** Short, monospace location shown next to the type label (file path / span). */
+function locationLabel(artefact: AnySignalReportArtefact): string | null {
+  switch (artefact.type) {
+    case "code_reference": {
+      const c = artefact.content as CodeReferenceContent;
+      return `${c.file_path}:${c.start_line}-${c.end_line}`;
+    }
+    case "code_diff":
+      return (artefact.content as CodeDiffContent).file_path;
+    case "line_reference": {
+      const c = artefact.content as LineReferenceContent;
+      return `${c.file_path}:${c.line}`;
+    }
+    default:
+      return null;
+  }
+}
+
+function CodeRefBlock({ code, language }: { code: string; language: string }) {
+  return (
+    <Box className="mt-1.5">
+      <CodeBlock size="1">
+        <HighlightedCode code={code} language={language} />
+      </CodeBlock>
+    </Box>
+  );
+}
+
+function RelevanceNote({ note }: { note: string }) {
+  if (!note.trim()) return null;
+  return <Text className="block text-(--gray-11) text-[12px]">{note}</Text>;
+}
+
+function ReviewersBody({ reviewers }: { reviewers: SuggestedReviewer[] }) {
+  if (reviewers.length === 0) {
+    return (
+      <Text className="block text-(--gray-10) text-[12px]">
+        No reviewers assigned.
+      </Text>
+    );
+  }
+  return (
+    <Flex direction="column" gap="1">
+      {reviewers.map((reviewer) => (
+        <Flex
+          key={reviewer.user?.uuid ?? reviewer.github_login}
+          align="center"
+          gap="2"
+          wrap="wrap"
+        >
+          {reviewer.github_login ? (
+            <img
+              src={`https://github.com/${reviewer.github_login}.png?size=28`}
+              alt=""
+              className="github-avatar h-[18px] w-[18px] shrink-0 rounded-full"
+              onLoad={(e) => e.currentTarget.classList.add("loaded")}
+            />
+          ) : null}
+          <Text className="text-[12px]">
+            {reviewer.user?.first_name ??
+              reviewer.github_name ??
+              reviewer.github_login}
+          </Text>
+          {reviewer.github_login ? (
+            <a
+              href={`https://github.com/${reviewer.github_login}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-0.5 text-[11px] text-gray-9 hover:text-gray-11"
+            >
+              @{reviewer.github_login}
+              <ArrowSquareOutIcon size={10} />
+            </a>
+          ) : null}
+        </Flex>
+      ))}
+    </Flex>
+  );
+}
+
+function ArtefactBody({
+  reportId,
+  artefact,
+}: {
+  reportId: string;
+  artefact: AnySignalReportArtefact;
+}) {
+  switch (artefact.type) {
+    case "code_reference": {
+      const c = artefact.content as CodeReferenceContent;
+      return (
+        <Box>
+          <RelevanceNote note={c.relevance_note} />
+          <CodeRefBlock
+            code={c.contents}
+            language={languageFromPath(c.file_path)}
+          />
+        </Box>
+      );
+    }
+    case "code_diff": {
+      const c = artefact.content as CodeDiffContent;
+      return (
+        <Box>
+          <RelevanceNote note={c.relevance_note} />
+          <Box className="mt-1.5">
+            <DiffBlock diff={c.diff} />
+          </Box>
+        </Box>
+      );
+    }
+    case "line_reference": {
+      const c = artefact.content as LineReferenceContent;
+      return (
+        <Box>
+          <RelevanceNote note={c.note} />
+          {c.contents ? (
+            <CodeRefBlock
+              code={c.contents}
+              language={languageFromPath(c.file_path)}
+            />
+          ) : null}
+        </Box>
+      );
+    }
+    case "commit":
+      return (
+        <ArtefactCommit
+          reportId={reportId}
+          artefactId={artefact.id}
+          content={artefact.content as CommitContent}
+        />
+      );
+    case "task_run":
+      return (
+        <ArtefactTaskRun content={artefact.content as TaskRunArtefactContent} />
+      );
+    case "note": {
+      const c = artefact.content as NoteContent;
+      return (
+        <Box className="text-[12px]">
+          <MarkdownRenderer content={c.note} />
+          {c.author ? (
+            <Text className="block text-(--gray-10) text-[11px]">
+              — {c.author}
+            </Text>
+          ) : null}
+        </Box>
+      );
+    }
+    case "priority_judgment": {
+      const c = artefact.content as PriorityJudgmentContent;
+      return (
+        <Flex direction="column" gap="1">
+          <SignalReportPriorityBadge priority={c.priority} />
+          {c.explanation ? <RelevanceNote note={c.explanation} /> : null}
+        </Flex>
+      );
+    }
+    case "actionability_judgment": {
+      const c = artefact.content as ActionabilityJudgmentContent;
+      return (
+        <Flex direction="column" gap="1">
+          <Flex align="center" gap="2" wrap="wrap">
+            <SignalReportActionabilityBadge actionability={c.actionability} />
+            {c.already_addressed ? (
+              <Badge color="amber" variant="soft">
+                Already addressed
+              </Badge>
+            ) : null}
+          </Flex>
+          {c.explanation ? <RelevanceNote note={c.explanation} /> : null}
+        </Flex>
+      );
+    }
+    case "signal_finding": {
+      const c = artefact.content as SignalFindingContent;
+      return (
+        <Flex direction="column" gap="1">
+          <Flex align="center" gap="2" wrap="wrap">
+            <Text className="font-mono text-(--gray-10) text-[11px]">
+              {c.signal_id}
+            </Text>
+            <Badge color={c.verified ? "green" : "gray"} variant="soft">
+              {c.verified ? "Verified" : "Unverified"}
+            </Badge>
+          </Flex>
+          {c.relevant_code_paths.length > 0 ? (
+            <Flex direction="column">
+              {c.relevant_code_paths.map((path) => (
+                <Text
+                  key={path}
+                  className="truncate font-mono text-(--gray-11) text-[11px]"
+                >
+                  {path}
+                </Text>
+              ))}
+            </Flex>
+          ) : null}
+        </Flex>
+      );
+    }
+    case "suggested_reviewers":
+      return (
+        <ReviewersBody reviewers={artefact.content as SuggestedReviewer[]} />
+      );
+    case "dismissal": {
+      const c = artefact.content as DismissalContent;
+      return (
+        <Flex direction="column" gap="1">
+          <Badge color="gray" variant="soft">
+            {prettify(c.reason)}
+          </Badge>
+          {c.note ? <RelevanceNote note={c.note} /> : null}
+        </Flex>
+      );
+    }
+    default: {
+      const c = artefact.content as SignalReportArtefactContent | null;
+      const text = typeof c?.content === "string" ? c.content : "";
+      return (
+        <Text className="block text-(--gray-10) text-[12px]">
+          {text || "No preview available."}
+        </Text>
+      );
+    }
+  }
+}
+
+function ArtefactRow({
+  reportId,
+  artefact,
+}: {
+  reportId: string;
+  artefact: AnySignalReportArtefact;
+}) {
+  const [showRaw, setShowRaw] = useState(false);
+  const location = locationLabel(artefact);
+
+  return (
+    <Box className="rounded-lg border border-gray-6 bg-gray-1 p-3">
+      <Flex align="center" justify="between" gap="2" className="mb-1.5">
+        <Flex align="center" gap="2" className="min-w-0">
+          <Text className="shrink-0 font-medium text-[12px]">
+            {typeLabel(artefact.type)}
+          </Text>
+          {location ? (
+            <Text className="truncate font-mono text-(--gray-10) text-[11px]">
+              {location}
+            </Text>
+          ) : null}
+        </Flex>
+        <Flex align="center" gap="2" className="shrink-0">
+          {/* Dev-only escape hatch for inspecting the raw artefact payload. */}
+          {import.meta.env.DEV ? (
+            <button
+              type="button"
+              onClick={() => setShowRaw((v) => !v)}
+              title="View raw JSON (dev only)"
+              aria-pressed={showRaw}
+              className={`rounded-sm px-1 font-mono text-[11px] transition-colors hover:bg-(--gray-3) ${
+                showRaw ? "text-(--gray-12)" : "text-(--gray-9)"
+              }`}
+            >
+              {"{ }"}
+            </button>
+          ) : null}
+          <RelativeTimestamp timestamp={artefact.created_at} />
+        </Flex>
+      </Flex>
+      <ArtefactBody reportId={reportId} artefact={artefact} />
+      {showRaw ? (
+        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap rounded-md border border-(--gray-6) bg-(--gray-2) p-2 font-mono text-(--gray-11) text-[11px]">
+          {JSON.stringify(artefact, null, 2)}
+        </pre>
+      ) : null}
+    </Box>
+  );
+}
+
+export function ArtefactLogList({
+  reportId,
+  artefacts,
+}: {
+  reportId: string;
+  artefacts: AnySignalReportArtefact[];
+}) {
+  if (artefacts.length === 0) {
+    return null;
+  }
+
+  const sorted = [...artefacts].sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+
+  return (
+    <Flex direction="column" gap="2">
+      {sorted.map((artefact) => (
+        <ArtefactRow
+          key={artefact.id}
+          reportId={reportId}
+          artefact={artefact}
+        />
+      ))}
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/inbox/components/detail/ArtefactTaskRun.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactTaskRun.tsx
@@ -1,0 +1,94 @@
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
+import type { Task, TaskRunArtefactContent } from "@posthog/shared/types";
+import { TaskLogsPanel } from "@posthog/ui/features/task-detail/components/TaskLogsPanel";
+import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { Badge, Box, Text } from "@radix-ui/themes";
+import { useState } from "react";
+
+const SIGNALS_PRODUCT = "signals";
+
+// Friendlier labels for the built-in signals-pipeline task types; custom-agent types fall back
+// to a humanized form of their identifier.
+const SIGNALS_TYPE_LABELS: Record<string, string> = {
+  research: "Research",
+  implementation: "Implementation",
+  repo_selection: "Repo selection",
+};
+
+function humanizeIdentifier(value: string): string {
+  const spaced = value.replace(/[_-]+/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Renders a `task_run` artefact: loads the referenced task and lets the user
+ * expand it to read the full conversation log (read-only) via `TaskLogsPanel`.
+ */
+export function ArtefactTaskRun({
+  content,
+}: {
+  content: TaskRunArtefactContent;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const taskQuery = useAuthenticatedQuery<Task>(
+    taskKeys.detail(content.task_id),
+    (client) => client.getTask(content.task_id),
+    { enabled: !!content.task_id, staleTime: 10_000 },
+  );
+
+  const task = taskQuery.data;
+  const isSignals = content.product === SIGNALS_PRODUCT;
+  const label = isSignals
+    ? (SIGNALS_TYPE_LABELS[content.type] ?? humanizeIdentifier(content.type))
+    : humanizeIdentifier(content.type);
+  const status = task?.latest_run?.status;
+
+  return (
+    <Box>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        disabled={!task}
+        className="-mx-1 flex w-full items-center gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-(--gray-3) disabled:cursor-default disabled:hover:bg-transparent"
+      >
+        {expanded ? (
+          <CaretDownIcon size={12} className="shrink-0 text-(--gray-10)" />
+        ) : (
+          <CaretRightIcon size={12} className="shrink-0 text-(--gray-10)" />
+        )}
+        <Badge color="gray" variant="soft" className="shrink-0">
+          {label}
+        </Badge>
+        {!isSignals ? (
+          <Badge color="iris" variant="soft" className="shrink-0">
+            {humanizeIdentifier(content.product)}
+          </Badge>
+        ) : null}
+        <Text className="min-w-0 flex-1 truncate text-(--gray-12) text-[12px]">
+          {taskQuery.isLoading
+            ? "Loading task…"
+            : (task?.title ?? content.task_id)}
+        </Text>
+        {status ? (
+          <Badge color="gray" variant="soft" className="shrink-0">
+            {status}
+          </Badge>
+        ) : null}
+      </button>
+
+      {taskQuery.isError ? (
+        <Text className="block text-(--red-11) text-[11px]">
+          Couldn’t load this task.
+        </Text>
+      ) : null}
+
+      {expanded && task ? (
+        <Box className="mt-2 h-[420px] overflow-hidden rounded-md border border-(--gray-6)">
+          <TaskLogsPanel taskId={content.task_id} task={task} hideInput />
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/ui/src/features/inbox/components/detail/DiffBlock.tsx
+++ b/packages/ui/src/features/inbox/components/detail/DiffBlock.tsx
@@ -1,5 +1,5 @@
-// Renders unified-diff text with per-line +/- coloring. Shared by the `code_diff`
-// artefact body and the `commit` artefact's commit-vs-parent diff.
+// Renders unified-diff text with per-line +/- coloring, used by the `commit`
+// artefact's commit-vs-parent diff view.
 export function DiffBlock({ diff }: { diff: string }) {
   const lines = diff.replace(/\n$/, "").split("\n");
   return (

--- a/packages/ui/src/features/inbox/components/detail/DiffBlock.tsx
+++ b/packages/ui/src/features/inbox/components/detail/DiffBlock.tsx
@@ -1,0 +1,27 @@
+// Renders unified-diff text with per-line +/- coloring. Shared by the `code_diff`
+// artefact body and the `commit` artefact's commit-vs-parent diff.
+export function DiffBlock({ diff }: { diff: string }) {
+  const lines = diff.replace(/\n$/, "").split("\n");
+  return (
+    <pre className="max-h-96 overflow-auto rounded-(--radius-3) border border-(--gray-6) bg-(--gray-2) p-2 font-mono text-[11px] leading-[1.5]">
+      {lines.map((line, i) => {
+        const added = line.startsWith("+") && !line.startsWith("+++");
+        const removed = line.startsWith("-") && !line.startsWith("---");
+        const hunk = line.startsWith("@@");
+        const cls = added
+          ? "bg-(--green-3) text-(--green-11)"
+          : removed
+            ? "bg-(--red-3) text-(--red-11)"
+            : hunk
+              ? "text-(--gray-10)"
+              : "text-(--gray-12)";
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable parse output, never reorders
+          <div key={i} className={cls}>
+            {line || " "}
+          </div>
+        );
+      })}
+    </pre>
+  );
+}

--- a/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
@@ -1,0 +1,32 @@
+import { ClockCounterClockwiseIcon } from "@phosphor-icons/react";
+import { ArtefactLogList } from "@posthog/ui/features/inbox/components/detail/ArtefactLogList";
+import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
+import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { Text } from "@radix-ui/themes";
+
+/**
+ * The report's artefact log ("Activity"), shared by every report detail
+ * surface (reports, pull requests, runs) so the work log follows the report
+ * wherever it is rendered. Renders nothing while loading or when the report
+ * has no artefacts.
+ */
+export function ReportActivitySection({ reportId }: { reportId: string }) {
+  const { data: artefactsResp } = useInboxReportArtefacts(reportId);
+  const artefacts = artefactsResp?.results ?? [];
+
+  if (artefacts.length === 0) return null;
+
+  return (
+    <RightColumnSection
+      Icon={ClockCounterClockwiseIcon}
+      title="Activity"
+      rightSlot={
+        <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
+          {artefacts.length} entr{artefacts.length === 1 ? "y" : "ies"}
+        </Text>
+      }
+    >
+      <ArtefactLogList reportId={reportId} artefacts={artefacts} />
+    </RightColumnSection>
+  );
+}

--- a/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
@@ -11,7 +11,13 @@ import { Text } from "@radix-ui/themes";
  * has no artefacts.
  */
 export function ReportActivitySection({ reportId }: { reportId: string }) {
-  const { data: artefactsResp } = useInboxReportArtefacts(reportId);
+  // The log is a live work record — agents append artefacts while the report is
+  // open, so don't let the app-wide 5-minute staleTime sit on it. Poll gently
+  // while mounted.
+  const { data: artefactsResp } = useInboxReportArtefacts(reportId, {
+    staleTime: 10_000,
+    refetchInterval: 20_000,
+  });
   const artefacts = artefactsResp?.results ?? [];
 
   if (artefacts.length === 0) return null;

--- a/packages/ui/src/features/inbox/hooks/useInboxReports.test.tsx
+++ b/packages/ui/src/features/inbox/hooks/useInboxReports.test.tsx
@@ -68,7 +68,7 @@ describe("useUpdateSuggestedReviewers", () => {
     vi.clearAllMocks();
   });
 
-  it("optimistically patches the suggested_reviewers artefact in the cache", async () => {
+  it("optimistically appends a new latest reviewers row, keeping the prior one", async () => {
     mockUpdateArtefact.mockResolvedValue(artefact([reviewer("octocat")]));
     const { result, queryClient } = renderUpdateHook();
 
@@ -92,12 +92,21 @@ describe("useUpdateSuggestedReviewers", () => {
     ]);
 
     const cached = queryClient.getQueryData<SignalReportArtefactsResponse>(key);
-    const cachedArtefact = cached?.results.find((a) => a.id === ARTEFACT_ID) as
-      | SuggestedReviewersArtefact
-      | undefined;
-    expect(cachedArtefact?.content.map((r) => r.github_login)).toEqual([
+    const reviewerRows = (cached?.results ?? []).filter(
+      (a): a is SuggestedReviewersArtefact => a.type === "suggested_reviewers",
+    );
+    // The prior row is preserved untouched as history.
+    const priorRow = reviewerRows.find((a) => a.id === ARTEFACT_ID);
+    expect(priorRow?.content.map((r) => r.github_login)).toEqual([
       "octocat",
+      "hubot",
     ]);
+    // A new synthetic row is appended and is the latest (current reviewers).
+    const latest = reviewerRows.reduce((a, b) =>
+      a.created_at > b.created_at ? a : b,
+    );
+    expect(latest.id).not.toBe(ARTEFACT_ID);
+    expect(latest.content.map((r) => r.github_login)).toEqual(["octocat"]);
   });
 
   it("rolls back the cache when the request fails", async () => {

--- a/packages/ui/src/features/inbox/hooks/useInboxReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxReports.ts
@@ -198,6 +198,7 @@ export function useInboxReportArtefacts(
   options?: {
     enabled?: boolean;
     staleTime?: number;
+    refetchInterval?: number;
     refetchOnWindowFocus?: boolean;
   },
 ) {

--- a/packages/ui/src/features/inbox/hooks/useInboxReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxReports.ts
@@ -225,15 +225,17 @@ export function useInboxReportSignals(
 
 interface UpdateSuggestedReviewersVariables {
   artefactId: string;
-  /** Full-replacement payload sent to the server. */
+  /** Reviewer list sent to the server (it appends a new suggested_reviewers status row). */
   content: SuggestedReviewerWriteEntry[];
-  /** Read-shape list used to optimistically patch the cache for immediate-apply UI. */
+  /** Read-shape list used to optimistically show the new current reviewers. */
   optimisticReviewers: SuggestedReviewersArtefact["content"];
 }
 
 /**
- * Persists a full replacement of a report's `suggested_reviewers` artefact and optimistically
- * patches the cached artefacts so the detail pane reflects the change instantly (immediate apply).
+ * Edits a report's suggested reviewers. The server appends a new `suggested_reviewers` status
+ * artefact (latest-wins), so the work-log keeps the full history of changes. We optimistically
+ * append a synthetic latest row — mirroring the server — so the detail pane reflects the change
+ * instantly (immediate apply); the refetch on settle reconciles it with the real row.
  */
 export function useUpdateSuggestedReviewers(reportId: string) {
   const queryClient = useQueryClient();
@@ -247,23 +249,25 @@ export function useUpdateSuggestedReviewers(reportId: string) {
     (client, { artefactId, content }) =>
       client.updateSignalReportArtefact(reportId, artefactId, content),
     {
-      onMutate: async ({ artefactId, optimisticReviewers }) => {
+      onMutate: async ({ optimisticReviewers }) => {
         await queryClient.cancelQueries({ queryKey });
         const previous =
           queryClient.getQueryData<SignalReportArtefactsResponse>(queryKey);
 
         if (previous) {
+          // Append a synthetic latest row rather than mutating the current one — "current
+          // reviewers" is derived as the latest suggested_reviewers artefact, so a row stamped
+          // now wins, and the prior row stays in the log as history (matching the server).
+          const optimisticRow: SuggestedReviewersArtefact = {
+            id: `optimistic-${Date.now()}`,
+            type: "suggested_reviewers",
+            content: optimisticReviewers,
+            created_at: new Date().toISOString(),
+          };
           queryClient.setQueryData<SignalReportArtefactsResponse>(queryKey, {
             ...previous,
-            results: previous.results.map((artefact) =>
-              artefact.id === artefactId &&
-              artefact.type === "suggested_reviewers"
-                ? ({
-                    ...artefact,
-                    content: optimisticReviewers,
-                  } as SuggestedReviewersArtefact)
-                : artefact,
-            ),
+            results: [...previous.results, optimisticRow],
+            count: previous.count + 1,
           });
         }
 

--- a/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -23,14 +23,10 @@ function humanizeIdentifier(value: string): string {
   return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
-function derivePurpose(
-  taskRun: { product: string; type: string } | undefined,
-): { purpose: ReportTaskPurpose; purposeLabel: string } | null {
-  if (!taskRun) {
-    // Freely-associated task with no task_run artefact (e.g. an agent that associated itself
-    // mid-run) — surface it generically rather than hiding it.
-    return { purpose: "other", purposeLabel: "Agent task" };
-  }
+function derivePurpose(taskRun: {
+  product: string;
+  type: string;
+}): { purpose: ReportTaskPurpose; purposeLabel: string } | null {
   if (taskRun.product === "signals") {
     if (taskRun.type === "research") {
       return { purpose: "research", purposeLabel: "Research" };
@@ -66,40 +62,44 @@ export function useReportTasks(
   return useAuthenticatedQuery<ReportTaskData[]>(
     ["inbox", "report-tasks", reportId],
     async (client) => {
-      const [reportTasks, artefacts] = await Promise.all([
-        client.getSignalReportTasks(reportId),
-        client.getSignalReportArtefacts(reportId),
-      ]);
-      // task id → its (product, type) from the report's task_run artefacts. The runtime
-      // `type` check is authoritative (the generic fallback artefact keeps `type: string`
-      // and defeats static narrowing).
+      // task_run artefacts ARE the task↔report association — one entry per associated task,
+      // keyed by content.task_id (earliest artefact wins for startedAt). The runtime `type`
+      // check is authoritative (the generic fallback artefact keeps `type: string` and
+      // defeats static narrowing).
+      const artefacts = await client.getSignalReportArtefacts(reportId);
       const taskRunByTaskId = new Map<
         string,
-        { product: string; type: string }
+        { product: string; type: string; startedAt: string }
       >();
       for (const artefact of artefacts.results) {
-        if (artefact.type === "task_run") {
-          const content = artefact.content as TaskRunArtefactContent;
-          taskRunByTaskId.set(content.task_id, {
-            product: content.product,
-            type: content.type,
-          });
-        }
+        if (artefact.type !== "task_run") continue;
+        const content = artefact.content as TaskRunArtefactContent;
+        const existing = taskRunByTaskId.get(content.task_id);
+        if (existing && existing.startedAt <= artefact.created_at) continue;
+        taskRunByTaskId.set(content.task_id, {
+          product: content.product,
+          type: content.type,
+          startedAt: artefact.created_at,
+        });
       }
 
-      const relevant = reportTasks.flatMap((rt) => {
-        const derived = derivePurpose(taskRunByTaskId.get(rt.task_id));
-        return derived ? [{ rt, ...derived }] : [];
-      });
+      const relevant = [...taskRunByTaskId.entries()].flatMap(
+        ([taskId, run]) => {
+          const derived = derivePurpose(run);
+          return derived
+            ? [{ taskId, startedAt: run.startedAt, ...derived }]
+            : [];
+        },
+      );
 
       const tasks = await Promise.all(
-        relevant.map(async ({ rt, purpose, purposeLabel }) => {
-          const task = await client.getTask(rt.task_id);
+        relevant.map(async ({ taskId, startedAt, purpose, purposeLabel }) => {
+          const task = await client.getTask(taskId);
           return {
             task,
             purpose,
             purposeLabel,
-            startedAt: rt.created_at,
+            startedAt,
           };
         }),
       );

--- a/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -1,19 +1,58 @@
 import type {
   SignalReportStatus,
-  SignalReportTask,
   Task,
+  TaskRunArtefactContent,
 } from "@posthog/shared/types";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 
-type Relationship = SignalReportTask["relationship"];
+// Task↔report associations are unlabelled — a task's purpose is derived from the report's
+// `task_run` artefacts (the signals pipeline writes product="signals" with one of these types;
+// custom agents write their own (product, type) pair).
+export type ReportTaskPurpose = "research" | "implementation" | "other";
 
-const DISPLAYED_RELATIONSHIPS: Relationship[] = ["implementation", "research"];
-
-interface ReportTaskData {
+export interface ReportTaskData {
   task: Task;
-  relationship: Relationship;
+  purpose: ReportTaskPurpose;
+  /** Human-readable row label — "Research" / "Implementation" / a humanized custom pair. */
+  purposeLabel: string;
   startedAt: string;
 }
+
+function humanizeIdentifier(value: string): string {
+  const words = value.replace(/[_-]+/g, " ").trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function derivePurpose(
+  taskRun: { product: string; type: string } | undefined,
+): { purpose: ReportTaskPurpose; purposeLabel: string } | null {
+  if (!taskRun) {
+    // Freely-associated task with no task_run artefact (e.g. an agent that associated itself
+    // mid-run) — surface it generically rather than hiding it.
+    return { purpose: "other", purposeLabel: "Agent task" };
+  }
+  if (taskRun.product === "signals") {
+    if (taskRun.type === "research") {
+      return { purpose: "research", purposeLabel: "Research" };
+    }
+    if (taskRun.type === "implementation") {
+      return { purpose: "implementation", purposeLabel: "Implementation" };
+    }
+    // repo_selection runs are plumbing, not report work — never displayed (matches the
+    // pre-derivation behavior of only showing research/implementation).
+    return null;
+  }
+  return {
+    purpose: "other",
+    purposeLabel: `${humanizeIdentifier(taskRun.product)} — ${humanizeIdentifier(taskRun.type)}`,
+  };
+}
+
+const PURPOSE_ORDER: ReportTaskPurpose[] = [
+  "implementation",
+  "research",
+  "other",
+];
 
 export function useReportTasks(
   reportId: string,
@@ -27,24 +66,46 @@ export function useReportTasks(
   return useAuthenticatedQuery<ReportTaskData[]>(
     ["inbox", "report-tasks", reportId],
     async (client) => {
-      const reportTasks = await client.getSignalReportTasks(reportId);
-      const relevant = reportTasks.filter((rt) =>
-        DISPLAYED_RELATIONSHIPS.includes(rt.relationship),
-      );
+      const [reportTasks, artefacts] = await Promise.all([
+        client.getSignalReportTasks(reportId),
+        client.getSignalReportArtefacts(reportId),
+      ]);
+      // task id → its (product, type) from the report's task_run artefacts. The runtime
+      // `type` check is authoritative (the generic fallback artefact keeps `type: string`
+      // and defeats static narrowing).
+      const taskRunByTaskId = new Map<
+        string,
+        { product: string; type: string }
+      >();
+      for (const artefact of artefacts.results) {
+        if (artefact.type === "task_run") {
+          const content = artefact.content as TaskRunArtefactContent;
+          taskRunByTaskId.set(content.task_id, {
+            product: content.product,
+            type: content.type,
+          });
+        }
+      }
+
+      const relevant = reportTasks.flatMap((rt) => {
+        const derived = derivePurpose(taskRunByTaskId.get(rt.task_id));
+        return derived ? [{ rt, ...derived }] : [];
+      });
+
       const tasks = await Promise.all(
-        relevant.map(async (rt) => {
+        relevant.map(async ({ rt, purpose, purposeLabel }) => {
           const task = await client.getTask(rt.task_id);
           return {
             task,
-            relationship: rt.relationship,
+            purpose,
+            purposeLabel,
             startedAt: rt.created_at,
           };
         }),
       );
       return tasks.sort(
         (a, b) =>
-          DISPLAYED_RELATIONSHIPS.indexOf(a.relationship) -
-          DISPLAYED_RELATIONSHIPS.indexOf(b.relationship),
+          PURPOSE_ORDER.indexOf(a.purpose) - PURPOSE_ORDER.indexOf(b.purpose),
       );
     },
     {


### PR DESCRIPTION
## Problem

Signal reports now accumulate a richer set of artefacts on the backend — code references, diffs, pushed commits, task runs, and notes — alongside the existing judgments and findings. The inbox had no way to surface them, so all that work-log context was invisible to reviewers.

This is the PostHog Code side of the artefact-log feature. The backend half (new artefact types, the append-only log, per-commit diffs, attribution, and unlabelled task↔report associations) lands in **PostHog/posthog#61545**.

## Changes

Adds a chronological **activity log** to the right column of the report detail pane (below the status sections), rendering every artefact type with a tailored body rather than raw JSON:

- **Code references / line references** — syntax-highlighted code blocks with the relevant span and note.
- **Code diffs** — unified-diff rendering with add/remove coloring (`DiffBlock`).
- **Commits** — one artefact per pushed commit (message, sha, repo@branch), with a collapsible "View diff" that fetches the commit-vs-parent diff on demand from the backend endpoint; missing/rewritten commits surface a clean message instead of a raw error, and oversized diffs show a truncation notice.
- **Task runs** — loads the linked task and expands to its full conversation log via `TaskLogsPanel`. Badged from the artefact's `(product, type)`: signals-pipeline runs show **Research** / **Implementation**; custom agents show their humanized product + type.
- **Notes / judgments / findings / reviewers** — each rendered as a point-in-time entry with a relative timestamp; judgment reasoning and long notes are collapsed behind a toggle.
- **Attribution byline** — every entry shows who produced it ("by Oliver" for user writes, "by agent" for task-attributed writes; system/pipeline writes show nothing), from the API's `created_by` / `task_id` attribution fields.
- A **dev-only raw-JSON inspector** on each row (hidden in release builds, same pattern as other dev-only controls).

Beyond rendering, this PR also tracks the backend's model changes:

- **The signed-commit hook** — after every successful `git_signed_commit` push, the harness automatically records one `commit` artefact per pushed commit on every signal report the task is associated with, attributed via the `X-PostHog-Task-Id` header. Best-effort: an artefact failure can never fail a commit that already landed. Credentials come from the sandbox env (live agentsh env file first), so it works identically in the Claude in-process server and the Codex stdio child.
- **Artefact-derived task association** — `SignalReportTask` is gone from the backend; a `task_run` artefact *is* the task↔report association. The Runs bars and the activity log now read the same artefacts: each association, its start time, and its purpose badge (Research / Implementation for the signals pipeline, humanized product + type for custom agents) all derive from the report's `task_run` artefacts. `getSignalReportTasks` and the `SignalReportTask` type are deleted (desktop + mobile).

Artefact content types are hand-written in `packages/shared/src/domain-types.ts` — every artefact extends a shared `SignalReportArtefactBase` carrying timestamps plus attribution — and normalized in `packages/api-client`'s `posthog-client.ts` (the `task_run` content carries `product`/`type`, matching the backend).

## How did you test this?

- `pnpm typecheck` — passes.
- `biome check` — clean on all changed files.
- `vitest` — git, agent, and app suites green, including new unit tests for the signed-commit hook (one POST per commit per report, header attribution, failures swallowed, no-op without a task or credentials).
- Manual: rendered a report seeded with one of each artefact type against a local backend; verified the `commit` diff loads against a real pushed commit, the `task_run` entry expands to the conversation log, and the timeline orders correctly by timestamp.
- No automated component tests were added for these renderers.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

