### PR TITLE
fix(code): persist and restore native window zoom across reloads

### DIFF
--- a/apps/code/src/main/menu.ts
+++ b/apps/code/src/main/menu.ts
@@ -20,6 +20,7 @@ import { container } from "./di/container";
 import { MAIN_TOKENS } from "./di/tokens";
 import { isDevBuild } from "./utils/env";
 import { getLogFilePath } from "./utils/logger";
+import { adjustZoom, setZoom } from "./utils/zoom";
 
 function findLatestCrashDump(): string | null {
   const pendingDir = path.join(app.getPath("crashDumps"), "pending");
@@ -308,9 +309,40 @@ function buildViewMenu(): MenuItemConstructorOptions {
       },
       { role: "toggleDevTools" },
       { type: "separator" },
-      { role: "resetZoom" },
-      { role: "zoomIn" },
-      { role: "zoomOut" },
+      {
+        label: "Reset Zoom",
+        accelerator: "CmdOrCtrl+0",
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) setZoom(win, 0);
+        },
+      },
+      {
+        label: "Zoom In",
+        accelerator: "CmdOrCtrl+Plus",
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) adjustZoom(win, 1);
+        },
+      },
+      {
+        // Alias so Cmd+= (no Shift) also zooms in; accelerator fires while hidden.
+        label: "Zoom In",
+        accelerator: "CmdOrCtrl+=",
+        visible: false,
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) adjustZoom(win, 1);
+        },
+      },
+      {
+        label: "Zoom Out",
+        accelerator: "CmdOrCtrl+-",
+        click: () => {
+          const win = BrowserWindow.getFocusedWindow();
+          if (win) adjustZoom(win, -1);
+        },
+      },
       { type: "separator" },
       { role: "togglefullscreen" },
       { type: "separator" },

--- a/apps/code/src/main/utils/store.ts
+++ b/apps/code/src/main/utils/store.ts
@@ -24,6 +24,8 @@ export interface WindowStateSchema {
   width: number;
   height: number;
   isMaximized: boolean;
+  // Native zoom level (0 = 100%), persisted across reloads and restarts.
+  zoomLevel: number;
 }
 
 const userDataDir = getUserDataDir();
@@ -50,5 +52,6 @@ export const windowStateStore = new Store<WindowStateSchema>({
     width: 1200,
     height: 600,
     isMaximized: true,
+    zoomLevel: 0,
   },
 });

--- a/apps/code/src/main/utils/zoom.ts
+++ b/apps/code/src/main/utils/zoom.ts
@@ -1,0 +1,54 @@
+import { logger } from "./logger";
+import { windowStateStore } from "./store";
+
+const log = logger.scope("zoom");
+
+// Structural subset of BrowserWindow, kept local so this util avoids an
+// `electron` import. A real BrowserWindow satisfies it.
+interface ZoomableWindow {
+  isDestroyed(): boolean;
+  webContents: {
+    getZoomLevel(): number;
+    setZoomLevel(level: number): void;
+  };
+}
+
+// Half a zoom level ≈ 9.5% per press; clamp to ~58%–173%.
+const ZOOM_STEP = 0.5;
+const ZOOM_MIN = -3;
+const ZOOM_MAX = 3;
+
+function clampZoom(level: number): number {
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level));
+}
+
+export function getSavedZoomLevel(): number {
+  return clampZoom(windowStateStore.get("zoomLevel", 0));
+}
+
+// Native zoom resets to 100% on every reload, so call this on each
+// `did-finish-load`, not just at startup.
+export function applySavedZoom(window: ZoomableWindow): void {
+  if (window.isDestroyed()) return;
+  const level = getSavedZoomLevel();
+  window.webContents.setZoomLevel(level);
+}
+
+function persistZoom(level: number): void {
+  windowStateStore.set("zoomLevel", level);
+}
+
+// Set absolute zoom level (0 = 100%) and persist.
+export function setZoom(window: ZoomableWindow, level: number): void {
+  if (window.isDestroyed()) return;
+  const next = clampZoom(level);
+  window.webContents.setZoomLevel(next);
+  persistZoom(next);
+  log.info("zoom set", { level: next });
+}
+
+// Adjust zoom by N steps and persist.
+export function adjustZoom(window: ZoomableWindow, steps: number): void {
+  if (window.isDestroyed()) return;
+  setZoom(window, window.webContents.getZoomLevel() + steps * ZOOM_STEP);
+}

--- a/apps/code/src/main/utils/zoom.ts
+++ b/apps/code/src/main/utils/zoom.ts
@@ -47,8 +47,9 @@ export function setZoom(window: ZoomableWindow, level: number): void {
   log.info("zoom set", { level: next });
 }
 
-// Adjust zoom by N steps and persist.
+// Adjust zoom by N steps and persist. Baseline comes from the persisted store,
+// not the live webContents, which is reset to 0 during reloads.
 export function adjustZoom(window: ZoomableWindow, steps: number): void {
   if (window.isDestroyed()) return;
-  setZoom(window, window.webContents.getZoomLevel() + steps * ZOOM_STEP);
+  setZoom(window, getSavedZoomLevel() + steps * ZOOM_STEP);
 }

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -17,6 +17,7 @@ import { trpcRouter } from "./trpc/router";
 import { isDevBuild } from "./utils/env";
 import { logger, readChromiumLogTail } from "./utils/logger";
 import { type WindowStateSchema, windowStateStore } from "./utils/store";
+import { applySavedZoom } from "./utils/zoom";
 
 const log = logger.scope("window");
 
@@ -34,7 +35,7 @@ function isPositionOnScreen(x: number, y: number): boolean {
   });
 }
 
-function getSavedWindowState(): WindowStateSchema {
+function getSavedWindowState(): Omit<WindowStateSchema, "zoomLevel"> {
   const state = {
     x: windowStateStore.get("x"),
     y: windowStateStore.get("y"),
@@ -98,6 +99,11 @@ function setupExternalLinkHandlers(window: BrowserWindow): void {
       shell.openExternal(url);
     }
   });
+}
+
+function setupZoomPersistence(window: BrowserWindow): void {
+  // Native zoom resets on every load (incl. crash-recovery reload); re-apply it.
+  window.webContents.on("did-finish-load", () => applySavedZoom(window));
 }
 
 function setupCrashLogging(window: BrowserWindow): void {
@@ -248,6 +254,7 @@ export function createWindow(): void {
   setupExternalLinkHandlers(mainWindow);
   setupEditableContextMenu(mainWindow);
   setupCrashLogging(mainWindow);
+  setupZoomPersistence(mainWindow);
   buildApplicationMenu();
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {


### PR DESCRIPTION
## Problem

Native window zoom (Cmd +/−) reset to 100% intermittently while resizing. #2003 added crash-recovery auto-reload, so a renderer hiccup during resize reloads the webContents, and native zoom was never persisted or restored.

## Changes

Persist `zoomLevel` in window-state and re-apply it on every `did-finish-load`. Replaced the native zoom menu roles with handlers that persist the level, so zoom survives reloads and restarts.

## How did you test this?

Ran `pnpm --filter code typecheck`, Biome lint on the touched files, and `check-host-boundaries.mjs`, all pass. Did not manually verify zoom restore in a packaged build.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?