### PR TITLE
feat(inbox): add copy-link button to pull request detail

### DIFF
--- a/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
+++ b/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
@@ -13,7 +13,6 @@ import {
   parsePrUrl,
 } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
-import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import {
   isTerminalStatus,
   type SignalReport,
@@ -49,13 +48,13 @@ import {
 } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { useInboxReportSignals } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useReportTasks } from "@posthog/ui/features/inbox/hooks/useReportTasks";
+import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 import { TaskLogsPanel } from "@posthog/ui/features/task-detail/components/TaskLogsPanel";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { openTask } from "@posthog/ui/router/useOpenTask";
 import { DropdownMenu, Flex, Text } from "@radix-ui/themes";
 import { Link } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 
 export function TaskRunStatusDot({ status }: { status: TaskRunStatus }) {
   const terminal = isTerminalStatus(status);
@@ -277,16 +276,6 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
     return hasInFlight && hasPriorTerminal;
   }, [reportTasks]);
 
-  const handleCopyLink = () => {
-    const url = buildInboxDeeplink(report.id, report.title, {
-      isDevBuild: import.meta.env.DEV,
-    });
-    navigator.clipboard
-      .writeText(url)
-      .then(() => toast.success("Link copied"))
-      .catch(() => toast.error("Couldn't copy link"));
-  };
-
   return (
     <Flex direction="column" className="min-h-full">
       <InboxDetailPageHeader
@@ -371,7 +360,7 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
               type="button"
               variant="outline"
               size="sm"
-              onClick={handleCopyLink}
+              onClick={() => copyInboxReportLink(report)}
               title="Copy a deep link to this run"
             >
               <CopyIcon size={12} />

--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -1,10 +1,12 @@
 import {
   ArrowSquareOutIcon,
+  CopyIcon,
   GitPullRequestIcon,
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
+import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import type { SignalReport } from "@posthog/shared/types";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxMetaSeparator } from "@posthog/ui/features/inbox/components/InboxMetaRow";
@@ -14,6 +16,7 @@ import { ReportDetailActions } from "@posthog/ui/features/inbox/components/Repor
 import { ReportTasksSection } from "@posthog/ui/features/inbox/components/ReportTasksSection";
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
 import { Text } from "@radix-ui/themes";
+import { toast } from "sonner";
 
 interface PullRequestDetailProps {
   reportId: string;
@@ -41,6 +44,16 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
   const prRef = report.implementation_pr_url
     ? parsePrUrl(report.implementation_pr_url)
     : null;
+
+  const handleCopyLink = () => {
+    const url = buildInboxDeeplink(report.id, report.title, {
+      isDevBuild: import.meta.env.DEV,
+    });
+    navigator.clipboard
+      .writeText(url)
+      .then(() => toast.success("Link copied"))
+      .catch(() => toast.error("Couldn't copy link"));
+  };
 
   return (
     <InboxDetailFrame
@@ -72,6 +85,15 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
       primaryAction={
         <>
           <ReportDetailActions report={report} />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleCopyLink}
+            title="Copy a deep link to this report"
+          >
+            <CopyIcon size={12} />
+          </Button>
           {prRef && report.implementation_pr_url ? (
             <Button
               type="button"

--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -6,7 +6,6 @@ import {
 } from "@phosphor-icons/react";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
-import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import type { SignalReport } from "@posthog/shared/types";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxMetaSeparator } from "@posthog/ui/features/inbox/components/InboxMetaRow";
@@ -15,8 +14,8 @@ import { PrDiffStats } from "@posthog/ui/features/inbox/components/PrDiffStats";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
 import { ReportTasksSection } from "@posthog/ui/features/inbox/components/ReportTasksSection";
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
+import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 import { Text } from "@radix-ui/themes";
-import { toast } from "sonner";
 
 interface PullRequestDetailProps {
   reportId: string;
@@ -44,16 +43,6 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
   const prRef = report.implementation_pr_url
     ? parsePrUrl(report.implementation_pr_url)
     : null;
-
-  const handleCopyLink = () => {
-    const url = buildInboxDeeplink(report.id, report.title, {
-      isDevBuild: import.meta.env.DEV,
-    });
-    navigator.clipboard
-      .writeText(url)
-      .then(() => toast.success("Link copied"))
-      .catch(() => toast.error("Couldn't copy link"));
-  };
 
   return (
     <InboxDetailFrame
@@ -89,7 +78,7 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
             type="button"
             variant="outline"
             size="sm"
-            onClick={handleCopyLink}
+            onClick={() => copyInboxReportLink(report)}
             title="Copy a deep link to this report"
           >
             <CopyIcon size={12} />

--- a/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -4,14 +4,13 @@ import {
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
-import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import type { SignalReport } from "@posthog/shared/types";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
 import { ReportTasksSection } from "@posthog/ui/features/inbox/components/ReportTasksSection";
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
-import { toast } from "sonner";
+import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 
 interface ReportDetailProps {
   reportId: string;
@@ -36,16 +35,6 @@ export function ReportDetail({
 }
 
 function ReportDetailContent({ report }: { report: SignalReport }) {
-  const handleCopyLink = () => {
-    const url = buildInboxDeeplink(report.id, report.title, {
-      isDevBuild: import.meta.env.DEV,
-    });
-    navigator.clipboard
-      .writeText(url)
-      .then(() => toast.success("Link copied"))
-      .catch(() => toast.error("Couldn't copy link"));
-  };
-
   return (
     <InboxDetailFrame
       report={report}
@@ -59,7 +48,7 @@ function ReportDetailContent({ report }: { report: SignalReport }) {
             type="button"
             variant="outline"
             size="sm"
-            onClick={handleCopyLink}
+            onClick={() => copyInboxReportLink(report)}
             title="Copy a deep link to this report"
           >
             <CopyIcon size={12} />

--- a/packages/ui/src/features/inbox/utils/copyInboxReportLink.ts
+++ b/packages/ui/src/features/inbox/utils/copyInboxReportLink.ts
@@ -1,0 +1,21 @@
+import { buildInboxDeeplink } from "@posthog/shared/deeplink";
+import type { SignalReport } from "@posthog/shared/types";
+import { toast } from "sonner";
+
+/**
+ * Copy a deep link (`<scheme>://inbox/{reportId}`) for an inbox report to the
+ * clipboard, toasting success or failure. Shared by every inbox detail surface
+ * (reports, runs, pull requests) so the link format and copy feedback stay in
+ * one place. The inbound side of these links lives in `useInboxDeepLink`.
+ */
+export function copyInboxReportLink(
+  report: Pick<SignalReport, "id" | "title">,
+): void {
+  const url = buildInboxDeeplink(report.id, report.title, {
+    isDevBuild: import.meta.env.DEV,
+  });
+  navigator.clipboard
+    .writeText(url)
+    .then(() => toast.success("Link copied"))
+    .catch(() => toast.error("Couldn't copy link"));
+}


### PR DESCRIPTION
## Problem

In the Inbox, pull request reports (the ones with the **Open in GitHub** button) had no way to copy a deep link to the report itself. Every other inbox detail screen — Reports and Runs — has a copy-deeplink button, but the PR detail view was missing it. Sometimes you still want to share a link to the inbox report, not just jump to GitHub.

## Changes

Added the same copy-deeplink button to `PullRequestDetail.tsx` that already exists on `ReportDetail.tsx` and `AgentRunDetail.tsx`:

- A `handleCopyLink` handler that builds the inbox deep link via `buildInboxDeeplink` and writes it to the clipboard, with the existing "Link copied" / "Couldn't copy link" toasts.
- An outline icon button (`CopyIcon`) placed in the header actions, just before **Open in GitHub**.

So PR reports now have both the copy-link button and the Open-in-GitHub button.

## How did you test this?

- Typechecked the `@posthog/ui` package — the change is clean (the only failures in the full-repo typecheck are pre-existing and unrelated: missing `@xterm/addon-webgl` and in-flight `core`/`workspace-server` changes on `main`).
- Reused the exact copy-link pattern already shipped on the sibling detail views; no new behavior invented.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?