### PR TITLE
feat(inbox): restore analytics events dropped in Inbox 2.0

### DIFF
--- a/packages/core/src/inbox/engagement.test.ts
+++ b/packages/core/src/inbox/engagement.test.ts
@@ -1,0 +1,125 @@
+import type { SignalReport } from "@posthog/shared/types";
+import { describe, expect, it } from "vitest";
+import { buildInboxViewedProperties } from "./engagement";
+
+function fakeReport(overrides: Partial<SignalReport> = {}): SignalReport {
+  return {
+    id: "r1",
+    title: "Test report",
+    summary: "Summary",
+    status: "ready",
+    total_weight: 1,
+    signal_count: 1,
+    created_at: "2026-06-05T00:00:00Z",
+    updated_at: "2026-06-05T00:00:00Z",
+    artefact_count: 0,
+    priority: null,
+    actionability: null,
+    is_suggested_reviewer: false,
+    source_products: [],
+    implementation_pr_url: null,
+    ...overrides,
+  };
+}
+
+const NO_FILTERS = {
+  sourceProductFilter: [],
+  priorityFilter: [],
+  searchQuery: "",
+  isDefaultScope: true,
+};
+
+describe("buildInboxViewedProperties", () => {
+  it("counts visible reports, tab badges, and total", () => {
+    const props = buildInboxViewedProperties({
+      visibleReports: [fakeReport({ id: "a" }), fakeReport({ id: "b" })],
+      totalCount: 65,
+      tabCounts: { pulls: 38, reports: 62, runs: 4 },
+      filters: NO_FILTERS,
+    });
+
+    expect(props.report_count).toBe(2);
+    expect(props.total_count).toBe(65);
+    expect(props.ready_count).toBe(2);
+    expect(props.pulls_count).toBe(38);
+    expect(props.reports_count).toBe(62);
+    expect(props.runs_count).toBe(4);
+    expect(props.is_empty).toBe(false);
+    expect(props.status_filter_count).toBe(0);
+  });
+
+  it("breaks visible reports down by priority and actionability", () => {
+    const props = buildInboxViewedProperties({
+      visibleReports: [
+        fakeReport({ priority: "P0", actionability: "immediately_actionable" }),
+        fakeReport({ priority: "P0", actionability: "requires_human_input" }),
+        fakeReport({ priority: "P2", actionability: "not_actionable" }),
+        fakeReport({ priority: null, actionability: null }),
+      ],
+      totalCount: 4,
+      tabCounts: { pulls: 0, reports: 4, runs: 0 },
+      filters: NO_FILTERS,
+    });
+
+    expect(props.priority_p0_count).toBe(2);
+    expect(props.priority_p2_count).toBe(1);
+    expect(props.priority_unknown_count).toBe(1);
+    expect(props.actionability_immediately_actionable_count).toBe(1);
+    expect(props.actionability_requires_human_input_count).toBe(1);
+    expect(props.actionability_not_actionable_count).toBe(1);
+    expect(props.actionability_unknown_count).toBe(1);
+  });
+
+  it("only counts ready reports toward ready_count", () => {
+    const props = buildInboxViewedProperties({
+      visibleReports: [
+        fakeReport({ status: "ready" }),
+        fakeReport({ status: "in_progress" }),
+      ],
+      totalCount: 2,
+      tabCounts: { pulls: 0, reports: 1, runs: 1 },
+      filters: NO_FILTERS,
+    });
+
+    expect(props.ready_count).toBe(1);
+  });
+
+  it("reports is_empty when the total count is zero", () => {
+    const props = buildInboxViewedProperties({
+      visibleReports: [],
+      totalCount: 0,
+      tabCounts: { pulls: 0, reports: 0, runs: 0 },
+      filters: NO_FILTERS,
+    });
+
+    expect(props.is_empty).toBe(true);
+    expect(props.has_active_filters).toBe(false);
+  });
+
+  it.each([
+    ["source product", { sourceProductFilter: ["error_tracking"] }],
+    ["priority", { priorityFilter: ["P0"] }],
+    ["search", { searchQuery: "  crash  " }],
+    ["non-default scope", { isDefaultScope: false }],
+  ])("flags has_active_filters for a %s filter", (_label, partial) => {
+    const props = buildInboxViewedProperties({
+      visibleReports: [fakeReport()],
+      totalCount: 1,
+      tabCounts: { pulls: 0, reports: 1, runs: 0 },
+      filters: { ...NO_FILTERS, ...partial },
+    });
+
+    expect(props.has_active_filters).toBe(true);
+  });
+
+  it("does not flag has_active_filters for a whitespace-only search", () => {
+    const props = buildInboxViewedProperties({
+      visibleReports: [fakeReport()],
+      totalCount: 1,
+      tabCounts: { pulls: 0, reports: 1, runs: 0 },
+      filters: { ...NO_FILTERS, searchQuery: "   " },
+    });
+
+    expect(props.has_active_filters).toBe(false);
+  });
+});

--- a/packages/core/src/inbox/engagement.ts
+++ b/packages/core/src/inbox/engagement.ts
@@ -1,4 +1,7 @@
-import type { InboxReportActionProperties } from "@posthog/shared/analytics-events";
+import type {
+  InboxReportActionProperties,
+  InboxViewedProperties,
+} from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/domain-types";
 
 /** Report age at fire time in hours, rounded to one decimal. Clamped at 0 to guard against clock skew. */
@@ -81,4 +84,102 @@ export function resolveActionProperties(
         : (matchedReport?.actionability ?? null);
 
   return { rank, list_size: listSize, priority, actionability };
+}
+
+export interface InboxViewedFilterState {
+  sourceProductFilter: string[];
+  priorityFilter: string[];
+  searchQuery: string;
+  /**
+   * True when the reviewer scope is the default ("For you"). False when the
+   * user has narrowed to a teammate or the whole project — treated as an
+   * active filter for `has_active_filters`.
+   */
+  isDefaultScope: boolean;
+}
+
+export interface BuildInboxViewedInput {
+  /**
+   * Reports currently visible to the user (after reviewer scope + search), used
+   * for `report_count`, `ready_count`, and the priority/actionability breakdown.
+   */
+  visibleReports: SignalReport[];
+  /** Server-reported total of reports matching the active query — the headline inbox number. */
+  totalCount: number;
+  /** Tab badge counts shown in the v2 header (the numbers the user actually sees). */
+  tabCounts: { pulls: number; reports: number; runs: number };
+  filters: InboxViewedFilterState;
+}
+
+/**
+ * Build the property payload for the `Inbox viewed` analytics event from the
+ * v2 inbox state. Pure so it can be unit-tested and reused across hosts.
+ *
+ * v2 dropped the per-status and per-reviewer filter UI, so `status_filter_count`
+ * is always 0 and `has_active_filters` is derived from the surviving source /
+ * priority / search filters plus a non-default reviewer scope.
+ */
+export function buildInboxViewedProperties(
+  input: BuildInboxViewedInput,
+): InboxViewedProperties {
+  const { visibleReports, totalCount, tabCounts, filters } = input;
+
+  const priorityCounts = { P0: 0, P1: 0, P2: 0, P3: 0, P4: 0, unknown: 0 };
+  const actionabilityCounts = {
+    immediately_actionable: 0,
+    requires_human_input: 0,
+    not_actionable: 0,
+    unknown: 0,
+  };
+  let readyCount = 0;
+  for (const r of visibleReports) {
+    if (r.status === "ready") readyCount += 1;
+    const p = r.priority;
+    if (p === "P0" || p === "P1" || p === "P2" || p === "P3" || p === "P4") {
+      priorityCounts[p] += 1;
+    } else {
+      priorityCounts.unknown += 1;
+    }
+    const a = r.actionability;
+    if (
+      a === "immediately_actionable" ||
+      a === "requires_human_input" ||
+      a === "not_actionable"
+    ) {
+      actionabilityCounts[a] += 1;
+    } else {
+      actionabilityCounts.unknown += 1;
+    }
+  }
+
+  const hasActiveFilters =
+    filters.sourceProductFilter.length > 0 ||
+    filters.priorityFilter.length > 0 ||
+    filters.searchQuery.trim().length > 0 ||
+    !filters.isDefaultScope;
+
+  return {
+    report_count: visibleReports.length,
+    total_count: totalCount,
+    ready_count: readyCount,
+    has_active_filters: hasActiveFilters,
+    source_product_filter: filters.sourceProductFilter,
+    status_filter_count: 0,
+    is_empty: totalCount === 0,
+    priority_p0_count: priorityCounts.P0,
+    priority_p1_count: priorityCounts.P1,
+    priority_p2_count: priorityCounts.P2,
+    priority_p3_count: priorityCounts.P3,
+    priority_p4_count: priorityCounts.P4,
+    priority_unknown_count: priorityCounts.unknown,
+    actionability_immediately_actionable_count:
+      actionabilityCounts.immediately_actionable,
+    actionability_requires_human_input_count:
+      actionabilityCounts.requires_human_input,
+    actionability_not_actionable_count: actionabilityCounts.not_actionable,
+    actionability_unknown_count: actionabilityCounts.unknown,
+    pulls_count: tabCounts.pulls,
+    reports_count: tabCounts.reports,
+    runs_count: tabCounts.runs,
+  };
 }

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -543,6 +543,14 @@ export interface InboxViewedProperties {
   actionability_requires_human_input_count: number;
   actionability_not_actionable_count: number;
   actionability_unknown_count: number;
+  /**
+   * Tab badge counts shown in the v2 inbox header on load — the actual numbers
+   * the user sees (Pull requests / Reports / Runs). Optional: only the desktop
+   * v2 shell populates these; the mobile event omits them.
+   */
+  pulls_count?: number;
+  reports_count?: number;
+  runs_count?: number;
 }
 
 export interface InboxReportOpenedProperties {

--- a/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
@@ -2,7 +2,10 @@ import { Spinner } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBackLink";
 import { useInboxReportById } from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import { useReportOpenTracker } from "@posthog/ui/features/inbox/hooks/useReportOpenTracker";
+import {
+  type InboxDetailTab,
+  useReportOpenTracker,
+} from "@posthog/ui/features/inbox/hooks/useReportOpenTracker";
 import { Flex, Text } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
@@ -56,17 +59,31 @@ export function InboxReportDetailGate({
 
   return (
     <>
-      <ReportOpenTracker report={resolvedReport} />
+      <ReportOpenTracker report={resolvedReport} tab={tabFromBackTo(backTo)} />
       {children(resolvedReport)}
     </>
   );
+}
+
+function tabFromBackTo(
+  backTo: InboxReportDetailGateProps["backTo"],
+): InboxDetailTab {
+  if (backTo === "/code/inbox/pulls") return "pulls";
+  if (backTo === "/code/inbox/runs") return "runs";
+  return "reports";
 }
 
 /**
  * Mounts only once a report is resolved, so the OPENED/CLOSED engagement events
  * bracket the time the detail body is actually on screen. Renders nothing.
  */
-function ReportOpenTracker({ report }: { report: SignalReport }) {
-  useReportOpenTracker(report);
+function ReportOpenTracker({
+  report,
+  tab,
+}: {
+  report: SignalReport;
+  tab: InboxDetailTab;
+}) {
+  useReportOpenTracker(report, tab);
   return null;
 }

--- a/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
@@ -2,6 +2,7 @@ import { Spinner } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBackLink";
 import { useInboxReportById } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useReportOpenTracker } from "@posthog/ui/features/inbox/hooks/useReportOpenTracker";
 import { Flex, Text } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
@@ -53,5 +54,19 @@ export function InboxReportDetailGate({
     );
   }
 
-  return <>{children(resolvedReport)}</>;
+  return (
+    <>
+      <ReportOpenTracker report={resolvedReport} />
+      {children(resolvedReport)}
+    </>
+  );
+}
+
+/**
+ * Mounts only once a report is resolved, so the OPENED/CLOSED engagement events
+ * bracket the time the detail body is actually on screen. Renders nothing.
+ */
+function ReportOpenTracker({ report }: { report: SignalReport }) {
+  useReportOpenTracker(report);
+  return null;
 }

--- a/packages/ui/src/features/inbox/components/InboxView.tsx
+++ b/packages/ui/src/features/inbox/components/InboxView.tsx
@@ -2,11 +2,12 @@ import { EnvelopeSimpleIcon } from "@phosphor-icons/react";
 import { isInboxDetailPath } from "@posthog/core/inbox/reportMembership";
 import { InboxPageHeader } from "@posthog/ui/features/inbox/components/InboxPageHeader";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
+import { resetReportOpenTrackerHistory } from "@posthog/ui/features/inbox/hooks/useReportOpenTracker";
 import { useTrackInboxViewed } from "@posthog/ui/features/inbox/hooks/useTrackInboxViewed";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { Flex, Text } from "@radix-ui/themes";
 import { Outlet, useRouterState } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 /**
  * Inbox shell. Owns the in-page header (title + RFC subtitle + tab bar) and
@@ -30,6 +31,12 @@ export function InboxView() {
   );
 
   useSetHeaderContent(headerContent);
+
+  // Scope report-to-report navigation history to this inbox visit so the first
+  // report opened after (re)entering the inbox has no stale previous_report_id.
+  useEffect(() => {
+    resetReportOpenTrackerHistory();
+  }, []);
 
   useTrackInboxViewed();
 

--- a/packages/ui/src/features/inbox/components/InboxView.tsx
+++ b/packages/ui/src/features/inbox/components/InboxView.tsx
@@ -2,6 +2,7 @@ import { EnvelopeSimpleIcon } from "@phosphor-icons/react";
 import { isInboxDetailPath } from "@posthog/core/inbox/reportMembership";
 import { InboxPageHeader } from "@posthog/ui/features/inbox/components/InboxPageHeader";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
+import { useTrackInboxViewed } from "@posthog/ui/features/inbox/hooks/useTrackInboxViewed";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { Flex, Text } from "@radix-ui/themes";
 import { Outlet, useRouterState } from "@tanstack/react-router";
@@ -29,6 +30,8 @@ export function InboxView() {
   );
 
   useSetHeaderContent(headerContent);
+
+  useTrackInboxViewed();
 
   const { counts } = useInboxAllReports();
   const pathname = useRouterState({ select: (s) => s.location.pathname });

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -92,5 +92,12 @@ export function useInboxAllReports(options?: {
     scopedReports,
     counts,
     scope,
+    // The effective filter values used for this query. Surfaced so consumers
+    // (e.g. analytics) can read them without subscribing to the filter store a
+    // second time. Reflect `ignoreFilters`, so they are empty when filters are
+    // ignored.
+    searchQuery,
+    sourceProductFilter,
+    priorityFilter,
   };
 }

--- a/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
+++ b/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
@@ -6,11 +6,21 @@ import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useRef } from "react";
 
 /**
- * Last report id opened in this session, used to populate
+ * Last report id opened during the current inbox visit, used to populate
  * `previous_report_id` on the next `INBOX_REPORT_OPENED`. Module-scoped so it
- * survives the detail screen unmounting between reports.
+ * survives the detail screen unmounting between reports, but reset per visit
+ * via {@link resetReportOpenTrackerHistory} so report-to-report navigation
+ * pairs never span separate visits.
  */
 let lastOpenedReportId: string | null = null;
+
+/**
+ * Clears the cross-report navigation history. Call when the inbox shell mounts
+ * so the first report opened in a new visit reports `previous_report_id: null`.
+ */
+export function resetReportOpenTrackerHistory(): void {
+  lastOpenedReportId = null;
+}
 
 /**
  * Fires `INBOX_REPORT_OPENED` when a detail screen mounts (or switches to a new

--- a/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
+++ b/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
@@ -1,9 +1,18 @@
 import { reportAgeHours } from "@posthog/core/inbox/engagement";
+import {
+  isAgentRunReport,
+  isPullRequestReport,
+  isReportTabReport,
+} from "@posthog/core/inbox/reportMembership";
+import type { InboxReportCloseMethod } from "@posthog/shared/analytics-events";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/types";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useRef } from "react";
+
+/** Originating inbox tab, derived from the detail route. */
+export type InboxDetailTab = "pulls" | "reports" | "runs";
 
 /**
  * Last report id opened during the current inbox visit, used to populate
@@ -24,35 +33,68 @@ export function resetReportOpenTrackerHistory(): void {
 
 /**
  * Fires `INBOX_REPORT_OPENED` when a detail screen mounts (or switches to a new
- * report) and `INBOX_REPORT_CLOSED` with the dwell time when it unmounts.
+ * report) and `INBOX_REPORT_CLOSED` with the dwell time when it closes.
  *
  * Restores the open/close engagement events dropped when Inbox 2.0 deleted
  * `useInboxEngagementTracker`. Driven by the detail route lifecycle via
  * `InboxReportDetailGate`, so it covers reports, pull requests, and runs.
  *
+ * `rank` / `list_size` mirror the originating tab's membership: the Runs tab is
+ * project-wide (`ignoreScope`/`ignoreFilters`), while the Pull requests and
+ * Reports tabs use the scoped/filtered list — so a report's rank is measured
+ * against the list it was actually opened from.
+ *
  * `open_method` and `scrolled` are not yet wired in the route-based UI (the v1
  * open-method plumbing and scroll tracker were removed), so they report
  * "unknown" and `false` respectively.
  */
-export function useReportOpenTracker(report: SignalReport): void {
-  const { scopedReports } = useInboxAllReports();
+export function useReportOpenTracker(
+  report: SignalReport,
+  tab: InboxDetailTab,
+): void {
+  // The Pull requests / Reports tabs render the scoped+filtered list; the Runs
+  // tab is project-wide. Build the list matching the originating tab so rank is
+  // relative to the rows the user actually saw (and runs aren't reported as
+  // rank -1 just because they're absent from the scoped list).
+  const scoped = useInboxAllReports().scopedReports;
+  const projectWide = useInboxAllReports({
+    ignoreScope: true,
+    ignoreFilters: true,
+  }).scopedReports;
+  const visible =
+    tab === "runs"
+      ? projectWide.filter(isAgentRunReport)
+      : tab === "pulls"
+        ? scoped.filter(isPullRequestReport)
+        : scoped.filter(isReportTabReport);
 
   // Keep the visible list reachable from the mount effect without making the
   // effect re-run (and thus re-fire OPENED) on every list refetch.
-  const scopedReportsRef = useRef(scopedReports);
-  scopedReportsRef.current = scopedReports;
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
 
-  // Snapshot report fields so the unmount cleanup reports the values as they
-  // were at open time, not whatever the prop is at teardown.
+  // Snapshot report fields so the close cleanup reports the values as they were
+  // at open time, not whatever the prop is at teardown.
   const reportRef = useRef(report);
   reportRef.current = report;
+
+  // Detect a report→report switch during render so the close cleanup can label
+  // it `next_report` rather than `navigated_away`. Writing a ref during render
+  // is the React-sanctioned "track the previous prop" pattern, and crucially it
+  // runs before the outgoing effect's cleanup, which is where we read it.
+  const renderedIdRef = useRef<string | null>(null);
+  const closeMethodRef = useRef<InboxReportCloseMethod>("navigated_away");
+  if (renderedIdRef.current !== null && renderedIdRef.current !== report.id) {
+    closeMethodRef.current = "next_report";
+  }
+  renderedIdRef.current = report.id;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: report.id is the trigger — the detail route stays mounted across report→report navigation, so we re-bracket OPENED/CLOSED on id change while reading the rest from refs.
   useEffect(() => {
     const openedAt = Date.now();
     const opened = reportRef.current;
-    const visible = scopedReportsRef.current;
-    const rank = visible.findIndex((r) => r.id === opened.id);
+    const list = visibleRef.current;
+    const rank = list.findIndex((r) => r.id === opened.id);
 
     track(ANALYTICS_EVENTS.INBOX_REPORT_OPENED, {
       report_id: opened.id,
@@ -63,7 +105,7 @@ export function useReportOpenTracker(report: SignalReport): void {
       actionability: opened.actionability ?? null,
       source_products: opened.source_products ?? [],
       rank,
-      list_size: visible.length,
+      list_size: list.length,
       open_method: "unknown",
       previous_report_id: lastOpenedReportId,
     });
@@ -78,8 +120,10 @@ export function useReportOpenTracker(report: SignalReport): void {
         actionability: opened.actionability ?? null,
         time_spent_ms: Date.now() - openedAt,
         scrolled: false,
-        close_method: "navigated_away",
+        close_method: closeMethodRef.current,
       });
+      // Reset to the exit default; a subsequent switch re-sets it during render.
+      closeMethodRef.current = "navigated_away";
     };
   }, [report.id]);
 }

--- a/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
+++ b/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
@@ -1,0 +1,75 @@
+import { reportAgeHours } from "@posthog/core/inbox/engagement";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import type { SignalReport } from "@posthog/shared/types";
+import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
+import { track } from "@posthog/ui/shell/analytics";
+import { useEffect, useRef } from "react";
+
+/**
+ * Last report id opened in this session, used to populate
+ * `previous_report_id` on the next `INBOX_REPORT_OPENED`. Module-scoped so it
+ * survives the detail screen unmounting between reports.
+ */
+let lastOpenedReportId: string | null = null;
+
+/**
+ * Fires `INBOX_REPORT_OPENED` when a detail screen mounts (or switches to a new
+ * report) and `INBOX_REPORT_CLOSED` with the dwell time when it unmounts.
+ *
+ * Restores the open/close engagement events dropped when Inbox 2.0 deleted
+ * `useInboxEngagementTracker`. Driven by the detail route lifecycle via
+ * `InboxReportDetailGate`, so it covers reports, pull requests, and runs.
+ *
+ * `open_method` and `scrolled` are not yet wired in the route-based UI (the v1
+ * open-method plumbing and scroll tracker were removed), so they report
+ * "unknown" and `false` respectively.
+ */
+export function useReportOpenTracker(report: SignalReport): void {
+  const { scopedReports } = useInboxAllReports();
+
+  // Keep the visible list reachable from the mount effect without making the
+  // effect re-run (and thus re-fire OPENED) on every list refetch.
+  const scopedReportsRef = useRef(scopedReports);
+  scopedReportsRef.current = scopedReports;
+
+  // Snapshot report fields so the unmount cleanup reports the values as they
+  // were at open time, not whatever the prop is at teardown.
+  const reportRef = useRef(report);
+  reportRef.current = report;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: report.id is the trigger — the detail route stays mounted across report→report navigation, so we re-bracket OPENED/CLOSED on id change while reading the rest from refs.
+  useEffect(() => {
+    const openedAt = Date.now();
+    const opened = reportRef.current;
+    const visible = scopedReportsRef.current;
+    const rank = visible.findIndex((r) => r.id === opened.id);
+
+    track(ANALYTICS_EVENTS.INBOX_REPORT_OPENED, {
+      report_id: opened.id,
+      report_title: opened.title ?? null,
+      report_age_hours: reportAgeHours(opened.created_at),
+      status: opened.status ?? null,
+      priority: opened.priority ?? null,
+      actionability: opened.actionability ?? null,
+      source_products: opened.source_products ?? [],
+      rank,
+      list_size: visible.length,
+      open_method: "unknown",
+      previous_report_id: lastOpenedReportId,
+    });
+    lastOpenedReportId = opened.id;
+
+    return () => {
+      track(ANALYTICS_EVENTS.INBOX_REPORT_CLOSED, {
+        report_id: opened.id,
+        report_title: opened.title ?? null,
+        report_age_hours: reportAgeHours(opened.created_at),
+        priority: opened.priority ?? null,
+        actionability: opened.actionability ?? null,
+        time_spent_ms: Date.now() - openedAt,
+        scrolled: false,
+        close_method: "navigated_away",
+      });
+    };
+  }, [report.id]);
+}

--- a/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
+++ b/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
@@ -1,0 +1,56 @@
+import { buildInboxViewedProperties } from "@posthog/core/inbox/engagement";
+import { INBOX_SCOPE_FOR_YOU } from "@posthog/core/inbox/reportMembership";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
+import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
+import { track } from "@posthog/ui/shell/analytics";
+import { useEffect, useRef } from "react";
+
+/**
+ * Fires `INBOX_VIEWED` once per inbox visit, after the report list settles,
+ * with the counts the user sees on load (tab badges, total, ready, and the
+ * priority/actionability breakdown of the visible reports).
+ *
+ * Restores the event dropped when Inbox 2.0 deleted `InboxSignalsTab`. Mounted
+ * from `InboxView`, so it fires once per visit and survives tab switches (the
+ * shell stays mounted while the `<Outlet />` swaps tab bodies).
+ */
+export function useTrackInboxViewed(): void {
+  const { scopedReports, totalCount, counts, scope, isLoading } =
+    useInboxAllReports();
+  const sourceProductFilter = useInboxSignalsFilterStore(
+    (s) => s.sourceProductFilter,
+  );
+  const priorityFilter = useInboxSignalsFilterStore((s) => s.priorityFilter);
+  const searchQuery = useInboxSignalsFilterStore((s) => s.searchQuery);
+
+  const firedRef = useRef(false);
+  useEffect(() => {
+    if (firedRef.current) return;
+    if (isLoading) return;
+    firedRef.current = true;
+    track(
+      ANALYTICS_EVENTS.INBOX_VIEWED,
+      buildInboxViewedProperties({
+        visibleReports: scopedReports,
+        totalCount,
+        tabCounts: counts,
+        filters: {
+          sourceProductFilter,
+          priorityFilter,
+          searchQuery,
+          isDefaultScope: scope === INBOX_SCOPE_FOR_YOU,
+        },
+      }),
+    );
+  }, [
+    isLoading,
+    scopedReports,
+    totalCount,
+    counts,
+    scope,
+    sourceProductFilter,
+    priorityFilter,
+    searchQuery,
+  ]);
+}

--- a/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
+++ b/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
@@ -2,7 +2,6 @@ import { buildInboxViewedProperties } from "@posthog/core/inbox/engagement";
 import { INBOX_SCOPE_FOR_YOU } from "@posthog/core/inbox/reportMembership";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
-import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useRef } from "react";
 
@@ -16,13 +15,16 @@ import { useEffect, useRef } from "react";
  * shell stays mounted while the `<Outlet />` swaps tab bodies).
  */
 export function useTrackInboxViewed(): void {
-  const { scopedReports, totalCount, counts, scope, isLoading } =
-    useInboxAllReports();
-  const sourceProductFilter = useInboxSignalsFilterStore(
-    (s) => s.sourceProductFilter,
-  );
-  const priorityFilter = useInboxSignalsFilterStore((s) => s.priorityFilter);
-  const searchQuery = useInboxSignalsFilterStore((s) => s.searchQuery);
+  const {
+    scopedReports,
+    totalCount,
+    counts,
+    scope,
+    isLoading,
+    sourceProductFilter,
+    priorityFilter,
+    searchQuery,
+  } = useInboxAllReports();
 
   const firedRef = useRef(false);
   useEffect(() => {


### PR DESCRIPTION
## Why

Inbox 2.0 (#2547) deleted `InboxSignalsTab` and `useInboxEngagementTracker`, which silently dropped **three desktop analytics events** — `INBOX_VIEWED`, `INBOX_REPORT_OPENED`, and `INBOX_REPORT_CLOSED`. Their property interfaces survived in `@posthog/shared` but nothing fired them, so desktop has shown a data cliff at that merge. (`INBOX_REPORT_ACTION`, `TASK_CREATED`, and `SIGNAL_SOURCE_CONNECTED` survived the rewrite.)

This came out of a Slack thread where we wanted to know "what numbers are users seeing each time the inbox page loads" (the 38 / 62 / 65 badge counts) — turns out we *used* to capture exactly that and lost it.

## What

**`INBOX_VIEWED`** — fires once per inbox visit with the counts the user sees on load.
- New pure helper `buildInboxViewedProperties` in `@posthog/core/inbox/engagement` (+ unit tests).
- `useTrackInboxViewed` mounted in `InboxView`, so it fires once and survives tab switches (the shell stays mounted while the `<Outlet />` swaps tab bodies).
- **Improvement:** added optional `pulls_count` / `reports_count` / `runs_count` — the actual tab badges users see. `total_count` comes from the server total.
- v2 dropped the status/reviewer filter UI, so `status_filter_count` is now `0` and `has_active_filters` is recomputed from source/priority/search + non-default reviewer scope.

**`INBOX_REPORT_OPENED` / `INBOX_REPORT_CLOSED`** — report open + dwell time.
- `useReportOpenTracker` wired into `InboxReportDetailGate`, which all three detail screens (reports, PRs, runs) funnel through. Fires OPENED on open, CLOSED with `time_spent_ms` on close, keyed on `report.id` so report→report navigation re-brackets correctly.

## Scope / caveats

- Skipped `INBOX_REPORT_SCROLLED` (lowest value; the single-column route layout changed the scroll container — separate follow-up if we want it).
- `open_method` reports `"unknown"` and `scrolled` is always `false`: the v1 open-method plumbing and scroll tracker were removed in the rewrite and are out of scope here. Opens + dwell are captured.
- Mobile already fires `INBOX_VIEWED` from its own self-contained analytics layer; left untouched.

## Testing

- `packages/core/src/inbox/engagement.test.ts` — 9 cases for `buildInboxViewedProperties` (counts, breakdowns, ready-only, empty, active-filter detection).
- `pnpm --filter @posthog/{shared,core,ui} typecheck` clean; Biome clean; mobile unaffected (new fields optional).