### PR TITLE
fix(signed-commit): treat already-committed staged tree as idempotent no-op

### DIFF
--- a/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/packages/agent/src/adapters/signed-commit-shared.ts
@@ -139,6 +139,17 @@ async function runSignedTool<A>(
 ): Promise<SignedCommitToolResult> {
   try {
     const result = await op(ctx, args);
+    if (result.commits.length === 0) {
+      // Staged content already present on the branch — idempotent no-op, not a failure.
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${result.branch} already contains the staged changes — nothing to commit.`,
+          },
+        ],
+      };
+    }
     const list = result.commits.map((c) => `- ${c.sha} ${c.url}`).join("\n");
     return { content: [{ type: "text", text: `${lead(result)}:\n${list}` }] };
   } catch (err) {

--- a/packages/git/src/signed-commit.ts
+++ b/packages/git/src/signed-commit.ts
@@ -814,6 +814,16 @@ export async function createSignedCommit(
 
   const changes = await buildFileChanges(ctx, tip);
   if (changes.additions.length === 0 && changes.deletions.length === 0) {
+    // The staged tree already equals the branch tip. If the index differs from HEAD there ARE
+    // staged changes — they're just already present on `branch` — so this is an idempotent
+    // no-op, not a "forgot to stage" error. Returning success stops the caller from retrying
+    // `git add` against a branch that already has the content.
+    const hasStagedChanges =
+      (await runGit(["diff", "--cached", "--quiet", "HEAD"], ctx.cwd))
+        .exitCode !== 0;
+    if (hasStagedChanges) {
+      return { branch, commits: [] };
+    }
     throw new Error(
       "No staged changes to commit. Stage files with `git add` first (or pass `paths`).",
     );


### PR DESCRIPTION
## Problem

`git_signed_commit` fails with a misleading error when the staged content is already present on the target branch. Because it computes the commit as the diff between staged tree and the target branch tip, re-committing the same content to a branch that already has it produces an empty diff

## Changes

- Distinguish two empty-diff cases in `createSignedCommit`:
  - staged content is already committed on the branch → idempotent no-op (`{ branch, commits: [] }`), instead of an error.
  - genuinely nothing staged → keep the existing actionable "git add first" error.
