### PR TITLE
fix(code): fix live progress on tool calls

### DIFF
--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
@@ -357,4 +357,50 @@ describe("createIncrementalConversationBuilder", () => {
       expect(tool2.turnContext.toolCalls.get("t1")?.status).toBe("completed");
     }
   });
+
+  it("gives the active turn a fresh toolCalls Map identity each call so an in-place tool update re-renders", () => {
+    // SessionUpdateView is memoized on `turnContext.toolCalls`, and tool_call_update
+    // mutates the tool entry in place. If the Map reference is reused across calls
+    // the memo bails and the completed status (and streamed output) stay hidden
+    // until the turn ends. Guard that the Map identity changes every event.
+    const inc = createIncrementalConversationBuilder();
+    const base = [userPromptMsg(1, 1, "go"), toolCallMsg(2, "t1")];
+    const r1 = inc.update(base, true);
+    const next = [...base, toolUpdateMsg(3, "t1", { status: "completed" })];
+    const r2 = inc.update(next, true);
+
+    const ctx1 = r1.items.find((i) => i.type === "session_update");
+    const ctx2 = r2.items.find((i) => i.type === "session_update");
+    if (ctx1?.type !== "session_update" || ctx2?.type !== "session_update") {
+      throw new Error("expected tool-call session_update rows");
+    }
+    expect(ctx2.turnContext.toolCalls).not.toBe(ctx1.turnContext.toolCalls);
+    expect(ctx2.turnContext.childItems).not.toBe(ctx1.turnContext.childItems);
+  });
+
+  it("surfaces a running agent's child tool calls live, before the turn completes", () => {
+    // A subagent appends child tool calls (parentToolCallId) while it runs. The
+    // parent row is memoized on `turnContext.childItems`; without a fresh Map ref
+    // the new children stay invisible until turn end. Guard that a child appended
+    // mid-turn changes the childItems Map identity and is present.
+    const inc = createIncrementalConversationBuilder();
+    const base = [
+      userPromptMsg(1, 1, "go"),
+      toolCallMsg(2, "agent1", {
+        _meta: { claudeCode: { toolName: "Agent" } },
+      }),
+    ];
+    const r1 = inc.update(base, true);
+    const next = [...base, childToolCallMsg(3, "child1", "agent1")];
+    const r2 = inc.update(next, true);
+
+    const row1 = r1.items.find((i) => i.type === "session_update");
+    const row2 = r2.items.find((i) => i.type === "session_update");
+    if (row1?.type !== "session_update" || row2?.type !== "session_update") {
+      throw new Error("expected agent session_update rows");
+    }
+    // New child arrived mid-turn: fresh Map identity so the memoized parent re-renders.
+    expect(row2.turnContext.childItems).not.toBe(row1.turnContext.childItems);
+    expect(row2.turnContext.childItems.get("agent1")?.length).toBe(1);
+  });
 });

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
@@ -132,8 +132,8 @@ function assembleItems(
   // so pass them through by reference.
   const activeContext: TurnContext | null = turn
     ? {
-        toolCalls: turn.context.toolCalls,
-        childItems: turn.context.childItems,
+        toolCalls: new Map(turn.context.toolCalls),
+        childItems: new Map(turn.context.childItems),
         turnCancelled: turn.context.turnCancelled,
         turnComplete: turn.context.turnComplete,
       }


### PR DESCRIPTION
## Problem

tool call progress never updates, until the entire turn is over

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

clone tool call context maps instead of passing by reference to trigger a re-render

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?