### PR TITLE
fix(inbox): make "Entire project" scope show project-wide reports

### DIFF
--- a/packages/core/src/inbox/reportFiltering.test.ts
+++ b/packages/core/src/inbox/reportFiltering.test.ts
@@ -98,22 +98,12 @@ describe("filterReportsBySearch", () => {
 });
 
 describe("buildSignalReportListOrdering", () => {
-  it("puts status then descending field", () => {
-    expect(buildSignalReportListOrdering("total_weight", "desc")).toBe(
-      "status,-total_weight",
-    );
-  });
-
-  it("puts status then ascending field", () => {
-    expect(buildSignalReportListOrdering("created_at", "asc")).toBe(
-      "status,created_at",
-    );
-  });
-
-  it("works for signal_count", () => {
-    expect(buildSignalReportListOrdering("signal_count", "desc")).toBe(
-      "status,-signal_count",
-    );
+  it.each([
+    ["total_weight", "desc", "status,-total_weight"],
+    ["created_at", "asc", "status,created_at"],
+    ["signal_count", "desc", "status,-signal_count"],
+  ] as const)("orders by status then %s (%s)", (field, direction, expected) => {
+    expect(buildSignalReportListOrdering(field, direction)).toBe(expected);
   });
 
   it("does not float the current user's reports via ordering", () => {

--- a/packages/core/src/inbox/reportFiltering.test.ts
+++ b/packages/core/src/inbox/reportFiltering.test.ts
@@ -98,21 +98,27 @@ describe("filterReportsBySearch", () => {
 });
 
 describe("buildSignalReportListOrdering", () => {
-  it("puts status then suggested reviewer then descending field", () => {
+  it("puts status then descending field", () => {
     expect(buildSignalReportListOrdering("total_weight", "desc")).toBe(
-      "status,-is_suggested_reviewer,-total_weight",
+      "status,-total_weight",
     );
   });
 
-  it("puts status then suggested reviewer then ascending field", () => {
+  it("puts status then ascending field", () => {
     expect(buildSignalReportListOrdering("created_at", "asc")).toBe(
-      "status,-is_suggested_reviewer,created_at",
+      "status,created_at",
     );
   });
 
   it("works for signal_count", () => {
     expect(buildSignalReportListOrdering("signal_count", "desc")).toBe(
-      "status,-is_suggested_reviewer,-signal_count",
+      "status,-signal_count",
+    );
+  });
+
+  it("does not float the current user's reports via ordering", () => {
+    expect(buildSignalReportListOrdering("priority", "asc")).not.toContain(
+      "is_suggested_reviewer",
     );
   });
 });

--- a/packages/core/src/inbox/reportFiltering.ts
+++ b/packages/core/src/inbox/reportFiltering.ts
@@ -61,10 +61,9 @@ export function buildStatusFilterParam(statuses: SignalReportStatus[]): string {
  * 1. Status rank (ready first – semantic server-side rank, always applied)
  * 2. Toolbar-selected field (priority, total_weight, created_at, etc.)
  *
- * The reviewer scope is applied via the `suggested_reviewers` query param, not
- * ordering — a `-is_suggested_reviewer` tiebreak would float the current user's
- * reports to the top of the first page and starve the "Entire project" scope of
- * non-self reports (only the first page is loaded).
+ * Reviewer scope is applied via the `suggested_reviewers` param, not ordering:
+ * a `-is_suggested_reviewer` tiebreak would float the user's reports to the top
+ * of the first (and only loaded) page, starving the "Entire project" scope.
  */
 export function buildSignalReportListOrdering(
   field: SignalReportOrderingField,

--- a/packages/core/src/inbox/reportFiltering.ts
+++ b/packages/core/src/inbox/reportFiltering.ts
@@ -59,15 +59,19 @@ export function buildStatusFilterParam(statuses: SignalReportStatus[]): string {
 /**
  * Comma-separated `ordering` for the signal report list API:
  * 1. Status rank (ready first – semantic server-side rank, always applied)
- * 2. Suggested reviewer (current user's reports first)
- * 3. Toolbar-selected field (priority, total_weight, created_at, etc.)
+ * 2. Toolbar-selected field (priority, total_weight, created_at, etc.)
+ *
+ * The reviewer scope is applied via the `suggested_reviewers` query param, not
+ * ordering — a `-is_suggested_reviewer` tiebreak would float the current user's
+ * reports to the top of the first page and starve the "Entire project" scope of
+ * non-self reports (only the first page is loaded).
  */
 export function buildSignalReportListOrdering(
   field: SignalReportOrderingField,
   direction: "asc" | "desc",
 ): string {
   const fieldKey = direction === "desc" ? `-${field}` : field;
-  return `status,-is_suggested_reviewer,${fieldKey}`;
+  return `status,${fieldKey}`;
 }
 
 export function buildSuggestedReviewerFilterParam(

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -8,9 +8,12 @@ import {
 } from "@posthog/core/inbox/reportFiltering";
 import {
   computeInboxTabCounts,
+  INBOX_SCOPE_FOR_YOU,
   matchesReviewerScope,
   parseTeammateInboxScope,
 } from "@posthog/core/inbox/reportMembership";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useInboxReportsInfinite } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useInboxReviewerScopeStore } from "@posthog/ui/features/inbox/stores/inboxReviewerScopeStore";
 import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
@@ -52,7 +55,22 @@ export function useInboxAllReports(options?: {
   const priorityFilter = useInboxSignalsFilterStore((s) =>
     ignoreFilters ? EMPTY_FILTER_ARRAY : s.priorityFilter,
   );
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
+
+  // The reviewer scope is applied server-side via `suggested_reviewers`.
+  // "For you" filters on the current user's uuid; a teammate scope on theirs;
+  // "Entire project" (and the Runs tab's `ignoreScope`) send nothing so the
+  // whole project comes back. This replaces the old `-is_suggested_reviewer`
+  // ordering tiebreak, which floated the current user's reports to the top of
+  // the first (and only loaded) page and made "Entire project" look identical
+  // to "For you".
   const teammateUuid = ignoreScope ? null : parseTeammateInboxScope(scope);
+  const reviewerUuid =
+    teammateUuid ??
+    (!ignoreScope && scope === INBOX_SCOPE_FOR_YOU
+      ? (currentUser?.uuid ?? null)
+      : null);
 
   const query = useInboxReportsInfinite(
     {
@@ -63,8 +81,8 @@ export function useInboxAllReports(options?: {
           ? sourceProductFilter.join(",")
           : undefined,
       priority: buildPriorityFilterParam(priorityFilter),
-      suggested_reviewers: teammateUuid
-        ? buildSuggestedReviewerFilterParam([teammateUuid])
+      suggested_reviewers: reviewerUuid
+        ? buildSuggestedReviewerFilterParam([reviewerUuid])
         : undefined,
     },
     {

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -58,19 +58,13 @@ export function useInboxAllReports(options?: {
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
 
-  // The reviewer scope is applied server-side via `suggested_reviewers`.
-  // "For you" filters on the current user's uuid; a teammate scope on theirs;
-  // "Entire project" (and the Runs tab's `ignoreScope`) send nothing so the
-  // whole project comes back. This replaces the old `-is_suggested_reviewer`
-  // ordering tiebreak, which floated the current user's reports to the top of
-  // the first (and only loaded) page and made "Entire project" look identical
-  // to "For you".
+  // Reviewer scope is applied server-side via `suggested_reviewers`: "For you"
+  // filters on the current user, a teammate scope on theirs, "Entire project"
+  // and the Runs tab (`ignoreScope`) send nothing.
+  const isForYou = !ignoreScope && scope === INBOX_SCOPE_FOR_YOU;
   const teammateUuid = ignoreScope ? null : parseTeammateInboxScope(scope);
   const reviewerUuid =
-    teammateUuid ??
-    (!ignoreScope && scope === INBOX_SCOPE_FOR_YOU
-      ? (currentUser?.uuid ?? null)
-      : null);
+    teammateUuid ?? (isForYou ? (currentUser?.uuid ?? null) : null);
 
   const query = useInboxReportsInfinite(
     {
@@ -86,6 +80,11 @@ export function useInboxAllReports(options?: {
         : undefined,
     },
     {
+      // "For you" must always carry the current user's `suggested_reviewers`
+      // filter, so hold the query until that uuid resolves rather than firing a
+      // throwaway project-wide fetch first. Other scopes don't depend on the
+      // user and run immediately.
+      enabled: !isForYou || reviewerUuid != null,
       refetchInterval: INBOX_REFETCH_INTERVAL_MS,
       refetchIntervalInBackground: false,
     },


### PR DESCRIPTION
## Problem

Selecting the **Entire project** reviewer scope in the inbox still only showed reports where you are the suggested reviewer — identical to **For you**.

## Root cause

`buildSignalReportListOrdering` always appended `-is_suggested_reviewer`, floating the current user's reports to the top of every status group. Because the inbox only loads the first page (`REPORTS_PAGE_SIZE = 100`, no infinite scroll wired) and projects have thousands of reports, that first page was entirely the user's own reports. Both `for-you` and `entire-project` sent no `suggested_reviewers` param, so the only thing distinguishing them was a client-side filter applied on top of an already user-dominated page.

## Fix

Remove the always-on `-is_suggested_reviewer` ordering tiebreak and apply the reviewer scope **server-side** via the existing `suggested_reviewers` query param instead:

- **For you** → `suggested_reviewers=<current user uuid>` (the float was what previously fed this scope, so it now filters explicitly).
- **Teammate** → `suggested_reviewers=<teammate uuid>` (unchanged).
- **Entire project** → no `suggested_reviewers`, ordered `status,<field>` → first page is the project-wide top reports.
- **Runs tab** (`ignoreScope`) → unchanged (still project-wide).

`ordering` and `suggested_reviewers` are part of the React Query key, so each scope is its own cached query and switching refetches cleanly.

## Files

- `packages/core/src/inbox/reportFiltering.ts` — drop the `-is_suggested_reviewer` tiebreak.
- `packages/ui/src/features/inbox/hooks/useInboxAllReports.ts` — resolve current user; filter For-you server-side by uuid.
- `packages/core/src/inbox/reportFiltering.test.ts` — updated ordering expectations + guard.

## Testing

- `reportFiltering` unit tests pass.
- Manual: **For you** still shows your suggested reports; **Entire project** now includes reports where you are not the suggested reviewer; a **teammate** scope shows that teammate's reports.

> Note: full-monorepo typecheck currently has pre-existing failures from unbuilt sibling packages (`@posthog/platform/*`, `workspace-server`, zod v3/v4 mismatch), unrelated to this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*