### PR TITLE
fix(inbox): restore Scout in the source filter dropdown

### DIFF
--- a/packages/ui/src/features/inbox/CLAUDE.md
+++ b/packages/ui/src/features/inbox/CLAUDE.md
@@ -106,7 +106,7 @@ When adding or changing UI, reuse those primitives first. Avoid encoding one-off
 - Do not reuse the deleted legacy `ReportListRow`, `ReportDetailPane`, or old list/detail stores.
 - Do not put page-level Inbox title or navigation into the global app header; `InboxView` owns the Inbox page chrome.
 - Do not add a configure shortcut back into the Inbox header; Responders configuration is a sidebar destination.
-- Do not add Scout UI until a corresponding backend exists in this repo.
+- Scout (`signals_scout`) is a real Cloud source product. Keep it covered wherever source products surface: `INBOX_SOURCE_OPTIONS`, `SOURCE_PRODUCT_META`, and the scout-name display in `SignalCard`. Do not add Scout management UI (fleet configuration, run history) until a corresponding backend exists in this repo.
 - Do not put preview shims or mock report data in `apps/code/index.html`; the app shell should stay minimal.
 - Do not call `electronTRPC` directly from Inbox code. Use the existing API client, React Query hooks, or tRPC client wrappers.
 - Do not preserve compatibility with unshipped intermediate UI shapes on this branch. Replace them cleanly.

--- a/packages/ui/src/features/inbox/filterOptions.tsx
+++ b/packages/ui/src/features/inbox/filterOptions.tsx
@@ -3,6 +3,7 @@ import {
   BugIcon,
   CalendarPlus,
   Clock,
+  CompassIcon,
   GithubLogoIcon,
   KanbanIcon,
   LifebuoyIcon,
@@ -99,6 +100,7 @@ export const INBOX_SOURCE_OPTIONS: {
     icon: <LifebuoyIcon size={14} />,
   },
   { value: "pganalyze", label: "pganalyze", icon: <PgAnalyzeIcon size={14} /> },
+  { value: "signals_scout", label: "Scout", icon: <CompassIcon size={14} /> },
 ];
 
 export function inboxSortOptionKey(


### PR DESCRIPTION
## Problem

Inbox 2.0 (#2547) rebuilt the source filter from a new `INBOX_SOURCE_OPTIONS` list and dropped the `signals_scout` entry added in #2505. Scout-sourced reports could no longer be filtered: the dropdown had no Scout row, and a persisted Scout filter rendered its chip with the raw `signals_scout` value because the label lookup falls back to the raw string when no option matches.

## Changes

- Add Scout (`signals_scout`, compass icon) back to `INBOX_SOURCE_OPTIONS` in `packages/ui/src/features/inbox/filterOptions.tsx`, so the source dropdown lists Scout again and the filter chip reads "Scout".
- Reword the inbox `CLAUDE.md` rule that said "Do not add Scout UI until a corresponding backend exists in this repo" — it reads as if Scout shouldn't appear anywhere, which is likely how the filter entry got dropped. It now states Scout is a real Cloud source product that must stay covered in filter options, source meta, and signal cards, and scopes the prohibition to Scout management UI (fleet configuration, run history).

Scout coverage that survived 2.0 and is unchanged here: `SOURCE_PRODUCT_META` badges and the scout-name source line on `SignalCard` (#2538).

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` passes.
- `pnpm --filter @posthog/ui test` — 690 tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?