### PR TITLE
fix(agent): Reconnect signed-commit MCP server after session refresh

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -16,6 +16,7 @@ type SdkQueryHandle = {
   interrupt: ReturnType<typeof vi.fn>;
   setModel: ReturnType<typeof vi.fn>;
   setMcpServers: ReturnType<typeof vi.fn>;
+  mcpServerStatus: ReturnType<typeof vi.fn>;
   supportedCommands: ReturnType<typeof vi.fn>;
   initializationResult: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -33,6 +34,7 @@ function makeQueryHandle(): SdkQueryHandle {
     interrupt: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue(undefined),
     setMcpServers: vi.fn().mockResolvedValue(undefined),
+    mcpServerStatus: vi.fn().mockResolvedValue([]),
     supportedCommands: vi.fn().mockResolvedValue([]),
     initializationResult: vi.fn().mockImplementation(() => nextInitPromise),
     close: vi.fn(),
@@ -55,9 +57,12 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 }));
 
 const fetchMcpToolMetadataMock = vi.fn().mockResolvedValue(undefined);
+const clearMcpToolMetadataCacheMock = vi.fn();
 vi.mock("./mcp/tool-metadata", () => ({
   fetchMcpToolMetadata: fetchMcpToolMetadataMock,
   getConnectedMcpServerNames: vi.fn().mockReturnValue([]),
+  getCachedMcpTools: vi.fn().mockReturnValue([]),
+  clearMcpToolMetadataCache: clearMcpToolMetadataCacheMock,
 }));
 
 // Import after the mocks so ClaudeAcpAgent resolves the mocked SDK
@@ -82,6 +87,17 @@ function installFakeSession(
   const endSpy = vi.spyOn(input, "end");
   const abortController = new AbortController();
 
+  // Each call returns a distinguishable FRESH instance so tests can prove the
+  // refresh/self-heal rebuilds rather than reusing the stale one.
+  let freshInstanceCounter = 0;
+  const buildInProcessMcpServers = vi.fn(() => ({
+    "posthog-code-tools": {
+      type: "sdk" as const,
+      name: "posthog-code-tools",
+      instance: { fresh: ++freshInstanceCounter },
+    },
+  }));
+
   const session = {
     query: oldQuery,
     queryOptions: {
@@ -93,11 +109,12 @@ function installFakeSession(
         "posthog-code-tools": {
           type: "sdk",
           name: "posthog-code-tools",
-          instance: {},
+          instance: { stale: true },
         },
       },
       abortController,
     },
+    buildInProcessMcpServers,
     input,
     cancelled: false,
     settingsManager: { dispose: vi.fn() },
@@ -123,7 +140,13 @@ function installFakeSession(
   (agent as unknown as { session: unknown }).session = session;
   (agent as unknown as { sessionId: string }).sessionId = sessionId;
 
-  return { session, oldQuery, endSpy, abortController };
+  return {
+    session,
+    oldQuery,
+    endSpy,
+    abortController,
+    buildInProcessMcpServers,
+  };
 }
 
 const freshMcpServers = [
@@ -145,6 +168,7 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
       models: [],
     });
     fetchMcpToolMetadataMock.mockClear();
+    clearMcpToolMetadataCacheMock.mockClear();
   });
 
   it("returns methodNotFound for unknown extension methods", async () => {
@@ -238,7 +262,7 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
     expect(endSpy).toHaveBeenCalledTimes(1);
 
     // New query: resume identity (not sessionId), http server refreshed, and
-    // the in-process local-tools server preserved.
+    // the in-process local-tools server rebuilt fresh.
     expect(lastQueryCall.options).toMatchObject({
       resume: "s-2",
       forkSession: false,
@@ -364,24 +388,140 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
     expect(lastQueryCall.options?.model).toBe(expected);
   });
 
-  it("preserves the in-process local-tools server across refresh", async () => {
+  it("rebuilds a FRESH in-process local-tools server across refresh", async () => {
     const agent = makeAgent();
-    installFakeSession(agent, "s-inprocess");
+    const { session, buildInProcessMcpServers } = installFakeSession(
+      agent,
+      "s-inprocess",
+    );
+    const staleInstance = (
+      session as unknown as {
+        queryOptions: { mcpServers: Record<string, { instance?: unknown }> };
+      }
+    ).queryOptions.mcpServers["posthog-code-tools"].instance;
 
-    // freshMcpServers carries only external (http) servers, so the sdk server
-    // must be carried over from the previous session options.
+    // freshMcpServers carries only external (http) servers. The sdk server must
+    // be rebuilt fresh — reusing the prior instance is what made the SDK throw
+    // "Already connected to a transport" and silently drop signed-commit tools.
     await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
       mcpServers: freshMcpServers,
     });
 
+    expect(buildInProcessMcpServers).toHaveBeenCalledTimes(1);
     const servers = lastQueryCall.options?.mcpServers as Record<
       string,
-      { type?: string }
+      { type?: string; name?: string; instance?: unknown }
     >;
-    expect(servers["posthog-code-tools"]).toEqual({
+    expect(servers["posthog-code-tools"]).toMatchObject({
       type: "sdk",
       name: "posthog-code-tools",
-      instance: {},
     });
+    // A brand-new instance object, never the stale reused one.
+    expect(servers["posthog-code-tools"].instance).not.toBe(staleInstance);
+    expect(servers["posthog-code-tools"].instance).toEqual({ fresh: 1 });
+  });
+
+  it("clears the MCP tool metadata cache on refresh", async () => {
+    const agent = makeAgent();
+    installFakeSession(agent, "s-cache");
+
+    await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
+      mcpServers: freshMcpServers,
+    });
+
+    expect(clearMcpToolMetadataCacheMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
+  beforeEach(() => {
+    clearMcpToolMetadataCacheMock.mockClear();
+    fetchMcpToolMetadataMock.mockClear();
+  });
+
+  function callHeal(agent: Agent, trigger = "test"): Promise<boolean> {
+    return (
+      agent as unknown as {
+        ensureLocalToolsConnected: (t: string) => Promise<boolean>;
+      }
+    ).ensureLocalToolsConnected(trigger);
+  }
+
+  it("is a no-op when the signed-commit server is connected", async () => {
+    const agent = makeAgent();
+    const { oldQuery } = installFakeSession(agent, "s-healthy");
+    oldQuery.mcpServerStatus.mockResolvedValue([
+      { name: "posthog-code-tools", status: "connected" },
+    ]);
+
+    await expect(callHeal(agent)).resolves.toBe(true);
+    expect(oldQuery.setMcpServers).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds and reconnects a fresh server when disconnected", async () => {
+    const agent = makeAgent();
+    const { oldQuery, buildInProcessMcpServers } = installFakeSession(
+      agent,
+      "s-down",
+    );
+    oldQuery.mcpServerStatus.mockResolvedValue([
+      { name: "posthog-code-tools", status: "failed" },
+    ]);
+
+    await expect(callHeal(agent)).resolves.toBe(true);
+
+    expect(buildInProcessMcpServers).toHaveBeenCalledTimes(1);
+    expect(oldQuery.setMcpServers).toHaveBeenCalledTimes(1);
+    const arg = oldQuery.setMcpServers.mock.calls[0][0] as Record<
+      string,
+      { type?: string; instance?: unknown }
+    >;
+    // External http server passed through unchanged; sdk server is fresh.
+    expect(arg.posthog).toMatchObject({ type: "http" });
+    expect(arg["posthog-code-tools"]).toMatchObject({ type: "sdk" });
+    expect(arg["posthog-code-tools"].instance).toEqual({ fresh: 1 });
+    expect(clearMcpToolMetadataCacheMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a server missing from status as disconnected", async () => {
+    const agent = makeAgent();
+    const { oldQuery } = installFakeSession(agent, "s-missing");
+    oldQuery.mcpServerStatus.mockResolvedValue([
+      { name: "some-other", status: "connected" },
+    ]);
+
+    await expect(callHeal(agent)).resolves.toBe(true);
+    expect(oldQuery.setMcpServers).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block the turn when the status RPC fails", async () => {
+    const agent = makeAgent();
+    const { oldQuery } = installFakeSession(agent, "s-statuserr");
+    oldQuery.mcpServerStatus.mockRejectedValue(new Error("rpc down"));
+
+    await expect(callHeal(agent)).resolves.toBe(true);
+    expect(oldQuery.setMcpServers).not.toHaveBeenCalled();
+  });
+
+  it("returns false when reconnect fails", async () => {
+    const agent = makeAgent();
+    const { oldQuery } = installFakeSession(agent, "s-reconnect-fail");
+    oldQuery.mcpServerStatus.mockResolvedValue([
+      { name: "posthog-code-tools", status: "failed" },
+    ]);
+    oldQuery.setMcpServers.mockRejectedValue(new Error("connect boom"));
+
+    await expect(callHeal(agent)).resolves.toBe(false);
+  });
+
+  it("is a no-op when no in-process server is enabled", async () => {
+    const agent = makeAgent();
+    const { session, oldQuery } = installFakeSession(agent, "s-none");
+    (
+      session as unknown as { buildInProcessMcpServers: () => unknown }
+    ).buildInProcessMcpServers = vi.fn(() => ({}));
+
+    await expect(callHeal(agent)).resolves.toBe(true);
+    expect(oldQuery.mcpServerStatus).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -87,8 +87,7 @@ function installFakeSession(
   const endSpy = vi.spyOn(input, "end");
   const abortController = new AbortController();
 
-  // Each call returns a distinguishable FRESH instance so tests can prove the
-  // refresh/self-heal rebuilds rather than reusing the stale one.
+  // Distinguishable fresh instance per call so tests can prove a rebuild.
   let freshInstanceCounter = 0;
   const buildInProcessMcpServers = vi.fn(() => ({
     "posthog-code-tools": {
@@ -400,9 +399,7 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
       }
     ).queryOptions.mcpServers["posthog-code-tools"].instance;
 
-    // freshMcpServers carries only external (http) servers. The sdk server must
-    // be rebuilt fresh — reusing the prior instance is what made the SDK throw
-    // "Already connected to a transport" and silently drop signed-commit tools.
+    // freshMcpServers carries only external servers; the sdk server is rebuilt.
     await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
       mcpServers: freshMcpServers,
     });

--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -114,6 +114,7 @@ function installFakeSession(
       abortController,
     },
     buildInProcessMcpServers,
+    localToolsServerNames: ["posthog-code-tools"],
     input,
     cancelled: false,
     settingsManager: { dispose: vi.fn() },
@@ -430,6 +431,8 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
   });
 });
 
+const DISCONNECTED_STATUS = [{ name: "posthog-code-tools", status: "failed" }];
+
 describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
   beforeEach(() => {
     clearMcpToolMetadataCacheMock.mockClear();
@@ -461,9 +464,7 @@ describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
       agent,
       "s-down",
     );
-    oldQuery.mcpServerStatus.mockResolvedValue([
-      { name: "posthog-code-tools", status: "failed" },
-    ]);
+    oldQuery.mcpServerStatus.mockResolvedValue(DISCONNECTED_STATUS);
 
     await expect(callHeal(agent)).resolves.toBe(true);
 
@@ -501,9 +502,7 @@ describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
         instance: { stale: true },
       },
     };
-    oldQuery.mcpServerStatus.mockResolvedValue([
-      { name: "posthog-code-tools", status: "failed" },
-    ]);
+    oldQuery.mcpServerStatus.mockResolvedValue(DISCONNECTED_STATUS);
 
     await expect(callHeal(agent)).resolves.toBe(true);
 
@@ -561,9 +560,7 @@ describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
   it("returns false when reconnect fails", async () => {
     const agent = makeAgent();
     const { oldQuery } = installFakeSession(agent, "s-reconnect-fail");
-    oldQuery.mcpServerStatus.mockResolvedValue([
-      { name: "posthog-code-tools", status: "failed" },
-    ]);
+    oldQuery.mcpServerStatus.mockResolvedValue(DISCONNECTED_STATUS);
     oldQuery.setMcpServers.mockRejectedValue(new Error("connect boom"));
 
     await expect(callHeal(agent)).resolves.toBe(false);
@@ -573,8 +570,8 @@ describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
     const agent = makeAgent();
     const { session, oldQuery } = installFakeSession(agent, "s-none");
     (
-      session as unknown as { buildInProcessMcpServers: () => unknown }
-    ).buildInProcessMcpServers = vi.fn(() => ({}));
+      session as unknown as { localToolsServerNames: string[] }
+    ).localToolsServerNames = [];
 
     await expect(callHeal(agent)).resolves.toBe(true);
     expect(oldQuery.mcpServerStatus).not.toHaveBeenCalled();

--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -457,7 +457,7 @@ describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
 
   it("rebuilds and reconnects a fresh server when disconnected", async () => {
     const agent = makeAgent();
-    const { oldQuery, buildInProcessMcpServers } = installFakeSession(
+    const { session, oldQuery, buildInProcessMcpServers } = installFakeSession(
       agent,
       "s-down",
     );
@@ -478,6 +478,47 @@ describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
     expect(arg["posthog-code-tools"]).toMatchObject({ type: "sdk" });
     expect(arg["posthog-code-tools"].instance).toEqual({ fresh: 1 });
     expect(clearMcpToolMetadataCacheMock).toHaveBeenCalledTimes(1);
+    // queryOptions is updated so later heals/refresh see the fresh server set.
+    expect(
+      (session as unknown as { queryOptions: { mcpServers: unknown } })
+        .queryOptions.mcpServers,
+    ).toBe(arg);
+  });
+
+  it("passes every external server through when reconnecting", async () => {
+    const agent = makeAgent();
+    const { session, oldQuery } = installFakeSession(agent, "s-multi");
+    (
+      session as unknown as {
+        queryOptions: { mcpServers: Record<string, unknown> };
+      }
+    ).queryOptions.mcpServers = {
+      posthog: { type: "http", url: "https://old" },
+      sentry: { type: "sse", url: "https://sse" },
+      "posthog-code-tools": {
+        type: "sdk",
+        name: "posthog-code-tools",
+        instance: { stale: true },
+      },
+    };
+    oldQuery.mcpServerStatus.mockResolvedValue([
+      { name: "posthog-code-tools", status: "failed" },
+    ]);
+
+    await expect(callHeal(agent)).resolves.toBe(true);
+
+    const arg = oldQuery.setMcpServers.mock.calls[0][0] as Record<
+      string,
+      { type?: string }
+    >;
+    expect(Object.keys(arg).sort()).toEqual([
+      "posthog",
+      "posthog-code-tools",
+      "sentry",
+    ]);
+    expect(arg.posthog).toMatchObject({ type: "http" });
+    expect(arg.sentry).toMatchObject({ type: "sse" });
+    expect(arg["posthog-code-tools"]).toMatchObject({ type: "sdk" });
   });
 
   it("treats a server missing from status as disconnected", async () => {
@@ -498,6 +539,23 @@ describe("ClaudeAcpAgent self-heal: ensureLocalToolsConnected", () => {
 
     await expect(callHeal(agent)).resolves.toBe(true);
     expect(oldQuery.setMcpServers).not.toHaveBeenCalled();
+  });
+
+  it("does not block the turn when the status RPC hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      const agent = makeAgent();
+      const { oldQuery } = installFakeSession(agent, "s-statushang");
+      oldQuery.mcpServerStatus.mockReturnValue(new Promise(() => {}));
+
+      const healPromise = callHeal(agent);
+      await vi.advanceTimersByTimeAsync(5_001);
+
+      await expect(healPromise).resolves.toBe(true);
+      expect(oldQuery.setMcpServers).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns false when reconnect fails", async () => {

--- a/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
@@ -47,6 +47,7 @@ function installFakeSession(
     query,
     queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
     buildInProcessMcpServers: () => ({}),
+    localToolsServerNames: [] as string[],
     input,
     cancelled: false,
     interruptReason: undefined,

--- a/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
@@ -46,6 +46,7 @@ function installFakeSession(
   const session = {
     query,
     queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
+    buildInProcessMcpServers: () => ({}),
     input,
     cancelled: false,
     interruptReason: undefined,

--- a/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
@@ -48,6 +48,7 @@ function installFakeSession(
   const session = {
     query,
     queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
+    buildInProcessMcpServers: () => ({}),
     input,
     cancelled: false,
     interruptReason: undefined,

--- a/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
@@ -51,6 +51,7 @@ function installFakeSession(
     query,
     queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
     buildInProcessMcpServers: () => ({}),
+    localToolsServerNames: [] as string[],
     input,
     cancelled: false,
     interruptReason: undefined,
@@ -80,6 +81,27 @@ function installFakeSession(
   (agent as unknown as { sessionId: string }).sessionId = sessionId;
 
   return { query, input };
+}
+
+// Mark the session as having an enabled (but currently disconnected) in-process
+// signed-commit server so the pre-prompt heal has something to reconnect.
+function enableSignedCommitServer(agent: Agent): void {
+  const session = (
+    agent as unknown as {
+      session: {
+        buildInProcessMcpServers: () => Record<string, unknown>;
+        localToolsServerNames: string[];
+      };
+    }
+  ).session;
+  session.localToolsServerNames = ["posthog-code-tools"];
+  session.buildInProcessMcpServers = () => ({
+    "posthog-code-tools": {
+      type: "sdk",
+      name: "posthog-code-tools",
+      instance: {},
+    },
+  });
 }
 
 function tick(): Promise<void> {
@@ -226,17 +248,7 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
     const { query, input } = installFakeSession(agent, sessionId);
 
     // Signed-commit server is enabled but the live query reports it absent.
-    (
-      agent as unknown as {
-        session: { buildInProcessMcpServers: () => Record<string, unknown> };
-      }
-    ).session.buildInProcessMcpServers = () => ({
-      "posthog-code-tools": {
-        type: "sdk",
-        name: "posthog-code-tools",
-        instance: {},
-      },
-    });
+    enableSignedCommitServer(agent);
     (query.mcpServerStatus as ReturnType<typeof vi.fn>).mockResolvedValue([
       { name: "posthog-code-tools", status: "failed" },
     ]);
@@ -266,17 +278,7 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
     const sessionId = "s-local-only";
     const { query } = installFakeSession(agent, sessionId);
 
-    (
-      agent as unknown as {
-        session: { buildInProcessMcpServers: () => Record<string, unknown> };
-      }
-    ).session.buildInProcessMcpServers = () => ({
-      "posthog-code-tools": {
-        type: "sdk",
-        name: "posthog-code-tools",
-        instance: {},
-      },
-    });
+    enableSignedCommitServer(agent);
 
     const promptPromise = agent.prompt({
       sessionId,

--- a/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
@@ -14,6 +14,8 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 vi.mock("./mcp/tool-metadata", () => ({
   fetchMcpToolMetadata: vi.fn().mockResolvedValue(undefined),
   getConnectedMcpServerNames: vi.fn().mockReturnValue([]),
+  getCachedMcpTools: vi.fn().mockReturnValue([]),
+  clearMcpToolMetadataCache: vi.fn(),
   setMcpToolApprovalStates: vi.fn(),
   isMcpToolReadOnly: vi.fn().mockReturnValue(false),
   getMcpToolMetadata: vi.fn().mockReturnValue(undefined),
@@ -216,5 +218,76 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
     expect(messageChunkTexts(client.sessionUpdate.mock.calls)).toEqual([
       "gateway answer",
     ]);
+  });
+
+  it("reconnects a disconnected signed-commit server before the turn", async () => {
+    const { agent } = makeAgent();
+    const sessionId = "s-heal";
+    const { query, input } = installFakeSession(agent, sessionId);
+
+    // Signed-commit server is enabled but the live query reports it absent.
+    (
+      agent as unknown as {
+        session: { buildInProcessMcpServers: () => Record<string, unknown> };
+      }
+    ).session.buildInProcessMcpServers = () => ({
+      "posthog-code-tools": {
+        type: "sdk",
+        name: "posthog-code-tools",
+        instance: {},
+      },
+    });
+    (query.mcpServerStatus as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: "posthog-code-tools", status: "failed" },
+    ]);
+
+    const promptPromise = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "commit this" }],
+    });
+    await tick();
+
+    // The pre-prompt heal fired before the model turn began.
+    expect(query.mcpServerStatus).toHaveBeenCalled();
+    expect(query.setMcpServers).toHaveBeenCalledTimes(1);
+    const arg = (query.setMcpServers as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as Record<string, unknown>;
+    expect(arg["posthog-code-tools"]).toMatchObject({ type: "sdk" });
+
+    await echoUserMessage(query, input);
+    await send(query, assistantMessage(sessionId, "msg_h", "done"));
+    await send(query, resultSuccess(sessionId));
+    const result = await promptPromise;
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  it("skips the pre-prompt heal for local-only commands", async () => {
+    const { agent } = makeAgent();
+    const sessionId = "s-local-only";
+    const { query } = installFakeSession(agent, sessionId);
+
+    (
+      agent as unknown as {
+        session: { buildInProcessMcpServers: () => Record<string, unknown> };
+      }
+    ).session.buildInProcessMcpServers = () => ({
+      "posthog-code-tools": {
+        type: "sdk",
+        name: "posthog-code-tools",
+        instance: {},
+      },
+    });
+
+    const promptPromise = agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "/context" }],
+    });
+    await tick();
+
+    expect(query.mcpServerStatus).not.toHaveBeenCalled();
+    expect(query.setMcpServers).not.toHaveBeenCalled();
+
+    await send(query, resultSuccess(sessionId));
+    await promptPromise;
   });
 });

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -446,11 +446,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       }
       promptReplayed = true;
     } else {
-      // Proactively restore the signed-commit MCP server before driving the
-      // turn, so a disconnection from an earlier mid-run refresh can't strand
-      // the commit the user is about to ask for. Skipped for local-only
-      // commands, which never invoke the model. Best-effort: the guard hook is
-      // the reactive backstop if this can't reconnect in time.
+      // Reconnect the signed-commit server before the turn (guard hook backstops).
       if (!isLocalOnlyCommand) {
         await this.ensureLocalToolsConnected("pre-prompt");
       }
@@ -1265,12 +1261,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const newAbortController = new AbortController();
     const { sessionId: _drop, ...rest } = prev.queryOptions;
 
-    // parseMcpServers yields only http/sse/stdio. The in-process ("sdk")
-    // local-tools server (signed commits) must be REBUILT fresh, not carried
-    // over: the abort above tore down the old Query's transport but left the
-    // reused McpServer instance with `_transport` still set, so connecting it
-    // on the new Query throws "Already connected to a transport" and the
-    // signed-commit tools silently vanish. A fresh instance connects cleanly.
+    // Rebuild the in-process ("sdk") server fresh; reusing the prior instance
+    // throws "Already connected to a transport" and drops the signed-commit tools.
     const freshInProcess = prev.buildInProcessMcpServers();
     if (Object.keys(freshInProcess).length > 0) {
       this.logger.info("signed_commit_mcp_rebuilt_on_refresh", {
@@ -1311,31 +1303,21 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       );
     }
 
-    // Re-fetch MCP tool metadata + slash commands — the server list changed.
-    // Clear first so servers dropped by this refresh don't linger in the cache
-    // and over-report via getConnectedMcpServerNames().
+    // Re-fetch metadata for the new server list; clear first so dropped servers
+    // don't linger in the cache.
     clearMcpToolMetadataCache();
     this.deferBackgroundFetches(newQuery);
   }
 
   /**
-   * Best-effort self-heal for the in-process signed-commit MCP server
-   * (`posthog-code-tools`). If it's enabled for this session but the live Query
-   * reports it missing or not connected, rebuild a FRESH instance and reconnect
-   * it via the SDK's live `setMcpServers` (external servers are passed through
-   * unchanged so they aren't dropped). Never throws. Returns whether the
-   * signed-commit tooling is usable after the call, so callers (e.g. the guard
-   * hook) can tailor their message.
-   *
-   * Triggered proactively before each prompt and reactively when the guard hook
-   * blocks a raw `git commit`/`push`, so the disconnection can never strand a
-   * commit the way a mid-run refresh used to.
+   * Best-effort self-heal: if the in-process signed-commit server is enabled but
+   * the live Query reports it disconnected, rebuild a fresh instance and
+   * reconnect via setMcpServers. Returns whether the tooling is usable after.
    */
   private async ensureLocalToolsConnected(trigger: string): Promise<boolean> {
     const desired = this.session.buildInProcessMcpServers();
     const names = Object.keys(desired);
     if (names.length === 0) {
-      // No in-process server expected (e.g. non-cloud run) — nothing to heal.
       return true;
     }
 
@@ -1634,11 +1616,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // push` are blocked by the PreToolUse guard (and the sandbox git shim), so
     // the agent commits via the signed-commit tool instead.
     //
-    // Built via a closure (stored on the session) so refresh and self-heal can
-    // rebuild a FRESH instance. A reused McpServer keeps its `_transport` set,
-    // so the SDK rejects re-connecting it with "Already connected to a
-    // transport" — which is exactly how the signed-commit server silently
-    // disappeared after a mid-run refresh.
+    // A closure so refresh/self-heal can rebuild a fresh instance (reusing one
+    // throws "Already connected to a transport").
     const buildInProcessMcpServers = (): Record<
       string,
       McpSdkServerConfigWithInstance

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -141,10 +141,28 @@ import type {
 
 const SESSION_VALIDATION_TIMEOUT_MS = 30_000;
 
+// Pre-prompt self-heal runs on every cloud turn; bound the status RPC so a
+// wedged control channel can't stall the turn.
+const MCP_STATUS_TIMEOUT_MS = 5_000;
+
 const DEFAULT_FORCE_CANCEL_GRACE_MS = 30_000;
 
 const MAX_TITLE_LENGTH = 256;
 const LOCAL_ONLY_COMMANDS = new Set(["/context", "/heapdump", "/extra-usage"]);
+
+// In-process servers carry `type: "sdk"`; the cast covers union members (stdio)
+// that don't declare `type`.
+function isSdkMcpServer(cfg: McpServerConfig): boolean {
+  return (cfg as { type?: string }).type === "sdk";
+}
+
+function externalMcpServers(
+  servers: Record<string, McpServerConfig> | undefined,
+): Record<string, McpServerConfig> {
+  return Object.fromEntries(
+    Object.entries(servers ?? {}).filter(([, cfg]) => !isSdkMcpServer(cfg)),
+  );
+}
 
 // Best-effort: silent on ENOENT, logs other errors so permission failures
 // aren't masked.
@@ -1303,10 +1321,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       );
     }
 
-    // Re-fetch metadata for the new server list; clear first so dropped servers
-    // don't linger in the cache.
-    clearMcpToolMetadataCache();
-    this.deferBackgroundFetches(newQuery);
+    this.refreshMcpMetadata(newQuery);
   }
 
   /**
@@ -1323,9 +1338,19 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     let statuses: McpServerStatus[];
     try {
-      statuses = await this.session.query.mcpServerStatus();
+      const status = await withTimeout(
+        this.session.query.mcpServerStatus(),
+        MCP_STATUS_TIMEOUT_MS,
+      );
+      // A slow or failed status RPC must not block the turn; assume healthy.
+      if (status.result === "timeout") {
+        this.logger.debug("ensureLocalToolsConnected: status check timed out", {
+          trigger,
+        });
+        return true;
+      }
+      statuses = status.value;
     } catch (error) {
-      // A failed status RPC must not block the turn; assume healthy.
       this.logger.debug("ensureLocalToolsConnected: status check failed", {
         trigger,
         error: error instanceof Error ? error.message : String(error),
@@ -1347,16 +1372,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     });
 
     try {
-      const external = Object.fromEntries(
-        Object.entries(this.session.queryOptions.mcpServers ?? {}).filter(
-          ([, cfg]) => (cfg as { type?: string }).type !== "sdk",
-        ),
-      );
-      const next = { ...external, ...desired };
+      const next = {
+        ...externalMcpServers(this.session.queryOptions.mcpServers),
+        ...desired,
+      };
       await this.session.query.setMcpServers(next);
       this.session.queryOptions.mcpServers = next;
-      clearMcpToolMetadataCache();
-      this.deferBackgroundFetches(this.session.query);
+      this.refreshMcpMetadata(this.session.query);
       this.logger.info("signed_commit_mcp_recovered", {
         trigger,
         sessionId: this.sessionId,
@@ -1371,6 +1393,12 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       });
       return false;
     }
+  }
+
+  /** Clear stale MCP tool metadata, then re-fetch it for the new server set. */
+  private refreshMcpMetadata(q: Query): void {
+    clearMcpToolMetadataCache();
+    this.deferBackgroundFetches(q);
   }
 
   async setSessionMode(

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -36,7 +36,6 @@ import {
   listSessions,
   type McpSdkServerConfigWithInstance,
   type McpServerConfig,
-  type McpServerStatus,
   type Options,
   type Query,
   query,
@@ -150,10 +149,10 @@ const DEFAULT_FORCE_CANCEL_GRACE_MS = 30_000;
 const MAX_TITLE_LENGTH = 256;
 const LOCAL_ONLY_COMMANDS = new Set(["/context", "/heapdump", "/extra-usage"]);
 
-// In-process servers carry `type: "sdk"`; the cast covers union members (stdio)
-// that don't declare `type`.
-function isSdkMcpServer(cfg: McpServerConfig): boolean {
-  return (cfg as { type?: string }).type === "sdk";
+function isSdkMcpServer(
+  cfg: McpServerConfig,
+): cfg is McpSdkServerConfigWithInstance {
+  return cfg.type === "sdk";
 }
 
 function externalMcpServers(
@@ -1283,7 +1282,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // throws "Already connected to a transport" and drops the signed-commit tools.
     const freshInProcess = prev.buildInProcessMcpServers();
     if (Object.keys(freshInProcess).length > 0) {
-      this.logger.info("signed_commit_mcp_rebuilt_on_refresh", {
+      this.logger.info("Rebuilt in-process MCP servers on refresh", {
         sessionId: this.sessionId,
         servers: Object.keys(freshInProcess),
       });
@@ -1330,65 +1329,52 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
    * reconnect via setMcpServers. Returns whether the tooling is usable after.
    */
   private async ensureLocalToolsConnected(trigger: string): Promise<boolean> {
-    const desired = this.session.buildInProcessMcpServers();
-    const names = Object.keys(desired);
+    const names = this.session.localToolsServerNames;
     if (names.length === 0) {
       return true;
     }
 
-    let statuses: McpServerStatus[];
-    try {
-      const status = await withTimeout(
-        this.session.query.mcpServerStatus(),
-        MCP_STATUS_TIMEOUT_MS,
-      );
-      // A slow or failed status RPC must not block the turn; assume healthy.
-      if (status.result === "timeout") {
-        this.logger.debug("ensureLocalToolsConnected: status check timed out", {
-          trigger,
-        });
-        return true;
-      }
-      statuses = status.value;
-    } catch (error) {
+    const status = await withTimeout(
+      this.session.query.mcpServerStatus(),
+      MCP_STATUS_TIMEOUT_MS,
+    ).catch((error) => {
       this.logger.debug("ensureLocalToolsConnected: status check failed", {
         trigger,
         error: error instanceof Error ? error.message : String(error),
       });
+      return { result: "timeout" as const };
+    });
+    // A slow or failed status RPC must not block the turn; assume healthy.
+    if (status.result !== "success") {
       return true;
     }
 
     const allConnected = names.every((name) =>
-      statuses.some((s) => s.name === name && s.status === "connected"),
+      status.value.some((s) => s.name === name && s.status === "connected"),
     );
     if (allConnected) {
       return true;
     }
 
-    this.logger.warn("signed_commit_mcp_unhealthy", {
-      trigger,
-      sessionId: this.sessionId,
-      servers: names,
-    });
+    const logCtx = { trigger, sessionId: this.sessionId, servers: names };
+    this.logger.warn(
+      "Signed-commit MCP server unhealthy; reconnecting",
+      logCtx,
+    );
 
     try {
       const next = {
         ...externalMcpServers(this.session.queryOptions.mcpServers),
-        ...desired,
+        ...this.session.buildInProcessMcpServers(),
       };
       await this.session.query.setMcpServers(next);
       this.session.queryOptions.mcpServers = next;
       this.refreshMcpMetadata(this.session.query);
-      this.logger.info("signed_commit_mcp_recovered", {
-        trigger,
-        sessionId: this.sessionId,
-        servers: names,
-      });
+      this.logger.info("Reconnected signed-commit MCP server", logCtx);
       return true;
     } catch (error) {
-      this.logger.error("signed_commit_mcp_recovery_failed", {
-        trigger,
-        sessionId: this.sessionId,
+      this.logger.error("Failed to reconnect signed-commit MCP server", {
+        ...logCtx,
         error: error instanceof Error ? error.message : String(error),
       });
       return false;
@@ -1634,9 +1620,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     const earlyModelId =
       settingsManager.getSettings().model || meta?.model || "";
-    const mcpServers = supportsMcpInjection(earlyModelId)
-      ? parseMcpServers(params, this.logger)
-      : {};
 
     // Register the in-process general local-tools MCP server. Tools self-gate
     // via the registry (e.g. signed-commit is cloud-only and needs a GH token),
@@ -1645,30 +1628,35 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // the agent commits via the signed-commit tool instead.
     //
     // A closure so refresh/self-heal can rebuild a fresh instance (reusing one
-    // throws "Already connected to a transport").
+    // throws "Already connected to a transport"). Capture only the fields it
+    // needs so the session doesn't pin the whole meta object.
+    const baseBranch = meta?.baseBranch;
+    const environment = meta?.environment;
     const buildInProcessMcpServers = (): Record<
       string,
       McpSdkServerConfigWithInstance
     > => {
       const server = createLocalToolsMcpServer(
-        {
-          cwd,
-          token: resolveGithubToken(),
-          taskId,
-          baseBranch: meta?.baseBranch,
-        },
-        meta,
+        { cwd, token: resolveGithubToken(), taskId, baseBranch },
+        { environment },
       );
       return server ? { [LOCAL_TOOLS_MCP_NAME]: server } : {};
     };
 
     const initialInProcess = buildInProcessMcpServers();
-    Object.assign(mcpServers, initialInProcess);
-    if (Object.keys(initialInProcess).length === 0 && cloudRun) {
+    const localToolsServerNames = Object.keys(initialInProcess);
+    if (localToolsServerNames.length === 0 && cloudRun) {
       this.logger.warn(
-        "Cloud run registered no local tools — missing GH_TOKEN/GITHUB_TOKEN? signed commits unavailable",
+        "Cloud run registered no local tools (missing GH_TOKEN/GITHUB_TOKEN?); signed commits unavailable",
       );
     }
+
+    const mcpServers: Record<string, McpServerConfig> = {
+      ...(supportsMcpInjection(earlyModelId)
+        ? parseMcpServers(params, this.logger)
+        : {}),
+      ...initialInProcess,
+    };
 
     const systemPrompt = buildSystemPrompt(meta?.systemPrompt);
 
@@ -1748,6 +1736,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       query: q,
       queryOptions: options,
       buildInProcessMcpServers,
+      localToolsServerNames,
       input,
       cancelled: false,
       settingsManager,

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -34,7 +34,9 @@ import {
   type CanUseTool,
   getSessionMessages,
   listSessions,
+  type McpSdkServerConfigWithInstance,
   type McpServerConfig,
+  type McpServerStatus,
   type Options,
   type Query,
   query,
@@ -94,6 +96,7 @@ import {
 import type { EnrichedReadCache } from "./hooks";
 import { createLocalToolsMcpServer } from "./mcp/local-tools";
 import {
+  clearMcpToolMetadataCache,
   fetchMcpToolMetadata,
   getCachedMcpTools,
   getConnectedMcpServerNames,
@@ -443,6 +446,14 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       }
       promptReplayed = true;
     } else {
+      // Proactively restore the signed-commit MCP server before driving the
+      // turn, so a disconnection from an earlier mid-run refresh can't strand
+      // the commit the user is about to ask for. Skipped for local-only
+      // commands, which never invoke the model. Best-effort: the guard hook is
+      // the reactive backstop if this can't reconnect in time.
+      if (!isLocalOnlyCommand) {
+        await this.ensureLocalToolsConnected("pre-prompt");
+      }
       this.session.input.push(userMessage);
     }
 
@@ -1254,17 +1265,23 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const newAbortController = new AbortController();
     const { sessionId: _drop, ...rest } = prev.queryOptions;
 
-    // parseMcpServers yields only http/sse/stdio – carry over any in-process
-    // ("sdk") server so the local-tools server (signed commits) survives.
-    const preservedInProcess = Object.fromEntries(
-      Object.entries(prev.queryOptions.mcpServers ?? {}).filter(
-        ([, cfg]) => (cfg as { type?: string }).type === "sdk",
-      ),
-    );
+    // parseMcpServers yields only http/sse/stdio. The in-process ("sdk")
+    // local-tools server (signed commits) must be REBUILT fresh, not carried
+    // over: the abort above tore down the old Query's transport but left the
+    // reused McpServer instance with `_transport` still set, so connecting it
+    // on the new Query throws "Already connected to a transport" and the
+    // signed-commit tools silently vanish. A fresh instance connects cleanly.
+    const freshInProcess = prev.buildInProcessMcpServers();
+    if (Object.keys(freshInProcess).length > 0) {
+      this.logger.info("signed_commit_mcp_rebuilt_on_refresh", {
+        sessionId: this.sessionId,
+        servers: Object.keys(freshInProcess),
+      });
+    }
 
     const newOptions: Options = {
       ...rest,
-      mcpServers: { ...mcpServers, ...preservedInProcess },
+      mcpServers: { ...mcpServers, ...freshInProcess },
       resume: this.sessionId,
       forkSession: false,
       abortController: newAbortController,
@@ -1295,7 +1312,83 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     }
 
     // Re-fetch MCP tool metadata + slash commands — the server list changed.
+    // Clear first so servers dropped by this refresh don't linger in the cache
+    // and over-report via getConnectedMcpServerNames().
+    clearMcpToolMetadataCache();
     this.deferBackgroundFetches(newQuery);
+  }
+
+  /**
+   * Best-effort self-heal for the in-process signed-commit MCP server
+   * (`posthog-code-tools`). If it's enabled for this session but the live Query
+   * reports it missing or not connected, rebuild a FRESH instance and reconnect
+   * it via the SDK's live `setMcpServers` (external servers are passed through
+   * unchanged so they aren't dropped). Never throws. Returns whether the
+   * signed-commit tooling is usable after the call, so callers (e.g. the guard
+   * hook) can tailor their message.
+   *
+   * Triggered proactively before each prompt and reactively when the guard hook
+   * blocks a raw `git commit`/`push`, so the disconnection can never strand a
+   * commit the way a mid-run refresh used to.
+   */
+  private async ensureLocalToolsConnected(trigger: string): Promise<boolean> {
+    const desired = this.session.buildInProcessMcpServers();
+    const names = Object.keys(desired);
+    if (names.length === 0) {
+      // No in-process server expected (e.g. non-cloud run) — nothing to heal.
+      return true;
+    }
+
+    let statuses: McpServerStatus[];
+    try {
+      statuses = await this.session.query.mcpServerStatus();
+    } catch (error) {
+      // A failed status RPC must not block the turn; assume healthy.
+      this.logger.debug("ensureLocalToolsConnected: status check failed", {
+        trigger,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return true;
+    }
+
+    const allConnected = names.every((name) =>
+      statuses.some((s) => s.name === name && s.status === "connected"),
+    );
+    if (allConnected) {
+      return true;
+    }
+
+    this.logger.warn("signed_commit_mcp_unhealthy", {
+      trigger,
+      sessionId: this.sessionId,
+      servers: names,
+    });
+
+    try {
+      const external = Object.fromEntries(
+        Object.entries(this.session.queryOptions.mcpServers ?? {}).filter(
+          ([, cfg]) => (cfg as { type?: string }).type !== "sdk",
+        ),
+      );
+      const next = { ...external, ...desired };
+      await this.session.query.setMcpServers(next);
+      this.session.queryOptions.mcpServers = next;
+      clearMcpToolMetadataCache();
+      this.deferBackgroundFetches(this.session.query);
+      this.logger.info("signed_commit_mcp_recovered", {
+        trigger,
+        sessionId: this.sessionId,
+        servers: names,
+      });
+      return true;
+    } catch (error) {
+      this.logger.error("signed_commit_mcp_recovery_failed", {
+        trigger,
+        sessionId: this.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
   }
 
   async setSessionMode(
@@ -1540,18 +1633,31 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // so adding a tool needs no change here. In cloud runs `git commit`/`git
     // push` are blocked by the PreToolUse guard (and the sandbox git shim), so
     // the agent commits via the signed-commit tool instead.
-    const localToolsServer = createLocalToolsMcpServer(
-      {
-        cwd,
-        token: resolveGithubToken(),
-        taskId,
-        baseBranch: meta?.baseBranch,
-      },
-      meta,
-    );
-    if (localToolsServer) {
-      mcpServers[LOCAL_TOOLS_MCP_NAME] = localToolsServer;
-    } else if (cloudRun) {
+    //
+    // Built via a closure (stored on the session) so refresh and self-heal can
+    // rebuild a FRESH instance. A reused McpServer keeps its `_transport` set,
+    // so the SDK rejects re-connecting it with "Already connected to a
+    // transport" — which is exactly how the signed-commit server silently
+    // disappeared after a mid-run refresh.
+    const buildInProcessMcpServers = (): Record<
+      string,
+      McpSdkServerConfigWithInstance
+    > => {
+      const server = createLocalToolsMcpServer(
+        {
+          cwd,
+          token: resolveGithubToken(),
+          taskId,
+          baseBranch: meta?.baseBranch,
+        },
+        meta,
+      );
+      return server ? { [LOCAL_TOOLS_MCP_NAME]: server } : {};
+    };
+
+    const initialInProcess = buildInProcessMcpServers();
+    Object.assign(mcpServers, initialInProcess);
+    if (Object.keys(initialInProcess).length === 0 && cloudRun) {
       this.logger.warn(
         "Cloud run registered no local tools — missing GH_TOKEN/GITHUB_TOKEN? signed commits unavailable",
       );
@@ -1612,6 +1718,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       enrichmentDeps: this.enrichment?.deps,
       enrichedReadCache: this.enrichedReadCache,
       cloudMode: cloudRun,
+      onEnsureLocalToolsConnected: () =>
+        this.ensureLocalToolsConnected("guard-hook"),
       taskState,
       onTaskStateChange: async () => {
         await this.client.sessionUpdate({
@@ -1632,6 +1740,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const session: Session = {
       query: q,
       queryOptions: options,
+      buildInProcessMcpServers,
       input,
       cancelled: false,
       settingsManager,

--- a/packages/agent/src/adapters/claude/hooks.test.ts
+++ b/packages/agent/src/adapters/claude/hooks.test.ts
@@ -366,6 +366,45 @@ describe("createSignedCommitGuardHook", () => {
     );
     expect(result).toEqual({ continue: true });
   });
+
+  test("attempts a heal and keeps the standard message when tools are available", async () => {
+    const onHeal = vi.fn().mockResolvedValue(true);
+    const healingGuard = createSignedCommitGuardHook(logger, onHeal);
+
+    const result = await healingGuard(
+      bashInput("git commit -m x"),
+      undefined,
+      opts,
+    );
+
+    expect(onHeal).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining("git_signed_commit"),
+      },
+    });
+  });
+
+  test("reassures the model when tools can't be restored", async () => {
+    const onHeal = vi.fn().mockResolvedValue(false);
+    const healingGuard = createSignedCommitGuardHook(logger, onHeal);
+
+    const result = await healingGuard(
+      bashInput("git push origin main"),
+      undefined,
+      opts,
+    );
+
+    expect(result).toMatchObject({
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining(
+          "safe in the working tree",
+        ),
+      },
+    });
+  });
 });
 
 describe("createTaskHook", () => {

--- a/packages/agent/src/adapters/claude/hooks.test.ts
+++ b/packages/agent/src/adapters/claude/hooks.test.ts
@@ -405,6 +405,26 @@ describe("createSignedCommitGuardHook", () => {
       },
     });
   });
+
+  test("treats a thrown heal callback as unavailable", async () => {
+    const onHeal = vi.fn().mockRejectedValue(new Error("reconnect boom"));
+    const healingGuard = createSignedCommitGuardHook(logger, onHeal);
+
+    const result = await healingGuard(
+      bashInput("git commit -m x"),
+      undefined,
+      opts,
+    );
+
+    expect(result).toMatchObject({
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining(
+          "safe in the working tree",
+        ),
+      },
+    });
+  });
 });
 
 describe("createTaskHook", () => {

--- a/packages/agent/src/adapters/claude/hooks.test.ts
+++ b/packages/agent/src/adapters/claude/hooks.test.ts
@@ -386,28 +386,10 @@ describe("createSignedCommitGuardHook", () => {
     });
   });
 
-  test("reassures the model when tools can't be restored", async () => {
-    const onHeal = vi.fn().mockResolvedValue(false);
-    const healingGuard = createSignedCommitGuardHook(logger, onHeal);
-
-    const result = await healingGuard(
-      bashInput("git push origin main"),
-      undefined,
-      opts,
-    );
-
-    expect(result).toMatchObject({
-      hookSpecificOutput: {
-        permissionDecision: "deny",
-        permissionDecisionReason: expect.stringContaining(
-          "safe in the working tree",
-        ),
-      },
-    });
-  });
-
-  test("treats a thrown heal callback as unavailable", async () => {
-    const onHeal = vi.fn().mockRejectedValue(new Error("reconnect boom"));
+  test.each([
+    ["resolves false", vi.fn().mockResolvedValue(false)],
+    ["throws", vi.fn().mockRejectedValue(new Error("reconnect boom"))],
+  ])("reassures the model when the heal %s", async (_label, onHeal) => {
     const healingGuard = createSignedCommitGuardHook(logger, onHeal);
 
     const result = await healingGuard(

--- a/packages/agent/src/adapters/claude/hooks.ts
+++ b/packages/agent/src/adapters/claude/hooks.ts
@@ -359,9 +359,7 @@ export const createSignedCommitGuardHook =
       `[SignedCommitGuard] Blocking unsigned git command: ${command}`,
     );
 
-    // The model usually reaches for raw git only when the signed-commit tool
-    // looks unavailable to it. Try to restore the in-process server before
-    // denying, then tailor the message to whether it came back.
+    // Try to restore the server before denying; tailor the message to the result.
     let toolsAvailable = true;
     if (onEnsureLocalToolsConnected) {
       try {

--- a/packages/agent/src/adapters/claude/hooks.ts
+++ b/packages/agent/src/adapters/claude/hooks.ts
@@ -341,7 +341,10 @@ function blocksUnsignedGit(command: string): boolean {
  * which creates GitHub-signed (Verified) commits via the API.
  */
 export const createSignedCommitGuardHook =
-  (logger: Logger): HookCallback =>
+  (
+    logger: Logger,
+    onEnsureLocalToolsConnected?: () => Promise<boolean>,
+  ): HookCallback =>
   async (input: HookInput, _toolUseID: string | undefined) => {
     if (input.hook_event_name !== "PreToolUse") return { continue: true };
     if (input.tool_name !== "Bash") return { continue: true };
@@ -355,16 +358,36 @@ export const createSignedCommitGuardHook =
     logger.info(
       `[SignedCommitGuard] Blocking unsigned git command: ${command}`,
     );
+
+    // The model usually reaches for raw git only when the signed-commit tool
+    // looks unavailable to it. Try to restore the in-process server before
+    // denying, then tailor the message to whether it came back.
+    let toolsAvailable = true;
+    if (onEnsureLocalToolsConnected) {
+      try {
+        toolsAvailable = await onEnsureLocalToolsConnected();
+      } catch {
+        toolsAvailable = false;
+      }
+    }
+
+    const reason = toolsAvailable
+      ? "Commits must be signed: `git commit` and `git push` are disabled here. " +
+        "Stage changes with `git add`, then call the `git_signed_commit` tool " +
+        `(${SIGNED_COMMIT_QUALIFIED_TOOL_NAME}) with a \`message\` to create a signed ` +
+        "commit on the branch."
+      : "Commits must be signed, and the signed-commit tooling is momentarily " +
+        "reconnecting, so it isn't available this instant. Your staged and unstaged " +
+        "changes are safe in the working tree — nothing is lost. Wait a moment, then " +
+        `call the \`git_signed_commit\` tool (${SIGNED_COMMIT_QUALIFIED_TOOL_NAME}) with a ` +
+        "`message`; raw `git commit`/`git push` stay disabled.";
+
     return {
       continue: true,
       hookSpecificOutput: {
         hookEventName: "PreToolUse" as const,
         permissionDecision: "deny" as const,
-        permissionDecisionReason:
-          "Commits must be signed: `git commit` and `git push` are disabled here. " +
-          "Stage changes with `git add`, then call the `git_signed_commit` tool " +
-          `(${SIGNED_COMMIT_QUALIFIED_TOOL_NAME}) with a \`message\` to create a signed ` +
-          "commit on the branch.",
+        permissionDecisionReason: reason,
       },
     };
   };

--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -1,6 +1,7 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { HookInput } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "../../../utils/logger";
 import { SUBAGENT_REWRITES } from "../hooks";
 import { buildSessionOptions } from "./options";
@@ -69,6 +70,64 @@ describe("buildSessionOptions", () => {
     });
 
     expect(options.agents?.["ph-explore"]).toEqual(override);
+  });
+
+  it("threads onEnsureLocalToolsConnected into the signed-commit guard (cloud)", async () => {
+    const healSpy = vi.fn().mockResolvedValue(true);
+    const options = buildSessionOptions({
+      ...makeParams(),
+      cloudMode: true,
+      onEnsureLocalToolsConnected: healSpy,
+    });
+
+    const gitCommit = {
+      session_id: "s",
+      transcript_path: "/tmp/t",
+      cwd: "/tmp",
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_use_id: "toolu_1",
+      tool_input: { command: "git commit -m x" },
+    } as HookInput;
+    const opts = { signal: new AbortController().signal };
+
+    const hooks = (options.hooks?.PreToolUse ?? []).flatMap(
+      (entry) => entry.hooks ?? [],
+    );
+    for (const hook of hooks) {
+      await hook(gitCommit, undefined, opts);
+    }
+
+    expect(healSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the signed-commit guard outside cloud mode", async () => {
+    const healSpy = vi.fn().mockResolvedValue(true);
+    const options = buildSessionOptions({
+      ...makeParams(),
+      cloudMode: false,
+      onEnsureLocalToolsConnected: healSpy,
+    });
+
+    const gitCommit = {
+      session_id: "s",
+      transcript_path: "/tmp/t",
+      cwd: "/tmp",
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_use_id: "toolu_1",
+      tool_input: { command: "git commit -m x" },
+    } as HookInput;
+    const opts = { signal: new AbortController().signal };
+
+    const hooks = (options.hooks?.PreToolUse ?? []).flatMap(
+      (entry) => entry.hooks ?? [],
+    );
+    for (const hook of hooks) {
+      await hook(gitCommit, undefined, opts);
+    }
+
+    expect(healSpy).not.toHaveBeenCalled();
   });
 
   describe("CLAUDE_CODE_EXECUTABLE", () => {

--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -1,11 +1,31 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import type { HookInput } from "@anthropic-ai/claude-agent-sdk";
+import type { HookInput, Options } from "@anthropic-ai/claude-agent-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "../../../utils/logger";
 import { SUBAGENT_REWRITES } from "../hooks";
 import { buildSessionOptions } from "./options";
 import { SettingsManager } from "./settings";
+
+const GIT_COMMIT_HOOK_INPUT = {
+  session_id: "s",
+  transcript_path: "/tmp/t",
+  cwd: "/tmp",
+  hook_event_name: "PreToolUse",
+  tool_name: "Bash",
+  tool_use_id: "toolu_1",
+  tool_input: { command: "git commit -m x" },
+} as HookInput;
+
+async function runPreToolUseHooks(options: Options): Promise<void> {
+  const opts = { signal: new AbortController().signal };
+  const hooks = (options.hooks?.PreToolUse ?? []).flatMap(
+    (entry) => entry.hooks ?? [],
+  );
+  for (const hook of hooks) {
+    await hook(GIT_COMMIT_HOOK_INPUT, undefined, opts);
+  }
+}
 
 function makeParams() {
   const cwd = path.join(os.tmpdir(), `options-test-${Date.now()}`);
@@ -74,58 +94,26 @@ describe("buildSessionOptions", () => {
 
   it("threads onEnsureLocalToolsConnected into the signed-commit guard (cloud)", async () => {
     const healSpy = vi.fn().mockResolvedValue(true);
-    const options = buildSessionOptions({
-      ...makeParams(),
-      cloudMode: true,
-      onEnsureLocalToolsConnected: healSpy,
-    });
-
-    const gitCommit = {
-      session_id: "s",
-      transcript_path: "/tmp/t",
-      cwd: "/tmp",
-      hook_event_name: "PreToolUse",
-      tool_name: "Bash",
-      tool_use_id: "toolu_1",
-      tool_input: { command: "git commit -m x" },
-    } as HookInput;
-    const opts = { signal: new AbortController().signal };
-
-    const hooks = (options.hooks?.PreToolUse ?? []).flatMap(
-      (entry) => entry.hooks ?? [],
+    await runPreToolUseHooks(
+      buildSessionOptions({
+        ...makeParams(),
+        cloudMode: true,
+        onEnsureLocalToolsConnected: healSpy,
+      }),
     );
-    for (const hook of hooks) {
-      await hook(gitCommit, undefined, opts);
-    }
 
     expect(healSpy).toHaveBeenCalledTimes(1);
   });
 
   it("omits the signed-commit guard outside cloud mode", async () => {
     const healSpy = vi.fn().mockResolvedValue(true);
-    const options = buildSessionOptions({
-      ...makeParams(),
-      cloudMode: false,
-      onEnsureLocalToolsConnected: healSpy,
-    });
-
-    const gitCommit = {
-      session_id: "s",
-      transcript_path: "/tmp/t",
-      cwd: "/tmp",
-      hook_event_name: "PreToolUse",
-      tool_name: "Bash",
-      tool_use_id: "toolu_1",
-      tool_input: { command: "git commit -m x" },
-    } as HookInput;
-    const opts = { signal: new AbortController().signal };
-
-    const hooks = (options.hooks?.PreToolUse ?? []).flatMap(
-      (entry) => entry.hooks ?? [],
+    await runPreToolUseHooks(
+      buildSessionOptions({
+        ...makeParams(),
+        cloudMode: false,
+        onEnsureLocalToolsConnected: healSpy,
+      }),
     );
-    for (const hook of hooks) {
-      await hook(gitCommit, undefined, opts);
-    }
 
     expect(healSpy).not.toHaveBeenCalled();
   });

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -62,6 +62,9 @@ export interface BuildOptionsParams {
   onPostHogResourceUsed?: (subTool: string, commandText?: string) => void;
   /** Cloud task session — enables the signed-commit guard. */
   cloudMode?: boolean;
+  /** Reactive self-heal invoked when the guard blocks a raw git commit/push.
+   * Returns whether signed-commit tooling is usable after the attempt. */
+  onEnsureLocalToolsConnected?: () => Promise<boolean>;
   /** Per-session task state populated by createTaskHook from SDK Task* events. */
   taskState: TaskState;
   /** Called after createTaskHook mutates taskState so callers can emit a plan
@@ -171,6 +174,7 @@ function buildHooks(
   enrichedReadCache: EnrichedReadCache | undefined,
   registeredAgents: ReadonlySet<string>,
   cloudMode: boolean,
+  onEnsureLocalToolsConnected: (() => Promise<boolean>) | undefined,
   taskState: TaskState,
   onTaskStateChange: (() => Promise<void>) | undefined,
 ): Options["hooks"] {
@@ -191,7 +195,9 @@ function buildHooks(
     createSubagentRewriteHook(logger, registeredAgents),
   ];
   if (cloudMode) {
-    preToolUseHooks.push(createSignedCommitGuardHook(logger));
+    preToolUseHooks.push(
+      createSignedCommitGuardHook(logger, onEnsureLocalToolsConnected),
+    );
   }
 
   const taskHook = createTaskHook(taskState, onTaskStateChange);
@@ -415,6 +421,7 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
       params.enrichedReadCache,
       registeredAgentNames,
       params.cloudMode ?? false,
+      params.onEnsureLocalToolsConnected,
       params.taskState,
       params.onTaskStateChange,
     ),

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -53,6 +53,9 @@ export type Session = BaseSession & {
     string,
     McpSdkServerConfigWithInstance
   >;
+  /** Names of the in-process servers registered at session start. Lets the
+   * self-heal check status without rebuilding instances on every prompt. */
+  localToolsServerNames: string[];
   input: Pushable<SDKUserMessage>;
   settingsManager: SettingsManager;
   permissionMode: CodeExecutionMode;

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -4,6 +4,7 @@ import type {
   TerminalOutputResponse,
 } from "@agentclientprotocol/sdk";
 import type {
+  McpSdkServerConfigWithInstance,
   Options,
   Query,
   SDKUserMessage,
@@ -46,6 +47,18 @@ export type Session = BaseSession & {
   query: Query;
   /** The Options object passed to query() — mutating it affects subsequent prompts */
   queryOptions: Options;
+  /**
+   * Rebuilds the in-process ("sdk") MCP servers (currently the signed-commit
+   * `posthog-code-tools` server) with a FRESH instance each call. A reused
+   * instance keeps its `_transport` set, so the SDK throws "Already connected"
+   * when a refreshed/rebuilt Query tries to connect it. Used on session refresh
+   * and by the self-heal path. Returns {} when no in-process server is enabled
+   * (e.g. non-cloud runs or missing GH token).
+   */
+  buildInProcessMcpServers: () => Record<
+    string,
+    McpSdkServerConfigWithInstance
+  >;
   input: Pushable<SDKUserMessage>;
   settingsManager: SettingsManager;
   permissionMode: CodeExecutionMode;

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -47,14 +47,8 @@ export type Session = BaseSession & {
   query: Query;
   /** The Options object passed to query() — mutating it affects subsequent prompts */
   queryOptions: Options;
-  /**
-   * Rebuilds the in-process ("sdk") MCP servers (currently the signed-commit
-   * `posthog-code-tools` server) with a FRESH instance each call. A reused
-   * instance keeps its `_transport` set, so the SDK throws "Already connected"
-   * when a refreshed/rebuilt Query tries to connect it. Used on session refresh
-   * and by the self-heal path. Returns {} when no in-process server is enabled
-   * (e.g. non-cloud runs or missing GH token).
-   */
+  /** Rebuilds the in-process ("sdk") signed-commit server with a fresh instance
+   * each call (reusing one throws "Already connected"); {} when none is enabled. */
   buildInProcessMcpServers: () => Record<
     string,
     McpSdkServerConfigWithInstance


### PR DESCRIPTION
## Problem

In cloud runs, a session refresh disconnected the signed-commit MCP server (posthog-code-tools), so the agent could no longer commit and a turn's work appeared lost while raw git stays blocked.<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Rebuild a fresh in-process server on refresh instead of reusing the dead instance (the SDK rejects re-connecting it with "Already connected to a transport")
2. Self-heal: reconnect the server before each prompt and when the guard hook blocks a raw git commit
3. Bound the status check with a timeout so a wedged control channel can't stall the turn
4. Clear stale MCP tool metadata cache on refresh and reconnect
5. Honest guard-hook message when signing is briefly unavailable (changes are safe in the working tree)
6. Tests for refresh rebuild, self-heal paths, status timeout, and guard wiring

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

Manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?