### PR TITLE
chore(ci): Skip jobs based on changes, fix react-doctor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           predicate-quantifier: every
           filters: |
+            # Wider excludes than code-quality.yml, which keeps .github/scripts
+            # and .vscode/.claude in scope because Biome lints them.
             code:
               - "!**/*.md"
               - "!docs/**"
@@ -37,7 +39,8 @@ jobs:
 
   build:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
+    # Fail closed: if change detection itself failed, run instead of skipping.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - "!**/*.md"
+              - "!docs/**"
+              - "!.github/**"
+              - "!.vscode/**"
+              - "!.claude/**"
+              - "!.husky/**"
+              - "!LICENSE"
+              - "!.gitignore"
+              - "!.env.example"
+            workflow:
+              - ".github/workflows/build.yml"
+
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -37,7 +37,8 @@ jobs:
 
   quality:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
+    # Fail closed: if change detection itself failed, run instead of skipping.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,7 +8,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          predicate-quantifier: every
+          filters: |
+            # Biome lints .github/scripts/*.mjs and tracked JSON in
+            # .vscode/.claude, so only workflow YAML and prose are ignored.
+            code:
+              - "!**/*.md"
+              - "!docs/**"
+              - "!.github/workflows/**"
+              - "!.husky/**"
+              - "!LICENSE"
+              - "!.gitignore"
+              - "!.env.example"
+            workflow:
+              - ".github/workflows/code-quality.yml"
+
   quality:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -44,6 +44,7 @@ jobs:
           REACT_DOCTOR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # -e omitted: exit codes are captured and inspected explicitly.
           set -uo pipefail
           CHANGED="${RUNNER_TEMP}/react-doctor-changed-files.txt"
           if ! git diff --name-only --diff-filter=ACMR "${REACT_DOCTOR_BASE_SHA}...${HEAD_SHA}" > "$CHANGED"; then
@@ -99,6 +100,7 @@ jobs:
           STATUS: ${{ steps.scan.outputs.exit-code }}
           REPORT: ${{ steps.scan.outputs.report }}
         run: |
+          # -e omitted: exit codes are captured and inspected explicitly.
           set -uo pipefail
           if [ "${STATUS:-1}" = "0" ]; then
             exit 0
@@ -109,6 +111,7 @@ jobs:
               exit 0
             fi
             if jq -e '.ok == false' "$REPORT" >/dev/null 2>&1; then
+              # Strip newlines so the message cannot end the ::warning command early.
               message=$(jq -r '.error.message // "unknown error"' "$REPORT" | tr -d '\n')
               echo "::warning title=React Doctor::Scanner crashed (${message}); not blocking the PR on a scanner failure."
               exit 0

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,6 +3,9 @@ name: React Doctor
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    # Workflow-level paths only work because react-doctor is not a required
+    # check. If it ever becomes required, move the skip into a gate job like
+    # test.yml, or path-skipped PRs will wait on it forever.
     paths:
       - "**/*.ts"
       - "**/*.tsx"
@@ -100,9 +103,15 @@ jobs:
           if [ "${STATUS:-1}" = "0" ]; then
             exit 0
           fi
-          if [ -n "${REPORT:-}" ] && jq -e '.ok == false' "$REPORT" >/dev/null 2>&1; then
-            message=$(jq -r '.error.message // "unknown error"' "$REPORT" | tr -d '\n')
-            echo "::warning title=React Doctor::Scanner crashed (${message}); not blocking the PR on a scanner failure."
-            exit 0
+          if [ -n "${REPORT:-}" ]; then
+            if ! jq -e . "$REPORT" >/dev/null 2>&1; then
+              echo "::warning title=React Doctor::Scanner exited ${STATUS:-1} without a valid JSON report; not blocking the PR on a scanner failure."
+              exit 0
+            fi
+            if jq -e '.ok == false' "$REPORT" >/dev/null 2>&1; then
+              message=$(jq -r '.error.message // "unknown error"' "$REPORT" | tr -d '\n')
+              echo "::warning title=React Doctor::Scanner crashed (${message}); not blocking the PR on a scanner failure."
+              exit 0
+            fi
           fi
           exit "${STATUS:-1}"

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,6 +3,12 @@ name: React Doctor
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.jsx"
+      - ".github/workflows/react-doctor.yml"
+      - ".github/scripts/react-doctor-comment.mjs"
 
 permissions:
   contents: read
@@ -48,10 +54,14 @@ jobs:
             exit 0
           fi
           REPORT="${RUNNER_TEMP}/react-doctor-report.json"
-          npx --yes react-doctor@0.4.2 . --blocking error --changed-files-from "$CHANGED" --json --json-compact > "$REPORT"
-          status=$?
+          status=0
+          npx --yes react-doctor@0.4.2 . --blocking error --changed-files-from "$CHANGED" --json --json-compact --no-telemetry > "$REPORT" || status=$?
           echo "exit-code=$status" >> "$GITHUB_OUTPUT"
           echo "report=$REPORT" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ]; then
+            echo "react-doctor exited with status ${status}; report follows." >&2
+            cat "$REPORT" >&2 || true
+          fi
 
       - name: Upsert sticky PR comment
         if: ${{ always() && steps.scan.outputs.report != '' }}
@@ -84,4 +94,15 @@ jobs:
         shell: bash
         env:
           STATUS: ${{ steps.scan.outputs.exit-code }}
-        run: exit "${STATUS:-1}"
+          REPORT: ${{ steps.scan.outputs.report }}
+        run: |
+          set -uo pipefail
+          if [ "${STATUS:-1}" = "0" ]; then
+            exit 0
+          fi
+          if [ -n "${REPORT:-}" ] && jq -e '.ok == false' "$REPORT" >/dev/null 2>&1; then
+            message=$(jq -r '.error.message // "unknown error"' "$REPORT" | tr -d '\n')
+            echo "::warning title=React Doctor::Scanner crashed (${message}); not blocking the PR on a scanner failure."
+            exit 0
+          fi
+          exit "${STATUS:-1}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           predicate-quantifier: every
           filters: |
+            # Wider excludes than code-quality.yml, which keeps .github/scripts
+            # and .vscode/.claude in scope because Biome lints them.
             code:
               - "!**/*.md"
               - "!docs/**"
@@ -37,7 +39,8 @@ jobs:
 
   unit-test:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
+    # Fail closed: if change detection itself failed, run instead of skipping.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,7 +73,8 @@ jobs:
 
   integration-test:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
+    # Fail closed: if change detection itself failed, run instead of skipping.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
     runs-on: macos-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - "!**/*.md"
+              - "!docs/**"
+              - "!.github/**"
+              - "!.vscode/**"
+              - "!.claude/**"
+              - "!.husky/**"
+              - "!LICENSE"
+              - "!.gitignore"
+              - "!.env.example"
+            workflow:
+              - ".github/workflows/test.yml"
+
   unit-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,6 +69,8 @@ jobs:
         run: pnpm test
 
   integration-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: macos-latest
     permissions:
       contents: read

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,7 +8,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - "!**/*.md"
+              - "!docs/**"
+              - "!.github/**"
+              - "!.vscode/**"
+              - "!.claude/**"
+              - "!.husky/**"
+              - "!LICENSE"
+              - "!.gitignore"
+              - "!.env.example"
+            workflow:
+              - ".github/workflows/typecheck.yml"
+
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           predicate-quantifier: every
           filters: |
+            # Wider excludes than code-quality.yml, which keeps .github/scripts
+            # and .vscode/.claude in scope because Biome lints them.
             code:
               - "!**/*.md"
               - "!docs/**"
@@ -37,7 +39,8 @@ jobs:
 
   typecheck:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true'
+    # Fail closed: if change detection itself failed, run instead of skipping.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true' || needs.changes.outputs.workflow == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

Every PR runs the full CI suite even when only docs or repo config change and react-doctor is broken.

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add paths-filter changes gate to build, test, typecheck and code-quality workflows
2. Skip those jobs when only markdown, docs or repo config files change
3. Re-run each gated workflow when its own YAML changes
4. Trigger react-doctor only on TS/TSX/JSX changes
5. Fix react-doctor exit code capture and disable telemetry

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

I did not

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?