### PR TITLE
feat(codex): offer Extra High reasoning for gpt-5.5

### DIFF
--- a/packages/agent/src/adapters/codex/models.test.ts
+++ b/packages/agent/src/adapters/codex/models.test.ts
@@ -4,6 +4,7 @@ import {
   formatCodexModelName,
   getReasoningEffortOptions,
   modelIdFromConfigOptions,
+  supportsXhighEffort,
 } from "./models";
 
 describe("formatCodexModelName", () => {
@@ -29,6 +30,21 @@ describe("getReasoningEffortOptions", () => {
       expect(values(modelId)).toEqual(["low", "medium", "high"]);
     },
   );
+
+  it('labels the extra tier "Extra High"', () => {
+    const xhigh = getReasoningEffortOptions("gpt-5.5").find(
+      (o) => o.value === "xhigh",
+    );
+    expect(xhigh?.name).toBe("Extra High");
+  });
+});
+
+describe("supportsXhighEffort", () => {
+  it("is true for the gpt-5.5 family and false for other models", () => {
+    expect(supportsXhighEffort("gpt-5.5-codex")).toBe(true);
+    expect(supportsXhighEffort("GPT-5.5")).toBe(true);
+    expect(supportsXhighEffort("gpt-5.3-codex")).toBe(false);
+  });
 });
 
 describe("modelIdFromConfigOptions", () => {

--- a/packages/agent/src/adapters/codex/models.test.ts
+++ b/packages/agent/src/adapters/codex/models.test.ts
@@ -1,11 +1,34 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { describe, expect, it } from "vitest";
-import { formatCodexModelName, modelIdFromConfigOptions } from "./models";
+import {
+  formatCodexModelName,
+  getReasoningEffortOptions,
+  modelIdFromConfigOptions,
+} from "./models";
 
 describe("formatCodexModelName", () => {
   it("uses raw lowercase model ids", () => {
     expect(formatCodexModelName("GPT-5.5")).toBe("gpt-5.5");
   });
+});
+
+describe("getReasoningEffortOptions", () => {
+  const values = (modelId: string) =>
+    getReasoningEffortOptions(modelId).map((o) => o.value);
+
+  it.each(["gpt-5.5", "gpt-5.5-codex", "openai/gpt-5.5", "GPT-5.5"])(
+    "offers Extra High for the gpt-5.5 family (%s)",
+    (modelId) => {
+      expect(values(modelId)).toEqual(["low", "medium", "high", "xhigh"]);
+    },
+  );
+
+  it.each(["gpt-5.3-codex", "gpt-5.1", "o3"])(
+    "caps at High for other models (%s)",
+    (modelId) => {
+      expect(values(modelId)).toEqual(["low", "medium", "high"]);
+    },
+  );
 });
 
 describe("modelIdFromConfigOptions", () => {

--- a/packages/agent/src/adapters/codex/models.ts
+++ b/packages/agent/src/adapters/codex/models.ts
@@ -15,10 +15,25 @@ const CODEX_REASONING_EFFORT_OPTIONS: ReasoningEffortOption[] = [
   { value: "high", name: "High" },
 ];
 
+// OpenAI's `reasoning_effort` exposes an "extra high" tier on the gpt-5.5
+// family (matching what the Codex app offers). Older Codex models top out at
+// "high", so gate the extra option on the model id rather than offering it
+// everywhere.
+export function supportsXhighEffort(modelId: string): boolean {
+  return modelId.toLowerCase().includes("gpt-5.5");
+}
+
 export function getReasoningEffortOptions(
-  _modelId: string,
+  modelId: string,
 ): ReasoningEffortOption[] {
-  return CODEX_REASONING_EFFORT_OPTIONS;
+  if (!supportsXhighEffort(modelId)) {
+    return CODEX_REASONING_EFFORT_OPTIONS;
+  }
+
+  return [
+    ...CODEX_REASONING_EFFORT_OPTIONS,
+    { value: "xhigh", name: "Extra High" },
+  ];
 }
 
 export function formatCodexModelName(value: string): string {

--- a/packages/agent/src/adapters/codex/models.ts
+++ b/packages/agent/src/adapters/codex/models.ts
@@ -15,10 +15,8 @@ const CODEX_REASONING_EFFORT_OPTIONS: ReasoningEffortOption[] = [
   { value: "high", name: "High" },
 ];
 
-// OpenAI's `reasoning_effort` exposes an "extra high" tier on the gpt-5.5
-// family (matching what the Codex app offers). Older Codex models top out at
-// "high", so gate the extra option on the model id rather than offering it
-// everywhere.
+// OpenAI's `reasoning_effort` exposes an "extra high" tier only on the gpt-5.5
+// family, matching what the Codex app offers. Older models top out at "high".
 export function supportsXhighEffort(modelId: string): boolean {
   return modelId.toLowerCase().includes("gpt-5.5");
 }
@@ -26,14 +24,11 @@ export function supportsXhighEffort(modelId: string): boolean {
 export function getReasoningEffortOptions(
   modelId: string,
 ): ReasoningEffortOption[] {
-  if (!supportsXhighEffort(modelId)) {
-    return CODEX_REASONING_EFFORT_OPTIONS;
+  const options = [...CODEX_REASONING_EFFORT_OPTIONS];
+  if (supportsXhighEffort(modelId)) {
+    options.push({ value: "xhigh", name: "Extra High" });
   }
-
-  return [
-    ...CODEX_REASONING_EFFORT_OPTIONS,
-    { value: "xhigh", name: "Extra High" },
-  ];
+  return options;
 }
 
 export function formatCodexModelName(value: string): string {

--- a/packages/agent/src/adapters/reasoning-effort.test.ts
+++ b/packages/agent/src/adapters/reasoning-effort.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isSupportedReasoningEffort } from "./reasoning-effort";
+
+describe("isSupportedReasoningEffort", () => {
+  it("accepts xhigh for the codex gpt-5.5 family", () => {
+    expect(isSupportedReasoningEffort("codex", "gpt-5.5", "xhigh")).toBe(true);
+    expect(isSupportedReasoningEffort("codex", "gpt-5.5-codex", "xhigh")).toBe(
+      true,
+    );
+  });
+
+  it("rejects xhigh for other codex models", () => {
+    expect(isSupportedReasoningEffort("codex", "gpt-5.3-codex", "xhigh")).toBe(
+      false,
+    );
+  });
+
+  it("rejects unknown effort values", () => {
+    expect(isSupportedReasoningEffort("codex", "gpt-5.5", "ultra")).toBe(false);
+  });
+
+  it("gates xhigh on Claude models by id", () => {
+    expect(
+      isSupportedReasoningEffort("claude", "claude-opus-4-8", "xhigh"),
+    ).toBe(true);
+    expect(
+      isSupportedReasoningEffort("claude", "claude-sonnet-4-6", "xhigh"),
+    ).toBe(false);
+  });
+});

--- a/packages/agent/src/agent.test.ts
+++ b/packages/agent/src/agent.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AcpConnectionConfig } from "./adapters/acp-connection";
+
+const createAcpConnectionMock = vi.hoisted(() =>
+  vi.fn(() => ({ cleanup: vi.fn() }) as never),
+);
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+vi.mock("./adapters/acp-connection", () => {
+  return {
+    createAcpConnection: createAcpConnectionMock,
+  };
+});
+
+import { Agent } from "./agent";
+
+describe("Agent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: [{ id: "gpt-5.5", owned_by: "openai" }],
+      }),
+    });
+  });
+
+  it("passes reasoning effort through to local Codex options", async () => {
+    const agent = new Agent({
+      posthog: {
+        apiUrl: "https://us.posthog.com",
+        getApiKey: vi.fn().mockResolvedValue("token"),
+        projectId: 1,
+      },
+      skipLogPersistence: true,
+    });
+
+    await agent.run("task-1", "run-1", {
+      adapter: "codex",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      repositoryPath: "/tmp/repo",
+    });
+
+    expect(createAcpConnectionMock).toHaveBeenCalledTimes(1);
+    const [[config]] = createAcpConnectionMock.mock.calls as unknown as [
+      [AcpConnectionConfig],
+    ];
+    expect(config.codexOptions).toEqual(
+      expect.objectContaining({
+        model: "gpt-5.5",
+        reasoningEffort: "xhigh",
+      }),
+    );
+  });
+});

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -135,6 +135,7 @@ export class Agent {
               apiKey: gatewayConfig.apiKey,
               binaryPath: options.codexBinaryPath,
               model: sanitizedModel,
+              reasoningEffort: options.reasoningEffort,
               instructions: options.instructions,
               additionalDirectories: options.additionalDirectories,
             }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -3,6 +3,7 @@ import type {
   HandoffLocalGitState as GitHandoffLocalGitState,
   PostHogAPIConfig,
 } from "@posthog/shared";
+import type { EffortLevel } from "@posthog/shared/domain-types";
 
 export type {
   ArtifactType,
@@ -52,6 +53,7 @@ export interface TaskExecutionOptions {
   model?: string;
   gatewayUrl?: string;
   codexBinaryPath?: string;
+  reasoningEffort?: EffortLevel;
   instructions?: string;
   processCallbacks?: ProcessSpawnedCallback;
   /** Callback invoked when the agent calls the create_output tool for structured output */

--- a/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/packages/workspace-server/src/services/agent/agent.test.ts
@@ -290,6 +290,23 @@ describe("AgentService", () => {
       const codexMcp = mockNewSession.mock.calls[1][0].mcpServers;
       expect(codexMcp).toEqual(claudeMcp);
     });
+
+    it("passes reasoning effort to local Codex startup options", async () => {
+      await service.startSession({
+        ...baseSessionParams,
+        adapter: "codex",
+        effort: "xhigh",
+      });
+
+      expect(mockAgentRun).toHaveBeenCalledWith(
+        "task-1",
+        "run-1",
+        expect.objectContaining({
+          adapter: "codex",
+          reasoningEffort: "xhigh",
+        }),
+      );
+    });
   });
 
   describe("idle timeout", () => {

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -689,6 +689,7 @@ When creating pull requests, add the following footer at the end of the PR descr
         codexBinaryPath:
           adapter === "codex" ? this.getCodexBinaryPath() : undefined,
         model,
+        reasoningEffort: adapter === "codex" ? effort : undefined,
         instructions: adapter === "codex" ? systemPrompt.append : undefined,
         additionalDirectories:
           adapter === "codex" ? additionalDirectories : undefined,


### PR DESCRIPTION
## Problem

In a Codex (OpenAI) task you can only pick Low/Medium/High reasoning effort, even though OpenAI's gpt-5.5 family supports an **Extra High** tier - the same one the Codex app exposes. So PostHog Code users on gpt-5.5 couldn't reach the model's top reasoning level.

There was also a local Desktop startup gap: after making Extra High selectable, the selected Codex effort needed to be forwarded into the local Codex process. Without that, the picker could show Extra High while the spawned Codex session still launched without the selected effort.

**Why:** A user on Slack asked for Extra High to be available for gpt-5.5 in Codex. It wasn't an API limitation - the picker was just hardcoded, and the local Codex launch path needed to thread the selected effort through.

## Changes

- `getReasoningEffortOptions` in `packages/agent/src/adapters/codex/models.ts` now appends `{ value: "xhigh", name: "Extra High" }` for the gpt-5.5 family (`gpt-5.5`, `gpt-5.5-codex`, `openai/gpt-5.5`).
- Local Codex sessions now pass the selected effort from workspace-server into `Agent.run`, then into `codexOptions.reasoningEffort`, so the Codex spawn path receives the selected reasoning effort.
- `xhigh` was already part of the shared `SupportedReasoningEffort` type, so the downstream API type did not need to change.
- Other Codex models still cap at High.

## How did you test this?

- Added Codex model option coverage for the gpt-5.5 family getting Extra High and other Codex models staying capped at High.
- Added shared reasoning-effort validation coverage for accepting `xhigh` on gpt-5.5 and rejecting unsupported efforts on other Codex models.
- Added local startup coverage for workspace-server forwarding Codex effort into `Agent.run`.
- Added agent coverage for forwarding `reasoningEffort` into local Codex options.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781339771802429)*
