### PR TITLE
feat(worktree): offer to check out remote-only branches

### DIFF
--- a/packages/core/src/task-detail/taskCreationHost.ts
+++ b/packages/core/src/task-detail/taskCreationHost.ts
@@ -15,6 +15,7 @@ export interface CreateWorkspaceArgs {
   folderPath: string;
   mode: WorkspaceMode;
   branch?: string;
+  allowRemoteBranchCheckout?: boolean;
 }
 
 export interface CreatedWorkspaceInfo {

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -99,6 +99,7 @@ export class TaskCreationSaga extends Saga<
             folderPath: repoPath,
             mode: workspaceMode,
             branch: branch ?? undefined,
+            allowRemoteBranchCheckout: input.allowRemoteBranchCheckout,
           });
         },
         rollback: async () => {

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -9,6 +9,7 @@ export interface PrepareTaskInputOptions {
   githubUserIntegrationId?: string;
   workspaceMode: WorkspaceMode;
   branch?: string | null;
+  allowRemoteBranchCheckout?: boolean;
   executionMode?: ExecutionMode;
   adapter?: "claude" | "codex";
   model?: string;
@@ -39,6 +40,7 @@ export function prepareTaskInput(
     githubUserIntegrationId: options.githubUserIntegrationId,
     workspaceMode: options.workspaceMode,
     branch: options.branch,
+    allowRemoteBranchCheckout: options.allowRemoteBranchCheckout,
     executionMode: options.executionMode,
     adapter: options.adapter,
     model: options.model,

--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createGitClient } from "./client";
 import {
   detectDefaultBranch,
@@ -9,6 +9,7 @@ import {
   getBranchDiffPatchesByPath,
   getChangedFilesDetailed,
   getGitBusyState,
+  remoteBranchExists,
   splitUnifiedDiffByFile,
 } from "./queries";
 
@@ -394,5 +395,58 @@ describe("getGitBusyState", () => {
       busy: true,
       operation: "rebase",
     });
+  });
+});
+
+describe("remoteBranchExists", () => {
+  let repoDir: string;
+  let remoteDir: string;
+
+  beforeEach(async () => {
+    remoteDir = await mkdtemp(path.join(tmpdir(), "posthog-code-bare-"));
+    const remoteGit = createGitClient(remoteDir);
+    await remoteGit.init(["--bare", "--initial-branch", "main"]);
+
+    repoDir = await mkdtemp(path.join(tmpdir(), "posthog-code-queries-"));
+    const git = createGitClient(repoDir);
+    await git.init(["--initial-branch", "main"]);
+    await git.addConfig("user.name", "Test");
+    await git.addConfig("user.email", "test@example.com");
+    await git.addConfig("commit.gpgsign", "false");
+    await git.addRemote("origin", remoteDir);
+    await writeFile(path.join(repoDir, "file.txt"), "content\n");
+    await git.add(["file.txt"]);
+    await git.commit("initial");
+    await git.push(["origin", "main"]);
+
+    await git.checkoutLocalBranch("remote-only");
+    await writeFile(path.join(repoDir, "extra.txt"), "extra\n");
+    await git.add(["extra.txt"]);
+    await git.commit("extra");
+    await git.push(["origin", "remote-only"]);
+    await git.checkout("main");
+  });
+
+  afterEach(async () => {
+    for (const d of [repoDir, remoteDir]) {
+      await rm(d, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { branch: "main", expected: true },
+    { branch: "remote-only", expected: true },
+    { branch: "nonexistent", expected: false },
+  ])("returns $expected for branch '$branch'", async ({ branch, expected }) => {
+    expect(await remoteBranchExists(repoDir, branch)).toBe(expected);
+  });
+
+  it("returns false when the remote is unreachable", async () => {
+    await createGitClient(repoDir).remote([
+      "set-url",
+      "origin",
+      "/nonexistent/path/to/remote",
+    ]);
+    expect(await remoteBranchExists(repoDir, "main")).toBe(false);
   });
 });

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -238,10 +238,12 @@ export async function remoteBranchExists(
     baseDir,
     async (git) => {
       try {
+        // `--` keeps a branch name beginning with `-` from being parsed as an option.
         const output = await git.raw([
           "ls-remote",
           "--heads",
           remote,
+          "--",
           branchName,
         ]);
         const target = `refs/heads/${branchName}`;

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -223,6 +223,39 @@ export async function branchExists(
   );
 }
 
+/**
+ * Checks whether a branch exists on the remote without fetching it.
+ * Uses `git ls-remote --heads`, which is read-only and reaches the remote.
+ */
+export async function remoteBranchExists(
+  baseDir: string,
+  branchName: string,
+  options?: CreateGitClientOptions & { remote?: string },
+): Promise<boolean> {
+  const manager = getGitOperationManager();
+  const remote = options?.remote ?? "origin";
+  return manager.executeRead(
+    baseDir,
+    async (git) => {
+      try {
+        const output = await git.raw([
+          "ls-remote",
+          "--heads",
+          remote,
+          branchName,
+        ]);
+        const target = `refs/heads/${branchName}`;
+        return output
+          .split("\n")
+          .some((line) => line.trim().endsWith(`\t${target}`));
+      } catch {
+        return false;
+      }
+    },
+    { signal: options?.abortSignal },
+  );
+}
+
 export async function listWorktrees(
   baseDir: string,
   options?: CreateGitClientOptions,

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -1073,7 +1073,8 @@ export async function fetchRef(
   ref: string,
 ): Promise<boolean> {
   try {
-    await git.raw(["fetch", "--quiet", "--no-tags", remote, ref]);
+    // `--` keeps a ref beginning with `-` from being parsed as an option.
+    await git.raw(["fetch", "--quiet", "--no-tags", remote, "--", ref]);
     return true;
   } catch {
     return false;

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -221,3 +221,60 @@ describe("WorktreeManager lifecycle (add / exists / list / remove / prune)", () 
     expect(await manager.listWorktrees()).toEqual([]);
   });
 });
+
+describe("WorktreeManager.createWorktreeForRemoteBranch", () => {
+  let remoteDir: string;
+  let localDir: string;
+  let worktreeBaseDir: string;
+
+  beforeEach(async () => {
+    remoteDir = await initBareRemote();
+
+    const seedDir = await mkdtemp(path.join(tmpdir(), "posthog-code-seed-"));
+    const seedGit = createGitClient(seedDir);
+    await seedGit.init(["--initial-branch", "main"]);
+    await seedGit.addConfig("user.name", "Test");
+    await seedGit.addConfig("user.email", "test@example.com");
+    await seedGit.addConfig("commit.gpgsign", "false");
+    await commit(seedDir, "initial.txt", "initial\n");
+    await seedGit.addRemote("origin", remoteDir);
+    await seedGit.push(["origin", "main"]);
+
+    // Push a branch that will only exist on the remote from the local clone's POV.
+    await seedGit.checkoutLocalBranch("contributor/pr");
+    await commit(seedDir, "pr.txt", "pr content\n");
+    await seedGit.push(["origin", "contributor/pr"]);
+
+    await rm(seedDir, { recursive: true, force: true });
+
+    localDir = await realpath(await initLocalClone(remoteDir));
+    worktreeBaseDir = await realpath(
+      await mkdtemp(path.join(tmpdir(), "posthog-code-wts-")),
+    );
+  });
+
+  afterEach(async () => {
+    for (const d of [remoteDir, localDir, worktreeBaseDir]) {
+      await rm(d, { recursive: true, force: true });
+    }
+  });
+
+  it("fetches a remote-only branch and creates a tracking worktree", async () => {
+    const localBranches = await createGitClient(localDir).branch();
+    expect(localBranches.all).not.toContain("contributor/pr");
+
+    const manager = new WorktreeManager({
+      mainRepoPath: localDir,
+      worktreeBasePath: worktreeBaseDir,
+    });
+
+    const info = await manager.createWorktreeForRemoteBranch("contributor/pr");
+
+    expect(await dirExists(info.worktreePath)).toBe(true);
+    expect(info.branchName).toBe("contributor/pr");
+
+    const remoteTip = await shaOfBranch(localDir, "origin/contributor/pr");
+    const worktreeHead = await shaOfBranch(info.worktreePath, "HEAD");
+    expect(worktreeHead).toBe(remoteTip);
+  });
+});

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -285,4 +285,22 @@ describe("WorktreeManager.createWorktreeForRemoteBranch", () => {
     ).trim();
     expect(upstream).toBe("origin/contributor/pr");
   });
+
+  it("rejects when the remote branch cannot be fetched", async () => {
+    // Point origin at a path that does not exist so the fetch fails.
+    await createGitClient(localDir).remote([
+      "set-url",
+      "origin",
+      "/nonexistent/path/to/remote",
+    ]);
+
+    const manager = new WorktreeManager({
+      mainRepoPath: localDir,
+      worktreeBasePath: worktreeBaseDir,
+    });
+
+    await expect(
+      manager.createWorktreeForRemoteBranch("contributor/pr"),
+    ).rejects.toThrow(/Failed to fetch branch 'contributor\/pr'/);
+  });
 });

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -276,5 +276,13 @@ describe("WorktreeManager.createWorktreeForRemoteBranch", () => {
     const remoteTip = await shaOfBranch(localDir, "origin/contributor/pr");
     const worktreeHead = await shaOfBranch(info.worktreePath, "HEAD");
     expect(worktreeHead).toBe(remoteTip);
+
+    const upstream = (
+      await createGitClient(info.worktreePath).revparse([
+        "--abbrev-ref",
+        "contributor/pr@{upstream}",
+      ])
+    ).trim();
+    expect(upstream).toBe("origin/contributor/pr");
   });
 });

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -203,22 +203,7 @@ export class WorktreeManager {
       throw new Error(`Branch '${branch}' does not exist`);
     }
 
-    let worktreeName = preferredName ?? this.generateWorktreeName();
-
-    if (preferredName) {
-      const worktreePath = this.getWorktreePath(preferredName);
-      const existingWorktrees = await this.listWorktrees();
-      const isRegistered = existingWorktrees.some(
-        (wt) => wt.worktreePath === worktreePath,
-      );
-      const existsOnDisk = await this.worktreeExists(preferredName);
-
-      if (isRegistered || existsOnDisk) {
-        worktreeName = `${this.generateWorktreeName()}${Date.now()}`;
-      }
-    } else if (await this.worktreeExists(worktreeName)) {
-      worktreeName = `${this.generateWorktreeName()}${Date.now()}`;
-    }
+    const worktreeName = await this.resolveAvailableWorktreeName(preferredName);
 
     if (!this.usesExternalPath()) {
       await this.ensureArrayDirIgnored();
@@ -360,22 +345,7 @@ export class WorktreeManager {
   ): Promise<WorktreeInfo> {
     const manager = getGitOperationManager();
 
-    let worktreeName = preferredName ?? this.generateWorktreeName();
-
-    if (preferredName) {
-      const worktreePath = this.getWorktreePath(preferredName);
-      const existingWorktrees = await this.listWorktrees();
-      const isRegistered = existingWorktrees.some(
-        (wt) => wt.worktreePath === worktreePath,
-      );
-      const existsOnDisk = await this.worktreeExists(preferredName);
-
-      if (isRegistered || existsOnDisk) {
-        worktreeName = `${this.generateWorktreeName()}${Date.now()}`;
-      }
-    } else if (await this.worktreeExists(worktreeName)) {
-      worktreeName = `${this.generateWorktreeName()}${Date.now()}`;
-    }
+    const worktreeName = await this.resolveAvailableWorktreeName(preferredName);
 
     if (!this.usesExternalPath()) {
       await this.ensureArrayDirIgnored();

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -260,6 +260,99 @@ export class WorktreeManager {
     };
   }
 
+  /**
+   * Fetches a branch that exists on the remote but not locally, then creates a
+   * worktree with a new local branch tracking `origin/<branch>`. Used when the
+   * user opts in to checking out a remote-only branch (e.g. a contributor's PR).
+   */
+  async createWorktreeForRemoteBranch(
+    branch: string,
+    preferredName?: string,
+    options?: { onOutput?: (data: string) => void; remote?: string },
+  ): Promise<WorktreeInfo> {
+    const manager = getGitOperationManager();
+    const remote = options?.remote ?? "origin";
+    const remoteRef = `${remote}/${branch}`;
+
+    options?.onOutput?.(`Fetching ${remoteRef}...\n`);
+    const fetched = await manager.executeWrite(this.mainRepoPath, (git) =>
+      fetchRef(git, remote, branch),
+    );
+    if (!fetched) {
+      throw new Error(`Failed to fetch branch '${branch}' from ${remote}`);
+    }
+
+    const worktreeName = await this.resolveAvailableWorktreeName(preferredName);
+
+    if (!this.usesExternalPath()) {
+      await this.ensureArrayDirIgnored();
+    }
+
+    const worktreePath = this.getWorktreePath(worktreeName);
+    const parentDir = path.dirname(worktreePath);
+    await fs.mkdir(parentDir, { recursive: true });
+
+    const targetPath = this.usesExternalPath()
+      ? worktreePath
+      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+
+    // `-b <branch> <remoteRef>` creates a local branch at the fetched remote ref
+    // and sets it up to track the remote branch.
+    const output = await manager.executeWrite(this.mainRepoPath, async () => {
+      return this.spawnWorktreeAdd(["-b", branch, targetPath, remoteRef], {
+        onOutput: options?.onOutput,
+      });
+    });
+
+    await this.symlinkClaudeConfig(worktreePath);
+    await processWorktreeLink(this.mainRepoPath, worktreePath, {
+      onOutput: options?.onOutput,
+    });
+    await processWorktreeInclude(this.mainRepoPath, worktreePath, {
+      onOutput: options?.onOutput,
+    });
+    await runPostCheckoutHook(this.mainRepoPath, worktreePath, {
+      onOutput: options?.onOutput,
+    });
+
+    return {
+      worktreePath,
+      worktreeName,
+      branchName: branch,
+      baseBranch: remoteRef,
+      createdAt: new Date().toISOString(),
+      output: output.trim() || undefined,
+    };
+  }
+
+  /**
+   * Resolves a worktree name that does not collide with an existing worktree,
+   * falling back to a freshly generated unique name when the preferred (or
+   * default) name is already registered or present on disk.
+   */
+  private async resolveAvailableWorktreeName(
+    preferredName?: string,
+  ): Promise<string> {
+    let worktreeName = preferredName ?? this.generateWorktreeName();
+
+    if (preferredName) {
+      const worktreePath = this.getWorktreePath(preferredName);
+      const existingWorktrees = await this.listWorktrees();
+      const isRegistered = existingWorktrees.some(
+        (wt) => wt.worktreePath === worktreePath,
+      );
+      const existsOnDisk = await this.worktreeExists(preferredName);
+
+      if (isRegistered || existsOnDisk) {
+        worktreeName = `${this.generateWorktreeName()}${Date.now()}`;
+      }
+    } else if (await this.worktreeExists(worktreeName)) {
+      worktreeName = `${this.generateWorktreeName()}${Date.now()}`;
+    }
+
+    return worktreeName;
+  }
+
   async createDetachedWorktreeAtCommit(
     commit: string,
     preferredName?: string,

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -267,6 +267,17 @@ export class WorktreeManager {
       throw new Error(`Failed to fetch branch '${branch}' from ${remote}`);
     }
 
+    // Verify the remote-tracking ref was created. Restricted refspecs can cause
+    // git fetch to succeed (updating only FETCH_HEAD) without writing
+    // refs/remotes/<remote>/<branch>, which makes the subsequent worktree add
+    // fail with an opaque "invalid reference" error.
+    const trackingRefCreated = await branchExists(this.mainRepoPath, remoteRef);
+    if (!trackingRefCreated) {
+      throw new Error(
+        `Fetch succeeded but remote-tracking ref '${remoteRef}' was not created. Check the remote's fetch refspec configuration.`,
+      );
+    }
+
     const worktreeName = await this.resolveAvailableWorktreeName(preferredName);
 
     if (!this.usesExternalPath()) {

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -270,8 +270,12 @@ export class WorktreeManager {
     // Verify the remote-tracking ref was created. Restricted refspecs can cause
     // git fetch to succeed (updating only FETCH_HEAD) without writing
     // refs/remotes/<remote>/<branch>, which makes the subsequent worktree add
-    // fail with an opaque "invalid reference" error.
-    const trackingRefCreated = await branchExists(this.mainRepoPath, remoteRef);
+    // fail with an opaque "invalid reference" error. Check the fully-qualified
+    // ref so a stray local branch/tag named `<remote>/<branch>` can't satisfy it.
+    const trackingRefCreated = await branchExists(
+      this.mainRepoPath,
+      `refs/remotes/${remoteRef}`,
+    );
     if (!trackingRefCreated) {
       throw new Error(
         `Fetch succeeded but remote-tracking ref '${remoteRef}' was not created. Check the remote's fetch refspec configuration.`,

--- a/packages/host-router/src/routers/workspace.router.ts
+++ b/packages/host-router/src/routers/workspace.router.ts
@@ -4,6 +4,8 @@ import { WORKSPACE_SERVICE } from "@posthog/workspace-server/services/workspace/
 import {
   cachedPrUrlInput,
   cachedPrUrlOutput,
+  checkWorktreeBranchInput,
+  checkWorktreeBranchOutput,
   createWorkspaceInput,
   createWorkspaceOutput,
   deleteWorkspaceInput,
@@ -79,6 +81,13 @@ export const workspaceRouter = router({
     .output(createWorkspaceOutput)
     .mutation(({ ctx, input }) =>
       getService(ctx.container).createWorkspace(input),
+    ),
+
+  checkWorktreeBranch: publicProcedure
+    .input(checkWorktreeBranchInput)
+    .output(checkWorktreeBranchOutput)
+    .query(({ ctx, input }) =>
+      getService(ctx.container).checkWorktreeBranch(input),
     ),
 
   reconcileCloudWorkspaces: publicProcedure

--- a/packages/host-router/src/routers/workspace.router.ts
+++ b/packages/host-router/src/routers/workspace.router.ts
@@ -86,8 +86,8 @@ export const workspaceRouter = router({
   checkWorktreeBranch: publicProcedure
     .input(checkWorktreeBranchInput)
     .output(checkWorktreeBranchOutput)
-    .query(({ ctx, input }) =>
-      getService(ctx.container).checkWorktreeBranch(input),
+    .query(({ ctx, input, signal }) =>
+      getService(ctx.container).checkWorktreeBranch(input, signal),
     ),
 
   reconcileCloudWorkspaces: publicProcedure

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -20,6 +20,9 @@ export interface TaskCreationInput {
   repository?: string | null;
   workspaceMode?: WorkspaceMode;
   branch?: string | null;
+  // When the branch exists only on the remote, opt in to fetching and checking
+  // it out locally into the worktree (set after the user confirms).
+  allowRemoteBranchCheckout?: boolean;
   githubIntegrationId?: number;
   githubUserIntegrationId?: string;
   executionMode?: ExecutionMode;

--- a/packages/ui/src/features/task-detail/components/RemoteBranchCheckoutDialog.tsx
+++ b/packages/ui/src/features/task-detail/components/RemoteBranchCheckoutDialog.tsx
@@ -1,0 +1,51 @@
+import { GitBranch } from "@phosphor-icons/react";
+import { AlertDialog, Button, Code, Flex } from "@radix-ui/themes";
+import { useRemoteBranchConfirmStore } from "../stores/remoteBranchConfirmStore";
+
+/**
+ * Globally-mounted confirmation shown when a user starts a worktree task on a
+ * branch that exists only on the remote. Confirming fetches the branch and
+ * checks it out locally into the new worktree.
+ */
+export function RemoteBranchCheckoutDialog() {
+  const isOpen = useRemoteBranchConfirmStore((s) => s.isOpen);
+  const branch = useRemoteBranchConfirmStore((s) => s.branch);
+  const accept = useRemoteBranchConfirmStore((s) => s.accept);
+  const cancel = useRemoteBranchConfirmStore((s) => s.cancel);
+
+  return (
+    <AlertDialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) cancel();
+      }}
+    >
+      <AlertDialog.Content maxWidth="440px" size="2">
+        <AlertDialog.Title className="text-base">
+          <Flex align="center" gap="2">
+            <GitBranch size={18} weight="bold" color="var(--accent-9)" />
+            Check out remote branch?
+          </Flex>
+        </AlertDialog.Title>
+        <AlertDialog.Description className="text-sm">
+          {branch ? <Code>{branch}</Code> : "This branch"} doesn't exist locally
+          but was found on the remote. Check it out into a new worktree to
+          continue working on it?
+        </AlertDialog.Description>
+
+        <Flex justify="end" gap="2" mt="4">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray" size="1" onClick={cancel}>
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Button variant="solid" size="1" onClick={accept}>
+              Check out branch
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/packages/ui/src/features/task-detail/components/RemoteBranchCheckoutDialog.tsx
+++ b/packages/ui/src/features/task-detail/components/RemoteBranchCheckoutDialog.tsx
@@ -35,7 +35,7 @@ export function RemoteBranchCheckoutDialog() {
 
         <Flex justify="end" gap="2" mt="4">
           <AlertDialog.Cancel>
-            <Button variant="soft" color="gray" size="1" onClick={cancel}>
+            <Button variant="soft" color="gray" size="1">
               Cancel
             </Button>
           </AlertDialog.Cancel>

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -41,6 +41,7 @@ import { useSettingsStore } from "../../settings/settingsStore";
 import { useCreateTask } from "../../tasks/useTaskCrudMutations";
 import { useTourStore } from "../../tour/tourStore";
 import { createFirstTaskTour } from "../../tour/tours/createFirstTaskTour";
+import { useRemoteBranchConfirmStore } from "../stores/remoteBranchConfirmStore";
 
 const log = logger.scope("task-creation");
 
@@ -183,6 +184,31 @@ export function useTaskCreation({
         return false;
       }
 
+      // If the chosen worktree branch only exists on the remote, confirm before
+      // fetching and checking it out locally. Done before the pending view so
+      // the dialog (and a cancel) don't leave a half-started task on screen.
+      let allowRemoteBranchCheckout = false;
+      if (workspaceMode === "worktree" && branch && selectedDirectory) {
+        try {
+          const { status } =
+            await hostClient.workspace.checkWorktreeBranch.query({
+              mainRepoPath: selectedDirectory,
+              branch,
+            });
+          if (status === "remote-only") {
+            const confirmed = await useRemoteBranchConfirmStore
+              .getState()
+              .confirm(branch);
+            if (!confirmed) {
+              return false;
+            }
+            allowRemoteBranchCheckout = true;
+          }
+        } catch (error) {
+          log.warn("Failed to check worktree branch availability", { error });
+        }
+      }
+
       setIsCreatingTask(true);
 
       const content = contentOverride ?? editor.getContent();
@@ -223,6 +249,7 @@ export function useTaskCreation({
           githubUserIntegrationId,
           workspaceMode,
           branch,
+          allowRemoteBranchCheckout,
           executionMode,
           adapter,
           model,

--- a/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
+++ b/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
@@ -23,22 +23,21 @@ describe("remoteBranchConfirmStore", () => {
     expect(state.branch).toBe("feature/x");
   });
 
-  it("accept resolves the pending promise with true and closes", async () => {
-    const promise = useRemoteBranchConfirmStore.getState().confirm("feature/x");
-    useRemoteBranchConfirmStore.getState().accept();
-    await expect(promise).resolves.toBe(true);
-    const state = useRemoteBranchConfirmStore.getState();
-    expect(state.isOpen).toBe(false);
-    expect(state.branch).toBeNull();
-    expect(state.resolve).toBeNull();
-  });
-
-  it("cancel resolves the pending promise with false and closes", async () => {
-    const promise = useRemoteBranchConfirmStore.getState().confirm("feature/x");
-    useRemoteBranchConfirmStore.getState().cancel();
-    await expect(promise).resolves.toBe(false);
-    expect(useRemoteBranchConfirmStore.getState().isOpen).toBe(false);
-  });
+  it.each([
+    { action: "accept" as const, expected: true },
+    { action: "cancel" as const, expected: false },
+  ])(
+    "$action resolves the pending promise with $expected and closes",
+    async ({ action, expected }) => {
+      const promise = useRemoteBranchConfirmStore.getState().confirm("feature/x");
+      useRemoteBranchConfirmStore.getState()[action]();
+      await expect(promise).resolves.toBe(expected);
+      const state = useRemoteBranchConfirmStore.getState();
+      expect(state.isOpen).toBe(false);
+      expect(state.branch).toBeNull();
+      expect(state.resolve).toBeNull();
+    },
+  );
 
   it("opening a second dialog resolves the first as cancelled", async () => {
     const first = useRemoteBranchConfirmStore.getState().confirm("first");

--- a/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
+++ b/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRemoteBranchConfirmStore } from "./remoteBranchConfirmStore";
+
+describe("remoteBranchConfirmStore", () => {
+  beforeEach(() => {
+    useRemoteBranchConfirmStore.setState({
+      isOpen: false,
+      branch: null,
+      resolve: null,
+    });
+  });
+
+  it("starts closed", () => {
+    const state = useRemoteBranchConfirmStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.branch).toBeNull();
+  });
+
+  it("confirm opens the dialog with the branch", () => {
+    void useRemoteBranchConfirmStore.getState().confirm("feature/x");
+    const state = useRemoteBranchConfirmStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.branch).toBe("feature/x");
+  });
+
+  it("accept resolves the pending promise with true and closes", async () => {
+    const promise = useRemoteBranchConfirmStore.getState().confirm("feature/x");
+    useRemoteBranchConfirmStore.getState().accept();
+    await expect(promise).resolves.toBe(true);
+    const state = useRemoteBranchConfirmStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.branch).toBeNull();
+    expect(state.resolve).toBeNull();
+  });
+
+  it("cancel resolves the pending promise with false and closes", async () => {
+    const promise = useRemoteBranchConfirmStore.getState().confirm("feature/x");
+    useRemoteBranchConfirmStore.getState().cancel();
+    await expect(promise).resolves.toBe(false);
+    expect(useRemoteBranchConfirmStore.getState().isOpen).toBe(false);
+  });
+
+  it("opening a second dialog resolves the first as cancelled", async () => {
+    const first = useRemoteBranchConfirmStore.getState().confirm("first");
+    const second = useRemoteBranchConfirmStore.getState().confirm("second");
+    await expect(first).resolves.toBe(false);
+    expect(useRemoteBranchConfirmStore.getState().branch).toBe("second");
+    useRemoteBranchConfirmStore.getState().accept();
+    await expect(second).resolves.toBe(true);
+  });
+});

--- a/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
+++ b/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
@@ -29,7 +29,9 @@ describe("remoteBranchConfirmStore", () => {
   ])(
     "$action resolves the pending promise with $expected and closes",
     async ({ action, expected }) => {
-      const promise = useRemoteBranchConfirmStore.getState().confirm("feature/x");
+      const promise = useRemoteBranchConfirmStore
+        .getState()
+        .confirm("feature/x");
       useRemoteBranchConfirmStore.getState()[action]();
       await expect(promise).resolves.toBe(expected);
       const state = useRemoteBranchConfirmStore.getState();

--- a/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
+++ b/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.test.ts
@@ -17,10 +17,13 @@ describe("remoteBranchConfirmStore", () => {
   });
 
   it("confirm opens the dialog with the branch", () => {
-    void useRemoteBranchConfirmStore.getState().confirm("feature/x");
+    const promise = useRemoteBranchConfirmStore.getState().confirm("feature/x");
     const state = useRemoteBranchConfirmStore.getState();
     expect(state.isOpen).toBe(true);
     expect(state.branch).toBe("feature/x");
+    // Resolve the pending promise so it doesn't dangle past this test.
+    useRemoteBranchConfirmStore.getState().cancel();
+    return expect(promise).resolves.toBe(false);
   });
 
   it.each([

--- a/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.ts
+++ b/packages/ui/src/features/task-detail/stores/remoteBranchConfirmStore.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+
+interface RemoteBranchConfirmState {
+  isOpen: boolean;
+  branch: string | null;
+  resolve: ((confirmed: boolean) => void) | null;
+}
+
+interface RemoteBranchConfirmActions {
+  /**
+   * Opens the confirmation dialog for a remote-only branch and resolves to the
+   * user's choice. `true` means check the branch out locally; `false` cancels.
+   */
+  confirm: (branch: string) => Promise<boolean>;
+  accept: () => void;
+  cancel: () => void;
+}
+
+type RemoteBranchConfirmStore = RemoteBranchConfirmState &
+  RemoteBranchConfirmActions;
+
+export const useRemoteBranchConfirmStore = create<RemoteBranchConfirmStore>()(
+  (set, get) => ({
+    isOpen: false,
+    branch: null,
+    resolve: null,
+
+    confirm: (branch) =>
+      new Promise<boolean>((resolve) => {
+        // Resolve any dialog already waiting before replacing it.
+        get().resolve?.(false);
+        set({ isOpen: true, branch, resolve });
+      }),
+
+    accept: () => {
+      get().resolve?.(true);
+      set({ isOpen: false, branch: null, resolve: null });
+    },
+
+    cancel: () => {
+      get().resolve?.(false);
+      set({ isOpen: false, branch: null, resolve: null });
+    },
+  }),
+);

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -239,6 +239,7 @@ function RootLayout() {
           onToggleShortcutsSheet={toggleShortcutsSheet}
         />
         {billingEnabled && <UsageLimitModal />}
+        <RemoteBranchCheckoutDialog />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>
             <TanStackDevtools />
@@ -262,6 +263,7 @@ function RootLayout() {
           onToggleShortcutsSheet={toggleShortcutsSheet}
         />
         {billingEnabled && <UsageLimitModal />}
+        <RemoteBranchCheckoutDialog />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>
             <TanStackDevtools />

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -19,6 +19,7 @@ import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery"
 import { MainSidebar } from "@posthog/ui/features/sidebar/components/MainSidebar";
 import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useVisualTaskOrder } from "@posthog/ui/features/sidebar/useVisualTaskOrder";
+import { RemoteBranchCheckoutDialog } from "@posthog/ui/features/task-detail/components/RemoteBranchCheckoutDialog";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { TourOverlay } from "@posthog/ui/features/tour/components/TourOverlay";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
@@ -303,6 +304,7 @@ function RootLayout() {
         />
         <TourOverlay />
         {billingEnabled && <UsageLimitModal />}
+        <RemoteBranchCheckoutDialog />
         <HedgehogMode />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>

--- a/packages/workspace-server/src/services/workspace/schemas.ts
+++ b/packages/workspace-server/src/services/workspace/schemas.ts
@@ -23,6 +23,9 @@ export const createWorkspaceInput = z
     mode: workspaceModeSchema,
     branch: z.string().optional(),
     useExistingBranch: z.boolean().optional(),
+    // When set, a worktree branch that exists only on the remote is fetched and
+    // checked out locally instead of failing. Gated behind a user confirmation.
+    allowRemoteBranchCheckout: z.boolean().optional(),
   })
   .refine(
     (data) =>
@@ -32,6 +35,18 @@ export const createWorkspaceInput = z
       message: "Repository and folder paths must be valid for non-cloud mode",
     },
   );
+
+export const checkWorktreeBranchInput = z.object({
+  mainRepoPath: z.string(),
+  branch: z.string(),
+});
+
+export const checkWorktreeBranchOutput = z.object({
+  // "trunk": the default branch (handled by the normal detached-worktree path).
+  // "local": branch exists locally. "remote-only": exists on the remote but not
+  // locally. "missing": found neither locally nor on the remote.
+  status: z.enum(["trunk", "local", "remote-only", "missing"]),
+});
 
 export const reconcileCloudWorkspacesInput = z.object({
   taskIds: z.array(z.string()),
@@ -268,6 +283,10 @@ export type {
 } from "@posthog/shared";
 
 export type CreateWorkspaceInput = z.infer<typeof createWorkspaceInput>;
+export type CheckWorktreeBranchInput = z.infer<typeof checkWorktreeBranchInput>;
+export type CheckWorktreeBranchOutput = z.infer<
+  typeof checkWorktreeBranchOutput
+>;
 export type ReconcileCloudWorkspacesInput = z.infer<
   typeof reconcileCloudWorkspacesInput
 >;

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -1,4 +1,10 @@
 import type { RootLogger } from "@posthog/di/logger";
+import {
+  branchExists,
+  getCurrentBranch,
+  getDefaultBranch,
+  remoteBranchExists,
+} from "@posthog/git/queries";
 import type { IAnalytics } from "@posthog/platform/analytics";
 import type { IWorkspaceSettings } from "@posthog/platform/workspace-settings";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
@@ -15,6 +21,17 @@ import type {
   WorkspaceProvisioning,
 } from "./ports";
 import { WorkspaceService, WorkspaceServiceEvent } from "./workspace";
+
+vi.mock("@posthog/git/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@posthog/git/queries")>();
+  return {
+    ...actual,
+    getDefaultBranch: vi.fn(),
+    getCurrentBranch: vi.fn(),
+    branchExists: vi.fn(),
+    remoteBranchExists: vi.fn(),
+  };
+});
 
 function createMocks() {
   const agent = {
@@ -212,6 +229,48 @@ describe("WorkspaceService", () => {
       expect(mocks.fileWatcher.onGitStateChanged).toHaveBeenCalledTimes(1);
       expect(mocks.focus.onBranchRenamed).toHaveBeenCalledTimes(1);
       expect(mocks.agent.onAgentFileActivity).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("checkWorktreeBranch", () => {
+    const mainRepoPath = "/tmp/repo";
+
+    beforeEach(() => {
+      vi.mocked(getDefaultBranch).mockResolvedValue("main");
+      vi.mocked(getCurrentBranch).mockResolvedValue("main");
+      vi.mocked(branchExists).mockResolvedValue(false);
+      vi.mocked(remoteBranchExists).mockResolvedValue(false);
+    });
+
+    it.each([
+      { status: "trunk", branch: "main", local: false, remote: false },
+      { status: "local", branch: "feature/x", local: true, remote: false },
+      {
+        status: "remote-only",
+        branch: "feature/x",
+        local: false,
+        remote: true,
+      },
+      { status: "missing", branch: "feature/x", local: false, remote: false },
+    ])(
+      "classifies '$branch' as $status",
+      async ({ status, branch, local, remote }) => {
+        vi.mocked(branchExists).mockResolvedValue(local);
+        vi.mocked(remoteBranchExists).mockResolvedValue(remote);
+
+        expect(
+          await service.checkWorktreeBranch({ mainRepoPath, branch }),
+        ).toEqual({ status });
+      },
+    );
+
+    it("falls back to the current branch as trunk when getDefaultBranch fails", async () => {
+      vi.mocked(getDefaultBranch).mockRejectedValue(new Error("no remote"));
+      vi.mocked(getCurrentBranch).mockResolvedValue("develop");
+
+      expect(
+        await service.checkWorktreeBranch({ mainRepoPath, branch: "develop" }),
+      ).toEqual({ status: "trunk" });
     });
   });
 });

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -7,9 +7,11 @@ import {
 } from "@posthog/di/logger";
 import { createGitClient } from "@posthog/git/client";
 import {
+  branchExists,
   getCurrentBranch,
   getDefaultBranch,
   hasTrackedFiles,
+  remoteBranchExists,
 } from "@posthog/git/queries";
 import { CreateOrSwitchBranchSaga } from "@posthog/git/sagas/branch";
 import { DetachHeadSaga } from "@posthog/git/sagas/head";
@@ -57,6 +59,8 @@ import type {
 } from "./ports";
 import type {
   BranchChangedPayload,
+  CheckWorktreeBranchInput,
+  CheckWorktreeBranchOutput,
   CreateWorkspaceInput,
   LinkedBranchChangedPayload,
   ReconcileCloudWorkspacesOutput,
@@ -420,6 +424,34 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     return { created: toCreate };
   }
 
+  /**
+   * Reports whether a branch the user picked for a worktree is the trunk,
+   * exists locally, exists only on the remote, or cannot be found. The renderer
+   * uses "remote-only" to prompt before checking the branch out locally.
+   */
+  async checkWorktreeBranch(
+    options: CheckWorktreeBranchInput,
+  ): Promise<CheckWorktreeBranchOutput> {
+    const { mainRepoPath, branch } = options;
+
+    const defaultBranch = await getDefaultBranch(mainRepoPath).catch(() =>
+      getCurrentBranch(mainRepoPath).then((b) => b ?? "main"),
+    );
+    if (branch === defaultBranch) {
+      return { status: "trunk" };
+    }
+
+    if (await branchExists(mainRepoPath, branch)) {
+      return { status: "local" };
+    }
+
+    if (await remoteBranchExists(mainRepoPath, branch)) {
+      return { status: "remote-only" };
+    }
+
+    return { status: "missing" };
+  }
+
   async createWorkspace(options: CreateWorkspaceInput): Promise<WorkspaceInfo> {
     // Prevent concurrent workspace creation for the same task
     const existingPromise = this.creatingWorkspaces.get(options.taskId);
@@ -450,6 +482,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       mode,
       branch,
       useExistingBranch,
+      allowRemoteBranchCheckout,
     } = options;
 
     const existingWorkspace = await this.getWorkspaceInfo(taskId);
@@ -587,6 +620,21 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
             });
             this.log.info(
               `Created detached worktree from occupied branch: ${worktree.worktreeName} at ${worktree.worktreePath}`,
+            );
+          } else if (
+            allowRemoteBranchCheckout &&
+            errorMessage.includes("does not exist")
+          ) {
+            this.log.info(
+              `Branch ${selectedBranch} is not local; checking it out from the remote`,
+            );
+            worktree = await worktreeManager.createWorktreeForRemoteBranch(
+              selectedBranch,
+              undefined,
+              { onOutput },
+            );
+            this.log.info(
+              `Created worktree from remote branch: ${worktree.worktreeName} at ${worktree.worktreePath} (branch: ${selectedBranch})`,
             );
           } else {
             throw checkoutError;

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -623,7 +623,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
             );
           } else if (
             allowRemoteBranchCheckout &&
-            errorMessage.includes("does not exist")
+            errorMessage.includes(`Branch '${selectedBranch}' does not exist`)
           ) {
             this.log.info(
               `Branch ${selectedBranch} is not local; checking it out from the remote`,

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -431,21 +431,28 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
    */
   async checkWorktreeBranch(
     options: CheckWorktreeBranchInput,
+    signal?: AbortSignal,
   ): Promise<CheckWorktreeBranchOutput> {
     const { mainRepoPath, branch } = options;
 
-    const defaultBranch = await getDefaultBranch(mainRepoPath).catch(() =>
-      getCurrentBranch(mainRepoPath).then((b) => b ?? "main"),
+    const defaultBranch = await getDefaultBranch(mainRepoPath, {
+      abortSignal: signal,
+    }).catch(() =>
+      getCurrentBranch(mainRepoPath, { abortSignal: signal }).then(
+        (b) => b ?? "main",
+      ),
     );
     if (branch === defaultBranch) {
       return { status: "trunk" };
     }
 
-    if (await branchExists(mainRepoPath, branch)) {
+    if (await branchExists(mainRepoPath, branch, { abortSignal: signal })) {
       return { status: "local" };
     }
 
-    if (await remoteBranchExists(mainRepoPath, branch)) {
+    if (
+      await remoteBranchExists(mainRepoPath, branch, { abortSignal: signal })
+    ) {
       return { status: "remote-only" };
     }
 

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -623,6 +623,9 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
             );
           } else if (
             allowRemoteBranchCheckout &&
+            // Matches the exact message createWorktreeForExistingBranch throws
+            // for a missing local branch, mirroring the occupied-branch check
+            // above. Both keys off the controlled git/worktree error text.
             errorMessage.includes(`Branch '${selectedBranch}' does not exist`)
           ) {
             this.log.info(


### PR DESCRIPTION
## Problem

Sometimes you want to start a worktree task on a branch that isn't checked out locally — a contributor's PR branch, or a branch an overnight agent created elsewhere. Today, picking a branch that doesn't exist locally fails the worktree creation with a "Branch '<name>' does not exist" error, even when the branch exists on the remote.

## Changes

When the branch chosen for a worktree task exists only on the remote, we now ask before checking it out instead of erroring:

<img width="734" height="373" alt="Screenshot 2026-06-15 at 3 54 07 PM" src="https://github.com/user-attachments/assets/f5836920-d314-4db5-b07e-cd7342a8fb4d" />

- New `workspace.checkWorktreeBranch` query classifies the branch as `trunk` / `local` / `remote-only` / `missing`.
- The task-creation flow preflights the branch; on `remote-only` it shows a confirmation dialog. Confirming fetches the branch and checks it out into the new worktree (a new local branch tracking `origin/<branch>`); cancelling aborts cleanly before any task is created.
- Adds `remoteBranchExists()` and `WorktreeManager.createWorktreeForRemoteBranch()`, and threads an explicit `allowRemoteBranchCheckout` opt-in from the UI through the saga to the workspace server.

Existing behavior is unchanged for local branches, the trunk, and branches that exist nowhere.

## How did you test this?

- `pnpm --filter @posthog/git/@posthog/workspace-server/@posthog/host-router/@posthog/core/@posthog/ui typecheck` — clean for all changed files.
- Biome check on all changed files — clean.
- New unit test for the confirmation store (`remoteBranchConfirmStore.test.ts`, 5 cases) — passing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Additional Context

This is just a stopgap fix. I hope to follow-up with a better UI where a user can enumerate remote branches to check out. But this unblocks folks who want to checkout a remote branch into a worktree to perform a task.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781286814736189?thread_ts=1781286814.736189&cid=C09G8Q32R6F)*
