### PR TITLE
fix(canvas): make the channel sidebar feel instant

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -851,11 +851,16 @@ export class PostHogAPIClient {
   // Desktop file system — the backend surface that backs canvas channels
   // (top-level folders) and dashboards. These routes aren't in the generated
   // OpenAPI client, so we use the raw fetcher.
-  async getDesktopFileSystem(): Promise<Schemas.FileSystem[]> {
+  // Channels are top-level folders on the desktop file system. Filtering to
+  // `type=folder` server-side (and requesting a large page) keeps us from
+  // paginating over every dashboard and filed task just to populate the
+  // sidebar channel list — the bulk of the initial-load cost otherwise.
+  async getDesktopFileSystemChannels(): Promise<Schemas.FileSystem[]> {
     const DESKTOP_FILE_SYSTEM_MAX_PAGES = 50;
+    const DESKTOP_FILE_SYSTEM_PAGE_SIZE = 200;
     const teamId = await this.getTeamId();
     const all: Schemas.FileSystem[] = [];
-    let urlPath: string = `/api/projects/${teamId}/desktop_file_system/`;
+    let urlPath: string = `/api/projects/${teamId}/desktop_file_system/?type=folder&limit=${DESKTOP_FILE_SYSTEM_PAGE_SIZE}`;
     for (let i = 0; i < DESKTOP_FILE_SYSTEM_MAX_PAGES; i++) {
       const url = new URL(`${this.api.baseUrl}${urlPath}`);
       const response = await this.api.fetcher.fetch({
@@ -865,7 +870,7 @@ export class PostHogAPIClient {
       });
       if (!response.ok) {
         throw new Error(
-          `Failed to fetch desktop file system: ${response.statusText}`,
+          `Failed to fetch desktop file system channels: ${response.statusText}`,
         );
       }
       const page = (await response.json()) as Schemas.PaginatedFileSystemList;
@@ -875,7 +880,7 @@ export class PostHogAPIClient {
       urlPath = `${nextUrl.pathname}${nextUrl.search}`;
     }
     log.warn(
-      `getDesktopFileSystem hit MAX_PAGES (${DESKTOP_FILE_SYSTEM_MAX_PAGES}); returning partial results`,
+      `getDesktopFileSystemChannels hit MAX_PAGES (${DESKTOP_FILE_SYSTEM_MAX_PAGES}); returning partial results`,
       { returned: all.length },
     );
     return all;

--- a/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
+++ b/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
@@ -15,7 +15,14 @@ vi.mock("@posthog/ui/features/auth/authClient", () => ({
 import { useChannelMutations, useChannels } from "./useChannels";
 
 function folder(id: string, path: string): Schemas.FileSystem {
-  return { id, path, type: "folder" } as unknown as Schemas.FileSystem;
+  return {
+    id,
+    path,
+    type: "folder",
+    depth: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    last_viewed_at: null,
+  };
 }
 
 let queryClient: QueryClient;
@@ -65,5 +72,30 @@ describe("useChannelMutations", () => {
         "beta",
       ]),
     );
+  });
+
+  it("does not duplicate a channel the poll already landed", async () => {
+    // The poll has already surfaced the channel we're about to create.
+    const existing = folder("1", "alpha");
+    mockClient.getDesktopFileSystemChannels.mockResolvedValue([existing]);
+
+    const list = renderHook(() => useChannels(), { wrapper });
+    await waitFor(() => expect(list.result.current.isLoading).toBe(false));
+    expect(list.result.current.channels.map((c) => c.id)).toEqual(["1"]);
+
+    // Create returns the same id; hang the refetch so only the optimistic
+    // cache write is exercised.
+    mockClient.createDesktopFileSystemChannel.mockResolvedValue(existing);
+    mockClient.getDesktopFileSystemChannels.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    await act(async () => {
+      await mutations.result.current.createChannel("alpha");
+    });
+
+    // The duplicate-id guard keeps the list at one entry.
+    expect(list.result.current.channels.map((c) => c.id)).toEqual(["1"]);
   });
 });

--- a/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
+++ b/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
@@ -1,0 +1,65 @@
+import type { Schemas } from "@posthog/api-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClient = vi.hoisted(() => ({
+  getDesktopFileSystem: vi.fn(),
+  createDesktopFileSystemChannel: vi.fn(),
+}));
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => mockClient,
+}));
+
+import { useChannelMutations, useChannels } from "./useChannels";
+
+function folder(id: string, path: string): Schemas.FileSystem {
+  return { id, path, type: "folder" } as unknown as Schemas.FileSystem;
+}
+
+let queryClient: QueryClient;
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useChannelMutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  it("shows the created channel immediately, before the refetch resolves", async () => {
+    // Seed the list with one existing channel.
+    mockClient.getDesktopFileSystem.mockResolvedValue([folder("1", "alpha")]);
+
+    const list = renderHook(() => useChannels(), { wrapper });
+    await waitFor(() => expect(list.result.current.isLoading).toBe(false));
+    expect(list.result.current.channels.map((c) => c.name)).toEqual(["alpha"]);
+
+    // Make the create return the new channel, but hang any subsequent refetch
+    // so we can prove the list updates without waiting on it.
+    const created = folder("2", "beta");
+    mockClient.createDesktopFileSystemChannel.mockResolvedValue(created);
+    mockClient.getDesktopFileSystem.mockReturnValue(new Promise(() => {}));
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    await act(async () => {
+      await mutations.result.current.createChannel("beta");
+    });
+
+    // The new channel is present from the optimistic cache write, sorted
+    // alphabetically alongside the existing one — without the hung refetch
+    // having resolved.
+    await waitFor(() =>
+      expect(list.result.current.channels.map((c) => c.name)).toEqual([
+        "alpha",
+        "beta",
+      ]),
+    );
+  });
+});

--- a/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
+++ b/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = vi.hoisted(() => ({
-  getDesktopFileSystem: vi.fn(),
+  getDesktopFileSystemChannels: vi.fn(),
   createDesktopFileSystemChannel: vi.fn(),
 }));
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
@@ -35,7 +35,9 @@ describe("useChannelMutations", () => {
 
   it("shows the created channel immediately, before the refetch resolves", async () => {
     // Seed the list with one existing channel.
-    mockClient.getDesktopFileSystem.mockResolvedValue([folder("1", "alpha")]);
+    mockClient.getDesktopFileSystemChannels.mockResolvedValue([
+      folder("1", "alpha"),
+    ]);
 
     const list = renderHook(() => useChannels(), { wrapper });
     await waitFor(() => expect(list.result.current.isLoading).toBe(false));
@@ -45,7 +47,9 @@ describe("useChannelMutations", () => {
     // so we can prove the list updates without waiting on it.
     const created = folder("2", "beta");
     mockClient.createDesktopFileSystemChannel.mockResolvedValue(created);
-    mockClient.getDesktopFileSystem.mockReturnValue(new Promise(() => {}));
+    mockClient.getDesktopFileSystemChannels.mockReturnValue(
+      new Promise(() => {}),
+    );
 
     const mutations = renderHook(() => useChannelMutations(), { wrapper });
     await act(async () => {

--- a/packages/ui/src/features/canvas/hooks/useChannels.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannels.ts
@@ -26,7 +26,7 @@ export function useChannels(options?: { enabled?: boolean }): {
 } {
   const query = useAuthenticatedQuery<Schemas.FileSystem[]>(
     CHANNELS_QUERY_KEY,
-    (client) => client.getDesktopFileSystem(),
+    (client) => client.getDesktopFileSystemChannels(),
     {
       enabled: options?.enabled ?? true,
       refetchInterval: CHANNELS_POLL_INTERVAL_MS,

--- a/packages/ui/src/features/canvas/hooks/useChannels.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannels.ts
@@ -56,7 +56,20 @@ export function useChannelMutations() {
       if (!client) throw new Error("Not authenticated");
       return client.createDesktopFileSystemChannel(name);
     },
-    onSuccess: invalidate,
+    onSuccess: (newFs) => {
+      // Insert the created channel into the cache immediately so the sidebar
+      // updates the instant the POST resolves, rather than waiting on the
+      // paginated refetch that `invalidate` triggers.
+      queryClient.setQueryData<Schemas.FileSystem[]>(
+        CHANNELS_QUERY_KEY,
+        (old) => {
+          if (!old) return [newFs];
+          if (old.some((fs) => fs.id === newFs.id)) return old;
+          return [...old, newFs];
+        },
+      );
+      invalidate();
+    },
   });
 
   const deleteMutation = useMutation({


### PR DESCRIPTION
The channel sidebar felt slow in two ways. Both come down to the same backing query — `["canvas-channels"]`, populated by a paginated GET over the desktop file system — and this PR fixes each.

## 1. A newly-created channel was slow to appear

On create, the code only called `invalidateQueries`, forcing a **full re-fetch** to complete before the new channel showed up — even though the create API already returns the fully-formed channel.

**Fix:** `createMutation.onSuccess` now writes the returned channel straight into the cache, then invalidates to reconcile in the background. The sidebar selector already sorts folders alphabetically, so it lands in the right spot the instant the POST resolves — before navigation completes. A duplicate-id guard avoids a double insert if the 30s poll landed it first.

## 2. The channel list was slow to load on app start

`getDesktopFileSystem()` fetched **every** entry in the desktop file system — all dashboards and filed tasks too — page by page, up to 50 sequential round-trips, then filtered to `type === "folder"` on the client. On startup the sidebar waited for that whole tree walk.

**Fix:** filter to `type=folder` server-side and request a larger page (`limit=200`), so the common case is a single round-trip returning only channels. The endpoint already accepts `type` filtering (channel tasks use `type=task`). The returned set is identical to the prior client-side filter, so behavior is unchanged. Renamed `getDesktopFileSystem` → `getDesktopFileSystemChannels` to reflect the narrowed contract (its only caller is this sidebar).

## Verification

- `useChannels.test.tsx` proves the created channel appears from the optimistic write *while the refetch is hung*.
- `pnpm --filter @posthog/api-client typecheck`, `pnpm --filter @posthog/ui typecheck`, the UI test, and Biome all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)