### PR TITLE
fix(sessions): keep queued messages in queue when cancelling

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1533,7 +1533,8 @@ export class SessionService {
     const hasQueuedMessages =
       freshSession &&
       freshSession.messageQueue.length > 0 &&
-      freshSession.status === "connected";
+      freshSession.status === "connected" &&
+      !freshSession.queuePaused;
 
     if (hasQueuedMessages) {
       setTimeout(() => {
@@ -1665,6 +1666,10 @@ export class SessionService {
       throw new Error(
         "Confirm the folder access dialog before sending your message.",
       );
+    }
+
+    if (session.queuePaused) {
+      this.d.store.updateSession(session.taskRunId, { queuePaused: false });
     }
 
     if (session.isCloud) {
@@ -1909,6 +1914,7 @@ export class SessionService {
     this.d.store.updateSession(session.taskRunId, {
       isPromptPending: false,
       promptStartedAt: null,
+      queuePaused: true,
     });
 
     if (session.isCloud) {
@@ -2162,7 +2168,7 @@ export class SessionService {
         isTerminal ||
         (session.cloudStatus === "in_progress" &&
           session.status === "connected");
-      if (!canSendNow || session.isPromptPending) return;
+      if (!canSendNow || session.isPromptPending || session.queuePaused) return;
 
       const drained = this.d.store.dequeueMessages(taskId);
       const combined = this.d.h.combineQueuedCloudPrompts(drained);

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -68,6 +68,13 @@ export interface AgentSession {
   pendingPermissions: Map<string, PermissionRequest>;
   pausedDurationMs: number;
   messageQueue: QueuedMessage[];
+  /**
+   * Set when the user cancels an in-flight prompt. Keeps queued messages in
+   * `messageQueue` but suppresses the auto-drain that a turn-end event would
+   * otherwise trigger, so a Stop doesn't immediately fire the next queued
+   * message. Cleared on the next user-initiated send (see `sendPrompt`).
+   */
+  queuePaused?: boolean;
   isCloud?: boolean;
   cloudStatus?: TaskRunStatus;
   cloudStage?: string | null;

--- a/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
@@ -1,8 +1,4 @@
 import {
-  combineQueuedCloudPrompts,
-  promptToQueuedEditorContent,
-} from "@posthog/core/sessions/cloudPrompt";
-import {
   SESSION_SERVICE,
   type SessionService,
 } from "@posthog/core/sessions/sessionService";
@@ -10,10 +6,7 @@ import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
 import { tryExecuteCodeCommand } from "@posthog/ui/features/message-editor/commands";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
-import {
-  type AgentSession,
-  sessionStoreSetters,
-} from "@posthog/ui/features/sessions/sessionStore";
+import type { AgentSession } from "@posthog/ui/features/sessions/sessionStore";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import {
   SHELL_CLIENT,
@@ -42,7 +35,7 @@ export function useSessionCallbacks({
   const sessionService = useService<SessionService>(SESSION_SERVICE);
   const shellClient = useService<ShellClient>(SHELL_CLIENT);
   const { markActivity, markAsViewed } = useTaskViewed();
-  const { requestFocus, setPendingContent } = useDraftStore((s) => s.actions);
+  const { requestFocus } = useDraftStore((s) => s.actions);
 
   const sessionRef = useRef(session);
   sessionRef.current = session;
@@ -94,30 +87,10 @@ export function useSessionCallbacks({
   );
 
   const handleCancelPrompt = useCallback(async () => {
-    const queuedMessages = sessionStoreSetters.dequeueMessages(taskId);
     const result = await sessionService.cancelPrompt(taskId);
     log.info("Prompt cancelled", { success: result });
-
-    const queuedPrompt = sessionRef.current?.isCloud
-      ? combineQueuedCloudPrompts(queuedMessages)
-      : queuedMessages.map((message) => message.content).join("\n\n");
-
-    if (queuedPrompt) {
-      const pendingContent = sessionRef.current?.isCloud
-        ? promptToQueuedEditorContent(queuedPrompt)
-        : {
-            segments: [
-              {
-                type: "text" as const,
-                text: typeof queuedPrompt === "string" ? queuedPrompt : "",
-              },
-            ],
-          };
-
-      setPendingContent(taskId, pendingContent);
-    }
     requestFocus(taskId);
-  }, [taskId, setPendingContent, requestFocus, sessionService]);
+  }, [taskId, requestFocus, sessionService]);
 
   const handleRetry = useCallback(async () => {
     try {


### PR DESCRIPTION
## Problem

- Cancelling (Stop) an in-flight message dumps all queued messages back into the input box as combined text — they lose queued state.

## Change

https://github.com/user-attachments/assets/ea042c39-9cbd-4f99-bfd2-38a8739fbba9



- Stop now cancels **only the in-flight turn**; queued messages stay queued (still shown as cards, individually removable).
- New `queuePaused` flag on `AgentSession`, set by `cancelPrompt`, suppresses the auto-drain on the cancel-induced turn-end.
- Flag cleared on next user send, so kept messages resume after that turn.
- `handleCancelPrompt` no longer drains the queue into the editor.

## Notes

- Resume is "on next send" — no new UI.
- Footer `(N queued)` hides after Stop (only shows while pending), but queued cards stay visible.

## Testing

- shared / core / agent typecheck clean
- `sessionServiceHost` (116) + `sessionStore` (10) tests pass
- Biome lint clean

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*