### PR TITLE
feat(scouts): widen runs window from 24h to 3 days

### DIFF
--- a/packages/core/src/scouts/scoutRunsWindow.test.ts
+++ b/packages/core/src/scouts/scoutRunsWindow.test.ts
@@ -4,6 +4,7 @@ import {
   fetchScoutRunsWindow,
   SCOUT_RUNS_WINDOW_HOURS,
   type ScoutRunsClient,
+  type ScoutRunsWindow,
   scoutRunsWindowLabel,
 } from "./scoutRunsWindow";
 
@@ -115,13 +116,23 @@ describe("fetchScoutRunsWindow", () => {
 });
 
 describe("scoutRunsWindowLabel", () => {
-  it("names the window and flags truncation", () => {
-    expect(scoutRunsWindowLabel({ runs: [], complete: true })).toBe(
-      "last 3 days",
-    );
-    expect(scoutRunsWindowLabel({ runs: [], complete: false })).toBe(
-      "last 3 days · truncated",
-    );
-    expect(scoutRunsWindowLabel(undefined)).toBe("last 3 days");
+  it.each([
+    {
+      name: "complete window",
+      window: { runs: [], complete: true } as ScoutRunsWindow,
+      expected: "last 3 days",
+    },
+    {
+      name: "truncated window",
+      window: { runs: [], complete: false } as ScoutRunsWindow,
+      expected: "last 3 days · truncated",
+    },
+    {
+      name: "undefined window",
+      window: undefined,
+      expected: "last 3 days",
+    },
+  ])("names the $name", ({ window, expected }) => {
+    expect(scoutRunsWindowLabel(window)).toBe(expected);
   });
 });

--- a/packages/core/src/scouts/scoutRunsWindow.test.ts
+++ b/packages/core/src/scouts/scoutRunsWindow.test.ts
@@ -116,10 +116,12 @@ describe("fetchScoutRunsWindow", () => {
 
 describe("scoutRunsWindowLabel", () => {
   it("names the window and flags truncation", () => {
-    expect(scoutRunsWindowLabel({ runs: [], complete: true })).toBe("last 24h");
-    expect(scoutRunsWindowLabel({ runs: [], complete: false })).toBe(
-      "last 24h · truncated",
+    expect(scoutRunsWindowLabel({ runs: [], complete: true })).toBe(
+      "last 3 days",
     );
-    expect(scoutRunsWindowLabel(undefined)).toBe("last 24h");
+    expect(scoutRunsWindowLabel({ runs: [], complete: false })).toBe(
+      "last 3 days · truncated",
+    );
+    expect(scoutRunsWindowLabel(undefined)).toBe("last 3 days");
   });
 });

--- a/packages/core/src/scouts/scoutRunsWindow.ts
+++ b/packages/core/src/scouts/scoutRunsWindow.ts
@@ -10,7 +10,17 @@ import type {
  * pattern). A fixed window gives users a stable frame for every number;
  * "the most recent 100 runs" does not.
  */
-export const SCOUT_RUNS_WINDOW_HOURS = 24;
+export const SCOUT_RUNS_WINDOW_HOURS = 72;
+
+/**
+ * Human-friendly span the window covers, e.g. "3 days" or "24h". Reads as days
+ * when the window is a whole number of days, otherwise falls back to hours.
+ */
+export const SCOUT_RUNS_WINDOW_SPAN = (() => {
+  if (SCOUT_RUNS_WINDOW_HOURS % 24 !== 0) return `${SCOUT_RUNS_WINDOW_HOURS}h`;
+  const days = SCOUT_RUNS_WINDOW_HOURS / 24;
+  return `${days} day${days === 1 ? "" : "s"}`;
+})();
 
 const PAGE_LIMIT = 100;
 const MAX_PAGES = 10;
@@ -29,9 +39,9 @@ export interface ScoutRunsWindow {
   complete: boolean;
 }
 
-/** Label for stats derived from a window, e.g. "last 24h". */
+/** Label for stats derived from a window, e.g. "last 3 days". */
 export function scoutRunsWindowLabel(window?: ScoutRunsWindow): string {
-  const base = `last ${SCOUT_RUNS_WINDOW_HOURS}h`;
+  const base = `last ${SCOUT_RUNS_WINDOW_SPAN}`;
   return window && !window.complete ? `${base} · truncated` : base;
 }
 

--- a/packages/ui/src/features/scouts/components/ScoutDetailView.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutDetailView.tsx
@@ -17,7 +17,7 @@ import {
   scoutSkillNameFromSlug,
 } from "@posthog/core/scouts/scoutPresentation";
 import {
-  SCOUT_RUNS_WINDOW_HOURS,
+  SCOUT_RUNS_WINDOW_SPAN,
   scoutRunsWindowLabel,
 } from "@posthog/core/scouts/scoutRunsWindow";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
@@ -85,7 +85,7 @@ export function ScoutDetailView({
 
   const config = configs?.find((entry) => entry.skill_name === skillName);
   // The runs endpoint has no skill_name filter yet (scouts-ui api gap 1), so
-  // select this scout's runs from the 24-hour fleet window client-side.
+  // select this scout's runs from the fleet window client-side.
   const scoutRuns = useMemo(
     () =>
       (runsWindow?.runs ?? []).filter((run) => run.skill_name === skillName),
@@ -232,7 +232,7 @@ export function ScoutDetailView({
                   {scoutRuns.length > 0
                     ? `No runs match this filter in the ${scoutRunsWindowLabel(runsWindow)}.`
                     : runsWindow && !runsWindow.complete
-                      ? `No runs fetched in the last ${SCOUT_RUNS_WINDOW_HOURS} hours – the fleet window was truncated before it could cover this scout, so runs may exist beyond what was fetched.`
+                      ? `No runs fetched in the last ${SCOUT_RUNS_WINDOW_SPAN} – the fleet window was truncated before it could cover this scout, so runs may exist beyond what was fetched.`
                       : `No runs in the ${scoutRunsWindowLabel(runsWindow)}.`}
                 </Text>
               ) : (
@@ -245,7 +245,7 @@ export function ScoutDetailView({
 
               <Text className="text-[12px] text-gray-10">
                 Showing this scout&apos;s runs from the last{" "}
-                {SCOUT_RUNS_WINDOW_HOURS} hours.
+                {SCOUT_RUNS_WINDOW_SPAN}.
               </Text>
             </Flex>
           </Flex>

--- a/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
@@ -18,7 +18,7 @@ import {
   SCOUT_RECENT_SIGNALS_PROMPT,
 } from "@posthog/core/scouts/scoutPrompts";
 import {
-  SCOUT_RUNS_WINDOW_HOURS,
+  SCOUT_RUNS_WINDOW_SPAN,
   scoutRunsWindowLabel,
 } from "@posthog/core/scouts/scoutRunsWindow";
 import type { ScoutChatType } from "@posthog/shared";
@@ -241,8 +241,8 @@ function ScoutsFleetList({ configs }: { configs: ScoutConfig[] }) {
 
       <Flex direction="column" gap="1">
         <Text className="text-[12px] text-gray-10">
-          Run counts and emitted totals cover the last {SCOUT_RUNS_WINDOW_HOURS}{" "}
-          hours of fleet runs. New scouts are created as{" "}
+          Run counts and emitted totals cover the last {SCOUT_RUNS_WINDOW_SPAN}{" "}
+          of fleet runs. New scouts are created as{" "}
           <span className="font-mono text-[11px]">signals-scout-*</span> skills
           in your PostHog project.
         </Text>

--- a/packages/ui/src/features/scouts/hooks/useScoutRuns.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutRuns.ts
@@ -7,7 +7,7 @@ import { useAuthStateValue } from "../../auth/store";
 import { scoutQueryKeys } from "./scoutQueryKeys";
 
 /**
- * Fleet-wide scout runs from the last 24 hours (newest first), assembled in
+ * Fleet-wide scout runs from the recent window (newest first), assembled in
  * core by walking the backend's 100-row pages. The backend has no per-scout
  * filter yet (scouts-ui api gap 1), so per-scout views filter this window
  * client-side. `complete` is false if pagination had to stop early.


### PR DESCRIPTION
## What

Widens the Scouts runs window from the last 24 hours to the last 3 days, and shows it as a friendly "3 days" label everywhere.

## Why

24h is a tight window for a fleet that runs on a daily-ish cadence — a single missed/late run leaves a view looking empty. 3 days gives a more stable frame for run counts, emitted totals, and per-scout history.

## How

- `SCOUT_RUNS_WINDOW_HOURS`: `24` → `72` (single source of truth driving the fetch window and all UI copy).
- Added a derived `SCOUT_RUNS_WINDOW_SPAN` that renders a whole number of days as e.g. `"3 days"` (falls back to `"<n>h"` for non-day windows), so copy reads "last 3 days" instead of "last 72 hours".
- Updated fleet + detail view copy and the window label, plus tests/comments.

## Follow-up

Considering making the window user-selectable (e.g. 24h / 3d / 7d). This PR just ships 3d as the new default so we can see how it feels.

## Test

- `packages/core` unit tests pass (`scoutRunsWindow`).
- `@posthog/core` + `@posthog/ui` typecheck clean.