### PR TITLE
feat(scouts): add "Make a scout" CTA to the fleet list

### DIFF
--- a/packages/core/src/scouts/scoutPrompts.ts
+++ b/packages/core/src/scouts/scoutPrompts.ts
@@ -1,5 +1,16 @@
 // Templated prompts behind the scout chat CTA chips. The agent leans on the
-// exploring-signals-scouts skill from the PostHog MCP.
+// exploring-signals-scouts and authoring-signals-scouts skills from the
+// PostHog MCP.
+
+export const SCOUT_AUTHOR_PROMPT = `I'd like to make a new scout for this PostHog project.
+
+Use the authoring-signals-scouts skill from the PostHog MCP to guide creating a new signals scout.
+
+First, take a quick scan of this PostHog project to ground your suggestions: skim its events, insights, dashboards, recently emitted signals, and the existing scout fleet so you understand what this product is and where automated monitoring would add value.
+
+Then ask me what sort of scout I'd like to make, and offer a few concrete suggestions tailored to what you found (for example specific funnels, error or latency spikes, churn or activation signals, or revenue metrics worth watching) — and call out gaps the current fleet doesn't already cover. Once I pick a direction, walk me through authoring the scout end to end.
+
+If the skill is unavailable, fall back to the signals-scout MCP tools directly (config list to see the existing fleet) plus the read-data and insight tools to scan the project.`;
 
 export const SCOUT_FLEET_OVERVIEW_PROMPT = `How is my scout fleet performing?
 

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -634,7 +634,8 @@ export interface InboxReportActionProperties {
 export type ScoutChatType =
   | "fleet_overview"
   | "recent_signals"
-  | "scout_checkin";
+  | "scout_checkin"
+  | "author_scout";
 
 export type ScoutSurface = "fleet_list" | "scout_detail" | "empty_state";
 

--- a/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
@@ -1,4 +1,10 @@
-import { CaretDownIcon, CompassIcon, SparkleIcon } from "@phosphor-icons/react";
+import type { Icon } from "@phosphor-icons/react";
+import {
+  CaretDownIcon,
+  CompassIcon,
+  PlusIcon,
+  SparkleIcon,
+} from "@phosphor-icons/react";
 import type { ScoutConfig } from "@posthog/api-client/posthog-client";
 import {
   computeFleetSummary,
@@ -7,6 +13,7 @@ import {
   sortConfigsForDisplay,
 } from "@posthog/core/scouts/scoutPresentation";
 import {
+  SCOUT_AUTHOR_PROMPT,
   SCOUT_FLEET_OVERVIEW_PROMPT,
   SCOUT_RECENT_SIGNALS_PROMPT,
 } from "@posthog/core/scouts/scoutPrompts";
@@ -208,6 +215,14 @@ function ScoutsFleetList({ configs }: { configs: ScoutConfig[] }) {
           loggerScope="scout-recent-signals"
           chatType="recent_signals"
         />
+        <ScoutChatCta
+          label="Make a scout"
+          prompt={SCOUT_AUTHOR_PROMPT}
+          taskLabel="scout authoring"
+          loggerScope="scout-author"
+          chatType="author_scout"
+          icon={PlusIcon}
+        />
       </Flex>
 
       {/* Bounded to roughly 10 rows; larger fleets scroll within the section. */}
@@ -248,12 +263,14 @@ function ScoutChatCta({
   taskLabel,
   loggerScope,
   chatType,
+  icon: IconComponent = SparkleIcon,
 }: {
   label: string;
   prompt: string;
   taskLabel: string;
   loggerScope: string;
   chatType: ScoutChatType;
+  icon?: Icon;
 }) {
   const { runTask, isRunning } = useScoutChatTask({
     prompt,
@@ -269,7 +286,7 @@ function ScoutChatCta({
       disabled={isRunning}
       className="flex w-fit items-center gap-1.5 rounded-full border border-border bg-(--color-panel-solid) px-3 py-1 text-[12px] text-gray-11 transition-colors duration-150 hover:border-(--gray-6) hover:bg-(--gray-2) hover:text-gray-12 disabled:cursor-default disabled:opacity-60 disabled:hover:border-border disabled:hover:bg-(--color-panel-solid)"
     >
-      <SparkleIcon size={12} className="text-(--iris-9)" />
+      <IconComponent size={12} className="text-(--iris-9)" />
       {isRunning ? `Starting ${taskLabel}...` : label}
     </button>
   );


### PR DESCRIPTION
## Problem

The scout fleet section on the agent page lets you ask about your existing scouts (fleet overview, recent signals), but there was no in-app entry point for *creating* a new scout. Users had to know to open the authoring helper skill themselves.

**Why:** make it a one-click action to author a new scout, guided and grounded in the user's own PostHog project.

## Changes

- Added a "Make a scout" prompt pill next to the two existing example CTAs above the scout list.
- The pill starts an auto-mode cloud chat with a prompt that uses the `authoring-signals-scouts` skill, takes a quick scan of the PostHog project, then asks the user what sort of scout they'd like and offers concrete suggestions tailored to what it found.
- Added an `author_scout` analytics chat type and let `ScoutChatCta` take a custom icon (the new pill uses a plus icon).

## How did you test this?

- `biome check` on the changed files (clean after import-order autofix).
- Verified `PlusIcon` / `Icon` are valid `@phosphor-icons/react` exports and the new `ScoutChatType` member is wired through. Full `pnpm typecheck` could not complete in this environment due to pre-existing, unrelated build failures in `@posthog/agent` (`file-enricher.ts` implicit-any), not touched by this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1781214076672809)*
