### PR TITLE
fix(agent): mark background task runs completed on normal stop

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -627,78 +627,103 @@ describe("AgentServer HTTP Mode", () => {
       expect(testServer.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
     });
 
-    it("marks background runs completed on a normal stop reason", async () => {
-      const order: string[] = [];
-      const testServer = new AgentServer({
-        port,
-        jwtPublicKey: TEST_PUBLIC_KEY,
-        repositoryPath: repo.path,
-        apiUrl: "http://localhost:8000",
-        apiKey: "test-api-key",
-        projectId: 1,
-        mode: "background",
-        taskId: "test-task-id",
-        runId: "test-run-id",
-      }) as unknown as {
-        eventStreamSender: {
-          enqueue: (event: Record<string, unknown>) => void;
-          stop: () => Promise<void>;
-        };
-        posthogAPI: {
-          updateTaskRun: (
-            taskId: string,
-            runId: string,
-            payload: Record<string, unknown>,
-          ) => Promise<unknown>;
-        };
-        signalTaskComplete(
-          payload: JwtPayload,
-          stopReason: string,
-        ): Promise<void>;
-      };
-      testServer.eventStreamSender = {
-        enqueue: vi.fn(() => {
-          order.push("enqueue");
-        }),
-        stop: vi.fn(async () => {
-          order.push("stop");
-        }),
-      };
-      testServer.posthogAPI = {
-        updateTaskRun: vi.fn(async () => {
-          order.push("update");
-          return {};
-        }),
-      };
-
-      await testServer.signalTaskComplete(
-        {
-          run_id: "run-1",
-          task_id: "task-1",
-          team_id: 1,
-          user_id: 1,
-          distinct_id: "distinct-id",
+    it.each([
+      {
+        label: "completed on a clean end_turn",
+        stopReason: "end_turn",
+        expectedStatus: "completed",
+        expectedMethod: "_posthog/task_complete",
+        expectsErrorMessage: false,
+      },
+      {
+        label: "failed when the run stops early (max_tokens)",
+        stopReason: "max_tokens",
+        expectedStatus: "failed",
+        expectedMethod: "_posthog/error",
+        expectsErrorMessage: true,
+      },
+    ])(
+      "marks a background run $label",
+      async ({
+        stopReason,
+        expectedStatus,
+        expectedMethod,
+        expectsErrorMessage,
+      }) => {
+        const order: string[] = [];
+        const testServer = new AgentServer({
+          port,
+          jwtPublicKey: TEST_PUBLIC_KEY,
+          repositoryPath: repo.path,
+          apiUrl: "http://localhost:8000",
+          apiKey: "test-api-key",
+          projectId: 1,
           mode: "background",
-        },
-        "end_turn",
-      );
-
-      expect(order).toEqual(["enqueue", "update", "stop"]);
-      expect(testServer.eventStreamSender.enqueue).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "notification",
-          notification: expect.objectContaining({
-            method: "_posthog/task_complete",
-            params: expect.objectContaining({ stopReason: "end_turn" }),
+          taskId: "test-task-id",
+          runId: "test-run-id",
+        }) as unknown as {
+          eventStreamSender: {
+            enqueue: (event: Record<string, unknown>) => void;
+            stop: () => Promise<void>;
+          };
+          posthogAPI: {
+            updateTaskRun: (
+              taskId: string,
+              runId: string,
+              payload: Record<string, unknown>,
+            ) => Promise<unknown>;
+          };
+          signalTaskComplete(
+            payload: JwtPayload,
+            stopReason: string,
+          ): Promise<void>;
+        };
+        testServer.eventStreamSender = {
+          enqueue: vi.fn(() => {
+            order.push("enqueue");
           }),
-        }),
-      );
-      expect(testServer.posthogAPI.updateTaskRun).toHaveBeenCalledWith(
-        "task-1",
-        "run-1",
-        { status: "completed" },
-      );
-    });
+          stop: vi.fn(async () => {
+            order.push("stop");
+          }),
+        };
+        testServer.posthogAPI = {
+          updateTaskRun: vi.fn(async () => {
+            order.push("update");
+            return {};
+          }),
+        };
+
+        await testServer.signalTaskComplete(
+          {
+            run_id: "run-1",
+            task_id: "task-1",
+            team_id: 1,
+            user_id: 1,
+            distinct_id: "distinct-id",
+            mode: "background",
+          },
+          stopReason,
+        );
+
+        expect(order).toEqual(["enqueue", "update", "stop"]);
+        expect(testServer.eventStreamSender.enqueue).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "notification",
+            notification: expect.objectContaining({
+              method: expectedMethod,
+              params: expect.objectContaining({ stopReason }),
+            }),
+          }),
+        );
+        expect(testServer.posthogAPI.updateTaskRun).toHaveBeenCalledWith(
+          "task-1",
+          "run-1",
+          expectsErrorMessage
+            ? { status: expectedStatus, error_message: expect.any(String) }
+            : { status: expectedStatus },
+        );
+      },
+    );
 
     it("persists structured turn completion notifications", () => {
       const appendRawLine = vi.fn();

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -627,6 +627,79 @@ describe("AgentServer HTTP Mode", () => {
       expect(testServer.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
     });
 
+    it("marks background runs completed on a normal stop reason", async () => {
+      const order: string[] = [];
+      const testServer = new AgentServer({
+        port,
+        jwtPublicKey: TEST_PUBLIC_KEY,
+        repositoryPath: repo.path,
+        apiUrl: "http://localhost:8000",
+        apiKey: "test-api-key",
+        projectId: 1,
+        mode: "background",
+        taskId: "test-task-id",
+        runId: "test-run-id",
+      }) as unknown as {
+        eventStreamSender: {
+          enqueue: (event: Record<string, unknown>) => void;
+          stop: () => Promise<void>;
+        };
+        posthogAPI: {
+          updateTaskRun: (
+            taskId: string,
+            runId: string,
+            payload: Record<string, unknown>,
+          ) => Promise<unknown>;
+        };
+        signalTaskComplete(
+          payload: JwtPayload,
+          stopReason: string,
+        ): Promise<void>;
+      };
+      testServer.eventStreamSender = {
+        enqueue: vi.fn(() => {
+          order.push("enqueue");
+        }),
+        stop: vi.fn(async () => {
+          order.push("stop");
+        }),
+      };
+      testServer.posthogAPI = {
+        updateTaskRun: vi.fn(async () => {
+          order.push("update");
+          return {};
+        }),
+      };
+
+      await testServer.signalTaskComplete(
+        {
+          run_id: "run-1",
+          task_id: "task-1",
+          team_id: 1,
+          user_id: 1,
+          distinct_id: "distinct-id",
+          mode: "background",
+        },
+        "end_turn",
+      );
+
+      expect(order).toEqual(["enqueue", "update", "stop"]);
+      expect(testServer.eventStreamSender.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "notification",
+          notification: expect.objectContaining({
+            method: "_posthog/task_complete",
+            params: expect.objectContaining({ stopReason: "end_turn" }),
+          }),
+        }),
+      );
+      expect(testServer.posthogAPI.updateTaskRun).toHaveBeenCalledWith(
+        "task-1",
+        "run-1",
+        { status: "completed" },
+      );
+    });
+
     it("persists structured turn completion notifications", () => {
       const appendRawLine = vi.fn();
       const testServer = new AgentServer({

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1975,25 +1975,29 @@ ${signedCommitInstructions}
       return;
     }
 
-    const status = isError ? "failed" : "completed";
+    // Only a clean `end_turn` means the run actually finished its work. Any
+    // other stop reason (error, or an early stop like `max_tokens`/`refusal`)
+    // means the agent halted before completing the task, so report it as
+    // failed rather than completed.
+    const isCompleted = stopReason === "end_turn";
+    const status = isCompleted ? "completed" : "failed";
+    const failureMessage = isError
+      ? (errorMessage ?? "Agent error")
+      : `Agent stopped before completing the task (stop reason: ${stopReason})`;
 
     this.enqueueTaskTerminalEvent(
-      isError
-        ? POSTHOG_NOTIFICATIONS.ERROR
-        : POSTHOG_NOTIFICATIONS.TASK_COMPLETE,
-      isError
-        ? {
-            source: "agent_server",
-            stopReason,
-            error: errorMessage ?? "Agent error",
-          }
-        : { source: "agent_server", stopReason },
+      isCompleted
+        ? POSTHOG_NOTIFICATIONS.TASK_COMPLETE
+        : POSTHOG_NOTIFICATIONS.ERROR,
+      isCompleted
+        ? { source: "agent_server", stopReason }
+        : { source: "agent_server", stopReason, error: failureMessage },
     );
 
     try {
       await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
         status,
-        ...(isError && { error_message: errorMessage ?? "Agent error" }),
+        ...(isCompleted ? {} : { error_message: failureMessage }),
       });
       this.logger.debug("Task completion signaled", { status, stopReason });
     } catch (error) {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1277,6 +1277,11 @@ export class AgentServer {
       if (result.stopReason === "end_turn") {
         await this.relayAgentResponse(payload);
       }
+
+      // Mark the run terminal. No-op for interactive sessions (they stay open
+      // for follow-ups); for background cloud-task runs this flips the run from
+      // "in_progress" to "completed".
+      await this.signalTaskComplete(payload, result.stopReason);
     } catch (error) {
       this.logger.error("Failed to send initial task message", error);
       if (this.session) {
@@ -1400,6 +1405,11 @@ export class AgentServer {
       if (result.stopReason === "end_turn") {
         await this.relayAgentResponse(payload);
       }
+
+      // Mark the run terminal. No-op for interactive sessions (they stay open
+      // for follow-ups); for background cloud-task runs this flips the run from
+      // "in_progress" to "completed".
+      await this.signalTaskComplete(payload, result.stopReason);
     } catch (error) {
       this.logger.error("Failed to send resume message", error);
       if (this.session) {
@@ -1951,25 +1961,39 @@ ${signedCommitInstructions}
       }
     }
 
-    if (stopReason !== "error") {
+    const isError = stopReason === "error";
+
+    // Interactive sessions stay open after a normal turn so the user can send
+    // follow-up messages — only an error is terminal there. Background
+    // (headless cloud-task) runs have no follow-up sender, so a normal
+    // end-of-turn IS the run's terminal state and must be reported as
+    // completed; otherwise the run stays "in_progress" forever.
+    if (!isError && this.getEffectiveMode(payload) !== "background") {
       this.logger.debug("Skipping status update for non-error stop reason", {
         stopReason,
       });
       return;
     }
 
-    const status = "failed";
+    const status = isError ? "failed" : "completed";
 
-    this.enqueueTaskTerminalEvent(POSTHOG_NOTIFICATIONS.ERROR, {
-      source: "agent_server",
-      stopReason,
-      error: errorMessage ?? "Agent error",
-    });
+    this.enqueueTaskTerminalEvent(
+      isError
+        ? POSTHOG_NOTIFICATIONS.ERROR
+        : POSTHOG_NOTIFICATIONS.TASK_COMPLETE,
+      isError
+        ? {
+            source: "agent_server",
+            stopReason,
+            error: errorMessage ?? "Agent error",
+          }
+        : { source: "agent_server", stopReason },
+    );
 
     try {
       await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
         status,
-        error_message: errorMessage ?? "Agent error",
+        ...(isError && { error_message: errorMessage ?? "Agent error" }),
       });
       this.logger.debug("Task completion signaled", { status, stopReason });
     } catch (error) {


### PR DESCRIPTION
## Problem

Cloud tasks triggered from the Tasks UI ran to completion but stayed stuck **In Progress** forever — they never transitioned to **Completed**. Background (headless) task runs set `status: "in_progress"` on init, but `signalTaskComplete` only ever wrote `"failed"`, and only when the stop reason was `"error"`. A normal end-of-turn produced no status update at all.

## Changes

- `signalTaskComplete` now reports a normal stop reason as `"completed"` for **background** runs — emitting the previously-defined-but-unused `_posthog/task_complete` event and stopping event ingest. Interactive sessions are unchanged: they still stay open after a normal turn so the user can send follow-up messages (only an error is terminal there).
- The initial- and resume-task-message success paths now call `signalTaskComplete`, so a finished background run flips `in_progress → completed`.

## How did you test this?

- Added a unit test asserting a background run on a normal (`end_turn`) stop reason enqueues `_posthog/task_complete` and PATCHes the run to `status: "completed"`.
- Ran `pnpm exec vitest run src/server/agent-server.test.ts` in `packages/agent`: the new test and all existing turn-completion tests pass (the interactive "leaves event ingest open for non-error stop reasons" test still passes unchanged). 3 pre-existing `buildCloudSystemPrompt` failures are unrelated to this change (they also fail on `main`, due to environment-specific system-prompt content).
- `pnpm --filter @posthog/agent typecheck` and `biome lint` on the changed files both clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781534489013349)*
