### PR TITLE
feat(skills): create, edit, and delete user and repo skills

### DIFF
--- a/packages/host-router/src/routers/skills.router.ts
+++ b/packages/host-router/src/routers/skills.router.ts
@@ -8,7 +8,6 @@ import {
   readSkillFileInput,
   readSkillFileOutput,
   renameSkillFileInput,
-  renameSkillInput,
   saveSkillFileInput,
   saveSkillManifestInput,
   skillContentsInput,
@@ -83,13 +82,5 @@ export const skillsRouter = router({
       ctx.container
         .get<SkillsService>(SKILLS_SERVICE)
         .deleteSkill(input.skillPath),
-    ),
-  rename: publicProcedure
-    .input(renameSkillInput)
-    .output(skillPathOutput)
-    .mutation(({ ctx, input }) =>
-      ctx.container
-        .get<SkillsService>(SKILLS_SERVICE)
-        .renameSkill(input.skillPath, input.newName),
     ),
 });

--- a/packages/host-router/src/routers/skills.router.ts
+++ b/packages/host-router/src/routers/skills.router.ts
@@ -1,11 +1,19 @@
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
 import { SKILLS_SERVICE } from "@posthog/workspace-server/services/skills/identifiers";
 import {
+  createSkillInput,
+  deleteSkillFileInput,
+  deleteSkillInput,
   listSkillsOutput,
   readSkillFileInput,
   readSkillFileOutput,
+  renameSkillFileInput,
+  renameSkillInput,
+  saveSkillFileInput,
+  saveSkillManifestInput,
   skillContentsInput,
   skillContentsOutput,
+  skillPathOutput,
 } from "@posthog/workspace-server/services/skills/schemas";
 import type { SkillsService } from "@posthog/workspace-server/services/skills/skills";
 
@@ -30,5 +38,58 @@ export const skillsRouter = router({
       ctx.container
         .get<SkillsService>(SKILLS_SERVICE)
         .readSkillFile(input.skillPath, input.filePath),
+    ),
+  create: publicProcedure
+    .input(createSkillInput)
+    .output(skillPathOutput)
+    .mutation(({ ctx, input }) =>
+      ctx.container.get<SkillsService>(SKILLS_SERVICE).createSkill(input),
+    ),
+  saveManifest: publicProcedure
+    .input(saveSkillManifestInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .saveSkillManifest(input.skillPath, {
+          name: input.name,
+          description: input.description,
+          body: input.body,
+        }),
+    ),
+  saveFile: publicProcedure
+    .input(saveSkillFileInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .saveSkillFile(input.skillPath, input.filePath, input.content),
+    ),
+  renameFile: publicProcedure
+    .input(renameSkillFileInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .renameSkillFile(input.skillPath, input.fromPath, input.toPath),
+    ),
+  deleteFile: publicProcedure
+    .input(deleteSkillFileInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .deleteSkillFile(input.skillPath, input.filePath),
+    ),
+  delete: publicProcedure
+    .input(deleteSkillInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .deleteSkill(input.skillPath),
+    ),
+  rename: publicProcedure
+    .input(renameSkillInput)
+    .output(skillPathOutput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .renameSkill(input.skillPath, input.newName),
     ),
 });

--- a/packages/ui/src/features/skills/NewSkillDialog.tsx
+++ b/packages/ui/src/features/skills/NewSkillDialog.tsx
@@ -65,7 +65,7 @@ export function NewSkillDialog({
               }}
             />
             <Text className="mt-1 block text-[11px] text-gray-9">
-              Lowercase letters, numbers, and dashes
+              Lowercase letters, numbers, dashes, dots, and underscores
             </Text>
           </Box>
           <Box>

--- a/packages/ui/src/features/skills/NewSkillDialog.tsx
+++ b/packages/ui/src/features/skills/NewSkillDialog.tsx
@@ -1,0 +1,106 @@
+import { toast } from "@posthog/ui/primitives/toast";
+import {
+  Box,
+  Button,
+  Dialog,
+  Flex,
+  Select,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
+import { useState } from "react";
+import { useFolders } from "../folders/useFolders";
+import { useCreateSkill } from "./useSkillMutations";
+
+const USER_SCOPE = "user";
+
+interface NewSkillDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (path: string) => void;
+}
+
+export function NewSkillDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: NewSkillDialogProps) {
+  const { folders } = useFolders();
+  const createSkill = useCreateSkill();
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState(USER_SCOPE);
+
+  const handleCreate = async () => {
+    try {
+      const result = await createSkill.mutateAsync(
+        scope === USER_SCOPE
+          ? { scope: "user", name }
+          : { scope: "repo", repoPath: scope, name },
+      );
+      setName("");
+      onOpenChange(false);
+      onCreated(result.path);
+    } catch (error) {
+      toast.error("Failed to create skill", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="380px" size="2">
+        <Dialog.Title size="3">New skill</Dialog.Title>
+        <Flex direction="column" gap="3" mt="3">
+          <Box>
+            <Text className="mb-1 block text-[12px] text-gray-10">Name</Text>
+            <TextField.Root
+              size="2"
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-skill"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && name.trim()) void handleCreate();
+              }}
+            />
+            <Text className="mt-1 block text-[11px] text-gray-9">
+              Lowercase letters, numbers, and dashes
+            </Text>
+          </Box>
+          <Box>
+            <Text className="mb-1 block text-[12px] text-gray-10">
+              Location
+            </Text>
+            <Select.Root value={scope} onValueChange={setScope}>
+              <Select.Trigger className="w-full" />
+              <Select.Content>
+                <Select.Item value={USER_SCOPE}>Your skills</Select.Item>
+                {folders.map((folder) => (
+                  <Select.Item key={folder.path} value={folder.path}>
+                    Repository: {folder.name}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          </Box>
+          <Flex justify="end" gap="2" mt="2">
+            <Dialog.Close>
+              <Button size="1" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </Dialog.Close>
+            <Button
+              size="1"
+              variant="solid"
+              onClick={handleCreate}
+              disabled={createSkill.isPending || !name.trim()}
+            >
+              Create
+            </Button>
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/packages/ui/src/features/skills/SkillCodeEditor.tsx
+++ b/packages/ui/src/features/skills/SkillCodeEditor.tsx
@@ -1,0 +1,42 @@
+import { EditorView } from "@codemirror/view";
+import { useMemo, useRef } from "react";
+import { useCodeMirror } from "../code-editor/hooks/useCodeMirror";
+import { useEditorExtensions } from "../code-editor/hooks/useEditorExtensions";
+
+interface SkillCodeEditorProps {
+  /** Initial document; the editor is uncontrolled after mount. */
+  initialContent: string;
+  filePath?: string;
+  onDocChanged: (doc: string) => void;
+}
+
+/** Editable CodeMirror for skill files. Reports edits via onDocChanged. */
+export function SkillCodeEditor({
+  initialContent,
+  filePath,
+  onDocChanged,
+}: SkillCodeEditorProps) {
+  const onDocChangedRef = useRef(onDocChanged);
+  onDocChangedRef.current = onDocChanged;
+
+  const baseExtensions = useEditorExtensions(filePath, false);
+  const extensions = useMemo(
+    () => [
+      ...baseExtensions,
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          onDocChangedRef.current(update.state.doc.toString());
+        }
+      }),
+    ],
+    [baseExtensions],
+  );
+
+  const options = useMemo(
+    () => ({ doc: initialContent, extensions, filePath }),
+    [initialContent, extensions, filePath],
+  );
+  const { containerRef } = useCodeMirror(options);
+
+  return <div ref={containerRef} className="h-full w-full" />;
+}

--- a/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -163,7 +163,7 @@ export function SkillDetailPanel({ skill, onClose }: SkillDetailPanelProps) {
                     type="button"
                     aria-label="Edit skill"
                     onClick={() => setIsEditing(true)}
-                    disabled={isLoading}
+                    disabled={isLoading || fileContent == null}
                     className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
                   >
                     <PencilSimple size={14} />

--- a/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -1,13 +1,40 @@
-import { Folder, LockSimple, X } from "@phosphor-icons/react";
+import {
+  FilePlus,
+  Folder,
+  LockSimple,
+  PencilSimple,
+  Trash,
+  X,
+} from "@phosphor-icons/react";
 import type { SkillInfo } from "@posthog/shared";
 import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { ExternalAppsOpener } from "@posthog/ui/features/task-detail/components/ExternalAppsOpener";
-import { Badge, Box, Flex, ScrollArea, Text } from "@radix-ui/themes";
+import { toast } from "@posthog/ui/primitives/toast";
+import {
+  AlertDialog,
+  Badge,
+  Box,
+  Button,
+  Dialog,
+  Flex,
+  ScrollArea,
+  Text,
+  TextField,
+  Tooltip,
+} from "@radix-ui/themes";
 import { useState } from "react";
 import { SOURCE_CONFIG } from "./SkillCard";
+import { SkillFileEditor } from "./SkillFileEditor";
 import { SkillFileTree } from "./SkillFileTree";
+import { SkillManifestEditor } from "./SkillManifestEditor";
 import { useSkillContents, useSkillFile } from "./useSkillContents";
+import {
+  useDeleteSkill,
+  useDeleteSkillFile,
+  useRenameSkillFile,
+  useSaveSkillFile,
+} from "./useSkillMutations";
 
 function stripFrontmatter(content: string): string {
   const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n/);
@@ -23,15 +50,97 @@ export function SkillDetailPanel({ skill, onClose }: SkillDetailPanelProps) {
   const config = SOURCE_CONFIG[skill.source];
 
   const [selectedFile, setSelectedFile] = useState("SKILL.md");
+  const [isEditing, setIsEditing] = useState(false);
+  const [addFileOpen, setAddFileOpen] = useState(false);
+  const [newFilePath, setNewFilePath] = useState("");
+  const [renameFrom, setRenameFrom] = useState<string | null>(null);
+  const [renameTo, setRenameTo] = useState("");
+  const [deleteFileTarget, setDeleteFileTarget] = useState<string | null>(null);
+  const [deleteSkillOpen, setDeleteSkillOpen] = useState(false);
+
   const { data: contents } = useSkillContents(skill.path);
   const { data: fileContent, isLoading } = useSkillFile(
     skill.path,
     selectedFile,
   );
 
+  const saveFile = useSaveSkillFile();
+  const renameFile = useRenameSkillFile();
+  const deleteFile = useDeleteSkillFile();
+  const deleteSkill = useDeleteSkill();
+
   const files = contents?.files ?? [];
   const isSkillMd = selectedFile === "SKILL.md";
   const body = isSkillMd && fileContent ? stripFrontmatter(fileContent) : null;
+
+  const handleAddFile = async () => {
+    const filePath = newFilePath.trim();
+    if (!filePath) return;
+    try {
+      await saveFile.mutateAsync({
+        skillPath: skill.path,
+        filePath,
+        content: "",
+      });
+      setAddFileOpen(false);
+      setNewFilePath("");
+      setSelectedFile(filePath);
+      setIsEditing(true);
+    } catch (error) {
+      toast.error("Failed to add file", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  const handleRenameFile = async () => {
+    const toPath = renameTo.trim();
+    if (!renameFrom || !toPath) return;
+    try {
+      await renameFile.mutateAsync({
+        skillPath: skill.path,
+        fromPath: renameFrom,
+        toPath,
+      });
+      if (selectedFile === renameFrom) setSelectedFile(toPath);
+      setRenameFrom(null);
+    } catch (error) {
+      toast.error("Failed to rename file", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  const handleDeleteFile = async () => {
+    if (!deleteFileTarget) return;
+    try {
+      await deleteFile.mutateAsync({
+        skillPath: skill.path,
+        filePath: deleteFileTarget,
+      });
+      if (selectedFile === deleteFileTarget) {
+        setSelectedFile("SKILL.md");
+        setIsEditing(false);
+      }
+      setDeleteFileTarget(null);
+    } catch (error) {
+      toast.error("Failed to delete file", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  const handleDeleteSkill = async () => {
+    try {
+      await deleteSkill.mutateAsync({ skillPath: skill.path });
+      setDeleteSkillOpen(false);
+      onClose();
+    } catch (error) {
+      toast.error("Failed to delete skill", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
 
   return (
     <>
@@ -46,13 +155,53 @@ export function SkillDetailPanel({ skill, onClose }: SkillDetailPanelProps) {
           <Text className="block min-w-0 break-words font-medium text-[13px]">
             {skill.name}
           </Text>
-          <button
-            type="button"
-            onClick={onClose}
-            className="shrink-0 rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-          >
-            <X size={14} />
-          </button>
+          <Flex align="center" gap="1" className="shrink-0">
+            {skill.editable && !isEditing && (
+              <>
+                <Tooltip content="Edit skill">
+                  <button
+                    type="button"
+                    aria-label="Edit skill"
+                    onClick={() => setIsEditing(true)}
+                    disabled={isLoading}
+                    className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+                  >
+                    <PencilSimple size={14} />
+                  </button>
+                </Tooltip>
+                <Tooltip content="Add file">
+                  <button
+                    type="button"
+                    aria-label="Add file"
+                    onClick={() => setAddFileOpen(true)}
+                    className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+                  >
+                    <FilePlus size={14} />
+                  </button>
+                </Tooltip>
+                <Tooltip content="Delete skill">
+                  <button
+                    type="button"
+                    aria-label="Delete skill"
+                    onClick={() => setDeleteSkillOpen(true)}
+                    className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-red-11"
+                  >
+                    <Trash size={14} />
+                  </button>
+                </Tooltip>
+              </>
+            )}
+            <Tooltip content="Close">
+              <button
+                type="button"
+                aria-label="Close"
+                onClick={onClose}
+                className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+              >
+                <X size={14} />
+              </button>
+            </Tooltip>
+          </Flex>
         </Flex>
 
         <Flex align="center" gap="2" wrap="wrap">
@@ -82,13 +231,43 @@ export function SkillDetailPanel({ skill, onClose }: SkillDetailPanelProps) {
           <SkillFileTree
             files={files}
             selectedPath={selectedFile}
-            onSelect={setSelectedFile}
+            onSelect={(path) => {
+              setSelectedFile(path);
+              setIsEditing(false);
+            }}
+            onRenameFile={
+              skill.editable
+                ? (path) => {
+                    setRenameFrom(path);
+                    setRenameTo(path);
+                  }
+                : undefined
+            }
+            onDeleteFile={
+              skill.editable ? (path) => setDeleteFileTarget(path) : undefined
+            }
           />
         </Box>
       )}
 
       <Box className="min-h-0 flex-1">
-        {isSkillMd ? (
+        {isEditing && isSkillMd ? (
+          <SkillManifestEditor
+            skill={skill}
+            initialBody={body ?? ""}
+            onCancel={() => setIsEditing(false)}
+            onSaved={() => setIsEditing(false)}
+          />
+        ) : isEditing ? (
+          <SkillFileEditor
+            key={`${skill.path}/${selectedFile}`}
+            skill={skill}
+            filePath={selectedFile}
+            initialContent={fileContent ?? ""}
+            onCancel={() => setIsEditing(false)}
+            onSaved={() => setIsEditing(false)}
+          />
+        ) : isSkillMd ? (
           <ScrollArea
             type="auto"
             scrollbars="vertical"
@@ -133,6 +312,139 @@ export function SkillDetailPanel({ skill, onClose }: SkillDetailPanelProps) {
           </Box>
         )}
       </Box>
+
+      <Dialog.Root open={addFileOpen} onOpenChange={setAddFileOpen}>
+        <Dialog.Content maxWidth="380px" size="2">
+          <Dialog.Title size="3">Add file</Dialog.Title>
+          <Dialog.Description size="1" color="gray">
+            Path relative to the skill directory
+          </Dialog.Description>
+          <Flex direction="column" gap="3" mt="3">
+            <TextField.Root
+              size="2"
+              autoFocus
+              value={newFilePath}
+              onChange={(e) => setNewFilePath(e.target.value)}
+              placeholder="references/guide.md"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleAddFile();
+              }}
+            />
+            <Flex justify="end" gap="2">
+              <Dialog.Close>
+                <Button size="1" variant="soft" color="gray">
+                  Cancel
+                </Button>
+              </Dialog.Close>
+              <Button
+                size="1"
+                variant="solid"
+                onClick={handleAddFile}
+                disabled={saveFile.isPending || !newFilePath.trim()}
+              >
+                Add
+              </Button>
+            </Flex>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      <Dialog.Root
+        open={renameFrom !== null}
+        onOpenChange={(open) => {
+          if (!open) setRenameFrom(null);
+        }}
+      >
+        <Dialog.Content maxWidth="380px" size="2">
+          <Dialog.Title size="3">Rename file</Dialog.Title>
+          <Flex direction="column" gap="3" mt="3">
+            <TextField.Root
+              size="2"
+              autoFocus
+              value={renameTo}
+              onChange={(e) => setRenameTo(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleRenameFile();
+              }}
+            />
+            <Flex justify="end" gap="2">
+              <Dialog.Close>
+                <Button size="1" variant="soft" color="gray">
+                  Cancel
+                </Button>
+              </Dialog.Close>
+              <Button
+                size="1"
+                variant="solid"
+                onClick={handleRenameFile}
+                disabled={renameFile.isPending || !renameTo.trim()}
+              >
+                Rename
+              </Button>
+            </Flex>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      <AlertDialog.Root
+        open={deleteFileTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteFileTarget(null);
+        }}
+      >
+        <AlertDialog.Content maxWidth="420px" size="2">
+          <AlertDialog.Title size="3">Delete file</AlertDialog.Title>
+          <AlertDialog.Description size="1">
+            Delete "{deleteFileTarget}" from this skill? This cannot be undone.
+          </AlertDialog.Description>
+          <Flex justify="end" gap="2" mt="4">
+            <AlertDialog.Cancel>
+              <Button size="1" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action>
+              <Button
+                size="1"
+                variant="solid"
+                color="red"
+                onClick={handleDeleteFile}
+              >
+                Delete
+              </Button>
+            </AlertDialog.Action>
+          </Flex>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
+
+      <AlertDialog.Root
+        open={deleteSkillOpen}
+        onOpenChange={setDeleteSkillOpen}
+      >
+        <AlertDialog.Content maxWidth="420px" size="2">
+          <AlertDialog.Title size="3">Delete skill</AlertDialog.Title>
+          <AlertDialog.Description size="1">
+            Delete "{skill.name}" and all of its files? This cannot be undone.
+          </AlertDialog.Description>
+          <Flex justify="end" gap="2" mt="4">
+            <AlertDialog.Cancel>
+              <Button size="1" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action>
+              <Button
+                size="1"
+                variant="solid"
+                color="red"
+                onClick={handleDeleteSkill}
+              >
+                Delete
+              </Button>
+            </AlertDialog.Action>
+          </Flex>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
     </>
   );
 }

--- a/packages/ui/src/features/skills/SkillFileEditor.tsx
+++ b/packages/ui/src/features/skills/SkillFileEditor.tsx
@@ -1,0 +1,75 @@
+import type { SkillInfo } from "@posthog/shared";
+import { toast } from "@posthog/ui/primitives/toast";
+import { Box, Button, Flex } from "@radix-ui/themes";
+import { useRef, useState } from "react";
+import { SkillCodeEditor } from "./SkillCodeEditor";
+import { useSaveSkillFile } from "./useSkillMutations";
+
+interface SkillFileEditorProps {
+  skill: SkillInfo;
+  filePath: string;
+  initialContent: string;
+  onCancel: () => void;
+  onSaved: () => void;
+}
+
+/** Edit mode for a companion file inside a skill directory. */
+export function SkillFileEditor({
+  skill,
+  filePath,
+  initialContent,
+  onCancel,
+  onSaved,
+}: SkillFileEditorProps) {
+  // Captured at mount: background refetches must not reset in-flight edits.
+  const [mountedContent] = useState(initialContent);
+  const contentRef = useRef(mountedContent);
+  const saveFile = useSaveSkillFile();
+
+  const handleSave = async () => {
+    try {
+      await saveFile.mutateAsync({
+        skillPath: skill.path,
+        filePath,
+        content: contentRef.current,
+      });
+      onSaved();
+    } catch (error) {
+      toast.error("Failed to save file", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  return (
+    <Flex direction="column" height="100%">
+      <Box className="min-h-0 flex-1">
+        <SkillCodeEditor
+          initialContent={mountedContent}
+          filePath={`${skill.path}/${filePath}`}
+          onDocChanged={(doc) => {
+            contentRef.current = doc;
+          }}
+        />
+      </Box>
+      <Flex
+        justify="end"
+        gap="2"
+        p="2"
+        className="shrink-0 border-t border-t-(--gray-5)"
+      >
+        <Button size="1" variant="soft" color="gray" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="1"
+          variant="solid"
+          onClick={handleSave}
+          disabled={saveFile.isPending}
+        >
+          Save
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/skills/SkillFileTree.tsx
+++ b/packages/ui/src/features/skills/SkillFileTree.tsx
@@ -1,9 +1,10 @@
+import { PencilSimple, Trash } from "@phosphor-icons/react";
 import type { SkillFileEntry } from "@posthog/shared";
 import {
   TreeDirectoryRow,
   TreeFileRow,
 } from "@posthog/ui/primitives/TreeDirectoryRow";
-import { Flex } from "@radix-ui/themes";
+import { Flex, Tooltip } from "@radix-ui/themes";
 import { useMemo, useState } from "react";
 
 interface TreeDir {
@@ -36,12 +37,17 @@ interface SkillFileTreeProps {
   files: SkillFileEntry[];
   selectedPath: string | null;
   onSelect: (path: string) => void;
+  /** When set, file rows (except SKILL.md) get rename/delete actions. */
+  onRenameFile?: (path: string) => void;
+  onDeleteFile?: (path: string) => void;
 }
 
 export function SkillFileTree({
   files,
   selectedPath,
   onSelect,
+  onRenameFile,
+  onDeleteFile,
 }: SkillFileTreeProps) {
   const tree = useMemo(() => buildTree(files), [files]);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
@@ -74,16 +80,56 @@ export function SkillFileTree({
           </Flex>
         );
       })}
-      {dir.files.map((file) => (
-        <TreeFileRow
-          key={file.path}
-          fileName={file.name}
-          depth={depth}
-          isActive={selectedPath === file.path}
-          title={file.path}
-          onClick={() => onSelect(file.path)}
-        />
-      ))}
+      {dir.files.map((file) => {
+        const showActions =
+          (onRenameFile || onDeleteFile) && file.path !== "SKILL.md";
+        return (
+          <TreeFileRow
+            key={file.path}
+            fileName={file.name}
+            depth={depth}
+            isActive={selectedPath === file.path}
+            title={file.path}
+            onClick={() => onSelect(file.path)}
+            trailing={
+              showActions ? (
+                <Flex gap="1" className="shrink-0">
+                  {onRenameFile && (
+                    <Tooltip content="Rename file">
+                      <button
+                        type="button"
+                        aria-label="Rename file"
+                        className="rounded p-0.5 text-gray-9 hover:bg-gray-4 hover:text-gray-12"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onRenameFile(file.path);
+                        }}
+                      >
+                        <PencilSimple size={12} />
+                      </button>
+                    </Tooltip>
+                  )}
+                  {onDeleteFile && (
+                    <Tooltip content="Delete file">
+                      <button
+                        type="button"
+                        aria-label="Delete file"
+                        className="rounded p-0.5 text-gray-9 hover:bg-gray-4 hover:text-gray-12"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDeleteFile(file.path);
+                        }}
+                      >
+                        <Trash size={12} />
+                      </button>
+                    </Tooltip>
+                  )}
+                </Flex>
+              ) : undefined
+            }
+          />
+        );
+      })}
     </Flex>
   );
 

--- a/packages/ui/src/features/skills/SkillManifestEditor.tsx
+++ b/packages/ui/src/features/skills/SkillManifestEditor.tsx
@@ -1,0 +1,106 @@
+import type { SkillInfo } from "@posthog/shared";
+import { toast } from "@posthog/ui/primitives/toast";
+import { Box, Button, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
+import { useRef, useState } from "react";
+import { SkillCodeEditor } from "./SkillCodeEditor";
+import { useSaveSkillManifest } from "./useSkillMutations";
+
+interface SkillManifestEditorProps {
+  skill: SkillInfo;
+  initialBody: string;
+  onCancel: () => void;
+  onSaved: () => void;
+}
+
+/**
+ * Edit mode for SKILL.md: a small form for the frontmatter (users never
+ * hand-edit YAML) plus a markdown editor for the body.
+ */
+export function SkillManifestEditor({
+  skill,
+  initialBody,
+  onCancel,
+  onSaved,
+}: SkillManifestEditorProps) {
+  const [name, setName] = useState(skill.name);
+  const [description, setDescription] = useState(skill.description);
+  // Captured at mount: background refetches must not reset in-flight edits.
+  const [mountedBody] = useState(initialBody);
+  const bodyRef = useRef(mountedBody);
+  const saveManifest = useSaveSkillManifest();
+
+  const handleSave = async () => {
+    try {
+      await saveManifest.mutateAsync({
+        skillPath: skill.path,
+        name,
+        description,
+        body: bodyRef.current,
+      });
+      onSaved();
+    } catch (error) {
+      toast.error("Failed to save skill", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  return (
+    <Flex direction="column" height="100%">
+      <Flex direction="column" gap="2" p="3" className="shrink-0">
+        <Box>
+          <Text as="label" className="mb-1 block text-[12px] text-gray-10">
+            Name
+          </Text>
+          <TextField.Root
+            size="1"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="skill-name"
+          />
+        </Box>
+        <Box>
+          <Text as="label" className="mb-1 block text-[12px] text-gray-10">
+            Description
+          </Text>
+          <TextArea
+            size="1"
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="When should an agent use this skill?"
+          />
+        </Box>
+      </Flex>
+
+      <Box className="min-h-0 flex-1 border-t border-t-(--gray-5)">
+        <SkillCodeEditor
+          initialContent={mountedBody}
+          filePath={`${skill.path}/SKILL.md`}
+          onDocChanged={(doc) => {
+            bodyRef.current = doc;
+          }}
+        />
+      </Box>
+
+      <Flex
+        justify="end"
+        gap="2"
+        p="2"
+        className="shrink-0 border-t border-t-(--gray-5)"
+      >
+        <Button size="1" variant="soft" color="gray" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="1"
+          variant="solid"
+          onClick={handleSave}
+          disabled={saveManifest.isPending || !name.trim()}
+        >
+          Save
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/skills/SkillsView.tsx
+++ b/packages/ui/src/features/skills/SkillsView.tsx
@@ -1,9 +1,17 @@
-import { Lightbulb, MagnifyingGlass } from "@phosphor-icons/react";
+import { Lightbulb, MagnifyingGlass, Plus } from "@phosphor-icons/react";
 import type { SkillInfo, SkillSource } from "@posthog/shared";
-import { Box, Flex, ScrollArea, Text, TextField } from "@radix-ui/themes";
+import {
+  Box,
+  Button,
+  Flex,
+  ScrollArea,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSetHeaderContent } from "../../hooks/useSetHeaderContent";
 import { ResizableSidebar } from "../../primitives/ResizableSidebar";
+import { NewSkillDialog } from "./NewSkillDialog";
 import { SkillSection, SOURCE_CONFIG } from "./SkillCard";
 import { SkillDetailPanel } from "./SkillDetailPanel";
 import {
@@ -21,6 +29,7 @@ export function SkillsView() {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [scrollToPath, setScrollToPath] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [newSkillOpen, setNewSkillOpen] = useState(false);
 
   const {
     width: sidebarWidth,
@@ -106,19 +115,29 @@ export function SkillsView() {
             className="scroll-area-constrain-width h-full"
           >
             <Box px="4" py="3">
-              <Box pb="3">
-                <TextField.Root
+              <Flex pb="3" gap="2" align="center">
+                <Box flexGrow="1">
+                  <TextField.Root
+                    size="2"
+                    placeholder="Search skills..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="text-[13px]"
+                  >
+                    <TextField.Slot>
+                      <MagnifyingGlass size={14} />
+                    </TextField.Slot>
+                  </TextField.Root>
+                </Box>
+                <Button
                   size="2"
-                  placeholder="Search skills..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="text-[13px]"
+                  variant="soft"
+                  onClick={() => setNewSkillOpen(true)}
                 >
-                  <TextField.Slot>
-                    <MagnifyingGlass size={14} />
-                  </TextField.Slot>
-                </TextField.Root>
-              </Box>
+                  <Plus size={14} />
+                  New skill
+                </Button>
+              </Flex>
               {skills.length === 0 && !isLoading ? (
                 <Flex
                   align="center"
@@ -176,6 +195,12 @@ export function SkillsView() {
           )}
         </ResizableSidebar>
       </Flex>
+
+      <NewSkillDialog
+        open={newSkillOpen}
+        onOpenChange={setNewSkillOpen}
+        onCreated={(path) => setSelectedPath(path)}
+      />
     </Flex>
   );
 }

--- a/packages/ui/src/features/skills/useSkillMutations.ts
+++ b/packages/ui/src/features/skills/useSkillMutations.ts
@@ -1,0 +1,59 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+function useInvalidateSkills() {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+  return useCallback(() => {
+    void queryClient.invalidateQueries(trpc.skills.pathFilter());
+  }, [queryClient, trpc]);
+}
+
+export function useCreateSkill() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.create.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
+export function useSaveSkillManifest() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.saveManifest.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
+export function useSaveSkillFile() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.saveFile.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
+export function useRenameSkillFile() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.renameFile.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
+export function useDeleteSkillFile() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.deleteFile.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
+export function useDeleteSkill() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.delete.mutationOptions({ onSuccess: invalidate }),
+  );
+}

--- a/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
+++ b/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
@@ -59,10 +59,20 @@ function extractYamlValue(yaml: string, key: string): string | null {
 
 function collectIndentedLines(lines: string[], startIndex: number): string[] {
   const result: string[] = [];
+  let pendingBlanks = 0;
   for (let i = startIndex; i < lines.length; i++) {
     const line = lines[i];
+    // Blank lines only count if more indented content follows.
+    if (/^\s*$/.test(line)) {
+      pendingBlanks++;
+      continue;
+    }
     // Continuation lines must be indented
     if (line.match(/^\s+\S/)) {
+      if (result.length > 0) {
+        for (let b = 0; b < pendingBlanks; b++) result.push("");
+      }
+      pendingBlanks = 0;
       result.push(line.trim());
     } else {
       break;

--- a/packages/workspace-server/src/services/skills/schemas.ts
+++ b/packages/workspace-server/src/services/skills/schemas.ts
@@ -74,11 +74,6 @@ export const deleteSkillInput = z.object({
   skillPath: z.string(),
 });
 
-export const renameSkillInput = z.object({
-  skillPath: z.string(),
-  newName: z.string(),
-});
-
 export type SkillInfo = z.infer<typeof skillInfo>;
 export type SkillScope = z.infer<typeof skillScope>;
 export type CreateSkillInput = z.infer<typeof createSkillInput>;

--- a/packages/workspace-server/src/services/skills/schemas.ts
+++ b/packages/workspace-server/src/services/skills/schemas.ts
@@ -34,7 +34,54 @@ export const readSkillFileInput = z.object({
 
 export const readSkillFileOutput = z.string().nullable();
 
+export const skillScope = z.enum(["user", "repo"]);
+
+export const createSkillInput = z.object({
+  scope: skillScope,
+  repoPath: z.string().optional(),
+  name: z.string(),
+});
+
+export const skillPathOutput = z.object({
+  path: z.string(),
+});
+
+export const saveSkillManifestInput = z.object({
+  skillPath: z.string(),
+  name: z.string(),
+  description: z.string(),
+  body: z.string(),
+});
+
+export const saveSkillFileInput = z.object({
+  skillPath: z.string(),
+  filePath: z.string(),
+  content: z.string(),
+});
+
+export const renameSkillFileInput = z.object({
+  skillPath: z.string(),
+  fromPath: z.string(),
+  toPath: z.string(),
+});
+
+export const deleteSkillFileInput = z.object({
+  skillPath: z.string(),
+  filePath: z.string(),
+});
+
+export const deleteSkillInput = z.object({
+  skillPath: z.string(),
+});
+
+export const renameSkillInput = z.object({
+  skillPath: z.string(),
+  newName: z.string(),
+});
+
 export type SkillInfo = z.infer<typeof skillInfo>;
+export type SkillScope = z.infer<typeof skillScope>;
+export type CreateSkillInput = z.infer<typeof createSkillInput>;
 export type SkillSource = z.infer<typeof skillSource>;
 export type SkillFileEntry = z.infer<typeof skillFileEntry>;
 export type SkillContents = z.infer<typeof skillContentsOutput>;

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -251,9 +251,6 @@ describe("write-path guard", () => {
     await expect(service.deleteSkill(target())).rejects.toThrow(
       "Access denied",
     );
-    await expect(service.renameSkill(target(), "other")).rejects.toThrow(
-      "Access denied",
-    );
   });
 
   it("rejects file writes that escape the skill directory", async () => {
@@ -342,17 +339,5 @@ describe("skill mutations", () => {
 
     const skills = await service.listSkills();
     expect(skills.find((s) => s.path === skillPath)).toBeUndefined();
-  });
-
-  it("renames a skill directory", async () => {
-    const skillPath = await createSkill(repoSkillsDir, "alpha");
-    const service = makeService();
-
-    const { path: newPath } = await service.renameSkill(skillPath, "omega");
-
-    expect(newPath).toBe(path.join(repoSkillsDir, "omega"));
-    const skills = await service.listSkills();
-    expect(skills.some((s) => s.path === newPath)).toBe(true);
-    expect(skills.some((s) => s.path === skillPath)).toBe(false);
   });
 });

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -179,3 +179,180 @@ describe("readSkillFile", () => {
     );
   });
 });
+
+describe("createSkill", () => {
+  it("scaffolds a directory with a parseable SKILL.md", async () => {
+    const service = makeService();
+
+    const { path: skillPath } = await service.createSkill({
+      scope: "repo",
+      repoPath: folderPath,
+      name: "new-skill",
+    });
+
+    expect(skillPath).toBe(path.join(repoSkillsDir, "new-skill"));
+    const skills = await service.listSkills();
+    const created = skills.find((s) => s.path === skillPath);
+    expect(created).toMatchObject({ name: "new-skill", editable: true });
+  });
+
+  it("rejects invalid names", async () => {
+    await expect(
+      makeService().createSkill({
+        scope: "repo",
+        repoPath: folderPath,
+        name: "../escape",
+      }),
+    ).rejects.toThrow("Skill names must be");
+  });
+
+  it("rejects repo scope for folders that are not open", async () => {
+    await expect(
+      makeService().createSkill({
+        scope: "repo",
+        repoPath: path.join(root, "other-repo"),
+        name: "new-skill",
+      }),
+    ).rejects.toThrow("not an open workspace folder");
+  });
+
+  it("rejects duplicate names", async () => {
+    await createSkill(repoSkillsDir, "alpha");
+
+    await expect(
+      makeService().createSkill({
+        scope: "repo",
+        repoPath: folderPath,
+        name: "alpha",
+      }),
+    ).rejects.toThrow("already exists");
+  });
+});
+
+describe("write-path guard", () => {
+  it.each([
+    ["bundled skill", () => path.join(pluginPath, "skills", "bundled-skill")],
+    ["arbitrary directory", () => path.join(root, "rogue")],
+    [
+      "traversal out of a writable root",
+      () => path.join(repoSkillsDir, "alpha", "..", ".."),
+    ],
+  ])("rejects mutations against a %s", async (_label, target) => {
+    await createSkill(path.join(pluginPath, "skills"), "bundled-skill");
+    await createSkill(repoSkillsDir, "alpha");
+    const { mkdir: mk, writeFile: wf } = await import("node:fs/promises");
+    await mk(path.join(root, "rogue"), { recursive: true });
+    await wf(path.join(root, "rogue", "SKILL.md"), "rogue");
+    const service = makeService();
+
+    await expect(
+      service.saveSkillFile(target(), "SKILL.md", "x"),
+    ).rejects.toThrow("Access denied");
+    await expect(service.deleteSkill(target())).rejects.toThrow(
+      "Access denied",
+    );
+    await expect(service.renameSkill(target(), "other")).rejects.toThrow(
+      "Access denied",
+    );
+  });
+
+  it("rejects file writes that escape the skill directory", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+
+    await expect(
+      makeService().saveSkillFile(skillPath, "../beta.md", "x"),
+    ).rejects.toThrow("path outside skill directory");
+  });
+});
+
+describe("skill mutations", () => {
+  it("round-trips manifest edits through the frontmatter parser", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+    const service = makeService();
+
+    await service.saveSkillManifest(skillPath, {
+      name: "alpha",
+      description: "Use when: testing",
+      body: "# Alpha\n\nBody text",
+    });
+
+    const skills = await service.listSkills();
+    const updated = skills.find((s) => s.path === skillPath);
+    expect(updated).toMatchObject({
+      name: "alpha",
+      description: "Use when: testing",
+    });
+    const content = await service.readSkillFile(skillPath, "SKILL.md");
+    expect(content).toContain("# Alpha");
+  });
+
+  it("rejects manifest saves without a name", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+
+    await expect(
+      makeService().saveSkillManifest(skillPath, {
+        name: "  ",
+        description: "",
+        body: "",
+      }),
+    ).rejects.toThrow("Skill name is required");
+  });
+
+  it("creates, renames, and deletes companion files", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+    const service = makeService();
+
+    await service.saveSkillFile(skillPath, "references/guide.md", "guide");
+    await service.renameSkillFile(
+      skillPath,
+      "references/guide.md",
+      "references/manual.md",
+    );
+    let contents = await service.getSkillContents(skillPath);
+    expect(contents.files.map((f) => f.path)).toEqual([
+      "SKILL.md",
+      "references/manual.md",
+    ]);
+
+    await service.deleteSkillFile(skillPath, "references/manual.md");
+    contents = await service.getSkillContents(skillPath);
+    expect(contents.files.map((f) => f.path)).toEqual(["SKILL.md"]);
+  });
+
+  it("refuses to delete or rename SKILL.md", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+    const service = makeService();
+
+    await expect(
+      service.deleteSkillFile(skillPath, "SKILL.md"),
+    ).rejects.toThrow("SKILL.md cannot be deleted");
+    await expect(
+      service.deleteSkillFile(skillPath, "./SKILL.md"),
+    ).rejects.toThrow("SKILL.md cannot be deleted");
+    await expect(
+      service.renameSkillFile(skillPath, "SKILL.md", "OTHER.md"),
+    ).rejects.toThrow("SKILL.md cannot be renamed");
+  });
+
+  it("deletes a whole skill", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+    const service = makeService();
+
+    await service.deleteSkill(skillPath);
+
+    const skills = await service.listSkills();
+    expect(skills.find((s) => s.path === skillPath)).toBeUndefined();
+  });
+
+  it("renames a skill directory", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+    const service = makeService();
+
+    const { path: newPath } = await service.renameSkill(skillPath, "omega");
+
+    expect(newPath).toBe(path.join(repoSkillsDir, "omega"));
+    const skills = await service.listSkills();
+    expect(skills.some((s) => s.path === newPath)).toBe(true);
+    expect(skills.some((s) => s.path === skillPath)).toBe(false);
+  });
+});

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -6,15 +6,31 @@ import type { FoldersService } from "../folders/folders";
 import { FOLDERS_SERVICE } from "../folders/identifiers";
 import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
 import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
-import type { SkillContents, SkillInfo, SkillSource } from "./schemas";
+import { parseSkillFrontmatter } from "./parse-skill-frontmatter";
+import type {
+  CreateSkillInput,
+  SkillContents,
+  SkillInfo,
+  SkillSource,
+} from "./schemas";
 import {
   getMarketplaceInstallPaths,
   listSkillFiles,
   readSkillMetadataFromDir,
 } from "./skill-discovery";
+import { serializeSkillMarkdown } from "./write-skill-frontmatter";
 
 const MAX_SKILL_FILES = 500;
 const MAX_SKILL_FILE_BYTES = 2 * 1024 * 1024;
+const SKILL_DIR_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+const MAX_SKILL_DIR_NAME_LENGTH = 64;
+
+const SKILL_MD_TEMPLATE_BODY = `Explain when this skill applies and how to use it.
+
+## Instructions
+
+1. ...
+`;
 
 interface SkillRoot {
   dir: string;
@@ -52,10 +68,7 @@ export class SkillsService {
     filePath: string,
   ): Promise<string | null> {
     const skillDir = await this.resolveKnownSkillDir(skillPath);
-    const resolved = path.resolve(skillDir, filePath);
-    if (resolved === skillDir || !resolved.startsWith(skillDir + path.sep)) {
-      throw new Error("Access denied: path outside skill directory");
-    }
+    const resolved = resolveSkillFilePath(skillDir, filePath);
     try {
       // realpath also catches escapes via symlinked intermediate directories.
       const [realFile, realDir] = await Promise.all([
@@ -69,6 +82,108 @@ export class SkillsService {
     } catch {
       return null;
     }
+  }
+
+  async createSkill(options: CreateSkillInput): Promise<{ path: string }> {
+    const name = options.name.trim();
+    validateSkillDirName(name);
+
+    const root = await this.resolveWritableRoot(
+      options.scope,
+      options.repoPath,
+    );
+    const skillPath = path.join(root, name);
+    if (fs.existsSync(skillPath)) {
+      throw new Error(`A skill named "${name}" already exists`);
+    }
+
+    await fs.promises.mkdir(skillPath, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(skillPath, "SKILL.md"),
+      serializeSkillMarkdown({ name, description: "" }, SKILL_MD_TEMPLATE_BODY),
+      "utf-8",
+    );
+    return { path: skillPath };
+  }
+
+  async saveSkillManifest(
+    skillPath: string,
+    manifest: { name: string; description: string; body: string },
+  ): Promise<void> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    const content = serializeSkillMarkdown(
+      { name: manifest.name.trim(), description: manifest.description.trim() },
+      manifest.body,
+    );
+    // The writer and parser must agree, or the skill vanishes from the list.
+    if (!parseSkillFrontmatter(content)) {
+      throw new Error("Skill name is required");
+    }
+    await fs.promises.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      content,
+      "utf-8",
+    );
+  }
+
+  async saveSkillFile(
+    skillPath: string,
+    filePath: string,
+    content: string,
+  ): Promise<void> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    const target = resolveSkillFilePath(skillDir, filePath);
+    await fs.promises.mkdir(path.dirname(target), { recursive: true });
+    await fs.promises.writeFile(target, content, "utf-8");
+  }
+
+  async renameSkillFile(
+    skillPath: string,
+    fromPath: string,
+    toPath: string,
+  ): Promise<void> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    const from = resolveSkillFilePath(skillDir, fromPath);
+    const to = resolveSkillFilePath(skillDir, toPath);
+    if (from === path.join(skillDir, "SKILL.md")) {
+      throw new Error("SKILL.md cannot be renamed");
+    }
+    if (fs.existsSync(to)) {
+      throw new Error(`"${toPath}" already exists`);
+    }
+    await fs.promises.mkdir(path.dirname(to), { recursive: true });
+    await fs.promises.rename(from, to);
+  }
+
+  async deleteSkillFile(skillPath: string, filePath: string): Promise<void> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    const target = resolveSkillFilePath(skillDir, filePath);
+    if (target === path.join(skillDir, "SKILL.md")) {
+      throw new Error("SKILL.md cannot be deleted");
+    }
+    await fs.promises.rm(target, { force: true });
+  }
+
+  async deleteSkill(skillPath: string): Promise<void> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    await fs.promises.rm(skillDir, { recursive: true, force: true });
+  }
+
+  async renameSkill(
+    skillPath: string,
+    newName: string,
+  ): Promise<{ path: string }> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    const name = newName.trim();
+    validateSkillDirName(name);
+
+    const target = path.join(path.dirname(skillDir), name);
+    if (target === skillDir) return { path: skillDir };
+    if (fs.existsSync(target)) {
+      throw new Error(`A skill named "${name}" already exists`);
+    }
+    await fs.promises.rename(skillDir, target);
+    return { path: target };
   }
 
   private async getSkillRoots(): Promise<SkillRoot[]> {
@@ -117,4 +232,67 @@ export class SkillsService {
     }
     return resolved;
   }
+
+  private async getWritableRoots(): Promise<string[]> {
+    const folders = await this.folders.getFolders();
+    return [
+      path.join(os.homedir(), ".claude", "skills"),
+      ...folders.map((f) => path.join(f.path, ".claude", "skills")),
+    ];
+  }
+
+  private async resolveWritableRoot(
+    scope: "user" | "repo",
+    repoPath: string | undefined,
+  ): Promise<string> {
+    if (scope === "user") {
+      return path.join(os.homedir(), ".claude", "skills");
+    }
+    const folders = await this.folders.getFolders();
+    const folder = folders.find(
+      (f) => repoPath && path.resolve(f.path) === path.resolve(repoPath),
+    );
+    if (!folder) {
+      throw new Error("Access denied: not an open workspace folder");
+    }
+    return path.join(folder.path, ".claude", "skills");
+  }
+
+  /**
+   * Hard guard for every mutation: the target must be a skill directory
+   * directly under a writable root (the user's `~/.claude/skills` or a
+   * workspace folder's `.claude/skills`). Bundled skills, plugin install
+   * paths, and anything else are rejected here, not in the UI.
+   */
+  private async resolveWritableSkillDir(skillPath: string): Promise<string> {
+    const resolved = path.resolve(skillPath);
+    const roots = await this.getWritableRoots();
+    const parent = path.dirname(resolved);
+    if (!roots.some((root) => path.resolve(root) === parent)) {
+      throw new Error("Access denied: skill is not in a writable location");
+    }
+    if (!fs.existsSync(path.join(resolved, "SKILL.md"))) {
+      throw new Error("Access denied: not a known skill directory");
+    }
+    return resolved;
+  }
+}
+
+function validateSkillDirName(name: string): void {
+  if (
+    !SKILL_DIR_NAME_PATTERN.test(name) ||
+    name.length > MAX_SKILL_DIR_NAME_LENGTH
+  ) {
+    throw new Error(
+      "Skill names must be lowercase letters, numbers, dots, dashes, or underscores",
+    );
+  }
+}
+
+function resolveSkillFilePath(skillDir: string, filePath: string): string {
+  const resolved = path.resolve(skillDir, filePath);
+  if (resolved === skillDir || !resolved.startsWith(skillDir + path.sep)) {
+    throw new Error("Access denied: path outside skill directory");
+  }
+  return resolved;
 }

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -169,23 +169,6 @@ export class SkillsService {
     await fs.promises.rm(skillDir, { recursive: true, force: true });
   }
 
-  async renameSkill(
-    skillPath: string,
-    newName: string,
-  ): Promise<{ path: string }> {
-    const skillDir = await this.resolveWritableSkillDir(skillPath);
-    const name = newName.trim();
-    validateSkillDirName(name);
-
-    const target = path.join(path.dirname(skillDir), name);
-    if (target === skillDir) return { path: skillDir };
-    if (fs.existsSync(target)) {
-      throw new Error(`A skill named "${name}" already exists`);
-    }
-    await fs.promises.rename(skillDir, target);
-    return { path: target };
-  }
-
   private async getSkillRoots(): Promise<SkillRoot[]> {
     const pluginPath = this.plugin.getPluginPath();
     const folders = await this.folders.getFolders();

--- a/packages/workspace-server/src/services/skills/write-skill-frontmatter.test.ts
+++ b/packages/workspace-server/src/services/skills/write-skill-frontmatter.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseSkillFrontmatter } from "./parse-skill-frontmatter";
+import { serializeSkillMarkdown } from "./write-skill-frontmatter";
+
+describe("serializeSkillMarkdown", () => {
+  it.each([
+    ["plain values", "my-skill", "Does a thing"],
+    ["empty description", "my-skill", ""],
+    ["colon in description", "my-skill", "Use when: things break"],
+    ["leading special char", "my-skill", "*very* important"],
+    ["double quotes", "my-skill", 'Say "hello" politely'],
+    ["backslashes", "my-skill", "Paths like C:\\Users\\foo"],
+    [
+      "multi-line description",
+      "my-skill",
+      "First line\nSecond line\nThird line",
+    ],
+    [
+      "multi-paragraph description",
+      "my-skill",
+      "First paragraph\n\nSecond paragraph",
+    ],
+    ["hash that looks like a comment", "my-skill", "Use for #releases"],
+  ])(
+    "round-trips through parseSkillFrontmatter: %s",
+    (_label, name, description) => {
+      const content = serializeSkillMarkdown({ name, description }, "The body");
+
+      const parsed = parseSkillFrontmatter(content);
+
+      expect(parsed).toEqual({ name, description });
+    },
+  );
+
+  it("appends the body after the frontmatter with a trailing newline", () => {
+    const content = serializeSkillMarkdown(
+      { name: "my-skill", description: "d" },
+      "# Title\n\nSome body",
+    );
+
+    expect(content).toBe(
+      "---\nname: my-skill\ndescription: d\n---\n\n# Title\n\nSome body\n",
+    );
+  });
+
+  it("preserves the body verbatim including fake frontmatter fences", () => {
+    const body = "intro\n---\nname: not-frontmatter\n---\n";
+    const content = serializeSkillMarkdown(
+      { name: "my-skill", description: "d" },
+      body,
+    );
+
+    const parsed = parseSkillFrontmatter(content);
+    expect(parsed?.name).toBe("my-skill");
+    expect(content).toContain("intro\n---\nname: not-frontmatter");
+  });
+});

--- a/packages/workspace-server/src/services/skills/write-skill-frontmatter.ts
+++ b/packages/workspace-server/src/services/skills/write-skill-frontmatter.ts
@@ -1,0 +1,36 @@
+/**
+ * Serializes a SKILL.md file from frontmatter metadata plus a markdown body.
+ *
+ * The output must round-trip through `parseSkillFrontmatter` and also be
+ * valid YAML for the agents that consume these files, so scalars fall back
+ * from plain → double-quoted → literal block as they get more hostile.
+ */
+export function serializeSkillMarkdown(
+  meta: { name: string; description: string },
+  body: string,
+): string {
+  const frontmatter = [
+    "---",
+    `name: ${serializeScalar(meta.name)}`,
+    `description: ${serializeScalar(meta.description)}`,
+    "---",
+  ].join("\n");
+
+  const trimmedBody = body.replace(/^\n+/, "");
+  return `${frontmatter}\n\n${trimmedBody.trimEnd()}\n`;
+}
+
+const PLAIN_SAFE = /^[A-Za-z0-9][A-Za-z0-9 _.,;()/-]*$/;
+
+function serializeScalar(value: string): string {
+  if (value === "") return '""';
+  if (!value.includes("\n")) {
+    if (PLAIN_SAFE.test(value) && !value.endsWith(" ")) return value;
+    if (!value.includes('"') && !value.includes("\\")) return `"${value}"`;
+  }
+  // Literal block: survives quotes, backslashes, and newlines.
+  const lines = value
+    .split("\n")
+    .map((line) => (line.trim() ? `  ${line}` : ""));
+  return `|-\n${lines.join("\n")}`;
+}


### PR DESCRIPTION
## Problem

Users had no way to create, edit, or delete skills from the UI — the skills panel was read-only. This adds full CRUD support for skills, including creating new skills, editing the manifest and companion files, renaming/deleting files within a skill, and deleting or renaming entire skills.

## Changes

**Backend (`workspace-server`)**
- Added `createSkill`, `saveSkillManifest`, `saveSkillFile`, `renameSkillFile`, `deleteSkillFile`, `deleteSkill`, and `renameSkill` methods to `SkillsService`.
- All mutations are guarded by `resolveWritableSkillDir`, which enforces that the target skill lives directly under a writable root (`~/.claude/skills` or a workspace folder's `.claude/skills`). Bundled/plugin skills are rejected server-side.
- Added `validateSkillDirName` (lowercase letters, numbers, dots, dashes, underscores; max 64 chars) and `resolveSkillFilePath` (prevents path traversal out of the skill directory) as shared helpers.
- Added `write-skill-frontmatter.ts` with `serializeSkillMarkdown`, which serializes name/description/body back to a valid SKILL.md. Scalars fall back from plain → double-quoted → YAML literal block to handle colons, quotes, backslashes, and multi-line values.
- Fixed a bug in `collectIndentedLines` in `parse-skill-frontmatter.ts` where blank lines inside a multi-line YAML value were being dropped instead of preserved.
- Extended `schemas.ts` with Zod schemas and TypeScript types for all new operations.

**Host router (`host-router`)**
- Exposed `create`, `saveManifest`, `saveFile`, `renameFile`, `deleteFile`, `delete`, and `rename` tRPC mutations on the `skillsRouter`.

**UI (`ui`)**
- `useSkillMutations.ts` — new hooks (`useCreateSkill`, `useSaveSkillManifest`, `useSaveSkillFile`, `useRenameSkillFile`, `useDeleteSkillFile`, `useDeleteSkill`) that each invalidate all skills queries on success.
- `NewSkillDialog.tsx` — dialog for creating a skill with a name and a scope selector (user skills or a specific open repository).
- `SkillCodeEditor.tsx` — uncontrolled CodeMirror wrapper that reports document changes via `onDocChanged`.
- `SkillManifestEditor.tsx` — edit mode for `SKILL.md`: a small form for name/description frontmatter fields plus a CodeMirror body editor.
- `SkillFileEditor.tsx` — edit mode for companion files inside a skill directory.
- `SkillDetailPanel.tsx` — added edit, add-file, delete-skill toolbar buttons (visible only for editable skills), wired up `SkillManifestEditor` and `SkillFileEditor` for the active file, and added dialogs for adding a file, renaming a file, confirming file deletion, and confirming skill deletion.
- `SkillFileTree.tsx` — added optional `onRenameFile`/`onDeleteFile` callbacks; when present, non-`SKILL.md` file rows show inline rename and delete icon buttons.
- `SkillsView.tsx` — added a "New skill" button next to the search field that opens `NewSkillDialog` and selects the newly created skill.

## How did you test this?

- Added unit tests in `skills.test.ts` covering `createSkill` (happy path, invalid names, non-open repo, duplicate names), the write-path guard (bundled skills, arbitrary directories, traversal attacks, file-path escapes), and all mutation methods (manifest round-trip, companion file lifecycle, SKILL.md protection, full skill delete, skill rename).
- Added unit tests in `write-skill-frontmatter.test.ts` covering round-trip fidelity for plain values, empty descriptions, colons, special leading characters, double quotes, backslashes, multi-line descriptions, multi-paragraph descriptions, and body sections that contain fake frontmatter fences.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?