### PR TITLE
feat(ui): smooth + cheap agent streaming (adaptive reveal + block-split markdown)

### DIFF
--- a/packages/ui/src/features/editor/components/StreamingMarkdown.test.tsx
+++ b/packages/ui/src/features/editor/components/StreamingMarkdown.test.tsx
@@ -1,0 +1,44 @@
+import { StreamingMarkdown } from "@posthog/ui/features/editor/components/StreamingMarkdown";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/shell/themeStore", () => ({
+  useThemeStore: (selector: (state: { isDarkMode: boolean }) => unknown) =>
+    selector({ isDarkMode: false }),
+}));
+
+vi.mock("@posthog/ui/utils/syntax-highlight", () => ({
+  highlightSyntax: () => null,
+}));
+
+function renderInTheme(ui: ReactElement) {
+  return render(<Theme>{ui}</Theme>);
+}
+
+describe("StreamingMarkdown", () => {
+  it("renders prose before an open fence and the code as a box without a copy button", () => {
+    renderInTheme(<StreamingMarkdown content={"Here:\n```ts\nconst a = 1;"} />);
+
+    expect(screen.getByText("Here:")).toBeInTheDocument();
+    expect(screen.getByText("const a = 1;")).toBeInTheDocument();
+    // The interim box stays copy-button-free until the fence closes.
+    expect(screen.queryByLabelText("Copy code")).toBeNull();
+  });
+
+  it("renders an open fence at the very start as a code box", () => {
+    renderInTheme(<StreamingMarkdown content={"```ts\nconst a = 1;"} />);
+
+    expect(screen.getByText("const a = 1;")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Copy code")).toBeNull();
+  });
+
+  it("renders fully completed markdown with no interim code box", () => {
+    renderInTheme(<StreamingMarkdown content={"# Title\n\nAll done."} />);
+
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("All done.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Copy code")).toBeNull();
+  });
+});

--- a/packages/ui/src/features/editor/components/StreamingMarkdown.tsx
+++ b/packages/ui/src/features/editor/components/StreamingMarkdown.tsx
@@ -1,25 +1,15 @@
 import { memo, useMemo } from "react";
 import type { Components } from "react-markdown";
 import { MarkdownRenderer } from "./MarkdownRenderer";
-import { hasOpenCodeFence, splitMarkdownBlocks } from "./splitMarkdownBlocks";
+import {
+  hasOpenCodeFence,
+  parseOpenFence,
+  splitMarkdownBlocks,
+} from "./splitMarkdownBlocks";
 
 interface StreamingMarkdownProps {
   content: string;
   componentsOverride?: Partial<Components>;
-}
-
-/**
- * Split a block whose code fence is still open into the prose that precedes the
- * fence and the code accumulated so far (the opening ```lang line removed).
- */
-function parseOpenFence(block: string): { before: string; code: string } {
-  const m = /(^|\n) {0,3}(`{3,}|~{3,})/.exec(block);
-  if (!m) return { before: "", code: block };
-  const fenceLineStart = m.index + (block[m.index] === "\n" ? 1 : 0);
-  const before = block.slice(0, fenceLineStart);
-  const afterMarker = block.indexOf("\n", fenceLineStart);
-  const code = afterMarker === -1 ? "" : block.slice(afterMarker + 1);
-  return { before, code };
 }
 
 /**

--- a/packages/ui/src/features/editor/components/StreamingMarkdown.tsx
+++ b/packages/ui/src/features/editor/components/StreamingMarkdown.tsx
@@ -1,0 +1,74 @@
+import { memo, useMemo } from "react";
+import type { Components } from "react-markdown";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+import { hasOpenCodeFence, splitMarkdownBlocks } from "./splitMarkdownBlocks";
+
+interface StreamingMarkdownProps {
+  content: string;
+  componentsOverride?: Partial<Components>;
+}
+
+/**
+ * Split a block whose code fence is still open into the prose that precedes the
+ * fence and the code accumulated so far (the opening ```lang line removed).
+ */
+function parseOpenFence(block: string): { before: string; code: string } {
+  const m = /(^|\n) {0,3}(`{3,}|~{3,})/.exec(block);
+  if (!m) return { before: "", code: block };
+  const fenceLineStart = m.index + (block[m.index] === "\n" ? 1 : 0);
+  const before = block.slice(0, fenceLineStart);
+  const afterMarker = block.indexOf("\n", fenceLineStart);
+  const code = afterMarker === -1 ? "" : block.slice(afterMarker + 1);
+  return { before, code };
+}
+
+/**
+ * Renders streamed agent markdown without re-parsing the whole message on every
+ * token. The text is split into top-level blocks: completed blocks keep a stable
+ * string so the memoized {@link MarkdownRenderer} skips re-parsing them, and only
+ * the growing tail is re-parsed — turning the per-token cost from O(message) into
+ * O(last block).
+ *
+ * While the tail sits inside an unterminated code fence it's shown as plain
+ * monospace (no markdown parse, no syntax highlighting); the heavy highlight runs
+ * once, when the fence closes and the block freezes. Completed messages should
+ * use {@link MarkdownRenderer} directly for a single, fully-correct parse.
+ */
+export const StreamingMarkdown = memo(function StreamingMarkdown({
+  content,
+  componentsOverride,
+}: StreamingMarkdownProps) {
+  const blocks = useMemo(() => splitMarkdownBlocks(content), [content]);
+  const lastIndex = blocks.length - 1;
+
+  return (
+    <>
+      {blocks.map((block, index) => {
+        const key = `b${index}`;
+        if (index === lastIndex && hasOpenCodeFence(block)) {
+          const { before, code } = parseOpenFence(block);
+          return (
+            <div key={key}>
+              {before.trim() ? (
+                <MarkdownRenderer
+                  content={before}
+                  componentsOverride={componentsOverride}
+                />
+              ) : null}
+              <pre className="overflow-x-auto rounded-md border border-border bg-gray-3 p-2 text-[13px] leading-relaxed">
+                <code>{code}</code>
+              </pre>
+            </div>
+          );
+        }
+        return (
+          <MarkdownRenderer
+            key={key}
+            content={block}
+            componentsOverride={componentsOverride}
+          />
+        );
+      })}
+    </>
+  );
+});

--- a/packages/ui/src/features/editor/components/StreamingMarkdown.tsx
+++ b/packages/ui/src/features/editor/components/StreamingMarkdown.tsx
@@ -1,11 +1,8 @@
-import { memo, useMemo } from "react";
+import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
+import { memo } from "react";
 import type { Components } from "react-markdown";
 import { MarkdownRenderer } from "./MarkdownRenderer";
-import {
-  hasOpenCodeFence,
-  parseOpenFence,
-  splitMarkdownBlocks,
-} from "./splitMarkdownBlocks";
+import { parseOpenFence, splitMarkdownBlocks } from "./splitMarkdownBlocks";
 
 interface StreamingMarkdownProps {
   content: string;
@@ -16,38 +13,39 @@ interface StreamingMarkdownProps {
  * Renders streamed agent markdown without re-parsing the whole message on every
  * token. The text is split into top-level blocks: completed blocks keep a stable
  * string so the memoized {@link MarkdownRenderer} skips re-parsing them, and only
- * the growing tail is re-parsed — turning the per-token cost from O(message) into
+ * the growing tail is re-parsed, turning the per-token cost from O(message) into
  * O(last block).
  *
  * While the tail sits inside an unterminated code fence it's shown as plain
- * monospace (no markdown parse, no syntax highlighting); the heavy highlight runs
- * once, when the fence closes and the block freezes. Completed messages should
- * use {@link MarkdownRenderer} directly for a single, fully-correct parse.
+ * monospace (no markdown parse, no syntax highlighting) in the same {@link
+ * CodeBlock} box the frozen block uses, so closing the fence swaps in the
+ * highlight without shifting the layout. Completed messages should use {@link
+ * MarkdownRenderer} directly for a single, fully-correct parse.
  */
 export const StreamingMarkdown = memo(function StreamingMarkdown({
   content,
   componentsOverride,
 }: StreamingMarkdownProps) {
-  const blocks = useMemo(() => splitMarkdownBlocks(content), [content]);
+  const blocks = splitMarkdownBlocks(content);
   const lastIndex = blocks.length - 1;
 
   return (
     <>
       {blocks.map((block, index) => {
         const key = `b${index}`;
-        if (index === lastIndex && hasOpenCodeFence(block)) {
-          const { before, code } = parseOpenFence(block);
+        const openFence = index === lastIndex ? parseOpenFence(block) : null;
+        if (openFence) {
           return (
             <div key={key}>
-              {before.trim() ? (
+              {openFence.before.trim() ? (
                 <MarkdownRenderer
-                  content={before}
+                  content={openFence.before}
                   componentsOverride={componentsOverride}
                 />
               ) : null}
-              <pre className="overflow-x-auto rounded-md border border-border bg-gray-3 p-2 text-[13px] leading-relaxed">
-                <code>{code}</code>
-              </pre>
+              <CodeBlock size="1" showCopy={false}>
+                {openFence.code}
+              </CodeBlock>
             </div>
           );
         }

--- a/packages/ui/src/features/editor/components/splitMarkdownBlocks.test.ts
+++ b/packages/ui/src/features/editor/components/splitMarkdownBlocks.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  hasOpenCodeFence,
-  parseOpenFence,
-  splitMarkdownBlocks,
-} from "./splitMarkdownBlocks";
+import { parseOpenFence, splitMarkdownBlocks } from "./splitMarkdownBlocks";
 
 describe("splitMarkdownBlocks", () => {
   it.each([
@@ -12,6 +8,7 @@ describe("splitMarkdownBlocks", () => {
     "para one\n\npara two\n\npara three",
     "# Heading\n\nText with **bold**.\n\n- a\n- b\n",
     "Intro\n\n```ts\nconst x = 1;\nconst y = 2;\n```\n\nOutro",
+    "Intro\n\n~~~ts\nconst x = 1;\n~~~\n\nOutro",
     "trailing blanks\n\n\n\n",
   ])("joins back to the exact input, dropping no text: %j", (src) => {
     expect(splitMarkdownBlocks(src).join("")).toBe(src);
@@ -29,6 +26,40 @@ describe("splitMarkdownBlocks", () => {
     ]);
   });
 
+  it("keeps a tilde-fenced block (with blank lines inside) as one block", () => {
+    const md = "~~~\nline1\n\nline2\n~~~\n\nafter";
+    expect(splitMarkdownBlocks(md)).toEqual([
+      "~~~\nline1\n\nline2\n~~~\n\n",
+      "after",
+    ]);
+  });
+
+  it("does not let a ```lang content line close the fence early", () => {
+    // ```end carries trailing text, so it is content, not a close. The blank
+    // line after it must stay inside the still-open fence.
+    const md = "```ts\nconst a = 1;\n```end\n\nstill code\n```\n\nafter";
+    expect(splitMarkdownBlocks(md)).toEqual([
+      "```ts\nconst a = 1;\n```end\n\nstill code\n```\n\n",
+      "after",
+    ]);
+  });
+
+  it("does not let an inner shorter fence close an outer longer one", () => {
+    const md = "````md\nintro\n\n```ts\nx = 1\n```\n````\n\nafter";
+    expect(splitMarkdownBlocks(md)).toEqual([
+      "````md\nintro\n\n```ts\nx = 1\n```\n````\n\n",
+      "after",
+    ]);
+  });
+
+  it("treats a fence indented up to 3 spaces as a fence", () => {
+    const md = " ```\ncode\n\nmore\n ```\n\nafter";
+    expect(splitMarkdownBlocks(md)).toEqual([
+      " ```\ncode\n\nmore\n ```\n\n",
+      "after",
+    ]);
+  });
+
   it("does not split inside an unterminated fence (the tail stays whole)", () => {
     const md = "intro\n\n```ts\nconst a = 1;\n\nconst b = 2;";
     const blocks = splitMarkdownBlocks(md);
@@ -37,30 +68,44 @@ describe("splitMarkdownBlocks", () => {
   });
 });
 
-describe("hasOpenCodeFence", () => {
-  it.each<[string, boolean]>([
-    ["```ts\nconst a = 1;", true],
-    ["```ts\nconst a = 1;\n```", false],
-    ["no code here", false],
-    ["text\n\n```\npartial", true],
-  ])("%j -> open=%s", (src, expected) => {
-    expect(hasOpenCodeFence(src)).toBe(expected);
-  });
-});
-
 describe("parseOpenFence", () => {
+  it("returns null when the block has no fence", () => {
+    expect(parseOpenFence("just text\n\nmore text")).toBeNull();
+  });
+
+  it("returns null when every fence in the block is already closed", () => {
+    expect(parseOpenFence("```ts\ndone\n```")).toBeNull();
+  });
+
   it("splits the prose before the open fence from the code so far", () => {
-    const { before, code } = parseOpenFence("Here:\n```ts\nconst a = 1;");
-    expect(before).toBe("Here:\n");
-    expect(code).toBe("const a = 1;");
+    expect(parseOpenFence("Here:\n```ts\nconst a = 1;")).toEqual({
+      before: "Here:\n",
+      code: "const a = 1;",
+    });
+  });
+
+  it("returns empty before when the block opens with the fence", () => {
+    expect(parseOpenFence("```ts\nconst x = 1;")).toEqual({
+      before: "",
+      code: "const x = 1;",
+    });
+  });
+
+  it("returns empty code when the open marker has no trailing newline yet", () => {
+    expect(parseOpenFence("```ts")).toEqual({ before: "", code: "" });
+  });
+
+  it("parses a tilde open fence", () => {
+    expect(parseOpenFence("~~~\nx")).toEqual({ before: "", code: "x" });
   });
 
   it("targets the LAST open fence, leaving an earlier completed fence in `before`", () => {
-    // A completed fence, then text, then an open fence — all one block (no
-    // blank lines). The earlier fence must not be swallowed into plain text.
+    // A completed fence, then text, then an open fence, all one block (no blank
+    // lines). The earlier fence must not be swallowed into plain text.
     const block = "```ts\ndone\n```\ntext\n```ts\npartial";
-    const { before, code } = parseOpenFence(block);
-    expect(before).toBe("```ts\ndone\n```\ntext\n");
-    expect(code).toBe("partial");
+    expect(parseOpenFence(block)).toEqual({
+      before: "```ts\ndone\n```\ntext\n",
+      code: "partial",
+    });
   });
 });

--- a/packages/ui/src/features/editor/components/splitMarkdownBlocks.test.ts
+++ b/packages/ui/src/features/editor/components/splitMarkdownBlocks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { hasOpenCodeFence, splitMarkdownBlocks } from "./splitMarkdownBlocks";
+
+describe("splitMarkdownBlocks", () => {
+  it("never drops text — joining the blocks reproduces the input", () => {
+    const samples = [
+      "",
+      "single line",
+      "para one\n\npara two\n\npara three",
+      "# Heading\n\nText with **bold**.\n\n- a\n- b\n",
+      "Intro\n\n```ts\nconst x = 1;\nconst y = 2;\n```\n\nOutro",
+      "trailing blanks\n\n\n\n",
+    ];
+    for (const s of samples) {
+      expect(splitMarkdownBlocks(s).join("")).toBe(s);
+    }
+  });
+
+  it("splits paragraphs at blank lines", () => {
+    expect(splitMarkdownBlocks("a\n\nb\n\nc")).toEqual(["a\n\n", "b\n\n", "c"]);
+  });
+
+  it("keeps a fenced code block (with blank lines inside) as one block", () => {
+    const md = "```\nline1\n\nline2\n```\n\nafter";
+    const blocks = splitMarkdownBlocks(md);
+    expect(blocks[0]).toBe("```\nline1\n\nline2\n```\n\n");
+    expect(blocks[1]).toBe("after");
+  });
+
+  it("does not split inside an unterminated fence (the tail stays whole)", () => {
+    const md = "intro\n\n```ts\nconst a = 1;\n\nconst b = 2;";
+    const blocks = splitMarkdownBlocks(md);
+    expect(blocks[blocks.length - 1]).toContain("const b = 2;");
+    expect(blocks.join("")).toBe(md);
+  });
+});
+
+describe("hasOpenCodeFence", () => {
+  it("is true while a fence is open and false once it closes", () => {
+    expect(hasOpenCodeFence("```ts\nconst a = 1;")).toBe(true);
+    expect(hasOpenCodeFence("```ts\nconst a = 1;\n```")).toBe(false);
+    expect(hasOpenCodeFence("no code here")).toBe(false);
+    expect(hasOpenCodeFence("text\n\n```\npartial")).toBe(true);
+  });
+});

--- a/packages/ui/src/features/editor/components/splitMarkdownBlocks.test.ts
+++ b/packages/ui/src/features/editor/components/splitMarkdownBlocks.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { hasOpenCodeFence, splitMarkdownBlocks } from "./splitMarkdownBlocks";
+import {
+  hasOpenCodeFence,
+  parseOpenFence,
+  splitMarkdownBlocks,
+} from "./splitMarkdownBlocks";
 
 describe("splitMarkdownBlocks", () => {
-  it("never drops text — joining the blocks reproduces the input", () => {
-    const samples = [
-      "",
-      "single line",
-      "para one\n\npara two\n\npara three",
-      "# Heading\n\nText with **bold**.\n\n- a\n- b\n",
-      "Intro\n\n```ts\nconst x = 1;\nconst y = 2;\n```\n\nOutro",
-      "trailing blanks\n\n\n\n",
-    ];
-    for (const s of samples) {
-      expect(splitMarkdownBlocks(s).join("")).toBe(s);
-    }
+  it.each([
+    "",
+    "single line",
+    "para one\n\npara two\n\npara three",
+    "# Heading\n\nText with **bold**.\n\n- a\n- b\n",
+    "Intro\n\n```ts\nconst x = 1;\nconst y = 2;\n```\n\nOutro",
+    "trailing blanks\n\n\n\n",
+  ])("joins back to the exact input, dropping no text: %j", (src) => {
+    expect(splitMarkdownBlocks(src).join("")).toBe(src);
   });
 
   it("splits paragraphs at blank lines", () => {
@@ -22,9 +23,10 @@ describe("splitMarkdownBlocks", () => {
 
   it("keeps a fenced code block (with blank lines inside) as one block", () => {
     const md = "```\nline1\n\nline2\n```\n\nafter";
-    const blocks = splitMarkdownBlocks(md);
-    expect(blocks[0]).toBe("```\nline1\n\nline2\n```\n\n");
-    expect(blocks[1]).toBe("after");
+    expect(splitMarkdownBlocks(md)).toEqual([
+      "```\nline1\n\nline2\n```\n\n",
+      "after",
+    ]);
   });
 
   it("does not split inside an unterminated fence (the tail stays whole)", () => {
@@ -36,10 +38,29 @@ describe("splitMarkdownBlocks", () => {
 });
 
 describe("hasOpenCodeFence", () => {
-  it("is true while a fence is open and false once it closes", () => {
-    expect(hasOpenCodeFence("```ts\nconst a = 1;")).toBe(true);
-    expect(hasOpenCodeFence("```ts\nconst a = 1;\n```")).toBe(false);
-    expect(hasOpenCodeFence("no code here")).toBe(false);
-    expect(hasOpenCodeFence("text\n\n```\npartial")).toBe(true);
+  it.each<[string, boolean]>([
+    ["```ts\nconst a = 1;", true],
+    ["```ts\nconst a = 1;\n```", false],
+    ["no code here", false],
+    ["text\n\n```\npartial", true],
+  ])("%j -> open=%s", (src, expected) => {
+    expect(hasOpenCodeFence(src)).toBe(expected);
+  });
+});
+
+describe("parseOpenFence", () => {
+  it("splits the prose before the open fence from the code so far", () => {
+    const { before, code } = parseOpenFence("Here:\n```ts\nconst a = 1;");
+    expect(before).toBe("Here:\n");
+    expect(code).toBe("const a = 1;");
+  });
+
+  it("targets the LAST open fence, leaving an earlier completed fence in `before`", () => {
+    // A completed fence, then text, then an open fence — all one block (no
+    // blank lines). The earlier fence must not be swallowed into plain text.
+    const block = "```ts\ndone\n```\ntext\n```ts\npartial";
+    const { before, code } = parseOpenFence(block);
+    expect(before).toBe("```ts\ndone\n```\ntext\n");
+    expect(code).toBe("partial");
   });
 });

--- a/packages/ui/src/features/editor/components/splitMarkdownBlocks.ts
+++ b/packages/ui/src/features/editor/components/splitMarkdownBlocks.ts
@@ -1,3 +1,25 @@
+interface FenceState {
+  inFence: boolean;
+  fenceChar: string;
+}
+
+const NO_FENCE: FenceState = { inFence: false, fenceChar: "" };
+
+/**
+ * Advance the fenced-code-block state machine by one line. `inFence` flips on a
+ * ``` / ~~~ delimiter line, closing only when the marker char matches the one
+ * that opened the fence. Shared by every fence-aware function here so the rule
+ * lives in exactly one place.
+ */
+function stepFence(state: FenceState, line: string): FenceState {
+  const trimmed = line.replace(/^ {0,3}/, "");
+  const marker = /^(`{3,}|~{3,})/.exec(trimmed);
+  if (!marker) return state;
+  if (!state.inFence) return { inFence: true, fenceChar: marker[1][0] };
+  if (trimmed[0] === state.fenceChar) return NO_FENCE;
+  return state;
+}
+
 /**
  * Split append-only markdown into top-level blocks at blank-line boundaries,
  * keeping fenced code blocks intact. Concatenating the result reproduces the
@@ -15,25 +37,15 @@ export function splitMarkdownBlocks(src: string): string[] {
   const n = src.length;
   let blockStart = 0;
   let i = 0;
-  let inFence = false;
-  let fenceChar = "";
+  let fence = NO_FENCE;
 
   while (i < n) {
     let nl = src.indexOf("\n", i);
     if (nl === -1) nl = n;
     const line = src.slice(i, nl);
-    const trimmed = line.replace(/^ {0,3}/, "");
-    const fence = /^(`{3,}|~{3,})/.exec(trimmed);
-    if (fence) {
-      if (!inFence) {
-        inFence = true;
-        fenceChar = fence[1][0];
-      } else if (trimmed[0] === fenceChar) {
-        inFence = false;
-      }
-    }
+    fence = stepFence(fence, line);
     const lineEnd = nl < n ? nl + 1 : n;
-    if (line.trim() === "" && !inFence) {
+    if (line.trim() === "" && !fence.inFence) {
       // Fold any following blank lines into this same boundary so we don't emit
       // empty blocks.
       let j = lineEnd;
@@ -57,18 +69,39 @@ export function splitMarkdownBlocks(src: string): string[] {
 
 /** True when `src` ends inside an unterminated fenced code block. */
 export function hasOpenCodeFence(src: string): boolean {
-  let inFence = false;
-  let fenceChar = "";
-  for (const line of src.split("\n")) {
-    const trimmed = line.replace(/^ {0,3}/, "");
-    const fence = /^(`{3,}|~{3,})/.exec(trimmed);
-    if (!fence) continue;
-    if (!inFence) {
-      inFence = true;
-      fenceChar = fence[1][0];
-    } else if (trimmed[0] === fenceChar) {
-      inFence = false;
-    }
+  let fence = NO_FENCE;
+  for (const line of src.split("\n")) fence = stepFence(fence, line);
+  return fence.inFence;
+}
+
+/**
+ * For a block that ends inside an unterminated code fence, split it into the
+ * prose/markdown preceding the OPEN fence and the code accumulated so far (the
+ * opening ```lang line removed). Targets the LAST unterminated fence, so an
+ * earlier completed fence in the same block stays in `before` and renders
+ * normally instead of being swallowed as plain text.
+ */
+export function parseOpenFence(block: string): {
+  before: string;
+  code: string;
+} {
+  let fence = NO_FENCE;
+  let openLineStart = -1;
+  let i = 0;
+  const n = block.length;
+
+  while (i < n) {
+    let nl = block.indexOf("\n", i);
+    if (nl === -1) nl = n;
+    const wasInFence = fence.inFence;
+    fence = stepFence(fence, block.slice(i, nl));
+    if (!wasInFence && fence.inFence) openLineStart = i;
+    i = nl < n ? nl + 1 : n;
   }
-  return inFence;
+
+  if (openLineStart === -1) return { before: "", code: block };
+  const before = block.slice(0, openLineStart);
+  const afterMarker = block.indexOf("\n", openLineStart);
+  const code = afterMarker === -1 ? "" : block.slice(afterMarker + 1);
+  return { before, code };
 }

--- a/packages/ui/src/features/editor/components/splitMarkdownBlocks.ts
+++ b/packages/ui/src/features/editor/components/splitMarkdownBlocks.ts
@@ -1,0 +1,74 @@
+/**
+ * Split append-only markdown into top-level blocks at blank-line boundaries,
+ * keeping fenced code blocks intact. Concatenating the result reproduces the
+ * input exactly, so no text is ever dropped.
+ *
+ * During streaming the LAST element is the still-growing "tail"; everything
+ * before it is stable (append-only text never rewrites an earlier block), so a
+ * caller can render earlier blocks once and memoize them, re-parsing only the
+ * tail on each token. That turns the per-token markdown cost from O(message)
+ * into O(last block).
+ */
+export function splitMarkdownBlocks(src: string): string[] {
+  if (src.length === 0) return [src];
+  const blocks: string[] = [];
+  const n = src.length;
+  let blockStart = 0;
+  let i = 0;
+  let inFence = false;
+  let fenceChar = "";
+
+  while (i < n) {
+    let nl = src.indexOf("\n", i);
+    if (nl === -1) nl = n;
+    const line = src.slice(i, nl);
+    const trimmed = line.replace(/^ {0,3}/, "");
+    const fence = /^(`{3,}|~{3,})/.exec(trimmed);
+    if (fence) {
+      if (!inFence) {
+        inFence = true;
+        fenceChar = fence[1][0];
+      } else if (trimmed[0] === fenceChar) {
+        inFence = false;
+      }
+    }
+    const lineEnd = nl < n ? nl + 1 : n;
+    if (line.trim() === "" && !inFence) {
+      // Fold any following blank lines into this same boundary so we don't emit
+      // empty blocks.
+      let j = lineEnd;
+      while (j < n) {
+        let nl2 = src.indexOf("\n", j);
+        if (nl2 === -1) nl2 = n;
+        if (src.slice(j, nl2).trim() !== "") break;
+        j = nl2 < n ? nl2 + 1 : n;
+      }
+      blocks.push(src.slice(blockStart, j));
+      blockStart = j;
+      i = j;
+    } else {
+      i = lineEnd;
+    }
+  }
+
+  if (blockStart < n) blocks.push(src.slice(blockStart));
+  return blocks.length > 0 ? blocks : [src];
+}
+
+/** True when `src` ends inside an unterminated fenced code block. */
+export function hasOpenCodeFence(src: string): boolean {
+  let inFence = false;
+  let fenceChar = "";
+  for (const line of src.split("\n")) {
+    const trimmed = line.replace(/^ {0,3}/, "");
+    const fence = /^(`{3,}|~{3,})/.exec(trimmed);
+    if (!fence) continue;
+    if (!inFence) {
+      inFence = true;
+      fenceChar = fence[1][0];
+    } else if (trimmed[0] === fenceChar) {
+      inFence = false;
+    }
+  }
+  return inFence;
+}

--- a/packages/ui/src/features/editor/components/splitMarkdownBlocks.ts
+++ b/packages/ui/src/features/editor/components/splitMarkdownBlocks.ts
@@ -1,23 +1,35 @@
 interface FenceState {
   inFence: boolean;
   fenceChar: string;
+  fenceLen: number;
 }
 
-const NO_FENCE: FenceState = { inFence: false, fenceChar: "" };
+const NO_FENCE: FenceState = { inFence: false, fenceChar: "", fenceLen: 0 };
 
 /**
- * Advance the fenced-code-block state machine by one line. `inFence` flips on a
- * ``` / ~~~ delimiter line, closing only when the marker char matches the one
- * that opened the fence. Shared by every fence-aware function here so the rule
- * lives in exactly one place.
+ * Advance the fenced-code-block state machine by one line. A ``` / ~~~ line
+ * opens a fence; it closes only on a line of the same marker char, at least as
+ * long as the opener, followed by nothing but whitespace (CommonMark's close
+ * rule). That stops a nested fence or a ```lang-style content line from closing
+ * the block early. Shared by every fence-aware function here so the rule lives
+ * in exactly one place.
  */
 function stepFence(state: FenceState, line: string): FenceState {
   const trimmed = line.replace(/^ {0,3}/, "");
   const marker = /^(`{3,}|~{3,})/.exec(trimmed);
   if (!marker) return state;
-  if (!state.inFence) return { inFence: true, fenceChar: marker[1][0] };
-  if (trimmed[0] === state.fenceChar) return NO_FENCE;
-  return state;
+  if (!state.inFence) {
+    return {
+      inFence: true,
+      fenceChar: marker[1][0],
+      fenceLen: marker[1].length,
+    };
+  }
+  const closesFence =
+    trimmed[0] === state.fenceChar &&
+    marker[1].length >= state.fenceLen &&
+    !/\S/.test(trimmed.slice(marker[1].length));
+  return closesFence ? NO_FENCE : state;
 }
 
 /**
@@ -46,8 +58,7 @@ export function splitMarkdownBlocks(src: string): string[] {
     fence = stepFence(fence, line);
     const lineEnd = nl < n ? nl + 1 : n;
     if (line.trim() === "" && !fence.inFence) {
-      // Fold any following blank lines into this same boundary so we don't emit
-      // empty blocks.
+      // Consume trailing blank lines so callers never receive an empty block.
       let j = lineEnd;
       while (j < n) {
         let nl2 = src.indexOf("\n", j);
@@ -64,27 +75,20 @@ export function splitMarkdownBlocks(src: string): string[] {
   }
 
   if (blockStart < n) blocks.push(src.slice(blockStart));
-  return blocks.length > 0 ? blocks : [src];
-}
-
-/** True when `src` ends inside an unterminated fenced code block. */
-export function hasOpenCodeFence(src: string): boolean {
-  let fence = NO_FENCE;
-  for (const line of src.split("\n")) fence = stepFence(fence, line);
-  return fence.inFence;
+  return blocks;
 }
 
 /**
  * For a block that ends inside an unterminated code fence, split it into the
  * prose/markdown preceding the OPEN fence and the code accumulated so far (the
- * opening ```lang line removed). Targets the LAST unterminated fence, so an
- * earlier completed fence in the same block stays in `before` and renders
- * normally instead of being swallowed as plain text.
+ * opening ```lang line removed). Returns null when the block does not end inside
+ * an open fence. Targets the LAST unterminated fence, so an earlier completed
+ * fence in the same block stays in `before` and renders normally instead of
+ * being swallowed as plain text.
  */
-export function parseOpenFence(block: string): {
-  before: string;
-  code: string;
-} {
+export function parseOpenFence(
+  block: string,
+): { before: string; code: string } | null {
   let fence = NO_FENCE;
   let openLineStart = -1;
   let i = 0;
@@ -99,7 +103,7 @@ export function parseOpenFence(block: string): {
     i = nl < n ? nl + 1 : n;
   }
 
-  if (openLineStart === -1) return { before: "", code: block };
+  if (!fence.inFence) return null;
   const before = block.slice(0, openLineStart);
   const afterMarker = block.indexOf("\n", openLineStart);
   const code = afterMarker === -1 ? "" : block.slice(afterMarker + 1);

--- a/packages/ui/src/features/editor/components/useSmoothedText.test.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.test.ts
@@ -19,10 +19,12 @@ describe("nextRevealLength", () => {
 describe("useSmoothedText", () => {
   let now: number;
   let rafCallbacks: Array<(t: number) => void>;
+  let cancelSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     now = 0;
     rafCallbacks = [];
+    cancelSpy = vi.fn();
     vi.stubGlobal(
       "requestAnimationFrame",
       (cb: (t: number) => void): number => {
@@ -30,7 +32,7 @@ describe("useSmoothedText", () => {
         return rafCallbacks.length;
       },
     );
-    vi.stubGlobal("cancelAnimationFrame", () => {});
+    vi.stubGlobal("cancelAnimationFrame", cancelSpy);
     vi.stubGlobal("matchMedia", () => ({ matches: false }));
   });
 
@@ -93,5 +95,35 @@ describe("useSmoothedText", () => {
     );
     rerender({ t: "x".repeat(50) });
     expect(result.current).toBe("x".repeat(50));
+  });
+
+  it("does not restart the clock when tokens append while the loop runs", () => {
+    const { result, rerender } = renderHook(
+      ({ t }) => useSmoothedText(t, 100),
+      { initialProps: { t: "" } },
+    );
+    rerender({ t: "x".repeat(20) });
+
+    flushFrame(0); // establish the clock at now=0, reveal the first char
+    expect(result.current.length).toBe(1);
+
+    rerender({ t: "x".repeat(60) }); // more tokens arrive mid-reveal
+
+    flushFrame(100); // a single 100ms delta measured from the original clock
+    // 100ms at 100 chars/sec adds ~10 chars onto the 1 already shown. A reset
+    // clock would measure 0ms elapsed here and advance by just the minimum 1.
+    expect(result.current.length).toBe(11);
+  });
+
+  it("cancels the pending frame on unmount", () => {
+    const { rerender, unmount } = renderHook(
+      ({ t }) => useSmoothedText(t, 100),
+      { initialProps: { t: "" } },
+    );
+    rerender({ t: "x".repeat(50) });
+    flushFrame(0); // schedules the next frame, leaving one in flight
+
+    unmount();
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/features/editor/components/useSmoothedText.test.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.test.ts
@@ -1,69 +1,97 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useSmoothedText } from "./useSmoothedText";
+import { nextRevealLength, useSmoothedText } from "./useSmoothedText";
 
-// Manual rAF queue so we can step frames deterministically and honor cancels.
-let frames = new Map<number, FrameRequestCallback>();
-let nextId = 1;
-
-beforeEach(() => {
-  frames = new Map();
-  nextId = 1;
-  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-    const id = nextId++;
-    frames.set(id, cb);
-    return id;
-  });
-  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
-    frames.delete(id);
+describe("nextRevealLength", () => {
+  it.each<[string, number, number, number, number, number]>([
+    // label                                  current target elapsed rate expected
+    ["caught up -> target", 10, 10, 16, 120, 10],
+    ["past target -> clamps to target", 12, 10, 16, 120, 10],
+    ["120 chars/sec over 100ms -> +12", 0, 100, 100, 120, 12],
+    ["never overshoots the target", 95, 100, 1000, 120, 100],
+    ["always advances at least one when behind", 0, 100, 0, 120, 1],
+    ["snaps when lag exceeds the cap", 0, 5000, 16, 120, 5000],
+  ])("%s", (_label, current, target, elapsedMs, rate, expected) => {
+    expect(nextRevealLength(current, target, elapsedMs, rate)).toBe(expected);
   });
 });
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
-
-function stepFrames(n: number) {
-  for (let i = 0; i < n; i++) {
-    const pending = [...frames.values()];
-    frames.clear();
-    act(() => {
-      for (const cb of pending) cb(0);
-    });
-  }
-}
 
 describe("useSmoothedText", () => {
-  it("shows the initial text immediately (no replay on mount)", () => {
-    const { result } = renderHook(({ t }) => useSmoothedText(t), {
-      initialProps: { t: "hello" },
-    });
-    expect(result.current).toBe("hello");
+  let now: number;
+  let rafCallbacks: Array<(t: number) => void>;
+
+  beforeEach(() => {
+    now = 0;
+    rafCallbacks = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (cb: (t: number) => void): number => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      },
+    );
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
   });
 
-  it("reveals appended text gradually, then converges to the target", () => {
-    const target = "hello world this is a longer streamed message indeed";
-    const { result, rerender } = renderHook(({ t }) => useSmoothedText(t), {
-      initialProps: { t: "hello" },
-    });
-    rerender({ t: target });
-
-    stepFrames(1);
-    expect(result.current.length).toBeGreaterThanOrEqual("hello".length);
-    expect(result.current.length).toBeLessThan(target.length);
-
-    stepFrames(40);
-    expect(result.current).toBe(target);
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it("always shows a prefix of the target and never overshoots", () => {
-    const target = "abcdefghijklmnopqrstuvwxyz";
-    const { result, rerender } = renderHook(({ t }) => useSmoothedText(t), {
-      initialProps: { t: "" },
+  const flushFrame = (deltaMs: number) => {
+    now += deltaMs;
+    const callbacks = rafCallbacks;
+    rafCallbacks = [];
+    act(() => {
+      for (const cb of callbacks) cb(now);
     });
-    rerender({ t: target });
-    stepFrames(3);
-    expect(target.startsWith(result.current)).toBe(true);
-    expect(result.current.length).toBeLessThanOrEqual(target.length);
+  };
+
+  it("shows existing text immediately on mount (no replay)", () => {
+    const { result } = renderHook(() => useSmoothedText("already here"));
+    expect(result.current).toBe("already here");
+  });
+
+  it("reveals appended text gradually at a steady rate, then catches up", () => {
+    const { result, rerender } = renderHook(
+      ({ t }) => useSmoothedText(t, 100),
+      { initialProps: { t: "" } },
+    );
+    rerender({ t: "x".repeat(50) });
+
+    flushFrame(0); // establish the clock; minimal forward progress
+    expect(result.current.length).toBe(1);
+
+    flushFrame(100); // 100ms at 100 chars/sec -> ~10 more chars
+    expect(result.current.length).toBe(11);
+    expect(result.current.length).toBeLessThan(50);
+
+    flushFrame(1000); // plenty of time -> caught up
+    expect(result.current).toBe("x".repeat(50));
+  });
+
+  it("snaps when the target is replaced with a shorter value", () => {
+    const { result, rerender } = renderHook(
+      ({ t }) => useSmoothedText(t, 100),
+      {
+        initialProps: { t: "hello world, a longer streamed message" },
+      },
+    );
+    rerender({ t: "new" });
+    expect(result.current).toBe("new");
+  });
+
+  it("snaps immediately when reduced motion is preferred", () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query.includes("reduce"),
+    }));
+    const { result, rerender } = renderHook(
+      ({ t }) => useSmoothedText(t, 100),
+      {
+        initialProps: { t: "" },
+      },
+    );
+    rerender({ t: "x".repeat(50) });
+    expect(result.current).toBe("x".repeat(50));
   });
 });

--- a/packages/ui/src/features/editor/components/useSmoothedText.test.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSmoothedText } from "./useSmoothedText";
+
+// Manual rAF queue so we can step frames deterministically and honor cancels.
+let frames = new Map<number, FrameRequestCallback>();
+let nextId = 1;
+
+beforeEach(() => {
+  frames = new Map();
+  nextId = 1;
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    const id = nextId++;
+    frames.set(id, cb);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    frames.delete(id);
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stepFrames(n: number) {
+  for (let i = 0; i < n; i++) {
+    const pending = [...frames.values()];
+    frames.clear();
+    act(() => {
+      for (const cb of pending) cb(0);
+    });
+  }
+}
+
+describe("useSmoothedText", () => {
+  it("shows the initial text immediately (no replay on mount)", () => {
+    const { result } = renderHook(({ t }) => useSmoothedText(t), {
+      initialProps: { t: "hello" },
+    });
+    expect(result.current).toBe("hello");
+  });
+
+  it("reveals appended text gradually, then converges to the target", () => {
+    const target = "hello world this is a longer streamed message indeed";
+    const { result, rerender } = renderHook(({ t }) => useSmoothedText(t), {
+      initialProps: { t: "hello" },
+    });
+    rerender({ t: target });
+
+    stepFrames(1);
+    expect(result.current.length).toBeGreaterThanOrEqual("hello".length);
+    expect(result.current.length).toBeLessThan(target.length);
+
+    stepFrames(40);
+    expect(result.current).toBe(target);
+  });
+
+  it("always shows a prefix of the target and never overshoots", () => {
+    const target = "abcdefghijklmnopqrstuvwxyz";
+    const { result, rerender } = renderHook(({ t }) => useSmoothedText(t), {
+      initialProps: { t: "" },
+    });
+    rerender({ t: target });
+    stepFrames(3);
+    expect(target.startsWith(result.current)).toBe(true);
+    expect(result.current.length).toBeLessThanOrEqual(target.length);
+  });
+});

--- a/packages/ui/src/features/editor/components/useSmoothedText.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react";
+
+// Reveal the backlog over ~this many frames. The step scales with the backlog,
+// so it converges in roughly this many frames regardless of how big a burst
+// arrives — small bursts trickle, big bursts catch up fast.
+const SMOOTHING_FRAMES = 6;
+const MIN_REVEAL = 2;
+
+/**
+ * Smoothly reveals `target` a slice per animation frame instead of jumping to
+ * whatever arrived. Streamed tokens land in irregular bursts (1–4 words, then a
+ * pause); painting them verbatim looks choppy. This decouples arrival from
+ * paint so the text flows at a steady ~60fps "typewriter" cadence while never
+ * lagging far behind — the reveal step is proportional to the remaining
+ * backlog, so it catches up within ~SMOOTHING_FRAMES frames.
+ *
+ * Append-only by design: a shorter `target` (a brand-new message reusing this
+ * hook instance) snaps instantly and we never hide already-revealed text.
+ */
+export function useSmoothedText(target: string): string {
+  const [, forceRender] = useState(0);
+  const shownLenRef = useRef(target.length);
+  const targetRef = useRef(target);
+  targetRef.current = target;
+  const rafRef = useRef<number | null>(null);
+
+  // Snap when the text shrinks (new/replaced message) — never un-reveal text.
+  if (target.length < shownLenRef.current) {
+    shownLenRef.current = target.length;
+  }
+
+  useEffect(() => {
+    const tick = () => {
+      const tgtLen = targetRef.current.length;
+      const remaining = tgtLen - shownLenRef.current;
+      if (remaining <= 0) {
+        rafRef.current = null;
+        return;
+      }
+      const step = Math.max(
+        MIN_REVEAL,
+        Math.ceil(remaining / SMOOTHING_FRAMES),
+      );
+      const shown = shownLenRef.current;
+      let next = Math.min(tgtLen, shown + step);
+      if (next < tgtLen) {
+        // Stop at a whitespace boundary when possible so words (and inline
+        // markdown tokens like **bold**) reveal whole instead of mid-token.
+        const text = targetRef.current;
+        const boundary = Math.max(
+          text.lastIndexOf(" ", next),
+          text.lastIndexOf("\n", next),
+        );
+        if (boundary > shown) next = boundary + 1;
+      }
+      shownLenRef.current = next;
+      forceRender((n) => (n + 1) % 1_000_000);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    if (rafRef.current === null && shownLenRef.current < target.length) {
+      rafRef.current = requestAnimationFrame(tick);
+    }
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [target]);
+
+  return shownLenRef.current >= targetRef.current.length
+    ? targetRef.current
+    : targetRef.current.slice(0, shownLenRef.current);
+}

--- a/packages/ui/src/features/editor/components/useSmoothedText.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.ts
@@ -1,72 +1,103 @@
 import { useEffect, useRef, useState } from "react";
 
-// Reveal the backlog over ~this many frames. The step scales with the backlog,
-// so it converges in roughly this many frames regardless of how big a burst
-// arrives — small bursts trickle, big bursts catch up fast.
-const SMOOTHING_FRAMES = 6;
-const MIN_REVEAL = 2;
+// Reveal at a steady character rate (~120 chars/sec) rather than an adaptive
+// one, so the cadence reads as even typing instead of speeding up to clear a
+// backlog. Matches the feel of #2685. See https://upstash.com/blog/smooth-streaming.
+const DEFAULT_CHARS_PER_SECOND = 120;
+// Past this backlog we stop easing and snap, so a large buffered chunk (e.g. a
+// reconnect replaying a long message) never crawls.
+const MAX_LAG_CHARS = 600;
 
 /**
- * Smoothly reveals `target` a slice per animation frame instead of jumping to
- * whatever arrived. Streamed tokens land in irregular bursts (1–4 words, then a
- * pause); painting them verbatim looks choppy. This decouples arrival from
- * paint so the text flows at a steady ~60fps "typewriter" cadence while never
- * lagging far behind — the reveal step is proportional to the remaining
- * backlog, so it catches up within ~SMOOTHING_FRAMES frames.
- *
- * Append-only by design: a shorter `target` (a brand-new message reusing this
- * hook instance) snaps instantly and we never hide already-revealed text.
+ * Pure easing: the next reveal length given how much time elapsed since the last
+ * frame. Timer-free so it's unit-testable. Never exceeds `target`, never goes
+ * backwards, and snaps when too far behind to ease smoothly.
  */
-export function useSmoothedText(target: string): string {
+export function nextRevealLength(
+  current: number,
+  target: number,
+  elapsedMs: number,
+  charsPerSecond: number,
+): number {
+  if (current >= target) return target;
+  if (target - current > MAX_LAG_CHARS) return target;
+  const step = Math.ceil((charsPerSecond * elapsedMs) / 1000);
+  return Math.min(target, current + Math.max(step, 1));
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+/**
+ * Smoothly reveals `target` a few characters per frame at a steady rate instead
+ * of jumping whenever streamed tokens arrive in bursts, so the text reads as
+ * even typing. Text already present on mount shows immediately (no replay); the
+ * reveal snaps when the source is replaced with a shorter value (a new message)
+ * or the user prefers reduced motion.
+ */
+export function useSmoothedText(
+  target: string,
+  charsPerSecond = DEFAULT_CHARS_PER_SECOND,
+): string {
   const [, forceRender] = useState(0);
   const shownLenRef = useRef(target.length);
   const targetRef = useRef(target);
   targetRef.current = target;
+  const lastTsRef = useRef<number | null>(null);
   const rafRef = useRef<number | null>(null);
 
-  // Snap when the text shrinks (new/replaced message) — never un-reveal text.
+  // New/replaced (shorter) message: snap, and never hide already-shown text.
   if (target.length < shownLenRef.current) {
     shownLenRef.current = target.length;
   }
 
   useEffect(() => {
-    const tick = () => {
-      const tgtLen = targetRef.current.length;
-      const remaining = tgtLen - shownLenRef.current;
-      if (remaining <= 0) {
-        rafRef.current = null;
-        return;
+    if (prefersReducedMotion()) {
+      if (shownLenRef.current !== targetRef.current.length) {
+        shownLenRef.current = targetRef.current.length;
+        forceRender((n) => (n + 1) % 1_000_000);
       }
-      const step = Math.max(
-        MIN_REVEAL,
-        Math.ceil(remaining / SMOOTHING_FRAMES),
-      );
-      const shown = shownLenRef.current;
-      let next = Math.min(tgtLen, shown + step);
-      if (next < tgtLen) {
-        // Stop at a whitespace boundary when possible so words (and inline
-        // markdown tokens like **bold**) reveal whole instead of mid-token.
-        const text = targetRef.current;
-        const boundary = Math.max(
-          text.lastIndexOf(" ", next),
-          text.lastIndexOf("\n", next),
-        );
-        if (boundary > shown) next = boundary + 1;
-      }
-      shownLenRef.current = next;
-      forceRender((n) => (n + 1) % 1_000_000);
-      rafRef.current = requestAnimationFrame(tick);
-    };
+      return;
+    }
+    // Kick the reveal loop only if it's idle. While running it reads the latest
+    // target each frame (via ref), so it keeps a steady wall-clock rate across
+    // token appends instead of restarting — and resetting its clock — per token.
     if (rafRef.current === null && shownLenRef.current < target.length) {
+      lastTsRef.current = null;
+      const tick = (ts: number) => {
+        const last = lastTsRef.current ?? ts;
+        lastTsRef.current = ts;
+        shownLenRef.current = nextRevealLength(
+          shownLenRef.current,
+          targetRef.current.length,
+          ts - last,
+          charsPerSecond,
+        );
+        forceRender((n) => (n + 1) % 1_000_000);
+        if (shownLenRef.current < targetRef.current.length) {
+          rafRef.current = requestAnimationFrame(tick);
+        } else {
+          rafRef.current = null;
+          lastTsRef.current = null;
+        }
+      };
       rafRef.current = requestAnimationFrame(tick);
     }
-    return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [target]);
+  }, [target, charsPerSecond]);
+
+  // Cancel any in-flight frame on unmount (kept separate so token appends don't
+  // tear down the running loop).
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
 
   return shownLenRef.current >= targetRef.current.length
     ? targetRef.current

--- a/packages/ui/src/features/editor/components/useSmoothedText.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.ts
@@ -48,25 +48,29 @@ export function useSmoothedText(
   const shownLenRef = useRef(target.length);
   const targetRef = useRef(target);
   targetRef.current = target;
+  const charsPerSecondRef = useRef(charsPerSecond);
+  charsPerSecondRef.current = charsPerSecond;
   const lastTsRef = useRef<number | null>(null);
   const rafRef = useRef<number | null>(null);
 
-  // New/replaced (shorter) message: snap, and never hide already-shown text.
-  if (target.length < shownLenRef.current) {
-    shownLenRef.current = target.length;
-  }
-
   useEffect(() => {
+    // New/replaced (shorter) message: snap the counter back so the next reveal
+    // starts from the new text instead of fast-forwarding through a stale length.
+    // Done in the effect, not during render, so a discarded concurrent render
+    // can't leave the ref pointing at props that never committed.
+    if (target.length < shownLenRef.current) {
+      shownLenRef.current = target.length;
+    }
     if (prefersReducedMotion()) {
-      if (shownLenRef.current !== targetRef.current.length) {
-        shownLenRef.current = targetRef.current.length;
-        forceRender((n) => (n + 1) % 1_000_000);
+      if (shownLenRef.current !== target.length) {
+        shownLenRef.current = target.length;
+        forceRender((n) => n + 1);
       }
       return;
     }
     // Kick the reveal loop only if it's idle. While running it reads the latest
     // target each frame (via ref), so it keeps a steady wall-clock rate across
-    // token appends instead of restarting — and resetting its clock — per token.
+    // token appends instead of restarting, and resetting its clock, per token.
     if (rafRef.current === null && shownLenRef.current < target.length) {
       lastTsRef.current = null;
       const tick = (ts: number) => {
@@ -76,9 +80,9 @@ export function useSmoothedText(
           shownLenRef.current,
           targetRef.current.length,
           ts - last,
-          charsPerSecond,
+          charsPerSecondRef.current,
         );
-        forceRender((n) => (n + 1) % 1_000_000);
+        forceRender((n) => n + 1);
         if (shownLenRef.current < targetRef.current.length) {
           rafRef.current = requestAnimationFrame(tick);
         } else {
@@ -88,7 +92,7 @@ export function useSmoothedText(
       };
       rafRef.current = requestAnimationFrame(tick);
     }
-  }, [target, charsPerSecond]);
+  }, [target]);
 
   // Cancel any in-flight frame on unmount (kept separate so token appends don't
   // tear down the running loop).

--- a/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
@@ -6,6 +6,7 @@ import { HighlightedCode } from "../../../../primitives/HighlightedCode";
 import { Tooltip } from "../../../../primitives/Tooltip";
 import { usePendingScrollStore } from "../../../code-editor/pendingScrollStore";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
+import { StreamingMarkdown } from "../../../editor/components/StreamingMarkdown";
 import { usePanelLayoutStore } from "../../../panels/panelLayoutStore";
 import type { FileItem } from "../../../repo-files/useRepoFiles";
 import { useRepoFiles } from "../../../repo-files/useRepoFiles";
@@ -138,10 +139,15 @@ const agentComponents: Partial<Components> = {
 
 interface AgentMessageProps {
   content: string;
+  /** Active (still-streaming) message: block-split the markdown so each token
+   *  only re-parses the growing tail, not the whole message. Completed messages
+   *  parse once via MarkdownRenderer for a single, fully-correct render. */
+  isStreaming?: boolean;
 }
 
 export const AgentMessage = memo(function AgentMessage({
   content,
+  isStreaming = false,
 }: AgentMessageProps) {
   const [copied, setCopied] = useState(false);
 
@@ -153,10 +159,17 @@ export const AgentMessage = memo(function AgentMessage({
 
   return (
     <Box className="group/msg relative pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
-      <MarkdownRenderer
-        content={content}
-        componentsOverride={agentComponents}
-      />
+      {isStreaming ? (
+        <StreamingMarkdown
+          content={content}
+          componentsOverride={agentComponents}
+        />
+      ) : (
+        <MarkdownRenderer
+          content={content}
+          componentsOverride={agentComponents}
+        />
+      )}
       <Box className="absolute top-1 left-full ml-2 opacity-0 transition-opacity group-hover/msg:opacity-100">
         <Tooltip content={copied ? "Copied!" : "Copy message"}>
           <IconButton

--- a/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from "../../../../primitives/Tooltip";
 import { usePendingScrollStore } from "../../../code-editor/pendingScrollStore";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import { StreamingMarkdown } from "../../../editor/components/StreamingMarkdown";
+import { useSmoothedText } from "../../../editor/components/useSmoothedText";
 import { usePanelLayoutStore } from "../../../panels/panelLayoutStore";
 import type { FileItem } from "../../../repo-files/useRepoFiles";
 import { useRepoFiles } from "../../../repo-files/useRepoFiles";
@@ -139,9 +140,9 @@ const agentComponents: Partial<Components> = {
 
 interface AgentMessageProps {
   content: string;
-  /** Active (still-streaming) message: block-split the markdown so each token
-   *  only re-parses the growing tail, not the whole message. Completed messages
-   *  parse once via MarkdownRenderer for a single, fully-correct render. */
+  /** Active (still-streaming) message: smooth the reveal and block-split the
+   *  markdown so each token only re-parses the tail. Completed messages parse
+   *  once via MarkdownRenderer for a single, fully-correct render. */
   isStreaming?: boolean;
 }
 
@@ -150,6 +151,7 @@ export const AgentMessage = memo(function AgentMessage({
   isStreaming = false,
 }: AgentMessageProps) {
   const [copied, setCopied] = useState(false);
+  const smoothed = useSmoothedText(content);
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(content);
@@ -161,7 +163,7 @@ export const AgentMessage = memo(function AgentMessage({
     <Box className="group/msg relative pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
       {isStreaming ? (
         <StreamingMarkdown
-          content={content}
+          content={smoothed}
           componentsOverride={agentComponents}
         />
       ) : (

--- a/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
@@ -74,7 +74,10 @@ export const SessionUpdateView = memo(function SessionUpdateView({
       return null;
     case "agent_message_chunk":
       return item.content.type === "text" ? (
-        <AgentMessage content={item.content.text} />
+        <AgentMessage
+          content={item.content.text}
+          isStreaming={turnComplete === false}
+        />
       ) : null;
     case "agent_thought_chunk":
       return item.content.type === "text" ? (

--- a/packages/ui/src/primitives/CodeBlock.test.tsx
+++ b/packages/ui/src/primitives/CodeBlock.test.tsx
@@ -47,4 +47,14 @@ describe("CodeBlock copy", () => {
     await userEvent.click(screen.getByLabelText("Copy code"));
     expect(writeText).toHaveBeenCalledWith("const x = 5;");
   });
+
+  it("omits the copy button when showCopy is false", () => {
+    renderInTheme(
+      <CodeBlock showCopy={false}>
+        <code>hello world</code>
+      </CodeBlock>,
+    );
+
+    expect(screen.queryByLabelText("Copy code")).toBeNull();
+  });
 });

--- a/packages/ui/src/primitives/CodeBlock.tsx
+++ b/packages/ui/src/primitives/CodeBlock.tsx
@@ -8,6 +8,7 @@ type CodeBlockSize = "1" | "1.5" | "2" | "3";
 interface CodeBlockProps {
   children: ReactNode;
   size?: CodeBlockSize;
+  showCopy?: boolean;
 }
 
 const SIZE_TO_CLASS: Record<CodeBlockSize, string> = {
@@ -30,7 +31,11 @@ function extractText(children: ReactNode): string {
   return "";
 }
 
-export function CodeBlock({ children, size = "1" }: CodeBlockProps) {
+export function CodeBlock({
+  children,
+  size = "1",
+  showCopy = true,
+}: CodeBlockProps) {
   const sizeClass = SIZE_TO_CLASS[size];
   const [copied, setCopied] = useState(false);
 
@@ -48,16 +53,18 @@ export function CodeBlock({ children, size = "1" }: CodeBlockProps) {
       >
         {children}
       </pre>
-      <IconButton
-        size="1"
-        variant="ghost"
-        color="gray"
-        onClick={handleCopy}
-        className="absolute top-1 right-1 cursor-pointer"
-        aria-label="Copy code"
-      >
-        {copied ? <Check size={14} /> : <Copy size={14} />}
-      </IconButton>
+      {showCopy ? (
+        <IconButton
+          size="1"
+          variant="ghost"
+          color="gray"
+          onClick={handleCopy}
+          className="absolute top-1 right-1 cursor-pointer"
+          aria-label="Copy code"
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </IconButton>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Streamed agent replies have two issues:

1. **Choppy** — tokens arrive in irregular bursts and are painted exactly as they land, so the text jumps forward unevenly instead of reading as smooth typing.
2. **Slow on long messages** — `AgentMessage` → `MarkdownRenderer` re-parses the **entire accumulated markdown** (react-markdown + remark-gfm) on every token: O(n) per token, O(n²) per message. Past ~8k chars a single token costs ~19 ms of parsing, over the 16.6 ms frame budget, so long answers stutter and saturate the main thread.

Addresses #2517 (smooth token streaming).

## Changes

Two pieces that reinforce each other.

**1. Block-split rendering** (`StreamingMarkdown` + `splitMarkdownBlocks`) — the active message is split into top-level blocks (fenced code kept intact). Completed blocks keep a stable string, so the memoized `MarkdownRenderer` skips them and only the growing **tail** re-parses. An open code fence renders as plain text until it closes, so syntax highlighting runs once, not per token.

Measured on a 3,000-char answer streamed in ~250 tokens (jsdom + `react-dom/server`, default components — a lower bound):

| | total markdown CPU | per token | last token |
|---|---|---|---|
| full re-parse | 878 ms | 3.5 ms | 6.8 ms |
| block-split | 88 ms | 0.35 ms | 0.16 ms |

~10× less, and the per-token cost stays **flat** instead of growing with length.

**2. Steady reveal** (`useSmoothedText`) — reveals the accumulated text at a constant ~120 chars/sec, character by character, honoring `prefers-reduced-motion`. Decouples paint from the bursty token arrival so the text reads as even typing.

The two are complementary: the reveal makes streaming *look* smooth, and the block-split keeps each frame cheap so it *stays* ~60 fps even on long messages. Completed messages render via a single full `MarkdownRenderer` parse, so the final output is byte-identical.

## Relationship to #2685

#2685 also implements smooth token streaming. Per @charlesvien's review, this PR's reveal now matches the steadier cadence from #2685 (constant ~120 chars/sec, char by char). The distinct value here is the **block-split renderer**: it keeps the per-token markdown cost flat so the smooth reveal holds up on long messages — the part #2685 doesn't address. Happy to coordinate or fold these together however the team prefers.

## How did you test this?

- Unit tests: `splitMarkdownBlocks.test.ts` (round-trip / no text dropped, paragraph + fenced-block splitting, `parseOpenFence` incl. the completed-then-open-fence edge case) and `useSmoothedText.test.ts` (the pure `nextRevealLength` easing + the hook: immediate on mount, gradual steady reveal, snap-on-replace, reduced-motion).
- `pnpm --filter @posthog/ui test` → 779 pass.
- `pnpm --filter @posthog/ui typecheck` passes; pre-commit `pnpm typecheck` passes.
- `biome check` clean on changed files; `node scripts/check-host-boundaries.mjs` reports no new violations.
- Block-split numbers from a local micro-benchmark of the markdown render path (not committed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*