### PR TITLE
feat(deep-links): canonical posthog-code:// links for scout & inbox share

### DIFF
--- a/apps/code/src/main/di/bindings.ts
+++ b/apps/code/src/main/di/bindings.ts
@@ -48,10 +48,12 @@ import type { SlackIntegrationService } from "@posthog/core/integrations/slack";
 import type {
   INBOX_LINK_SERVICE,
   NEW_TASK_LINK_SERVICE,
+  SCOUT_LINK_SERVICE,
   TASK_LINK_SERVICE,
 } from "@posthog/core/links/identifiers";
 import type { InboxLinkService } from "@posthog/core/links/inbox-link";
 import type { NewTaskLinkService } from "@posthog/core/links/new-task-link";
+import type { ScoutLinkService } from "@posthog/core/links/scout-link";
 import type { TaskLinkService } from "@posthog/core/links/task-link";
 import type {
   LLM_GATEWAY_HOST,
@@ -253,6 +255,7 @@ import type {
   PROCESS_TRACKING_SERVICE as MAIN_PROCESS_TRACKING_SERVICE,
   PROVISIONING_SERVICE as MAIN_PROVISIONING_SERVICE,
   REPOSITORY_REPOSITORY as MAIN_REPOSITORY_REPOSITORY,
+  SCOUT_LINK_SERVICE as MAIN_SCOUT_LINK_SERVICE,
   SECURE_STORE_BACKEND as MAIN_SECURE_STORE_BACKEND,
   SECURE_STORE_SERVICE as MAIN_SECURE_STORE_SERVICE,
   SETTINGS_STORE as MAIN_SETTINGS_STORE,
@@ -396,9 +399,11 @@ export interface MainBindings {
   // Links
   [MAIN_TASK_LINK_SERVICE]: TaskLinkService;
   [MAIN_INBOX_LINK_SERVICE]: InboxLinkService;
+  [MAIN_SCOUT_LINK_SERVICE]: ScoutLinkService;
   [MAIN_NEW_TASK_LINK_SERVICE]: NewTaskLinkService;
   [TASK_LINK_SERVICE]: TaskLinkService;
   [INBOX_LINK_SERVICE]: InboxLinkService;
+  [SCOUT_LINK_SERVICE]: ScoutLinkService;
   [NEW_TASK_LINK_SERVICE]: NewTaskLinkService;
 
   // Watcher registry

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -50,10 +50,12 @@ import { integrationsModule } from "@posthog/core/integrations/integrations.modu
 import {
   INBOX_LINK_SERVICE,
   NEW_TASK_LINK_SERVICE,
+  SCOUT_LINK_SERVICE,
   TASK_LINK_SERVICE,
 } from "@posthog/core/links/identifiers";
 import { InboxLinkService } from "@posthog/core/links/inbox-link";
 import { NewTaskLinkService } from "@posthog/core/links/new-task-link";
+import { ScoutLinkService } from "@posthog/core/links/scout-link";
 import { TaskLinkService } from "@posthog/core/links/task-link";
 import {
   LLM_GATEWAY_HOST,
@@ -264,6 +266,7 @@ import {
   PROCESS_TRACKING_SERVICE as MAIN_PROCESS_TRACKING_SERVICE,
   PROVISIONING_SERVICE as MAIN_PROVISIONING_SERVICE,
   REPOSITORY_REPOSITORY as MAIN_REPOSITORY_REPOSITORY,
+  SCOUT_LINK_SERVICE as MAIN_SCOUT_LINK_SERVICE,
   SECURE_STORE_BACKEND as MAIN_SECURE_STORE_BACKEND,
   SECURE_STORE_SERVICE as MAIN_SECURE_STORE_SERVICE,
   SETTINGS_STORE as MAIN_SETTINGS_STORE,
@@ -613,6 +616,8 @@ container.bind(MAIN_TASK_LINK_SERVICE).to(TaskLinkService);
 container.bind(TASK_LINK_SERVICE).toService(MAIN_TOKENS.TaskLinkService);
 container.bind(MAIN_INBOX_LINK_SERVICE).to(InboxLinkService);
 container.bind(INBOX_LINK_SERVICE).toService(MAIN_TOKENS.InboxLinkService);
+container.bind(MAIN_SCOUT_LINK_SERVICE).to(ScoutLinkService);
+container.bind(SCOUT_LINK_SERVICE).toService(MAIN_TOKENS.ScoutLinkService);
 container.bind(MAIN_NEW_TASK_LINK_SERVICE).to(NewTaskLinkService);
 container.bind(NEW_TASK_LINK_SERVICE).toService(MAIN_TOKENS.NewTaskLinkService);
 container.load(watcherRegistryModule);

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -97,6 +97,9 @@ export const TASK_LINK_SERVICE = Symbol.for(
 export const INBOX_LINK_SERVICE = Symbol.for(
   "posthog.host.main.inbox-link.service",
 );
+export const SCOUT_LINK_SERVICE = Symbol.for(
+  "posthog.host.main.scout-link.service",
+);
 export const NEW_TASK_LINK_SERVICE = Symbol.for(
   "posthog.host.main.new-task-link.service",
 );
@@ -150,6 +153,7 @@ export const MAIN_TOKENS = Object.freeze({
   UpdatesService: UPDATES_SERVICE,
   TaskLinkService: TASK_LINK_SERVICE,
   InboxLinkService: INBOX_LINK_SERVICE,
+  ScoutLinkService: SCOUT_LINK_SERVICE,
   NewTaskLinkService: NEW_TASK_LINK_SERVICE,
   WatcherRegistryService: WATCHER_REGISTRY_SERVICE,
   ProvisioningService: PROVISIONING_SERVICE,

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -24,6 +24,7 @@ import {
 import type { SlackIntegrationService } from "@posthog/core/integrations/slack";
 import type { InboxLinkService } from "@posthog/core/links/inbox-link";
 import type { NewTaskLinkService } from "@posthog/core/links/new-task-link";
+import type { ScoutLinkService } from "@posthog/core/links/scout-link";
 import type { TaskLinkService } from "@posthog/core/links/task-link";
 import { NOTIFICATION_SERVICE } from "@posthog/core/notification/identifiers";
 import type { NotificationService } from "@posthog/core/notification/notification";
@@ -223,6 +224,7 @@ async function initializeServices(): Promise<void> {
   container.get<UpdatesService>(MAIN_TOKENS.UpdatesService);
   container.get<TaskLinkService>(MAIN_TOKENS.TaskLinkService);
   container.get<InboxLinkService>(MAIN_TOKENS.InboxLinkService);
+  container.get<ScoutLinkService>(MAIN_TOKENS.ScoutLinkService);
   container.get<NewTaskLinkService>(MAIN_TOKENS.NewTaskLinkService);
   container.get<GitHubIntegrationService>(GITHUB_INTEGRATION_SERVICE);
   container.get<SlackIntegrationService>(SLACK_INTEGRATION_SERVICE);

--- a/docs/DEEP-LINKS.md
+++ b/docs/DEEP-LINKS.md
@@ -10,7 +10,7 @@ PostHog Code registers custom URL schemes so the desktop app can be opened with 
 | Development | `posthog-code-dev://` |
 | Legacy (production only) | `twig://`, `array://` |
 
-All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `new`, `plan`, `issue`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
+All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `scout`, `new`, `plan`, `issue`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
 
 If the app is not running, the OS launches it and the link is queued until the renderer is ready. If the app is minimised, it is restored and focused before the link is handled.
 
@@ -100,6 +100,22 @@ Open a specific inbox report.
 posthog-code://inbox/report_abc123
 ```
 
+### `posthog-code://scout/<skillSlug>`
+
+Open a scout's detail page, optionally focused on a specific finding (expanded
+and scrolled into view). This is the link copied by the "Share" CTA on a scout
+emission card.
+
+| Segment / Parameter | Required | Description |
+|---|---|---|
+| `<skillSlug>` | Yes | Scout route slug, i.e. the skill name with the `signals-scout-` prefix stripped (e.g. `error-tracking`) |
+| `finding` | No | Emission id to expand and scroll to. Best effort – only resolves while the finding is still inside the scout's runs window. |
+
+```
+posthog-code://scout/error-tracking
+posthog-code://scout/error-tracking?finding=abc123
+```
+
 ## OAuth callback links
 
 These are issued by external services and consumed by the app. You should not need to construct them yourself, but they are documented for completeness.
@@ -161,13 +177,14 @@ In development the same payload is delivered to `http://localhost:8238/mcp-oauth
 | Handler | Source |
 |---|---|
 | Dispatcher | [apps/code/src/main/services/deep-link/service.ts](../apps/code/src/main/services/deep-link/service.ts) |
-| `task` | [apps/code/src/main/services/task-link/service.ts](../apps/code/src/main/services/task-link/service.ts) |
-| `inbox` | [apps/code/src/main/services/inbox-link/service.ts](../apps/code/src/main/services/inbox-link/service.ts) |
-| `new`, `plan`, `issue` | [apps/code/src/main/services/new-task-link/service.ts](../apps/code/src/main/services/new-task-link/service.ts) |
-| `callback` | [apps/code/src/main/services/oauth/service.ts](../apps/code/src/main/services/oauth/service.ts) |
-| `integration` | [apps/code/src/main/services/github-integration/service.ts](../apps/code/src/main/services/github-integration/service.ts) |
-| `slack-integration` | [apps/code/src/main/services/slack-integration/service.ts](../apps/code/src/main/services/slack-integration/service.ts) |
-| `mcp-oauth-complete` | [apps/code/src/main/services/mcp-callback/service.ts](../apps/code/src/main/services/mcp-callback/service.ts) |
-| Scheme constants | [apps/code/src/shared/deeplink.ts](../apps/code/src/shared/deeplink.ts) |
+| `task` | [packages/core/src/links/task-link.ts](../packages/core/src/links/task-link.ts) |
+| `inbox` | [packages/core/src/links/inbox-link.ts](../packages/core/src/links/inbox-link.ts) |
+| `scout` | [packages/core/src/links/scout-link.ts](../packages/core/src/links/scout-link.ts) |
+| `new`, `plan`, `issue` | [packages/core/src/links/new-task-link.ts](../packages/core/src/links/new-task-link.ts) |
+| `callback` | [packages/core/src/oauth/oauth.ts](../packages/core/src/oauth/oauth.ts) |
+| `integration` | [packages/core/src/integrations/github.ts](../packages/core/src/integrations/github.ts) |
+| `slack-integration` | [packages/core/src/integrations/slack.ts](../packages/core/src/integrations/slack.ts) |
+| `mcp-oauth-complete` | [packages/workspace-server/src/services/mcp-callback/mcp-callback.ts](../packages/workspace-server/src/services/mcp-callback/mcp-callback.ts) |
+| Scheme constants & link builders | [packages/shared/src/deep-links.ts](../packages/shared/src/deep-links.ts) |
 
-To add a new deep link, register a handler with `DeepLinkService.registerHandler(key, handler)` and route renderer-side events through the [`deepLinkRouter`](../apps/code/src/main/trpc/routers/deep-link.ts) tRPC router.
+To add a new deep link, register a handler with `DeepLinkService.registerHandler(key, handler)` (typically from a `@injectable()` service in `packages/core/src/links/`), expose renderer-side events through the [`deepLinkRouter`](../packages/host-router/src/routers/deep-link.router.ts) tRPC router, and add a builder + handler hook on the renderer side. The `scout` handler is a minimal reference for path + query-param links.

--- a/packages/core/src/links/identifiers.ts
+++ b/packages/core/src/links/identifiers.ts
@@ -7,6 +7,7 @@ export interface LinkLogger {
 
 export const TASK_LINK_SERVICE = Symbol.for("posthog.core.taskLinkService");
 export const INBOX_LINK_SERVICE = Symbol.for("posthog.core.inboxLinkService");
+export const SCOUT_LINK_SERVICE = Symbol.for("posthog.core.scoutLinkService");
 export const NEW_TASK_LINK_SERVICE = Symbol.for(
   "posthog.core.newTaskLinkService",
 );

--- a/packages/core/src/links/scout-link.test.ts
+++ b/packages/core/src/links/scout-link.test.ts
@@ -4,7 +4,11 @@ import type {
 } from "@posthog/platform/deep-link";
 import type { IMainWindow } from "@posthog/platform/main-window";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ScoutLinkEvent, ScoutLinkService } from "./scout-link";
+import {
+  ScoutLinkEvent,
+  type ScoutLinkPayload,
+  ScoutLinkService,
+} from "./scout-link";
 
 function makeLogger() {
   const logger = {
@@ -64,33 +68,44 @@ describe("ScoutLinkService", () => {
     );
   });
 
-  it("emits OpenScout with the finding id when a listener is attached", () => {
+  it.each<{
+    name: string;
+    path: string;
+    search: string;
+    expected: ScoutLinkPayload;
+  }>([
+    {
+      name: "emits OpenScout with the finding id from the query param",
+      path: "error-tracking",
+      search: "finding=abc-123",
+      expected: { skillSlug: "error-tracking", findingId: "abc-123" },
+    },
+    {
+      name: "emits OpenScout without a finding id when none is supplied",
+      path: "error-tracking",
+      search: "",
+      expected: { skillSlug: "error-tracking", findingId: undefined },
+    },
+    {
+      name: "takes only the first path segment as the skill slug",
+      path: "error-tracking/extra/segments",
+      search: "",
+      expected: { skillSlug: "error-tracking", findingId: undefined },
+    },
+    {
+      name: "decodes a percent-encoded skill slug",
+      path: "error%2Dtracking",
+      search: "",
+      expected: { skillSlug: "error-tracking", findingId: undefined },
+    },
+  ])("$name", ({ path, search, expected }) => {
     const listener = vi.fn();
     service.on(ScoutLinkEvent.OpenScout, listener);
 
-    const result = deepLinkService.trigger(
-      "scout",
-      "error-tracking",
-      "finding=abc-123",
-    );
+    const result = deepLinkService.trigger("scout", path, search);
 
     expect(result).toBe(true);
-    expect(listener).toHaveBeenCalledWith({
-      skillSlug: "error-tracking",
-      findingId: "abc-123",
-    });
-  });
-
-  it("emits OpenScout without a finding id when none is supplied", () => {
-    const listener = vi.fn();
-    service.on(ScoutLinkEvent.OpenScout, listener);
-
-    deepLinkService.trigger("scout", "error-tracking");
-
-    expect(listener).toHaveBeenCalledWith({
-      skillSlug: "error-tracking",
-      findingId: undefined,
-    });
+    expect(listener).toHaveBeenCalledWith(expected);
   });
 
   it("queues a pending deep link when no listener is attached", () => {
@@ -103,30 +118,6 @@ describe("ScoutLinkService", () => {
     expect(service.consumePendingDeepLink()).toBeNull();
   });
 
-  it("takes only the first path segment as the skill slug", () => {
-    const listener = vi.fn();
-    service.on(ScoutLinkEvent.OpenScout, listener);
-
-    deepLinkService.trigger("scout", "error-tracking/extra/segments");
-
-    expect(listener).toHaveBeenCalledWith({
-      skillSlug: "error-tracking",
-      findingId: undefined,
-    });
-  });
-
-  it("decodes a percent-encoded skill slug", () => {
-    const listener = vi.fn();
-    service.on(ScoutLinkEvent.OpenScout, listener);
-
-    deepLinkService.trigger("scout", "error%2Dtracking");
-
-    expect(listener).toHaveBeenCalledWith({
-      skillSlug: "error-tracking",
-      findingId: undefined,
-    });
-  });
-
   it("returns false and does not emit when the path is empty", () => {
     const listener = vi.fn();
     service.on(ScoutLinkEvent.OpenScout, listener);
@@ -137,19 +128,27 @@ describe("ScoutLinkService", () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
-  it("focuses the main window on link arrival", () => {
+  it.each<{ name: string; minimized: boolean; expectRestore: boolean }>([
+    {
+      name: "focuses the main window on link arrival",
+      minimized: false,
+      expectRestore: false,
+    },
+    {
+      name: "restores then focuses the main window when it is minimized",
+      minimized: true,
+      expectRestore: true,
+    },
+  ])("$name", ({ minimized, expectRestore }) => {
+    mainWindow.isMinimized.mockReturnValue(minimized);
+
     deepLinkService.trigger("scout", "error-tracking");
 
     expect(mainWindow.focus).toHaveBeenCalledTimes(1);
-    expect(mainWindow.restore).not.toHaveBeenCalled();
-  });
-
-  it("restores the main window when it is minimized", () => {
-    mainWindow.isMinimized.mockReturnValue(true);
-
-    deepLinkService.trigger("scout", "error-tracking");
-
-    expect(mainWindow.restore).toHaveBeenCalledTimes(1);
-    expect(mainWindow.focus).toHaveBeenCalledTimes(1);
+    if (expectRestore) {
+      expect(mainWindow.restore).toHaveBeenCalledTimes(1);
+    } else {
+      expect(mainWindow.restore).not.toHaveBeenCalled();
+    }
   });
 });

--- a/packages/core/src/links/scout-link.test.ts
+++ b/packages/core/src/links/scout-link.test.ts
@@ -1,0 +1,155 @@
+import type {
+  DeepLinkHandler,
+  IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
+import type { IMainWindow } from "@posthog/platform/main-window";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ScoutLinkEvent, ScoutLinkService } from "./scout-link";
+
+function makeLogger() {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    scope: vi.fn(() => logger),
+  };
+  return logger;
+}
+
+function makeDeepLinkService() {
+  const handlers = new Map<string, DeepLinkHandler>();
+  const service = {
+    registerHandler: vi.fn((key: string, handler: DeepLinkHandler) => {
+      handlers.set(key, handler);
+    }),
+    trigger: (key: string, path: string, search = "") => {
+      const handler = handlers.get(key);
+      if (!handler) throw new Error(`No handler for ${key}`);
+      return handler(path, new URLSearchParams(search));
+    },
+  };
+  return service as unknown as IDeepLinkRegistry & {
+    trigger: (key: string, path: string, search?: string) => boolean;
+  };
+}
+
+function makeMainWindow() {
+  return {
+    focus: vi.fn(),
+    restore: vi.fn(),
+    isMinimized: vi.fn().mockReturnValue(false),
+  } as unknown as IMainWindow & {
+    focus: ReturnType<typeof vi.fn>;
+    restore: ReturnType<typeof vi.fn>;
+    isMinimized: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("ScoutLinkService", () => {
+  let deepLinkService: ReturnType<typeof makeDeepLinkService>;
+  let mainWindow: ReturnType<typeof makeMainWindow>;
+  let service: ScoutLinkService;
+
+  beforeEach(() => {
+    deepLinkService = makeDeepLinkService();
+    mainWindow = makeMainWindow();
+    service = new ScoutLinkService(deepLinkService, mainWindow, makeLogger());
+  });
+
+  it("registers a 'scout' handler on the DeepLinkService", () => {
+    expect(deepLinkService.registerHandler).toHaveBeenCalledWith(
+      "scout",
+      expect.any(Function),
+    );
+  });
+
+  it("emits OpenScout with the finding id when a listener is attached", () => {
+    const listener = vi.fn();
+    service.on(ScoutLinkEvent.OpenScout, listener);
+
+    const result = deepLinkService.trigger(
+      "scout",
+      "error-tracking",
+      "finding=abc-123",
+    );
+
+    expect(result).toBe(true);
+    expect(listener).toHaveBeenCalledWith({
+      skillSlug: "error-tracking",
+      findingId: "abc-123",
+    });
+  });
+
+  it("emits OpenScout without a finding id when none is supplied", () => {
+    const listener = vi.fn();
+    service.on(ScoutLinkEvent.OpenScout, listener);
+
+    deepLinkService.trigger("scout", "error-tracking");
+
+    expect(listener).toHaveBeenCalledWith({
+      skillSlug: "error-tracking",
+      findingId: undefined,
+    });
+  });
+
+  it("queues a pending deep link when no listener is attached", () => {
+    deepLinkService.trigger("scout", "web-analytics", "finding=f-1");
+
+    const pending = service.consumePendingDeepLink();
+    expect(pending).toEqual({ skillSlug: "web-analytics", findingId: "f-1" });
+
+    // Draining clears it
+    expect(service.consumePendingDeepLink()).toBeNull();
+  });
+
+  it("takes only the first path segment as the skill slug", () => {
+    const listener = vi.fn();
+    service.on(ScoutLinkEvent.OpenScout, listener);
+
+    deepLinkService.trigger("scout", "error-tracking/extra/segments");
+
+    expect(listener).toHaveBeenCalledWith({
+      skillSlug: "error-tracking",
+      findingId: undefined,
+    });
+  });
+
+  it("decodes a percent-encoded skill slug", () => {
+    const listener = vi.fn();
+    service.on(ScoutLinkEvent.OpenScout, listener);
+
+    deepLinkService.trigger("scout", "error%2Dtracking");
+
+    expect(listener).toHaveBeenCalledWith({
+      skillSlug: "error-tracking",
+      findingId: undefined,
+    });
+  });
+
+  it("returns false and does not emit when the path is empty", () => {
+    const listener = vi.fn();
+    service.on(ScoutLinkEvent.OpenScout, listener);
+
+    const result = deepLinkService.trigger("scout", "");
+
+    expect(result).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("focuses the main window on link arrival", () => {
+    deepLinkService.trigger("scout", "error-tracking");
+
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1);
+    expect(mainWindow.restore).not.toHaveBeenCalled();
+  });
+
+  it("restores the main window when it is minimized", () => {
+    mainWindow.isMinimized.mockReturnValue(true);
+
+    deepLinkService.trigger("scout", "error-tracking");
+
+    expect(mainWindow.restore).toHaveBeenCalledTimes(1);
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/links/scout-link.ts
+++ b/packages/core/src/links/scout-link.ts
@@ -1,0 +1,104 @@
+import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
+import {
+  DEEP_LINK_SERVICE,
+  type IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
+import {
+  type IMainWindow,
+  MAIN_WINDOW_SERVICE,
+} from "@posthog/platform/main-window";
+import { TypedEventEmitter } from "@posthog/shared";
+import { inject, injectable } from "inversify";
+import type { LinkLogger } from "./identifiers";
+
+export const ScoutLinkEvent = {
+  OpenScout: "openScout",
+} as const;
+
+export interface ScoutLinkPayload {
+  /** Route slug for the scout (e.g. "error-tracking"). */
+  skillSlug: string;
+  /** Emission id to expand and scroll to, if the link carried one. */
+  findingId?: string;
+}
+
+export interface ScoutLinkEvents {
+  [ScoutLinkEvent.OpenScout]: ScoutLinkPayload;
+}
+
+@injectable()
+export class ScoutLinkService extends TypedEventEmitter<ScoutLinkEvents> {
+  private pendingDeepLink: ScoutLinkPayload | null = null;
+  private readonly log: LinkLogger;
+
+  constructor(
+    @inject(DEEP_LINK_SERVICE)
+    private readonly deepLinkService: IDeepLinkRegistry,
+    @inject(MAIN_WINDOW_SERVICE)
+    private readonly mainWindow: IMainWindow,
+    @inject(ROOT_LOGGER)
+    rootLogger: RootLogger,
+  ) {
+    super();
+    this.log = rootLogger.scope("scout-link-service");
+
+    this.deepLinkService.registerHandler("scout", (path, searchParams) =>
+      this.handleScoutLink(path, searchParams),
+    );
+  }
+
+  private handleScoutLink(
+    path: string,
+    searchParams: URLSearchParams,
+  ): boolean {
+    const skillSlug = decodeSegment(path.split("/")[0]);
+
+    if (!skillSlug) {
+      this.log.warn("Scout link missing skill slug");
+      return false;
+    }
+
+    const findingId = searchParams.get("finding") ?? undefined;
+    const payload: ScoutLinkPayload = { skillSlug, findingId };
+
+    const hasListeners = this.listenerCount(ScoutLinkEvent.OpenScout) > 0;
+
+    if (hasListeners) {
+      this.log.info(
+        `Emitting scout link event: skillSlug=${skillSlug} findingId=${findingId ?? "(none)"}`,
+      );
+      this.emit(ScoutLinkEvent.OpenScout, payload);
+    } else {
+      this.log.info(
+        `Queueing scout link (renderer not ready): skillSlug=${skillSlug}`,
+      );
+      this.pendingDeepLink = payload;
+    }
+
+    this.log.info("Deep link focusing window", { skillSlug });
+    if (this.mainWindow.isMinimized()) {
+      this.mainWindow.restore();
+    }
+    this.mainWindow.focus();
+
+    return true;
+  }
+
+  public consumePendingDeepLink(): ScoutLinkPayload | null {
+    const pending = this.pendingDeepLink;
+    this.pendingDeepLink = null;
+    if (pending) {
+      this.log.info(`Consumed pending scout link: skillSlug=${pending.skillSlug}`);
+    }
+    return pending;
+  }
+}
+
+function decodeSegment(segment: string | undefined): string {
+  if (!segment) return "";
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/packages/core/src/links/scout-link.ts
+++ b/packages/core/src/links/scout-link.ts
@@ -88,7 +88,9 @@ export class ScoutLinkService extends TypedEventEmitter<ScoutLinkEvents> {
     const pending = this.pendingDeepLink;
     this.pendingDeepLink = null;
     if (pending) {
-      this.log.info(`Consumed pending scout link: skillSlug=${pending.skillSlug}`);
+      this.log.info(
+        `Consumed pending scout link: skillSlug=${pending.skillSlug}`,
+      );
     }
     return pending;
   }

--- a/packages/core/src/scouts/scoutPresentation.ts
+++ b/packages/core/src/scouts/scoutPresentation.ts
@@ -1,5 +1,9 @@
 import type { ScoutConfig, ScoutRun } from "@posthog/api-client/posthog-client";
 
+// Single source of truth lives in `@posthog/shared` so `buildScoutDeeplink`
+// (which cannot import core) and the UI share one slug implementation.
+export { scoutSkillNameFromSlug, scoutSkillSlug } from "@posthog/shared";
+
 /**
  * Canonical scouts shipped in the PostHog repo (products/signals/skills).
  * The configs endpoint does not yet distinguish canonical from hand-authored
@@ -38,15 +42,6 @@ export function prettifyScoutSkillName(skillName: string): string {
     .trim();
   if (!cleaned) return skillName;
   return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
-}
-
-/** Route param form: "signals-scout-error-tracking" → "error-tracking" */
-export function scoutSkillSlug(skillName: string): string {
-  return skillName.replace(/^signals-scout-/, "");
-}
-
-export function scoutSkillNameFromSlug(slug: string): string {
-  return slug.startsWith("signals-scout-") ? slug : `signals-scout-${slug}`;
 }
 
 export type ScoutRunStatus =

--- a/packages/host-router/src/routers/deep-link.router.ts
+++ b/packages/host-router/src/routers/deep-link.router.ts
@@ -10,15 +10,15 @@ import {
   type PendingInboxDeepLink,
 } from "@posthog/core/links/inbox-link";
 import {
-  ScoutLinkEvent,
-  type ScoutLinkPayload,
-  type ScoutLinkService,
-} from "@posthog/core/links/scout-link";
-import {
   NewTaskLinkEvent,
   type NewTaskLinkPayload,
   type NewTaskLinkService,
 } from "@posthog/core/links/new-task-link";
+import {
+  ScoutLinkEvent,
+  type ScoutLinkPayload,
+  type ScoutLinkService,
+} from "@posthog/core/links/scout-link";
 import {
   type PendingDeepLink,
   TaskLinkEvent,

--- a/packages/host-router/src/routers/deep-link.router.ts
+++ b/packages/host-router/src/routers/deep-link.router.ts
@@ -1,6 +1,7 @@
 import {
   INBOX_LINK_SERVICE,
   NEW_TASK_LINK_SERVICE,
+  SCOUT_LINK_SERVICE,
   TASK_LINK_SERVICE,
 } from "@posthog/core/links/identifiers";
 import {
@@ -8,6 +9,11 @@ import {
   type InboxLinkService,
   type PendingInboxDeepLink,
 } from "@posthog/core/links/inbox-link";
+import {
+  ScoutLinkEvent,
+  type ScoutLinkPayload,
+  type ScoutLinkService,
+} from "@posthog/core/links/scout-link";
 import {
   NewTaskLinkEvent,
   type NewTaskLinkPayload,
@@ -54,6 +60,25 @@ export const deepLinkRouter = router({
     ({ ctx }): PendingInboxDeepLink | null => {
       return ctx.container
         .get<InboxLinkService>(INBOX_LINK_SERVICE)
+        .consumePendingDeepLink();
+    },
+  ),
+
+  onOpenScout: publicProcedure.subscription(async function* (opts) {
+    const service =
+      opts.ctx.container.get<ScoutLinkService>(SCOUT_LINK_SERVICE);
+    const iterable = service.toIterable(ScoutLinkEvent.OpenScout, {
+      signal: opts.signal,
+    });
+    for await (const data of iterable) {
+      yield data;
+    }
+  }),
+
+  getPendingScoutLink: publicProcedure.query(
+    ({ ctx }): ScoutLinkPayload | null => {
+      return ctx.container
+        .get<ScoutLinkService>(SCOUT_LINK_SERVICE)
         .consumePendingDeepLink();
     },
   ),

--- a/packages/shared/src/deep-links.test.ts
+++ b/packages/shared/src/deep-links.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildInboxDeeplink,
+  buildScoutDeeplink,
   decodePlanBase64,
   getDeeplinkProtocol,
   isPostHogCodeDeeplink,
@@ -93,6 +94,47 @@ describe("buildInboxDeeplink", () => {
         isDevBuild: false,
       }),
     ).toBe("posthog-code://inbox/abc-123/Hello-world");
+  });
+});
+
+describe("buildScoutDeeplink", () => {
+  it("builds a bare scout link with no finding", () => {
+    expect(
+      buildScoutDeeplink("error-tracking", null, { isDevBuild: false }),
+    ).toBe("posthog-code://scout/error-tracking");
+    expect(
+      buildScoutDeeplink("error-tracking", undefined, { isDevBuild: false }),
+    ).toBe("posthog-code://scout/error-tracking");
+  });
+
+  it("appends the finding id as a query param", () => {
+    expect(
+      buildScoutDeeplink("error-tracking", "abc-123", { isDevBuild: false }),
+    ).toBe("posthog-code://scout/error-tracking?finding=abc-123");
+  });
+
+  it("strips the signals-scout- prefix from a full skill name", () => {
+    expect(
+      buildScoutDeeplink("signals-scout-error-tracking", "f-1", {
+        isDevBuild: false,
+      }),
+    ).toBe("posthog-code://scout/error-tracking?finding=f-1");
+  });
+
+  it("uses the dev scheme for dev builds", () => {
+    expect(
+      buildScoutDeeplink("web-analytics", null, { isDevBuild: true }),
+    ).toBe("posthog-code-dev://scout/web-analytics");
+  });
+
+  it("encodes special characters in the finding id", () => {
+    expect(
+      buildScoutDeeplink("error-tracking", "id with spaces&=", {
+        isDevBuild: false,
+      }),
+    ).toBe(
+      "posthog-code://scout/error-tracking?finding=id%20with%20spaces%26%3D",
+    );
   });
 });
 

--- a/packages/shared/src/deep-links.test.ts
+++ b/packages/shared/src/deep-links.test.ts
@@ -98,42 +98,59 @@ describe("buildInboxDeeplink", () => {
 });
 
 describe("buildScoutDeeplink", () => {
-  it("builds a bare scout link with no finding", () => {
-    expect(
-      buildScoutDeeplink("error-tracking", null, { isDevBuild: false }),
-    ).toBe("posthog-code://scout/error-tracking");
-    expect(
-      buildScoutDeeplink("error-tracking", undefined, { isDevBuild: false }),
-    ).toBe("posthog-code://scout/error-tracking");
-  });
-
-  it("appends the finding id as a query param", () => {
-    expect(
-      buildScoutDeeplink("error-tracking", "abc-123", { isDevBuild: false }),
-    ).toBe("posthog-code://scout/error-tracking?finding=abc-123");
-  });
-
-  it("strips the signals-scout- prefix from a full skill name", () => {
-    expect(
-      buildScoutDeeplink("signals-scout-error-tracking", "f-1", {
-        isDevBuild: false,
-      }),
-    ).toBe("posthog-code://scout/error-tracking?finding=f-1");
-  });
-
-  it("uses the dev scheme for dev builds", () => {
-    expect(
-      buildScoutDeeplink("web-analytics", null, { isDevBuild: true }),
-    ).toBe("posthog-code-dev://scout/web-analytics");
-  });
-
-  it("encodes special characters in the finding id", () => {
-    expect(
-      buildScoutDeeplink("error-tracking", "id with spaces&=", {
-        isDevBuild: false,
-      }),
-    ).toBe(
-      "posthog-code://scout/error-tracking?finding=id%20with%20spaces%26%3D",
+  it.each<{
+    name: string;
+    skillName: string;
+    findingId: string | null | undefined;
+    isDevBuild: boolean;
+    expected: string;
+  }>([
+    {
+      name: "builds a bare scout link when finding is null",
+      skillName: "error-tracking",
+      findingId: null,
+      isDevBuild: false,
+      expected: "posthog-code://scout/error-tracking",
+    },
+    {
+      name: "builds a bare scout link when finding is undefined",
+      skillName: "error-tracking",
+      findingId: undefined,
+      isDevBuild: false,
+      expected: "posthog-code://scout/error-tracking",
+    },
+    {
+      name: "appends the finding id as a query param",
+      skillName: "error-tracking",
+      findingId: "abc-123",
+      isDevBuild: false,
+      expected: "posthog-code://scout/error-tracking?finding=abc-123",
+    },
+    {
+      name: "strips the signals-scout- prefix from a full skill name",
+      skillName: "signals-scout-error-tracking",
+      findingId: "f-1",
+      isDevBuild: false,
+      expected: "posthog-code://scout/error-tracking?finding=f-1",
+    },
+    {
+      name: "uses the dev scheme for dev builds",
+      skillName: "web-analytics",
+      findingId: null,
+      isDevBuild: true,
+      expected: "posthog-code-dev://scout/web-analytics",
+    },
+    {
+      name: "encodes special characters in the finding id",
+      skillName: "error-tracking",
+      findingId: "id with spaces&=",
+      isDevBuild: false,
+      expected:
+        "posthog-code://scout/error-tracking?finding=id%20with%20spaces%26%3D",
+    },
+  ])("$name", ({ skillName, findingId, isDevBuild, expected }) => {
+    expect(buildScoutDeeplink(skillName, findingId, { isDevBuild })).toBe(
+      expected,
     );
   });
 });

--- a/packages/shared/src/deep-links.ts
+++ b/packages/shared/src/deep-links.ts
@@ -40,6 +40,26 @@ export function buildInboxDeeplink(
   return slug ? `${base}/${slug}` : base;
 }
 
+/**
+ * Build a canonical deep link to a scout's detail page, optionally focused on a
+ * specific finding (`<scheme>://scout/<skillSlug>?finding=<id>`).
+ *
+ * `skillName` may be the full scout skill name (`signals-scout-error-tracking`)
+ * or an already-stripped route slug (`error-tracking`); the `signals-scout-`
+ * prefix is removed so the path always matches the renderer route param.
+ */
+export function buildScoutDeeplink(
+  skillName: string,
+  findingId: string | null | undefined,
+  { isDevBuild }: { isDevBuild: boolean },
+): string {
+  const slug = skillName.replace(/^signals-scout-/, "");
+  const base = `${getDeeplinkProtocol(isDevBuild)}://scout/${encodeURIComponent(slug)}`;
+  return findingId
+    ? `${base}?finding=${encodeURIComponent(findingId)}`
+    : base;
+}
+
 export interface GitHubIssueRef {
   owner: string;
   repo: string;

--- a/packages/shared/src/deep-links.ts
+++ b/packages/shared/src/deep-links.ts
@@ -55,9 +55,7 @@ export function buildScoutDeeplink(
 ): string {
   const slug = skillName.replace(/^signals-scout-/, "");
   const base = `${getDeeplinkProtocol(isDevBuild)}://scout/${encodeURIComponent(slug)}`;
-  return findingId
-    ? `${base}?finding=${encodeURIComponent(findingId)}`
-    : base;
+  return findingId ? `${base}?finding=${encodeURIComponent(findingId)}` : base;
 }
 
 export interface GitHubIssueRef {

--- a/packages/shared/src/deep-links.ts
+++ b/packages/shared/src/deep-links.ts
@@ -1,3 +1,5 @@
+import { scoutSkillSlug } from "./scout-naming";
+
 export const DEEPLINK_PROTOCOL_PRODUCTION = "posthog-code";
 export const DEEPLINK_PROTOCOL_DEVELOPMENT = "posthog-code-dev";
 
@@ -53,7 +55,7 @@ export function buildScoutDeeplink(
   findingId: string | null | undefined,
   { isDevBuild }: { isDevBuild: boolean },
 ): string {
-  const slug = skillName.replace(/^signals-scout-/, "");
+  const slug = scoutSkillSlug(skillName);
   const base = `${getDeeplinkProtocol(isDevBuild)}://scout/${encodeURIComponent(slug)}`;
   return findingId ? `${base}?finding=${encodeURIComponent(findingId)}` : base;
 }

--- a/packages/shared/src/deeplink.ts
+++ b/packages/shared/src/deeplink.ts
@@ -1,5 +1,6 @@
 export {
   buildInboxDeeplink,
+  buildScoutDeeplink,
   DEEPLINK_PROTOCOL_DEVELOPMENT,
   DEEPLINK_PROTOCOL_PRODUCTION,
   getDeeplinkProtocol,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -119,6 +119,7 @@ export {
   type SagaResult,
   type SagaStep,
 } from "./saga";
+export { scoutSkillNameFromSlug, scoutSkillSlug } from "./scout-naming";
 export {
   isProPlan,
   PLAN_FREE,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,7 @@ export {
 } from "./cloud-prompt";
 export {
   buildInboxDeeplink,
+  buildScoutDeeplink,
   DEEPLINK_PROTOCOL_DEVELOPMENT,
   DEEPLINK_PROTOCOL_PRODUCTION,
   decodePlanBase64,

--- a/packages/shared/src/scout-naming.ts
+++ b/packages/shared/src/scout-naming.ts
@@ -1,0 +1,15 @@
+const SCOUT_SKILL_PREFIX = "signals-scout-";
+
+/** Route param form: "signals-scout-error-tracking" → "error-tracking" */
+export function scoutSkillSlug(skillName: string): string {
+  return skillName.startsWith(SCOUT_SKILL_PREFIX)
+    ? skillName.slice(SCOUT_SKILL_PREFIX.length)
+    : skillName;
+}
+
+/** Inverse of `scoutSkillSlug`: "error-tracking" → "signals-scout-error-tracking" */
+export function scoutSkillNameFromSlug(slug: string): string {
+  return slug.startsWith(SCOUT_SKILL_PREFIX)
+    ? slug
+    : `${SCOUT_SKILL_PREFIX}${slug}`;
+}

--- a/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
+++ b/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
@@ -13,6 +13,7 @@ import {
   parsePrUrl,
 } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
+import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import {
   isTerminalStatus,
   type SignalReport,
@@ -277,7 +278,9 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
   }, [reportTasks]);
 
   const handleCopyLink = () => {
-    const url = `${window.location.origin}/code/inbox/runs/${report.id}`;
+    const url = buildInboxDeeplink(report.id, report.title, {
+      isDevBuild: import.meta.env.DEV,
+    });
     navigator.clipboard
       .writeText(url)
       .then(() => toast.success("Link copied"))
@@ -369,6 +372,7 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
               variant="outline"
               size="sm"
               onClick={handleCopyLink}
+              title="Copy a deep link to this run"
             >
               <CopyIcon size={12} />
               Copy link

--- a/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -4,6 +4,7 @@ import {
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
+import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import type { SignalReport } from "@posthog/shared/types";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
@@ -36,7 +37,9 @@ export function ReportDetail({
 
 function ReportDetailContent({ report }: { report: SignalReport }) {
   const handleCopyLink = () => {
-    const url = `${window.location.origin}/code/inbox/reports/${report.id}`;
+    const url = buildInboxDeeplink(report.id, report.title, {
+      isDevBuild: import.meta.env.DEV,
+    });
     navigator.clipboard
       .writeText(url)
       .then(() => toast.success("Link copied"))

--- a/packages/ui/src/features/scouts/components/ScoutFindingShareButton.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingShareButton.tsx
@@ -1,13 +1,13 @@
 import { LinkIcon } from "@phosphor-icons/react";
 import type { ScoutEmission } from "@posthog/api-client/posthog-client";
-import { scoutSkillSlug } from "@posthog/core/scouts/scoutPresentation";
-import { ANALYTICS_EVENTS } from "@posthog/shared";
+import { ANALYTICS_EVENTS, buildScoutDeeplink } from "@posthog/shared";
 import { track } from "@posthog/ui/shell/analytics";
 import { toast } from "sonner";
 
 /**
- * Per-finding "Share" CTA on a scout emission card: copies a link that drops
- * a coworker onto this scout's detail page with the finding expanded and
+ * Per-finding "Share" CTA on a scout emission card: copies a canonical
+ * `posthog-code://scout/<slug>?finding=<id>` deep link that opens (and focuses)
+ * the desktop app on this scout's detail page with the finding expanded and
  * scrolled into view. Best effort – the link only resolves while the finding
  * is still inside the scout's runs window.
  */
@@ -19,13 +19,9 @@ export function ScoutFindingShareButton({
   skillName: string;
 }) {
   const handleCopyLink = () => {
-    // The app router uses hash history, so the route (and its search params)
-    // must live after the `#`. Keep the pre-hash part of the current URL so
-    // host-level query params survive in the copied link.
-    const base = window.location.href.split("#")[0];
-    const url = `${base}#/code/agents/scouts/${scoutSkillSlug(
-      skillName,
-    )}?finding=${encodeURIComponent(emission.id)}`;
+    const url = buildScoutDeeplink(skillName, emission.id, {
+      isDevBuild: import.meta.env.DEV,
+    });
     navigator.clipboard
       .writeText(url)
       .then(() => {

--- a/packages/ui/src/features/scouts/hooks/useScoutDeepLink.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutDeepLink.ts
@@ -1,0 +1,56 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { navigateToScoutDetail } from "@posthog/ui/router/navigationBridge";
+import { logger } from "@posthog/ui/shell/logger";
+import { useQuery } from "@tanstack/react-query";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { useCallback, useEffect } from "react";
+
+const log = logger.scope("scout-deep-link");
+
+/**
+ * Hook that handles scout detail deep links (`<scheme>://scout/{skillSlug}?finding={id}`,
+ * e.g. `posthog-code://…` in production and `posthog-code-dev://…` in local dev)
+ * and opens the scout detail page, expanding the finding when one is supplied.
+ *
+ * Mirrors `useInboxDeepLink`: drains any link that arrived before the renderer
+ * was ready (the main process clears its pending entry on read) and also
+ * subscribes for links delivered while the app is already running.
+ */
+export function useScoutDeepLink() {
+  const trpcReact = useHostTRPC();
+  const isAuthenticated = useAuthStateValue(
+    (s) => s.status === "authenticated",
+  );
+
+  const pendingDeepLink = useQuery(
+    trpcReact.deepLink.getPendingScoutLink.queryOptions(undefined, {
+      enabled: isAuthenticated,
+      // Drain once per session – the main process clears its pending entry on read.
+      staleTime: Number.POSITIVE_INFINITY,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }),
+  );
+
+  const openScout = useCallback((skillSlug: string, findingId?: string) => {
+    log.info(
+      `Opening scout from deep link: skillSlug=${skillSlug} findingId=${findingId ?? "(none)"}`,
+    );
+    navigateToScoutDetail(skillSlug, findingId);
+  }, []);
+
+  useEffect(() => {
+    if (pendingDeepLink.data?.skillSlug) {
+      openScout(pendingDeepLink.data.skillSlug, pendingDeepLink.data.findingId);
+    }
+  }, [pendingDeepLink.data, openScout]);
+
+  useSubscription(
+    trpcReact.deepLink.onOpenScout.subscriptionOptions(undefined, {
+      onData: (data) => {
+        if (data?.skillSlug) openScout(data.skillSlug, data.findingId);
+      },
+    }),
+  );
+}

--- a/packages/ui/src/router/navigationBridge.ts
+++ b/packages/ui/src/router/navigationBridge.ts
@@ -61,6 +61,17 @@ export function navigateToInboxReportDetail(reportId: string): void {
   });
 }
 
+export function navigateToScoutDetail(
+  skillSlug: string,
+  findingId?: string,
+): void {
+  void getRouterOrNull()?.navigate({
+    to: "/code/agents/scouts/$skillName",
+    params: { skillName: skillSlug },
+    search: findingId ? { finding: findingId } : {},
+  });
+}
+
 export function navigateToAgents(): void {
   void getRouterOrNull()?.navigate({ to: "/code/agents" });
 }

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -15,6 +15,7 @@ import { useTaskDeepLink } from "@posthog/ui/features/deep-links/useTaskDeepLink
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useInboxDeepLink } from "@posthog/ui/features/inbox/hooks/useInboxDeepLink";
 import { useIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
+import { useScoutDeepLink } from "@posthog/ui/features/scouts/hooks/useScoutDeepLink";
 import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery";
 import { MainSidebar } from "@posthog/ui/features/sidebar/components/MainSidebar";
 import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
@@ -113,6 +114,7 @@ function RootLayout() {
   useIntegrations();
   useTaskDeepLink();
   useInboxDeepLink();
+  useScoutDeepLink();
   useSetupDiscovery();
   useNewTaskDeepLink();
 


### PR DESCRIPTION
## Summary

The scout **Share** CTA and the inbox **copy-link** buttons previously copied renderer-only URLs (a hash-router URL for scouts, `window.location.origin/...` web URLs for inbox) that **cannot launch or focus the desktop app**. This routes all of them through the canonical `posthog-code://` deep-link scheme, matching the existing `inbox` / `task` handler architecture.

### Scouts (new canonical path)
- **`buildScoutDeeplink`** in `@posthog/shared` → `posthog-code://scout/<slug>?finding=<id>` (dev-aware scheme, strips `signals-scout-` prefix, URL-encodes).
- **`ScoutLinkService`** in `@posthog/core` registers a `scout` deep-link handler, mirroring `InboxLinkService`: parses the slug + `finding` query param, emits `OpenScout` (or queues a pending link until the renderer is ready), and focuses/restores the window. Wired through DI (tokens, bindings, container, eager init in `index.ts`).
- **tRPC**: `onOpenScout` subscription + `getPendingScoutLink` query on the deep-link router.
- **Renderer**: `useScoutDeepLink` hook (mounted in `__root.tsx`) + `navigateToScoutDetail` bridge.
- `ScoutFindingShareButton` now emits the canonical link.

### Inbox (aligned)
- `ReportDetail` and `AgentRunDetail` copy buttons now use `buildInboxDeeplink` (the builder that already existed but was only used for agent prompts) instead of web-origin URLs — so they emit app-launching links. The `ReportDetail` tooltip ("Copy a deep link…") is now accurate; added a matching tooltip to the run button.

### Docs
- Documented `posthog-code://scout/<skillSlug>?finding=` in `DEEP-LINKS.md`, added `scout` to the handler list, and **fixed the stale handler-source table** (handlers live in `packages/core/src/links/`, not `apps/code/src/main/services/...`).

## Test plan
- [x] `scout-link` service tests (9) — handler registration, finding parsing, pending-queue drain, slug decoding, window focus/restore.
- [x] `buildScoutDeeplink` tests (5) — bare/with-finding, prefix strip, dev scheme, encoding.
- [x] `pnpm --filter @posthog/core test` green; shared deep-links tests green.
- [x] Typecheck clean for `@posthog/shared`, `@posthog/core`, `@posthog/host-router`, and the apps/code main-process config (`tsc -p tsconfig.node.json` exit 0).

> Note: local `pnpm typecheck` reports pre-existing `@posthog/quill` / `@posthog/quill-charts` errors in `features/canvas/*` (stale external dep locally, from #2657) — unrelated to this change and not in any file touched here.