### PR TITLE
fix(sessions): Stop notification blasts from cloud history replay

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -13,7 +13,11 @@ import {
 import { createTestRepo, type TestRepo } from "../test/fixtures/api";
 import { createPostHogHandlers } from "../test/mocks/msw-handlers";
 import type { TaskRun } from "../types";
-import { AgentServer, SSE_KEEPALIVE_INTERVAL_MS } from "./agent-server";
+import {
+  AgentServer,
+  isTurnCompleteNotification,
+  SSE_KEEPALIVE_INTERVAL_MS,
+} from "./agent-server";
 import { type JwtPayload, SANDBOX_CONNECTION_AUDIENCE } from "./jwt";
 
 const mockedClaudeSdk = vi.hoisted(() => {
@@ -657,6 +661,56 @@ describe("AgentServer HTTP Mode", () => {
           stopReason: "end_turn",
         },
       });
+    });
+
+    it("skips one broadcast after the adapter emitted its own turn_complete", () => {
+      const appendRawLine = vi.fn();
+      const testServer = new AgentServer({
+        port,
+        jwtPublicKey: TEST_PUBLIC_KEY,
+        repositoryPath: repo.path,
+        apiUrl: "http://localhost:8000",
+        apiKey: "test-api-key",
+        projectId: 1,
+        mode: "interactive",
+        taskId: "test-task-id",
+        runId: "test-run-id",
+      }) as unknown as {
+        session: unknown;
+        adapterEmittedTurnComplete: boolean;
+        broadcastTurnComplete(stopReason: string): void;
+      };
+      testServer.session = {
+        acpSessionId: "session-1",
+        payload: { run_id: "run-1" },
+        logWriter: { appendRawLine },
+      };
+      testServer.adapterEmittedTurnComplete = true;
+
+      testServer.broadcastTurnComplete("end_turn");
+      expect(appendRawLine).not.toHaveBeenCalled();
+
+      testServer.broadcastTurnComplete("end_turn");
+      expect(appendRawLine).toHaveBeenCalledTimes(1);
+    });
+
+    it("recognizes adapter turn_complete notifications on the tapped stream", () => {
+      expect(
+        isTurnCompleteNotification({
+          jsonrpc: "2.0",
+          method: "_posthog/turn_complete",
+          params: { sessionId: "s", stopReason: "end_turn" },
+        }),
+      ).toBe(true);
+      expect(
+        isTurnCompleteNotification({
+          jsonrpc: "2.0",
+          method: "_posthog/usage_update",
+          params: {},
+        }),
+      ).toBe(false);
+      expect(isTurnCompleteNotification(null)).toBe(false);
+      expect(isTurnCompleteNotification("turn_complete")).toBe(false);
     });
   });
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -198,6 +198,15 @@ function createTappedWritableStream(
   });
 }
 
+export function isTurnCompleteNotification(message: unknown): boolean {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    (message as { method?: unknown }).method ===
+      POSTHOG_NOTIFICATIONS.TURN_COMPLETE
+  );
+}
+
 interface SseController {
   send: (data: unknown) => void;
   close: () => void;
@@ -241,6 +250,7 @@ export class AgentServer {
   private posthogAPI: PostHogAPIClient;
   private eventStreamSender: TaskRunEventStreamSender | null = null;
   private questionRelayedToSlack = false;
+  private adapterEmittedTurnComplete = false;
   private detectedPrUrl: string | null = null;
   private lastReportedBranch: string | null = null;
   private resumeState: ResumeState | null = null;
@@ -997,7 +1007,11 @@ export class AgentServer {
     });
 
     // Tap both streams to broadcast all ACP messages via SSE (mimics local transport)
+    this.adapterEmittedTurnComplete = false;
     const onAcpMessage = (message: unknown) => {
+      if (isTurnCompleteNotification(message)) {
+        this.adapterEmittedTurnComplete = true;
+      }
       this.broadcastEvent({
         type: "notification",
         timestamp: new Date().toISOString(),
@@ -2493,6 +2507,10 @@ ${signedCommitInstructions}
 
   private broadcastTurnComplete(stopReason: string): void {
     if (!this.session) return;
+    if (this.adapterEmittedTurnComplete) {
+      this.adapterEmittedTurnComplete = false;
+      return;
+    }
     const notification = {
       jsonrpc: "2.0",
       method: POSTHOG_NOTIFICATIONS.TURN_COMPLETE,

--- a/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -1,0 +1,225 @@
+import type { AgentSession, StoredLogEntry } from "@posthog/shared";
+import type { CloudTaskUpdatePayload } from "@posthog/shared/domain-types";
+import { describe, expect, it, vi } from "vitest";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+const TASK_ID = "task-1";
+const RUN_ID = "run-1";
+
+function turnComplete(): StoredLogEntry {
+  return {
+    type: "notification",
+    notification: {
+      method: "_posthog/turn_complete",
+      params: { sessionId: RUN_ID, stopReason: "end_turn" },
+    },
+  };
+}
+
+function permissionRequest(
+  requestId: string,
+  toolCallId: string,
+): StoredLogEntry {
+  return {
+    type: "notification",
+    notification: {
+      method: "_posthog/permission_request",
+      params: {
+        requestId,
+        toolCall: { toolCallId, title: "Run command", kind: "execute" },
+        options: [],
+      },
+    },
+  };
+}
+
+function createHarness() {
+  const sessions: Record<string, AgentSession> = {};
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    setSession: (session: AgentSession) => {
+      sessions[session.taskRunId] = session;
+    },
+    updateSession: (taskRunId: string, updates: Partial<AgentSession>) => {
+      const session = sessions[taskRunId];
+      if (session) Object.assign(session, updates);
+    },
+    appendEvents: (
+      taskRunId: string,
+      events: AgentSession["events"],
+      newLineCount?: number,
+    ) => {
+      const session = sessions[taskRunId];
+      if (!session) return;
+      session.events = [...session.events, ...events];
+      if (newLineCount !== undefined) {
+        session.processedLineCount = newLineCount;
+      }
+    },
+    updateCloudStatus: (
+      taskRunId: string,
+      fields: { status?: AgentSession["cloudStatus"] },
+    ) => {
+      const session = sessions[taskRunId];
+      if (session && fields.status !== undefined) {
+        session.cloudStatus = fields.status;
+      }
+    },
+    setPendingPermissions: (
+      taskRunId: string,
+      permissions: AgentSession["pendingPermissions"],
+    ) => {
+      const session = sessions[taskRunId];
+      if (session) session.pendingPermissions = permissions;
+    },
+    clearTailOptimisticItems: vi.fn(),
+    appendOptimisticItem: vi.fn(),
+    replaceOptimisticWithEvent: vi.fn(),
+    clearMessageQueue: vi.fn(),
+  };
+
+  let onUpdate: ((update: CloudTaskUpdatePayload) => void) | undefined;
+  const notifyPromptComplete = vi.fn();
+  const notifyPermissionRequest = vi.fn();
+  const markActivity = vi.fn();
+  const noopLog = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+
+  const deps = {
+    store,
+    log: noopLog,
+    notifyPromptComplete,
+    notifyPermissionRequest,
+    taskViewedApi: { markActivity },
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    trpc: {
+      agent: {
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+        getPreviewConfigOptions: {
+          query: vi.fn().mockResolvedValue([]),
+        },
+      },
+      logs: {
+        readLocalLogs: { query: vi.fn().mockResolvedValue("") },
+      },
+      cloudTask: {
+        onUpdate: {
+          subscribe: (
+            _input: unknown,
+            handlers: { onData: (update: CloudTaskUpdatePayload) => void },
+          ) => {
+            onUpdate = handlers.onData;
+            return { unsubscribe: vi.fn() };
+          },
+        },
+        watch: { mutate: vi.fn().mockResolvedValue(undefined) },
+        unwatch: { mutate: vi.fn().mockResolvedValue(undefined) },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  service.watchCloudTask(TASK_ID, RUN_ID, "https://us.posthog.com", 1);
+  if (!onUpdate) throw new Error("watchCloudTask did not subscribe");
+
+  return {
+    sendUpdate: (update: CloudTaskUpdatePayload) => onUpdate?.(update),
+    notifyPromptComplete,
+    notifyPermissionRequest,
+    markActivity,
+  };
+}
+
+describe("cloud task update notifications", () => {
+  it("does not notify for turn_completes replayed in a snapshot", () => {
+    const harness = createHarness();
+
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "snapshot",
+      newEntries: [turnComplete(), turnComplete(), turnComplete()],
+      totalEntryCount: 3,
+    });
+
+    expect(harness.notifyPromptComplete).not.toHaveBeenCalled();
+    expect(harness.markActivity).not.toHaveBeenCalled();
+  });
+
+  it("notifies once for a live turn_complete delta after the snapshot", () => {
+    const harness = createHarness();
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "snapshot",
+      newEntries: [turnComplete(), turnComplete()],
+      totalEntryCount: 2,
+    });
+
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "logs",
+      newEntries: [turnComplete()],
+      totalEntryCount: 3,
+    });
+
+    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
+    expect(harness.notifyPromptComplete).toHaveBeenCalledWith(
+      "Cloud Task",
+      "end_turn",
+      TASK_ID,
+    );
+    expect(harness.markActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies a pending permission once across repeated snapshots", () => {
+    const harness = createHarness();
+    const snapshot = () =>
+      harness.sendUpdate({
+        taskId: TASK_ID,
+        runId: RUN_ID,
+        kind: "snapshot",
+        newEntries: [permissionRequest("r1", "t1")],
+        totalEntryCount: 1,
+      });
+
+    snapshot();
+    expect(harness.notifyPermissionRequest).toHaveBeenCalledTimes(1);
+
+    snapshot();
+    snapshot();
+    expect(harness.notifyPermissionRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies again when the same tool call asks with a new requestId", () => {
+    const harness = createHarness();
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "snapshot",
+      newEntries: [permissionRequest("r1", "t1")],
+      totalEntryCount: 1,
+    });
+    expect(harness.notifyPermissionRequest).toHaveBeenCalledTimes(1);
+
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "permission_request",
+      requestId: "r2",
+      toolCall: { toolCallId: "t1", title: "Run command", kind: "execute" },
+      options: [],
+    });
+    expect(harness.notifyPermissionRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/sessions/derivePendingPermissionRequests.test.ts
+++ b/packages/core/src/sessions/derivePendingPermissionRequests.test.ts
@@ -1,6 +1,9 @@
 import type { StoredLogEntry } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
-import { derivePendingPermissionRequests } from "./sessionService";
+import {
+  derivePendingPermissionRequests,
+  isPermissionRequestAlreadySurfaced,
+} from "./sessionService";
 
 describe("derivePendingPermissionRequests", () => {
   const request = (requestId: string, toolCallId: string): StoredLogEntry => ({
@@ -61,5 +64,52 @@ describe("derivePendingPermissionRequests", () => {
     ]);
 
     expect(pending).toEqual([]);
+  });
+});
+
+describe("isPermissionRequestAlreadySurfaced", () => {
+  const update = (requestId: string, toolCallId: string) => ({
+    requestId,
+    toolCall: { toolCallId, title: "Ready to code?", kind: "execute" },
+    options: [],
+  });
+
+  it.each([
+    {
+      name: "same request still pending is a snapshot re-surface",
+      pendingToolCallIds: ["t1"],
+      trackedRequestId: "r1",
+      expected: true,
+    },
+    {
+      name: "request never surfaced notifies",
+      pendingToolCallIds: [],
+      trackedRequestId: undefined,
+      expected: false,
+    },
+    {
+      name: "new requestId for the same tool call is a new ask",
+      pendingToolCallIds: ["t1"],
+      trackedRequestId: "r0",
+      expected: false,
+    },
+    {
+      name: "tracked id without a pending entry notifies again",
+      pendingToolCallIds: [],
+      trackedRequestId: "r1",
+      expected: false,
+    },
+  ])("$name", ({ pendingToolCallIds, trackedRequestId, expected }) => {
+    const pendingPermissions = new Map(
+      pendingToolCallIds.map((id) => [id, {}]),
+    );
+
+    expect(
+      isPermissionRequestAlreadySurfaced(
+        pendingPermissions,
+        trackedRequestId,
+        update("r1", "t1"),
+      ),
+    ).toBe(expected);
   });
 });

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -344,6 +344,23 @@ export function derivePendingPermissionRequests(
   return [...requests.values()].filter((r) => !resolved.has(r.requestId));
 }
 
+/**
+ * Whether a derived permission request has already been surfaced for this
+ * session. Snapshot replays re-deliver still-pending requests on every
+ * bootstrap and re-subscribe; only the first delivery should notify. A
+ * different requestId for the same tool call is a new ask and must notify.
+ */
+export function isPermissionRequestAlreadySurfaced(
+  pendingPermissions: ReadonlyMap<string, unknown>,
+  trackedRequestId: string | undefined,
+  update: DerivedPermissionRequest,
+): boolean {
+  return (
+    trackedRequestId === update.requestId &&
+    pendingPermissions.has(update.toolCall.toolCallId)
+  );
+}
+
 export class SessionService {
   private connectingTasks = new Map<string, Promise<void>>();
   private reconcilingTasks = new Set<string>();
@@ -1581,6 +1598,16 @@ export class SessionService {
       this.d.log.warn("Session not found for cloud permission request", {
         taskRunId,
       });
+      return;
+    }
+
+    if (
+      isPermissionRequestAlreadySurfaced(
+        session.pendingPermissions,
+        this.cloudPermissionRequestIds.get(update.toolCall.toolCallId),
+        update,
+      )
+    ) {
       return;
     }
 
@@ -3944,8 +3971,13 @@ export class SessionService {
           this.d.store.clearTailOptimisticItems(taskRunId);
         }
         this.d.store.appendEvents(taskRunId, newEvents, expectedCount);
+        // Snapshots are historical replay (bootstrap, re-subscribe, post-
+        // reconnect), not live activity. Marking them live would fire a
+        // completion notification for every historical turn_complete, e.g.
+        // a fresh install replaying a run's full backlog. Only `logs`
+        // deltas come from the live SSE stream.
         this.updatePromptStateFromEvents(taskRunId, newEvents, {
-          isLive: true,
+          isLive: update.kind === "logs",
         });
       } else {
         this.cloudLogGapReconciler.reconcile({

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -3971,11 +3971,6 @@ export class SessionService {
           this.d.store.clearTailOptimisticItems(taskRunId);
         }
         this.d.store.appendEvents(taskRunId, newEvents, expectedCount);
-        // Snapshots are historical replay (bootstrap, re-subscribe, post-
-        // reconnect), not live activity. Marking them live would fire a
-        // completion notification for every historical turn_complete, e.g.
-        // a fresh install replaying a run's full backlog. Only `logs`
-        // deltas come from the live SSE stream.
         this.updatePromptStateFromEvents(taskRunId, newEvents, {
           isLive: update.kind === "logs",
         });


### PR DESCRIPTION
## Problem

Fresh installs blast one completion sound per historical turn_complete because cloud watcher snapshots are processed as live activity (reported as ~15 meeps right after install, replayed from pre-existing signal runs).

Closes https://github.com/PostHog/code/issues/2452

## Changes

1. Treat only `logs` SSE deltas as live; snapshot replays no longer notify or mark activity
2. Dedup re-surfaced pending permissions by requestId so each ask notifies once, not per snapshot
3. Add isPermissionRequestAlreadySurfaced helper with parameterised tests

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manully

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?