### PR TITLE
feat(skills): PostHog cloud team skills — read path

### DIFF
--- a/apps/code/src/renderer/desktop-contributions.ts
+++ b/apps/code/src/renderer/desktop-contributions.ts
@@ -3,6 +3,7 @@ import { inboxCoreModule } from "@posthog/core/inbox/inbox.module";
 import { githubConnectModule } from "@posthog/core/integrations/githubConnect.module";
 import { onboardingModule } from "@posthog/core/onboarding/onboarding.module";
 import { setupCoreModule } from "@posthog/core/setup/setup.module";
+import { skillsCoreModule } from "@posthog/core/skills/skills.module";
 import { CONTRIBUTION } from "@posthog/di/contribution";
 import { agentUiModule } from "@posthog/ui/features/agent/agent.module";
 import { authUiModule } from "@posthog/ui/features/auth/auth.module";
@@ -38,6 +39,7 @@ export function registerDesktopContributions(): void {
     provisioningUiModule,
     setupCoreModule,
     setupUiModule,
+    skillsCoreModule,
     workspaceUiModule,
   ]) {
     container.load(module);

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -143,6 +143,58 @@ export interface UserGitHubIntegration {
   created_at?: string;
 }
 
+export interface LlmSkillCreatedBy {
+  id?: number;
+  email?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+}
+
+export interface LlmSkillFileManifest {
+  path: string;
+  content_type: string;
+}
+
+export interface LlmSkillFile {
+  path: string;
+  content: string;
+  content_type: string;
+}
+
+export interface LlmSkillListItem {
+  id: string;
+  name: string;
+  description: string;
+  allowed_tools: unknown[];
+  metadata: Record<string, unknown>;
+  version: number;
+  is_latest: boolean;
+  latest_version?: number | null;
+  version_count?: number | null;
+  created_by: LlmSkillCreatedBy | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LlmSkill extends LlmSkillListItem {
+  /** The SKILL.md markdown content. */
+  body: string;
+  /** Companion file manifest (paths only; fetch contents separately). */
+  files: LlmSkillFileManifest[];
+}
+
+export interface LlmSkillResolveResponse {
+  skill: LlmSkill;
+  versions: Array<{
+    id: string;
+    version: number;
+    created_by: LlmSkillCreatedBy | null;
+    created_at: string;
+    is_latest: boolean;
+  }>;
+  has_more: boolean;
+}
+
 export interface SignalSourceConfig {
   id: string;
   source_product:
@@ -3626,5 +3678,78 @@ export class PostHogAPIClient {
       throw new Error(`Failed to fetch spend analysis: ${response.status}`);
     }
     return (await response.json()) as SpendAnalysisResponse;
+  }
+
+  /**
+   * Lists the team's LLM skills (latest versions, no bodies).
+   * Returns null when the feature is unavailable for this org (the
+   * llm-analytics-skills flag gates the endpoint server-side with a 403).
+   */
+  async listLlmSkills(): Promise<LlmSkillListItem[] | null> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/environments/${teamId}/llm_skills/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (response.status === 403) return null;
+    if (!response.ok) {
+      throw new Error(`Failed to fetch team skills: ${response.statusText}`);
+    }
+    const data = (await response.json()) as { results?: LlmSkillListItem[] };
+    return data.results ?? [];
+  }
+
+  /** Fetches the latest version of a team skill, including body and file manifest. */
+  async getLlmSkillByName(name: string): Promise<LlmSkill> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/environments/${teamId}/llm_skills/name/${encodeURIComponent(name)}`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch team skill: ${response.statusText}`);
+    }
+    return (await response.json()) as LlmSkill;
+  }
+
+  /** Resolves a team skill plus its version history. */
+  async resolveLlmSkill(name: string): Promise<LlmSkillResolveResponse> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/environments/${teamId}/llm_skills/resolve/name/${encodeURIComponent(name)}`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to resolve team skill: ${response.statusText}`);
+    }
+    return (await response.json()) as LlmSkillResolveResponse;
+  }
+
+  /** Fetches one companion file of a team skill. */
+  async getLlmSkillFile(name: string, filePath: string): Promise<LlmSkillFile> {
+    const teamId = await this.getTeamId();
+    const encodedPath = filePath.split("/").map(encodeURIComponent).join("/");
+    const urlPath = `/api/environments/${teamId}/llm_skills/name/${encodeURIComponent(name)}/files/${encodedPath}`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch team skill file: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as LlmSkillFile;
   }
 }

--- a/packages/core/src/skills/identifiers.ts
+++ b/packages/core/src/skills/identifiers.ts
@@ -1,0 +1,3 @@
+export const TEAM_SKILLS_SERVICE = Symbol.for(
+  "posthog.core.skills.teamSkillsService",
+);

--- a/packages/core/src/skills/skills.module.ts
+++ b/packages/core/src/skills/skills.module.ts
@@ -1,0 +1,7 @@
+import { ContainerModule } from "inversify";
+import { TEAM_SKILLS_SERVICE } from "./identifiers";
+import { TeamSkillsService } from "./teamSkillsService";
+
+export const skillsCoreModule = new ContainerModule(({ bind }) => {
+  bind(TEAM_SKILLS_SERVICE).to(TeamSkillsService).inSingletonScope();
+});

--- a/packages/core/src/skills/teamSkillsService.test.ts
+++ b/packages/core/src/skills/teamSkillsService.test.ts
@@ -24,8 +24,10 @@ function makeItem(overrides: Partial<LlmSkillListItem>): LlmSkillListItem {
 
 function makeClient(result: LlmSkillListItem[] | null): PostHogAPIClient {
   return {
-    listLlmSkills: vi.fn().mockResolvedValue(result),
-  } as unknown as PostHogAPIClient;
+    listLlmSkills: vi
+      .fn<PostHogAPIClient["listLlmSkills"]>()
+      .mockResolvedValue(result),
+  } satisfies Partial<PostHogAPIClient> as unknown as PostHogAPIClient;
 }
 
 describe("TeamSkillsService.listTeamSkills", () => {

--- a/packages/core/src/skills/teamSkillsService.test.ts
+++ b/packages/core/src/skills/teamSkillsService.test.ts
@@ -1,0 +1,82 @@
+import type {
+  LlmSkillListItem,
+  PostHogAPIClient,
+} from "@posthog/api-client/posthog-client";
+import { describe, expect, it, vi } from "vitest";
+import { TeamSkillsService } from "./teamSkillsService";
+
+function makeItem(overrides: Partial<LlmSkillListItem>): LlmSkillListItem {
+  return {
+    id: "skill-1",
+    name: "pr-shepherd",
+    description: "Shepherds PRs",
+    allowed_tools: [],
+    metadata: {},
+    version: 2,
+    is_latest: true,
+    latest_version: 2,
+    created_by: { email: "dev@posthog.com" },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-02-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeClient(result: LlmSkillListItem[] | null): PostHogAPIClient {
+  return {
+    listLlmSkills: vi.fn().mockResolvedValue(result),
+  } as unknown as PostHogAPIClient;
+}
+
+describe("TeamSkillsService.listTeamSkills", () => {
+  it("reports the feature as unavailable when the API returns null", async () => {
+    const listing = await new TeamSkillsService().listTeamSkills(
+      makeClient(null),
+      [],
+    );
+
+    expect(listing).toEqual({ available: false, skills: [] });
+  });
+
+  it("maps team skills and marks ones that exist locally", async () => {
+    const client = makeClient([
+      makeItem({}),
+      makeItem({ id: "skill-2", name: "release-notes", created_by: null }),
+    ]);
+
+    const listing = await new TeamSkillsService().listTeamSkills(client, [
+      "release-notes",
+      "unrelated-local",
+    ]);
+
+    expect(listing.available).toBe(true);
+    expect(listing.skills).toEqual([
+      {
+        id: "skill-1",
+        name: "pr-shepherd",
+        description: "Shepherds PRs",
+        version: 2,
+        updatedAt: "2026-02-01T00:00:00Z",
+        createdByEmail: "dev@posthog.com",
+        installedLocally: false,
+      },
+      expect.objectContaining({
+        name: "release-notes",
+        createdByEmail: null,
+        installedLocally: true,
+      }),
+    ]);
+  });
+
+  it("drops non-latest versions", async () => {
+    const client = makeClient([
+      makeItem({ is_latest: false, version: 1 }),
+      makeItem({ id: "skill-1b", version: 2 }),
+    ]);
+
+    const listing = await new TeamSkillsService().listTeamSkills(client, []);
+
+    expect(listing.skills).toHaveLength(1);
+    expect(listing.skills[0]?.id).toBe("skill-1b");
+  });
+});

--- a/packages/core/src/skills/teamSkillsService.ts
+++ b/packages/core/src/skills/teamSkillsService.ts
@@ -1,0 +1,62 @@
+import type {
+  LlmSkillListItem,
+  PostHogAPIClient,
+} from "@posthog/api-client/posthog-client";
+import { injectable } from "inversify";
+
+export interface TeamSkillInfo {
+  id: string;
+  name: string;
+  description: string;
+  version: number;
+  updatedAt: string;
+  createdByEmail: string | null;
+  /** A local skill with the same name already exists on this machine. */
+  installedLocally: boolean;
+}
+
+export interface TeamSkillsListing {
+  /** False when the org does not have the team-skills feature enabled. */
+  available: boolean;
+  skills: TeamSkillInfo[];
+}
+
+@injectable()
+export class TeamSkillsService {
+  /**
+   * Lists team skills merged with the local listing: the availability
+   * decision (flag off → absent group, no errors) and the "already
+   * installed locally" marking both live here, so the UI keeps one hook.
+   */
+  async listTeamSkills(
+    client: PostHogAPIClient,
+    localSkillNames: string[],
+  ): Promise<TeamSkillsListing> {
+    const items = await client.listLlmSkills();
+    if (items === null) {
+      return { available: false, skills: [] };
+    }
+    const localNames = new Set(localSkillNames);
+    return {
+      available: true,
+      skills: items
+        .filter((item) => item.is_latest)
+        .map((item) => toTeamSkillInfo(item, localNames)),
+    };
+  }
+}
+
+function toTeamSkillInfo(
+  item: LlmSkillListItem,
+  localNames: Set<string>,
+): TeamSkillInfo {
+  return {
+    id: item.id,
+    name: item.name,
+    description: item.description,
+    version: item.latest_version ?? item.version,
+    updatedAt: item.updated_at,
+    createdByEmail: item.created_by?.email ?? null,
+    installedLocally: localNames.has(item.name),
+  };
+}

--- a/packages/ui/src/features/skills/SkillsView.tsx
+++ b/packages/ui/src/features/skills/SkillsView.tsx
@@ -22,12 +22,16 @@ import {
   useSkillsSelectionActions,
 } from "./skillsSelectionStore";
 import { useSkillsSidebarStore } from "./skillsSidebarStore";
+import { TeamSkillsTab } from "./TeamSkillsTab";
 import { useSkills } from "./useSkills";
 import { useSkillsWatcher } from "./useSkillsWatcher";
+import { useTeamSkills } from "./useTeamSkills";
 
 const SOURCE_ORDER: SkillSource[] = ["user", "marketplace", "repo", "bundled"];
 
-type SkillsTab = "installed" | "marketplace";
+// Installed = on disk, usable by agents right now. Team and Marketplace are
+// remote catalogs; installing materializes a skill into Installed.
+type SkillsTab = "installed" | "team" | "marketplace";
 
 export function SkillsView() {
   const { data: skills = [], isLoading } = useSkills();
@@ -38,6 +42,9 @@ export function SkillsView() {
   const [scrollToPath, setScrollToPath] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [newSkillOpen, setNewSkillOpen] = useState(false);
+
+  const { data: teamListing } = useTeamSkills(skills);
+  const teamAvailable = teamListing?.available ?? false;
 
   const {
     width: sidebarWidth,
@@ -127,6 +134,11 @@ export function SkillsView() {
             <TabsTrigger value="installed" className="gap-1.5 px-2.5 py-2">
               <span className="font-medium text-[13px]">Installed</span>
             </TabsTrigger>
+            {teamAvailable && (
+              <TabsTrigger value="team" className="gap-1.5 px-2.5 py-2">
+                <span className="font-medium text-[13px]">Team</span>
+              </TabsTrigger>
+            )}
             <TabsTrigger value="marketplace" className="gap-1.5 px-2.5 py-2">
               <span className="font-medium text-[13px]">Marketplace</span>
             </TabsTrigger>
@@ -136,6 +148,8 @@ export function SkillsView() {
 
       {tab === "marketplace" ? (
         <MarketplaceBrowse />
+      ) : tab === "team" && teamAvailable ? (
+        <TeamSkillsTab skills={teamListing?.skills ?? []} />
       ) : (
         <Flex className="min-h-0 flex-1">
           <Box flexGrow="1" className="min-w-0">

--- a/packages/ui/src/features/skills/SkillsView.tsx
+++ b/packages/ui/src/features/skills/SkillsView.tsx
@@ -45,6 +45,9 @@ export function SkillsView() {
 
   const { data: teamListing } = useTeamSkills(skills);
   const teamAvailable = teamListing?.available ?? false;
+  // Team access revoked mid-session: fall back to Installed.
+  const activeTab: SkillsTab =
+    tab === "team" && !teamAvailable ? "installed" : tab;
 
   const {
     width: sidebarWidth,
@@ -127,7 +130,7 @@ export function SkillsView() {
     <Flex direction="column" height="100%" className="overflow-hidden">
       <Box px="4" className="shrink-0 border-b border-b-(--gray-5)">
         <Tabs
-          value={tab}
+          value={activeTab}
           onValueChange={(value: string) => setTab(value as SkillsTab)}
         >
           <TabsList variant="line" className="h-auto gap-0.5">
@@ -146,9 +149,9 @@ export function SkillsView() {
         </Tabs>
       </Box>
 
-      {tab === "marketplace" ? (
+      {activeTab === "marketplace" ? (
         <MarketplaceBrowse />
-      ) : tab === "team" && teamAvailable ? (
+      ) : activeTab === "team" ? (
         <TeamSkillsTab skills={teamListing?.skills ?? []} />
       ) : (
         <Flex className="min-h-0 flex-1">

--- a/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
@@ -1,0 +1,137 @@
+import { UsersThree, X } from "@phosphor-icons/react";
+import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
+import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { Badge, Box, Flex, ScrollArea, Text, Tooltip } from "@radix-ui/themes";
+import { useState } from "react";
+import { SkillFileTree } from "./SkillFileTree";
+import { stripFrontmatter } from "./stripFrontmatter";
+import { useTeamSkillDetail, useTeamSkillFile } from "./useTeamSkills";
+
+interface TeamSkillDetailPanelProps {
+  skill: TeamSkillInfo;
+  onClose: () => void;
+}
+
+/** Read-only view of a PostHog cloud team skill (body + companion files). */
+export function TeamSkillDetailPanel({
+  skill,
+  onClose,
+}: TeamSkillDetailPanelProps) {
+  const [selectedFile, setSelectedFile] = useState("SKILL.md");
+  const { data: detail, isLoading } = useTeamSkillDetail(skill.name);
+  const isSkillMd = selectedFile === "SKILL.md";
+  const { data: file, isLoading: isFileLoading } = useTeamSkillFile(
+    skill.name,
+    isSkillMd ? null : selectedFile,
+  );
+
+  const treeFiles = [
+    { path: "SKILL.md", size: detail?.body.length ?? 0 },
+    ...(detail?.files ?? []).map((f) => ({ path: f.path, size: 0 })),
+  ];
+
+  return (
+    <>
+      <Flex
+        direction="column"
+        gap="2"
+        px="3"
+        py="2"
+        className="shrink-0 border-b border-b-(--gray-5)"
+      >
+        <Flex align="start" justify="between" gap="2">
+          <Text className="block min-w-0 break-words font-medium text-[13px]">
+            {skill.name}
+          </Text>
+          <Tooltip content="Close">
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="shrink-0 rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+            >
+              <X size={14} />
+            </button>
+          </Tooltip>
+        </Flex>
+
+        <Flex align="center" gap="2" wrap="wrap">
+          <Badge size="1" variant="soft" color="gray">
+            <UsersThree size={10} className="text-gray-9" />
+            Team
+          </Badge>
+          <Badge size="1" variant="soft" color="gray">
+            v{skill.version}
+          </Badge>
+          {skill.createdByEmail && (
+            <Badge size="1" variant="soft" color="gray">
+              {skill.createdByEmail}
+            </Badge>
+          )}
+          {skill.installedLocally && (
+            <Badge size="1" variant="soft" color="green">
+              Installed
+            </Badge>
+          )}
+        </Flex>
+      </Flex>
+
+      {treeFiles.length > 1 && (
+        <Box className="max-h-[40%] shrink-0 overflow-y-auto border-b border-b-(--gray-5) py-1">
+          <SkillFileTree
+            files={treeFiles}
+            selectedPath={selectedFile}
+            onSelect={setSelectedFile}
+          />
+        </Box>
+      )}
+
+      <Box className="min-h-0 flex-1">
+        {isSkillMd ? (
+          <ScrollArea
+            type="auto"
+            scrollbars="vertical"
+            className="scroll-area-constrain-width h-full"
+          >
+            <Flex direction="column" gap="3" p="3">
+              {skill.description && (
+                <Text className="text-[12px] text-gray-10">
+                  {skill.description}
+                </Text>
+              )}
+              {isLoading ? (
+                <Text className="text-[12px] text-gray-9">Loading...</Text>
+              ) : detail?.body ? (
+                <Box className="rounded border border-gray-5 bg-gray-1 px-4 py-3 text-[13px]">
+                  <MarkdownRenderer content={stripFrontmatter(detail.body)} />
+                </Box>
+              ) : (
+                <Text className="text-[12px] text-gray-9">
+                  No content in SKILL.md
+                </Text>
+              )}
+            </Flex>
+          </ScrollArea>
+        ) : isFileLoading ? (
+          <Box p="3">
+            <Text className="text-[12px] text-gray-9">Loading...</Text>
+          </Box>
+        ) : file ? (
+          <CodeMirrorEditor
+            content={file.content}
+            filePath={selectedFile}
+            relativePath={selectedFile}
+            readOnly
+          />
+        ) : (
+          <Box p="3">
+            <Text className="text-[12px] text-gray-9">
+              Unable to display this file
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </>
+  );
+}

--- a/packages/ui/src/features/skills/TeamSkillsSection.tsx
+++ b/packages/ui/src/features/skills/TeamSkillsSection.tsx
@@ -1,0 +1,58 @@
+import { UsersThree } from "@phosphor-icons/react";
+import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
+import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+
+interface TeamSkillsSectionProps {
+  skills: TeamSkillInfo[];
+  selectedName: string | null;
+  onSelect: (skill: TeamSkillInfo) => void;
+}
+
+/** Skill cards shared via PostHog cloud, read-only here. */
+export function TeamSkillsSection({
+  skills,
+  selectedName,
+  onSelect,
+}: TeamSkillsSectionProps) {
+  return (
+    <Flex direction="column" gap="1">
+      {skills.map((skill) => (
+        <Flex
+          key={skill.id}
+          align="center"
+          gap="2"
+          px="3"
+          py="2"
+          className={`cursor-pointer rounded-lg border transition-colors ${
+            selectedName === skill.name
+              ? "border-accent-8 bg-accent-3"
+              : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
+          }`}
+          onClick={() => onSelect(skill)}
+        >
+          <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
+            <UsersThree size={14} weight="duotone" className="text-gray-11" />
+          </Box>
+          <Flex direction="column" gap="0" className="min-w-0 flex-1">
+            <Text className="truncate font-medium text-[13px] text-gray-12">
+              {skill.name}
+            </Text>
+            {skill.description && (
+              <Text className="truncate text-[12px] text-gray-10">
+                {skill.description}
+              </Text>
+            )}
+          </Flex>
+          {skill.installedLocally && (
+            <Badge size="1" variant="soft" color="green" className="shrink-0">
+              Installed
+            </Badge>
+          )}
+          <Badge size="1" variant="soft" color="gray" className="shrink-0">
+            v{skill.version}
+          </Badge>
+        </Flex>
+      ))}
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/skills/TeamSkillsTab.tsx
+++ b/packages/ui/src/features/skills/TeamSkillsTab.tsx
@@ -1,0 +1,104 @@
+import { MagnifyingGlass, UsersThree } from "@phosphor-icons/react";
+import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
+import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
+import { Box, Flex, ScrollArea, Text, TextField } from "@radix-ui/themes";
+import { useMemo, useState } from "react";
+import { useSkillsSidebarStore } from "./skillsSidebarStore";
+import { TeamSkillDetailPanel } from "./TeamSkillDetailPanel";
+import { TeamSkillsSection } from "./TeamSkillsSection";
+
+interface TeamSkillsTabProps {
+  /** Latest team skills, already merged with the local listing. */
+  skills: TeamSkillInfo[];
+}
+
+/** Skills your team published to PostHog cloud; install to use locally. */
+export function TeamSkillsTab({ skills }: TeamSkillsTabProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selected, setSelected] = useState<TeamSkillInfo | null>(null);
+
+  const {
+    width: sidebarWidth,
+    setWidth: setSidebarWidth,
+    isResizing,
+    setIsResizing,
+  } = useSkillsSidebarStore();
+
+  const filtered = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return skills;
+    return skills.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(query) ||
+        skill.description.toLowerCase().includes(query),
+    );
+  }, [skills, searchQuery]);
+
+  return (
+    <Flex className="min-h-0 flex-1">
+      <Box flexGrow="1" className="min-w-0">
+        <ScrollArea type="auto" className="scroll-area-constrain-width h-full">
+          <Box px="4" py="3">
+            <Box pb="3">
+              <TextField.Root
+                size="2"
+                placeholder="Search team skills..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="text-[13px]"
+              >
+                <TextField.Slot>
+                  <MagnifyingGlass size={14} />
+                </TextField.Slot>
+              </TextField.Root>
+            </Box>
+
+            {filtered.length === 0 ? (
+              <Flex
+                align="center"
+                justify="center"
+                direction="column"
+                gap="3"
+                className="py-12"
+              >
+                <Box className="rounded-lg border border-gray-6 border-dashed p-4">
+                  <UsersThree size={24} className="text-gray-8" />
+                </Box>
+                <Text className="max-w-[360px] text-center text-[13px] text-gray-10">
+                  {skills.length === 0
+                    ? "No team skills yet. Publish one of your skills to share it with your team."
+                    : "No team skills match your search"}
+                </Text>
+              </Flex>
+            ) : (
+              <TeamSkillsSection
+                skills={filtered}
+                selectedName={selected?.name ?? null}
+                onSelect={(skill) =>
+                  setSelected((prev) => (prev?.id === skill.id ? null : skill))
+                }
+              />
+            )}
+          </Box>
+        </ScrollArea>
+      </Box>
+
+      <ResizableSidebar
+        open={!!selected}
+        width={sidebarWidth}
+        setWidth={setSidebarWidth}
+        isResizing={isResizing}
+        setIsResizing={setIsResizing}
+        side="right"
+      >
+        {selected && (
+          <TeamSkillDetailPanel
+            key={selected.id}
+            skill={selected}
+            onClose={() => setSelected(null)}
+          />
+        )}
+      </ResizableSidebar>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/skills/useTeamSkills.ts
+++ b/packages/ui/src/features/skills/useTeamSkills.ts
@@ -1,0 +1,42 @@
+import { TEAM_SKILLS_SERVICE } from "@posthog/core/skills/identifiers";
+import type { TeamSkillsService } from "@posthog/core/skills/teamSkillsService";
+import { useService } from "@posthog/di/react";
+import type { SkillInfo } from "@posthog/shared";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useMemo } from "react";
+
+export const teamSkillsKeys = {
+  list: (localNames: string[]) => ["team-skills", "list", localNames] as const,
+  detail: (name: string) => ["team-skills", "detail", name] as const,
+  file: (name: string, path: string) =>
+    ["team-skills", "file", name, path] as const,
+};
+
+export function useTeamSkills(localSkills: SkillInfo[]) {
+  const service = useService<TeamSkillsService>(TEAM_SKILLS_SERVICE);
+  const localNames = useMemo(
+    () => [...new Set(localSkills.map((s) => s.name))].sort(),
+    [localSkills],
+  );
+  return useAuthenticatedQuery(
+    teamSkillsKeys.list(localNames),
+    (client) => service.listTeamSkills(client, localNames),
+    { staleTime: 60_000, retry: false },
+  );
+}
+
+export function useTeamSkillDetail(name: string | null) {
+  return useAuthenticatedQuery(
+    teamSkillsKeys.detail(name ?? ""),
+    (client) => client.getLlmSkillByName(name ?? ""),
+    { enabled: name !== null, staleTime: 60_000, retry: false },
+  );
+}
+
+export function useTeamSkillFile(name: string, filePath: string | null) {
+  return useAuthenticatedQuery(
+    teamSkillsKeys.file(name, filePath ?? ""),
+    (client) => client.getLlmSkillFile(name, filePath ?? ""),
+    { enabled: filePath !== null, staleTime: 60_000, retry: false },
+  );
+}


### PR DESCRIPTION
## Problem

Users have no way to browse or inspect skills that their team has published to PostHog cloud. Without visibility into team-shared skills, there's no path to discovering and installing them locally.

## Changes

Adds a **Team Skills** tab to the Skills view that surfaces skills published by the team to PostHog cloud. The tab is conditionally shown only when the org has the team-skills feature enabled (gated server-side via a 403 response).

- Added API client types (`LlmSkill`, `LlmSkillListItem`, `LlmSkillResolveResponse`, etc.) and four new methods: `listLlmSkills`, `getLlmSkillByName`, `resolveLlmSkill`, and `getLlmSkillFile`.
- Introduced `TeamSkillsService` (injectable singleton) that fetches the team skill listing, filters to latest versions only, and cross-references local skill names to mark which skills are already installed.
- Registered `skillsCoreModule` in the desktop DI container.
- Added `useTeamSkills`, `useTeamSkillDetail`, and `useTeamSkillFile` React Query hooks.
- Built `TeamSkillsTab`, `TeamSkillsSection`, and `TeamSkillDetailPanel` components. The detail panel shows the `SKILL.md` body rendered as Markdown, a file tree for companion files, and a read-only code editor for non-Markdown files. Skills already installed locally are badged as **Installed**.

## How did you test this?

Unit tests were added for `TeamSkillsService.listTeamSkills` covering: feature unavailability (API returns `null`), correct mapping and local-install marking, and filtering out non-latest versions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?