### PR TITLE
docs(agents): encourage parameterised tests in test guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ See [docs/conventions.md](./docs/conventions.md).
 - Unit tests: Vitest.
 - E2E tests: Playwright.
 - Test core/UI services and stores with faked injected dependencies and explicit props.
+- Prefer a parameterised test shape (`it.each`/`test.each`) when several cases exercise the same logic with different inputs and expectations. Keep separate tests when cases differ in setup, assertions, or intent.
 - Colocate tests as `.test.ts` or `.test.tsx`.
 - Put E2E tests in `tests/e2e/`.
 - After touching `@posthog/platform`, rebuild or typecheck its `dist/`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -98,6 +98,22 @@ describe("store", () => {
 });
 ```
 
+## Parameterised Tests
+
+Prefer a parameterised test shape when several cases exercise the same logic with different inputs and expectations. Use Vitest's `it.each` / `test.each` instead of copy-pasting near-identical `it` blocks.
+
+```ts
+it.each([
+  { input: "main", expected: true },
+  { input: "feature/x", expected: false },
+  { input: "", expected: false },
+])("isDefaultBranch($input) === $expected", ({ input, expected }) => {
+  expect(isDefaultBranch(input)).toBe(expected);
+});
+```
+
+Keep cases as separate `it` blocks when they differ in setup, assertions, or intent — parameterise repetition, not distinct behaviors.
+
 ## Mocking
 
 Hoist mocks for modules that must be mocked before import evaluation.


### PR DESCRIPTION
## Problem

Greptile flags "Prefer a parameterised test shape" on essentially every PR. The principle is sound but uncodified, so it shows up as repetitive review noise instead of being a documented convention.

## Changes

Codify the parameterised-test preference in the test guidelines:
- Added a bullet to `AGENTS.md` under Testing.
- Added a `Parameterised Tests` section with an `it.each` example to `docs/testing.md`, including the caveat to keep distinct cases as separate tests.

## How did you test this?

Docs-only change — no tests run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781107020626769?thread_ts=1781107020.626769&cid=C09G8Q32R6F)*
