### PR TITLE
feat(skills): Codex unification — bring your skills, use them anywhere

### DIFF
--- a/packages/core/src/skills/analyzeSkills.ts
+++ b/packages/core/src/skills/analyzeSkills.ts
@@ -26,6 +26,7 @@ const SOURCE_PRECEDENCE: SkillSource[] = [
   "user",
   "marketplace",
   "bundled",
+  "codex",
 ];
 
 const SOURCE_LABEL: Record<SkillSource, string> = {
@@ -33,6 +34,7 @@ const SOURCE_LABEL: Record<SkillSource, string> = {
   user: "user",
   marketplace: "marketplace",
   bundled: "bundled",
+  codex: "Codex",
 };
 
 function precedence(source: SkillSource): number {

--- a/packages/host-router/src/routers/skills.router.ts
+++ b/packages/host-router/src/routers/skills.router.ts
@@ -6,6 +6,7 @@ import {
   deleteSkillInput,
   exportSkillInput,
   exportSkillOutput,
+  importCodexSkillInput,
   installTeamSkillInput,
   listSkillsOutput,
   readSkillFileInput,
@@ -109,6 +110,14 @@ export const skillsRouter = router({
     .output(skillPathOutput)
     .mutation(({ ctx, input }) =>
       ctx.container.get<SkillsService>(SKILLS_SERVICE).installTeamSkill(input),
+    ),
+  importCodex: publicProcedure
+    .input(importCodexSkillInput)
+    .output(skillPathOutput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .importCodexSkill(input.skillPath, input.overwrite ?? false),
     ),
   watch: publicProcedure.subscription(async function* (opts) {
     const service = opts.ctx.container.get<SkillsService>(SKILLS_SERVICE);

--- a/packages/shared/src/skills.ts
+++ b/packages/shared/src/skills.ts
@@ -1,4 +1,4 @@
-export type SkillSource = "bundled" | "user" | "repo" | "marketplace";
+export type SkillSource = "bundled" | "user" | "repo" | "marketplace" | "codex";
 
 export interface SkillInfo {
   name: string;

--- a/packages/ui/src/features/skills/SkillCard.tsx
+++ b/packages/ui/src/features/skills/SkillCard.tsx
@@ -1,6 +1,7 @@
 import {
   Folder,
   Package,
+  Robot,
   Storefront,
   User,
   Warning,
@@ -29,6 +30,7 @@ export const SOURCE_CONFIG: Record<
     label: "Marketplace",
     sectionTitle: "Marketplace",
   },
+  codex: { icon: Robot, label: "Codex", sectionTitle: "Codex" },
 };
 
 interface SkillCardProps {

--- a/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -1,5 +1,6 @@
 import {
   CloudArrowUp,
+  DownloadSimple,
   FilePlus,
   Folder,
   LockSimple,
@@ -37,6 +38,7 @@ import { useSkillContents, useSkillFile } from "./useSkillContents";
 import {
   useDeleteSkill,
   useDeleteSkillFile,
+  useImportCodexSkill,
   useRenameSkillFile,
   useSaveSkillFile,
 } from "./useSkillMutations";
@@ -67,6 +69,7 @@ export function SkillDetailPanel({
   const [deleteFileTarget, setDeleteFileTarget] = useState<string | null>(null);
   const [deleteSkillOpen, setDeleteSkillOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
+  const [confirmImportOverwrite, setConfirmImportOverwrite] = useState(false);
 
   const { data: contents } = useSkillContents(skill.path);
   const { data: fileContent, isLoading } = useSkillFile(
@@ -79,6 +82,7 @@ export function SkillDetailPanel({
   const deleteFile = useDeleteSkillFile();
   const deleteSkill = useDeleteSkill();
   const publishSkill = usePublishSkill();
+  const importCodexSkill = useImportCodexSkill();
 
   const files = contents?.files ?? [];
   const isSkillMd = selectedFile === "SKILL.md";
@@ -154,6 +158,28 @@ export function SkillDetailPanel({
     } catch (error) {
       toast.error("Failed to publish skill", {
         description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  const handleImport = async (overwrite: boolean) => {
+    try {
+      await importCodexSkill.mutateAsync({
+        skillPath: skill.path,
+        overwrite,
+      });
+      setConfirmImportOverwrite(false);
+      toast.success(`Imported ${skill.name}`, {
+        description: "Now editable under Your skills",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (!overwrite && message.includes("already exists")) {
+        setConfirmImportOverwrite(true);
+        return;
+      }
+      toast.error("Failed to import skill", {
+        description: message || undefined,
       });
     }
   };
@@ -259,6 +285,17 @@ export function SkillDetailPanel({
               <LockSimple size={10} className="text-gray-9" />
               Read-only
             </Badge>
+          )}
+          {skill.source === "codex" && (
+            <Button
+              size="1"
+              variant="solid"
+              onClick={() => void handleImport(false)}
+              disabled={importCodexSkill.isPending}
+            >
+              <DownloadSimple size={12} />
+              Import
+            </Button>
           )}
           {skill.source !== "bundled" && (
             <ExternalAppsOpener targetPath={skill.path} />
@@ -471,6 +508,36 @@ export function SkillDetailPanel({
                 onClick={handleDeleteFile}
               >
                 Delete
+              </Button>
+            </AlertDialog.Action>
+          </Flex>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
+
+      <AlertDialog.Root
+        open={confirmImportOverwrite}
+        onOpenChange={setConfirmImportOverwrite}
+      >
+        <AlertDialog.Content maxWidth="420px" size="2">
+          <AlertDialog.Title size="3">Replace local skill</AlertDialog.Title>
+          <AlertDialog.Description size="1">
+            A skill named "{skill.name}" already exists in your skills.
+            Importing will replace your local version, including any edits.
+          </AlertDialog.Description>
+          <Flex justify="end" gap="2" mt="4">
+            <AlertDialog.Cancel>
+              <Button size="1" variant="soft" color="gray">
+                Cancel
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action>
+              <Button
+                size="1"
+                variant="solid"
+                color="red"
+                onClick={() => void handleImport(true)}
+              >
+                Replace
               </Button>
             </AlertDialog.Action>
           </Flex>

--- a/packages/ui/src/features/skills/SkillsView.tsx
+++ b/packages/ui/src/features/skills/SkillsView.tsx
@@ -27,7 +27,13 @@ import { useSkills } from "./useSkills";
 import { useSkillsWatcher } from "./useSkillsWatcher";
 import { useTeamSkills } from "./useTeamSkills";
 
-const SOURCE_ORDER: SkillSource[] = ["user", "marketplace", "repo", "bundled"];
+const SOURCE_ORDER: SkillSource[] = [
+  "user",
+  "marketplace",
+  "repo",
+  "codex",
+  "bundled",
+];
 
 // Installed = on disk, usable by agents right now. Team and Marketplace are
 // remote catalogs; installing materializes a skill into Installed.

--- a/packages/ui/src/features/skills/useSkillMutations.ts
+++ b/packages/ui/src/features/skills/useSkillMutations.ts
@@ -57,3 +57,11 @@ export function useDeleteSkill() {
     trpc.skills.delete.mutationOptions({ onSuccess: invalidate }),
   );
 }
+
+export function useImportCodexSkill() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.importCodex.mutationOptions({ onSuccess: invalidate }),
+  );
+}

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.test.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.test.ts
@@ -1,0 +1,113 @@
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  addMirroredName,
+  mirrorUserSkillsToCodex,
+  readCodexMirrorState,
+} from "./codex-mirror";
+
+let root: string;
+let userDir: string;
+let codexDir: string;
+
+async function createSkill(dir: string, name: string, body = `# ${name}`) {
+  await mkdir(path.join(dir, name), { recursive: true });
+  await writeFile(path.join(dir, name, "SKILL.md"), body);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "codex-mirror-test-"));
+  userDir = path.join(root, "user-skills");
+  codexDir = path.join(root, "codex-skills");
+  await mkdir(userDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("mirrorUserSkillsToCodex", () => {
+  it("copies user skills into the codex dir and records them", async () => {
+    await createSkill(userDir, "alpha");
+    await createSkill(userDir, "beta");
+
+    await mirrorUserSkillsToCodex(userDir, codexDir);
+
+    expect(
+      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
+    ).toBe("# alpha");
+    expect(existsSync(path.join(codexDir, "beta", "SKILL.md"))).toBe(true);
+    const state = await readCodexMirrorState(codexDir);
+    expect(state.mirrored.sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("never overwrites a codex skill we did not put there", async () => {
+    await mkdir(codexDir, { recursive: true });
+    await createSkill(codexDir, "alpha", "codex original");
+    await createSkill(userDir, "alpha", "user version");
+
+    await mirrorUserSkillsToCodex(userDir, codexDir);
+
+    expect(
+      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
+    ).toBe("codex original");
+    const state = await readCodexMirrorState(codexDir);
+    expect(state.mirrored).toEqual([]);
+  });
+
+  it("overwrites skills we previously mirrored and carries edits out", async () => {
+    await createSkill(userDir, "alpha", "v1");
+    await mirrorUserSkillsToCodex(userDir, codexDir);
+
+    await writeFile(path.join(userDir, "alpha", "SKILL.md"), "v2");
+    await mirrorUserSkillsToCodex(userDir, codexDir);
+
+    expect(
+      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
+    ).toBe("v2");
+  });
+
+  it("removes mirrors whose source skill is gone", async () => {
+    await createSkill(userDir, "alpha");
+    await mirrorUserSkillsToCodex(userDir, codexDir);
+
+    await rm(path.join(userDir, "alpha"), { recursive: true });
+    await mirrorUserSkillsToCodex(userDir, codexDir);
+
+    expect(existsSync(path.join(codexDir, "alpha"))).toBe(false);
+    expect((await readCodexMirrorState(codexDir)).mirrored).toEqual([]);
+  });
+
+  it("takes ownership of an imported skill via addMirroredName", async () => {
+    // Codex-authored skill, imported to user skills (import records the name).
+    await mkdir(codexDir, { recursive: true });
+    await createSkill(codexDir, "alpha", "codex original");
+    await createSkill(userDir, "alpha", "imported then edited");
+    await addMirroredName(codexDir, "alpha");
+
+    await mirrorUserSkillsToCodex(userDir, codexDir);
+
+    expect(
+      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
+    ).toBe("imported then edited");
+  });
+});
+
+describe("readCodexMirrorState", () => {
+  it("returns an empty state for a missing or corrupt file", async () => {
+    expect(await readCodexMirrorState(codexDir)).toEqual({
+      version: 1,
+      mirrored: [],
+    });
+
+    await mkdir(codexDir, { recursive: true });
+    await writeFile(path.join(codexDir, ".posthog-mirror.json"), "not json");
+    expect(await readCodexMirrorState(codexDir)).toEqual({
+      version: 1,
+      mirrored: [],
+    });
+  });
+});

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
@@ -1,0 +1,108 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { findSkillDirs } from "../skills/skill-discovery";
+
+const MIRROR_STATE_FILE = ".posthog-mirror.json";
+
+export interface CodexMirrorState {
+  version: number;
+  /** Skill directory names in ~/.agents/skills that we put there. */
+  mirrored: string[];
+}
+
+export function getCodexSkillsDir(): string {
+  return path.join(os.homedir(), ".agents", "skills");
+}
+
+export async function readCodexMirrorState(
+  codexDir: string,
+): Promise<CodexMirrorState> {
+  try {
+    const content = await fs.promises.readFile(
+      path.join(codexDir, MIRROR_STATE_FILE),
+      "utf-8",
+    );
+    const data = JSON.parse(content) as CodexMirrorState;
+    if (!Array.isArray(data.mirrored)) {
+      return { version: 1, mirrored: [] };
+    }
+    return {
+      version: 1,
+      mirrored: data.mirrored.filter((n) => typeof n === "string"),
+    };
+  } catch {
+    return { version: 1, mirrored: [] };
+  }
+}
+
+export async function writeCodexMirrorState(
+  codexDir: string,
+  state: CodexMirrorState,
+): Promise<void> {
+  await fs.promises.mkdir(codexDir, { recursive: true });
+  await fs.promises.writeFile(
+    path.join(codexDir, MIRROR_STATE_FILE),
+    `${JSON.stringify(state, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+/** Marks a codex skill as ours, so future mirrors may overwrite it. */
+export async function addMirroredName(
+  codexDir: string,
+  name: string,
+): Promise<void> {
+  const state = await readCodexMirrorState(codexDir);
+  if (!state.mirrored.includes(name)) {
+    state.mirrored.push(name);
+    await writeCodexMirrorState(codexDir, state);
+  }
+}
+
+/**
+ * One-way mirror, ours out: copies every user skill into the Codex skills
+ * dir so skills created, edited, or installed in PostHog Code work in Codex
+ * sessions too.
+ *
+ * Safety rule: never overwrite a skill in ~/.agents/skills we didn't put
+ * there. Colliding names are skipped — the collision surfaces in the Skills
+ * tab as a shadowing warning. Mirrors whose source skill is gone are
+ * removed (it's a mirror, not an archive).
+ */
+export async function mirrorUserSkillsToCodex(
+  userSkillsDir: string,
+  codexDir: string,
+): Promise<void> {
+  const state = await readCodexMirrorState(codexDir);
+  const previouslyMirrored = new Set(state.mirrored);
+  const userNames = await findSkillDirs(userSkillsDir);
+  await fs.promises.mkdir(codexDir, { recursive: true });
+
+  const nextMirrored: string[] = [];
+  for (const name of userNames) {
+    const target = path.join(codexDir, name);
+    if (fs.existsSync(target) && !previouslyMirrored.has(name)) {
+      continue;
+    }
+    await fs.promises.rm(target, { recursive: true, force: true });
+    await fs.promises.cp(path.join(userSkillsDir, name), target, {
+      recursive: true,
+    });
+    nextMirrored.push(name);
+  }
+
+  for (const name of previouslyMirrored) {
+    if (!userNames.includes(name)) {
+      await fs.promises.rm(path.join(codexDir, name), {
+        recursive: true,
+        force: true,
+      });
+    }
+  }
+
+  await writeCodexMirrorState(codexDir, {
+    version: 1,
+    mirrored: nextMirrored,
+  });
+}

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
@@ -86,10 +86,17 @@ export async function mirrorUserSkillsToCodex(
       continue;
     }
     await fs.promises.rm(target, { recursive: true, force: true });
-    await fs.promises.cp(path.join(userSkillsDir, name), target, {
-      recursive: true,
-    });
-    nextMirrored.push(name);
+    try {
+      // dereference: mirrored skills must be self-contained.
+      await fs.promises.cp(path.join(userSkillsDir, name), target, {
+        recursive: true,
+        dereference: true,
+      });
+      nextMirrored.push(name);
+    } catch {
+      // Skip unreadable skills (e.g. broken symlinks); drop the partial copy.
+      await fs.promises.rm(target, { recursive: true, force: true });
+    }
   }
 
   for (const name of previouslyMirrored) {

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
@@ -22,6 +22,7 @@ import {
 } from "@posthog/platform/storage-paths";
 import { TypedEventEmitter } from "@posthog/shared";
 import { inject, injectable, postConstruct, preDestroy } from "inversify";
+import { getCodexSkillsDir, mirrorUserSkillsToCodex } from "./codex-mirror";
 import {
   overlayDownloadedSkills,
   syncCodexSkills,
@@ -31,7 +32,8 @@ import {
 const SKILLS_ZIP_URL = process.env.SKILLS_ZIP_URL ?? "";
 const CONTEXT_MILL_ZIP_URL = process.env.CONTEXT_MILL_ZIP_URL ?? "";
 const UPDATE_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
-const CODEX_SKILLS_DIR = join(homedir(), ".agents", "skills");
+const CODEX_SKILLS_DIR = getCodexSkillsDir();
+const USER_SKILLS_DIR = join(homedir(), ".claude", "skills");
 
 interface PosthogPluginEvents {
   skillsUpdated: true;
@@ -97,6 +99,7 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
     await overlayDownloadedSkills(this.runtimeSkillsDir, this.runtimePluginDir);
 
     await syncCodexSkills(this.getPluginPath(), CODEX_SKILLS_DIR);
+    await this.mirrorUserSkills();
 
     // Start periodic updates
     this.intervalId = setInterval(() => {
@@ -116,6 +119,19 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
    * - In prod: use the runtime plugin dir (with downloaded updates).
    * - Fallback: bundled plugin path.
    */
+  /**
+   * Mirrors the user's skills out to Codex ("bring your skills, use them
+   * anywhere"). Never fatal: a broken mirror must not affect the official
+   * skills pipeline.
+   */
+  private async mirrorUserSkills(): Promise<void> {
+    try {
+      await mirrorUserSkillsToCodex(USER_SKILLS_DIR, CODEX_SKILLS_DIR);
+    } catch (err) {
+      this.log.warn("Mirroring user skills to Codex failed", { error: err });
+    }
+  }
+
   getPluginPath(): string {
     if (!this.appMeta.isProduction) {
       return this.bundledPluginDir;
@@ -159,6 +175,7 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
       });
 
       if (result.success) {
+        await this.mirrorUserSkills();
         this.emit("skillsUpdated", true);
       } else {
         this.log.warn("Skills update failed", {

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
@@ -122,9 +122,9 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
   /**
    * Mirrors the user's skills out to Codex ("bring your skills, use them
    * anywhere"). Never fatal: a broken mirror must not affect the official
-   * skills pipeline.
+   * skills pipeline or the mutation that triggered it.
    */
-  private async mirrorUserSkills(): Promise<void> {
+  async mirrorUserSkills(): Promise<void> {
     try {
       await mirrorUserSkillsToCodex(USER_SKILLS_DIR, CODEX_SKILLS_DIR);
     } catch (err) {

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
@@ -12,12 +12,20 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 import { existsSync } from "node:fs";
+import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import {
   collectSkillFiles,
   findSkillDirPrefix,
   SkillsMarketplaceService,
   unzipWithLimit,
 } from "./skills-marketplace";
+
+function makeService(): SkillsMarketplaceService {
+  const plugin = {
+    mirrorUserSkills: async () => {},
+  } as unknown as PosthogPluginService;
+  return new SkillsMarketplaceService(plugin);
+}
 
 let root: string;
 
@@ -93,7 +101,7 @@ describe("collectSkillFiles", () => {
 
 describe("search", () => {
   it("maps skills.sh results and marks installed skills", async () => {
-    const service = new SkillsMarketplaceService();
+    const service = makeService();
     // Install state: "commit" is already installed.
     const stateDir = path.join(root, ".claude", "skills");
     await import("node:fs/promises").then((fsp) =>
@@ -149,7 +157,7 @@ describe("search", () => {
       throw new Error("should not fetch");
     });
 
-    expect(await new SkillsMarketplaceService().search(" a ")).toEqual({
+    expect(await makeService().search(" a ")).toEqual({
       results: [],
     });
   });
@@ -158,7 +166,7 @@ describe("search", () => {
 describe("preview", () => {
   it("returns the full file list with contents and a scripts flag", async () => {
     stubFetch(() => zipResponse(makeRepoZip()));
-    const service = new SkillsMarketplaceService();
+    const service = makeService();
 
     const preview = await service.preview({
       source: "getsentry/skills",
@@ -185,7 +193,7 @@ describe("preview", () => {
       ),
     );
 
-    const preview = await new SkillsMarketplaceService().preview({
+    const preview = await makeService().preview({
       source: "getsentry/skills",
       skillId: "commit",
     });
@@ -198,7 +206,7 @@ describe("preview", () => {
     stubFetch(() => zipResponse(makeRepoZip()));
 
     await expect(
-      new SkillsMarketplaceService().preview({
+      makeService().preview({
         source: "getsentry/skills",
         skillId: "nope",
       }),
@@ -209,7 +217,7 @@ describe("preview", () => {
     stubFetch(() => zipResponse(makeRepoZip()));
 
     await expect(
-      new SkillsMarketplaceService().preview({
+      makeService().preview({
         source: "https://evil.example/x",
         skillId: "commit",
       }),
@@ -220,7 +228,7 @@ describe("preview", () => {
 describe("install", () => {
   it("copies the skill into the user skills dir and records the badge state", async () => {
     stubFetch(() => zipResponse(makeRepoZip()));
-    const service = new SkillsMarketplaceService();
+    const service = makeService();
 
     const { path: installedPath } = await service.install({
       source: "getsentry/skills",
@@ -249,7 +257,7 @@ describe("install", () => {
 
   it("requires overwrite when the skill already exists, then replaces it", async () => {
     stubFetch(() => zipResponse(makeRepoZip()));
-    const service = new SkillsMarketplaceService();
+    const service = makeService();
 
     const { path: installedPath } = await service.install({
       source: "getsentry/skills",
@@ -274,7 +282,7 @@ describe("install", () => {
     stubFetch(() => zipResponse(makeRepoZip()));
 
     await expect(
-      new SkillsMarketplaceService().install({
+      makeService().install({
         source: "getsentry/skills",
         skillId: "../escape",
       }),
@@ -293,7 +301,7 @@ describe("archive download guards", () => {
     );
 
     await expect(
-      new SkillsMarketplaceService().preview({
+      makeService().preview({
         source: "getsentry/skills",
         skillId: "commit",
       }),
@@ -302,7 +310,7 @@ describe("archive download guards", () => {
 
   it("reuses the cached archive within the TTL", async () => {
     stubFetch(() => zipResponse(makeRepoZip()));
-    const service = new SkillsMarketplaceService();
+    const service = makeService();
 
     await service.preview({ source: "getsentry/skills", skillId: "commit" });
     await service.preview({ source: "getsentry/skills", skillId: "other" });

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -2,8 +2,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Unzipped } from "fflate";
-import { injectable } from "inversify";
+import { inject, injectable } from "inversify";
 import { unzipAsync } from "../posthog-plugin/extract-zip";
+import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
+import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import { validateSkillDirName } from "../skills/skills";
 import {
   type MarketplacePreviewFile,
@@ -116,6 +118,11 @@ export function collectSkillFiles(
 export class SkillsMarketplaceService {
   private archives = new Map<string, CachedArchive>();
 
+  constructor(
+    @inject(POSTHOG_PLUGIN_SERVICE)
+    private readonly plugin: PosthogPluginService,
+  ) {}
+
   async search(query: string): Promise<MarketplaceSearchOutput> {
     const trimmed = query.trim();
     if (trimmed.length < 2) return { results: [] };
@@ -198,6 +205,8 @@ export class SkillsMarketplaceService {
     const state = await readInstalledState();
     state.installed[ref.skillId] = { repo: ref.source };
     await writeInstalledState(state);
+
+    void this.plugin.mirrorUserSkills().catch(() => {});
 
     return { path: target };
   }

--- a/packages/workspace-server/src/services/skills/schemas.ts
+++ b/packages/workspace-server/src/services/skills/schemas.ts
@@ -1,7 +1,13 @@
 import type { ExportedSkill as SharedExportedSkill } from "@posthog/shared";
 import { z } from "zod";
 
-export const skillSource = z.enum(["bundled", "user", "repo", "marketplace"]);
+export const skillSource = z.enum([
+  "bundled",
+  "user",
+  "repo",
+  "marketplace",
+  "codex",
+]);
 
 export const skillInfo = z.object({
   name: z.string(),
@@ -95,6 +101,11 @@ export const exportSkillOutput = z.object({
   /** Files excluded from the export (binary or oversized). */
   skipped: z.array(z.string()),
 }) satisfies z.ZodType<SharedExportedSkill & { skipped: string[] }>;
+
+export const importCodexSkillInput = z.object({
+  skillPath: z.string(),
+  overwrite: z.boolean().optional(),
+});
 
 export const installTeamSkillInput = z.object({
   name: z.string(),

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -24,6 +24,7 @@ let repoSkillsDir: string;
 function makeService(): SkillsService {
   const plugin = {
     getPluginPath: () => pluginPath,
+    mirrorUserSkills: async () => {},
   } as unknown as PosthogPluginService;
   const folders = {
     getFolders: async () => [{ path: folderPath, name: "my-repo" }],

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -2,11 +2,19 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FoldersService } from "../folders/folders";
 import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import { WatcherService } from "../watcher/service";
 import { SkillsService } from "./skills";
+
+const codexHome = vi.hoisted(() => ({ dir: "" }));
+
+vi.mock("../posthog-plugin/codex-mirror", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../posthog-plugin/codex-mirror")>();
+  return { ...actual, getCodexSkillsDir: () => codexHome.dir };
+});
 
 let root: string;
 let pluginPath: string;
@@ -39,6 +47,7 @@ beforeEach(async () => {
   pluginPath = path.join(root, "plugin");
   folderPath = path.join(root, "repo");
   repoSkillsDir = path.join(folderPath, ".claude", "skills");
+  codexHome.dir = path.join(root, "codex-skills");
   await mkdir(path.join(pluginPath, "skills"), { recursive: true });
   await mkdir(repoSkillsDir, { recursive: true });
 });
@@ -179,6 +188,70 @@ describe("readSkillFile", () => {
     expect(await makeService().readSkillFile(skillPath, "alias.md")).toBe(
       "real content",
     );
+  });
+});
+
+describe("codex skills", () => {
+  it("lists codex skills, hiding bundled-synced and mirrored copies", async () => {
+    await mkdir(codexHome.dir, { recursive: true });
+    await createSkill(codexHome.dir, "codex-only");
+    // Copy synced there by the official bundled pipeline:
+    await createSkill(path.join(pluginPath, "skills"), "bundled-skill");
+    await createSkill(codexHome.dir, "bundled-skill");
+    // Copy mirrored out from the user's skills:
+    await createSkill(codexHome.dir, "mirrored-skill");
+    await writeFile(
+      path.join(codexHome.dir, ".posthog-mirror.json"),
+      JSON.stringify({ version: 1, mirrored: ["mirrored-skill"] }),
+    );
+
+    const skills = await makeService().listSkills();
+    const codexSkills = skills.filter((s) => s.source === "codex");
+
+    expect(codexSkills.map((s) => s.name)).toEqual(["codex-only"]);
+    expect(codexSkills[0]?.editable).toBe(false);
+  });
+
+  it("imports a codex skill into the user skills dir and takes mirror ownership", async () => {
+    await mkdir(codexHome.dir, { recursive: true });
+    await createSkill(codexHome.dir, "codex-only");
+    const service = makeService();
+
+    // The user skills root is the real homedir; intercept the copy by
+    // asserting on the returned path and cleaning up.
+    const { homedir } = await import("node:os");
+    const target = path.join(homedir(), ".claude", "skills", "codex-only");
+    const targetExisted = (await import("node:fs")).existsSync(target);
+    if (targetExisted) {
+      // Avoid clobbering a real local skill with this name.
+      return;
+    }
+    try {
+      const result = await service.importCodexSkill(
+        path.join(codexHome.dir, "codex-only"),
+      );
+      expect(result.path).toBe(target);
+      const content = await service.readSkillFile(target, "SKILL.md");
+      expect(content).toContain("codex-only");
+
+      const state = JSON.parse(
+        await (await import("node:fs/promises")).readFile(
+          path.join(codexHome.dir, ".posthog-mirror.json"),
+          "utf-8",
+        ),
+      );
+      expect(state.mirrored).toContain("codex-only");
+    } finally {
+      await rm(target, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects importing paths outside the codex skills dir", async () => {
+    await createSkill(repoSkillsDir, "alpha");
+
+    await expect(
+      makeService().importCodexSkill(path.join(repoSkillsDir, "alpha")),
+    ).rejects.toThrow("not a Codex skill directory");
   });
 });
 

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -5,6 +5,11 @@ import { inject, injectable } from "inversify";
 import { WATCHER_SERVICE } from "../../di/tokens";
 import type { FoldersService } from "../folders/folders";
 import { FOLDERS_SERVICE } from "../folders/identifiers";
+import {
+  addMirroredName,
+  getCodexSkillsDir,
+  readCodexMirrorState,
+} from "../posthog-plugin/codex-mirror";
 import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
 import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import type { WatcherService } from "../watcher/service";
@@ -62,7 +67,9 @@ export class SkillsService {
         readSkillMetadataFromDir(root.dir, root.source, root.repoName),
       ),
     );
-    return results.flat();
+    const skills = results.flat();
+    const mirrorState = await readCodexMirrorState(getCodexSkillsDir());
+    return dedupeCodexSkills(skills, new Set(mirrorState.mirrored));
   }
 
   async getSkillContents(skillPath: string): Promise<SkillContents> {
@@ -175,6 +182,41 @@ export class SkillsService {
   async deleteSkill(skillPath: string): Promise<void> {
     const skillDir = await this.resolveWritableSkillDir(skillPath);
     await fs.promises.rm(skillDir, { recursive: true, force: true });
+  }
+
+  /**
+   * Imports a Codex-authored skill into ~/.claude/skills, after which it is
+   * an ordinary editable user skill. The mirror takes ownership of the Codex
+   * copy so future syncs carry edits back without clobbering or duplicating.
+   */
+  async importCodexSkill(
+    skillPath: string,
+    overwrite = false,
+  ): Promise<{ path: string }> {
+    const resolved = path.resolve(skillPath);
+    const codexRoot = path.resolve(getCodexSkillsDir());
+    if (
+      path.dirname(resolved) !== codexRoot ||
+      !fs.existsSync(path.join(resolved, "SKILL.md"))
+    ) {
+      throw new Error("Access denied: not a Codex skill directory");
+    }
+    const name = path.basename(resolved);
+    validateSkillDirName(name);
+
+    const target = path.join(os.homedir(), ".claude", "skills", name);
+    if (fs.existsSync(target) && !overwrite) {
+      throw new Error(
+        `A skill named "${name}" already exists. Importing will replace your local version.`,
+      );
+    }
+    if (fs.existsSync(target)) {
+      await fs.promises.rm(target, { recursive: true, force: true });
+    }
+    await fs.promises.mkdir(path.dirname(target), { recursive: true });
+    await fs.promises.cp(resolved, target, { recursive: true });
+    await addMirroredName(codexRoot, name);
+    return { path: target };
   }
 
   /**
@@ -364,6 +406,7 @@ export class SkillsService {
         dir: path.join(p, "skills"),
         source: "marketplace" as const,
       })),
+      { dir: getCodexSkillsDir(), source: "codex" as const },
     ];
   }
 
@@ -461,6 +504,29 @@ async function waitForDir(dir: string, signal?: AbortSignal): Promise<boolean> {
     await delay(MISSING_DIR_POLL_MS, signal);
   }
   return false;
+}
+
+/**
+ * Hides Codex copies we are responsible for: bundled skills synced by the
+ * official pipeline and user skills mirrored out. What remains is genuinely
+ * the user's Codex-only skills.
+ */
+function dedupeCodexSkills(
+  skills: SkillInfo[],
+  mirroredNames: Set<string>,
+): SkillInfo[] {
+  const bundledNames = new Set(
+    skills.filter((s) => s.source === "bundled").map((s) => s.name),
+  );
+  return skills.filter((skill) => {
+    if (skill.source !== "codex") return true;
+    const dirName = path.basename(skill.path);
+    return (
+      !bundledNames.has(skill.name) &&
+      !mirroredNames.has(dirName) &&
+      !mirroredNames.has(skill.name)
+    );
+  });
 }
 
 function stripFrontmatterBlock(content: string): string {

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -60,6 +60,11 @@ export class SkillsService {
     private readonly watcher: WatcherService,
   ) {}
 
+  /** Fire-and-forget Codex mirror after local mutations. */
+  private queueCodexMirror(): void {
+    void this.plugin.mirrorUserSkills().catch(() => {});
+  }
+
   async listSkills(): Promise<SkillInfo[]> {
     const roots = await this.getSkillRoots();
     const results = await Promise.all(
@@ -118,6 +123,7 @@ export class SkillsService {
       serializeSkillMarkdown({ name, description: "" }, SKILL_MD_TEMPLATE_BODY),
       "utf-8",
     );
+    this.queueCodexMirror();
     return { path: skillPath };
   }
 
@@ -139,6 +145,7 @@ export class SkillsService {
       content,
       "utf-8",
     );
+    this.queueCodexMirror();
   }
 
   async saveSkillFile(
@@ -150,6 +157,7 @@ export class SkillsService {
     const target = resolveSkillFilePath(skillDir, filePath);
     await fs.promises.mkdir(path.dirname(target), { recursive: true });
     await fs.promises.writeFile(target, content, "utf-8");
+    this.queueCodexMirror();
   }
 
   async renameSkillFile(
@@ -168,6 +176,7 @@ export class SkillsService {
     }
     await fs.promises.mkdir(path.dirname(to), { recursive: true });
     await fs.promises.rename(from, to);
+    this.queueCodexMirror();
   }
 
   async deleteSkillFile(skillPath: string, filePath: string): Promise<void> {
@@ -177,11 +186,13 @@ export class SkillsService {
       throw new Error("SKILL.md cannot be deleted");
     }
     await fs.promises.rm(target, { force: true });
+    this.queueCodexMirror();
   }
 
   async deleteSkill(skillPath: string): Promise<void> {
     const skillDir = await this.resolveWritableSkillDir(skillPath);
     await fs.promises.rm(skillDir, { recursive: true, force: true });
+    this.queueCodexMirror();
   }
 
   /**
@@ -214,8 +225,12 @@ export class SkillsService {
       await fs.promises.rm(target, { recursive: true, force: true });
     }
     await fs.promises.mkdir(path.dirname(target), { recursive: true });
-    await fs.promises.cp(resolved, target, { recursive: true });
+    await fs.promises.cp(resolved, target, {
+      recursive: true,
+      dereference: true,
+    });
     await addMirroredName(codexRoot, name);
+    this.queueCodexMirror();
     return { path: target };
   }
 
@@ -313,6 +328,7 @@ export class SkillsService {
       await fs.promises.rm(staging, { recursive: true, force: true });
       throw error;
     }
+    this.queueCodexMirror();
     return { path: target };
   }
 


### PR DESCRIPTION
## Problem

Users who work in both PostHog Code and Codex have no way to access their Codex-authored skills from the Skills tab, and no way to bring those skills into their editable user skills collection. Similarly, skills created or installed in PostHog Code are invisible to Codex sessions.

## Changes

**New `codex` skill source**
- Added `"codex"` as a valid `SkillSource` type and wired it through the Zod schema, precedence ordering, source labels, and UI display config (using a `Robot` icon).
- Codex skills appear in their own "Codex" section in the Skills view, between repo and bundled skills.
- Codex skills are read-only in the UI.

**Codex skill deduplication**
- Skills in `~/.agents/skills` that were synced there by the official bundled pipeline, or mirrored out from the user's own skills, are hidden from the Codex section to avoid confusing duplicates. Only genuinely Codex-authored skills surface.

**Import Codex skill**
- Added an "Import" button on the detail panel for Codex skills. Clicking it copies the skill into `~/.claude/skills`, making it an ordinary editable user skill.
- If a skill with the same name already exists locally, an overwrite confirmation dialog is shown before replacing it.
- After import, the mirror takes ownership of the Codex copy so future user-skill mirrors carry edits back without duplicating or clobbering.
- Added `importCodex` tRPC mutation and `useImportCodexSkill` hook.
- Path validation ensures only skills inside the Codex skills directory can be imported.

**User-to-Codex mirroring (`codex-mirror.ts`)**
- Introduced a one-way mirror that copies every user skill into `~/.agents/skills` so skills created, edited, or installed in PostHog Code are available in Codex sessions.
- A `.posthog-mirror.json` state file tracks which skills were placed there by the mirror, ensuring the mirror never overwrites Codex-native skills it didn't create.
- Mirrors whose source skill has been deleted are cleaned up automatically.
- Mirroring runs on startup and after each periodic skills update. Failures are logged as warnings and never interrupt the main skills pipeline.

## How did you test this?

- Added unit tests for `mirrorUserSkillsToCodex` covering: initial copy, collision avoidance, update propagation, deletion cleanup, and import ownership handoff.
- Added unit tests for `readCodexMirrorState` covering missing and corrupt state files.
- Added integration tests in `skills.test.ts` covering: listing codex skills with deduplication, importing a codex skill with mirror ownership, and rejection of paths outside the codex skills directory.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?