### PR TITLE
fix(storybook): resolve workspace .tsx imports and mount app providers

### DIFF
--- a/apps/code/.storybook/main.ts
+++ b/apps/code/.storybook/main.ts
@@ -5,6 +5,7 @@ import type { StorybookConfig } from "@storybook/react-vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { mergeConfig } from "vite";
+import { workspaceAliases } from "../vite.shared.mts";
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -26,40 +27,86 @@ const config: StorybookConfig = {
     getAbsolutePath("@storybook/addon-docs"),
   ],
   framework: getAbsolutePath("@storybook/react-vite"),
+  // Use the TypeScript-compiler docgen instead of the default Babel react-docgen.
+  // The Babel parser chokes on the legacy Inversify decorators (`@injectable()`)
+  // in the @posthog/core services that components pull in; the TS-based docgen
+  // handles them and only inspects `.tsx` components.
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+  },
   async viteFinal(config) {
     return mergeConfig(config, {
       plugins: [tailwindcss(), react()],
       resolve: {
-        alias: {
-          "@": path.resolve(__dirname, "../src"),
-          "@main": path.resolve(__dirname, "../src/main"),
-          "@renderer": path.resolve(__dirname, "../src/renderer"),
-          "@shared": path.resolve(__dirname, "../src/shared"),
-          "@api": path.resolve(__dirname, "../src/api"),
-          "@features": path.resolve(__dirname, "../src/renderer/features"),
-          "@components": path.resolve(__dirname, "../src/renderer/components"),
-          "@stores": path.resolve(__dirname, "../src/renderer/stores"),
-          "@hooks": path.resolve(__dirname, "../src/renderer/hooks"),
-          "@utils": path.resolve(__dirname, "../src/renderer/utils"),
-          "@posthog/agent/adapters/claude/permissions/permission-options":
-            path.resolve(
+        alias: [
+          {
+            find: "@main",
+            replacement: path.resolve(__dirname, "../src/main"),
+          },
+          {
+            find: "@renderer",
+            replacement: path.resolve(__dirname, "../src/renderer"),
+          },
+          {
+            find: "@shared",
+            replacement: path.resolve(__dirname, "../src/shared"),
+          },
+          { find: "@api", replacement: path.resolve(__dirname, "../src/api") },
+          {
+            find: "@features",
+            replacement: path.resolve(__dirname, "../src/renderer/features"),
+          },
+          {
+            find: "@components",
+            replacement: path.resolve(__dirname, "../src/renderer/components"),
+          },
+          {
+            find: "@stores",
+            replacement: path.resolve(__dirname, "../src/renderer/stores"),
+          },
+          {
+            find: "@hooks",
+            replacement: path.resolve(__dirname, "../src/renderer/hooks"),
+          },
+          {
+            find: "@utils",
+            replacement: path.resolve(__dirname, "../src/renderer/utils"),
+          },
+          { find: "@", replacement: path.resolve(__dirname, "../src") },
+          // Keep @posthog/agent on its prebuilt, browser-safe dist bundle. These
+          // must precede the workspace source aliases below so they win.
+          {
+            find: "@posthog/agent/adapters/claude/permissions/permission-options",
+            replacement: path.resolve(
               __dirname,
               "../../../packages/agent/dist/adapters/claude/permissions/permission-options.js",
             ),
-          "@posthog/agent/adapters/claude/conversion/tool-use-to-acp":
-            path.resolve(
+          },
+          {
+            find: "@posthog/agent/adapters/claude/conversion/tool-use-to-acp",
+            replacement: path.resolve(
               __dirname,
               "../../../packages/agent/dist/adapters/claude/conversion/tool-use-to-acp.js",
             ),
-          "@posthog/agent/adapters/claude/questions/utils": path.resolve(
-            __dirname,
-            "../../../packages/agent/dist/adapters/claude/questions/utils.js",
-          ),
-          "@posthog/electron-trpc/renderer": path.resolve(
-            __dirname,
-            "./mocks/electron-trpc.ts",
-          ),
-        },
+          },
+          {
+            find: "@posthog/agent/adapters/claude/questions/utils",
+            replacement: path.resolve(
+              __dirname,
+              "../../../packages/agent/dist/adapters/claude/questions/utils.js",
+            ),
+          },
+          {
+            find: "@posthog/electron-trpc/renderer",
+            replacement: path.resolve(__dirname, "./mocks/electron-trpc.ts"),
+          },
+          // Resolve the remaining @posthog/* workspace packages to source, exactly
+          // like the renderer (vite.shared.mts). Without this, Storybook resolves
+          // them through each package's "./*" exports map, which only falls
+          // through to ".ts" — so any ".tsx" subpath import (e.g. a feature view)
+          // fails to resolve and the story 404s.
+          ...workspaceAliases.filter((a) => !String(a.find).includes("agent")),
+        ],
       },
     });
   },

--- a/apps/code/.storybook/preview.tsx
+++ b/apps/code/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import { Theme } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 import type { Preview } from "@storybook/react-vite";
 import "../../../packages/ui/src/styles/globals.css";
+import { withAppProviders } from "./withAppProviders";
 
 const preview: Preview = {
   parameters: {
@@ -21,6 +22,7 @@ const preview: Preview = {
   },
 
   decorators: [
+    withAppProviders,
     (Story, context) => {
       const isDark = context.globals.theme !== "light";
       return (

--- a/apps/code/.storybook/withAppProviders.tsx
+++ b/apps/code/.storybook/withAppProviders.tsx
@@ -19,7 +19,7 @@ import {
 } from "@tanstack/react-router";
 import { createTRPCClient } from "@trpc/client";
 import { Container } from "inversify";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 // A host-agnostic stand-in for the host tRPC client. Components that resolve
 // HOST_TRPC_CLIENT from DI get these no-op responses; queries issued through the
@@ -109,30 +109,46 @@ function storyContainer(bindings: Container): ServiceContainer {
  * useService, useRouterState, …) then render in Storybook instead of throwing
  * "must be used within a <Provider>".
  */
+interface ProviderStack {
+  queryClient: QueryClient;
+  hostTrpcClient: ReturnType<typeof createTRPCClient<HostRouter>>;
+  container: ServiceContainer;
+}
+
+function createProviderStack(): ProviderStack {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+    },
+  });
+
+  const hostTrpcClient = createTRPCClient<HostRouter>({
+    links: [ipcLink()],
+  });
+
+  const bindings = new Container();
+  bindings
+    .bind<HostTrpcClient>(HOST_TRPC_CLIENT)
+    .toConstantValue(noopHostClient);
+  bindings.bind(IMPERATIVE_QUERY_CLIENT).toConstantValue(queryClient);
+  bindings.bind(DIFF_WORKER_FACTORY).toConstantValue(() => stubWorker);
+  const container = storyContainer(bindings);
+  setRootContainer(container);
+
+  return { queryClient, hostTrpcClient, container };
+}
+
 export const withAppProviders: Decorator = (Story) => {
-  // The provider singletons don't depend on the story; build them once per mount.
-  const { queryClient, hostTrpcClient, container } = useMemo(() => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false, refetchOnWindowFocus: false },
-      },
-    });
-
-    const hostTrpcClient = createTRPCClient<HostRouter>({
-      links: [ipcLink()],
-    });
-
-    const bindings = new Container();
-    bindings
-      .bind<HostTrpcClient>(HOST_TRPC_CLIENT)
-      .toConstantValue(noopHostClient);
-    bindings.bind(IMPERATIVE_QUERY_CLIENT).toConstantValue(queryClient);
-    bindings.bind(DIFF_WORKER_FACTORY).toConstantValue(() => stubWorker);
-    const container = storyContainer(bindings);
-    setRootContainer(container);
-
-    return { queryClient, hostTrpcClient, container };
-  }, []);
+  // The provider singletons don't depend on the story; build them once per
+  // mount. Lazy ref rather than useMemo: setRootContainer mutates a global, and
+  // Strict Mode double-invokes useMemo initializers, which would build (and
+  // globally register) a container that React then abandons. The ref object is
+  // stable across the double render, so this runs exactly once.
+  const stackRef = useRef<ProviderStack | null>(null);
+  if (stackRef.current === null) {
+    stackRef.current = createProviderStack();
+  }
+  const { queryClient, hostTrpcClient, container } = stackRef.current;
 
   // The router's root route renders the story, so it's keyed on the story.
   const router = useMemo(

--- a/apps/code/.storybook/withAppProviders.tsx
+++ b/apps/code/.storybook/withAppProviders.tsx
@@ -1,0 +1,154 @@
+import { type ServiceContainer, setRootContainer } from "@posthog/di/container";
+import { ServiceProvider } from "@posthog/di/react";
+import { ipcLink } from "@posthog/electron-trpc/renderer";
+import {
+  HOST_TRPC_CLIENT,
+  type HostTrpcClient,
+} from "@posthog/host-router/client";
+import { HostTRPCProvider } from "@posthog/host-router/react";
+import type { HostRouter } from "@posthog/host-router/router";
+import { DIFF_WORKER_FACTORY } from "@posthog/ui/shell/diffWorkerHost";
+import { IMPERATIVE_QUERY_CLIENT } from "@posthog/ui/shell/queryClient";
+import type { Decorator } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { createTRPCClient } from "@trpc/client";
+import { Container } from "inversify";
+import { useMemo } from "react";
+
+// A host-agnostic stand-in for the host tRPC client. Components that resolve
+// HOST_TRPC_CLIENT from DI get these no-op responses; queries issued through the
+// React `useHostTRPC()` context go through the mocked ipc link and simply stay
+// pending, which is fine for visual stories.
+const noopHostClient = {
+  git: {
+    getGhStatus: {
+      query: async () => ({
+        installed: true,
+        version: "2.0.0",
+        authenticated: true,
+        username: "storybook",
+        error: null,
+      }),
+    },
+    searchGithubRefs: { query: async () => [] },
+    getGithubPullRequest: { query: async () => null },
+    getGithubIssue: { query: async () => null },
+  },
+  fs: {
+    listRepoFiles: { query: async () => [] },
+    readAbsoluteFile: { query: async () => null },
+  },
+  os: {
+    selectDirectory: { query: async () => null },
+    selectAttachments: { query: async () => [] },
+    readFileAsDataUrl: { query: async () => null },
+    saveClipboardImage: {
+      mutate: async () => ({ path: "", name: "", mimeType: "" }),
+    },
+    saveClipboardText: { mutate: async () => ({ path: "", name: "" }) },
+    saveClipboardFile: { mutate: async () => ({ path: "", name: "" }) },
+    downscaleImageFile: { mutate: async () => ({ path: "", name: "" }) },
+  },
+  skills: {
+    list: { query: async () => [] },
+  },
+} as unknown as HostTrpcClient;
+
+// Diffs are computed in a web worker. Storybook has no worker backend, so hand
+// out an inert stub: components render, diffs just never resolve.
+const stubWorker = {
+  postMessage() {},
+  terminate() {},
+  addEventListener() {},
+  removeEventListener() {},
+  dispatchEvent() {
+    return false;
+  },
+  onmessage: null,
+  onmessageerror: null,
+  onerror: null,
+} as unknown as Worker;
+
+// An inert, infinitely-chainable stand-in for any core service a deep component
+// tree resolves that we haven't (and don't need to) wire up for visuals — e.g.
+// the external-apps service behind a "open in editor" button. Property access
+// yields another stub and calls return one, so `service.foo().bar` never throws.
+// Methods invoked from event handlers are simply no-ops in Storybook.
+function inertServiceStub(): unknown {
+  const target = () => undefined;
+  return new Proxy(target, {
+    get: () => inertServiceStub(),
+    apply: () => inertServiceStub(),
+  });
+}
+
+// A ServiceContainer that resolves the few services stories genuinely need and
+// falls back to an inert stub for everything else. `isBound` stays truthful so
+// `useServiceOptional` still returns null for unbound optional services.
+function storyContainer(bindings: Container): ServiceContainer {
+  return {
+    get: (id) => (bindings.isBound(id) ? bindings.get(id) : inertServiceStub()),
+    getAll: (id) => (bindings.isBound(id) ? bindings.getAll(id) : []),
+    isBound: (id) => bindings.isBound(id),
+    bind: (id) => bindings.bind(id),
+  } as unknown as ServiceContainer;
+}
+
+/**
+ * Wraps every story in the same provider stack the renderer mounts at boot:
+ * a QueryClient, the host tRPC context, the DI service container, and a minimal
+ * TanStack Router. Components that reach for any of these (useHostTRPC,
+ * useService, useRouterState, …) then render in Storybook instead of throwing
+ * "must be used within a <Provider>".
+ */
+export const withAppProviders: Decorator = (Story) => {
+  // The provider singletons don't depend on the story; build them once per mount.
+  const { queryClient, hostTrpcClient, container } = useMemo(() => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, refetchOnWindowFocus: false },
+      },
+    });
+
+    const hostTrpcClient = createTRPCClient<HostRouter>({
+      links: [ipcLink()],
+    });
+
+    const bindings = new Container();
+    bindings
+      .bind<HostTrpcClient>(HOST_TRPC_CLIENT)
+      .toConstantValue(noopHostClient);
+    bindings.bind(IMPERATIVE_QUERY_CLIENT).toConstantValue(queryClient);
+    bindings.bind(DIFF_WORKER_FACTORY).toConstantValue(() => stubWorker);
+    const container = storyContainer(bindings);
+    setRootContainer(container);
+
+    return { queryClient, hostTrpcClient, container };
+  }, []);
+
+  // The router's root route renders the story, so it's keyed on the story.
+  const router = useMemo(
+    () =>
+      createRouter({
+        routeTree: createRootRoute({ component: () => <Story /> }),
+        history: createMemoryHistory({ initialEntries: ["/"] }),
+      }),
+    [Story],
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <HostTRPCProvider trpcClient={hostTrpcClient} queryClient={queryClient}>
+        <ServiceProvider container={container}>
+          <RouterProvider router={router} />
+        </ServiceProvider>
+      </HostTRPCProvider>
+    </QueryClientProvider>
+  );
+};

--- a/apps/code/.storybook/withAppProviders.tsx
+++ b/apps/code/.storybook/withAppProviders.tsx
@@ -80,10 +80,12 @@ const stubWorker = {
 // the external-apps service behind a "open in editor" button. Property access
 // yields another stub and calls return one, so `service.foo().bar` never throws.
 // Methods invoked from event handlers are simply no-ops in Storybook.
+// `then` must be undefined: otherwise the stub is thenable and `await
+// service.foo()` would never settle (the stubbed `then` never calls resolve).
 function inertServiceStub(): unknown {
   const target = () => undefined;
   return new Proxy(target, {
-    get: () => inertServiceStub(),
+    get: (_target, prop) => (prop === "then" ? undefined : inertServiceStub()),
     apply: () => inertServiceStub(),
   });
 }

--- a/apps/code/vite.shared.mts
+++ b/apps/code/vite.shared.mts
@@ -40,7 +40,7 @@ const baseAliases: Alias[] = [
   { find: "@shared", replacement: path.resolve(__dirname, "./src/shared") },
 ];
 
-const workspaceAliases: Alias[] = [
+export const workspaceAliases: Alias[] = [
   {
     find: /^@posthog\/agent\/(.+)$/,
     replacement: path.resolve(__dirname, "../../packages/agent/src/$1.ts"),

--- a/packages/ui/src/features/archive/ArchivedTasksView.stories.tsx
+++ b/packages/ui/src/features/archive/ArchivedTasksView.stories.tsx
@@ -1,4 +1,4 @@
-import type { ArchivedTask } from "@posthog/shared/archive-domain";
+import type { ArchivedTask } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   ArchivedTasksViewPresentation,

--- a/packages/ui/src/features/message-editor/components/PromptInput.stories.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.stories.tsx
@@ -1,74 +1,15 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
-import { setRootContainer } from "@posthog/di/container";
-import { ServiceProvider } from "@posthog/di/react";
-import {
-  HOST_TRPC_CLIENT,
-  type HostTrpcClient,
-} from "@posthog/host-router/client";
 import { PromptInput } from "@posthog/ui/features/message-editor/components/PromptInput";
 import type { MentionChip } from "@posthog/ui/features/message-editor/content";
 import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components/ReasoningLevelSelector";
 import { UnifiedModelSelector } from "@posthog/ui/features/sessions/components/UnifiedModelSelector";
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
-import { IMPERATIVE_QUERY_CLIENT } from "@posthog/ui/shell/queryClient";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Container } from "inversify";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-// --- Host-agnostic story providers ---
-
-const noopHostClient = {
-  git: {
-    getGhStatus: {
-      query: async () => ({
-        installed: true,
-        version: "2.0.0",
-        authenticated: true,
-        username: "storybook",
-        error: null,
-      }),
-    },
-    searchGithubRefs: { query: async () => [] },
-    getGithubPullRequest: { query: async () => null },
-    getGithubIssue: { query: async () => null },
-  },
-  fs: {
-    listRepoFiles: { query: async () => [] },
-    readAbsoluteFile: { query: async () => null },
-  },
-  os: {
-    selectDirectory: { query: async () => null },
-    selectAttachments: { query: async () => [] },
-    readFileAsDataUrl: { query: async () => null },
-    saveClipboardImage: {
-      mutate: async () => ({ path: "", name: "", mimeType: "" }),
-    },
-    saveClipboardText: { mutate: async () => ({ path: "", name: "" }) },
-    saveClipboardFile: { mutate: async () => ({ path: "", name: "" }) },
-    downscaleImageFile: { mutate: async () => ({ path: "", name: "" }) },
-  },
-} as unknown as HostTrpcClient;
-
-const storyQueryClient = new QueryClient();
-
-const storyContainer = new Container();
-storyContainer
-  .bind<HostTrpcClient>(HOST_TRPC_CLIENT)
-  .toConstantValue(noopHostClient);
-storyContainer.bind(IMPERATIVE_QUERY_CLIENT).toConstantValue(storyQueryClient);
-setRootContainer(storyContainer);
-
-function StoryProviders({ children }: { children: ReactNode }) {
-  return (
-    <QueryClientProvider client={storyQueryClient}>
-      <ServiceProvider container={storyContainer}>
-        <div className="max-w-[800px]">{children}</div>
-      </ServiceProvider>
-    </QueryClientProvider>
-  );
-}
+// The host tRPC, DI, and query providers are supplied globally by the
+// `withAppProviders` decorator in `.storybook/preview.tsx`.
 
 // --- Mock data matching SessionConfigOption shape ---
 
@@ -196,9 +137,9 @@ const meta: Meta<typeof PromptInputWithSelectors> = {
   },
   decorators: [
     (Story) => (
-      <StoryProviders>
+      <div className="max-w-[800px]">
         <Story />
-      </StoryProviders>
+      </div>
     ),
   ],
   args: {


### PR DESCRIPTION
## Problem

Storybook stories that import a `.tsx` from a workspace package (e.g. `@posthog/ui/features/archive/ArchivedTasksView`) failed to load with **"Failed to fetch dynamically imported module"**. The underlying Vite error was `Failed to resolve import`.

Root cause: Storybook resolved those bare specifiers through each workspace package's `"./*": ["./src/*.ts", "./src/*.tsx"]` exports map. Vite matches the first pattern (`.ts`); for a `.tsx` target that `.ts` candidate doesn't exist, so resolution fails instead of falling through. Any `.tsx` subpath import broke — `.ts` ones happened to work. The renderer never hits this because it aliases `@posthog/*` → `packages/*/src` and lets extension resolution find the `.tsx`; the Storybook config just lacked those aliases.

## Changes

- **`.storybook/main.ts`** — alias the `@posthog/*` workspace packages to source (reusing the renderer's `workspaceAliases`), so extension resolution finds `.tsx`. Also switch docgen to `react-docgen-typescript`: the default Babel `react-docgen` chokes on the legacy Inversify `@injectable()` decorators that core services pull in.
- **`vite.shared.mts`** — export `workspaceAliases` so the Storybook config can share it.
- **`.storybook/withAppProviders.tsx`** *(new)* — a global decorator that mounts the same provider stack the renderer boots: `QueryClient`, the host tRPC context, a DI service container (binds what stories need; hands out inert stubs for unbound services so deep trees don't throw, while keeping `isBound` truthful for `useServiceOptional`), and a minimal TanStack Router. Components using `useHostTRPC` / `useService` / `useRouterState` now render instead of throwing "must be used within a `<Provider>`".
- **`.storybook/preview.tsx`** — register the decorator globally.
- **`PromptInput.stories.tsx`** — drop the now-redundant (and incomplete — missing `HostTRPCProvider`) per-story provider boilerplate.
- **`ArchivedTasksView.stories.tsx`** — import `ArchivedTask` from the canonical `@posthog/shared` root instead of the unexported `/archive-domain` subpath.

## Verification

Drove every story in a headless browser: **all 133 stories render, 0 failures** (previously every `.tsx`-importing story 404'd, and CreatePrDialog / ConversationView / PromptInput / ToolCallBlock hit provider errors). Lint passes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*