### PR TITLE
feat(scouts): add Discuss button to individual scout findings

### DIFF
--- a/packages/core/src/scouts/scoutPrompts.test.ts
+++ b/packages/core/src/scouts/scoutPrompts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildScoutFindingDiscussPrompt } from "./scoutPrompts";
+
+const base = {
+  skillName: "signals-scout-error-tracking",
+  displayName: "Error tracking",
+  findingId: "finding-123",
+  description: "Spike in TypeError on /checkout over the last hour.",
+  severity: "high",
+  confidence: 0.82,
+};
+
+describe("buildScoutFindingDiscussPrompt", () => {
+  it("includes the finding metadata, description, and scout skill", () => {
+    const prompt = buildScoutFindingDiscussPrompt(base);
+
+    expect(prompt).toContain("Error tracking scout");
+    expect(prompt).toContain("`signals-scout-error-tracking`");
+    expect(prompt).toContain("Finding ID: finding-123");
+    expect(prompt).toContain("Severity: high");
+    expect(prompt).toContain("Confidence: 82%");
+    expect(prompt).toContain(base.description);
+    expect(prompt).toContain("exploring-signals-scouts");
+  });
+
+  it("leads with the user's question when one is provided", () => {
+    const prompt = buildScoutFindingDiscussPrompt({
+      ...base,
+      question: "  Is this caused by the latest deploy?  ",
+    });
+
+    expect(prompt).toContain(
+      "Answer this first: Is this caused by the latest deploy?",
+    );
+    expect(prompt).not.toContain("brief readout");
+  });
+
+  it("falls back to a readout when no question is given", () => {
+    const prompt = buildScoutFindingDiscussPrompt({ ...base, question: "   " });
+
+    expect(prompt).toContain("brief readout");
+    expect(prompt).not.toContain("Answer this first");
+  });
+
+  it("omits the severity line when severity is null", () => {
+    const prompt = buildScoutFindingDiscussPrompt({ ...base, severity: null });
+
+    expect(prompt).not.toContain("Severity:");
+  });
+});

--- a/packages/core/src/scouts/scoutPrompts.test.ts
+++ b/packages/core/src/scouts/scoutPrompts.test.ts
@@ -4,9 +4,10 @@ import { buildScoutFindingDiscussPrompt } from "./scoutPrompts";
 const base = {
   skillName: "signals-scout-error-tracking",
   displayName: "Error tracking",
+  runId: "run-abc",
   findingId: "finding-123",
   description: "Spike in TypeError on /checkout over the last hour.",
-  severity: "high",
+  severity: "high" as string | null,
   confidence: 0.82,
 };
 
@@ -16,6 +17,7 @@ describe("buildScoutFindingDiscussPrompt", () => {
 
     expect(prompt).toContain("Error tracking scout");
     expect(prompt).toContain("`signals-scout-error-tracking`");
+    expect(prompt).toContain("Run ID: run-abc");
     expect(prompt).toContain("Finding ID: finding-123");
     expect(prompt).toContain("Severity: high");
     expect(prompt).toContain("Confidence: 82%");
@@ -23,28 +25,36 @@ describe("buildScoutFindingDiscussPrompt", () => {
     expect(prompt).toContain("exploring-signals-scouts");
   });
 
-  it("leads with the user's question when one is provided", () => {
-    const prompt = buildScoutFindingDiscussPrompt({
-      ...base,
-      question: "  Is this caused by the latest deploy?  ",
-    });
+  it.each([
+    {
+      name: "leads with the user's question when one is provided",
+      overrides: { question: "  Is this caused by the latest deploy?  " },
+      contains: ["Answer this first: Is this caused by the latest deploy?"],
+      notContains: ["brief readout"],
+    },
+    {
+      name: "falls back to a readout for a whitespace-only question",
+      overrides: { question: "   " },
+      contains: ["brief readout"],
+      notContains: ["Answer this first"],
+    },
+    {
+      name: "falls back to a readout when no question is given",
+      overrides: {},
+      contains: ["brief readout"],
+      notContains: ["Answer this first"],
+    },
+    {
+      name: "omits the severity line when severity is null",
+      overrides: { severity: null },
+      contains: [],
+      notContains: ["Severity:"],
+    },
+  ])("$name", ({ overrides, contains, notContains }) => {
+    const prompt = buildScoutFindingDiscussPrompt({ ...base, ...overrides });
 
-    expect(prompt).toContain(
-      "Answer this first: Is this caused by the latest deploy?",
-    );
-    expect(prompt).not.toContain("brief readout");
-  });
-
-  it("falls back to a readout when no question is given", () => {
-    const prompt = buildScoutFindingDiscussPrompt({ ...base, question: "   " });
-
-    expect(prompt).toContain("brief readout");
-    expect(prompt).not.toContain("Answer this first");
-  });
-
-  it("omits the severity line when severity is null", () => {
-    const prompt = buildScoutFindingDiscussPrompt({ ...base, severity: null });
-
-    expect(prompt).not.toContain("Severity:");
+    for (const substring of contains) expect(prompt).toContain(substring);
+    for (const substring of notContains)
+      expect(prompt).not.toContain(substring);
   });
 });

--- a/packages/core/src/scouts/scoutPrompts.ts
+++ b/packages/core/src/scouts/scoutPrompts.ts
@@ -42,6 +42,7 @@ Group by scout, newest first. Close with a short note on overall signal quality 
 export function buildScoutFindingDiscussPrompt({
   skillName,
   displayName,
+  runId,
   findingId,
   description,
   severity,
@@ -50,6 +51,7 @@ export function buildScoutFindingDiscussPrompt({
 }: {
   skillName: string;
   displayName: string;
+  runId: string;
   findingId: string;
   description: string;
   severity: string | null;
@@ -59,6 +61,7 @@ export function buildScoutFindingDiscussPrompt({
   const trimmedQuestion = question?.trim();
   const meta = [
     `Scout: \`${skillName}\` (${displayName})`,
+    `Run ID: ${runId}`,
     `Finding ID: ${findingId}`,
     severity ? `Severity: ${severity}` : null,
     `Confidence: ${Math.round(confidence * 100)}%`,
@@ -79,7 +82,7 @@ ${
     : "Give me a brief readout on what this finding means and whether it looks genuinely actionable or like noise, then ask what I want to dig into."
 }
 
-Use the exploring-signals-scouts skill from the PostHog MCP to ground your investigation: pull the \`${skillName}\` scout's recent runs and this finding's context, cross-reference the relevant product data, and assess whether it's real and worth acting on. If the skill is unavailable, fall back to the signals-scout MCP tools directly (config list, runs list, run emissions) plus the read-data and insight tools.`;
+Use the exploring-signals-scouts skill from the PostHog MCP to ground your investigation: fetch this exact run's emissions (run ${runId}) for the finding's full context, pull the \`${skillName}\` scout's recent runs, cross-reference the relevant product data, and assess whether it's real and worth acting on. If the skill is unavailable, fall back to the signals-scout MCP tools directly (config list, runs list, run emissions) plus the read-data and insight tools.`;
 }
 
 /** Per-scout variant of the templated questions, scoped to one skill. */

--- a/packages/core/src/scouts/scoutPrompts.ts
+++ b/packages/core/src/scouts/scoutPrompts.ts
@@ -34,6 +34,54 @@ Use the exploring-signals-scouts skill from the PostHog MCP to pull the most rec
 
 Group by scout, newest first. Close with a short note on overall signal quality and any scouts that look noisy or suspiciously silent. If the skill is unavailable, fall back to the signals-scout MCP tools directly (runs list with emitted filter, run emissions).`;
 
+/**
+ * Templated prompt for digging into a single finding a scout emitted, scoped to
+ * that finding plus an optional free-text question the user typed before kicking
+ * the task off (mirrors the inbox report Discuss flow).
+ */
+export function buildScoutFindingDiscussPrompt({
+  skillName,
+  displayName,
+  findingId,
+  description,
+  severity,
+  confidence,
+  question,
+}: {
+  skillName: string;
+  displayName: string;
+  findingId: string;
+  description: string;
+  severity: string | null;
+  confidence: number;
+  question?: string;
+}): string {
+  const trimmedQuestion = question?.trim();
+  const meta = [
+    `Scout: \`${skillName}\` (${displayName})`,
+    `Finding ID: ${findingId}`,
+    severity ? `Severity: ${severity}` : null,
+    `Confidence: ${Math.round(confidence * 100)}%`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return `I want to dig into a specific finding my ${displayName} scout emitted and work out whether it needs action.
+
+${meta}
+
+Finding:
+${description}
+
+${
+  trimmedQuestion
+    ? `Answer this first: ${trimmedQuestion}`
+    : "Give me a brief readout on what this finding means and whether it looks genuinely actionable or like noise, then ask what I want to dig into."
+}
+
+Use the exploring-signals-scouts skill from the PostHog MCP to ground your investigation: pull the \`${skillName}\` scout's recent runs and this finding's context, cross-reference the relevant product data, and assess whether it's real and worth acting on. If the skill is unavailable, fall back to the signals-scout MCP tools directly (config list, runs list, run emissions) plus the read-data and insight tools.`;
+}
+
 /** Per-scout variant of the templated questions, scoped to one skill. */
 export function buildScoutCheckinPrompt(
   skillName: string,

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -635,6 +635,7 @@ export type ScoutChatType =
   | "fleet_overview"
   | "recent_signals"
   | "scout_checkin"
+  | "finding_discuss"
   | "author_scout";
 
 export type ScoutSurface = "fleet_list" | "scout_detail" | "empty_state";

--- a/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
@@ -11,12 +11,15 @@ import { SeverityBadge } from "./ScoutBadges";
 export function ScoutEmissionCard({
   emission,
   skillName,
+  actions,
   footerEnd,
   defaultExpanded = false,
 }: {
   emission: ScoutEmission;
   /** The emitting scout, attached to analytics events when known. */
   skillName?: string;
+  /** Interactive controls shown after the finding id at the footer's left. */
+  actions?: ReactNode;
   /** Replaces the default pipeline note at the footer's right edge. */
   footerEnd?: ReactNode;
   defaultExpanded?: boolean;
@@ -68,6 +71,7 @@ export function ScoutEmissionCard({
           className="border-t border-t-(--gray-5) text-[11px] text-gray-10"
         >
           <Text className="font-mono text-[11px]">{emission.finding_id}</Text>
+          {actions}
           <span className="flex-1" />
           {footerEnd ?? (
             <Text className="text-[11px] text-gray-9">

--- a/packages/ui/src/features/scouts/components/ScoutFindingDiscussButton.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingDiscussButton.tsx
@@ -35,6 +35,7 @@ export function ScoutFindingDiscussButton({
       buildScoutFindingDiscussPrompt({
         skillName,
         displayName,
+        runId: emission.run_id,
         findingId: emission.finding_id,
         description: emission.description,
         severity: emission.severity,
@@ -44,6 +45,7 @@ export function ScoutFindingDiscussButton({
     [
       skillName,
       displayName,
+      emission.run_id,
       emission.finding_id,
       emission.description,
       emission.severity,
@@ -62,15 +64,14 @@ export function ScoutFindingDiscussButton({
   });
 
   const submit = useCallback(() => {
-    if (question.trim().length === 0) return;
-    // `runTask` closes over the current question-laden prompt, so clearing
-    // state afterwards is safe and leaves the popover ready for next time.
+    if (isRunning) return;
+    // A question is optional: an empty submit resolves to the "brief readout"
+    // prompt. `runTask` closes over the current prompt, so clearing state
+    // afterwards is safe and leaves the popover ready for next time.
     void runTask();
     setQuestion("");
     setOpen(false);
-  }, [question, runTask]);
-
-  const submitDisabled = question.trim().length === 0 || isRunning;
+  }, [isRunning, runTask]);
 
   return (
     <Popover.Root
@@ -87,11 +88,7 @@ export function ScoutFindingDiscussButton({
           title="Discuss this finding with your agent"
           className="inline-flex shrink-0 items-center gap-1 text-[11px] text-accent-11 no-underline transition-colors hover:text-accent-12 disabled:cursor-default disabled:opacity-60"
         >
-          {isRunning ? (
-            <Spinner size="1" />
-          ) : (
-            <ChatCircleIcon size={11} />
-          )}
+          {isRunning ? <Spinner size="1" /> : <ChatCircleIcon size={11} />}
           Discuss
         </button>
       </Popover.Trigger>
@@ -111,7 +108,7 @@ export function ScoutFindingDiscussButton({
           <TextArea
             aria-label="Question to discuss about this finding"
             autoFocus
-            placeholder="Ask about this finding…"
+            placeholder="Ask about this finding… (optional)"
             resize="vertical"
             rows={5}
             size="2"
@@ -141,7 +138,7 @@ export function ScoutFindingDiscussButton({
                 type="submit"
                 variant="primary"
                 size="sm"
-                disabled={submitDisabled}
+                disabled={isRunning}
               >
                 Discuss
               </Button>

--- a/packages/ui/src/features/scouts/components/ScoutFindingDiscussButton.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingDiscussButton.tsx
@@ -1,0 +1,154 @@
+import { ChatCircleIcon } from "@phosphor-icons/react";
+import type { ScoutEmission } from "@posthog/api-client/posthog-client";
+import { prettifyScoutSkillName } from "@posthog/core/scouts/scoutPresentation";
+import { buildScoutFindingDiscussPrompt } from "@posthog/core/scouts/scoutPrompts";
+import { Button } from "@posthog/quill";
+import { Flex, Popover, Spinner, Text, TextArea } from "@radix-ui/themes";
+import { useCallback, useMemo, useState } from "react";
+import { useScoutChatTask } from "../hooks/useScoutChatTask";
+
+const isMac =
+  typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+
+/**
+ * Per-finding "Discuss" CTA on a scout emission card: opens a popover for an
+ * optional question, then fires a one-click auto-mode cloud task that digs into
+ * this specific finding. Mirrors the inbox report Discuss flow.
+ */
+export function ScoutFindingDiscussButton({
+  emission,
+  skillName,
+}: {
+  emission: ScoutEmission;
+  skillName: string;
+}) {
+  const [question, setQuestion] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const displayName = useMemo(
+    () => prettifyScoutSkillName(skillName),
+    [skillName],
+  );
+
+  const prompt = useMemo(
+    () =>
+      buildScoutFindingDiscussPrompt({
+        skillName,
+        displayName,
+        findingId: emission.finding_id,
+        description: emission.description,
+        severity: emission.severity,
+        confidence: emission.confidence,
+        question: question.trim() || undefined,
+      }),
+    [
+      skillName,
+      displayName,
+      emission.finding_id,
+      emission.description,
+      emission.severity,
+      emission.confidence,
+      question,
+    ],
+  );
+
+  const { runTask, isRunning } = useScoutChatTask({
+    prompt,
+    taskLabel: "finding discussion",
+    loggerScope: "scout-finding-discuss",
+    chatType: "finding_discuss",
+    surface: "scout_detail",
+    skillName,
+  });
+
+  const submit = useCallback(() => {
+    if (question.trim().length === 0) return;
+    // `runTask` closes over the current question-laden prompt, so clearing
+    // state afterwards is safe and leaves the popover ready for next time.
+    void runTask();
+    setQuestion("");
+    setOpen(false);
+  }, [question, runTask]);
+
+  const submitDisabled = question.trim().length === 0 || isRunning;
+
+  return (
+    <Popover.Root
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuestion("");
+      }}
+    >
+      <Popover.Trigger>
+        <button
+          type="button"
+          disabled={isRunning}
+          title="Discuss this finding with your agent"
+          className="inline-flex shrink-0 items-center gap-1 text-[11px] text-accent-11 no-underline transition-colors hover:text-accent-12 disabled:cursor-default disabled:opacity-60"
+        >
+          {isRunning ? (
+            <Spinner size="1" />
+          ) : (
+            <ChatCircleIcon size={11} />
+          )}
+          Discuss
+        </button>
+      </Popover.Trigger>
+      <Popover.Content
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="w-[420px] border border-(--gray-6) bg-(--color-panel-solid) p-3 shadow-6"
+      >
+        <form
+          className="flex flex-col gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            submit();
+          }}
+        >
+          <TextArea
+            aria-label="Question to discuss about this finding"
+            autoFocus
+            placeholder="Ask about this finding…"
+            resize="vertical"
+            rows={5}
+            size="2"
+            value={question}
+            onChange={(event) => setQuestion(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                submit();
+              }
+            }}
+          />
+          <Flex justify="between" align="center" gap="2">
+            <Text size="1" color="gray">
+              {isMac ? "⌘↵" : "Ctrl+↵"} to send
+            </Text>
+            <Flex gap="2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={submitDisabled}
+              >
+                Discuss
+              </Button>
+            </Flex>
+          </Flex>
+        </form>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/packages/ui/src/features/scouts/components/ScoutSignalsSection.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutSignalsSection.tsx
@@ -6,6 +6,7 @@ import { Box, Flex, Text } from "@radix-ui/themes";
 import { useState } from "react";
 import { useScoutRunEmissions } from "../hooks/useScoutRunEmissions";
 import { ScoutEmissionCard } from "./ScoutEmissionCard";
+import { ScoutFindingDiscussButton } from "./ScoutFindingDiscussButton";
 import { ScoutTaskRunLink } from "./ScoutTaskRunLink";
 
 /**
@@ -122,6 +123,12 @@ function RunEmissions({ run }: { run: ScoutRun }) {
           key={emission.id}
           emission={emission}
           skillName={run.skill_name}
+          actions={
+            <ScoutFindingDiscussButton
+              emission={emission}
+              skillName={run.skill_name}
+            />
+          }
           footerEnd={
             taskRunUrl ? (
               <ScoutTaskRunLink run={run} taskRunUrl={taskRunUrl} />


### PR DESCRIPTION
## What

Adds a per-finding **Discuss** button to scout findings in the Scout view, mirroring the existing Discuss flow on inbox report items. Click Discuss → optionally type a question/text → it kicks off an auto-mode cloud task that digs into that specific finding, as another way to decide whether the finding needs action or warrants more discussion.

## How it works

The button sits in the footer of each finding card (next to the finding ID and the "Open task run" link). Clicking it opens a popover with a textarea ("Ask about this finding…"), Cancel/Discuss buttons, and `⌘↵`/`Ctrl+↵` to send — the same UX as the report Discuss popover. On submit it creates a cloud task whose prompt hands the agent the finding's scout, ID, severity, confidence, description, and your question, instructing it to use the `exploring-signals-scouts` skill to assess whether the finding is real and worth acting on, then navigates to the new task.

## Changes

- **`packages/core/src/scouts/scoutPrompts.ts`** — new `buildScoutFindingDiscussPrompt(...)` with a question-first branch and a "brief readout" fallback.
- **`packages/core/src/scouts/scoutPrompts.test.ts`** — unit tests for the new prompt builder.
- **`packages/shared/src/analytics-events.ts`** — add `"finding_discuss"` to `ScoutChatType` so the existing `SCOUT_CHAT_STARTED` telemetry covers this CTA.
- **`packages/ui/src/features/scouts/components/ScoutFindingDiscussButton.tsx`** — new popover component wired to the existing `useScoutChatTask` hook (repo/integration/model resolution, task creation, navigation, error toasts).
- **`packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx`** — optional `actions` footer slot (stays presentational).
- **`packages/ui/src/features/scouts/components/ScoutSignalsSection.tsx`** — injects the Discuss button per emission.

## Design notes

- Reuses the existing `useScoutChatTask` / `useInboxCloudTaskRunner` cloud-task plumbing rather than rebuilding it — the same pattern the per-scout "chat" sparkle button already uses, so repo fallback, model resolution, toasts, and analytics come for free.
- `ScoutEmissionCard` stays presentational: the task-creating button is injected via a prop.

## Verification

- `typecheck` passes for `@posthog/shared`, `@posthog/core`, `@posthog/ui`.
- Biome lint/format clean on touched files.
- Core test suite passes, including the new prompt tests.

## Worth a look in review

This creates a real cloud task per finding (consistent with the report Discuss button), so the footer now offers a fairly heavyweight action on every emission card — worth eyeballing in the running app to confirm placement/visual weight feels right next to "Open task run".

🤖 Generated with [Claude Code](https://claude.com/claude-code)