### PR TITLE
fix(proxy): stop the 30s auth fetch timeout from killing streamed LLM requests

### DIFF
--- a/packages/workspace-server/src/services/auth-proxy/auth-proxy.test.ts
+++ b/packages/workspace-server/src/services/auth-proxy/auth-proxy.test.ts
@@ -1,0 +1,118 @@
+import type { RootLogger } from "@posthog/di/logger";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProxyService } from "./auth-proxy";
+import type { AuthProxyAuth } from "./ports";
+
+type AuthMock = {
+  authenticatedFetch: ReturnType<typeof vi.fn>;
+};
+
+describe("AuthProxyService", () => {
+  let authMock: AuthMock;
+  let service: AuthProxyService;
+
+  beforeEach(() => {
+    authMock = { authenticatedFetch: vi.fn() };
+    const loggerMock: RootLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      scope: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      }),
+    };
+    service = new AuthProxyService(
+      authMock as unknown as AuthProxyAuth,
+      loggerMock,
+    );
+  });
+
+  afterEach(async () => {
+    await service.stop();
+    vi.restoreAllMocks();
+  });
+
+  it("forwards requests and returns the upstream body and status", async () => {
+    authMock.authenticatedFetch.mockResolvedValue(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const proxyUrl = await service.start("https://gateway.example");
+    const res = await fetch(`${proxyUrl}/v1/messages`, {
+      method: "POST",
+      body: "{}",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('{"ok":true}');
+    const [url] = authMock.authenticatedFetch.mock.calls[0];
+    expect(url).toBe("https://gateway.example/v1/messages");
+  });
+
+  it("passes a connection-lifetime signal so authenticatedFetch's default timeout does not apply", async () => {
+    authMock.authenticatedFetch.mockResolvedValue(new Response("ok"));
+
+    const proxyUrl = await service.start("https://gateway.example");
+    await fetch(`${proxyUrl}/v1/messages`, { method: "POST", body: "{}" });
+
+    const [, options] = authMock.authenticatedFetch.mock.calls[0];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect(options.signal.aborted).toBe(false);
+  });
+
+  it("aborts the upstream fetch when the client disconnects mid-stream", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    authMock.authenticatedFetch.mockImplementation(
+      async (_url: string, options: RequestInit) => {
+        upstreamSignal = options.signal ?? undefined;
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+            // Never closes — simulates an in-flight LLM stream.
+          },
+        });
+        return new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      },
+    );
+
+    const proxyUrl = await service.start("https://gateway.example");
+    const clientAbort = new AbortController();
+    const res = await fetch(`${proxyUrl}/v1/messages`, {
+      signal: clientAbort.signal,
+    });
+    const reader = res.body?.getReader();
+    await reader?.read();
+
+    expect(upstreamSignal?.aborted).toBe(false);
+    clientAbort.abort();
+
+    await vi.waitFor(() => {
+      expect(upstreamSignal?.aborted).toBe(true);
+    });
+  });
+
+  it("streams the upstream body through to the client", async () => {
+    authMock.authenticatedFetch.mockResolvedValue(
+      new Response("data: one\n\ndata: two\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    const proxyUrl = await service.start("https://gateway.example");
+    const res = await fetch(`${proxyUrl}/v1/messages`);
+
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    expect(await res.text()).toBe("data: one\n\ndata: two\n\n");
+  });
+});

--- a/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
+++ b/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
@@ -8,6 +8,18 @@ import { inject, injectable } from "inversify";
 import { AUTH_PROXY_AUTH } from "./identifiers";
 import type { AuthProxyAuth } from "./ports";
 
+function waitForDrainOrClose(res: http.ServerResponse): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const settle = () => {
+      res.off("drain", settle);
+      res.off("close", settle);
+      resolve();
+    };
+    res.once("drain", settle);
+    res.once("close", settle);
+  });
+}
+
 @injectable()
 export class AuthProxyService {
   private server: http.Server | null = null;
@@ -144,9 +156,20 @@ export class AuthProxyService {
         headers[key] = value;
       }
     }
+    // The client connection governs the request lifetime. An explicit signal
+    // also opts out of authenticatedFetch's default timeout, which would
+    // abort streaming LLM responses that outlive it.
+    const abort = new AbortController();
+    res.on("close", () => {
+      if (!res.writableEnded) {
+        abort.abort();
+      }
+    });
+
     const fetchOptions: RequestInit = {
       method: req.method ?? "GET",
       headers,
+      signal: abort.signal,
     };
 
     if (req.method !== "GET" && req.method !== "HEAD") {
@@ -188,22 +211,24 @@ export class AuthProxyService {
       }
 
       const reader = response.body.getReader();
-      const pump = async (): Promise<void> => {
+      while (true) {
         const { done, value } = await reader.read();
         if (done) {
           res.end();
           return;
         }
-        const canContinue = res.write(value);
-        if (canContinue) {
-          return pump();
+        if (!res.write(value)) {
+          await waitForDrainOrClose(res);
         }
-        res.once("drain", () => pump());
-      };
-
-      await pump();
+      }
     } catch (err) {
-      this.log.error("Proxy forward error", { url, err });
+      if (options.signal?.aborted) {
+        this.log.debug("Upstream fetch aborted after client disconnect", {
+          url,
+        });
+      } else {
+        this.log.error("Proxy forward error", { url, err });
+      }
       if (!res.headersSent) {
         res.writeHead(502);
       }

--- a/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
+++ b/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
@@ -5,20 +5,9 @@ import {
   type ScopedLogger,
 } from "@posthog/di/logger";
 import { inject, injectable } from "inversify";
+import { streamBodyToResponse } from "../proxy-stream/proxy-stream";
 import { AUTH_PROXY_AUTH } from "./identifiers";
 import type { AuthProxyAuth } from "./ports";
-
-function waitForDrainOrClose(res: http.ServerResponse): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const settle = () => {
-      res.off("drain", settle);
-      res.off("close", settle);
-      resolve();
-    };
-    res.once("drain", settle);
-    res.once("close", settle);
-  });
-}
 
 @injectable()
 export class AuthProxyService {
@@ -205,22 +194,7 @@ export class AuthProxyService {
 
       res.writeHead(response.status, responseHeaders);
 
-      if (!response.body) {
-        res.end();
-        return;
-      }
-
-      const reader = response.body.getReader();
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          res.end();
-          return;
-        }
-        if (!res.write(value)) {
-          await waitForDrainOrClose(res);
-        }
-      }
+      await streamBodyToResponse(response.body, res);
     } catch (err) {
       if (options.signal?.aborted) {
         this.log.debug("Upstream fetch aborted after client disconnect", {

--- a/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
+++ b/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
@@ -114,6 +114,24 @@ describe("McpProxyService", () => {
       expect(url).toBe("https://upstream.example");
     });
 
+    it("passes a connection-lifetime signal so authenticatedFetch's default timeout does not apply", async () => {
+      authServiceMock.authenticatedFetch.mockResolvedValue(
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await service.start();
+      const proxyUrl = service.register("alpha", "https://upstream.example");
+
+      await fetch(proxyUrl);
+
+      const [, options] = authServiceMock.authenticatedFetch.mock.calls[0];
+      expect(options.signal).toBeInstanceOf(AbortSignal);
+      expect(options.signal.aborted).toBe(false);
+    });
+
     it("forwards POST body bytes to the upstream URL", async () => {
       authServiceMock.authenticatedFetch.mockResolvedValue(
         new Response('{"ok":true}', {

--- a/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
+++ b/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
@@ -8,6 +8,18 @@ import { inject, injectable, preDestroy } from "inversify";
 import { MCP_PROXY_AUTH } from "./identifiers";
 import type { McpProxyAuth } from "./ports";
 
+function waitForDrainOrClose(res: http.ServerResponse): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const settle = () => {
+      res.off("drain", settle);
+      res.off("close", settle);
+      resolve();
+    };
+    res.once("drain", settle);
+    res.once("close", settle);
+  });
+}
+
 function truncateRequestBody(body: RequestInit["body"]): string | undefined {
   if (body == null) return undefined;
   if (typeof body === "string") return body.slice(0, 2000);
@@ -151,9 +163,20 @@ export class McpProxyService {
       }
     }
 
+    // The client connection governs the request lifetime. An explicit signal
+    // also opts out of authenticatedFetch's default timeout, which would
+    // abort long-running MCP tool calls that outlive it.
+    const abort = new AbortController();
+    res.on("close", () => {
+      if (!res.writableEnded) {
+        abort.abort();
+      }
+    });
+
     const fetchOptions: RequestInit = {
       method: req.method ?? "GET",
       headers,
+      signal: abort.signal,
     };
 
     if (req.method !== "GET" && req.method !== "HEAD") {
@@ -209,7 +232,7 @@ export class McpProxyService {
             this.writeBufferedResponse(response, retryBuf, res);
             return;
           }
-          this.writeStreamingResponse(response, res);
+          await this.writeStreamingResponse(response, res);
           return;
         }
 
@@ -234,15 +257,23 @@ export class McpProxyService {
         return;
       }
 
-      this.writeStreamingResponse(response, res);
+      await this.writeStreamingResponse(response, res);
     } catch (err) {
-      this.log.error("MCP proxy forward error", {
-        id,
-        url,
-        method: options.method,
-        requestBody: truncateRequestBody(options.body),
-        err,
-      });
+      if (options.signal?.aborted) {
+        this.log.debug("Upstream fetch aborted after client disconnect", {
+          id,
+          url,
+          method: options.method,
+        });
+      } else {
+        this.log.error("MCP proxy forward error", {
+          id,
+          url,
+          method: options.method,
+          requestBody: truncateRequestBody(options.body),
+          err,
+        });
+      }
       if (!res.headersSent) {
         res.writeHead(502);
       }
@@ -300,18 +331,15 @@ export class McpProxyService {
     res.on("close", () => {
       void reader.cancel().catch(() => {});
     });
-    const pump = async (): Promise<void> => {
+    while (true) {
       const { done, value } = await reader.read();
       if (done) {
         res.end();
         return;
       }
-      const canContinue = res.write(value);
-      if (canContinue) {
-        return pump();
+      if (!res.write(value)) {
+        await waitForDrainOrClose(res);
       }
-      res.once("drain", () => pump());
-    };
-    await pump();
+    }
   }
 }

--- a/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
+++ b/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
@@ -5,20 +5,9 @@ import {
   type ScopedLogger,
 } from "@posthog/di/logger";
 import { inject, injectable, preDestroy } from "inversify";
+import { streamBodyToResponse } from "../proxy-stream/proxy-stream";
 import { MCP_PROXY_AUTH } from "./identifiers";
 import type { McpProxyAuth } from "./ports";
-
-function waitForDrainOrClose(res: http.ServerResponse): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const settle = () => {
-      res.off("drain", settle);
-      res.off("close", settle);
-      resolve();
-    };
-    res.once("drain", settle);
-    res.once("close", settle);
-  });
-}
 
 function truncateRequestBody(body: RequestInit["body"]): string | undefined {
   if (body == null) return undefined;
@@ -323,23 +312,6 @@ export class McpProxyService {
     res: http.ServerResponse,
   ): Promise<void> {
     res.writeHead(response.status, this.buildResponseHeaders(response));
-    if (!response.body) {
-      res.end();
-      return;
-    }
-    const reader = response.body.getReader();
-    res.on("close", () => {
-      void reader.cancel().catch(() => {});
-    });
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        res.end();
-        return;
-      }
-      if (!res.write(value)) {
-        await waitForDrainOrClose(res);
-      }
-    }
+    await streamBodyToResponse(response.body, res);
   }
 }

--- a/packages/workspace-server/src/services/proxy-stream/proxy-stream.test.ts
+++ b/packages/workspace-server/src/services/proxy-stream/proxy-stream.test.ts
@@ -1,0 +1,78 @@
+import http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamBodyToResponse } from "./proxy-stream";
+
+describe("streamBodyToResponse", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      if (!server) return resolve();
+      server.close(() => resolve());
+    });
+    server = undefined;
+  });
+
+  async function serve(
+    handler: (res: http.ServerResponse) => void,
+  ): Promise<string> {
+    const srv = http.createServer((_req, res) => handler(res));
+    server = srv;
+    await new Promise<void>((resolve) =>
+      srv.listen(0, "127.0.0.1", () => resolve()),
+    );
+    const addr = srv.address() as { port: number };
+    return `http://127.0.0.1:${addr.port}`;
+  }
+
+  it("copies the body to the response and ends it", async () => {
+    const url = await serve((res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      void streamBodyToResponse(
+        new Response("data: one\n\ndata: two\n\n").body,
+        res,
+      );
+    });
+
+    const res = await fetch(url);
+
+    expect(await res.text()).toBe("data: one\n\ndata: two\n\n");
+  });
+
+  it("ends the response when the body is null", async () => {
+    const url = await serve((res) => {
+      res.writeHead(200);
+      void streamBodyToResponse(null, res);
+    });
+
+    const res = await fetch(url);
+
+    expect(await res.text()).toBe("");
+  });
+
+  it("cancels the upstream body when the client disconnects", async () => {
+    let cancelled = false;
+    const url = await serve((res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+          // Never closes — simulates an in-flight upstream stream.
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      void streamBodyToResponse(body, res);
+    });
+
+    const clientAbort = new AbortController();
+    const res = await fetch(url, { signal: clientAbort.signal });
+    await res.body?.getReader().read();
+    clientAbort.abort();
+
+    await vi.waitFor(() => {
+      expect(cancelled).toBe(true);
+    });
+  });
+});

--- a/packages/workspace-server/src/services/proxy-stream/proxy-stream.ts
+++ b/packages/workspace-server/src/services/proxy-stream/proxy-stream.ts
@@ -1,0 +1,43 @@
+import type http from "node:http";
+
+function waitForDrainOrClose(res: http.ServerResponse): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const settle = () => {
+      res.off("drain", settle);
+      res.off("close", settle);
+      resolve();
+    };
+    res.once("drain", settle);
+    res.once("close", settle);
+  });
+}
+
+/**
+ * Copy a fetch Response body to an http.ServerResponse, respecting
+ * backpressure. The caller writes the response head first. A client
+ * disconnect cancels the upstream read; upstream errors reject so the
+ * caller can handle them alongside its other fetch failures.
+ */
+export async function streamBodyToResponse(
+  body: ReadableStream<Uint8Array> | null,
+  res: http.ServerResponse,
+): Promise<void> {
+  if (!body) {
+    res.end();
+    return;
+  }
+  const reader = body.getReader();
+  res.on("close", () => {
+    void reader.cancel().catch(() => {});
+  });
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      res.end();
+      return;
+    }
+    if (!res.write(value)) {
+      await waitForDrainOrClose(res);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Since v0.54.15 (today), the agent "sits and spins forever" for a large number of users. Any agent turn whose LLM request — time-to-first-token plus the full stream — exceeds 30 seconds is aborted client-side, the agent SDK retries, each retry dies at the same 30s wall, and the UI spins indefinitely. Only turns that complete in under 30s succeed, which is why it intermittently "sometimes works" (first short message in a fresh session) and reliably fails once a session has any real context.

Root cause: #2582 added a default `AbortSignal.timeout(30_000)` to `executeAuthenticatedFetch` to stop a hung token refresh from wedging bootstrap. The auth proxy forwards every agent LLM request (`/posthog_code/v1/messages`) through that same path without passing a signal, so the 30s default applied to long-lived streaming requests. The MCP proxy has the identical exposure for long-running tool calls.

The fingerprint in logs is a storm of:

```
[error] (auth-proxy) Proxy forward error {
  url: 'https://gateway.us.posthog.com/posthog_code/v1/messages?beta=true',
  err: 'TimeoutError: The operation was aborted due to timeout'
```

repeating at exactly 30-second intervals. This error class first appears on Jun 10 — `AbortSignal.timeout` is the only thing on this path that can produce it. Reproduced in both the prod build (v0.54.18) and local dev.

## Changes

- **Auth proxy**: forwarded requests now carry an `AbortSignal` tied to the client connection. An explicit signal opts out of `authenticatedFetch`'s 30s default (`init.signal ?? AbortSignal.timeout(...)`), so streamed LLM responses are no longer killed — while #2582's timeout still protects the short token/bootstrap calls it was written for. Client disconnects (e.g. cancelling a turn) now also cancel the upstream request instead of orphaning it.
- **MCP proxy**: same fix for long-running MCP tool calls.
- Both streaming pumps await drain via a close-aware helper, so a mid-stream disconnect rejects into the existing catch instead of leaking a pending promise; client-disconnect aborts log at debug instead of error. Two floating `writeStreamingResponse(...)` promises in the MCP proxy are now awaited.

## How did you test this code?

- New `auth-proxy.test.ts`: basic forwarding, regression test that forwarded requests carry a non-aborted signal (suppressing the default timeout), upstream abort on client disconnect mid-stream, and streaming passthrough.
- Matching signal regression test added to `mcp-proxy.test.ts`.
- All 18 proxy tests pass; `pnpm --filter @posthog/workspace-server typecheck` and biome are clean. (`src/db/repositories` failures in a full suite run are a pre-existing local sqlite-binding issue, identical without these changes.)

Note for release management: the regression ships in **v0.54.15 and v0.54.18** — this likely warrants a hotfix release once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)