### PR TITLE
fix(ci): Bump react-doctor to 0.5.4 to fix monorepo scan

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -59,7 +59,7 @@ jobs:
           fi
           REPORT="${RUNNER_TEMP}/react-doctor-report.json"
           status=0
-          npx --yes react-doctor@0.4.2 . --blocking error --changed-files-from "$CHANGED" --json --json-compact --no-telemetry > "$REPORT" || status=$?
+          npx --yes react-doctor@0.5.4 . --blocking error --changed-files-from "$CHANGED" --json --json-compact --no-telemetry > "$REPORT" || status=$?
           echo "exit-code=$status" >> "$GITHUB_OUTPUT"
           echo "report=$REPORT" >> "$GITHUB_OUTPUT"
           if [ "$status" -ne 0 ]; then


### PR DESCRIPTION
## Problem

React Doctor cannot complete on this pnpm monorepo. Version 0.4.2 roots its diff baseline at the repo root, whose `package.json` has no React dependency, so every PR scan crashes with `NoReactDependencyError` before any file is checked.

## Changes

1. Bump the pinned `react-doctor` from `0.4.2` to `0.5.4` in `.github/workflows/react-doctor.yml`. 0.5.4 fixes the monorepo baseline so the scan maps changed files to their workspace packages (`packages/ui`, `apps/*`, ...) instead of the React-less repo root.

## How did you test this?

Reproduced the exact CI invocation locally (same base SHA, changed-files list and flags):

1. `0.4.2` reproduces the reported failure: `NoReactDependencyError` on the baseline temp dir.
2. `0.5.4` passes: `ok: true`, `error: null`, exit code `0`. It correctly scans the changed React files in `packages/ui` and surfaces one `jsx-no-jsx-as-prop` warning, which does not block under `--blocking error`.
3. Confirmed CI can still fetch `0.5.4`: `min-release-age` is an npm 11+ feature and CI's node-22 ships npm 10, which ignores it (the same reason the recent `0.4.2` downloaded there).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
