### PR TITLE
feat(sessions): Add steer and queue messaging modes

### DIFF
--- a/packages/agent/src/adapters/claude/UPSTREAM.md
+++ b/packages/agent/src/adapters/claude/UPSTREAM.md
@@ -34,6 +34,7 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 - Branch naming in system prompt
 - `broadcastUserMessage` in prompt()
 - `interruptReason` on cancel
+- Steer mode: `_meta.steer` maps to `priority:"next"` in `promptToClaude` (`acp-to-sdk.ts`). A mid-turn branch in `prompt()` pushes the message into the running turn's input and returns immediately with a benign `end_turn` instead of queueing a new turn. Advertised via `_meta.posthog.steering:"native"` in `initialize()`
 - `SYSTEM_REMINDER` stripping from Read tool results
 - WebFetch `resourceLink` content enrichment
 - `customTitle` in listSessions (PostHog Code is ahead of upstream here)

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -79,7 +79,7 @@ import {
   estimateSkillsTokens,
   estimateSystemPrompt,
 } from "./context-breakdown";
-import { promptToClaude } from "./conversion/acp-to-sdk";
+import { isSteerMeta, promptToClaude } from "./conversion/acp-to-sdk";
 import {
   handleResultMessage,
   handleStreamEvent,
@@ -434,8 +434,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     }
 
     if (this.session.promptRunning) {
-      const isSteer =
-        (params._meta as Record<string, unknown> | undefined)?.steer === true;
+      const isSteer = isSteerMeta(params._meta);
       if (isSteer) {
         // Fold this message into the turn already running instead of queueing a
         // new turn. promptToClaude tagged it priority:"next" so the SDK delivers

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -274,6 +274,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         _meta: {
           posthog: {
             resumeSession: true,
+            steering: "native",
           },
           claudeCode: {
             promptQueueing: true,
@@ -433,6 +434,19 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     }
 
     if (this.session.promptRunning) {
+      const isSteer =
+        (params._meta as Record<string, unknown> | undefined)?.steer === true;
+      if (isSteer) {
+        // Fold this message into the turn already running instead of queueing a
+        // new turn. promptToClaude tagged it priority:"next" so the SDK delivers
+        // it at the next tool-call boundary. Return immediately with a benign
+        // end_turn: the in-flight turn (not this call) owns the loop and the
+        // real stop reason. The client tells steers apart by the request's
+        // _meta.steer, not by this value.
+        this.session.input.push(userMessage);
+        await this.broadcastUserMessage(params);
+        return { stopReason: "end_turn" };
+      }
       this.session.input.push(userMessage);
       const order = this.session.nextPendingOrder++;
       const cancelled = await new Promise<boolean>((resolve) => {

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
@@ -1,6 +1,7 @@
 import type { PromptRequest } from "@agentclientprotocol/sdk";
 import { describe, expect, it } from "vitest";
 import {
+  isSteerMeta,
   promptToClaude,
   readToolGuidanceForPath,
   workspacePromptFromFileUri,
@@ -24,6 +25,19 @@ describe("workspacePromptFromFileUri", () => {
     const s = workspacePromptFromFileUri("file:///tmp/x.pdf");
     expect(s).toContain("Read");
     expect(s).toContain("file_path: /tmp/x.pdf");
+  });
+});
+
+describe("isSteerMeta", () => {
+  it.each([
+    [{ steer: true }, true],
+    [{ steer: false }, false],
+    [{}, false],
+    [undefined, false],
+    [null, false],
+    [{ steer: "true" }, false],
+  ])("detects steer in %o as %s", (meta, expected) => {
+    expect(isSteerMeta(meta)).toBe(expected);
   });
 });
 

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.test.ts
@@ -56,6 +56,24 @@ describe("promptToClaude", () => {
     expect(text).toContain("pages");
   });
 
+  it("tags a steer message with priority 'next' for tool-boundary delivery", () => {
+    const result = promptToClaude({
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "use a different approach" }],
+      _meta: { steer: true },
+    });
+    expect(result.priority).toBe("next");
+  });
+
+  it("leaves priority and shouldQuery unset for a normal message", () => {
+    const result = promptToClaude({
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "hello" }],
+    });
+    expect(result.priority).toBeUndefined();
+    expect(result.shouldQuery).toBeUndefined();
+  });
+
   it("drops embedded body for file:// resource but keeps attachment:// payload", () => {
     const hugeInline = `${"y".repeat(30_000)}KEEP_ATTACH${"y".repeat(30_000)}`;
     const fileRes = promptToClaude({

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
@@ -154,8 +154,8 @@ export function promptToClaude(prompt: PromptRequest): SDKUserMessage {
   const content: ContentBlockParam[] = [];
   const context: ContentBlockParam[] = [];
 
-  const prContext = (prompt._meta as Record<string, unknown> | undefined)
-    ?.prContext;
+  const meta = prompt._meta as Record<string, unknown> | undefined;
+  const prContext = meta?.prContext;
   if (typeof prContext === "string") {
     content.push(sdkText(prContext));
   }
@@ -166,10 +166,18 @@ export function promptToClaude(prompt: PromptRequest): SDKUserMessage {
 
   content.push(...context);
 
-  return {
+  const message: SDKUserMessage = {
     type: "user",
     message: { role: "user", content },
     session_id: prompt.sessionId,
     parent_tool_use_id: null,
   };
+
+  // A steer is folded into the turn already running: priority "next" tells the
+  // SDK to deliver it at the next tool-call boundary rather than as a new turn.
+  if (meta?.steer === true) {
+    message.priority = "next";
+  }
+
+  return message;
 }

--- a/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
+++ b/packages/agent/src/adapters/claude/conversion/acp-to-sdk.ts
@@ -150,6 +150,15 @@ function processPromptChunk(
   }
 }
 
+/** True when an ACP request's `_meta` marks it as a mid-turn steer. */
+export function isSteerMeta(meta: unknown): boolean {
+  return (
+    typeof meta === "object" &&
+    meta !== null &&
+    (meta as Record<string, unknown>).steer === true
+  );
+}
+
 export function promptToClaude(prompt: PromptRequest): SDKUserMessage {
   const content: ContentBlockParam[] = [];
   const context: ContentBlockParam[] = [];
@@ -175,7 +184,7 @@ export function promptToClaude(prompt: PromptRequest): SDKUserMessage {
 
   // A steer is folded into the turn already running: priority "next" tells the
   // SDK to deliver it at the next tool-call boundary rather than as a new turn.
-  if (meta?.steer === true) {
+  if (isSteerMeta(meta)) {
     message.priority = "next";
   }
 

--- a/packages/agent/src/adapters/codex/codex-agent.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.ts
@@ -401,6 +401,7 @@ export class CodexAcpAgent extends BaseAcpAgent {
         _meta: {
           posthog: {
             resumeSession: true,
+            steering: "interrupt-resend",
           },
         },
       },

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1808,6 +1808,7 @@ export class SessionService {
       is_initial: false,
       execution_type: "local",
       prompt_length_chars: promptText.length,
+      is_steer: true,
     });
 
     return this.d.trpc.agent.prompt.mutate({

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1255,6 +1255,21 @@ export class SessionService {
     this.idleKilledSubscription = null;
   }
 
+  /**
+   * A steer message rides on `session/prompt` with `_meta.steer`. It is folded
+   * into the running turn, so its request must not participate in turn-state
+   * bookkeeping (currentPromptId / isPromptPending) or the live turn would be
+   * cut short. Its response carries a foreign request id, so the currentPromptId
+   * guard ignores it without needing a marker here.
+   */
+  private isSteerMessage(msg: AcpMessage["message"]): boolean {
+    if (isJsonRpcRequest(msg) && msg.method === "session/prompt") {
+      const params = msg.params as { _meta?: { steer?: boolean } } | undefined;
+      return params?._meta?.steer === true;
+    }
+    return false;
+  }
+
   private updatePromptStateFromEvents(
     taskRunId: string,
     events: AcpMessage[],
@@ -1262,6 +1277,12 @@ export class SessionService {
   ): void {
     for (const acpMsg of events) {
       const msg = acpMsg.message;
+      // A steer is injected into the running turn, not a turn of its own. Skip
+      // its request so it never claims currentPromptId. Otherwise the steer's
+      // instant response would clear the live turn's pending state.
+      if (this.isSteerMessage(msg)) {
+        continue;
+      }
       if (isJsonRpcRequest(msg) && msg.method === "session/prompt") {
         this.d.store.updateSession(taskRunId, {
           isPromptPending: true,
@@ -1648,6 +1669,7 @@ export class SessionService {
   async sendPrompt(
     taskId: string,
     prompt: string | ContentBlock[],
+    options?: { steer?: boolean },
   ): Promise<{ stopReason: string }> {
     if (!this.d.getIsOnline()) {
       throw new Error(
@@ -1665,6 +1687,23 @@ export class SessionService {
       throw new Error(
         "Confirm the folder access dialog before sending your message.",
       );
+    }
+
+    // Steer: the user sent a message mid-turn and asked to fold it into the
+    // running turn rather than queue it. Native (Claude) injects at the next
+    // tool boundary; everything else interrupts the turn and resends below as a
+    // fresh prompt. Compaction always falls through to the queue.
+    if (options?.steer && session.isPromptPending && !session.isCompacting) {
+      const supportsNativeSteer =
+        !session.isCloud && session.adapter === "claude";
+      if (supportsNativeSteer) {
+        return this.sendSteerPrompt(session, prompt);
+      }
+      await this.cancelPrompt(taskId);
+      const refreshed = this.d.store.getSessionByTaskId(taskId);
+      if (refreshed) {
+        session = refreshed;
+      }
     }
 
     if (session.isCloud) {
@@ -1748,6 +1787,33 @@ export class SessionService {
 
     return this.sendLocalPrompt(session, blocks, promptText, {
       optimisticApplied: true,
+    });
+  }
+
+  /**
+   * Send a steer message: folded into the turn already running rather than
+   * queued. It renders when its `session/prompt` echo arrives and is injected
+   * by the agent at the next tool boundary. The running turn keeps ownership of
+   * the prompt lifecycle, so this never touches isPromptPending.
+   */
+  private async sendSteerPrompt(
+    session: AgentSession,
+    prompt: string | ContentBlock[],
+  ): Promise<{ stopReason: string }> {
+    const blocks = normalizePromptToBlocks(prompt);
+    const promptText = extractPromptText(prompt);
+
+    this.d.track(ANALYTICS_EVENTS.PROMPT_SENT, {
+      task_id: session.taskId,
+      is_initial: false,
+      execution_type: "local",
+      prompt_length_chars: promptText.length,
+    });
+
+    return this.d.trpc.agent.prompt.mutate({
+      sessionId: session.taskRunId,
+      prompt: blocks,
+      steer: true,
     });
   }
 

--- a/packages/host-router/src/routers/agent.router.ts
+++ b/packages/host-router/src/routers/agent.router.ts
@@ -45,7 +45,9 @@ export const agentRouter = router({
     .mutation(({ ctx, input }) =>
       ctx.container
         .get<AgentService>(AGENT_SERVICE)
-        .prompt(input.sessionId, input.prompt as ContentBlock[]),
+        .prompt(input.sessionId, input.prompt as ContentBlock[], {
+          steer: input.steer,
+        }),
     ),
 
   cancel: publicProcedure

--- a/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -24,6 +24,7 @@ export const SHORTCUTS = {
   FIND_IN_CONVERSATION: "mod+f",
   BLUR: "escape",
   SUBMIT_BLUR: "mod+enter",
+  SWITCH_MESSAGING_MODE: "mod+s",
 } as const;
 
 export type ShortcutCategory = "general" | "navigation" | "panels" | "editor";
@@ -62,6 +63,13 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     keys: SHORTCUTS.SHORTCUTS_SHEET,
     description: "Show keyboard shortcuts",
     category: "general",
+  },
+  {
+    id: "switch-messaging-mode",
+    keys: SHORTCUTS.SWITCH_MESSAGING_MODE,
+    description: "Switch Steer / Queue mode",
+    category: "editor",
+    context: "Session composer",
   },
   {
     id: "inbox",

--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -2,6 +2,7 @@ import "./message-editor.css";
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { ArrowUp, Stop } from "@phosphor-icons/react";
 import { InputGroup, InputGroupAddon, InputGroupButton } from "@posthog/quill";
+import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { cycleModeOption } from "@posthog/ui/features/sessions/sessionStore";
 import { hasOpenOverlay } from "@posthog/ui/utils/overlay";
 import { Flex, Text, Tooltip } from "@radix-ui/themes";
@@ -42,6 +43,7 @@ export interface PromptInputProps {
   // toolbar slots
   modelSelector?: React.ReactElement | null | false;
   reasoningSelector?: React.ReactElement | null | false;
+  messagingModeToggle?: React.ReactNode;
   historyButton?: React.ReactNode;
   // prompt history provider
   getPromptHistory?: () => string[];
@@ -51,6 +53,7 @@ export interface PromptInputProps {
   onBashCommand?: (command: string) => void;
   onBashModeChange?: (isBashMode: boolean) => void;
   onCancel?: () => void;
+  onToggleMessagingMode?: () => void;
   onAttachFiles?: (files: File[]) => void;
   onEmptyChange?: (isEmpty: boolean) => void;
   onFocus?: () => void;
@@ -82,6 +85,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       enableCommands = true,
       modelSelector,
       reasoningSelector,
+      messagingModeToggle,
       historyButton,
       getPromptHistory,
       onBeforeSubmit,
@@ -89,6 +93,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       onBashCommand,
       onBashModeChange,
       onCancel,
+      onToggleMessagingMode,
       onAttachFiles,
       onEmptyChange,
       onFocus,
@@ -238,6 +243,23 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       [editor, modeOption, onModeChange, allowBypassPermissions, disabled],
     );
 
+    useHotkeys(
+      SHORTCUTS.SWITCH_MESSAGING_MODE,
+      (e) => {
+        if (!editor?.isFocused) return;
+        if (hasOpenOverlay()) return;
+        if (!onToggleMessagingMode) return;
+        e.preventDefault();
+        onToggleMessagingMode();
+      },
+      {
+        enableOnFormTags: true,
+        enableOnContentEditable: true,
+        enabled: !disabled && !!onToggleMessagingMode,
+      },
+      [editor, onToggleMessagingMode, disabled],
+    );
+
     const handleContainerClick = useCallback(
       (e: React.MouseEvent) => {
         const target = e.target as HTMLElement;
@@ -344,6 +366,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
             )}
             {modelSelector && <span>{modelSelector}</span>}
             {reasoningSelector && <span>{reasoningSelector}</span>}
+            {messagingModeToggle && <span>{messagingModeToggle}</span>}
             {isBashMode && (
               <Text className="font-mono text-(--blue-9) text-[13px]">
                 ! bash

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -22,7 +22,9 @@ import { PlanStatusBar } from "@posthog/ui/features/sessions/components/PlanStat
 import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components/ReasoningLevelSelector";
 import { RawLogsView } from "@posthog/ui/features/sessions/components/raw-logs/RawLogsView";
 import { SessionResourcesBar } from "@posthog/ui/features/sessions/components/SessionResourcesBar";
+import { SteerQueueToggle } from "@posthog/ui/features/sessions/components/SteerQueueToggle";
 import { CHAT_CONTENT_MAX_WIDTH } from "@posthog/ui/features/sessions/constants";
+import { useToggleMessagingMode } from "@posthog/ui/features/sessions/hooks/useToggleMessagingMode";
 import {
   useAdapterForTask,
   useModeConfigOptionForTask,
@@ -161,6 +163,7 @@ export function SessionView({
   const modeOption = useModeConfigOptionForTask(taskId);
   const thoughtOption = useThoughtLevelConfigOptionForTask(taskId);
   const adapter = useAdapterForTask(taskId);
+  const toggleMessagingMode = useToggleMessagingMode(taskId);
   const { allowBypassPermissions } = useSettingsStore();
   const { isOnline } = useConnectivity();
   const currentModeId = modeOption?.currentValue;
@@ -625,6 +628,12 @@ export function SessionView({
                               />
                             ) : null
                           }
+                          messagingModeToggle={
+                            taskId ? (
+                              <SteerQueueToggle taskId={taskId} />
+                            ) : undefined
+                          }
+                          onToggleMessagingMode={toggleMessagingMode}
                           onBeforeSubmit={handleBeforeSubmit}
                           onSubmit={handleSubmit}
                           onBashCommand={onBashCommand}

--- a/packages/ui/src/features/sessions/components/SteerQueueToggle.tsx
+++ b/packages/ui/src/features/sessions/components/SteerQueueToggle.tsx
@@ -1,0 +1,63 @@
+import { Lightning, Stack } from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
+import {
+  formatHotkey,
+  SHORTCUTS,
+} from "@posthog/ui/features/command/keyboard-shortcuts";
+import {
+  useMessagingMode,
+  useSupportsNativeSteer,
+} from "@posthog/ui/features/sessions/hooks/useMessagingMode";
+import { useToggleMessagingMode } from "@posthog/ui/features/sessions/hooks/useToggleMessagingMode";
+import { useQueuedMessagesForTask } from "@posthog/ui/features/sessions/useSession";
+import { Tooltip } from "@radix-ui/themes";
+
+interface SteerQueueToggleProps {
+  taskId: string;
+  disabled?: boolean;
+}
+
+export function SteerQueueToggle({ taskId, disabled }: SteerQueueToggleProps) {
+  const mode = useMessagingMode(taskId);
+  const supportsNativeSteer = useSupportsNativeSteer(taskId);
+  const queuedCount = useQueuedMessagesForTask(taskId).length;
+  const toggle = useToggleMessagingMode(taskId);
+
+  const isSteer = mode === "steer";
+  const shortcut = formatHotkey(SHORTCUTS.SWITCH_MESSAGING_MODE);
+  const label = isSteer
+    ? "Steer"
+    : queuedCount > 0
+      ? `Queue (${queuedCount})`
+      : "Queue";
+
+  const tooltip = isSteer
+    ? supportsNativeSteer
+      ? `Steer: injects your message mid-turn at the next tool boundary. ${shortcut} to switch to Queue.`
+      : `Steer: interrupts the current turn and resends with your message. ${shortcut} to switch to Queue.`
+    : `Queue: holds messages until the current turn ends. ${shortcut} to switch to Steer.`;
+
+  const colorClass = isSteer ? "text-purple-11" : "text-gray-11";
+
+  return (
+    <Tooltip content={tooltip}>
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        disabled={disabled}
+        aria-label={`Messaging mode: ${label}`}
+        onClick={toggle}
+      >
+        <span className={colorClass}>
+          {isSteer ? (
+            <Lightning size={12} weight="fill" />
+          ) : (
+            <Stack size={12} />
+          )}
+        </span>
+        <span className={colorClass}>{label}</span>
+      </Button>
+    </Tooltip>
+  );
+}

--- a/packages/ui/src/features/sessions/components/SteerQueueToggle.tsx
+++ b/packages/ui/src/features/sessions/components/SteerQueueToggle.tsx
@@ -14,10 +14,9 @@ import { Tooltip } from "@radix-ui/themes";
 
 interface SteerQueueToggleProps {
   taskId: string;
-  disabled?: boolean;
 }
 
-export function SteerQueueToggle({ taskId, disabled }: SteerQueueToggleProps) {
+export function SteerQueueToggle({ taskId }: SteerQueueToggleProps) {
   const mode = useMessagingMode(taskId);
   const supportsNativeSteer = useSupportsNativeSteer(taskId);
   const queuedCount = useQueuedMessagesForTask(taskId).length;
@@ -45,7 +44,6 @@ export function SteerQueueToggle({ taskId, disabled }: SteerQueueToggleProps) {
         type="button"
         variant="default"
         size="sm"
-        disabled={disabled}
         aria-label={`Messaging mode: ${label}`}
         onClick={toggle}
       >

--- a/packages/ui/src/features/sessions/hooks/useMessagingMode.ts
+++ b/packages/ui/src/features/sessions/hooks/useMessagingMode.ts
@@ -1,0 +1,30 @@
+import {
+  type MessagingMode,
+  useMessagingModeStore,
+} from "@posthog/ui/features/sessions/messagingModeStore";
+import { useSessionStore } from "@posthog/ui/features/sessions/sessionStore";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+
+/** Effective messaging mode for a task: per-task override, else global default. */
+export function useMessagingMode(taskId: string | undefined): MessagingMode {
+  const override = useMessagingModeStore((s) =>
+    taskId ? s.modesByTaskId[taskId] : undefined,
+  );
+  const globalDefault = useSettingsStore((s) => s.defaultMessagingMode);
+  return override ?? globalDefault;
+}
+
+/**
+ * Whether the task's session steers natively (Claude, local) versus falling
+ * back to interrupt-and-resend (Codex, cloud). Drives the steer label/tooltip,
+ * not whether steer is allowed: every adapter supports steer in some form.
+ */
+export function useSupportsNativeSteer(taskId: string | undefined): boolean {
+  return useSessionStore((s) => {
+    if (!taskId) return false;
+    const taskRunId = s.taskIdIndex[taskId];
+    if (!taskRunId) return false;
+    const session = s.sessions[taskRunId];
+    return !!session && !session.isCloud && session.adapter === "claude";
+  });
+}

--- a/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
@@ -10,6 +10,7 @@ import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
 import { tryExecuteCodeCommand } from "@posthog/ui/features/message-editor/commands";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
+import { useMessagingMode } from "@posthog/ui/features/sessions/hooks/useMessagingMode";
 import {
   type AgentSession,
   sessionStoreSetters,
@@ -47,6 +48,8 @@ export function useSessionCallbacks({
   const sessionRef = useRef(session);
   sessionRef.current = session;
 
+  const messagingMode = useMessagingMode(taskId);
+
   const handleSendPrompt = useCallback(
     async (text: string) => {
       const currentSession = sessionRef.current;
@@ -68,7 +71,9 @@ export function useSessionCallbacks({
       try {
         markAsViewed(taskId);
         markActivity(taskId);
-        await sessionService.sendPrompt(taskId, text);
+        await sessionService.sendPrompt(taskId, text, {
+          steer: messagingMode === "steer",
+        });
 
         const view = getAppViewSnapshot();
         const isViewingTask =
@@ -90,6 +95,7 @@ export function useSessionCallbacks({
       markAsViewed,
       task.latest_run,
       sessionService,
+      messagingMode,
     ],
   );
 

--- a/packages/ui/src/features/sessions/hooks/useToggleMessagingMode.ts
+++ b/packages/ui/src/features/sessions/hooks/useToggleMessagingMode.ts
@@ -29,14 +29,24 @@ export function useToggleMessagingMode(taskId: string | undefined): () => void {
     if (next === "steer") {
       // Flush buffered messages into the running turn in queued order so a
       // message typed first lands first. rawPrompt preserves rich content.
+      // They are already dequeued, so roll any failed send back onto the queue
+      // rather than dropping it silently.
       const queued = sessionStoreSetters.dequeueMessages(taskId);
       void (async () => {
+        const failed: typeof queued = [];
         for (const message of queued) {
-          await sessionService
-            .sendPrompt(taskId, message.rawPrompt ?? message.content, {
-              steer: true,
-            })
-            .catch(() => {});
+          try {
+            await sessionService.sendPrompt(
+              taskId,
+              message.rawPrompt ?? message.content,
+              { steer: true },
+            );
+          } catch {
+            failed.push(message);
+          }
+        }
+        if (failed.length > 0) {
+          sessionStoreSetters.prependQueuedMessages(taskId, failed);
         }
       })();
     }

--- a/packages/ui/src/features/sessions/hooks/useToggleMessagingMode.ts
+++ b/packages/ui/src/features/sessions/hooks/useToggleMessagingMode.ts
@@ -1,0 +1,38 @@
+import {
+  SESSION_SERVICE,
+  type SessionService,
+} from "@posthog/core/sessions/sessionService";
+import { useService } from "@posthog/di/react";
+import { useMessagingMode } from "@posthog/ui/features/sessions/hooks/useMessagingMode";
+import { useMessagingModeStore } from "@posthog/ui/features/sessions/messagingModeStore";
+import { sessionStoreSetters } from "@posthog/ui/features/sessions/sessionStore";
+import { useCallback } from "react";
+
+/**
+ * Toggle a task between Steer and Queue, transferring pending messages so they
+ * follow the new mode:
+ * - Queue -> Steer: locally buffered messages are flushed into the running turn
+ *   as steers (sent to the backend now).
+ * - Steer -> Queue: future messages buffer locally. Steers already handed to the
+ *   backend keep injecting; the Claude SDK exposes no way to recall them.
+ */
+export function useToggleMessagingMode(taskId: string | undefined): () => void {
+  const sessionService = useService<SessionService>(SESSION_SERVICE);
+  const mode = useMessagingMode(taskId);
+  const setMode = useMessagingModeStore((s) => s.setMode);
+
+  return useCallback(() => {
+    if (!taskId) return;
+    const next = mode === "steer" ? "queue" : "steer";
+    setMode(taskId, next);
+
+    if (next === "steer") {
+      const queued = sessionStoreSetters.dequeueMessages(taskId);
+      for (const message of queued) {
+        void sessionService.sendPrompt(taskId, message.content, {
+          steer: true,
+        });
+      }
+    }
+  }, [taskId, mode, setMode, sessionService]);
+}

--- a/packages/ui/src/features/sessions/hooks/useToggleMessagingMode.ts
+++ b/packages/ui/src/features/sessions/hooks/useToggleMessagingMode.ts
@@ -27,12 +27,18 @@ export function useToggleMessagingMode(taskId: string | undefined): () => void {
     setMode(taskId, next);
 
     if (next === "steer") {
+      // Flush buffered messages into the running turn in queued order so a
+      // message typed first lands first. rawPrompt preserves rich content.
       const queued = sessionStoreSetters.dequeueMessages(taskId);
-      for (const message of queued) {
-        void sessionService.sendPrompt(taskId, message.content, {
-          steer: true,
-        });
-      }
+      void (async () => {
+        for (const message of queued) {
+          await sessionService
+            .sendPrompt(taskId, message.rawPrompt ?? message.content, {
+              steer: true,
+            })
+            .catch(() => {});
+        }
+      })();
     }
   }, [taskId, mode, setMode, sessionService]);
 }

--- a/packages/ui/src/features/sessions/messagingModeStore.test.ts
+++ b/packages/ui/src/features/sessions/messagingModeStore.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useMessagingModeStore } from "./messagingModeStore";
+
+describe("messagingModeStore", () => {
+  beforeEach(() => {
+    useMessagingModeStore.setState({ modesByTaskId: {} });
+  });
+
+  it("stores a per-task mode override", () => {
+    useMessagingModeStore.getState().setMode("task-1", "steer");
+    expect(useMessagingModeStore.getState().modesByTaskId["task-1"]).toBe(
+      "steer",
+    );
+  });
+
+  it("keeps overrides independent per task", () => {
+    useMessagingModeStore.getState().setMode("task-1", "steer");
+    useMessagingModeStore.getState().setMode("task-2", "queue");
+    expect(useMessagingModeStore.getState().modesByTaskId).toEqual({
+      "task-1": "steer",
+      "task-2": "queue",
+    });
+  });
+});

--- a/packages/ui/src/features/sessions/messagingModeStore.ts
+++ b/packages/ui/src/features/sessions/messagingModeStore.ts
@@ -1,0 +1,27 @@
+import { electronStorage } from "@posthog/ui/shell/rendererStorage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type MessagingMode = "queue" | "steer";
+
+interface MessagingModeState {
+  modesByTaskId: Record<string, MessagingMode>;
+  setMode: (taskId: string, mode: MessagingMode) => void;
+}
+
+export const useMessagingModeStore = create<MessagingModeState>()(
+  persist(
+    (set) => ({
+      modesByTaskId: {},
+      setMode: (taskId, mode) =>
+        set((state) => ({
+          modesByTaskId: { ...state.modesByTaskId, [taskId]: mode },
+        })),
+    }),
+    {
+      name: "messaging-mode-storage",
+      storage: electronStorage,
+      partialize: (state) => ({ modesByTaskId: state.modesByTaskId }),
+    },
+  ),
+);

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -12,6 +12,7 @@ import {
   type AutoConvertLongText,
   type CompletionSound,
   type DefaultInitialTaskMode,
+  type DefaultMessagingMode,
   type DefaultReasoningEffort,
   type DiffOpenMode,
   type SendMessagesWith,
@@ -82,6 +83,7 @@ export function GeneralSettings() {
     completionVolume,
     autoConvertLongText,
     defaultInitialTaskMode,
+    defaultMessagingMode,
     defaultReasoningEffort,
     diffOpenMode,
     sendMessagesWith,
@@ -94,6 +96,7 @@ export function GeneralSettings() {
     setCompletionVolume,
     setAutoConvertLongText,
     setDefaultInitialTaskMode,
+    setDefaultMessagingMode,
     setDefaultReasoningEffort,
     setDiffOpenMode,
     setSendMessagesWith,
@@ -197,6 +200,18 @@ export function GeneralSettings() {
       setDefaultInitialTaskMode(value);
     },
     [defaultInitialTaskMode, setDefaultInitialTaskMode],
+  );
+
+  const handleDefaultMessagingModeChange = useCallback(
+    (value: DefaultMessagingMode) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "default_messaging_mode",
+        new_value: value,
+        old_value: defaultMessagingMode,
+      });
+      setDefaultMessagingMode(value);
+    },
+    [defaultMessagingMode, setDefaultMessagingMode],
   );
 
   const handleDefaultReasoningEffortChange = useCallback(
@@ -416,6 +431,25 @@ export function GeneralSettings() {
           <Select.Content>
             <Select.Item value="plan">Plan</Select.Item>
             <Select.Item value="last_used">Last used</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </SettingRow>
+
+      <SettingRow
+        label="Default messaging mode"
+        description="Mode new sessions start in. Steer applies messages mid-turn. Queue holds them until the turn ends."
+      >
+        <Select.Root
+          value={defaultMessagingMode}
+          onValueChange={(value) =>
+            handleDefaultMessagingModeChange(value as DefaultMessagingMode)
+          }
+          size="1"
+        >
+          <Select.Trigger className="min-w-[100px]" />
+          <Select.Content>
+            <Select.Item value="queue">Queue</Select.Item>
+            <Select.Item value="steer">Steer</Select.Item>
           </Select.Content>
         </Select.Root>
       </SettingRow>

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -13,6 +13,7 @@ export type DefaultRunMode = "local" | "cloud" | "last_used";
 export type LocalWorkspaceMode = "worktree" | "local";
 export type AgentAdapter = "claude" | "codex";
 export type DefaultInitialTaskMode = "plan" | "last_used";
+export type DefaultMessagingMode = "queue" | "steer";
 export type DefaultReasoningEffort =
   | "low"
   | "medium"
@@ -68,6 +69,8 @@ interface SettingsStore {
   defaultInitialTaskMode: DefaultInitialTaskMode;
   lastUsedInitialTaskMode: ExecutionMode;
   defaultReasoningEffort: DefaultReasoningEffort;
+  defaultMessagingMode: DefaultMessagingMode;
+  setDefaultMessagingMode: (mode: DefaultMessagingMode) => void;
   setDefaultRunMode: (mode: DefaultRunMode) => void;
   setLastUsedRunMode: (mode: "local" | "cloud") => void;
   setLastUsedLocalWorkspaceMode: (mode: LocalWorkspaceMode) => void;
@@ -163,6 +166,7 @@ export const useSettingsStore = create<SettingsStore>()(
       defaultInitialTaskMode: "plan",
       lastUsedInitialTaskMode: "plan",
       defaultReasoningEffort: "last_used",
+      defaultMessagingMode: "queue",
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
       setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
       setLastUsedLocalWorkspaceMode: (mode) =>
@@ -192,6 +196,7 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ lastUsedInitialTaskMode: mode }),
       setDefaultReasoningEffort: (effort) =>
         set({ defaultReasoningEffort: effort }),
+      setDefaultMessagingMode: (mode) => set({ defaultMessagingMode: mode }),
 
       // Notifications
       desktopNotifications: true,
@@ -301,6 +306,7 @@ export const useSettingsStore = create<SettingsStore>()(
         defaultInitialTaskMode: state.defaultInitialTaskMode,
         lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,
         defaultReasoningEffort: state.defaultReasoningEffort,
+        defaultMessagingMode: state.defaultMessagingMode,
 
         // Notifications
         desktopNotifications: state.desktopNotifications,

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -1041,10 +1041,26 @@ When creating pull requests, add the following footer at the end of the PR descr
   async prompt(
     sessionId: string,
     prompt: ContentBlock[],
+    options?: { steer?: boolean },
   ): Promise<PromptOutput> {
     const session = this.sessions.get(sessionId);
     if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    // A steer is injected into the turn that is already running, which owns the
+    // promptPending/sleep/idle lifecycle. Forward it fire-and-forget so this
+    // call does not flip that shared state out from under the live turn.
+    if (options?.steer) {
+      const result = await session.clientSideConnection.prompt({
+        sessionId: getAgentSessionId(session),
+        prompt,
+        _meta: { steer: true },
+      });
+      return {
+        stopReason: result.stopReason,
+        _meta: result._meta as PromptOutput["_meta"],
+      };
     }
 
     // Prepend pending context if present

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -138,6 +138,7 @@ export const contentBlockSchema = z.looseObject({
 export const promptInput = z.object({
   sessionId: z.string(),
   prompt: z.array(contentBlockSchema),
+  steer: z.boolean().optional(),
 });
 
 export type PromptInput = z.infer<typeof promptInput>;


### PR DESCRIPTION
## Problem

Messages sent while the agent was working could only queue until the turn finished, so there was no way to steer a run already in progress.

Closes https://github.com/PostHog/code/issues/1056

## Changes

- Add a Steer/Queue toggle to the composer, a `mod+s` shortcut and a "Default messaging mode" setting in General settings
- Steer Claude local turns natively by folding the message into the running turn at the next tool boundary (`priority: "next"`)
- Fall back to interrupt-and-resend for Codex and cloud sessions
- Persist a per-task mode override layered over the global default
- Skip turn-state bookkeeping for steer messages so the running turn keeps its prompt lifecycle
- Thread `steer` through the agent prompt router, schema and workspace-server

## How did you test this?
Manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?