### PR TITLE
fix(home): loosen header stat spacing and standardize view-toggle button size

### DIFF
--- a/packages/ui/src/features/home/components/HomeView.tsx
+++ b/packages/ui/src/features/home/components/HomeView.tsx
@@ -101,7 +101,7 @@ export function HomeView() {
               </Text>
             </Flex>
             {hasContent ? (
-              <Flex align="center" gap="3" className="text-[12px]">
+              <Flex align="center" gap="5" className="text-[12px]">
                 {needsAttention.length > 0 ? (
                   <Stat
                     color="var(--amber-9)"
@@ -229,27 +229,27 @@ function ViewModeToggle({ value, onChange }: ViewModeToggleProps) {
       title="Switch view (press v to cycle)"
     >
       <Button
-        size="xs"
+        size="sm"
         variant={value === "list" ? "primary" : "link-muted"}
         onClick={() => onChange("list")}
       >
-        <ListBullets size={12} />
+        <ListBullets size={14} />
         List
       </Button>
       <Button
-        size="xs"
+        size="sm"
         variant={value === "board" ? "primary" : "link-muted"}
         onClick={() => onChange("board")}
       >
-        <Kanban size={12} />
+        <Kanban size={14} />
         Board
       </Button>
       <Button
-        size="xs"
+        size="sm"
         variant={value === "config" ? "primary" : "link-muted"}
         onClick={() => onChange("config")}
       >
-        <Graph size={12} />
+        <Graph size={14} />
         Config
       </Button>
     </Flex>
@@ -266,7 +266,7 @@ function Stat({
   pulse?: boolean;
 }) {
   return (
-    <Flex align="center" gap="1.5">
+    <Flex align="center" gap="2">
       <span
         className={`inline-block h-2 w-2 rounded-full ${pulse ? "animate-pulse" : ""}`}
         style={{ backgroundColor: color }}


### PR DESCRIPTION
## What

Two small polish fixes to the **Home** view header (`packages/ui/src/features/home/components/HomeView.tsx`):

1. **Left side — status stats spacing.** The `running` / `in progress` / `needs attention` stats were cramped together (`gap-3`, 12px), and each dot sat tight against its label (`gap-1.5`, 6px). Widened to `gap-5` (24px) between stats and `gap-2` (8px) dot→label.
2. **Right side — view-toggle button size.** The `List` / `Board` / `Config` toggle used `size="xs"`, smaller than the `size="sm"` standard used almost everywhere else in `packages/ui` (98 `sm` usages vs 30 `xs`). Bumped all three to `size="sm"` and scaled their icons `12 → 14px` to stay proportionate.


Before:
<img width="2536" height="200" alt="CleanShot 2026-06-10 at 12 53 10@2x" src="https://github.com/user-attachments/assets/f6c37144-92a8-4959-8c1d-f42a9989c7fa" />


After:
<img width="2396" height="194" alt="CleanShot 2026-06-10 at 12 51 16@2x" src="https://github.com/user-attachments/assets/c44a2774-5a4f-44cc-93f8-0a9729812e26" />


## Why

The header read as a clump on the left and the toggle buttons looked undersized next to other toolbars (e.g. Inbox, code review).

## Testing

- `pnpm --filter @posthog/ui typecheck` + pre-commit biome/typecheck pass.
- Verified live in the dev app (Home view is behind the `posthog-code-home-tab` flag): stats now have clear breathing room and the toggle matches standard button sizing in both light and dark mode.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*