### PR TITLE
feat(sidebar): surface unread tasks with an exclamation icon

### DIFF
--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -1,6 +1,5 @@
 import {
   ChatCircle,
-  Circle,
   Cloud as CloudIcon,
   GitBranch,
   GitMerge,
@@ -9,6 +8,7 @@ import {
   Pause,
   PushPin,
   SlackLogo,
+  WarningCircle,
 } from "@phosphor-icons/react";
 import type { WorkspaceMode } from "@posthog/shared";
 import {
@@ -276,6 +276,23 @@ export function TaskIcon({
       </Tooltip>
     );
   }
+  if (isGenerating) {
+    return <DotsCircleSpinner size={size} className="text-accent-11" />;
+  }
+  // Unread outranks the cloud/PR/diff status icons: when an agent finishes a
+  // task there is fresh activity the user has not seen, and that "needs
+  // attention" signal must win over the completed-cloud or PR icon that would
+  // otherwise hide it. Viewing the task clears `isUnread`, so the normal status
+  // icon returns automatically.
+  if (isUnread) {
+    return (
+      <Tooltip content="Unread — new activity" side="right">
+        <span className="flex items-center justify-center">
+          <WarningCircle size={size} weight="fill" color="var(--amber-11)" />
+        </span>
+      </Tooltip>
+    );
+  }
   if (isTerminalCloud) {
     return (
       <CloudStatusIcon
@@ -286,9 +303,6 @@ export function TaskIcon({
       />
     );
   }
-  if (isGenerating) {
-    return <DotsCircleSpinner size={size} className="text-accent-11" />;
-  }
   if (isSuspended) {
     return (
       <Tooltip content="Suspended" side="right">
@@ -296,13 +310,6 @@ export function TaskIcon({
           <Pause size={size} color="var(--gray-9)" />
         </span>
       </Tooltip>
-    );
-  }
-  if (isUnread) {
-    return (
-      <span className="flex items-center justify-center">
-        <Circle size={8} weight="fill" color="var(--green-11)" />
-      </span>
     );
   }
   if (prState || hasDiff) {

--- a/packages/ui/src/features/sidebar/taskMetaApi.ts
+++ b/packages/ui/src/features/sidebar/taskMetaApi.ts
@@ -7,11 +7,24 @@ import {
   HOST_TRPC_CLIENT,
   type HostTrpcClient,
 } from "@posthog/host-router/client";
+import {
+  IMPERATIVE_QUERY_CLIENT,
+  type ImperativeQueryClient,
+} from "@posthog/ui/shell/queryClient";
 
 export type { TaskTimestamps };
 
+// Outer array partial-matches tRPC's `[["workspace", "getAllTaskTimestamps"], { type }]`.
+const TASK_TIMESTAMPS_QUERY_KEY = [["workspace", "getAllTaskTimestamps"]];
+
 function workspace() {
   return resolveService<HostTrpcClient>(HOST_TRPC_CLIENT).workspace;
+}
+
+function invalidateTimestamps(): void {
+  void resolveService<ImperativeQueryClient>(
+    IMPERATIVE_QUERY_CLIENT,
+  ).invalidateQueries({ queryKey: TASK_TIMESTAMPS_QUERY_KEY });
 }
 
 export const taskViewedApi = {
@@ -20,11 +33,11 @@ export const taskViewedApi = {
   },
 
   markAsViewed(taskId: string): void {
-    void workspace().markViewed.mutate({ taskId });
+    void workspace().markViewed.mutate({ taskId }).then(invalidateTimestamps);
   },
 
   markActivity(taskId: string): void {
-    void workspace().markActivity.mutate({ taskId });
+    void workspace().markActivity.mutate({ taskId }).then(invalidateTimestamps);
   },
 };
 


### PR DESCRIPTION
## Problem

- Agent finishes task → not obvious in task list what needs attention / what's unseen
- Read/unread plumbing already existed (`lastViewedAt`/`lastActivityAt`, `markActivity` on turn-complete, `markAsViewed` on open) but didn't surface:
  - **Masked** — in `TaskIcon`, unread sat below cloud/PR icons → on finish, cloud/PR icon won, unread never showed
  - **Too subtle** — when shown, tiny 8px green dot
  - **Stale** — off-screen completion wrote timestamp to backend but never updated react-query cache (`getAllTaskTimestamps`, staleTime 30s) → `isUnread` stuck false until next focus/reconnect refetch

## Change


https://github.com/user-attachments/assets/e11ecabe-e4a3-499d-bd79-92897ecc495a



- Promote unread above cloud/PR/diff/suspended in `TaskIcon`, render as amber `WarningCircle` ❗ ("Unread — new activity")
- Imperative `markActivity`/`markViewed` now invalidate timestamps query after mutate → unread shows instant on off-screen completion
- Open task → `markAsViewed` clears `isUnread` → normal status icon returns (marked read on view)
- Live states (generating / needs-permission) still win — not "finished and unseen"
- Shared by sidebar list, command palette, canvas channel list (all via `TaskIcon`) → consistent everywhere

### Activity → read/unread lifecycle

`markActivity` only fires for a live session (local agent, or cloud while watched). Unwatched-cloud completion has no `markActivity` — it rides server `updated_at` + the 30s task-list poll instead.

```mermaid
stateDiagram-v2
    [*] --> Unviewed
    Unviewed --> Read: markAsViewed (open)
    Read --> Unread: markActivity (local / watched-cloud finish)
    Read --> Unread: server updated_at + poll (unwatched cloud, ≤30s)
    Unread --> Read: markAsViewed (open)
    note right of Unread
        markActivity path: invalidate timestamps
        query → sidebar recomputes isUnread instantly
    end note
```

### TaskIcon priority (after)

```mermaid
flowchart TD
    A[task state] --> B{needsPermission?}
    B -->|yes| P[HandPalm]
    B -->|no| C{isGenerating?}
    C -->|yes| G[spinner]
    C -->|no| D{isUnread?}
    D -->|yes| U["amber WarningCircle ❗"]
    D -->|no| E{terminal cloud?}
    E -->|yes| CL[cloud status]
    E -->|no| F{isSuspended?}
    F -->|yes| S[Pause]
    F -->|no| H{PR / diff?}
    H -->|yes| PR[PR / branch]
    H -->|no| Z[pinned / Slack / chat]
```

## Note

- `isUnread` only true once viewed at least once (`lastViewedAt != null`) → tasks never opened (e.g. Slack) won't flag til first open. Lower-noise default; easy to flip.
- Currently-focused task stays read (continuously re-marked viewed) — exclamation is for tasks you've opened then navigated away from.

## Testing

- `biome lint` clean on changed files
- Remaining package typecheck errors = pre-existing unbuilt-`dist` build-order noise, unrelated

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*