### PR TITLE
fix(agent): route hosted dev to its own LLM gateway

### DIFF
--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildGatewayPropertyHeaders, resolveGatewayProduct } from "./gateway";
+import {
+  buildGatewayPropertyHeaders,
+  getLlmGatewayUrl,
+  resolveGatewayProduct,
+} from "./gateway";
 
 describe("resolveGatewayProduct", () => {
   it.each([
@@ -109,5 +113,28 @@ describe("buildGatewayPropertyHeaders", () => {
     expect(buildGatewayPropertyHeaders({ task_title: "café" })).toBe(
       "x-posthog-property-task_title: café",
     );
+  });
+});
+
+describe("getLlmGatewayUrl", () => {
+  it.each([
+    {
+      posthogHost: "https://us.posthog.com",
+      expected: "https://gateway.us.posthog.com/posthog_code",
+    },
+    {
+      posthogHost: "https://eu.posthog.com",
+      expected: "https://gateway.eu.posthog.com/posthog_code",
+    },
+    {
+      posthogHost: "https://app.dev.posthog.dev",
+      expected: "https://gateway.dev.posthog.dev/posthog_code",
+    },
+    {
+      posthogHost: "http://localhost:8000",
+      expected: "http://localhost:3308/posthog_code",
+    },
+  ] as const)("$posthogHost -> $expected", ({ posthogHost, expected }) => {
+    expect(getLlmGatewayUrl(posthogHost)).toBe(expected);
   });
 });

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -64,6 +64,13 @@ function getGatewayBaseUrl(posthogHost: string): string {
     return `${url.protocol}//host.docker.internal:3308`;
   }
 
+  // The hosted dev environment runs its own LLM gateway with its own auth DB,
+  // so a dev-minted `pha_` token can't be routed to the US gateway — that's
+  // a different DB and returns 401 Authentication required.
+  if (hostname === "app.dev.posthog.dev") {
+    return "https://gateway.dev.posthog.dev";
+  }
+
   const region = hostname.match(/^(us|eu)\.posthog\.com$/)?.[1] ?? "us";
   return `https://gateway.${region}.posthog.com`;
 }


### PR DESCRIPTION
## Problem

PostHog Code on the hosted dev environment (`app.dev.posthog.dev`) fails with `401 {"detail":"Authentication required"}` on the initial task message. `getGatewayBaseUrl` only matches `us.posthog.com` / `eu.posthog.com` / `localhost` / `host.docker.internal`; everything else falls through to the implicit US fallback. A dev-minted `pha_` access token then gets sent to `gateway.us.posthog.com`, which 401s because that token lives in dev's DB, not US's.

## Changes

Add an explicit `app.dev.posthog.dev → https://gateway.dev.posthog.dev` branch in `getGatewayBaseUrl`, mirroring how us/eu work today. The dev gateway is already deployed (see `argocd/llm-gateway/values/values.httpproxy.dev.yaml` in posthog/charts).

Add a focused parameterized test for `getLlmGatewayUrl` covering us / eu / dev / localhost so future regions are easy to add and easy to verify.

## How did you test this code?

Agent-authored. `npx vitest run src/utils/gateway.test.ts` — 19/19 pass (15 existing + 4 new for `getLlmGatewayUrl`). The wider `pnpm test` suite has pre-existing unrelated failures in adapters that can't resolve `@posthog/git/signed-commit` at vitest time — same set fails on `main` without this change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.7). Traced from a dev sandbox connectivity diag (`LLM_GATEWAY_URL=UNSET`) → `agent-server.ts:1999` falls back to `getLlmGatewayUrl(apiUrl, product)` → `getGatewayBaseUrl` default branch sends dev to US. PostHog/code#2641 (env-override product-aware) pairs with this so dev unblocks even if anyone sets `LLM_GATEWAY_URL` directly.
