### PR TITLE
feat(scouts): show skill description as tooltip on scout name

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -228,6 +228,12 @@ export interface ScoutConfig {
   enabled: boolean;
   /** False means dry-run: the scout runs but findings are not emitted. */
   emit: boolean;
+  /**
+   * Summary of what the scout investigates, from the skill's description
+   * metadata. Empty string when the skill is absent or carries no description;
+   * absent entirely on backends predating the field.
+   */
+  description?: string;
   run_interval_minutes: number;
   last_run_at: string | null;
   created_at: string;

--- a/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
@@ -46,8 +46,10 @@ export function ScoutRowCard({
   const surface: ScoutSurface = linkToDetail ? "fleet_list" : "scout_detail";
 
   const description = config.description?.trim();
+  // `relative z-[1]` lifts the name above the Link's full-card `after:inset-0`
+  // overlay so the tooltip's pointer-enter fires; clicks still bubble to the Link.
   const titleText = (
-    <Text className="truncate font-medium text-[13px] text-gray-12">
+    <Text className="relative z-[1] truncate font-medium text-[13px] text-gray-12">
       {prettifyScoutSkillName(config.skill_name)}
     </Text>
   );

--- a/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
@@ -45,10 +45,16 @@ export function ScoutRowCard({
   const cloudSkillUrl = skillUrl(config.skill_name);
   const surface: ScoutSurface = linkToDetail ? "fleet_list" : "scout_detail";
 
-  const title = (
+  const description = config.description?.trim();
+  const titleText = (
     <Text className="truncate font-medium text-[13px] text-gray-12">
       {prettifyScoutSkillName(config.skill_name)}
     </Text>
+  );
+  const title = description ? (
+    <Tooltip content={description}>{titleText}</Tooltip>
+  ) : (
+    titleText
   );
 
   return (


### PR DESCRIPTION
## Summary
- Add `description` to the `ScoutConfig` type in `@posthog/api-client` — the scout-config list endpoint now returns each scout's skill description (sourced from the `signals-scout-*` skill's metadata in PostHog/posthog `scout_harness`)
- Show that description as a hover tooltip on the scout name in `ScoutRowCard`, so the fleet list on the Agents page (and the scout detail header, which shares the card) gives a quick steer on what each scout investigates
- Field is optional client-side; scouts with no description (or older backends omitting the field) render the plain name with no tooltip

## Test plan
- `pnpm --filter @posthog/api-client typecheck` and `pnpm --filter @posthog/ui typecheck` pass
- Biome clean on both touched files
- Hover a scout name in Agents → Scouts fleet list and confirm the description tooltip appears; scouts without a description show no tooltip