### PR TITLE
feat(folder-picker): show up to 10 recent repositories

### DIFF
--- a/packages/ui/src/features/folder-picker/FolderPicker.tsx
+++ b/packages/ui/src/features/folder-picker/FolderPicker.tsx
@@ -47,7 +47,7 @@ export function FolderPicker({
     getFolderByPath,
   } = useFolders();
 
-  const recentFolders = getRecentFolders(10);
+  const recentFolders = getRecentFolders();
   const displayValue = getFolderDisplayName(value);
   const isField = variant === "field";
 

--- a/packages/ui/src/features/folder-picker/FolderPicker.tsx
+++ b/packages/ui/src/features/folder-picker/FolderPicker.tsx
@@ -47,7 +47,7 @@ export function FolderPicker({
     getFolderByPath,
   } = useFolders();
 
-  const recentFolders = getRecentFolders();
+  const recentFolders = getRecentFolders(10);
   const displayValue = getFolderDisplayName(value);
   const isField = variant === "field";
 

--- a/packages/ui/src/features/folders/useFolders.ts
+++ b/packages/ui/src/features/folders/useFolders.ts
@@ -56,7 +56,7 @@ export function useFolders() {
   );
 
   const getRecentFolders = useCallback(
-    (limit = 5) =>
+    (limit = 10) =>
       [...existingFolders]
         .sort(
           (a, b) =>


### PR DESCRIPTION
## Problem

We work across a lot of repos internally, and the folder picker only surfaced the 5 most recent repositories — too limiting when switching between many.

## Changes

Bumped the recent repositories shown in the folder picker's "Recent" list from 5 to 10 (`getRecentFolders(10)` in `FolderPicker.tsx`).

## How did you test this?

Not manually tested beyond confirming the change. It's a one-line bump of an existing display limit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1781680206175249)*
