### PR TITLE
feat(mobile): configurable font size with larger iOS default

### DIFF
--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -9,6 +9,7 @@ import { usePushTokenStore } from "@/features/notifications/stores/pushTokenStor
 import {
   type CompletionSound,
   type DefaultReasoningEffort,
+  type FontSizePreference,
   type InitialTaskMode,
   type ThemePreference,
   usePreferencesStore,
@@ -28,6 +29,16 @@ const THEME_OPTIONS = [
   { value: "light", label: "Light" },
   { value: "dark", label: "Dark" },
 ] as const;
+
+const FONT_SIZE_OPTIONS: ReadonlyArray<{
+  value: FontSizePreference;
+  label: string;
+}> = [
+  { value: "small", label: "Small" },
+  { value: "default", label: "Default" },
+  { value: "large", label: "Large" },
+  { value: "xlarge", label: "Extra Large" },
+];
 
 const SOUND_OPTIONS: ReadonlyArray<{ value: CompletionSound; label: string }> =
   [
@@ -81,6 +92,10 @@ function themeLabel(theme: ThemePreference): string {
   return THEME_OPTIONS.find((o) => o.value === theme)?.label ?? "Match system";
 }
 
+function fontSizeLabel(size: FontSizePreference): string {
+  return FONT_SIZE_OPTIONS.find((o) => o.value === size)?.label ?? "Default";
+}
+
 function soundLabel(sound: CompletionSound): string {
   return SOUND_OPTIONS.find((o) => o.value === sound)?.label ?? "Meep";
 }
@@ -128,6 +143,8 @@ export default function SettingsScreen() {
   );
   const theme = usePreferencesStore((s) => s.theme);
   const setTheme = usePreferencesStore((s) => s.setTheme);
+  const fontSize = usePreferencesStore((s) => s.fontSize);
+  const setFontSize = usePreferencesStore((s) => s.setFontSize);
   const completionSound = usePreferencesStore((s) => s.completionSound);
   const setCompletionSound = usePreferencesStore((s) => s.setCompletionSound);
   const completionVolume = usePreferencesStore((s) => s.completionVolume);
@@ -150,6 +167,7 @@ export default function SettingsScreen() {
   const clearDismissed = useDismissedReportsStore((s) => s.clearDismissed);
 
   const [themeSheetOpen, setThemeSheetOpen] = useState(false);
+  const [fontSizeSheetOpen, setFontSizeSheetOpen] = useState(false);
   const [soundSheetOpen, setSoundSheetOpen] = useState(false);
   const [volumeSheetOpen, setVolumeSheetOpen] = useState(false);
   const [taskModeSheetOpen, setTaskModeSheetOpen] = useState(false);
@@ -225,11 +243,24 @@ export default function SettingsScreen() {
             label="Theme"
             description="Choose light, dark, or follow your system preference"
             onPress={() => setThemeSheetOpen(true)}
-            showDivider={false}
             rightSlot={
               <>
                 <Text className="text-[14px] text-gray-11">
                   {themeLabel(theme)}
+                </Text>
+                <CaretRight size={14} color={themeColors.gray[10]} />
+              </>
+            }
+          />
+          <SettingsRow
+            label="Font size"
+            description="Scale text size across the app"
+            onPress={() => setFontSizeSheetOpen(true)}
+            showDivider={false}
+            rightSlot={
+              <>
+                <Text className="text-[14px] text-gray-11">
+                  {fontSizeLabel(fontSize)}
                 </Text>
                 <CaretRight size={14} color={themeColors.gray[10]} />
               </>
@@ -502,6 +533,18 @@ export default function SettingsScreen() {
         onChange={(value) => setTheme(value as ThemePreference)}
         onClose={() => setThemeSheetOpen(false)}
         options={THEME_OPTIONS.map((option) => ({
+          value: option.value,
+          label: option.label,
+        }))}
+      />
+
+      <SelectSheet
+        open={fontSizeSheetOpen}
+        title="Font size"
+        value={fontSize}
+        onChange={(value) => setFontSize(value as FontSizePreference)}
+        onClose={() => setFontSizeSheetOpen(false)}
+        options={FONT_SIZE_OPTIONS.map((option) => ({
           value: option.value,
           label: option.label,
         }))}

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { usePreferencesStore } from "./preferencesStore";
+import {
+  FONT_SCALE_BY_PREFERENCE,
+  type FontSizePreference,
+  usePreferencesStore,
+} from "./preferencesStore";
 
 const INITIAL_STATE = usePreferencesStore.getState();
 
@@ -49,4 +53,33 @@ describe("preferencesStore reasoning effort", () => {
     expect(state.defaultReasoningEffort).toBe("low");
     expect(state.lastUsedReasoningEffort).toBe("max");
   });
+});
+
+describe("preferencesStore font size", () => {
+  it("defaults to a known preference with a 'default' scale of 1", () => {
+    const { fontSize } = usePreferencesStore.getState();
+    expect(FONT_SCALE_BY_PREFERENCE[fontSize]).toBeGreaterThanOrEqual(1);
+    expect(FONT_SCALE_BY_PREFERENCE.default).toBe(1);
+  });
+
+  it.each([
+    ["small", true],
+    ["large", false],
+    ["xlarge", false],
+  ] as const)("orders the %s scale relative to default", (size, smaller) => {
+    const scale = FONT_SCALE_BY_PREFERENCE[size];
+    if (smaller) {
+      expect(scale).toBeLessThan(1);
+    } else {
+      expect(scale).toBeGreaterThan(1);
+    }
+  });
+
+  it.each(["small", "default", "large", "xlarge"] as const)(
+    "updates fontSize to %s via setter",
+    (size: FontSizePreference) => {
+      usePreferencesStore.getState().setFontSize(size);
+      expect(usePreferencesStore.getState().fontSize).toBe(size);
+    },
+  );
 });

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.test.ts
@@ -63,16 +63,11 @@ describe("preferencesStore font size", () => {
   });
 
   it.each([
-    ["small", true],
-    ["large", false],
-    ["xlarge", false],
-  ] as const)("orders the %s scale relative to default", (size, smaller) => {
-    const scale = FONT_SCALE_BY_PREFERENCE[size];
-    if (smaller) {
-      expect(scale).toBeLessThan(1);
-    } else {
-      expect(scale).toBeGreaterThan(1);
-    }
+    ["small", 0.9],
+    ["large", 1.15],
+    ["xlarge", 1.3],
+  ] as const)("FONT_SCALE_BY_PREFERENCE.%s equals %s", (size, expected) => {
+    expect(FONT_SCALE_BY_PREFERENCE[size]).toBe(expected);
   });
 
   it.each(["small", "default", "large", "xlarge"] as const)(

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.ts
@@ -1,8 +1,32 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Platform } from "react-native";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 export type ThemePreference = "light" | "dark" | "system";
+
+export type FontSizePreference = "small" | "default" | "large" | "xlarge";
+
+/**
+ * Multiplier applied to every rendered font size. Consumed by the global
+ * `Text.render` patch in `lib/textDefaults`, which scales each text node's
+ * explicit `fontSize` by this factor. Children without an explicit size keep
+ * inheriting their (already-scaled) parent, so the whole UI scales uniformly.
+ */
+export const FONT_SCALE_BY_PREFERENCE: Record<FontSizePreference, number> = {
+  small: 0.9,
+  default: 1,
+  large: 1.15,
+  xlarge: 1.3,
+};
+
+/**
+ * iOS reads noticeably smaller than Android at the same point size, so iOS
+ * ships one notch larger out of the box. Other platforms keep the 1.0
+ * baseline. Either way the user can change it in Settings.
+ */
+const DEFAULT_FONT_SIZE: FontSizePreference =
+  Platform.OS === "ios" ? "large" : "default";
 
 export type CompletionSound =
   | "meep"
@@ -31,6 +55,9 @@ interface PreferencesState {
 
   theme: ThemePreference;
   setTheme: (theme: ThemePreference) => void;
+
+  fontSize: FontSizePreference;
+  setFontSize: (size: FontSizePreference) => void;
 
   completionSound: CompletionSound;
   setCompletionSound: (sound: CompletionSound) => void;
@@ -64,6 +91,9 @@ export const usePreferencesStore = create<PreferencesState>()(
       theme: "system",
       setTheme: (theme) => set({ theme }),
 
+      fontSize: DEFAULT_FONT_SIZE,
+      setFontSize: (size) => set({ fontSize: size }),
+
       completionSound: "meep",
       setCompletionSound: (sound) => set({ completionSound: sound }),
       completionVolume: 70,
@@ -92,6 +122,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         pingsEnabled: state.pingsEnabled,
         pushNotificationsEnabled: state.pushNotificationsEnabled,
         theme: state.theme,
+        fontSize: state.fontSize,
         completionSound: state.completionSound,
         completionVolume: state.completionVolume,
         defaultInitialTaskMode: state.defaultInitialTaskMode,

--- a/apps/mobile/src/lib/textDefaults.ts
+++ b/apps/mobile/src/lib/textDefaults.ts
@@ -1,10 +1,5 @@
 import { cloneElement, type ReactElement } from "react";
-import {
-  StyleSheet,
-  Text,
-  type TextProps,
-  type TextStyle,
-} from "react-native";
+import { StyleSheet, Text, type TextProps, type TextStyle } from "react-native";
 import {
   FONT_SCALE_BY_PREFERENCE,
   usePreferencesStore,

--- a/apps/mobile/src/lib/textDefaults.ts
+++ b/apps/mobile/src/lib/textDefaults.ts
@@ -1,21 +1,58 @@
 import { cloneElement, type ReactElement } from "react";
-import { Text, type TextProps } from "react-native";
+import {
+  StyleSheet,
+  Text,
+  type TextProps,
+  type TextStyle,
+} from "react-native";
+import {
+  FONT_SCALE_BY_PREFERENCE,
+  usePreferencesStore,
+} from "@/features/preferences/stores/preferencesStore";
 
 // Apply Open Runde as the default fontFamily for every <Text>, including those
-// imported directly from react-native. User-provided styles (e.g. font-mono via
-// NativeWind className) appear later in the style array and override the default.
+// imported directly from react-native, and scale every explicit fontSize by the
+// user's chosen font-size preference. User-provided styles (e.g. font-mono via
+// NativeWind className) appear later in the style array and override the
+// default; the scaled fontSize is appended last so it always wins.
 type PatchableText = {
   render: (...args: unknown[]) => ReactElement<TextProps>;
   __posthogPatched?: boolean;
 };
 const TextRef = Text as unknown as PatchableText;
 
+const FONT_FAMILY_STYLE = { fontFamily: "Open Runde" } as const;
+
 if (!TextRef.__posthogPatched) {
   const baseRender = TextRef.render;
   TextRef.render = function patchedRender(...args) {
     const element = baseRender.apply(this, args);
+
+    // Read the scale imperatively (this runs outside React, so no hooks). The
+    // value is persisted and read on every render, so changing it in Settings
+    // takes effect as each screen re-renders.
+    const scale =
+      FONT_SCALE_BY_PREFERENCE[usePreferencesStore.getState().fontSize];
+
+    if (scale === 1) {
+      return cloneElement(element, {
+        style: [FONT_FAMILY_STYLE, element.props.style],
+      });
+    }
+
+    // Only scale a fontSize that is explicitly set on this node. Nodes without
+    // one inherit their (already-scaled) parent in React Native, so injecting a
+    // default here would break inheritance for nested <Text>.
+    const flattened = StyleSheet.flatten(element.props.style) as
+      | TextStyle
+      | undefined;
+    const scaledStyle =
+      flattened && typeof flattened.fontSize === "number"
+        ? { fontSize: flattened.fontSize * scale }
+        : null;
+
     return cloneElement(element, {
-      style: [{ fontFamily: "Open Runde" }, element.props.style],
+      style: [FONT_FAMILY_STYLE, element.props.style, scaledStyle],
     });
   };
   TextRef.__posthogPatched = true;


### PR DESCRIPTION
## What

Two related asks for the mobile app:
1. **Bigger default font size on iOS** — text reads noticeably smaller on iOS than Android at the same point size.
2. **Make the font size configurable** — a user setting that scales text across the app.

## Approach

The mobile app has **no central font-size token** — sizes are set per-component via NativeWind classes (`text-sm`, `text-base`, …) across ~15+ files. Rather than touch every usage, this adds a single **global scale multiplier** at the one place text styling is already centralized: the `Text.render` patch in `lib/textDefaults.ts` (which already injects the default font family).

- **`preferencesStore`** — new persisted `fontSize` preference (`small | default | large | xlarge`) with a `FONT_SCALE_BY_PREFERENCE` map (`0.9 / 1.0 / 1.15 / 1.3`). Default is **`large` on iOS**, **`default` (1.0, unchanged) on Android** — so Android behavior is untouched and iOS ships larger out of the box.
- **`textDefaults.ts`** — the global `Text.render` patch now multiplies each node's *explicit* `fontSize` by the selected scale. Nodes without an explicit size are left alone so they keep inheriting their already-scaled parent — this preserves React Native's text-inheritance semantics for nested `<Text>`. Scaling is skipped entirely when the multiplier is `1`.
- **Settings → Appearance** — a new "Font size" row + select sheet, matching the existing discrete-picker pattern (Theme, Sound, etc.).
- **Tests** — unit coverage for the new preference and the scale ordering.

## Decisions made (easy to change)

- **Discrete presets** (Small / Default / Large / Extra Large) rather than a continuous slider, to match the existing settings UX.
- **iOS-only larger default**; Android keeps the current 1.0 baseline.
- **Scale values** 0.9 / 1.0 / 1.15 / 1.3 — tweakable in `FONT_SCALE_BY_PREFERENCE`.

## Notes

- The patch reads the scale imperatively on each render, so a change takes effect as screens re-render (immediate on the Settings screen itself, which subscribes) and is persisted across launches. There's no forced global remount, to avoid resetting navigation state.
- Couldn't run vitest/biome in this environment (deps not installed); targeted `tsc` of the changed files is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)