### PR TITLE
fix(git): prevent reverting remote commits

### DIFF
--- a/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/packages/agent/src/adapters/signed-commit-shared.ts
@@ -29,8 +29,9 @@ export const SIGNED_COMMIT_TOOL_DESCRIPTION =
   "blocked because all commits must be signed. The commit is created via GitHub's API and " +
   "your local checkout is kept in sync. For a new branch, pass `branch` (prefixed with " +
   "`posthog-code/`) and the tool creates it on the remote. Refuses while a merge/rebase/" +
-  "cherry-pick is in progress, and refuses staged files that copy base-branch content into " +
-  "the PR — to bring the base branch in, use `git_signed_merge` instead.";
+  "cherry-pick is in progress, refuses staged files that copy base-branch content into the PR " +
+  "(to bring the base branch in, use `git_signed_merge`), and refuses when the remote branch " +
+  "has advanced past your checkout (e.g. a CI bot pushed) — sync it first, then retry.";
 
 export const signedCommitToolSchema = {
   message: z.string().describe("Commit headline (first line)."),

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1751,6 +1751,18 @@ Histories containing merge commits are refused — rebase (which flattens merges
 If a signed-git tool refuses with a "merge in progress" or "leak" error, follow its recovery
 instructions instead of retrying the same call.
 
+## Re-committing to a branch with an open PR
+Before committing again to a branch that already has an open PR, fetch it first. The remote
+branch can advance between your commits — CI automation often auto-commits regenerated
+artifacts (codegen, lockfiles, formatting) onto open PR branches, and collaborators can push
+too. Committing from a stale local checkout silently reverts those commits, so
+\`git_signed_commit\` refuses when the remote branch is ahead of your checkout. If it does, or
+before your next commit, update your checkout — stash any uncommitted work across the update so
+you don't lose it: \`git stash --include-untracked\`, \`git fetch origin <branch>\`,
+\`git reset --hard origin/<branch>\`, \`git stash pop\` (resolve any conflicts), then re-stage
+and commit. A soft/mixed reset would keep your stale files and re-commit the revert, so the
+hard reset is the safe one here — your work is held in the stash.
+
 ## Attribution
 Do NOT add "Co-Authored-By" trailers or "Generated with [Claude Code]" lines to your
 commit messages. The \`git_signed_commit\` tool automatically appends the only trailers

--- a/packages/git/src/signed-commit.test.ts
+++ b/packages/git/src/signed-commit.test.ts
@@ -261,7 +261,7 @@ describe("operationInProgressError", () => {
 });
 
 describe("behindRemoteError", () => {
-  it("names the branch, the short tip, and the sync recovery", () => {
+  it("names the branch and short tip, gives the recovery, and stays generic", () => {
     const msg = behindRemoteError(
       "posthog-code/feature",
       "0123456789abcdef0123456789abcdef01234567",
@@ -274,10 +274,7 @@ describe("behindRemoteError", () => {
     expect(msg).toContain("git reset --hard origin/posthog-code/feature");
     expect(msg).toContain("git stash pop");
     expect(msg).toContain("REVERTING");
-  });
-
-  it("stays generic — no repo-specific bot or codegen names", () => {
-    const msg = behindRemoteError("feature", "abc123");
+    // Generic — no repo-specific bot or codegen names.
     expect(msg).not.toContain("tests-posthog");
     expect(msg).not.toContain("OpenAPI");
   });
@@ -398,29 +395,41 @@ describe("assertNotBehindRemote", () => {
     return git(dir, "rev-parse", "HEAD");
   }
 
-  // Scenario: an agent clone whose checkout is one commit behind a branch that
-  // a "bot" advanced on the shared remote.
-  function setupBranchAdvancedByBot(): {
-    agent: string;
-    branch: string;
-    botTip: string;
-  } {
+  // Bare remote + an agent clone with an initial main commit pushed.
+  function setupBaseRepo(): { remote: string; agent: string } {
     const remote = tmp("remote");
     git(remote, "init", "--bare", "--initial-branch", "main");
-
-    const branch = "posthog-code/feature";
-
-    // Agent: initial commit on main, branch off, first commit, push the branch.
     const agent = tmp("agent");
     initRepo(agent);
     git(agent, "remote", "add", "origin", remote);
     commit(agent, "base.txt", "base\n");
     git(agent, "push", "origin", "main");
-    git(agent, "checkout", "-b", branch);
-    commit(agent, "feature.txt", "v1\n");
-    git(agent, "push", "origin", branch);
+    return { remote, agent };
+  }
 
-    // Bot: separate clone pushes a regen commit onto the same branch.
+  // setupBaseRepo plus a feature branch committed and pushed; `tip` is its head.
+  function setupPushedBranch(): {
+    remote: string;
+    agent: string;
+    branch: string;
+    tip: string;
+  } {
+    const { remote, agent } = setupBaseRepo();
+    const branch = "posthog-code/feature";
+    git(agent, "checkout", "-b", branch);
+    const tip = commit(agent, "feature.txt", "v1\n");
+    git(agent, "push", "origin", branch);
+    return { remote, agent, branch, tip };
+  }
+
+  // Scenario that bit us: a "bot" advances the pushed branch on the remote, so
+  // the agent's checkout sits one commit behind.
+  function setupBranchAdvancedByBot(): {
+    agent: string;
+    branch: string;
+    botTip: string;
+  } {
+    const { remote, agent, branch } = setupPushedBranch();
     const bot = tmp("bot");
     git(bot, "clone", remote, ".");
     git(bot, "config", "user.name", "tests-posthog[bot]");
@@ -429,7 +438,6 @@ describe("assertNotBehindRemote", () => {
     git(bot, "checkout", branch);
     const botTip = commit(bot, "generated.ts", "// regenerated\n");
     git(bot, "push", "origin", branch);
-
     return { agent, branch, botTip };
   }
 
@@ -457,17 +465,7 @@ describe("assertNotBehindRemote", () => {
   });
 
   it("is a no-op when the remote has not advanced, leaving staged work ready", async () => {
-    const remote = tmp("remote");
-    git(remote, "init", "--bare", "--initial-branch", "main");
-    const branch = "posthog-code/feature";
-    const agent = tmp("agent");
-    initRepo(agent);
-    git(agent, "remote", "add", "origin", remote);
-    commit(agent, "base.txt", "base\n");
-    git(agent, "push", "origin", "main");
-    git(agent, "checkout", "-b", branch);
-    const tip = commit(agent, "feature.txt", "v1\n");
-    git(agent, "push", "origin", branch);
+    const { agent, branch, tip } = setupPushedBranch();
 
     // Agent stages its next change; no bot has pushed since.
     writeFileSync(path.join(agent, "docs.md"), "edit\n");
@@ -482,13 +480,8 @@ describe("assertNotBehindRemote", () => {
   });
 
   it("allows committing when the local checkout is ahead of the remote tip", async () => {
-    const remote = tmp("remote");
-    git(remote, "init", "--bare", "--initial-branch", "main");
-    const agent = tmp("agent");
-    initRepo(agent);
-    git(agent, "remote", "add", "origin", remote);
-    const tip = commit(agent, "base.txt", "base\n");
-    git(agent, "push", "origin", "main");
+    const { agent } = setupBaseRepo();
+    const tip = git(agent, "rev-parse", "HEAD");
     // Local advances past the pushed tip without publishing — tip is an ancestor
     // of HEAD, so there is nothing to revert.
     commit(agent, "more.txt", "local\n");

--- a/packages/git/src/signed-commit.test.ts
+++ b/packages/git/src/signed-commit.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  assertNotBehindRemote,
+  behindRemoteError,
   chunkFileChanges,
   detectBaseLeaks,
   interpretMergeApiResult,
@@ -254,6 +260,29 @@ describe("operationInProgressError", () => {
   });
 });
 
+describe("behindRemoteError", () => {
+  it("names the branch, the short tip, and the sync recovery", () => {
+    const msg = behindRemoteError(
+      "posthog-code/feature",
+      "0123456789abcdef0123456789abcdef01234567",
+    );
+    expect(msg).toContain("posthog-code/feature");
+    expect(msg).toContain("0123456789ab"); // 12-char short tip
+    expect(msg).not.toContain("0123456789abc"); // not the full oid
+    expect(msg).toContain("git stash --include-untracked");
+    expect(msg).toContain("git fetch origin posthog-code/feature");
+    expect(msg).toContain("git reset --hard origin/posthog-code/feature");
+    expect(msg).toContain("git stash pop");
+    expect(msg).toContain("REVERTING");
+  });
+
+  it("stays generic — no repo-specific bot or codegen names", () => {
+    const msg = behindRemoteError("feature", "abc123");
+    expect(msg).not.toContain("tests-posthog");
+    expect(msg).not.toContain("OpenAPI");
+  });
+});
+
 describe("interpretMergeApiResult", () => {
   it.each([
     {
@@ -326,5 +355,146 @@ describe("interpretMergeApiResult", () => {
       exitCode: 0,
     });
     expect(outcome.kind).toBe("error");
+  });
+});
+
+describe("assertNotBehindRemote", () => {
+  const cleanups: string[] = [];
+
+  afterEach(() => {
+    while (cleanups.length) {
+      const dir = cleanups.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function git(cwd: string, ...args: string[]): string {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      // The cloud sandbox installs a git-guard shim that blocks `commit`/`push`;
+      // its documented escape hatch lets the fixture build real history here.
+      env: { ...process.env, POSTHOG_ALLOW_UNSIGNED_GIT: "1" },
+    }).trim();
+  }
+
+  function tmp(label: string): string {
+    const dir = mkdtempSync(path.join(tmpdir(), `posthog-${label}-`));
+    cleanups.push(dir);
+    return dir;
+  }
+
+  function initRepo(dir: string): void {
+    git(dir, "init", "--initial-branch", "main");
+    git(dir, "config", "user.name", "Test");
+    git(dir, "config", "user.email", "test@example.com");
+    git(dir, "config", "commit.gpgsign", "false");
+  }
+
+  function commit(dir: string, file: string, contents: string): string {
+    writeFileSync(path.join(dir, file), contents);
+    git(dir, "add", file);
+    git(dir, "commit", "-m", `add ${file}`);
+    return git(dir, "rev-parse", "HEAD");
+  }
+
+  // Scenario: an agent clone whose checkout is one commit behind a branch that
+  // a "bot" advanced on the shared remote.
+  function setupBranchAdvancedByBot(): {
+    agent: string;
+    branch: string;
+    botTip: string;
+  } {
+    const remote = tmp("remote");
+    git(remote, "init", "--bare", "--initial-branch", "main");
+
+    const branch = "posthog-code/feature";
+
+    // Agent: initial commit on main, branch off, first commit, push the branch.
+    const agent = tmp("agent");
+    initRepo(agent);
+    git(agent, "remote", "add", "origin", remote);
+    commit(agent, "base.txt", "base\n");
+    git(agent, "push", "origin", "main");
+    git(agent, "checkout", "-b", branch);
+    commit(agent, "feature.txt", "v1\n");
+    git(agent, "push", "origin", branch);
+
+    // Bot: separate clone pushes a regen commit onto the same branch.
+    const bot = tmp("bot");
+    git(bot, "clone", remote, ".");
+    git(bot, "config", "user.name", "tests-posthog[bot]");
+    git(bot, "config", "user.email", "bot@example.com");
+    git(bot, "config", "commit.gpgsign", "false");
+    git(bot, "checkout", branch);
+    const botTip = commit(bot, "generated.ts", "// regenerated\n");
+    git(bot, "push", "origin", branch);
+
+    return { agent, branch, botTip };
+  }
+
+  it("refuses a second commit from a checkout that never pulled the bot commit", () => {
+    const { agent, branch, botTip } = setupBranchAdvancedByBot();
+
+    // Fetches the tip (as createSignedCommit does) but HEAD still predates it.
+    git(agent, "fetch", "--no-tags", "origin", branch);
+
+    return expect(
+      assertNotBehindRemote({ cwd: agent, token: "x" }, branch, botTip),
+    ).rejects.toThrow(/advanced past your local checkout/);
+  });
+
+  it("allows committing when the checkout is up to date with the remote tip", async () => {
+    const { agent, branch } = setupBranchAdvancedByBot();
+    git(agent, "fetch", "--no-tags", "origin", branch);
+    // Sync the checkout to the advanced remote tip, mirroring the recovery path.
+    git(agent, "reset", "--hard", `origin/${branch}`);
+    const tip = git(agent, "rev-parse", "HEAD");
+
+    await expect(
+      assertNotBehindRemote({ cwd: agent, token: "x" }, branch, tip),
+    ).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when the remote has not advanced, leaving staged work ready", async () => {
+    const remote = tmp("remote");
+    git(remote, "init", "--bare", "--initial-branch", "main");
+    const branch = "posthog-code/feature";
+    const agent = tmp("agent");
+    initRepo(agent);
+    git(agent, "remote", "add", "origin", remote);
+    commit(agent, "base.txt", "base\n");
+    git(agent, "push", "origin", "main");
+    git(agent, "checkout", "-b", branch);
+    const tip = commit(agent, "feature.txt", "v1\n");
+    git(agent, "push", "origin", branch);
+
+    // Agent stages its next change; no bot has pushed since.
+    writeFileSync(path.join(agent, "docs.md"), "edit\n");
+    git(agent, "add", "docs.md");
+    git(agent, "fetch", "--no-tags", "origin", branch);
+
+    await expect(
+      assertNotBehindRemote({ cwd: agent, token: "x" }, branch, tip),
+    ).resolves.toBeUndefined();
+    // The guard only reads git state — the staged change is still ready to commit.
+    expect(git(agent, "diff", "--cached", "--name-only")).toBe("docs.md");
+  });
+
+  it("allows committing when the local checkout is ahead of the remote tip", async () => {
+    const remote = tmp("remote");
+    git(remote, "init", "--bare", "--initial-branch", "main");
+    const agent = tmp("agent");
+    initRepo(agent);
+    git(agent, "remote", "add", "origin", remote);
+    const tip = commit(agent, "base.txt", "base\n");
+    git(agent, "push", "origin", "main");
+    // Local advances past the pushed tip without publishing — tip is an ancestor
+    // of HEAD, so there is nothing to revert.
+    commit(agent, "more.txt", "local\n");
+
+    await expect(
+      assertNotBehindRemote({ cwd: agent, token: "x" }, "main", tip),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/git/src/signed-commit.test.ts
+++ b/packages/git/src/signed-commit.test.ts
@@ -261,22 +261,29 @@ describe("operationInProgressError", () => {
 });
 
 describe("behindRemoteError", () => {
-  it("names the branch and short tip, gives the recovery, and stays generic", () => {
-    const msg = behindRemoteError(
-      "posthog-code/feature",
-      "0123456789abcdef0123456789abcdef01234567",
-    );
-    expect(msg).toContain("posthog-code/feature");
-    expect(msg).toContain("0123456789ab"); // 12-char short tip
-    expect(msg).not.toContain("0123456789abc"); // not the full oid
-    expect(msg).toContain("git stash --include-untracked");
-    expect(msg).toContain("git fetch origin posthog-code/feature");
-    expect(msg).toContain("git reset --hard origin/posthog-code/feature");
-    expect(msg).toContain("git stash pop");
-    expect(msg).toContain("REVERTING");
-    // Generic — no repo-specific bot or codegen names.
-    expect(msg).not.toContain("tests-posthog");
-    expect(msg).not.toContain("OpenAPI");
+  const msg = behindRemoteError(
+    "posthog-code/feature",
+    "0123456789abcdef0123456789abcdef01234567",
+  );
+
+  it.each([
+    "posthog-code/feature", // names the branch
+    "0123456789ab", // 12-char short tip
+    "git stash --include-untracked", // work-preserving recovery
+    "git fetch origin posthog-code/feature",
+    "git reset --hard origin/posthog-code/feature",
+    "git stash pop",
+    "REVERTING",
+  ])("mentions %j", (needle) => {
+    expect(msg).toContain(needle);
+  });
+
+  it.each([
+    "0123456789abc", // the full oid — tip is truncated to 12 chars
+    "tests-posthog", // repo-specific bot name
+    "OpenAPI", // repo-specific artifact name
+  ])("stays generic: omits %j", (needle) => {
+    expect(msg).not.toContain(needle);
   });
 });
 

--- a/packages/git/src/signed-commit.ts
+++ b/packages/git/src/signed-commit.ts
@@ -255,6 +255,52 @@ async function remoteTip(
   return out.split("\t")[0]?.trim() || null;
 }
 
+/** Agent-facing refusal when the remote branch has advanced past the local checkout. */
+export function behindRemoteError(branch: string, tip: string): string {
+  const shortTip = tip.slice(0, 12);
+  return (
+    `Refusing to commit: remote branch '${branch}' has advanced past your local checkout ` +
+    `(remote tip ${shortTip} is not in your local history). Something pushed to the branch ` +
+    `after your last commit — often CI automation that auto-commits regenerated artifacts ` +
+    `(codegen, lockfiles, formatting) onto open PRs, or another collaborator. Committing now ` +
+    `would build the new commit on the remote tip while taking file contents from your stale ` +
+    `tree, silently REVERTING those commits. Recovery (preserves your uncommitted work): ` +
+    `\`git stash --include-untracked\`, then \`git fetch origin ${branch}\` and ` +
+    `\`git reset --hard origin/${branch}\`, then \`git stash pop\` — resolve any pop conflicts, ` +
+    `as they mark real overlaps with the new commits — then re-stage and retry ` +
+    `git_signed_commit. The hard reset is safe here: your work is saved in the stash, and only ` +
+    `a hard reset pulls the new commits' files into your working tree (a soft/mixed reset would ` +
+    `keep your stale copies and re-commit the revert). If you were integrating the base branch, ` +
+    `use git_signed_merge / git_signed_rewrite instead.`
+  );
+}
+
+/**
+ * Refuse when the remote `tip` has commits the local checkout lacks: the commit
+ * builds on `tip` but takes file contents from the index (based on local HEAD),
+ * so the staged diff would re-express every remotely-changed file as its stale
+ * local blob, silently reverting them. No-op on an unborn HEAD or an
+ * unresolvable relationship, so a missing object never blocks a real commit.
+ * Caller must have fetched `tip` first.
+ */
+export async function assertNotBehindRemote(
+  ctx: SignedCommitCtx,
+  branch: string,
+  tip: string,
+): Promise<void> {
+  const head = await runGit(["rev-parse", "HEAD"], ctx.cwd);
+  if (head.exitCode !== 0) return;
+  if (head.stdout.toString("utf8").trim() === tip) return;
+  // exit 1 ⇒ tip not reachable from HEAD ⇒ remote has commits we lack ⇒ refuse.
+  const reachable = await runGit(
+    ["merge-base", "--is-ancestor", tip, "HEAD"],
+    ctx.cwd,
+  );
+  if (reachable.exitCode === 1) {
+    throw new Error(behindRemoteError(branch, tip));
+  }
+}
+
 async function refApi(
   ctx: SignedCommitCtx,
   args: string[],
@@ -810,6 +856,9 @@ export async function createSignedCommit(
     // Existing branch: make its tip object local so the staged diff (and any
     // later reset) can resolve it.
     await runGit(["fetch", "--no-tags", "origin", branch], ctx.cwd);
+    // Committing a stale tree onto an advanced tip would silently revert the
+    // commits we never pulled.
+    await assertNotBehindRemote(ctx, branch, tip);
   }
 
   const changes = await buildFileChanges(ctx, tip);


### PR DESCRIPTION
## Problem

Agent didn't check if there were new commits on remote, possibly overwriting them in the subsequent commit (for example leading to silently dropping CI artifacts).

## Changes

- **`packages/git`** — `assertNotBehindRemote`: after fetching an existing branch, fail closed when the remote tip has commits the local checkout lacks. The error outputs the divergence and gives a work-preserving recovery (`stash --include-untracked` → `fetch` → `reset --hard` → `stash pop`). Mirrors the existing merge-in-progress / base-leak refusals; new and up-to-date branches are unaffected.
- **`packages/agent`** — documents the failure mode in the agent's git-workflow prompt and the tool description.

## Tests

Real-git + bare-remote fixture reproducing the bug (commit → simulated bot push → second commit from a stale checkout → refused), plus up-to-date, local-ahead, and no-op (staged work preserved) cases. 39/39 pass.
