### PR TITLE
feat(agent): guide cloud agents to use the PostHog memory MCP tool

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1700,6 +1700,11 @@ export class AgentServer {
    * Guidance for the shared, semantically-searchable PostHog memory store exposed through the
    * `memory` MCP tool. Appended to every cloud-run system prompt so cloud agents recall durable
    * context across runs and persist new learnings — the same memory store Max/PostHog AI uses.
+   *
+   * Applies to both cloud runtimes: `_doInitializeSession` passes the PostHog MCP server (which
+   * carries the `memory` tool) via `newSession({ mcpServers })` for Claude and Codex alike, and
+   * the Codex adapter forwards those servers to the Codex CLI, so the tool is callable on both.
+   * `buildCodexInstructions` reusing this text for Codex runs is therefore intentional.
    */
   private buildMemoryInstructions(): string {
     return `

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1629,7 +1629,7 @@ export class AgentServer {
     prUrl?: string | null,
     slackThreadUrl?: string | null,
   ): string | { append: string } {
-    const cloudAppend = this.buildCloudSystemPrompt(prUrl, slackThreadUrl);
+    const cloudAppend = `${this.buildCloudSystemPrompt(prUrl, slackThreadUrl)}\n${this.buildMemoryInstructions()}`;
     const userPrompt = this.config.claudeCode?.systemPrompt;
 
     // String override: combine user prompt with cloud instructions
@@ -1694,6 +1694,23 @@ export class AgentServer {
       `2. Make changes, commit, and push to that branch\n` +
       `You MUST NOT create a new branch, close the existing PR, or create a new PR.`
     );
+  }
+
+  /**
+   * Guidance for the shared, semantically-searchable PostHog memory store exposed through the
+   * `memory` MCP tool. Appended to every cloud-run system prompt so cloud agents recall durable
+   * context across runs and persist new learnings — the same memory store Max/PostHog AI uses.
+   */
+  private buildMemoryInstructions(): string {
+    return `
+# Persistent Memory
+You have access to PostHog's persistent memory through the \`memory\` MCP tool — a shared,
+semantically-searchable store of durable facts about this user, their company, product, and
+preferences (the same memories used across PostHog AI). Memories persist across runs, so:
+- Before non-trivial work, recall context with the \`memory\` tool using \`action: "query"\` (semantic search) to surface durable facts, decisions, and prior discussions.
+- When you learn something durable — product setup, conventions, definitions, preferences, decisions — store it with \`action: "create"\`. Do this pre-emptively; you don't need to be asked. Query first to avoid duplicates.
+- Use \`action: "update"\`/\`"delete"\` to keep memories accurate, and \`action: "list_metadata_keys"\` to keep metadata tags consistent.
+- Memories are for durable facts, not transient task state. New memories become searchable once their embedding is processed.`;
   }
 
   private buildCloudSystemPrompt(


### PR DESCRIPTION
## Problem

Claude-style agent memories produced during PostHog Code **cloud runs** went nowhere — there was no persistent, shared memory store wired into cloud agents, so they couldn't recall durable context across runs or carry learnings forward.

## Changes

Appends a short **Persistent Memory** section to every cloud-run system prompt (`buildSessionSystemPrompt` → applied across all `buildCloudSystemPrompt` branches) telling cloud agents to use the PostHog `memory` MCP tool to recall durable facts before non-trivial work and to store new learnings pre-emptively.

The `memory` MCP tool is added server-side in PostHog/posthog (PostHog/posthog#62875), backed by the same `AgentMemory` / `document_embeddings` store Max/PostHog AI uses. No tool-allowlist change is needed here: cloud agents forward every PostHog MCP tool verbatim (`newSession({ mcpServers })`) under bypass-permissions, so the tool becomes available automatically — this PR only encourages its use.

## How did you test this?

I'm an agent, so I did not manually run the app. Automated checks I actually ran:

- `pnpm --filter @posthog/agent typecheck` — clean (after building workspace deps).
- The existing `agent-server.test.ts` cloud-prompt assertions use `toContain`, which this additive change preserves; that suite could not execute in my sandbox because its git-fixture setup calls `git commit`, which is blocked in this environment (the failure reproduces on unmodified `main`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09KTRWD3HD/p1781167930861249?thread_ts=1781167930.861249&cid=C09KTRWD3HD)*
