### PR TITLE
fix(inbox): correct analytics edge cases from #2670 review

### DIFF
--- a/packages/core/src/inbox/engagement.test.ts
+++ b/packages/core/src/inbox/engagement.test.ts
@@ -1,6 +1,9 @@
 import type { SignalReport } from "@posthog/shared/types";
 import { describe, expect, it } from "vitest";
-import { buildInboxViewedProperties } from "./engagement";
+import {
+  buildInboxViewedProperties,
+  inboxDetailTabReports,
+} from "./engagement";
 
 function fakeReport(overrides: Partial<SignalReport> = {}): SignalReport {
   return {
@@ -121,5 +124,47 @@ describe("buildInboxViewedProperties", () => {
     });
 
     expect(props.has_active_filters).toBe(false);
+  });
+});
+
+describe("inboxDetailTabReports", () => {
+  const pull = fakeReport({
+    id: "pr",
+    status: "ready",
+    implementation_pr_url: "https://github.com/x/y/pull/1",
+  });
+  const reportRow = fakeReport({ id: "rep", status: "ready" });
+  const queuedRun = fakeReport({ id: "queued", status: "candidate" });
+  const liveRun = fakeReport({ id: "live", status: "in_progress" });
+  const failedRun = fakeReport({ id: "failed", status: "failed" });
+
+  it("keeps only PR-tab rows for the pulls tab", () => {
+    expect(
+      inboxDetailTabReports("pulls", [pull, queuedRun, reportRow]),
+    ).toEqual([pull]);
+  });
+
+  it("keeps only report-tab rows for the reports tab", () => {
+    expect(
+      inboxDetailTabReports("reports", [reportRow, pull, queuedRun, failedRun]),
+    ).toEqual([reportRow]);
+  });
+
+  it("includes queued, live, and finished runs for the runs tab", () => {
+    expect(
+      inboxDetailTabReports("runs", [queuedRun, liveRun, failedRun]),
+    ).toEqual([queuedRun, liveRun, failedRun]);
+  });
+
+  it("ranks a recently-finished run against the runs list (not rank -1)", () => {
+    // The regression: `failed`/`ready` runs render in the Runs tab's "Recently
+    // finished" section but aren't `isAgentRunReport`, so they used to fall out
+    // of the tracked list and report rank -1.
+    const visible = inboxDetailTabReports("runs", [
+      queuedRun,
+      liveRun,
+      failedRun,
+    ]);
+    expect(visible.findIndex((r) => r.id === failedRun.id)).toBe(2);
   });
 });

--- a/packages/core/src/inbox/engagement.test.ts
+++ b/packages/core/src/inbox/engagement.test.ts
@@ -2,6 +2,7 @@ import type { SignalReport } from "@posthog/shared/types";
 import { describe, expect, it } from "vitest";
 import {
   buildInboxViewedProperties,
+  type InboxDetailTab,
   inboxDetailTabReports,
 } from "./engagement";
 
@@ -138,22 +139,52 @@ describe("inboxDetailTabReports", () => {
   const liveRun = fakeReport({ id: "live", status: "in_progress" });
   const failedRun = fakeReport({ id: "failed", status: "failed" });
 
-  it("keeps only PR-tab rows for the pulls tab", () => {
-    expect(
-      inboxDetailTabReports("pulls", [pull, queuedRun, reportRow]),
-    ).toEqual([pull]);
+  const cases: Array<[InboxDetailTab, SignalReport[], SignalReport[]]> = [
+    ["pulls", [pull, queuedRun, reportRow], [pull]],
+    ["reports", [reportRow, pull, queuedRun, failedRun], [reportRow]],
+    ["runs", [queuedRun, liveRun, failedRun], [queuedRun, liveRun, failedRun]],
+  ];
+  it.each(cases)(
+    "keeps the rows the %s tab renders",
+    (tab, input, expected) => {
+      expect(inboxDetailTabReports(tab, input)).toEqual(expected);
+    },
+  );
+
+  it("treats a ready non-run report as a finished run on the runs tab", () => {
+    // `ready` is shared by isReportTabReport and isFinishedRunReport, so a ready
+    // report renders in both the Reports tab and the Runs tab's "Recently
+    // finished" section. The runs list reflects that overlap.
+    expect(inboxDetailTabReports("runs", [queuedRun, reportRow])).toEqual([
+      queuedRun,
+      reportRow,
+    ]);
   });
 
-  it("keeps only report-tab rows for the reports tab", () => {
-    expect(
-      inboxDetailTabReports("reports", [reportRow, pull, queuedRun, failedRun]),
-    ).toEqual([reportRow]);
-  });
-
-  it("includes queued, live, and finished runs for the runs tab", () => {
-    expect(
-      inboxDetailTabReports("runs", [queuedRun, liveRun, failedRun]),
-    ).toEqual([queuedRun, liveRun, failedRun]);
+  it("orders runs Queued → Live → Finished, newest-first within a section", () => {
+    const olderFinished = fakeReport({
+      id: "fin-old",
+      status: "ready",
+      updated_at: "2026-06-01T00:00:00Z",
+    });
+    const newerFinished = fakeReport({
+      id: "fin-new",
+      status: "failed",
+      updated_at: "2026-06-09T00:00:00Z",
+    });
+    // Deliberately shuffled input; output must follow the rendered order.
+    const visible = inboxDetailTabReports("runs", [
+      olderFinished,
+      liveRun,
+      newerFinished,
+      queuedRun,
+    ]);
+    expect(visible.map((r) => r.id)).toEqual([
+      "queued",
+      "live",
+      "fin-new",
+      "fin-old",
+    ]);
   });
 
   it("ranks a recently-finished run against the runs list (not rank -1)", () => {

--- a/packages/core/src/inbox/engagement.ts
+++ b/packages/core/src/inbox/engagement.ts
@@ -3,6 +3,37 @@ import type {
   InboxViewedProperties,
 } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/domain-types";
+import {
+  isAgentRunReport,
+  isFinishedRunReport,
+  isPullRequestReport,
+  isReportTabReport,
+} from "./reportMembership";
+
+/** Originating inbox tab a report detail was opened from, derived from the route. */
+export type InboxDetailTab = "pulls" | "reports" | "runs";
+
+/**
+ * The list of reports a detail screen's `rank` / `list_size` should be measured
+ * against — i.e. the rows the originating tab actually rendered. Pure so it can
+ * be unit-tested and stays aligned with the tab components.
+ *
+ * The Runs tab also renders a "Recently finished" section, so finished runs are
+ * included here; without them, opening a recently-finished run would report
+ * `rank: -1` against a list it isn't part of.
+ */
+export function inboxDetailTabReports(
+  tab: InboxDetailTab,
+  reports: SignalReport[],
+): SignalReport[] {
+  if (tab === "runs") {
+    return reports.filter((r) => isAgentRunReport(r) || isFinishedRunReport(r));
+  }
+  if (tab === "pulls") {
+    return reports.filter(isPullRequestReport);
+  }
+  return reports.filter(isReportTabReport);
+}
 
 /** Report age at fire time in hours, rounded to one decimal. Clamped at 0 to guard against clock skew. */
 export function reportAgeHours(createdAt: string | null | undefined): number {

--- a/packages/core/src/inbox/engagement.ts
+++ b/packages/core/src/inbox/engagement.ts
@@ -4,10 +4,9 @@ import type {
 } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/domain-types";
 import {
-  isAgentRunReport,
-  isFinishedRunReport,
   isPullRequestReport,
   isReportTabReport,
+  orderedRunsTabReports,
 } from "./reportMembership";
 
 /** Originating inbox tab a report detail was opened from, derived from the route. */
@@ -15,19 +14,22 @@ export type InboxDetailTab = "pulls" | "reports" | "runs";
 
 /**
  * The list of reports a detail screen's `rank` / `list_size` should be measured
- * against — i.e. the rows the originating tab actually rendered. Pure so it can
- * be unit-tested and stays aligned with the tab components.
+ * against — i.e. the rows the originating tab actually rendered, in the order it
+ * rendered them. Pure so it can be unit-tested and stays aligned with the tab
+ * components.
  *
- * The Runs tab also renders a "Recently finished" section, so finished runs are
- * included here; without them, opening a recently-finished run would report
- * `rank: -1` against a list it isn't part of.
+ * The Runs tab partitions and sorts into Queued → Live → Recently finished, so
+ * runs reuse {@link orderedRunsTabReports} (the same selector `RunsTab` renders
+ * from) rather than raw query order. That also pulls in finished runs, which
+ * otherwise would report `rank: -1` against a list they aren't part of. The
+ * Pull requests / Reports tabs render their filtered list in query order.
  */
 export function inboxDetailTabReports(
   tab: InboxDetailTab,
   reports: SignalReport[],
 ): SignalReport[] {
   if (tab === "runs") {
-    return reports.filter((r) => isAgentRunReport(r) || isFinishedRunReport(r));
+    return orderedRunsTabReports(reports);
   }
   if (tab === "pulls") {
     return reports.filter(isPullRequestReport);

--- a/packages/core/src/inbox/reportMembership.test.ts
+++ b/packages/core/src/inbox/reportMembership.test.ts
@@ -12,6 +12,7 @@ import {
   isPullRequestReport,
   isReportTabReport,
   matchesReviewerScope,
+  partitionRunsTabReports,
   teammateInboxScope,
 } from "./reportMembership";
 
@@ -266,5 +267,60 @@ describe("tabFilters", () => {
         runs: 2,
       });
     });
+  });
+});
+
+describe("partitionRunsTabReports", () => {
+  it("buckets queued / live / finished and sorts each newest-first", () => {
+    const queuedOld = fakeReport({
+      id: "q-old",
+      status: "potential",
+      updated_at: "2026-06-01T00:00:00Z",
+    });
+    const queuedNew = fakeReport({
+      id: "q-new",
+      status: "candidate",
+      updated_at: "2026-06-08T00:00:00Z",
+    });
+    const live = fakeReport({ id: "live", status: "in_progress" });
+    const finishedReady = fakeReport({
+      id: "fin-ready",
+      status: "ready",
+      updated_at: "2026-06-02T00:00:00Z",
+    });
+    const finishedFailed = fakeReport({
+      id: "fin-failed",
+      status: "failed",
+      updated_at: "2026-06-09T00:00:00Z",
+    });
+    const pull = fakeReport({
+      id: "pr",
+      status: "ready",
+      updated_at: "2026-06-05T00:00:00Z",
+      implementation_pr_url: "https://github.com/x/y/pull/1",
+    });
+
+    const {
+      queued,
+      live: liveBucket,
+      finished,
+    } = partitionRunsTabReports([
+      queuedOld,
+      finishedReady,
+      live,
+      queuedNew,
+      finishedFailed,
+      pull,
+    ]);
+
+    expect(queued.map((r) => r.id)).toEqual(["q-new", "q-old"]);
+    expect(liveBucket.map((r) => r.id)).toEqual(["live"]);
+    // A ready PR row is also a finished run, so it lands in the finished bucket
+    // and is ordered purely by recency (06-09 > 06-05 > 06-02).
+    expect(finished.map((r) => r.id)).toEqual([
+      "fin-failed",
+      "pr",
+      "fin-ready",
+    ]);
   });
 });

--- a/packages/core/src/inbox/reportMembership.ts
+++ b/packages/core/src/inbox/reportMembership.ts
@@ -144,6 +144,53 @@ export function isAgentRunReport(report: SignalReport): boolean {
   return isQueuedRunReport(report) || isLiveRunReport(report);
 }
 
+function runReportTimestampMs(report: SignalReport): number {
+  const value = report.updated_at ?? report.created_at;
+  if (!value) return 0;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+export interface RunsTabSections {
+  queued: SignalReport[];
+  live: SignalReport[];
+  finished: SignalReport[];
+}
+
+/**
+ * Partition reports into the Runs tab's three rendered sections, each sorted
+ * newest-first. The single source of truth shared by `RunsTab` (section
+ * rendering) and the open tracker (so `INBOX_REPORT_OPENED.rank` is measured
+ * against the row order the user actually saw, not raw query order).
+ */
+export function partitionRunsTabReports(
+  reports: SignalReport[],
+): RunsTabSections {
+  const queued: SignalReport[] = [];
+  const live: SignalReport[] = [];
+  const finished: SignalReport[] = [];
+  for (const report of reports) {
+    if (isQueuedRunReport(report)) queued.push(report);
+    else if (isLiveRunReport(report)) live.push(report);
+    else if (isFinishedRunReport(report)) finished.push(report);
+  }
+  const newestFirst = (a: SignalReport, b: SignalReport) =>
+    runReportTimestampMs(b) - runReportTimestampMs(a);
+  queued.sort(newestFirst);
+  live.sort(newestFirst);
+  finished.sort(newestFirst);
+  return { queued, live, finished };
+}
+
+/**
+ * Flat Runs-tab order — Queued, then Live, then Recently finished — matching the
+ * top-to-bottom order of the rendered sections.
+ */
+export function orderedRunsTabReports(reports: SignalReport[]): SignalReport[] {
+  const { queued, live, finished } = partitionRunsTabReports(reports);
+  return [...queued, ...live, ...finished];
+}
+
 export function isReportTabReport(report: SignalReport): boolean {
   if (isExcludedFromInbox(report)) return false;
   if (report.status === "failed") return false; // failed runs live in the Runs tab only

--- a/packages/ui/src/features/inbox/components/RunsTab.tsx
+++ b/packages/ui/src/features/inbox/components/RunsTab.tsx
@@ -2,9 +2,7 @@ import { RobotIcon } from "@phosphor-icons/react";
 import {
   INBOX_SCOPE_ENTIRE_PROJECT,
   INBOX_SCOPE_FOR_YOU,
-  isFinishedRunReport,
-  isLiveRunReport,
-  isQueuedRunReport,
+  partitionRunsTabReports,
 } from "@posthog/core/inbox/reportMembership";
 import {
   Empty,
@@ -13,7 +11,6 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
-import type { SignalReport } from "@posthog/shared/types";
 import { AgentRunCard } from "@posthog/ui/features/inbox/components/AgentRunCard";
 import { CardSkeleton } from "@posthog/ui/features/inbox/components/CardSkeleton";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
@@ -23,12 +20,6 @@ import { useMemo, useState } from "react";
 
 const RECENTLY_FINISHED_LIMIT = 10;
 const QUEUED_LIMIT = 10;
-
-function timestampMs(value: string | null | undefined): number {
-  if (!value) return 0;
-  const ms = new Date(value).getTime();
-  return Number.isFinite(ms) ? ms : 0;
-}
 
 export function RunsTab() {
   // Runs is project-wide and intentionally chrome-less. Reviewer assignment
@@ -44,20 +35,7 @@ export function RunsTab() {
   const [showAllQueued, setShowAllQueued] = useState(false);
 
   const { queuedRuns, liveRuns, finishedRuns } = useMemo(() => {
-    const queued: typeof scopedReports = [];
-    const live: typeof scopedReports = [];
-    const finished: typeof scopedReports = [];
-    for (const report of scopedReports) {
-      if (isQueuedRunReport(report)) queued.push(report);
-      else if (isLiveRunReport(report)) live.push(report);
-      else if (isFinishedRunReport(report)) finished.push(report);
-    }
-    const newestFirst = (a: SignalReport, b: SignalReport) =>
-      timestampMs(b.updated_at ?? b.created_at) -
-      timestampMs(a.updated_at ?? a.created_at);
-    queued.sort(newestFirst);
-    live.sort(newestFirst);
-    finished.sort(newestFirst);
+    const { queued, live, finished } = partitionRunsTabReports(scopedReports);
     return { queuedRuns: queued, liveRuns: live, finishedRuns: finished };
   }, [scopedReports]);
 

--- a/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
+++ b/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
@@ -1,9 +1,8 @@
-import { reportAgeHours } from "@posthog/core/inbox/engagement";
 import {
-  isAgentRunReport,
-  isPullRequestReport,
-  isReportTabReport,
-} from "@posthog/core/inbox/reportMembership";
+  type InboxDetailTab,
+  inboxDetailTabReports,
+  reportAgeHours,
+} from "@posthog/core/inbox/engagement";
 import type { InboxReportCloseMethod } from "@posthog/shared/analytics-events";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/types";
@@ -11,8 +10,7 @@ import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAll
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useRef } from "react";
 
-/** Originating inbox tab, derived from the detail route. */
-export type InboxDetailTab = "pulls" | "reports" | "runs";
+export type { InboxDetailTab };
 
 /**
  * Last report id opened during the current inbox visit, used to populate
@@ -53,20 +51,13 @@ export function useReportOpenTracker(
   tab: InboxDetailTab,
 ): void {
   // The Pull requests / Reports tabs render the scoped+filtered list; the Runs
-  // tab is project-wide. Build the list matching the originating tab so rank is
-  // relative to the rows the user actually saw (and runs aren't reported as
-  // rank -1 just because they're absent from the scoped list).
-  const scoped = useInboxAllReports().scopedReports;
-  const projectWide = useInboxAllReports({
-    ignoreScope: true,
-    ignoreFilters: true,
-  }).scopedReports;
-  const visible =
-    tab === "runs"
-      ? projectWide.filter(isAgentRunReport)
-      : tab === "pulls"
-        ? scoped.filter(isPullRequestReport)
-        : scoped.filter(isReportTabReport);
+  // tab is project-wide. Mount only the query matching the originating tab so
+  // rank is relative to the rows the user actually saw (and so a non-run detail
+  // doesn't start the unused project-wide poll alongside the scoped one).
+  const { scopedReports } = useInboxAllReports(
+    tab === "runs" ? { ignoreScope: true, ignoreFilters: true } : undefined,
+  );
+  const visible = inboxDetailTabReports(tab, scopedReports);
 
   // Keep the visible list reachable from the mount effect without making the
   // effect re-run (and thus re-fire OPENED) on every list refetch.

--- a/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
+++ b/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
@@ -20,7 +20,7 @@ export function useTrackInboxViewed(): void {
     totalCount,
     counts,
     scope,
-    isLoading,
+    isSuccess,
     sourceProductFilter,
     priorityFilter,
     searchQuery,
@@ -29,7 +29,10 @@ export function useTrackInboxViewed(): void {
   const firedRef = useRef(false);
   useEffect(() => {
     if (firedRef.current) return;
-    if (isLoading) return;
+    // Gate on a successful load, not just `!isLoading`: an errored initial
+    // request also leaves `isLoading` false with an empty list, and `firedRef`
+    // would then lock in a bogus empty-inbox view that a later refetch can't fix.
+    if (!isSuccess) return;
     firedRef.current = true;
     track(
       ANALYTICS_EVENTS.INBOX_VIEWED,
@@ -46,7 +49,7 @@ export function useTrackInboxViewed(): void {
       }),
     );
   }, [
-    isLoading,
+    isSuccess,
     scopedReports,
     totalCount,
     counts,


### PR DESCRIPTION
Follow-up to #2670 addressing three correctness edge cases raised by Codex in that PR's review that weren't resolved before merge.

## What

**1. Finished runs were tracked with `rank: -1`** (`useReportOpenTracker`)
The Runs tab renders a "Recently finished" section (`isFinishedRunReport` = `ready`/`failed`), but the open tracker built the run list with `isAgentRunReport` (queued|live) only. Opening a recently-finished run therefore emitted `rank: -1` and a `list_size` that omitted finished runs — the same class of bug the original `rank: -1` fix in #2670 was meant to close, just incomplete.

**2. Unused project-wide query on non-run details** (`useReportOpenTracker`)
The tracker mounted *both* `useInboxAllReports()` (scoped) and `useInboxAllReports({ ignoreScope, ignoreFilters })` (project-wide) unconditionally, but only ever used one per tab. On a PR/report detail route, neither list tab is mounted, so the unused project-wide variant spun up an extra polling query for the whole time the detail was open. Now only the query matching the originating tab is mounted.

**3. `INBOX_VIEWED` could fire as an empty inbox on load error** (`useTrackInboxViewed`)
Gating on `!isLoading` meant an errored initial request (isLoading `false`, empty list) recorded an empty-inbox view, and `firedRef` locked it in for the visit so a later successful refetch couldn't correct it. Now gated on `isSuccess`.

## How

The tab → visible-reports selection is extracted into a pure `inboxDetailTabReports` helper in `@posthog/core/inbox/engagement`, so the finished-run logic is unit-tested and stays aligned with the tab components.

## Not included

Two other Codex comments from that review were intentionally left out:
- **Reset open-history before child detail effects run** — real but narrow (only the deep-link-into-detail entry path, only `previous_report_id`).
- **Use the Runs tab's list for `INBOX_VIEWED`** — a design choice, not a bug; `INBOX_VIEWED` is one shell-level event and already carries the runs tab badge count.

## Testing

- `packages/core/src/inbox/engagement.test.ts` — added 4 cases for `inboxDetailTabReports`, including the recently-finished-run rank regression.
- `pnpm --filter @posthog/{core,ui} typecheck` clean; Biome clean; full `engagement` suite green.
