### PR TITLE
fix(workspace): don't delete task workspace association on a transient missing path

### DIFF
--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -802,19 +802,21 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       return { exists: true };
     }
 
+    // NOTE: this is a read-only check. It must never mutate the DB. A missing
+    // path can be transient (volume not mounted yet on relaunch, a git worktree
+    // momentarily absent, settings resolving a path differently mid-boot), and
+    // deleting the association here permanently strips a task of its local
+    // working directory. The caller surfaces { exists: false } as an error
+    // state; the association is only ever removed via an explicit deleteWorkspace.
     const folderPath = this.getFolderPath(association.folderId);
     if (!folderPath) {
-      this.removeTaskAssociation(taskId);
       return { exists: false, missingPath: "(folder not found)" };
     }
 
     if (association.mode === "local") {
       const exists = fs.existsSync(folderPath);
       if (!exists) {
-        log.info(
-          `Folder for task ${taskId} no longer exists, removing association`,
-        );
-        this.removeTaskAssociation(taskId);
+        log.info(`Folder for task ${taskId} no longer exists`);
         return { exists: false, missingPath: folderPath };
       }
       return { exists: true };
@@ -824,10 +826,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       const worktreePath = deriveWorktreePath(folderPath, association.worktree);
       const exists = fs.existsSync(worktreePath);
       if (!exists) {
-        log.info(
-          `Worktree for task ${taskId} no longer exists, removing association`,
-        );
-        this.removeTaskAssociation(taskId);
+        log.info(`Worktree for task ${taskId} no longer exists`);
         return { exists: false, missingPath: worktreePath };
       }
       return { exists: true };

--- a/apps/code/src/main/services/workspace/service.ts
+++ b/apps/code/src/main/services/workspace/service.ts
@@ -802,12 +802,9 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       return { exists: true };
     }
 
-    // NOTE: this is a read-only check. It must never mutate the DB. A missing
-    // path can be transient (volume not mounted yet on relaunch, a git worktree
-    // momentarily absent, settings resolving a path differently mid-boot), and
-    // deleting the association here permanently strips a task of its local
-    // working directory. The caller surfaces { exists: false } as an error
-    // state; the association is only ever removed via an explicit deleteWorkspace.
+    // Read-only: never mutate here. A missing path can be transient (unmounted
+    // volume, slug/layout mismatch), so deleting the association would wrongly
+    // strip a task's working dir. Removal happens only via deleteWorkspace.
     const folderPath = this.getFolderPath(association.folderId);
     if (!folderPath) {
       return { exists: false, missingPath: "(folder not found)" };

--- a/apps/code/src/main/services/workspace/service.verify.test.ts
+++ b/apps/code/src/main/services/workspace/service.verify.test.ts
@@ -63,33 +63,46 @@ describe("WorkspaceService.verifyWorkspaceExists", () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("reports a missing worktree without deleting the association", async () => {
-    const { service, repositoryRepo, workspaceRepo, worktreeRepo } =
-      createService();
+  // The worktree dir lives at the new layout <base>/<name>/<repo>.
+  it.each([
+    { label: "existing worktree", createWorktree: true, expectExists: true },
+    { label: "missing worktree", createWorktree: false, expectExists: false },
+  ])(
+    "$label: reports exists=$expectExists and never deletes the association",
+    async ({ createWorktree, expectExists }) => {
+      const { service, repositoryRepo, workspaceRepo, worktreeRepo } =
+        createService();
 
-    // Repo folder exists, but the worktree directory does not.
-    const repoPath = path.join(tmpDir, REPO_NAME);
-    await fsp.mkdir(repoPath, { recursive: true });
-    const repo = repositoryRepo.create({ path: repoPath });
-    const workspace = workspaceRepo.create({
-      taskId: TASK_ID,
-      repositoryId: repo.id,
-      mode: "worktree",
-    });
-    worktreeRepo.create({
-      workspaceId: workspace.id,
-      name: WORKTREE_NAME,
-      path: path.join(testWorktreeBasePath, REPO_NAME, WORKTREE_NAME),
-    });
+      const repoPath = path.join(tmpDir, REPO_NAME);
+      const worktreePath = path.join(
+        testWorktreeBasePath,
+        WORKTREE_NAME,
+        REPO_NAME,
+      );
+      await fsp.mkdir(repoPath, { recursive: true });
+      if (createWorktree) await fsp.mkdir(worktreePath, { recursive: true });
 
-    const result = await service.verifyWorkspaceExists(TASK_ID);
+      const repo = repositoryRepo.create({ path: repoPath });
+      const workspace = workspaceRepo.create({
+        taskId: TASK_ID,
+        repositoryId: repo.id,
+        mode: "worktree",
+      });
+      worktreeRepo.create({
+        workspaceId: workspace.id,
+        name: WORKTREE_NAME,
+        path: worktreePath,
+      });
 
-    expect(result.exists).toBe(false);
-    expect(result.missingPath).toContain(WORKTREE_NAME);
-    // Association must survive so the task can recover later.
-    expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
-    expect(worktreeRepo.findByWorkspaceId(workspace.id)).not.toBeNull();
-  });
+      const result = await service.verifyWorkspaceExists(TASK_ID);
+
+      expect(result.exists).toBe(expectExists);
+      if (!expectExists) expect(result.missingPath).toContain(WORKTREE_NAME);
+      // Association must survive so the task can recover later.
+      expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
+      expect(worktreeRepo.findByWorkspaceId(workspace.id)).not.toBeNull();
+    },
+  );
 
   it("reports a missing local folder without deleting the association", async () => {
     const { service, repositoryRepo, workspaceRepo } = createService();
@@ -106,37 +119,6 @@ describe("WorkspaceService.verifyWorkspaceExists", () => {
 
     expect(result.exists).toBe(false);
     expect(result.missingPath).toBe(repoPath);
-    expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
-  });
-
-  it("confirms an existing worktree", async () => {
-    const { service, repositoryRepo, workspaceRepo, worktreeRepo } =
-      createService();
-
-    const repoPath = path.join(tmpDir, REPO_NAME);
-    const worktreePath = path.join(
-      testWorktreeBasePath,
-      REPO_NAME,
-      WORKTREE_NAME,
-    );
-    await fsp.mkdir(repoPath, { recursive: true });
-    await fsp.mkdir(worktreePath, { recursive: true });
-
-    const repo = repositoryRepo.create({ path: repoPath });
-    const workspace = workspaceRepo.create({
-      taskId: TASK_ID,
-      repositoryId: repo.id,
-      mode: "worktree",
-    });
-    worktreeRepo.create({
-      workspaceId: workspace.id,
-      name: WORKTREE_NAME,
-      path: worktreePath,
-    });
-
-    const result = await service.verifyWorkspaceExists(TASK_ID);
-
-    expect(result.exists).toBe(true);
     expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
   });
 });

--- a/apps/code/src/main/services/workspace/service.verify.test.ts
+++ b/apps/code/src/main/services/workspace/service.verify.test.ts
@@ -1,0 +1,145 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: false,
+    getPath: (name: string) => {
+      if (name === "home") return os.homedir();
+      return os.tmpdir();
+    },
+  },
+}));
+
+let testWorktreeBasePath = "/tmp/worktrees";
+vi.mock("../settingsStore", () => ({
+  getWorktreeLocation: () => testWorktreeBasePath,
+}));
+
+// Importing the real DI container, analytics client, and focus service drags in
+// electron / native modules. None are exercised by verifyWorkspaceExists, so
+// stub them out to keep this a fast, isolated unit test.
+vi.mock("../../di/container", () => ({ container: {} }));
+vi.mock("@main/services/posthog-analytics", () => ({ trackAppEvent: vi.fn() }));
+vi.mock("../focus/service", () => ({
+  FocusService: class {},
+  FocusServiceEvent: {},
+}));
+
+import { createMockRepositoryRepository } from "../../db/repositories/repository-repository.mock";
+import { createMockWorkspaceRepository } from "../../db/repositories/workspace-repository.mock";
+import { createMockWorktreeRepository } from "../../db/repositories/worktree-repository.mock";
+import { WorkspaceService } from "./service";
+
+const TASK_ID = "task-1";
+const REPO_NAME = "posthog";
+const WORKTREE_NAME = "plucky-summit-59";
+
+function createService() {
+  const repositoryRepo = createMockRepositoryRepository();
+  const workspaceRepo = createMockWorkspaceRepository();
+  const worktreeRepo = createMockWorktreeRepository();
+
+  const service = new WorkspaceService();
+  // WorkspaceService uses property injection; wire the repos in directly.
+  Object.assign(service, {
+    repositoryRepo,
+    workspaceRepo,
+    worktreeRepo,
+  });
+
+  return { service, repositoryRepo, workspaceRepo, worktreeRepo };
+}
+
+describe("WorkspaceService.verifyWorkspaceExists", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "ws-verify-"));
+    testWorktreeBasePath = path.join(tmpDir, "worktrees");
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reports a missing worktree without deleting the association", async () => {
+    const { service, repositoryRepo, workspaceRepo, worktreeRepo } =
+      createService();
+
+    // Repo folder exists, but the worktree directory does not (e.g. a volume
+    // not mounted yet on relaunch, or a worktree pruned out from under us).
+    const repoPath = path.join(tmpDir, REPO_NAME);
+    await fsp.mkdir(repoPath, { recursive: true });
+    const repo = repositoryRepo.create({ path: repoPath });
+    const workspace = workspaceRepo.create({
+      taskId: TASK_ID,
+      repositoryId: repo.id,
+      mode: "worktree",
+    });
+    worktreeRepo.create({
+      workspaceId: workspace.id,
+      name: WORKTREE_NAME,
+      path: path.join(testWorktreeBasePath, REPO_NAME, WORKTREE_NAME),
+    });
+
+    const result = await service.verifyWorkspaceExists(TASK_ID);
+
+    expect(result.exists).toBe(false);
+    expect(result.missingPath).toContain(WORKTREE_NAME);
+    // The association must survive so the task can recover on the next launch.
+    expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
+    expect(worktreeRepo.findByWorkspaceId(workspace.id)).not.toBeNull();
+  });
+
+  it("reports a missing local folder without deleting the association", async () => {
+    const { service, repositoryRepo, workspaceRepo } = createService();
+
+    const repoPath = path.join(tmpDir, "gone");
+    const repo = repositoryRepo.create({ path: repoPath });
+    workspaceRepo.create({
+      taskId: TASK_ID,
+      repositoryId: repo.id,
+      mode: "local",
+    });
+
+    const result = await service.verifyWorkspaceExists(TASK_ID);
+
+    expect(result.exists).toBe(false);
+    expect(result.missingPath).toBe(repoPath);
+    expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
+  });
+
+  it("confirms an existing worktree", async () => {
+    const { service, repositoryRepo, workspaceRepo, worktreeRepo } =
+      createService();
+
+    const repoPath = path.join(tmpDir, REPO_NAME);
+    const worktreePath = path.join(
+      testWorktreeBasePath,
+      REPO_NAME,
+      WORKTREE_NAME,
+    );
+    await fsp.mkdir(repoPath, { recursive: true });
+    await fsp.mkdir(worktreePath, { recursive: true });
+
+    const repo = repositoryRepo.create({ path: repoPath });
+    const workspace = workspaceRepo.create({
+      taskId: TASK_ID,
+      repositoryId: repo.id,
+      mode: "worktree",
+    });
+    worktreeRepo.create({
+      workspaceId: workspace.id,
+      name: WORKTREE_NAME,
+      path: worktreePath,
+    });
+
+    const result = await service.verifyWorkspaceExists(TASK_ID);
+
+    expect(result.exists).toBe(true);
+    expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
+  });
+});

--- a/apps/code/src/main/services/workspace/service.verify.test.ts
+++ b/apps/code/src/main/services/workspace/service.verify.test.ts
@@ -18,9 +18,7 @@ vi.mock("../settingsStore", () => ({
   getWorktreeLocation: () => testWorktreeBasePath,
 }));
 
-// Importing the real DI container, analytics client, and focus service drags in
-// electron / native modules. None are exercised by verifyWorkspaceExists, so
-// stub them out to keep this a fast, isolated unit test.
+// Stub modules that drag in electron / native deps but aren't used here.
 vi.mock("../../di/container", () => ({ container: {} }));
 vi.mock("@main/services/posthog-analytics", () => ({ trackAppEvent: vi.fn() }));
 vi.mock("../focus/service", () => ({
@@ -69,8 +67,7 @@ describe("WorkspaceService.verifyWorkspaceExists", () => {
     const { service, repositoryRepo, workspaceRepo, worktreeRepo } =
       createService();
 
-    // Repo folder exists, but the worktree directory does not (e.g. a volume
-    // not mounted yet on relaunch, or a worktree pruned out from under us).
+    // Repo folder exists, but the worktree directory does not.
     const repoPath = path.join(tmpDir, REPO_NAME);
     await fsp.mkdir(repoPath, { recursive: true });
     const repo = repositoryRepo.create({ path: repoPath });
@@ -89,7 +86,7 @@ describe("WorkspaceService.verifyWorkspaceExists", () => {
 
     expect(result.exists).toBe(false);
     expect(result.missingPath).toContain(WORKTREE_NAME);
-    // The association must survive so the task can recover on the next launch.
+    // Association must survive so the task can recover later.
     expect(workspaceRepo.findByTaskId(TASK_ID)).not.toBeNull();
     expect(worktreeRepo.findByWorkspaceId(workspace.id)).not.toBeNull();
   });

--- a/apps/code/src/main/utils/worktree-helpers.test.ts
+++ b/apps/code/src/main/utils/worktree-helpers.test.ts
@@ -1,0 +1,48 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let testWorktreeBasePath = "/tmp/worktrees";
+vi.mock("../services/settingsStore", () => ({
+  getWorktreeLocation: () => testWorktreeBasePath,
+}));
+
+import { deriveWorktreePath } from "./worktree-helpers";
+
+const REPO = "/repos/posthog";
+const REPO_NAME = "posthog";
+const NAME = "plucky-summit-59";
+
+describe("deriveWorktreePath", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "wt-helpers-"));
+    testWorktreeBasePath = tmpDir;
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the new layout (<base>/<name>/<repo>) when it exists on disk", async () => {
+    const newPath = path.join(tmpDir, NAME, REPO_NAME);
+    await fsp.mkdir(newPath, { recursive: true });
+
+    expect(deriveWorktreePath(REPO, NAME)).toBe(newPath);
+  });
+
+  it("falls back to the legacy layout (<base>/<repo>/<name>) when only it exists", async () => {
+    const legacyPath = path.join(tmpDir, REPO_NAME, NAME);
+    await fsp.mkdir(legacyPath, { recursive: true });
+
+    expect(deriveWorktreePath(REPO, NAME)).toBe(legacyPath);
+  });
+
+  it("defaults to the new layout when neither exists (creation case)", () => {
+    expect(deriveWorktreePath(REPO, NAME)).toBe(
+      path.join(tmpDir, NAME, REPO_NAME),
+    );
+  });
+});

--- a/apps/code/src/main/utils/worktree-helpers.test.ts
+++ b/apps/code/src/main/utils/worktree-helpers.test.ts
@@ -26,23 +26,26 @@ describe("deriveWorktreePath", () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("returns the new layout (<base>/<name>/<repo>) when it exists on disk", async () => {
-    const newPath = path.join(tmpDir, NAME, REPO_NAME);
-    await fsp.mkdir(newPath, { recursive: true });
+  it.each([
+    {
+      label: "new layout when it exists on disk",
+      create: () => path.join(tmpDir, NAME, REPO_NAME),
+      expected: () => path.join(tmpDir, NAME, REPO_NAME),
+    },
+    {
+      label: "legacy layout when only it exists",
+      create: () => path.join(tmpDir, REPO_NAME, NAME),
+      expected: () => path.join(tmpDir, REPO_NAME, NAME),
+    },
+    {
+      label: "new layout by default when neither exists (creation case)",
+      create: () => null,
+      expected: () => path.join(tmpDir, NAME, REPO_NAME),
+    },
+  ])("resolves the $label", async ({ create, expected }) => {
+    const dir = create();
+    if (dir) await fsp.mkdir(dir, { recursive: true });
 
-    expect(deriveWorktreePath(REPO, NAME)).toBe(newPath);
-  });
-
-  it("falls back to the legacy layout (<base>/<repo>/<name>) when only it exists", async () => {
-    const legacyPath = path.join(tmpDir, REPO_NAME, NAME);
-    await fsp.mkdir(legacyPath, { recursive: true });
-
-    expect(deriveWorktreePath(REPO, NAME)).toBe(legacyPath);
-  });
-
-  it("defaults to the new layout when neither exists (creation case)", () => {
-    expect(deriveWorktreePath(REPO, NAME)).toBe(
-      path.join(tmpDir, NAME, REPO_NAME),
-    );
+    expect(deriveWorktreePath(REPO, NAME)).toBe(expected());
   });
 });

--- a/apps/code/src/main/utils/worktree-helpers.ts
+++ b/apps/code/src/main/utils/worktree-helpers.ts
@@ -1,18 +1,27 @@
+import * as fs from "node:fs";
 import path from "node:path";
 import { getWorktreeLocation } from "../services/settingsStore";
 
-function isLegacyWorktreeName(name: string): boolean {
-  return !/^\d+$/.test(name);
-}
-
+/**
+ * Resolves the on-disk path of a worktree, matching WorktreeManager's layout
+ * (`<base>/<name>/<repo>`). Older worktrees used `<base>/<repo>/<name>`, so we
+ * fall back to that when the new layout isn't present on disk.
+ *
+ * This must be filesystem-aware rather than guessing from the name: worktree
+ * names are now human-readable slugs (e.g. "plucky-summit-59"), so the name
+ * alone no longer indicates which layout was used.
+ */
 export function deriveWorktreePath(
   folderPath: string,
   worktreeName: string,
 ): string {
   const worktreeBasePath = getWorktreeLocation();
   const repoName = path.basename(folderPath);
-  if (isLegacyWorktreeName(worktreeName)) {
-    return path.join(worktreeBasePath, repoName, worktreeName);
-  }
-  return path.join(worktreeBasePath, worktreeName, repoName);
+
+  const newFormatPath = path.join(worktreeBasePath, worktreeName, repoName);
+  const legacyFormatPath = path.join(worktreeBasePath, repoName, worktreeName);
+
+  if (fs.existsSync(newFormatPath)) return newFormatPath;
+  if (fs.existsSync(legacyFormatPath)) return legacyFormatPath;
+  return newFormatPath;
 }

--- a/apps/code/src/main/utils/worktree-helpers.ts
+++ b/apps/code/src/main/utils/worktree-helpers.ts
@@ -3,13 +3,9 @@ import path from "node:path";
 import { getWorktreeLocation } from "../services/settingsStore";
 
 /**
- * Resolves the on-disk path of a worktree, matching WorktreeManager's layout
- * (`<base>/<name>/<repo>`). Older worktrees used `<base>/<repo>/<name>`, so we
- * fall back to that when the new layout isn't present on disk.
- *
- * This must be filesystem-aware rather than guessing from the name: worktree
- * names are now human-readable slugs (e.g. "plucky-summit-59"), so the name
- * alone no longer indicates which layout was used.
+ * Resolves a worktree's on-disk path. Prefers the current layout
+ * (`<base>/<name>/<repo>`) and falls back to the legacy `<base>/<repo>/<name>`.
+ * Checks disk rather than the name: names are now slugs, not numbers.
  */
 export function deriveWorktreePath(
   folderPath: string,


### PR DESCRIPTION
## Problem

Local/worktree tasks started getting "deleted" on app relaunch a few days ago:

```
(workspace) Worktree for task <id> no longer exists, removing association
(session-service) Workspace no longer exists { taskId, missingPath: '.../worktrees/posthog/plucky-summit-59' }
```

**Root cause:** PR #2340 (Jun 5, "use human-readable names for worktree branches") changed generated worktree names from numeric (`4823`) to slugs (`plucky-summit-59`). `deriveWorktreePath` used `isLegacyWorktreeName`, which treats any **non-numeric** name as the legacy layout `<base>/<repo>/<name>` — but `WorktreeManager` actually creates worktrees at `<base>/<name>/<repo>`. So `verifyWorkspaceExists` checked the wrong path (`.../worktrees/posthog/plucky-summit-59`), found nothing, and reported every human-readable worktree as missing.

That alone would show an error state — but `verifyWorkspaceExists` (a read-only tRPC query) compounded it by **permanently deleting** the workspace/worktree DB rows on a missing path, so the association was destroyed on relaunch.

**Why:** the name no longer indicates the layout, and a verify/read call should never mutate state.

## Changes

- **`deriveWorktreePath` is now filesystem-aware** — prefer the new layout, fall back to legacy only when that's the one on disk (mirrors the suspension/archive resolvers). Fixes the path mismatch at the source.
- **`verifyWorkspaceExists` is non-destructive** — it only reports `{ exists, missingPath }`; association removal happens solely via the explicit `deleteWorkspace` flow. Safety net so a transient/incorrect missing path can never wipe data again.
- Unit tests for both.

## How did you test this?

- Added and ran `worktree-helpers.test.ts` and `service.verify.test.ts` (6 tests, all passing).
- Typechecked the changed files (clean; remaining repo typecheck errors are unbuilt workspace packages in the fresh checkout, unrelated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1781044711016799)*