### PR TITLE
fix(tasks): don't flash the Slack icon on newly created tasks

### DIFF
--- a/packages/ui/src/features/tasks/taskKeys.ts
+++ b/packages/ui/src/features/tasks/taskKeys.ts
@@ -1,12 +1,19 @@
+export interface TaskListFilters {
+  repository?: string;
+  createdBy?: number;
+  originProduct?: string;
+  internal?: boolean;
+}
+
 export const taskKeys = {
   all: ["tasks"] as const,
   lists: () => [...taskKeys.all, "list"] as const,
-  list: (filters?: {
-    repository?: string;
-    createdBy?: number;
-    originProduct?: string;
-    internal?: boolean;
-  }) => [...taskKeys.lists(), filters] as const,
+  list: (filters?: TaskListFilters) => [...taskKeys.lists(), filters] as const,
+  // Extract the filters object from a `list` query key. Keeps knowledge of the
+  // key's shape (filters live in the last slot) here, next to `list`, instead
+  // of letting consumers reach in by positional index.
+  filtersOf: (queryKey: readonly unknown[]): TaskListFilters | undefined =>
+    queryKey[queryKey.length - 1] as TaskListFilters | undefined,
   allSummaries: () => [...taskKeys.all, "summaries"] as const,
   summaries: (ids: string[]) =>
     [...taskKeys.allSummaries(), [...ids].sort()] as const,

--- a/packages/ui/src/features/tasks/useTaskCrudMutations.test.tsx
+++ b/packages/ui/src/features/tasks/useTaskCrudMutations.test.tsx
@@ -93,12 +93,47 @@ describe("useCreateTask.invalidateTasks", () => {
     vi.clearAllMocks();
   });
 
-  it("seeds plain list caches but not the slack-origin list", () => {
+  it.each([
+    { name: "plain list", filters: undefined, expectedLength: 1 },
+    {
+      name: "repository-scoped list",
+      filters: { repository: "owner/repo" },
+      expectedLength: 1,
+    },
+    {
+      name: "slack-origin list",
+      filters: { originProduct: "slack" },
+      expectedLength: 0,
+    },
+  ])(
+    "seeds the $name with the new task ($expectedLength entr(y/ies))",
+    ({ filters, expectedLength }) => {
+      const queryClient = new QueryClient();
+      const key = taskKeys.list(filters);
+      queryClient.setQueryData<Task[]>(key, []);
+
+      const localWrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+      const { result } = renderHook(() => useCreateTask(), {
+        wrapper: localWrapper,
+      });
+
+      result.current.invalidateTasks(createTask());
+
+      // Origin-less lists mirror the new task; origin-scoped lists (read by the
+      // sidebar to brand icons by id membership) must not be seeded.
+      expect(queryClient.getQueryData<Task[]>(key)).toHaveLength(
+        expectedLength,
+      );
+    },
+  );
+
+  it("still invalidates every list, including the slack-origin one", () => {
     const queryClient = new QueryClient();
-    const plainKey = taskKeys.list();
-    const slackKey = taskKeys.list({ originProduct: "slack" });
-    queryClient.setQueryData<Task[]>(plainKey, []);
-    queryClient.setQueryData<Task[]>(slackKey, []);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     const localWrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -109,10 +144,9 @@ describe("useCreateTask.invalidateTasks", () => {
 
     result.current.invalidateTasks(createTask());
 
-    // The new, non-slack task lands in the plain list...
-    expect(queryClient.getQueryData<Task[]>(plainKey)).toHaveLength(1);
-    // ...but never pollutes the slack-origin list, which the sidebar reads to
-    // brand task icons by id membership.
-    expect(queryClient.getQueryData<Task[]>(slackKey)).toHaveLength(0);
+    // Seeding is scoped, but the refetch is not: all lists (slack included) are
+    // invalidated so they reconcile with the server. A future refactor must not
+    // "fix" the no-seed expectation above by dropping a list from refetch.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: taskKeys.lists() });
   });
 });

--- a/packages/ui/src/features/tasks/useTaskCrudMutations.test.tsx
+++ b/packages/ui/src/features/tasks/useTaskCrudMutations.test.tsx
@@ -1,3 +1,4 @@
+import type { Task } from "@posthog/shared/domain-types";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -27,13 +28,28 @@ vi.mock("@posthog/di/react", () => ({
   useService: () => deletionService,
 }));
 
-import { useDeleteTask } from "./useTaskCrudMutations";
+import { taskKeys } from "./taskKeys";
+import { useCreateTask, useDeleteTask } from "./useTaskCrudMutations";
 
 function wrapper({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient();
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
+}
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "new-task",
+    task_number: 1,
+    slug: "new-task",
+    title: "New task",
+    description: "New task",
+    created_at: "2026-06-15T00:00:00.000Z",
+    updated_at: "2026-06-15T00:00:00.000Z",
+    origin_product: "user_created",
+    ...overrides,
+  };
 }
 
 describe("useDeleteTask.deleteWithConfirm", () => {
@@ -69,5 +85,34 @@ describe("useDeleteTask.deleteWithConfirm", () => {
     });
 
     expect(ok).toBe(false);
+  });
+});
+
+describe("useCreateTask.invalidateTasks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("seeds plain list caches but not the slack-origin list", () => {
+    const queryClient = new QueryClient();
+    const plainKey = taskKeys.list();
+    const slackKey = taskKeys.list({ originProduct: "slack" });
+    queryClient.setQueryData<Task[]>(plainKey, []);
+    queryClient.setQueryData<Task[]>(slackKey, []);
+
+    const localWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useCreateTask(), {
+      wrapper: localWrapper,
+    });
+
+    result.current.invalidateTasks(createTask());
+
+    // The new, non-slack task lands in the plain list...
+    expect(queryClient.getQueryData<Task[]>(plainKey)).toHaveLength(1);
+    // ...but never pollutes the slack-origin list, which the sidebar reads to
+    // brand task icons by id membership.
+    expect(queryClient.getQueryData<Task[]>(slackKey)).toHaveLength(0);
   });
 });

--- a/packages/ui/src/features/tasks/useTaskCrudMutations.ts
+++ b/packages/ui/src/features/tasks/useTaskCrudMutations.ts
@@ -18,19 +18,20 @@ export function useCreateTask() {
 
   const invalidateTasks = (newTask?: Task) => {
     if (newTask) {
-      // Only seed list caches that aren't filtered by origin_product. The
-      // slack-origin list (used by useSlackTasks) is read by the sidebar to
-      // brand a task's icon by id membership; inserting a freshly created,
-      // non-slack task there would make it briefly render as a Slack task
-      // until the list refetches.
+      // Only seed list caches that aren't scoped to a specific origin_product.
+      // An origin-scoped list (e.g. the slack-origin list behind useSlackTasks)
+      // is read by the sidebar to brand a task's icon by id membership, so
+      // seeding a freshly created, non-slack task into it would make that task
+      // briefly render as a Slack task until the list refetches. Origin-less
+      // lists, by contrast, should mirror every new task.
       queryClient.setQueriesData<Task[]>(
         {
           queryKey: taskKeys.lists(),
           predicate: (query) => {
-            const filters = query.queryKey[2] as
-              | { originProduct?: string }
-              | undefined;
-            return !filters?.originProduct;
+            const isOriginScopedList = Boolean(
+              taskKeys.filtersOf(query.queryKey)?.originProduct,
+            );
+            return !isOriginScopedList;
           },
         },
         (old) => insertTaskDedup(old, newTask),

--- a/packages/ui/src/features/tasks/useTaskCrudMutations.ts
+++ b/packages/ui/src/features/tasks/useTaskCrudMutations.ts
@@ -18,8 +18,21 @@ export function useCreateTask() {
 
   const invalidateTasks = (newTask?: Task) => {
     if (newTask) {
+      // Only seed list caches that aren't filtered by origin_product. The
+      // slack-origin list (used by useSlackTasks) is read by the sidebar to
+      // brand a task's icon by id membership; inserting a freshly created,
+      // non-slack task there would make it briefly render as a Slack task
+      // until the list refetches.
       queryClient.setQueriesData<Task[]>(
-        { queryKey: taskKeys.lists() },
+        {
+          queryKey: taskKeys.lists(),
+          predicate: (query) => {
+            const filters = query.queryKey[2] as
+              | { originProduct?: string }
+              | undefined;
+            return !filters?.originProduct;
+          },
+        },
         (old) => insertTaskDedup(old, newTask),
       );
     }


### PR DESCRIPTION
## Problem

A newly created task in posthog/code would sometimes flash the **Slack icon** while it was still loading, even though it wasn't a Slack-triggered task. It self-corrected a moment later.

Root cause: `useCreateTask.invalidateTasks` optimistically inserts the new task into **every** task-list cache via `setQueriesData({ queryKey: taskKeys.lists() }, ...)`, and `taskKeys.lists()` prefix-matches the slack-origin list too (`useSlackTasks`). Because `/tasks/summaries/` omits `origin_product`, the sidebar infers a task's Slack origin purely by id membership in that slack list (`buildSidebarData.ts`). So the freshly created, non-slack task landed in `slackTaskIds` and rendered the Slack icon until `useSlackTasks` refetched from the server and dropped it.

## Changes

Scope the optimistic insert to list caches that aren't filtered by `origin_product`, using a `predicate` that skips any list query whose filter has `originProduct` set. The slack-origin cache stays clean, so the new task never transiently shows the Slack icon.

## How did you test this?

- Added a regression test in `useTaskCrudMutations.test.tsx` asserting `invalidateTasks` seeds the plain list but not the slack-origin list. `pnpm exec vitest run useTaskCrudMutations.test.tsx` → 3 passed.
- `biome lint` clean on both changed files.
- `pnpm --filter @posthog/ui typecheck` passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781519901530239?thread_ts=1781519901.530239&cid=C0ACRAMJUAG)*
