### PR TITLE
feat(ui): default completion sound to meep

### DIFF
--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -184,7 +184,7 @@ export const useSettingsStore = create<SettingsStore>()(
       desktopNotifications: true,
       dockBadgeNotifications: true,
       dockBounceNotifications: false,
-      completionSound: "none",
+      completionSound: "meep",
       completionVolume: 80,
       setDesktopNotifications: (enabled) =>
         set({ desktopNotifications: enabled }),


### PR DESCRIPTION
## Problem

Desktop shipped with `completionSound: "none"`, so a fresh install played no sound when a task finished. Mobile has defaulted to `"meep"` since it launched, so the two hosts disagreed.

## Changes

Set the default `completionSound` to `"meep"` in `packages/ui/src/features/settings/settingsStore.ts`. `"meep"` was already a valid option and wired into playback, so nothing else changed. Only applies to users with no persisted setting (fresh install or after clearing app data); saved preferences are untouched.

## How did you test this?

Ran `pnpm --filter @posthog/ui typecheck` (after building `@posthog/shared` and `@posthog/platform`); no errors in the touched file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?