### PR TITLE
feat(inbox): show live PR status on pull request detail

### DIFF
--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -14,6 +14,7 @@ import { PrDiffStats } from "@posthog/ui/features/inbox/components/PrDiffStats";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
 import { ReportTasksSection } from "@posthog/ui/features/inbox/components/ReportTasksSection";
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
+import { ReportImplementationPrLink } from "@posthog/ui/features/inbox/components/utils/ReportImplementationPrLink";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 import { Text } from "@radix-ui/themes";
 
@@ -64,6 +65,10 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
         report.implementation_pr_url ? (
           <>
             <InboxMetaSeparator />
+            <ReportImplementationPrLink
+              prUrl={report.implementation_pr_url}
+              size="md"
+            />
             <PrDiffStats
               prUrl={report.implementation_pr_url}
               hideWhileLoading

--- a/packages/ui/src/features/inbox/components/utils/ReportImplementationPrLink.tsx
+++ b/packages/ui/src/features/inbox/components/utils/ReportImplementationPrLink.tsx
@@ -1,4 +1,4 @@
-import { GitMerge, GitPullRequestIcon } from "@phosphor-icons/react";
+import { GitMergeIcon, GitPullRequestIcon } from "@phosphor-icons/react";
 import { cn } from "@posthog/quill";
 import { usePrDetails } from "@posthog/ui/features/git-interaction/usePrDetails";
 import { Tooltip } from "@radix-ui/themes";
@@ -46,18 +46,22 @@ export function ReportImplementationPrLink({
   onLinkClick,
 }: ReportImplementationPrLinkProps) {
   const {
-    meta: { state, merged, isLoading },
+    meta: { state, merged, draft, isLoading },
   } = usePrDetails(prUrl);
 
   const isSm = size === "sm";
 
+  // A draft PR is still `state === "open"` on GitHub, so check `draft` before
+  // falling through to the open (green) styling.
   const colorClass = isLoading
     ? "bg-gray-4 text-gray-11 hover:bg-gray-5"
     : merged
       ? "bg-violet-4 text-violet-11 hover:bg-violet-5"
       : state === "closed"
         ? "bg-red-4 text-red-11 hover:bg-red-5"
-        : "bg-green-4 text-green-11 hover:bg-green-5";
+        : draft
+          ? "bg-gray-4 text-gray-11 hover:bg-gray-5"
+          : "bg-green-4 text-green-11 hover:bg-green-5";
 
   const { reference: prReference, prNumber } = parseGitHubPrReference(prUrl);
 
@@ -65,7 +69,9 @@ export function ReportImplementationPrLink({
     ? `Merged – ${prReference}`
     : state === "closed"
       ? `Closed – ${prReference}`
-      : prReference;
+      : draft
+        ? `Draft – ${prReference}`
+        : `Open – ${prReference}`;
 
   const iconSize = isSm ? 10 : 12;
 
@@ -88,7 +94,7 @@ export function ReportImplementationPrLink({
         )}
       >
         {merged ? (
-          <GitMerge size={iconSize} weight="bold" />
+          <GitMergeIcon size={iconSize} weight="bold" />
         ) : (
           <GitPullRequestIcon size={iconSize} weight="bold" />
         )}


### PR DESCRIPTION
## Problem

Inbox pull-request reports showed diff stats (`+490 −73`) but no indication of the linked PR's actual state. From the report you couldn't tell whether the PR was still open, a draft, already merged, or closed without clicking through to GitHub.

## Changes

- Surface the GitHub PR's **live status** as a colored badge in the pull request detail meta row, next to the diff stats:
  - **Open** → green
  - **Draft** → gray
  - **Merged** → violet (with a merge icon)
  - **Closed** → red
- The badge links to the PR and tooltips the full `owner/repo#number` reference plus state.
- This wires up the previously-unused `ReportImplementationPrLink` component via the existing `usePrDetails` hook (`git.getPrDetailsByUrl` → `{ state, merged, draft }`). One request per detail view — no N+1.
- Taught `ReportImplementationPrLink` to distinguish **draft** PRs (it already received the `draft` field but ignored it; a draft is still `state === "open"` on GitHub).
- Drive-by: swapped the deprecated `GitMerge` icon for `GitMergeIcon`.

### Scope note

This covers the **detail view** only. The inbox *list* cards intentionally avoid N+1 by batching diff stats through a single GraphQL request (`getPrDiffStatsBatch`). Adding live status to the cards cleanly means extending that GraphQL batch to also carry `state`/`isDraft` — a small backend follow-up in `core` + `workspace-server`, kept out of this PR to keep it focused. Happy to do that next.

## How did you test this?

- `biome check` and `@posthog/ui` typecheck both clean.
- Reused the existing, already-designed badge component and the `usePrDetails` hook already used by code-review and command-center surfaces.
- Local manual verification of the badge states in the running app (by the author).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?