### PR TITLE
Extract shared worktree create steps into helpers

### DIFF
--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -170,16 +170,7 @@ export class WorktreeManager {
       });
     });
 
-    await this.symlinkClaudeConfig(worktreePath);
-    await processWorktreeLink(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await processWorktreeInclude(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await runPostCheckoutHook(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
+    await this.finalizeWorktree(worktreePath, options?.onOutput);
 
     return {
       worktreePath,
@@ -204,19 +195,8 @@ export class WorktreeManager {
     }
 
     const worktreeName = await this.resolveAvailableWorktreeName(preferredName);
-
-    if (!this.usesExternalPath()) {
-      await this.ensureArrayDirIgnored();
-    }
-
-    const worktreePath = this.getWorktreePath(worktreeName);
-
-    const parentDir = path.dirname(worktreePath);
-    await fs.mkdir(parentDir, { recursive: true });
-
-    const targetPath = this.usesExternalPath()
-      ? worktreePath
-      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+    const { worktreePath, targetPath } =
+      await this.prepareWorktreePath(worktreeName);
 
     const output = await manager.executeWrite(this.mainRepoPath, async () => {
       return this.spawnWorktreeAdd([targetPath, branch], {
@@ -224,16 +204,7 @@ export class WorktreeManager {
       });
     });
 
-    await this.symlinkClaudeConfig(worktreePath);
-    await processWorktreeLink(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await processWorktreeInclude(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await runPostCheckoutHook(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
+    await this.finalizeWorktree(worktreePath, options?.onOutput);
 
     return {
       worktreePath,
@@ -283,18 +254,8 @@ export class WorktreeManager {
     }
 
     const worktreeName = await this.resolveAvailableWorktreeName(preferredName);
-
-    if (!this.usesExternalPath()) {
-      await this.ensureArrayDirIgnored();
-    }
-
-    const worktreePath = this.getWorktreePath(worktreeName);
-    const parentDir = path.dirname(worktreePath);
-    await fs.mkdir(parentDir, { recursive: true });
-
-    const targetPath = this.usesExternalPath()
-      ? worktreePath
-      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+    const { worktreePath, targetPath } =
+      await this.prepareWorktreePath(worktreeName);
 
     // `-b <branch> <remoteRef>` creates a local branch at the fetched remote ref
     // and sets it up to track the remote branch.
@@ -304,16 +265,7 @@ export class WorktreeManager {
       });
     });
 
-    await this.symlinkClaudeConfig(worktreePath);
-    await processWorktreeLink(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await processWorktreeInclude(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await runPostCheckoutHook(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
+    await this.finalizeWorktree(worktreePath, options?.onOutput);
 
     return {
       worktreePath,
@@ -353,6 +305,44 @@ export class WorktreeManager {
     return worktreeName;
   }
 
+  /**
+   * Ensures the worktree's parent directory exists and computes the path passed
+   * to `git worktree add`. For in-array worktrees it also makes sure the array
+   * directory is gitignored. Returns the absolute worktree path and the
+   * (possibly relative) target path the git command should use.
+   */
+  private async prepareWorktreePath(
+    worktreeName: string,
+  ): Promise<{ worktreePath: string; targetPath: string }> {
+    if (!this.usesExternalPath()) {
+      await this.ensureArrayDirIgnored();
+    }
+
+    const worktreePath = this.getWorktreePath(worktreeName);
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+
+    const targetPath = this.usesExternalPath()
+      ? worktreePath
+      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+
+    return { worktreePath, targetPath };
+  }
+
+  /**
+   * Runs the post-create steps shared by every worktree: symlink the Claude
+   * config, then process the worktree link/include files and the post-checkout
+   * hook.
+   */
+  private async finalizeWorktree(
+    worktreePath: string,
+    onOutput?: (data: string) => void,
+  ): Promise<void> {
+    await this.symlinkClaudeConfig(worktreePath);
+    await processWorktreeLink(this.mainRepoPath, worktreePath, { onOutput });
+    await processWorktreeInclude(this.mainRepoPath, worktreePath, { onOutput });
+    await runPostCheckoutHook(this.mainRepoPath, worktreePath, { onOutput });
+  }
+
   async createDetachedWorktreeAtCommit(
     commit: string,
     preferredName?: string,
@@ -361,18 +351,8 @@ export class WorktreeManager {
     const manager = getGitOperationManager();
 
     const worktreeName = await this.resolveAvailableWorktreeName(preferredName);
-
-    if (!this.usesExternalPath()) {
-      await this.ensureArrayDirIgnored();
-    }
-
-    const worktreePath = this.getWorktreePath(worktreeName);
-    const parentDir = path.dirname(worktreePath);
-    await fs.mkdir(parentDir, { recursive: true });
-
-    const targetPath = this.usesExternalPath()
-      ? worktreePath
-      : `./${WORKTREE_FOLDER_NAME}/${worktreeName}/${this.repoName}`;
+    const { worktreePath, targetPath } =
+      await this.prepareWorktreePath(worktreeName);
 
     const output = await manager.executeWrite(this.mainRepoPath, async () => {
       return this.spawnWorktreeAdd(["--detach", targetPath, commit], {
@@ -380,16 +360,7 @@ export class WorktreeManager {
       });
     });
 
-    await this.symlinkClaudeConfig(worktreePath);
-    await processWorktreeLink(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await processWorktreeInclude(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
-    await runPostCheckoutHook(this.mainRepoPath, worktreePath, {
-      onOutput: options?.onOutput,
-    });
+    await this.finalizeWorktree(worktreePath, options?.onOutput);
 
     return {
       worktreePath,


### PR DESCRIPTION
## Problem

**Pure Refactoring**

The four `create*` methods in `WorktreeManager` each repeated the same two blocks: computing the worktree path (gitignore check, mkdir, targetPath) and running the post-create steps (symlink Claude config, link/include processing, post-checkout hook).

## Changes

Extracted those blocks into two private helpers:

- `prepareWorktreePath(worktreeName)` handles the gitignore check, mkdir, and targetPath derivation, returning `{ worktreePath, targetPath }`.
- `finalizeWorktree(worktreePath, onOutput)` runs the four post-create steps.

No behavior change.

## How did you test this?

Ran `pnpm --filter @posthog/git test`. The worktree suite passes (`src/worktree.test.ts`, 7 tests). 260 of 261 tests in the package pass. The one failure is an unrelated checkpoint saga test that asserts a specific git merge-conflict message; it fails on `main` too and is tied to the local git version, not this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?