### PR TITLE
feat(agent): tell Slack-bound agent to echo labeled mention tokens

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1729,6 +1729,9 @@ You are replying in a Slack thread. Slack readers want short, skimmable answers 
 - Prefer plain prose. Treat bullet lists as the exception, not the norm, and avoid headers and tables unless they genuinely make a complex answer clearer.
 - Do not narrate your thinking or list every step you took; report what matters and the result.
 - This is a default, not a hard rule. If the user (or their saved memory) asks for more depth or a specific format, follow that instead.
+
+# Mentioning users
+When you want to ping a Slack user in your reply, copy their \`<@U…|displayname>\` token verbatim from the message context — Slack renders that as a real mention. Writing \`@displayname\` as plain text does NOT ping them.
 `
       : "";
     const signedCommitInstructions = `


### PR DESCRIPTION
## Problem

Slack only renders `<@U_ID|displayname>` (or bare `<@U_ID>`) as a real ping. When the agent writes plain `@displayname` text in its reply, Slack treats it as text — the user it's referring to doesn't get notified.

The PostHog/posthog companion PR (https://github.com/PostHog/posthog/pull/63495) makes the backend deliver Slack's labeled wire form `<@U_ID|displayname>` in the message context the agent sees. This PR closes the loop on the agent side: tell it to copy that token verbatim into its reply.

## Changes

Add a one-paragraph instruction to the Slack-origin system prompt (next to the existing `# Response Style` section):

```
# Mentioning users
When you want to ping a Slack user in your reply, copy their `<@U…|displayname>` token verbatim from the message context — Slack renders that as a real mention. Writing `@displayname` as plain text does NOT ping them.
```

Only added when `getCloudInteractionOrigin() === "slack"`, so non-Slack interactions are unaffected.

## How did you test this?

Manual: end-to-end test from a Slack thread where the user `@`-mentions someone. With backend PR + this prompt change in place, the agent's reply renders mentioned users as actual Slack pings. Without the prompt change, the agent tends to paraphrase to plain `@name` and the ping is lost.

No automated tests added — the change is in a string literal.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?