### PR TITLE
chore(ci): Temporarily disable scheduled code releases

### DIFF
--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -1,8 +1,9 @@
 name: Tag PostHog Code Release
 
 on:
-  schedule:
-    - cron: "0 1,17 * * *"
+  # Scheduled releases temporarily disabled, uncomment to re-enable
+  # schedule:
+  #   - cron: "0 1,17 * * *"
   workflow_dispatch:
     inputs:
       quiet_retries:


### PR DESCRIPTION
I'm pausing the auto-releases for now without losing the ability to release on demand, just add "Create Release" on a PR before it merges to create one. I'm doing this to get the upcoming refactor in, going to do a minor bump and handoff to Jonathan when he's up.