### PR TITLE
fix(worktree): reuse an existing worktree instead of duplicating it

### DIFF
--- a/packages/core/src/task-detail/taskCreationHost.ts
+++ b/packages/core/src/task-detail/taskCreationHost.ts
@@ -16,6 +16,7 @@ export interface CreateWorkspaceArgs {
   mode: WorkspaceMode;
   branch?: string;
   allowRemoteBranchCheckout?: boolean;
+  reuseExistingWorktree?: boolean;
 }
 
 export interface CreatedWorkspaceInfo {

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -100,6 +100,7 @@ export class TaskCreationSaga extends Saga<
             mode: workspaceMode,
             branch: branch ?? undefined,
             allowRemoteBranchCheckout: input.allowRemoteBranchCheckout,
+            reuseExistingWorktree: input.reuseExistingWorktree,
           });
         },
         rollback: async () => {

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -10,6 +10,7 @@ export interface PrepareTaskInputOptions {
   workspaceMode: WorkspaceMode;
   branch?: string | null;
   allowRemoteBranchCheckout?: boolean;
+  reuseExistingWorktree?: boolean;
   executionMode?: ExecutionMode;
   adapter?: "claude" | "codex";
   model?: string;
@@ -42,6 +43,7 @@ export function prepareTaskInput(
     workspaceMode: options.workspaceMode,
     branch: options.branch,
     allowRemoteBranchCheckout: options.allowRemoteBranchCheckout,
+    reuseExistingWorktree: options.reuseExistingWorktree,
     executionMode: options.executionMode,
     adapter: options.adapter,
     model: options.model,

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -23,6 +23,9 @@ export interface TaskCreationInput {
   // When the branch exists only on the remote, opt in to fetching and checking
   // it out locally into the worktree (set after the user confirms).
   allowRemoteBranchCheckout?: boolean;
+  // When a worktree is already checked out on the branch, opt in to reusing it
+  // for this task instead of creating a new one (set after the user confirms).
+  reuseExistingWorktree?: boolean;
   githubIntegrationId?: number;
   githubUserIntegrationId?: string;
   executionMode?: ExecutionMode;

--- a/packages/ui/src/features/task-detail/components/ExistingWorktreeDialog.tsx
+++ b/packages/ui/src/features/task-detail/components/ExistingWorktreeDialog.tsx
@@ -1,0 +1,71 @@
+import { FolderOpen, Warning } from "@phosphor-icons/react";
+import { AlertDialog, Button, Code, Flex, Text } from "@radix-ui/themes";
+import { useExistingWorktreeConfirmStore } from "../stores/existingWorktreeConfirmStore";
+
+/**
+ * Globally-mounted confirmation shown when a user starts a worktree task on a
+ * branch that already has a worktree checked out. Confirming reuses that
+ * worktree for the task instead of creating a new one.
+ */
+export function ExistingWorktreeDialog() {
+  const isOpen = useExistingWorktreeConfirmStore((s) => s.isOpen);
+  const branch = useExistingWorktreeConfirmStore((s) => s.branch);
+  const worktreePath = useExistingWorktreeConfirmStore((s) => s.worktreePath);
+  const accept = useExistingWorktreeConfirmStore((s) => s.accept);
+  const cancel = useExistingWorktreeConfirmStore((s) => s.cancel);
+
+  return (
+    <AlertDialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) cancel();
+      }}
+    >
+      <AlertDialog.Content maxWidth="460px" size="2">
+        <AlertDialog.Title className="text-base">
+          <Flex align="center" gap="2">
+            <FolderOpen size={18} weight="bold" color="var(--accent-9)" />
+            Worktree already exists
+          </Flex>
+        </AlertDialog.Title>
+        <AlertDialog.Description className="text-sm">
+          A worktree is already checked out on{" "}
+          {branch ? <Code>{branch}</Code> : "this branch"}
+          {worktreePath ? (
+            <>
+              {" "}
+              at <Code>{worktreePath}</Code>
+            </>
+          ) : null}
+          . Continue and use that worktree for this task?
+        </AlertDialog.Description>
+
+        <Flex align="start" gap="2" mt="3">
+          <Warning
+            size={16}
+            weight="bold"
+            color="var(--amber-9)"
+            className="mt-px shrink-0"
+          />
+          <Text size="1" color="gray">
+            Deleting this task later removes the worktree and any uncommitted
+            work in it, even though it existed beforehand.
+          </Text>
+        </Flex>
+
+        <Flex justify="end" gap="2" mt="4">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray" size="1">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Button variant="solid" size="1" onClick={accept}>
+              Use existing worktree
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -40,8 +40,10 @@ import { useTaskInputHistoryStore } from "../../message-editor/taskInputHistoryS
 import type { EditorHandle } from "../../message-editor/types";
 import { useSettingsStore } from "../../settings/settingsStore";
 import { useCreateTask } from "../../tasks/useTaskCrudMutations";
+import { useTasks } from "../../tasks/useTasks";
 import { useTourStore } from "../../tour/tourStore";
 import { createFirstTaskTour } from "../../tour/tours/createFirstTaskTour";
+import { useExistingWorktreeConfirmStore } from "../stores/existingWorktreeConfirmStore";
 import { useRemoteBranchConfirmStore } from "../stores/remoteBranchConfirmStore";
 
 const log = logger.scope("task-creation");
@@ -177,6 +179,8 @@ export function useTaskCreation({
   );
   const { invalidateTasks } = useCreateTask();
   const { isOnline } = useConnectivity();
+  // Used to name the task occupying a branch's worktree when reuse is blocked.
+  const { data: tasks } = useTasks();
 
   const hasRequiredPath = allowNoRepo
     ? true
@@ -199,18 +203,41 @@ export function useTaskCreation({
         return false;
       }
 
-      // If the chosen worktree branch only exists on the remote, confirm before
-      // fetching and checking it out locally. Done before the pending view so
-      // the dialog (and a cancel) don't leave a half-started task on screen.
+      // Confirm a couple of worktree branch situations before starting the
+      // task. Done before the pending view so a dialog (and a cancel) don't
+      // leave a half-started task on screen. Reusing an existing worktree takes
+      // priority over checking out a remote branch.
       let allowRemoteBranchCheckout = false;
+      let reuseExistingWorktree = false;
       if (workspaceMode === "worktree" && branch && selectedDirectory) {
         try {
-          const { status } =
+          const { status, existingWorktreePath, existingWorktreeTaskId } =
             await hostClient.workspace.checkWorktreeBranch.query({
               mainRepoPath: selectedDirectory,
               branch,
             });
-          if (status === "remote-only") {
+          if (existingWorktreeTaskId) {
+            // The branch's worktree already belongs to another task. Don't
+            // create a duplicate; point the user at the task using it.
+            const occupant = tasks?.find(
+              (t) => t.id === existingWorktreeTaskId,
+            );
+            toast.error("Worktree already in use", {
+              description: occupant
+                ? `${branch} already has a worktree used by "${occupant.title}". Open that task to keep working there.`
+                : `${branch} already has a worktree used by another task.`,
+            });
+            return false;
+          }
+          if (existingWorktreePath) {
+            const confirmed = await useExistingWorktreeConfirmStore
+              .getState()
+              .confirm(branch, existingWorktreePath);
+            if (!confirmed) {
+              return false;
+            }
+            reuseExistingWorktree = true;
+          } else if (status === "remote-only") {
             const confirmed = await useRemoteBranchConfirmStore
               .getState()
               .confirm(branch);
@@ -267,6 +294,7 @@ export function useTaskCreation({
           workspaceMode,
           branch,
           allowRemoteBranchCheckout,
+          reuseExistingWorktree,
           executionMode,
           adapter,
           model,
@@ -396,6 +424,7 @@ export function useTaskCreation({
       trpc,
       queryClient,
       taskService,
+      tasks,
     ],
   );
 

--- a/packages/ui/src/features/task-detail/stores/existingWorktreeConfirmStore.test.ts
+++ b/packages/ui/src/features/task-detail/stores/existingWorktreeConfirmStore.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useExistingWorktreeConfirmStore } from "./existingWorktreeConfirmStore";
+
+describe("existingWorktreeConfirmStore", () => {
+  beforeEach(() => {
+    useExistingWorktreeConfirmStore.setState({
+      isOpen: false,
+      branch: null,
+      worktreePath: null,
+      resolve: null,
+    });
+  });
+
+  it("starts closed", () => {
+    const state = useExistingWorktreeConfirmStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.branch).toBeNull();
+    expect(state.worktreePath).toBeNull();
+  });
+
+  it("confirm opens the dialog with the branch and path", () => {
+    void useExistingWorktreeConfirmStore
+      .getState()
+      .confirm("feature/x", "/wt/feature-x");
+    const state = useExistingWorktreeConfirmStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.branch).toBe("feature/x");
+    expect(state.worktreePath).toBe("/wt/feature-x");
+  });
+
+  it("accept resolves the pending promise with true and closes", async () => {
+    const promise = useExistingWorktreeConfirmStore
+      .getState()
+      .confirm("feature/x", "/wt/feature-x");
+    useExistingWorktreeConfirmStore.getState().accept();
+    await expect(promise).resolves.toBe(true);
+    const state = useExistingWorktreeConfirmStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.branch).toBeNull();
+    expect(state.worktreePath).toBeNull();
+    expect(state.resolve).toBeNull();
+  });
+
+  it("cancel resolves the pending promise with false and closes", async () => {
+    const promise = useExistingWorktreeConfirmStore
+      .getState()
+      .confirm("feature/x", "/wt/feature-x");
+    useExistingWorktreeConfirmStore.getState().cancel();
+    await expect(promise).resolves.toBe(false);
+    expect(useExistingWorktreeConfirmStore.getState().isOpen).toBe(false);
+  });
+
+  it("opening a second dialog resolves the first as cancelled", async () => {
+    const first = useExistingWorktreeConfirmStore
+      .getState()
+      .confirm("first", "/wt/first");
+    const second = useExistingWorktreeConfirmStore
+      .getState()
+      .confirm("second", "/wt/second");
+    await expect(first).resolves.toBe(false);
+    expect(useExistingWorktreeConfirmStore.getState().worktreePath).toBe(
+      "/wt/second",
+    );
+    useExistingWorktreeConfirmStore.getState().accept();
+    await expect(second).resolves.toBe(true);
+  });
+});

--- a/packages/ui/src/features/task-detail/stores/existingWorktreeConfirmStore.ts
+++ b/packages/ui/src/features/task-detail/stores/existingWorktreeConfirmStore.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+interface ExistingWorktreeConfirmState {
+  isOpen: boolean;
+  branch: string | null;
+  worktreePath: string | null;
+  resolve: ((confirmed: boolean) => void) | null;
+}
+
+interface ExistingWorktreeConfirmActions {
+  /**
+   * Opens the confirmation dialog for a branch that already has a worktree and
+   * resolves to the user's choice. `true` reuses the existing worktree for the
+   * task; `false` cancels.
+   */
+  confirm: (branch: string, worktreePath: string) => Promise<boolean>;
+  accept: () => void;
+  cancel: () => void;
+}
+
+type ExistingWorktreeConfirmStore = ExistingWorktreeConfirmState &
+  ExistingWorktreeConfirmActions;
+
+export const useExistingWorktreeConfirmStore =
+  create<ExistingWorktreeConfirmStore>()((set, get) => ({
+    isOpen: false,
+    branch: null,
+    worktreePath: null,
+    resolve: null,
+
+    confirm: (branch, worktreePath) =>
+      new Promise<boolean>((resolve) => {
+        // Resolve any dialog already waiting before replacing it.
+        get().resolve?.(false);
+        set({ isOpen: true, branch, worktreePath, resolve });
+      }),
+
+    accept: () => {
+      get().resolve?.(true);
+      set({ isOpen: false, branch: null, worktreePath: null, resolve: null });
+    },
+
+    cancel: () => {
+      get().resolve?.(false);
+      set({ isOpen: false, branch: null, worktreePath: null, resolve: null });
+    },
+  }));

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -27,6 +27,7 @@ import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery"
 import { MainSidebar } from "@posthog/ui/features/sidebar/components/MainSidebar";
 import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useVisualTaskOrder } from "@posthog/ui/features/sidebar/useVisualTaskOrder";
+import { ExistingWorktreeDialog } from "@posthog/ui/features/task-detail/components/ExistingWorktreeDialog";
 import { RemoteBranchCheckoutDialog } from "@posthog/ui/features/task-detail/components/RemoteBranchCheckoutDialog";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { TourOverlay } from "@posthog/ui/features/tour/components/TourOverlay";
@@ -323,6 +324,7 @@ function RootLayout() {
           mode={feedbackMode}
           onFinished={handleFeedbackFinished}
         />
+        <ExistingWorktreeDialog />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>
             <TanStackDevtools />
@@ -347,6 +349,7 @@ function RootLayout() {
         />
         {billingEnabled && <UsageLimitModal />}
         <RemoteBranchCheckoutDialog />
+        <ExistingWorktreeDialog />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>
             <TanStackDevtools />
@@ -389,6 +392,7 @@ function RootLayout() {
         <TourOverlay />
         {billingEnabled && <UsageLimitModal />}
         <RemoteBranchCheckoutDialog />
+        <ExistingWorktreeDialog />
         <HedgehogMode />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>

--- a/packages/workspace-server/src/services/workspace/schemas.ts
+++ b/packages/workspace-server/src/services/workspace/schemas.ts
@@ -26,6 +26,9 @@ export const createWorkspaceInput = z
     // When set, a worktree branch that exists only on the remote is fetched and
     // checked out locally instead of failing. Gated behind a user confirmation.
     allowRemoteBranchCheckout: z.boolean().optional(),
+    // When set, an existing worktree already checked out on the branch is reused
+    // for the task instead of creating a new one. Gated behind a confirmation.
+    reuseExistingWorktree: z.boolean().optional(),
   })
   .refine(
     (data) =>
@@ -46,6 +49,15 @@ export const checkWorktreeBranchOutput = z.object({
   // "local": branch exists locally. "remote-only": exists on the remote but not
   // locally. "missing": found neither locally nor on the remote.
   status: z.enum(["trunk", "local", "remote-only", "missing"]),
+  // Path of an *unused* worktree already checked out on this branch, if any.
+  // Set only when no task is associated with it; the renderer offers to reuse
+  // it. Null when there is no managed worktree, or when one exists but is
+  // already taken by a task (see existingWorktreeTaskId).
+  existingWorktreePath: z.string().nullable(),
+  // Id of the task already using the managed worktree on this branch, if any.
+  // When set, the renderer blocks reuse and points the user at that task.
+  // Mutually exclusive with existingWorktreePath.
+  existingWorktreeTaskId: z.string().nullable(),
 });
 
 export const reconcileCloudWorkspacesInput = z.object({

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -6,6 +6,7 @@ import {
   branchExists,
   getCurrentBranch,
   getDefaultBranch,
+  hasTrackedFiles,
   remoteBranchExists,
 } from "@posthog/git/queries";
 import type { IAnalytics } from "@posthog/platform/analytics";
@@ -17,12 +18,14 @@ import { createMockWorkspaceRepository } from "../../db/repositories/workspace-r
 import { createMockWorktreeRepository } from "../../db/repositories/worktree-repository.mock";
 import type { ProcessTrackingService } from "../process-tracking/process-tracking";
 import type { SuspensionService } from "../suspension/suspension";
+import { listLinkedWorktrees } from "../worktree-query/worktree-query";
 import type {
   WorkspaceAgent,
   WorkspaceFileWatcher,
   WorkspaceFocus,
   WorkspaceProvisioning,
 } from "./ports";
+import type { CreateWorkspaceInput } from "./schemas";
 import { WorkspaceService, WorkspaceServiceEvent } from "./workspace";
 
 vi.mock("@posthog/git/queries", async (importOriginal) => {
@@ -33,6 +36,7 @@ vi.mock("@posthog/git/queries", async (importOriginal) => {
     getCurrentBranch: vi.fn(),
     branchExists: vi.fn(),
     remoteBranchExists: vi.fn(),
+    hasTrackedFiles: vi.fn(),
   };
 });
 
@@ -44,6 +48,8 @@ vi.mock("../worktree-query/worktree-query", async (importOriginal) => {
   return {
     ...actual,
     deleteWorktree: vi.fn(async () => {}),
+    listTwigWorktrees: vi.fn(),
+    listLinkedWorktrees: vi.fn(),
   };
 });
 
@@ -277,6 +283,7 @@ describe("WorkspaceService", () => {
       vi.mocked(getCurrentBranch).mockResolvedValue("main");
       vi.mocked(branchExists).mockResolvedValue(false);
       vi.mocked(remoteBranchExists).mockResolvedValue(false);
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([]);
     });
 
     it.each([
@@ -297,9 +304,94 @@ describe("WorkspaceService", () => {
 
         expect(
           await service.checkWorktreeBranch({ mainRepoPath, branch }),
-        ).toEqual({ status });
+        ).toEqual({
+          status,
+          existingWorktreePath: null,
+          existingWorktreeTaskId: null,
+        });
       },
     );
+
+    it("offers an unused worktree on the branch for reuse", async () => {
+      vi.mocked(branchExists).mockResolvedValue(true);
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([
+        {
+          worktreePath: "/tmp/worktrees/feature-x/repo",
+          head: "abc123",
+          branch: "feature/x",
+        },
+      ]);
+
+      expect(
+        await service.checkWorktreeBranch({
+          mainRepoPath,
+          branch: "feature/x",
+        }),
+      ).toEqual({
+        status: "local",
+        existingWorktreePath: "/tmp/worktrees/feature-x/repo",
+        existingWorktreeTaskId: null,
+      });
+    });
+
+    it("offers an unused worktree outside the managed base path for reuse", async () => {
+      vi.mocked(branchExists).mockResolvedValue(true);
+      // A worktree the user created by hand, well outside the managed base path.
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([
+        {
+          worktreePath: "/Users/me/projects/feature-x",
+          head: "abc123",
+          branch: "feature/x",
+        },
+      ]);
+
+      expect(
+        await service.checkWorktreeBranch({
+          mainRepoPath,
+          branch: "feature/x",
+        }),
+      ).toEqual({
+        status: "local",
+        existingWorktreePath: "/Users/me/projects/feature-x",
+        existingWorktreeTaskId: null,
+      });
+    });
+
+    it("reports the occupying task instead of offering reuse when the worktree is taken", async () => {
+      vi.mocked(branchExists).mockResolvedValue(true);
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([
+        {
+          worktreePath: "/tmp/worktrees/feature-x/repo",
+          head: "abc123",
+          branch: "feature/x",
+        },
+      ]);
+      // Associate a task with that worktree path so getWorktreeTasks finds it.
+      // deriveWorktreePath (new layout) reconstructs <base>/<name>/<repo>, so
+      // name "feature-x" + repo "repo" resolves to the path above.
+      const folder = mocks.repositoryRepo.create({ path: mainRepoPath });
+      const occupantWorkspace = mocks.workspaceRepo.create({
+        taskId: "occupant-task",
+        repositoryId: folder.id,
+        mode: "worktree",
+      });
+      mocks.worktreeRepo.create({
+        workspaceId: occupantWorkspace.id,
+        name: "feature-x",
+        path: "/tmp/worktrees/feature-x/repo",
+      });
+
+      expect(
+        await service.checkWorktreeBranch({
+          mainRepoPath,
+          branch: "feature/x",
+        }),
+      ).toEqual({
+        status: "local",
+        existingWorktreePath: null,
+        existingWorktreeTaskId: "occupant-task",
+      });
+    });
 
     it("falls back to the current branch as trunk when getDefaultBranch fails", async () => {
       vi.mocked(getDefaultBranch).mockRejectedValue(new Error("no remote"));
@@ -307,8 +399,211 @@ describe("WorkspaceService", () => {
 
       expect(
         await service.checkWorktreeBranch({ mainRepoPath, branch: "develop" }),
-      ).toEqual({ status: "trunk" });
+      ).toEqual({
+        status: "trunk",
+        existingWorktreePath: null,
+        existingWorktreeTaskId: null,
+      });
     });
+  });
+
+  describe("createWorkspace (worktree reuse)", () => {
+    const mainRepoPath = "/tmp/repo";
+
+    beforeEach(() => {
+      vi.mocked(getDefaultBranch).mockResolvedValue("main");
+      vi.mocked(getCurrentBranch).mockResolvedValue("main");
+      // The reuse success path checks whether the worktree has files; pretend it
+      // does so the empty-workspace warning branch (and its fs reads) is skipped.
+      vi.mocked(hasTrackedFiles).mockResolvedValue(true);
+    });
+
+    function reuseInput(taskId: string): CreateWorkspaceInput {
+      return {
+        taskId,
+        mainRepoPath,
+        folderId: "folder-1",
+        folderPath: mainRepoPath,
+        mode: "worktree",
+        branch: "feature/x",
+        reuseExistingWorktree: true,
+      };
+    }
+
+    it("reuses an unused worktree and stores its layout-aware name (legacy layout)", async () => {
+      // Legacy layout is <base>/<repo>/<name>, so the name is the final segment
+      // ("feature-x"), not the parent dir. No task owns it, so reuse proceeds and
+      // the recovered name is persisted via worktreeRepo.create.
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([
+        {
+          worktreePath: "/tmp/worktrees/repo/feature-x",
+          head: "abc123",
+          branch: "feature/x",
+        },
+      ]);
+      const createWorktree = vi.spyOn(mocks.worktreeRepo, "create");
+
+      const workspace = await service.createWorkspace(reuseInput("new-task"));
+
+      expect(workspace.worktree?.worktreeName).toBe("feature-x");
+      expect(workspace.worktree?.worktreePath).toBe(
+        "/tmp/worktrees/repo/feature-x",
+      );
+      expect(createWorktree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "feature-x",
+          path: "/tmp/worktrees/repo/feature-x",
+        }),
+      );
+    });
+
+    it("fails the create step when the worktree was claimed between preflight and create", async () => {
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([
+        {
+          worktreePath: "/tmp/worktrees/feature-x/repo",
+          head: "abc123",
+          branch: "feature/x",
+        },
+      ]);
+      // Associate another task with that worktree path so the re-check's
+      // getWorktreeTasks finds an occupant (same fixture as the checkWorktreeBranch
+      // occupied case: new layout <base>/<name>/<repo> round-trips to the path).
+      const folder = mocks.repositoryRepo.create({ path: mainRepoPath });
+      const occupantWorkspace = mocks.workspaceRepo.create({
+        taskId: "occupant-task",
+        repositoryId: folder.id,
+        mode: "worktree",
+      });
+      mocks.worktreeRepo.create({
+        workspaceId: occupantWorkspace.id,
+        name: "feature-x",
+        path: "/tmp/worktrees/feature-x/repo",
+      });
+
+      await expect(
+        service.createWorkspace(reuseInput("new-task")),
+      ).rejects.toThrow(/already used by task occupant-task/);
+    });
+  });
+
+  describe("worktree path resolved from the stored row", () => {
+    const tempDirs: string[] = [];
+
+    afterEach(() => {
+      for (const dir of tempDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    function mkTemp(prefix: string): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+      tempDirs.push(dir);
+      return dir;
+    }
+
+    it("projects an externally-located worktree from its stored path", async () => {
+      const externalPath = "/external/checkout/my-worktree";
+      seedWorktreeTask(mocks, {
+        taskId: "ext",
+        repoPath: "/code/myrepo",
+        name: "fancy-slug",
+        worktreePath: externalPath,
+      });
+
+      expect(await service.getWorkspace("ext")).toMatchObject({
+        mode: "worktree",
+        worktreePath: externalPath,
+        worktreeName: "fancy-slug",
+      });
+      expect(await service.getWorkspaceInfo("ext")).toMatchObject({
+        mode: "worktree",
+        worktree: expect.objectContaining({
+          worktreePath: externalPath,
+          worktreeName: "fancy-slug",
+        }),
+      });
+    });
+
+    it("matches occupancy by the stored path, not a derived one", () => {
+      const externalPath = "/external/checkout/my-worktree";
+      seedWorktreeTask(mocks, {
+        taskId: "ext",
+        repoPath: "/code/myrepo",
+        name: "fancy-slug",
+        worktreePath: externalPath,
+      });
+
+      expect(service.getWorktreeTasks(externalPath)).toEqual([
+        { taskId: "ext" },
+      ]);
+      // The name would derive to <base>/<name>/<repo>; that path must not match.
+      expect(
+        service.getWorktreeTasks("/tmp/worktrees/fancy-slug/myrepo"),
+      ).toEqual([]);
+    });
+
+    it("verifies existence by the stored external path", async () => {
+      const externalPath = mkTemp("external-wt-");
+      seedWorktreeTask(mocks, {
+        taskId: "ext",
+        repoPath: "/code/myrepo",
+        name: "fancy-slug",
+        worktreePath: externalPath,
+      });
+
+      // The on-disk worktree lives at its stored external path; a derived
+      // <base>/<name>/<repo> would not exist, so this would report missing.
+      expect(await service.verifyWorkspaceExists("ext")).toEqual({
+        exists: true,
+      });
+
+      fs.rmSync(externalPath, { recursive: true, force: true });
+      expect(await service.verifyWorkspaceExists("ext")).toEqual({
+        exists: false,
+        missingPath: externalPath,
+      });
+    });
+
+    // Identical setup (empty managed `<base>/<repo>` parent, then delete the only
+    // worktree for that repo); only the stored worktree path differs. This proves
+    // the cleanup guard discriminates on whether the path is under the base path,
+    // rather than always (or never) reclaiming the parent folder.
+    it.each([
+      {
+        label:
+          "leaves the managed parent folder alone for an external worktree",
+        makeWorktreePath: () => mkTemp("external-wt-"),
+        managedParentSurvives: true,
+      },
+      {
+        label:
+          "reclaims the empty managed parent folder for a worktree under the base path",
+        makeWorktreePath: (base: string) =>
+          path.join(base, "some-name", "myrepo"),
+        managedParentSurvives: false,
+      },
+    ])(
+      "deleteWorkspace via the stored path $label",
+      async ({ makeWorktreePath, managedParentSurvives }) => {
+        const base = mkTemp("wt-base-");
+        mocks.workspaceSettings.getWorktreeLocation = () => base;
+
+        const repoPath = "/code/myrepo";
+        const managedParent = path.join(base, "myrepo");
+        fs.mkdirSync(managedParent);
+
+        seedWorktreeTask(mocks, {
+          taskId: "task",
+          repoPath,
+          name: "some-name",
+          worktreePath: makeWorktreePath(base),
+        });
+
+        await service.deleteWorkspace("task", repoPath);
+
+        expect(fs.existsSync(managedParent)).toBe(managedParentSurvives);
+      },
+    );
   });
 
   describe("worktree path resolved from the stored row", () => {

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -53,6 +53,24 @@ vi.mock("../worktree-query/worktree-query", async (importOriginal) => {
   };
 });
 
+// WorkspaceService constructs a WorktreeManager internally; stub the git-backed
+// creation methods so tests can drive the create-path branches without real git.
+const mockWorktreeManager = {
+  createWorktree: vi.fn(),
+  createWorktreeForExistingBranch: vi.fn(),
+  createWorktreeForRemoteBranch: vi.fn(),
+};
+
+vi.mock("@posthog/git/worktree", () => ({
+  WorktreeManager: class {
+    createWorktree = mockWorktreeManager.createWorktree;
+    createWorktreeForExistingBranch =
+      mockWorktreeManager.createWorktreeForExistingBranch;
+    createWorktreeForRemoteBranch =
+      mockWorktreeManager.createWorktreeForRemoteBranch;
+  },
+}));
+
 function createMocks() {
   const agent = {
     cancelSessionsByTaskId: vi.fn(async () => {}),
@@ -367,8 +385,8 @@ describe("WorkspaceService", () => {
         },
       ]);
       // Associate a task with that worktree path so getWorktreeTasks finds it.
-      // deriveWorktreePath (new layout) reconstructs <base>/<name>/<repo>, so
-      // name "feature-x" + repo "repo" resolves to the path above.
+      // Occupancy matches on the stored `path` column (set explicitly below),
+      // not on anything derived from `name` + repo.
       const folder = mocks.repositoryRepo.create({ path: mainRepoPath });
       const occupantWorkspace = mocks.workspaceRepo.create({
         taskId: "occupant-task",
@@ -393,6 +411,26 @@ describe("WorkspaceService", () => {
       });
     });
 
+    it("does not offer reuse for a worktree on the trunk branch", async () => {
+      // Trunk supports many coexisting detached worktrees, so an existing
+      // worktree on it must not be offered for reuse.
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([
+        {
+          worktreePath: "/tmp/worktrees/main/repo",
+          head: "abc123",
+          branch: "main",
+        },
+      ]);
+
+      expect(
+        await service.checkWorktreeBranch({ mainRepoPath, branch: "main" }),
+      ).toEqual({
+        status: "trunk",
+        existingWorktreePath: null,
+        existingWorktreeTaskId: null,
+      });
+    });
+
     it("falls back to the current branch as trunk when getDefaultBranch fails", async () => {
       vi.mocked(getDefaultBranch).mockRejectedValue(new Error("no remote"));
       vi.mocked(getCurrentBranch).mockResolvedValue("develop");
@@ -413,6 +451,12 @@ describe("WorkspaceService", () => {
     beforeEach(() => {
       vi.mocked(getDefaultBranch).mockResolvedValue("main");
       vi.mocked(getCurrentBranch).mockResolvedValue("main");
+      // This package's vitest config does not reset mocks between tests, so
+      // default to no linked worktrees; each test sets its own value.
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([]);
+      mockWorktreeManager.createWorktree.mockReset();
+      mockWorktreeManager.createWorktreeForExistingBranch.mockReset();
+      mockWorktreeManager.createWorktreeForRemoteBranch.mockReset();
       // The reuse success path checks whether the worktree has files; pretend it
       // does so the empty-workspace warning branch (and its fs reads) is skipped.
       vi.mocked(hasTrackedFiles).mockResolvedValue(true);
@@ -457,6 +501,33 @@ describe("WorkspaceService", () => {
       );
     });
 
+    it("reuses an unused worktree and stores its layout-aware name (new layout)", async () => {
+      // New layout is <base>/<name>/<repo>, so the final segment equals the repo
+      // name ("repo") and the name is the parent dir ("feature-x"). No task owns
+      // it, so reuse proceeds and the recovered name is persisted.
+      vi.mocked(listLinkedWorktrees).mockResolvedValue([
+        {
+          worktreePath: "/tmp/worktrees/feature-x/repo",
+          head: "abc123",
+          branch: "feature/x",
+        },
+      ]);
+      const createWorktree = vi.spyOn(mocks.worktreeRepo, "create");
+
+      const workspace = await service.createWorkspace(reuseInput("new-task"));
+
+      expect(workspace.worktree?.worktreeName).toBe("feature-x");
+      expect(workspace.worktree?.worktreePath).toBe(
+        "/tmp/worktrees/feature-x/repo",
+      );
+      expect(createWorktree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "feature-x",
+          path: "/tmp/worktrees/feature-x/repo",
+        }),
+      );
+    });
+
     it("fails the create step when the worktree was claimed between preflight and create", async () => {
       vi.mocked(listLinkedWorktrees).mockResolvedValue([
         {
@@ -466,8 +537,9 @@ describe("WorkspaceService", () => {
         },
       ]);
       // Associate another task with that worktree path so the re-check's
-      // getWorktreeTasks finds an occupant (same fixture as the checkWorktreeBranch
-      // occupied case: new layout <base>/<name>/<repo> round-trips to the path).
+      // getWorktreeTasks finds an occupant. Occupancy matches on the stored
+      // `path` column (set explicitly below), same as the checkWorktreeBranch
+      // occupied case.
       const folder = mocks.repositoryRepo.create({ path: mainRepoPath });
       const occupantWorkspace = mocks.workspaceRepo.create({
         taskId: "occupant-task",
@@ -484,126 +556,25 @@ describe("WorkspaceService", () => {
         service.createWorkspace(reuseInput("new-task")),
       ).rejects.toThrow(/already used by task occupant-task/);
     });
-  });
 
-  describe("worktree path resolved from the stored row", () => {
-    const tempDirs: string[] = [];
+    it("fails instead of creating a detached worktree when an occupied branch is hit without the reuse flag", async () => {
+      // No reuse flag: the upfront reuse path is bypassed (e.g. the preflight
+      // check errored), so creation falls through to a branch checkout, and git
+      // reports the branch is already used by a worktree. The old behavior
+      // silently created a detached duplicate; it must now fail loudly.
+      mockWorktreeManager.createWorktreeForExistingBranch.mockRejectedValue(
+        new Error("fatal: 'feature/x' is already used by worktree at /wt"),
+      );
 
-    afterEach(() => {
-      for (const dir of tempDirs.splice(0)) {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    });
-
-    function mkTemp(prefix: string): string {
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-      tempDirs.push(dir);
-      return dir;
-    }
-
-    it("projects an externally-located worktree from its stored path", async () => {
-      const externalPath = "/external/checkout/my-worktree";
-      seedWorktreeTask(mocks, {
-        taskId: "ext",
-        repoPath: "/code/myrepo",
-        name: "fancy-slug",
-        worktreePath: externalPath,
-      });
-
-      expect(await service.getWorkspace("ext")).toMatchObject({
-        mode: "worktree",
-        worktreePath: externalPath,
-        worktreeName: "fancy-slug",
-      });
-      expect(await service.getWorkspaceInfo("ext")).toMatchObject({
-        mode: "worktree",
-        worktree: expect.objectContaining({
-          worktreePath: externalPath,
-          worktreeName: "fancy-slug",
+      await expect(
+        service.createWorkspace({
+          ...reuseInput("new-task"),
+          reuseExistingWorktree: false,
         }),
-      });
+      ).rejects.toThrow(/already has a worktree checked out/);
+
+      expect(mockWorktreeManager.createWorktree).not.toHaveBeenCalled();
     });
-
-    it("matches occupancy by the stored path, not a derived one", () => {
-      const externalPath = "/external/checkout/my-worktree";
-      seedWorktreeTask(mocks, {
-        taskId: "ext",
-        repoPath: "/code/myrepo",
-        name: "fancy-slug",
-        worktreePath: externalPath,
-      });
-
-      expect(service.getWorktreeTasks(externalPath)).toEqual([
-        { taskId: "ext" },
-      ]);
-      // The name would derive to <base>/<name>/<repo>; that path must not match.
-      expect(
-        service.getWorktreeTasks("/tmp/worktrees/fancy-slug/myrepo"),
-      ).toEqual([]);
-    });
-
-    it("verifies existence by the stored external path", async () => {
-      const externalPath = mkTemp("external-wt-");
-      seedWorktreeTask(mocks, {
-        taskId: "ext",
-        repoPath: "/code/myrepo",
-        name: "fancy-slug",
-        worktreePath: externalPath,
-      });
-
-      // The on-disk worktree lives at its stored external path; a derived
-      // <base>/<name>/<repo> would not exist, so this would report missing.
-      expect(await service.verifyWorkspaceExists("ext")).toEqual({
-        exists: true,
-      });
-
-      fs.rmSync(externalPath, { recursive: true, force: true });
-      expect(await service.verifyWorkspaceExists("ext")).toEqual({
-        exists: false,
-        missingPath: externalPath,
-      });
-    });
-
-    // Identical setup (empty managed `<base>/<repo>` parent, then delete the only
-    // worktree for that repo); only the stored worktree path differs. This proves
-    // the cleanup guard discriminates on whether the path is under the base path,
-    // rather than always (or never) reclaiming the parent folder.
-    it.each([
-      {
-        label:
-          "leaves the managed parent folder alone for an external worktree",
-        makeWorktreePath: () => mkTemp("external-wt-"),
-        managedParentSurvives: true,
-      },
-      {
-        label:
-          "reclaims the empty managed parent folder for a worktree under the base path",
-        makeWorktreePath: (base: string) =>
-          path.join(base, "some-name", "myrepo"),
-        managedParentSurvives: false,
-      },
-    ])(
-      "deleteWorkspace via the stored path $label",
-      async ({ makeWorktreePath, managedParentSurvives }) => {
-        const base = mkTemp("wt-base-");
-        mocks.workspaceSettings.getWorktreeLocation = () => base;
-
-        const repoPath = "/code/myrepo";
-        const managedParent = path.join(base, "myrepo");
-        fs.mkdirSync(managedParent);
-
-        seedWorktreeTask(mocks, {
-          taskId: "task",
-          repoPath,
-          name: "some-name",
-          worktreePath: makeWorktreePath(base),
-        });
-
-        await service.deleteWorkspace("task", repoPath);
-
-        expect(fs.existsSync(managedParent)).toBe(managedParentSurvives);
-      },
-    );
   });
 
   describe("worktree path resolved from the stored row", () => {

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -41,6 +41,7 @@ import { SUSPENSION_SERVICE } from "../suspension/identifiers";
 import type { SuspensionService } from "../suspension/suspension";
 import {
   deleteWorktree as deleteGitWorktree,
+  listLinkedWorktrees,
   listTwigWorktrees,
   resolveLocalWorktreePath,
 } from "../worktree-query/worktree-query";
@@ -434,28 +435,87 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
   ): Promise<CheckWorktreeBranchOutput> {
     const { mainRepoPath, branch } = options;
 
-    const defaultBranch = await getDefaultBranch(mainRepoPath, {
-      abortSignal: signal,
-    }).catch(() =>
-      getCurrentBranch(mainRepoPath, { abortSignal: signal }).then(
-        (b) => b ?? "main",
+    const [existingWorktree, defaultBranch] = await Promise.all([
+      this.findExistingWorktreeForBranch(mainRepoPath, branch),
+      getDefaultBranch(mainRepoPath, { abortSignal: signal }).catch(() =>
+        getCurrentBranch(mainRepoPath, { abortSignal: signal }).then(
+          (b) => b ?? "main",
+        ),
       ),
-    );
+    ]);
+    // Reuse is only offered for an *unused* worktree. If a task already holds
+    // the worktree on this branch, report that task instead so the renderer can
+    // block the duplicate and point the user at it.
+    let worktree: {
+      existingWorktreePath: string | null;
+      existingWorktreeTaskId: string | null;
+    } = { existingWorktreePath: null, existingWorktreeTaskId: null };
+    if (existingWorktree) {
+      const [occupant] = this.getWorktreeTasks(existingWorktree.worktreePath);
+      worktree = occupant
+        ? {
+            existingWorktreePath: null,
+            existingWorktreeTaskId: occupant.taskId,
+          }
+        : {
+            existingWorktreePath: existingWorktree.worktreePath,
+            existingWorktreeTaskId: null,
+          };
+    }
+
     if (branch === defaultBranch) {
-      return { status: "trunk" };
+      return { status: "trunk", ...worktree };
     }
 
     if (await branchExists(mainRepoPath, branch, { abortSignal: signal })) {
-      return { status: "local" };
+      return { status: "local", ...worktree };
     }
 
     if (
       await remoteBranchExists(mainRepoPath, branch, { abortSignal: signal })
     ) {
-      return { status: "remote-only" };
+      return { status: "remote-only", ...worktree };
     }
 
-    return { status: "missing" };
+    return { status: "missing", ...worktree };
+  }
+
+  /**
+   * Finds a worktree already checked out on `branch` in any location, returning
+   * it as a `WorktreeInfo` ready to reuse, or null when none exists. Worktrees
+   * outside the managed base path qualify too: the stored `path` column is the
+   * source of truth for a task's worktree, so an externally-created worktree
+   * round-trips just like a managed one.
+   */
+  private async findExistingWorktreeForBranch(
+    mainRepoPath: string,
+    branch: string,
+  ): Promise<WorktreeInfo | null> {
+    const linkedWorktrees = await listLinkedWorktrees(mainRepoPath);
+    const match = linkedWorktrees.find((wt) => wt.branch === branch);
+    if (!match) return null;
+
+    // `worktreeName` is a cosmetic label only; `worktreePath` is authoritative.
+    // Recover the name layout-aware for managed worktrees: new layout is
+    // `<base>/<name>/<repo>` (name is the parent dir), legacy is
+    // `<base>/<repo>/<name>` (name is the final segment). For an external
+    // worktree neither layout holds, so the final segment is a sensible label.
+    const repoName = path.basename(mainRepoPath);
+    const finalSegment = path.basename(match.worktreePath);
+    const worktreeName =
+      finalSegment === repoName
+        ? path.basename(path.dirname(match.worktreePath))
+        : finalSegment;
+
+    // baseBranch/createdAt are unknown for an already-existing worktree; mirror
+    // WorktreeManager.listWorktrees() and leave them empty rather than fabricate.
+    return {
+      worktreePath: match.worktreePath,
+      worktreeName,
+      branchName: branch,
+      baseBranch: "",
+      createdAt: "",
+    };
   }
 
   async createWorkspace(options: CreateWorkspaceInput): Promise<WorkspaceInfo> {
@@ -489,6 +549,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       branch,
       useExistingBranch,
       allowRemoteBranchCheckout,
+      reuseExistingWorktree,
     } = options;
 
     const existingWorkspace = await this.getWorkspaceInfo(taskId);
@@ -586,7 +647,26 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         this.provisioning.emitOutput(taskId, data);
       };
 
-      if (isTrunkSelected) {
+      const existingWorktree = reuseExistingWorktree
+        ? await this.findExistingWorktreeForBranch(mainRepoPath, selectedBranch)
+        : null;
+
+      // Reuse only an unused worktree. The renderer already gates on this, but
+      // re-check here so a lost race (the worktree got claimed between preflight
+      // and now) fails the saga step rather than sharing one worktree across two
+      // tasks.
+      if (existingWorktree) {
+        const [occupant] = this.getWorktreeTasks(existingWorktree.worktreePath);
+        if (occupant) {
+          throw new Error(
+            `Worktree at ${existingWorktree.worktreePath} is already used by task ${occupant.taskId}`,
+          );
+        }
+        this.log.info(
+          `Reusing existing worktree for branch ${selectedBranch}: ${existingWorktree.worktreePath}`,
+        );
+        worktree = existingWorktree;
+      } else if (isTrunkSelected) {
         this.log.info(
           `Trunk branch selected (${defaultBranch}), creating detached worktree`,
         );

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -443,16 +443,27 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         ),
       ),
     ]);
+    // Trunk intentionally supports many coexisting detached worktrees, so never
+    // offer to reuse an existing worktree for it; a trunk task always gets its
+    // own.
+    if (branch === defaultBranch) {
+      return {
+        status: "trunk",
+        existingWorktreePath: null,
+        existingWorktreeTaskId: null,
+      };
+    }
+
     // Reuse is only offered for an *unused* worktree. If a task already holds
     // the worktree on this branch, report that task instead so the renderer can
     // block the duplicate and point the user at it.
-    let worktree: {
+    let reuseFields: {
       existingWorktreePath: string | null;
       existingWorktreeTaskId: string | null;
     } = { existingWorktreePath: null, existingWorktreeTaskId: null };
     if (existingWorktree) {
       const [occupant] = this.getWorktreeTasks(existingWorktree.worktreePath);
-      worktree = occupant
+      reuseFields = occupant
         ? {
             existingWorktreePath: null,
             existingWorktreeTaskId: occupant.taskId,
@@ -463,21 +474,17 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
           };
     }
 
-    if (branch === defaultBranch) {
-      return { status: "trunk", ...worktree };
-    }
-
     if (await branchExists(mainRepoPath, branch, { abortSignal: signal })) {
-      return { status: "local", ...worktree };
+      return { status: "local", ...reuseFields };
     }
 
     if (
       await remoteBranchExists(mainRepoPath, branch, { abortSignal: signal })
     ) {
-      return { status: "remote-only", ...worktree };
+      return { status: "remote-only", ...reuseFields };
     }
 
-    return { status: "missing", ...worktree };
+    return { status: "missing", ...reuseFields };
   }
 
   /**
@@ -697,15 +704,13 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
               ? checkoutError.message
               : String(checkoutError);
           if (errorMessage.includes("is already used by worktree")) {
-            this.log.info(
-              `Branch ${selectedBranch} is occupied, falling back to detached worktree`,
-            );
-            worktree = await worktreeManager.createWorktree({
-              baseBranch: selectedBranch,
-              onOutput,
-            });
-            this.log.info(
-              `Created detached worktree from occupied branch: ${worktree.worktreeName} at ${worktree.worktreePath}`,
+            // The branch already has a worktree. Reuse is handled upfront
+            // (checkWorktreeBranch + reuseExistingWorktree); reaching here means
+            // that path was bypassed (e.g. the preflight check errored). Fail
+            // loudly instead of creating a detached duplicate that lands on a
+            // detached HEAD rather than the requested branch.
+            throw new Error(
+              `Branch ${selectedBranch} already has a worktree checked out`,
             );
           } else if (
             allowRemoteBranchCheckout &&
@@ -1296,6 +1301,10 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       .map((a) => ({ taskId: a.taskId }));
   }
 
+  // Paths are compared verbatim against the stored `path` column, which holds
+  // git's reported worktree path as-is (the same value `listLinkedWorktrees`
+  // returns). Don't normalize one side only (e.g. add `path.resolve` here but
+  // not where the path is stored) or occupancy matching silently breaks.
   getWorktreeTasks(worktreePath: string): Array<{ taskId: string }> {
     const associations = this.getAllTaskAssociations();
     const result: Array<{ taskId: string }> = [];

--- a/packages/workspace-server/src/services/worktree-query/worktree-query.test.ts
+++ b/packages/workspace-server/src/services/worktree-query/worktree-query.test.ts
@@ -11,7 +11,11 @@ vi.mock("@posthog/git/queries", () => ({
   listWorktrees: (...args: unknown[]) => listWorktrees(...args),
 }));
 
-import { getWorktreeFileUsage, listTwigWorktrees } from "./worktree-query";
+import {
+  getWorktreeFileUsage,
+  listLinkedWorktrees,
+  listTwigWorktrees,
+} from "./worktree-query";
 
 afterEach(() => {
   vol.reset();
@@ -62,6 +66,31 @@ describe("listTwigWorktrees", () => {
     ]);
 
     expect(await listTwigWorktrees(MAIN, BASE)).toEqual([]);
+  });
+});
+
+describe("listLinkedWorktrees", () => {
+  it("excludes the main repo but keeps worktrees in any location", async () => {
+    listWorktrees.mockResolvedValue([
+      { path: MAIN, head: "h0", branch: "main" },
+      { path: `${BASE}/feat`, head: "h1", branch: "feat" },
+      { path: "/elsewhere/rogue", head: "h2", branch: "rogue" },
+    ]);
+
+    const result = await listLinkedWorktrees(MAIN);
+
+    expect(result).toEqual([
+      { worktreePath: `${BASE}/feat`, head: "h1", branch: "feat" },
+      { worktreePath: "/elsewhere/rogue", head: "h2", branch: "rogue" },
+    ]);
+  });
+
+  it("returns an empty list when only the main repo exists", async () => {
+    listWorktrees.mockResolvedValue([
+      { path: MAIN, head: "h0", branch: "main" },
+    ]);
+
+    expect(await listLinkedWorktrees(MAIN)).toEqual([]);
   });
 });
 

--- a/packages/workspace-server/src/services/worktree-query/worktree-query.ts
+++ b/packages/workspace-server/src/services/worktree-query/worktree-query.ts
@@ -74,6 +74,25 @@ export async function listTwigWorktrees(
     }));
 }
 
+/**
+ * Every linked git worktree for the repo, in any location (excludes the main
+ * repo). Unlike `listTwigWorktrees`, this is not limited to the managed base
+ * path, so it surfaces worktrees the user created by hand elsewhere. Pure git
+ * query; taskId enrichment is the caller's concern.
+ */
+export async function listLinkedWorktrees(
+  mainRepoPath: string,
+): Promise<RawTwigWorktree[]> {
+  const rawWorktrees = await listWorktrees(mainRepoPath);
+  return rawWorktrees
+    .filter((wt) => path.resolve(wt.path) !== path.resolve(mainRepoPath))
+    .map((wt) => ({
+      worktreePath: wt.path,
+      head: wt.head,
+      branch: wt.branch,
+    }));
+}
+
 async function hasExcludeFileEntries(
   mainRepoPath: string,
   fileName: string,


### PR DESCRIPTION
## Problem

Starting a worktree task on a branch that already has a worktree didn't error. It silently went wrong. `git worktree add` fails, the code catches it, and **creates a second, *detached* worktree** at the branch's commit. You end up with a junk duplicate that isn't even on the branch.

## Fix

Handle the already-has-a-worktree case correctly instead of duplicating, for a worktree **in any location** — including one you created by hand outside PostHog's managed base path. When the branch already has a worktree, we look at whether a task is already using it:

- **Unused worktree (no task owns it):** offer to **reuse it** — the scenario this unlocks. A confirmation dialog ("Worktree already exists — use it?") adopts that worktree for the task (registers the association, no `git worktree add`); cancelling aborts before any task is created. The dialog warns that deleting the task later removes the worktree and any uncommitted work in it, even though it existed beforehand.
- **Owned worktree (a task already has it):** **fail clearly** — show an error naming the task that holds the worktree and abort, so you can open that task and keep working there. This is where the silent duplicate used to happen.

Either way, every worktree stays associated with at most one task — the same as before this change.

How it works:

- `workspace.checkWorktreeBranch` reports `existingWorktreePath` only for an unused worktree on the branch, and `existingWorktreeTaskId` when a task already holds it (mutually exclusive).
- A `reuseExistingWorktree` opt-in threads from the UI through the saga to the workspace server; `doCreateWorkspace` re-checks occupancy before reusing and fails the step if the worktree was claimed between preflight and create.
- Discovery uses `listLinkedWorktrees` — every linked worktree for the repo, in any location (only the main repo is excluded). It is **not** limited to the managed base path. The stored `path` column is the source of truth for a task's worktree (since the path refactor in #2709), so an externally-created worktree round-trips just like a managed one. `listTwigWorktrees` stays in place for the managed-only worktree listing (`listGitWorktrees`).
- The reused worktree's `name` is a cosmetic label only; it is recovered layout-aware for managed worktrees and degrades to the path's final segment for an external one.

The unused-worktree prompt takes priority over the remote-only-branch prompt (a branch with a worktree also exists locally).

<img width="856" height="416" alt="Screenshot 2026-06-16 at 4 54 35 PM" src="https://github.com/user-attachments/assets/bf914d0d-c02b-4ce9-9f7f-1805e1a9435a" />

> [!Note]
> Stacked on #2709 (resolve worktree path from the stored value, not derived from name) — that refactor makes the stored `path` authoritative, which is what lets a worktree outside the base path attach to a task. Base/merge that PR first; this PR targets its branch.

## How did you test this?

- `pnpm --filter @posthog/workspace-server test` for the touched suites: `workspace.test` and `worktree-query.test` — 32 passing, including a new `checkWorktreeBranch` case that offers an out-of-base-path worktree for reuse and new `listLinkedWorktrees` coverage (keeps worktrees in any location, excludes the main repo).
- `typecheck` clean across all changed packages (workspace-server / host-router / ui / core / shared).
- Biome check clean on all changed files.
- Unit tests for the confirmation store (`existingWorktreeConfirmStore.test.ts`, 5 cases).
- Manual test

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781286814736189?thread_ts=1781286814.736189&cid=C09G8Q32R6F)*
