### PR TITLE
fix(sidebar): show spinner while archiving a task

### DIFF
--- a/packages/core/src/archive/archiveOrchestration.test.ts
+++ b/packages/core/src/archive/archiveOrchestration.test.ts
@@ -64,6 +64,35 @@ describe("archiveTask", () => {
     expect(harness.list.some((a) => a.taskId === TASK_ID)).toBe(true);
   });
 
+  it("with optimistic:false, defers cache writes until archive resolves", async () => {
+    let idsWhenArchiveCalled: string[] = ["sentinel"];
+    harness.deps.archive = vi.fn().mockImplementation(async () => {
+      // Snapshot the cache at the moment the request is made — the row must
+      // still be present (not yet marked archived) while it's in flight.
+      idsWhenArchiveCalled = [...harness.ids];
+    });
+
+    await archiveTask(TASK_ID, harness.deps, { optimistic: false });
+
+    expect(idsWhenArchiveCalled).not.toContain(TASK_ID);
+    // Once the archive resolves, the row is removed from the list.
+    expect(harness.ids).toContain(TASK_ID);
+    expect(harness.list.some((a) => a.taskId === TASK_ID)).toBe(true);
+  });
+
+  it("with optimistic:false, leaves caches untouched when archive fails", async () => {
+    harness.deps.getPinnedTaskIds = vi.fn().mockResolvedValue([TASK_ID]);
+    harness.deps.archive = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(
+      archiveTask(TASK_ID, harness.deps, { optimistic: false }),
+    ).rejects.toThrow("boom");
+
+    expect(harness.ids).not.toContain(TASK_ID);
+    expect(harness.list).toEqual([]);
+    expect(harness.deps.togglePin).toHaveBeenCalledWith(TASK_ID);
+  });
+
   it("rolls back caches and re-pins when archive fails", async () => {
     harness.deps.getPinnedTaskIds = vi.fn().mockResolvedValue([TASK_ID]);
     harness.deps.archive = vi.fn().mockRejectedValue(new Error("boom"));

--- a/packages/core/src/archive/archiveOrchestration.ts
+++ b/packages/core/src/archive/archiveOrchestration.ts
@@ -46,6 +46,13 @@ export interface ArchiveOrchestrationDeps {
 
 export interface ArchiveTaskOptions {
   skipNavigate?: boolean;
+  /**
+   * When true (default), the task is removed from the sidebar list immediately
+   * via an optimistic cache write and rolled back on failure. When false, the
+   * row stays put until the archive actually succeeds — used by the interactive
+   * single-archive flow so the row can show a spinner until it's confirmed gone.
+   */
+  optimistic?: boolean;
 }
 
 export async function archiveTask(
@@ -53,6 +60,7 @@ export async function archiveTask(
   deps: ArchiveOrchestrationDeps,
   options?: ArchiveTaskOptions,
 ): Promise<void> {
+  const optimistic = options?.optimistic ?? true;
   const workspace = await deps.getWorkspace(taskId);
   const pinnedTaskIds = await deps.getPinnedTaskIds();
   const wasPinned = pinnedTaskIds.includes(taskId);
@@ -70,12 +78,18 @@ export async function archiveTask(
 
   await deps.cache.cancelPathFilter();
 
-  deps.cache.setArchivedTaskIds((old) => appendArchivedTaskId(old, taskId));
-
   const optimisticArchived = buildOptimisticArchivedTask(taskId, workspace);
-  deps.cache.setArchiveList((old) =>
-    appendOptimisticArchivedTask(old, optimisticArchived),
-  );
+
+  const applyArchivedCacheWrites = () => {
+    deps.cache.setArchivedTaskIds((old) => appendArchivedTaskId(old, taskId));
+    deps.cache.setArchiveList((old) =>
+      appendOptimisticArchivedTask(old, optimisticArchived),
+    );
+  };
+
+  if (optimistic) {
+    applyArchivedCacheWrites();
+  }
 
   if (
     workspace?.worktreePath &&
@@ -87,6 +101,11 @@ export async function archiveTask(
   try {
     await deps.disconnectFromTask(taskId);
     await deps.archive(taskId);
+    // Non-optimistic flows keep the row visible during the request, then remove
+    // it the moment the archive succeeds.
+    if (!optimistic) {
+      applyArchivedCacheWrites();
+    }
     deps.cache.invalidatePathFilter();
   } catch (error) {
     deps.logError("Failed to archive task", error);

--- a/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/packages/ui/src/features/archive/useArchiveTask.ts
@@ -143,7 +143,7 @@ export async function archiveTaskImperative(
   taskId: string,
   queryClient: QueryClient,
   keys: ArchiveCacheKeys,
-  options?: { skipNavigate?: boolean },
+  options?: { skipNavigate?: boolean; optimistic?: boolean },
 ): Promise<void> {
   await archiveTask(
     taskId,
@@ -174,7 +174,11 @@ export function useArchiveTask() {
   const keys = useArchiveCacheKeys();
 
   const archiveTask = async ({ taskId }: { taskId: string }) => {
-    await archiveTaskImperative(taskId, queryClient, keys);
+    // Non-optimistic: keep the row in place (with a spinner) until the archive
+    // is confirmed, rather than removing it instantly and rolling back on error.
+    await archiveTaskImperative(taskId, queryClient, keys, {
+      optimistic: false,
+    });
     toast.success("Task archived");
   };
 

--- a/packages/ui/src/features/sidebar/archivingTasksStore.test.ts
+++ b/packages/ui/src/features/sidebar/archivingTasksStore.test.ts
@@ -7,8 +7,7 @@ describe("archivingTasksStore", () => {
   });
 
   it("marks a task as archiving and back", () => {
-    const { startArchiving, stopArchiving } =
-      useArchivingTasksStore.getState();
+    const { startArchiving, stopArchiving } = useArchivingTasksStore.getState();
 
     startArchiving("task-1");
     expect(useArchivingTasksStore.getState().isArchiving("task-1")).toBe(true);
@@ -30,8 +29,7 @@ describe("archivingTasksStore", () => {
   });
 
   it("is idempotent and keeps a stable reference when nothing changes", () => {
-    const { startArchiving, stopArchiving } =
-      useArchivingTasksStore.getState();
+    const { startArchiving, stopArchiving } = useArchivingTasksStore.getState();
 
     startArchiving("task-1");
     const setAfterStart = useArchivingTasksStore.getState().archivingTaskIds;

--- a/packages/ui/src/features/sidebar/archivingTasksStore.test.ts
+++ b/packages/ui/src/features/sidebar/archivingTasksStore.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useArchivingTasksStore } from "./archivingTasksStore";
+
+describe("archivingTasksStore", () => {
+  beforeEach(() => {
+    useArchivingTasksStore.setState({ archivingTaskIds: new Set() });
+  });
+
+  it("marks a task as archiving and back", () => {
+    const { startArchiving, stopArchiving } =
+      useArchivingTasksStore.getState();
+
+    startArchiving("task-1");
+    expect(useArchivingTasksStore.getState().isArchiving("task-1")).toBe(true);
+
+    stopArchiving("task-1");
+    expect(useArchivingTasksStore.getState().isArchiving("task-1")).toBe(false);
+  });
+
+  it("tracks multiple tasks independently", () => {
+    const { startArchiving } = useArchivingTasksStore.getState();
+
+    startArchiving("task-1");
+    startArchiving("task-2");
+
+    const state = useArchivingTasksStore.getState();
+    expect(state.isArchiving("task-1")).toBe(true);
+    expect(state.isArchiving("task-2")).toBe(true);
+    expect(state.isArchiving("task-3")).toBe(false);
+  });
+
+  it("is idempotent and keeps a stable reference when nothing changes", () => {
+    const { startArchiving, stopArchiving } =
+      useArchivingTasksStore.getState();
+
+    startArchiving("task-1");
+    const setAfterStart = useArchivingTasksStore.getState().archivingTaskIds;
+
+    // Starting an already-archiving task does not replace the set.
+    startArchiving("task-1");
+    expect(useArchivingTasksStore.getState().archivingTaskIds).toBe(
+      setAfterStart,
+    );
+
+    // Stopping a task that isn't archiving is a no-op.
+    stopArchiving("task-2");
+    expect(useArchivingTasksStore.getState().archivingTaskIds).toBe(
+      setAfterStart,
+    );
+  });
+});

--- a/packages/ui/src/features/sidebar/archivingTasksStore.ts
+++ b/packages/ui/src/features/sidebar/archivingTasksStore.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+
+interface ArchivingTasksState {
+  /** Task IDs with an archive request currently in flight. */
+  archivingTaskIds: Set<string>;
+}
+
+interface ArchivingTasksActions {
+  isArchiving: (taskId: string) => boolean;
+  startArchiving: (taskId: string) => void;
+  stopArchiving: (taskId: string) => void;
+}
+
+type ArchivingTasksStore = ArchivingTasksState & ArchivingTasksActions;
+
+/**
+ * Tracks which tasks are mid-archive so the sidebar can show a per-row spinner
+ * and treat clicks, pin toggles, and right-clicks on those rows as no-ops until
+ * the archive resolves.
+ */
+export const useArchivingTasksStore = create<ArchivingTasksStore>(
+  (set, get) => ({
+    archivingTaskIds: new Set(),
+
+    isArchiving: (taskId) => get().archivingTaskIds.has(taskId),
+
+    startArchiving: (taskId) =>
+      set((state) => {
+        if (state.archivingTaskIds.has(taskId)) return state;
+        const next = new Set(state.archivingTaskIds);
+        next.add(taskId);
+        return { archivingTaskIds: next };
+      }),
+
+    stopArchiving: (taskId) =>
+      set((state) => {
+        if (!state.archivingTaskIds.has(taskId)) return state;
+        const next = new Set(state.archivingTaskIds);
+        next.delete(taskId);
+        return { archivingTaskIds: next };
+      }),
+  }),
+);

--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -70,6 +70,7 @@ export function SidebarItem({
   subtitle,
   isActive,
   isSelected,
+  isDimmed,
   draggable,
   onDragStart,
   onClick,
@@ -85,6 +86,7 @@ export function SidebarItem({
         "group flex w-full cursor-default text-left text-[13px] leading-snug transition-colors",
         "focus-visible:-outline-offset-2 focus-visible:outline-2 focus-visible:outline-accent-8",
         "disabled:opacity-100 data-active:bg-fill-selected data-selected:bg-(--gray-3)",
+        isDimmed && "opacity-50",
       )}
       data-active={isActive || undefined}
       data-selected={(isSelected && !isActive) || undefined}

--- a/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -12,6 +12,7 @@ import {
   useArchiveCacheKeys,
   useArchiveTask,
 } from "@posthog/ui/features/archive/useArchiveTask";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useInboxReports } from "@posthog/ui/features/inbox/hooks/useInboxReports";
@@ -232,6 +233,11 @@ function SidebarMenuComponent() {
   }, [activeTaskId, selectedTaskIds]);
 
   const handleTaskClick = (taskId: string, e: React.MouseEvent) => {
+    // Ignore clicks on a row that's mid-archive.
+    if (useArchivingTasksStore.getState().isArchiving(taskId)) {
+      e.preventDefault();
+      return;
+    }
     if (e.shiftKey) {
       e.preventDefault();
       selectRange(taskId, orderedVisibleTaskIds, activeTaskId);
@@ -292,6 +298,12 @@ function SidebarMenuComponent() {
     e: React.MouseEvent,
     isPinned: boolean,
   ) => {
+    // Right-clicking a row that's mid-archive is a no-op.
+    if (useArchivingTasksStore.getState().isArchiving(taskId)) {
+      e.preventDefault();
+      return;
+    }
+
     // Bulk menu when 2+ tasks are in the effective selection (active + cmd/shift-clicked)
     // and the right-clicked task is one of them. Otherwise clear and fall through.
     if (effectiveBulkIds.length > 1) {
@@ -320,7 +332,7 @@ function SidebarMenuComponent() {
         isSuspended: taskData?.isSuspended,
         isInCommandCenter,
         hasEmptyCommandCenterCell,
-        onTogglePin: () => togglePin(taskId),
+        onTogglePin: () => handleTaskTogglePin(taskId),
         onArchive: handleTaskArchive,
         onArchivePrior: handleArchivePrior,
         onAddToCommandCenter: () => {
@@ -337,24 +349,54 @@ function SidebarMenuComponent() {
     }
   };
 
+  // Runs the archive while marking the row as in-flight, so its sidebar entry
+  // shows a spinner and ignores clicks/pins/right-clicks until it resolves.
+  // Guards against repeated clicks: a second call while archiving is a no-op.
+  const runArchive = useCallback(
+    (taskId: string) => {
+      const store = useArchivingTasksStore.getState();
+      if (store.isArchiving(taskId)) return;
+      store.startArchiving(taskId);
+      void archiveTask({ taskId })
+        .catch((error) => {
+          log.error("Failed to archive task", error);
+          toast.error("Failed to archive task");
+        })
+        .finally(() => {
+          useArchivingTasksStore.getState().stopArchiving(taskId);
+        });
+    },
+    [archiveTask],
+  );
+
   const handleTaskArchive = useCallback(
     (taskId: string) => {
+      if (useArchivingTasksStore.getState().isArchiving(taskId)) return;
       const task = allSidebarTasks.find((t) => t.id === taskId);
       if (task && isTaskActivelyRunning(task)) {
         setArchiveConfirm({ taskId, taskTitle: task.title });
         return;
       }
-      void archiveTask({ taskId });
+      runArchive(taskId);
     },
-    [allSidebarTasks, archiveTask],
+    [allSidebarTasks, runArchive],
   );
 
   const handleConfirmArchive = useCallback(() => {
     if (!archiveConfirm) return;
     const { taskId } = archiveConfirm;
     setArchiveConfirm(null);
-    void archiveTask({ taskId });
-  }, [archiveConfirm, archiveTask]);
+    runArchive(taskId);
+  }, [archiveConfirm, runArchive]);
+
+  const handleTaskTogglePin = useCallback(
+    (taskId: string) => {
+      // Pinning/unpinning a row that's mid-archive is a no-op.
+      if (useArchivingTasksStore.getState().isArchiving(taskId)) return;
+      togglePin(taskId);
+    },
+    [togglePin],
+  );
 
   const handleArchivePrior = useCallback(
     async (taskId: string) => {
@@ -512,7 +554,7 @@ function SidebarMenuComponent() {
               onTaskDoubleClick={handleTaskDoubleClick}
               onTaskContextMenu={handleTaskContextMenu}
               onTaskArchive={handleTaskArchive}
-              onTaskTogglePin={togglePin}
+              onTaskTogglePin={handleTaskTogglePin}
               onTaskEditSubmit={handleTaskEditSubmit}
               onTaskEditCancel={handleTaskEditCancel}
               hasMore={sidebarData.hasMore}

--- a/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -12,10 +12,10 @@ import {
   useArchiveCacheKeys,
   useArchiveTask,
 } from "@posthog/ui/features/archive/useArchiveTask";
-import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useInboxReports } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTaskSelectionStore } from "@posthog/ui/features/sidebar/taskSelectionStore";
 import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -10,8 +10,8 @@ import type {
 import { MenuLabel } from "@posthog/quill";
 import { normalizeRepoKey } from "@posthog/shared";
 import { builderHog } from "@posthog/ui/assets/hedgehogs";
-import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { DraggableFolder } from "@posthog/ui/features/sidebar/components/DraggableFolder";
 import { TaskItem } from "@posthog/ui/features/sidebar/components/items/TaskItem";
 import { SidebarSection } from "@posthog/ui/features/sidebar/components/SidebarSection";

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -10,6 +10,7 @@ import type {
 import { MenuLabel } from "@posthog/quill";
 import { normalizeRepoKey } from "@posthog/shared";
 import { builderHog } from "@posthog/ui/assets/hedgehogs";
+import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { DraggableFolder } from "@posthog/ui/features/sidebar/components/DraggableFolder";
 import { TaskItem } from "@posthog/ui/features/sidebar/components/items/TaskItem";
@@ -88,6 +89,9 @@ function TaskRow({
     workspace?.mode ??
     (task.taskRunEnvironment === "cloud" ? "cloud" : undefined);
   const { prState, hasDiff } = useTaskPrStatus(task);
+  const isArchiving = useArchivingTasksStore((s) =>
+    s.archivingTaskIds.has(task.id),
+  );
 
   return (
     <TaskItem
@@ -96,6 +100,7 @@ function TaskRow({
       label={task.title}
       isActive={isActive}
       isSelected={isSelected}
+      isArchiving={isArchiving}
       hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -211,7 +211,8 @@ export function TaskItem({
       label={label}
       isActive={isActive}
       isSelected={isSelected}
-      draggable
+      isDimmed={isArchiving}
+      draggable={!isArchiving}
       onDragStart={handleDragStart}
       onClick={onClick}
       onDoubleClick={onDoubleClick}

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -4,12 +4,13 @@ import type { WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DotsCircleSpinner } from "../../../../primitives/DotsCircleSpinner";
 import { NestedButton } from "../../../../primitives/NestedButton";
 import { Tooltip } from "../../../../primitives/Tooltip";
 import { openExternalUrl } from "../../../../shell/openExternal";
 import type { SidebarPrState } from "../../useTaskPrStatus";
 import { SidebarItem } from "../SidebarItem";
-import { TaskIcon } from "./TaskIcon";
+import { ICON_SIZE, TaskIcon } from "./TaskIcon";
 
 function PrBadge({ url, number }: { url: string; number: number }) {
   return (
@@ -34,6 +35,8 @@ interface TaskItemProps {
   label: string;
   isActive: boolean;
   isSelected?: boolean;
+  /** Archive request in flight: show a spinner and suppress hover actions. */
+  isArchiving?: boolean;
   hideHoverActions?: boolean;
   workspaceMode?: WorkspaceMode;
   worktreePath?: string;
@@ -106,6 +109,7 @@ export function TaskItem({
   label,
   isActive,
   isSelected = false,
+  isArchiving = false,
   hideHoverActions = false,
   workspaceMode,
   isSuspended = false,
@@ -129,7 +133,9 @@ export function TaskItem({
   onEditSubmit,
   onEditCancel,
 }: TaskItemProps) {
-  const icon = (
+  const icon = isArchiving ? (
+    <DotsCircleSpinner size={ICON_SIZE} className="text-gray-10" />
+  ) : (
     <TaskIcon
       workspaceMode={workspaceMode}
       isGenerating={isGenerating}
@@ -160,7 +166,7 @@ export function TaskItem({
     ) : null;
 
   const toolbar =
-    !hideHoverActions && (onArchive || onTogglePin) ? (
+    !isArchiving && !hideHoverActions && (onArchive || onTogglePin) ? (
       <TaskHoverToolbar
         isPinned={isPinned}
         onTogglePin={onTogglePin}


### PR DESCRIPTION
phode couldn't really cope if you archived task b while task a was still archiving

well, not any more

<img width="772" height="800" alt="CleanShot 2026-06-12 at 20 17 09" src="https://github.com/user-attachments/assets/44075fcb-d798-4140-9d38-fa5980ec880b" />

## Problem

Archiving a task from the sidebar was unreliable. Clicking *Archive* fired the request and immediately removed the row (optimistic), so there was no feedback that anything was happening, failures were swallowed silently, and clicking archive/pin/right-click repeatedly during the in-flight window produced inconsistent results ("archiving doesn't always seem to take").

## Changes

- The conversation you click *Archive* on now shows a **spinner** in its row and stays put until the archive actually **succeeds**, then disappears.
- While a row is archiving, **clicking it, toggling its pin, and right-clicking are no-ops**, and repeated archive clicks are ignored.
- A failed archive now surfaces an error toast instead of failing silently.

Implemented via a small `archivingTasksStore` (UI view state) tracking in-flight ids, plus an `optimistic` flag on the `archiveTask` orchestration so the interactive single-archive path defers its cache removal to success (bulk/`archive-prior` keep the instant optimistic behavior).

## How did you test this?

- `packages/core` unit tests for the orchestration's deferred (`optimistic: false`) path — defers cache writes until archive resolves, and leaves caches untouched on failure.
- New unit tests for `archivingTasksStore`.
- `pnpm --filter @posthog/core --filter @posthog/ui typecheck` and Biome lint on the changed files, both clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781269709959239?thread_ts=1781269709.959239&cid=C0ACRAMJUAG)*