### PR TITLE
feat(inbox): show live PR status on pull request list cards

### DIFF
--- a/packages/core/src/git/router-schemas.ts
+++ b/packages/core/src/git/router-schemas.ts
@@ -360,8 +360,8 @@ export const prDiffStatsSchema = z.object({
   additions: z.number(),
   deletions: z.number(),
   changedFiles: z.number(),
-  /** Lowercased GitHub PR state: "open" | "closed" | "merged". */
-  state: z.string(),
+  /** Lowercased GitHub PR state. */
+  state: z.enum(["open", "closed", "merged"]),
   merged: z.boolean(),
   draft: z.boolean(),
 });

--- a/packages/core/src/git/router-schemas.ts
+++ b/packages/core/src/git/router-schemas.ts
@@ -352,10 +352,18 @@ export const getPrChangedFilesInput = z.object({
 export const getPrChangedFilesOutput = z.array(changedFileSchema);
 
 // getPrDiffStatsBatch schemas
+//
+// Beyond the diff numbers, the batch also carries the PR's live status
+// (`state`/`merged`/`draft`) so list cards can render it from the single
+// batched GraphQL request instead of firing one REST call per visible PR.
 export const prDiffStatsSchema = z.object({
   additions: z.number(),
   deletions: z.number(),
   changedFiles: z.number(),
+  /** Lowercased GitHub PR state: "open" | "closed" | "merged". */
+  state: z.string(),
+  merged: z.boolean(),
+  draft: z.boolean(),
 });
 export type PrDiffStats = z.infer<typeof prDiffStatsSchema>;
 

--- a/packages/ui/src/features/git-interaction/usePrActions.ts
+++ b/packages/ui/src/features/git-interaction/usePrActions.ts
@@ -20,6 +20,13 @@ export function usePrActions(prUrl: string | null) {
           trpc.git.getPrDetailsByUrl.queryKey({ prUrl: variables.prUrl }),
           getOptimisticPrState(variables.action),
         );
+        // The inbox Pulls list reads PR status from the batched
+        // `getPrDiffStatsBatch` query (separate cache, 5-min staleTime), so
+        // patching the detail cache above isn't enough — invalidate the batch
+        // so the list badge reflects the new state on next view.
+        void queryClient.invalidateQueries(
+          trpc.git.getPrDiffStatsBatch.pathFilter(),
+        );
       } else {
         toast.error("Failed to update PR", { description: data.message });
       }

--- a/packages/ui/src/features/inbox/components/PullRequestCard.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestCard.tsx
@@ -14,6 +14,7 @@ import { InboxCardTitle } from "@posthog/ui/features/inbox/components/InboxCardT
 import { PrDiffStats } from "@posthog/ui/features/inbox/components/PrDiffStats";
 import { PriorityMonogram } from "@posthog/ui/features/inbox/components/PriorityMonogram";
 import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
+import { ReportImplementationPrLink } from "@posthog/ui/features/inbox/components/utils/ReportImplementationPrLink";
 import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
 import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { Button as UiButton } from "@posthog/ui/primitives/Button";
@@ -121,10 +122,16 @@ export function PullRequestCard({
       >
         <Flex align="center" gap="2" className="shrink-0">
           {report.implementation_pr_url && (
-            <PrDiffStats
-              prUrl={report.implementation_pr_url}
-              hideWhileLoading
-            />
+            <>
+              <ReportImplementationPrLink
+                prUrl={report.implementation_pr_url}
+                size="sm"
+              />
+              <PrDiffStats
+                prUrl={report.implementation_pr_url}
+                hideWhileLoading
+              />
+            </>
           )}
           <SuggestedReviewerAvatarStack
             reportId={report.id}

--- a/packages/ui/src/features/inbox/components/PullRequestCard.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestCard.tsx
@@ -122,7 +122,7 @@ export function PullRequestCard({
       >
         <Flex align="center" gap="2" className="shrink-0">
           {report.implementation_pr_url && (
-            <>
+            <Flex direction="column" align="end" gap="1" className="shrink-0">
               <ReportImplementationPrLink
                 prUrl={report.implementation_pr_url}
                 size="sm"
@@ -131,7 +131,7 @@ export function PullRequestCard({
                 prUrl={report.implementation_pr_url}
                 hideWhileLoading
               />
-            </>
+            </Flex>
           )}
           <SuggestedReviewerAvatarStack
             reportId={report.id}

--- a/packages/ui/src/features/inbox/components/utils/ReportImplementationPrLink.tsx
+++ b/packages/ui/src/features/inbox/components/utils/ReportImplementationPrLink.tsx
@@ -1,4 +1,5 @@
 import { GitMergeIcon, GitPullRequestIcon } from "@phosphor-icons/react";
+import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
 import { cn } from "@posthog/quill";
 import { usePrDetails } from "@posthog/ui/features/git-interaction/usePrDetails";
 import { usePrDiffStatsFromBatch } from "@posthog/ui/features/inbox/context/PrDiffStatsBatchContext";
@@ -14,32 +15,8 @@ interface ReportImplementationPrLinkProps {
   onLinkClick?: () => void;
 }
 
-function parseGitHubPrReference(prUrl: string): {
-  reference: string;
-  prNumber: string;
-} {
-  try {
-    const parsed = new URL(prUrl);
-    const match = parsed.pathname.match(
-      /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:$|[/?#])/,
-    );
-    if (match) {
-      return {
-        reference: `${match[1]}/${match[2]}#${match[3]}`,
-        prNumber: `#${match[3]}`,
-      };
-    }
-  } catch {
-    // Fall through to regex fallback for non-URL-safe inputs
-  }
-
-  const prMatch = prUrl.match(/\/pull\/(\d+)(?:$|[/?#])/);
-  const prNumber = prMatch ? `#${prMatch[1]}` : "PR";
-  return {
-    reference: prUrl,
-    prNumber,
-  };
-}
+/** The only states we render a badge for; anything else is treated as unknown. */
+const KNOWN_PR_STATES = new Set(["open", "closed", "merged"]);
 
 export function ReportImplementationPrLink({
   prUrl,
@@ -66,9 +43,19 @@ export function ReportImplementationPrLink({
     ? batchEntry.isLoading && !batchEntry.stats
     : fallback.meta.isLoading;
 
-  // If neither source could resolve a status (PR 404s, gh failed, or the batch
-  // had no entry for this PR), don't render a misleading "open" badge.
-  if (!isLoading && state === null) return null;
+  // Only render for a canonical GitHub PR URL. This both keeps the badge in
+  // sync with the gated "Open in GitHub" action and avoids turning an arbitrary
+  // (possibly unsafe-scheme) string into a clickable external link.
+  const prRef = parsePrUrl(prUrl);
+  if (!prRef) return null;
+
+  // `getPrDetailsByUrl` falls back to `{ state: "unknown" }` when the lookup
+  // fails (gh offline, private repo, unparseable URL), and a batch miss leaves
+  // state null. Once settled, render nothing for an unresolved state rather
+  // than a misleading green "open" badge.
+  if (!isLoading && (state === null || !KNOWN_PR_STATES.has(state))) {
+    return null;
+  }
 
   const isSm = size === "sm";
 
@@ -84,15 +71,18 @@ export function ReportImplementationPrLink({
           ? "bg-gray-4 text-gray-11 hover:bg-gray-5"
           : "bg-green-4 text-green-11 hover:bg-green-5";
 
-  const { reference: prReference, prNumber } = parseGitHubPrReference(prUrl);
+  const prReference = `${prRef.repoSlug}#${prRef.number}`;
+  const prNumber = `#${prRef.number}`;
 
-  const tooltip = merged
-    ? `Merged – ${prReference}`
-    : state === "closed"
-      ? `Closed – ${prReference}`
-      : draft
-        ? `Draft – ${prReference}`
-        : `Open – ${prReference}`;
+  const tooltip = isLoading
+    ? prReference
+    : merged
+      ? `Merged – ${prReference}`
+      : state === "closed"
+        ? `Closed – ${prReference}`
+        : draft
+          ? `Draft – ${prReference}`
+          : `Open – ${prReference}`;
 
   const iconSize = isSm ? 10 : 12;
 

--- a/packages/ui/src/features/inbox/components/utils/ReportImplementationPrLink.tsx
+++ b/packages/ui/src/features/inbox/components/utils/ReportImplementationPrLink.tsx
@@ -1,6 +1,7 @@
 import { GitMergeIcon, GitPullRequestIcon } from "@phosphor-icons/react";
 import { cn } from "@posthog/quill";
 import { usePrDetails } from "@posthog/ui/features/git-interaction/usePrDetails";
+import { usePrDiffStatsFromBatch } from "@posthog/ui/features/inbox/context/PrDiffStatsBatchContext";
 import { Tooltip } from "@radix-ui/themes";
 
 export type ImplementationPrLinkSize = "sm" | "md";
@@ -45,9 +46,29 @@ export function ReportImplementationPrLink({
   size = "sm",
   onLinkClick,
 }: ReportImplementationPrLinkProps) {
-  const {
-    meta: { state, merged, draft, isLoading },
-  } = usePrDetails(prUrl);
+  // On list surfaces the surrounding `PrDiffStatsBatchContext` already carries
+  // this PR's status from the single batched request, so read it from there and
+  // skip the per-PR query. Fall back to `usePrDetails` only on the standalone
+  // detail view, where no batch provider is mounted.
+  const batchEntry = usePrDiffStatsFromBatch(prUrl);
+  const fallback = usePrDetails(batchEntry.hasBatch ? null : prUrl);
+
+  const state = batchEntry.hasBatch
+    ? (batchEntry.stats?.state ?? null)
+    : fallback.meta.state;
+  const merged = batchEntry.hasBatch
+    ? (batchEntry.stats?.merged ?? false)
+    : fallback.meta.merged;
+  const draft = batchEntry.hasBatch
+    ? (batchEntry.stats?.draft ?? false)
+    : fallback.meta.draft;
+  const isLoading = batchEntry.hasBatch
+    ? batchEntry.isLoading && !batchEntry.stats
+    : fallback.meta.isLoading;
+
+  // If neither source could resolve a status (PR 404s, gh failed, or the batch
+  // had no entry for this PR), don't render a misleading "open" badge.
+  if (!isLoading && state === null) return null;
 
   const isSm = size === "sm";
 

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -316,8 +316,8 @@ export const prDiffStatsSchema = z.object({
   additions: z.number(),
   deletions: z.number(),
   changedFiles: z.number(),
-  /** Lowercased GitHub PR state: "open" | "closed" | "merged". */
-  state: z.string(),
+  /** Lowercased GitHub PR state. */
+  state: z.enum(["open", "closed", "merged"]),
   merged: z.boolean(),
   draft: z.boolean(),
 });

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -308,10 +308,18 @@ export type PrDetailsByUrlOutput = z.infer<typeof getPrDetailsByUrlOutput>;
 
 export const getPrChangedFilesInput = z.object({ prUrl: z.string() });
 
+// Also carries the PR's live status (`state`/`merged`/`draft`) so list cards
+// can render it from the single batched GraphQL request instead of firing one
+// REST call per visible PR. Mirrors `prDiffStatsSchema` in
+// `@posthog/core/git/router-schemas`.
 export const prDiffStatsSchema = z.object({
   additions: z.number(),
   deletions: z.number(),
   changedFiles: z.number(),
+  /** Lowercased GitHub PR state: "open" | "closed" | "merged". */
+  state: z.string(),
+  merged: z.boolean(),
+  draft: z.boolean(),
 });
 export type PrDiffStats = z.infer<typeof prDiffStatsSchema>;
 

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -117,6 +117,24 @@ function toUnifiedDiffPatch(
   return `diff --git a/${oldPath} b/${filename}\n--- ${fromPath}\n+++ ${toPath}\n${rawPatch}`;
 }
 
+/**
+ * Narrow GitHub GraphQL's `PullRequestState` (OPEN | CLOSED | MERGED) to the
+ * lowercased literal the batch schema expects. Anything unexpected falls back
+ * to "open" so one odd value can never fail validation for the whole batch.
+ */
+function normalizeGraphqlPrState(
+  graphqlState: string,
+): "open" | "closed" | "merged" {
+  switch (graphqlState) {
+    case "MERGED":
+      return "merged";
+    case "CLOSED":
+      return "closed";
+    default:
+      return "open";
+  }
+}
+
 export function mapPrState(
   state: string | null,
   merged: boolean,
@@ -1093,7 +1111,7 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         additions: node.additions,
         deletions: node.deletions,
         changedFiles: node.changedFiles,
-        state: node.state.toLowerCase(),
+        state: normalizeGraphqlPrState(node.state),
         merged: node.state === "MERGED",
         draft: node.isDraft,
       };

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -1054,7 +1054,7 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
   ): Promise<Record<string, PrDiffStats>> {
     const aliasFragments = chunk
       .map(([, { parsed }], index) => {
-        return `pr${index}: repository(owner: "${escapeGraphqlString(parsed.owner)}", name: "${escapeGraphqlString(parsed.repo)}") { pullRequest(number: ${parsed.number}) { additions deletions changedFiles } }`;
+        return `pr${index}: repository(owner: "${escapeGraphqlString(parsed.owner)}", name: "${escapeGraphqlString(parsed.repo)}") { pullRequest(number: ${parsed.number}) { additions deletions changedFiles state isDraft } }`;
       })
       .join("\n");
     const query = `query InboxPrDiffStatsBatch {\n${aliasFragments}\n}`;
@@ -1075,6 +1075,8 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
             additions: number;
             deletions: number;
             changedFiles: number;
+            state: string;
+            isDraft: boolean;
           } | null;
         } | null
       >;
@@ -1085,10 +1087,15 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
       const [, { urls }] = chunk[i];
       const node = parsed.data?.[`pr${i}`]?.pullRequest;
       if (!node) continue;
+      // GraphQL `PullRequestState` is OPEN | CLOSED | MERGED; normalise to the
+      // lowercase state + merged boolean shape the badge expects.
       const stats: PrDiffStats = {
         additions: node.additions,
         deletions: node.deletions,
         changedFiles: node.changedFiles,
+        state: node.state.toLowerCase(),
+        merged: node.state === "MERGED",
+        draft: node.isDraft,
       };
       for (const url of urls) {
         out[url] = stats;


### PR DESCRIPTION
## Problem

Follow-up to #2694 (merged), which added a live PR-status badge to the pull request **detail** view. This brings that status to the **list cards** in the Pulls tab, plus addresses review feedback from both PRs.

The naive approach (a `usePrDetails` call per card) would be an N+1: one `gh api` REST call per visible PR, and GitHub is rate-limited.

## Changes

### Live status on list cards (no extra API calls)
- **`workspace-server`** — the `getPrDiffStatsBatch` GraphQL query already fetches diff stats for every visible PR in one request. Added `state isDraft` to the same fragment and normalised GitHub's `OPEN | CLOSED | MERGED` enum into the `{ state, merged, draft }` shape the badge expects. **Zero additional requests.**
- **`core` + `workspace-server` schemas** — added `state`/`merged`/`draft` to `prDiffStatsSchema` (both copies).
- **`ReportImplementationPrLink`** — now reads status from the surrounding `PrDiffStatsBatchContext` when present (list), falling back to the per-PR `usePrDetails` query only when there's no batch provider (detail view) — mirroring how `PrDiffStats` already works.
- **`PullRequestCard`** — renders the status badge, stacked **above** the line-diff to use horizontal space efficiently.

### Review feedback addressed (from #2694 + #2695 bots)
- **Unknown-state handling** (Codex) — `getPrDetailsByUrl` returns `{ state: "unknown" }` on failure; the badge now renders nothing for any unresolved state instead of a misleading green "open".
- **URL validation** (Codex) — the badge validates via `parsePrUrl` (the same gate as "Open in GitHub") and renders nothing for non-canonical/unsafe URLs, so it never exposes an unvalidated external link.
- **Tooltip loading guard** (Greptile) — the tooltip is guarded by `isLoading` so it doesn't show default values while pending.
- **`state` as `z.enum`** (Greptile) — `state` is now `z.enum(["open","closed","merged"])` in both schema copies; the server maps GitHub's GraphQL enum with a safe `"open"` fallback so an unexpected value can't fail validation for the whole batch.

## How did you test this?

- `biome check` + typecheck clean across `@posthog/core`, `@posthog/workspace-server`, and `@posthog/ui`.
- No tests reference the batch shape; schema change is additive.
- Local manual verification in the running app (by the author). **Note:** this touches `workspace-server`, so the app needs a full restart (not just renderer HMR) to serve the new GraphQL fields.

## Notes

- Originally stacked on #2694; since that merged, this PR is now rebased directly onto `main` and folds in the #2694 review fixes too.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?