### PR TITLE
fix(settings): Stop persistent settings resetting to defaults

### DIFF
--- a/apps/code/src/renderer/di/bindings.ts
+++ b/apps/code/src/renderer/di/bindings.ts
@@ -198,10 +198,6 @@ import {
   type ImperativeQueryClient,
 } from "@posthog/ui/shell/queryClient";
 import {
-  RENDERER_STATE_STORAGE,
-  type RendererStateStorage,
-} from "@posthog/ui/shell/rendererStorage";
-import {
   FILE_PATH_RESOLVER,
   type FilePathResolver,
 } from "@posthog/ui/utils/getFilePath";
@@ -212,7 +208,7 @@ import { TASK_SERVICE as RENDERER_TASK_SERVICE, TRPC_CLIENT } from "./tokens";
  * Strongly-typed binding map for the renderer composition-root container.
  *
  * Covers every token directly bound on the renderer `container` across
- * `di/container.ts`, `desktop-services.ts`, `utils/electronStorage.ts`, and
+ * `di/container.ts`, `desktop-services.ts`, and
  * `desktop-contributions.ts`. Tokens resolved purely through plain
  * `container.load(module)` are not listed here (TypedContainer accepts plain
  * ContainerModules without typing their internal bindings).
@@ -285,9 +281,6 @@ export interface RendererBindings {
   [FEATURE_FLAGS]: FeatureFlags;
   [AUTH_SIDE_EFFECTS]: IAuthSideEffects;
   [SETUP_STORE]: ISetupStore;
-
-  // --- utils/electronStorage.ts ---
-  [RENDERER_STATE_STORAGE]: RendererStateStorage;
 
   // --- desktop-contributions.ts ---
   [CONTRIBUTION]: Contribution;

--- a/apps/code/src/renderer/main.tsx
+++ b/apps/code/src/renderer/main.tsx
@@ -1,10 +1,13 @@
 import "reflect-metadata";
-// Side effect: registers the host (electron-trpc-backed) storage with @posthog/ui
-// before any persisted store hydrates.
+// Side effect: registers the host (electron-trpc-backed) storage with @posthog/ui.
+// Persisted stores hydrate from it once it registers, wherever in the import
+// graph they are created.
 import "@utils/electronStorage";
+// Side effect: composes the renderer container and calls setRootContainer.
+// Must precede the updates adapter below, which resolves UPDATES_CLIENT at
+// module scope.
+import "@renderer/di/container";
 // Side effect: drives the updates subscription + toast via the core update store.
-// Resolves UPDATES_CLIENT, which renderer/di/container.ts binds (loaded via the
-// electronStorage import above).
 import "@renderer/platform-adapters/updates";
 // Side effect: attaches window focus/visibility listeners so `focused` is accurate before inbox queries mount.
 import "@posthog/ui/shell/rendererWindowFocusStore";

--- a/apps/code/src/renderer/utils/electronStorage.ts
+++ b/apps/code/src/renderer/utils/electronStorage.ts
@@ -1,12 +1,10 @@
 import {
   electronStorage,
-  RENDERER_STATE_STORAGE,
-  type RendererStateStorage,
+  registerRendererStateStorage,
 } from "@posthog/ui/shell/rendererStorage";
-import { container } from "@renderer/di/container";
 import { trpcClient } from "../trpc";
 
-const electronStorageRaw: RendererStateStorage = {
+registerRendererStateStorage({
   getItem: async (key: string): Promise<string | null> => {
     return await trpcClient.secureStore.getItem.query({ key });
   },
@@ -16,10 +14,6 @@ const electronStorageRaw: RendererStateStorage = {
   removeItem: async (key: string): Promise<void> => {
     await trpcClient.secureStore.removeItem.query({ key });
   },
-};
-
-container
-  .bind<RendererStateStorage>(RENDERER_STATE_STORAGE)
-  .toConstantValue(electronStorageRaw);
+});
 
 export { electronStorage };

--- a/apps/code/src/renderer/utils/electronStorage.ts
+++ b/apps/code/src/renderer/utils/electronStorage.ts
@@ -1,7 +1,4 @@
-import {
-  electronStorage,
-  registerRendererStateStorage,
-} from "@posthog/ui/shell/rendererStorage";
+import { registerRendererStateStorage } from "@posthog/ui/shell/rendererStorage";
 import { trpcClient } from "../trpc";
 
 registerRendererStateStorage({
@@ -15,5 +12,3 @@ registerRendererStateStorage({
     await trpcClient.secureStore.removeItem.query({ key });
   },
 });
-
-export { electronStorage };

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,7 @@
 import "reflect-metadata";
+// Side effect: registers the web persistence backend for @posthog/ui stores
+// before any of the imports below create them.
+import "./web-storage";
 import "@posthog/ui/styles/globals.css";
 import { boot } from "@posthog/di/contribution";
 import { ServiceProvider } from "@posthog/di/react";

--- a/apps/web/src/web-storage.ts
+++ b/apps/web/src/web-storage.ts
@@ -1,0 +1,12 @@
+import { registerRendererStateStorage } from "@posthog/ui/shell/rendererStorage";
+
+// The web host does not persist UI state yet. Without a registered backend,
+// persisted stores would wait forever and _hasHydrated would never flip,
+// which blocks hydration-gated features like draft saving. The null backend
+// completes hydration with defaults, matching web behavior before the
+// registration seam. Swap in window.localStorage to enable persistence.
+registerRendererStateStorage({
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+});

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -3971,6 +3971,11 @@ export class SessionService {
           this.d.store.clearTailOptimisticItems(taskRunId);
         }
         this.d.store.appendEvents(taskRunId, newEvents, expectedCount);
+        // Snapshots are historical replay (bootstrap, re-subscribe, post-
+        // reconnect), not live activity. Marking them live would fire a
+        // completion notification for every historical turn_complete, e.g.
+        // a fresh install replaying a run's full backlog. Only `logs`
+        // deltas come from the live SSE stream.
         this.updatePromptStateFromEvents(taskRunId, newEvents, {
           isLive: update.kind === "logs",
         });

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -3971,11 +3971,6 @@ export class SessionService {
           this.d.store.clearTailOptimisticItems(taskRunId);
         }
         this.d.store.appendEvents(taskRunId, newEvents, expectedCount);
-        // Snapshots are historical replay (bootstrap, re-subscribe, post-
-        // reconnect), not live activity. Marking them live would fire a
-        // completion notification for every historical turn_complete, e.g.
-        // a fresh install replaying a run's full backlog. Only `logs`
-        // deltas come from the live SSE stream.
         this.updatePromptStateFromEvents(taskRunId, newEvents, {
           isLive: update.kind === "logs",
         });

--- a/packages/ui/src/features/command-center/commandCenterStore.test.ts
+++ b/packages/ui/src/features/command-center/commandCenterStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@utils/electronStorage", () => ({
+vi.mock("@posthog/ui/shell/rendererStorage", () => ({
   electronStorage: {
     getItem: () => null,
     setItem: () => {},

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -1,16 +1,12 @@
+import { registerRendererStateStorage } from "@posthog/ui/shell/rendererStorage";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const { getItem, setItem, removeItem } = vi.hoisted(() => ({
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-}));
-
-vi.mock("@posthog/di/container", () => ({
-  resolveService: () => ({ getItem, setItem, removeItem }),
-}));
-
 import { useSettingsStore } from "./settingsStore";
+
+const getItem = vi.fn();
+const setItem = vi.fn();
+const removeItem = vi.fn();
+
+registerRendererStateStorage({ getItem, setItem, removeItem });
 
 describe("feature settingsStore cloud selections", () => {
   beforeEach(() => {

--- a/packages/ui/src/shell/rendererStorage.test.ts
+++ b/packages/ui/src/shell/rendererStorage.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type RendererStorageModule = typeof import("./rendererStorage");
+
+async function importFreshRendererStorage(): Promise<RendererStorageModule> {
+  vi.resetModules();
+  return await import("./rendererStorage");
+}
+
+function fakeBackend(data: Record<string, string>) {
+  return {
+    getItem: vi.fn(async (key: string) => data[key] ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      data[key] = value;
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      delete data[key];
+    }),
+  };
+}
+
+function jsonStorageOf(module: RendererStorageModule) {
+  const storage = module.electronStorage;
+  if (!storage) {
+    throw new Error("electronStorage is not defined");
+  }
+  return storage;
+}
+
+describe("rendererStorage", () => {
+  it("serves reads issued before the host registers its storage", async () => {
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+
+    const read = storage.getItem("settings-storage");
+
+    module.registerRendererStateStorage(
+      fakeBackend({
+        "settings-storage": JSON.stringify({
+          state: { defaultInitialTaskMode: "last_used" },
+          version: 0,
+        }),
+      }),
+    );
+
+    await expect(read).resolves.toMatchObject({
+      state: { defaultInitialTaskMode: "last_used" },
+    });
+  });
+
+  it("drops writes racing the initial read, then writes through", async () => {
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({
+      "settings-storage": JSON.stringify({ state: { mode: "saved" } }),
+    });
+
+    const read = storage.getItem("settings-storage");
+    const racingWrite = storage.setItem("settings-storage", {
+      state: { mode: "default" },
+      version: 0,
+    });
+
+    module.registerRendererStateStorage(backend);
+    await Promise.all([read, racingWrite]);
+    expect(backend.setItem).not.toHaveBeenCalled();
+
+    await storage.setItem("settings-storage", {
+      state: { mode: "changed" },
+      version: 0,
+    });
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes writes through for keys that were never read", async () => {
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({});
+
+    const write = storage.setItem("write-only", {
+      state: { value: 1 },
+      version: 0,
+    });
+    module.registerRendererStateStorage(backend);
+    await write;
+
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates a store created before the host storage registers", async () => {
+    const module = await importFreshRendererStorage();
+    const backend = fakeBackend({
+      "settings-storage": JSON.stringify({
+        state: { defaultInitialTaskMode: "last_used" },
+        version: 0,
+      }),
+    });
+
+    const useStore = create<{ defaultInitialTaskMode: string }>()(
+      persist(() => ({ defaultInitialTaskMode: "plan" }), {
+        name: "settings-storage",
+        storage: jsonStorageOf(module),
+      }),
+    );
+
+    expect(useStore.getState().defaultInitialTaskMode).toBe("plan");
+
+    module.registerRendererStateStorage(backend);
+    await vi.waitFor(() => {
+      expect(useStore.getState().defaultInitialTaskMode).toBe("last_used");
+    });
+
+    useStore.setState({ defaultInitialTaskMode: "plan" });
+    await vi.waitFor(() => {
+      expect(backend.setItem).toHaveBeenCalled();
+    });
+    const persisted = JSON.parse(
+      backend.setItem.mock.calls[backend.setItem.mock.calls.length - 1][1],
+    );
+    expect(persisted.state.defaultInitialTaskMode).toBe("plan");
+  });
+});

--- a/packages/ui/src/shell/rendererStorage.test.ts
+++ b/packages/ui/src/shell/rendererStorage.test.ts
@@ -89,6 +89,89 @@ describe("rendererStorage", () => {
     expect(backend.setItem).toHaveBeenCalledTimes(1);
   });
 
+  it("settles concurrent initial reads of the same key once", async () => {
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({
+      "settings-storage": JSON.stringify({
+        state: { mode: "saved" },
+        version: 0,
+      }),
+    });
+
+    const first = storage.getItem("settings-storage");
+    const second = storage.getItem("settings-storage");
+    module.registerRendererStateStorage(backend);
+
+    await expect(first).resolves.toMatchObject({ state: { mode: "saved" } });
+    await expect(second).resolves.toMatchObject({ state: { mode: "saved" } });
+
+    await storage.setItem("settings-storage", {
+      state: { mode: "changed" },
+      version: 0,
+    });
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a key settled when the initial read rejects so later writes pass", async () => {
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({});
+    backend.getItem.mockRejectedValueOnce(new Error("backend unavailable"));
+
+    const read = storage.getItem("settings-storage");
+    module.registerRendererStateStorage(backend);
+    await expect(read).rejects.toThrow("backend unavailable");
+
+    await storage.setItem("settings-storage", {
+      state: { mode: "changed" },
+      version: 0,
+    });
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards removeItem issued before and after registration", async () => {
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({});
+
+    const removal = storage.removeItem("settings-storage");
+    module.registerRendererStateStorage(backend);
+    await removal;
+    expect(backend.removeItem).toHaveBeenCalledTimes(1);
+
+    await storage.removeItem("settings-storage");
+    expect(backend.removeItem).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps in-flight waiters on the first backend and routes later calls to the second", async () => {
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const first = fakeBackend({
+      "settings-storage": JSON.stringify({
+        state: { from: "first" },
+        version: 0,
+      }),
+    });
+    const second = fakeBackend({
+      "settings-storage": JSON.stringify({
+        state: { from: "second" },
+        version: 0,
+      }),
+    });
+
+    const read = storage.getItem("settings-storage");
+    module.registerRendererStateStorage(first);
+    module.registerRendererStateStorage(second);
+
+    await expect(read).resolves.toMatchObject({ state: { from: "first" } });
+
+    await expect(storage.getItem("settings-storage")).resolves.toMatchObject({
+      state: { from: "second" },
+    });
+    expect(second.getItem).toHaveBeenCalledTimes(1);
+  });
+
   it("hydrates a store created before the host storage registers", async () => {
     const module = await importFreshRendererStorage();
     const backend = fakeBackend({

--- a/packages/ui/src/shell/rendererStorage.ts
+++ b/packages/ui/src/shell/rendererStorage.ts
@@ -1,35 +1,64 @@
-import { resolveService } from "@posthog/di/container";
 import { createJSONStorage, type StateStorage } from "zustand/middleware";
 
 export interface RendererStateStorage extends StateStorage {}
 
-export const RENDERER_STATE_STORAGE = Symbol.for(
-  "posthog.ui.RendererStateStorage",
-);
+let hostStorage: RendererStateStorage | null = null;
+let resolveHostStorage: ((storage: RendererStateStorage) => void) | null = null;
+const hostStorageReady = new Promise<RendererStateStorage>((resolve) => {
+  resolveHostStorage = resolve;
+});
 
-function rawStorage(): StateStorage | null {
-  try {
-    return resolveService<RendererStateStorage>(RENDERER_STATE_STORAGE);
-  } catch {
-    return null;
-  }
+const pendingFirstReads = new Set<string>();
+const settledFirstReads = new Set<string>();
+
+/**
+ * Hosts call this during boot with their persistence backend. Persisted UI
+ * stores are created at module-evaluation time, which can run before the host
+ * composition root has finished, so reads and writes issued before
+ * registration wait for the backend instead of treating "not registered yet"
+ * as "no saved data". That fallback hydrated every store with defaults and
+ * the next write then overwrote the persisted state with those defaults.
+ */
+export function registerRendererStateStorage(
+  storage: RendererStateStorage,
+): void {
+  hostStorage = storage;
+  resolveHostStorage?.(storage);
+  resolveHostStorage = null;
 }
 
-const lazyStorage: StateStorage = {
-  getItem: (key) => {
-    const storage = rawStorage();
-    return storage ? storage.getItem(key) : null;
+const deferredHostStorage: StateStorage = {
+  getItem: async (key) => {
+    const isFirstRead =
+      !settledFirstReads.has(key) && !pendingFirstReads.has(key);
+    if (isFirstRead) {
+      pendingFirstReads.add(key);
+    }
+    try {
+      const storage = hostStorage ?? (await hostStorageReady);
+      return await storage.getItem(key);
+    } finally {
+      if (isFirstRead) {
+        pendingFirstReads.delete(key);
+        settledFirstReads.add(key);
+      }
+    }
   },
-  setItem: (key, value) => {
-    const storage = rawStorage();
-    return storage ? storage.setItem(key, value) : undefined;
+  setItem: async (key, value) => {
+    // A write racing the initial read serializes pre-hydration (default)
+    // state, and hydration replaces in-memory state for persisted keys right
+    // after. The snapshot is stale either way, so drop it instead of letting
+    // it overwrite the values the read is about to return.
+    if (pendingFirstReads.has(key)) {
+      return;
+    }
+    const storage = hostStorage ?? (await hostStorageReady);
+    await storage.setItem(key, value);
   },
-  removeItem: (key) => {
-    const storage = rawStorage();
-    return storage ? storage.removeItem(key) : undefined;
+  removeItem: async (key) => {
+    const storage = hostStorage ?? (await hostStorageReady);
+    await storage.removeItem(key);
   },
 };
 
-export const rendererSecureStore: StateStorage = lazyStorage;
-
-export const electronStorage = createJSONStorage(() => lazyStorage);
+export const electronStorage = createJSONStorage(() => deferredHostStorage);

--- a/packages/ui/src/shell/rendererStorage.ts
+++ b/packages/ui/src/shell/rendererStorage.ts
@@ -1,12 +1,20 @@
 import { createJSONStorage, type StateStorage } from "zustand/middleware";
+import { logger } from "./logger";
 
-export interface RendererStateStorage extends StateStorage {}
+export type RendererStateStorage = StateStorage;
+
+const log = logger.scope("renderer-storage");
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 let hostStorage: RendererStateStorage | null = null;
-let resolveHostStorage: ((storage: RendererStateStorage) => void) | null = null;
-const hostStorageReady = new Promise<RendererStateStorage>((resolve) => {
-  resolveHostStorage = resolve;
-});
+const hostStorageReady = deferred<RendererStateStorage>();
 
 const pendingFirstReads = new Set<string>();
 const settledFirstReads = new Set<string>();
@@ -18,13 +26,15 @@ const settledFirstReads = new Set<string>();
  * registration wait for the backend instead of treating "not registered yet"
  * as "no saved data". That fallback hydrated every store with defaults and
  * the next write then overwrote the persisted state with those defaults.
+ *
+ * Registering again replaces the backend for new calls; waiters already in
+ * flight settle against the first registration.
  */
 export function registerRendererStateStorage(
   storage: RendererStateStorage,
 ): void {
   hostStorage = storage;
-  resolveHostStorage?.(storage);
-  resolveHostStorage = null;
+  hostStorageReady.resolve(storage);
 }
 
 const deferredHostStorage: StateStorage = {
@@ -35,7 +45,7 @@ const deferredHostStorage: StateStorage = {
       pendingFirstReads.add(key);
     }
     try {
-      const storage = hostStorage ?? (await hostStorageReady);
+      const storage = hostStorage ?? (await hostStorageReady.promise);
       return await storage.getItem(key);
     } finally {
       if (isFirstRead) {
@@ -52,12 +62,24 @@ const deferredHostStorage: StateStorage = {
     if (pendingFirstReads.has(key)) {
       return;
     }
-    const storage = hostStorage ?? (await hostStorageReady);
-    await storage.setItem(key, value);
+    try {
+      const storage = hostStorage ?? (await hostStorageReady.promise);
+      await storage.setItem(key, value);
+    } catch (error) {
+      // zustand persist fires writes without awaiting them; a rejection here
+      // would only surface as an unhandled rejection.
+      log.error("Failed to persist state", { key, error });
+    }
   },
   removeItem: async (key) => {
-    const storage = hostStorage ?? (await hostStorageReady);
-    await storage.removeItem(key);
+    // Removal is explicit intent rather than a stale state snapshot, so it is
+    // not dropped while the initial read is in flight.
+    try {
+      const storage = hostStorage ?? (await hostStorageReady.promise);
+      await storage.removeItem(key);
+    } catch (error) {
+      log.error("Failed to remove persisted state", { key, error });
+    }
   },
 };
 


### PR DESCRIPTION
## Problem

since the package split, persisted UI stores hydrate before the host registers its storage backend. The fallback for this just boots every store with defaults and the next write permanently overwrites saved settings. to be clear, this is specifically a problem with any state persisted through the electronStorage adapter in `@posthog/ui/shell/rendererStorage`.

<!-- Closes #ISSUE_ID -->

## Changes

1. Replace resolve-or-null storage lookup with a registration deferred; reads wait for the backend
2. Drop writes racing a key's initial read (stale pre-hydration snapshots)
3. Register the electron-trpc backend without importing the DI container; pin the updates adapter import order in main.tsx
4. Register a localStorage backend on web so sticky settings work there too
5. Remove the dead RENDERER_STATE_STORAGE token and rendererSecureStore export
6. Add rendererStorage regression tests; point settingsStore tests at the registration seam

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?