### PR TITLE
fix(models): remove Fable from model pickers until ZDR is sorted

### DIFF
--- a/apps/mobile/src/features/tasks/composer/options.ts
+++ b/apps/mobile/src/features/tasks/composer/options.ts
@@ -37,12 +37,6 @@ export interface ModelOption {
 
 export const MODELS: ModelOption[] = [
   {
-    value: "claude-fable-5",
-    label: "Claude Fable 5",
-    description: "Newest, most capable",
-    supportsReasoning: true,
-  },
-  {
     value: "claude-opus-4-8",
     label: "Claude Opus 4.8",
     description: "Most capable, slower",

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -46,6 +46,12 @@ describe("formatGatewayModelName", () => {
     expect(isBlockedModelId("ANTHROPIC/CLAUDE-HAIKU-4-5")).toBe(true);
   });
 
+  it("blocks Fable until data retention / ZDR is resolved", () => {
+    expect(isBlockedModelId("claude-fable-5")).toBe(true);
+    expect(isBlockedModelId("anthropic/claude-fable-5")).toBe(true);
+    expect(isBlockedModelId("ANTHROPIC/CLAUDE-FABLE-5")).toBe(true);
+  });
+
   it("blocks deprecated Codex gateway models", () => {
     expect(isBlockedModelId("gpt-5.2")).toBe(true);
     expect(isBlockedModelId("gpt-5.3")).toBe(true);

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -36,6 +36,10 @@ const BLOCKED_MODELS = new Set([
   "anthropic/claude-sonnet-4-5",
   "claude-haiku-4-5",
   "anthropic/claude-haiku-4-5",
+  // Fable is temporarily blocked: it requires data retention to be enabled,
+  // which conflicts with our ZDR requirement, so it fails when selected.
+  "claude-fable-5",
+  "anthropic/claude-fable-5",
 ]);
 
 export function isBlockedModelId(modelId: string): boolean {


### PR DESCRIPTION
## Problem

Fable is selectable in the model pickers but doesn't actually work: it requires Anthropic data retention to be enabled, which conflicts with our ZDR requirement, so picking it just fails (the message is sent but no LLM is invoked). Until the ZDR/data-retention issue is resolved, the model shouldn't be offered.

## Changes

- Add `claude-fable-5` (and the `anthropic/` prefixed id) to `BLOCKED_MODELS` in `packages/agent/src/gateway-models.ts`, so it's filtered out of the gateway-fed desktop model list.
- Remove the hardcoded Fable entry from the mobile composer model picker.

## How did you test this?

- `pnpm --filter agent test gateway-models` — passes, including the new case asserting Fable is blocked.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781076716530809?thread_ts=1781076716.530809&cid=C09G8Q32R6F)*
