### PR TITLE
fix(tasks): prevent horizontal scroll in task view at narrow widths

### DIFF
--- a/packages/ui/src/features/sessions/components/VirtualizedList.tsx
+++ b/packages/ui/src/features/sessions/components/VirtualizedList.tsx
@@ -243,7 +243,7 @@ function VirtualizedListInner<T>(
       <div
         ref={parentRef}
         onScroll={handleScroll}
-        className="scroll-mask-8 flex-1 overflow-auto"
+        className="scroll-mask-8 flex-1 overflow-y-auto overflow-x-hidden"
         style={{ scrollbarGutter: "stable" }}
       >
         <div


### PR DESCRIPTION
## Problem

On smaller window widths (e.g. the task view at 2/3 width on a 16" MacBook Pro) the task view scrolled horizontally, which should never happen.

## Changes

The virtualized conversation/raw-log scroll container used `overflow-auto`, which enables both horizontal and vertical scrolling. Any child wider than the container (a long unwrapped line, a wide tool output) made the whole pane scroll sideways at narrow widths.

Switched it to `overflow-y-auto overflow-x-hidden`. Wide content already manages its own horizontal scroll within bounded children — raw log entries use a per-entry `overflow-x-auto` and code blocks scroll internally — so the outer virtualized container never needs to scroll horizontally.

## How did you test this?

Did not run the app. Change is a one-line Tailwind class swap on the virtualized list scroll container, verified by tracing the layout: both consumers (conversation messages, raw logs) handle horizontal overflow within their own bounded children.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781313058853859)*
