### PR TITLE
fix(models): order fable last and persist the selected model

### DIFF
--- a/packages/agent/src/adapters/base-acp-agent.ts
+++ b/packages/agent/src/adapters/base-acp-agent.ts
@@ -147,7 +147,9 @@ export abstract class BaseAcpAgent implements Agent {
       // Sort by tier so the picker is deterministic and code-named models
       // (e.g. fable) stay pinned last instead of floating to wherever the
       // gateway lists them.
-      .sort((a, b) => getClaudeModelTier(a.value) - getClaudeModelTier(b.value));
+      .sort(
+        (a, b) => getClaudeModelTier(a.value) - getClaudeModelTier(b.value),
+      );
 
     const isAnthropicModelId = (modelId: string): boolean =>
       modelId.startsWith("claude-") || modelId.startsWith("anthropic/");

--- a/packages/agent/src/adapters/base-acp-agent.ts
+++ b/packages/agent/src/adapters/base-acp-agent.ts
@@ -21,7 +21,7 @@ import {
   fetchGatewayModels,
   formatGatewayModelName,
   type GatewayModel,
-  getClaudeModelTier,
+  getClaudeModelRecency,
   isAnthropicModel,
 } from "../gateway-models";
 import { Logger } from "../utils/logger";
@@ -144,11 +144,11 @@ export abstract class BaseAcpAgent implements Agent {
         name: formatGatewayModelName(model),
         description: `Context: ${model.context_window.toLocaleString()} tokens`,
       }))
-      // Sort by tier so the picker is deterministic and code-named models
-      // (e.g. fable) stay pinned last instead of floating to wherever the
-      // gateway lists them.
+      // Sort oldest-to-newest so the picker is deterministic and the newest
+      // model lands at the end of the list, closest to the trigger.
       .sort(
-        (a, b) => getClaudeModelTier(a.value) - getClaudeModelTier(b.value),
+        (a, b) =>
+          getClaudeModelRecency(a.value) - getClaudeModelRecency(b.value),
       );
 
     const isAnthropicModelId = (modelId: string): boolean =>

--- a/packages/agent/src/adapters/base-acp-agent.ts
+++ b/packages/agent/src/adapters/base-acp-agent.ts
@@ -21,6 +21,7 @@ import {
   fetchGatewayModels,
   formatGatewayModelName,
   type GatewayModel,
+  getClaudeModelTier,
   isAnthropicModel,
 } from "../gateway-models";
 import { Logger } from "../utils/logger";
@@ -142,7 +143,11 @@ export abstract class BaseAcpAgent implements Agent {
         value: model.id,
         name: formatGatewayModelName(model),
         description: `Context: ${model.context_window.toLocaleString()} tokens`,
-      }));
+      }))
+      // Sort by tier so the picker is deterministic and code-named models
+      // (e.g. fable) stay pinned last instead of floating to wherever the
+      // gateway lists them.
+      .sort((a, b) => getClaudeModelTier(a.value) - getClaudeModelTier(b.value));
 
     const isAnthropicModelId = (modelId: string): boolean =>
       modelId.startsWith("claude-") || modelId.startsWith("anthropic/");

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatGatewayModelName, isBlockedModelId } from "./gateway-models";
+import {
+  formatGatewayModelName,
+  getClaudeModelTier,
+  isBlockedModelId,
+} from "./gateway-models";
 
 describe("formatGatewayModelName", () => {
   it("keeps Claude models in friendly title case", () => {
@@ -53,5 +57,33 @@ describe("formatGatewayModelName", () => {
     expect(isBlockedModelId("openai/gpt-5.2")).toBe(true);
     expect(isBlockedModelId("OPENAI/GPT-5.3")).toBe(true);
     expect(isBlockedModelId("OPENAI/GPT-5.3-CODEX")).toBe(true);
+  });
+});
+
+describe("getClaudeModelTier", () => {
+  it("orders flagship tiers ahead of code-named releases", () => {
+    expect(getClaudeModelTier("claude-opus-4-8")).toBe(0);
+    expect(getClaudeModelTier("claude-sonnet-4-6")).toBe(1);
+    expect(getClaudeModelTier("claude-haiku-4-5")).toBe(2);
+    expect(getClaudeModelTier("claude-fable-5")).toBe(3);
+  });
+
+  it("sorts fable last among the available Claude models", () => {
+    const ids = ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6"];
+    const sorted = [...ids].sort(
+      (a, b) => getClaudeModelTier(a) - getClaudeModelTier(b),
+    );
+    expect(sorted).toEqual([
+      "claude-opus-4-8",
+      "claude-sonnet-4-6",
+      "claude-fable-5",
+    ]);
+  });
+
+  it("sorts unknown models after every known tier", () => {
+    expect(getClaudeModelTier("claude-mystery-9")).toBe(4);
+    expect(getClaudeModelTier("claude-mystery-9")).toBeGreaterThan(
+      getClaudeModelTier("claude-fable-5"),
+    );
   });
 });

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -86,4 +86,11 @@ describe("getClaudeModelTier", () => {
       getClaudeModelTier("claude-fable-5"),
     );
   });
+
+  it("resolves to the earlier tier when an id matches multiple keywords", () => {
+    // Substring match follows CLAUDE_TIER_ORDER: "opus" precedes "fable", so an
+    // id containing both pins to the opus tier. This pins the precedence
+    // contract so the behaviour is intentional rather than coincidental.
+    expect(getClaudeModelTier("claude-opus-fable-experiment")).toBe(0);
+  });
 });

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -61,11 +61,13 @@ describe("formatGatewayModelName", () => {
 });
 
 describe("getClaudeModelTier", () => {
-  it("orders flagship tiers ahead of code-named releases", () => {
-    expect(getClaudeModelTier("claude-opus-4-8")).toBe(0);
-    expect(getClaudeModelTier("claude-sonnet-4-6")).toBe(1);
-    expect(getClaudeModelTier("claude-haiku-4-5")).toBe(2);
-    expect(getClaudeModelTier("claude-fable-5")).toBe(3);
+  it.each([
+    ["claude-opus-4-8", 0],
+    ["claude-sonnet-4-6", 1],
+    ["claude-haiku-4-5", 2],
+    ["claude-fable-5", 3],
+  ])("orders %s into tier %i", (modelId, tier) => {
+    expect(getClaudeModelTier(modelId)).toBe(tier);
   });
 
   it("sorts fable last among the available Claude models", () => {

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -82,6 +82,28 @@ describe("getClaudeModelTier", () => {
     ]);
   });
 
+  it("produces the full picker display order regardless of gateway order", () => {
+    // Models as the gateway might return them — arbitrary order.
+    const gatewayOrder = [
+      "claude-fable-5",
+      "claude-haiku-4-5",
+      "claude-mystery-9",
+      "claude-opus-4-8",
+      "claude-sonnet-4-6",
+    ];
+    const displayed = [...gatewayOrder].sort(
+      (a, b) => getClaudeModelTier(a) - getClaudeModelTier(b),
+    );
+    // Picker order: opus → sonnet → haiku → fable → any unknown model last.
+    expect(displayed).toEqual([
+      "claude-opus-4-8",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+      "claude-fable-5",
+      "claude-mystery-9",
+    ]);
+  });
+
   it("sorts unknown models after every known tier", () => {
     expect(getClaudeModelTier("claude-mystery-9")).toBe(4);
     expect(getClaudeModelTier("claude-mystery-9")).toBeGreaterThan(

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatGatewayModelName,
-  getClaudeModelTier,
+  getClaudeModelRecency,
   isBlockedModelId,
 } from "./gateway-models";
 
@@ -60,61 +60,52 @@ describe("formatGatewayModelName", () => {
   });
 });
 
-describe("getClaudeModelTier", () => {
+describe("getClaudeModelRecency", () => {
   it.each([
-    ["claude-opus-4-8", 0],
-    ["claude-sonnet-4-6", 1],
-    ["claude-haiku-4-5", 2],
-    ["claude-fable-5", 3],
-  ])("orders %s into tier %i", (modelId, tier) => {
-    expect(getClaudeModelTier(modelId)).toBe(tier);
+    ["claude-haiku-4-5", 4005],
+    ["claude-sonnet-4-6", 4006],
+    ["claude-opus-4-7", 4007],
+    ["claude-opus-4-8", 4008],
+    ["claude-fable-5", 5000],
+  ])("ranks %s by its embedded version (%i)", (modelId, rank) => {
+    expect(getClaudeModelRecency(modelId)).toBe(rank);
   });
 
-  it("sorts fable last among the available Claude models", () => {
-    const ids = ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6"];
-    const sorted = [...ids].sort(
-      (a, b) => getClaudeModelTier(a) - getClaudeModelTier(b),
+  it("ignores a trailing date suffix when reading the version", () => {
+    expect(getClaudeModelRecency("claude-haiku-4-5-20251001")).toBe(4005);
+  });
+
+  it("ranks a model with no recognisable version as newest", () => {
+    expect(getClaudeModelRecency("claude-mystery")).toBe(
+      Number.MAX_SAFE_INTEGER,
     );
-    expect(sorted).toEqual([
-      "claude-opus-4-8",
-      "claude-sonnet-4-6",
-      "claude-fable-5",
-    ]);
+    expect(getClaudeModelRecency("claude-mystery")).toBeGreaterThan(
+      getClaudeModelRecency("claude-fable-5"),
+    );
   });
 
-  it("produces the full picker display order regardless of gateway order", () => {
+  it("produces the full picker display order, oldest to newest", () => {
     // Models as the gateway might return them — arbitrary order.
     const gatewayOrder = [
       "claude-fable-5",
-      "claude-haiku-4-5",
-      "claude-mystery-9",
       "claude-opus-4-8",
+      "claude-mystery",
+      "claude-haiku-4-5",
       "claude-sonnet-4-6",
+      "claude-opus-4-7",
     ];
     const displayed = [...gatewayOrder].sort(
-      (a, b) => getClaudeModelTier(a) - getClaudeModelTier(b),
+      (a, b) => getClaudeModelRecency(a) - getClaudeModelRecency(b),
     );
-    // Picker order: opus → sonnet → haiku → fable → any unknown model last.
+    // The menu opens upward, so the newest model (last here) sits closest to
+    // the trigger. Unknown/unversioned models rank newest and trail the list.
     expect(displayed).toEqual([
-      "claude-opus-4-8",
-      "claude-sonnet-4-6",
       "claude-haiku-4-5",
+      "claude-sonnet-4-6",
+      "claude-opus-4-7",
+      "claude-opus-4-8",
       "claude-fable-5",
-      "claude-mystery-9",
+      "claude-mystery",
     ]);
-  });
-
-  it("sorts unknown models after every known tier", () => {
-    expect(getClaudeModelTier("claude-mystery-9")).toBe(4);
-    expect(getClaudeModelTier("claude-mystery-9")).toBeGreaterThan(
-      getClaudeModelTier("claude-fable-5"),
-    );
-  });
-
-  it("resolves to the earlier tier when an id matches multiple keywords", () => {
-    // Substring match follows CLAUDE_TIER_ORDER: "opus" precedes "fable", so an
-    // id containing both pins to the opus tier. This pins the precedence
-    // contract so the behaviour is intentional rather than coincidental.
-    expect(getClaudeModelTier("claude-opus-fable-experiment")).toBe(0);
   });
 });

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -174,21 +174,22 @@ export function getProviderName(ownedBy: string): string {
   return PROVIDER_NAMES[ownedBy] ?? ownedBy;
 }
 
-// Display order for Claude model tiers in pickers. Code-named releases such as
-// "claude-fable-5" don't contain a tier keyword, so without an explicit entry
-// they'd land at an arbitrary gateway-determined position. Listing "fable" last
-// keeps it pinned after the flagships; any future unknown model sorts after it
-// while preserving the gateway's relative order. Matching is substring-based
-// and precedence follows array order: the first keyword here that appears in
-// the id wins, so an id containing two keywords resolves to the earlier tier.
-const CLAUDE_TIER_ORDER = ["opus", "sonnet", "haiku", "fable"];
-
-export function getClaudeModelTier(modelId: string): number {
-  const lowerId = modelId.toLowerCase();
-  for (let i = 0; i < CLAUDE_TIER_ORDER.length; i++) {
-    if (lowerId.includes(CLAUDE_TIER_ORDER[i])) return i;
-  }
-  return CLAUDE_TIER_ORDER.length;
+// Sort key for ordering models oldest-to-newest in pickers. The model menu
+// opens upward (side="top"), so the last item sits closest to the trigger —
+// sorting ascending by this key puts the newest model right under the user's
+// cursor. The key is the version embedded in the model id, e.g.
+// "claude-sonnet-4-6" -> 4006, "claude-opus-4-8" -> 4008, "claude-fable-5" ->
+// 5000; a higher number means a newer model. An id with no recognisable
+// version (a brand-new or unexpected release) ranks as newest so it still
+// surfaces at the end rather than at an arbitrary gateway-determined position.
+// Only the first version group is read, so a trailing date suffix (e.g.
+// "-20251001") is ignored; the minor component is assumed to be < 1000.
+export function getClaudeModelRecency(modelId: string): number {
+  const match = modelId.toLowerCase().match(/-(\d+)(?:[-.](\d+))?/);
+  if (!match) return Number.MAX_SAFE_INTEGER;
+  const major = Number(match[1]);
+  const minor = match[2] ? Number(match[2]) : 0;
+  return major * 1000 + minor;
 }
 
 const PROVIDER_PREFIXES = ["anthropic/", "openai/", "google-vertex/"];

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -178,7 +178,9 @@ export function getProviderName(ownedBy: string): string {
 // "claude-fable-5" don't contain a tier keyword, so without an explicit entry
 // they'd land at an arbitrary gateway-determined position. Listing "fable" last
 // keeps it pinned after the flagships; any future unknown model sorts after it
-// while preserving the gateway's relative order.
+// while preserving the gateway's relative order. Matching is substring-based
+// and precedence follows array order: the first keyword here that appears in
+// the id wins, so an id containing two keywords resolves to the earlier tier.
 const CLAUDE_TIER_ORDER = ["opus", "sonnet", "haiku", "fable"];
 
 export function getClaudeModelTier(modelId: string): number {

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -174,6 +174,21 @@ export function getProviderName(ownedBy: string): string {
   return PROVIDER_NAMES[ownedBy] ?? ownedBy;
 }
 
+// Display order for Claude model tiers in pickers. Code-named releases such as
+// "claude-fable-5" don't contain a tier keyword, so without an explicit entry
+// they'd land at an arbitrary gateway-determined position. Listing "fable" last
+// keeps it pinned after the flagships; any future unknown model sorts after it
+// while preserving the gateway's relative order.
+const CLAUDE_TIER_ORDER = ["opus", "sonnet", "haiku", "fable"];
+
+export function getClaudeModelTier(modelId: string): number {
+  const lowerId = modelId.toLowerCase();
+  for (let i = 0; i < CLAUDE_TIER_ORDER.length; i++) {
+    if (lowerId.includes(CLAUDE_TIER_ORDER[i])) return i;
+  }
+  return CLAUDE_TIER_ORDER.length;
+}
+
 const PROVIDER_PREFIXES = ["anthropic/", "openai/", "google-vertex/"];
 
 export function formatGatewayModelName(model: GatewayModel): string {

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -116,6 +116,7 @@ export function TaskInput({
     defaultInitialTaskMode,
     lastUsedInitialTaskMode,
     setLastUsedReasoningEffort,
+    setLastUsedModel,
   } = useSettingsStore();
 
   const editorRef = useRef<EditorHandle>(null);
@@ -526,9 +527,10 @@ export function TaskInput({
     (value: string) => {
       if (modelOption) {
         setConfigOption(modelOption.id, value);
+        setLastUsedModel(value);
       }
     },
-    [modelOption, setConfigOption],
+    [modelOption, setConfigOption, setLastUsedModel],
   );
 
   const handleThoughtChange = useCallback(

--- a/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -88,9 +88,7 @@ export function usePreviewConfig(
         // without this the user's last pick (e.g. fable) is lost on every
         // refetch/remount. Restore it through applyConfigChange so the dependent
         // effort options are recomputed for the restored model.
-        const modelOpt = initial.find(
-          (o) => o.id === "model" || o.category === "model",
-        );
+        const modelOpt = getOptionByCategory(initial, "model");
         if (
           lastUsedModel &&
           modelOpt?.type === "select" &&

--- a/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -1,5 +1,6 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { getReasoningEffortOptions } from "@posthog/agent/adapters/reasoning-effort";
+import { flattenConfigValues } from "@posthog/core/task-detail/configOptions";
 import {
   applyConfigChange,
   deriveInitialConfig,
@@ -69,20 +70,49 @@ export function usePreviewConfig(
           lastUsedInitialTaskMode,
           defaultReasoningEffort,
           lastUsedReasoningEffort,
+          lastUsedModel,
         } = useSettingsStore.getState();
 
-        setConfigOptions(
-          deriveInitialConfig(
-            options,
-            {
-              defaultInitialTaskMode,
-              lastUsedInitialTaskMode,
+        let initial = deriveInitialConfig(
+          options,
+          {
+            defaultInitialTaskMode,
+            lastUsedInitialTaskMode,
+            defaultReasoningEffort,
+            lastUsedReasoningEffort,
+          },
+          adapter,
+        );
+
+        // The server always returns its default model as the current value, so
+        // without this the user's last pick (e.g. fable) is lost on every
+        // refetch/remount. Restore it through applyConfigChange so the dependent
+        // effort options are recomputed for the restored model.
+        const modelOpt = initial.find(
+          (o) => o.id === "model" || o.category === "model",
+        );
+        if (
+          lastUsedModel &&
+          modelOpt?.type === "select" &&
+          modelOpt.currentValue !== lastUsedModel &&
+          flattenConfigValues(modelOpt).includes(lastUsedModel)
+        ) {
+          initial = applyConfigChange(initial, {
+            adapter,
+            configId: modelOpt.id,
+            value: lastUsedModel,
+            effortOptions:
+              getReasoningEffortOptions(adapter, lastUsedModel) ?? undefined,
+            settings: {
+              defaultInitialTaskMode: "",
+              lastUsedInitialTaskMode: undefined,
               defaultReasoningEffort,
               lastUsedReasoningEffort,
             },
-            adapter,
-          ),
-        );
+          });
+        }
+
+        setConfigOptions(initial);
         setIsLoading(false);
       })
       .catch((error) => {

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_GATEWAY_MODEL,
   fetchGatewayModels,
   formatGatewayModelName,
+  getClaudeModelTier,
   getProviderName,
   isAnthropicModel,
   isOpenAIModel,
@@ -1802,15 +1803,6 @@ For git operations while detached:
       provider: getProviderName(model.owned_by),
     }));
 
-    const CLAUDE_TIER_ORDER = ["opus", "sonnet", "haiku"];
-    const getModelTier = (modelId: string): number => {
-      const lowerId = modelId.toLowerCase();
-      for (let i = 0; i < CLAUDE_TIER_ORDER.length; i++) {
-        if (lowerId.includes(CLAUDE_TIER_ORDER[i])) return i;
-      }
-      return CLAUDE_TIER_ORDER.length;
-    };
-
     return mapped.sort((a, b) => {
       const providerOrder = ["Anthropic", "OpenAI", "Gemini"];
       const aProviderIdx = providerOrder.indexOf(a.provider ?? "");
@@ -1820,7 +1812,7 @@ For git operations while detached:
         const bIdx = bProviderIdx === -1 ? 999 : bProviderIdx;
         return aIdx - bIdx;
       }
-      return getModelTier(a.modelId) - getModelTier(b.modelId);
+      return getClaudeModelTier(a.modelId) - getClaudeModelTier(b.modelId);
     });
   }
 
@@ -1840,6 +1832,15 @@ For git operations while detached:
         name: formatGatewayModelName(model),
         description: `Context: ${model.context_window.toLocaleString()} tokens`,
       }));
+
+    // The gateway returns models in an arbitrary order. Sort Claude models by
+    // tier so the picker is deterministic and code-named models (e.g. fable)
+    // stay pinned last instead of floating to wherever the gateway lists them.
+    if (adapter === "claude") {
+      modelOptions.sort(
+        (a, b) => getClaudeModelTier(a.value) - getClaudeModelTier(b.value),
+      );
+    }
 
     const defaultModel =
       adapter === "codex"

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -30,7 +30,7 @@ import {
   DEFAULT_GATEWAY_MODEL,
   fetchGatewayModels,
   formatGatewayModelName,
-  getClaudeModelTier,
+  getClaudeModelRecency,
   getProviderName,
   isAnthropicModel,
   isOpenAIModel,
@@ -1812,7 +1812,9 @@ For git operations while detached:
         const bIdx = bProviderIdx === -1 ? 999 : bProviderIdx;
         return aIdx - bIdx;
       }
-      return getClaudeModelTier(a.modelId) - getClaudeModelTier(b.modelId);
+      return (
+        getClaudeModelRecency(a.modelId) - getClaudeModelRecency(b.modelId)
+      );
     });
   }
 
@@ -1833,12 +1835,13 @@ For git operations while detached:
         description: `Context: ${model.context_window.toLocaleString()} tokens`,
       }));
 
-    // The gateway returns models in an arbitrary order. Sort Claude models by
-    // tier so the picker is deterministic and code-named models (e.g. fable)
-    // stay pinned last instead of floating to wherever the gateway lists them.
+    // The gateway returns models in an arbitrary order. Sort Claude models
+    // oldest-to-newest so the picker is deterministic and the newest model
+    // lands at the end of the list, closest to the trigger.
     if (adapter === "claude") {
       modelOptions.sort(
-        (a, b) => getClaudeModelTier(a.value) - getClaudeModelTier(b.value),
+        (a, b) =>
+          getClaudeModelRecency(a.value) - getClaudeModelRecency(b.value),
       );
     }
 


### PR DESCRIPTION

<img width="628" height="654" alt="CleanShot 2026-06-11 at 12 12 38@2x" src="https://github.com/user-attachments/assets/c708cee8-7d24-4afa-b5c9-c6e91aa534f8" />


## Problem

In the new-task flow, the `fable` model (a) wasn't ordered last in the model picker, and (b) didn't survive as the displayed model once selected — it reverted to the default (Claude Opus 4.8) on the next refetch/remount. Reported by Paul: "model selection or display is having a senior moment."

## Changes

- **Ordering:** `getPreviewConfigOptions` and the in-session `getModelConfigOptions` mapped the gateway's `/v1/models` response with no sorting, so models appeared in whatever order the gateway returned. Added a shared `getClaudeModelRecency` helper and sort both Claude pickers by it, oldest-to-newest. The existing admin `getGatewayModels` sort reuses the same helper.
- **Persistence:** the selected model lived only in ephemeral hook state; `deriveInitialConfig` restored `mode` and `effort` from settings but not the model, and the server always returned its default as `currentValue`. Wired the already-present-but-never-called `setLastUsedModel` into `handleModelChange`, and restored `lastUsedModel` in `usePreviewConfig` via `applyConfigChange` so the dependent reasoning-effort options are recomputed for the restored model.

### Model display order

The model menu opens **upward** (`side="top"` in `UnifiedModelSelector`), so the last item in the list sits closest to the trigger — right under the cursor that just opened it. Models are therefore sorted **oldest → newest**, putting the newest model closest to the mouse for selection.

Ordering is by the version number embedded in the model id (`getClaudeModelRecency`), e.g. `claude-sonnet-4-6` → `4006`, `claude-opus-4-8` → `4008`, `claude-fable-5` → `5000` — higher is newer. For example, the available Claude models display as:

1. `claude-sonnet-4-6` (oldest)
2. `claude-opus-4-7`
3. `claude-opus-4-8`
4. `claude-fable-5` (newest — closest to the cursor)

Notes:
- A model id with no recognisable version (a brand-new or unexpected release) ranks as newest, so it trails the list rather than landing at an arbitrary gateway-determined position.
- Only the first version group is read, so a trailing date suffix (e.g. `-20251001`) is ignored; the minor component is assumed `< 1000`.

## How did you test this?

- `pnpm --filter @posthog/agent test gateway-models` — recency-ordering tests (13 passing), including:
  - `getClaudeModelRecency` returns the expected rank per model (parameterised).
  - a trailing date suffix is ignored when reading the version.
  - a model with no recognisable version ranks as newest.
  - **the full picker display order** (`sonnet-4-6 → opus-4-7 → opus-4-8 → fable-5 → unversioned`) holds regardless of the gateway's input order.
- `pnpm typecheck` on `@posthog/agent`, `@posthog/workspace-server`, `@posthog/ui` — clean.
- `biome ci` on all changed files — clean (also fixed a formatting issue the `quality` check caught).
- Pre-existing unrelated `@posthog/agent` test failures (agent-server, resume-saga, etc. — stale `@posthog/git` dist) were confirmed to fail identically on a clean tree before these changes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781171234920529?thread_ts=1781171234.920529&cid=C09G8Q32R6F)*
