### PR TITLE
fix(canvas): load dashboards with server-side filter instead of full FS scan

### DIFF
--- a/packages/core/src/canvas/dashboardsService.test.ts
+++ b/packages/core/src/canvas/dashboardsService.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DashboardQueryService } from "./dashboardQueryService";
+import { DashboardsService } from "./dashboardsService";
+import type { DesktopFsClient, FsEntryBase } from "./desktopFsClient";
+
+// A dashboard FS row carrying our payload under `meta`, as the backend returns it.
+function dashboardRow(
+  id: string,
+  name: string,
+  channelId: string,
+  updatedAt: number,
+): FsEntryBase & { meta: Record<string, unknown> } {
+  return {
+    id,
+    path: `Channels/${channelId}/${name}`,
+    type: "dashboard",
+    meta: { channelId, updatedAt, templateId: "dashboard", spec: null },
+  };
+}
+
+// A fake DesktopFsClient exposing only the two methods `list` touches:
+// getEntry (to resolve the channel folder path) and listByQuery (the filtered
+// fetch). listByQuery is declared with explicit params so spy calls carry args.
+function fakeFs(rows: FsEntryBase[]) {
+  const listByQuery = vi.fn(
+    async (_query: string, _errorLabel: string): Promise<FsEntryBase[]> => rows,
+  );
+  const fs = {
+    getEntry: async (id: string) => ({ id, path: `Channels/${id}` }),
+    listByQuery,
+  };
+  return { fs: fs as unknown as DesktopFsClient, listByQuery };
+}
+
+describe("DashboardsService.list", () => {
+  it("fetches with a parent-scoped, type-filtered query", async () => {
+    const { fs, listByQuery } = fakeFs([]);
+    const service = new DashboardsService(
+      fs,
+      {} as DashboardQueryService,
+      {} as never,
+    );
+
+    await service.list("chan-1");
+
+    expect(listByQuery).toHaveBeenCalledTimes(1);
+    const [query] = listByQuery.mock.calls[0];
+    expect(query).toContain("parent=");
+    expect(query).toContain(encodeURIComponent("Channels/chan-1"));
+    expect(query).toContain("type=dashboard");
+  });
+
+  it("maps rows to summaries sorted by updatedAt descending", async () => {
+    const { fs } = fakeFs([
+      dashboardRow("a", "Older", "chan-1", 100),
+      dashboardRow("b", "Newer", "chan-1", 300),
+      dashboardRow("c", "Middle", "chan-1", 200),
+    ]);
+    const service = new DashboardsService(
+      fs,
+      {} as DashboardQueryService,
+      {} as never,
+    );
+
+    const result = await service.list("chan-1");
+
+    expect(result.map((d) => d.id)).toEqual(["b", "c", "a"]);
+    expect(result[0]).toMatchObject({ name: "Newer", channelId: "chan-1" });
+  });
+});

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -87,20 +87,21 @@ export class DashboardsService {
     }
   }
 
-  private listAll(): Promise<FsEntry[]> {
-    return this.fs.listAll<FsEntry>("dashboards");
-  }
-
   private getEntry(id: string): Promise<FsEntry | null> {
     return this.fs.getEntry<FsEntry>(id, "dashboard");
   }
 
   async list(channelId: string): Promise<DashboardSummary[]> {
-    const entries = await this.listAll();
+    // Fetch only this channel's dashboards via a server-side filter
+    // (`parent=<channelPath>&type=dashboard`) rather than walking the whole
+    // project file system and filtering client-side. Dashboards are created as
+    // direct children of the channel folder, so the parent filter matches them.
+    const channelPath = await this.channelPath(channelId);
+    const entries = await this.fs.listByQuery<FsEntry>(
+      `parent=${encodeURIComponent(channelPath)}&type=${DASHBOARD_TYPE}`,
+      "dashboards",
+    );
     return entries
-      .filter(
-        (e) => e.type === DASHBOARD_TYPE && e.meta?.channelId === channelId,
-      )
       .map((e) => toRecord(e))
       .sort((a, b) => b.updatedAt - a.updatedAt)
       .map(

--- a/packages/core/src/canvas/desktopFsClient.ts
+++ b/packages/core/src/canvas/desktopFsClient.ts
@@ -50,9 +50,18 @@ export class DesktopFsClient {
     return (await res.json()) as T;
   }
 
-  async listAll<T extends FsEntryBase>(errorLabel: string): Promise<T[]> {
+  // List rows matching a server-side-filtered query (e.g.
+  // `parent=<path>&type=dashboard`), paging until exhausted. Filtering on the
+  // backend keeps this to the matching rows instead of walking the whole project
+  // file system — the desktop_file_system can hold thousands of rows (one `task`
+  // row per task), so an unfiltered scan is both slow and silently truncated by
+  // the page cap. Callers should always pass a `parent`/`type` filter.
+  async listByQuery<T extends FsEntryBase>(
+    query: string,
+    errorLabel: string,
+  ): Promise<T[]> {
     const all: T[] = [];
-    let suffix = "";
+    let suffix = `?${query}`;
     for (let i = 0; i < MAX_PAGES; i++) {
       const res = await this.fetch(suffix);
       if (!res.ok)

--- a/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
@@ -21,11 +21,12 @@ import {
   useDashboards,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useSeedShowcase } from "@posthog/ui/features/canvas/hooks/useSeedShowcase";
+import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { toast } from "@posthog/ui/primitives/toast";
 import { ErrorBoundary } from "@posthog/ui/shell/ErrorBoundary";
 import { Box, Flex, Grid, ScrollArea } from "@radix-ui/themes";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { memo, useState } from "react";
 
 // Render each dashboard's live spec at 1/SCALE of the card width, then shrink so
 // the full layout fits inside the fixed-height preview frame as a thumbnail.
@@ -76,7 +77,7 @@ export function WebsiteDashboardsIndex({ channelId }: { channelId: string }) {
   );
 }
 
-function DashboardCard({
+const DashboardCard = memo(function DashboardCard({
   channelId,
   summary,
 }: {
@@ -95,27 +96,7 @@ function DashboardCard({
         className="no-underline"
       >
         <Card className="gap-0 overflow-hidden p-0">
-          <Box className="relative h-44 overflow-hidden border-border border-b bg-muted">
-            {isNonEmptySpec(spec) ? (
-              <Box
-                className="pointer-events-none absolute top-0 left-0 origin-top-left"
-                style={{
-                  transform: `scale(${PREVIEW_SCALE})`,
-                  width: `${100 / PREVIEW_SCALE}%`,
-                }}
-              >
-                <ErrorBoundary
-                  name="dashboard-preview"
-                  resetKey={spec}
-                  fallback={<PreviewPlaceholder label="Preview unavailable" />}
-                >
-                  <CanvasRenderer spec={spec} state={spec.state} />
-                </ErrorBoundary>
-              </Box>
-            ) : (
-              <PreviewPlaceholder label="Empty canvas" />
-            )}
-          </Box>
+          <DashboardPreview spec={spec} />
           <CardContent className="flex flex-col gap-0.5 p-3">
             <Text size="sm" weight="medium" className="truncate">
               {summary.name}
@@ -134,6 +115,42 @@ function DashboardCard({
       {/* Sibling of the Link (not nested) so opening the menu or deleting never
           navigates into the dashboard. */}
       <DashboardCardMenu id={summary.id} name={summary.name} />
+    </Box>
+  );
+});
+
+// The scaled-down preview frame. The full chart tree is expensive to mount, so
+// we defer rendering it until the card scrolls near the viewport (`once` keeps
+// it mounted afterward). Off-screen cards in a long grid stay cheap.
+function DashboardPreview({ spec }: { spec: Spec | null | undefined }) {
+  const [ref, inView] = useInView<HTMLDivElement>({ once: true });
+
+  return (
+    <Box
+      ref={ref}
+      className="relative h-44 overflow-hidden border-border border-b bg-muted"
+    >
+      {isNonEmptySpec(spec) ? (
+        inView ? (
+          <Box
+            className="pointer-events-none absolute top-0 left-0 origin-top-left"
+            style={{
+              transform: `scale(${PREVIEW_SCALE})`,
+              width: `${100 / PREVIEW_SCALE}%`,
+            }}
+          >
+            <ErrorBoundary
+              name="dashboard-preview"
+              resetKey={spec}
+              fallback={<PreviewPlaceholder label="Preview unavailable" />}
+            >
+              <CanvasRenderer spec={spec} state={spec.state} />
+            </ErrorBoundary>
+          </Box>
+        ) : null
+      ) : (
+        <PreviewPlaceholder label="Empty canvas" />
+      )}
     </Box>
   );
 }

--- a/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
@@ -147,7 +147,9 @@ function DashboardPreview({ spec }: { spec: Spec | null | undefined }) {
               <CanvasRenderer spec={spec} state={spec.state} />
             </ErrorBoundary>
           </Box>
-        ) : null
+        ) : (
+          <PreviewPlaceholder label="Loading preview…" />
+        )
       ) : (
         <PreviewPlaceholder label="Empty canvas" />
       )}


### PR DESCRIPTION
## Problem

Canvases take a long time to load. `DashboardsService.list(channelId)` called `DesktopFsClient.listAll()`, which paged through **every row of every type** in the project's `desktop_file_system` serially, then filtered to dashboards client-side.

Real projects hold thousands of rows (one `task` row per filed task). On one measured project the FS had **~8,788 rows** at 100 rows/page. So every time you opened a channel's Canvases grid it fired **dozens of sequential** renderer→main IPC + authenticated cloud-API round-trips before a single thumbnail rendered — the "forever."

Worse, the loop was capped at `MAX_PAGES = 50` (5,000 rows), so on large projects canvases past that point **silently vanished** from the grid.

## Fix

The `desktop_file_system` API already supports server-side filtering (`?parent=&type=`), and `ChannelTasksService` already uses it. This applies the same approach to dashboards:

- **`desktopFsClient.ts`** — replace the unfiltered `listAll()` with `listByQuery(query, errorLabel)`, which paginates over a server-side-filtered query.
- **`dashboardsService.ts`** — `list()` now resolves the channel folder path and fetches only `parent=<path>&type=dashboard`. One path lookup + one small filtered list, and the page-cap truncation bug is gone.
- **`dashboardsService.test.ts`** — new test asserting the parent-scoped, type-filtered query and updatedAt-descending sort.

## Front-end render

- **`WebsiteDashboardsIndex.tsx`** — defer mounting each canvas's full `CanvasRenderer` (charts and all) until the card scrolls near the viewport, via the existing `useInView` hook (`once: true` so it stays mounted). Previously a channel with many canvases mounted every chart tree on first paint. Also memoized `DashboardCard`.

## Deliberately not done

Memoizing the recursive `ViewNode`/`EditNode` walk was investigated and rejected: both take the whole `spec` as a prop, and streaming replaces the entire `spec` object every frame, so `React.memo` could never short-circuit — it would only add shallow-compare cost. A real fix needs per-element props (a larger refactor).

## Verification

- `dashboardsService.test.ts`: 2 new tests pass; existing canvas tests pass.
- Biome lint clean on all changed files.
- Typecheck clean for changed files (remaining errors are pre-existing, in unbuilt workspace deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)