### PR TITLE
feat(inbox): add Scouts source toggle to Self-driving settings

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -712,6 +712,7 @@ export interface SignalSourceConnectedProperties {
   source_product:
     | "session_replay"
     | "error_tracking"
+    | "signals_scout"
     | "github"
     | "linear"
     | "zendesk"

--- a/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -4,6 +4,7 @@ import {
   BugIcon,
   ChatsIcon,
   CircleNotchIcon,
+  CompassIcon,
   GithubLogoIcon,
   KanbanIcon,
   TicketIcon,
@@ -19,6 +20,7 @@ import { memo, useCallback } from "react";
 export interface SignalSourceValues {
   session_replay: boolean;
   error_tracking: boolean;
+  signals_scout: boolean;
   github: boolean;
   linear: boolean;
   zendesk: boolean;
@@ -298,6 +300,10 @@ export function SignalSourceToggles({
     (checked: boolean) => onToggle("conversations", checked),
     [onToggle],
   );
+  const toggleScouts = useCallback(
+    (checked: boolean) => onToggle("signals_scout", checked),
+    [onToggle],
+  );
   const togglePgAnalyze = useCallback(
     (checked: boolean) => onToggle("pganalyze", checked),
     [onToggle],
@@ -354,6 +360,18 @@ export function SignalSourceToggles({
                 />
               ) : undefined
             }
+          />
+          <SignalSourceToggleCard
+            icon={<CompassIcon size={20} />}
+            label="Scouts"
+            labelSuffix={<Badge color="orange">Beta</Badge>}
+            description="Scheduled agents that sweep this project and surface findings"
+            checked={value.signals_scout}
+            onCheckedChange={toggleScouts}
+            disabled={disabled}
+            syncStatus={sourceStates?.signals_scout?.syncStatus}
+            docsUrl="https://posthog.com/docs/self-driving"
+            docsLabel="Scouts"
           />
           {evaluationsUrl && (
             <EvaluationsSection evaluationsUrl={evaluationsUrl} />
@@ -449,7 +467,7 @@ export function SignalSourceTogglesSkeleton() {
           PostHog data
         </Text>
         <Flex direction="column" gap="3">
-          {Array.from({ length: 3 }).map((_, index) => (
+          {Array.from({ length: 4 }).map((_, index) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: static loading placeholders
             <SignalSourceToggleCardSkeleton key={index} />
           ))}

--- a/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
+++ b/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
@@ -15,10 +15,11 @@ type SourceType = SignalSourceConfig["source_type"];
 type SetupSourceProduct = "github" | "linear" | "zendesk" | "pganalyze";
 
 const SOURCE_TYPE_MAP: Record<
-  Exclude<SourceProduct, "error_tracking" | "llm_analytics" | "signals_scout">,
+  Exclude<SourceProduct, "error_tracking" | "llm_analytics">,
   SourceType
 > = {
   session_replay: "session_analysis_cluster",
+  signals_scout: "cross_source_issue",
   github: "issue",
   linear: "issue",
   zendesk: "ticket",
@@ -35,6 +36,7 @@ const ERROR_TRACKING_SOURCE_TYPES: SourceType[] = [
 const SOURCE_LABELS: Record<keyof SignalSourceValues, string> = {
   session_replay: "Session replay",
   error_tracking: "Error tracking",
+  signals_scout: "Scouts",
   github: "GitHub Issues",
   linear: "Linear Issues",
   zendesk: "Zendesk Tickets",
@@ -55,6 +57,7 @@ const DATA_WAREHOUSE_SOURCES: Record<
 const ALL_SOURCE_PRODUCTS: (keyof SignalSourceValues)[] = [
   "session_replay",
   "error_tracking",
+  "signals_scout",
   "github",
   "linear",
   "zendesk",
@@ -74,6 +77,7 @@ function computeValues(
   const result: SignalSourceValues = {
     session_replay: false,
     error_tracking: false,
+    signals_scout: false,
     github: false,
     linear: false,
     zendesk: false,
@@ -312,7 +316,7 @@ export function useSignalSourceToggles() {
                 SOURCE_TYPE_MAP[
                   product as Exclude<
                     SourceProduct,
-                    "error_tracking" | "llm_analytics" | "signals_scout"
+                    "error_tracking" | "llm_analytics"
                   >
                 ],
               enabled: true,


### PR DESCRIPTION
## Summary

Adds a **Scouts** toggle to the Self-driving settings source list, alongside **Error Tracking**, **Support**, and **Session Replay** (the "PostHog data" column).

Until Scouts is enabled by default, this gives users a way to opt in manually from settings.

## How it works

Enabling the toggle creates/updates a `SignalSourceConfig` with `source_product: "signals_scout"` and `source_type: "cross_source_issue"` via the existing `createSignalSourceConfig` / `updateSignalSourceConfig` API — no backend or api-client changes needed (both values already exist in the type unions).

This is exactly the row the scout emit path gates on in the Cloud backend (`products/signals/backend/scout_harness/tools/emit.py` → `SignalSourceConfig.is_source_enabled(team_id, "signals_scout", "cross_source_issue")`), so flipping it on actually unblocks scout findings reaching the inbox.

## Scope

- Added **only** to the Self-driving settings surface (`SignalSourcesSettings` → `SignalSourceToggles`).
- **Not** added to the Responders/agents roster (`RESPONDER_AGENT_GROUPS` is an explicit list and is left untouched), per the requirement.

## Changes

- `SignalSourceToggles.tsx`: new `signals_scout` field on `SignalSourceValues`, a Scouts toggle card (Compass icon, "Beta" badge), and bumped the PostHog-data skeleton count 3 → 4.
- `useSignalSourceToggles.ts`: wired `signals_scout` into `SOURCE_TYPE_MAP` (`cross_source_issue`), `SOURCE_LABELS`, `ALL_SOURCE_PRODUCTS`, and `computeValues`.
- `analytics-events.ts`: added `signals_scout` to the `SignalSourceConnectedProperties.source_product` union.

## Testing

- `pnpm --filter @posthog/ui typecheck` — passes
- `biome check` on changed files — clean
- `pnpm --filter @posthog/ui test src/features/inbox` — 705 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)