### PR TITLE
feat(skills): skills.sh marketplace browse and install

### DIFF
--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -178,6 +178,7 @@ import { processTrackingModule } from "@posthog/workspace-server/services/proces
 import { SECURE_STORE_SERVICE } from "@posthog/workspace-server/services/secure-store/identifiers";
 import { shellModule } from "@posthog/workspace-server/services/shell/shell.module";
 import { skillsModule } from "@posthog/workspace-server/services/skills/skills.module";
+import { skillsMarketplaceModule } from "@posthog/workspace-server/services/skills-marketplace/skills-marketplace.module";
 import {
   SUSPENSION_FILE_WATCHER,
   SUSPENSION_SERVICE,
@@ -574,6 +575,7 @@ container
 container.load(posthogPluginModule);
 container.bind(MAIN_POSTHOG_PLUGIN_SERVICE).toService(POSTHOG_PLUGIN_SERVICE);
 container.load(skillsModule);
+container.load(skillsMarketplaceModule);
 container.load(onboardingImportModule);
 container.load(additionalDirectoriesModule);
 container.bind(MAIN_SLEEP_SERVICE).to(SleepService);

--- a/packages/host-router/src/routers/skills.router.ts
+++ b/packages/host-router/src/routers/skills.router.ts
@@ -15,6 +15,16 @@ import {
   skillPathOutput,
 } from "@posthog/workspace-server/services/skills/schemas";
 import type { SkillsService } from "@posthog/workspace-server/services/skills/skills";
+import { SKILLS_MARKETPLACE_SERVICE } from "@posthog/workspace-server/services/skills-marketplace/identifiers";
+import {
+  marketplaceInstallInput,
+  marketplaceInstallOutput,
+  marketplacePreviewOutput,
+  marketplaceSearchInput,
+  marketplaceSearchOutput,
+  marketplaceSkillRef,
+} from "@posthog/workspace-server/services/skills-marketplace/schemas";
+import type { SkillsMarketplaceService } from "@posthog/workspace-server/services/skills-marketplace/skills-marketplace";
 
 export const skillsRouter = router({
   list: publicProcedure
@@ -88,5 +98,34 @@ export const skillsRouter = router({
     for await (const event of service.watchSkills(opts.signal)) {
       yield event;
     }
+  }),
+  marketplace: router({
+    search: publicProcedure
+      .input(marketplaceSearchInput)
+      .output(marketplaceSearchOutput)
+      .query(({ ctx, input }) =>
+        ctx.container
+          .get<SkillsMarketplaceService>(SKILLS_MARKETPLACE_SERVICE)
+          .search(input.query),
+      ),
+    preview: publicProcedure
+      .input(marketplaceSkillRef)
+      .output(marketplacePreviewOutput)
+      .query(({ ctx, input }) =>
+        ctx.container
+          .get<SkillsMarketplaceService>(SKILLS_MARKETPLACE_SERVICE)
+          .preview(input),
+      ),
+    install: publicProcedure
+      .input(marketplaceInstallInput)
+      .output(marketplaceInstallOutput)
+      .mutation(({ ctx, input }) =>
+        ctx.container
+          .get<SkillsMarketplaceService>(SKILLS_MARKETPLACE_SERVICE)
+          .install(
+            { source: input.source, skillId: input.skillId },
+            input.overwrite ?? false,
+          ),
+      ),
   }),
 });

--- a/packages/ui/src/features/skills/MarketplaceBrowse.tsx
+++ b/packages/ui/src/features/skills/MarketplaceBrowse.tsx
@@ -1,0 +1,161 @@
+import { MagnifyingGlass, Storefront } from "@phosphor-icons/react";
+import { useDebouncedValue } from "@posthog/ui/primitives/hooks/useDebouncedValue";
+import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
+import {
+  Badge,
+  Box,
+  Flex,
+  ScrollArea,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
+import { useState } from "react";
+import { MarketplaceSkillPanel } from "./MarketplaceSkillPanel";
+import { useSkillsSidebarStore } from "./skillsSidebarStore";
+import {
+  type MarketplaceSkillSummary,
+  useMarketplaceSearch,
+} from "./useMarketplace";
+
+const installsFormatter = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+});
+
+export function MarketplaceBrowse() {
+  const [query, setQuery] = useState("");
+  const { debounced: debouncedQuery } = useDebouncedValue(query, 300);
+  const [selected, setSelected] = useState<MarketplaceSkillSummary | null>(
+    null,
+  );
+
+  const { data, isLoading, error } = useMarketplaceSearch(debouncedQuery);
+  const results = data?.results ?? [];
+
+  const {
+    width: sidebarWidth,
+    setWidth: setSidebarWidth,
+    isResizing,
+    setIsResizing,
+  } = useSkillsSidebarStore();
+
+  return (
+    <Flex className="min-h-0 flex-1">
+      <Box flexGrow="1" className="min-w-0">
+        <ScrollArea type="auto" className="scroll-area-constrain-width h-full">
+          <Box px="4" py="3">
+            <Box pb="3">
+              <TextField.Root
+                size="2"
+                placeholder="Search community skills..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="text-[13px]"
+              >
+                <TextField.Slot>
+                  <MagnifyingGlass size={14} />
+                </TextField.Slot>
+              </TextField.Root>
+            </Box>
+
+            {debouncedQuery.trim().length < 2 ? (
+              <BrowseEmptyState message="Search the community skills index from skills.sh" />
+            ) : error ? (
+              <BrowseEmptyState message="Could not reach the skills index. Check your connection and try again." />
+            ) : isLoading ? (
+              <Text className="text-[12px] text-gray-9">Searching...</Text>
+            ) : results.length === 0 ? (
+              <BrowseEmptyState message="No skills found" />
+            ) : (
+              <Flex direction="column" gap="1">
+                {results.map((result) => (
+                  <Flex
+                    key={result.id}
+                    align="center"
+                    gap="2"
+                    px="3"
+                    py="2"
+                    className={`cursor-pointer rounded-lg border transition-colors ${
+                      selected?.id === result.id
+                        ? "border-accent-8 bg-accent-3"
+                        : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
+                    }`}
+                    onClick={() =>
+                      setSelected((prev) =>
+                        prev?.id === result.id ? null : result,
+                      )
+                    }
+                  >
+                    <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
+                      <Storefront
+                        size={14}
+                        weight="duotone"
+                        className="text-gray-11"
+                      />
+                    </Box>
+                    <Flex direction="column" gap="0" className="min-w-0 flex-1">
+                      <Text className="truncate font-medium text-[13px] text-gray-12">
+                        {result.name}
+                      </Text>
+                      <Text className="truncate text-[12px] text-gray-10">
+                        {result.source}
+                      </Text>
+                    </Flex>
+                    {result.installed && (
+                      <Badge
+                        size="1"
+                        variant="soft"
+                        color="green"
+                        className="shrink-0"
+                      >
+                        Installed
+                      </Badge>
+                    )}
+                    <Text className="shrink-0 text-[12px] text-gray-9 tabular-nums">
+                      {installsFormatter.format(result.installs)}
+                    </Text>
+                  </Flex>
+                ))}
+              </Flex>
+            )}
+          </Box>
+        </ScrollArea>
+      </Box>
+
+      <ResizableSidebar
+        open={!!selected}
+        width={sidebarWidth}
+        setWidth={setSidebarWidth}
+        isResizing={isResizing}
+        setIsResizing={setIsResizing}
+        side="right"
+      >
+        {selected && (
+          <MarketplaceSkillPanel
+            key={selected.id}
+            result={selected}
+            onClose={() => setSelected(null)}
+          />
+        )}
+      </ResizableSidebar>
+    </Flex>
+  );
+}
+
+function BrowseEmptyState({ message }: { message: string }) {
+  return (
+    <Flex
+      align="center"
+      justify="center"
+      direction="column"
+      gap="3"
+      className="py-12"
+    >
+      <Box className="rounded-lg border border-gray-6 border-dashed p-4">
+        <Storefront size={24} className="text-gray-8" />
+      </Box>
+      <Text className="max-w-[360px] text-center text-[13px] text-gray-10">
+        {message}
+      </Text>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/skills/MarketplaceSkillPanel.tsx
+++ b/packages/ui/src/features/skills/MarketplaceSkillPanel.tsx
@@ -1,0 +1,216 @@
+import { DownloadSimple, Warning, X } from "@phosphor-icons/react";
+import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { toast } from "@posthog/ui/primitives/toast";
+import {
+  AlertDialog,
+  Badge,
+  Box,
+  Button,
+  Callout,
+  Flex,
+  ScrollArea,
+  Text,
+  Tooltip,
+} from "@radix-ui/themes";
+import { useState } from "react";
+import { SkillFileTree } from "./SkillFileTree";
+import { stripFrontmatter } from "./stripFrontmatter";
+import {
+  type MarketplaceSkillSummary,
+  useInstallMarketplaceSkill,
+  useMarketplacePreview,
+} from "./useMarketplace";
+
+const installsFormatter = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+});
+
+interface MarketplaceSkillPanelProps {
+  result: MarketplaceSkillSummary;
+  onClose: () => void;
+}
+
+/**
+ * Pre-install preview: every file in the skill is visible before anything
+ * touches disk. Installing a skill is installing code an agent will run.
+ */
+export function MarketplaceSkillPanel({
+  result,
+  onClose,
+}: MarketplaceSkillPanelProps) {
+  const [selectedFile, setSelectedFile] = useState("SKILL.md");
+  const [confirmOverwrite, setConfirmOverwrite] = useState(false);
+  const { data: preview, isLoading } = useMarketplacePreview({
+    source: result.source,
+    skillId: result.skillId,
+  });
+  const install = useInstallMarketplaceSkill();
+
+  const files = preview?.files ?? [];
+  const selected = files.find((f) => f.path === selectedFile);
+  const isSkillMd = selectedFile === "SKILL.md";
+
+  const handleInstall = async (overwrite: boolean) => {
+    try {
+      await install.mutateAsync({
+        source: result.source,
+        skillId: result.skillId,
+        overwrite,
+      });
+      setConfirmOverwrite(false);
+      toast.success(`Installed ${result.name}`, {
+        description: "Now available under Your skills",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (!overwrite && message.includes("already exists")) {
+        setConfirmOverwrite(true);
+        return;
+      }
+      toast.error("Failed to install skill", {
+        description: message || undefined,
+      });
+    }
+  };
+
+  return (
+    <>
+      <Flex
+        direction="column"
+        gap="2"
+        px="3"
+        py="2"
+        className="shrink-0 border-b border-b-(--gray-5)"
+      >
+        <Flex align="start" justify="between" gap="2">
+          <Text className="block min-w-0 break-words font-medium text-[13px]">
+            {result.name}
+          </Text>
+          <Tooltip content="Close">
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="shrink-0 rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+            >
+              <X size={14} />
+            </button>
+          </Tooltip>
+        </Flex>
+
+        <Flex align="center" gap="2" wrap="wrap">
+          <Badge size="1" variant="soft" color="gray">
+            {result.source}
+          </Badge>
+          <Badge size="1" variant="soft" color="gray">
+            {installsFormatter.format(result.installs)} installs
+          </Badge>
+          {result.installed && (
+            <Badge size="1" variant="soft" color="green">
+              Installed
+            </Badge>
+          )}
+          <Button
+            size="1"
+            variant="solid"
+            onClick={() => void handleInstall(false)}
+            disabled={install.isPending || isLoading}
+          >
+            <DownloadSimple size={12} />
+            {result.installed ? "Reinstall" : "Install"}
+          </Button>
+        </Flex>
+
+        {preview?.hasScripts && (
+          <Callout.Root size="1" color="amber" variant="surface">
+            <Callout.Icon>
+              <Warning size={12} />
+            </Callout.Icon>
+            <Callout.Text className="text-[12px]">
+              This skill contains scripts that agents can execute. Review every
+              file before installing.
+            </Callout.Text>
+          </Callout.Root>
+        )}
+      </Flex>
+
+      {files.length > 1 && (
+        <Box className="max-h-[40%] shrink-0 overflow-y-auto border-b border-b-(--gray-5) py-1">
+          <SkillFileTree
+            files={files.map((f) => ({ path: f.path, size: f.size }))}
+            selectedPath={selectedFile}
+            onSelect={setSelectedFile}
+          />
+        </Box>
+      )}
+
+      <Box className="min-h-0 flex-1">
+        {isLoading ? (
+          <Box p="3">
+            <Text className="text-[12px] text-gray-9">Loading...</Text>
+          </Box>
+        ) : selected?.content == null ? (
+          <Box p="3">
+            <Text className="text-[12px] text-gray-9">
+              {selected
+                ? "Unable to display this file"
+                : "No content to preview"}
+            </Text>
+          </Box>
+        ) : isSkillMd ? (
+          <ScrollArea
+            type="auto"
+            scrollbars="vertical"
+            className="scroll-area-constrain-width h-full"
+          >
+            <Box p="3">
+              <Box className="rounded border border-gray-5 bg-gray-1 px-4 py-3 text-[13px]">
+                <MarkdownRenderer
+                  content={stripFrontmatter(selected.content)}
+                />
+              </Box>
+            </Box>
+          </ScrollArea>
+        ) : (
+          <CodeMirrorEditor
+            content={selected.content}
+            filePath={selectedFile}
+            relativePath={selectedFile}
+            readOnly
+          />
+        )}
+      </Box>
+
+      <AlertDialog.Root
+        open={confirmOverwrite}
+        onOpenChange={setConfirmOverwrite}
+      >
+        <AlertDialog.Content maxWidth="420px" size="2">
+          <AlertDialog.Title size="3">Replace local skill</AlertDialog.Title>
+          <AlertDialog.Description size="1">
+            A skill named "{result.skillId}" already exists in your skills.
+            Reinstalling will replace your local version, including any edits.
+          </AlertDialog.Description>
+          <Flex justify="end" gap="2" mt="4">
+            <AlertDialog.Cancel>
+              <Button size="1" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action>
+              <Button
+                size="1"
+                variant="solid"
+                color="red"
+                onClick={() => void handleInstall(true)}
+              >
+                Replace
+              </Button>
+            </AlertDialog.Action>
+          </Flex>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
+    </>
+  );
+}

--- a/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -31,6 +31,7 @@ import { SOURCE_CONFIG } from "./SkillCard";
 import { SkillFileEditor } from "./SkillFileEditor";
 import { SkillFileTree } from "./SkillFileTree";
 import { SkillManifestEditor } from "./SkillManifestEditor";
+import { stripFrontmatter } from "./stripFrontmatter";
 import { useSkillContents, useSkillFile } from "./useSkillContents";
 import {
   useDeleteSkill,
@@ -38,11 +39,6 @@ import {
   useRenameSkillFile,
   useSaveSkillFile,
 } from "./useSkillMutations";
-
-function stripFrontmatter(content: string): string {
-  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n/);
-  return match ? content.slice(match[0].length).trimStart() : content;
-}
 
 interface SkillDetailPanelProps {
   skill: SkillInfo;

--- a/packages/ui/src/features/skills/SkillsView.tsx
+++ b/packages/ui/src/features/skills/SkillsView.tsx
@@ -1,5 +1,6 @@
 import { Lightbulb, MagnifyingGlass, Plus } from "@phosphor-icons/react";
 import { analyzeSkills } from "@posthog/core/skills/analyzeSkills";
+import { Tabs, TabsList, TabsTrigger } from "@posthog/quill";
 import type { SkillInfo, SkillSource } from "@posthog/shared";
 import {
   Box,
@@ -12,6 +13,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSetHeaderContent } from "../../hooks/useSetHeaderContent";
 import { ResizableSidebar } from "../../primitives/ResizableSidebar";
+import { MarketplaceBrowse } from "./MarketplaceBrowse";
 import { NewSkillDialog } from "./NewSkillDialog";
 import { SkillSection, SOURCE_CONFIG } from "./SkillCard";
 import { SkillDetailPanel } from "./SkillDetailPanel";
@@ -25,10 +27,13 @@ import { useSkillsWatcher } from "./useSkillsWatcher";
 
 const SOURCE_ORDER: SkillSource[] = ["user", "marketplace", "repo", "bundled"];
 
+type SkillsTab = "installed" | "marketplace";
+
 export function SkillsView() {
   const { data: skills = [], isLoading } = useSkills();
   useSkillsWatcher();
 
+  const [tab, setTab] = useState<SkillsTab>("installed");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [scrollToPath, setScrollToPath] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -113,95 +118,115 @@ export function SkillsView() {
 
   return (
     <Flex direction="column" height="100%" className="overflow-hidden">
-      <Flex className="min-h-0 flex-1">
-        <Box flexGrow="1" className="min-w-0">
-          <ScrollArea
-            type="auto"
-            className="scroll-area-constrain-width h-full"
-          >
-            <Box px="4" py="3">
-              <Flex pb="3" gap="2" align="center">
-                <Box flexGrow="1">
-                  <TextField.Root
-                    size="2"
-                    placeholder="Search skills..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="text-[13px]"
-                  >
-                    <TextField.Slot>
-                      <MagnifyingGlass size={14} />
-                    </TextField.Slot>
-                  </TextField.Root>
-                </Box>
-                <Button
-                  size="2"
-                  variant="soft"
-                  onClick={() => setNewSkillOpen(true)}
-                >
-                  <Plus size={14} />
-                  New skill
-                </Button>
-              </Flex>
-              {skills.length === 0 && !isLoading ? (
-                <Flex
-                  align="center"
-                  justify="center"
-                  direction="column"
-                  gap="3"
-                  className="py-12"
-                >
-                  <Box className="rounded-lg border border-gray-6 border-dashed p-4">
-                    <Lightbulb size={24} className="text-gray-8" />
-                  </Box>
-                  <Text className="text-[13px] text-gray-10">
-                    No skills found
-                  </Text>
-                </Flex>
-              ) : (
-                <Flex direction="column" gap="5">
-                  {SOURCE_ORDER.map((source) => {
-                    const items = grouped.get(source);
-                    if (!items || items.length === 0) return null;
-                    const config = SOURCE_CONFIG[source];
-
-                    return (
-                      <SkillSection
-                        key={source}
-                        title={config.sectionTitle}
-                        skills={items}
-                        selectedPath={selectedSkill?.path ?? null}
-                        onSelect={handleSelect}
-                        scrollToPath={scrollToPath}
-                        onScrolledIntoView={handleScrolledIntoView}
-                        analysis={analysis}
-                      />
-                    );
-                  })}
-                </Flex>
-              )}
-            </Box>
-          </ScrollArea>
-        </Box>
-
-        <ResizableSidebar
-          open={!!selectedSkill}
-          width={sidebarWidth}
-          setWidth={setSidebarWidth}
-          isResizing={isResizing}
-          setIsResizing={setIsResizing}
-          side="right"
+      <Box px="4" className="shrink-0 border-b border-b-(--gray-5)">
+        <Tabs
+          value={tab}
+          onValueChange={(value: string) => setTab(value as SkillsTab)}
         >
-          {selectedSkill && (
-            <SkillDetailPanel
-              key={selectedSkill.path}
-              skill={selectedSkill}
-              issues={analysis[selectedSkill.path] ?? []}
-              onClose={handleCloseSidebar}
-            />
-          )}
-        </ResizableSidebar>
-      </Flex>
+          <TabsList variant="line" className="h-auto gap-0.5">
+            <TabsTrigger value="installed" className="gap-1.5 px-2.5 py-2">
+              <span className="font-medium text-[13px]">Installed</span>
+            </TabsTrigger>
+            <TabsTrigger value="marketplace" className="gap-1.5 px-2.5 py-2">
+              <span className="font-medium text-[13px]">Marketplace</span>
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </Box>
+
+      {tab === "marketplace" ? (
+        <MarketplaceBrowse />
+      ) : (
+        <Flex className="min-h-0 flex-1">
+          <Box flexGrow="1" className="min-w-0">
+            <ScrollArea
+              type="auto"
+              className="scroll-area-constrain-width h-full"
+            >
+              <Box px="4" py="3">
+                <Flex pb="3" gap="2" align="center">
+                  <Box flexGrow="1">
+                    <TextField.Root
+                      size="2"
+                      placeholder="Search skills..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="text-[13px]"
+                    >
+                      <TextField.Slot>
+                        <MagnifyingGlass size={14} />
+                      </TextField.Slot>
+                    </TextField.Root>
+                  </Box>
+                  <Button
+                    size="2"
+                    variant="soft"
+                    onClick={() => setNewSkillOpen(true)}
+                  >
+                    <Plus size={14} />
+                    New skill
+                  </Button>
+                </Flex>
+                {skills.length === 0 && !isLoading ? (
+                  <Flex
+                    align="center"
+                    justify="center"
+                    direction="column"
+                    gap="3"
+                    className="py-12"
+                  >
+                    <Box className="rounded-lg border border-gray-6 border-dashed p-4">
+                      <Lightbulb size={24} className="text-gray-8" />
+                    </Box>
+                    <Text className="text-[13px] text-gray-10">
+                      No skills found
+                    </Text>
+                  </Flex>
+                ) : (
+                  <Flex direction="column" gap="5">
+                    {SOURCE_ORDER.map((source) => {
+                      const items = grouped.get(source);
+                      if (!items || items.length === 0) return null;
+                      const config = SOURCE_CONFIG[source];
+
+                      return (
+                        <SkillSection
+                          key={source}
+                          title={config.sectionTitle}
+                          skills={items}
+                          selectedPath={selectedSkill?.path ?? null}
+                          onSelect={handleSelect}
+                          scrollToPath={scrollToPath}
+                          onScrolledIntoView={handleScrolledIntoView}
+                          analysis={analysis}
+                        />
+                      );
+                    })}
+                  </Flex>
+                )}
+              </Box>
+            </ScrollArea>
+          </Box>
+
+          <ResizableSidebar
+            open={!!selectedSkill}
+            width={sidebarWidth}
+            setWidth={setSidebarWidth}
+            isResizing={isResizing}
+            setIsResizing={setIsResizing}
+            side="right"
+          >
+            {selectedSkill && (
+              <SkillDetailPanel
+                key={selectedSkill.path}
+                skill={selectedSkill}
+                issues={analysis[selectedSkill.path] ?? []}
+                onClose={handleCloseSidebar}
+              />
+            )}
+          </ResizableSidebar>
+        </Flex>
+      )}
 
       <NewSkillDialog
         open={newSkillOpen}

--- a/packages/ui/src/features/skills/stripFrontmatter.ts
+++ b/packages/ui/src/features/skills/stripFrontmatter.ts
@@ -1,0 +1,5 @@
+/** Strips a leading YAML frontmatter block from a SKILL.md body. */
+export function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n/);
+  return match ? content.slice(match[0].length).trimStart() : content;
+}

--- a/packages/ui/src/features/skills/useMarketplace.ts
+++ b/packages/ui/src/features/skills/useMarketplace.ts
@@ -1,0 +1,45 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export interface MarketplaceSkillSummary {
+  id: string;
+  skillId: string;
+  name: string;
+  installs: number;
+  source: string;
+  installed: boolean;
+}
+
+export function useMarketplaceSearch(query: string) {
+  const trpc = useHostTRPC();
+  return useQuery(
+    trpc.skills.marketplace.search.queryOptions(
+      { query },
+      { enabled: query.trim().length >= 2, staleTime: 60_000 },
+    ),
+  );
+}
+
+export function useMarketplacePreview(
+  ref: { source: string; skillId: string } | null,
+) {
+  const trpc = useHostTRPC();
+  return useQuery(
+    trpc.skills.marketplace.preview.queryOptions(
+      { source: ref?.source ?? "", skillId: ref?.skillId ?? "" },
+      { enabled: ref !== null, staleTime: 5 * 60_000 },
+    ),
+  );
+}
+
+export function useInstallMarketplaceSkill() {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.skills.marketplace.install.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.skills.pathFilter());
+      },
+    }),
+  );
+}

--- a/packages/workspace-server/src/services/posthog-plugin/extract-zip.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/extract-zip.ts
@@ -1,15 +1,20 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { type Unzipped, unzip } from "fflate";
+import { type UnzipOptions, type Unzipped, unzip } from "fflate";
 
 // fflate's async unzip yields the event loop so the Electron main thread
 // stays responsive on large archives. Do not switch back to unzipSync.
-export function unzipAsync(data: Uint8Array): Promise<Unzipped> {
+export function unzipAsync(
+  data: Uint8Array,
+  opts?: UnzipOptions,
+): Promise<Unzipped> {
   return new Promise((resolve, reject) => {
-    unzip(data, (err, unzipped) => {
+    const done = (err: Error | null, unzipped: Unzipped) => {
       if (err) reject(err);
       else resolve(unzipped);
-    });
+    };
+    if (opts) unzip(data, opts, done);
+    else unzip(data, done);
   });
 }
 

--- a/packages/workspace-server/src/services/skills-marketplace/identifiers.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/identifiers.ts
@@ -1,0 +1,3 @@
+export const SKILLS_MARKETPLACE_SERVICE = Symbol.for(
+  "posthog.workspace.skillsMarketplaceService",
+);

--- a/packages/workspace-server/src/services/skills-marketplace/schemas.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/schemas.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+export const marketplaceSkillRef = z.object({
+  /** GitHub repository in "owner/repo" form. */
+  source: z.string(),
+  /** Skill directory name inside the repository. */
+  skillId: z.string(),
+});
+
+export const marketplaceSearchInput = z.object({
+  query: z.string(),
+});
+
+export const marketplaceSearchResult = z.object({
+  id: z.string(),
+  skillId: z.string(),
+  name: z.string(),
+  installs: z.number(),
+  source: z.string(),
+  installed: z.boolean(),
+});
+
+export const marketplaceSearchOutput = z.object({
+  results: z.array(marketplaceSearchResult),
+});
+
+export const marketplacePreviewFile = z.object({
+  // Path relative to the skill directory, using "/" separators.
+  path: z.string(),
+  size: z.number(),
+  /** Null when the file is binary or too large to preview. */
+  content: z.string().nullable(),
+});
+
+export const marketplacePreviewOutput = z.object({
+  files: z.array(marketplacePreviewFile),
+  hasScripts: z.boolean(),
+});
+
+export const marketplaceInstallInput = marketplaceSkillRef.extend({
+  overwrite: z.boolean().optional(),
+});
+
+export const marketplaceInstallOutput = z.object({
+  path: z.string(),
+});
+
+/** Shape of the skills.sh search API response (external boundary). */
+export const skillsShSearchResponse = z.object({
+  skills: z.array(
+    z.object({
+      id: z.string(),
+      skillId: z.string(),
+      name: z.string(),
+      installs: z.number().optional(),
+      source: z.string(),
+    }),
+  ),
+});
+
+export type MarketplaceSkillRef = z.infer<typeof marketplaceSkillRef>;
+export type MarketplaceSearchOutput = z.infer<typeof marketplaceSearchOutput>;
+export type MarketplacePreviewOutput = z.infer<typeof marketplacePreviewOutput>;
+export type MarketplacePreviewFile = z.infer<typeof marketplacePreviewFile>;

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.module.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.module.ts
@@ -1,0 +1,9 @@
+import { ContainerModule } from "inversify";
+import { SKILLS_MARKETPLACE_SERVICE } from "./identifiers";
+import { SkillsMarketplaceService } from "./skills-marketplace";
+
+export const skillsMarketplaceModule = new ContainerModule(({ bind }) => {
+  bind(SKILLS_MARKETPLACE_SERVICE)
+    .to(SkillsMarketplaceService)
+    .inSingletonScope();
+});

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
@@ -16,6 +16,7 @@ import {
   collectSkillFiles,
   findSkillDirPrefix,
   SkillsMarketplaceService,
+  unzipWithLimit,
 } from "./skills-marketplace";
 
 let root: string;
@@ -278,5 +279,54 @@ describe("install", () => {
         skillId: "../escape",
       }),
     ).rejects.toThrow("Skill names must be");
+  });
+});
+
+describe("archive download guards", () => {
+  it("rejects archives whose declared content-length exceeds the cap", async () => {
+    stubFetch(
+      () =>
+        new Response(new Uint8Array(makeRepoZip()), {
+          status: 200,
+          headers: { "content-length": String(101 * 1024 * 1024) },
+        }),
+    );
+
+    await expect(
+      new SkillsMarketplaceService().preview({
+        source: "getsentry/skills",
+        skillId: "commit",
+      }),
+    ).rejects.toThrow("too large to download");
+  });
+
+  it("reuses the cached archive within the TTL", async () => {
+    stubFetch(() => zipResponse(makeRepoZip()));
+    const service = new SkillsMarketplaceService();
+
+    await service.preview({ source: "getsentry/skills", skillId: "commit" });
+    await service.preview({ source: "getsentry/skills", skillId: "other" });
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unzipWithLimit", () => {
+  it("rejects archives that decompress past the budget", async () => {
+    const zip = zipSync({
+      "repo-HEAD/big.bin": new Uint8Array(64 * 1024),
+    });
+
+    await expect(
+      unzipWithLimit(new Uint8Array(zip), 16 * 1024, "a/b"),
+    ).rejects.toThrow("too large to unpack");
+  });
+
+  it("inflates archives within the budget", async () => {
+    const zip = zipSync({ "repo-HEAD/small.txt": strToU8("hello") });
+
+    const entries = await unzipWithLimit(new Uint8Array(zip), 16 * 1024, "a/b");
+
+    expect(Object.keys(entries)).toContain("repo-HEAD/small.txt");
   });
 });

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
@@ -1,0 +1,282 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { strToU8, zipSync } from "fflate";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testHome = vi.hoisted(() => ({ dir: "" }));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  const homedir = () => testHome.dir;
+  return { ...actual, homedir, default: { ...actual, homedir } };
+});
+
+import { existsSync } from "node:fs";
+import {
+  collectSkillFiles,
+  findSkillDirPrefix,
+  SkillsMarketplaceService,
+} from "./skills-marketplace";
+
+let root: string;
+
+function makeRepoZip(extraEntries: Record<string, Uint8Array> = {}): Buffer {
+  return Buffer.from(
+    zipSync({
+      "skills-HEAD/README.md": strToU8("# repo"),
+      "skills-HEAD/skills/commit/SKILL.md": strToU8(
+        "---\nname: commit\ndescription: Commits things\n---\nBody",
+      ),
+      "skills-HEAD/skills/commit/references/guide.md": strToU8("guide"),
+      "skills-HEAD/skills/commit/scripts/run.sh": strToU8("echo hi"),
+      "skills-HEAD/skills/other/SKILL.md": strToU8("---\nname: other\n---\n"),
+      ...extraEntries,
+    }),
+  );
+}
+
+function stubFetch(handler: (url: string) => Response | Promise<Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL) => handler(String(input))),
+  );
+}
+
+function zipResponse(zip: Buffer): Response {
+  return new Response(new Uint8Array(zip), { status: 200 });
+}
+
+beforeEach(async () => {
+  // /tmp directly: node:os is mocked, so os.tmpdir() is off the table here.
+  root = await mkdtemp(path.join("/tmp", "skills-marketplace-test-"));
+  testHome.dir = root;
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("findSkillDirPrefix", () => {
+  it("finds the shallowest directory with the skill id", () => {
+    const entries = {
+      "repo-HEAD/nested/deep/commit/SKILL.md": strToU8("x"),
+      "repo-HEAD/skills/commit/SKILL.md": strToU8("x"),
+    };
+
+    expect(findSkillDirPrefix(entries, "commit")).toBe(
+      "repo-HEAD/skills/commit/",
+    );
+  });
+
+  it("returns null when absent", () => {
+    expect(findSkillDirPrefix({}, "commit")).toBeNull();
+  });
+});
+
+describe("collectSkillFiles", () => {
+  it("drops entries that would escape the install directory", () => {
+    const prefix = "repo-HEAD/skills/commit/";
+    const entries = {
+      [`${prefix}SKILL.md`]: strToU8("ok"),
+      [`${prefix}../evil.md`]: strToU8("bad"),
+      [`${prefix}nested/../../evil2.md`]: strToU8("bad"),
+      [`${prefix}back\\slash.md`]: strToU8("bad"),
+    };
+
+    const files = collectSkillFiles(entries, prefix);
+
+    expect([...files.keys()]).toEqual(["SKILL.md"]);
+  });
+});
+
+describe("search", () => {
+  it("maps skills.sh results and marks installed skills", async () => {
+    const service = new SkillsMarketplaceService();
+    // Install state: "commit" is already installed.
+    const stateDir = path.join(root, ".claude", "skills");
+    await import("node:fs/promises").then((fsp) =>
+      fsp.mkdir(stateDir, { recursive: true }),
+    );
+    await writeFile(
+      path.join(stateDir, "installed.json"),
+      JSON.stringify({
+        version: 1,
+        installed: { commit: { repo: "getsentry/skills" } },
+      }),
+    );
+
+    stubFetch((url) => {
+      expect(url).toContain("skills.sh/api/search");
+      expect(url).toContain("q=commit");
+      return new Response(
+        JSON.stringify({
+          skills: [
+            {
+              id: "getsentry/skills/commit",
+              skillId: "commit",
+              name: "commit",
+              installs: 2693,
+              source: "getsentry/skills",
+            },
+            {
+              id: "acme/tools/review",
+              skillId: "review",
+              name: "review",
+              source: "acme/tools",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const { results } = await service.search("commit");
+
+    expect(results).toEqual([
+      expect.objectContaining({ skillId: "commit", installed: true }),
+      expect.objectContaining({
+        skillId: "review",
+        installs: 0,
+        installed: false,
+      }),
+    ]);
+  });
+
+  it("returns empty results for queries under two characters", async () => {
+    stubFetch(() => {
+      throw new Error("should not fetch");
+    });
+
+    expect(await new SkillsMarketplaceService().search(" a ")).toEqual({
+      results: [],
+    });
+  });
+});
+
+describe("preview", () => {
+  it("returns the full file list with contents and a scripts flag", async () => {
+    stubFetch(() => zipResponse(makeRepoZip()));
+    const service = new SkillsMarketplaceService();
+
+    const preview = await service.preview({
+      source: "getsentry/skills",
+      skillId: "commit",
+    });
+
+    expect(preview.files.map((f) => f.path)).toEqual([
+      "SKILL.md",
+      "references/guide.md",
+      "scripts/run.sh",
+    ]);
+    expect(preview.files[0]?.content).toContain("Commits things");
+    expect(preview.hasScripts).toBe(true);
+  });
+
+  it("marks binary files as non-previewable", async () => {
+    stubFetch(() =>
+      zipResponse(
+        makeRepoZip({
+          "skills-HEAD/skills/commit/assets/logo.png": new Uint8Array([
+            0x89, 0x50, 0x00, 0x47,
+          ]),
+        }),
+      ),
+    );
+
+    const preview = await new SkillsMarketplaceService().preview({
+      source: "getsentry/skills",
+      skillId: "commit",
+    });
+
+    const logo = preview.files.find((f) => f.path === "assets/logo.png");
+    expect(logo?.content).toBeNull();
+  });
+
+  it("throws when the skill is not in the repository", async () => {
+    stubFetch(() => zipResponse(makeRepoZip()));
+
+    await expect(
+      new SkillsMarketplaceService().preview({
+        source: "getsentry/skills",
+        skillId: "nope",
+      }),
+    ).rejects.toThrow('Skill "nope" was not found');
+  });
+
+  it("rejects malformed repository references", async () => {
+    stubFetch(() => zipResponse(makeRepoZip()));
+
+    await expect(
+      new SkillsMarketplaceService().preview({
+        source: "https://evil.example/x",
+        skillId: "commit",
+      }),
+    ).rejects.toThrow("Invalid repository reference");
+  });
+});
+
+describe("install", () => {
+  it("copies the skill into the user skills dir and records the badge state", async () => {
+    stubFetch(() => zipResponse(makeRepoZip()));
+    const service = new SkillsMarketplaceService();
+
+    const { path: installedPath } = await service.install({
+      source: "getsentry/skills",
+      skillId: "commit",
+    });
+
+    expect(installedPath).toBe(path.join(root, ".claude", "skills", "commit"));
+    expect(
+      await readFile(path.join(installedPath, "SKILL.md"), "utf-8"),
+    ).toContain("Commits things");
+    expect(existsSync(path.join(installedPath, "scripts", "run.sh"))).toBe(
+      true,
+    );
+
+    const state = JSON.parse(
+      await readFile(
+        path.join(root, ".claude", "skills", "installed.json"),
+        "utf-8",
+      ),
+    );
+    expect(state).toEqual({
+      version: 1,
+      installed: { commit: { repo: "getsentry/skills" } },
+    });
+  });
+
+  it("requires overwrite when the skill already exists, then replaces it", async () => {
+    stubFetch(() => zipResponse(makeRepoZip()));
+    const service = new SkillsMarketplaceService();
+
+    const { path: installedPath } = await service.install({
+      source: "getsentry/skills",
+      skillId: "commit",
+    });
+    await writeFile(path.join(installedPath, "local-edit.md"), "mine");
+
+    await expect(
+      service.install({ source: "getsentry/skills", skillId: "commit" }),
+    ).rejects.toThrow("already exists");
+
+    await service.install(
+      { source: "getsentry/skills", skillId: "commit" },
+      true,
+    );
+    // Overwrite replaces the directory wholesale; local edits are gone.
+    expect(existsSync(path.join(installedPath, "local-edit.md"))).toBe(false);
+    expect(existsSync(path.join(installedPath, "SKILL.md"))).toBe(true);
+  });
+
+  it("rejects invalid skill ids", async () => {
+    stubFetch(() => zipResponse(makeRepoZip()));
+
+    await expect(
+      new SkillsMarketplaceService().install({
+        source: "getsentry/skills",
+        skillId: "../escape",
+      }),
+    ).rejects.toThrow("Skill names must be");
+  });
+});

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -1,0 +1,247 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Unzipped } from "fflate";
+import { injectable } from "inversify";
+import { unzipAsync } from "../posthog-plugin/extract-zip";
+import { validateSkillDirName } from "../skills/skills";
+import {
+  type MarketplacePreviewFile,
+  type MarketplacePreviewOutput,
+  type MarketplaceSearchOutput,
+  type MarketplaceSkillRef,
+  skillsShSearchResponse,
+} from "./schemas";
+
+const SKILLS_SH_SEARCH_URL = "https://skills.sh/api/search";
+const REPO_SOURCE_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MAX_ARCHIVE_BYTES = 100 * 1024 * 1024;
+const MAX_PREVIEW_FILE_BYTES = 256 * 1024;
+const ARCHIVE_CACHE_TTL_MS = 5 * 60_000;
+const ARCHIVE_CACHE_MAX_ENTRIES = 4;
+
+interface InstalledSkillsFile {
+  version: number;
+  installed: Record<string, { repo: string }>;
+}
+
+interface CachedArchive {
+  fetchedAt: number;
+  entries: Unzipped;
+}
+
+function userSkillsDir(): string {
+  return path.join(os.homedir(), ".claude", "skills");
+}
+
+function installedStatePath(): string {
+  return path.join(userSkillsDir(), "installed.json");
+}
+
+/**
+ * Reads the versioned install-state file. Its only purpose is the
+ * "Installed" badge in browse results — installs are copy-and-forget.
+ */
+export async function readInstalledState(): Promise<InstalledSkillsFile> {
+  try {
+    const content = await fs.promises.readFile(installedStatePath(), "utf-8");
+    const data = JSON.parse(content) as InstalledSkillsFile;
+    if (!data.installed || typeof data.installed !== "object") {
+      return { version: 1, installed: {} };
+    }
+    return { version: 1, installed: data.installed };
+  } catch {
+    return { version: 1, installed: {} };
+  }
+}
+
+async function writeInstalledState(state: InstalledSkillsFile): Promise<void> {
+  await fs.promises.mkdir(userSkillsDir(), { recursive: true });
+  await fs.promises.writeFile(
+    installedStatePath(),
+    `${JSON.stringify(state, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+/**
+ * Finds the archive prefix of the directory named `skillId` that contains a
+ * SKILL.md, e.g. "repo-HEAD/skills/commit/". Prefers the shallowest match.
+ */
+export function findSkillDirPrefix(
+  entries: Unzipped,
+  skillId: string,
+): string | null {
+  const suffix = `/${skillId}/SKILL.md`;
+  const matches = Object.keys(entries)
+    .filter((key) => key.endsWith(suffix))
+    .sort((a, b) => a.split("/").length - b.split("/").length);
+  const match = matches[0];
+  if (!match) return null;
+  return match.slice(0, match.length - "SKILL.md".length);
+}
+
+function isProbablyText(bytes: Uint8Array): boolean {
+  const sample = bytes.subarray(0, 4096);
+  return !sample.includes(0);
+}
+
+/** Rejects zip entries that would escape the install directory (zip-slip). */
+function isSafeRelativePath(relPath: string): boolean {
+  if (relPath.length === 0 || relPath.includes("\\")) return false;
+  const segments = relPath.split("/");
+  return segments.every(
+    (segment) => segment.length > 0 && segment !== "." && segment !== "..",
+  );
+}
+
+export function collectSkillFiles(
+  entries: Unzipped,
+  prefix: string,
+): Map<string, Uint8Array> {
+  const files = new Map<string, Uint8Array>();
+  for (const [key, bytes] of Object.entries(entries)) {
+    if (!key.startsWith(prefix) || key.endsWith("/")) continue;
+    const relPath = key.slice(prefix.length);
+    if (!isSafeRelativePath(relPath)) continue;
+    files.set(relPath, bytes);
+  }
+  return files;
+}
+
+@injectable()
+export class SkillsMarketplaceService {
+  private archives = new Map<string, CachedArchive>();
+
+  async search(query: string): Promise<MarketplaceSearchOutput> {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) return { results: [] };
+
+    const url = new URL(SKILLS_SH_SEARCH_URL);
+    url.searchParams.set("q", trimmed);
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`skills.sh search failed: ${response.status}`);
+    }
+    const data = skillsShSearchResponse.parse(await response.json());
+    const state = await readInstalledState();
+
+    return {
+      results: data.skills.map((skill) => ({
+        id: skill.id,
+        skillId: skill.skillId,
+        name: skill.name,
+        installs: skill.installs ?? 0,
+        source: skill.source,
+        installed: skill.skillId in state.installed,
+      })),
+    };
+  }
+
+  async preview(ref: MarketplaceSkillRef): Promise<MarketplacePreviewOutput> {
+    const files = await this.getSkillFiles(ref);
+
+    const previewFiles: MarketplacePreviewFile[] = [...files.entries()]
+      .map(([relPath, bytes]) => ({
+        path: relPath,
+        size: bytes.byteLength,
+        content:
+          bytes.byteLength <= MAX_PREVIEW_FILE_BYTES && isProbablyText(bytes)
+            ? new TextDecoder().decode(bytes)
+            : null,
+      }))
+      .sort((a, b) => {
+        if (a.path === "SKILL.md") return -1;
+        if (b.path === "SKILL.md") return 1;
+        return a.path.localeCompare(b.path);
+      });
+
+    return {
+      files: previewFiles,
+      hasScripts: previewFiles.some((f) => f.path.startsWith("scripts/")),
+    };
+  }
+
+  /**
+   * Copy-and-forget install: extract the skill directory into
+   * ~/.claude/skills/<skillId>. From then on it is an ordinary, editable
+   * user skill; installed.json only feeds the "Installed" badge.
+   */
+  async install(
+    ref: MarketplaceSkillRef,
+    overwrite = false,
+  ): Promise<{ path: string }> {
+    validateSkillDirName(ref.skillId);
+    const target = path.join(userSkillsDir(), ref.skillId);
+    if (fs.existsSync(target) && !overwrite) {
+      throw new Error(
+        `A skill named "${ref.skillId}" already exists. Reinstalling will replace your local version.`,
+      );
+    }
+
+    const files = await this.getSkillFiles(ref);
+
+    if (fs.existsSync(target)) {
+      await fs.promises.rm(target, { recursive: true, force: true });
+    }
+    for (const [relPath, bytes] of files) {
+      const filePath = path.join(target, relPath);
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.promises.writeFile(filePath, bytes);
+    }
+
+    const state = await readInstalledState();
+    state.installed[ref.skillId] = { repo: ref.source };
+    await writeInstalledState(state);
+
+    return { path: target };
+  }
+
+  private async getSkillFiles(
+    ref: MarketplaceSkillRef,
+  ): Promise<Map<string, Uint8Array>> {
+    const entries = await this.getRepoArchive(ref.source);
+    const prefix = findSkillDirPrefix(entries, ref.skillId);
+    if (!prefix) {
+      throw new Error(`Skill "${ref.skillId}" was not found in ${ref.source}`);
+    }
+    const files = collectSkillFiles(entries, prefix);
+    if (!files.has("SKILL.md")) {
+      throw new Error(
+        `Skill "${ref.skillId}" in ${ref.source} has no SKILL.md`,
+      );
+    }
+    return files;
+  }
+
+  private async getRepoArchive(source: string): Promise<Unzipped> {
+    if (!REPO_SOURCE_PATTERN.test(source)) {
+      throw new Error(`Invalid repository reference: ${source}`);
+    }
+
+    const cached = this.archives.get(source);
+    if (cached && Date.now() - cached.fetchedAt < ARCHIVE_CACHE_TTL_MS) {
+      return cached.entries;
+    }
+
+    const response = await fetch(
+      `https://codeload.github.com/${source}/zip/HEAD`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to download ${source}: ${response.status}`);
+    }
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > MAX_ARCHIVE_BYTES) {
+      throw new Error(`Repository ${source} is too large to download`);
+    }
+    const entries = await unzipAsync(new Uint8Array(buffer));
+
+    this.archives.set(source, { fetchedAt: Date.now(), entries });
+    while (this.archives.size > ARCHIVE_CACHE_MAX_ENTRIES) {
+      const oldest = this.archives.keys().next().value;
+      if (oldest === undefined) break;
+      this.archives.delete(oldest);
+    }
+    return entries;
+  }
+}

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -16,9 +16,12 @@ import {
 const SKILLS_SH_SEARCH_URL = "https://skills.sh/api/search";
 const REPO_SOURCE_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const MAX_ARCHIVE_BYTES = 100 * 1024 * 1024;
+const MAX_UNZIPPED_BYTES = 500 * 1024 * 1024;
 const MAX_PREVIEW_FILE_BYTES = 256 * 1024;
 const ARCHIVE_CACHE_TTL_MS = 5 * 60_000;
 const ARCHIVE_CACHE_MAX_ENTRIES = 4;
+const SEARCH_TIMEOUT_MS = 10_000;
+const ARCHIVE_DOWNLOAD_TIMEOUT_MS = 60_000;
 
 interface InstalledSkillsFile {
   version: number;
@@ -119,7 +122,9 @@ export class SkillsMarketplaceService {
 
     const url = new URL(SKILLS_SH_SEARCH_URL);
     url.searchParams.set("q", trimmed);
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(SEARCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
       throw new Error(`skills.sh search failed: ${response.status}`);
     }
@@ -221,20 +226,26 @@ export class SkillsMarketplaceService {
 
     const cached = this.archives.get(source);
     if (cached && Date.now() - cached.fetchedAt < ARCHIVE_CACHE_TTL_MS) {
+      // LRU: refresh recency on hit.
+      this.archives.delete(source);
+      this.archives.set(source, cached);
       return cached.entries;
     }
 
     const response = await fetch(
       `https://codeload.github.com/${source}/zip/HEAD`,
+      { signal: AbortSignal.timeout(ARCHIVE_DOWNLOAD_TIMEOUT_MS) },
     );
     if (!response.ok) {
       throw new Error(`Failed to download ${source}: ${response.status}`);
     }
-    const buffer = await response.arrayBuffer();
-    if (buffer.byteLength > MAX_ARCHIVE_BYTES) {
+    const declaredBytes = Number(response.headers.get("content-length") ?? 0);
+    if (declaredBytes > MAX_ARCHIVE_BYTES) {
       throw new Error(`Repository ${source} is too large to download`);
     }
-    const entries = await unzipAsync(new Uint8Array(buffer));
+    // codeload responses are chunked; the cap is enforced while streaming.
+    const buffer = await readBodyWithLimit(response, MAX_ARCHIVE_BYTES, source);
+    const entries = await unzipWithLimit(buffer, MAX_UNZIPPED_BYTES, source);
 
     this.archives.set(source, { fetchedAt: Date.now(), entries });
     while (this.archives.size > ARCHIVE_CACHE_MAX_ENTRIES) {
@@ -244,4 +255,61 @@ export class SkillsMarketplaceService {
     }
     return entries;
   }
+}
+
+async function readBodyWithLimit(
+  response: Response,
+  maxBytes: number,
+  source: string,
+): Promise<Uint8Array> {
+  const tooLarge = () =>
+    new Error(`Repository ${source} is too large to download`);
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    if (buffer.byteLength > maxBytes) throw tooLarge();
+    return buffer;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw tooLarge();
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+/** Inflates the archive within a decompressed-bytes budget (zip-bomb guard). */
+export function unzipWithLimit(
+  data: Uint8Array,
+  maxTotalBytes: number,
+  source: string,
+): Promise<Unzipped> {
+  let total = 0;
+  let exceeded = false;
+  return unzipAsync(data, {
+    filter: (file) => {
+      total += file.originalSize;
+      if (total > maxTotalBytes) exceeded = true;
+      return !exceeded;
+    },
+  }).then((entries) => {
+    if (exceeded) {
+      throw new Error(`Repository ${source} is too large to unpack`);
+    }
+    return entries;
+  });
 }

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -337,7 +337,7 @@ export class SkillsService {
   }
 }
 
-function validateSkillDirName(name: string): void {
+export function validateSkillDirName(name: string): void {
   if (
     !SKILL_DIR_NAME_PATTERN.test(name) ||
     name.length > MAX_SKILL_DIR_NAME_LENGTH


### PR DESCRIPTION
## Problem

Users have no way to discover and install community skills from within the app. They must manually find and copy skill files, with no browsing, previewing, or one-click install experience.

## Changes

**Backend: `SkillsMarketplaceService`**
- Added a new `skills-marketplace` service that integrates with the `skills.sh` search API to find community skills by query.
- Skills are fetched as GitHub repository ZIP archives, with a short-lived in-process cache (5 min TTL, max 4 entries) to avoid redundant downloads.
- `preview()` returns all files in a skill directory before anything touches disk, flagging skills that contain executable scripts and marking binary files as non-previewable.
- `install()` extracts the skill into `~/.claude/skills/<skillId>` as an ordinary editable user skill. An `installed.json` state file tracks which skills came from the marketplace solely to power the "Installed" badge in search results.
- Zip-slip protection is enforced: any archive entry with path traversal sequences or backslashes is silently dropped.
- `validateSkillDirName` is exported from the skills service so the marketplace service can reuse it.
- The module is registered in the DI container and wired into the host router under `skills.marketplace.{search,preview,install}`.

**Frontend: Marketplace UI**
- `SkillsView` gains an "Installed" / "Marketplace" tab bar. The existing skills list is shown under "Installed"; the new `MarketplaceBrowse` component is shown under "Marketplace".
- `MarketplaceBrowse` provides a debounced search input (300 ms) that queries the marketplace. Results show skill name, source repo, install count, and an "Installed" badge when applicable. Selecting a result opens a resizable `MarketplaceSkillPanel` sidebar.
- `MarketplaceSkillPanel` shows a full pre-install file preview. `SKILL.md` is rendered as Markdown (frontmatter stripped); all other files open in the read-only CodeMirror editor. A warning callout is shown when the skill contains scripts. Installing a skill that already exists locally prompts an overwrite confirmation dialog.
- `stripFrontmatter` is extracted into its own module and shared between `SkillDetailPanel` and `MarketplaceSkillPanel`.
- React Query hooks (`useMarketplaceSearch`, `useMarketplacePreview`, `useInstallMarketplaceSkill`) are added in `useMarketplace.ts`. A successful install invalidates the skills query so the "Installed" tab reflects the new skill immediately.

## How did you test this?

A full unit test suite was added for `SkillsMarketplaceService` covering:
- `findSkillDirPrefix` — shallowest-match selection and absent-skill handling.
- `collectSkillFiles` — zip-slip path traversal rejection.
- `search` — correct mapping of `skills.sh` results, installed-state decoration, and short-query early-exit.
- `preview` — full file list with contents, binary file detection, missing-skill error, and invalid repository reference rejection.
- `install` — successful extraction and state file write, overwrite guard and replacement, and invalid skill ID rejection.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?