### PR TITLE
fix(git): skip PR revalidation when worktree directory is missing

### DIFF
--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -289,6 +289,50 @@ describe("GitService.getPrUrlForBranch", () => {
   });
 });
 
+describe("GitService.getTaskPrStatus (missing worktree directory)", () => {
+  let service: GitService;
+  let workspaceService: {
+    getWorkspace: ReturnType<typeof vi.fn>;
+    emit: ReturnType<typeof vi.fn>;
+  };
+  let workspaceRepo: {
+    findByTaskId: ReturnType<typeof vi.fn>;
+    updatePrCache: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    workspaceService = { getWorkspace: vi.fn(), emit: vi.fn() };
+    workspaceRepo = {
+      findByTaskId: vi.fn().mockReturnValue(null),
+      updatePrCache: vi.fn(),
+    };
+    service = new GitService(
+      {} as LlmGatewayService,
+      workspaceService as unknown as WorkspaceService,
+      { getSessionEnvForTask: async () => ({}) } as unknown as AgentService,
+      workspaceRepo as unknown as IWorkspaceRepository,
+    );
+  });
+
+  it("returns no diff and never touches git when the worktree directory is gone", async () => {
+    workspaceService.getWorkspace.mockResolvedValue({
+      mode: "worktree",
+      worktreePath: "/tmp/posthog-code-worktree-does-not-exist-xyz",
+      folderPath: null,
+      linkedBranch: null,
+    });
+    const diffSpy = vi.spyOn(service, "getDiffStats");
+
+    // Before the existence guard this rejected with "Cannot use simple-git on a
+    // directory that does not exist"; now it resolves cleanly to no diff.
+    const result = await service.getTaskPrStatus("task-1", null);
+
+    expect(result).toEqual({ prState: null, hasDiff: false });
+    expect(diffSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("mapPrState", () => {
   it("returns merged when merged boolean is true", () => {
     expect(mapPrState("open", true, false)).toBe("merged");

--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecGh = vi.hoisted(() => vi.fn());
@@ -318,14 +319,19 @@ describe("GitService.getTaskPrStatus (missing worktree directory)", () => {
   it("returns no diff and never touches git when the worktree directory is gone", async () => {
     workspaceService.getWorkspace.mockResolvedValue({
       mode: "worktree",
-      worktreePath: "/tmp/posthog-code-worktree-does-not-exist-xyz",
+      worktreePath: "/some/worktree",
       folderPath: null,
       linkedBranch: null,
     });
+    // Force the missing-dir guard regardless of the real filesystem.
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
     const diffSpy = vi.spyOn(service, "getDiffStats");
 
     // Pre-guard this rejected; now it resolves to no diff.
     const result = await service.getTaskPrStatus("task-1", null);
+    // Drain the fire-and-forget revalidation so the computeTaskPrStatus
+    // guard (background path) is covered too, not just computeWorktreeHasDiff.
+    await new Promise((resolve) => setImmediate(resolve));
 
     expect(result).toEqual({ prState: null, hasDiff: false });
     expect(diffSpy).not.toHaveBeenCalled();

--- a/apps/code/src/main/services/git/service.test.ts
+++ b/apps/code/src/main/services/git/service.test.ts
@@ -324,8 +324,7 @@ describe("GitService.getTaskPrStatus (missing worktree directory)", () => {
     });
     const diffSpy = vi.spyOn(service, "getDiffStats");
 
-    // Before the existence guard this rejected with "Cannot use simple-git on a
-    // directory that does not exist"; now it resolves cleanly to no diff.
+    // Pre-guard this rejected; now it resolves to no diff.
     const result = await service.getTaskPrStatus("task-1", null);
 
     expect(result).toEqual({ prState: null, hasDiff: false });

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -2020,9 +2020,7 @@ ${truncatedDiff || "(no diff available)"}${contextSection}`;
       return false;
     }
     if (workspace.linkedBranch) return false;
-    // The workspace row can outlive its worktree directory (manually deleted,
-    // pruned, or the parent repo moved). Running git against a missing path
-    // makes simple-git throw, so skip it and report no diff.
+    // Worktree dir can be gone while the row remains; git would throw.
     if (!fs.existsSync(workspace.worktreePath)) return false;
     const [diffStats, syncStatus] = await Promise.all([
       this.getDiffStats(workspace.worktreePath),
@@ -2118,10 +2116,7 @@ ${truncatedDiff || "(no diff available)"}${contextSection}`;
 
     if (isCloud) return { prUrl: null, prState: null, hasDiff: false };
 
-    // A local task's repo/worktree directory can be deleted out from under the
-    // workspace row. Bail before touching git so simple-git doesn't throw
-    // "Cannot use simple-git on a directory that does not exist" on every
-    // sidebar revalidation cycle.
+    // Repo/worktree dir can be gone while the row remains; git would throw.
     if (repoPath && !fs.existsSync(repoPath)) {
       return { prUrl: null, prState: null, hasDiff: false };
     }

--- a/apps/code/src/main/services/git/service.ts
+++ b/apps/code/src/main/services/git/service.ts
@@ -2020,6 +2020,10 @@ ${truncatedDiff || "(no diff available)"}${contextSection}`;
       return false;
     }
     if (workspace.linkedBranch) return false;
+    // The workspace row can outlive its worktree directory (manually deleted,
+    // pruned, or the parent repo moved). Running git against a missing path
+    // makes simple-git throw, so skip it and report no diff.
+    if (!fs.existsSync(workspace.worktreePath)) return false;
     const [diffStats, syncStatus] = await Promise.all([
       this.getDiffStats(workspace.worktreePath),
       this.getGitSyncStatus(workspace.worktreePath),
@@ -2113,6 +2117,14 @@ ${truncatedDiff || "(no diff available)"}${contextSection}`;
     }
 
     if (isCloud) return { prUrl: null, prState: null, hasDiff: false };
+
+    // A local task's repo/worktree directory can be deleted out from under the
+    // workspace row. Bail before touching git so simple-git doesn't throw
+    // "Cannot use simple-git on a directory that does not exist" on every
+    // sidebar revalidation cycle.
+    if (repoPath && !fs.existsSync(repoPath)) {
+      return { prUrl: null, prState: null, hasDiff: false };
+    }
 
     if (linkedBranch && repoPath) {
       const prUrl = await this.getPrUrlForBranch(repoPath, linkedBranch);


### PR DESCRIPTION
## Problem

PostHog Code logs `Failed to revalidate task PR status` constantly with `Error: Cannot use simple-git on a directory that does not exist`.

A workspace row in the local DB can outlive its worktree directory (manually deleted, pruned, or the parent repo moved). The sidebar renders every task via `useTaskPrStatus`, which polls `workspace.getTaskPrStatus`. For a worktree task with no cached PR, revalidation runs git (`getDiffStats`) against the cached path — and `simple-git` throws when that directory no longer exists. The error is caught and logged on every poll cycle, producing constant noise.

## Changes

Guard the worktree git calls with an `fs.existsSync` check before touching git:
- `computeTaskPrStatus` — bail to empty PR state when `repoPath` is gone (covers both the worktree and linked-branch paths).
- `computeWorktreeHasDiff` — return `hasDiff: false` when the worktree path is gone.

Behaviour is unchanged for live worktrees. A task whose directory is missing now quietly shows no PR/diff state instead of throwing, and self-heals if the directory reappears. I deliberately did not delete the stale workspace row, since a path can be temporarily unavailable (e.g. an unmounted volume) and we don't want to lose data.

## How did you test this?

- Added a regression unit test in `service.test.ts` asserting `getTaskPrStatus` resolves to `{ prState: null, hasDiff: false }` and never calls `getDiffStats` when the worktree directory is missing (previously it rejected).
- `pnpm --filter code exec vitest run src/main/services/git/service.test.ts` — 28 passed.
- `pnpm --filter code typecheck` — clean.
- `biome check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1781044629682099)*
