### PR TITLE
fix(models): preserve the selected model across session resume

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -327,39 +327,33 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
     expect(fetchMcpToolMetadataMock.mock.calls[0][0]).toBe(createdQueries[0]);
   });
 
-  it("re-roots the new query on the live session model", async () => {
+  // The fake session is created on sonnet (queryOptions.model); modelId
+  // simulates the user switching models mid-session.
+  it.each([
+    {
+      name: "re-roots the new query on the live session model",
+      modelId: "claude-fable-5",
+      expected: "claude-fable-5",
+    },
+    {
+      name: "maps the live session model to its SDK alias",
+      modelId: "claude-opus-4-8",
+      expected: "opus",
+    },
+    {
+      name: "keeps the creation-time model when the session has no modelId",
+      modelId: undefined,
+      expected: "claude-sonnet-4-6",
+    },
+  ])("$name", async ({ modelId, expected }) => {
     const agent = makeAgent();
-    // Session was created on sonnet (queryOptions.model) but the user
-    // switched to fable mid-session (session.modelId).
-    installFakeSession(agent, "s-model", { modelId: "claude-fable-5" });
+    installFakeSession(agent, "s-model", { modelId });
 
     await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
       mcpServers: freshMcpServers,
     });
 
-    expect(lastQueryCall.options?.model).toBe("claude-fable-5");
-  });
-
-  it("maps the live session model to its SDK alias", async () => {
-    const agent = makeAgent();
-    installFakeSession(agent, "s-model-alias", { modelId: "claude-opus-4-8" });
-
-    await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
-      mcpServers: freshMcpServers,
-    });
-
-    expect(lastQueryCall.options?.model).toBe("opus");
-  });
-
-  it("keeps the creation-time model when the session has no modelId", async () => {
-    const agent = makeAgent();
-    installFakeSession(agent, "s-model-unset");
-
-    await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
-      mcpServers: freshMcpServers,
-    });
-
-    expect(lastQueryCall.options?.model).toBe("claude-sonnet-4-6");
+    expect(lastQueryCall.options?.model).toBe(expected);
   });
 
   it("preserves the in-process local-tools server across refresh", async () => {

--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -327,6 +327,41 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
     expect(fetchMcpToolMetadataMock.mock.calls[0][0]).toBe(createdQueries[0]);
   });
 
+  it("re-roots the new query on the live session model", async () => {
+    const agent = makeAgent();
+    // Session was created on sonnet (queryOptions.model) but the user
+    // switched to fable mid-session (session.modelId).
+    installFakeSession(agent, "s-model", { modelId: "claude-fable-5" });
+
+    await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
+      mcpServers: freshMcpServers,
+    });
+
+    expect(lastQueryCall.options?.model).toBe("claude-fable-5");
+  });
+
+  it("maps the live session model to its SDK alias", async () => {
+    const agent = makeAgent();
+    installFakeSession(agent, "s-model-alias", { modelId: "claude-opus-4-8" });
+
+    await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
+      mcpServers: freshMcpServers,
+    });
+
+    expect(lastQueryCall.options?.model).toBe("opus");
+  });
+
+  it("keeps the creation-time model when the session has no modelId", async () => {
+    const agent = makeAgent();
+    installFakeSession(agent, "s-model-unset");
+
+    await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
+      mcpServers: freshMcpServers,
+    });
+
+    expect(lastQueryCall.options?.model).toBe("claude-sonnet-4-6");
+  });
+
   it("preserves the in-process local-tools server across refresh", async () => {
     const agent = makeAgent();
     installFakeSession(agent, "s-inprocess");

--- a/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SdkQueryHandle = {
+  interrupt: ReturnType<typeof vi.fn>;
+  setModel: ReturnType<typeof vi.fn>;
+  setMcpServers: ReturnType<typeof vi.fn>;
+  supportedCommands: ReturnType<typeof vi.fn>;
+  initializationResult: ReturnType<typeof vi.fn>;
+  [Symbol.asyncIterator]: () => AsyncIterator<never>;
+};
+
+function makeQueryHandle(): SdkQueryHandle {
+  return {
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    setMcpServers: vi.fn().mockResolvedValue(undefined),
+    supportedCommands: vi.fn().mockResolvedValue([]),
+    initializationResult: vi.fn().mockResolvedValue({
+      result: "success",
+      commands: [],
+      models: [],
+    }),
+    [Symbol.asyncIterator]: async function* () {
+      /* never yields */
+    } as never,
+  };
+}
+
+const createdQueries: SdkQueryHandle[] = [];
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(() => {
+    const handle = makeQueryHandle();
+    createdQueries.push(handle);
+    return handle;
+  }),
+  getSessionMessages: vi.fn().mockResolvedValue([]),
+  listSessions: vi.fn().mockResolvedValue([]),
+  createSdkMcpServer: vi.fn(() => ({
+    type: "sdk",
+    name: "stub",
+    instance: {},
+  })),
+  tool: vi.fn(),
+}));
+
+vi.mock("./mcp/tool-metadata", () => ({
+  fetchMcpToolMetadata: vi.fn().mockResolvedValue(undefined),
+  getConnectedMcpServerNames: vi.fn().mockReturnValue([]),
+  setMcpToolApprovalStates: vi.fn(),
+  getMcpToolApprovalState: vi.fn().mockReturnValue("approved"),
+  getMcpToolMetadata: vi.fn().mockReturnValue(undefined),
+}));
+
+// Import after the mocks so ClaudeAcpAgent resolves the mocked SDK
+const { ClaudeAcpAgent } = await import("./claude-agent");
+type Agent = InstanceType<typeof ClaudeAcpAgent>;
+
+function makeAgent(): Agent {
+  const client = {
+    sessionUpdate: vi.fn().mockResolvedValue(undefined),
+    extNotification: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AgentSideConnection;
+  return new ClaudeAcpAgent(client);
+}
+
+function getModelConfigOption(response: {
+  configOptions?: Array<{ id: string; currentValue?: unknown }> | null;
+}) {
+  return response.configOptions?.find((opt) => opt.id === "model");
+}
+
+// Real temp dirs: createSession validates cwd and SettingsManager reads
+// settings from disk; CLAUDE_CONFIG_DIR keeps both away from the real home.
+const cwd = mkdtempSync(path.join(os.tmpdir(), "claude-agent-test-cwd-"));
+const configDir = mkdtempSync(
+  path.join(os.tmpdir(), "claude-agent-test-config-"),
+);
+const savedEnv = {
+  ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+};
+
+afterAll(() => {
+  rmSync(cwd, { recursive: true, force: true });
+  rmSync(configDir, { recursive: true, force: true });
+  process.env.ANTHROPIC_BASE_URL = savedEnv.ANTHROPIC_BASE_URL;
+  process.env.CLAUDE_CONFIG_DIR = savedEnv.CLAUDE_CONFIG_DIR;
+  if (savedEnv.ANTHROPIC_BASE_URL === undefined) {
+    delete process.env.ANTHROPIC_BASE_URL;
+  }
+  if (savedEnv.CLAUDE_CONFIG_DIR === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR;
+  }
+});
+
+describe("ClaudeAcpAgent session model on resume", () => {
+  beforeEach(() => {
+    createdQueries.length = 0;
+    // No gateway: fetchGatewayModels returns [] and the requested model is
+    // kept as a custom option — mirrors the gateway-outage failure mode.
+    delete process.env.ANTHROPIC_BASE_URL;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+  });
+
+  it("applies meta.model to the SDK when resuming", async () => {
+    const agent = makeAgent();
+
+    const response = await agent.resumeSession({
+      sessionId: "0197a000-0000-7000-8000-000000000001",
+      cwd,
+      mcpServers: [],
+      _meta: { taskRunId: "run-1", model: "claude-fable-5" },
+    });
+
+    // The SDK does not carry the model across resume — without an explicit
+    // setModel the resumed session silently runs the SDK default (opus).
+    expect(createdQueries).toHaveLength(1);
+    expect(createdQueries[0].setModel).toHaveBeenCalledWith("claude-fable-5");
+    expect(getModelConfigOption(response)?.currentValue).toBe("claude-fable-5");
+  });
+
+  it("pins the default model explicitly when resuming without meta.model", async () => {
+    const agent = makeAgent();
+
+    const response = await agent.resumeSession({
+      sessionId: "0197a000-0000-7000-8000-000000000002",
+      cwd,
+      mcpServers: [],
+      _meta: { taskRunId: "run-2" },
+    });
+
+    expect(createdQueries).toHaveLength(1);
+    expect(createdQueries[0].setModel).toHaveBeenCalledWith("opus");
+    expect(getModelConfigOption(response)?.currentValue).toBe(
+      "claude-opus-4-8",
+    );
+  });
+
+  it("does not call setModel for a new session on the default model", async () => {
+    const agent = makeAgent();
+
+    await agent.newSession({
+      cwd,
+      mcpServers: [],
+      _meta: { taskRunId: "run-3" },
+    });
+
+    // New sessions already pass options.model to the SDK at spawn.
+    expect(createdQueries).toHaveLength(1);
+    expect(createdQueries[0].setModel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
@@ -107,39 +107,42 @@ describe("ClaudeAcpAgent session model on resume", () => {
     process.env.CLAUDE_CONFIG_DIR = configDir;
   });
 
-  it("applies meta.model to the SDK when resuming", async () => {
-    const agent = makeAgent();
-
-    const response = await agent.resumeSession({
+  // The SDK does not carry the model across resume — without an explicit
+  // setModel the resumed session silently runs the SDK default (opus).
+  it.each([
+    {
+      name: "applies meta.model to the SDK when resuming",
       sessionId: "0197a000-0000-7000-8000-000000000001",
-      cwd,
-      mcpServers: [],
-      _meta: { taskRunId: "run-1", model: "claude-fable-5" },
-    });
-
-    // The SDK does not carry the model across resume — without an explicit
-    // setModel the resumed session silently runs the SDK default (opus).
-    expect(createdQueries).toHaveLength(1);
-    expect(createdQueries[0].setModel).toHaveBeenCalledWith("claude-fable-5");
-    expect(getModelConfigOption(response)?.currentValue).toBe("claude-fable-5");
-  });
-
-  it("pins the default model explicitly when resuming without meta.model", async () => {
-    const agent = makeAgent();
-
-    const response = await agent.resumeSession({
+      model: "claude-fable-5",
+      expectedSetModel: "claude-fable-5",
+      expectedCurrentValue: "claude-fable-5",
+    },
+    {
+      name: "pins the default model explicitly when resuming without meta.model",
       sessionId: "0197a000-0000-7000-8000-000000000002",
-      cwd,
-      mcpServers: [],
-      _meta: { taskRunId: "run-2" },
-    });
+      model: undefined,
+      expectedSetModel: "opus",
+      expectedCurrentValue: "claude-opus-4-8",
+    },
+  ])(
+    "$name",
+    async ({ sessionId, model, expectedSetModel, expectedCurrentValue }) => {
+      const agent = makeAgent();
 
-    expect(createdQueries).toHaveLength(1);
-    expect(createdQueries[0].setModel).toHaveBeenCalledWith("opus");
-    expect(getModelConfigOption(response)?.currentValue).toBe(
-      "claude-opus-4-8",
-    );
-  });
+      const response = await agent.resumeSession({
+        sessionId,
+        cwd,
+        mcpServers: [],
+        _meta: { taskRunId: "run-1", model },
+      });
+
+      expect(createdQueries).toHaveLength(1);
+      expect(createdQueries[0].setModel).toHaveBeenCalledWith(expectedSetModel);
+      expect(getModelConfigOption(response)?.currentValue).toBe(
+        expectedCurrentValue,
+      );
+    },
+  );
 
   it("does not call setModel for a new session on the default model", async () => {
     const agent = makeAgent();

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1268,6 +1268,9 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       resume: this.sessionId,
       forkSession: false,
       abortController: newAbortController,
+      // `rest.model` is the creation-time value; the user may have switched
+      // models since, so re-root the new Query on the live session model.
+      ...(prev.modelId && { model: toSdkModelId(prev.modelId) }),
     };
 
     const newInput = new Pushable<SDKUserMessage>();
@@ -1745,7 +1748,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     const resolvedSdkModel = toSdkModelId(resolvedModelId);
 
-    if (!isResume && resolvedSdkModel !== DEFAULT_MODEL) {
+    // New sessions start with options.model = DEFAULT_MODEL, so only a
+    // non-default pick needs a setModel call. Resumed sessions always need
+    // it: the SDK does not carry the model across resume and would silently
+    // run its default otherwise.
+    if (isResume || resolvedSdkModel !== DEFAULT_MODEL) {
       await this.session.query.setModel(resolvedSdkModel);
     }
 

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -712,6 +712,15 @@ export class SessionService {
       const persistedMode =
         modeOpt?.type === "select" ? modeOpt.currentValue : undefined;
 
+      // Resumed SDK sessions don't remember the model — without this the
+      // session silently falls back to the default model on every reconnect.
+      const modelOpt = getConfigOptionByCategory(
+        persistedConfigOptions,
+        "model",
+      );
+      const persistedModel =
+        modelOpt?.type === "select" ? modelOpt.currentValue : undefined;
+
       this.d.trpc.workspace.verify
         .query({ taskId })
         .then((workspaceResult) => {
@@ -743,6 +752,7 @@ export class SessionService {
         sessionId,
         adapter: resolvedAdapter,
         permissionMode: persistedMode,
+        model: persistedModel,
         customInstructions: customInstructions || undefined,
       });
 

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -184,6 +184,7 @@ export const reconnectSessionInput = z.object({
   /** Additional directories Claude can access beyond cwd (for worktree support) */
   additionalDirectories: z.array(z.string()).optional(),
   permissionMode: z.string().optional(),
+  model: z.string().optional(),
   customInstructions: z.string().max(2000).optional(),
   effort: effortLevelSchema.optional(),
   jsonSchema: z.record(z.string(), z.unknown()).nullish(),


### PR DESCRIPTION
## Problem

User report: mid-task, the selected model (e.g. fable) silently changes back to opus right after a permission request. Repro'd end-to-end — the meep is the messenger, not the cause. The regression happens earlier, at session resume:

1. **Every resume/reconnect dropped the model.** The auto-reconnect path (idle-kill recovery, app relaunch, websocket drop) never sent the model — `ReconnectSessionInput` didn't have the field — and on resume the SDK was never told the model either: `options.model` is only set for new sessions and `query.setModel()` was skipped behind a `!isResume` guard. A resumed SDK session runs its default model (opus).
2. **The client-side config restore usually patched it back**, but it's best-effort: if the gateway `/v1/models` fetch failed, the restore threw `Invalid value for config option model` (swallowed as a warning) and the server stayed on opus while the picker still showed fable. Inference actually ran on opus from that point.
3. **The next `config_option_update` broadcast surfaced it**: plan-meep approval emits the full server-side configOptions array, which wholesale-replaced the UI state *and* the persisted selection — so the picker visibly flipped to opus right after the meep, and the wrong model stuck.

Evidence from the repro (broken build): SDK transcript shows turn 1 served by `claude-fable-5` and the post-reconnect turn served by `claude-opus-4-8` while the UI still displayed fable.

## Fix

- **`workspace-server`**: add optional `model` to `ReconnectSessionInput` (`toSessionConfig` → `resumeSession` `_meta` already forwarded it).
- **`core`**: `reconnectToLocalSession` reads the persisted model config option (same pattern as the persisted mode) and sends it with the reconnect mutation.
- **`agent`**: `createSession` now calls `query.setModel()` on every resume — the SDK does not carry the model across resume. `refreshSession` re-roots its new query on the live `session.modelId` instead of the stale creation-time `options.model`.

## Verification

- New unit tests: resume applies `meta.model` via `setModel` (even when the gateway model list is empty), resume without a model pins the default explicitly, new-session-on-default skips the redundant call; `refreshSession` carries the live model (incl. SDK alias mapping).
- Live end-to-end check on the fixed build, replaying the original repro (idle-kill reconnect under a simulated gateway outage, then plan-meep approval): zero restore failures in logs, the picker stays on fable, and the SDK transcript records `claude-fable-5` for every turn — including the post-reconnect turn that ran on opus before the fix.
- `pnpm --filter @posthog/agent test` (694), `--filter @posthog/workspace-server test` (395), `--filter @posthog/core test` (1453), typecheck + Biome clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*