### PR TITLE
feat(agent): make Slack-origin responses concise

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1486,6 +1486,50 @@ describe("AgentServer HTTP Mode", () => {
         },
       );
 
+      it.each([
+        {
+          label: "no repository, no PR",
+          config: { repositoryPath: undefined },
+        },
+        { label: "repository, no PR", config: {} },
+      ])(
+        "injects concise response-style guidance for Slack-origin runs ($label)",
+        ({ config }) => {
+          process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+          const s = createServer(config);
+          const prompt = (
+            s as unknown as TestableServer
+          ).buildCloudSystemPrompt();
+          expect(prompt).toContain("# Response Style");
+          expect(prompt).toContain("be concise by default");
+          expect(prompt).toContain(
+            "Answer simple questions in a single sentence",
+          );
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        },
+      );
+
+      it.each([
+        { label: "no origin set", origin: undefined },
+        { label: "signal_report origin", origin: "signal_report" },
+        { label: "posthog_code origin", origin: "posthog_code" },
+      ])(
+        "omits response-style guidance for non-Slack runs ($label)",
+        ({ origin }) => {
+          if (origin) {
+            process.env.POSTHOG_CODE_INTERACTION_ORIGIN = origin;
+          } else {
+            delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+          }
+          const s = createServer();
+          const prompt = (
+            s as unknown as TestableServer
+          ).buildCloudSystemPrompt();
+          expect(prompt).not.toContain("# Response Style");
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        },
+      );
+
       it("injects identity for Slack-origin runs with an existing PR", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
         const s = createServer();
@@ -1535,7 +1579,7 @@ describe("AgentServer HTTP Mode", () => {
           expect(prompt).toContain(
             "*Created with [PostHog Code](https://posthog.com/code?ref=pr)*",
           );
-          expect(prompt).not.toContain("Slack thread");
+          expect(prompt).not.toContain("from a [Slack thread]");
         } finally {
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         }

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1721,6 +1721,14 @@ export class AgentServer {
       ? `
 # Identity
 You are the PostHog Slack app, PostHog's agent for helping users with their product data and coding tasks from Slack. When introducing yourself or referring to yourself in messages to the user, identify as "PostHog Slack app". Do NOT refer to yourself as Claude, an Anthropic assistant, or any underlying model name.
+
+# Response Style
+You are replying in a Slack thread. Slack readers want short, skimmable answers — be concise by default.
+- Answer simple questions in a single sentence. Keep everything else brief — a few sentences at most.
+- Lead with the answer or the outcome. Skip preamble, restating the question, and sign-offs.
+- Prefer plain prose. Treat bullet lists as the exception, not the norm, and avoid headers and tables unless they genuinely make a complex answer clearer.
+- Do not narrate your thinking or list every step you took; report what matters and the result.
+- This is a default, not a hard rule. If the user (or their saved memory) asks for more depth or a specific format, follow that instead.
 `
       : "";
     const signedCommitInstructions = `


### PR DESCRIPTION
## Problem

Customers reported that the PostHog Slack app's replies are too wordy. Slack readers want short, skimmable answers, but the agent's cloud system prompt had no length guidance for Slack-origin runs, so a one-line answer could come back as several paragraphs.

**Why:** repeated direct user feedback that the Slack bot is too verbose — a simple question should get a short answer.

## Changes

Adds a Slack-only **Response Style** block to the cloud system prompt, gated on the same Slack-origin check as the existing identity block (so the web/PR experience is unchanged). It tells the agent to default to concise, skimmable replies — a single sentence for simple questions, plain prose over bullets/headers/tables, no preamble or sign-offs — while staying a default that explicit user requests and saved memory can still override.

## How did you test this?

Added parameterized tests asserting the block is present for Slack-origin runs and absent for non-Slack runs, and ran `pnpm --filter @posthog/agent typecheck` plus Biome — both clean. The full Vitest suite could not run in this sandbox (the test harness's repo-setup step shells out to `git commit`, which is blocked here), but the new assertions mirror the existing identity-block tests.

Tested locally

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781238065827849?thread_ts=1781238065.827849&cid=C09G8Q32R6F)*
