### PR TITLE
fix(analytics): Resolve feature flags before first render

### DIFF
--- a/apps/code/src/main/posthog-session-arg.test.ts
+++ b/apps/code/src/main/posthog-session-arg.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseSessionIdArg } from "./posthog-session-arg";
+
+describe("parseSessionIdArg", () => {
+  it("returns the value when the flag is present", () => {
+    expect(parseSessionIdArg(["--posthog-session-id=abc-123"])).toBe("abc-123");
+  });
+
+  it("finds the flag among other arguments", () => {
+    expect(
+      parseSessionIdArg(["--foo", "--posthog-session-id=xyz", "--bar"]),
+    ).toBe("xyz");
+  });
+
+  it("returns null when the flag is absent", () => {
+    expect(parseSessionIdArg(["--type=renderer", "--no-sandbox"])).toBeNull();
+  });
+
+  it("ignores arguments that only share the prefix", () => {
+    expect(parseSessionIdArg(["--posthog-session-id-extra=foo"])).toBeNull();
+  });
+
+  it("returns an empty string when the flag has no value", () => {
+    expect(parseSessionIdArg(["--posthog-session-id="])).toBe("");
+  });
+});

--- a/apps/code/src/main/posthog-session-arg.ts
+++ b/apps/code/src/main/posthog-session-arg.ts
@@ -1,0 +1,9 @@
+export const POSTHOG_SESSION_ID_ARG = "--posthog-session-id=";
+
+export function parseSessionIdArg(argv: string[]): string | null {
+  return (
+    argv
+      .find((arg) => arg.startsWith(POSTHOG_SESSION_ID_ARG))
+      ?.slice(POSTHOG_SESSION_ID_ARG.length) ?? null
+  );
+}

--- a/apps/code/src/main/preload.ts
+++ b/apps/code/src/main/preload.ts
@@ -1,9 +1,14 @@
 import { exposeElectronTRPC } from "@posthog/electron-trpc/main";
 import { contextBridge, webUtils } from "electron";
 import "electron-log/preload";
+import { parseSessionIdArg } from "./posthog-session-arg";
 
 contextBridge.exposeInMainWorld("electronUtils", {
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
+});
+
+contextBridge.exposeInMainWorld("__posthogBootstrap", {
+  sessionId: parseSessionIdArg(process.argv),
 });
 
 if (process.argv.includes("--posthog-code-dev")) {

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -13,6 +13,8 @@ import {
 import { container } from "./di/container";
 import { buildApplicationMenu } from "./menu";
 import type { ElectronMainWindow } from "./platform-adapters/electron-main-window";
+import { posthogNodeAnalytics } from "./platform-adapters/posthog-analytics";
+import { POSTHOG_SESSION_ID_ARG } from "./posthog-session-arg";
 import { trpcRouter } from "./trpc/router";
 import { collectMemorySnapshot } from "./utils/crash-diagnostics";
 import { isDevBuild } from "./utils/env";
@@ -203,7 +205,10 @@ export function createWindow(): void {
       preload: path.join(__dirname, "preload.js"),
       enableBlinkFeatures: "GetDisplayMedia",
       partition: "persist:main",
-      additionalArguments: isDev ? ["--posthog-code-dev"] : [],
+      additionalArguments: [
+        ...(isDev ? ["--posthog-code-dev"] : []),
+        `${POSTHOG_SESSION_ID_ARG}${posthogNodeAnalytics.getOrCreateSessionId()}`,
+      ],
       ...(isDev && { webSecurity: false }),
     },
   });

--- a/apps/code/src/renderer/contributions/app-boot.contributions.ts
+++ b/apps/code/src/renderer/contributions/app-boot.contributions.ts
@@ -13,13 +13,15 @@ const log = logger.scope("app-boot");
 export class AnalyticsBootContribution implements Contribution {
   start(): void {
     void (async () => {
-      let sessionId: string | undefined;
-      try {
-        ({ sessionId } = await trpcClient.analytics.getSessionId.query());
-      } catch (error) {
-        log.warn("Failed to fetch session id from main", { error });
+      if (!window.__posthogBootstrap?.sessionId) {
+        let sessionId: string | undefined;
+        try {
+          ({ sessionId } = await trpcClient.analytics.getSessionId.query());
+        } catch (error) {
+          log.warn("Failed to fetch session id from main", { error });
+        }
+        initializePostHog(sessionId);
       }
-      initializePostHog(sessionId);
       trpcClient.os.getAppVersion
         .query()
         .then(registerAppVersion)

--- a/apps/code/src/renderer/main.tsx
+++ b/apps/code/src/renderer/main.tsx
@@ -16,6 +16,7 @@ import { preloadHighlighter } from "@pierre/diffs";
 import { boot } from "@posthog/di/contribution";
 import { ServiceProvider } from "@posthog/di/react";
 import App from "@posthog/ui/shell/App";
+import { initializePostHog } from "@posthog/ui/shell/posthogAnalyticsImpl";
 import { registerDesktopContributions } from "@renderer/desktop-contributions";
 import { container } from "@renderer/di/container";
 import "@renderer/desktop-services";
@@ -73,6 +74,11 @@ void preloadHighlighter({
 document.title = import.meta.env.DEV
   ? "PostHog Code (Development)"
   : "PostHog Code";
+
+const bootstrapSessionId = window.__posthogBootstrap?.sessionId;
+if (bootstrapSessionId) {
+  initializePostHog(bootstrapSessionId);
+}
 
 registerDesktopContributions();
 void boot(container);

--- a/apps/code/src/renderer/types/electron.d.ts
+++ b/apps/code/src/renderer/types/electron.d.ts
@@ -5,5 +5,8 @@ declare global {
     electronUtils?: {
       getPathForFile: (file: File) => string;
     };
+    __posthogBootstrap?: {
+      sessionId: string | null;
+    };
   }
 }


### PR DESCRIPTION
## Problem

The "Cloud" option in the workspace-mode picker intermittently vanished on launch and only returned after a hard refresh or restart. It is gated by the `twig-cloud-mode-toggle` feature flag, but the renderer deferred PostHog initialization behind an async `getSessionId` IPC round-trip. React mounted first, so `useFeatureFlag` read the flag as `false` (flags not loaded yet) and hid the option until init finished and flags arrived. Every `useFeatureFlag` consumer was exposed to the same race; the `|| import.meta.env.DEV` fallback masked it during local development.

Closes #2598

## Changes

1. Pass the main-owned session id to the renderer synchronously via `additionalArguments`
2. Expose it on `window.__posthogBootstrap` from the preload
3. Initialize PostHog before React mounts so flags resolve on the first render
4. Keep `AnalyticsBootContribution` as an idempotent async fallback when the bridge value is absent
5. Session stitching is preserved — the renderer still uses the main process session id

## How did you test this?

- `pnpm --filter code typecheck` (main + renderer tsconfigs) — pass
- `biome check` on the changed files — clean (also enforced by the pre-commit hook)
- `pnpm --filter code exec vitest run src/main/platform-adapters/posthog-analytics.test.ts` — 7/7 pass
- `pnpm --filter @posthog/ui exec vitest run src/shell/posthogAnalyticsImpl.test.ts` — 11/11 pass

Not yet run: an end-to-end check on a production build with `twig-cloud-mode-toggle` enabled — the flag path is dev-forced on, so the race only manifests in production builds. A genuinely cold flag cache still has a one-time load window until the network flags response arrives, which is expected first-load behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
