### PR TITLE
fix(auth): stop a hung token refresh from wedging bootstrap

### DIFF
--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -305,6 +305,66 @@ describe("AuthService", () => {
     );
   });
 
+  it("completes bootstrap anonymously when the stored-session restore hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      seedStoredSession({ selectedProjectId: 42 });
+      stubAuthFetch();
+      // Half-open socket: the refresh never resolves or rejects.
+      oauthFlow.refreshToken.mockReturnValue(new Promise<never>(() => {}));
+
+      const initPromise = service.initialize();
+      await vi.advanceTimersByTimeAsync(20_001);
+      await initPromise;
+
+      expect(service.getState()).toMatchObject({
+        status: "anonymous",
+        bootstrapComplete: true,
+        cloudRegion: "us",
+        currentProjectId: 42,
+      });
+      expect(sessionPort.getCurrent()).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("upgrades to authenticated when the slow restore lands after the deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      seedStoredSession({ selectedProjectId: 42 });
+      stubAuthFetch();
+      let resolveRefresh!: (value: unknown) => void;
+      oauthFlow.refreshToken.mockReturnValue(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+      const initPromise = service.initialize();
+      await vi.advanceTimersByTimeAsync(20_001);
+      await initPromise;
+
+      expect(service.getState().status).toBe("anonymous");
+
+      resolveRefresh(
+        mockTokenResponse({
+          accessToken: "late-access-token",
+          refreshToken: "late-refresh-token",
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        bootstrapComplete: true,
+        currentProjectId: 42,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("forces a token refresh when explicitly requested", async () => {
     oauthFlow.startFlow.mockResolvedValue(
       mockTokenResponse({

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -11,6 +11,7 @@ import {
   OAUTH_SCOPE_VERSION,
   sleepWithBackoff,
   TypedEventEmitter,
+  withTimeout,
 } from "@posthog/shared";
 import { inject, injectable, postConstruct, preDestroy } from "inversify";
 import {
@@ -40,6 +41,8 @@ import {
 } from "./schemas";
 
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
+const AUTH_FETCH_TIMEOUT_MS = 30_000;
+const AUTH_BOOTSTRAP_DEADLINE_MS = 20_000;
 type FetchLike = (
   input: string | Request,
   init?: RequestInit,
@@ -386,6 +389,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     return fetchImpl(input, {
       ...init,
       headers,
+      signal: init.signal ?? AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
     });
   }
   private async doInitialize(): Promise<void> {
@@ -416,16 +420,35 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     }
 
     try {
-      await this.refreshAndSyncSession(storedSession);
+      const restore = this.refreshAndSyncSession(storedSession);
+      const outcome = await withTimeout(restore, AUTH_BOOTSTRAP_DEADLINE_MS);
+      if (outcome.result === "timeout") {
+        this.logger.warn(
+          "Auth bootstrap exceeded deadline; completing anonymously and restoring in the background",
+        );
+        // Keep awaiting so a late success still upgrades state; swallow rejection.
+        restore.catch((error) => {
+          this.logger.warn("Background auth restore failed after deadline", {
+            error,
+          });
+        });
+        this.completeBootstrapAnonymously(storedSession);
+      }
     } catch (error) {
       this.logger.warn("Failed to restore stored auth session", { error });
-      this.session = null;
-      this.setAnonymousState({
-        bootstrapComplete: true,
-        cloudRegion: storedSession.cloudRegion,
-        currentProjectId: storedSession.selectedProjectId,
-      });
+      this.completeBootstrapAnonymously(storedSession);
     }
+  }
+  private completeBootstrapAnonymously(
+    storedSession: StoredSessionInput,
+  ): void {
+    // Stored session stays on disk so connectivity/resume recovery can retry.
+    this.session = null;
+    this.setAnonymousState({
+      bootstrapComplete: true,
+      cloudRegion: storedSession.cloudRegion,
+      currentProjectId: storedSession.selectedProjectId,
+    });
   }
   private async ensureValidSession(
     forceRefresh = false,

--- a/packages/core/src/oauth/oauth.ts
+++ b/packages/core/src/oauth/oauth.ts
@@ -34,6 +34,7 @@ import type {
 } from "./schemas";
 
 const OAUTH_TIMEOUT_MS = 180_000; // 3 minutes
+const TOKEN_FETCH_TIMEOUT_MS = 30_000;
 const DEV_CALLBACK_PORT = 8237;
 
 const NETWORK_ERROR_MESSAGE =
@@ -211,6 +212,7 @@ export class OAuthService {
           refresh_token: refreshToken,
           client_id: getOauthClientIdFromRegion(region),
         }),
+        signal: AbortSignal.timeout(TOKEN_FETCH_TIMEOUT_MS),
       });
 
       if (!response.ok) {
@@ -365,6 +367,7 @@ export class OAuthService {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body,
+          signal: AbortSignal.timeout(TOKEN_FETCH_TIMEOUT_MS),
         });
       } catch (error) {
         // fetch threw — DNS/TLS/socket failure. The raw message ("Failed to fetch",

--- a/packages/ui/src/features/auth/auth.contribution.ts
+++ b/packages/ui/src/features/auth/auth.contribution.ts
@@ -3,8 +3,14 @@ import {
   HOST_TRPC_CLIENT,
   type HostTrpcClient,
 } from "@posthog/host-router/client";
+import { withTimeout } from "@posthog/shared";
+import { logger } from "@posthog/ui/shell/logger";
 import { inject, injectable } from "inversify";
 import { useAuthStore } from "./store";
+
+const log = logger.scope("auth-contribution");
+// boot() starts contributions serially, so a stuck host query must not wedge it.
+const INITIAL_STATE_TIMEOUT_MS = 10_000;
 
 @injectable()
 export class AuthContribution implements Contribution {
@@ -18,7 +24,16 @@ export class AuthContribution implements Contribution {
       onData: (state) => useAuthStore.getState().setAuthState(state),
     });
 
-    const initial = await this.hostClient.auth.getState.query();
-    useAuthStore.getState().setAuthState(initial);
+    const outcome = await withTimeout(
+      this.hostClient.auth.getState.query(),
+      INITIAL_STATE_TIMEOUT_MS,
+    );
+    if (outcome.result === "success") {
+      useAuthStore.getState().setAuthState(outcome.value);
+    } else {
+      log.warn(
+        "Initial auth state query timed out; relying on state subscription",
+      );
+    }
   }
 }

--- a/packages/ui/src/shell/App.tsx
+++ b/packages/ui/src/shell/App.tsx
@@ -19,6 +19,7 @@ import { UpdateBanner } from "@posthog/ui/features/sidebar/components/UpdateBann
 import { LoginTransition } from "@posthog/ui/primitives/LoginTransition";
 import { router } from "@posthog/ui/router/router";
 import { track } from "@posthog/ui/shell/analytics";
+import { BootstrapFallback } from "@posthog/ui/shell/BootstrapFallback";
 import { ErrorBoundary } from "@posthog/ui/shell/ErrorBoundary";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
@@ -95,14 +96,7 @@ function App() {
   };
 
   if (!isBootstrapped) {
-    return (
-      <Flex align="center" justify="center" minHeight="100vh">
-        <Flex align="center" gap="3">
-          <Spinner size="3" />
-          <Text color="gray">Loading...</Text>
-        </Flex>
-      </Flex>
-    );
+    return <BootstrapFallback />;
   }
 
   // Rendering: onboarding (includes auth + invite code gate) → main app

--- a/packages/ui/src/shell/BootstrapFallback.tsx
+++ b/packages/ui/src/shell/BootstrapFallback.tsx
@@ -1,0 +1,53 @@
+import { EXTERNAL_LINKS } from "@posthog/shared";
+import { Button } from "@posthog/ui/primitives/Button";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { Flex, Spinner, Text } from "@radix-ui/themes";
+import { useEffect, useState } from "react";
+
+// Sits above the core bootstrap deadline so this only shows once boot has truly given up.
+const STALL_TIMEOUT_MS = 25_000;
+
+export function BootstrapFallback(): React.ReactNode {
+  const [stalled, setStalled] = useState(false);
+
+  useEffect(() => {
+    const id = setTimeout(() => setStalled(true), STALL_TIMEOUT_MS);
+    return () => clearTimeout(id);
+  }, []);
+
+  if (!stalled) {
+    return (
+      <Flex align="center" justify="center" minHeight="100vh">
+        <Flex align="center" gap="3">
+          <Spinner size="3" />
+          <Text color="gray">Loading...</Text>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex align="center" justify="center" minHeight="100vh">
+      <Flex
+        direction="column"
+        align="center"
+        gap="4"
+        className="max-w-[360px] text-center"
+      >
+        <Text size="4" weight="bold">
+          PostHog is taking longer than expected to start
+        </Text>
+        <Text color="gray">This usually clears up with a restart.</Text>
+        <Flex gap="3">
+          <Button onClick={() => window.location.reload()}>Retry</Button>
+          <Button
+            variant="soft"
+            onClick={() => openExternalUrl(EXTERNAL_LINKS.discord)}
+          >
+            Get support
+          </Button>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}


### PR DESCRIPTION
## Problem

on a degraded network, the desktop app could get stuck on "Loading…" forever and never reach the app.

Root cause is a long-latent defect boot-time OAuth refresh (`oauth.ts:refreshToken`) used a bare `fetch` with no timeout. an half-open socket leaves `doInitialize()` awaiting forever, `bootstrapComplete` never flips, and the renderer sits on the spinner indefinitely. Splitting the app into packages put auth init on a cross-process boot path and gated the whole renderer on it, which is what made this latent failure mode reachable at boot.

<img width="3148" height="2122" alt="image" src="https://github.com/user-attachments/assets/7b28a76e-fc86-4b5b-9982-463cf09ad98d" />

as per [thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781101013736529)

## Changes

- added timeouts to token refresh, token exchange, and authenticated API requests. Hung network calls now fail into the existing retry path instead of hanging indefinitely
- added a bootstrap deadline to `doInitialize()`
- added a timeout to the auth contribution's initial `getState` call. Since `boot()` waits on contributions serially, a stuck query can otherwise block startup
- replace the infinite loading spinner with a recoverable screen
