### PR TITLE
feat(agents): agent-applications console (port from agent_platform)

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -13,6 +13,18 @@ import {
   SEAT_PRODUCT_KEY,
 } from "@posthog/shared";
 import type {
+  AgentAggregateStats,
+  AgentApplication,
+  AgentApplicationSessionDetail,
+  AgentApplicationSessionsListResponse,
+  AgentApprovalRequest,
+  AgentApprovalsListParams,
+  AgentFleetLiveSessionsResponse,
+  AgentRevision,
+  AgentSessionsListParams,
+  DecideApprovalRequest,
+} from "@posthog/shared/agent-platform-types";
+import type {
   ActionabilityJudgmentArtefact,
   AvailableSuggestedReviewer,
   AvailableSuggestedReviewersResponse,
@@ -3968,5 +3980,273 @@ export class PostHogAPIClient {
       );
     }
     return (await response.json()) as LlmSkillFile;
+  }
+
+  // --- Agent platform ------------------------------------------------------
+  // Deployed agents (`agent_platform` Django app). These routes aren't in the
+  // generated OpenAPI client, so they use the raw fetcher. Applications are
+  // addressable by UUID or slug in the `{idOrSlug}` segment.
+
+  private agentApplicationsPath(teamId: number): string {
+    return `/api/projects/${teamId}/agent_applications/`;
+  }
+
+  /** Lists non-archived agent applications for the current team. */
+  async listAgentApplications(): Promise<AgentApplication[]> {
+    const MAX_PAGES = 50;
+    const teamId = await this.getTeamId();
+    const all: AgentApplication[] = [];
+    let urlPath = `${this.agentApplicationsPath(teamId)}?limit=100`;
+    for (let i = 0; i < MAX_PAGES; i++) {
+      const url = new URL(`${this.api.baseUrl}${urlPath}`);
+      const response = await this.api.fetcher.fetch({
+        method: "get",
+        url,
+        path: urlPath,
+      });
+      const page = (await response.json()) as {
+        results?: AgentApplication[];
+        next?: string | null;
+      };
+      all.push(...(page.results ?? []));
+      if (!page.next) return all;
+      const nextUrl = new URL(page.next);
+      urlPath = `${nextUrl.pathname}${nextUrl.search}`;
+    }
+    return all;
+  }
+
+  /** Fetches a single agent application by UUID or slug; null if not found. */
+  async getAgentApplication(
+    idOrSlug: string,
+  ): Promise<AgentApplication | null> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    try {
+      const response = await this.api.fetcher.fetch({
+        method: "get",
+        url,
+        path,
+      });
+      return (await response.json()) as AgentApplication;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("[404]") || msg.includes("[403]")) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /** Per-application roll-up stats. `since` is an ISO timestamp window start. */
+  async getAgentApplicationStats(
+    idOrSlug: string,
+    since?: string,
+  ): Promise<AgentAggregateStats> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/stats/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    if (since) {
+      url.searchParams.set("since", since);
+    }
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    return (await response.json()) as AgentAggregateStats;
+  }
+
+  /** Lists sessions for an application (paginated, filterable by state). */
+  async listAgentApplicationSessions(
+    idOrSlug: string,
+    params?: AgentSessionsListParams,
+  ): Promise<AgentApplicationSessionsListResponse> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/sessions/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    if (params?.limit != null) {
+      url.searchParams.set("limit", String(params.limit));
+    }
+    if (params?.offset != null) {
+      url.searchParams.set("offset", String(params.offset));
+    }
+    if (params?.state?.length) {
+      url.searchParams.set("state", params.state.join(","));
+    }
+    if (params?.revision_id) {
+      url.searchParams.set("revision_id", params.revision_id);
+    }
+    if (params?.created_after) {
+      url.searchParams.set("created_after", params.created_after);
+    }
+    if (params?.created_before) {
+      url.searchParams.set("created_before", params.created_before);
+    }
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    const data = (await response.json()) as {
+      results?: AgentApplicationSessionsListResponse["results"];
+      count?: number;
+    };
+    return {
+      results: data.results ?? [],
+      count: data.count ?? data.results?.length ?? 0,
+    };
+  }
+
+  /** Full session detail incl. transcript; `lastN` trims to trailing messages. */
+  async getAgentApplicationSession(
+    idOrSlug: string,
+    sessionId: string,
+    lastN?: number,
+  ): Promise<AgentApplicationSessionDetail | null> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/sessions/${encodeURIComponent(sessionId)}/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    if (lastN != null) {
+      url.searchParams.set("last_n", String(lastN));
+    }
+    try {
+      const response = await this.api.fetcher.fetch({
+        method: "get",
+        url,
+        path,
+      });
+      return (await response.json()) as AgentApplicationSessionDetail;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("[404]") || msg.includes("[403]")) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /** Lists tool-approval requests for an application (team-admin only). */
+  async listAgentApplicationApprovals(
+    idOrSlug: string,
+    params?: AgentApprovalsListParams,
+  ): Promise<AgentApprovalRequest[]> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/approvals/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    if (params?.state) {
+      url.searchParams.set("state", params.state);
+    }
+    if (params?.limit != null) {
+      url.searchParams.set("limit", String(params.limit));
+    }
+    if (params?.offset != null) {
+      url.searchParams.set("offset", String(params.offset));
+    }
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    const data = (await response.json()) as {
+      results?: AgentApprovalRequest[];
+    };
+    return data.results ?? [];
+  }
+
+  /** Approve or reject a queued tool-approval request. */
+  async decideAgentApproval(
+    idOrSlug: string,
+    approvalId: string,
+    body: DecideApprovalRequest,
+  ): Promise<AgentApprovalRequest> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/approvals/${encodeURIComponent(approvalId)}/decide/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path,
+      overrides: { body: JSON.stringify(body) },
+    });
+    return (await response.json()) as AgentApprovalRequest;
+  }
+
+  /** Lists revisions for an application (newest first, paginated). */
+  async listAgentRevisions(idOrSlug: string): Promise<AgentRevision[]> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/revisions/`;
+    const url = new URL(`${this.api.baseUrl}${path}?limit=100`);
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    const data = (await response.json()) as { results?: AgentRevision[] };
+    return data.results ?? [];
+  }
+
+  /** Fetches a single revision by id; null if not found. */
+  async getAgentRevision(
+    idOrSlug: string,
+    revisionId: string,
+  ): Promise<AgentRevision | null> {
+    const teamId = await this.getTeamId();
+    const path = `${this.agentApplicationsPath(teamId)}${encodeURIComponent(idOrSlug)}/revisions/${encodeURIComponent(revisionId)}/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    try {
+      const response = await this.api.fetcher.fetch({
+        method: "get",
+        url,
+        path,
+      });
+      return (await response.json()) as AgentRevision;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("[404]") || msg.includes("[403]")) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /** Team-wide fleet roll-up stats. `since` is an ISO timestamp window start. */
+  async getAgentFleetStats(since?: string): Promise<AgentAggregateStats> {
+    const teamId = await this.getTeamId();
+    const path = `/api/projects/${teamId}/agent_fleet/stats/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    if (since) {
+      url.searchParams.set("since", since);
+    }
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    return (await response.json()) as AgentAggregateStats;
+  }
+
+  /** Live (non-terminal) sessions across every agent on the team. */
+  async listAgentFleetLiveSessions(
+    limit?: number,
+  ): Promise<AgentFleetLiveSessionsResponse> {
+    const teamId = await this.getTeamId();
+    const path = `/api/projects/${teamId}/agent_fleet/live_sessions/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    if (limit != null) {
+      url.searchParams.set("limit", String(limit));
+    }
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    const data = (await response.json()) as {
+      results?: AgentFleetLiveSessionsResponse["results"];
+    };
+    return { results: data.results ?? [] };
+  }
+
+  /** All tool-approval requests across the team (team-admin only). */
+  async listAgentFleetApprovals(
+    params?: AgentApprovalsListParams,
+  ): Promise<AgentApprovalRequest[]> {
+    const teamId = await this.getTeamId();
+    const path = `/api/projects/${teamId}/agent_fleet/approvals/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    if (params?.state) {
+      url.searchParams.set("state", params.state);
+    }
+    if (params?.agent_id) {
+      url.searchParams.set("agent_id", params.agent_id);
+    }
+    if (params?.limit != null) {
+      url.searchParams.set("limit", String(params.limit));
+    }
+    if (params?.offset != null) {
+      url.searchParams.set("offset", String(params.offset));
+    }
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    const data = (await response.json()) as {
+      results?: AgentApprovalRequest[];
+    };
+    return data.results ?? [];
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/analytics-events.d.ts",
       "import": "./dist/analytics-events.js"
     },
+    "./agent-platform-types": {
+      "types": "./dist/agent-platform-types.d.ts",
+      "import": "./dist/agent-platform-types.js"
+    },
     "./domain-types": {
       "types": "./dist/domain-types.d.ts",
       "import": "./dist/domain-types.js"

--- a/packages/shared/src/agent-platform-types.ts
+++ b/packages/shared/src/agent-platform-types.ts
@@ -1,0 +1,297 @@
+// Domain types for the agent_platform product surface (deployed agents,
+// their revisions, sessions, approvals, and fleet rollups). These mirror the
+// PostHog Cloud REST serializers (Django app `agent_platform`) and are the wire
+// shapes returned by the corresponding PostHogAPIClient methods. Field names
+// stay snake_case to match the JSON exactly, as with the other shared wire
+// types (see inbox-types.ts).
+
+// --- Enums -----------------------------------------------------------------
+
+export type AgentSessionState =
+  | "queued"
+  | "running"
+  | "completed"
+  | "closed"
+  | "cancelled"
+  | "failed";
+
+export type AgentSessionPrincipalKind =
+  | "anonymous"
+  | "service"
+  | "internal"
+  | "shared_secret"
+  | "slack";
+
+export type AgentRevisionState = "draft" | "ready" | "live" | "archived";
+
+export type AgentApprovalRequestState =
+  | "queued"
+  | "approving"
+  | "dispatched"
+  | "dispatched_failed"
+  | "rejected"
+  | "expired";
+
+export type AgentApprovalDecision = "approve" | "reject";
+
+// --- Applications ----------------------------------------------------------
+
+/** Resolved creator (from `created_by_id`), or null if unset/deleted. */
+export interface AgentApplicationCreator {
+  id?: number;
+  first_name?: string;
+  email?: string;
+}
+
+export interface AgentApplication {
+  id: string;
+  team_id: number;
+  name: string;
+  /** Globally-unique URL identifier; server-minted unless explicitly allowed. */
+  slug?: string;
+  description?: string;
+  live_revision: string | null;
+  archived?: boolean;
+  archived_at: string | null;
+  created_by_id: number | null;
+  created_by: AgentApplicationCreator | null;
+  created_at: string;
+  updated_at: string;
+  /** Slack Event Subscriptions request URL; null without a public ingress URL. */
+  slack_events_url: string | null;
+  /** Slack Interactivity request URL; null without a public ingress URL. */
+  slack_interactivity_url: string | null;
+  /** Mode-aware base URL the agent's trigger routes hang off; null without ingress. */
+  ingress_base_url: string | null;
+}
+
+/** Per-application or team-wide roll-up stats. */
+export interface AgentAggregateStats {
+  liveCount: number;
+  sessionsInWindowCount: number;
+  spendInWindowUsd: number;
+  lastActivityAt: string | null;
+  failedInWindowCount: number;
+  pendingApprovalsCount: number;
+}
+
+// --- Revisions -------------------------------------------------------------
+
+/**
+ * The agent spec carried on a revision. Fully typed elaboration (triggers,
+ * tools, mcps, skills, limits) lands with the config editor milestone; for now
+ * the known top-level fields are surfaced and the rest passes through.
+ */
+export interface AgentSpec {
+  model: string;
+  triggers?: unknown[];
+  tools?: unknown[];
+  mcps?: unknown[];
+  skills?: unknown[];
+  integrations?: string[];
+  secrets?: string[];
+  limits?: {
+    max_turns?: number;
+    max_tool_calls?: number;
+    max_wall_seconds?: number;
+  };
+  entrypoint?: string;
+  reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh";
+  [key: string]: unknown;
+}
+
+export interface AgentRevision {
+  id: string;
+  application: string;
+  parent_revision?: string | null;
+  state: AgentRevisionState;
+  bundle_uri?: string;
+  bundle_sha256: string | null;
+  spec?: AgentSpec;
+  created_by_id: number | null;
+  created_by: AgentApplicationCreator | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// --- Sessions --------------------------------------------------------------
+
+export interface AgentSessionUsageTotal {
+  tokens_in: number;
+  tokens_out: number;
+  cache_read: number;
+  cache_write: number;
+  cost_input: number;
+  cost_output: number;
+  cost_cache_read: number;
+  cost_cache_write: number;
+  cost_total: number;
+}
+
+export interface AgentSessionPrincipal {
+  kind: AgentSessionPrincipalKind;
+  /** Stable principal id (PAT id, slack user id, …); absent for anonymous. */
+  id?: string;
+  team_id?: number;
+}
+
+/** Trigger-specific metadata stamped at session creation; shape varies by kind. */
+export type AgentSessionTriggerMetadata = Record<string, unknown>;
+
+export interface AgentSessionSummary {
+  id: string;
+  application_id: string;
+  revision_id: string;
+  state: AgentSessionState;
+  external_key: string | null;
+  trigger_metadata?: AgentSessionTriggerMetadata | null;
+  principal: AgentSessionPrincipal | null;
+  /** Count of messages in the conversation. */
+  turns: number;
+  /** Last assistant text (~120 chars); null before any assistant turn. */
+  preview: string | null;
+  usage_total: AgentSessionUsageTotal;
+  retry_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgentApplicationSessionsListResponse {
+  results: AgentSessionSummary[];
+  count: number;
+}
+
+// --- Conversation transcript (stored shape on a session) -------------------
+// The SSE→ACP adapter (chat milestone) consumes these; for the read surface
+// they back the session-detail transcript.
+
+export interface AgentConversationUserMessage {
+  role: "user";
+  /** String shorthand, or array of {type:'text'|'image', …} parts. */
+  content: unknown;
+  /** Epoch milliseconds. */
+  timestamp: number;
+}
+
+export interface AgentConversationAssistantMessage {
+  role: "assistant";
+  /** Array of text/thinking/toolCall parts. */
+  content: unknown[];
+  timestamp: number;
+  api?: string;
+  provider?: string;
+  model?: string;
+  usage?: Record<string, unknown>;
+  stopReason?: string;
+  errorMessage?: string;
+}
+
+export interface AgentConversationToolResultMessage {
+  role: "tool";
+  toolCallId: string;
+  toolName: string;
+  /** Array of {type:'text'|'image', …} parts. */
+  content: unknown[];
+  isError: boolean;
+  timestamp: number;
+}
+
+export type AgentConversationMessage =
+  | AgentConversationUserMessage
+  | AgentConversationAssistantMessage
+  | AgentConversationToolResultMessage;
+
+export interface AgentApplicationSessionDetail {
+  id: string;
+  application_id: string;
+  revision_id: string;
+  team_id: number;
+  state: AgentSessionState;
+  external_key: string | null;
+  trigger_metadata?: AgentSessionTriggerMetadata | null;
+  principal: AgentSessionPrincipal | null;
+  usage_total: AgentSessionUsageTotal;
+  conversation: AgentConversationMessage[];
+  /** Messages that arrived while a turn was in flight. */
+  pending_inputs: AgentConversationMessage[];
+  retry_count: number;
+  created_at: string;
+  updated_at: string;
+  /** True when `last_n` was supplied AND the full conversation exceeded it. */
+  conversation_trimmed: boolean;
+  /** Total messages in the untrimmed conversation; present only when trimmed. */
+  conversation_total_turns?: number;
+}
+
+// --- Fleet -----------------------------------------------------------------
+
+export interface AgentFleetLiveSessionSummary {
+  id: string;
+  application_id: string;
+  revision_id: string;
+  team_id: number;
+  state: AgentSessionState;
+  external_key: string | null;
+  trigger_metadata?: AgentSessionTriggerMetadata | null;
+  principal: AgentSessionPrincipal | null;
+  turns: number;
+  preview: string | null;
+  usage_total: AgentSessionUsageTotal;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgentFleetLiveSessionsResponse {
+  results: AgentFleetLiveSessionSummary[];
+}
+
+// --- Approvals -------------------------------------------------------------
+
+export interface AgentApprovalRequest {
+  id: string;
+  session_id: string;
+  application_id: string;
+  team_id: number;
+  revision_id: string;
+  turn: number;
+  tool_call_id: string;
+  tool_name: string;
+  proposed_args: Record<string, unknown>;
+  decided_args: Record<string, unknown> | null;
+  assistant_message: Record<string, unknown>;
+  approver_scope: Record<string, unknown>;
+  state: AgentApprovalRequestState;
+  decision_by: string | null;
+  decision_at: string | null;
+  decision_reason: string | null;
+  dispatch_outcome: Record<string, unknown> | null;
+  created_at: string;
+  expires_at: string;
+}
+
+/** Body for POST …/approvals/{id}/decide/. */
+export interface DecideApprovalRequest {
+  decision: AgentApprovalDecision;
+  /** Honoured only when the tool's approval_policy.allow_edit is true. */
+  edited_args?: Record<string, unknown>;
+  reason?: string;
+}
+
+// --- Query params ----------------------------------------------------------
+
+export interface AgentSessionsListParams {
+  limit?: number;
+  offset?: number;
+  /** Comma-separated states accepted server-side; pass an array, joined by the client. */
+  state?: AgentSessionState[];
+  revision_id?: string;
+  created_after?: string;
+  created_before?: string;
+}
+
+export interface AgentApprovalsListParams {
+  state?: AgentApprovalRequestState;
+  agent_id?: string;
+  limit?: number;
+  offset?: number;
+}

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: [
     "src/index.ts",
+    "src/agent-platform-types.ts",
     "src/analytics-events.ts",
     "src/constants.ts",
     "src/deeplink.ts",

--- a/packages/ui/src/features/agent-applications/agent-applications.module.ts
+++ b/packages/ui/src/features/agent-applications/agent-applications.module.ts
@@ -1,0 +1,9 @@
+import { ContainerModule } from "inversify";
+
+/**
+ * UI module for the agent-applications feature (deployed agent_platform
+ * agents). Currently holds no bindings — the chat/concierge contributions and
+ * any view-state slices are added in later milestones. Registered in
+ * apps/code/src/renderer/desktop-contributions.ts once it binds a CONTRIBUTION.
+ */
+export const agentApplicationsUiModule = new ContainerModule(() => {});

--- a/packages/ui/src/features/agent-applications/components/AgentApplicationDetailView.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentApplicationDetailView.tsx
@@ -1,0 +1,236 @@
+import { ArrowLeftIcon, RobotIcon } from "@phosphor-icons/react";
+import { formatRelativeTimeShort } from "@posthog/shared";
+import type {
+  AgentSessionPrincipal,
+  AgentSessionSummary,
+} from "@posthog/shared/agent-platform-types";
+import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { Badge } from "@posthog/ui/primitives/Badge";
+import { Flex, Text } from "@radix-ui/themes";
+import { Link } from "@tanstack/react-router";
+import { type ReactNode, useMemo } from "react";
+import { useAgentApplication } from "../hooks/useAgentApplication";
+import { useAgentApplicationSessions } from "../hooks/useAgentApplicationSessions";
+import { useAgentApplicationStats } from "../hooks/useAgentApplicationStats";
+import { formatSpendUsd, sessionStateColor } from "../utils/format";
+
+/**
+ * Per-agent detail: overview + stat strip + recent sessions. The chat surface
+ * and config editor land in later milestones.
+ */
+export function AgentApplicationDetailView({ idOrSlug }: { idOrSlug: string }) {
+  const {
+    data: application,
+    isLoading,
+    isError,
+  } = useAgentApplication(idOrSlug);
+  const { data: stats } = useAgentApplicationStats(idOrSlug);
+  const { data: sessions, isLoading: sessionsLoading } =
+    useAgentApplicationSessions(idOrSlug, { limit: 25 });
+
+  const title = application?.name ?? idOrSlug;
+  const headerContent = useMemo(
+    () => (
+      <Flex align="center" gap="2" className="w-full min-w-0">
+        <RobotIcon size={12} className="shrink-0 text-gray-10" />
+        <Text
+          className="truncate whitespace-nowrap font-medium text-[13px]"
+          title={title}
+        >
+          {title}
+        </Text>
+      </Flex>
+    ),
+    [title],
+  );
+  useSetHeaderContent(headerContent);
+
+  return (
+    <Flex direction="column" className="h-full min-h-0">
+      <Flex
+        direction="column"
+        gap="2"
+        className="cursor-default select-none border-(--gray-5) border-b px-6 pt-5 pb-5"
+      >
+        <Link
+          to="/code/agents/applications"
+          className="flex w-fit items-center gap-1.5 text-[12px] text-gray-11 no-underline hover:text-gray-12"
+        >
+          <ArrowLeftIcon size={13} />
+          Applications
+        </Link>
+        <Flex align="center" gap="2" wrap="wrap">
+          <Text className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">
+            {title}
+          </Text>
+          {application ? (
+            <Badge color={application.live_revision ? "green" : "gray"}>
+              {application.live_revision ? "Live" : "Draft"}
+            </Badge>
+          ) : null}
+        </Flex>
+        {application?.description?.trim() ? (
+          <Text className="max-w-3xl text-[12.5px] text-gray-11 leading-snug">
+            {application.description}
+          </Text>
+        ) : null}
+      </Flex>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="mx-auto max-w-4xl px-6 py-6">
+          {isLoading ? (
+            <div className="h-24 animate-pulse rounded-(--radius-2) border border-border bg-(--gray-2)" />
+          ) : isError || !application ? (
+            <EmptyState
+              title="Couldn't load this agent"
+              description="It may have been archived, or the agent platform API returned an error."
+            />
+          ) : (
+            <Flex direction="column" gap="6">
+              <StatStrip
+                liveCount={stats?.liveCount ?? 0}
+                sessionsInWindowCount={stats?.sessionsInWindowCount ?? 0}
+                spendInWindowUsd={stats?.spendInWindowUsd ?? 0}
+                failedInWindowCount={stats?.failedInWindowCount ?? 0}
+              />
+
+              <section>
+                <Text className="mb-3 block font-semibold text-[13px] text-gray-12">
+                  Recent sessions
+                </Text>
+                {sessionsLoading ? (
+                  <Flex direction="column" gap="2">
+                    {[0, 1, 2].map((i) => (
+                      <div
+                        key={i}
+                        className="h-[52px] animate-pulse rounded-(--radius-2) border border-border bg-(--gray-2)"
+                      />
+                    ))}
+                  </Flex>
+                ) : !sessions || sessions.results.length === 0 ? (
+                  <EmptyState
+                    title="No sessions yet"
+                    description="Sessions this agent runs will appear here."
+                  />
+                ) : (
+                  <Flex direction="column" gap="2">
+                    {sessions.results.map((session) => (
+                      <SessionRow key={session.id} session={session} />
+                    ))}
+                  </Flex>
+                )}
+              </section>
+            </Flex>
+          )}
+        </div>
+      </div>
+    </Flex>
+  );
+}
+
+function StatStrip({
+  liveCount,
+  sessionsInWindowCount,
+  spendInWindowUsd,
+  failedInWindowCount,
+}: {
+  liveCount: number;
+  sessionsInWindowCount: number;
+  spendInWindowUsd: number;
+  failedInWindowCount: number;
+}) {
+  return (
+    <Flex
+      gap="0"
+      className="overflow-hidden rounded-(--radius-2) border border-border bg-(--color-panel-solid)"
+    >
+      <Stat label="Live" value={String(liveCount)} />
+      <Stat label="Sessions (24h)" value={String(sessionsInWindowCount)} />
+      <Stat label="Spend (24h)" value={formatSpendUsd(spendInWindowUsd)} />
+      <Stat label="Failed (24h)" value={String(failedInWindowCount)} last />
+    </Flex>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  last,
+}: {
+  label: string;
+  value: string;
+  last?: boolean;
+}) {
+  return (
+    <Flex
+      direction="column"
+      gap="1"
+      className={`min-w-0 flex-1 px-4 py-3 ${
+        last ? "" : "border-(--gray-5) border-r"
+      }`}
+    >
+      <Text className="truncate text-[11px] text-gray-10 uppercase tracking-wide">
+        {label}
+      </Text>
+      <Text className="font-semibold text-[18px] text-gray-12 leading-none">
+        {value}
+      </Text>
+    </Flex>
+  );
+}
+
+function principalLabel(principal: AgentSessionPrincipal | null): string {
+  if (!principal) return "anonymous";
+  return principal.kind;
+}
+
+function SessionRow({ session }: { session: AgentSessionSummary }) {
+  return (
+    <Flex
+      align="center"
+      justify="between"
+      gap="3"
+      className="rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-4 py-3"
+    >
+      <Flex direction="column" gap="1" className="min-w-0">
+        <Flex align="center" gap="2" className="min-w-0">
+          <Badge color={sessionStateColor(session.state)}>
+            {session.state}
+          </Badge>
+          <Text className="truncate text-[12.5px] text-gray-12">
+            {session.preview?.trim() ? session.preview : "No assistant output"}
+          </Text>
+        </Flex>
+        <Text className="truncate text-[11px] text-gray-10">
+          {principalLabel(session.principal)} · {session.turns} turns ·{" "}
+          {formatSpendUsd(session.usage_total.cost_total)}
+        </Text>
+      </Flex>
+      <Text className="shrink-0 text-[11px] text-gray-10">
+        {formatRelativeTimeShort(session.updated_at)}
+      </Text>
+    </Flex>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: ReactNode;
+}) {
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      gap="1"
+      className="rounded-(--radius-2) border border-(--gray-5) border-dashed px-6 py-10 text-center"
+    >
+      <Text className="font-medium text-[13px] text-gray-12">{title}</Text>
+      <Text className="max-w-md text-[12px] text-gray-11 leading-snug">
+        {description}
+      </Text>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
@@ -1,0 +1,53 @@
+import { RobotIcon } from "@phosphor-icons/react";
+import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { Flex, Text } from "@radix-ui/themes";
+import { useMemo } from "react";
+
+/**
+ * Landing for the agent-platform console: the list of deployed agent
+ * applications plus the fleet overview. M1 renders the chrome only — the
+ * list, fleet stat strip, and live-now panel are wired to the
+ * agent_platform REST API in a later milestone.
+ */
+export function AgentApplicationsListView() {
+  const headerContent = useMemo(
+    () => (
+      <Flex align="center" gap="2" className="w-full min-w-0">
+        <RobotIcon size={12} className="shrink-0 text-gray-10" />
+        <Text
+          className="truncate whitespace-nowrap font-medium text-[13px]"
+          title="Applications"
+        >
+          Applications
+        </Text>
+      </Flex>
+    ),
+    [],
+  );
+
+  useSetHeaderContent(headerContent);
+
+  return (
+    <Flex direction="column" className="h-full min-h-0">
+      <Flex
+        direction="column"
+        gap="0.5"
+        className="cursor-default select-none border-(--gray-5) border-b px-6 pt-5 pb-5"
+      >
+        <Text className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">
+          Applications
+        </Text>
+        <Text className="max-w-3xl text-[12.5px] text-gray-11 leading-snug">
+          Deployed agents on the agent platform – their configuration, sessions,
+          memory, and approvals.
+        </Text>
+      </Flex>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="mx-auto max-w-4xl px-6 py-6">
+          <Text className="text-[12.5px] text-gray-11">No agents yet.</Text>
+        </div>
+      </div>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
@@ -1,13 +1,17 @@
-import { RobotIcon } from "@phosphor-icons/react";
+import { CaretRightIcon, RobotIcon } from "@phosphor-icons/react";
+import type { AgentApplication } from "@posthog/shared/agent-platform-types";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { Badge } from "@posthog/ui/primitives/Badge";
 import { Flex, Text } from "@radix-ui/themes";
-import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { type ReactNode, useMemo } from "react";
+import { useAgentApplications } from "../hooks/useAgentApplications";
+import { useAgentFleetStats } from "../hooks/useAgentFleetStats";
+import { formatSpendUsd } from "../utils/format";
 
 /**
- * Landing for the agent-platform console: the list of deployed agent
- * applications plus the fleet overview. M1 renders the chrome only — the
- * list, fleet stat strip, and live-now panel are wired to the
- * agent_platform REST API in a later milestone.
+ * Landing for the agent-platform console: a fleet stat strip plus the list of
+ * deployed agent applications. Each row links to the per-agent detail view.
  */
 export function AgentApplicationsListView() {
   const headerContent = useMemo(
@@ -27,6 +31,14 @@ export function AgentApplicationsListView() {
 
   useSetHeaderContent(headerContent);
 
+  const {
+    data: applications,
+    isLoading,
+    isError,
+    error,
+  } = useAgentApplications();
+  const { data: fleetStats } = useAgentFleetStats();
+
   return (
     <Flex direction="column" className="h-full min-h-0">
       <Flex
@@ -45,9 +57,180 @@ export function AgentApplicationsListView() {
 
       <div className="min-h-0 flex-1 overflow-auto">
         <div className="mx-auto max-w-4xl px-6 py-6">
-          <Text className="text-[12.5px] text-gray-11">No agents yet.</Text>
+          <Flex direction="column" gap="5">
+            <FleetStatStrip
+              liveCount={fleetStats?.liveCount ?? 0}
+              sessionsInWindowCount={fleetStats?.sessionsInWindowCount ?? 0}
+              spendInWindowUsd={fleetStats?.spendInWindowUsd ?? 0}
+              failedInWindowCount={fleetStats?.failedInWindowCount ?? 0}
+              pendingApprovalsCount={fleetStats?.pendingApprovalsCount ?? 0}
+            />
+
+            {isLoading ? (
+              <ApplicationsSkeleton />
+            ) : isError ? (
+              <EmptyState
+                title="Couldn't load applications"
+                description={
+                  error instanceof Error
+                    ? error.message
+                    : "The agent platform API returned an error."
+                }
+              />
+            ) : !applications || applications.length === 0 ? (
+              <EmptyState
+                title="No agents yet"
+                description="Deployed agents on the agent platform will show up here."
+              />
+            ) : (
+              <Flex direction="column" gap="2">
+                {applications.map((app) => (
+                  <ApplicationRow key={app.id} application={app} />
+                ))}
+              </Flex>
+            )}
+          </Flex>
         </div>
       </div>
+    </Flex>
+  );
+}
+
+interface FleetStatStripProps {
+  liveCount: number;
+  sessionsInWindowCount: number;
+  spendInWindowUsd: number;
+  failedInWindowCount: number;
+  pendingApprovalsCount: number;
+}
+
+function FleetStatStrip({
+  liveCount,
+  sessionsInWindowCount,
+  spendInWindowUsd,
+  failedInWindowCount,
+  pendingApprovalsCount,
+}: FleetStatStripProps) {
+  return (
+    <Flex
+      gap="0"
+      className="overflow-hidden rounded-(--radius-2) border border-border bg-(--color-panel-solid)"
+    >
+      <Stat label="Live" value={String(liveCount)} />
+      <Stat label="Sessions (24h)" value={String(sessionsInWindowCount)} />
+      <Stat label="Spend (24h)" value={formatSpendUsd(spendInWindowUsd)} />
+      <Stat
+        label="Failed (24h)"
+        value={String(failedInWindowCount)}
+        emphasize={failedInWindowCount > 0 ? "red" : undefined}
+      />
+      <Stat
+        label="Approvals"
+        value={String(pendingApprovalsCount)}
+        emphasize={pendingApprovalsCount > 0 ? "amber" : undefined}
+        last
+      />
+    </Flex>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  emphasize,
+  last,
+}: {
+  label: string;
+  value: string;
+  emphasize?: "red" | "amber";
+  last?: boolean;
+}) {
+  const valueColor =
+    emphasize === "red"
+      ? "text-(--red-11)"
+      : emphasize === "amber"
+        ? "text-(--amber-11)"
+        : "text-gray-12";
+  return (
+    <Flex
+      direction="column"
+      gap="1"
+      className={`min-w-0 flex-1 px-4 py-3 ${
+        last ? "" : "border-(--gray-5) border-r"
+      }`}
+    >
+      <Text className="truncate text-[11px] text-gray-10 uppercase tracking-wide">
+        {label}
+      </Text>
+      <Text className={`font-semibold text-[18px] leading-none ${valueColor}`}>
+        {value}
+      </Text>
+    </Flex>
+  );
+}
+
+function ApplicationRow({ application }: { application: AgentApplication }) {
+  const isLive = application.live_revision != null;
+  return (
+    <Link
+      to="/code/agents/applications/$idOrSlug"
+      params={{ idOrSlug: application.slug ?? application.id }}
+      className="flex items-center justify-between gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-4 py-3.5 no-underline transition-colors duration-150 hover:border-(--gray-6) hover:bg-(--gray-2)"
+    >
+      <Flex align="center" gap="3" className="min-w-0">
+        <RobotIcon size={20} className="shrink-0 text-gray-11" />
+        <Flex direction="column" gap="0.5" className="min-w-0">
+          <Flex align="center" gap="2" className="min-w-0">
+            <Text className="truncate font-medium text-[13px] text-gray-12">
+              {application.name}
+            </Text>
+            <Badge color={isLive ? "green" : "gray"}>
+              {isLive ? "Live" : "Draft"}
+            </Badge>
+          </Flex>
+          <Text className="truncate text-[12px] text-gray-11 leading-snug">
+            {application.description?.trim()
+              ? application.description
+              : (application.slug ?? application.id)}
+          </Text>
+        </Flex>
+      </Flex>
+      <CaretRightIcon size={14} className="shrink-0 text-gray-10" />
+    </Link>
+  );
+}
+
+function ApplicationsSkeleton() {
+  return (
+    <Flex direction="column" gap="2">
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="h-[58px] animate-pulse rounded-(--radius-2) border border-border bg-(--gray-2)"
+        />
+      ))}
+    </Flex>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: ReactNode;
+}) {
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      gap="1"
+      className="rounded-(--radius-2) border border-(--gray-5) border-dashed px-6 py-10 text-center"
+    >
+      <Text className="font-medium text-[13px] text-gray-12">{title}</Text>
+      <Text className="max-w-md text-[12px] text-gray-11 leading-snug">
+        {description}
+      </Text>
     </Flex>
   );
 }

--- a/packages/ui/src/features/agent-applications/hooks/agentApplicationsKeys.ts
+++ b/packages/ui/src/features/agent-applications/hooks/agentApplicationsKeys.ts
@@ -1,0 +1,20 @@
+export const agentApplicationsKeys = {
+  list: (projectId: number | null) =>
+    ["agent-applications", "list", projectId] as const,
+  detail: (projectId: number | null, idOrSlug: string) =>
+    ["agent-applications", "detail", projectId, idOrSlug] as const,
+  stats: (projectId: number | null, idOrSlug: string) =>
+    ["agent-applications", "stats", projectId, idOrSlug] as const,
+  sessions: (projectId: number | null, idOrSlug: string) =>
+    ["agent-applications", "sessions", projectId, idOrSlug] as const,
+  session: (projectId: number | null, idOrSlug: string, sessionId: string) =>
+    ["agent-applications", "session", projectId, idOrSlug, sessionId] as const,
+  approvals: (projectId: number | null, idOrSlug: string) =>
+    ["agent-applications", "approvals", projectId, idOrSlug] as const,
+  revisions: (projectId: number | null, idOrSlug: string) =>
+    ["agent-applications", "revisions", projectId, idOrSlug] as const,
+  fleetStats: (projectId: number | null) =>
+    ["agent-applications", "fleet", "stats", projectId] as const,
+  fleetLiveSessions: (projectId: number | null) =>
+    ["agent-applications", "fleet", "live-sessions", projectId] as const,
+};

--- a/packages/ui/src/features/agent-applications/hooks/useAgentApplication.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentApplication.ts
@@ -1,0 +1,14 @@
+import type { AgentApplication } from "@posthog/shared/agent-platform-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+import { agentApplicationsKeys } from "./agentApplicationsKeys";
+
+/** Fetches a single agent application by UUID or slug. */
+export function useAgentApplication(idOrSlug: string) {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<AgentApplication | null>(
+    agentApplicationsKeys.detail(projectId, idOrSlug),
+    (client) => client.getAgentApplication(idOrSlug),
+    { enabled: !!projectId && !!idOrSlug, staleTime: 30_000 },
+  );
+}

--- a/packages/ui/src/features/agent-applications/hooks/useAgentApplicationSessions.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentApplicationSessions.ts
@@ -1,0 +1,25 @@
+import type {
+  AgentApplicationSessionsListResponse,
+  AgentSessionsListParams,
+} from "@posthog/shared/agent-platform-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+import { agentApplicationsKeys } from "./agentApplicationsKeys";
+
+const EMPTY: AgentApplicationSessionsListResponse = { results: [], count: 0 };
+
+/** Lists sessions for an agent application. */
+export function useAgentApplicationSessions(
+  idOrSlug: string,
+  params?: AgentSessionsListParams,
+) {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<AgentApplicationSessionsListResponse>(
+    [...agentApplicationsKeys.sessions(projectId, idOrSlug), params ?? null],
+    (client) =>
+      projectId
+        ? client.listAgentApplicationSessions(idOrSlug, params)
+        : Promise.resolve(EMPTY),
+    { enabled: !!projectId && !!idOrSlug, staleTime: 15_000 },
+  );
+}

--- a/packages/ui/src/features/agent-applications/hooks/useAgentApplicationStats.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentApplicationStats.ts
@@ -1,0 +1,14 @@
+import type { AgentAggregateStats } from "@posthog/shared/agent-platform-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+import { agentApplicationsKeys } from "./agentApplicationsKeys";
+
+/** Per-application roll-up stats (live, sessions, spend, failures). */
+export function useAgentApplicationStats(idOrSlug: string) {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<AgentAggregateStats | null>(
+    agentApplicationsKeys.stats(projectId, idOrSlug),
+    (client) => client.getAgentApplicationStats(idOrSlug),
+    { enabled: !!projectId && !!idOrSlug, staleTime: 30_000 },
+  );
+}

--- a/packages/ui/src/features/agent-applications/hooks/useAgentApplications.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentApplications.ts
@@ -1,0 +1,15 @@
+import type { AgentApplication } from "@posthog/shared/agent-platform-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+import { agentApplicationsKeys } from "./agentApplicationsKeys";
+
+/** Lists the deployed agent applications for the current project. */
+export function useAgentApplications() {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<AgentApplication[]>(
+    agentApplicationsKeys.list(projectId),
+    (client) =>
+      projectId ? client.listAgentApplications() : Promise.resolve([]),
+    { enabled: !!projectId, staleTime: 30_000 },
+  );
+}

--- a/packages/ui/src/features/agent-applications/hooks/useAgentFleetStats.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentFleetStats.ts
@@ -1,0 +1,15 @@
+import type { AgentAggregateStats } from "@posthog/shared/agent-platform-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+import { agentApplicationsKeys } from "./agentApplicationsKeys";
+
+/** Team-wide fleet roll-up stats (live count, spend, failures, approvals). */
+export function useAgentFleetStats() {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<AgentAggregateStats | null>(
+    agentApplicationsKeys.fleetStats(projectId),
+    (client) =>
+      projectId ? client.getAgentFleetStats() : Promise.resolve(null),
+    { enabled: !!projectId, staleTime: 30_000 },
+  );
+}

--- a/packages/ui/src/features/agent-applications/utils/format.ts
+++ b/packages/ui/src/features/agent-applications/utils/format.ts
@@ -1,0 +1,52 @@
+import type {
+  AgentRevisionState,
+  AgentSessionState,
+} from "@posthog/shared/agent-platform-types";
+
+/** Formats a USD spend value for the fleet / agent stat strips. */
+export function formatSpendUsd(value: number | null | undefined): string {
+  if (value == null) return "$0";
+  if (value === 0) return "$0";
+  if (value < 0.01) return "<$0.01";
+  return `$${value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/** Radix Badge colour for a session lifecycle state. */
+export function sessionStateColor(
+  state: AgentSessionState,
+): "green" | "blue" | "gray" | "red" | "amber" {
+  switch (state) {
+    case "running":
+      return "blue";
+    case "queued":
+      return "amber";
+    case "completed":
+    case "closed":
+      return "green";
+    case "failed":
+      return "red";
+    case "cancelled":
+      return "gray";
+    default:
+      return "gray";
+  }
+}
+
+/** Radix Badge colour for a revision lifecycle state. */
+export function revisionStateColor(
+  state: AgentRevisionState,
+): "green" | "blue" | "gray" | "amber" {
+  switch (state) {
+    case "live":
+      return "green";
+    case "ready":
+      return "blue";
+    case "draft":
+      return "amber";
+    default:
+      return "gray";
+  }
+}

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -1,4 +1,9 @@
-import { ArrowSquareOutIcon, PlugsConnectedIcon } from "@phosphor-icons/react";
+import {
+  ArrowSquareOutIcon,
+  CaretRightIcon,
+  PlugsConnectedIcon,
+  RobotIcon,
+} from "@phosphor-icons/react";
 import {
   REPORT_MODEL_RESOLVER,
   type ReportModelResolver,
@@ -128,6 +133,30 @@ export function ConfigureAgentsSection() {
         }
       >
         <ScoutsFleetSection />
+      </Subsection>
+
+      <Subsection
+        title="Applications"
+        description="Agents you design and deploy on the agent platform. Configure them, watch their sessions, and chat with each deployment."
+      >
+        <Link
+          to="/code/agents/applications"
+          className="flex items-center justify-between gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-4 py-3.5 no-underline transition-colors duration-150 hover:border-(--gray-6) hover:bg-(--gray-2)"
+        >
+          <Flex align="center" gap="3" className="min-w-0">
+            <RobotIcon size={20} className="shrink-0 text-gray-11" />
+            <Flex direction="column" gap="0" className="min-w-0">
+              <Text className="font-medium text-[13px] text-gray-12">
+                Manage applications
+              </Text>
+              <Text className="text-[12px] text-gray-11 leading-snug">
+                Browse deployed agents, edit their configuration, and open a
+                live chat with any deployment.
+              </Text>
+            </Flex>
+          </Flex>
+          <CaretRightIcon size={14} className="shrink-0 text-gray-10" />
+        </Link>
       </Subsection>
 
       <Subsection

--- a/packages/ui/src/router/routeTree.gen.ts
+++ b/packages/ui/src/router/routeTree.gen.ts
@@ -34,9 +34,11 @@ import { Route as CodeInboxReportsRouteImport } from './routes/code/inbox/report
 import { Route as CodeInboxPullsRouteImport } from './routes/code/inbox/pulls'
 import { Route as CodeInboxAgentsRouteImport } from './routes/code/inbox/agents'
 import { Route as CodeAgentsScoutsRouteImport } from './routes/code/agents/scouts'
+import { Route as CodeAgentsApplicationsRouteImport } from './routes/code/agents/applications'
 import { Route as CodeInboxRunsIndexRouteImport } from './routes/code/inbox/runs.index'
 import { Route as CodeInboxReportsIndexRouteImport } from './routes/code/inbox/reports.index'
 import { Route as CodeInboxPullsIndexRouteImport } from './routes/code/inbox/pulls.index'
+import { Route as CodeAgentsApplicationsIndexRouteImport } from './routes/code/agents/applications/index'
 import { Route as WebsiteChannelIdTasksTaskIdRouteImport } from './routes/website/$channelId/tasks/$taskId'
 import { Route as WebsiteChannelIdDashboardsDashboardIdRouteImport } from './routes/website/$channelId/dashboards/$dashboardId'
 import { Route as CodeTasksPendingKeyRouteImport } from './routes/code/tasks/pending.$key'
@@ -171,6 +173,11 @@ const CodeAgentsScoutsRoute = CodeAgentsScoutsRouteImport.update({
   path: '/scouts',
   getParentRoute: () => CodeAgentsRoute,
 } as any)
+const CodeAgentsApplicationsRoute = CodeAgentsApplicationsRouteImport.update({
+  id: '/applications',
+  path: '/applications',
+  getParentRoute: () => CodeAgentsRoute,
+} as any)
 const CodeInboxRunsIndexRoute = CodeInboxRunsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -186,6 +193,12 @@ const CodeInboxPullsIndexRoute = CodeInboxPullsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => CodeInboxPullsRoute,
 } as any)
+const CodeAgentsApplicationsIndexRoute =
+  CodeAgentsApplicationsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => CodeAgentsApplicationsRoute,
+  } as any)
 const WebsiteChannelIdTasksTaskIdRoute =
   WebsiteChannelIdTasksTaskIdRouteImport.update({
     id: '/$channelId/tasks/$taskId',
@@ -247,6 +260,7 @@ export interface FileRoutesByFullPath {
   '/code/': typeof CodeIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/website/': typeof WebsiteIndexRoute
+  '/code/agents/applications': typeof CodeAgentsApplicationsRouteWithChildren
   '/code/agents/scouts': typeof CodeAgentsScoutsRouteWithChildren
   '/code/inbox/agents': typeof CodeInboxAgentsRoute
   '/code/inbox/pulls': typeof CodeInboxPullsRouteWithChildren
@@ -265,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/code/tasks/pending/$key': typeof CodeTasksPendingKeyRoute
   '/website/$channelId/dashboards/$dashboardId': typeof WebsiteChannelIdDashboardsDashboardIdRoute
   '/website/$channelId/tasks/$taskId': typeof WebsiteChannelIdTasksTaskIdRoute
+  '/code/agents/applications/': typeof CodeAgentsApplicationsIndexRoute
   '/code/inbox/pulls/': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports/': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs/': typeof CodeInboxRunsIndexRoute
@@ -296,6 +311,7 @@ export interface FileRoutesByTo {
   '/code/tasks/pending/$key': typeof CodeTasksPendingKeyRoute
   '/website/$channelId/dashboards/$dashboardId': typeof WebsiteChannelIdDashboardsDashboardIdRoute
   '/website/$channelId/tasks/$taskId': typeof WebsiteChannelIdTasksTaskIdRoute
+  '/code/agents/applications': typeof CodeAgentsApplicationsIndexRoute
   '/code/inbox/pulls': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs': typeof CodeInboxRunsIndexRoute
@@ -317,6 +333,7 @@ export interface FileRoutesById {
   '/code/': typeof CodeIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/website/': typeof WebsiteIndexRoute
+  '/code/agents/applications': typeof CodeAgentsApplicationsRouteWithChildren
   '/code/agents/scouts': typeof CodeAgentsScoutsRouteWithChildren
   '/code/inbox/agents': typeof CodeInboxAgentsRoute
   '/code/inbox/pulls': typeof CodeInboxPullsRouteWithChildren
@@ -335,6 +352,7 @@ export interface FileRoutesById {
   '/code/tasks/pending/$key': typeof CodeTasksPendingKeyRoute
   '/website/$channelId/dashboards/$dashboardId': typeof WebsiteChannelIdDashboardsDashboardIdRoute
   '/website/$channelId/tasks/$taskId': typeof WebsiteChannelIdTasksTaskIdRoute
+  '/code/agents/applications/': typeof CodeAgentsApplicationsIndexRoute
   '/code/inbox/pulls/': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports/': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs/': typeof CodeInboxRunsIndexRoute
@@ -357,6 +375,7 @@ export interface FileRouteTypes {
     | '/code/'
     | '/settings/'
     | '/website/'
+    | '/code/agents/applications'
     | '/code/agents/scouts'
     | '/code/inbox/agents'
     | '/code/inbox/pulls'
@@ -375,6 +394,7 @@ export interface FileRouteTypes {
     | '/code/tasks/pending/$key'
     | '/website/$channelId/dashboards/$dashboardId'
     | '/website/$channelId/tasks/$taskId'
+    | '/code/agents/applications/'
     | '/code/inbox/pulls/'
     | '/code/inbox/reports/'
     | '/code/inbox/runs/'
@@ -406,6 +426,7 @@ export interface FileRouteTypes {
     | '/code/tasks/pending/$key'
     | '/website/$channelId/dashboards/$dashboardId'
     | '/website/$channelId/tasks/$taskId'
+    | '/code/agents/applications'
     | '/code/inbox/pulls'
     | '/code/inbox/reports'
     | '/code/inbox/runs'
@@ -426,6 +447,7 @@ export interface FileRouteTypes {
     | '/code/'
     | '/settings/'
     | '/website/'
+    | '/code/agents/applications'
     | '/code/agents/scouts'
     | '/code/inbox/agents'
     | '/code/inbox/pulls'
@@ -444,6 +466,7 @@ export interface FileRouteTypes {
     | '/code/tasks/pending/$key'
     | '/website/$channelId/dashboards/$dashboardId'
     | '/website/$channelId/tasks/$taskId'
+    | '/code/agents/applications/'
     | '/code/inbox/pulls/'
     | '/code/inbox/reports/'
     | '/code/inbox/runs/'
@@ -645,6 +668,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CodeAgentsScoutsRouteImport
       parentRoute: typeof CodeAgentsRoute
     }
+    '/code/agents/applications': {
+      id: '/code/agents/applications'
+      path: '/applications'
+      fullPath: '/code/agents/applications'
+      preLoaderRoute: typeof CodeAgentsApplicationsRouteImport
+      parentRoute: typeof CodeAgentsRoute
+    }
     '/code/inbox/runs/': {
       id: '/code/inbox/runs/'
       path: '/'
@@ -665,6 +695,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/code/inbox/pulls/'
       preLoaderRoute: typeof CodeInboxPullsIndexRouteImport
       parentRoute: typeof CodeInboxPullsRoute
+    }
+    '/code/agents/applications/': {
+      id: '/code/agents/applications/'
+      path: '/'
+      fullPath: '/code/agents/applications/'
+      preLoaderRoute: typeof CodeAgentsApplicationsIndexRouteImport
+      parentRoute: typeof CodeAgentsApplicationsRoute
     }
     '/website/$channelId/tasks/$taskId': {
       id: '/website/$channelId/tasks/$taskId'
@@ -747,6 +784,20 @@ const WebsiteRouteChildren: WebsiteRouteChildren = {
 const WebsiteRouteWithChildren =
   WebsiteRoute._addFileChildren(WebsiteRouteChildren)
 
+interface CodeAgentsApplicationsRouteChildren {
+  CodeAgentsApplicationsIndexRoute: typeof CodeAgentsApplicationsIndexRoute
+}
+
+const CodeAgentsApplicationsRouteChildren: CodeAgentsApplicationsRouteChildren =
+  {
+    CodeAgentsApplicationsIndexRoute: CodeAgentsApplicationsIndexRoute,
+  }
+
+const CodeAgentsApplicationsRouteWithChildren =
+  CodeAgentsApplicationsRoute._addFileChildren(
+    CodeAgentsApplicationsRouteChildren,
+  )
+
 interface CodeAgentsScoutsSkillNameRouteChildren {
   CodeAgentsScoutsSkillNameIndexRoute: typeof CodeAgentsScoutsSkillNameIndexRoute
 }
@@ -773,11 +824,13 @@ const CodeAgentsScoutsRouteWithChildren =
   CodeAgentsScoutsRoute._addFileChildren(CodeAgentsScoutsRouteChildren)
 
 interface CodeAgentsRouteChildren {
+  CodeAgentsApplicationsRoute: typeof CodeAgentsApplicationsRouteWithChildren
   CodeAgentsScoutsRoute: typeof CodeAgentsScoutsRouteWithChildren
   CodeAgentsIndexRoute: typeof CodeAgentsIndexRoute
 }
 
 const CodeAgentsRouteChildren: CodeAgentsRouteChildren = {
+  CodeAgentsApplicationsRoute: CodeAgentsApplicationsRouteWithChildren,
   CodeAgentsScoutsRoute: CodeAgentsScoutsRouteWithChildren,
   CodeAgentsIndexRoute: CodeAgentsIndexRoute,
 }

--- a/packages/ui/src/router/routeTree.gen.ts
+++ b/packages/ui/src/router/routeTree.gen.ts
@@ -46,7 +46,9 @@ import { Route as CodeInboxRunsReportIdRouteImport } from './routes/code/inbox/r
 import { Route as CodeInboxReportsReportIdRouteImport } from './routes/code/inbox/reports.$reportId'
 import { Route as CodeInboxPullsReportIdRouteImport } from './routes/code/inbox/pulls.$reportId'
 import { Route as CodeAgentsScoutsSkillNameRouteImport } from './routes/code/agents/scouts.$skillName'
+import { Route as CodeAgentsApplicationsIdOrSlugRouteImport } from './routes/code/agents/applications/$idOrSlug'
 import { Route as CodeAgentsScoutsSkillNameIndexRouteImport } from './routes/code/agents/scouts.$skillName.index'
+import { Route as CodeAgentsApplicationsIdOrSlugIndexRouteImport } from './routes/code/agents/applications/$idOrSlug/index'
 
 const WebsiteRoute = WebsiteRouteImport.update({
   id: '/website',
@@ -238,11 +240,23 @@ const CodeAgentsScoutsSkillNameRoute =
     path: '/$skillName',
     getParentRoute: () => CodeAgentsScoutsRoute,
   } as any)
+const CodeAgentsApplicationsIdOrSlugRoute =
+  CodeAgentsApplicationsIdOrSlugRouteImport.update({
+    id: '/$idOrSlug',
+    path: '/$idOrSlug',
+    getParentRoute: () => CodeAgentsApplicationsRoute,
+  } as any)
 const CodeAgentsScoutsSkillNameIndexRoute =
   CodeAgentsScoutsSkillNameIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => CodeAgentsScoutsSkillNameRoute,
+  } as any)
+const CodeAgentsApplicationsIdOrSlugIndexRoute =
+  CodeAgentsApplicationsIdOrSlugIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => CodeAgentsApplicationsIdOrSlugRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -272,6 +286,7 @@ export interface FileRoutesByFullPath {
   '/code/agents/': typeof CodeAgentsIndexRoute
   '/code/inbox/': typeof CodeInboxIndexRoute
   '/website/$channelId/': typeof WebsiteChannelIdIndexRoute
+  '/code/agents/applications/$idOrSlug': typeof CodeAgentsApplicationsIdOrSlugRouteWithChildren
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
@@ -283,6 +298,7 @@ export interface FileRoutesByFullPath {
   '/code/inbox/pulls/': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports/': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs/': typeof CodeInboxRunsIndexRoute
+  '/code/agents/applications/$idOrSlug/': typeof CodeAgentsApplicationsIdOrSlugIndexRoute
   '/code/agents/scouts/$skillName/': typeof CodeAgentsScoutsSkillNameIndexRoute
 }
 export interface FileRoutesByTo {
@@ -315,6 +331,7 @@ export interface FileRoutesByTo {
   '/code/inbox/pulls': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs': typeof CodeInboxRunsIndexRoute
+  '/code/agents/applications/$idOrSlug': typeof CodeAgentsApplicationsIdOrSlugIndexRoute
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameIndexRoute
 }
 export interface FileRoutesById {
@@ -345,6 +362,7 @@ export interface FileRoutesById {
   '/code/agents/': typeof CodeAgentsIndexRoute
   '/code/inbox/': typeof CodeInboxIndexRoute
   '/website/$channelId/': typeof WebsiteChannelIdIndexRoute
+  '/code/agents/applications/$idOrSlug': typeof CodeAgentsApplicationsIdOrSlugRouteWithChildren
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
@@ -356,6 +374,7 @@ export interface FileRoutesById {
   '/code/inbox/pulls/': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports/': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs/': typeof CodeInboxRunsIndexRoute
+  '/code/agents/applications/$idOrSlug/': typeof CodeAgentsApplicationsIdOrSlugIndexRoute
   '/code/agents/scouts/$skillName/': typeof CodeAgentsScoutsSkillNameIndexRoute
 }
 export interface FileRouteTypes {
@@ -387,6 +406,7 @@ export interface FileRouteTypes {
     | '/code/agents/'
     | '/code/inbox/'
     | '/website/$channelId/'
+    | '/code/agents/applications/$idOrSlug'
     | '/code/agents/scouts/$skillName'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
@@ -398,6 +418,7 @@ export interface FileRouteTypes {
     | '/code/inbox/pulls/'
     | '/code/inbox/reports/'
     | '/code/inbox/runs/'
+    | '/code/agents/applications/$idOrSlug/'
     | '/code/agents/scouts/$skillName/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -430,6 +451,7 @@ export interface FileRouteTypes {
     | '/code/inbox/pulls'
     | '/code/inbox/reports'
     | '/code/inbox/runs'
+    | '/code/agents/applications/$idOrSlug'
     | '/code/agents/scouts/$skillName'
   id:
     | '__root__'
@@ -459,6 +481,7 @@ export interface FileRouteTypes {
     | '/code/agents/'
     | '/code/inbox/'
     | '/website/$channelId/'
+    | '/code/agents/applications/$idOrSlug'
     | '/code/agents/scouts/$skillName'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
@@ -470,6 +493,7 @@ export interface FileRouteTypes {
     | '/code/inbox/pulls/'
     | '/code/inbox/reports/'
     | '/code/inbox/runs/'
+    | '/code/agents/applications/$idOrSlug/'
     | '/code/agents/scouts/$skillName/'
   fileRoutesById: FileRoutesById
 }
@@ -752,12 +776,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CodeAgentsScoutsSkillNameRouteImport
       parentRoute: typeof CodeAgentsScoutsRoute
     }
+    '/code/agents/applications/$idOrSlug': {
+      id: '/code/agents/applications/$idOrSlug'
+      path: '/$idOrSlug'
+      fullPath: '/code/agents/applications/$idOrSlug'
+      preLoaderRoute: typeof CodeAgentsApplicationsIdOrSlugRouteImport
+      parentRoute: typeof CodeAgentsApplicationsRoute
+    }
     '/code/agents/scouts/$skillName/': {
       id: '/code/agents/scouts/$skillName/'
       path: '/'
       fullPath: '/code/agents/scouts/$skillName/'
       preLoaderRoute: typeof CodeAgentsScoutsSkillNameIndexRouteImport
       parentRoute: typeof CodeAgentsScoutsSkillNameRoute
+    }
+    '/code/agents/applications/$idOrSlug/': {
+      id: '/code/agents/applications/$idOrSlug/'
+      path: '/'
+      fullPath: '/code/agents/applications/$idOrSlug/'
+      preLoaderRoute: typeof CodeAgentsApplicationsIdOrSlugIndexRouteImport
+      parentRoute: typeof CodeAgentsApplicationsIdOrSlugRoute
     }
   }
 }
@@ -784,12 +822,30 @@ const WebsiteRouteChildren: WebsiteRouteChildren = {
 const WebsiteRouteWithChildren =
   WebsiteRoute._addFileChildren(WebsiteRouteChildren)
 
+interface CodeAgentsApplicationsIdOrSlugRouteChildren {
+  CodeAgentsApplicationsIdOrSlugIndexRoute: typeof CodeAgentsApplicationsIdOrSlugIndexRoute
+}
+
+const CodeAgentsApplicationsIdOrSlugRouteChildren: CodeAgentsApplicationsIdOrSlugRouteChildren =
+  {
+    CodeAgentsApplicationsIdOrSlugIndexRoute:
+      CodeAgentsApplicationsIdOrSlugIndexRoute,
+  }
+
+const CodeAgentsApplicationsIdOrSlugRouteWithChildren =
+  CodeAgentsApplicationsIdOrSlugRoute._addFileChildren(
+    CodeAgentsApplicationsIdOrSlugRouteChildren,
+  )
+
 interface CodeAgentsApplicationsRouteChildren {
+  CodeAgentsApplicationsIdOrSlugRoute: typeof CodeAgentsApplicationsIdOrSlugRouteWithChildren
   CodeAgentsApplicationsIndexRoute: typeof CodeAgentsApplicationsIndexRoute
 }
 
 const CodeAgentsApplicationsRouteChildren: CodeAgentsApplicationsRouteChildren =
   {
+    CodeAgentsApplicationsIdOrSlugRoute:
+      CodeAgentsApplicationsIdOrSlugRouteWithChildren,
     CodeAgentsApplicationsIndexRoute: CodeAgentsApplicationsIndexRoute,
   }
 

--- a/packages/ui/src/router/routes/code/agents/applications.tsx
+++ b/packages/ui/src/router/routes/code/agents/applications.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/agents/applications")({
+  component: Outlet,
+});

--- a/packages/ui/src/router/routes/code/agents/applications/$idOrSlug.tsx
+++ b/packages/ui/src/router/routes/code/agents/applications/$idOrSlug.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/agents/applications/$idOrSlug")({
+  component: Outlet,
+});

--- a/packages/ui/src/router/routes/code/agents/applications/$idOrSlug/index.tsx
+++ b/packages/ui/src/router/routes/code/agents/applications/$idOrSlug/index.tsx
@@ -1,0 +1,11 @@
+import { AgentApplicationDetailView } from "@posthog/ui/features/agent-applications/components/AgentApplicationDetailView";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/agents/applications/$idOrSlug/")({
+  component: AgentApplicationDetailRoute,
+});
+
+function AgentApplicationDetailRoute() {
+  const { idOrSlug } = Route.useParams();
+  return <AgentApplicationDetailView idOrSlug={idOrSlug} />;
+}

--- a/packages/ui/src/router/routes/code/agents/applications/index.tsx
+++ b/packages/ui/src/router/routes/code/agents/applications/index.tsx
@@ -1,0 +1,6 @@
+import { AgentApplicationsListView } from "@posthog/ui/features/agent-applications/components/AgentApplicationsListView";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/agents/applications/")({
+  component: AgentApplicationsListView,
+});


### PR DESCRIPTION
## What

Ports the **agent_platform console** (from posthog/posthog `ass` branch) into Code as a new **agent-applications** area for deployed agents. Reworks the `/code/agents` tab so its top level is generic agent design/config, with **Scouts** and the new **Applications** as sub-options.

This is a **multi-milestone** effort; this PR grows as each milestone lands. Draft until the chat + concierge are wired.

## Milestones

- [x] **M1 — IA rework + scaffolding**: `agent-applications` feature, route tree (`/code/agents/applications`), surfaced as a subsection link card on the Agents landing.
- [x] **M2 — API + domain**: agent_platform domain types in `@posthog/shared`; `PostHogAPIClient` read methods (applications, stats, sessions, approvals, revisions, fleet); TanStack Query hooks; live fleet stat strip + application list + per-agent detail (overview + recent sessions).
- [ ] **M3 — SSE→ACP chat adapter**: render deployed-agent chat through Code's native `ConversationView` (agent-ingress SSE events map ~1:1 onto ACP `SessionUpdate`).
- [ ] **M4 — Concierge dock**: AI-driven config edits (port of the console concierge).
- [ ] **M5 — Standalone chat package**: embeddable chat for deployed agents.

## Notes

- IA call (confirmed): Applications is a sub-option under `/code/agents`, not a new top-level sidebar tab.
- Follows the inbox pattern: shared wire types → `PostHogAPIClient` methods → UI hooks. No core passthrough service (forbidden); the core service arrives in M3 with the chat reducer.
- Verified per milestone: `@posthog/ui`/`@posthog/shared`/`@posthog/api-client` typecheck clean, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)