### PR TITLE
fix(inbox): refetch + virtualize + server-search the people pickers

### DIFF
--- a/packages/ui/src/features/inbox/components/InboxScopeSelect.tsx
+++ b/packages/ui/src/features/inbox/components/InboxScopeSelect.tsx
@@ -1,56 +1,63 @@
-import { AsteriskSimpleIcon, CaretDownIcon } from "@phosphor-icons/react";
+import {
+  AsteriskSimpleIcon,
+  CaretDownIcon,
+  CheckIcon,
+} from "@phosphor-icons/react";
 import {
   INBOX_SCOPE_ENTIRE_PROJECT,
   INBOX_SCOPE_FOR_YOU,
-  type InboxScope,
-  isTeammateInboxScope,
   parseTeammateInboxScope,
   teammateInboxScope,
 } from "@posthog/core/inbox/reportMembership";
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-} from "@posthog/quill";
+import { PeoplePickerList } from "@posthog/ui/features/inbox/components/PeoplePickerList";
 import { ReviewerAvatar } from "@posthog/ui/features/inbox/components/ReviewerAvatar";
-import { getSuggestedReviewerDisplayName } from "@posthog/ui/features/inbox/filterOptions";
+import {
+  getSuggestedReviewerDisplayName,
+  type SuggestedReviewerFilterOption,
+} from "@posthog/ui/features/inbox/filterOptions";
 import { useInboxScopeOptions } from "@posthog/ui/features/inbox/hooks/useInboxScopeOptions";
+import { useReviewerPickerOptions } from "@posthog/ui/features/inbox/hooks/useReviewerPickerOptions";
 import { useInboxReviewerScopeStore } from "@posthog/ui/features/inbox/stores/inboxReviewerScopeStore";
-import { SegmentedControl } from "@radix-ui/themes";
-import { useMemo, useRef, useState } from "react";
+import { useDebounce } from "@posthog/ui/primitives/hooks/useDebounce";
+import { Popover, SegmentedControl } from "@radix-ui/themes";
+import { useMemo, useState } from "react";
 
 /**
  * Two-segment scope toggle. Left segment is "For you"; right segment shows
- * either "Entire project" or the currently-selected teammate's name, and
- * opens a Quill Combobox with a searchable list of "Entire project + each
- * teammate" when clicked.
+ * either "Entire project" or the currently-selected teammate's name, and opens
+ * a searchable, virtualized list of "Entire project + each teammate" when
+ * clicked.
+ *
+ * The list lives inside a Popover whose content only mounts while open, so the
+ * underlying people query re-fetches on every open (it previously stayed
+ * mounted and went stale until the 60s background refetch). Search is
+ * server-side; an empty result surfaces a hint to connect a GitHub profile.
  *
  * Segments share equal width – Radix Themes' SegmentedControl indicator is
  * hardcoded to equal-width math (`width: calc(100% / N)` + percentage
  * translate), so a fit-content override desyncs the pill from the items.
  * Keeping the default avoids a custom toggle just for this surface.
  */
-const PICKER_ENTIRE_PROJECT_VALUE = "__entire-project__";
 
 type SegmentValue = "for-you" | "entire-project";
 
 export function InboxScopeSelect() {
   const scope = useInboxReviewerScopeStore((s) => s.scope);
   const setScope = useInboxReviewerScopeStore((s) => s.setScope);
-  const anchorRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
+  // Base (always-on) list, used to resolve the selected teammate's name for the
+  // segment label even while the dropdown is closed.
   const { teammateOptions } = useInboxScopeOptions();
 
+  const selectedTeammateUuid = parseTeammateInboxScope(scope);
+
   const selectedTeammate = useMemo(() => {
-    const teammateUuid = parseTeammateInboxScope(scope);
-    if (!teammateUuid) return null;
+    if (!selectedTeammateUuid) return null;
     return (
-      teammateOptions.find((option) => option.uuid === teammateUuid) ?? null
+      teammateOptions.find((option) => option.uuid === selectedTeammateUuid) ??
+      null
     );
-  }, [scope, teammateOptions]);
+  }, [selectedTeammateUuid, teammateOptions]);
 
   const segmentValue: SegmentValue =
     scope === INBOX_SCOPE_FOR_YOU ? "for-you" : "entire-project";
@@ -59,18 +66,6 @@ export function InboxScopeSelect() {
     ? getSuggestedReviewerDisplayName(selectedTeammate)
     : "Entire project";
 
-  const pickerItems = useMemo(() => {
-    const items: string[] = [PICKER_ENTIRE_PROJECT_VALUE];
-    for (const teammate of teammateOptions) {
-      items.push(teammateInboxScope(teammate.uuid));
-    }
-    return items;
-  }, [teammateOptions]);
-
-  const pickerValue: string = isTeammateInboxScope(scope)
-    ? scope
-    : PICKER_ENTIRE_PROJECT_VALUE;
-
   const handleSegmentValueChange = (next: string) => {
     if (next === "for-you") {
       setScope(INBOX_SCOPE_FOR_YOU);
@@ -78,124 +73,143 @@ export function InboxScopeSelect() {
     }
   };
 
-  const handlePickerValueChange = (value: unknown) => {
-    if (typeof value !== "string") return;
-    if (value === PICKER_ENTIRE_PROJECT_VALUE) {
-      setScope(INBOX_SCOPE_ENTIRE_PROJECT);
-    } else {
-      setScope(value as InboxScope);
-    }
+  const selectEntireProject = () => {
+    setScope(INBOX_SCOPE_ENTIRE_PROJECT);
+    setOpen(false);
+  };
+
+  const selectTeammate = (teammate: SuggestedReviewerFilterOption) => {
+    setScope(teammateInboxScope(teammate.uuid));
     setOpen(false);
   };
 
   return (
-    <Combobox
-      items={pickerItems}
-      value={pickerValue}
-      onValueChange={handlePickerValueChange}
-      open={open}
-      onOpenChange={setOpen}
-    >
-      <div ref={anchorRef} className="ml-2 inline-flex">
-        <SegmentedControl.Root
-          value={segmentValue}
-          size="1"
-          onValueChange={handleSegmentValueChange}
-          aria-label="Inbox scope"
-        >
-          <SegmentedControl.Item value="for-you">For you</SegmentedControl.Item>
-          <SegmentedControl.Item
-            value="entire-project"
-            onClick={() => setOpen(true)}
-            aria-haspopup="listbox"
-            aria-expanded={open}
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Anchor>
+        <div className="ml-2 inline-flex">
+          <SegmentedControl.Root
+            value={segmentValue}
+            size="1"
+            onValueChange={handleSegmentValueChange}
+            aria-label="Inbox scope"
           >
-            <span className="inline-flex items-center gap-1.5">
-              {rightLabel}
-              <CaretDownIcon
-                size={10}
-                weight="bold"
-                className="text-muted-foreground"
-              />
-            </span>
-          </SegmentedControl.Item>
-        </SegmentedControl.Root>
-      </div>
-      <ComboboxContent
-        anchor={anchorRef}
+            <SegmentedControl.Item value="for-you">
+              For you
+            </SegmentedControl.Item>
+            <SegmentedControl.Item
+              value="entire-project"
+              onClick={() => setOpen(true)}
+              aria-haspopup="listbox"
+              aria-expanded={open}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                {rightLabel}
+                <CaretDownIcon
+                  size={10}
+                  weight="bold"
+                  className="text-muted-foreground"
+                />
+              </span>
+            </SegmentedControl.Item>
+          </SegmentedControl.Root>
+        </div>
+      </Popover.Anchor>
+      <Popover.Content
         align="end"
         side="bottom"
         sideOffset={6}
-        // The segmented toggle already shows which scope is active, so the
-        // Combobox's built-in right-edge check on the selected row is just
-        // visual noise — hide it and reclaim the reserved padding.
-        className="min-w-[220px] [&_[data-slot=combobox-item]>span.absolute]:hidden [&_[data-slot=combobox-item][aria-selected=true]]:pe-2!"
+        className="min-w-[240px] max-w-[320px] p-2"
       >
-        <ComboboxInput
-          placeholder="Search people…"
-          showTrigger={false}
-          autoFocus
+        <ScopePickerContent
+          selectedTeammateUuid={selectedTeammateUuid}
+          isEntireProjectSelected={scope === INBOX_SCOPE_ENTIRE_PROJECT}
+          onSelectEntireProject={selectEntireProject}
+          onSelectTeammate={selectTeammate}
         />
-        <ComboboxEmpty>No matching people.</ComboboxEmpty>
-        <ComboboxList className="max-h-[min(16rem,calc(var(--available-height,16rem)-5rem))]">
-          {(itemValue: string) => {
-            if (itemValue === PICKER_ENTIRE_PROJECT_VALUE) {
-              return (
-                <ComboboxItem
-                  key={PICKER_ENTIRE_PROJECT_VALUE}
-                  value={PICKER_ENTIRE_PROJECT_VALUE}
-                  title="Entire project everyone team"
-                  className="gap-2"
-                >
-                  <span
-                    className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-(--gray-8) border-dashed text-gray-10"
-                    aria-hidden
-                  >
-                    <AsteriskSimpleIcon size={12} weight="bold" />
-                  </span>
-                  <span className="min-w-0 flex-1 truncate text-left">
-                    Entire project
-                  </span>
-                </ComboboxItem>
-              );
-            }
-            const teammateUuid = parseTeammateInboxScope(
-              itemValue as InboxScope,
-            );
-            if (!teammateUuid) return null;
-            const teammate = teammateOptions.find(
-              (t) => t.uuid === teammateUuid,
-            );
-            if (!teammate) return null;
-            const displayName = getSuggestedReviewerDisplayName(teammate);
-            const searchText = [
-              displayName,
-              teammate.name,
-              teammate.email,
-              teammate.github_login,
-            ]
-              .filter(Boolean)
-              .join(" ");
-            return (
-              <ComboboxItem
-                key={itemValue}
-                value={itemValue}
-                title={searchText}
-                className="gap-2"
-              >
-                <ReviewerAvatar
-                  seed={teammate.uuid}
-                  name={teammate.name}
-                  email={teammate.email}
-                />
-                <span className="min-w-0 flex-1 truncate text-left">
-                  {displayName}
-                </span>
-              </ComboboxItem>
-            );
-          }}
-        </ComboboxList>
-      </ComboboxContent>
-    </Combobox>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}
+
+function ScopePickerContent({
+  selectedTeammateUuid,
+  isEntireProjectSelected,
+  onSelectEntireProject,
+  onSelectTeammate,
+}: {
+  selectedTeammateUuid: string | null;
+  isEntireProjectSelected: boolean;
+  onSelectEntireProject: () => void;
+  onSelectTeammate: (teammate: SuggestedReviewerFilterOption) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 200);
+  const { options, isFetching } = useReviewerPickerOptions({
+    query: debouncedSearch,
+    enabled: true,
+  });
+
+  // "For you" already covers the current user, so the teammate list excludes
+  // them.
+  const teammates = useMemo(
+    () => options.filter((option) => !option.isMe),
+    [options],
+  );
+
+  return (
+    <PeoplePickerList
+      searchQuery={search}
+      onSearchQueryChange={setSearch}
+      people={teammates}
+      isFetching={isFetching}
+      autoFocus
+      leadingSlot={
+        <button
+          type="button"
+          onClick={onSelectEntireProject}
+          className="flex w-full items-center gap-2 rounded-(--radius-1) px-1 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none"
+        >
+          <span
+            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-(--gray-8) border-dashed text-gray-10"
+            aria-hidden
+          >
+            <AsteriskSimpleIcon size={12} weight="bold" />
+          </span>
+          <span className="min-w-0 flex-1 truncate">Entire project</span>
+          <span
+            className="flex h-4 w-4 shrink-0 items-center justify-center text-gray-12"
+            aria-hidden
+          >
+            {isEntireProjectSelected ? (
+              <CheckIcon size={12} weight="bold" />
+            ) : null}
+          </span>
+        </button>
+      }
+      renderRow={(teammate) => {
+        const displayName = getSuggestedReviewerDisplayName(teammate);
+        const selected = teammate.uuid === selectedTeammateUuid;
+        return (
+          <button
+            type="button"
+            onClick={() => onSelectTeammate(teammate)}
+            className="flex w-full items-center gap-2 rounded-(--radius-1) px-1 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none"
+          >
+            <ReviewerAvatar
+              seed={teammate.uuid}
+              name={teammate.name}
+              email={teammate.email}
+            />
+            <span className="min-w-0 flex-1 truncate">{displayName}</span>
+            <span
+              className="flex h-4 w-4 shrink-0 items-center justify-center text-gray-12"
+              aria-hidden
+            >
+              {selected ? <CheckIcon size={12} weight="bold" /> : null}
+            </span>
+          </button>
+        );
+      }}
+    />
   );
 }

--- a/packages/ui/src/features/inbox/components/PeoplePickerList.tsx
+++ b/packages/ui/src/features/inbox/components/PeoplePickerList.tsx
@@ -1,0 +1,160 @@
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import type { SuggestedReviewerFilterOption } from "@posthog/ui/features/inbox/filterOptions";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { Flex, Spinner, Text } from "@radix-ui/themes";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { type ReactNode, useRef } from "react";
+
+const ESTIMATED_ROW_HEIGHT = 44;
+const OVERSCAN = 8;
+
+interface PeoplePickerListProps {
+  searchQuery: string;
+  onSearchQueryChange: (next: string) => void;
+  searchPlaceholder?: string;
+  /** People to render in the (virtualized) list. */
+  people: SuggestedReviewerFilterOption[];
+  isFetching: boolean;
+  renderRow: (
+    person: SuggestedReviewerFilterOption,
+    index: number,
+  ) => ReactNode;
+  /**
+   * Optional non-person row pinned above the searchable list (e.g. an "Entire
+   * project" option). Hidden while the user is searching.
+   */
+  leadingSlot?: ReactNode;
+  autoFocus?: boolean;
+}
+
+/**
+ * Searchable, virtualized people list shared by the inbox reviewer and scope
+ * pickers. Only the visible rows are mounted, so it stays responsive for large
+ * orgs. Search is driven by the caller (server-side); when there are no
+ * results it surfaces the "ask them to connect GitHub" hint.
+ */
+export function PeoplePickerList({
+  searchQuery,
+  onSearchQueryChange,
+  searchPlaceholder = "Search people…",
+  people,
+  isFetching,
+  renderRow,
+  leadingSlot,
+  autoFocus,
+}: PeoplePickerListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isSearching = searchQuery.trim().length > 0;
+
+  const virtualizer = useVirtualizer({
+    count: people.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: OVERSCAN,
+    getItemKey: (index) => people[index]?.uuid ?? index,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+  const isEmpty = people.length === 0;
+
+  return (
+    <Flex direction="column" gap="2">
+      <Flex
+        align="center"
+        gap="2"
+        px="2"
+        py="1"
+        className="rounded-(--radius-2) border border-(--gray-6) bg-(--color-background)"
+      >
+        <MagnifyingGlassIcon size={12} className="shrink-0 text-gray-10" />
+        <input
+          type="text"
+          // biome-ignore lint/a11y/noAutofocus: the picker opens from an explicit user action
+          autoFocus={autoFocus}
+          placeholder={searchPlaceholder}
+          value={searchQuery}
+          onChange={(event) => onSearchQueryChange(event.target.value)}
+          className="min-w-0 flex-1 bg-transparent text-[12px] text-gray-12 outline-none placeholder:text-(--gray-9)"
+        />
+        {isFetching && !isEmpty ? <Spinner size="1" /> : null}
+      </Flex>
+
+      {leadingSlot && !isSearching ? leadingSlot : null}
+
+      {isEmpty ? (
+        isFetching ? (
+          <Flex align="center" justify="center" py="3">
+            <Spinner size="1" />
+          </Flex>
+        ) : (
+          <PeoplePickerEmptyState />
+        )
+      ) : (
+        <div
+          ref={scrollRef}
+          className="max-h-[280px] overflow-y-auto"
+          style={{ scrollbarGutter: "stable" }}
+        >
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              position: "relative",
+              width: "100%",
+            }}
+          >
+            {virtualItems.map((virtualItem) => {
+              const person = people[virtualItem.index];
+              if (!person) return null;
+              return (
+                <div
+                  key={virtualItem.key}
+                  ref={virtualizer.measureElement}
+                  data-index={virtualItem.index}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  {renderRow(person, virtualItem.index)}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </Flex>
+  );
+}
+
+function PeoplePickerEmptyState() {
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+  const integrationsUrl = buildPostHogUrl("/settings/user", cloudRegion);
+
+  return (
+    <div className="px-1 py-2">
+      <Text as="p" className="text-[12px] text-gray-11 leading-snug">
+        Someone not showing up here?
+      </Text>
+      <Text as="p" className="text-[12px] text-gray-10 leading-snug">
+        Ask them to{" "}
+        {integrationsUrl ? (
+          <button
+            type="button"
+            onClick={() => openExternalUrl(integrationsUrl)}
+            className="text-(--accent-11) underline hover:text-(--accent-12)"
+          >
+            connect their GitHub profile with PostHog
+          </button>
+        ) : (
+          "connect their GitHub profile with PostHog"
+        )}
+        .
+      </Text>
+    </div>
+  );
+}

--- a/packages/ui/src/features/inbox/components/SuggestedReviewersSection.tsx
+++ b/packages/ui/src/features/inbox/components/SuggestedReviewersSection.tsx
@@ -1,10 +1,4 @@
-import {
-  CheckIcon,
-  MagnifyingGlassIcon,
-  PlusIcon,
-  User,
-  XIcon,
-} from "@phosphor-icons/react";
+import { CheckIcon, PlusIcon, User, XIcon } from "@phosphor-icons/react";
 import type {
   AvailableSuggestedReviewer,
   SignalReport,
@@ -14,21 +8,23 @@ import type {
 } from "@posthog/shared/types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { PeoplePickerList } from "@posthog/ui/features/inbox/components/PeoplePickerList";
 import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
 import { MeBadge } from "@posthog/ui/features/inbox/components/utils/MeBadge";
 import { SuggestedReviewerAvatar } from "@posthog/ui/features/inbox/components/utils/SuggestedReviewerAvatar";
 import {
-  buildSuggestedReviewerFilterOptions,
   getSuggestedReviewerDisplayName,
+  type SuggestedReviewerFilterOption,
 } from "@posthog/ui/features/inbox/filterOptions";
 import {
-  useInboxAvailableSuggestedReviewers,
   useInboxReportArtefacts,
   useUpdateSuggestedReviewers,
 } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
+import { useReviewerPickerOptions } from "@posthog/ui/features/inbox/hooks/useReviewerPickerOptions";
+import { useDebounce } from "@posthog/ui/primitives/hooks/useDebounce";
 import { Flex, Popover, Spinner, Text } from "@radix-ui/themes";
-import { useDeferredValue, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 function reviewerMatchesAvailable(
   reviewer: SuggestedReviewer,
@@ -85,7 +81,9 @@ function SuggestedReviewersBody({
 
   const [addOpen, setAddOpen] = useState(false);
   const [reviewerQuery, setReviewerQuery] = useState("");
-  const deferredQuery = useDeferredValue(reviewerQuery);
+  // Collapse the debounce window to 0 while the popover is closed so the next
+  // open starts from a clean query instead of replaying the last keystroke.
+  const debouncedQuery = useDebounce(reviewerQuery, addOpen ? 200 : 0);
 
   const { mutate: updateReviewers, isPending } = useUpdateSuggestedReviewers(
     report.id,
@@ -100,25 +98,10 @@ function SuggestedReviewersBody({
     return [reviewers[meIndex], ...reviewers.filter((_, i) => i !== meIndex)];
   }, [reviewers, meUuid]);
 
-  const { data: availableReviewers, isFetching } =
-    useInboxAvailableSuggestedReviewers({
-      enabled: !!client && addOpen,
-    });
-
-  const addableOptions = useMemo(() => {
-    const options = buildSuggestedReviewerFilterOptions(
-      availableReviewers?.results ?? [],
-      currentUser,
-    );
-    const q = deferredQuery.trim().toLowerCase();
-    if (!q) return options;
-    return options.filter(
-      (option) =>
-        option.name.toLowerCase().includes(q) ||
-        option.email.toLowerCase().includes(q) ||
-        option.github_login.toLowerCase().includes(q),
-    );
-  }, [availableReviewers?.results, currentUser, deferredQuery]);
+  const { options: addableOptions, isFetching } = useReviewerPickerOptions({
+    query: debouncedQuery,
+    enabled: !!client && addOpen,
+  });
 
   const removeReviewer = (target: SuggestedReviewer) => {
     const next = reviewers.filter((r) => r !== target);
@@ -185,7 +168,6 @@ function SuggestedReviewersBody({
               reviewers.some((r) => reviewerMatchesAvailable(r, option))
             }
             onToggle={toggleReviewer}
-            hasResults={!!availableReviewers?.results?.length}
           />
         </Flex>
       }
@@ -322,18 +304,16 @@ function AddReviewerPopover({
   isPending,
   isAssigned,
   onToggle,
-  hasResults,
 }: {
   open: boolean;
   onOpenChange: (next: boolean) => void;
   query: string;
   onQueryChange: (next: string) => void;
   isFetching: boolean;
-  options: ReturnType<typeof buildSuggestedReviewerFilterOptions>;
+  options: SuggestedReviewerFilterOption[];
   isPending: boolean;
   isAssigned: (option: AvailableSuggestedReviewer) => boolean;
   onToggle: (option: AvailableSuggestedReviewer) => void;
-  hasResults: boolean;
 }) {
   return (
     <Popover.Root modal open={open} onOpenChange={onOpenChange}>
@@ -353,78 +333,49 @@ function AddReviewerPopover({
         sideOffset={6}
         className="min-w-[280px] max-w-[320px] p-2"
       >
-        <Flex direction="column" gap="2">
-          <Flex
-            align="center"
-            gap="2"
-            px="2"
-            py="1"
-            className="rounded-(--radius-2) border border-(--gray-6) bg-(--color-background)"
-          >
-            <MagnifyingGlassIcon size={12} className="shrink-0 text-gray-10" />
-            <input
-              type="text"
-              placeholder="Filter users…"
-              value={query}
-              onChange={(e) => onQueryChange(e.target.value)}
-              className="min-w-0 flex-1 bg-transparent text-[12px] text-gray-12 outline-none placeholder:text-(--gray-9)"
-            />
-          </Flex>
-          <div className="max-h-[280px] overflow-y-auto">
-            {isFetching && !hasResults ? (
-              <Flex align="center" justify="center" py="3">
-                <Spinner size="1" />
-              </Flex>
-            ) : options.length === 0 ? (
-              <Text className="px-1 py-2 text-[12px] text-gray-10">
-                No users found.
-              </Text>
-            ) : (
-              <Flex direction="column">
-                {options.map((option) => {
-                  const assigned = isAssigned(option);
-                  const displayName = getSuggestedReviewerDisplayName(option);
-                  return (
-                    <button
-                      key={option.uuid}
-                      type="button"
-                      disabled={isPending}
-                      className="flex w-full items-start justify-between rounded-(--radius-1) px-1 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none disabled:opacity-60"
-                      onClick={() => onToggle(option)}
-                    >
-                      <Flex align="center" gap="2" className="min-w-0">
-                        {option.github_login ? (
-                          <SuggestedReviewerAvatar
-                            githubLogin={option.github_login}
-                            size="sm"
-                          />
-                        ) : null}
-                        <Flex direction="column" gap="0" className="min-w-0">
-                          <Text className="truncate text-[12px]">
-                            {displayName}
-                          </Text>
-                          {option.email ? (
-                            <Text className="truncate text-[11px] text-gray-10">
-                              {option.email}
-                            </Text>
-                          ) : null}
-                        </Flex>
-                      </Flex>
-                      <span
-                        className="flex h-4 w-4 shrink-0 items-center justify-center text-gray-12"
-                        aria-hidden
-                      >
-                        {assigned ? (
-                          <CheckIcon size={12} weight="bold" />
-                        ) : null}
-                      </span>
-                    </button>
-                  );
-                })}
-              </Flex>
-            )}
-          </div>
-        </Flex>
+        <PeoplePickerList
+          searchQuery={query}
+          onSearchQueryChange={onQueryChange}
+          searchPlaceholder="Filter users…"
+          people={options}
+          isFetching={isFetching}
+          autoFocus
+          renderRow={(option) => {
+            const assigned = isAssigned(option);
+            const displayName = getSuggestedReviewerDisplayName(option);
+            return (
+              <button
+                type="button"
+                disabled={isPending}
+                className="flex w-full items-start justify-between rounded-(--radius-1) px-1 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none disabled:opacity-60"
+                onClick={() => onToggle(option)}
+              >
+                <Flex align="center" gap="2" className="min-w-0">
+                  {option.github_login ? (
+                    <SuggestedReviewerAvatar
+                      githubLogin={option.github_login}
+                      size="sm"
+                    />
+                  ) : null}
+                  <Flex direction="column" gap="0" className="min-w-0">
+                    <Text className="truncate text-[12px]">{displayName}</Text>
+                    {option.email ? (
+                      <Text className="truncate text-[11px] text-gray-10">
+                        {option.email}
+                      </Text>
+                    ) : null}
+                  </Flex>
+                </Flex>
+                <span
+                  className="flex h-4 w-4 shrink-0 items-center justify-center text-gray-12"
+                  aria-hidden
+                >
+                  {assigned ? <CheckIcon size={12} weight="bold" /> : null}
+                </span>
+              </button>
+            );
+          }}
+        />
       </Popover.Content>
     </Popover.Root>
   );

--- a/packages/ui/src/features/inbox/hooks/useReviewerPickerOptions.ts
+++ b/packages/ui/src/features/inbox/hooks/useReviewerPickerOptions.ts
@@ -25,7 +25,6 @@ interface UseReviewerPickerOptionsParams {
 export interface ReviewerPickerOptions {
   options: SuggestedReviewerFilterOption[];
   isFetching: boolean;
-  hasResults: boolean;
 }
 
 /**
@@ -68,6 +67,5 @@ export function useReviewerPickerOptions(
   return {
     options,
     isFetching,
-    hasResults: !!data?.results?.length,
   };
 }

--- a/packages/ui/src/features/inbox/hooks/useReviewerPickerOptions.ts
+++ b/packages/ui/src/features/inbox/hooks/useReviewerPickerOptions.ts
@@ -1,0 +1,73 @@
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import {
+  buildSuggestedReviewerFilterOptions,
+  type SuggestedReviewerFilterOption,
+} from "@posthog/ui/features/inbox/filterOptions";
+import { useInboxAvailableSuggestedReviewers } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useMemo } from "react";
+
+interface UseReviewerPickerOptionsParams {
+  /**
+   * Server-side search term. An empty string fetches the full base list; any
+   * other value is forwarded to the `available_reviewers` endpoint, which does
+   * the matching server-side.
+   */
+  query?: string;
+  /**
+   * Gate the underlying fetch. Pass the picker's open state so the list
+   * re-fetches every time it is opened (the query mounts fresh, and
+   * `refetchOnMount: "always"` then pulls the latest people).
+   */
+  enabled?: boolean;
+}
+
+export interface ReviewerPickerOptions {
+  options: SuggestedReviewerFilterOption[];
+  isFetching: boolean;
+  hasResults: boolean;
+}
+
+/**
+ * Shared data source for the people pickers (suggested reviewers + inbox scope
+ * teammate selector). Centralises server-side search and the "pin me to the
+ * top" behaviour so both surfaces stay consistent.
+ */
+export function useReviewerPickerOptions(
+  params?: UseReviewerPickerOptionsParams,
+): ReviewerPickerOptions {
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
+  const query = params?.query?.trim() ?? "";
+  const isSearching = query.length > 0;
+
+  const { data, isFetching } = useInboxAvailableSuggestedReviewers({
+    query,
+    enabled: params?.enabled,
+  });
+
+  const options = useMemo(
+    () =>
+      buildSuggestedReviewerFilterOptions(
+        data?.results ?? [],
+        // Only pin the current user onto the unfiltered base list. While the
+        // user is searching the server already decides who matches, so forcing
+        // "me" in would surface the current user for unrelated queries.
+        isSearching || !currentUser
+          ? null
+          : {
+              uuid: currentUser.uuid,
+              email: currentUser.email,
+              first_name: currentUser.first_name,
+              last_name: currentUser.last_name,
+            },
+      ),
+    [data?.results, currentUser, isSearching],
+  );
+
+  return {
+    options,
+    isFetching,
+    hasResults: !!data?.results?.length,
+  };
+}


### PR DESCRIPTION
## Problem

The inbox **assignee / "Entire project"** scope selector broke: it didn't re-fetch, so the people list went stale (reported by Olly/Rafa in Slack). While in there, the PostHog/code people listings in both **Reviewers** and **Entire project** also needed: a virtualized list, server-side search, and a helpful empty state.

## Changes

- New shared `PeoplePickerList` — a searchable, **virtualized** people list (only visible rows mount, so it stays responsive for large orgs) with the empty-state hint.
- New shared `useReviewerPickerOptions` hook driving **server-side search** through the `available_reviewers` `?query=` param (debounced), and pinning "me" only on the unfiltered base list.
- **Reviewers** picker (`SuggestedReviewersSection`) and **inbox scope** picker (`InboxScopeSelect`) both rewired onto the shared list.
- **Re-fetch bug fix:** the scope dropdown's data now lives inside a Popover whose content only mounts while open, so the query re-mounts and re-fetches on every open instead of staying mounted and stale.
- **Empty state:** when no people match, the dropdown shows _"Someone not showing up here? Ask them to connect their GitHub profile with PostHog"_, linking to the personal settings page (`/settings/user`).

> Note on "fetch missing entries as you scroll": the `available_reviewers` endpoint returns the full set of people in one response (a UUID→person dict, no `count`/pagination), so there are no missing pages to fetch — virtualization covers the rendering cost. True incremental fetch-on-scroll would need a paginated backend endpoint (in the `posthog` Django repo) first; the shared list is structured so it can be extended to infinite scroll if/when that lands.

## How did you test this?

- `pnpm build` (all packages) — green.
- `pnpm --filter @posthog/ui typecheck` — green.
- `biome check` on the changed/added files — clean.
- No existing tests reference these components; mobile uses its own separate inbox flow and is unaffected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781192703338229?thread_ts=1781192703.338229&cid=C09SK2PAGKF)*
