### PR TITLE
chore(ci): Enable scheduled code releases

### DIFF
--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -1,9 +1,8 @@
 name: Tag PostHog Code Release
 
 on:
-  # Scheduled releases temporarily disabled, uncomment to re-enable
-  # schedule:
-  #   - cron: "0 1,17 * * *"
+  schedule:
+    - cron: "0 1,17 * * *"
   workflow_dispatch:
     inputs:
       quiet_retries:


### PR DESCRIPTION
Reverts PostHog/code#2562

I disabled auto releases because @jonathanlab is merging the refactor here shortly (within an hour or so)

Stable release (pre-refactor): [v0.53.124](https://github.com/PostHog/code/releases/tag/v0.53.124)
Stable commit: [dbf6b5120e828bbe7f627730f3d00992322d99f4](https://github.com/PostHog/code/commit/dbf6b5120e828bbe7f627730f3d00992322d99f4)

If we need to revert the main branch, revert to the stable commit and force-push (**not the stable release!**). Please keep in mind we'll need to cherry-pick any changes merged after the refactor, hopefully this scenario does not occur.

**Why was this not merged iteratively?** It's one of those rare situations where doing this iteratively would of been more of a pain than all at-once, because this is going to break all in-flight PR's and you don't want to KEEP doing that and have 80+ PR's on various versions of the codebase and package structures. At least now, we have a migration guide that makes it very easy for an agent to update each in-flight PR to the newest structure!