### PR TITLE
feat(settings): label meep sounds as lorg and smol

### DIFF
--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -42,7 +42,7 @@ const FONT_SIZE_OPTIONS: ReadonlyArray<{
 
 const SOUND_OPTIONS: ReadonlyArray<{ value: CompletionSound; label: string }> =
   [
-    { value: "meep", label: "Meep" },
+    { value: "meep", label: "Meep (lorg)" },
     { value: "meep-smol", label: "Meep (smol)" },
     { value: "knock", label: "Knock" },
     { value: "ring", label: "Ring" },

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -357,7 +357,7 @@ export function GeneralSettings() {
               <Select.Item value="guitar">Guitar solo</Select.Item>
               <Select.Item value="danilo">I'm ready</Select.Item>
               <Select.Item value="revi">Cute noise</Select.Item>
-              <Select.Item value="meep">Meep</Select.Item>
+              <Select.Item value="meep">Meep (lorg)</Select.Item>
               <Select.Item value="meep-smol">Meep (smol)</Select.Item>
               <Select.Item value="bubbles">Bubbles</Select.Item>
               <Select.Item value="drop">Drop</Select.Item>


### PR DESCRIPTION
## Problem

The two meep notification sounds were labelled "Meep" and "Meep (smol)", which didn't make it clear that the first is the larger variant. Per the Slack thread, they should read "meep (lorg)" and "meep (smol)".

## Changes

Renamed the larger meep option's label from "Meep" to "Meep (lorg)" in the sound picker, on both desktop (`GeneralSettings.tsx`) and mobile (`settings/index.tsx`). The "Meep (smol)" label was already correct. Underlying sound values are unchanged.

## How did you test this?

Not tested beyond the edit — purely a display-label change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/CT2BU33N1/p1781559380714749?thread_ts=1781559380.714749&cid=CT2BU33N1)*