### PR TITLE
feat(skills): publish skills to the team and install team skills locally

### DIFF
--- a/apps/code/src/renderer/di/bindings.ts
+++ b/apps/code/src/renderer/di/bindings.ts
@@ -79,6 +79,8 @@ import {
   TITLE_GENERATOR_LOGGER,
 } from "@posthog/core/sessions/titleGeneratorIdentifiers";
 import { type ISetupStore, SETUP_STORE } from "@posthog/core/setup/identifiers";
+import { SKILLS_WORKSPACE_CLIENT } from "@posthog/core/skills/identifiers";
+import type { SkillsWorkspaceClient } from "@posthog/core/skills/teamSkillsService";
 import {
   TASK_CREATION_EFFECTS,
   TASK_CREATION_HOST,
@@ -254,6 +256,7 @@ export interface RendererBindings {
   [NEW_TASK_LINK_RESOLVER]: NewTaskLinkResolver;
   [CODE_REVIEW_WORKSPACE_CLIENT]: CodeReviewWorkspaceClient;
   [REVERT_HUNK_SERVICE]: RevertHunkService;
+  [SKILLS_WORKSPACE_CLIENT]: SkillsWorkspaceClient;
   [CLOUD_ARTIFACT_READ_FILE_AS_BASE64]: ReadFileAsBase64;
   [LLM_GATEWAY_SERVICE]: LlmGatewayService;
   [TITLE_GENERATOR_FILE_READ_CLIENT]: FileReadClient;

--- a/apps/code/src/renderer/di/container.ts
+++ b/apps/code/src/renderer/di/container.ts
@@ -47,6 +47,8 @@ import {
   TITLE_GENERATOR_FILE_READ_CLIENT,
   TITLE_GENERATOR_LOGGER,
 } from "@posthog/core/sessions/titleGeneratorIdentifiers";
+import { SKILLS_WORKSPACE_CLIENT } from "@posthog/core/skills/identifiers";
+import type { SkillsWorkspaceClient } from "@posthog/core/skills/teamSkillsService";
 import {
   TASK_CREATION_EFFECTS,
   TASK_CREATION_HOST,
@@ -319,6 +321,13 @@ container.bind(CODE_REVIEW_WORKSPACE_CLIENT).toConstantValue({
   },
 } satisfies CodeReviewWorkspaceClient);
 container.bind(REVERT_HUNK_SERVICE).to(RevertHunkService).inSingletonScope();
+
+// skills (team publish/install reach workspace-server through this slice)
+container.bind(SKILLS_WORKSPACE_CLIENT).toConstantValue({
+  exportSkill: (skillPath: string) =>
+    trpcClient.skills.export.query({ skillPath }),
+  installTeamSkill: (input) => trpcClient.skills.installTeamSkill.mutate(input),
+} satisfies SkillsWorkspaceClient);
 
 // sessions (cloud-artifact + title-generator)
 container.load(sessionsModule);

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -183,6 +183,12 @@ export interface LlmSkill extends LlmSkillListItem {
   files: LlmSkillFileManifest[];
 }
 
+export interface LlmSkillFileInput {
+  path: string;
+  content: string;
+  content_type?: string;
+}
+
 export interface LlmSkillResolveResponse {
   skill: LlmSkill;
   versions: Array<{
@@ -3732,6 +3738,68 @@ export class PostHogAPIClient {
       throw new Error(`Failed to resolve team skill: ${response.statusText}`);
     }
     return (await response.json()) as LlmSkillResolveResponse;
+  }
+
+  /** Creates a brand-new team skill (version 1). */
+  async createLlmSkill(input: {
+    name: string;
+    description: string;
+    body: string;
+    files?: LlmSkillFileInput[];
+  }): Promise<LlmSkill> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/environments/${teamId}/llm_skills/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path: urlPath,
+      overrides: { body: JSON.stringify(input) },
+    });
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as {
+        detail?: string;
+      };
+      throw new Error(
+        errorData.detail ??
+          `Failed to create team skill: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as LlmSkill;
+  }
+
+  /**
+   * Publishes a new version of an existing team skill. `base_version` must
+   * match the current latest version (409 otherwise).
+   */
+  async publishLlmSkillVersion(
+    name: string,
+    input: {
+      body: string;
+      description?: string;
+      files?: LlmSkillFileInput[];
+      base_version: number;
+    },
+  ): Promise<LlmSkill> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/environments/${teamId}/llm_skills/name/${encodeURIComponent(name)}`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "patch",
+      url,
+      path: urlPath,
+      overrides: { body: JSON.stringify(input) },
+    });
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as {
+        detail?: string;
+      };
+      throw new Error(
+        errorData.detail ??
+          `Failed to publish team skill: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as LlmSkill;
   }
 
   /** Fetches one companion file of a team skill. */

--- a/packages/core/src/skills/identifiers.ts
+++ b/packages/core/src/skills/identifiers.ts
@@ -1,3 +1,7 @@
 export const TEAM_SKILLS_SERVICE = Symbol.for(
   "posthog.core.skills.teamSkillsService",
 );
+
+export const SKILLS_WORKSPACE_CLIENT = Symbol.for(
+  "posthog.core.skills.workspaceClient",
+);

--- a/packages/core/src/skills/teamSkillsService.test.ts
+++ b/packages/core/src/skills/teamSkillsService.test.ts
@@ -3,7 +3,14 @@ import type {
   PostHogAPIClient,
 } from "@posthog/api-client/posthog-client";
 import { describe, expect, it, vi } from "vitest";
+import type { SkillsWorkspaceClient } from "./teamSkillsService";
 import { TeamSkillsService } from "./teamSkillsService";
+
+function makeService(
+  workspace: Partial<SkillsWorkspaceClient> = {},
+): TeamSkillsService {
+  return new TeamSkillsService(workspace as SkillsWorkspaceClient);
+}
 
 function makeItem(overrides: Partial<LlmSkillListItem>): LlmSkillListItem {
   return {
@@ -32,10 +39,7 @@ function makeClient(result: LlmSkillListItem[] | null): PostHogAPIClient {
 
 describe("TeamSkillsService.listTeamSkills", () => {
   it("reports the feature as unavailable when the API returns null", async () => {
-    const listing = await new TeamSkillsService().listTeamSkills(
-      makeClient(null),
-      [],
-    );
+    const listing = await makeService().listTeamSkills(makeClient(null), []);
 
     expect(listing).toEqual({ available: false, skills: [] });
   });
@@ -46,7 +50,7 @@ describe("TeamSkillsService.listTeamSkills", () => {
       makeItem({ id: "skill-2", name: "release-notes", created_by: null }),
     ]);
 
-    const listing = await new TeamSkillsService().listTeamSkills(client, [
+    const listing = await makeService().listTeamSkills(client, [
       "release-notes",
       "unrelated-local",
     ]);
@@ -76,7 +80,7 @@ describe("TeamSkillsService.listTeamSkills", () => {
       makeItem({ id: "skill-1b", version: 2 }),
     ]);
 
-    const listing = await new TeamSkillsService().listTeamSkills(client, []);
+    const listing = await makeService().listTeamSkills(client, []);
 
     expect(listing.skills).toHaveLength(1);
     expect(listing.skills[0]?.id).toBe("skill-1b");
@@ -98,7 +102,7 @@ describe("TeamSkillsService.publishSkill", () => {
       createLlmSkill,
     } as unknown as PostHogAPIClient;
 
-    const result = await new TeamSkillsService().publishSkill(client, exported);
+    const result = await makeService().publishSkill(client, exported);
 
     expect(createLlmSkill).toHaveBeenCalledWith({
       name: "pr-shepherd",
@@ -120,7 +124,7 @@ describe("TeamSkillsService.publishSkill", () => {
       publishLlmSkillVersion,
     } as unknown as PostHogAPIClient;
 
-    const result = await new TeamSkillsService().publishSkill(client, exported);
+    const result = await makeService().publishSkill(client, exported);
 
     expect(publishLlmSkillVersion).toHaveBeenCalledWith("pr-shepherd", {
       body: "# Body",
@@ -133,7 +137,7 @@ describe("TeamSkillsService.publishSkill", () => {
 
   it("rejects publishing without a description", async () => {
     await expect(
-      new TeamSkillsService().publishSkill(makeClient([]), {
+      makeService().publishSkill(makeClient([]), {
         ...exported,
         description: "  ",
       }),
@@ -142,7 +146,7 @@ describe("TeamSkillsService.publishSkill", () => {
 
   it("rejects publishing when the feature is unavailable", async () => {
     await expect(
-      new TeamSkillsService().publishSkill(makeClient(null), exported),
+      makeService().publishSkill(makeClient(null), exported),
     ).rejects.toThrow("not enabled");
   });
 });
@@ -168,7 +172,7 @@ describe("TeamSkillsService.fetchSkillForInstall", () => {
         })),
     } as unknown as PostHogAPIClient;
 
-    const skill = await new TeamSkillsService().fetchSkillForInstall(
+    const skill = await makeService().fetchSkillForInstall(
       client,
       "pr-shepherd",
     );
@@ -185,5 +189,61 @@ describe("TeamSkillsService.fetchSkillForInstall", () => {
         { path: "scripts/run.sh", content: "content of scripts/run.sh" },
       ],
     });
+  });
+});
+
+describe("TeamSkillsService.publishLocalSkill", () => {
+  it("exports from disk, publishes, and reports skipped files", async () => {
+    const exportSkill = vi.fn().mockResolvedValue({
+      name: "pr-shepherd",
+      description: "Shepherds PRs",
+      body: "# Body",
+      files: [],
+      skipped: ["assets/logo.png"],
+    });
+    const createLlmSkill = vi.fn().mockResolvedValue(makeItem({ version: 1 }));
+    const client = {
+      listLlmSkills: vi.fn().mockResolvedValue([]),
+      createLlmSkill,
+    } as unknown as PostHogAPIClient;
+
+    const result = await makeService({ exportSkill }).publishLocalSkill(
+      client,
+      "/home/.claude/skills/pr-shepherd",
+    );
+
+    expect(exportSkill).toHaveBeenCalledWith(
+      "/home/.claude/skills/pr-shepherd",
+    );
+    expect(result).toEqual({ version: 1, skipped: ["assets/logo.png"] });
+  });
+});
+
+describe("TeamSkillsService.installTeamSkillLocally", () => {
+  it("fetches the skill and materializes it with the overwrite flag", async () => {
+    const installTeamSkill = vi
+      .fn()
+      .mockResolvedValue({ path: "/home/.claude/skills/pr-shepherd" });
+    const client = {
+      getLlmSkillByName: vi.fn().mockResolvedValue({
+        name: "pr-shepherd",
+        description: "Shepherds PRs",
+        body: "# Body",
+        files: [],
+      }),
+    } as unknown as PostHogAPIClient;
+
+    const result = await makeService({
+      installTeamSkill,
+    }).installTeamSkillLocally(client, "pr-shepherd", true);
+
+    expect(installTeamSkill).toHaveBeenCalledWith({
+      name: "pr-shepherd",
+      description: "Shepherds PRs",
+      body: "# Body",
+      files: [],
+      overwrite: true,
+    });
+    expect(result).toEqual({ path: "/home/.claude/skills/pr-shepherd" });
   });
 });

--- a/packages/core/src/skills/teamSkillsService.test.ts
+++ b/packages/core/src/skills/teamSkillsService.test.ts
@@ -82,3 +82,108 @@ describe("TeamSkillsService.listTeamSkills", () => {
     expect(listing.skills[0]?.id).toBe("skill-1b");
   });
 });
+
+describe("TeamSkillsService.publishSkill", () => {
+  const exported = {
+    name: "pr-shepherd",
+    description: "Shepherds PRs",
+    body: "# Body",
+    files: [{ path: "references/guide.md", content: "guide" }],
+  };
+
+  it("creates a new skill on first publish", async () => {
+    const createLlmSkill = vi.fn().mockResolvedValue(makeItem({ version: 1 }));
+    const client = {
+      listLlmSkills: vi.fn().mockResolvedValue([]),
+      createLlmSkill,
+    } as unknown as PostHogAPIClient;
+
+    const result = await new TeamSkillsService().publishSkill(client, exported);
+
+    expect(createLlmSkill).toHaveBeenCalledWith({
+      name: "pr-shepherd",
+      description: "Shepherds PRs",
+      body: "# Body",
+      files: exported.files,
+    });
+    expect(result).toEqual({ version: 1 });
+  });
+
+  it("publishes a new version against the current latest", async () => {
+    const publishLlmSkillVersion = vi
+      .fn()
+      .mockResolvedValue(makeItem({ version: 3 }));
+    const client = {
+      listLlmSkills: vi
+        .fn()
+        .mockResolvedValue([makeItem({ version: 2, latest_version: 2 })]),
+      publishLlmSkillVersion,
+    } as unknown as PostHogAPIClient;
+
+    const result = await new TeamSkillsService().publishSkill(client, exported);
+
+    expect(publishLlmSkillVersion).toHaveBeenCalledWith("pr-shepherd", {
+      body: "# Body",
+      description: "Shepherds PRs",
+      files: exported.files,
+      base_version: 2,
+    });
+    expect(result).toEqual({ version: 3 });
+  });
+
+  it("rejects publishing without a description", async () => {
+    await expect(
+      new TeamSkillsService().publishSkill(makeClient([]), {
+        ...exported,
+        description: "  ",
+      }),
+    ).rejects.toThrow("Add a description");
+  });
+
+  it("rejects publishing when the feature is unavailable", async () => {
+    await expect(
+      new TeamSkillsService().publishSkill(makeClient(null), exported),
+    ).rejects.toThrow("not enabled");
+  });
+});
+
+describe("TeamSkillsService.fetchSkillForInstall", () => {
+  it("fetches the body plus every companion file", async () => {
+    const client = {
+      getLlmSkillByName: vi.fn().mockResolvedValue({
+        name: "pr-shepherd",
+        description: "Shepherds PRs",
+        body: "# Body",
+        files: [
+          { path: "references/guide.md", content_type: "text/plain" },
+          { path: "scripts/run.sh", content_type: "text/plain" },
+        ],
+      }),
+      getLlmSkillFile: vi
+        .fn()
+        .mockImplementation(async (_name: string, path: string) => ({
+          path,
+          content: `content of ${path}`,
+          content_type: "text/plain",
+        })),
+    } as unknown as PostHogAPIClient;
+
+    const skill = await new TeamSkillsService().fetchSkillForInstall(
+      client,
+      "pr-shepherd",
+    );
+
+    expect(skill).toEqual({
+      name: "pr-shepherd",
+      description: "Shepherds PRs",
+      body: "# Body",
+      files: [
+        {
+          path: "references/guide.md",
+          content: "content of references/guide.md",
+        },
+        { path: "scripts/run.sh", content: "content of scripts/run.sh" },
+      ],
+    });
+  });
+});

--- a/packages/core/src/skills/teamSkillsService.ts
+++ b/packages/core/src/skills/teamSkillsService.ts
@@ -21,6 +21,13 @@ export interface TeamSkillsListing {
   skills: TeamSkillInfo[];
 }
 
+export interface ExportedSkill {
+  name: string;
+  description: string;
+  body: string;
+  files: { path: string; content: string }[];
+}
+
 @injectable()
 export class TeamSkillsService {
   /**
@@ -42,6 +49,72 @@ export class TeamSkillsService {
       skills: items
         .filter((item) => item.is_latest)
         .map((item) => toTeamSkillInfo(item, localNames)),
+    };
+  }
+
+  /**
+   * Publishes a local skill to the team: creates the LLMSkill on first
+   * publish, otherwise publishes a new version against the current latest
+   * (versioning comes free from the model's version/is_latest).
+   */
+  async publishSkill(
+    client: PostHogAPIClient,
+    exported: ExportedSkill,
+  ): Promise<{ version: number }> {
+    if (!exported.name.trim()) {
+      throw new Error("The skill needs a name before it can be published");
+    }
+    if (!exported.description.trim()) {
+      throw new Error(
+        "Add a description before publishing — teammates' agents rely on it",
+      );
+    }
+
+    const items = await client.listLlmSkills();
+    if (items === null) {
+      throw new Error("Team skills are not enabled for this organization");
+    }
+    const existing = items.find(
+      (item) => item.name === exported.name && item.is_latest,
+    );
+
+    const published = existing
+      ? await client.publishLlmSkillVersion(exported.name, {
+          body: exported.body,
+          description: exported.description,
+          files: exported.files,
+          base_version: existing.latest_version ?? existing.version,
+        })
+      : await client.createLlmSkill({
+          name: exported.name,
+          description: exported.description,
+          body: exported.body,
+          files: exported.files,
+        });
+
+    return { version: published.version };
+  }
+
+  /**
+   * Fetches everything needed to materialize a team skill on disk: the
+   * latest body plus every companion file's content.
+   */
+  async fetchSkillForInstall(
+    client: PostHogAPIClient,
+    name: string,
+  ): Promise<ExportedSkill> {
+    const detail = await client.getLlmSkillByName(name);
+    const files = await Promise.all(
+      detail.files.map(async (manifest) => {
+        const file = await client.getLlmSkillFile(name, manifest.path);
+        return { path: file.path, content: file.content };
+      }),
+    );
+    return {
+      name: detail.name,
+      description: detail.description,
+      body: detail.body,
+      files,
     };
   }
 }

--- a/packages/core/src/skills/teamSkillsService.ts
+++ b/packages/core/src/skills/teamSkillsService.ts
@@ -2,7 +2,11 @@ import type {
   LlmSkillListItem,
   PostHogAPIClient,
 } from "@posthog/api-client/posthog-client";
-import { injectable } from "inversify";
+import type { ExportedSkill } from "@posthog/shared";
+import { inject, injectable } from "inversify";
+import { SKILLS_WORKSPACE_CLIENT } from "./identifiers";
+
+export type { ExportedSkill };
 
 export interface TeamSkillInfo {
   id: string;
@@ -21,15 +25,43 @@ export interface TeamSkillsListing {
   skills: TeamSkillInfo[];
 }
 
-export interface ExportedSkill {
-  name: string;
-  description: string;
-  body: string;
-  files: { path: string; content: string }[];
+/** The slice of workspace-server this service needs, bound by the host. */
+export interface SkillsWorkspaceClient {
+  exportSkill(
+    skillPath: string,
+  ): Promise<ExportedSkill & { skipped: string[] }>;
+  installTeamSkill(
+    input: ExportedSkill & { overwrite: boolean },
+  ): Promise<{ path: string }>;
 }
 
 @injectable()
 export class TeamSkillsService {
+  constructor(
+    @inject(SKILLS_WORKSPACE_CLIENT)
+    private readonly workspace: SkillsWorkspaceClient,
+  ) {}
+
+  /** Exports the local skill from disk, then creates or versions the team copy. */
+  async publishLocalSkill(
+    client: PostHogAPIClient,
+    skillPath: string,
+  ): Promise<{ version: number; skipped: string[] }> {
+    const exported = await this.workspace.exportSkill(skillPath);
+    const { version } = await this.publishSkill(client, exported);
+    return { version, skipped: exported.skipped };
+  }
+
+  /** Materializes a team skill into the local user skills dir (copy-and-forget). */
+  async installTeamSkillLocally(
+    client: PostHogAPIClient,
+    name: string,
+    overwrite = false,
+  ): Promise<{ path: string }> {
+    const skill = await this.fetchSkillForInstall(client, name);
+    return this.workspace.installTeamSkill({ ...skill, overwrite });
+  }
+
   /**
    * Lists team skills merged with the local listing: the availability
    * decision (flag off → absent group, no errors) and the "already

--- a/packages/host-router/src/routers/skills.router.ts
+++ b/packages/host-router/src/routers/skills.router.ts
@@ -4,6 +4,9 @@ import {
   createSkillInput,
   deleteSkillFileInput,
   deleteSkillInput,
+  exportSkillInput,
+  exportSkillOutput,
+  installTeamSkillInput,
   listSkillsOutput,
   readSkillFileInput,
   readSkillFileOutput,
@@ -92,6 +95,20 @@ export const skillsRouter = router({
       ctx.container
         .get<SkillsService>(SKILLS_SERVICE)
         .deleteSkill(input.skillPath),
+    ),
+  export: publicProcedure
+    .input(exportSkillInput)
+    .output(exportSkillOutput)
+    .query(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .exportSkill(input.skillPath),
+    ),
+  installTeamSkill: publicProcedure
+    .input(installTeamSkillInput)
+    .output(skillPathOutput)
+    .mutation(({ ctx, input }) =>
+      ctx.container.get<SkillsService>(SKILLS_SERVICE).installTeamSkill(input),
     ),
   watch: publicProcedure.subscription(async function* (opts) {
     const service = opts.ctx.container.get<SkillsService>(SKILLS_SERVICE);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -159,7 +159,13 @@ export type {
   SignalReportOrderingField,
   SignalReportStatus,
 } from "./signal-types";
-export type { SkillFileEntry, SkillInfo, SkillSource } from "./skills";
+export type {
+  ExportedSkill,
+  ExportedSkillFile,
+  SkillFileEntry,
+  SkillInfo,
+  SkillSource,
+} from "./skills";
 export type {
   ArtifactType,
   PostHogAPIConfig,

--- a/packages/shared/src/skills.ts
+++ b/packages/shared/src/skills.ts
@@ -17,3 +17,17 @@ export interface SkillFileEntry {
   path: string;
   size: number;
 }
+
+export interface ExportedSkillFile {
+  /** Path relative to the skill directory, using "/" separators. */
+  path: string;
+  content: string;
+}
+
+/** A skill serialized for transport: team publish and install. */
+export interface ExportedSkill {
+  name: string;
+  description: string;
+  body: string;
+  files: ExportedSkillFile[];
+}

--- a/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  CloudArrowUp,
   FilePlus,
   Folder,
   LockSimple,
@@ -39,17 +40,21 @@ import {
   useRenameSkillFile,
   useSaveSkillFile,
 } from "./useSkillMutations";
+import { usePublishSkill } from "./useTeamSkillMutations";
 
 interface SkillDetailPanelProps {
   skill: SkillInfo;
   onClose: () => void;
   issues?: SkillIssue[];
+  /** Whether team skills are available for publishing. */
+  canPublish?: boolean;
 }
 
 export function SkillDetailPanel({
   skill,
   onClose,
   issues = [],
+  canPublish = false,
 }: SkillDetailPanelProps) {
   const config = SOURCE_CONFIG[skill.source];
 
@@ -61,6 +66,7 @@ export function SkillDetailPanel({
   const [renameTo, setRenameTo] = useState("");
   const [deleteFileTarget, setDeleteFileTarget] = useState<string | null>(null);
   const [deleteSkillOpen, setDeleteSkillOpen] = useState(false);
+  const [publishOpen, setPublishOpen] = useState(false);
 
   const { data: contents } = useSkillContents(skill.path);
   const { data: fileContent, isLoading } = useSkillFile(
@@ -72,6 +78,7 @@ export function SkillDetailPanel({
   const renameFile = useRenameSkillFile();
   const deleteFile = useDeleteSkillFile();
   const deleteSkill = useDeleteSkill();
+  const publishSkill = usePublishSkill();
 
   const files = contents?.files ?? [];
   const isSkillMd = selectedFile === "SKILL.md";
@@ -134,6 +141,23 @@ export function SkillDetailPanel({
     }
   };
 
+  const handlePublish = async () => {
+    try {
+      const result = await publishSkill.mutateAsync({ skillPath: skill.path });
+      setPublishOpen(false);
+      toast.success(`Published ${skill.name} (v${result.version})`, {
+        description:
+          result.skipped.length > 0
+            ? `Skipped ${result.skipped.length} binary/oversized file(s): ${result.skipped.join(", ")}`
+            : "Teammates can now install it from the Team group",
+      });
+    } catch (error) {
+      toast.error("Failed to publish skill", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
   const handleDeleteSkill = async () => {
     try {
       await deleteSkill.mutateAsync({ skillPath: skill.path });
@@ -162,6 +186,18 @@ export function SkillDetailPanel({
           <Flex align="center" gap="1" className="shrink-0">
             {skill.editable && !isEditing && (
               <>
+                {canPublish && (
+                  <Tooltip content="Publish to team">
+                    <button
+                      type="button"
+                      aria-label="Publish to team"
+                      onClick={() => setPublishOpen(true)}
+                      className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+                    >
+                      <CloudArrowUp size={14} />
+                    </button>
+                  </Tooltip>
+                )}
                 <Tooltip content="Edit skill">
                   <button
                     type="button"
@@ -437,6 +473,31 @@ export function SkillDetailPanel({
                 Delete
               </Button>
             </AlertDialog.Action>
+          </Flex>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
+
+      <AlertDialog.Root open={publishOpen} onOpenChange={setPublishOpen}>
+        <AlertDialog.Content maxWidth="420px" size="2">
+          <AlertDialog.Title size="3">Publish to team</AlertDialog.Title>
+          <AlertDialog.Description size="1">
+            Publish "{skill.name}" to your team? Teammates will be able to view
+            and install it. Re-publishing creates a new version.
+          </AlertDialog.Description>
+          <Flex justify="end" gap="2" mt="4">
+            <AlertDialog.Cancel>
+              <Button size="1" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <Button
+              size="1"
+              variant="solid"
+              onClick={handlePublish}
+              disabled={publishSkill.isPending}
+            >
+              Publish
+            </Button>
           </Flex>
         </AlertDialog.Content>
       </AlertDialog.Root>

--- a/packages/ui/src/features/skills/SkillsView.tsx
+++ b/packages/ui/src/features/skills/SkillsView.tsx
@@ -238,6 +238,7 @@ export function SkillsView() {
                 key={selectedSkill.path}
                 skill={selectedSkill}
                 issues={analysis[selectedSkill.path] ?? []}
+                canPublish={!!teamListing?.available}
                 onClose={handleCloseSidebar}
               />
             )}

--- a/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
@@ -1,11 +1,22 @@
-import { UsersThree, X } from "@phosphor-icons/react";
+import { DownloadSimple, UsersThree, X } from "@phosphor-icons/react";
 import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
 import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
-import { Badge, Box, Flex, ScrollArea, Text, Tooltip } from "@radix-ui/themes";
+import { toast } from "@posthog/ui/primitives/toast";
+import {
+  AlertDialog,
+  Badge,
+  Box,
+  Button,
+  Flex,
+  ScrollArea,
+  Text,
+  Tooltip,
+} from "@radix-ui/themes";
 import { useState } from "react";
 import { SkillFileTree } from "./SkillFileTree";
 import { stripFrontmatter } from "./stripFrontmatter";
+import { useInstallTeamSkill } from "./useTeamSkillMutations";
 import { useTeamSkillDetail, useTeamSkillFile } from "./useTeamSkills";
 
 interface TeamSkillDetailPanelProps {
@@ -19,12 +30,33 @@ export function TeamSkillDetailPanel({
   onClose,
 }: TeamSkillDetailPanelProps) {
   const [selectedFile, setSelectedFile] = useState("SKILL.md");
+  const [confirmOverwrite, setConfirmOverwrite] = useState(false);
   const { data: detail, isLoading } = useTeamSkillDetail(skill.name);
   const isSkillMd = selectedFile === "SKILL.md";
   const { data: file, isLoading: isFileLoading } = useTeamSkillFile(
     skill.name,
     isSkillMd ? null : selectedFile,
   );
+  const install = useInstallTeamSkill();
+
+  const handleInstall = async (overwrite: boolean) => {
+    try {
+      await install.mutateAsync({ name: skill.name, overwrite });
+      setConfirmOverwrite(false);
+      toast.success(`Installed ${skill.name}`, {
+        description: "Now available under Your skills",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (!overwrite && message.includes("already exists")) {
+        setConfirmOverwrite(true);
+        return;
+      }
+      toast.error("Failed to install skill", {
+        description: message || undefined,
+      });
+    }
+  };
 
   const treeFiles = [
     { path: "SKILL.md", size: detail?.body.length ?? 0 },
@@ -74,6 +106,15 @@ export function TeamSkillDetailPanel({
               Installed
             </Badge>
           )}
+          <Button
+            size="1"
+            variant="solid"
+            onClick={() => void handleInstall(false)}
+            disabled={install.isPending || isLoading}
+          >
+            <DownloadSimple size={12} />
+            {skill.installedLocally ? "Reinstall" : "Install"}
+          </Button>
         </Flex>
       </Flex>
 
@@ -132,6 +173,36 @@ export function TeamSkillDetailPanel({
           </Box>
         )}
       </Box>
+
+      <AlertDialog.Root
+        open={confirmOverwrite}
+        onOpenChange={setConfirmOverwrite}
+      >
+        <AlertDialog.Content maxWidth="420px" size="2">
+          <AlertDialog.Title size="3">Replace local skill</AlertDialog.Title>
+          <AlertDialog.Description size="1">
+            A skill named "{skill.name}" already exists in your skills.
+            Reinstalling will replace your local version, including any edits.
+          </AlertDialog.Description>
+          <Flex justify="end" gap="2" mt="4">
+            <AlertDialog.Cancel>
+              <Button size="1" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action>
+              <Button
+                size="1"
+                variant="solid"
+                color="red"
+                onClick={() => void handleInstall(true)}
+              >
+                Replace
+              </Button>
+            </AlertDialog.Action>
+          </Flex>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
     </>
   );
 }

--- a/packages/ui/src/features/skills/useTeamSkillMutations.ts
+++ b/packages/ui/src/features/skills/useTeamSkillMutations.ts
@@ -1,0 +1,50 @@
+import { TEAM_SKILLS_SERVICE } from "@posthog/core/skills/identifiers";
+import type { TeamSkillsService } from "@posthog/core/skills/teamSkillsService";
+import { useService } from "@posthog/di/react";
+import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
+import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
+import { useQueryClient } from "@tanstack/react-query";
+
+/** Publishes a local user/repo skill to the team as a new LLMSkill version. */
+export function usePublishSkill() {
+  const service = useService<TeamSkillsService>(TEAM_SKILLS_SERVICE);
+  const hostClient = useHostTRPCClient();
+  const queryClient = useQueryClient();
+  return useAuthenticatedMutation(
+    async (client, variables: { skillPath: string }) => {
+      const exported = await hostClient.skills.export.query({
+        skillPath: variables.skillPath,
+      });
+      const { version } = await service.publishSkill(client, exported);
+      return { version, skipped: exported.skipped };
+    },
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({ queryKey: ["team-skills"] });
+      },
+    },
+  );
+}
+
+/** Materializes a team skill into ~/.claude/skills (copy-and-forget). */
+export function useInstallTeamSkill() {
+  const service = useService<TeamSkillsService>(TEAM_SKILLS_SERVICE);
+  const hostClient = useHostTRPCClient();
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+  return useAuthenticatedMutation(
+    async (client, variables: { name: string; overwrite?: boolean }) => {
+      const skill = await service.fetchSkillForInstall(client, variables.name);
+      return hostClient.skills.installTeamSkill.mutate({
+        ...skill,
+        overwrite: variables.overwrite ?? false,
+      });
+    },
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.skills.pathFilter());
+        void queryClient.invalidateQueries({ queryKey: ["team-skills"] });
+      },
+    },
+  );
+}

--- a/packages/ui/src/features/skills/useTeamSkillMutations.ts
+++ b/packages/ui/src/features/skills/useTeamSkillMutations.ts
@@ -1,23 +1,17 @@
 import { TEAM_SKILLS_SERVICE } from "@posthog/core/skills/identifiers";
 import type { TeamSkillsService } from "@posthog/core/skills/teamSkillsService";
 import { useService } from "@posthog/di/react";
-import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
+import { useHostTRPC } from "@posthog/host-router/react";
 import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
 import { useQueryClient } from "@tanstack/react-query";
 
 /** Publishes a local user/repo skill to the team as a new LLMSkill version. */
 export function usePublishSkill() {
   const service = useService<TeamSkillsService>(TEAM_SKILLS_SERVICE);
-  const hostClient = useHostTRPCClient();
   const queryClient = useQueryClient();
   return useAuthenticatedMutation(
-    async (client, variables: { skillPath: string }) => {
-      const exported = await hostClient.skills.export.query({
-        skillPath: variables.skillPath,
-      });
-      const { version } = await service.publishSkill(client, exported);
-      return { version, skipped: exported.skipped };
-    },
+    (client, variables: { skillPath: string }) =>
+      service.publishLocalSkill(client, variables.skillPath),
     {
       onSuccess: () => {
         void queryClient.invalidateQueries({ queryKey: ["team-skills"] });
@@ -29,17 +23,15 @@ export function usePublishSkill() {
 /** Materializes a team skill into ~/.claude/skills (copy-and-forget). */
 export function useInstallTeamSkill() {
   const service = useService<TeamSkillsService>(TEAM_SKILLS_SERVICE);
-  const hostClient = useHostTRPCClient();
   const trpc = useHostTRPC();
   const queryClient = useQueryClient();
   return useAuthenticatedMutation(
-    async (client, variables: { name: string; overwrite?: boolean }) => {
-      const skill = await service.fetchSkillForInstall(client, variables.name);
-      return hostClient.skills.installTeamSkill.mutate({
-        ...skill,
-        overwrite: variables.overwrite ?? false,
-      });
-    },
+    (client, variables: { name: string; overwrite?: boolean }) =>
+      service.installTeamSkillLocally(
+        client,
+        variables.name,
+        variables.overwrite ?? false,
+      ),
     {
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.skills.pathFilter());

--- a/packages/workspace-server/src/services/skills/schemas.ts
+++ b/packages/workspace-server/src/services/skills/schemas.ts
@@ -75,6 +75,36 @@ export const deleteSkillInput = z.object({
   skillPath: z.string(),
 });
 
+export const exportSkillInput = z.object({
+  skillPath: z.string(),
+});
+
+export const exportedSkillFile = z.object({
+  // Path relative to the skill directory, using "/" separators.
+  path: z.string(),
+  content: z.string(),
+});
+
+export const exportSkillOutput = z.object({
+  name: z.string(),
+  description: z.string(),
+  body: z.string(),
+  files: z.array(exportedSkillFile),
+  /** Files excluded from the export (binary or oversized). */
+  skipped: z.array(z.string()),
+});
+
+export const installTeamSkillInput = z.object({
+  name: z.string(),
+  description: z.string(),
+  body: z.string(),
+  files: z.array(exportedSkillFile),
+  overwrite: z.boolean().optional(),
+});
+
+export type ExportedSkill = z.infer<typeof exportSkillOutput>;
+export type InstallTeamSkillInput = z.infer<typeof installTeamSkillInput>;
+
 export type SkillInfo = z.infer<typeof skillInfo>;
 export type SkillScope = z.infer<typeof skillScope>;
 export type CreateSkillInput = z.infer<typeof createSkillInput>;

--- a/packages/workspace-server/src/services/skills/schemas.ts
+++ b/packages/workspace-server/src/services/skills/schemas.ts
@@ -1,3 +1,4 @@
+import type { ExportedSkill as SharedExportedSkill } from "@posthog/shared";
 import { z } from "zod";
 
 export const skillSource = z.enum(["bundled", "user", "repo", "marketplace"]);
@@ -85,6 +86,7 @@ export const exportedSkillFile = z.object({
   content: z.string(),
 });
 
+// Pinned to the shared ExportedSkill contract so the shapes cannot drift.
 export const exportSkillOutput = z.object({
   name: z.string(),
   description: z.string(),
@@ -92,7 +94,7 @@ export const exportSkillOutput = z.object({
   files: z.array(exportedSkillFile),
   /** Files excluded from the export (binary or oversized). */
   skipped: z.array(z.string()),
-});
+}) satisfies z.ZodType<SharedExportedSkill & { skipped: string[] }>;
 
 export const installTeamSkillInput = z.object({
   name: z.string(),
@@ -100,7 +102,7 @@ export const installTeamSkillInput = z.object({
   body: z.string(),
   files: z.array(exportedSkillFile),
   overwrite: z.boolean().optional(),
-});
+}) satisfies z.ZodType<SharedExportedSkill & { overwrite?: boolean }>;
 
 export type ExportedSkill = z.infer<typeof exportSkillOutput>;
 export type InstallTeamSkillInput = z.infer<typeof installTeamSkillInput>;

--- a/packages/workspace-server/src/services/skills/skill-discovery.ts
+++ b/packages/workspace-server/src/services/skills/skill-discovery.ts
@@ -35,6 +35,8 @@ export async function findSkillDirs(
     .filter(
       (e) =>
         (e.isDirectory() || e.isSymbolicLink()) &&
+        // Hidden dirs are never skills (also hides install staging dirs).
+        !e.name.startsWith(".") &&
         fs.existsSync(path.join(sourceSkillsDir, e.name, "SKILL.md")),
     )
     .map((e) => e.name);

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -269,6 +270,31 @@ describe("installTeamSkill", () => {
           files: [{ path: "../evil.md", content: "bad" }],
         }),
       ).rejects.toThrow("path outside skill directory");
+      expect(existsSync(target)).toBe(false);
+    } finally {
+      await rm(target, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the existing skill when an overwrite payload is invalid", async () => {
+    const name = "posthog-code-test-skill-f4e84f1a";
+    const { homedir } = await import("node:os");
+    const target = path.join(homedir(), ".claude", "skills", name);
+    const service = makeService();
+    try {
+      await service.installTeamSkill({ ...input, name });
+
+      await expect(
+        service.installTeamSkill({
+          ...input,
+          name,
+          overwrite: true,
+          files: [{ path: "../evil.md", content: "bad" }],
+        }),
+      ).rejects.toThrow("path outside skill directory");
+
+      const manifest = await service.readSkillFile(target, "SKILL.md");
+      expect(manifest).toContain("# Team body");
     } finally {
       await rm(target, { recursive: true, force: true });
     }

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -181,6 +181,100 @@ describe("readSkillFile", () => {
   });
 });
 
+describe("exportSkill", () => {
+  it("splits frontmatter from the body and collects text companion files", async () => {
+    const skillPath = await createSkill(
+      repoSkillsDir,
+      "alpha",
+      "---\nname: alpha\ndescription: About alpha\n---\n\n# Alpha body",
+    );
+    await mkdir(path.join(skillPath, "references"), { recursive: true });
+    await writeFile(path.join(skillPath, "references", "guide.md"), "guide");
+    await writeFile(
+      path.join(skillPath, "logo.bin"),
+      Buffer.from([0x89, 0x00, 0x4e, 0x47]),
+    );
+
+    const exported = await makeService().exportSkill(skillPath);
+
+    expect(exported).toEqual({
+      name: "alpha",
+      description: "About alpha",
+      body: "# Alpha body",
+      files: [{ path: "references/guide.md", content: "guide" }],
+      skipped: ["logo.bin"],
+    });
+  });
+
+  it("refuses to export non-writable skills", async () => {
+    await createSkill(path.join(pluginPath, "skills"), "bundled-skill");
+
+    await expect(
+      makeService().exportSkill(
+        path.join(pluginPath, "skills", "bundled-skill"),
+      ),
+    ).rejects.toThrow("Access denied");
+  });
+});
+
+describe("installTeamSkill", () => {
+  const input = {
+    name: "team-skill",
+    description: "From the team",
+    body: "# Team body",
+    files: [{ path: "references/guide.md", content: "guide" }],
+  };
+
+  it("requires overwrite for an existing skill, then replaces it", async () => {
+    // installTeamSkill writes to the real user skills root, so use a name
+    // that's vanishingly unlikely to exist and clean it up.
+    const { homedir } = await import("node:os");
+    const name = "posthog-code-test-skill-f4e84f1a";
+    const target = path.join(homedir(), ".claude", "skills", name);
+    const service = makeService();
+    try {
+      const first = await service.installTeamSkill({ ...input, name });
+      expect(first.path).toBe(target);
+
+      await expect(
+        service.installTeamSkill({ ...input, name }),
+      ).rejects.toThrow("already exists");
+
+      await service.installTeamSkill({ ...input, name, overwrite: true });
+      const manifest = await service.readSkillFile(target, "SKILL.md");
+      expect(manifest).toContain("From the team");
+      expect(manifest).toContain("# Team body");
+      const guide = await service.readSkillFile(target, "references/guide.md");
+      expect(guide).toBe("guide");
+    } finally {
+      await rm(target, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects invalid names and unsafe file paths", async () => {
+    const service = makeService();
+
+    await expect(
+      service.installTeamSkill({ ...input, name: "../escape" }),
+    ).rejects.toThrow("Skill names must be");
+
+    const name = "posthog-code-test-skill-f4e84f1a";
+    const { homedir } = await import("node:os");
+    const target = path.join(homedir(), ".claude", "skills", name);
+    try {
+      await expect(
+        service.installTeamSkill({
+          ...input,
+          name,
+          files: [{ path: "../evil.md", content: "bad" }],
+        }),
+      ).rejects.toThrow("path outside skill directory");
+    } finally {
+      await rm(target, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("watchSkillDirs", () => {
   it(
     "emits a debounced change event when a watched dir changes",

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -11,6 +11,8 @@ import type { WatcherService } from "../watcher/service";
 import { parseSkillFrontmatter } from "./parse-skill-frontmatter";
 import type {
   CreateSkillInput,
+  ExportedSkill,
+  InstallTeamSkillInput,
   SkillContents,
   SkillInfo,
   SkillSource,
@@ -173,6 +175,81 @@ export class SkillsService {
   async deleteSkill(skillPath: string): Promise<void> {
     const skillDir = await this.resolveWritableSkillDir(skillPath);
     await fs.promises.rm(skillDir, { recursive: true, force: true });
+  }
+
+  /**
+   * Reads a writable skill directory into a publishable shape: frontmatter
+   * split out, body without frontmatter, and every text companion file.
+   * Binary or oversized files are skipped and reported.
+   */
+  async exportSkill(skillPath: string): Promise<ExportedSkill> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    const manifest = await fs.promises.readFile(
+      path.join(skillDir, "SKILL.md"),
+      "utf-8",
+    );
+    const frontmatter = parseSkillFrontmatter(manifest);
+    const name = frontmatter?.name ?? path.basename(skillDir);
+    const description = frontmatter?.description ?? "";
+    const body = stripFrontmatterBlock(manifest);
+
+    const entries = await listSkillFiles(skillDir, MAX_SKILL_FILES);
+    const files: { path: string; content: string }[] = [];
+    const skipped: string[] = [];
+    for (const entry of entries) {
+      if (entry.path === "SKILL.md") continue;
+      if (entry.size > MAX_SKILL_FILE_BYTES) {
+        skipped.push(entry.path);
+        continue;
+      }
+      const bytes = await fs.promises.readFile(
+        path.join(skillDir, ...entry.path.split("/")),
+      );
+      if (bytes.subarray(0, 4096).includes(0)) {
+        skipped.push(entry.path);
+        continue;
+      }
+      files.push({ path: entry.path, content: bytes.toString("utf-8") });
+    }
+
+    return { name, description, body, files, skipped };
+  }
+
+  /**
+   * Materializes a team skill into ~/.claude/skills (agents need files on
+   * disk). From then on it follows the same copy-and-forget rule as
+   * marketplace installs.
+   */
+  async installTeamSkill(
+    input: InstallTeamSkillInput,
+  ): Promise<{ path: string }> {
+    const name = input.name.trim();
+    validateSkillDirName(name);
+    const target = path.join(os.homedir(), ".claude", "skills", name);
+    if (fs.existsSync(target) && !input.overwrite) {
+      throw new Error(
+        `A skill named "${name}" already exists. Installing will replace your local version.`,
+      );
+    }
+    if (fs.existsSync(target)) {
+      await fs.promises.rm(target, { recursive: true, force: true });
+    }
+
+    await fs.promises.mkdir(target, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(target, "SKILL.md"),
+      serializeSkillMarkdown(
+        { name, description: input.description },
+        input.body,
+      ),
+      "utf-8",
+    );
+    for (const file of input.files) {
+      const filePath = resolveSkillFilePath(target, file.path);
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.promises.writeFile(filePath, file.content, "utf-8");
+    }
+    return { path: target };
   }
 
   /**
@@ -362,6 +439,11 @@ async function waitForDir(dir: string, signal?: AbortSignal): Promise<boolean> {
     await delay(MISSING_DIR_POLL_MS, signal);
   }
   return false;
+}
+
+function stripFrontmatterBlock(content: string): string {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  return match ? content.slice(match[0].length).replace(/^\n+/, "") : content;
 }
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -225,29 +225,51 @@ export class SkillsService {
   ): Promise<{ path: string }> {
     const name = input.name.trim();
     validateSkillDirName(name);
-    const target = path.join(os.homedir(), ".claude", "skills", name);
+    const userRoot = path.join(os.homedir(), ".claude", "skills");
+    const target = path.join(userRoot, name);
     if (fs.existsSync(target) && !input.overwrite) {
       throw new Error(
         `A skill named "${name}" already exists. Installing will replace your local version.`,
       );
     }
-    if (fs.existsSync(target)) {
-      await fs.promises.rm(target, { recursive: true, force: true });
-    }
 
-    await fs.promises.mkdir(target, { recursive: true });
-    await fs.promises.writeFile(
-      path.join(target, "SKILL.md"),
-      serializeSkillMarkdown(
-        { name, description: input.description },
-        input.body,
-      ),
-      "utf-8",
+    // Stage first: a bad payload must not corrupt or delete the existing skill.
+    await fs.promises.mkdir(userRoot, { recursive: true });
+    const staging = await fs.promises.mkdtemp(
+      path.join(userRoot, `.install-${name}-`),
     );
-    for (const file of input.files) {
-      const filePath = resolveSkillFilePath(target, file.path);
-      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-      await fs.promises.writeFile(filePath, file.content, "utf-8");
+    const previous = `${staging}-previous`;
+    try {
+      await fs.promises.writeFile(
+        path.join(staging, "SKILL.md"),
+        serializeSkillMarkdown(
+          { name, description: input.description },
+          input.body,
+        ),
+        "utf-8",
+      );
+      for (const file of input.files) {
+        const filePath = resolveSkillFilePath(staging, file.path);
+        await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.promises.writeFile(filePath, file.content, "utf-8");
+      }
+
+      const hadExisting = fs.existsSync(target);
+      if (hadExisting) {
+        await fs.promises.rename(target, previous);
+      }
+      try {
+        await fs.promises.rename(staging, target);
+      } catch (error) {
+        if (hadExisting) {
+          await fs.promises.rename(previous, target).catch(() => {});
+        }
+        throw error;
+      }
+      await fs.promises.rm(previous, { recursive: true, force: true });
+    } catch (error) {
+      await fs.promises.rm(staging, { recursive: true, force: true });
+      throw error;
     }
     return { path: target };
   }


### PR DESCRIPTION
## Problem

Team skills exist as a read-only concept — users can browse them but have no way to publish a local skill to the team or install a team skill onto their machine. This blocks the core share-and-reuse workflow for team skills.

## Changes

**Publishing local skills to the team**
- Added `createLlmSkill` and `publishLlmSkillVersion` API client methods, along with the `LlmSkillFileInput` interface, to support creating a new skill and bumping its version respectively.
- Added `publishSkill` to `TeamSkillsService`, which creates the skill on first publish or patches a new version against the current latest. Validates that a name and description are present before calling the API.
- Added `exportSkill` to `SkillsService`, which reads a writable skill directory into a publishable shape: frontmatter is split out, the body is extracted, and every text companion file is included. Binary files and files exceeding the size limit are skipped and reported back to the caller.
- Wired up an `export` tRPC procedure and a `usePublishSkill` mutation hook. A "Publish to team" button (cloud-upload icon) appears in `SkillDetailPanel` when `canPublish` is true, guarded by a confirmation dialog. On success, a toast shows the published version number and any skipped files.

**Installing team skills locally**
- Added `fetchSkillForInstall` to `TeamSkillsService`, which fetches the latest skill body and resolves every companion file's content in parallel.
- Added `installTeamSkill` to `SkillsService`, which materializes the skill under `~/.claude/skills`. Validates the skill name, guards against path traversal in companion file paths, and requires an explicit `overwrite: true` flag if the skill already exists locally.
- Wired up an `installTeamSkill` tRPC procedure and a `useInstallTeamSkill` mutation hook. An Install/Reinstall button appears in `TeamSkillDetailPanel`. If the skill already exists, an overwrite confirmation dialog is shown before proceeding.

## How did you test this?

- Added unit tests for `TeamSkillsService.publishSkill` covering first-publish (create), subsequent publish (version bump), missing description, and unavailable feature.
- Added unit tests for `TeamSkillsService.fetchSkillForInstall` verifying that the body and all companion file contents are resolved.
- Added integration tests for `exportSkill` verifying frontmatter extraction, companion file collection, binary file skipping, and access denial for non-writable skills.
- Added integration tests for `installTeamSkill` covering the happy path, the overwrite guard, invalid skill names, and path traversal rejection.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?