### PR TITLE
feat(archive): Add undo button to task archived toast

### DIFF
--- a/packages/ui/src/features/archive/undoArchive.test.ts
+++ b/packages/ui/src/features/archive/undoArchive.test.ts
@@ -30,7 +30,7 @@ describe("undoArchive", () => {
 
     expect(restore).toHaveBeenCalledTimes(1);
     expect(restore).toHaveBeenCalledWith("task-1", true);
-    expect(toastSuccess).toHaveBeenCalledWith("Task Archive Undone");
+    expect(toastSuccess).toHaveBeenCalledWith("Task archive undone");
     expect(toastError).not.toHaveBeenCalled();
   });
 
@@ -50,7 +50,7 @@ describe("undoArchive", () => {
     expect(restore).toHaveBeenNthCalledWith(2, "task-1", true, {
       recreateBranch: true,
     });
-    expect(toastSuccess).toHaveBeenCalledWith("Task Archive Undone");
+    expect(toastSuccess).toHaveBeenCalledWith("Task archive undone");
     expect(toastError).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/features/archive/undoArchive.test.ts
+++ b/packages/ui/src/features/archive/undoArchive.test.ts
@@ -21,7 +21,7 @@ describe("undoArchive", () => {
     toastError.mockClear();
   });
 
-  it("restores on the first attempt and confirms with a success toast", async () => {
+  it("restores on the first attempt and confirms with a toast", async () => {
     const restore = vi
       .fn()
       .mockResolvedValue({ kind: "restored", navigateToTaskId: "task-1" });
@@ -30,7 +30,7 @@ describe("undoArchive", () => {
 
     expect(restore).toHaveBeenCalledTimes(1);
     expect(restore).toHaveBeenCalledWith("task-1", true);
-    expect(toastSuccess).toHaveBeenCalledWith("Task restored");
+    expect(toastSuccess).toHaveBeenCalledWith("Task undone");
     expect(toastError).not.toHaveBeenCalled();
   });
 
@@ -50,7 +50,7 @@ describe("undoArchive", () => {
     expect(restore).toHaveBeenNthCalledWith(2, "task-1", true, {
       recreateBranch: true,
     });
-    expect(toastSuccess).toHaveBeenCalledWith("Task restored");
+    expect(toastSuccess).toHaveBeenCalledWith("Task undone");
     expect(toastError).not.toHaveBeenCalled();
   });
 
@@ -89,5 +89,23 @@ describe("undoArchive", () => {
 
     expect(toastError).toHaveBeenCalledWith("Failed to restore task");
     expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("ignores a repeated undo while the first is still in flight", async () => {
+    let resolveRestore: (value: unknown) => void = () => {};
+    const restore = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRestore = resolve;
+        }),
+    );
+
+    const first = undoArchive("task-1", restore as unknown as Restore);
+    const second = undoArchive("task-1", restore as unknown as Restore);
+    resolveRestore({ kind: "restored", navigateToTaskId: "task-1" });
+    await Promise.all([first, second]);
+
+    expect(restore).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/features/archive/undoArchive.test.ts
+++ b/packages/ui/src/features/archive/undoArchive.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UseUnarchiveTask } from "./useUnarchiveTask";
+
+const toastSuccess = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@posthog/ui/primitives/toast", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+vi.mock("@posthog/ui/shell/logger", () => ({
+  logger: { scope: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }) },
+}));
+
+import { undoArchive } from "./undoArchive";
+
+type Restore = UseUnarchiveTask["restore"];
+
+describe("undoArchive", () => {
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  it("restores on the first attempt and confirms with a success toast", async () => {
+    const restore = vi
+      .fn()
+      .mockResolvedValue({ kind: "restored", navigateToTaskId: "task-1" });
+
+    await undoArchive("task-1", restore as unknown as Restore);
+
+    expect(restore).toHaveBeenCalledTimes(1);
+    expect(restore).toHaveBeenCalledWith("task-1", true);
+    expect(toastSuccess).toHaveBeenCalledWith("Task restored");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("retries with branch recreation when the branch is missing", async () => {
+    const restore = vi
+      .fn()
+      .mockResolvedValueOnce({
+        kind: "branch-not-found",
+        taskId: "task-1",
+        branchName: "feat/x",
+      })
+      .mockResolvedValueOnce({ kind: "restored", navigateToTaskId: "task-1" });
+
+    await undoArchive("task-1", restore as unknown as Restore);
+
+    expect(restore).toHaveBeenNthCalledWith(1, "task-1", true);
+    expect(restore).toHaveBeenNthCalledWith(2, "task-1", true, {
+      recreateBranch: true,
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Task restored");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when the branch is still missing after retry", async () => {
+    const restore = vi.fn().mockResolvedValue({
+      kind: "branch-not-found",
+      taskId: "task-1",
+      branchName: "feat/x",
+    });
+
+    await undoArchive("task-1", restore as unknown as Restore);
+
+    expect(restore).toHaveBeenCalledTimes(2);
+    expect(toastError).toHaveBeenCalledWith(
+      "Failed to restore task: branch 'feat/x' not found",
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the error message when restore reports an error", async () => {
+    const restore = vi
+      .fn()
+      .mockResolvedValue({ kind: "error", message: "server boom" });
+
+    await undoArchive("task-1", restore as unknown as Restore);
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Failed to restore task: server boom",
+    );
+  });
+
+  it("shows a generic error toast when restore throws", async () => {
+    const restore = vi.fn().mockRejectedValue(new Error("network down"));
+
+    await undoArchive("task-1", restore as unknown as Restore);
+
+    expect(toastError).toHaveBeenCalledWith("Failed to restore task");
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/features/archive/undoArchive.test.ts
+++ b/packages/ui/src/features/archive/undoArchive.test.ts
@@ -30,7 +30,7 @@ describe("undoArchive", () => {
 
     expect(restore).toHaveBeenCalledTimes(1);
     expect(restore).toHaveBeenCalledWith("task-1", true);
-    expect(toastSuccess).toHaveBeenCalledWith("Task undone");
+    expect(toastSuccess).toHaveBeenCalledWith("Task Archive Undone");
     expect(toastError).not.toHaveBeenCalled();
   });
 
@@ -50,7 +50,7 @@ describe("undoArchive", () => {
     expect(restore).toHaveBeenNthCalledWith(2, "task-1", true, {
       recreateBranch: true,
     });
-    expect(toastSuccess).toHaveBeenCalledWith("Task undone");
+    expect(toastSuccess).toHaveBeenCalledWith("Task Archive Undone");
     expect(toastError).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/features/archive/undoArchive.ts
+++ b/packages/ui/src/features/archive/undoArchive.ts
@@ -4,10 +4,14 @@ import type { UseUnarchiveTask } from "./useUnarchiveTask";
 
 const log = logger.scope("undo-archive");
 
+const inFlight = new Set<string>();
+
 export async function undoArchive(
   taskId: string,
   restore: UseUnarchiveTask["restore"],
 ): Promise<void> {
+  if (inFlight.has(taskId)) return;
+  inFlight.add(taskId);
   try {
     let outcome = await restore(taskId, true);
     // Undo is a transient toast action: silently recreate a missing branch
@@ -16,7 +20,7 @@ export async function undoArchive(
       outcome = await restore(taskId, true, { recreateBranch: true });
     }
     if (outcome.kind === "restored") {
-      toast.success("Task restored");
+      toast.success("Task undone");
       return;
     }
     const reason =
@@ -28,5 +32,7 @@ export async function undoArchive(
   } catch (error) {
     log.error("Failed to restore archived task", error);
     toast.error("Failed to restore task");
+  } finally {
+    inFlight.delete(taskId);
   }
 }

--- a/packages/ui/src/features/archive/undoArchive.ts
+++ b/packages/ui/src/features/archive/undoArchive.ts
@@ -20,7 +20,7 @@ export async function undoArchive(
       outcome = await restore(taskId, true, { recreateBranch: true });
     }
     if (outcome.kind === "restored") {
-      toast.success("Task undone");
+      toast.success("Task Archive Undone");
       return;
     }
     const reason =

--- a/packages/ui/src/features/archive/undoArchive.ts
+++ b/packages/ui/src/features/archive/undoArchive.ts
@@ -20,7 +20,7 @@ export async function undoArchive(
       outcome = await restore(taskId, true, { recreateBranch: true });
     }
     if (outcome.kind === "restored") {
-      toast.success("Task Archive Undone");
+      toast.success("Task archive undone");
       return;
     }
     const reason =

--- a/packages/ui/src/features/archive/undoArchive.ts
+++ b/packages/ui/src/features/archive/undoArchive.ts
@@ -1,0 +1,32 @@
+import { toast } from "@posthog/ui/primitives/toast";
+import { logger } from "@posthog/ui/shell/logger";
+import type { UseUnarchiveTask } from "./useUnarchiveTask";
+
+const log = logger.scope("undo-archive");
+
+export async function undoArchive(
+  taskId: string,
+  restore: UseUnarchiveTask["restore"],
+): Promise<void> {
+  try {
+    let outcome = await restore(taskId, true);
+    // Undo is a transient toast action: silently recreate a missing branch
+    // rather than interrupting with the Archived tasks page's confirm dialog.
+    if (outcome.kind === "branch-not-found") {
+      outcome = await restore(taskId, true, { recreateBranch: true });
+    }
+    if (outcome.kind === "restored") {
+      toast.success("Task restored");
+      return;
+    }
+    const reason =
+      outcome.kind === "branch-not-found"
+        ? `branch '${outcome.branchName}' not found`
+        : outcome.message;
+    log.error("Failed to restore archived task", { taskId, reason });
+    toast.error(`Failed to restore task: ${reason}`);
+  } catch (error) {
+    log.error("Failed to restore archived task", error);
+    toast.error("Failed to restore task");
+  }
+}

--- a/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/packages/ui/src/features/archive/useArchiveTask.ts
@@ -29,9 +29,12 @@ import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { logger } from "@posthog/ui/shell/logger";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { type UseUnarchiveTask, useUnarchiveTask } from "./useUnarchiveTask";
+import { undoArchive } from "./undoArchive";
+import { useUnarchiveTask } from "./useUnarchiveTask";
 
 const log = logger.scope("archive-task");
+
+const UNDO_TOAST_DURATION_MS = 8000;
 
 export interface ArchiveCacheKeys {
   archivedTaskIdsQueryKey: readonly unknown[];
@@ -170,19 +173,6 @@ export async function archiveTasksImperative(
   );
 }
 
-async function undoArchive(
-  taskId: string,
-  restore: UseUnarchiveTask["restore"],
-) {
-  let outcome = await restore(taskId, true);
-  if (outcome.kind === "branch-not-found") {
-    outcome = await restore(taskId, true, { recreateBranch: true });
-  }
-  if (outcome.kind === "error") {
-    toast.error(`Failed to restore task: ${outcome.message}`);
-  }
-}
-
 export function useArchiveTask() {
   const queryClient = useQueryClient();
   const keys = useArchiveCacheKeys();
@@ -195,7 +185,7 @@ export function useArchiveTask() {
       optimistic: false,
     });
     toast.success("Task archived", {
-      duration: 8000,
+      duration: UNDO_TOAST_DURATION_MS,
       action: {
         label: "Undo",
         onClick: () => void undoArchive(taskId, restore),

--- a/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/packages/ui/src/features/archive/useArchiveTask.ts
@@ -184,11 +184,16 @@ export function useArchiveTask() {
     await archiveTaskImperative(taskId, queryClient, keys, {
       optimistic: false,
     });
+    const toastId = `archive-undo-${taskId}`;
     toast.success("Task archived", {
+      id: toastId,
       duration: UNDO_TOAST_DURATION_MS,
       action: {
         label: "Undo",
-        onClick: () => void undoArchive(taskId, restore),
+        onClick: () => {
+          toast.dismiss(toastId);
+          void undoArchive(taskId, restore);
+        },
       },
     });
   };

--- a/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/packages/ui/src/features/archive/useArchiveTask.ts
@@ -29,6 +29,7 @@ import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { logger } from "@posthog/ui/shell/logger";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { type UseUnarchiveTask, useUnarchiveTask } from "./useUnarchiveTask";
 
 const log = logger.scope("archive-task");
 
@@ -169,9 +170,23 @@ export async function archiveTasksImperative(
   );
 }
 
+async function undoArchive(
+  taskId: string,
+  restore: UseUnarchiveTask["restore"],
+) {
+  let outcome = await restore(taskId, true);
+  if (outcome.kind === "branch-not-found") {
+    outcome = await restore(taskId, true, { recreateBranch: true });
+  }
+  if (outcome.kind === "error") {
+    toast.error(`Failed to restore task: ${outcome.message}`);
+  }
+}
+
 export function useArchiveTask() {
   const queryClient = useQueryClient();
   const keys = useArchiveCacheKeys();
+  const { restore } = useUnarchiveTask();
 
   const archiveTask = async ({ taskId }: { taskId: string }) => {
     // Non-optimistic: keep the row in place (with a spinner) until the archive
@@ -179,7 +194,13 @@ export function useArchiveTask() {
     await archiveTaskImperative(taskId, queryClient, keys, {
       optimistic: false,
     });
-    toast.success("Task archived");
+    toast.success("Task archived", {
+      duration: 8000,
+      action: {
+        label: "Undo",
+        onClick: () => void undoArchive(taskId, restore),
+      },
+    });
   };
 
   return { archiveTask };

--- a/packages/ui/src/primitives/toast.tsx
+++ b/packages/ui/src/primitives/toast.tsx
@@ -103,6 +103,7 @@ export const toast = {
       description?: string;
       id?: string | number;
       action?: ToastAction;
+      duration?: number;
     },
   ) => {
     return sonnerToast.custom(
@@ -115,7 +116,7 @@ export const toast = {
           action={options?.action}
         />
       ),
-      { id: options?.id },
+      { id: options?.id, duration: options?.duration },
     );
   },
 

--- a/packages/ui/src/primitives/toast.tsx
+++ b/packages/ui/src/primitives/toast.tsx
@@ -86,6 +86,8 @@ function ToastComponent(props: ToastProps) {
 }
 
 export const toast = {
+  dismiss: (id?: string | number) => sonnerToast.dismiss(id),
+
   loading: (title: ReactNode, description?: string) => {
     return sonnerToast.custom((id) => (
       <ToastComponent


### PR DESCRIPTION
## Problem

Archiving a task is easy to trigger by accident, and the only way to reverse it is to open the Archived tasks page and unarchive from there. There is no quick in-place undo.

## Changes

1. Add an Undo action to the "Task archived" toast that restores the task in place
2. Reuse the existing `useUnarchiveTask().restore()` flow, no new API or server changes
3. On the rare branch-not-found case, auto-retry with branch recreation and surface a toast error only on hard failure
4. Add a `duration` option to `toast.success` and keep the archived toast up ~8s for reaction time

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` passes
- `pnpm exec biome lint` on both changed files is clean (also enforced by the pre-commit hook)
- Manual in-app verification (archive then Undo from the sidebar) not yet run; the Undo reuses the same restore path the Archived tasks page already uses

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?