### PR TITLE
fix(sessions): advance generating verb on tool completion, not a timer

### DIFF
--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -115,6 +115,7 @@ export function ConversationView({
     items: conversationItems,
     lastTurnInfo,
     isCompacting,
+    completedToolCallCount,
   } = useConversationItems(events, isPromptPending, {
     showDebugLogs,
   });
@@ -348,6 +349,7 @@ export function ConversationView({
         pausedDurationMs={pausedDurationMs}
         isCompacting={isCompacting}
         usage={contextUsage}
+        completedToolCallCount={completedToolCallCount}
       />
     </div>
   );

--- a/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -159,14 +159,13 @@ export function GeneratingIndicator({
 
   // Advance the word only when a tool/MCP call finishes (activityKey changes),
   // not on an interval. The initial word stays put until the first call settles.
+  // Adjusted during render (React's blessed pattern for deriving state from a
+  // changed prop) rather than in an effect, so it never paints a stale word.
   const prevActivityKeyRef = useRef(activityKey);
-  useEffect(() => {
-    if (activityKey === undefined || activityKey === prevActivityKeyRef.current) {
-      return;
-    }
+  if (activityKey !== undefined && activityKey !== prevActivityKeyRef.current) {
     prevActivityKeyRef.current = activityKey;
     setActivity((current) => getNextThinkingMessage(current));
-  }, [activityKey]);
+  }
 
   return (
     <Flex

--- a/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -95,6 +95,18 @@ function getRandomThinkingMessage(): string {
   ];
 }
 
+/** Pick a new word that differs from the current one, so consecutive changes
+ *  always read as a change. */
+function getNextThinkingMessage(current: string): string {
+  if (THINKING_MESSAGES.length <= 1) return THINKING_MESSAGES[0];
+  let next = current;
+  while (next === current) {
+    next =
+      THINKING_MESSAGES[Math.floor(Math.random() * THINKING_MESSAGES.length)];
+  }
+  return next;
+}
+
 export function formatDuration(ms: number, fractionDigits = 2): string {
   const totalSeconds = Math.floor(ms / 1000);
   const mins = Math.floor(totalSeconds / 60);
@@ -119,11 +131,16 @@ interface GeneratingIndicatorProps {
   startedAt?: number | null;
   /** Accumulated time (ms) spent waiting for user input, subtracted from elapsed display. */
   pausedDurationMs?: number;
+  /** Monotonic counter of finished tool/MCP calls. The status word advances
+   *  each time this changes, so it tracks real work completing rather than a
+   *  timer — a stalled agent keeps the same word. */
+  activityKey?: number;
 }
 
 export function GeneratingIndicator({
   startedAt,
   pausedDurationMs,
+  activityKey,
 }: GeneratingIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
   const [activity, setActivity] = useState(getRandomThinkingMessage);
@@ -140,13 +157,16 @@ export function GeneratingIndicator({
     return () => clearInterval(interval);
   }, [startedAt]);
 
+  // Advance the word only when a tool/MCP call finishes (activityKey changes),
+  // not on an interval. The initial word stays put until the first call settles.
+  const prevActivityKeyRef = useRef(activityKey);
   useEffect(() => {
-    const interval = setInterval(() => {
-      setActivity(getRandomThinkingMessage());
-    }, 2000);
-
-    return () => clearInterval(interval);
-  }, []);
+    if (activityKey === undefined || activityKey === prevActivityKeyRef.current) {
+      return;
+    }
+    prevActivityKeyRef.current = activityKey;
+    setActivity((current) => getNextThinkingMessage(current));
+  }, [activityKey]);
 
   return (
     <Flex

--- a/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -20,6 +20,9 @@ interface SessionFooterProps {
   pausedDurationMs?: number;
   isCompacting?: boolean;
   usage?: ContextUsage | null;
+  /** Number of tool calls finished so far; the generating indicator advances
+   *  its status word each time this changes. */
+  completedToolCallCount?: number;
 }
 
 export function SessionFooter({
@@ -33,6 +36,7 @@ export function SessionFooter({
   pausedDurationMs,
   isCompacting = false,
   usage,
+  completedToolCallCount,
 }: SessionFooterProps) {
   const rightSide = (
     <Flex align="center" gap="3" className="ml-auto shrink-0">
@@ -69,6 +73,7 @@ export function SessionFooter({
             <GeneratingIndicator
               startedAt={promptStartedAt}
               pausedDurationMs={pausedDurationMs}
+              activityKey={completedToolCallCount}
             />
             {queuedCount > 0 && (
               <Text className="truncate text-[13px] text-muted-foreground">

--- a/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -477,6 +477,115 @@ describe("buildConversationItems", () => {
       ).toBe(false);
     });
   });
+
+  describe("completedToolCallCount", () => {
+    const toolCallMsg = (
+      ts: number,
+      toolCallId: string,
+      extra: Record<string, unknown> = {},
+    ): AcpMessage => ({
+      type: "acp_message",
+      ts,
+      message: {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId,
+            kind: "execute",
+            status: "pending",
+            title: toolCallId,
+            ...extra,
+          },
+        },
+      },
+    });
+
+    const toolUpdateMsg = (
+      ts: number,
+      toolCallId: string,
+      extra: Record<string, unknown>,
+    ): AcpMessage => ({
+      type: "acp_message",
+      ts,
+      message: {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          update: { sessionUpdate: "tool_call_update", toolCallId, ...extra },
+        },
+      },
+    });
+
+    it("starts at zero with no tool calls", () => {
+      const result = buildConversationItems([userPromptMsg(1, 1, "hi")], null);
+      expect(result.completedToolCallCount).toBe(0);
+    });
+
+    it("stays at zero while a tool call is still pending", () => {
+      const events = [userPromptMsg(1, 1, "go"), toolCallMsg(2, "t1")];
+      expect(buildConversationItems(events, true).completedToolCallCount).toBe(
+        0,
+      );
+    });
+
+    it("counts a tool call once it reaches a terminal status", () => {
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        toolCallMsg(2, "t1"),
+        toolUpdateMsg(3, "t1", { status: "completed" }),
+      ];
+      expect(buildConversationItems(events, true).completedToolCallCount).toBe(
+        1,
+      );
+    });
+
+    it("does not double-count repeated updates after settling", () => {
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        toolCallMsg(2, "t1"),
+        toolUpdateMsg(3, "t1", { status: "completed" }),
+        toolUpdateMsg(4, "t1", {
+          status: "completed",
+          content: [{ type: "content", content: { type: "text", text: "x" } }],
+        }),
+      ];
+      expect(buildConversationItems(events, true).completedToolCallCount).toBe(
+        1,
+      );
+    });
+
+    it("counts failed and cancelled as finished too", () => {
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        toolCallMsg(2, "t1"),
+        toolUpdateMsg(3, "t1", { status: "failed" }),
+        toolCallMsg(4, "t2"),
+        toolUpdateMsg(5, "t2", { status: "cancelled" }),
+      ];
+      expect(buildConversationItems(events, true).completedToolCallCount).toBe(
+        2,
+      );
+    });
+
+    it("accumulates across multiple completed tool calls and turns", () => {
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        toolCallMsg(2, "t1"),
+        toolUpdateMsg(3, "t1", { status: "completed" }),
+        toolCallMsg(4, "t2"),
+        toolUpdateMsg(5, "t2", { status: "completed" }),
+        promptResponseMsg(6, 1),
+        userPromptMsg(7, 2, "again"),
+        toolCallMsg(8, "t3"),
+        toolUpdateMsg(9, "t3", { status: "completed" }),
+      ];
+      expect(buildConversationItems(events, true).completedToolCallCount).toBe(
+        3,
+      );
+    });
+  });
 });
 
 // Local alias kept intentionally narrow to the shape we care about in tests.

--- a/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -530,16 +530,19 @@ describe("buildConversationItems", () => {
       );
     });
 
-    it("counts a tool call once it reaches a terminal status", () => {
-      const events = [
-        userPromptMsg(1, 1, "go"),
-        toolCallMsg(2, "t1"),
-        toolUpdateMsg(3, "t1", { status: "completed" }),
-      ];
-      expect(buildConversationItems(events, true).completedToolCallCount).toBe(
-        1,
-      );
-    });
+    it.each(["completed", "failed", "cancelled"])(
+      "counts a tool call once it settles to %s",
+      (status) => {
+        const events = [
+          userPromptMsg(1, 1, "go"),
+          toolCallMsg(2, "t1"),
+          toolUpdateMsg(3, "t1", { status }),
+        ];
+        expect(
+          buildConversationItems(events, true).completedToolCallCount,
+        ).toBe(1);
+      },
+    );
 
     it("does not double-count repeated updates after settling", () => {
       const events = [
@@ -553,19 +556,6 @@ describe("buildConversationItems", () => {
       ];
       expect(buildConversationItems(events, true).completedToolCallCount).toBe(
         1,
-      );
-    });
-
-    it("counts failed and cancelled as finished too", () => {
-      const events = [
-        userPromptMsg(1, 1, "go"),
-        toolCallMsg(2, "t1"),
-        toolUpdateMsg(3, "t1", { status: "failed" }),
-        toolCallMsg(4, "t2"),
-        toolUpdateMsg(5, "t2", { status: "cancelled" }),
-      ];
-      expect(buildConversationItems(events, true).completedToolCallCount).toBe(
-        2,
       );
     });
 

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -77,6 +77,9 @@ export interface BuildResult {
   items: ConversationItem[];
   lastTurnInfo: LastTurnInfo | null;
   isCompacting: boolean;
+  /** Number of tool calls settled into a terminal status so far. Monotonic
+   *  within a thread; consumers treat a change as "a tool/MCP call finished". */
+  completedToolCallCount: number;
 }
 
 interface ProgressCardState {
@@ -126,6 +129,11 @@ export interface ItemBuilder {
    *  reads it after to detect a card being mutated inside an already frozen
    *  (completed) turn, which would otherwise go unseen. */
   lowestTouchedProgressIndex: number;
+  /** Count of tool calls that have reached a terminal status (completed /
+   *  failed / cancelled). Increments once per tool call when it first settles.
+   *  Drives the generating indicator's status word so it advances on real work
+   *  finishing rather than on a timer. */
+  completedToolCallCount: number;
 }
 
 export function createItemBuilder(): ItemBuilder {
@@ -140,7 +148,14 @@ export function createItemBuilder(): ItemBuilder {
     nextId: () => idCounter++,
     progressCards: new Map(),
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
+    completedToolCallCount: 0,
   };
+}
+
+const TERMINAL_TOOL_STATUSES = new Set(["completed", "failed", "cancelled"]);
+
+function isTerminalToolStatus(status: string | null | undefined): boolean {
+  return status != null && TERMINAL_TOOL_STATUSES.has(status);
 }
 
 function isThoughtItem(
@@ -201,7 +216,12 @@ export function buildConversationItems(
 
   const lastTurnInfo = readLastTurnInfo(b);
 
-  return { items: b.items, lastTurnInfo, isCompacting: b.isCompacting };
+  return {
+    items: b.items,
+    lastTurnInfo,
+    isCompacting: b.isCompacting,
+    completedToolCallCount: b.completedToolCallCount,
+  };
 }
 
 /**
@@ -718,10 +738,17 @@ function processSessionUpdate(b: ItemBuilder, update: SessionUpdate) {
       if (!turn) break;
       const existing = turn.toolCalls.get(update.toolCallId);
       if (existing) {
+        const wasTerminal = isTerminalToolStatus(existing.status);
         Object.assign(existing, update);
+        if (!wasTerminal && isTerminalToolStatus(existing.status)) {
+          b.completedToolCallCount++;
+        }
       } else {
         const toolCall = { ...update };
         turn.toolCalls.set(update.toolCallId, toolCall);
+        if (isTerminalToolStatus(toolCall.status)) {
+          b.completedToolCallCount++;
+        }
         const parentId = getParentToolCallId(update);
         if (parentId) {
           pushChildItem(b, parentId, toolCall);
@@ -737,8 +764,12 @@ function processSessionUpdate(b: ItemBuilder, update: SessionUpdate) {
       if (!turn) break;
       const existing = turn.toolCalls.get(update.toolCallId);
       if (existing) {
+        const wasTerminal = isTerminalToolStatus(existing.status);
         const { sessionUpdate: _, ...rest } = update;
         Object.assign(existing, rest);
+        if (!wasTerminal && isTerminalToolStatus(existing.status)) {
+          b.completedToolCallCount++;
+        }
       }
       break;
     }

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
@@ -181,6 +181,7 @@ function normalize(result: BuildResult) {
     items: result.items.map(normItem),
     lastTurnInfo: result.lastTurnInfo,
     isCompacting: result.isCompacting,
+    completedToolCallCount: result.completedToolCallCount,
   };
 }
 

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
@@ -109,6 +109,7 @@ export function createIncrementalConversationBuilder() {
       items: assembleItems(builder, activeStart),
       lastTurnInfo: readLastTurnInfoForOutput(builder),
       isCompacting: builder.isCompacting,
+      completedToolCallCount: builder.completedToolCallCount,
     };
   }
 


### PR DESCRIPTION
## Problem

In a task run, the "generating" status word (the gerund — *Pondering…*, *Scanning…*, etc.) cycled on a fixed 2-second timer. It kept changing even when the agent was stuck, so the one signal you'd reach for to answer "is it still working or stalled?" was untrustworthy.

## Changes

The word now advances **only when a tool/MCP call finishes**, not on a timer.

- The conversation builder counts tool calls that settle into a terminal status (`completed` / `failed` / `cancelled`), counting each call once, and exposes `completedToolCallCount` on `BuildResult`.
- `GeneratingIndicator` swaps its word when that count changes (and never repeats the same word twice in a row). The 2s interval is gone.
- A stalled agent now keeps the same word; the pulsing brain icon and elapsing timer still show liveness.

Scope is the desktop/web app. Mobile's separate `ThinkingIndicator` is unchanged.

## How did you test this?

- Added unit tests for `completedToolCallCount` (pending stays 0, settles to 1 on completion, no double-count on repeat updates, counts failed/cancelled, accumulates across turns) and extended the incremental/full-rebuild equivalence check to cover the new field.
- `pnpm --filter @posthog/ui exec vitest run src/features/sessions` — 233 passed.
- `pnpm --filter @posthog/ui typecheck` — clean. Biome lint — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781649826606099?thread_ts=1781649826.606099&cid=C09G8Q32R6F)*
