### PR TITLE
fix(ui): fix various UI flashes (/cuiflash skill run)

### DIFF
--- a/packages/ui/src/features/auth/useAuthMutations.test.tsx
+++ b/packages/ui/src/features/auth/useAuthMutations.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const onLogout = vi.fn();
+const getStateQuery = vi.fn();
+const logoutMutate = vi.fn();
+
+vi.mock("@posthog/host-router/react", () => ({
+  useHostTRPCClient: () => ({
+    auth: {
+      getState: { query: getStateQuery },
+      logout: { mutate: logoutMutate },
+    },
+  }),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useService: () => ({
+    onLogout,
+    onAuthSuccess: vi.fn(),
+    beforeProjectSwitch: vi.fn(),
+    onProjectSelected: vi.fn(),
+  }),
+}));
+
+vi.mock("./authQueries", () => ({
+  clearAuthScopedQueries: vi.fn(),
+  refreshAuthStateQuery: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ANONYMOUS_AUTH_STATE, useAuthStore } from "./store";
+import { useLogoutMutation } from "./useAuthMutations";
+
+let queryClient: QueryClient;
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useLogoutMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    getStateQuery.mockResolvedValue({ cloudRegion: "us" });
+    logoutMutate.mockResolvedValue(undefined);
+    useAuthStore.setState({
+      authState: {
+        ...ANONYMOUS_AUTH_STATE,
+        status: "authenticated",
+        bootstrapComplete: true,
+        cloudRegion: "us",
+        currentOrgId: "org-1",
+        currentProjectId: 1,
+      },
+    });
+  });
+
+  it("clears the auth store to anonymous on success without waiting for the subscription push", async () => {
+    const { result } = renderHook(() => useLogoutMutation(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() =>
+      expect(useAuthStore.getState().authState.status).toBe("anonymous"),
+    );
+    const state = useAuthStore.getState().authState;
+    // bootstrapComplete stays true so App renders the auth screen, not the
+    // boot spinner.
+    expect(state.bootstrapComplete).toBe(true);
+    expect(state.currentOrgId).toBeNull();
+    expect(state.currentProjectId).toBeNull();
+    expect(onLogout).toHaveBeenCalledWith("us");
+  });
+});

--- a/packages/ui/src/features/auth/useAuthMutations.ts
+++ b/packages/ui/src/features/auth/useAuthMutations.ts
@@ -4,6 +4,7 @@ import type { CloudRegion } from "@posthog/shared";
 import { useMutation } from "@tanstack/react-query";
 import { clearAuthScopedQueries, refreshAuthStateQuery } from "./authQueries";
 import { AUTH_SIDE_EFFECTS, type IAuthSideEffects } from "./identifiers";
+import { ANONYMOUS_AUTH_STATE, useAuthStore } from "./store";
 
 export function useLoginMutation() {
   const hostClient = useHostTRPCClient();
@@ -71,6 +72,18 @@ export function useLogoutMutation() {
       await hostClient.auth.logout.mutate();
       return previous;
     },
-    onSuccess: (previous) => fx.onLogout(previous.cloudRegion),
+    onSuccess: (previous) => {
+      fx.onLogout(previous.cloudRegion);
+      // The renderer auth store otherwise only flips to anonymous when the
+      // tRPC subscription pushes, one IPC round trip later, during which the
+      // authenticated shell renders with drained caches before AuthScreen.
+      // Paint the confirmed signed-out state synchronously so the transition
+      // goes straight to the auth screen. bootstrapComplete stays true so
+      // App.tsx renders AuthScreen, not the boot spinner. The later
+      // subscription push delivers the same anonymous state (idempotent).
+      useAuthStore
+        .getState()
+        .setAuthState({ ...ANONYMOUS_AUTH_STATE, bootstrapComplete: true });
+    },
   });
 }

--- a/packages/ui/src/features/auth/useCurrentUser.test.tsx
+++ b/packages/ui/src/features/auth/useCurrentUser.test.tsx
@@ -1,0 +1,108 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authState = {
+  status: "authenticated" as "authenticated" | "anonymous",
+  bootstrapComplete: true,
+  cloudRegion: "us" as "us" | "eu" | "dev" | null,
+  orgProjectsMap: {},
+  currentOrgId: "org-1" as string | null,
+  currentProjectId: 1 as number | null,
+  hasCodeAccess: true,
+  needsScopeReauth: false,
+};
+
+vi.mock("./store", () => ({
+  useAuthStateValue: (selector: (state: typeof authState) => unknown) =>
+    selector(authState),
+}));
+
+import { useCurrentUser } from "./useCurrentUser";
+
+/** A promise we resolve by hand, to hold a fetch in flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+let queryClient: QueryClient;
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useCurrentUser", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    authState.status = "authenticated";
+    authState.cloudRegion = "us";
+    authState.currentProjectId = 1;
+  });
+
+  it("keeps the previous user painted while a project/org switch re-fetches", async () => {
+    const userA = { email: "a@example.com" } as Awaited<
+      ReturnType<PostHogAPIClient["getCurrentUser"]>
+    >;
+    const userB = { email: "b@example.com" } as typeof userA;
+    const first = deferred<typeof userA>();
+    const second = deferred<typeof userA>();
+    const getCurrentUser = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const client = { getCurrentUser } as unknown as PostHogAPIClient;
+
+    const { result, rerender } = renderHook(() => useCurrentUser({ client }), {
+      wrapper,
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBe(true);
+
+    first.resolve(userA);
+    await waitFor(() => expect(result.current.data).toEqual(userA));
+
+    // Switch project: the query key carries currentProjectId, so this re-keys
+    // to a fresh entry. The second fetch is held in flight.
+    authState.currentProjectId = 2;
+    rerender();
+
+    await waitFor(() => expect(result.current.isPlaceholderData).toBe(true));
+    expect(result.current.data).toEqual(userA);
+
+    second.resolve(userB);
+    await waitFor(() => expect(result.current.data).toEqual(userB));
+    expect(result.current.isPlaceholderData).toBe(false);
+  });
+
+  it("does not carry a placeholder user across logout", async () => {
+    const userA = { email: "a@example.com" } as Awaited<
+      ReturnType<PostHogAPIClient["getCurrentUser"]>
+    >;
+    const getCurrentUser = vi.fn().mockResolvedValue(userA);
+    const client = { getCurrentUser } as unknown as PostHogAPIClient;
+
+    const { result, rerender } = renderHook(() => useCurrentUser({ client }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.data).toEqual(userA));
+
+    // Sign out: identity becomes null, disabling the query and dropping the
+    // placeholder so no stale user lingers on the signed-out screen.
+    authState.status = "anonymous";
+    authState.cloudRegion = null;
+    authState.currentProjectId = null;
+    rerender();
+
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/ui/src/features/auth/useCurrentUser.ts
+++ b/packages/ui/src/features/auth/useCurrentUser.ts
@@ -1,6 +1,6 @@
 import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
 import { getAuthIdentity } from "@posthog/core/auth/authIdentity";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useAuthStateValue } from "./store";
 
 export const AUTH_SCOPED_QUERY_META = {
@@ -33,6 +33,13 @@ export function useCurrentUser(options?: {
     },
     enabled: !!client && !!authIdentity && (options?.enabled ?? true),
     staleTime: 5 * 60 * 1000,
+    // The query key carries currentProjectId, so a project/org switch re-keys
+    // to a fresh, dataless entry. Paint the last-confirmed user while the new
+    // identity refetches instead of flashing the empty state. Gated on being
+    // signed in so the placeholder dies with the session (logout → no stale
+    // user). Anything org-specific on the user (e.g. membership_level) must
+    // treat isPlaceholderData as unknown rather than trusting it.
+    placeholderData: authIdentity ? keepPreviousData : undefined,
     refetchOnWindowFocus: options?.refetchOnWindowFocus,
     meta: AUTH_SCOPED_QUERY_META,
   });

--- a/packages/ui/src/features/auth/useOrgRole.test.tsx
+++ b/packages/ui/src/features/auth/useOrgRole.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type UserResult = {
+  data: { organization?: { membership_level: number } | null } | undefined;
+  isLoading: boolean;
+  isPlaceholderData: boolean;
+};
+
+let userResult: UserResult;
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => null,
+}));
+
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => userResult,
+}));
+
+import { ORGANIZATION_ADMIN_LEVEL, useIsOrgAdmin } from "./useOrgRole";
+
+describe("useIsOrgAdmin", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns null while the user query is loading", () => {
+    userResult = { data: undefined, isLoading: true, isPlaceholderData: false };
+    const { result } = renderHook(() => useIsOrgAdmin());
+    expect(result.current.isAdmin).toBeNull();
+  });
+
+  it("returns null while showing placeholder data carried across an org switch", () => {
+    // Placeholder data is the *previous* org's membership, so an admin in the
+    // old org must not read as admin in the one being switched to.
+    userResult = {
+      data: { organization: { membership_level: ORGANIZATION_ADMIN_LEVEL } },
+      isLoading: false,
+      isPlaceholderData: true,
+    };
+    const { result } = renderHook(() => useIsOrgAdmin());
+    expect(result.current.isAdmin).toBeNull();
+  });
+
+  it("returns true for an admin once the current org resolves", () => {
+    userResult = {
+      data: { organization: { membership_level: ORGANIZATION_ADMIN_LEVEL } },
+      isLoading: false,
+      isPlaceholderData: false,
+    };
+    const { result } = renderHook(() => useIsOrgAdmin());
+    expect(result.current.isAdmin).toBe(true);
+  });
+
+  it("returns false for a non-admin member", () => {
+    userResult = {
+      data: { organization: { membership_level: 1 } },
+      isLoading: false,
+      isPlaceholderData: false,
+    };
+    const { result } = renderHook(() => useIsOrgAdmin());
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it("returns null when the user has no organization", () => {
+    userResult = {
+      data: { organization: null },
+      isLoading: false,
+      isPlaceholderData: false,
+    };
+    const { result } = renderHook(() => useIsOrgAdmin());
+    expect(result.current.isAdmin).toBeNull();
+  });
+});

--- a/packages/ui/src/features/auth/useOrgRole.ts
+++ b/packages/ui/src/features/auth/useOrgRole.ts
@@ -5,8 +5,12 @@ export const ORGANIZATION_ADMIN_LEVEL = 8;
 
 export function useIsOrgAdmin(): { isAdmin: boolean | null } {
   const client = useOptionalAuthenticatedClient();
-  const { data, isLoading } = useCurrentUser({ client });
+  const { data, isLoading, isPlaceholderData } = useCurrentUser({ client });
   const level = data?.organization?.membership_level ?? null;
-  if (isLoading || level === null) return { isAdmin: null };
+  // membership_level is for the user's current org, so placeholder data carried
+  // across an org switch is the wrong org's role. Treat it as unknown until the
+  // new identity resolves.
+  if (isLoading || isPlaceholderData || level === null)
+    return { isAdmin: null };
   return { isAdmin: level >= ORGANIZATION_ADMIN_LEVEL };
 }

--- a/packages/ui/src/features/sidebar/components/ProjectSwitcher.test.tsx
+++ b/packages/ui/src/features/sidebar/components/ProjectSwitcher.test.tsx
@@ -1,0 +1,111 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type CurrentUser = {
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  organizations?: unknown[];
+};
+
+let currentUser: CurrentUser | undefined;
+let switchPending = false;
+
+const authState = {
+  status: "authenticated" as const,
+  bootstrapComplete: true,
+  cloudRegion: "us" as const,
+  orgProjectsMap: {
+    "org-1": { orgName: "Acme", projects: [{ id: 1, name: "Main" }] },
+  } as Record<
+    string,
+    { orgName: string; projects: { id: number; name: string }[] }
+  >,
+  currentOrgId: "org-1" as string | null,
+  currentProjectId: 1 as number | null,
+  hasCodeAccess: true,
+  needsScopeReauth: false,
+};
+
+vi.mock("@posthog/ui/features/auth/store", () => ({
+  useAuthStateValue: (selector: (state: typeof authState) => unknown) =>
+    selector(authState),
+}));
+
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: currentUser, isPlaceholderData: false }),
+}));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => null,
+}));
+
+vi.mock("@posthog/ui/features/auth/useAuthMutations", () => ({
+  useSelectProjectMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useSwitchOrgMutation: () => ({ mutate: vi.fn(), isPending: switchPending }),
+  useLogoutMutation: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useService: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("@posthog/ui/shell/openExternal", () => ({ openExternalUrl: vi.fn() }));
+vi.mock("@posthog/ui/features/settings/hooks/useOpenSettings", () => ({
+  openSettings: vi.fn(),
+}));
+vi.mock("@posthog/ui/utils/urls", () => ({ getPostHogUrl: () => null }));
+
+import { ProjectSwitcher } from "./ProjectSwitcher";
+
+function renderSwitcher() {
+  return render(
+    <Theme>
+      <ProjectSwitcher />
+    </Theme>,
+  );
+}
+
+describe("ProjectSwitcher trigger", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    currentUser = undefined;
+    switchPending = false;
+    authState.currentProjectId = 1;
+    authState.currentOrgId = "org-1";
+  });
+
+  it("shows a skeleton, never the literal 'No email', while the user loads", () => {
+    currentUser = undefined;
+    renderSwitcher();
+
+    expect(screen.getAllByText("Main").length).toBeGreaterThan(0);
+    expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
+    expect(screen.queryByText("No email")).not.toBeInTheDocument();
+  });
+
+  it("paints the email once the user resolves", () => {
+    currentUser = { email: "alice@example.com" };
+    renderSwitcher();
+
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(document.querySelector(".animate-pulse")).not.toBeInTheDocument();
+  });
+
+  it("shows a spinner instead of the chevron while a switch is in flight", () => {
+    // Fake timers keep the spinner's animation interval from firing state
+    // updates outside act(); render still paints the current braille frame.
+    vi.useFakeTimers();
+    try {
+      currentUser = { email: "alice@example.com" };
+      switchPending = true;
+      renderSwitcher();
+
+      expect(document.querySelector(".rotate-270")).toBeNull();
+      expect(screen.getByText(/[⠀-⣿]/)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -49,6 +49,7 @@ import {
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useProjects } from "@posthog/ui/features/projects/useProjects";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { DotsCircleSpinner } from "@posthog/ui/primitives/DotsCircleSpinner";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { isMac } from "@posthog/ui/utils/platform";
 import { getPostHogUrl } from "@posthog/ui/utils/urls";
@@ -65,6 +66,8 @@ export function ProjectSwitcher() {
   const selectProjectMutation = useSelectProjectMutation();
   const switchOrgMutation = useSwitchOrgMutation();
   const logoutMutation = useLogoutMutation();
+  const switchPending =
+    selectProjectMutation.isPending || switchOrgMutation.isPending;
   const { groupedProjects, currentProject, currentProjectId } = useProjects();
 
   const currentOrgGroup =
@@ -173,11 +176,19 @@ export function ProjectSwitcher() {
                 {currentProject?.name ?? "No project selected"}
               </ItemTitle>
               <ItemDescription className="text-[11px]">
-                {currentUser?.email ?? "No email"}
+                {currentUser ? (
+                  currentUser.email
+                ) : (
+                  <span className="my-0.5 inline-block h-3 w-32 animate-pulse rounded bg-gray-5 align-middle" />
+                )}
               </ItemDescription>
             </ItemContent>
             <ItemActions>
-              <ChevronRightIcon className="size-4 rotate-270 group-aria-expanded/item:rotate-90" />
+              {switchPending ? (
+                <DotsCircleSpinner size={16} className="text-gray-10" />
+              ) : (
+                <ChevronRightIcon className="size-4 rotate-270 group-aria-expanded/item:rotate-90" />
+              )}
             </ItemActions>
           </Item>
         }


### PR DESCRIPTION
## Problem

A cuiflash audit of the org/project switcher redesign (#2638) turned up two spots where the auth flow paints a state that bets on the wrong outcome while data is still resolving (a "wrong-UI flash"):

- **Switcher trigger** showed the literal `No email` on every cold boot and after every project/org switch. `useCurrentUser`'s query key carries `currentProjectId`, so a switch re-keys to a fresh, dataless entry (and `clearAuthScopedQueries` evicts the old one), blanking the email even though the user never changed.
- **Logout** left the authenticated app shell on screen with drained caches for one IPC round trip, because the renderer auth store only flipped to anonymous when the tRPC subscription pushed.

## Changes

**Switcher trigger** (`useCurrentUser`, `useOrgRole`, `ProjectSwitcher`)
- `useCurrentUser` uses `placeholderData: keepPreviousData`, gated on being signed in, so a re-keyed query keeps the last-confirmed user painted while the new identity refetches. The placeholder is dropped on logout so no stale user lingers on the signed-out screen.
- `useIsOrgAdmin` treats `isPlaceholderData` as unknown: `membership_level` is the *previous* org's role across a switch, so it returns `null` until the new identity resolves.
- The trigger renders a layout-stable pulse skeleton (matching the dropdown body) instead of `No email` while the user is genuinely unverified, and shows a spinner in place of the chevron while a switch is in flight, so the 2-3s switch reads as "switching" rather than stale.

**Logout** (`useAuthMutations`)
- `useLogoutMutation.onSuccess` sets the anonymous auth state synchronously (with `bootstrapComplete: true`) so the transition goes straight to the auth screen instead of flashing the emptied shell. The later subscription push delivers the same state, so it stays idempotent. Shared hook, so this covers desktop and web.

A third audit candidate, an Electron theme flash, was investigated and dropped: `themeStore` persists to synchronous `localStorage` and the window only shows on `ready-to-show`, so the first painted frame is already correctly themed. There is no flash window, and the originally-planned main-process read would have targeted the wrong store.

## How did you test this?

Added unit tests (Vitest), all passing:
- `useCurrentUser.test.tsx`: holds a fetch in flight and asserts the previous user stays painted (`isPlaceholderData` true) across a project re-key, and that no placeholder survives logout.
- `useOrgRole.test.tsx`: `isAdmin` is `null` while placeholder data from the previous org is showing.
- `ProjectSwitcher.test.tsx`: skeleton (never the literal `No email`) while the user loads, email once resolved, spinner instead of the chevron while a switch is pending.
- `useAuthMutations.test.tsx`: the store is anonymous with `bootstrapComplete: true` after logout, without any subscription push.

Also ran `pnpm --filter @posthog/ui test` (719 tests green) and `pnpm --filter @posthog/ui typecheck` (clean), Biome clean on changed files.

No automated e2e: the host transport is Electron IPC with no `page.route` seam and no precedent in `tests/e2e/`; per `docs/testing.md` these are unit-tested.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
