### PR TITLE
fix(inbox): show true tab counts and hide zero counts

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2737,6 +2737,12 @@ export class PostHogAPIClient {
     if (params?.priority) {
       url.searchParams.set("priority", params.priority);
     }
+    if (params?.has_implementation_pr != null) {
+      url.searchParams.set(
+        "has_implementation_pr",
+        String(params.has_implementation_pr),
+      );
+    }
 
     const response = await this.api.fetcher.fetch({
       method: "get",

--- a/packages/core/src/inbox/reportFiltering.ts
+++ b/packages/core/src/inbox/reportFiltering.ts
@@ -19,20 +19,6 @@ function normalizeReviewerId(value: string): string {
   return value.trim();
 }
 
-/**
- * Reports that are surfaced to the current user as needing review: ready,
- * immediately actionable, and addressed to them. Used for both the sidebar
- * red badge count and the inbox toolbar "up for review" byline so the two
- * numbers always agree.
- */
-export function isReportUpForReview(report: SignalReport): boolean {
-  return (
-    report.status === "ready" &&
-    report.is_suggested_reviewer === true &&
-    report.actionability === "immediately_actionable"
-  );
-}
-
 export function filterReportsBySearch(
   reports: SignalReport[],
   query: string,

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -505,6 +505,11 @@ export interface SignalReportsQueryParams {
   suggested_reviewers?: string;
   /** Comma-separated `P0`–`P4` priorities — only returns reports with one of these priorities. */
   priority?: string;
+  /**
+   * Filter by whether a shipped implementation pull request exists. `true` keeps only PR
+   * reports, `false` only non-PR reports. Pair with `limit: 1` to count PR reports cheaply.
+   */
+  has_implementation_pr?: boolean;
 }
 
 /** Values match `SignalReportTask.Relationship` on the PostHog API. */

--- a/packages/ui/src/features/home/components/HomeView.tsx
+++ b/packages/ui/src/features/home/components/HomeView.tsx
@@ -286,9 +286,11 @@ function Section({ title, count, icon, children }: SectionProps) {
       >
         {icon}
         <Text className="font-semibold text-[12px] text-gray-12">{title}</Text>
-        <Text className="rounded-full bg-(--gray-a3) px-1.5 py-px font-medium text-(--gray-11) text-[10.5px] tabular-nums">
-          {count}
-        </Text>
+        {count > 0 && (
+          <Text className="rounded-full bg-(--gray-a3) px-1.5 py-px font-medium text-(--gray-11) text-[10.5px] tabular-nums">
+            {count}
+          </Text>
+        )}
       </Flex>
       {children}
     </Box>

--- a/packages/ui/src/features/inbox/components/InboxReportListTab.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportListTab.tsx
@@ -73,6 +73,12 @@ interface InboxReportListTabProps {
     reports: SignalReport[];
     children: ReactNode;
   }>;
+  /**
+   * Fetch a server-filtered PR-only list instead of the broad pipeline list, so
+   * the tab body comes from the same source as the Pull-requests count (a PR
+   * past the broad list's first page would otherwise not render).
+   */
+  pullRequestsOnly?: boolean;
 }
 
 /**
@@ -89,8 +95,11 @@ export function InboxReportListTab({
   searchPlaceholder,
   emptyState,
   CardListWrapper,
+  pullRequestsOnly = false,
 }: InboxReportListTabProps) {
-  const { scopedReports, allReports, isLoading } = useInboxAllReports();
+  const { scopedReports, allReports, isLoading } = useInboxAllReports({
+    pullRequestsOnly,
+  });
   const scope = useInboxReviewerScopeStore((s) => s.scope);
   const [dismissReport, setDismissReport] = useState<SignalReport | null>(null);
 

--- a/packages/ui/src/features/inbox/components/InboxTabBar.tsx
+++ b/packages/ui/src/features/inbox/components/InboxTabBar.tsx
@@ -49,15 +49,17 @@ export function InboxTabBar({ counts }: InboxTabBarProps) {
                 <span className="font-medium text-[13px]">
                   {INBOX_TAB_LABEL[key]}
                 </span>
-                <span
-                  className={
-                    isActive
-                      ? "text-[12px] text-gray-11 tabular-nums"
-                      : "text-[12px] text-gray-10 tabular-nums"
-                  }
-                >
-                  {counts[key]}
-                </span>
+                {counts[key] > 0 && (
+                  <span
+                    className={
+                      isActive
+                        ? "text-[12px] text-gray-11 tabular-nums"
+                        : "text-[12px] text-gray-10 tabular-nums"
+                    }
+                  >
+                    {counts[key]}
+                  </span>
+                )}
               </TabsTrigger>
             );
           })}

--- a/packages/ui/src/features/inbox/components/PullRequestsTab.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestsTab.tsx
@@ -14,6 +14,7 @@ export function PullRequestsTab() {
   return (
     <InboxReportListTab
       predicate={isPullRequestReport}
+      pullRequestsOnly
       Card={PullRequestCard}
       CardListWrapper={PullRequestsBatchProvider}
       searchPlaceholder="Search pull requests…"

--- a/packages/ui/src/features/inbox/components/RunsTab.tsx
+++ b/packages/ui/src/features/inbox/components/RunsTab.tsx
@@ -187,7 +187,11 @@ function RunsSection({
           <Text className="font-semibold text-[13px] text-gray-12">
             {title}
           </Text>
-          <Text className="text-[12px] text-gray-10 tabular-nums">{count}</Text>
+          {count > 0 && (
+            <Text className="text-[12px] text-gray-10 tabular-nums">
+              {count}
+            </Text>
+          )}
           {isLive && count > 0 && (
             <span
               className="inline-flex h-1.5 w-1.5 animate-pulse rounded-full bg-(--blue-9)"

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -9,12 +9,17 @@ import {
 import {
   computeInboxTabCounts,
   INBOX_SCOPE_FOR_YOU,
+  isExcludedFromInbox,
+  isReportTabReport,
   matchesReviewerScope,
   parseTeammateInboxScope,
 } from "@posthog/core/inbox/reportMembership";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
-import { useInboxReportsInfinite } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import {
+  useInboxReports,
+  useInboxReportsInfinite,
+} from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useInboxReviewerScopeStore } from "@posthog/ui/features/inbox/stores/inboxReviewerScopeStore";
 import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
 import { useMemo } from "react";
@@ -90,6 +95,28 @@ export function useInboxAllReports(options?: {
     },
   );
 
+  // True count of pull-request reports for the active scope. The infinite list
+  // only holds the first page(s), so deriving pulls from loaded reports caps at
+  // the page size and depends on ordering (a PR can sit past page 1). A cheap
+  // `limit: 1` count query with the server-side `has_implementation_pr` filter
+  // returns the real total regardless of page size.
+  const pullRequestCountQuery = useInboxReports(
+    {
+      status: INBOX_PIPELINE_STATUS_FILTER,
+      has_implementation_pr: true,
+      suggested_reviewers: reviewerUuid
+        ? buildSuggestedReviewerFilterParam([reviewerUuid])
+        : undefined,
+      limit: 1,
+    },
+    {
+      enabled: !isForYou || reviewerUuid != null,
+      refetchInterval: INBOX_REFETCH_INTERVAL_MS,
+      refetchIntervalInBackground: false,
+    },
+  );
+  const pullRequestTotal = pullRequestCountQuery.data?.count ?? 0;
+
   const scopedReports = useMemo(() => {
     const byScope = ignoreScope
       ? query.allReports
@@ -99,10 +126,28 @@ export function useInboxAllReports(options?: {
       : byScope;
   }, [query.allReports, scope, searchQuery, ignoreScope]);
 
-  const counts = useMemo(
-    () => computeInboxTabCounts(query.allReports, scope),
-    [query.allReports, scope],
-  );
+  const counts = useMemo(() => {
+    const loaded = computeInboxTabCounts(query.allReports, scope);
+    // The list is an infinite query that only holds the pages loaded so far
+    // (100 per page), so the loaded-derived Reports count caps at the page
+    // size and reads as a misleading "100". Reports is the dominant bucket, so
+    // derive its true size from the backend's total `count` (unaffected by the
+    // page cap) minus the loaded non-report items (pulls, in-motion runs, and
+    // failed runs) that the total also includes. Pulls/Runs stay loaded-derived
+    // — they are small, newest-first sets that fit on the first page.
+    const loadedNonReport = query.allReports.filter(
+      (r) =>
+        matchesReviewerScope(r, scope) &&
+        !isExcludedFromInbox(r) &&
+        !isReportTabReport(r),
+    ).length;
+    return {
+      ...loaded,
+      // True backend counts, unaffected by the list's page-size cap.
+      pulls: pullRequestTotal,
+      reports: Math.max(0, query.totalCount - loadedNonReport),
+    };
+  }, [query.allReports, query.totalCount, scope, pullRequestTotal]);
 
   return {
     ...query,

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -10,6 +10,7 @@ import {
   computeInboxTabCounts,
   INBOX_SCOPE_FOR_YOU,
   isExcludedFromInbox,
+  isPullRequestReport,
   isReportTabReport,
   matchesReviewerScope,
   parseTeammateInboxScope,
@@ -104,6 +105,14 @@ export function useInboxAllReports(options?: {
     {
       status: INBOX_PIPELINE_STATUS_FILTER,
       has_implementation_pr: true,
+      // Mirror the list query's active filters so the badge matches the tab
+      // body. These are empty when `ignoreFilters` is set (sidebar usage), so
+      // the count stays scope-only there.
+      source_product:
+        sourceProductFilter.length > 0
+          ? sourceProductFilter.join(",")
+          : undefined,
+      priority: buildPriorityFilterParam(priorityFilter),
       suggested_reviewers: reviewerUuid
         ? buildSuggestedReviewerFilterParam([reviewerUuid])
         : undefined,
@@ -129,23 +138,28 @@ export function useInboxAllReports(options?: {
   const counts = useMemo(() => {
     const loaded = computeInboxTabCounts(query.allReports, scope);
     // The list is an infinite query that only holds the pages loaded so far
-    // (100 per page), so the loaded-derived Reports count caps at the page
-    // size and reads as a misleading "100". Reports is the dominant bucket, so
-    // derive its true size from the backend's total `count` (unaffected by the
-    // page cap) minus the loaded non-report items (pulls, in-motion runs, and
-    // failed runs) that the total also includes. Pulls/Runs stay loaded-derived
-    // — they are small, newest-first sets that fit on the first page.
-    const loadedNonReport = query.allReports.filter(
+    // (100 per page), so the loaded-derived Reports count caps at the page size
+    // and reads as a misleading "100". Reports is the dominant bucket, so derive
+    // its true size from the backend total `count` (unaffected by the page cap)
+    // minus the non-report items the total also includes. PRs use the true
+    // `pullRequestTotal` (also a real backend count), so PRs sitting past the
+    // loaded page don't inflate Reports. Runs/failed without a PR stay
+    // loaded-derived — small, newest-first, and an accepted approximation.
+    const loadedOtherNonReport = query.allReports.filter(
       (r) =>
         matchesReviewerScope(r, scope) &&
         !isExcludedFromInbox(r) &&
-        !isReportTabReport(r),
+        !isReportTabReport(r) &&
+        !isPullRequestReport(r),
     ).length;
     return {
       ...loaded,
       // True backend counts, unaffected by the list's page-size cap.
       pulls: pullRequestTotal,
-      reports: Math.max(0, query.totalCount - loadedNonReport),
+      reports: Math.max(
+        0,
+        query.totalCount - pullRequestTotal - loadedOtherNonReport,
+      ),
     };
   }, [query.allReports, query.totalCount, scope, pullRequestTotal]);
 

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -42,9 +42,15 @@ const EMPTY_FILTER_ARRAY: never[] = [];
 export function useInboxAllReports(options?: {
   ignoreScope?: boolean;
   ignoreFilters?: boolean;
+  pullRequestsOnly?: boolean;
 }) {
   const ignoreScope = options?.ignoreScope ?? false;
   const ignoreFilters = options?.ignoreFilters ?? false;
+  // The Pull requests tab fetches a server-filtered list (reports that have a
+  // shipped PR) so its list body comes from the same source as its count — a PR
+  // sitting past the broad list's first page no longer renders an empty tab
+  // under a positive badge.
+  const pullRequestsOnly = options?.pullRequestsOnly ?? false;
   const scope = useInboxReviewerScopeStore((s) => s.scope);
   const searchQuery = useInboxSignalsFilterStore((s) =>
     ignoreFilters ? "" : s.searchQuery,
@@ -75,6 +81,7 @@ export function useInboxAllReports(options?: {
   const query = useInboxReportsInfinite(
     {
       status: INBOX_PIPELINE_STATUS_FILTER,
+      has_implementation_pr: pullRequestsOnly ? true : undefined,
       ordering: buildSignalReportListOrdering(sortField, sortDirection),
       source_product:
         sourceProductFilter.length > 0

--- a/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
+++ b/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
@@ -50,12 +50,20 @@ export function useReportOpenTracker(
   report: SignalReport,
   tab: InboxDetailTab,
 ): void {
-  // The Pull requests / Reports tabs render the scoped+filtered list; the Runs
-  // tab is project-wide. Mount only the query matching the originating tab so
-  // rank is relative to the rows the user actually saw (and so a non-run detail
-  // doesn't start the unused project-wide poll alongside the scoped one).
+  // Mount only the query matching the originating tab so rank is relative to the
+  // rows the user actually saw (and so a non-run detail doesn't start the unused
+  // project-wide poll alongside the scoped one):
+  //   - Runs tab is project-wide (ignoreScope/ignoreFilters).
+  //   - Pull requests tab renders the server-filtered PR-only list, so mirror
+  //     that here — otherwise a PR past the broad list's first page would get
+  //     rank -1 and a list_size from the broad list, not the rows shown.
+  //   - Reports tab renders the scoped+filtered broad list.
   const { scopedReports } = useInboxAllReports(
-    tab === "runs" ? { ignoreScope: true, ignoreFilters: true } : undefined,
+    tab === "runs"
+      ? { ignoreScope: true, ignoreFilters: true }
+      : tab === "pulls"
+        ? { pullRequestsOnly: true }
+        : undefined,
   );
   const visible = inboxDetailTabReports(tab, scopedReports);
 

--- a/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
@@ -1,12 +1,7 @@
-import {
-  INBOX_PIPELINE_STATUS_FILTER,
-  INBOX_REFETCH_INTERVAL_MS,
-  isReportUpForReview,
-} from "@posthog/core/inbox/reportFiltering";
 import { HOME_TAB_FLAG } from "@posthog/shared/constants";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
-import { useInboxReports } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import {
@@ -24,7 +19,6 @@ import {
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { useCommandMenuStore } from "@posthog/ui/shell/commandMenuStore";
-import { useRendererWindowFocusStore } from "@posthog/ui/shell/rendererWindowFocusStore";
 import { Box, Flex } from "@radix-ui/themes";
 import { useRouterState } from "@tanstack/react-router";
 import { AgentsItem } from "./items/AgentsItem";
@@ -87,17 +81,12 @@ export function SidebarNavSection({
   const isSkillsActive = view.type === "skills";
   const isMcpServersActive = view.type === "mcp-servers";
 
-  const inboxPollingActive = useRendererWindowFocusStore((s) => s.focused);
-  const { data: inboxProbe } = useInboxReports(
-    { status: INBOX_PIPELINE_STATUS_FILTER },
-    {
-      refetchInterval: inboxPollingActive ? INBOX_REFETCH_INTERVAL_MS : false,
-      refetchIntervalInBackground: false,
-      staleTime: inboxPollingActive ? INBOX_REFETCH_INTERVAL_MS : 15_000,
-    },
-  );
-  const inboxResults = inboxProbe?.results ?? [];
-  const inboxSignalCount = inboxResults.filter(isReportUpForReview).length;
+  // Open pull requests in the inbox — the main CTA, and the same count the inbox
+  // Pull requests tab shows, so the badge and the tab always agree.
+  // `ignoreFilters` keeps the badge stable against the inbox's filter chrome;
+  // scope still follows the user's For-you / project choice.
+  const { counts: inboxCounts } = useInboxAllReports({ ignoreFilters: true });
+  const inboxPullRequestCount = inboxCounts.pulls;
 
   // Only subscribe to the task list when a parent hasn't already supplied the
   // count — keeps the standalone (Channels) render self-contained without
@@ -140,7 +129,7 @@ export function SidebarNavSection({
         <InboxItem
           isActive={isInboxActive}
           onClick={navigateToInbox}
-          signalCount={inboxSignalCount}
+          pullRequestCount={inboxPullRequestCount}
         />
       </Box>
 

--- a/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
@@ -9,20 +9,20 @@ import { SidebarKbdHint } from "./SidebarKbdHint";
 interface InboxItemProps {
   isActive: boolean;
   onClick: () => void;
-  signalCount?: number;
+  pullRequestCount?: number;
 }
 
 export function InboxItem({
   isActive,
   onClick,
-  signalCount = 0,
+  pullRequestCount = 0,
 }: InboxItemProps) {
   return (
     <Tooltip
       content={
-        signalCount > 0
-          ? `${signalCount} actionable report${signalCount === 1 ? "" : "s"} assigned to you`
-          : "No actionable reports assigned to you yet"
+        pullRequestCount > 0
+          ? `${pullRequestCount} pull request${pullRequestCount === 1 ? "" : "s"} to review`
+          : "No pull requests to review"
       }
       side="right"
     >
@@ -36,8 +36,8 @@ export function InboxItem({
             <>
               Inbox
               <SidebarCountBadge
-                count={signalCount}
-                title={`${signalCount} actionable reports for you`}
+                count={pullRequestCount}
+                title={`${pullRequestCount} pull requests to review`}
               />
             </>
           }


### PR DESCRIPTION
## Problem

The inbox tab counts (Pull requests / Reports / Runs) and the sidebar "Inbox" badge were all derived from only the **loaded page** of reports (100/page). With many reports this produced wrong, confusing numbers:

- The **Reports** tab capped at a misleading `100` regardless of the real total.
- The sidebar badge and the **Pull requests** tab disagreed (e.g. badge `1`, tab `15`) because each sampled a different ordering of the first 100 — a PR can sit past page 1.
- Empty tabs/sections showed a pointless `0`.

## Changes

<img width="1572" height="770" alt="image" src="https://github.com/user-attachments/assets/706e03d1-8d1d-4ffe-9ebc-f48b508ddcb6" />


- **Hide a count when it's 0** — tabs, Runs sections, and Home sections no longer render a bare `0`.
- **Reports tab → true total** — uses the backend's total `count` (minus loaded non-report items) instead of the page-capped loaded count.
- **Pull-requests count → true total** — a cheap `limit=1` count query using the new server-side `has_implementation_pr` filter returns the real PR total regardless of page size or ordering. Drives both the Pull requests tab and the sidebar badge.
- **Sidebar Inbox badge** now reflects the **Pull requests** count (the main CTA) and reads the *same computed count* as the tab, so the two can't drift apart. (Badge hides at 0, so it only appears when there are PRs to review.)
- Removed the now-unused `isReportUpForReview` helper.

## Dependency

Requires the backend filter from **PostHog/posthog#64143** (`has_implementation_pr`) to be **deployed first**. Until then the count query's param is simply ignored by the old backend (it would return an unfiltered count), so this should merge after that ships.

## Testing

- `pnpm typecheck` (shared, api-client, core, ui) — clean.
- `pnpm biome lint` on all changed files — clean.
- `pnpm --filter @posthog/ui test` — 745 passing.