### PR TITLE
ci: pin publish-windows runner to windows-2022

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -200,7 +200,7 @@ jobs:
 
   publish-windows:
     needs: [prepare-release]
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary

Pins the `publish-windows` job runner in the code-release workflow from `windows-latest` to `windows-2022` 
```diff
   publish-windows:
     needs: [prepare-release]
-    runs-on: windows-latest
+    runs-on: windows-2022
```

## Test plan

- CI workflow change only; validated on the next scheduled/triggered code release run.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*