### PR TITLE
fix(agent): Send cloud Claude reasoning effort without plugins

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1173,6 +1173,22 @@ describe("AgentServer HTTP Mode", () => {
 
       expect(meta).toBeUndefined();
     });
+
+    it("includes both plugins and effort for claude runs", () => {
+      const s = createServer({
+        reasoningEffort: "medium",
+        claudeCode: { plugins: [{ type: "local", path: "/tmp/plugin" }] },
+      });
+
+      const meta = (s as unknown as TestableServer).buildClaudeCodeSessionMeta(
+        "claude",
+      );
+
+      expect(meta?.claudeCode.options).toEqual({
+        plugins: [{ type: "local", path: "/tmp/plugin" }],
+        effort: "medium",
+      });
+    });
   });
 
   describe("detectedPrUrl tracking", () => {

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1189,6 +1189,20 @@ describe("AgentServer HTTP Mode", () => {
         effort: "medium",
       });
     });
+
+    it("returns only plugins when effort is not set", () => {
+      const s = createServer({
+        claudeCode: { plugins: [{ type: "local", path: "/tmp/plugin" }] },
+      });
+
+      const meta = (s as unknown as TestableServer).buildClaudeCodeSessionMeta(
+        "claude",
+      );
+
+      expect(meta?.claudeCode.options).toEqual({
+        plugins: [{ type: "local", path: "/tmp/plugin" }],
+      });
+    });
   });
 
   describe("detectedPrUrl tracking", () => {

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -213,6 +213,9 @@ interface TestableServer {
   ): string | { append: string };
   buildCodexInstructions(systemPrompt: string | { append: string }): string;
   getRuntimeAdapter(): "claude" | "codex";
+  buildClaudeCodeSessionMeta(
+    runtimeAdapter: "claude" | "codex",
+  ): { claudeCode: { options: Record<string, unknown> } } | undefined;
 }
 
 let nextTestPort = 20000;
@@ -1137,6 +1140,38 @@ describe("AgentServer HTTP Mode", () => {
       expect(
         (s as unknown as TestableServer).buildCodexInstructions(sessionPrompt),
       ).toContain("Cloud Task Execution");
+    });
+  });
+
+  describe("buildClaudeCodeSessionMeta", () => {
+    it("sends claude reasoning effort even when no plugins are configured", () => {
+      const s = createServer({ reasoningEffort: "high" });
+
+      const meta = (s as unknown as TestableServer).buildClaudeCodeSessionMeta(
+        "claude",
+      );
+
+      expect(meta?.claudeCode.options).toEqual({ effort: "high" });
+    });
+
+    it("does not send claudeCode effort for codex runs", () => {
+      const s = createServer({ reasoningEffort: "high" });
+
+      const meta = (s as unknown as TestableServer).buildClaudeCodeSessionMeta(
+        "codex",
+      );
+
+      expect(meta).toBeUndefined();
+    });
+
+    it("returns undefined when neither plugins nor effort are set", () => {
+      const s = createServer();
+
+      const meta = (s as unknown as TestableServer).buildClaudeCodeSessionMeta(
+        "claude",
+      );
+
+      expect(meta).toBeUndefined();
     });
   });
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1067,19 +1067,7 @@ export class AgentServer {
         jsonSchema: preTask?.json_schema ?? null,
         permissionMode: initialPermissionMode,
         ...(this.config.baseBranch && { baseBranch: this.config.baseBranch }),
-        ...(this.config.claudeCode?.plugins?.length && {
-          claudeCode: {
-            options: {
-              ...(this.config.claudeCode?.plugins?.length && {
-                plugins: this.config.claudeCode.plugins,
-              }),
-              ...(runtimeAdapter === "claude" &&
-                this.config.reasoningEffort && {
-                  effort: this.config.reasoningEffort,
-                }),
-            },
-          },
-        }),
+        ...this.buildClaudeCodeSessionMeta(runtimeAdapter),
       },
     });
 
@@ -1668,6 +1656,32 @@ export class AgentServer {
     return typeof systemPrompt === "string"
       ? systemPrompt
       : systemPrompt.append;
+  }
+
+  /**
+   * Builds the optional `claudeCode` session meta. Reasoning effort and plugins
+   * are independent: effort must reach Claude even when no plugins are set, so
+   * it cannot sit behind a plugins guard.
+   */
+  private buildClaudeCodeSessionMeta(
+    runtimeAdapter: "claude" | "codex",
+  ): { claudeCode: { options: Record<string, unknown> } } | undefined {
+    const plugins = this.config.claudeCode?.plugins;
+    const effort =
+      runtimeAdapter === "claude" ? this.config.reasoningEffort : undefined;
+
+    if (!plugins?.length && !effort) {
+      return undefined;
+    }
+
+    const options: Record<string, unknown> = {};
+    if (plugins?.length) {
+      options.plugins = plugins;
+    }
+    if (effort) {
+      options.effort = effort;
+    }
+    return { claudeCode: { options } };
   }
 
   private getCloudInteractionOrigin(): string | undefined {


### PR DESCRIPTION
## Problem

Cloud Claude runs configured without plugins silently dropped the selected reasoning effort. `effort` was nested inside a `claudeCode.plugins?.length` gate, so plugin-less runs never sent it.

## Changes

1. Extract `buildClaudeCodeSessionMeta` so reasoning effort and plugins are independent
2. Send Claude `effort` whenever it is set, not only when plugins are present
3. Add tests for effort-only, codex, neither, and plugins+effort combinations

## How did you test this?

Manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
