### PR TITLE
feat(mobile): add optional feedback to Create PR on inbox reports (port #2541)

### DIFF
--- a/apps/mobile/src/app/inbox/[...id].tsx
+++ b/apps/mobile/src/app/inbox/[...id].tsx
@@ -26,6 +26,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useUserQuery } from "@/features/auth";
 import { MarkdownText } from "@/features/chat/components/MarkdownText";
 import { getReportRepository } from "@/features/inbox/api";
+import { buildCreatePrReportPrompt } from "@/features/inbox/buildCreatePrReportPrompt";
+import { CreatePrFeedbackSheet } from "@/features/inbox/components/CreatePrFeedbackSheet";
 import { DiscussReportSheet } from "@/features/inbox/components/DiscussReportSheet";
 import {
   type DismissReportResult,
@@ -149,6 +151,7 @@ export default function ReportDetailScreen() {
   const [reportRepo, setReportRepo] = useState<string | null>(null);
   const [dismissOpen, setDismissOpen] = useState(false);
   const [discussOpen, setDiscussOpen] = useState(false);
+  const [createPrFeedbackOpen, setCreatePrFeedbackOpen] = useState(false);
   const [signalsExpanded, setSignalsExpanded] = useState(false);
 
   const artefactsQuery = useInboxReportArtefacts(reportId ?? null);
@@ -280,28 +283,37 @@ export default function ReportDetailScreen() {
       ),
   );
 
-  const handleStartTask = useCallback(() => {
-    if (!report) return;
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    tracker.signalAction({
-      report_id: report.id,
-      report_title: report.title ?? null,
-      report_age_hours: computeReportAgeHours(report.created_at),
-      action_type: "create_pr",
-      surface: "detail_pane",
-      is_bulk: false,
-      bulk_size: 1,
-    });
-    const prompt = `Act on this signal report. Investigate the root cause, implement the fix, and open a PR if appropriate.\n\n${report.summary ?? ""}`;
-    router.push({
-      pathname: "/task",
-      params: {
-        prompt,
-        ...(reportRepo ? { repo: reportRepo } : {}),
-        signalReport: report.id,
-      },
-    });
-  }, [report, router, reportRepo, tracker]);
+  const handleStartTask = useCallback(
+    (feedback?: string) => {
+      if (!report) return;
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      setCreatePrFeedbackOpen(false);
+      tracker.signalAction({
+        report_id: report.id,
+        report_title: report.title ?? null,
+        report_age_hours: computeReportAgeHours(report.created_at),
+        action_type: "create_pr",
+        surface: "detail_pane",
+        is_bulk: false,
+        bulk_size: 1,
+        has_feedback: !!feedback,
+        ...(feedback ? { feedback_text: feedback.slice(0, 500) } : {}),
+      });
+      const prompt = buildCreatePrReportPrompt({
+        summary: report.summary,
+        feedback,
+      });
+      router.push({
+        pathname: "/task",
+        params: {
+          prompt,
+          ...(reportRepo ? { repo: reportRepo } : {}),
+          signalReport: report.id,
+        },
+      });
+    },
+    [report, router, reportRepo, tracker],
+  );
 
   const handleDismissed = useCallback(
     (result: DismissReportResult) => {
@@ -579,19 +591,32 @@ export default function ReportDetailScreen() {
         </Pressable>
 
         {canStartTask && (
-          <Pressable
-            onPress={handleStartTask}
-            className="flex-row items-center gap-2 rounded-full bg-accent-9 px-4 py-3.5 shadow-lg active:opacity-80"
-          >
-            {isAwaitingInput ? (
-              <Plus size={18} color="#ffffff" weight="bold" />
-            ) : (
-              <Play size={18} color="#ffffff" weight="fill" />
-            )}
-            <Text className="font-semibold text-[15px] text-white">
-              {primaryActionLabel}
-            </Text>
-          </Pressable>
+          <View className="flex-row items-center overflow-hidden rounded-full bg-accent-9 shadow-lg">
+            <Pressable
+              onPress={() => handleStartTask()}
+              className="flex-row items-center gap-2 py-3.5 pr-3 pl-4 active:opacity-80"
+            >
+              {isAwaitingInput ? (
+                <Plus size={18} color="#ffffff" weight="bold" />
+              ) : (
+                <Play size={18} color="#ffffff" weight="fill" />
+              )}
+              <Text className="font-semibold text-[15px] text-white">
+                {primaryActionLabel}
+              </Text>
+            </Pressable>
+            <View className="h-6 w-px bg-white/25" />
+            <Pressable
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                setCreatePrFeedbackOpen(true);
+              }}
+              accessibilityLabel="Add feedback"
+              className="py-3.5 pr-4 pl-3 active:opacity-80"
+            >
+              <CaretDown size={16} color="#ffffff" weight="bold" />
+            </Pressable>
+          </View>
         )}
       </View>
 
@@ -609,6 +634,13 @@ export default function ReportDetailScreen() {
         reportTitle={report.title}
         onClose={() => setDiscussOpen(false)}
         onSubmit={handleDiscussSubmit}
+      />
+
+      <CreatePrFeedbackSheet
+        visible={createPrFeedbackOpen}
+        isAwaitingInput={isAwaitingInput}
+        onClose={() => setCreatePrFeedbackOpen(false)}
+        onSubmit={handleStartTask}
       />
     </>
   );

--- a/apps/mobile/src/features/inbox/buildCreatePrReportPrompt.test.ts
+++ b/apps/mobile/src/features/inbox/buildCreatePrReportPrompt.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildCreatePrReportPrompt } from "./buildCreatePrReportPrompt";
+
+describe("buildCreatePrReportPrompt", () => {
+  it("returns the base prompt unchanged when no feedback is given", () => {
+    const prompt = buildCreatePrReportPrompt({ summary: "A summary" });
+    expect(prompt).toBe(
+      "Act on this signal report. Investigate the root cause, implement the fix, and open a PR if appropriate.\n\nA summary",
+    );
+  });
+
+  it("appends a feedback section when feedback is provided", () => {
+    const prompt = buildCreatePrReportPrompt({
+      summary: "A summary",
+      feedback: "Use the staging database",
+    });
+    expect(prompt).toContain(
+      "Additional feedback from the user (take this into account, including any questions raised in the report thread):\nUse the staging database",
+    );
+  });
+
+  it("trims feedback before appending it", () => {
+    const prompt = buildCreatePrReportPrompt({
+      summary: "A summary",
+      feedback: "  Use the staging database  ",
+    });
+    expect(prompt).toContain(":\nUse the staging database");
+    expect(prompt.endsWith("Use the staging database")).toBe(true);
+  });
+
+  it("treats whitespace-only feedback as no feedback", () => {
+    const base = buildCreatePrReportPrompt({ summary: "A summary" });
+    const prompt = buildCreatePrReportPrompt({
+      summary: "A summary",
+      feedback: "   ",
+    });
+    expect(prompt).toBe(base);
+  });
+
+  it("tolerates a missing summary", () => {
+    const prompt = buildCreatePrReportPrompt({});
+    expect(prompt).toBe(
+      "Act on this signal report. Investigate the root cause, implement the fix, and open a PR if appropriate.\n\n",
+    );
+  });
+});

--- a/apps/mobile/src/features/inbox/buildCreatePrReportPrompt.test.ts
+++ b/apps/mobile/src/features/inbox/buildCreatePrReportPrompt.test.ts
@@ -1,46 +1,39 @@
 import { describe, expect, it } from "vitest";
 import { buildCreatePrReportPrompt } from "./buildCreatePrReportPrompt";
 
+const BASE =
+  "Act on this signal report. Investigate the root cause, implement the fix, and open a PR if appropriate.";
+const FEEDBACK_PREFIX =
+  "Additional feedback from the user (take this into account, including any questions raised in the report thread):";
+
 describe("buildCreatePrReportPrompt", () => {
-  it("returns the base prompt unchanged when no feedback is given", () => {
-    const prompt = buildCreatePrReportPrompt({ summary: "A summary" });
-    expect(prompt).toBe(
-      "Act on this signal report. Investigate the root cause, implement the fix, and open a PR if appropriate.\n\nA summary",
-    );
-  });
-
-  it("appends a feedback section when feedback is provided", () => {
-    const prompt = buildCreatePrReportPrompt({
-      summary: "A summary",
-      feedback: "Use the staging database",
-    });
-    expect(prompt).toContain(
-      "Additional feedback from the user (take this into account, including any questions raised in the report thread):\nUse the staging database",
-    );
-  });
-
-  it("trims feedback before appending it", () => {
-    const prompt = buildCreatePrReportPrompt({
-      summary: "A summary",
-      feedback: "  Use the staging database  ",
-    });
-    expect(prompt).toContain(":\nUse the staging database");
-    expect(prompt.endsWith("Use the staging database")).toBe(true);
-  });
-
-  it("treats whitespace-only feedback as no feedback", () => {
-    const base = buildCreatePrReportPrompt({ summary: "A summary" });
-    const prompt = buildCreatePrReportPrompt({
-      summary: "A summary",
-      feedback: "   ",
-    });
-    expect(prompt).toBe(base);
-  });
-
-  it("tolerates a missing summary", () => {
-    const prompt = buildCreatePrReportPrompt({});
-    expect(prompt).toBe(
-      "Act on this signal report. Investigate the root cause, implement the fix, and open a PR if appropriate.\n\n",
-    );
+  it.each([
+    {
+      name: "returns the base prompt unchanged when no feedback is given",
+      input: { summary: "A summary" },
+      expected: `${BASE}\n\nA summary`,
+    },
+    {
+      name: "appends a feedback section when feedback is provided",
+      input: { summary: "A summary", feedback: "Use the staging database" },
+      expected: `${BASE}\n\nA summary\n\n${FEEDBACK_PREFIX}\nUse the staging database`,
+    },
+    {
+      name: "trims feedback before appending it",
+      input: { summary: "A summary", feedback: "  Use the staging database  " },
+      expected: `${BASE}\n\nA summary\n\n${FEEDBACK_PREFIX}\nUse the staging database`,
+    },
+    {
+      name: "treats whitespace-only feedback as no feedback",
+      input: { summary: "A summary", feedback: "   " },
+      expected: `${BASE}\n\nA summary`,
+    },
+    {
+      name: "tolerates a missing summary",
+      input: {},
+      expected: `${BASE}\n\n`,
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(buildCreatePrReportPrompt(input)).toBe(expected);
   });
 });

--- a/apps/mobile/src/features/inbox/buildCreatePrReportPrompt.ts
+++ b/apps/mobile/src/features/inbox/buildCreatePrReportPrompt.ts
@@ -1,0 +1,14 @@
+interface BuildCreatePrReportPromptOptions {
+  summary?: string | null;
+  feedback?: string;
+}
+
+export function buildCreatePrReportPrompt({
+  summary,
+  feedback,
+}: BuildCreatePrReportPromptOptions): string {
+  const base = `Act on this signal report. Investigate the root cause, implement the fix, and open a PR if appropriate.\n\n${summary ?? ""}`;
+  const trimmed = feedback?.trim();
+  if (!trimmed) return base;
+  return `${base}\n\nAdditional feedback from the user (take this into account, including any questions raised in the report thread):\n${trimmed}`;
+}

--- a/apps/mobile/src/features/inbox/components/CreatePrFeedbackSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/CreatePrFeedbackSheet.tsx
@@ -1,0 +1,93 @@
+import { Text } from "@components/text";
+import * as Haptics from "expo-haptics";
+import { Play, Plus } from "phosphor-react-native";
+import { useEffect, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  TextInput,
+  View,
+} from "react-native";
+import { SheetContainer } from "@/components/SheetContainer";
+import { useThemeColors } from "@/lib/theme";
+
+interface CreatePrFeedbackSheetProps {
+  visible: boolean;
+  isAwaitingInput: boolean;
+  onClose: () => void;
+  onSubmit: (feedback: string) => void;
+}
+
+export function CreatePrFeedbackSheet({
+  visible,
+  isAwaitingInput,
+  onClose,
+  onSubmit,
+}: CreatePrFeedbackSheetProps) {
+  const themeColors = useThemeColors();
+  const [feedback, setFeedback] = useState("");
+  const confirmLabel = isAwaitingInput ? "Implement as new task" : "Start task";
+
+  useEffect(() => {
+    if (visible) setFeedback("");
+  }, [visible]);
+
+  const handleSubmit = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    onSubmit(feedback.trim());
+  };
+
+  return (
+    <SheetContainer open={visible} onClose={onClose} bottomGap="default">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <View className="px-4 pt-2 pb-3">
+          <Text className="mb-1 font-semibold text-[16px] text-gray-12">
+            Add feedback
+          </Text>
+          <Text className="mb-3 text-[13px] text-gray-11 leading-snug">
+            Optional. The agent takes this into account, including any questions
+            raised in the report thread.
+          </Text>
+          <TextInput
+            value={feedback}
+            onChangeText={setFeedback}
+            placeholder="Add any extra feedback, e.g. answers to questions raised in the report thread..."
+            placeholderTextColor={themeColors.gray[9]}
+            multiline
+            maxLength={2000}
+            autoFocus
+            className="min-h-[96px] rounded-xl bg-gray-2 px-3 py-3 text-[14px] text-gray-12"
+            style={{ textAlignVertical: "top" }}
+          />
+          <View className="mt-3 flex-row items-center justify-end gap-2">
+            <Pressable
+              onPress={onClose}
+              hitSlop={6}
+              className="rounded-full px-4 py-2.5 active:opacity-60"
+            >
+              <Text className="text-[14px] text-gray-11">Cancel</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleSubmit}
+              accessibilityRole="button"
+              accessibilityLabel={confirmLabel}
+              className="flex-row items-center gap-1.5 rounded-full bg-accent-9 px-4 py-2.5 active:opacity-80"
+            >
+              {isAwaitingInput ? (
+                <Plus size={16} color="#ffffff" weight="bold" />
+              ) : (
+                <Play size={16} color="#ffffff" weight="fill" />
+              )}
+              <Text className="font-semibold text-[14px] text-white">
+                {confirmLabel}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </SheetContainer>
+  );
+}

--- a/apps/mobile/src/features/inbox/components/CreatePrFeedbackSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/CreatePrFeedbackSheet.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@components/text";
 import * as Haptics from "expo-haptics";
 import { Play, Plus } from "phosphor-react-native";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
@@ -27,11 +27,15 @@ export function CreatePrFeedbackSheet({
 }: CreatePrFeedbackSheetProps) {
   const themeColors = useThemeColors();
   const [feedback, setFeedback] = useState("");
+  const [prevVisible, setPrevVisible] = useState(visible);
   const confirmLabel = isAwaitingInput ? "Implement as new task" : "Start task";
 
-  useEffect(() => {
+  // Reset the draft when the sheet opens. Adjusting during render (rather than
+  // in an effect) avoids a flash of the previous value on the next open.
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
     if (visible) setFeedback("");
-  }, [visible]);
+  }
 
   const handleSubmit = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -132,6 +132,8 @@ export interface InboxReportActionProperties {
   task_section?: "research" | "implementation";
   has_question?: boolean;
   question_text?: string;
+  has_feedback?: boolean;
+  feedback_text?: string;
   suggested_reviewer_login?: string;
   suggested_reviewer_uuid?: string;
 }


### PR DESCRIPTION
Ports desktop PR #2541 (_feat(inbox): add feedback dropdown to Create PR button_) to the React Native / Expo mobile app.

## What changed

On the inbox report detail screen, the start-task / "Create PR" action gains an **optional feedback** affordance. A caret next to the primary button opens a bottom sheet where the user can type extra free-text feedback (e.g. answers to questions raised in the report thread). The plain button still starts the task with no feedback — the sheet is opt-in, matching desktop.

- **`buildCreatePrReportPrompt`** — new mobile-local prompt-builder helper. Appends the same feedback section as desktop (`Additional feedback from the user (take this into account, including any questions raised in the report thread):`) when feedback is present after trimming; returns the base prompt unchanged otherwise. Unit-tested (present / absent / whitespace-only / no summary).
- **`CreatePrFeedbackSheet`** — new bottom sheet following the established `DiscussReportSheet` pattern (multiline input, Cancel + confirm). Confirm label/icon derive from `isAwaitingInput` so they match the primary button.
- **`[...id].tsx`** — `handleStartTask(feedback?)` is now the single entry point for both the plain button and the sheet; folds feedback into the prompt via the helper.
- **Analytics** — the `create_pr` action now carries `has_feedback` and `feedback_text` (truncated to 500 chars), mirroring the discuss action's `has_question` / `question_text`. Added the corresponding fields to the mobile inbox analytics types.

Mobile-only port — no desktop (`apps/code`) or shared-package code was touched.

## Testing

- `vitest run` for the new prompt-builder test — passes.
- Biome lint and `tsc` clean over the changed mobile files.