### PR TITLE
fix(thread): surface agent messages + plans, per-group spinner, trim noise

### DIFF
--- a/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -32,7 +32,7 @@ function markdownUrlTransform(value: string): string {
 }
 
 const HeadingText = ({ children }: { children: React.ReactNode }) => (
-  <Text as="p" mb="3" className="text-(--accent-11) text-sm">
+  <Text as="p" className="mb-2 text-(--accent-11) text-sm leading-relaxed">
     <strong>{children}</strong>
   </Text>
 );
@@ -44,31 +44,20 @@ export const baseComponents: Components = {
   h4: ({ children }) => <HeadingText>{children}</HeadingText>,
   h5: ({ children }) => <HeadingText>{children}</HeadingText>,
   h6: ({ children }) => <HeadingText>{children}</HeadingText>,
-  p: ({ children, node }) => {
-    const isStrongOnly =
-      node?.children?.length === 1 &&
-      node.children[0].type === "element" &&
-      node.children[0].tagName === "strong";
-
-    return (
-      <Text as="p" mb={isStrongOnly ? "2" : "3"}>
-        {children}
-      </Text>
-    );
-  },
+  p: ({ children }) => (
+    <Text as="p" className="mb-2">
+      {children}
+    </Text>
+  ),
   blockquote: ({ children }) => (
-    <Blockquote size="1" mb="3" style={{ borderColor: "var(--accent-6)" }}>
+    <Blockquote size="1" mb="2" style={{ borderColor: "var(--accent-6)" }}>
       {children}
     </Blockquote>
   ),
   code: ({ children, className }) => {
     const match = className?.match(/language-(\w+)/);
     if (!match) {
-      return (
-        <Code variant="ghost" className="text-(--accent-11)">
-          {children}
-        </Code>
-      );
+      return <Code variant="ghost">{children}</Code>;
     }
     return (
       <HighlightedCode
@@ -80,9 +69,7 @@ export const baseComponents: Components = {
   pre: ({ children }) => <CodeBlock size="1">{children}</CodeBlock>,
   em: ({ children }) => <em>{children}</em>,
   i: ({ children }) => <i>{children}</i>,
-  strong: ({ children }) => (
-    <strong className="text-(--accent-11)">{children}</strong>
-  ),
+  strong: ({ children }) => <strong>{children}</strong>,
   del: ({ children }) => (
     <del className="text-(--gray-9) line-through">{children}</del>
   ),
@@ -154,7 +141,7 @@ export const baseComponents: Components = {
           checked={checked}
           size="1"
           style={{ verticalAlign: "middle" }}
-          className="mr-2"
+          className="mr-1"
         />
       );
     }

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -3,6 +3,7 @@ import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { useService } from "@posthog/di/react";
 import {
   Button,
+  cn,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -318,7 +319,10 @@ export function ConversationView({
                 return (
                   <div
                     key={it.id}
-                    className={isPlainMessage ? "pl-5" : undefined}
+                    className={cn(
+                      isPlainMessage ? "pl-5" : undefined,
+                      "empty:hidden",
+                    )}
                   >
                     {renderItem(it)}
                   </div>

--- a/packages/ui/src/features/sessions/components/VirtualizedList.tsx
+++ b/packages/ui/src/features/sessions/components/VirtualizedList.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@posthog/quill";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type CSSProperties,
@@ -271,7 +272,7 @@ function VirtualizedListInner<T>(
                 }}
               >
                 <div
-                  className={itemClassName}
+                  className={cn(itemClassName, "[&_p:last-of-type]:mb-0")}
                   style={itemStyle}
                   data-conversation-item-id={itemKey}
                 >

--- a/packages/ui/src/features/sessions/components/new-thread/ToolCallGroupChip.tsx
+++ b/packages/ui/src/features/sessions/components/new-thread/ToolCallGroupChip.tsx
@@ -2,6 +2,7 @@ import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 import type { GroupSummary } from "@posthog/ui/features/sessions/components/new-thread/buildThreadGroups";
 import { motion as motionConfig } from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
 import { ToolRow } from "@posthog/ui/features/sessions/components/session-update/ToolRow";
+import { DotsCircleSpinner } from "@posthog/ui/primitives/DotsCircleSpinner";
 import { motion, useReducedMotion } from "framer-motion";
 import type { ReactNode } from "react";
 
@@ -30,8 +31,18 @@ export function ToolCallGroupChip({
   const reduceMotion = useReducedMotion();
   const animate = motionConfig.enabled && !reduceMotion;
   const Caret = expanded ? CaretDownIcon : CaretRightIcon;
-  const running = !turnComplete && summary.liveLabel != null;
-  const label = running ? summary.liveLabel : summary.doneLabel;
+  // Spin on THIS group's own in-flight tool, not the turn — a turn split across
+  // several chips (by messages/plans) must not keep finished chips spinning.
+  const running = !turnComplete && summary.active && summary.liveLabel != null;
+  // While running, show both what's happened so far (doneLabel reflects the
+  // running tallies) and what's happening now (the live tool title), so a
+  // collapsed turn reads as actively-working rather than stalled.
+  const hasDone = summary.hasCountableWork;
+  const label = running
+    ? hasDone
+      ? `${summary.doneLabel} · ${summary.liveLabel}`
+      : (summary.liveLabel as string)
+    : summary.doneLabel;
 
   return (
     <motion.div
@@ -64,8 +75,11 @@ export function ToolCallGroupChip({
           ) : null
         }
       >
-        <span className="truncate font-medium text-[13px] text-gray-11 transition-colors group-hover:text-gray-12">
-          {label}
+        <span className="flex min-w-0 items-center gap-1.5 font-medium text-[13px] text-gray-11 transition-colors group-hover:text-gray-12">
+          {running ? (
+            <DotsCircleSpinner size={12} className="shrink-0 text-gray-10" />
+          ) : null}
+          <span className="truncate">{label}</span>
         </span>
       </ToolRow>
     </motion.div>

--- a/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
+++ b/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
@@ -22,6 +22,19 @@ export interface GroupSummary {
   liveLabel: string | null;
   /** Verb-led summary shown once the turn completes. */
   doneLabel: string;
+  /**
+   * This group's last tool call is still pending/in_progress. A turn can span
+   * several groups (messages/plans split it), so spin on the group's own work,
+   * not the turn — otherwise finished earlier groups keep spinning until the
+   * whole turn ends.
+   */
+  active: boolean;
+  /**
+   * The group did some countable tool work (i.e. doneLabel is a real summary,
+   * not the "Worked" fallback). Lets the chip decide whether to show the
+   * summary without depending on the fallback string.
+   */
+  hasCountableWork: boolean;
 }
 
 /**
@@ -71,6 +84,29 @@ function isAlwaysVisibleItem(item: ConversationItem): boolean {
   );
 }
 
+/**
+ * The agent's direct text to the user. Never folded — it surfaces as its own
+ * chat row so a collapsed turn never swallows something said to the user.
+ */
+function isDirectMessageItem(item: ConversationItem): boolean {
+  return (
+    item.type === "session_update" &&
+    item.update.sessionUpdate === "agent_message_chunk"
+  );
+}
+
+/**
+ * A plan presented for approval (the ExitPlanMode / switch_mode tool call,
+ * rendered by PlanApprovalView). Never folded — a plan is meant to be read.
+ */
+function isPlanItem(item: ConversationItem): boolean {
+  return (
+    item.type === "session_update" &&
+    item.update.sessionUpdate === "tool_call" &&
+    item.update.kind === "switch_mode"
+  );
+}
+
 function summarize(items: ConversationItem[]): GroupSummary {
   const counts: GroupCounts = {
     execute: 0,
@@ -85,6 +121,7 @@ function summarize(items: ConversationItem[]): GroupSummary {
     messages: 0,
   };
   let liveLabel: string | null = null;
+  let lastToolStatus: string | undefined;
   const icons: GroupIconEntry[] = [];
   const seenIcons = new Set<string>();
 
@@ -100,6 +137,7 @@ function summarize(items: ConversationItem[]): GroupSummary {
     if (update.sessionUpdate === "tool_call") {
       // Most recent tool's title — what the chip shows while still running.
       if (update.title) liveLabel = update.title;
+      lastToolStatus = update.status;
       const name = getToolName(update);
       if (name && grouping.subagentToolNames.has(name)) {
         counts.subagents++;
@@ -145,7 +183,27 @@ function summarize(items: ConversationItem[]): GroupSummary {
     }
   }
 
-  return { counts, icons, liveLabel, doneLabel: buildDoneLabel(counts) };
+  const active =
+    lastToolStatus === "pending" || lastToolStatus === "in_progress";
+  const hasCountableWork =
+    counts.execute +
+      counts.read +
+      counts.edit +
+      counts.delete +
+      counts.move +
+      counts.search +
+      counts.fetch +
+      counts.subagents +
+      counts.other >
+    0;
+  return {
+    counts,
+    icons,
+    liveLabel,
+    active,
+    hasCountableWork,
+    doneLabel: buildDoneLabel(counts),
+  };
 }
 
 // Completed turns are frozen by reference in the conversation builder, so their
@@ -198,33 +256,11 @@ export function buildThreadGroups(
 
   const flush = () => {
     if (buffer.length === 0) return;
-    const first = buffer[0];
+    const leading = buffer;
+    const first = leading[0];
     const turnComplete =
       first.type === "session_update" && first.turnContext.turnComplete;
     const groupId = `group:${first.id}`;
-
-    // Peel the trailing assistant answer (a run of agent_message_chunks at the
-    // end of the turn) out of the group so it stays visible even when collapsed.
-    const leading = [...buffer];
-    const trailing: ConversationItem[] = [];
-    while (leading.length > 0) {
-      const last = leading[leading.length - 1];
-      if (
-        last.type === "session_update" &&
-        last.update.sessionUpdate === "agent_message_chunk"
-      ) {
-        trailing.unshift(leading.pop() as ConversationItem);
-      } else {
-        break;
-      }
-    }
-
-    // Nothing collapsible (turn was only an assistant answer): render inline.
-    if (leading.length === 0) {
-      for (const item of buffer) pushItemRow(item);
-      buffer = [];
-      return;
-    }
 
     // Base behavior from the global mode; a per-group override (true=expanded,
     // false=collapsed) wins. A chip is shown whenever the group is collapsible
@@ -251,7 +287,6 @@ export function buildThreadGroups(
     } else {
       for (const item of leading) pushItemRow(item);
     }
-    for (const item of trailing) pushItemRow(item);
     buffer = [];
   };
 
@@ -269,8 +304,13 @@ export function buildThreadGroups(
           // Keep MCP-app tool calls standalone so their iframes stay mounted.
           flush();
           keepMounted.push(pushItemRow(item));
-        } else if (isAlwaysVisibleItem(item)) {
-          // Setup/clone progress and the like never collapse into a group.
+        } else if (
+          isAlwaysVisibleItem(item) ||
+          isDirectMessageItem(item) ||
+          isPlanItem(item)
+        ) {
+          // Setup/clone progress, the agent's direct messages, and plans never
+          // collapse into a group — they surface as their own chat rows.
           flush();
           pushItemRow(item);
         } else {

--- a/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
@@ -152,7 +152,7 @@ export const AgentMessage = memo(function AgentMessage({
   }, [content]);
 
   return (
-    <Box className="group/msg relative py-1 pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
+    <Box className="group/msg relative pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
       <MarkdownRenderer
         content={content}
         componentsOverride={agentComponents}

--- a/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
@@ -38,7 +38,7 @@ export function SubagentToolView({
   const hasChildren = childItems.length > 0;
 
   return (
-    <Box className="my-2 max-w-4xl overflow-hidden rounded-lg border border-gray-6 bg-gray-1">
+    <Box className="max-w-4xl overflow-hidden rounded-sm border border-gray-6 bg-gray-1">
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
@@ -69,7 +69,8 @@ export function SubagentToolView({
       </button>
 
       {isExpanded && hasChildren && (
-        <Box className="space-y-1 border-gray-6 border-t px-2 py-2">
+        // [&_.tool-row-collapsible]:pl-1 so that inner ToolRow triggers have some more spacing on left
+        <Box className="space-y-1 border-gray-6 border-t px-2 py-2 [&_.tool-row-collapsible]:pl-1">
           {childItems.map((child) => {
             if (child.type !== "session_update") return null;
             return (

--- a/packages/ui/src/features/sessions/components/session-update/ThoughtView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ThoughtView.tsx
@@ -14,8 +14,12 @@ export const ThoughtView = memo(function ThoughtView({
 }: ThoughtViewProps) {
   const hasContent = content.trim().length > 0;
 
+  // An empty thought that's done streaming is pure noise — a bare "Thinking"
+  // header with nothing under it. Only show it while content is still arriving.
+  if (!hasContent && !isLoading) return null;
+
   return (
-    <div className="pl-3">
+    <div>
       <ToolRow
         icon={Brain}
         isLoading={isLoading}

--- a/packages/ui/src/features/sessions/components/session-update/ToolCallBlock.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ToolCallBlock.tsx
@@ -58,7 +58,7 @@ export function ToolCallBlock({
       turnComplete: turnComplete ?? false,
     };
     return (
-      <Box className="pl-3">
+      <Box>
         <SubagentToolView
           {...props}
           childItems={childItems}
@@ -107,7 +107,7 @@ export function ToolCallBlock({
     }
   })();
 
-  return <Box className="pl-3">{content}</Box>;
+  return <Box>{content}</Box>;
 }
 
 function buildChildToolCallsMap(

--- a/packages/ui/src/features/sessions/components/session-update/ToolRow.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ToolRow.tsx
@@ -108,8 +108,12 @@ export function ToolRow({
   }
 
   return (
-    <Collapsible.Root open={isOpen} onOpenChange={setOpen}>
-      <Collapsible.Trigger className="group mb-0 flex w-full min-w-0 cursor-pointer items-start gap-2 py-0.5 text-left">
+    <Collapsible.Root
+      open={isOpen}
+      onOpenChange={setOpen}
+      className="tool-row-collapsible"
+    >
+      <Collapsible.Trigger className="group mb-0 flex w-full min-w-0 cursor-pointer items-start gap-2 rounded-sm py-0.5 pl-1 text-left hover:bg-fill-hover data-panel-open:bg-fill-selected">
         {leadingNode}
         {header}
       </Collapsible.Trigger>

--- a/packages/ui/src/primitives/List.tsx
+++ b/packages/ui/src/primitives/List.tsx
@@ -38,8 +38,8 @@ export function List({ children, as = "ul" }: ListProps) {
 
   return (
     <Component
-      className={`mt-2 mb-3 list-outside marker:text-[var(--accent-10)] ${
-        as === "ol" ? "list-decimal pl-6" : "list-disc pl-4"
+      className={`my-2 list-outside pl-6 ${
+        as === "ol" ? "list-decimal" : "list-disc"
       }`}
     >
       {children}


### PR DESCRIPTION
## What

The conversation thread folded a turn's entire activity into one collapsible chip. That buried the agent's **direct messages** and **plans**, and the chip's running state was tied to the whole turn so finished work kept spinning.

- **Surface direct messages** — `agent_message_chunk` items never fold; they render as their own chat row wherever they occur in a turn (not just trailing).
- **Surface plans** — the `switch_mode` (ExitPlanMode) tool call never folds; renders via `PlanApprovalView` standalone.
- **Per-group spinner** — chip spins on the group's own in-flight tool (`summary.active`), not turn-level `turnComplete`. A turn split across chips no longer keeps finished chips spinning. While running, the chip reads `what happened · what's happening` with a spinner.
- **Trim noise** — hide an empty, done-streaming "Thinking" row.
- **Styling cleanup** — tighter markdown margins, selected-fill on open tool rows, drop dead variants/classes.

## Verified

Driven live against the running app over CDP:
- Direct messages interleave between collapsed chips (`Worked` → "Checking." → `1 tool call` → answer).
- Running chip: `⠏ Ran 1 command · Sleep 15 then echo ok` (spinner + both labels).
- Per-group spinner fix confirmed after the regression report.

lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)