### PR TITLE
refactor(worktree): resolve worktree path from stored value, not derived from name

### DIFF
--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -367,13 +367,36 @@ describe("WorkspaceService", () => {
       ).toEqual([]);
     });
 
+    it("verifies existence by the stored external path", async () => {
+      const externalPath = mkTemp("external-wt-");
+      seedWorktreeTask(mocks, {
+        taskId: "ext",
+        repoPath: "/code/myrepo",
+        name: "fancy-slug",
+        worktreePath: externalPath,
+      });
+
+      // The on-disk worktree lives at its stored external path; a derived
+      // <base>/<name>/<repo> would not exist, so this would report missing.
+      expect(await service.verifyWorkspaceExists("ext")).toEqual({
+        exists: true,
+      });
+
+      fs.rmSync(externalPath, { recursive: true, force: true });
+      expect(await service.verifyWorkspaceExists("ext")).toEqual({
+        exists: false,
+        missingPath: externalPath,
+      });
+    });
+
     // Identical setup (empty managed `<base>/<repo>` parent, then delete the only
     // worktree for that repo); only the stored worktree path differs. This proves
     // the cleanup guard discriminates on whether the path is under the base path,
     // rather than always (or never) reclaiming the parent folder.
     it.each([
       {
-        label: "leaves an external worktree's parent dirs untouched",
+        label:
+          "leaves the managed parent folder alone for an external worktree",
         makeWorktreePath: () => mkTemp("external-wt-"),
         managedParentSurvives: true,
       },

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { RootLogger } from "@posthog/di/logger";
 import {
   branchExists,
@@ -8,7 +11,7 @@ import {
 import type { IAnalytics } from "@posthog/platform/analytics";
 import type { IWorkspaceSettings } from "@posthog/platform/workspace-settings";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockRepositoryRepository } from "../../db/repositories/repository-repository.mock";
 import { createMockWorkspaceRepository } from "../../db/repositories/workspace-repository.mock";
 import { createMockWorktreeRepository } from "../../db/repositories/worktree-repository.mock";
@@ -30,6 +33,17 @@ vi.mock("@posthog/git/queries", async (importOriginal) => {
     getCurrentBranch: vi.fn(),
     branchExists: vi.fn(),
     remoteBranchExists: vi.fn(),
+  };
+});
+
+// Neutralize the real git worktree removal so delete tests exercise only the
+// service's path resolution and managed-folder cleanup, not actual git/fs ops.
+vi.mock("../worktree-query/worktree-query", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../worktree-query/worktree-query")>();
+  return {
+    ...actual,
+    deleteWorktree: vi.fn(async () => {}),
   };
 });
 
@@ -88,6 +102,29 @@ function createMocks() {
     analytics,
     log,
   };
+}
+
+/** Seed a worktree-mode workspace whose stored row carries `name` and `path`. */
+function seedWorktreeTask(
+  mocks: ReturnType<typeof createMocks>,
+  opts: {
+    taskId: string;
+    repoPath: string;
+    name: string;
+    worktreePath: string;
+  },
+): void {
+  const repo = mocks.repositoryRepo.create({ path: opts.repoPath });
+  const workspace = mocks.workspaceRepo.create({
+    taskId: opts.taskId,
+    repositoryId: repo.id,
+    mode: "worktree",
+  });
+  mocks.worktreeRepo.create({
+    workspaceId: workspace.id,
+    name: opts.name,
+    path: opts.worktreePath,
+  });
 }
 
 function makeService(mocks: ReturnType<typeof createMocks>): WorkspaceService {
@@ -271,6 +308,111 @@ describe("WorkspaceService", () => {
       expect(
         await service.checkWorktreeBranch({ mainRepoPath, branch: "develop" }),
       ).toEqual({ status: "trunk" });
+    });
+  });
+
+  describe("worktree path resolved from the stored row", () => {
+    const tempDirs: string[] = [];
+
+    afterEach(() => {
+      for (const dir of tempDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    function mkTemp(prefix: string): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+      tempDirs.push(dir);
+      return dir;
+    }
+
+    it("projects an externally-located worktree from its stored path", async () => {
+      const externalPath = "/external/checkout/my-worktree";
+      seedWorktreeTask(mocks, {
+        taskId: "ext",
+        repoPath: "/code/myrepo",
+        name: "fancy-slug",
+        worktreePath: externalPath,
+      });
+
+      expect(await service.getWorkspace("ext")).toMatchObject({
+        mode: "worktree",
+        worktreePath: externalPath,
+        worktreeName: "fancy-slug",
+      });
+      expect(await service.getWorkspaceInfo("ext")).toMatchObject({
+        mode: "worktree",
+        worktree: expect.objectContaining({
+          worktreePath: externalPath,
+          worktreeName: "fancy-slug",
+        }),
+      });
+    });
+
+    it("matches occupancy by the stored path, not a derived one", () => {
+      const externalPath = "/external/checkout/my-worktree";
+      seedWorktreeTask(mocks, {
+        taskId: "ext",
+        repoPath: "/code/myrepo",
+        name: "fancy-slug",
+        worktreePath: externalPath,
+      });
+
+      expect(service.getWorktreeTasks(externalPath)).toEqual([
+        { taskId: "ext" },
+      ]);
+      // The name would derive to <base>/<name>/<repo>; that path must not match.
+      expect(
+        service.getWorktreeTasks("/tmp/worktrees/fancy-slug/myrepo"),
+      ).toEqual([]);
+    });
+
+    it("deletes via the stored path and leaves an external worktree's parent dirs untouched", async () => {
+      const base = mkTemp("wt-base-");
+      mocks.workspaceSettings.getWorktreeLocation = () => base;
+
+      const repoPath = "/code/myrepo";
+      const managedParent = path.join(base, "myrepo");
+      fs.mkdirSync(managedParent);
+      const externalPath = mkTemp("external-wt-");
+
+      seedWorktreeTask(mocks, {
+        taskId: "ext",
+        repoPath,
+        name: "ext-name",
+        worktreePath: externalPath,
+      });
+
+      await service.deleteWorkspace("ext", repoPath);
+
+      // The guard short-circuits managed-folder cleanup for external worktrees.
+      expect(fs.existsSync(managedParent)).toBe(true);
+      // The external worktree dir itself is removed by git (mocked), never by
+      // the managed-folder cleanup.
+      expect(fs.existsSync(externalPath)).toBe(true);
+    });
+
+    it("reclaims the empty managed parent folder for a worktree under the base path", async () => {
+      const base = mkTemp("wt-base-");
+      mocks.workspaceSettings.getWorktreeLocation = () => base;
+
+      const repoPath = "/code/myrepo";
+      const managedParent = path.join(base, "myrepo");
+      fs.mkdirSync(managedParent);
+      const managedPath = path.join(base, "some-name", "myrepo");
+
+      seedWorktreeTask(mocks, {
+        taskId: "mng",
+        repoPath,
+        name: "some-name",
+        worktreePath: managedPath,
+      });
+
+      await service.deleteWorkspace("mng", repoPath);
+
+      // Same setup as the external case, but a managed path clears the guard, so
+      // the empty parent folder is reclaimed. This proves the guard discriminates.
+      expect(fs.existsSync(managedParent)).toBe(false);
     });
   });
 });

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -367,52 +367,44 @@ describe("WorkspaceService", () => {
       ).toEqual([]);
     });
 
-    it("deletes via the stored path and leaves an external worktree's parent dirs untouched", async () => {
-      const base = mkTemp("wt-base-");
-      mocks.workspaceSettings.getWorktreeLocation = () => base;
+    // Identical setup (empty managed `<base>/<repo>` parent, then delete the only
+    // worktree for that repo); only the stored worktree path differs. This proves
+    // the cleanup guard discriminates on whether the path is under the base path,
+    // rather than always (or never) reclaiming the parent folder.
+    it.each([
+      {
+        label: "leaves an external worktree's parent dirs untouched",
+        makeWorktreePath: () => mkTemp("external-wt-"),
+        managedParentSurvives: true,
+      },
+      {
+        label:
+          "reclaims the empty managed parent folder for a worktree under the base path",
+        makeWorktreePath: (base: string) =>
+          path.join(base, "some-name", "myrepo"),
+        managedParentSurvives: false,
+      },
+    ])(
+      "deleteWorkspace via the stored path $label",
+      async ({ makeWorktreePath, managedParentSurvives }) => {
+        const base = mkTemp("wt-base-");
+        mocks.workspaceSettings.getWorktreeLocation = () => base;
 
-      const repoPath = "/code/myrepo";
-      const managedParent = path.join(base, "myrepo");
-      fs.mkdirSync(managedParent);
-      const externalPath = mkTemp("external-wt-");
+        const repoPath = "/code/myrepo";
+        const managedParent = path.join(base, "myrepo");
+        fs.mkdirSync(managedParent);
 
-      seedWorktreeTask(mocks, {
-        taskId: "ext",
-        repoPath,
-        name: "ext-name",
-        worktreePath: externalPath,
-      });
+        seedWorktreeTask(mocks, {
+          taskId: "task",
+          repoPath,
+          name: "some-name",
+          worktreePath: makeWorktreePath(base),
+        });
 
-      await service.deleteWorkspace("ext", repoPath);
+        await service.deleteWorkspace("task", repoPath);
 
-      // The guard short-circuits managed-folder cleanup for external worktrees.
-      expect(fs.existsSync(managedParent)).toBe(true);
-      // The external worktree dir itself is removed by git (mocked), never by
-      // the managed-folder cleanup.
-      expect(fs.existsSync(externalPath)).toBe(true);
-    });
-
-    it("reclaims the empty managed parent folder for a worktree under the base path", async () => {
-      const base = mkTemp("wt-base-");
-      mocks.workspaceSettings.getWorktreeLocation = () => base;
-
-      const repoPath = "/code/myrepo";
-      const managedParent = path.join(base, "myrepo");
-      fs.mkdirSync(managedParent);
-      const managedPath = path.join(base, "some-name", "myrepo");
-
-      seedWorktreeTask(mocks, {
-        taskId: "mng",
-        repoPath,
-        name: "some-name",
-        worktreePath: managedPath,
-      });
-
-      await service.deleteWorkspace("mng", repoPath);
-
-      // Same setup as the external case, but a managed path clears the guard, so
-      // the empty parent folder is reclaimed. This proves the guard discriminates.
-      expect(fs.existsSync(managedParent)).toBe(false);
-    });
+        expect(fs.existsSync(managedParent)).toBe(managedParentSurvives);
+      },
+    );
   });
 });

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -935,19 +935,17 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     let worktreeInfo: WorktreeInfo | null = null;
     let branchName: string | null = null;
 
-    if (association.mode === "worktree") {
-      if (folderPath) {
-        const worktreePath = association.path;
-        const gitBranch = await getBranchFromPath(worktreePath);
-        branchName = gitBranch ?? association.branchName;
-        worktreeInfo = {
-          worktreePath,
-          worktreeName: association.worktree,
-          branchName,
-          baseBranch: "main",
-          createdAt: new Date().toISOString(),
-        };
-      }
+    if (association.mode === "worktree" && folderPath) {
+      const worktreePath = association.path;
+      const gitBranch = await getBranchFromPath(worktreePath);
+      branchName = gitBranch ?? association.branchName;
+      worktreeInfo = {
+        worktreePath,
+        worktreeName: association.worktree,
+        branchName,
+        baseBranch: "main",
+        createdAt: new Date().toISOString(),
+      };
     } else if (association.mode === "local" && folderPath) {
       branchName = await getBranchFromPath(folderPath);
     }

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -89,7 +89,10 @@ type TaskAssociation =
 /** True when `child` resolves to a path strictly inside `parent`. */
 function isPathUnder(child: string, parent: string): boolean {
   const rel = path.relative(parent, child);
-  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+  const up = `..${path.sep}`;
+  return (
+    rel !== "" && rel !== ".." && !rel.startsWith(up) && !path.isAbsolute(rel)
+  );
 }
 
 export const WorkspaceServiceEvent = {

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -39,7 +39,6 @@ import type { ProcessTrackingService } from "../process-tracking/process-trackin
 import { getBranchFromPath, hasAnyFiles } from "../repo-fs-query/repo-fs-query";
 import { SUSPENSION_SERVICE } from "../suspension/identifiers";
 import type { SuspensionService } from "../suspension/suspension";
-import { deriveWorktreePath as deriveWorktreePathFromBase } from "../worktree-path/worktree-path";
 import {
   deleteWorktree as deleteGitWorktree,
   listTwigWorktrees,
@@ -80,9 +79,18 @@ type TaskAssociation =
       taskId: string;
       folderId: string;
       mode: "worktree";
+      /** Cosmetic worktree name, surfaced as `worktreeName` in projections. */
       worktree: string;
+      /** Authoritative on-disk worktree path, read from the stored row. */
+      path: string;
       branchName: string | null;
     };
+
+/** True when `child` resolves to a path strictly inside `parent`. */
+function isPathUnder(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
 
 export const WorkspaceServiceEvent = {
   Error: "error",
@@ -139,14 +147,6 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
   private creatingWorkspaces = new Map<string, Promise<WorkspaceInfo>>();
   private branchWatcherInitialized = false;
 
-  private deriveWorktreePath(folderPath: string, worktreeName: string): string {
-    return deriveWorktreePathFromBase(
-      this.workspaceSettings.getWorktreeLocation(),
-      folderPath,
-      worktreeName,
-    );
-  }
-
   private findTaskAssociation(taskId: string): TaskAssociation | null {
     const workspace = this.workspaceRepo.findByTaskId(taskId);
     if (!workspace) return null;
@@ -169,6 +169,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         folderId: workspace.repositoryId,
         mode: "worktree",
         worktree: worktree.name,
+        path: worktree.path,
         branchName: null,
       };
     }
@@ -209,6 +210,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
           folderId: workspace.repositoryId,
           mode: "worktree",
           worktree: worktree.name,
+          path: worktree.path,
           branchName: null,
         });
       } else {
@@ -250,10 +252,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     const associations = this.getAllTaskAssociations();
     for (const assoc of associations) {
       if (assoc.mode !== "worktree") continue;
-      const folderPath = this.getFolderPath(assoc.folderId);
-      if (!folderPath) continue;
-      const derivedPath = this.deriveWorktreePath(folderPath, assoc.worktree);
-      if (derivedPath === worktreePath && assoc.branchName !== newBranch) {
+      if (assoc.path === worktreePath && assoc.branchName !== newBranch) {
         this.updateAssociationBranchName(assoc.taskId, newBranch);
         this.emit(WorkspaceServiceEvent.BranchChanged, {
           taskId: assoc.taskId,
@@ -277,11 +276,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       if (!folderPath) continue;
 
       if (assoc.mode === "worktree") {
-        const worktreePath = this.deriveWorktreePath(
-          folderPath,
-          assoc.worktree,
-        );
-        if (worktreePath !== repoPath) continue;
+        if (assoc.path !== repoPath) continue;
 
         const currentBranch = await getBranchFromPath(repoPath);
         if (currentBranch !== null && currentBranch !== assoc.branchName) {
@@ -721,7 +716,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     let worktreePath: string | null = null;
 
     if (association.mode === "worktree") {
-      worktreePath = this.deriveWorktreePath(folderPath, association.worktree);
+      worktreePath = association.path;
     }
 
     await this.agent.cancelSessionsByTaskId(taskId);
@@ -743,7 +738,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       );
 
       if (otherWorkspacesForFolder.length === 0) {
-        await this.cleanupRepoWorktreeFolder(folderPath);
+        await this.cleanupRepoWorktreeFolder(folderPath, worktreePath);
       }
     }
 
@@ -760,8 +755,19 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     this.workspaceRepo.deleteByTaskId(taskId);
   }
 
-  private async cleanupRepoWorktreeFolder(folderPath: string): Promise<void> {
+  private async cleanupRepoWorktreeFolder(
+    folderPath: string,
+    worktreePath: string,
+  ): Promise<void> {
     const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
+
+    // Safety check 0: Only reclaim the managed `<base>/<repo>` parent folder for
+    // worktrees that actually live under the managed base path. Externally
+    // located worktrees never created it, so its contents are unrelated.
+    if (!isPathUnder(worktreePath, worktreeBasePath)) {
+      return;
+    }
+
     const repoName = path.basename(folderPath);
     const repoWorktreeFolderPath = path.join(worktreeBasePath, repoName);
 
@@ -838,10 +844,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     }
 
     if (association.mode === "worktree") {
-      const worktreePath = this.deriveWorktreePath(
-        folderPath,
-        association.worktree,
-      );
+      const worktreePath = association.path;
       const exists = fs.existsSync(worktreePath);
       if (!exists) {
         this.log.info(`Worktree for task ${taskId} no longer exists`);
@@ -884,7 +887,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
 
     if (assoc.mode === "worktree") {
       worktreeName = assoc.worktree;
-      worktreePath = this.deriveWorktreePath(folderPath, worktreeName);
+      worktreePath = assoc.path;
       const gitBranch = await getBranchFromPath(worktreePath);
       branchName = gitBranch ?? assoc.branchName;
     } else if (assoc.mode === "local") {
@@ -934,10 +937,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
 
     if (association.mode === "worktree") {
       if (folderPath) {
-        const worktreePath = this.deriveWorktreePath(
-          folderPath,
-          association.worktree,
-        );
+        const worktreePath = association.path;
         const gitBranch = await getBranchFromPath(worktreePath);
         branchName = gitBranch ?? association.branchName;
         worktreeInfo = {
@@ -994,7 +994,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
 
       if (assoc.mode === "worktree") {
         worktreeName = assoc.worktree;
-        worktreePath = this.deriveWorktreePath(folderPath, worktreeName);
+        worktreePath = assoc.path;
       }
 
       let branchName: string | null = null;
@@ -1118,10 +1118,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
 
     for (const assoc of associations) {
       if (assoc.mode !== "worktree") continue;
-      const folderPath = this.getFolderPath(assoc.folderId);
-      if (!folderPath) continue;
-      const derivedPath = this.deriveWorktreePath(folderPath, assoc.worktree);
-      if (derivedPath === worktreePath) {
+      if (assoc.path === worktreePath) {
         result.push({ taskId: assoc.taskId });
       }
     }

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -755,15 +755,21 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     this.workspaceRepo.deleteByTaskId(taskId);
   }
 
+  /**
+   * Reclaims the managed `<base>/<repo>` parent folder once its last worktree is
+   * gone. The folder that gets removed is derived from `folderPath`, not from
+   * `worktreePath`; `worktreePath` is read only to confirm the deleted worktree
+   * was managed (lived under the base path) before reclaiming anything.
+   */
   private async cleanupRepoWorktreeFolder(
     folderPath: string,
     worktreePath: string,
   ): Promise<void> {
     const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
 
-    // Safety check 0: Only reclaim the managed `<base>/<repo>` parent folder for
-    // worktrees that actually live under the managed base path. Externally
-    // located worktrees never created it, so its contents are unrelated.
+    // Only reclaim the managed `<base>/<repo>` parent folder for worktrees that
+    // actually live under the managed base path. Externally located worktrees
+    // never created it, so its contents are unrelated.
     if (!isPathUnder(worktreePath, worktreeBasePath)) {
       return;
     }


### PR DESCRIPTION
## Problem

> [!NOTE]
> This is pretty much a pure refactoring to make room for some future Worktree improvements.

`WorkspaceService` ignored the `worktrees.path` column and recomputed each task's worktree path everywhere from the worktree name, assuming it lives at `<base>/<name>/<repo>`. That means a worktree located outside the app's managed base path can't round-trip through the name-to-path formula, so it can't be attached to a task. This is a standalone prerequisite that unblocks a later feature: importing worktrees created by other tools.

## Changes

The persisted `path` column is now the source of truth. A task resolves its worktree path by reading the worktree row, never by deriving it from name plus base path.

The `TaskAssociation` worktree variant carries the authoritative `path` (read straight from the row that `findTaskAssociation`/`getAllTaskAssociations` already load) alongside the now-cosmetic `name`. All 9 read, delete, and occupancy call sites use `assoc.path` instead of re-deriving: the branch-rename watchers (`handleFocusBranchRenamed`, `handleGitStateChanged`), `deleteWorkspace`, `verifyWorkspaceExists`, `getWorkspace`, `getWorkspaceInfo`, `getAllWorkspaces`, and `getWorktreeTasks`. The private `deriveWorktreePath` helper is removed from this service.

`cleanupRepoWorktreeFolder` is guarded so it only reclaims the managed `<base>/<repo>` parent folder when the deleted worktree actually lived under the managed base path. Externally located worktrees never created it, so their parent dirs stay untouched. The under-path check uses `path.relative`, not `startsWith`, which would false-positive `/base-evil` against `/base`.

This is a behavioral no-op for app-created worktrees. I checked the local dev and prod SQLite `worktrees` tables and every stored `path` already equals `<base>/<name>/<repo>`, which is exactly what `deriveWorktreePath` returned, so no data migration is needed.

The legacy name-recovery hack the original scope referenced (`findExistingWorktreeForBranch` and the `finalSegment === repoName ? parent : finalSegment` logic) no longer exists in the tree, already removed in a prior change, so that item produced no diff. The shared `worktree-path/worktree-path.ts` module stays because `archive`, `shell`, and `suspension` still use it. The "import existing worktree" UI and the `adopted` deletion flag remain out of scope for a future PR.

## How did you test this?

`pnpm --filter @posthog/workspace-server test workspace.test` passes with 16 tests: the 12 existing ones unchanged (proving the no-op for managed worktrees) plus 4 new ones. The new coverage exercises a worktree whose `path` is not under the base path: its projection resolves to the stored path, occupancy via `getWorktreeTasks` matches by stored path, and delete uses the stored path without removing any parent folder. A contrast test with a managed path under the base proves the cleanup guard discriminates rather than being a blanket no-op. I confirmed it is non-vacuous by mutation: removing the guard fails exactly the external-worktree test.

`pnpm --filter @posthog/workspace-server typecheck` passes and Biome lint/format is clean on the changed files.

The repo's `repositories.test.ts` DB round-trip suite fails locally with a pre-existing `better-sqlite3` native ABI mismatch (node 20 versus the expected node 22), unrelated to this change and in files I did not touch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?