### PR TITLE
feat(settings): configurable branch name prefix

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1689,7 +1689,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       ...initialInProcess,
     };
 
-    const systemPrompt = buildSystemPrompt(meta?.systemPrompt);
+    const systemPrompt = buildSystemPrompt(
+      meta?.systemPrompt,
+      meta?.branchPrefix,
+    );
 
     if (meta?.mcpToolApprovals) {
       setMcpToolApprovalStates(meta.mcpToolApprovals);

--- a/packages/agent/src/adapters/claude/session/instructions.ts
+++ b/packages/agent/src/adapters/claude/session/instructions.ts
@@ -1,10 +1,17 @@
-const BRANCH_NAMING = `
+import { BRANCH_PREFIX } from "@posthog/shared";
+
+function buildBranchNaming(branchPrefix: string = BRANCH_PREFIX): string {
+  const namingLine = branchPrefix
+    ? `When creating a new branch, prefix it with \`${branchPrefix}\` (e.g. \`${branchPrefix}fix-login-redirect\`).`
+    : "When creating a new branch, use a short, descriptive name.";
+  return `
 # Branch Naming
 
 When working in a detached HEAD state, create a descriptive branch name based on the work being done before committing. Do this automatically without asking the user.
 
-When creating a new branch, prefix it with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`).
+${namingLine}
 `;
+}
 
 const PLAN_MODE = `
 # Plan Mode
@@ -26,4 +33,6 @@ If an MCP tool call is explicitly denied with a message, relay that denial messa
 If an MCP tool call returns an error, treat it as a normal tool error — troubleshoot, retry, or inform the user about the specific error. Do NOT assume it is a permissions issue and do NOT direct the user to any settings page.
 `;
 
-export const APPENDED_INSTRUCTIONS = BRANCH_NAMING + PLAN_MODE + MCP_TOOLS;
+export function buildAppendedInstructions(branchPrefix?: string): string {
+  return buildBranchNaming(branchPrefix) + PLAN_MODE + MCP_TOOLS;
+}

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -26,7 +26,7 @@ import {
 } from "../hooks";
 import type { CodeExecutionMode } from "../tools";
 import type { EffortLevel } from "../types";
-import { APPENDED_INSTRUCTIONS } from "./instructions";
+import { buildAppendedInstructions } from "./instructions";
 import { loadUserClaudeJsonMcpServers } from "./mcp-config";
 import { DEFAULT_MODEL } from "./models";
 import type { SettingsManager } from "./settings";
@@ -92,11 +92,13 @@ export interface BuildOptionsParams {
 
 export function buildSystemPrompt(
   customPrompt?: unknown,
+  branchPrefix?: string,
 ): Options["systemPrompt"] {
+  const appended = buildAppendedInstructions(branchPrefix);
   const defaultPrompt: Options["systemPrompt"] = {
     type: "preset",
     preset: "claude_code",
-    append: APPENDED_INSTRUCTIONS,
+    append: appended,
   };
 
   if (!customPrompt) {
@@ -104,7 +106,7 @@ export function buildSystemPrompt(
   }
 
   if (typeof customPrompt === "string") {
-    return customPrompt + APPENDED_INSTRUCTIONS;
+    return customPrompt + appended;
   }
 
   if (
@@ -115,7 +117,7 @@ export function buildSystemPrompt(
   ) {
     return {
       ...defaultPrompt,
-      append: customPrompt.append + APPENDED_INSTRUCTIONS,
+      append: customPrompt.append + appended,
     };
   }
 

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -169,6 +169,8 @@ export type NewSessionMeta = {
   model?: string;
   /** Base branch of the task's repo (e.g. "master"), for the signed-git tools. */
   baseBranch?: string;
+  /** Prefix for branches the agent creates (system-prompt branch naming). */
+  branchPrefix?: string;
   /**
    * Repo-less channel "generic chat box" session: enables the lazy-repo tools
    * (list_repos / clone_repo) and channel guidance. The agent decides at

--- a/packages/core/src/git-interaction/branchName.test.ts
+++ b/packages/core/src/git-interaction/branchName.test.ts
@@ -114,37 +114,33 @@ describe("suggestBranchName", () => {
     ).toBe("posthog-code/fix-bug-4");
   });
 
-  it("supports a custom prefix", () => {
-    expect(suggestBranchName("Fix bug", "abc", [], "team/")).toBe(
-      "team/fix-bug",
-    );
-    expect(suggestBranchName("Fix bug", "abc", ["team/fix-bug"], "team/")).toBe(
-      "team/fix-bug-2",
-    );
-  });
+  it.each([
+    { existing: [] as string[], expected: "team/fix-bug" },
+    { existing: ["team/fix-bug"], expected: "team/fix-bug-2" },
+  ])(
+    "uses a custom prefix (existing $existing -> $expected)",
+    ({ existing, expected }) => {
+      expect(suggestBranchName("Fix bug", "abc", existing, "team/")).toBe(
+        expected,
+      );
+    },
+  );
 });
 
 describe("validateBranchPrefix", () => {
-  it("allows an empty prefix (no prefix)", () => {
-    expect(validateBranchPrefix("")).toBeNull();
+  it.each([
+    { prefix: "", expected: null },
+    { prefix: "team/", expected: null },
+    { prefix: "posthog-code/", expected: null },
+    { prefix: "-x/", expected: "Branch prefix cannot start with a dash." },
+  ])("returns $expected for prefix $prefix", ({ prefix, expected }) => {
+    expect(validateBranchPrefix(prefix)).toBe(expected);
   });
 
-  it("allows normal prefixes", () => {
-    expect(validateBranchPrefix("team/")).toBeNull();
-    expect(validateBranchPrefix("posthog-code/")).toBeNull();
-  });
-
-  it("rejects a leading dash (flag-like)", () => {
-    expect(validateBranchPrefix("-x/")).toBe(
-      "Branch prefix cannot start with a dash.",
-    );
-  });
-
-  it("rejects spaces", () => {
-    expect(validateBranchPrefix("my team/")).not.toBeNull();
-  });
-
-  it('rejects ".."', () => {
-    expect(validateBranchPrefix("../")).not.toBeNull();
-  });
+  it.each(["my team/", "../", "~/"])(
+    "rejects an invalid prefix (%j)",
+    (prefix) => {
+      expect(validateBranchPrefix(prefix)).not.toBeNull();
+    },
+  );
 });

--- a/packages/core/src/git-interaction/branchName.test.ts
+++ b/packages/core/src/git-interaction/branchName.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeBranchName,
   suggestBranchName,
   validateBranchName,
+  validateBranchPrefix,
 } from "./branchName";
 
 describe("sanitizeBranchName", () => {
@@ -111,5 +112,39 @@ describe("suggestBranchName", () => {
         "posthog-code/fix-bug-3",
       ]),
     ).toBe("posthog-code/fix-bug-4");
+  });
+
+  it("supports a custom prefix", () => {
+    expect(suggestBranchName("Fix bug", "abc", [], "team/")).toBe(
+      "team/fix-bug",
+    );
+    expect(suggestBranchName("Fix bug", "abc", ["team/fix-bug"], "team/")).toBe(
+      "team/fix-bug-2",
+    );
+  });
+});
+
+describe("validateBranchPrefix", () => {
+  it("allows an empty prefix (no prefix)", () => {
+    expect(validateBranchPrefix("")).toBeNull();
+  });
+
+  it("allows normal prefixes", () => {
+    expect(validateBranchPrefix("team/")).toBeNull();
+    expect(validateBranchPrefix("posthog-code/")).toBeNull();
+  });
+
+  it("rejects a leading dash (flag-like)", () => {
+    expect(validateBranchPrefix("-x/")).toBe(
+      "Branch prefix cannot start with a dash.",
+    );
+  });
+
+  it("rejects spaces", () => {
+    expect(validateBranchPrefix("my team/")).not.toBeNull();
+  });
+
+  it('rejects ".."', () => {
+    expect(validateBranchPrefix("../")).not.toBeNull();
   });
 });

--- a/packages/core/src/git-interaction/branchName.ts
+++ b/packages/core/src/git-interaction/branchName.ts
@@ -54,7 +54,23 @@ export function validateBranchName(name: string): string | null {
   return null;
 }
 
-export function deriveBranchName(title: string, fallbackId: string): string {
+// A user-configured branch prefix is prepended to generated branch names, so it
+// must form a valid leading segment. Empty means "no prefix". We reject a
+// leading dash defensively (git could read it as a flag) and otherwise validate
+// it as the start of a real branch name.
+export function validateBranchPrefix(prefix: string): string | null {
+  if (prefix === "") return null;
+  if (prefix.startsWith("-")) {
+    return "Branch prefix cannot start with a dash.";
+  }
+  return validateBranchName(`${prefix}example`);
+}
+
+export function deriveBranchName(
+  title: string,
+  fallbackId: string,
+  prefix: string = BRANCH_PREFIX,
+): string {
   const slug = title
     .toLowerCase()
     .trim()
@@ -64,16 +80,17 @@ export function deriveBranchName(title: string, fallbackId: string): string {
     .slice(0, 60)
     .replace(/-$/, "");
 
-  if (!slug) return `${BRANCH_PREFIX}task-${fallbackId}`;
-  return `${BRANCH_PREFIX}${slug}`;
+  if (!slug) return `${prefix}task-${fallbackId}`;
+  return `${prefix}${slug}`;
 }
 
 export function suggestBranchName(
   title: string,
   fallbackId: string,
   existingBranches: string[],
+  prefix: string = BRANCH_PREFIX,
 ): string {
-  const base = deriveBranchName(title, fallbackId);
+  const base = deriveBranchName(title, fallbackId, prefix);
 
   if (!existingBranches.includes(base)) return base;
 

--- a/packages/core/src/git-interaction/deriveBranchName.test.ts
+++ b/packages/core/src/git-interaction/deriveBranchName.test.ts
@@ -49,19 +49,14 @@ describe("deriveBranchName", () => {
     );
   });
 
-  it("uses a custom prefix when provided", () => {
-    expect(deriveBranchName("Fix login bug", "abc123", "team/")).toBe(
-      "team/fix-login-bug",
-    );
-  });
-
-  it("supports an empty prefix", () => {
-    expect(deriveBranchName("Fix login bug", "abc123", "")).toBe(
-      "fix-login-bug",
-    );
-  });
-
-  it("applies a custom prefix to the task-ID fallback", () => {
-    expect(deriveBranchName("", "abc123", "team/")).toBe("team/task-abc123");
-  });
+  it.each([
+    { title: "Fix login bug", prefix: "team/", expected: "team/fix-login-bug" },
+    { title: "Fix login bug", prefix: "", expected: "fix-login-bug" },
+    { title: "", prefix: "team/", expected: "team/task-abc123" },
+  ])(
+    "applies a custom prefix ($title, $prefix -> $expected)",
+    ({ title, prefix, expected }) => {
+      expect(deriveBranchName(title, "abc123", prefix)).toBe(expected);
+    },
+  );
 });

--- a/packages/core/src/git-interaction/deriveBranchName.test.ts
+++ b/packages/core/src/git-interaction/deriveBranchName.test.ts
@@ -48,4 +48,20 @@ describe("deriveBranchName", () => {
       "posthog-code/task-abc123",
     );
   });
+
+  it("uses a custom prefix when provided", () => {
+    expect(deriveBranchName("Fix login bug", "abc123", "team/")).toBe(
+      "team/fix-login-bug",
+    );
+  });
+
+  it("supports an empty prefix", () => {
+    expect(deriveBranchName("Fix login bug", "abc123", "")).toBe(
+      "fix-login-bug",
+    );
+  });
+
+  it("applies a custom prefix to the task-ID fallback", () => {
+    expect(deriveBranchName("", "abc123", "team/")).toBe("team/task-abc123");
+  });
 });

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -256,7 +256,10 @@ export interface SessionServiceDeps {
     setAdapter(taskRunId: string, adapter: Adapter): void;
     removeAdapter(taskRunId: string): void;
   };
-  readonly settings: { customInstructions?: string | null };
+  readonly settings: {
+    customInstructions?: string | null;
+    branchPrefix?: string | null;
+  };
   usageLimit: { show: (...args: any[]) => any };
   readonly addDirectoryDialog: { open: boolean };
   taskViewedApi: { markActivity(taskId: string): void };
@@ -904,7 +907,7 @@ export class SessionService {
           this.d.log.warn("Failed to verify workspace", { taskId, err });
         });
 
-      const { customInstructions } = this.d.settings;
+      const { customInstructions, branchPrefix } = this.d.settings;
       const result = await this.d.trpc.agent.reconnect.mutate({
         taskId,
         taskRunId,
@@ -917,6 +920,7 @@ export class SessionService {
         permissionMode: persistedMode,
         model: persistedModel,
         customInstructions: customInstructions || undefined,
+        branchPrefix: branchPrefix ?? undefined,
       });
 
       if (result) {
@@ -1217,7 +1221,10 @@ export class SessionService {
       throw new Error("Failed to create task run. Please try again.");
     }
 
-    const { customInstructions: startCustomInstructions } = this.d.settings;
+    const {
+      customInstructions: startCustomInstructions,
+      branchPrefix: startBranchPrefix,
+    } = this.d.settings;
     const preferredModel = model ?? this.d.DEFAULT_GATEWAY_MODEL;
     const result = await this.d.trpc.agent.start.mutate({
       taskId,
@@ -1228,6 +1235,7 @@ export class SessionService {
       permissionMode: executionMode,
       adapter,
       customInstructions: startCustomInstructions || undefined,
+      branchPrefix: startBranchPrefix ?? undefined,
       effort: effortLevelSchema.safeParse(reasoningLevel).success
         ? (reasoningLevel as EffortLevel)
         : undefined,

--- a/packages/ui/src/features/git-interaction/utils/getSuggestedBranchName.ts
+++ b/packages/ui/src/features/git-interaction/utils/getSuggestedBranchName.ts
@@ -4,6 +4,7 @@ import {
 } from "@posthog/core/git-interaction/branchName";
 import type { Task } from "@posthog/shared/domain-types";
 import type { QueryClient } from "@tanstack/react-query";
+import { useSettingsStore } from "../../settings/settingsStore";
 import type { GitCacheKeyProvider } from "../gitCacheProvider";
 
 export function getSuggestedBranchName(
@@ -24,12 +25,14 @@ export function getSuggestedBranchName(
     ? String(task.task_number)
     : (task?.slug ?? taskId);
 
-  if (!repoPath) return deriveBranchName(task?.title ?? "", fallbackId);
+  const prefix = useSettingsStore.getState().branchPrefix;
+
+  if (!repoPath) return deriveBranchName(task?.title ?? "", fallbackId, prefix);
 
   const cached =
     queryClient.getQueryData<string[]>(
       provider.gitQueryKey("getAllBranches", { directoryPath: repoPath }),
     ) ?? [];
 
-  return suggestBranchName(task?.title ?? "", fallbackId, cached);
+  return suggestBranchName(task?.title ?? "", fallbackId, cached, prefix);
 }

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -1,4 +1,5 @@
 import { ArrowSquareOut } from "@phosphor-icons/react";
+import { validateBranchPrefix } from "@posthog/core/git-interaction/branchName";
 import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
@@ -17,12 +18,21 @@ import {
   type SendMessagesWith,
   useSettingsStore,
 } from "@posthog/ui/features/settings/settingsStore";
+import { useDebounce } from "@posthog/ui/primitives/hooks/useDebounce";
 import { track } from "@posthog/ui/shell/analytics";
 import type { ThemePreference } from "@posthog/ui/shell/themeStore";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
-import { Button, Flex, Link, Select, Switch, Text } from "@radix-ui/themes";
+import {
+  Button,
+  Flex,
+  Link,
+  Select,
+  Switch,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export function GeneralSettings() {
   const hostTRPC = useHostTRPC();
@@ -207,6 +217,22 @@ export function GeneralSettings() {
     [slotMachineMode, setSlotMachineMode],
   );
 
+  // Git / branch prefix state
+  const branchPrefix = useSettingsStore((s) => s.branchPrefix);
+  const setBranchPrefix = useSettingsStore((s) => s.setBranchPrefix);
+  const [draftBranchPrefix, setDraftBranchPrefix] = useState(branchPrefix);
+  const debouncedBranchPrefix = useDebounce(draftBranchPrefix, 500);
+  const branchPrefixError = validateBranchPrefix(draftBranchPrefix);
+  useEffect(() => {
+    setDraftBranchPrefix(branchPrefix);
+  }, [branchPrefix]);
+  useEffect(() => {
+    if (debouncedBranchPrefix === branchPrefix) return;
+    // Don't persist an invalid prefix; the inline error prompts a fix.
+    if (validateBranchPrefix(debouncedBranchPrefix) !== null) return;
+    setBranchPrefix(debouncedBranchPrefix);
+  }, [debouncedBranchPrefix, branchPrefix, setBranchPrefix]);
+
   const accountUrl = buildPostHogUrl("/settings/user", cloudRegion);
 
   return (
@@ -383,6 +409,37 @@ export function GeneralSettings() {
             <Select.Item value="last-active-pane">Last active pane</Select.Item>
           </Select.Content>
         </Select.Root>
+      </SettingRow>
+
+      {/* Git */}
+      <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">
+        Git
+      </Text>
+
+      <SettingRow
+        label="Branch name prefix"
+        description="Prefix for branches PostHog Code creates for new tasks. Leave empty for no prefix."
+        noBorder
+      >
+        <Flex direction="column" align="end" gap="1">
+          <TextField.Root
+            value={draftBranchPrefix}
+            onChange={(e) => setDraftBranchPrefix(e.target.value)}
+            placeholder="posthog-code/"
+            size="1"
+            className="min-w-[200px]"
+            color={branchPrefixError ? "red" : undefined}
+          />
+          {branchPrefixError ? (
+            <Text color="red" className="text-[12px]">
+              {branchPrefixError}
+            </Text>
+          ) : (
+            <Text color="gray" className="text-[12px]">
+              Example: posthog-code/
+            </Text>
+          )}
+        </Flex>
       </SettingRow>
 
       {/* Conversation */}

--- a/packages/ui/src/features/settings/sections/worktrees/WorktreesSettings.tsx
+++ b/packages/ui/src/features/settings/sections/worktrees/WorktreesSettings.tsx
@@ -1,4 +1,3 @@
-import { validateBranchPrefix } from "@posthog/core/git-interaction/branchName";
 import {
   buildTaskMap,
   groupWorktrees,
@@ -8,8 +7,7 @@ import { deleteWorktree as runDeleteWorktree } from "@posthog/core/settings/work
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { Flex, Switch, Text, TextField } from "@radix-ui/themes";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useDebounce } from "../../../../primitives/hooks/useDebounce";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "../../../../primitives/toast";
 import { logger } from "../../../../shell/logger";
 import { useFolders } from "../../../folders/useFolders";
@@ -18,7 +16,6 @@ import { useDeleteTask } from "../../../tasks/useTaskCrudMutations";
 import { useTasks } from "../../../tasks/useTasks";
 import { WORKSPACE_QUERY_KEY } from "../../../workspace/identifiers";
 import { SettingRow } from "../../SettingRow";
-import { useSettingsStore } from "../../settingsStore";
 import { WorktreeGroupSection } from "./WorktreeGroupSection";
 
 const log = logger.scope("worktrees-settings");
@@ -35,21 +32,6 @@ export function WorktreesSettings() {
 
   const { folders } = useFolders();
   const { data: tasks } = useTasks();
-
-  const branchPrefix = useSettingsStore((s) => s.branchPrefix);
-  const setBranchPrefix = useSettingsStore((s) => s.setBranchPrefix);
-  const [draftBranchPrefix, setDraftBranchPrefix] = useState(branchPrefix);
-  const debouncedBranchPrefix = useDebounce(draftBranchPrefix, 500);
-  const branchPrefixError = validateBranchPrefix(draftBranchPrefix);
-  useEffect(() => {
-    setDraftBranchPrefix(branchPrefix);
-  }, [branchPrefix]);
-  useEffect(() => {
-    if (debouncedBranchPrefix === branchPrefix) return;
-    // Don't persist an invalid prefix; the inline error prompts a fix.
-    if (validateBranchPrefix(debouncedBranchPrefix) !== null) return;
-    setBranchPrefix(debouncedBranchPrefix);
-  }, [debouncedBranchPrefix, branchPrefix, setBranchPrefix]);
 
   const worktreeQueries = useQueries({
     queries: folders.map((folder) => ({
@@ -151,30 +133,6 @@ export function WorktreesSettings() {
   return (
     <Flex direction="column" gap="5">
       <Flex direction="column">
-        <SettingRow
-          label="Branch name prefix"
-          description="Prefix for branches PostHog Code creates for new tasks. Leave empty for no prefix."
-        >
-          <Flex direction="column" align="end" gap="1">
-            <TextField.Root
-              value={draftBranchPrefix}
-              onChange={(e) => setDraftBranchPrefix(e.target.value)}
-              placeholder="posthog-code/"
-              size="1"
-              className="min-w-[200px]"
-              color={branchPrefixError ? "red" : undefined}
-            />
-            {branchPrefixError ? (
-              <Text color="red" className="text-[12px]">
-                {branchPrefixError}
-              </Text>
-            ) : (
-              <Text color="gray" className="text-[12px]">
-                Example: posthog-code/
-              </Text>
-            )}
-          </Flex>
-        </SettingRow>
         <SettingRow
           label="Automatically suspend stale worktrees"
           description="Suspend stale worktrees to save disk space. Suspended worktrees can be restored at any time. Only disable if you prefer to manage worktrees manually."

--- a/packages/ui/src/features/settings/sections/worktrees/WorktreesSettings.tsx
+++ b/packages/ui/src/features/settings/sections/worktrees/WorktreesSettings.tsx
@@ -1,3 +1,4 @@
+import { validateBranchPrefix } from "@posthog/core/git-interaction/branchName";
 import {
   buildTaskMap,
   groupWorktrees,
@@ -7,7 +8,8 @@ import { deleteWorktree as runDeleteWorktree } from "@posthog/core/settings/work
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { Flex, Switch, Text, TextField } from "@radix-ui/themes";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useDebounce } from "../../../../primitives/hooks/useDebounce";
 import { toast } from "../../../../primitives/toast";
 import { logger } from "../../../../shell/logger";
 import { useFolders } from "../../../folders/useFolders";
@@ -16,6 +18,7 @@ import { useDeleteTask } from "../../../tasks/useTaskCrudMutations";
 import { useTasks } from "../../../tasks/useTasks";
 import { WORKSPACE_QUERY_KEY } from "../../../workspace/identifiers";
 import { SettingRow } from "../../SettingRow";
+import { useSettingsStore } from "../../settingsStore";
 import { WorktreeGroupSection } from "./WorktreeGroupSection";
 
 const log = logger.scope("worktrees-settings");
@@ -32,6 +35,21 @@ export function WorktreesSettings() {
 
   const { folders } = useFolders();
   const { data: tasks } = useTasks();
+
+  const branchPrefix = useSettingsStore((s) => s.branchPrefix);
+  const setBranchPrefix = useSettingsStore((s) => s.setBranchPrefix);
+  const [draftBranchPrefix, setDraftBranchPrefix] = useState(branchPrefix);
+  const debouncedBranchPrefix = useDebounce(draftBranchPrefix, 500);
+  const branchPrefixError = validateBranchPrefix(draftBranchPrefix);
+  useEffect(() => {
+    setDraftBranchPrefix(branchPrefix);
+  }, [branchPrefix]);
+  useEffect(() => {
+    if (debouncedBranchPrefix === branchPrefix) return;
+    // Don't persist an invalid prefix; the inline error prompts a fix.
+    if (validateBranchPrefix(debouncedBranchPrefix) !== null) return;
+    setBranchPrefix(debouncedBranchPrefix);
+  }, [debouncedBranchPrefix, branchPrefix, setBranchPrefix]);
 
   const worktreeQueries = useQueries({
     queries: folders.map((folder) => ({
@@ -133,6 +151,30 @@ export function WorktreesSettings() {
   return (
     <Flex direction="column" gap="5">
       <Flex direction="column">
+        <SettingRow
+          label="Branch name prefix"
+          description="Prefix for branches PostHog Code creates for new tasks. Leave empty for no prefix."
+        >
+          <Flex direction="column" align="end" gap="1">
+            <TextField.Root
+              value={draftBranchPrefix}
+              onChange={(e) => setDraftBranchPrefix(e.target.value)}
+              placeholder="posthog-code/"
+              size="1"
+              className="min-w-[200px]"
+              color={branchPrefixError ? "red" : undefined}
+            />
+            {branchPrefixError ? (
+              <Text color="red" className="text-[12px]">
+                {branchPrefixError}
+              </Text>
+            ) : (
+              <Text color="gray" className="text-[12px]">
+                Example: posthog-code/
+              </Text>
+            )}
+          </Flex>
+        </SettingRow>
         <SettingRow
           label="Automatically suspend stale worktrees"
           description="Suspend stale worktrees to save disk space. Suspended worktrees can be restored at any time. Only disable if you prefer to manage worktrees manually."

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -1,5 +1,9 @@
 import type { UserRepositoryIntegrationRef } from "@posthog/core/integrations/repositories";
-import type { ExecutionMode, WorkspaceMode } from "@posthog/shared";
+import {
+  BRANCH_PREFIX,
+  type ExecutionMode,
+  type WorkspaceMode,
+} from "@posthog/shared";
 import {
   COLLAPSE_MODE_DEFAULT,
   type CollapseMode,
@@ -134,6 +138,10 @@ interface SettingsStore {
   // Diff viewer
   diffOpenMode: DiffOpenMode;
   setDiffOpenMode: (mode: DiffOpenMode) => void;
+
+  // Git / branches
+  branchPrefix: string;
+  setBranchPrefix: (value: string) => void;
 
   // System / power / permissions
   allowBypassPermissions: boolean;
@@ -284,6 +292,10 @@ export const useSettingsStore = create<SettingsStore>()(
       diffOpenMode: "auto",
       setDiffOpenMode: (mode) => set({ diffOpenMode: mode }),
 
+      // Git / branches
+      branchPrefix: BRANCH_PREFIX,
+      setBranchPrefix: (value) => set({ branchPrefix: value }),
+
       // System / power / permissions
       allowBypassPermissions: false,
       preventSleepWhileRunning: false,
@@ -390,6 +402,9 @@ export const useSettingsStore = create<SettingsStore>()(
 
         // Diff viewer
         diffOpenMode: state.diffOpenMode,
+
+        // Git / branches
+        branchPrefix: state.branchPrefix,
 
         // System / power / permissions
         allowBypassPermissions: state.allowBypassPermissions,

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -61,6 +61,7 @@ import {
 } from "@posthog/platform/workspace-settings";
 import {
   type AcpMessage,
+  BRANCH_PREFIX,
   isAuthError,
   serializeError,
   TypedEventEmitter,
@@ -266,6 +267,8 @@ interface SessionConfig {
   permissionMode?: string;
   /** Custom instructions injected into the system prompt */
   customInstructions?: string;
+  /** Prefix for branches the agent creates (system-prompt branch naming). */
+  branchPrefix?: string;
   /** Replaces the PostHog system prompt entirely (constrained surfaces). */
   systemPromptOverride?: string;
   /** Tool names denied for this session (passed to the Claude SDK). */
@@ -549,6 +552,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     systemPromptOverride?: string,
     channelMode?: boolean,
     knownLocalFolders?: RegisteredFolder[],
+    branchPrefix?: string,
   ): {
     append: string;
   } {
@@ -557,6 +561,11 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     if (systemPromptOverride) {
       return { append: systemPromptOverride };
     }
+
+    const prefix = branchPrefix ?? BRANCH_PREFIX;
+    const branchNamingLine = prefix
+      ? `When creating new branches, prefix them with \`${prefix}\` (e.g. \`${prefix}fix-login-redirect\`).`
+      : "Use short, descriptive branch names for new branches.";
 
     let prompt = `PostHog context: use project ${credentials.projectId} on ${credentials.apiHost}. When using PostHog MCP tools, operate only on this project.`;
 
@@ -580,7 +589,7 @@ EOF
 )"
 \`\`\`
 
-When creating new branches, prefix them with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`).
+${branchNamingLine}
 
 When creating pull requests, add the following footer at the end of the PR description:
 \`\`\`
@@ -677,6 +686,7 @@ If a repository IS genuinely required, attach one in this priority order:
       adapter,
       permissionMode,
       customInstructions,
+      branchPrefix,
       systemPromptOverride,
       disallowedTools,
       effort,
@@ -760,6 +770,7 @@ If a repository IS genuinely required, attach one in this priority order:
         systemPromptOverride,
         channelMode,
         knownLocalFolders,
+        branchPrefix,
       );
 
       const bundledSkillsDir = join(
@@ -928,6 +939,7 @@ If a repository IS genuinely required, attach one in this priority order:
               environment: "local",
               sessionId: importedSessionId,
               systemPrompt,
+              ...(branchPrefix !== undefined && { branchPrefix }),
               ...(channelMode && { channelMode }),
               mcpToolApprovals: toolApprovals,
               ...(permissionMode && { permissionMode }),
@@ -1000,6 +1012,7 @@ If a repository IS genuinely required, attach one in this priority order:
             environment: "local",
             sessionId: existingSessionId,
             systemPrompt,
+            ...(branchPrefix !== undefined && { branchPrefix }),
             ...(channelMode && { channelMode }),
             mcpToolApprovals: toolApprovals,
             ...(permissionMode && { permissionMode }),
@@ -1026,6 +1039,7 @@ If a repository IS genuinely required, attach one in this priority order:
             taskRunId,
             environment: "local",
             systemPrompt,
+            ...(branchPrefix !== undefined && { branchPrefix }),
             ...(channelMode && { channelMode }),
             mcpToolApprovals: toolApprovals,
             ...(permissionMode && { permissionMode }),
@@ -1905,6 +1919,7 @@ For git operations while detached:
         "permissionMode" in params ? params.permissionMode : undefined,
       customInstructions:
         "customInstructions" in params ? params.customInstructions : undefined,
+      branchPrefix: "branchPrefix" in params ? params.branchPrefix : undefined,
       systemPromptOverride:
         "systemPromptOverride" in params
           ? params.systemPromptOverride

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -55,6 +55,11 @@ export const startSessionInput = z.object({
   additionalDirectories: z.array(z.string()).optional(),
   customInstructions: z.string().max(2000).optional(),
   /**
+   * Prefix for branches the agent creates, surfaced in the system prompt's
+   * branch-naming instruction. Defaults to `BRANCH_PREFIX` when omitted.
+   */
+  branchPrefix: z.string().max(100).optional(),
+  /**
    * Replaces the PostHog system prompt entirely for this session. Used by
    * constrained, single-purpose surfaces (e.g. the canvas generator) that drive
    * the agent with their own prompt rather than the default coding prompt.
@@ -199,6 +204,7 @@ export const reconnectSessionInput = z.object({
   permissionMode: z.string().optional(),
   model: z.string().optional(),
   customInstructions: z.string().max(2000).optional(),
+  branchPrefix: z.string().max(100).optional(),
   effort: effortLevelSchema.optional(),
   jsonSchema: z.record(z.string(), z.unknown()).nullish(),
 });


### PR DESCRIPTION
## Problem

The branch name PostHog Code generates for a task is hardcoded with the `posthog-code/` prefix. Some users want a different prefix — or none — to match their team's branch conventions.

Closes PostHog/posthog#76277

## Changes

- New **"Branch name prefix"** setting under **Settings → Worktrees** (`branchPrefix`), defaulting to the current `posthog-code/` so existing behavior is unchanged.
- `deriveBranchName` / `suggestBranchName` take an optional `prefix` argument (default `BRANCH_PREFIX`); existing callers are unaffected.
- `getSuggestedBranchName` reads the setting, so the generated branch name honors it wherever the app suggests one (Create PR, "Branch here").
- The prefix is validated before it's saved (`validateBranchPrefix`): rejects names git would reject and a leading `-`; empty = no prefix. Invalid input shows an inline error and isn't persisted.

<img width="820" src="https://raw.githubusercontent.com/KarloAldrete/code/main/.github/pr-media/branch-name-prefix.png" alt="Branch name prefix setting under Settings -> Worktrees" />

## How did you test this?

- `pnpm --filter @posthog/core --filter @posthog/ui typecheck` — clean.
- `biome lint packages/core/src/git-interaction` + Biome check on all changed files — clean, no `noRestrictedImports`.
- `vitest run` on `branchName.test.ts` + `deriveBranchName.test.ts` — 38 passing (added: custom prefix, empty prefix, task-ID fallback with prefix, `validateBranchPrefix`).
- Manually (by the contributor): set a custom prefix in Settings → Worktrees; "Create branch" on a worktree task used the configured prefix; an empty prefix dropped it; invalid values showed the inline error.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*