### PR TITLE
fix(auth): retry org fetch so a transient blip can't reset the project

### DIFF
--- a/apps/code/src/main/services/auth/service.test.ts
+++ b/apps/code/src/main/services/auth/service.test.ts
@@ -573,6 +573,180 @@ describe("AuthService", () => {
     });
   });
 
+  describe("transient org fetch failures", () => {
+    it("retries the org fetch on a transient network failure and keeps the selected project", async () => {
+      seedStoredSession({ selectedProjectId: 84 });
+      vi.mocked(oauthService.refreshToken).mockResolvedValue(
+        mockTokenResponse(),
+      );
+
+      let orgCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | Request) => {
+          const url = typeof input === "string" ? input : input.url;
+
+          if (url.includes("/api/users/@me/")) {
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                uuid: "user-1",
+                organization: { id: "org-1" },
+              }),
+            } as unknown as Response;
+          }
+
+          if (/\/api\/organizations\/[^/]+\/$/.test(url)) {
+            orgCallCount++;
+            if (orgCallCount === 1) {
+              throw new TypeError("fetch failed");
+            }
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                name: "Org 1",
+                teams: [
+                  { id: 42, name: "Project 42" },
+                  { id: 84, name: "Project 84" },
+                ],
+              }),
+            } as unknown as Response;
+          }
+
+          return {
+            ok: true,
+            json: vi.fn().mockResolvedValue({ has_access: true }),
+          } as unknown as Response;
+        }) as typeof fetch,
+      );
+
+      await service.initialize();
+
+      expect(orgCallCount).toBe(2);
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        currentProjectId: 84,
+        orgProjectsMap: {
+          "org-1": {
+            orgName: "Org 1",
+            projects: [
+              { id: 42, name: "Project 42" },
+              { id: 84, name: "Project 84" },
+            ],
+          },
+        },
+      });
+    });
+
+    it("preserves previously-known projects and the selected project when the org fetch fails on refresh", async () => {
+      const orgs = {
+        "org-1": {
+          name: "Org 1",
+          projects: [
+            { id: 42, name: "Project 42" },
+            { id: 84, name: "Project 84" },
+          ],
+        },
+      };
+      vi.mocked(oauthService.startFlow).mockResolvedValue(mockTokenResponse());
+      vi.mocked(oauthService.refreshToken).mockResolvedValue(
+        mockTokenResponse(),
+      );
+      stubAuthFetch({ orgs });
+
+      await service.login("us");
+      await service.selectProject(84);
+
+      let orgCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | Request) => {
+          const url = typeof input === "string" ? input : input.url;
+
+          if (url.includes("/api/users/@me/")) {
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                uuid: "user-1",
+                organization: { id: "org-1" },
+              }),
+            } as unknown as Response;
+          }
+
+          if (/\/api\/organizations\/[^/]+\/$/.test(url)) {
+            orgCallCount++;
+            throw new TypeError("fetch failed");
+          }
+
+          return {
+            ok: true,
+            json: vi.fn().mockResolvedValue({ has_access: true }),
+          } as unknown as Response;
+        }) as typeof fetch,
+      );
+
+      await service.refreshAccessToken();
+
+      expect(orgCallCount).toBe(3);
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        currentProjectId: 84,
+        orgProjectsMap: {
+          "org-1": {
+            orgName: "Org 1",
+            projects: [
+              { id: 42, name: "Project 42" },
+              { id: 84, name: "Project 84" },
+            ],
+          },
+        },
+      });
+    });
+
+    it("does not retry org fetch on a 4xx response", async () => {
+      seedStoredSession({ selectedProjectId: 84 });
+      vi.mocked(oauthService.refreshToken).mockResolvedValue(
+        mockTokenResponse(),
+      );
+
+      let orgCallCount = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | Request) => {
+          const url = typeof input === "string" ? input : input.url;
+
+          if (url.includes("/api/users/@me/")) {
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                uuid: "user-1",
+                organization: { id: "org-1" },
+              }),
+            } as unknown as Response;
+          }
+
+          if (/\/api\/organizations\/[^/]+\/$/.test(url)) {
+            orgCallCount++;
+            return {
+              ok: false,
+              status: 403,
+              json: vi.fn().mockResolvedValue({}),
+            } as unknown as Response;
+          }
+
+          return {
+            ok: true,
+            json: vi.fn().mockResolvedValue({ has_access: true }),
+          } as unknown as Response;
+        }) as typeof fetch,
+      );
+
+      await service.initialize();
+
+      expect(orgCallCount).toBe(1);
+    });
+  });
+
   describe("switchOrg", () => {
     const twoOrgs = {
       "org-1": {

--- a/apps/code/src/main/services/auth/service.ts
+++ b/apps/code/src/main/services/auth/service.ts
@@ -580,6 +580,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       tokenResponse.access_token,
       options.cloudRegion,
       scopedOrgIds,
+      this.session?.orgProjectsMap ?? {},
     );
     const lastPrefs = accountKey
       ? this.authPreferenceRepository.get(accountKey, options.cloudRegion)
@@ -609,6 +610,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     accessToken: string,
     cloudRegion: CloudRegion,
     orgIds: string[],
+    previousMap: OrgProjectsMap,
   ): Promise<OrgProjectsMap> {
     const entries = await Promise.all(
       orgIds.map(async (orgId): Promise<[string, OrgProjects]> => {
@@ -617,7 +619,13 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
           cloudRegion,
           orgId,
         );
-        return [orgId, result ?? { orgName: "(unknown)", projects: [] }];
+        if (result) {
+          return [orgId, result];
+        }
+        return [
+          orgId,
+          previousMap[orgId] ?? { orgName: "(unknown)", projects: [] },
+        ];
       }),
     );
 
@@ -640,6 +648,41 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     cloudRegion: CloudRegion,
     orgId: string,
   ): Promise<OrgProjects | null> {
+    for (
+      let attempt = 0;
+      attempt < AuthService.ORG_FETCH_MAX_ATTEMPTS;
+      attempt++
+    ) {
+      const result = await this.fetchOrgWithProjectsOnce(
+        accessToken,
+        cloudRegion,
+        orgId,
+      );
+      if (result.ok) {
+        return result.data;
+      }
+      if (!result.retryable) {
+        break;
+      }
+
+      const isLastAttempt = attempt === AuthService.ORG_FETCH_MAX_ATTEMPTS - 1;
+      if (isLastAttempt) {
+        break;
+      }
+
+      log.warn("Transient org fetch failure, retrying", { orgId, attempt });
+      await sleepWithBackoff(attempt, AuthService.REFRESH_BACKOFF);
+    }
+
+    return null;
+  }
+  private async fetchOrgWithProjectsOnce(
+    accessToken: string,
+    cloudRegion: CloudRegion,
+    orgId: string,
+  ): Promise<
+    { ok: true; data: OrgProjects } | { ok: false; retryable: boolean }
+  > {
     const apiHost = getCloudUrlFromRegion(cloudRegion);
     try {
       const res = await this.executeAuthenticatedFetch(
@@ -648,7 +691,9 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
         {},
         accessToken,
       );
-      if (!res.ok) return null;
+      if (!res.ok) {
+        return { ok: false, retryable: res.status >= 500 };
+      }
       const raw = (await res.json().catch(() => null)) as {
         name?: unknown;
         teams?: unknown;
@@ -662,10 +707,10 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
         .map((t) => t as { id?: unknown; name?: unknown })
         .filter((t) => typeof t.id === "number" && typeof t.name === "string")
         .map((t) => ({ id: t.id as number, name: t.name as string }));
-      return { orgName, projects };
+      return { ok: true, data: { orgName, projects } };
     } catch (error) {
       log.warn("Failed to fetch org with projects", { orgId, error });
-      return null;
+      return { ok: false, retryable: true };
     }
   }
   private async authenticateWithFlow(
@@ -857,6 +902,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     }
   }
   private static readonly REFRESH_MAX_ATTEMPTS = 3;
+  private static readonly ORG_FETCH_MAX_ATTEMPTS = 3;
   private static readonly REFRESH_BACKOFF: BackoffOptions = {
     initialDelayMs: 1_000,
     maxDelayMs: 5_000,


### PR DESCRIPTION
## Problem

A transient network failure on `GET /api/organizations/{orgId}/` during session refresh silently wiped the user's selected project. From the logs:

```
(auth-service) Failed to fetch org with projects { orgId: '...', error: 'TypeError: fetch failed' }
```

a single dropped request returned `null`, which got substituted with `{ orgName: "(unknown)", projects: [] }`. `pickInitialProjectId` then ran against an empty list, couldn't find the preferred id, and returned `null`, wiping the selection. When projects reloaded, the UI landed on a default project, perceived as a random switch.

## Changes

1. split `fetchOrgWithProjects` into a single-attempt `fetchOrgWithProjectsOnce` (returns a discriminated `{ ok, retryable }` result) wrapped in a retry loop
2. `buildOrgProjectsMap` now takes the previous `orgProjectsMap` and, when a fetch still fails after retries, falls back to the previously-known projects for that org instead of empty