### PR TITLE
fix(inbox): pluralize Scout label in signal source dropdown

### DIFF
--- a/packages/ui/src/features/inbox/filterOptions.tsx
+++ b/packages/ui/src/features/inbox/filterOptions.tsx
@@ -100,7 +100,7 @@ export const INBOX_SOURCE_OPTIONS: {
     icon: <LifebuoyIcon size={14} />,
   },
   { value: "pganalyze", label: "pganalyze", icon: <PgAnalyzeIcon size={14} /> },
-  { value: "signals_scout", label: "Scout", icon: <CompassIcon size={14} /> },
+  { value: "signals_scout", label: "Scouts", icon: <CompassIcon size={14} /> },
 ];
 
 export function inboxSortOptionKey(


### PR DESCRIPTION
## Summary
- The signal source dropdown in the Inbox showed "Scout"; it should read "Scouts".
- Updated the `signals_scout` option label in `INBOX_SOURCE_OPTIONS`.

## Notes
This is a copy-only change to the dropdown label; the underlying `signals_scout` value and backend contract are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)