### PR TITLE
feat(cloud-agent): harden signed-git tools against base-branch merge leaks

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1362,7 +1362,12 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // push` are blocked by the PreToolUse guard (and the sandbox git shim), so
     // the agent commits via the signed-commit tool instead.
     const localToolsServer = createLocalToolsMcpServer(
-      { cwd, token: resolveGithubToken(), taskId },
+      {
+        cwd,
+        token: resolveGithubToken(),
+        taskId,
+        baseBranch: meta?.baseBranch,
+      },
       meta,
     );
     if (localToolsServer) {

--- a/packages/agent/src/adapters/claude/mcp/local-tools.test.ts
+++ b/packages/agent/src/adapters/claude/mcp/local-tools.test.ts
@@ -43,7 +43,10 @@ describe("createLocalToolsMcpServer", () => {
     await client.connect(clientTransport);
 
     const { tools } = await client.listTools();
-    expect(tools.map((t) => t.name)).toContain("git_signed_commit");
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("git_signed_commit");
+    expect(names).toContain("git_signed_merge");
+    expect(names).toContain("git_signed_rewrite");
 
     await client.close();
   });

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -155,6 +155,8 @@ export type NewSessionMeta = {
   allowedDomains?: string[];
   /** Model ID to use for this session (e.g. "claude-sonnet-4-6") */
   model?: string;
+  /** Base branch of the task's repo (e.g. "master"), for the signed-git tools. */
+  baseBranch?: string;
   jsonSchema?: Record<string, unknown> | null;
   mcpToolApprovals?: McpToolApprovals;
   claudeCode?: {

--- a/packages/agent/src/adapters/codex/codex-agent.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.ts
@@ -109,6 +109,7 @@ interface NewSessionMeta {
   systemPrompt?: string;
   permissionMode?: string;
   model?: string;
+  baseBranch?: string;
   persistence?: { taskId?: string; runId?: string; logUrl?: string };
   claudeCode?: {
     options?: Record<string, unknown>;
@@ -633,6 +634,7 @@ export class CodexAcpAgent extends BaseAcpAgent {
       cwd,
       token: resolveGithubToken(),
       taskId: resolveTaskId(meta),
+      baseBranch: meta?.baseBranch,
     };
     const tools = enabledLocalTools(ctx, meta);
     if (tools.length === 0) {

--- a/packages/agent/src/adapters/codex/local-tools-mcp-server.ts
+++ b/packages/agent/src/adapters/codex/local-tools-mcp-server.ts
@@ -31,7 +31,12 @@ if (!ctxEnv) {
   die("POSTHOG_LOCAL_TOOLS_CTX env var is required");
 }
 
-let parsed: { cwd: string; taskId?: string; token?: string };
+let parsed: {
+  cwd: string;
+  taskId?: string;
+  token?: string;
+  baseBranch?: string;
+};
 try {
   parsed = JSON.parse(Buffer.from(ctxEnv, "base64").toString("utf-8"));
 } catch (err) {
@@ -46,6 +51,7 @@ const ctx: LocalToolCtx = {
   cwd: parsed.cwd,
   token: parsed.token ?? readGithubTokenFromEnv(),
   taskId: parsed.taskId,
+  baseBranch: parsed.baseBranch,
 };
 
 const enabledNames = (process.env.POSTHOG_LOCAL_TOOLS_ENABLED ?? "")

--- a/packages/agent/src/adapters/local-tools/index.ts
+++ b/packages/agent/src/adapters/local-tools/index.ts
@@ -1,5 +1,6 @@
 import type { LocalTool, LocalToolCtx, LocalToolGateMeta } from "./registry";
 import { signedCommitTool } from "./tools/signed-commit";
+import { signedMergeTool } from "./tools/signed-merge";
 import { signedRewriteTool } from "./tools/signed-rewrite";
 
 export {
@@ -12,7 +13,11 @@ export {
 } from "./registry";
 
 /** Every tool the general local MCP server can expose. Add new tools here. */
-export const LOCAL_TOOLS: LocalTool[] = [signedCommitTool, signedRewriteTool];
+export const LOCAL_TOOLS: LocalTool[] = [
+  signedCommitTool,
+  signedMergeTool,
+  signedRewriteTool,
+];
 
 /** Tools whose gate passes for the given context — the set to actually expose. */
 export function enabledLocalTools(

--- a/packages/agent/src/adapters/local-tools/registry.ts
+++ b/packages/agent/src/adapters/local-tools/registry.ts
@@ -15,6 +15,11 @@ export interface LocalToolCtx {
   /** GitHub token available to the sandbox, if any. */
   token?: string;
   taskId?: string;
+  /**
+   * Base branch of the task's repo (e.g. "master"); the signed-git tools fall
+   * back to origin/HEAD detection when unset.
+   */
+  baseBranch?: string;
 }
 
 /** Minimal session-meta shape needed to gate tools (e.g. cloud-only). */

--- a/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
@@ -76,6 +76,19 @@ describe("signed-commit tool handler", () => {
     expect(input).toEqual({ message: "chore: bump" });
   });
 
+  it("forwards baseBranch from the tool context", async () => {
+    await signedCommitTool.handler(
+      {
+        cwd: "/tmp/workspace/repos/posthog/code",
+        token: "ghs_x",
+        baseBranch: "master",
+      },
+      { message: "chore: bump" },
+    );
+    const [ctx] = createSignedCommit.mock.calls[0];
+    expect(ctx.baseBranch).toBe("master");
+  });
+
   it("returns the no-token error without invoking createSignedCommit", async () => {
     const savedGh = process.env.GH_TOKEN;
     const savedGithub = process.env.GITHUB_TOKEN;

--- a/packages/agent/src/adapters/local-tools/tools/signed-git-tool.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-git-tool.ts
@@ -42,7 +42,10 @@ export function defineSignedGitTool<S extends z.ZodRawShape, R>(opts: {
         unknown
       >;
       const cwd = argCwd ? path.resolve(ctx.cwd, argCwd) : ctx.cwd;
-      return opts.run({ cwd, token, taskId: ctx.taskId }, input as R);
+      return opts.run(
+        { cwd, token, taskId: ctx.taskId, baseBranch: ctx.baseBranch },
+        input as R,
+      );
     },
   });
 }

--- a/packages/agent/src/adapters/local-tools/tools/signed-merge.test.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-merge.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createSignedMerge = vi.fn();
+
+vi.mock("@posthog/git/signed-commit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@posthog/git/signed-commit")>();
+  return {
+    ...actual,
+    createSignedMerge: (...args: unknown[]) => createSignedMerge(...args),
+  };
+});
+
+// Importing the tool after the mock so its transitive `createSignedMerge`
+// reference resolves to the mock above.
+const { signedMergeTool } = await import("./signed-merge");
+
+describe("signed-merge tool handler", () => {
+  beforeEach(() => {
+    createSignedMerge.mockReset();
+    createSignedMerge.mockResolvedValue({
+      branch: "posthog-code/feature",
+      base: "master",
+      merged: true,
+      commit: {
+        sha: "deadbeef",
+        url: "https://github.com/x/y/commit/deadbeef",
+      },
+    });
+  });
+
+  it("defaults to the session cwd when args.cwd is absent", async () => {
+    await signedMergeTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      {},
+    );
+    const [ctx] = createSignedMerge.mock.calls[0];
+    expect(ctx.cwd).toBe("/tmp/workspace/repos/posthog/code");
+  });
+
+  it("resolves a relative args.cwd against the session cwd", async () => {
+    await signedMergeTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      { cwd: "../posthog" },
+    );
+    const [ctx] = createSignedMerge.mock.calls[0];
+    expect(ctx.cwd).toBe("/tmp/workspace/repos/posthog/posthog");
+  });
+
+  it("does not forward cwd to createSignedMerge input", async () => {
+    await signedMergeTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      { base: "master", cwd: "/elsewhere" },
+    );
+    const [, input] = createSignedMerge.mock.calls[0];
+    expect(input).not.toHaveProperty("cwd");
+    expect(input).toEqual({ base: "master" });
+  });
+
+  it("forwards baseBranch from the tool context", async () => {
+    await signedMergeTool.handler(
+      {
+        cwd: "/tmp/workspace/repos/posthog/code",
+        token: "ghs_x",
+        baseBranch: "master",
+      },
+      {},
+    );
+    const [ctx] = createSignedMerge.mock.calls[0];
+    expect(ctx.baseBranch).toBe("master");
+  });
+
+  it("returns the no-token error without invoking createSignedMerge", async () => {
+    const savedGh = process.env.GH_TOKEN;
+    const savedGithub = process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    try {
+      const result = await signedMergeTool.handler(
+        { cwd: "/tmp/workspace/repos/posthog/code" },
+        {},
+      );
+      expect(result.isError).toBe(true);
+      expect(createSignedMerge).not.toHaveBeenCalled();
+    } finally {
+      if (savedGh !== undefined) process.env.GH_TOKEN = savedGh;
+      if (savedGithub !== undefined) process.env.GITHUB_TOKEN = savedGithub;
+    }
+  });
+
+  it("formats an up-to-date result without a commit list", async () => {
+    createSignedMerge.mockResolvedValue({
+      branch: "posthog-code/feature",
+      base: "master",
+      merged: false,
+    });
+    const result = await signedMergeTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      {},
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("already up to date");
+  });
+
+  it("surfaces a local-sync warning alongside the merge commit", async () => {
+    createSignedMerge.mockResolvedValue({
+      branch: "posthog-code/feature",
+      base: "master",
+      merged: true,
+      commit: {
+        sha: "deadbeef",
+        url: "https://github.com/x/y/commit/deadbeef",
+      },
+      localSyncWarning: "the merge is on the remote, but syncing failed",
+    });
+    const result = await signedMergeTool.handler(
+      { cwd: "/tmp/workspace/repos/posthog/code", token: "ghs_x" },
+      {},
+    );
+    expect(result.content[0].text).toContain("deadbeef");
+    expect(result.content[0].text).toContain("Warning:");
+  });
+});

--- a/packages/agent/src/adapters/local-tools/tools/signed-merge.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-merge.ts
@@ -1,0 +1,14 @@
+import {
+  runSignedMergeTool,
+  SIGNED_MERGE_TOOL_DESCRIPTION,
+  SIGNED_MERGE_TOOL_NAME,
+  signedMergeToolSchema,
+} from "../../signed-commit-shared";
+import { defineSignedGitTool } from "./signed-git-tool";
+
+export const signedMergeTool = defineSignedGitTool({
+  name: SIGNED_MERGE_TOOL_NAME,
+  description: SIGNED_MERGE_TOOL_DESCRIPTION,
+  schema: signedMergeToolSchema,
+  run: runSignedMergeTool,
+});

--- a/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/packages/agent/src/adapters/signed-commit-shared.ts
@@ -195,7 +195,7 @@ export async function runSignedMergeTool(
     }
     const lines = [
       `Merged ${result.base} into ${result.branch}:`,
-      `- ${result.commit?.sha} ${result.commit?.url}`,
+      `- ${result.commit.sha} ${result.commit.url}`,
     ];
     if (result.localSyncWarning) {
       lines.push(`Warning: ${result.localSyncWarning}`);

--- a/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/packages/agent/src/adapters/signed-commit-shared.ts
@@ -1,9 +1,11 @@
 import {
   createSignedCommit,
+  createSignedMerge,
   createSignedRewrite,
   type SignedCommitCtx,
   type SignedCommitInput,
   type SignedCommitResult,
+  type SignedMergeInput,
   type SignedRewriteInput,
 } from "@posthog/git/signed-commit";
 import { z } from "zod";
@@ -26,7 +28,9 @@ export const SIGNED_COMMIT_TOOL_DESCRIPTION =
   "first (or pass `paths`), then call this instead of `git commit`/`git push` — those are " +
   "blocked because all commits must be signed. The commit is created via GitHub's API and " +
   "your local checkout is kept in sync. For a new branch, pass `branch` (prefixed with " +
-  "`posthog-code/`) and the tool creates it on the remote.";
+  "`posthog-code/`) and the tool creates it on the remote. Refuses while a merge/rebase/" +
+  "cherry-pick is in progress, and refuses staged files that copy base-branch content into " +
+  "the PR — to bring the base branch in, use `git_signed_merge` instead.";
 
 export const signedCommitToolSchema = {
   message: z.string().describe("Commit headline (first line)."),
@@ -60,10 +64,11 @@ export const SIGNED_REWRITE_QUALIFIED_TOOL_NAME = qualifiedLocalToolName(
 
 export const SIGNED_REWRITE_TOOL_DESCRIPTION =
   "Force-update a branch with GitHub-signed (Verified) history, the signed-commit equivalent " +
-  "of `git push --force`. First rebase/merge locally with normal `git` (resolving conflicts and " +
+  "of `git push --force`. First rebase locally with normal `git` (resolving conflicts and " +
   "finishing with `git rebase --continue`, NOT `git commit`); then call this to republish the " +
   "branch's commits as Verified and atomically move the remote branch onto them. Use this to " +
-  "update an existing PR after a rebase or conflict fix. Rewrites the current branch by default.";
+  "update an existing PR after a rebase or conflict fix. Rewrites the current branch by default. " +
+  "Histories containing merge commits are refused — rebase (which flattens merges) first.";
 
 export const signedRewriteToolSchema = {
   branch: z
@@ -82,6 +87,37 @@ export const signedRewriteToolSchema = {
     .optional()
     .describe(
       "Path to the git checkout to rewrite; defaults to the session's working directory. " +
+        "Relative paths resolve against the session cwd.",
+    ),
+};
+
+export const SIGNED_MERGE_TOOL_NAME = "git_signed_merge";
+export const SIGNED_MERGE_QUALIFIED_TOOL_NAME = qualifiedLocalToolName(
+  SIGNED_MERGE_TOOL_NAME,
+);
+
+export const SIGNED_MERGE_TOOL_DESCRIPTION =
+  "Merge the base branch INTO the current PR branch as a GitHub-signed (Verified) " +
+  'two-parent merge commit, created server-side (the API behind GitHub\'s "Update branch" ' +
+  "button). Use this to bring a PR up to date with its base — NEVER run `git merge` and " +
+  "then `git_signed_commit`: that linearizes the merge and floods the PR with base-branch " +
+  "changes. If GitHub reports a conflict, rebase locally (`git rebase origin/<base>`) and " +
+  "use `git_signed_rewrite` instead.";
+
+export const signedMergeToolSchema = {
+  branch: z
+    .string()
+    .optional()
+    .describe("PR branch to update; defaults to the current branch."),
+  base: z
+    .string()
+    .optional()
+    .describe("Branch to merge in; defaults to the repo's base branch."),
+  cwd: z
+    .string()
+    .optional()
+    .describe(
+      "Path to the git checkout to merge in; defaults to the session's working directory. " +
         "Relative paths resolve against the session cwd.",
     ),
 };
@@ -139,4 +175,39 @@ export function runSignedRewriteTool(
     ctx,
     args,
   );
+}
+
+export async function runSignedMergeTool(
+  ctx: SignedCommitCtx,
+  args: SignedMergeInput,
+): Promise<SignedCommitToolResult> {
+  try {
+    const result = await createSignedMerge(ctx, args);
+    if (!result.merged) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${result.branch} is already up to date with ${result.base} — nothing to merge.`,
+          },
+        ],
+      };
+    }
+    const lines = [
+      `Merged ${result.base} into ${result.branch}:`,
+      `- ${result.commit?.sha} ${result.commit?.url}`,
+    ];
+    if (result.localSyncWarning) {
+      lines.push(`Warning: ${result.localSyncWarning}`);
+    }
+    return { content: [{ type: "text", text: lines.join("\n") }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        { type: "text", text: `${SIGNED_MERGE_TOOL_NAME} failed: ${message}` },
+      ],
+      isError: true,
+    };
+  }
 }

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -27,6 +27,7 @@ import {
 } from "../adapters/error-classification";
 import {
   SIGNED_COMMIT_QUALIFIED_TOOL_NAME,
+  SIGNED_MERGE_QUALIFIED_TOOL_NAME,
   SIGNED_REWRITE_QUALIFIED_TOOL_NAME,
 } from "../adapters/signed-commit-shared";
 import type { PermissionMode } from "../execution-mode";
@@ -1051,6 +1052,7 @@ export class AgentServer {
         allowedDomains: this.config.allowedDomains,
         jsonSchema: preTask?.json_schema ?? null,
         permissionMode: initialPermissionMode,
+        ...(this.config.baseBranch && { baseBranch: this.config.baseBranch }),
         ...(this.config.claudeCode?.plugins?.length && {
           claudeCode: {
             options: {
@@ -1716,12 +1718,24 @@ It creates a GitHub-signed ("Verified") commit on the branch and keeps your loca
 sync. To start a new branch, pass \`branch\` (prefixed with \`posthog-code/\`) — the tool creates
 it on the remote for you.
 
+## Updating from the base branch
+To bring the base branch into your PR branch, call the \`git_signed_merge\` tool (full name
+\`${SIGNED_MERGE_QUALIFIED_TOOL_NAME}\`) — it creates a Verified two-parent merge commit
+server-side (like GitHub's "Update branch" button). NEVER run \`git merge\` followed by
+\`git_signed_commit\`: a merge in progress is refused, because the commit API would linearize
+the merge and dump every base-branch change into your PR. If \`git_signed_merge\` reports a
+conflict, fix it with a rebase instead: \`git rebase origin/<base>\`, resolve, \`git rebase
+--continue\`, then call \`git_signed_rewrite\`.
+
 ## Rewriting / force-pushing (rebases, conflict fixes)
 \`git push --force\` is also blocked. To update a branch after a local rebase or conflict
-resolution, rebase/merge locally with normal \`git\` (resolve conflicts and finish with
+resolution, rebase locally with normal \`git\` (resolve conflicts and finish with
 \`git rebase --continue\`, NOT \`git commit\`), then call the \`git_signed_rewrite\` tool (full
 name \`${SIGNED_REWRITE_QUALIFIED_TOOL_NAME}\`). It republishes the branch's commits as Verified
 and atomically force-updates the remote branch. This is how you fix conflicts on an existing PR.
+Histories containing merge commits are refused — rebase (which flattens merges) first.
+If a signed-git tool refuses with a "merge in progress" or "leak" error, follow its recovery
+instructions instead of retrying the same call.
 
 ## Attribution
 Do NOT add "Co-Authored-By" trailers or "Generated with [Claude Code]" lines to your
@@ -1759,7 +1773,7 @@ This task already has an open pull request: ${prUrl}
 After completing the requested changes:
 1. Check out the existing PR branch with \`gh pr checkout ${prUrl}\`
 2. Stage your changes with \`git add\`, then call the \`git_signed_commit\` tool with a clear \`message\` (do NOT use \`git commit\`/\`git push\` — they are blocked). This commits to the existing PR branch.
-   - If the branch has conflicts with its base, fetch and rebase locally (\`git fetch origin <base>\`, \`git rebase origin/<base>\`, resolve, \`git rebase --continue\`), then call the \`git_signed_rewrite\` tool to force-update this same PR branch.
+   - If the branch is behind its base, call the \`git_signed_merge\` tool first — it merges the base in server-side with a Verified merge commit. Only if it reports a conflict: fetch and rebase locally (\`git fetch origin <base>\`, \`git rebase origin/<base>\`, resolve, \`git rebase --continue\`), then call the \`git_signed_rewrite\` tool to force-update this same PR branch.
 3. For every PR review comment or review thread you addressed, treat the thread as done only after BOTH of these:
    - Reply on the thread with a short note describing what changed (reference the commit SHA when useful) using \`gh api -X POST /repos/{owner}/{repo}/pulls/{n}/comments/{id}/replies -f body='...'\`.
    - Resolve the thread via the \`resolveReviewThread\` GraphQL mutation: \`gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id="<thread-node-id>"\`.

--- a/packages/git/src/signed-commit.test.ts
+++ b/packages/git/src/signed-commit.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   chunkFileChanges,
+  detectBaseLeaks,
+  interpretMergeApiResult,
   OversizedFileError,
+  operationInProgressError,
+  parseRawDiffZ,
+  type RawDiffEntry,
   splitCommitMessage,
 } from "./signed-commit";
 
@@ -91,5 +96,235 @@ describe("splitCommitMessage", () => {
     },
   ])("$name", ({ raw, expected }) => {
     expect(splitCommitMessage(raw)).toEqual(expected);
+  });
+});
+
+const ZERO_OID = "0".repeat(40);
+const OID_A = "a".repeat(40);
+const OID_B = "b".repeat(40);
+
+function rawEntry(
+  status: string,
+  path: string,
+  oldOid: string,
+  newOid: string,
+): string {
+  return `:100644 100644 ${oldOid} ${newOid} ${status}\0${path}\0`;
+}
+
+describe("parseRawDiffZ", () => {
+  it.each([
+    {
+      name: "modification",
+      input: rawEntry("M", "src/file.ts", OID_A, OID_B),
+      expected: [
+        { path: "src/file.ts", oldOid: OID_A, newOid: OID_B, status: "M" },
+      ],
+    },
+    {
+      name: "addition",
+      input: rawEntry("A", "new.ts", ZERO_OID, OID_A),
+      expected: [
+        { path: "new.ts", oldOid: ZERO_OID, newOid: OID_A, status: "A" },
+      ],
+    },
+    {
+      name: "deletion has the all-zeros new OID",
+      input: rawEntry("D", "gone.ts", OID_A, ZERO_OID),
+      expected: [
+        { path: "gone.ts", oldOid: OID_A, newOid: ZERO_OID, status: "D" },
+      ],
+    },
+    {
+      name: "type change",
+      input: rawEntry("T", "link", OID_A, OID_B),
+      expected: [{ path: "link", oldOid: OID_A, newOid: OID_B, status: "T" }],
+    },
+    {
+      name: "multiple entries",
+      input:
+        rawEntry("M", "a.ts", OID_A, OID_B) +
+        rawEntry("D", "b with spaces.ts", OID_B, ZERO_OID),
+      expected: [
+        { path: "a.ts", oldOid: OID_A, newOid: OID_B, status: "M" },
+        {
+          path: "b with spaces.ts",
+          oldOid: OID_B,
+          newOid: ZERO_OID,
+          status: "D",
+        },
+      ],
+    },
+    { name: "empty input", input: "", expected: [] },
+  ])("$name", ({ input, expected }) => {
+    expect(parseRawDiffZ(input)).toEqual(expected);
+  });
+});
+
+describe("detectBaseLeaks", () => {
+  const staged = (path: string, newOid: string): RawDiffEntry => ({
+    path,
+    oldOid: OID_A,
+    newOid,
+    status: newOid === ZERO_OID ? "D" : "M",
+  });
+
+  it.each([
+    {
+      name: "flags a staged file matching base content outside the PR diff",
+      staged: [staged("leaked.ts", OID_B)],
+      prFiles: new Set<string>(),
+      baseChanged: new Map([["leaked.ts", OID_B]]),
+      expected: ["leaked.ts"],
+    },
+    {
+      name: "exempts files already in the PR diff",
+      staged: [staged("mine.ts", OID_B)],
+      prFiles: new Set(["mine.ts"]),
+      baseChanged: new Map([["mine.ts", OID_B]]),
+      expected: [],
+    },
+    {
+      name: "exempts genuine edits to a base-touched file (OID differs)",
+      staged: [staged("contested.ts", OID_A)],
+      prFiles: new Set<string>(),
+      baseChanged: new Map([["contested.ts", OID_B]]),
+      expected: [],
+    },
+    {
+      name: "flags a staged deletion matching a base-side deletion",
+      staged: [staged("removed-on-base.ts", ZERO_OID)],
+      prFiles: new Set<string>(),
+      baseChanged: new Map([["removed-on-base.ts", ZERO_OID]]),
+      expected: ["removed-on-base.ts"],
+    },
+    {
+      name: "passes a PR-authored deletion of a base-untouched file",
+      staged: [staged("mine-to-delete.ts", ZERO_OID)],
+      prFiles: new Set<string>(),
+      baseChanged: new Map<string, string>(),
+      expected: [],
+    },
+    {
+      name: "empty staged set yields no leaks",
+      staged: [],
+      prFiles: new Set<string>(),
+      baseChanged: new Map([["x.ts", OID_B]]),
+      expected: [],
+    },
+    {
+      name: "mixed: only the base-matching outsider is flagged",
+      staged: [
+        staged("leaked.ts", OID_B),
+        staged("mine.ts", OID_B),
+        staged("edited.ts", OID_A),
+      ],
+      prFiles: new Set(["mine.ts"]),
+      baseChanged: new Map([
+        ["leaked.ts", OID_B],
+        ["mine.ts", OID_B],
+        ["edited.ts", OID_B],
+      ]),
+      expected: ["leaked.ts"],
+    },
+  ])("$name", ({ staged, prFiles, baseChanged, expected }) => {
+    expect(detectBaseLeaks(staged, prFiles, baseChanged)).toEqual(expected);
+  });
+});
+
+describe("operationInProgressError", () => {
+  it("explains linearization and both recovery paths for a merge", () => {
+    const msg = operationInProgressError("merge");
+    expect(msg).toContain("MERGE_HEAD");
+    expect(msg).toContain("LINEARIZE");
+    expect(msg).toContain("git merge --abort");
+    expect(msg).toContain("git_signed_merge");
+    expect(msg).toContain("git_signed_rewrite");
+  });
+
+  it("directs a rebase to --continue and git_signed_rewrite", () => {
+    const msg = operationInProgressError("rebase");
+    expect(msg).toContain("git rebase --continue");
+    expect(msg).toContain("git_signed_rewrite");
+  });
+
+  it("directs a cherry-pick to --continue/--abort", () => {
+    const msg = operationInProgressError("cherry-pick");
+    expect(msg).toContain("git cherry-pick --continue");
+  });
+});
+
+describe("interpretMergeApiResult", () => {
+  it.each([
+    {
+      name: "201 with a body is merged",
+      res: {
+        stdout: JSON.stringify({
+          sha: OID_A,
+          html_url: "https://github.com/o/r/commit/a",
+        }),
+        stderr: "",
+        exitCode: 0,
+      },
+      expected: {
+        kind: "merged",
+        sha: OID_A,
+        url: "https://github.com/o/r/commit/a",
+      },
+    },
+    {
+      name: "204 (empty body) is up-to-date",
+      res: { stdout: "", stderr: "", exitCode: 0 },
+      expected: { kind: "up-to-date" },
+    },
+    {
+      name: "whitespace-only body is up-to-date",
+      res: { stdout: "\n", stderr: "", exitCode: 0 },
+      expected: { kind: "up-to-date" },
+    },
+    {
+      name: "HTTP 409 is a conflict",
+      res: {
+        stdout: "",
+        stderr: "gh: Merge conflict (HTTP 409)",
+        exitCode: 1,
+      },
+      expected: { kind: "conflict" },
+    },
+    {
+      name: "HTTP 404 is forbidden",
+      res: { stdout: "", stderr: "gh: Not Found (HTTP 404)", exitCode: 1 },
+      expected: { kind: "forbidden" },
+    },
+    {
+      name: "HTTP 403 is forbidden",
+      res: { stdout: "", stderr: "gh: Forbidden (HTTP 403)", exitCode: 1 },
+      expected: { kind: "forbidden" },
+    },
+    {
+      name: "other failures surface the stderr",
+      res: { stdout: "", stderr: "boom", exitCode: 1 },
+      expected: { kind: "error", message: "boom" },
+    },
+  ])("$name", ({ res, expected }) => {
+    expect(interpretMergeApiResult(res)).toEqual(expected);
+  });
+
+  it("treats a 200 body without a sha as an error", () => {
+    const outcome = interpretMergeApiResult({
+      stdout: JSON.stringify({ message: "weird" }),
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(outcome.kind).toBe("error");
+  });
+
+  it("treats non-JSON success output as an error", () => {
+    const outcome = interpretMergeApiResult({
+      stdout: "<html>proxy error</html>",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(outcome.kind).toBe("error");
   });
 });

--- a/packages/git/src/signed-commit.ts
+++ b/packages/git/src/signed-commit.ts
@@ -3,8 +3,10 @@
 // which has no named exports. This module never runs in the browser.
 import * as childProcess from "node:child_process";
 import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { mapWithConcurrency } from "./concurrency";
-import { execGh, execGhWithRetry } from "./gh";
+import { execGh, execGhWithRetry, type GhExecResult } from "./gh";
 import { buildPostHogTrailers } from "./trailers";
 import { parseGithubUrl } from "./utils";
 
@@ -126,6 +128,64 @@ async function gitText(args: string[], cwd: string): Promise<string> {
   return r.stdout.toString("utf8").trim();
 }
 
+/** Conflicted/multi-parent git operation that may be mid-flight in a checkout. */
+export type GitOperationInProgress = "merge" | "rebase" | "cherry-pick";
+
+const OPERATION_MARKERS: readonly [string, GitOperationInProgress][] = [
+  ["MERGE_HEAD", "merge"],
+  ["CHERRY_PICK_HEAD", "cherry-pick"],
+  ["rebase-merge", "rebase"],
+  ["rebase-apply", "rebase"],
+];
+
+async function detectOperationInProgress(
+  cwd: string,
+): Promise<GitOperationInProgress | null> {
+  // `--git-path` resolves the marker locations correctly inside worktrees,
+  // returning paths relative to the process cwd.
+  const out = await gitText(
+    [
+      "rev-parse",
+      ...OPERATION_MARKERS.flatMap(([marker]) => ["--git-path", marker]),
+    ],
+    cwd,
+  );
+  const markerPaths = out.split("\n");
+  for (let i = 0; i < OPERATION_MARKERS.length; i++) {
+    const markerPath = markerPaths[i];
+    if (markerPath && fs.existsSync(path.resolve(cwd, markerPath))) {
+      return OPERATION_MARKERS[i][1];
+    }
+  }
+  return null;
+}
+
+/** Agent-facing refusal for publishing while a git operation is mid-flight. */
+export function operationInProgressError(op: GitOperationInProgress): string {
+  if (op === "merge") {
+    return (
+      "A merge is in progress (MERGE_HEAD exists). Commits are published via GitHub's " +
+      "createCommitOnBranch API, which can only create single-parent commits — committing " +
+      "a staged merge would LINEARIZE it, attributing every base-branch change since the " +
+      "branch point to this PR (this is how PRs balloon to 100k+ changed lines). " +
+      "Recovery: run `git merge --abort`, then either call `git_signed_merge` to merge the " +
+      "base branch server-side (clean merges), or run `git rebase origin/<base>`, resolve " +
+      "conflicts, finish with `git rebase --continue`, and call `git_signed_rewrite`."
+    );
+  }
+  if (op === "rebase") {
+    return (
+      "A rebase is in progress. Finish it first — resolve conflicts, `git add` the files, " +
+      "then `git rebase --continue` (or back out with `git rebase --abort`) — and publish " +
+      "the rebased branch with `git_signed_rewrite`."
+    );
+  }
+  return (
+    "A cherry-pick is in progress. Finish it first with `git cherry-pick --continue` " +
+    "(or back out with `git cherry-pick --abort`), then retry."
+  );
+}
+
 async function resolveRepoNameWithOwner(ctx: SignedCommitCtx): Promise<string> {
   const url = await gitText(["remote", "get-url", "origin"], ctx.cwd);
   const parsed = parseGithubUrl(url);
@@ -225,6 +285,31 @@ function createRef(
       `sha=${sha}`,
     ],
     `Failed to create branch '${branch}'`,
+  );
+}
+
+/**
+ * Fast-forward-only ref update: GitHub rejects a non-fast-forward PATCH
+ * without `force`, so a concurrently moved branch fails safely instead of
+ * being clobbered.
+ */
+function fastForwardRef(
+  ctx: SignedCommitCtx,
+  repo: string,
+  branch: string,
+  sha: string,
+): Promise<void> {
+  return refApi(
+    ctx,
+    [
+      "api",
+      "-X",
+      "PATCH",
+      `/repos/${repo}/git/refs/heads/${branch}`,
+      "-f",
+      `sha=${sha}`,
+    ],
+    `Failed to fast-forward '${branch}'`,
   );
 }
 
@@ -385,6 +470,134 @@ export function chunkFileChanges(
   return chunks;
 }
 
+/** One entry of `git diff-index` / `git diff-tree` raw `-z` output. */
+export interface RawDiffEntry {
+  path: string;
+  oldOid: string;
+  /** All-zeros for deletions (and for an unmerged/dirty index entry). */
+  newOid: string;
+  /** Status letter: A/M/D/T/U… (`--no-renames` rules out two-path R/C entries). */
+  status: string;
+}
+
+/** Parses raw `-z` diff output: `:<oldmode> <newmode> <oldoid> <newoid> <status>\0<path>\0…` */
+export function parseRawDiffZ(text: string): RawDiffEntry[] {
+  const tokens = text.split("\0");
+  const entries: RawDiffEntry[] = [];
+  for (let i = 0; i + 1 < tokens.length; i += 2) {
+    const meta = tokens[i];
+    if (!meta.startsWith(":")) continue;
+    const fields = meta.slice(1).split(" ");
+    if (fields.length < 5) continue;
+    entries.push({
+      path: tokens[i + 1],
+      oldOid: fields[2],
+      newOid: fields[3],
+      status: fields[4],
+    });
+  }
+  return entries;
+}
+
+/**
+ * Staged files that would copy base-branch content into the PR: not part of
+ * the PR's existing diff, and staged with exactly the blob the base tip has
+ * (matching all-zero OIDs make a staged deletion of a base-deleted file a
+ * leak too, while PR-authored deletions of base-untouched files pass).
+ */
+export function detectBaseLeaks(
+  staged: readonly RawDiffEntry[],
+  prFiles: ReadonlySet<string>,
+  baseChanged: ReadonlyMap<string, string>,
+): string[] {
+  return staged
+    .filter((e) => !prFiles.has(e.path) && baseChanged.get(e.path) === e.newOid)
+    .map((e) => e.path);
+}
+
+const LEAK_SAMPLE_SIZE = 10;
+
+/**
+ * Hard gate against the mass-file-leak failure: a botched base-branch merge
+ * staged for `git_signed_commit` attributes every base-side change to the PR.
+ * Best-effort like `syncLocalCheckout` — environments where the base can't be
+ * resolved (no origin/HEAD, failed fetch, shallow history without a merge
+ * base) skip the check with a warning rather than blocking the commit.
+ */
+async function assertNoBaseLeak(
+  ctx: SignedCommitCtx,
+  branch: string,
+  tip: string,
+): Promise<void> {
+  const skip = (reason: string) => {
+    process.stderr.write(
+      `[signed-commit] base-leak check skipped: ${reason}\n`,
+    );
+  };
+
+  const base = await resolveBaseBranch(ctx);
+  if (!base || base === branch) return;
+
+  const fetched = await runGit(["fetch", "--no-tags", "origin", base], ctx.cwd);
+  if (fetched.exitCode !== 0) {
+    return skip(`fetch origin/${base} failed: ${fetched.stderr.trim()}`);
+  }
+  const baseTipRes = await runGit(
+    ["rev-parse", `refs/remotes/origin/${base}^{commit}`],
+    ctx.cwd,
+  );
+  if (baseTipRes.exitCode !== 0) {
+    return skip(`could not resolve origin/${base}`);
+  }
+  const baseTip = baseTipRes.stdout.toString("utf8").trim();
+
+  const mergeBaseRes = await runGit(["merge-base", baseTip, tip], ctx.cwd);
+  if (mergeBaseRes.exitCode !== 0) {
+    return skip(
+      `no merge base between origin/${base} and ${tip.slice(0, 12)} (shallow clone?)`,
+    );
+  }
+  const mergeBase = mergeBaseRes.stdout.toString("utf8").trim();
+  if (mergeBase === baseTip) return; // branch already contains the base tip
+
+  // Three metadata-only diffs (no content reads), so this stays fast even on
+  // very large repos. Plumbing output uses full blob OIDs, safe to compare.
+  const [stagedRaw, prNames, baseRaw] = await Promise.all([
+    gitText(["diff-index", "--cached", "-z", "--no-renames", tip], ctx.cwd),
+    gitText(
+      ["diff-tree", "-r", "-z", "--name-only", "--no-renames", mergeBase, tip],
+      ctx.cwd,
+    ),
+    gitText(
+      ["diff-tree", "-r", "-z", "--no-renames", mergeBase, baseTip],
+      ctx.cwd,
+    ),
+  ]);
+
+  const leaks = detectBaseLeaks(
+    parseRawDiffZ(stagedRaw),
+    new Set(prNames.split("\0").filter(Boolean)),
+    new Map(parseRawDiffZ(baseRaw).map((e) => [e.path, e.newOid])),
+  );
+  if (leaks.length === 0) return;
+
+  const sample = leaks.slice(0, LEAK_SAMPLE_SIZE).join("\n  ");
+  const more =
+    leaks.length > LEAK_SAMPLE_SIZE
+      ? `\n  …and ${leaks.length - LEAK_SAMPLE_SIZE} more`
+      : "";
+  throw new Error(
+    `Refusing to commit: ${leaks.length} staged file(s) exactly match origin/${base} ` +
+      "content but are not part of this PR's diff — committing them would copy " +
+      "base-branch changes into the PR (the mass-file-leak failure). This usually means " +
+      `a merge from the base branch was staged. Leaked files:\n  ${sample}${more}\n` +
+      "Recovery: unstage everything (`git reset`), restore base-owned files from the " +
+      "branch tip (`git checkout <tip> -- <paths>`), re-stage only the files you actually " +
+      "changed, and retry. To bring the base branch into the PR, call `git_signed_merge` " +
+      "instead.",
+  );
+}
+
 const CREATE_COMMIT_MUTATION = `mutation($input: CreateCommitOnBranchInput!) {
   createCommitOnBranch(input: $input) { commit { oid url } }
 }`;
@@ -477,16 +690,15 @@ async function syncLocalCheckout(
   }
 }
 
-async function publishChanges(
+async function publishChunks(
   ctx: SignedCommitCtx,
   repo: string,
   branch: string,
   baseOid: string,
   headline: string,
   body: string,
-  changes: FileChanges,
+  chunks: FileChanges[],
 ): Promise<{ commits: { sha: string; url: string }[]; tip: string }> {
-  const chunks = chunkFileChanges(changes, DEFAULT_MAX_PAYLOAD_BYTES);
   const commits: { sha: string; url: string }[] = [];
   let tip = baseOid;
   for (let i = 0; i < chunks.length; i++) {
@@ -509,10 +721,71 @@ async function publishChanges(
   return { commits, tip };
 }
 
+function publishChanges(
+  ctx: SignedCommitCtx,
+  repo: string,
+  branch: string,
+  baseOid: string,
+  headline: string,
+  body: string,
+  changes: FileChanges,
+): Promise<{ commits: { sha: string; url: string }[]; tip: string }> {
+  const chunks = chunkFileChanges(changes, DEFAULT_MAX_PAYLOAD_BYTES);
+  return publishChunks(ctx, repo, branch, baseOid, headline, body, chunks);
+}
+
+/**
+ * Like `publishChanges`, but a payload split across multiple commits is
+ * published to a scratch ref first and the real branch only moves once all
+ * chunks landed — a mid-flight failure can't leave partial "part i/n" commits
+ * on the branch. Single-chunk commits keep the direct fast path.
+ */
+async function publishChangesAtomic(
+  ctx: SignedCommitCtx,
+  repo: string,
+  branch: string,
+  baseOid: string,
+  headline: string,
+  body: string,
+  changes: FileChanges,
+): Promise<{ commits: { sha: string; url: string }[]; tip: string }> {
+  const chunks = chunkFileChanges(changes, DEFAULT_MAX_PAYLOAD_BYTES);
+  if (chunks.length === 1) {
+    return publishChunks(ctx, repo, branch, baseOid, headline, body, chunks);
+  }
+
+  const scratch = `posthog-code/commit-tmp/${crypto.randomUUID()}`;
+  await createRef(ctx, repo, scratch, baseOid);
+  try {
+    const published = await publishChunks(
+      ctx,
+      repo,
+      scratch,
+      baseOid,
+      headline,
+      body,
+      chunks,
+    );
+    // The chunk chain grew from `baseOid` (the branch tip we read), so this is
+    // a fast-forward; it fails safely if the branch moved meanwhile.
+    await fastForwardRef(ctx, repo, branch, published.tip);
+    return published;
+  } finally {
+    await deleteRef(ctx, repo, scratch).catch(() => {});
+  }
+}
+
 export async function createSignedCommit(
   ctx: SignedCommitCtx,
   input: SignedCommitInput,
 ): Promise<SignedCommitResult> {
+  // Refuse before touching the index: a staged merge/rebase/cherry-pick must
+  // never reach createCommitOnBranch, which would linearize it.
+  const op = await detectOperationInProgress(ctx.cwd);
+  if (op) {
+    throw new Error(operationInProgressError(op));
+  }
+
   // Repo (from origin remote) and branch (from HEAD) are independent reads.
   const [repo, branch] = await Promise.all([
     resolveRepoNameWithOwner(ctx),
@@ -546,11 +819,13 @@ export async function createSignedCommit(
     );
   }
 
+  await assertNoBaseLeak(ctx, branch, tip);
+
   const body = [input.body, buildPostHogTrailers(ctx.taskId).join("\n")]
     .filter(Boolean)
     .join("\n\n");
 
-  const { commits, tip: newTip } = await publishChanges(
+  const { commits, tip: newTip } = await publishChangesAtomic(
     ctx,
     repo,
     branch,
@@ -635,6 +910,22 @@ export async function createSignedRewrite(
     );
   }
 
+  // Replaying first-parent diffs across a local merge folds the entire
+  // merged-in branch into one giant commit attributed to this PR.
+  const mergeCount = await gitText(
+    ["rev-list", "--count", "--merges", `${onto}..HEAD`],
+    ctx.cwd,
+  );
+  if (mergeCount !== "0") {
+    throw new Error(
+      `Refusing to rewrite: ${onto.slice(0, 12)}..HEAD contains ${mergeCount} merge commit(s), ` +
+        "and replaying them would dump every merged-in change (e.g. the whole base branch) " +
+        "into this PR. Recovery: `git rebase origin/<base>` (a rebase flattens merges), " +
+        "resolve any conflicts, `git rebase --continue`, then retry git_signed_rewrite. " +
+        "To simply bring the base branch into the PR, use `git_signed_merge` instead.",
+    );
+  }
+
   const list = await gitText(
     ["rev-list", "--reverse", "--first-parent", `${onto}..HEAD`],
     ctx.cwd,
@@ -695,4 +986,205 @@ export async function createSignedRewrite(
     // bookkeeping, so a delete failure is non-fatal.
     await deleteRef(ctx, repo, scratch).catch(() => {});
   }
+}
+
+export interface SignedMergeInput {
+  /** PR branch to update; defaults to the current branch. */
+  branch?: string;
+  /** Branch (or sha) to merge in; defaults to the detected base branch. */
+  base?: string;
+}
+
+export interface SignedMergeResult {
+  branch: string;
+  base: string;
+  /** false when the branch already contained the base (HTTP 204). */
+  merged: boolean;
+  commit?: { sha: string; url: string };
+  /** Set when the remote merge succeeded but the local checkout could not be synced. */
+  localSyncWarning?: string;
+}
+
+export type MergeApiOutcome =
+  | { kind: "merged"; sha: string; url: string }
+  | { kind: "up-to-date" }
+  | { kind: "conflict" }
+  | { kind: "forbidden" }
+  | { kind: "error"; message: string };
+
+/** Pure mapping of a `gh api /repos/:repo/merges` result to a merge outcome. */
+export function interpretMergeApiResult(res: GhExecResult): MergeApiOutcome {
+  if (res.exitCode === 0) {
+    const body = res.stdout.trim();
+    if (!body) return { kind: "up-to-date" }; // HTTP 204: nothing to merge
+    try {
+      const parsed = JSON.parse(body) as { sha?: string; html_url?: string };
+      if (parsed.sha) {
+        return { kind: "merged", sha: parsed.sha, url: parsed.html_url ?? "" };
+      }
+    } catch {
+      // fall through to the generic error below
+    }
+    return {
+      kind: "error",
+      message: `unexpected merge response: ${body.slice(0, 300)}`,
+    };
+  }
+  const errText = `${res.stderr} ${res.error ?? ""} ${res.stdout}`;
+  if (/HTTP 409/.test(errText)) return { kind: "conflict" };
+  if (/HTTP 40[34]/.test(errText)) return { kind: "forbidden" };
+  return {
+    kind: "error",
+    message: (res.stderr || res.error || res.stdout).trim(),
+  };
+}
+
+/**
+ * Merges the base branch INTO the PR branch as a true two-parent merge commit
+ * created server-side by GitHub (`POST /repos/{repo}/merges` — the API behind
+ * the "Update branch" button), so the commit is GitHub-signed and no history
+ * is rewritten. Conflicting merges are refused by GitHub; the caller is
+ * directed to the rebase + git_signed_rewrite path instead.
+ */
+export async function createSignedMerge(
+  ctx: SignedCommitCtx,
+  input: SignedMergeInput,
+): Promise<SignedMergeResult> {
+  // A half-finished local merge/rebase would make the post-merge sync land on
+  // top of a dirty state; refuse with the same guidance as the commit path.
+  const op = await detectOperationInProgress(ctx.cwd);
+  if (op) {
+    throw new Error(operationInProgressError(op));
+  }
+
+  const [repo, branch] = await Promise.all([
+    resolveRepoNameWithOwner(ctx),
+    resolveBranchName(ctx, { message: "", branch: input.branch }),
+  ]);
+
+  const base = input.base ?? (await resolveBaseBranch(ctx));
+  if (!base) {
+    throw new Error(
+      "Could not determine the base branch — pass `base` explicitly (e.g. master).",
+    );
+  }
+  if (base === branch) {
+    throw new Error(`Cannot merge '${base}' into itself.`);
+  }
+
+  const tip = await remoteTip(ctx, branch);
+  if (tip === null) {
+    throw new Error(
+      `Branch '${branch}' does not exist on the remote. Use git_signed_commit to create it first.`,
+    );
+  }
+
+  // Only sync the working tree afterwards when it is actually on the target
+  // branch — and in that case require it to be clean and published, so the
+  // fast-forward below is guaranteed to apply.
+  const currentBranch = (
+    await runGit(["rev-parse", "--abbrev-ref", "HEAD"], ctx.cwd)
+  ).stdout
+    .toString("utf8")
+    .trim();
+  const onTargetBranch = currentBranch === branch;
+  if (onTargetBranch) {
+    const status = await gitText(
+      ["status", "--porcelain", "--untracked-files=no"],
+      ctx.cwd,
+    );
+    if (status) {
+      throw new Error(
+        "Local checkout has uncommitted changes. Commit them first with git_signed_commit " +
+          "(the merge updates the working tree), then retry git_signed_merge.",
+      );
+    }
+    const head = await gitText(["rev-parse", "HEAD"], ctx.cwd);
+    if (head !== tip) {
+      throw new Error(
+        `Local HEAD (${head.slice(0, 12)}) does not match the remote tip of '${branch}' ` +
+          `(${tip.slice(0, 12)}). Publish local commits with git_signed_commit (or reset to ` +
+          "the remote tip) first, then retry.",
+      );
+    }
+  }
+
+  const message = [
+    `Merge branch '${base}' into ${branch}`,
+    buildPostHogTrailers(ctx.taskId).join("\n"),
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const res = await execGhWithRetry(
+    [
+      "api",
+      "-X",
+      "POST",
+      `/repos/${repo}/merges`,
+      "-f",
+      `base=${branch}`,
+      "-f",
+      `head=${base}`,
+      "-f",
+      `commit_message=${message}`,
+    ],
+    {
+      cwd: ctx.cwd,
+      env: ghTokenEnv(ctx.token),
+      timeoutMs: GH_GRAPHQL_TIMEOUT_MS,
+    },
+    { maxAttempts: 3 },
+  );
+
+  const outcome = interpretMergeApiResult(res);
+  if (outcome.kind === "up-to-date") {
+    return { branch, base, merged: false };
+  }
+  if (outcome.kind === "conflict") {
+    throw new Error(
+      `Merge conflict between '${base}' and '${branch}' — GitHub cannot auto-merge. ` +
+        `Recovery: \`git fetch origin ${base}\`, \`git rebase origin/${base}\`, resolve ` +
+        "conflicts, `git rebase --continue`, then call git_signed_rewrite to publish.",
+    );
+  }
+  if (outcome.kind === "forbidden") {
+    throw new Error(
+      "GitHub refused the merge (HTTP 403/404): the token may lack push access to " +
+        `'${branch}', or the repo/branch was not found.`,
+    );
+  }
+  if (outcome.kind === "error") {
+    throw new Error(`Merge API failed: ${outcome.message}`);
+  }
+
+  // Sync the local checkout with a real fast-forward merge so the working
+  // tree gains the base's changes. (`syncLocalCheckout` would keep the old
+  // tree, making the merge look like unstaged reversions — staging those
+  // would silently undo it.)
+  let localSyncWarning: string | undefined;
+  if (onTargetBranch) {
+    const fetchRes = await runGit(
+      ["fetch", "--no-tags", "origin", branch],
+      ctx.cwd,
+    );
+    const syncRes =
+      fetchRes.exitCode === 0
+        ? await runGit(["merge", "--ff-only", outcome.sha], ctx.cwd)
+        : fetchRes;
+    if (syncRes.exitCode !== 0) {
+      localSyncWarning =
+        `the merge is on the remote, but syncing the local checkout failed ` +
+        `(${syncRes.stderr.trim()}). Run \`git fetch origin ${branch} && ` +
+        `git merge --ff-only origin/${branch}\` before further local work.`;
+    }
+  }
+
+  return {
+    branch,
+    base,
+    merged: true,
+    commit: { sha: outcome.sha, url: outcome.url },
+    localSyncWarning,
+  };
 }

--- a/packages/git/src/signed-commit.ts
+++ b/packages/git/src/signed-commit.ts
@@ -995,15 +995,17 @@ export interface SignedMergeInput {
   base?: string;
 }
 
-export interface SignedMergeResult {
-  branch: string;
-  base: string;
-  /** false when the branch already contained the base (HTTP 204). */
-  merged: boolean;
-  commit?: { sha: string; url: string };
-  /** Set when the remote merge succeeded but the local checkout could not be synced. */
-  localSyncWarning?: string;
-}
+export type SignedMergeResult =
+  /** The branch already contained the base (HTTP 204). */
+  | { branch: string; base: string; merged: false }
+  | {
+      branch: string;
+      base: string;
+      merged: true;
+      commit: { sha: string; url: string };
+      /** Set when the remote merge succeeded but the local checkout could not be synced. */
+      localSyncWarning?: string;
+    };
 
 export type MergeApiOutcome =
   | { kind: "merged"; sha: string; url: string }


### PR DESCRIPTION
## Problem

Cloud task runs keep producing PRs with 100k+ changed lines. Root cause (traced through task run `cea2825a` on posthog/posthog#62130): `git_signed_commit` publishes via GitHub's `createCommitOnBranch` mutation, which can only create **single-parent** commits. When an agent runs `git merge origin/master`, resolves conflicts, and then commits with the tool (raw `git commit`/`git push` are blocked in the sandbox), the merge gets **linearized** — every file the base branch changed since the branch point is attributed to the PR. In the traced run the PR diff exploded to 1,734 files. A transient mid-publish failure also left a partial "part 1/3" commit on the remote branch.

There was also no sanctioned way to bring the base branch into a PR without rewriting history: the system prompt directed agents to rebase + `git_signed_rewrite` (a force-update) for every base update, even conflict-free ones.

## Changes

`packages/git/src/signed-commit.ts`:
- **Operation-in-progress guard**: `git_signed_commit` (and the new merge tool) refuse while a merge/rebase/cherry-pick is mid-flight, with an error explaining the linearization failure and the recovery paths.
- **Base-leak hard-block**: before publishing, three metadata-only diffs detect staged files that exactly match `origin/<base>` blob content without being part of the PR's diff — the signature of a staged base merge — and refuse the commit. Skips gracefully (with a warning) when the base can't be resolved (shallow clone, no origin/HEAD).
- **Atomic multi-chunk publish**: payloads split across multiple commits go to a scratch ref first; the real branch fast-forwards only once all chunks landed, so a transient failure can't leave partial commits on a PR.
- **`git_signed_rewrite` guard**: refuses ranges containing merge commits (first-parent replay across a local merge folds the whole merged-in branch into the PR).
- **New `createSignedMerge`**: merges the base branch into the PR branch via GitHub's `POST /repos/{repo}/merges` (the API behind the "Update branch" button) — a true two-parent, GitHub-signed merge commit with no history rewriting. On 409 it directs to the rebase + rewrite path. Local checkout syncs via `merge --ff-only` so the working tree actually gains the base's changes.

`packages/agent`:
- Registers `git_signed_merge` as a cloud local tool (both Claude and Codex adapters pick it up from `LOCAL_TOOLS`).
- Threads the task's `baseBranch` from agent-server config through both adapters into the signed-git tool context (previously the field existed but was never populated; origin/HEAD detection remains the fallback).
- Cloud system prompt: new "Updating from the base branch" section steering agents to `git_signed_merge` and explicitly warning against `git merge` + `git_signed_commit`; rewrite instructions now say rebase (not rebase/merge); tool descriptions document the new refusals.

## How did you test this?

- New unit tests for the pure helpers: `parseRawDiffZ`, `detectBaseLeaks` (leak/exempt/deletion matrix), `operationInProgressError`, `interpretMergeApiResult` (201/204/409/403/404/garbage) — 33 pass in `@posthog/git`.
- New `signed-merge` tool handler suite + `baseBranch` forwarding cases + MCP exposure assertion — 22 pass across the local-tools and Claude MCP suites in `@posthog/agent`.
- `pnpm --filter @posthog/git typecheck` and `pnpm --filter @posthog/agent typecheck` clean; Biome clean on touched files.
- Not yet verified end-to-end in a cloud sandbox: that `/repos/{repo}/merges` commits carry the Verified badge (expected — same server-side machinery as the Update-branch button). If they don't, the GraphQL `mergeBranch` mutation is a drop-in replacement.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?