### PR TITLE
fix(mobile): persist selected execution mode across prompts

### DIFF
--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -155,6 +155,7 @@ export default function NewTaskScreen() {
   // re-pick the same one for every new task.
   const lastRepository = useTaskStore((s) => s.lastRepository);
   const setLastRepository = useTaskStore((s) => s.setLastRepository);
+  const setComposerConfig = useTaskStore((s) => s.setComposerConfig);
   const [prompt, setPrompt] = useState(initialPrompt ?? "");
   const [selection, setSelectionState] = useState<RepositorySelection>(() => {
     if (initialRepo) {
@@ -319,6 +320,12 @@ export default function NewTaskScreen() {
       pendingTaskPromptStoreApi.move(pendingKey, task.id);
       currentPendingKey = task.id;
 
+      // Seed the per-task composer config with the mode/model/reasoning the
+      // user picked here, so the task detail screen reflects them and every
+      // subsequent run (resume-after-terminal) reuses the selected mode rather
+      // than falling back to DEFAULT_EXECUTION_MODE ("plan").
+      setComposerConfig(task.id, { mode, model, reasoning });
+
       const pendingUserMessage =
         attachments.length > 0
           ? serializeCloudPrompt(
@@ -360,6 +367,7 @@ export default function NewTaskScreen() {
     selection,
     signalReport,
     getUserIntegrationId,
+    setComposerConfig,
   ]);
 
   const hasContent = !!prompt.trim() || attachments.length > 0;


### PR DESCRIPTION
## Problem

In the mobile app, the execution mode reverts to **plan** after every subsequent prompt, even when the user changes it (e.g. to "accept edits") at task creation. The selected mode should persist for the duration of the session.

## Root cause

The new-task screen (`apps/mobile/src/app/task/index.tsx`) let the user pick a mode and passed it as `initialPermissionMode` to the *first* cloud run — but never wrote that choice into `taskStore.composerConfigByTaskId[task.id]`.

So on the task detail screen, `composerConfig` for that task was `undefined` and `composerMode` fell back to `DEFAULT_EXECUTION_MODE = "plan"`. Since each agent turn completes its run on the cloud, every follow-up prompt goes through the resume-after-terminal path, which starts a fresh run with `initialPermissionMode: composerMode` — i.e. `"plan"`. That's why it reverted on every subsequent prompt.

(The agent retains the mode correctly *within* a single run — the reversion was purely the mobile client sending `"plan"` to each new run.)

## Fix

When a task is created, seed the per-task composer config with the mode/model/reasoning the user selected:

```ts
setComposerConfig(task.id, { mode, model, reasoning });
```

Now the detail screen reflects the chosen mode, and every subsequent resume run reuses it for the duration of the session. This also keeps model and reasoning selections consistent across follow-ups, which had the same gap.

Changing the mode mid-session via the detail-screen pill already persisted correctly (`handleModeChange` calls `setComposerConfig`), so that path is unaffected.

## Notes

- Tasks created before this fix (no stored config) still default to `"plan"`, which is the intended fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)