### PR TITLE
fix(inbox): rename LLM analytics source label to AI observability

### DIFF
--- a/packages/ui/src/features/inbox/filterOptions.tsx
+++ b/packages/ui/src/features/inbox/filterOptions.tsx
@@ -88,7 +88,7 @@ export const INBOX_SOURCE_OPTIONS: {
   },
   {
     value: "llm_analytics",
-    label: "LLM analytics",
+    label: "AI observability",
     icon: <BrainIcon size={14} />,
   },
   { value: "github", label: "GitHub", icon: <GithubLogoIcon size={14} /> },


### PR DESCRIPTION
## Problem

The inbox source filter dropdown still labelled the AI observability source as "LLM analytics". Everywhere else in the codebase — `SOURCE_PRODUCT_META`, the mobile filter sheet, the docs link — already uses "AI observability", so the dropdown was the lone inconsistency.

**Why:** Leon flagged that the source for AIO was still surfaced as "LLM Analytics" and should be renamed to "AI Observability" for consistency.

## Changes

- Rename the `llm_analytics` source label in `INBOX_SOURCE_OPTIONS` from "LLM analytics" to "AI observability". The internal `llm_analytics` key (backend contract) is unchanged.

## How did you test this?

- Visual change only; no automated tests run. Verified there were no other user-facing "LLM analytics" display labels left in the codebase.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781128764933289?thread_ts=1781128764.933289&cid=C09G8Q32R6F)*
