### PR TITLE
fix(ci): publish release when macOS builds, even if other platforms fail

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -370,6 +370,10 @@ jobs:
 
   finalize-release:
     needs: [publish-macos, publish-windows, publish-linux]
+    # macOS is the primary platform: publish the release as long as macOS built
+    # successfully, even if Windows or Linux failed. always() is required so this
+    # job isn't skipped when a non-macOS publish job fails.
+    if: always() && needs.publish-macos.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
macOS is the primary platform, so gate `finalize-release` on `publish-macos` succeeding, with `always()` so a Windows or Linux failure no longer skips the job