### PR TITLE
refactor(skills): apply simplify-pass cleanups across the stack

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -189,18 +189,6 @@ export interface LlmSkillFileInput {
   content_type?: string;
 }
 
-export interface LlmSkillResolveResponse {
-  skill: LlmSkill;
-  versions: Array<{
-    id: string;
-    version: number;
-    created_by: LlmSkillCreatedBy | null;
-    created_at: string;
-    is_latest: boolean;
-  }>;
-  has_more: boolean;
-}
-
 export interface SignalSourceConfig {
   id: string;
   source_product:
@@ -3722,22 +3710,6 @@ export class PostHogAPIClient {
       throw new Error(`Failed to fetch team skill: ${response.statusText}`);
     }
     return (await response.json()) as LlmSkill;
-  }
-
-  /** Resolves a team skill plus its version history. */
-  async resolveLlmSkill(name: string): Promise<LlmSkillResolveResponse> {
-    const teamId = await this.getTeamId();
-    const urlPath = `/api/environments/${teamId}/llm_skills/resolve/name/${encodeURIComponent(name)}`;
-    const url = new URL(`${this.api.baseUrl}${urlPath}`);
-    const response = await this.api.fetcher.fetch({
-      method: "get",
-      url,
-      path: urlPath,
-    });
-    if (!response.ok) {
-      throw new Error(`Failed to resolve team skill: ${response.statusText}`);
-    }
-    return (await response.json()) as LlmSkillResolveResponse;
   }
 
   /** Creates a brand-new team skill (version 1). */

--- a/packages/core/src/skills/teamSkillsService.test.ts
+++ b/packages/core/src/skills/teamSkillsService.test.ts
@@ -4,7 +4,10 @@ import type {
 } from "@posthog/api-client/posthog-client";
 import { describe, expect, it, vi } from "vitest";
 import type { SkillsWorkspaceClient } from "./teamSkillsService";
-import { TeamSkillsService } from "./teamSkillsService";
+import {
+  markInstalledTeamSkills,
+  TeamSkillsService,
+} from "./teamSkillsService";
 
 function makeService(
   workspace: Partial<SkillsWorkspaceClient> = {},
@@ -39,21 +42,18 @@ function makeClient(result: LlmSkillListItem[] | null): PostHogAPIClient {
 
 describe("TeamSkillsService.listTeamSkills", () => {
   it("reports the feature as unavailable when the API returns null", async () => {
-    const listing = await makeService().listTeamSkills(makeClient(null), []);
+    const listing = await makeService().listTeamSkills(makeClient(null));
 
     expect(listing).toEqual({ available: false, skills: [] });
   });
 
-  it("maps team skills and marks ones that exist locally", async () => {
+  it("maps team skills", async () => {
     const client = makeClient([
       makeItem({}),
       makeItem({ id: "skill-2", name: "release-notes", created_by: null }),
     ]);
 
-    const listing = await makeService().listTeamSkills(client, [
-      "release-notes",
-      "unrelated-local",
-    ]);
+    const listing = await makeService().listTeamSkills(client);
 
     expect(listing.available).toBe(true);
     expect(listing.skills).toEqual([
@@ -66,11 +66,7 @@ describe("TeamSkillsService.listTeamSkills", () => {
         createdByEmail: "dev@posthog.com",
         installedLocally: false,
       },
-      expect.objectContaining({
-        name: "release-notes",
-        createdByEmail: null,
-        installedLocally: true,
-      }),
+      expect.objectContaining({ name: "release-notes", createdByEmail: null }),
     ]);
   });
 
@@ -80,10 +76,31 @@ describe("TeamSkillsService.listTeamSkills", () => {
       makeItem({ id: "skill-1b", version: 2 }),
     ]);
 
-    const listing = await makeService().listTeamSkills(client, []);
+    const listing = await makeService().listTeamSkills(client);
 
     expect(listing.skills).toHaveLength(1);
     expect(listing.skills[0]?.id).toBe("skill-1b");
+  });
+});
+
+describe("markInstalledTeamSkills", () => {
+  it("marks team skills that exist locally by name", async () => {
+    const listing = await makeService().listTeamSkills(
+      makeClient([
+        makeItem({}),
+        makeItem({ id: "skill-2", name: "release-notes" }),
+      ]),
+    );
+
+    const marked = markInstalledTeamSkills(listing, [
+      "release-notes",
+      "unrelated-local",
+    ]);
+
+    expect(marked.skills.map((s) => [s.name, s.installedLocally])).toEqual([
+      ["pr-shepherd", false],
+      ["release-notes", true],
+    ]);
   });
 });
 

--- a/packages/core/src/skills/teamSkillsService.ts
+++ b/packages/core/src/skills/teamSkillsService.ts
@@ -35,6 +35,24 @@ export interface SkillsWorkspaceClient {
   ): Promise<{ path: string }>;
 }
 
+/**
+ * Marks team skills that already exist locally by name. Pure, so callers
+ * can re-apply it when the local listing changes without refetching.
+ */
+export function markInstalledTeamSkills(
+  listing: TeamSkillsListing,
+  localSkillNames: string[],
+): TeamSkillsListing {
+  const localNames = new Set(localSkillNames);
+  return {
+    ...listing,
+    skills: listing.skills.map((skill) => ({
+      ...skill,
+      installedLocally: localNames.has(skill.name),
+    })),
+  };
+}
+
 @injectable()
 export class TeamSkillsService {
   constructor(
@@ -63,24 +81,18 @@ export class TeamSkillsService {
   }
 
   /**
-   * Lists team skills merged with the local listing: the availability
-   * decision (flag off → absent group, no errors) and the "already
-   * installed locally" marking both live here, so the UI keeps one hook.
+   * Lists the team's latest skills, owning the availability decision
+   * (flag off → absent group, no errors). Combine with
+   * markInstalledTeamSkills for the merged local+team view.
    */
-  async listTeamSkills(
-    client: PostHogAPIClient,
-    localSkillNames: string[],
-  ): Promise<TeamSkillsListing> {
+  async listTeamSkills(client: PostHogAPIClient): Promise<TeamSkillsListing> {
     const items = await client.listLlmSkills();
     if (items === null) {
       return { available: false, skills: [] };
     }
-    const localNames = new Set(localSkillNames);
     return {
       available: true,
-      skills: items
-        .filter((item) => item.is_latest)
-        .map((item) => toTeamSkillInfo(item, localNames)),
+      skills: items.filter((item) => item.is_latest).map(toTeamSkillInfo),
     };
   }
 
@@ -151,10 +163,7 @@ export class TeamSkillsService {
   }
 }
 
-function toTeamSkillInfo(
-  item: LlmSkillListItem,
-  localNames: Set<string>,
-): TeamSkillInfo {
+function toTeamSkillInfo(item: LlmSkillListItem): TeamSkillInfo {
   return {
     id: item.id,
     name: item.name,
@@ -162,6 +171,6 @@ function toTeamSkillInfo(
     version: item.latest_version ?? item.version,
     updatedAt: item.updated_at,
     createdByEmail: item.created_by?.email ?? null,
-    installedLocally: localNames.has(item.name),
+    installedLocally: false,
   };
 }

--- a/packages/host-router/src/routers/skills.router.ts
+++ b/packages/host-router/src/routers/skills.router.ts
@@ -63,11 +63,7 @@ export const skillsRouter = router({
     .mutation(({ ctx, input }) =>
       ctx.container
         .get<SkillsService>(SKILLS_SERVICE)
-        .saveSkillManifest(input.skillPath, {
-          name: input.name,
-          description: input.description,
-          body: input.body,
-        }),
+        .saveSkillManifest(input.skillPath, input),
     ),
   saveFile: publicProcedure
     .input(saveSkillFileInput)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -166,6 +166,7 @@ export type {
   SkillInfo,
   SkillSource,
 } from "./skills";
+export { stripFrontmatter } from "./skills";
 export type {
   ArtifactType,
   PostHogAPIConfig,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -166,7 +166,7 @@ export type {
   SkillInfo,
   SkillSource,
 } from "./skills";
-export { stripFrontmatter } from "./skills";
+export { SKILL_EXISTS_MARKER, stripFrontmatter } from "./skills";
 export type {
   ArtifactType,
   PostHogAPIConfig,

--- a/packages/shared/src/skills.ts
+++ b/packages/shared/src/skills.ts
@@ -31,3 +31,13 @@ export interface ExportedSkill {
   body: string;
   files: ExportedSkillFile[];
 }
+
+/**
+ * Strips a leading YAML frontmatter block from a SKILL.md document.
+ * CRLF-aware so render (UI) and export (workspace-server) agree on the body.
+ */
+export function stripFrontmatter(content: string): string {
+  const match = content.match(/^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/);
+  if (!match) return content;
+  return content.slice(match[0].length).replace(/^(?:[ \t]*\r?\n)+/, "");
+}

--- a/packages/shared/src/skills.ts
+++ b/packages/shared/src/skills.ts
@@ -33,6 +33,12 @@ export interface ExportedSkill {
 }
 
 /**
+ * Server "skill already exists" messages must include this marker verbatim;
+ * the UI keys its overwrite-confirmation flow on it.
+ */
+export const SKILL_EXISTS_MARKER = "already exists";
+
+/**
  * Strips a leading YAML frontmatter block from a SKILL.md document.
  * CRLF-aware so render (UI) and export (workspace-server) agree on the body.
  */

--- a/packages/ui/src/features/skills/MarketplaceBrowse.tsx
+++ b/packages/ui/src/features/skills/MarketplaceBrowse.tsx
@@ -11,15 +11,13 @@ import {
 } from "@radix-ui/themes";
 import { useState } from "react";
 import { MarketplaceSkillPanel } from "./MarketplaceSkillPanel";
+import { SkillListCard } from "./SkillListCard";
 import { useSkillsSidebarStore } from "./skillsSidebarStore";
 import {
+  installsFormatter,
   type MarketplaceSkillSummary,
   useMarketplaceSearch,
 } from "./useMarketplace";
-
-const installsFormatter = new Intl.NumberFormat(undefined, {
-  notation: "compact",
-});
 
 export function MarketplaceBrowse() {
   const [query, setQuery] = useState("");
@@ -68,52 +66,41 @@ export function MarketplaceBrowse() {
             ) : (
               <Flex direction="column" gap="1">
                 {results.map((result) => (
-                  <Flex
+                  <SkillListCard
                     key={result.id}
-                    align="center"
-                    gap="2"
-                    px="3"
-                    py="2"
-                    className={`cursor-pointer rounded-lg border transition-colors ${
-                      selected?.id === result.id
-                        ? "border-accent-8 bg-accent-3"
-                        : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
-                    }`}
-                    onClick={() =>
-                      setSelected((prev) =>
-                        prev?.id === result.id ? null : result,
-                      )
-                    }
-                  >
-                    <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
+                    icon={
                       <Storefront
                         size={14}
                         weight="duotone"
                         className="text-gray-11"
                       />
-                    </Box>
-                    <Flex direction="column" gap="0" className="min-w-0 flex-1">
-                      <Text className="truncate font-medium text-[13px] text-gray-12">
-                        {result.name}
-                      </Text>
-                      <Text className="truncate text-[12px] text-gray-10">
-                        {result.source}
-                      </Text>
-                    </Flex>
-                    {result.installed && (
-                      <Badge
-                        size="1"
-                        variant="soft"
-                        color="green"
-                        className="shrink-0"
-                      >
-                        Installed
-                      </Badge>
-                    )}
-                    <Text className="shrink-0 text-[12px] text-gray-9 tabular-nums">
-                      {installsFormatter.format(result.installs)}
-                    </Text>
-                  </Flex>
+                    }
+                    title={result.name}
+                    subtitle={result.source}
+                    isSelected={selected?.id === result.id}
+                    onClick={() =>
+                      setSelected((prev) =>
+                        prev?.id === result.id ? null : result,
+                      )
+                    }
+                    trailing={
+                      <>
+                        {result.installed && (
+                          <Badge
+                            size="1"
+                            variant="soft"
+                            color="green"
+                            className="shrink-0"
+                          >
+                            Installed
+                          </Badge>
+                        )}
+                        <Text className="shrink-0 text-[12px] text-gray-9 tabular-nums">
+                          {installsFormatter.format(result.installs)}
+                        </Text>
+                      </>
+                    }
+                  />
                 ))}
               </Flex>
             )}

--- a/packages/ui/src/features/skills/MarketplaceSkillPanel.tsx
+++ b/packages/ui/src/features/skills/MarketplaceSkillPanel.tsx
@@ -1,9 +1,9 @@
 import { DownloadSimple, Warning, X } from "@phosphor-icons/react";
+import { stripFrontmatter } from "@posthog/shared";
 import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { toast } from "@posthog/ui/primitives/toast";
 import {
-  AlertDialog,
   Badge,
   Box,
   Button,
@@ -14,17 +14,15 @@ import {
   Tooltip,
 } from "@radix-ui/themes";
 import { useState } from "react";
+import { ReplaceSkillDialog } from "./ReplaceSkillDialog";
 import { SkillFileTree } from "./SkillFileTree";
-import { stripFrontmatter } from "./stripFrontmatter";
+import { isSkillExistsError, skillErrorDescription } from "./skillErrors";
 import {
+  installsFormatter,
   type MarketplaceSkillSummary,
   useInstallMarketplaceSkill,
   useMarketplacePreview,
 } from "./useMarketplace";
-
-const installsFormatter = new Intl.NumberFormat(undefined, {
-  notation: "compact",
-});
 
 interface MarketplaceSkillPanelProps {
   result: MarketplaceSkillSummary;
@@ -63,13 +61,12 @@ export function MarketplaceSkillPanel({
         description: "Now available under Your skills",
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "";
-      if (!overwrite && message.includes("already exists")) {
+      if (!overwrite && isSkillExistsError(error)) {
         setConfirmOverwrite(true);
         return;
       }
       toast.error("Failed to install skill", {
-        description: message || undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -182,35 +179,13 @@ export function MarketplaceSkillPanel({
         )}
       </Box>
 
-      <AlertDialog.Root
+      <ReplaceSkillDialog
         open={confirmOverwrite}
         onOpenChange={setConfirmOverwrite}
-      >
-        <AlertDialog.Content maxWidth="420px" size="2">
-          <AlertDialog.Title size="3">Replace local skill</AlertDialog.Title>
-          <AlertDialog.Description size="1">
-            A skill named "{result.skillId}" already exists in your skills.
-            Reinstalling will replace your local version, including any edits.
-          </AlertDialog.Description>
-          <Flex justify="end" gap="2" mt="4">
-            <AlertDialog.Cancel>
-              <Button size="1" variant="soft" color="gray">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-            <AlertDialog.Action>
-              <Button
-                size="1"
-                variant="solid"
-                color="red"
-                onClick={() => void handleInstall(true)}
-              >
-                Replace
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+        skillName={result.skillId}
+        verb="Reinstalling"
+        onConfirm={() => void handleInstall(true)}
+      />
     </>
   );
 }

--- a/packages/ui/src/features/skills/NewSkillDialog.tsx
+++ b/packages/ui/src/features/skills/NewSkillDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@radix-ui/themes";
 import { useState } from "react";
 import { useFolders } from "../folders/useFolders";
+import { skillErrorDescription } from "./skillErrors";
 import { useCreateSkill } from "./useSkillMutations";
 
 const USER_SCOPE = "user";
@@ -42,7 +43,7 @@ export function NewSkillDialog({
       onCreated(result.path);
     } catch (error) {
       toast.error("Failed to create skill", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };

--- a/packages/ui/src/features/skills/ReplaceSkillDialog.tsx
+++ b/packages/ui/src/features/skills/ReplaceSkillDialog.tsx
@@ -1,0 +1,43 @@
+import { AlertDialog, Button, Flex } from "@radix-ui/themes";
+
+interface ReplaceSkillDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  skillName: string;
+  /** Leads the warning sentence, e.g. "Reinstalling" or "Importing". */
+  verb: string;
+  onConfirm: () => void;
+}
+
+/** Confirm-overwrite dialog shared by every install/import surface. */
+export function ReplaceSkillDialog({
+  open,
+  onOpenChange,
+  skillName,
+  verb,
+  onConfirm,
+}: ReplaceSkillDialogProps) {
+  return (
+    <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Content maxWidth="420px" size="2">
+        <AlertDialog.Title size="3">Replace local skill</AlertDialog.Title>
+        <AlertDialog.Description size="1">
+          A skill named "{skillName}" already exists in your skills. {verb} will
+          replace your local version, including any edits.
+        </AlertDialog.Description>
+        <Flex justify="end" gap="2" mt="4">
+          <AlertDialog.Cancel>
+            <Button size="1" variant="soft" color="gray">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Button size="1" variant="solid" color="red" onClick={onConfirm}>
+              Replace
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/packages/ui/src/features/skills/SkillCard.tsx
+++ b/packages/ui/src/features/skills/SkillCard.tsx
@@ -11,8 +11,9 @@ import type {
   SkillIssue,
 } from "@posthog/core/skills/analyzeSkills";
 import type { SkillInfo, SkillSource } from "@posthog/shared";
-import { Badge, Box, Flex, Text, Tooltip } from "@radix-ui/themes";
+import { Badge, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useEffect, useRef } from "react";
+import { SkillListCard } from "./SkillListCard";
 
 export const SOURCE_CONFIG: Record<
   SkillSource,
@@ -62,56 +63,38 @@ export function SkillCard({
   }, [scrollIntoView, onScrolledIntoView]);
 
   return (
-    <Flex
-      ref={ref}
-      align="center"
-      gap="2"
-      px="3"
-      py="2"
-      className={`cursor-pointer rounded-lg border transition-colors ${
-        isSelected
-          ? "border-accent-8 bg-accent-3"
-          : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
-      }`}
+    <SkillListCard
+      cardRef={ref}
+      icon={<Icon size={14} weight="duotone" className="text-gray-11" />}
+      title={skill.name}
+      subtitle={skill.description || undefined}
+      isSelected={isSelected}
       onClick={onClick}
-    >
-      <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
-        <Icon size={14} weight="duotone" className="text-gray-11" />
-      </Box>
-
-      <Flex direction="column" gap="0" className="min-w-0 flex-1">
-        <Text className="truncate font-medium text-[13px] text-gray-12">
-          {skill.name}
-        </Text>
-        {skill.description && (
-          <Text className="truncate text-[12px] text-gray-10">
-            {skill.description}
-          </Text>
-        )}
-      </Flex>
-
-      {issues.length > 0 && (
-        <Tooltip
-          content={
-            <Flex direction="column" gap="1">
-              {issues.map((issue) => (
-                <Text key={issue.message} size="1">
-                  {issue.message}
-                </Text>
-              ))}
-            </Flex>
-          }
-        >
-          <Warning size={14} className="shrink-0 text-amber-11" />
-        </Tooltip>
-      )}
-
-      {skill.repoName && (
-        <Badge size="1" variant="soft" color="gray" className="shrink-0">
-          {skill.repoName}
-        </Badge>
-      )}
-    </Flex>
+      trailing={
+        <>
+          {issues.length > 0 && (
+            <Tooltip
+              content={
+                <Flex direction="column" gap="1">
+                  {issues.map((issue) => (
+                    <Text key={issue.message} size="1">
+                      {issue.message}
+                    </Text>
+                  ))}
+                </Flex>
+              }
+            >
+              <Warning size={14} className="shrink-0 text-amber-11" />
+            </Tooltip>
+          )}
+          {skill.repoName && (
+            <Badge size="1" variant="soft" color="gray" className="shrink-0">
+              {skill.repoName}
+            </Badge>
+          )}
+        </>
+      }
+    />
   );
 }
 

--- a/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@phosphor-icons/react";
 import type { SkillIssue } from "@posthog/core/skills/analyzeSkills";
 import type { SkillInfo } from "@posthog/shared";
+import { stripFrontmatter } from "@posthog/shared";
 import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { ExternalAppsOpener } from "@posthog/ui/features/task-detail/components/ExternalAppsOpener";
@@ -29,11 +30,12 @@ import {
   Tooltip,
 } from "@radix-ui/themes";
 import { useState } from "react";
+import { ReplaceSkillDialog } from "./ReplaceSkillDialog";
 import { SOURCE_CONFIG } from "./SkillCard";
 import { SkillFileEditor } from "./SkillFileEditor";
 import { SkillFileTree } from "./SkillFileTree";
 import { SkillManifestEditor } from "./SkillManifestEditor";
-import { stripFrontmatter } from "./stripFrontmatter";
+import { isSkillExistsError, skillErrorDescription } from "./skillErrors";
 import { useSkillContents, useSkillFile } from "./useSkillContents";
 import {
   useDeleteSkill,
@@ -103,7 +105,7 @@ export function SkillDetailPanel({
       setIsEditing(true);
     } catch (error) {
       toast.error("Failed to add file", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -121,7 +123,7 @@ export function SkillDetailPanel({
       setRenameFrom(null);
     } catch (error) {
       toast.error("Failed to rename file", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -140,7 +142,7 @@ export function SkillDetailPanel({
       setDeleteFileTarget(null);
     } catch (error) {
       toast.error("Failed to delete file", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -157,7 +159,7 @@ export function SkillDetailPanel({
       });
     } catch (error) {
       toast.error("Failed to publish skill", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -173,13 +175,12 @@ export function SkillDetailPanel({
         description: "Now editable under Your skills",
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "";
-      if (!overwrite && message.includes("already exists")) {
+      if (!overwrite && isSkillExistsError(error)) {
         setConfirmImportOverwrite(true);
         return;
       }
       toast.error("Failed to import skill", {
-        description: message || undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -191,7 +192,7 @@ export function SkillDetailPanel({
       onClose();
     } catch (error) {
       toast.error("Failed to delete skill", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -514,35 +515,13 @@ export function SkillDetailPanel({
         </AlertDialog.Content>
       </AlertDialog.Root>
 
-      <AlertDialog.Root
+      <ReplaceSkillDialog
         open={confirmImportOverwrite}
         onOpenChange={setConfirmImportOverwrite}
-      >
-        <AlertDialog.Content maxWidth="420px" size="2">
-          <AlertDialog.Title size="3">Replace local skill</AlertDialog.Title>
-          <AlertDialog.Description size="1">
-            A skill named "{skill.name}" already exists in your skills.
-            Importing will replace your local version, including any edits.
-          </AlertDialog.Description>
-          <Flex justify="end" gap="2" mt="4">
-            <AlertDialog.Cancel>
-              <Button size="1" variant="soft" color="gray">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-            <AlertDialog.Action>
-              <Button
-                size="1"
-                variant="solid"
-                color="red"
-                onClick={() => void handleImport(true)}
-              >
-                Replace
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+        skillName={skill.name}
+        verb="Importing"
+        onConfirm={() => void handleImport(true)}
+      />
 
       <AlertDialog.Root open={publishOpen} onOpenChange={setPublishOpen}>
         <AlertDialog.Content maxWidth="420px" size="2">

--- a/packages/ui/src/features/skills/SkillFileEditor.tsx
+++ b/packages/ui/src/features/skills/SkillFileEditor.tsx
@@ -3,6 +3,7 @@ import { toast } from "@posthog/ui/primitives/toast";
 import { Box, Button, Flex } from "@radix-ui/themes";
 import { useRef, useState } from "react";
 import { SkillCodeEditor } from "./SkillCodeEditor";
+import { skillErrorDescription } from "./skillErrors";
 import { useSaveSkillFile } from "./useSkillMutations";
 
 interface SkillFileEditorProps {
@@ -36,7 +37,7 @@ export function SkillFileEditor({
       onSaved();
     } catch (error) {
       toast.error("Failed to save file", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };

--- a/packages/ui/src/features/skills/SkillListCard.tsx
+++ b/packages/ui/src/features/skills/SkillListCard.tsx
@@ -1,0 +1,56 @@
+import { Box, Flex, Text } from "@radix-ui/themes";
+import type { ReactNode, Ref } from "react";
+
+interface SkillListCardProps {
+  /** Forwarded to the row element (e.g. for scroll-into-view). */
+  cardRef?: Ref<HTMLDivElement>;
+  icon: ReactNode;
+  title: string;
+  subtitle?: string;
+  isSelected: boolean;
+  onClick: () => void;
+  /** Badges or counts rendered after the text block. */
+  trailing?: ReactNode;
+}
+
+/** Shared card row for every skills list (local, team, marketplace). */
+export function SkillListCard({
+  cardRef,
+  icon,
+  title,
+  subtitle,
+  isSelected,
+  onClick,
+  trailing,
+}: SkillListCardProps) {
+  return (
+    <Flex
+      ref={cardRef}
+      align="center"
+      gap="2"
+      px="3"
+      py="2"
+      className={`cursor-pointer rounded-lg border transition-colors ${
+        isSelected
+          ? "border-accent-8 bg-accent-3"
+          : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
+      }`}
+      onClick={onClick}
+    >
+      <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
+        {icon}
+      </Box>
+
+      <Flex direction="column" gap="0" className="min-w-0 flex-1">
+        <Text className="truncate font-medium text-[13px] text-gray-12">
+          {title}
+        </Text>
+        {subtitle && (
+          <Text className="truncate text-[12px] text-gray-10">{subtitle}</Text>
+        )}
+      </Flex>
+
+      {trailing}
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/skills/SkillManifestEditor.tsx
+++ b/packages/ui/src/features/skills/SkillManifestEditor.tsx
@@ -3,6 +3,7 @@ import { toast } from "@posthog/ui/primitives/toast";
 import { Box, Button, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
 import { useRef, useState } from "react";
 import { SkillCodeEditor } from "./SkillCodeEditor";
+import { skillErrorDescription } from "./skillErrors";
 import { useSaveSkillManifest } from "./useSkillMutations";
 
 interface SkillManifestEditorProps {
@@ -40,7 +41,7 @@ export function SkillManifestEditor({
       onSaved();
     } catch (error) {
       toast.error("Failed to save skill", {
-        description: error instanceof Error ? error.message : undefined,
+        description: skillErrorDescription(error),
       });
     }
   };

--- a/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
+++ b/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
@@ -1,10 +1,10 @@
 import { DownloadSimple, UsersThree, X } from "@phosphor-icons/react";
 import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
+import { stripFrontmatter } from "@posthog/shared";
 import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { toast } from "@posthog/ui/primitives/toast";
 import {
-  AlertDialog,
   Badge,
   Box,
   Button,
@@ -14,8 +14,9 @@ import {
   Tooltip,
 } from "@radix-ui/themes";
 import { useState } from "react";
+import { ReplaceSkillDialog } from "./ReplaceSkillDialog";
 import { SkillFileTree } from "./SkillFileTree";
-import { stripFrontmatter } from "./stripFrontmatter";
+import { isSkillExistsError, skillErrorDescription } from "./skillErrors";
 import { useInstallTeamSkill } from "./useTeamSkillMutations";
 import { useTeamSkillDetail, useTeamSkillFile } from "./useTeamSkills";
 
@@ -47,13 +48,12 @@ export function TeamSkillDetailPanel({
         description: "Now available under Your skills",
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "";
-      if (!overwrite && message.includes("already exists")) {
+      if (!overwrite && isSkillExistsError(error)) {
         setConfirmOverwrite(true);
         return;
       }
       toast.error("Failed to install skill", {
-        description: message || undefined,
+        description: skillErrorDescription(error),
       });
     }
   };
@@ -174,35 +174,13 @@ export function TeamSkillDetailPanel({
         )}
       </Box>
 
-      <AlertDialog.Root
+      <ReplaceSkillDialog
         open={confirmOverwrite}
         onOpenChange={setConfirmOverwrite}
-      >
-        <AlertDialog.Content maxWidth="420px" size="2">
-          <AlertDialog.Title size="3">Replace local skill</AlertDialog.Title>
-          <AlertDialog.Description size="1">
-            A skill named "{skill.name}" already exists in your skills.
-            Reinstalling will replace your local version, including any edits.
-          </AlertDialog.Description>
-          <Flex justify="end" gap="2" mt="4">
-            <AlertDialog.Cancel>
-              <Button size="1" variant="soft" color="gray">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-            <AlertDialog.Action>
-              <Button
-                size="1"
-                variant="solid"
-                color="red"
-                onClick={() => void handleInstall(true)}
-              >
-                Replace
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+        skillName={skill.name}
+        verb="Reinstalling"
+        onConfirm={() => void handleInstall(true)}
+      />
     </>
   );
 }

--- a/packages/ui/src/features/skills/TeamSkillsSection.tsx
+++ b/packages/ui/src/features/skills/TeamSkillsSection.tsx
@@ -1,6 +1,7 @@
 import { UsersThree } from "@phosphor-icons/react";
 import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
-import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+import { Badge, Flex } from "@radix-ui/themes";
+import { SkillListCard } from "./SkillListCard";
 
 interface TeamSkillsSectionProps {
   skills: TeamSkillInfo[];
@@ -17,41 +18,33 @@ export function TeamSkillsSection({
   return (
     <Flex direction="column" gap="1">
       {skills.map((skill) => (
-        <Flex
+        <SkillListCard
           key={skill.id}
-          align="center"
-          gap="2"
-          px="3"
-          py="2"
-          className={`cursor-pointer rounded-lg border transition-colors ${
-            selectedName === skill.name
-              ? "border-accent-8 bg-accent-3"
-              : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
-          }`}
-          onClick={() => onSelect(skill)}
-        >
-          <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
+          icon={
             <UsersThree size={14} weight="duotone" className="text-gray-11" />
-          </Box>
-          <Flex direction="column" gap="0" className="min-w-0 flex-1">
-            <Text className="truncate font-medium text-[13px] text-gray-12">
-              {skill.name}
-            </Text>
-            {skill.description && (
-              <Text className="truncate text-[12px] text-gray-10">
-                {skill.description}
-              </Text>
-            )}
-          </Flex>
-          {skill.installedLocally && (
-            <Badge size="1" variant="soft" color="green" className="shrink-0">
-              Installed
-            </Badge>
-          )}
-          <Badge size="1" variant="soft" color="gray" className="shrink-0">
-            v{skill.version}
-          </Badge>
-        </Flex>
+          }
+          title={skill.name}
+          subtitle={skill.description || undefined}
+          isSelected={selectedName === skill.name}
+          onClick={() => onSelect(skill)}
+          trailing={
+            <>
+              {skill.installedLocally && (
+                <Badge
+                  size="1"
+                  variant="soft"
+                  color="green"
+                  className="shrink-0"
+                >
+                  Installed
+                </Badge>
+              )}
+              <Badge size="1" variant="soft" color="gray" className="shrink-0">
+                v{skill.version}
+              </Badge>
+            </>
+          }
+        />
       ))}
     </Flex>
   );

--- a/packages/ui/src/features/skills/skillErrors.ts
+++ b/packages/ui/src/features/skills/skillErrors.ts
@@ -1,0 +1,15 @@
+import { getErrorMessage } from "@posthog/shared";
+
+/**
+ * The skills write endpoints throw plain Errors whose messages cross the
+ * tRPC IPC boundary as strings, so conflict detection is centralized
+ * message matching rather than instanceof checks.
+ */
+export function isSkillExistsError(error: unknown): boolean {
+  return getErrorMessage(error).includes("already exists");
+}
+
+/** Toast-friendly error description: the message, or nothing. */
+export function skillErrorDescription(error: unknown): string | undefined {
+  return getErrorMessage(error) || undefined;
+}

--- a/packages/ui/src/features/skills/skillErrors.ts
+++ b/packages/ui/src/features/skills/skillErrors.ts
@@ -1,12 +1,8 @@
-import { getErrorMessage } from "@posthog/shared";
+import { getErrorMessage, SKILL_EXISTS_MARKER } from "@posthog/shared";
 
-/**
- * The skills write endpoints throw plain Errors whose messages cross the
- * tRPC IPC boundary as strings, so conflict detection is centralized
- * message matching rather than instanceof checks.
- */
+/** Write endpoints throw plain Errors; conflicts match the shared marker. */
 export function isSkillExistsError(error: unknown): boolean {
-  return getErrorMessage(error).includes("already exists");
+  return getErrorMessage(error).includes(SKILL_EXISTS_MARKER);
 }
 
 /** Toast-friendly error description: the message, or nothing. */

--- a/packages/ui/src/features/skills/stripFrontmatter.ts
+++ b/packages/ui/src/features/skills/stripFrontmatter.ts
@@ -1,5 +1,0 @@
-/** Strips a leading YAML frontmatter block from a SKILL.md body. */
-export function stripFrontmatter(content: string): string {
-  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n/);
-  return match ? content.slice(match[0].length).trimStart() : content;
-}

--- a/packages/ui/src/features/skills/useMarketplace.ts
+++ b/packages/ui/src/features/skills/useMarketplace.ts
@@ -1,6 +1,11 @@
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+/** Compact install-count formatting shared by the marketplace surfaces. */
+export const installsFormatter = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+});
+
 export interface MarketplaceSkillSummary {
   id: string;
   skillId: string;

--- a/packages/ui/src/features/skills/useTeamSkillMutations.ts
+++ b/packages/ui/src/features/skills/useTeamSkillMutations.ts
@@ -4,6 +4,7 @@ import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
 import { useQueryClient } from "@tanstack/react-query";
+import { teamSkillsKeys } from "./useTeamSkills";
 
 /** Publishes a local user/repo skill to the team as a new LLMSkill version. */
 export function usePublishSkill() {
@@ -14,7 +15,7 @@ export function usePublishSkill() {
       service.publishLocalSkill(client, variables.skillPath),
     {
       onSuccess: () => {
-        void queryClient.invalidateQueries({ queryKey: ["team-skills"] });
+        void queryClient.invalidateQueries({ queryKey: teamSkillsKeys.all });
       },
     },
   );
@@ -35,7 +36,7 @@ export function useInstallTeamSkill() {
     {
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.skills.pathFilter());
-        void queryClient.invalidateQueries({ queryKey: ["team-skills"] });
+        void queryClient.invalidateQueries({ queryKey: teamSkillsKeys.all });
       },
     },
   );

--- a/packages/ui/src/features/skills/useTeamSkills.ts
+++ b/packages/ui/src/features/skills/useTeamSkills.ts
@@ -1,28 +1,42 @@
 import { TEAM_SKILLS_SERVICE } from "@posthog/core/skills/identifiers";
-import type { TeamSkillsService } from "@posthog/core/skills/teamSkillsService";
+import {
+  markInstalledTeamSkills,
+  type TeamSkillsService,
+} from "@posthog/core/skills/teamSkillsService";
 import { useService } from "@posthog/di/react";
 import type { SkillInfo } from "@posthog/shared";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useMemo } from "react";
 
 export const teamSkillsKeys = {
-  list: (localNames: string[]) => ["team-skills", "list", localNames] as const,
-  detail: (name: string) => ["team-skills", "detail", name] as const,
+  all: ["team-skills"] as const,
+  list: () => [...teamSkillsKeys.all, "list"] as const,
+  detail: (name: string) => [...teamSkillsKeys.all, "detail", name] as const,
   file: (name: string, path: string) =>
-    ["team-skills", "file", name, path] as const,
+    [...teamSkillsKeys.all, "file", name, path] as const,
 };
 
 export function useTeamSkills(localSkills: SkillInfo[]) {
   const service = useService<TeamSkillsService>(TEAM_SKILLS_SERVICE);
-  const localNames = useMemo(
-    () => [...new Set(localSkills.map((s) => s.name))].sort(),
-    [localSkills],
-  );
-  return useAuthenticatedQuery(
-    teamSkillsKeys.list(localNames),
-    (client) => service.listTeamSkills(client, localNames),
+  const query = useAuthenticatedQuery(
+    teamSkillsKeys.list(),
+    (client) => service.listTeamSkills(client),
     { staleTime: 60_000, retry: false },
   );
+
+  // Marking is pure and local-only, so local skill changes never refetch
+  // the team listing.
+  const localNames = useMemo(
+    () => [...new Set(localSkills.map((s) => s.name))],
+    [localSkills],
+  );
+  const data = useMemo(
+    () =>
+      query.data ? markInstalledTeamSkills(query.data, localNames) : undefined,
+    [query.data, localNames],
+  );
+
+  return { ...query, data };
 }
 
 export function useTeamSkillDetail(name: string | null) {

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
@@ -79,37 +79,41 @@ export async function mirrorUserSkillsToCodex(
   const userNames = await findSkillDirs(userSkillsDir);
   await fs.promises.mkdir(codexDir, { recursive: true });
 
-  const nextMirrored: string[] = [];
-  for (const name of userNames) {
-    const target = path.join(codexDir, name);
-    if (fs.existsSync(target) && !previouslyMirrored.has(name)) {
-      continue;
-    }
-    await fs.promises.rm(target, { recursive: true, force: true });
-    try {
-      // dereference: mirrored skills must be self-contained.
-      await fs.promises.cp(path.join(userSkillsDir, name), target, {
-        recursive: true,
-        dereference: true,
-      });
-      nextMirrored.push(name);
-    } catch {
-      // Skip unreadable skills (e.g. broken symlinks); drop the partial copy.
+  const copied = await Promise.all(
+    userNames.map(async (name) => {
+      const target = path.join(codexDir, name);
+      if (fs.existsSync(target) && !previouslyMirrored.has(name)) {
+        return null;
+      }
       await fs.promises.rm(target, { recursive: true, force: true });
-    }
-  }
+      try {
+        // dereference: mirrored skills must be self-contained.
+        await fs.promises.cp(path.join(userSkillsDir, name), target, {
+          recursive: true,
+          dereference: true,
+        });
+        return name;
+      } catch {
+        // Skip unreadable skills (e.g. broken symlinks); drop the partial copy.
+        await fs.promises.rm(target, { recursive: true, force: true });
+        return null;
+      }
+    }),
+  );
 
-  for (const name of previouslyMirrored) {
-    if (!userNames.includes(name)) {
-      await fs.promises.rm(path.join(codexDir, name), {
-        recursive: true,
-        force: true,
-      });
-    }
-  }
+  await Promise.all(
+    [...previouslyMirrored]
+      .filter((name) => !userNames.includes(name))
+      .map((name) =>
+        fs.promises.rm(path.join(codexDir, name), {
+          recursive: true,
+          force: true,
+        }),
+      ),
+  );
 
   await writeCodexMirrorState(codexDir, {
     version: 1,
-    mirrored: nextMirrored,
+    mirrored: copied.filter((name): name is string => name !== null),
   });
 }

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { cp, mkdir, rm, writeFile } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   ROOT_LOGGER,
@@ -22,6 +22,7 @@ import {
 } from "@posthog/platform/storage-paths";
 import { TypedEventEmitter } from "@posthog/shared";
 import { inject, injectable, postConstruct, preDestroy } from "inversify";
+import { getUserSkillsDir } from "../skills/skill-discovery";
 import { getCodexSkillsDir, mirrorUserSkillsToCodex } from "./codex-mirror";
 import {
   overlayDownloadedSkills,
@@ -33,7 +34,7 @@ const SKILLS_ZIP_URL = process.env.SKILLS_ZIP_URL ?? "";
 const CONTEXT_MILL_ZIP_URL = process.env.CONTEXT_MILL_ZIP_URL ?? "";
 const UPDATE_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const CODEX_SKILLS_DIR = getCodexSkillsDir();
-const USER_SKILLS_DIR = join(homedir(), ".claude", "skills");
+const USER_SKILLS_DIR = getUserSkillsDir();
 
 interface PosthogPluginEvents {
   skillsUpdated: true;
@@ -113,13 +114,6 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
   }
 
   /**
-   * Returns the path to the plugin directory that should be used for agent sessions.
-   *
-   * - In dev mode: Vite already merged shipped + remote + local-dev skills, so use bundled path.
-   * - In prod: use the runtime plugin dir (with downloaded updates).
-   * - Fallback: bundled plugin path.
-   */
-  /**
    * Mirrors the user's skills out to Codex ("bring your skills, use them
    * anywhere"). Never fatal: a broken mirror must not affect the official
    * skills pipeline or the mutation that triggered it.
@@ -132,6 +126,13 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
     }
   }
 
+  /**
+   * Returns the path to the plugin directory that should be used for agent sessions.
+   *
+   * - In dev mode: Vite already merged shipped + remote + local-dev skills, so use bundled path.
+   * - In prod: use the runtime plugin dir (with downloaded updates).
+   * - Fallback: bundled plugin path.
+   */
   getPluginPath(): string {
     if (!this.appMeta.isProduction) {
       return this.bundledPluginDir;

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { SKILL_EXISTS_MARKER } from "@posthog/shared";
 import type { Unzipped } from "fflate";
 import { inject, injectable } from "inversify";
 import { unzipAsync } from "../posthog-plugin/extract-zip";
@@ -178,7 +179,7 @@ export class SkillsMarketplaceService {
     const target = path.join(getUserSkillsDir(), ref.skillId);
     if (fs.existsSync(target) && !overwrite) {
       throw new Error(
-        `A skill named "${ref.skillId}" already exists. Reinstalling will replace your local version.`,
+        `A skill named "${ref.skillId}" ${SKILL_EXISTS_MARKER}. Reinstalling will replace your local version.`,
       );
     }
 

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import type { Unzipped } from "fflate";
 import { inject, injectable } from "inversify";
 import { unzipAsync } from "../posthog-plugin/extract-zip";
 import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
 import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
+import { getUserSkillsDir, isProbablyText } from "../skills/skill-discovery";
 import { validateSkillDirName } from "../skills/skills";
 import {
   type MarketplacePreviewFile,
@@ -35,12 +35,8 @@ interface CachedArchive {
   entries: Unzipped;
 }
 
-function userSkillsDir(): string {
-  return path.join(os.homedir(), ".claude", "skills");
-}
-
 function installedStatePath(): string {
-  return path.join(userSkillsDir(), "installed.json");
+  return path.join(getUserSkillsDir(), "installed.json");
 }
 
 /**
@@ -61,7 +57,7 @@ export async function readInstalledState(): Promise<InstalledSkillsFile> {
 }
 
 async function writeInstalledState(state: InstalledSkillsFile): Promise<void> {
-  await fs.promises.mkdir(userSkillsDir(), { recursive: true });
+  await fs.promises.mkdir(getUserSkillsDir(), { recursive: true });
   await fs.promises.writeFile(
     installedStatePath(),
     `${JSON.stringify(state, null, 2)}\n`,
@@ -84,11 +80,6 @@ export function findSkillDirPrefix(
   const match = matches[0];
   if (!match) return null;
   return match.slice(0, match.length - "SKILL.md".length);
-}
-
-function isProbablyText(bytes: Uint8Array): boolean {
-  const sample = bytes.subarray(0, 4096);
-  return !sample.includes(0);
 }
 
 /** Rejects zip entries that would escape the install directory (zip-slip). */
@@ -184,7 +175,7 @@ export class SkillsMarketplaceService {
     overwrite = false,
   ): Promise<{ path: string }> {
     validateSkillDirName(ref.skillId);
-    const target = path.join(userSkillsDir(), ref.skillId);
+    const target = path.join(getUserSkillsDir(), ref.skillId);
     if (fs.existsSync(target) && !overwrite) {
       throw new Error(
         `A skill named "${ref.skillId}" already exists. Reinstalling will replace your local version.`,

--- a/packages/workspace-server/src/services/skills/skill-discovery.ts
+++ b/packages/workspace-server/src/services/skills/skill-discovery.ts
@@ -20,6 +20,16 @@ export function isEditableSource(source: SkillSource): boolean {
   return source === "user" || source === "repo";
 }
 
+/** The user-level skills root (`~/.claude/skills`), owned by us. */
+export function getUserSkillsDir(): string {
+  return path.join(os.homedir(), ".claude", "skills");
+}
+
+/** Heuristic: content with NUL bytes in the first 4 KiB is binary. */
+export function isProbablyText(bytes: Uint8Array): boolean {
+  return !bytes.subarray(0, 4096).includes(0);
+}
+
 export async function findSkillDirs(
   sourceSkillsDir: string,
 ): Promise<string[]> {

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -9,11 +9,17 @@ import { WatcherService } from "../watcher/service";
 import { SkillsService } from "./skills";
 
 const codexHome = vi.hoisted(() => ({ dir: "" }));
+const userSkillsHome = vi.hoisted(() => ({ dir: "" }));
 
 vi.mock("../posthog-plugin/codex-mirror", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../posthog-plugin/codex-mirror")>();
   return { ...actual, getCodexSkillsDir: () => codexHome.dir };
+});
+
+vi.mock("./skill-discovery", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./skill-discovery")>();
+  return { ...actual, getUserSkillsDir: () => userSkillsHome.dir };
 });
 
 let root: string;
@@ -49,6 +55,7 @@ beforeEach(async () => {
   folderPath = path.join(root, "repo");
   repoSkillsDir = path.join(folderPath, ".claude", "skills");
   codexHome.dir = path.join(root, "codex-skills");
+  userSkillsHome.dir = path.join(root, "user-skills");
   await mkdir(path.join(pluginPath, "skills"), { recursive: true });
   await mkdir(repoSkillsDir, { recursive: true });
 });
@@ -218,33 +225,22 @@ describe("codex skills", () => {
     await createSkill(codexHome.dir, "codex-only");
     const service = makeService();
 
-    // The user skills root is the real homedir; intercept the copy by
-    // asserting on the returned path and cleaning up.
-    const { homedir } = await import("node:os");
-    const target = path.join(homedir(), ".claude", "skills", "codex-only");
-    const targetExisted = (await import("node:fs")).existsSync(target);
-    if (targetExisted) {
-      // Avoid clobbering a real local skill with this name.
-      return;
-    }
-    try {
-      const result = await service.importCodexSkill(
-        path.join(codexHome.dir, "codex-only"),
-      );
-      expect(result.path).toBe(target);
-      const content = await service.readSkillFile(target, "SKILL.md");
-      expect(content).toContain("codex-only");
+    const target = path.join(userSkillsHome.dir, "codex-only");
+    const result = await service.importCodexSkill(
+      path.join(codexHome.dir, "codex-only"),
+    );
 
-      const state = JSON.parse(
-        await (await import("node:fs/promises")).readFile(
-          path.join(codexHome.dir, ".posthog-mirror.json"),
-          "utf-8",
-        ),
-      );
-      expect(state.mirrored).toContain("codex-only");
-    } finally {
-      await rm(target, { recursive: true, force: true });
-    }
+    expect(result.path).toBe(target);
+    const content = await service.readSkillFile(target, "SKILL.md");
+    expect(content).toContain("codex-only");
+
+    const state = JSON.parse(
+      await (await import("node:fs/promises")).readFile(
+        path.join(codexHome.dir, ".posthog-mirror.json"),
+        "utf-8",
+      ),
+    );
+    expect(state.mirrored).toContain("codex-only");
   });
 
   it("rejects importing paths outside the codex skills dir", async () => {
@@ -301,29 +297,23 @@ describe("installTeamSkill", () => {
   };
 
   it("requires overwrite for an existing skill, then replaces it", async () => {
-    // installTeamSkill writes to the real user skills root, so use a name
-    // that's vanishingly unlikely to exist and clean it up.
-    const { homedir } = await import("node:os");
-    const name = "posthog-code-test-skill-f4e84f1a";
-    const target = path.join(homedir(), ".claude", "skills", name);
+    const name = "team-skill";
+    const target = path.join(userSkillsHome.dir, name);
     const service = makeService();
-    try {
-      const first = await service.installTeamSkill({ ...input, name });
-      expect(first.path).toBe(target);
 
-      await expect(
-        service.installTeamSkill({ ...input, name }),
-      ).rejects.toThrow("already exists");
+    const first = await service.installTeamSkill({ ...input, name });
+    expect(first.path).toBe(target);
 
-      await service.installTeamSkill({ ...input, name, overwrite: true });
-      const manifest = await service.readSkillFile(target, "SKILL.md");
-      expect(manifest).toContain("From the team");
-      expect(manifest).toContain("# Team body");
-      const guide = await service.readSkillFile(target, "references/guide.md");
-      expect(guide).toBe("guide");
-    } finally {
-      await rm(target, { recursive: true, force: true });
-    }
+    await expect(service.installTeamSkill({ ...input, name })).rejects.toThrow(
+      "already exists",
+    );
+
+    await service.installTeamSkill({ ...input, name, overwrite: true });
+    const manifest = await service.readSkillFile(target, "SKILL.md");
+    expect(manifest).toContain("From the team");
+    expect(manifest).toContain("# Team body");
+    const guide = await service.readSkillFile(target, "references/guide.md");
+    expect(guide).toBe("guide");
   });
 
   it("rejects invalid names and unsafe file paths", async () => {
@@ -333,45 +323,35 @@ describe("installTeamSkill", () => {
       service.installTeamSkill({ ...input, name: "../escape" }),
     ).rejects.toThrow("Skill names must be");
 
-    const name = "posthog-code-test-skill-f4e84f1a";
-    const { homedir } = await import("node:os");
-    const target = path.join(homedir(), ".claude", "skills", name);
-    try {
-      await expect(
-        service.installTeamSkill({
-          ...input,
-          name,
-          files: [{ path: "../evil.md", content: "bad" }],
-        }),
-      ).rejects.toThrow("path outside skill directory");
-      expect(existsSync(target)).toBe(false);
-    } finally {
-      await rm(target, { recursive: true, force: true });
-    }
+    const name = "team-skill";
+    const target = path.join(userSkillsHome.dir, name);
+    await expect(
+      service.installTeamSkill({
+        ...input,
+        name,
+        files: [{ path: "../evil.md", content: "bad" }],
+      }),
+    ).rejects.toThrow("path outside skill directory");
+    expect(existsSync(target)).toBe(false);
   });
 
   it("keeps the existing skill when an overwrite payload is invalid", async () => {
-    const name = "posthog-code-test-skill-f4e84f1a";
-    const { homedir } = await import("node:os");
-    const target = path.join(homedir(), ".claude", "skills", name);
+    const name = "team-skill";
+    const target = path.join(userSkillsHome.dir, name);
     const service = makeService();
-    try {
-      await service.installTeamSkill({ ...input, name });
+    await service.installTeamSkill({ ...input, name });
 
-      await expect(
-        service.installTeamSkill({
-          ...input,
-          name,
-          overwrite: true,
-          files: [{ path: "../evil.md", content: "bad" }],
-        }),
-      ).rejects.toThrow("path outside skill directory");
+    await expect(
+      service.installTeamSkill({
+        ...input,
+        name,
+        overwrite: true,
+        files: [{ path: "../evil.md", content: "bad" }],
+      }),
+    ).rejects.toThrow("path outside skill directory");
 
-      const manifest = await service.readSkillFile(target, "SKILL.md");
-      expect(manifest).toContain("# Team body");
-    } finally {
-      await rm(target, { recursive: true, force: true });
-    }
+    const manifest = await service.readSkillFile(target, "SKILL.md");
+    expect(manifest).toContain("# Team body");
   });
 });
 

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { stripFrontmatter } from "@posthog/shared";
+import { SKILL_EXISTS_MARKER, stripFrontmatter } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import { WATCHER_SERVICE } from "../../di/tokens";
 import type { FoldersService } from "../folders/folders";
@@ -116,7 +116,7 @@ export class SkillsService {
     );
     const skillPath = path.join(root, name);
     if (fs.existsSync(skillPath)) {
-      throw new Error(`A skill named "${name}" already exists`);
+      throw new Error(`A skill named "${name}" ${SKILL_EXISTS_MARKER}`);
     }
 
     await fs.promises.mkdir(skillPath, { recursive: true });
@@ -220,7 +220,7 @@ export class SkillsService {
     const target = path.join(getUserSkillsDir(), name);
     if (fs.existsSync(target) && !overwrite) {
       throw new Error(
-        `A skill named "${name}" already exists. Importing will replace your local version.`,
+        `A skill named "${name}" ${SKILL_EXISTS_MARKER}. Importing will replace your local version.`,
       );
     }
     if (fs.existsSync(target)) {
@@ -295,7 +295,7 @@ export class SkillsService {
     const target = path.join(userRoot, name);
     if (fs.existsSync(target) && !input.overwrite) {
       throw new Error(
-        `A skill named "${name}" already exists. Installing will replace your local version.`,
+        `A skill named "${name}" ${SKILL_EXISTS_MARKER}. Installing will replace your local version.`,
       );
     }
 
@@ -349,14 +349,8 @@ export class SkillsService {
    * `touch` from a terminal, ...).
    */
   async *watchSkills(signal?: AbortSignal): AsyncGenerator<{ changed: true }> {
-<<<<<<< HEAD
-    const userRoot = path.join(os.homedir(), ".claude", "skills");
-    // The user root is ours to create; missing repo roots are polled for.
-=======
     const userRoot = getUserSkillsDir();
-    // The user root is ours to create; repo roots are watched as soon as
-    // they appear (watchSkillDirs polls for dirs that don't exist yet).
->>>>>>> c61f657d5 (refactor(skills): apply simplify-pass cleanups across the stack)
+    // The user root is ours to create; missing repo roots are polled for.
     await fs.promises.mkdir(userRoot, { recursive: true }).catch(() => {});
     const folders = await this.folders.getFolders();
     const dirs = [

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import { stripFrontmatter } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import { WATCHER_SERVICE } from "../../di/tokens";
 import type { FoldersService } from "../folders/folders";
@@ -24,6 +24,8 @@ import type {
 } from "./schemas";
 import {
   getMarketplaceInstallPaths,
+  getUserSkillsDir,
+  isProbablyText,
   listSkillFiles,
   readSkillMetadataFromDir,
 } from "./skill-discovery";
@@ -215,7 +217,7 @@ export class SkillsService {
     const name = path.basename(resolved);
     validateSkillDirName(name);
 
-    const target = path.join(os.homedir(), ".claude", "skills", name);
+    const target = path.join(getUserSkillsDir(), name);
     if (fs.existsSync(target) && !overwrite) {
       throw new Error(
         `A skill named "${name}" already exists. Importing will replace your local version.`,
@@ -248,28 +250,35 @@ export class SkillsService {
     const frontmatter = parseSkillFrontmatter(manifest);
     const name = frontmatter?.name ?? path.basename(skillDir);
     const description = frontmatter?.description ?? "";
-    const body = stripFrontmatterBlock(manifest);
+    const body = stripFrontmatter(manifest);
 
-    const entries = await listSkillFiles(skillDir, MAX_SKILL_FILES);
-    const files: { path: string; content: string }[] = [];
-    const skipped: string[] = [];
-    for (const entry of entries) {
-      if (entry.path === "SKILL.md") continue;
-      if (entry.size > MAX_SKILL_FILE_BYTES) {
-        skipped.push(entry.path);
-        continue;
-      }
-      const bytes = await fs.promises.readFile(
-        path.join(skillDir, ...entry.path.split("/")),
-      );
-      if (bytes.subarray(0, 4096).includes(0)) {
-        skipped.push(entry.path);
-        continue;
-      }
-      files.push({ path: entry.path, content: bytes.toString("utf-8") });
-    }
+    const entries = (await listSkillFiles(skillDir, MAX_SKILL_FILES)).filter(
+      (entry) => entry.path !== "SKILL.md",
+    );
+    const results = await Promise.all(
+      entries.map(async (entry) => {
+        if (entry.size > MAX_SKILL_FILE_BYTES) {
+          return { path: entry.path, content: null };
+        }
+        const bytes = await fs.promises.readFile(
+          path.join(skillDir, ...entry.path.split("/")),
+        );
+        return {
+          path: entry.path,
+          content: isProbablyText(bytes) ? bytes.toString("utf-8") : null,
+        };
+      }),
+    );
 
-    return { name, description, body, files, skipped };
+    return {
+      name,
+      description,
+      body,
+      files: results.filter(
+        (r): r is { path: string; content: string } => r.content !== null,
+      ),
+      skipped: results.filter((r) => r.content === null).map((r) => r.path),
+    };
   }
 
   /**
@@ -282,7 +291,7 @@ export class SkillsService {
   ): Promise<{ path: string }> {
     const name = input.name.trim();
     validateSkillDirName(name);
-    const userRoot = path.join(os.homedir(), ".claude", "skills");
+    const userRoot = getUserSkillsDir();
     const target = path.join(userRoot, name);
     if (fs.existsSync(target) && !input.overwrite) {
       throw new Error(
@@ -305,11 +314,13 @@ export class SkillsService {
         ),
         "utf-8",
       );
-      for (const file of input.files) {
-        const filePath = resolveSkillFilePath(staging, file.path);
-        await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-        await fs.promises.writeFile(filePath, file.content, "utf-8");
-      }
+      await Promise.all(
+        input.files.map(async (file) => {
+          const filePath = resolveSkillFilePath(staging, file.path);
+          await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+          await fs.promises.writeFile(filePath, file.content, "utf-8");
+        }),
+      );
 
       const hadExisting = fs.existsSync(target);
       if (hadExisting) {
@@ -338,8 +349,14 @@ export class SkillsService {
    * `touch` from a terminal, ...).
    */
   async *watchSkills(signal?: AbortSignal): AsyncGenerator<{ changed: true }> {
+<<<<<<< HEAD
     const userRoot = path.join(os.homedir(), ".claude", "skills");
     // The user root is ours to create; missing repo roots are polled for.
+=======
+    const userRoot = getUserSkillsDir();
+    // The user root is ours to create; repo roots are watched as soon as
+    // they appear (watchSkillDirs polls for dirs that don't exist yet).
+>>>>>>> c61f657d5 (refactor(skills): apply simplify-pass cleanups across the stack)
     await fs.promises.mkdir(userRoot, { recursive: true }).catch(() => {});
     const folders = await this.folders.getFolders();
     const dirs = [
@@ -409,10 +426,7 @@ export class SkillsService {
 
     return [
       { dir: path.join(pluginPath, "skills"), source: "bundled" as const },
-      {
-        dir: path.join(os.homedir(), ".claude", "skills"),
-        source: "user" as const,
-      },
+      { dir: getUserSkillsDir(), source: "user" as const },
       ...folders.map((f) => ({
         dir: path.join(f.path, ".claude", "skills"),
         source: "repo" as const,
@@ -453,7 +467,7 @@ export class SkillsService {
   private async getWritableRoots(): Promise<string[]> {
     const folders = await this.folders.getFolders();
     return [
-      path.join(os.homedir(), ".claude", "skills"),
+      getUserSkillsDir(),
       ...folders.map((f) => path.join(f.path, ".claude", "skills")),
     ];
   }
@@ -463,7 +477,7 @@ export class SkillsService {
     repoPath: string | undefined,
   ): Promise<string> {
     if (scope === "user") {
-      return path.join(os.homedir(), ".claude", "skills");
+      return getUserSkillsDir();
     }
     const folders = await this.folders.getFolders();
     const folder = folders.find(
@@ -536,18 +550,13 @@ function dedupeCodexSkills(
   );
   return skills.filter((skill) => {
     if (skill.source !== "codex") return true;
-    const dirName = path.basename(skill.path);
+    // The mirror state stores directory names; frontmatter names only
+    // matter for the bundled copies, which keep theirs verbatim.
     return (
       !bundledNames.has(skill.name) &&
-      !mirroredNames.has(dirName) &&
-      !mirroredNames.has(skill.name)
+      !mirroredNames.has(path.basename(skill.path))
     );
   });
-}
-
-function stripFrontmatterBlock(content: string): string {
-  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
-  return match ? content.slice(match[0].length).replace(/^\n+/, "") : content;
 }
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
## Problem

Several small pieces of logic were duplicated or misplaced across the skills feature, making it harder to maintain and extend. Specifically: the "already installed locally" marking was coupled to the team skills fetch, `stripFrontmatter` existed only in the UI package, error-handling patterns were repeated inline across many components, and the card row layout was copy-pasted across three different list surfaces.

## Changes

**Decouple local-install marking from the team skills fetch**
`listTeamSkills` no longer accepts `localSkillNames` and no longer marks skills as installed. A new pure function `markInstalledTeamSkills` handles that separately. `useTeamSkills` now fetches the team listing once and applies `markInstalledTeamSkills` in a `useMemo`, so local skill changes never trigger a refetch of the remote listing. The query key structure is also cleaned up with a shared `teamSkillsKeys.all` root so invalidations are consistent.

**Move `stripFrontmatter` to `@posthog/shared`**
The UI-local `stripFrontmatter.ts` is deleted. A CRLF-aware version now lives in `packages/shared/src/skills.ts` and is exported from the package index. All consumers (`SkillDetailPanel`, `MarketplaceSkillPanel`, `TeamSkillDetailPanel`, the workspace-server export path) import from `@posthog/shared`.

**Centralise skill error helpers**
A new `skillErrors.ts` module exposes `isSkillExistsError` and `skillErrorDescription`. All the scattered `error instanceof Error ? error.message : ""` / `.includes("already exists")` patterns across `SkillDetailPanel`, `TeamSkillDetailPanel`, `MarketplaceSkillPanel`, `SkillFileEditor`, `SkillManifestEditor`, `NewSkillDialog`, and `SkillFileEditor` are replaced with calls to these helpers.

**Extract `SkillListCard` shared component**
The identical card-row markup (icon box, title/subtitle text block, trailing slot, selection highlight) was duplicated in `SkillCard`, `TeamSkillsSection`, and `MarketplaceBrowse`. It is now a single `SkillListCard` component with `icon`, `title`, `subtitle`, `isSelected`, `onClick`, and `trailing` props.

**Extract `ReplaceSkillDialog` shared component**
The confirm-overwrite `AlertDialog` was duplicated in `MarketplaceSkillPanel`, `TeamSkillDetailPanel`, and `SkillDetailPanel`. It is now a single `ReplaceSkillDialog` component parameterised by `skillName`, `verb` ("Reinstalling" / "Importing"), and `onConfirm`.

**Consolidate `getUserSkillsDir` and `isProbablyText`**
Both helpers were defined inline in multiple workspace-server files. They now live in `skill-discovery.ts` and are imported wherever needed, removing the repeated `os.homedir()` path construction.

**Parallelise file I/O in the workspace server**
Sequential `for` loops in `mirrorUserSkillsToCodex`, `exportSkill`, and `installSkill` are replaced with `Promise.all` calls.

**Move `installsFormatter` to `useMarketplace.ts`**
The `Intl.NumberFormat` instance was duplicated in `MarketplaceBrowse` and `MarketplaceSkillPanel`; it is now exported once from `useMarketplace.ts`.

**Remove unused `resolveLlmSkill` API method**
`resolveLlmSkill` and its `LlmSkillResolveResponse` type are removed from the API client as they are no longer called anywhere.

## How did you test this?

- Updated unit tests for `TeamSkillsService.listTeamSkills` to reflect the removed `localSkillNames` parameter.
- Added a new `markInstalledTeamSkills` unit test covering name-based matching and unrelated local names.
- Existing tests for `publishSkill` and other service methods continue to pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?