### PR TITLE
fix(tasks): gate "File to…" submenu behind project-bluebird flag

### DIFF
--- a/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -3,11 +3,13 @@ import {
   resolveTaskContextMenuIntent,
 } from "@posthog/core/tasks/contextMenuActions";
 import { useHostTRPCClient } from "@posthog/host-router/react";
+import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useExternalAppAction } from "@posthog/ui/features/external-apps/useExternalAppAction";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useRestoreTask } from "@posthog/ui/features/suspension/useRestoreTask";
 import { useSuspendTask } from "@posthog/ui/features/suspension/useSuspendTask";
 import { useDeleteTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
@@ -25,7 +27,13 @@ export function useTaskContextMenu() {
   const { archiveTask } = useArchiveTask();
   const { suspendTask } = useSuspendTask();
   const { restoreTask } = useRestoreTask();
-  const { channels } = useChannels();
+  // "File to…" is a Project Bluebird feature. Gate the channel fetch behind the
+  // flag so the submenu (and its API request) never reaches ungated users.
+  const bluebirdEnabled = useFeatureFlag(
+    PROJECT_BLUEBIRD_FLAG,
+    import.meta.env.DEV,
+  );
+  const { channels } = useChannels({ enabled: bluebirdEnabled });
   const { fileTask } = useChannelTaskMutations();
 
   const showContextMenu = useCallback(


### PR DESCRIPTION
## Problem

The task context menu (`useTaskContextMenu.ts`) called `useChannels()` **unconditionally** and passed the result into `showTaskContextMenu`. The core context-menu service renders the **"File to…"** submenu whenever `channels.length > 0`.

"File to…" is a **Project Bluebird** feature — gated everywhere else behind `PROJECT_BLUEBIRD_FLAG` (Channels space, app nav, etc.). This call site missed the gate, so any user with channels saw the submenu and the hook fired a real `getDesktopFileSystem()` request. The feature leaked to production.

## Fix

Gate the channel fetch behind the flag, matching the existing pattern in `__root.tsx` (same flag, same hook, same `import.meta.env.DEV` default):

```ts
const bluebirdEnabled = useFeatureFlag(PROJECT_BLUEBIRD_FLAG, import.meta.env.DEV);
const { channels } = useChannels({ enabled: bluebirdEnabled });
```

When the flag is off, `useChannels` returns `channels: []`, so no API request fires and the core service's `channels.length > 0` guard hides the submenu. No other changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)