### PR TITLE
fix(sessions): Stop cloud task watcher restart loop

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2941,6 +2941,24 @@ export class SessionService {
       return () => {};
     }
 
+    // An already-finished run we've already hydrated has no live stream to
+    // attach to: the snapshot in the store is the complete, final conversation.
+    // Re-watching it refetches the same logs, immediately stops again on the
+    // terminal snapshot, and that snapshot rewrites session.configOptions,
+    // which re-fires the reconcile effect and spins a start/stop loop. Skip it.
+    // Gated on no live watcher: a stale watcher for a different run still needs
+    // the stop-and-restart below.
+    if (!existingWatcher) {
+      const hydrated = this.d.store.getSessionByTaskId(taskId);
+      if (
+        hydrated?.taskRunId === taskRunId &&
+        isTerminalStatus(hydrated.cloudStatus) &&
+        hydrated.processedLineCount !== undefined
+      ) {
+        return () => {};
+      }
+    }
+
     // Different run — full cleanup of old watcher first
     if (existingWatcher) {
       this.stopCloudTaskWatch(taskId);

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -943,6 +943,89 @@ describe("SessionService", () => {
       expect(unsubscribe).not.toHaveBeenCalled();
     });
 
+    it.each<[string, Partial<AgentSession>, boolean]>([
+      [
+        "skips a hydrated terminal (completed) run",
+        { cloudStatus: "completed", processedLineCount: 5 },
+        false,
+      ],
+      [
+        "skips a hydrated terminal (failed) run",
+        { cloudStatus: "failed", processedLineCount: 5 },
+        false,
+      ],
+      [
+        "watches a terminal run that is not yet hydrated",
+        { cloudStatus: "completed", processedLineCount: undefined },
+        true,
+      ],
+      [
+        "watches a hydrated run that is still in progress",
+        { cloudStatus: "in_progress", processedLineCount: 5 },
+        true,
+      ],
+      [
+        "watches when the hydrated terminal session is for a different run",
+        {
+          taskRunId: "run-999",
+          cloudStatus: "completed",
+          processedLineCount: 5,
+        },
+        true,
+      ],
+    ])("watchCloudTask %s", (_name, sessionOverrides, shouldWatch) => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          taskId: "task-123",
+          taskRunId: "run-123",
+          ...sessionOverrides,
+        }),
+      );
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+
+      expect(mockTrpcCloudTask.onUpdate.subscribe).toHaveBeenCalledTimes(
+        shouldWatch ? 1 : 0,
+      );
+      expect(mockTrpcCloudTask.watch.mutate).toHaveBeenCalledTimes(
+        shouldWatch ? 1 : 0,
+      );
+    });
+
+    it("does not re-subscribe across repeated calls for a hydrated terminal run", () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          taskId: "task-123",
+          taskRunId: "run-123",
+          cloudStatus: "completed",
+          processedLineCount: 5,
+        }),
+      );
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+
+      expect(mockTrpcCloudTask.onUpdate.subscribe).not.toHaveBeenCalled();
+      expect(mockTrpcCloudTask.watch.mutate).not.toHaveBeenCalled();
+    });
+
     it("preserves an existing status callback when reusing a watcher without one", () => {
       const service = getSessionService();
       const onStatusChange = vi.fn();


### PR DESCRIPTION
## Problem

Sitting on a finished (terminal) cloud task spins the cloud-task watcher in a tight start/stop loop (~2x/sec): the terminal snapshot tears the watcher down and rewrites `session.configOptions`, which re-fires the `useSessionConnection` reconcile effect, which re-subscribes and re-bootstraps. The result is console spam and a full log-history refetch every cycle.

## Changes

1. Guard `watchCloudTask` to skip re-watching a terminal run already hydrated in the store
2. First open still fetches the snapshot once; new runs and live (non-terminal) runs are unaffected
3. Add regression tests: skip when terminal + hydrated, still watch when terminal-not-hydrated or in-progress

## How did you test this?
Manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
