### PR TITLE
fix(settings): keep 'Back to app' working after switching environment tabs

### DIFF
--- a/packages/ui/src/features/settings/sections/environments/EnvironmentsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/environments/EnvironmentsSettings.tsx
@@ -22,8 +22,11 @@ export function EnvironmentsSettings() {
     activeCategory === "cloud-environments" ? "cloud" : "local";
 
   const handleSegmentChange = (value: string) => {
+    // Replace rather than push so switching tabs doesn't pile up history
+    // entries that "Back to app" would otherwise step back through.
     navigateToSettings(
       value === "cloud" ? "cloud-environments" : "environments",
+      { replace: true },
     );
   };
 


### PR DESCRIPTION
## Problem

In settings → Environments, tapping the Local/Cloud tabs and then "Back to app" doesn't return you to the app — it walks back through the tab history you visited, one `history.back()` at a time.

Each tab switch pushed a new router history entry, while "Back to app" is just a single `history.back()`. The settings sidebar already avoids this by navigating with `replace: true`; the environment tabs didn't.

## Changes

Switch the Local/Cloud tab navigation in `EnvironmentsSettings` to use `replace: true`, matching the settings sidebar. Now switching tabs no longer accumulates history entries, so "Back to app" leaves settings in one step.

## How did you test this?

Not tested locally — `node_modules` isn't installed in this environment so typecheck/tests couldn't run. The change uses the existing, already-typed `options` parameter on `navigateToSettings`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781266383722219?thread_ts=1781266383.722219&cid=C0ACRAMJUAG)*
