### PR TITLE
fix(codex): remove invalid xhigh effort option for gpt-5.5

### DIFF
--- a/packages/agent/src/adapters/codex/models.test.ts
+++ b/packages/agent/src/adapters/codex/models.test.ts
@@ -4,7 +4,6 @@ import {
   formatCodexModelName,
   getReasoningEffortOptions,
   modelIdFromConfigOptions,
-  supportsXhighEffort,
 } from "./models";
 
 describe("formatCodexModelName", () => {
@@ -17,34 +16,12 @@ describe("getReasoningEffortOptions", () => {
   const values = (modelId: string) =>
     getReasoningEffortOptions(modelId).map((o) => o.value);
 
-  it.each(["gpt-5.5", "gpt-5.5-codex", "openai/gpt-5.5", "GPT-5.5"])(
-    "offers Extra High for the gpt-5.5 family (%s)",
-    (modelId) => {
-      expect(values(modelId)).toEqual(["low", "medium", "high", "xhigh"]);
-    },
-  );
-
-  it.each(["gpt-5.3-codex", "gpt-5.1", "o3"])(
-    "caps at High for other models (%s)",
+  it.each(["gpt-5.5", "gpt-5.5-codex", "openai/gpt-5.5", "GPT-5.5", "o3"])(
+    "caps at High for all models (%s)",
     (modelId) => {
       expect(values(modelId)).toEqual(["low", "medium", "high"]);
     },
   );
-
-  it('labels the extra tier "Extra High"', () => {
-    const xhigh = getReasoningEffortOptions("gpt-5.5").find(
-      (o) => o.value === "xhigh",
-    );
-    expect(xhigh?.name).toBe("Extra High");
-  });
-});
-
-describe("supportsXhighEffort", () => {
-  it("is true for the gpt-5.5 family and false for other models", () => {
-    expect(supportsXhighEffort("gpt-5.5-codex")).toBe(true);
-    expect(supportsXhighEffort("GPT-5.5")).toBe(true);
-    expect(supportsXhighEffort("gpt-5.3-codex")).toBe(false);
-  });
 });
 
 describe("modelIdFromConfigOptions", () => {

--- a/packages/agent/src/adapters/codex/models.ts
+++ b/packages/agent/src/adapters/codex/models.ts
@@ -15,20 +15,10 @@ const CODEX_REASONING_EFFORT_OPTIONS: ReasoningEffortOption[] = [
   { value: "high", name: "High" },
 ];
 
-// OpenAI's `reasoning_effort` exposes an "extra high" tier only on the gpt-5.5
-// family, matching what the Codex app offers. Older models top out at "high".
-export function supportsXhighEffort(modelId: string): boolean {
-  return modelId.toLowerCase().includes("gpt-5.5");
-}
-
 export function getReasoningEffortOptions(
-  modelId: string,
+  _modelId: string,
 ): ReasoningEffortOption[] {
-  const options = [...CODEX_REASONING_EFFORT_OPTIONS];
-  if (supportsXhighEffort(modelId)) {
-    options.push({ value: "xhigh", name: "Extra High" });
-  }
-  return options;
+  return [...CODEX_REASONING_EFFORT_OPTIONS];
 }
 
 export function formatCodexModelName(value: string): string {

--- a/packages/agent/src/adapters/reasoning-effort.test.ts
+++ b/packages/agent/src/adapters/reasoning-effort.test.ts
@@ -2,14 +2,11 @@ import { describe, expect, it } from "vitest";
 import { isSupportedReasoningEffort } from "./reasoning-effort";
 
 describe("isSupportedReasoningEffort", () => {
-  it("accepts xhigh for the codex gpt-5.5 family", () => {
-    expect(isSupportedReasoningEffort("codex", "gpt-5.5", "xhigh")).toBe(true);
+  it("rejects xhigh for codex models, including the gpt-5.5 family", () => {
+    expect(isSupportedReasoningEffort("codex", "gpt-5.5", "xhigh")).toBe(false);
     expect(isSupportedReasoningEffort("codex", "gpt-5.5-codex", "xhigh")).toBe(
-      true,
+      false,
     );
-  });
-
-  it("rejects xhigh for other codex models", () => {
     expect(isSupportedReasoningEffort("codex", "gpt-5.3-codex", "xhigh")).toBe(
       false,
     );

--- a/packages/agent/src/agent.test.ts
+++ b/packages/agent/src/agent.test.ts
@@ -40,7 +40,7 @@ describe("Agent", () => {
     await agent.run("task-1", "run-1", {
       adapter: "codex",
       model: "gpt-5.5",
-      reasoningEffort: "xhigh",
+      reasoningEffort: "high",
       repositoryPath: "/tmp/repo",
     });
 
@@ -51,7 +51,7 @@ describe("Agent", () => {
     expect(config.codexOptions).toEqual(
       expect.objectContaining({
         model: "gpt-5.5",
-        reasoningEffort: "xhigh",
+        reasoningEffort: "high",
       }),
     );
   });

--- a/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/packages/workspace-server/src/services/agent/agent.test.ts
@@ -323,7 +323,7 @@ describe("AgentService", () => {
       await service.startSession({
         ...baseSessionParams,
         adapter: "codex",
-        effort: "xhigh",
+        effort: "high",
       });
 
       expect(mockAgentRun).toHaveBeenCalledWith(
@@ -331,7 +331,7 @@ describe("AgentService", () => {
         "run-1",
         expect.objectContaining({
           adapter: "codex",
-          reasoningEffort: "xhigh",
+          reasoningEffort: "high",
         }),
       );
     });


### PR DESCRIPTION
## Problem

`xhigh` ("Extra High") is not a valid `reasoning_effort` value for the GPT 5.5 family in OpenAI's Codex API, but our app was advertising it as a selectable option — so picking it would fail.

## Changes

Removed the `xhigh` reasoning-effort tier from the Codex adapter; it now caps at `high` for all models. Claude models (Opus/Fable) still support `xhigh`, so that path is unchanged.

## How did you test this?

- `pnpm --filter @posthog/agent test` for the codex models, reasoning-effort, and agent suites
- `pnpm --filter @posthog/workspace-server test` for the agent service suite
- `pnpm --filter @posthog/agent typecheck`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781681818688969?thread_ts=1781681818.688969&cid=C09G8Q32R6F)*
