### PR TITLE
fix(inbox): label report tasks with the report title

### DIFF
--- a/packages/core/src/inbox/reportTaskCreation.ts
+++ b/packages/core/src/inbox/reportTaskCreation.ts
@@ -28,6 +28,7 @@ export function selectModelFromOptions(
 export interface BuildSignalReportTaskInput {
   prompt: string;
   reportId: string;
+  reportTitle?: string | null;
   cloudRepository: string;
   githubUserIntegrationId: string;
   adapter: "claude" | "codex";
@@ -43,6 +44,7 @@ export function buildSignalReportTaskInput(
   const {
     prompt,
     reportId,
+    reportTitle,
     cloudRepository,
     githubUserIntegrationId,
     adapter,
@@ -53,6 +55,8 @@ export function buildSignalReportTaskInput(
   return {
     content: prompt,
     taskDescription: prompt,
+    // Label the task with the report title; the prompt itself is generic.
+    title: reportTitle ?? undefined,
     repository: cloudRepository,
     githubUserIntegrationId,
     workspaceMode: "cloud",

--- a/packages/core/src/inbox/signalReportTaskService.test.ts
+++ b/packages/core/src/inbox/signalReportTaskService.test.ts
@@ -76,6 +76,30 @@ describe("SignalReportTaskService", () => {
     expect(result.status).toBe("created");
   });
 
+  it("labels the task with the report title", async () => {
+    const { service, createTask } = makeService();
+    const result = await service.createSignalReportTask(
+      makeInput({ reportTitle: "Checkout flow throws on empty cart" }),
+      vi.fn(),
+    );
+    expect(result.status).toBe("created");
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Checkout flow throws on empty cart",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("omits the title when the report has none", async () => {
+    const { service, createTask } = makeService();
+    await service.createSignalReportTask(
+      makeInput({ reportTitle: null }),
+      vi.fn(),
+    );
+    expect(createTask.mock.calls[0]?.[0]?.title).toBeUndefined();
+  });
+
   it("aborts with missing-model when no model can be resolved", async () => {
     const { service, createTask } = makeService(
       {},

--- a/packages/core/src/inbox/signalReportTaskService.ts
+++ b/packages/core/src/inbox/signalReportTaskService.ts
@@ -90,6 +90,7 @@ export class SignalReportTaskService {
     const taskInput = buildSignalReportTaskInput({
       prompt,
       reportId: input.reportId,
+      reportTitle: input.reportTitle,
       cloudRepository: input.cloudRepository,
       githubUserIntegrationId: input.githubUserIntegrationId,
       adapter: input.adapter,

--- a/packages/core/src/sessions/chatTitle.test.ts
+++ b/packages/core/src/sessions/chatTitle.test.ts
@@ -69,7 +69,11 @@ describe("decideTitleGeneration", () => {
       promptCount: 1,
       lastGeneratedAtCount: 0,
       initialDescriptionHandled: false,
-      task: { title: "Custom", description: "d" },
+      task: {
+        title: "Custom",
+        description: "d",
+        origin_product: "user_created",
+      },
     });
     expect(decision.shouldGenerateFromPrompts).toBe(true);
   });
@@ -79,7 +83,11 @@ describe("decideTitleGeneration", () => {
       promptCount: 1 + REGENERATE_INTERVAL,
       lastGeneratedAtCount: 1,
       initialDescriptionHandled: false,
-      task: { title: "Custom", description: "d" },
+      task: {
+        title: "Custom",
+        description: "d",
+        origin_product: "user_created",
+      },
     });
     expect(decision.shouldGenerateFromPrompts).toBe(true);
   });
@@ -89,9 +97,28 @@ describe("decideTitleGeneration", () => {
       promptCount: 0,
       lastGeneratedAtCount: 0,
       initialDescriptionHandled: false,
-      task: { title: "Fix login", description: "Fix login" },
+      task: {
+        title: "Fix login",
+        description: "Fix login",
+        origin_product: "user_created",
+      },
     });
     expect(decision.shouldGenerateFromTaskDescription).toBe(true);
+  });
+
+  it("never auto-generates for report-scoped tasks", () => {
+    const decision = decideTitleGeneration({
+      promptCount: 1,
+      lastGeneratedAtCount: 0,
+      initialDescriptionHandled: false,
+      task: {
+        title: "Checkout flow throws on empty cart",
+        description: "Act on PostHog inbox report abc …",
+        origin_product: "signal_report",
+      },
+    });
+    expect(decision.shouldGenerateFromPrompts).toBe(false);
+    expect(decision.shouldGenerateFromTaskDescription).toBe(false);
   });
 });
 

--- a/packages/core/src/sessions/chatTitle.ts
+++ b/packages/core/src/sessions/chatTitle.ts
@@ -36,10 +36,21 @@ export function decideTitleGeneration(input: {
   promptCount: number;
   lastGeneratedAtCount: number;
   initialDescriptionHandled: boolean;
-  task: Pick<Task, "title" | "description">;
+  task: Pick<Task, "title" | "description" | "origin_product">;
 }): TitleGenerationDecision {
   const { promptCount, lastGeneratedAtCount, initialDescriptionHandled, task } =
     input;
+
+  // Report-scoped tasks are seeded with the report's own title at creation. Their
+  // prompt is a generic "Act on PostHog inbox report …" preamble (the agent
+  // fetches the report via MCP), so auto-summarizing it would only replace the
+  // report title with a meaningless one. Leave their title alone.
+  if (task.origin_product === "signal_report") {
+    return {
+      shouldGenerateFromPrompts: false,
+      shouldGenerateFromTaskDescription: false,
+    };
+  }
 
   const shouldGenerateFromPrompts =
     (promptCount === 1 && lastGeneratedAtCount === 0) ||

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -419,6 +419,43 @@ describe("TaskCreationSaga", () => {
     expect(createTaskMock.mock.calls[0]?.[0]).not.toHaveProperty("title");
   });
 
+  it("forwards an explicit title to createTask", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: createTaskMock,
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: createTaskRunMock,
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: vi.fn(),
+      } as never,
+      host,
+      sessionService,
+      track: vi.fn(),
+    });
+
+    await saga.run({
+      content: "Act on PostHog inbox report abc",
+      title: "Checkout flow throws on empty cart",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    expect(createTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Checkout flow throws on empty cart",
+      }),
+    );
+  });
+
   it("uses user authorship for repo-less cloud tasks with a selected user GitHub integration", async () => {
     const createdTask = createTask({
       repository: null,

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -400,8 +400,13 @@ export class TaskCreationSaga extends Saga<
       name: "task_creation",
       execute: async () => {
         const description = input.taskDescription ?? input.content ?? "";
+        const title = input.title?.trim();
         const result = await this.deps.posthogClient.createTask({
           description,
+          // Only forward an explicit title; otherwise the backend derives one
+          // from the description. Keep the key absent (not undefined) so callers
+          // that never set a title send no title field at all.
+          ...(title ? { title } : {}),
           repository: repository ?? undefined,
           github_integration:
             input.workspaceMode === "cloud" &&

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -15,6 +15,10 @@ export interface TaskCreationInput {
   // For creating new task (required if no taskId)
   content?: string;
   taskDescription?: string;
+  // Explicit task title. When omitted, the backend auto-generates one from the
+  // description; report-scoped flows pass the report title so the task is
+  // labelled with the report instead of the generic prompt preamble.
+  title?: string | null;
   filePaths?: string[];
   repoPath?: string;
   repository?: string | null;

--- a/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
+++ b/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
@@ -51,6 +51,10 @@ export function useCreatePrReport({
       return {
         content: prompt,
         taskDescription: prompt,
+        // The prompt is intentionally generic (the agent fetches the report via
+        // MCP), so label the task with the report title instead of letting the
+        // backend auto-generate one from the preamble.
+        title: ctx.reportTitle ?? undefined,
         repository: ctx.cloudRepository,
         githubUserIntegrationId: ctx.githubUserIntegrationId,
         workspaceMode: "cloud",

--- a/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
+++ b/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
@@ -39,6 +39,9 @@ export function useDiscussReport({
       return {
         content: prompt,
         taskDescription: prompt,
+        // Label the task with the report title rather than the generic prompt
+        // preamble the backend would otherwise summarize.
+        title: ctx.reportTitle ?? undefined,
         repository: ctx.cloudRepository,
         githubUserIntegrationId: ctx.githubUserIntegrationId,
         workspaceMode: "cloud",

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -121,6 +121,19 @@ describe("useChatTitleGenerator", () => {
     expect(mockGenerateTitle).not.toHaveBeenCalled();
   });
 
+  it("never generates for report-scoped tasks, even on the first prompt", () => {
+    mockPrompts.value = ["Act on PostHog inbox report abc"];
+    renderHook(() =>
+      useChatTitleGenerator(
+        createTask({
+          title: "Checkout flow throws on empty cart",
+          origin_product: "signal_report",
+        }),
+      ),
+    );
+    expect(mockGenerateTitle).not.toHaveBeenCalled();
+  });
+
   it("generates title from the saved task description before prompt events arrive", async () => {
     mockGenerateTitle.mockResolvedValue({
       title: "Fix login bug",


### PR DESCRIPTION
## Problem

Tasks created from an inbox report (the **Create PR** / "Act on" action, and **Discuss**) showed dumb generic titles like *"Act on PostHog inbox report"* and ignored the report's own title.

The title is produced by LLM title *generators* that summarize the create-PR/discuss prompt. That prompt (`buildCreatePrReportPrompt`) is intentionally generic — it points the agent at the inbox MCP tools rather than inlining the report — so the best title a generator can squeeze out of it is literally "Act on PostHog inbox report". Two generators are involved:

- **Initial title:** PostHog/posthog's `generate_task_title()` (`TaskSerializer.create`) when the API receives no explicit title.
- **Overwrite on open:** this repo's `TitleGeneratorService` via `useChatTitleGenerator`. The inbox flow calls `openTask()` after creating, mounting the hook, which on the agent's first prompt re-summarizes that generic prompt and `updateTask({ title })`.

## Changes

Make report-scoped tasks carry the report's own title, and stop the generators from rewriting it:

- Plumb an optional `title` through `TaskCreationInput` → `TaskCreationSaga` → `createTask`, and have the Create-PR / Discuss inbox hooks (and `SignalReportTaskService`) set it to the report title. The backend already honors an explicit title; non-report tasks send none and keep auto-generating, so they're unaffected.
- `decideTitleGeneration` now skips auto-title generation entirely for `signal_report`-origin tasks, so `useChatTitleGenerator` can no longer clobber the seeded report title by summarizing the generic preamble.

## How did you test this?

- `vitest run` for the affected `@posthog/core` and `@posthog/ui` files — added coverage that the report title is forwarded as the task title, omitted when the report has none, and that auto-title generation never runs for report-scoped tasks (unit + hook level). All pass.
- `turbo typecheck` for `@posthog/shared`, `@posthog/core`, `@posthog/ui` — pass.
- `biome check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781196324488669?thread_ts=1781196324.488669&cid=C09SK2PAGKF)*