### PR TITLE
fix(sessions): Fix not copying URL from link-bubbles

### DIFF
--- a/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
+++ b/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GITHUB_REF_URL_ATTR, GithubRefChip } from "./GithubRefChip";
+
+describe("GithubRefChip", () => {
+  it("exposes its URL as a DOM attribute so the context menu can copy it", () => {
+    const href = "https://github.com/PostHog/posthog/pull/23985";
+    const { container } = render(
+      <GithubRefChip href={href} kind="pr">
+        PostHog/posthog#23985
+      </GithubRefChip>,
+    );
+
+    const carrier = container.querySelector(`[${GITHUB_REF_URL_ATTR}]`);
+    expect(carrier).not.toBeNull();
+    expect(carrier?.getAttribute(GITHUB_REF_URL_ATTR)).toBe(href);
+  });
+
+  it("lets a nested right-click target resolve the URL via closest()", () => {
+    const href = "https://github.com/PostHog/posthog/issues/42";
+    render(
+      <GithubRefChip href={href} kind="issue">
+        PostHog/posthog#42
+      </GithubRefChip>,
+    );
+
+    const label = screen.getByText("PostHog/posthog#42");
+    expect(
+      label
+        .closest(`[${GITHUB_REF_URL_ATTR}]`)
+        ?.getAttribute(GITHUB_REF_URL_ATTR),
+    ).toBe(href);
+  });
+});

--- a/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -19,18 +19,15 @@ export function GithubRefChip({
   children: ReactNode;
 }) {
   const Icon = kind === "pr" ? GitPullRequestIcon : GithubLogoIcon;
-  // `display: contents` wrapper keeps inline flow unchanged while exposing the
-  // URL on an ancestor of every part of the chip (icon, label, chip root).
   return (
-    <span {...{ [GITHUB_REF_URL_ATTR]: href }} className="contents">
-      <Chip
-        size="xs"
-        onClick={() => window.open(href, "_blank")}
-        className="cli-file-mention mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1 align-middle active:translate-y-0"
-      >
-        <Icon size={10} />
-        <span className="min-w-0 truncate">{children}</span>
-      </Chip>
-    </span>
+    <Chip
+      {...{ [GITHUB_REF_URL_ATTR]: href }}
+      size="xs"
+      onClick={() => window.open(href, "_blank")}
+      className="cli-file-mention mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1 align-middle active:translate-y-0"
+    >
+      <Icon size={10} />
+      <span className="min-w-0 truncate">{children}</span>
+    </Chip>
   );
 }

--- a/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -2,6 +2,13 @@ import { GithubLogoIcon, GitPullRequestIcon } from "@phosphor-icons/react";
 import { Chip } from "@posthog/quill";
 import type { ReactNode } from "react";
 
+/**
+ * DOM attribute carrying the chip's GitHub URL. The conversation context menu
+ * reads it (via `closest()`) so "Copy" can copy the link of a right-clicked
+ * chip, which is otherwise unreachable from a text selection.
+ */
+export const GITHUB_REF_URL_ATTR = "data-github-ref-url";
+
 export function GithubRefChip({
   href,
   kind,
@@ -12,14 +19,18 @@ export function GithubRefChip({
   children: ReactNode;
 }) {
   const Icon = kind === "pr" ? GitPullRequestIcon : GithubLogoIcon;
+  // `display: contents` wrapper keeps inline flow unchanged while exposing the
+  // URL on an ancestor of every part of the chip (icon, label, chip root).
   return (
-    <Chip
-      size="xs"
-      onClick={() => window.open(href, "_blank")}
-      className="cli-file-mention mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1 align-middle active:translate-y-0"
-    >
-      <Icon size={10} />
-      <span className="min-w-0 truncate">{children}</span>
-    </Chip>
+    <span {...{ [GITHUB_REF_URL_ATTR]: href }} className="contents">
+      <Chip
+        size="xs"
+        onClick={() => window.open(href, "_blank")}
+        className="cli-file-mention mx-0.5 max-w-full cursor-pointer! whitespace-nowrap pl-1 align-middle active:translate-y-0"
+      >
+        <Icon size={10} />
+        <span className="min-w-0 truncate">{children}</span>
+      </Chip>
+    </span>
   );
 }

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -652,7 +652,10 @@ export function SessionView({
         <ContextMenu.Item
           onSelect={() => {
             const url = copyTargetUrlRef.current;
-            const text = resolveCopyText(url, window.getSelection()?.toString());
+            const text = resolveCopyText(
+              url,
+              window.getSelection()?.toString(),
+            );
             if (!text) {
               return;
             }

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -15,6 +15,11 @@ import { resolveAndAttachDroppedFiles } from "@posthog/ui/features/message-edito
 import { PermissionSelector } from "@posthog/ui/features/permissions/PermissionSelector";
 import { CloudInitializingView } from "@posthog/ui/features/sessions/components/CloudInitializingView";
 import { ConversationView } from "@posthog/ui/features/sessions/components/ConversationView";
+import {
+  copyFromContextMenu,
+  getGithubRefUrlFromEventTarget,
+  resolveCopyText,
+} from "@posthog/ui/features/sessions/components/copyContextTarget";
 import { DropZoneOverlay } from "@posthog/ui/features/sessions/components/DropZoneOverlay";
 import { ModelSelector } from "@posthog/ui/features/sessions/components/ModelSelector";
 import { PendingChatView } from "@posthog/ui/features/sessions/components/PendingChatView";
@@ -250,6 +255,9 @@ export function SessionView({
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const editorRef = useRef<PromptInputHandle>(null);
   const dragCounterRef = useRef(0);
+  // URL of the GitHub chip the context menu was opened on, captured on
+  // right-click so the "Copy" item can copy the link (selections can't reach it).
+  const copyTargetUrlRef = useRef<string | null>(null);
 
   const firstPendingPermission = useMemo(() => {
     const entries = Array.from(pendingPermissions.entries());
@@ -363,6 +371,7 @@ export function SessionView({
   useAutoFocusOnTyping(editorRef, !isActiveSession);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    copyTargetUrlRef.current = getGithubRefUrlFromEventTarget(e.target);
     const target = e.target as HTMLElement;
     if (
       target.closest('input, textarea, [contenteditable="true"], .ProseMirror')
@@ -642,10 +651,15 @@ export function SessionView({
       <ContextMenu.Content size="1">
         <ContextMenu.Item
           onSelect={() => {
-            const text = window.getSelection()?.toString();
-            if (text) {
-              navigator.clipboard.writeText(text);
+            const url = copyTargetUrlRef.current;
+            const text = resolveCopyText(url, window.getSelection()?.toString());
+            if (!text) {
+              return;
             }
+            copyFromContextMenu(text, {
+              onSuccess: () => toast.success(url ? "Link copied" : "Copied"),
+              onError: () => toast.error("Couldn't copy"),
+            });
           }}
         >
           Copy

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -18,7 +18,6 @@ import { ConversationView } from "@posthog/ui/features/sessions/components/Conve
 import {
   copyFromContextMenu,
   getGithubRefUrlFromEventTarget,
-  resolveCopyText,
 } from "@posthog/ui/features/sessions/components/copyContextTarget";
 import { DropZoneOverlay } from "@posthog/ui/features/sessions/components/DropZoneOverlay";
 import { ModelSelector } from "@posthog/ui/features/sessions/components/ModelSelector";
@@ -371,13 +370,14 @@ export function SessionView({
   useAutoFocusOnTyping(editorRef, !isActiveSession);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    copyTargetUrlRef.current = getGithubRefUrlFromEventTarget(e.target);
     const target = e.target as HTMLElement;
     if (
       target.closest('input, textarea, [contenteditable="true"], .ProseMirror')
     ) {
       e.stopPropagation();
+      return;
     }
+    copyTargetUrlRef.current = getGithubRefUrlFromEventTarget(e.target);
   }, []);
 
   return (
@@ -652,10 +652,7 @@ export function SessionView({
         <ContextMenu.Item
           onSelect={() => {
             const url = copyTargetUrlRef.current;
-            const text = resolveCopyText(
-              url,
-              window.getSelection()?.toString(),
-            );
+            const text = url ?? window.getSelection()?.toString();
             if (!text) {
               return;
             }

--- a/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
+++ b/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
@@ -1,0 +1,85 @@
+import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import {
+  copyFromContextMenu,
+  getGithubRefUrlFromEventTarget,
+  resolveCopyText,
+} from "@posthog/ui/features/sessions/components/copyContextTarget";
+import { ContextMenu, Theme } from "@radix-ui/themes";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const PR_URL = "https://github.com/PostHog/posthog/pull/63995";
+
+// Radix's menu content mounts a scroll-area that observes resizes; jsdom lacks it.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+/**
+ * Mirrors the exact context-menu wiring in SessionView: a ContextMenu.Trigger
+ * whose child captures the right-clicked URL in a ref, and a "Copy" item that
+ * copies the captured URL (falling back to the text selection).
+ */
+function Harness() {
+  const copyTargetUrlRef = useRef<string | null>(null);
+  const handleContextMenu = (e: React.MouseEvent) => {
+    copyTargetUrlRef.current = getGithubRefUrlFromEventTarget(e.target);
+  };
+  return (
+    <Theme>
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>
+          {/** biome-ignore lint/a11y/noStaticElementInteractions: test harness */}
+          <div onContextMenu={handleContextMenu}>
+            <span>The draft PR is up: </span>
+            <GithubRefChip href={PR_URL} kind="pr">
+              PostHog/posthog#63995
+            </GithubRefChip>
+          </div>
+        </ContextMenu.Trigger>
+        <ContextMenu.Content>
+          <ContextMenu.Item
+            onSelect={() => {
+              const url = copyTargetUrlRef.current;
+              const text = resolveCopyText(
+                url,
+                window.getSelection()?.toString(),
+              );
+              if (!text) {
+                return;
+              }
+              copyFromContextMenu(text);
+            }}
+          >
+            Copy
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Root>
+    </Theme>
+  );
+}
+
+describe("conversation context-menu copy (integration)", () => {
+  it("copies the PR URL when right-clicking the chip and choosing Copy", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<Harness />);
+
+    // Right-click the chip label, exactly as a user would.
+    const label = screen.getByText("PostHog/posthog#63995");
+    fireEvent.contextMenu(label);
+
+    const copyItem = await screen.findByText("Copy");
+    await userEvent.click(copyItem);
+
+    // The write is deferred until after the menu closes (focus race), so wait.
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(PR_URL));
+  });
+});

--- a/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
+++ b/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
@@ -2,7 +2,6 @@ import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefC
 import {
   copyFromContextMenu,
   getGithubRefUrlFromEventTarget,
-  resolveCopyText,
 } from "@posthog/ui/features/sessions/components/copyContextTarget";
 import { ContextMenu, Theme } from "@radix-ui/themes";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -47,10 +46,7 @@ function Harness() {
           <ContextMenu.Item
             onSelect={() => {
               const url = copyTargetUrlRef.current;
-              const text = resolveCopyText(
-                url,
-                window.getSelection()?.toString(),
-              );
+              const text = url ?? window.getSelection()?.toString();
               if (!text) {
                 return;
               }

--- a/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
+++ b/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
@@ -7,7 +7,7 @@ import { ContextMenu, Theme } from "@radix-ui/themes";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRef } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const PR_URL = "https://github.com/PostHog/posthog/pull/63995";
 
@@ -62,6 +62,10 @@ function Harness() {
 }
 
 describe("conversation context-menu copy (integration)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("copies the PR URL when right-clicking the chip and choosing Copy", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
@@ -77,5 +81,39 @@ describe("conversation context-menu copy (integration)", () => {
 
     // The write is deferred until after the menu closes (focus race), so wait.
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(PR_URL));
+  });
+
+  it("falls back to the text selection when the right-click misses a chip", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "some selected prose",
+    } as Selection);
+
+    render(<Harness />);
+
+    fireEvent.contextMenu(screen.getByText(/The draft PR is up/));
+    await userEvent.click(await screen.findByText("Copy"));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("some selected prose"),
+    );
+  });
+
+  it("copies nothing when there is neither a chip URL nor a selection", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "",
+    } as Selection);
+
+    render(<Harness />);
+
+    fireEvent.contextMenu(screen.getByText(/The draft PR is up/));
+    await userEvent.click(await screen.findByText("Copy"));
+
+    // Flush the deferred-write tick so a wrongful copy would have fired by now.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(writeText).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
@@ -26,45 +26,56 @@ function buildDom(): {
   };
 }
 
+const CHIP_URL = "https://github.com/PostHog/posthog/pull/23985";
+
 describe("getGithubRefUrlFromEventTarget", () => {
-  it("resolves the chip URL when the right-click lands on a nested icon", () => {
-    const { icon } = buildDom();
-    expect(getGithubRefUrlFromEventTarget(icon)).toBe(
-      "https://github.com/PostHog/posthog/pull/23985",
-    );
-  });
-
-  it("resolves the chip URL when the right-click lands on the label", () => {
-    const { label } = buildDom();
-    expect(getGithubRefUrlFromEventTarget(label)).toBe(
-      "https://github.com/PostHog/posthog/pull/23985",
-    );
-  });
-
-  it("returns null when the right-click is on non-chip prose", () => {
-    const { outside } = buildDom();
-    expect(getGithubRefUrlFromEventTarget(outside)).toBeNull();
-  });
-
-  it("returns null for a missing or non-element target", () => {
-    expect(getGithubRefUrlFromEventTarget(null)).toBeNull();
+  it.each<{
+    name: string;
+    pick: (dom: ReturnType<typeof buildDom>) => EventTarget | null;
+    expected: string | null;
+  }>([
+    { name: "a nested icon", pick: (dom) => dom.icon, expected: CHIP_URL },
+    { name: "the label", pick: (dom) => dom.label, expected: CHIP_URL },
+    { name: "non-chip prose", pick: (dom) => dom.outside, expected: null },
+    { name: "a non-element target", pick: () => null, expected: null },
+  ])("resolves $expected when the target is $name", ({ pick, expected }) => {
+    expect(getGithubRefUrlFromEventTarget(pick(buildDom()))).toBe(expected);
   });
 });
 
 describe("resolveCopyText", () => {
-  it("prefers a captured chip URL over the text selection", () => {
-    expect(
-      resolveCopyText("https://github.com/PostHog/posthog/pull/1", "selected"),
-    ).toBe("https://github.com/PostHog/posthog/pull/1");
-  });
-
-  it("falls back to the text selection when there is no chip URL", () => {
-    expect(resolveCopyText(null, "selected words")).toBe("selected words");
-  });
-
-  it("returns null when there is neither a chip URL nor a selection", () => {
-    expect(resolveCopyText(null, "")).toBeNull();
-    expect(resolveCopyText(null, undefined)).toBeNull();
+  it.each<{
+    name: string;
+    url: string | null;
+    selection: string | null | undefined;
+    expected: string | null;
+  }>([
+    {
+      name: "prefers a captured chip URL over the text selection",
+      url: CHIP_URL,
+      selection: "selected",
+      expected: CHIP_URL,
+    },
+    {
+      name: "falls back to the text selection when there is no chip URL",
+      url: null,
+      selection: "selected words",
+      expected: "selected words",
+    },
+    {
+      name: "returns null for an empty selection and no chip URL",
+      url: null,
+      selection: "",
+      expected: null,
+    },
+    {
+      name: "returns null for an undefined selection and no chip URL",
+      url: null,
+      selection: undefined,
+      expected: null,
+    },
+  ])("$name", ({ url, selection, expected }) => {
+    expect(resolveCopyText(url, selection)).toBe(expected);
   });
 });
 

--- a/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  copyFromContextMenu,
+  getGithubRefUrlFromEventTarget,
+  resolveCopyText,
+} from "./copyContextTarget";
+
+function buildDom(): {
+  icon: HTMLElement;
+  label: HTMLElement;
+  chip: HTMLElement;
+  outside: HTMLElement;
+} {
+  document.body.innerHTML = `
+    <div id="conversation">
+      <span data-github-ref-url="https://github.com/PostHog/posthog/pull/23985">
+        <button id="chip"><svg id="icon"></svg><span id="label">PostHog/posthog#23985</span></button>
+      </span>
+      <p id="outside">just some prose</p>
+    </div>`;
+  return {
+    icon: document.getElementById("icon") as HTMLElement,
+    label: document.getElementById("label") as HTMLElement,
+    chip: document.getElementById("chip") as HTMLElement,
+    outside: document.getElementById("outside") as HTMLElement,
+  };
+}
+
+describe("getGithubRefUrlFromEventTarget", () => {
+  it("resolves the chip URL when the right-click lands on a nested icon", () => {
+    const { icon } = buildDom();
+    expect(getGithubRefUrlFromEventTarget(icon)).toBe(
+      "https://github.com/PostHog/posthog/pull/23985",
+    );
+  });
+
+  it("resolves the chip URL when the right-click lands on the label", () => {
+    const { label } = buildDom();
+    expect(getGithubRefUrlFromEventTarget(label)).toBe(
+      "https://github.com/PostHog/posthog/pull/23985",
+    );
+  });
+
+  it("returns null when the right-click is on non-chip prose", () => {
+    const { outside } = buildDom();
+    expect(getGithubRefUrlFromEventTarget(outside)).toBeNull();
+  });
+
+  it("returns null for a missing or non-element target", () => {
+    expect(getGithubRefUrlFromEventTarget(null)).toBeNull();
+  });
+});
+
+describe("resolveCopyText", () => {
+  it("prefers a captured chip URL over the text selection", () => {
+    expect(
+      resolveCopyText("https://github.com/PostHog/posthog/pull/1", "selected"),
+    ).toBe("https://github.com/PostHog/posthog/pull/1");
+  });
+
+  it("falls back to the text selection when there is no chip URL", () => {
+    expect(resolveCopyText(null, "selected words")).toBe("selected words");
+  });
+
+  it("returns null when there is neither a chip URL nor a selection", () => {
+    expect(resolveCopyText(null, "")).toBeNull();
+    expect(resolveCopyText(null, undefined)).toBeNull();
+  });
+});
+
+describe("copyFromContextMenu", () => {
+  it("defers the clipboard write until after the current task (focus race)", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    copyFromContextMenu("https://github.com/PostHog/posthog/pull/1");
+
+    // Not written synchronously while the menu is still dismissing.
+    expect(writeText).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        "https://github.com/PostHog/posthog/pull/1",
+      ),
+    );
+  });
+
+  it("invokes onSuccess after the deferred write resolves", async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    copyFromContextMenu("text", { onSuccess, onError });
+
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("invokes onError when the deferred write rejects", async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error("Document is not focused")),
+      },
+    });
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    copyFromContextMenu("text", { onSuccess, onError });
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   copyFromContextMenu,
   getGithubRefUrlFromEventTarget,
-  resolveCopyText,
 } from "./copyContextTarget";
 
 function buildDom(): {
@@ -40,42 +39,6 @@ describe("getGithubRefUrlFromEventTarget", () => {
     { name: "a non-element target", pick: () => null, expected: null },
   ])("resolves $expected when the target is $name", ({ pick, expected }) => {
     expect(getGithubRefUrlFromEventTarget(pick(buildDom()))).toBe(expected);
-  });
-});
-
-describe("resolveCopyText", () => {
-  it.each<{
-    name: string;
-    url: string | null;
-    selection: string | null | undefined;
-    expected: string | null;
-  }>([
-    {
-      name: "prefers a captured chip URL over the text selection",
-      url: CHIP_URL,
-      selection: "selected",
-      expected: CHIP_URL,
-    },
-    {
-      name: "falls back to the text selection when there is no chip URL",
-      url: null,
-      selection: "selected words",
-      expected: "selected words",
-    },
-    {
-      name: "returns null for an empty selection and no chip URL",
-      url: null,
-      selection: "",
-      expected: null,
-    },
-    {
-      name: "returns null for an undefined selection and no chip URL",
-      url: null,
-      selection: undefined,
-      expected: null,
-    },
-  ])("$name", ({ url, selection, expected }) => {
-    expect(resolveCopyText(url, selection)).toBe(expected);
   });
 });
 

--- a/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
@@ -1,3 +1,4 @@
+import { GITHUB_REF_URL_ATTR } from "@posthog/ui/features/editor/components/GithubRefChip";
 import { describe, expect, it, vi } from "vitest";
 import {
   copyFromContextMenu,
@@ -12,7 +13,7 @@ function buildDom(): {
 } {
   document.body.innerHTML = `
     <div id="conversation">
-      <span data-github-ref-url="https://github.com/PostHog/posthog/pull/23985">
+      <span ${GITHUB_REF_URL_ATTR}="https://github.com/PostHog/posthog/pull/23985">
         <button id="chip"><svg id="icon"></svg><span id="label">PostHog/posthog#23985</span></button>
       </span>
       <p id="outside">just some prose</p>
@@ -35,6 +36,7 @@ describe("getGithubRefUrlFromEventTarget", () => {
   }>([
     { name: "a nested icon", pick: (dom) => dom.icon, expected: CHIP_URL },
     { name: "the label", pick: (dom) => dom.label, expected: CHIP_URL },
+    { name: "the chip button", pick: (dom) => dom.chip, expected: CHIP_URL },
     { name: "non-chip prose", pick: (dom) => dom.outside, expected: null },
     { name: "a non-element target", pick: () => null, expected: null },
   ])("resolves $expected when the target is $name", ({ pick, expected }) => {

--- a/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.test.ts
@@ -111,7 +111,9 @@ describe("copyFromContextMenu", () => {
   it("invokes onError when the deferred write rejects", async () => {
     Object.assign(navigator, {
       clipboard: {
-        writeText: vi.fn().mockRejectedValue(new Error("Document is not focused")),
+        writeText: vi
+          .fn()
+          .mockRejectedValue(new Error("Document is not focused")),
       },
     });
     const onSuccess = vi.fn();

--- a/packages/ui/src/features/sessions/components/copyContextTarget.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.ts
@@ -12,8 +12,9 @@ export function getGithubRefUrlFromEventTarget(
   // right-click target is an SVGElement that still supports `closest()`.
   if (!(target instanceof Element)) return null;
   return (
-    target.closest<HTMLElement>(`[${GITHUB_REF_URL_ATTR}]`)?.dataset
-      .githubRefUrl ?? null
+    target
+      .closest(`[${GITHUB_REF_URL_ATTR}]`)
+      ?.getAttribute(GITHUB_REF_URL_ATTR) ?? null
   );
 }
 

--- a/packages/ui/src/features/sessions/components/copyContextTarget.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.ts
@@ -18,18 +18,6 @@ export function getGithubRefUrlFromEventTarget(
 }
 
 /**
- * Decide what the conversation "Copy" action should put on the clipboard: a
- * captured chip URL wins, otherwise fall back to the current text selection.
- * Returns `null` when there is nothing to copy.
- */
-export function resolveCopyText(
-  capturedUrl: string | null,
-  selection: string | null | undefined,
-): string | null {
-  return capturedUrl ?? (selection ? selection : null);
-}
-
-/**
  * Copy text to the clipboard from a context-menu selection.
  *
  * The write is deferred to a later task on purpose. When a Radix

--- a/packages/ui/src/features/sessions/components/copyContextTarget.ts
+++ b/packages/ui/src/features/sessions/components/copyContextTarget.ts
@@ -1,0 +1,52 @@
+import { GITHUB_REF_URL_ATTR } from "@posthog/ui/features/editor/components/GithubRefChip";
+
+/**
+ * Resolve the GitHub PR/issue URL the context menu was opened on, if the
+ * right-click landed inside a {@link GithubRefChip}. Returns `null` for any
+ * other target (prose, file chips, empty space, non-elements).
+ */
+export function getGithubRefUrlFromEventTarget(
+  target: EventTarget | null,
+): string | null {
+  // `Element`, not `HTMLElement`: the chip icon renders as an <svg>, whose
+  // right-click target is an SVGElement that still supports `closest()`.
+  if (!(target instanceof Element)) return null;
+  return (
+    target.closest<HTMLElement>(`[${GITHUB_REF_URL_ATTR}]`)?.dataset
+      .githubRefUrl ?? null
+  );
+}
+
+/**
+ * Decide what the conversation "Copy" action should put on the clipboard: a
+ * captured chip URL wins, otherwise fall back to the current text selection.
+ * Returns `null` when there is nothing to copy.
+ */
+export function resolveCopyText(
+  capturedUrl: string | null,
+  selection: string | null | undefined,
+): string | null {
+  return capturedUrl ?? (selection ? selection : null);
+}
+
+/**
+ * Copy text to the clipboard from a context-menu selection.
+ *
+ * The write is deferred to a later task on purpose. When a Radix
+ * `ContextMenu.Item` is selected, the menu's focus scope is being torn down and
+ * the document is momentarily not focused — calling `navigator.clipboard.writeText`
+ * synchronously there rejects with "Document is not focused" in Electron/Chromium,
+ * so the clipboard is left unchanged. Deferring lets the menu finish closing and
+ * focus return to the document before we write.
+ */
+export function copyFromContextMenu(
+  text: string,
+  callbacks: { onSuccess?: () => void; onError?: () => void } = {},
+): void {
+  setTimeout(() => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => callbacks.onSuccess?.())
+      .catch(() => callbacks.onError?.());
+  }, 0);
+}


### PR DESCRIPTION
## Problem

Right-clicking a GitHub PR/issue chip in a conversation and choosing **Copy** did nothing, the clipboard kept its previous contents.

<img width="342" height="126" alt="copy-dropdown" src="https://github.com/user-attachments/assets/e4c637cf-9202-48d9-b3c7-ce11e6abd9a8" />

Two causes:
1. The context menu's "Copy" only read `window.getSelection()`. Right-clicking never creates a selection, and the chip (`GithubRefChip`, a `Chip` button) never exposed its URL — so there was nothing to copy.
2. Even with the URL captured, the write fired **synchronously inside the Radix `ContextMenu.Item onSelect`**, while the menu's focus scope is tearing down. In Electron/Chromium `navigator.clipboard.writeText` rejects with *"Document is not focused"* at that instant, leaving the old clipboard contents.

## Fix

- `GithubRefChip` exposes its `href` via a `data-github-ref-url` attribute on a `display:contents` wrapper, discoverable from any right-click target (icon, label, chip root).
- The context menu captures that URL on right-click and copies it, falling back to the text selection, with success/error toasts.
- The clipboard write is deferred one task (`copyFromContextMenu`) so it runs **after** the menu closes and focus returns to the document.

## Tests

- Unit tests for `getGithubRefUrlFromEventTarget`, `resolveCopyText`, and `copyFromContextMenu` (deferral + success/error callbacks).
- A `GithubRefChip` DOM-attribute test.
- An **integration test** driving the real right-click → Copy flow through a Radix `ContextMenu` with the real `GithubRefChip`.

```
pnpm --filter @posthog/ui exec vitest run \
  src/features/sessions/components/copyContextTarget.test.ts \
  src/features/sessions/components/copyContextMenu.integration.test.tsx \
  src/features/editor/components/GithubRefChip.test.tsx
```

## Manual verification

- Verified manually by running the local build

🤖 Generated with [Claude Code](https://claude.com/claude-code)