### PR TITLE
fix(net): force IPv4 and disable Happy Eyeballs in Node entrypoints

### DIFF
--- a/apps/code/src/main/bootstrap.ts
+++ b/apps/code/src/main/bootstrap.ts
@@ -16,6 +16,7 @@
 
 import dns from "node:dns";
 import { mkdirSync } from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { app, crashReporter, protocol } from "electron";
@@ -62,6 +63,11 @@ crashReporter.start({ uploadToServer: false });
 // Force IPv4 resolution when "localhost" is used so the agent hits 127.0.0.1
 // instead of ::1. This matches how the renderer already reaches the PostHog API.
 dns.setDefaultResultOrder("ipv4first");
+
+// Disable "Happy Eyeballs": PostHog's many-address ELB times out the connect
+// when IPv6 is unreachable (e.g. Tailscale), as family racing abandons each
+// IPv4 attempt before it completes. ipv4first alone isn't enough.
+net.setDefaultAutoSelectFamily(false);
 
 // Call fixPath early to ensure PATH is correct for any child processes
 fixPath();

--- a/packages/workspace-server/src/serve.ts
+++ b/packages/workspace-server/src/serve.ts
@@ -1,6 +1,14 @@
 import "reflect-metadata";
+import dns from "node:dns";
+import net from "node:net";
 import { serve } from "@hono/node-server";
 import { createApp } from "./app";
+
+// Prefer IPv4 and disable "Happy Eyeballs" (mirrors apps/code main bootstrap).
+// This child makes all outbound HTTPS to PostHog/the gateway; its many-address
+// ELB times out when IPv6 is unreachable (e.g. Tailscale).
+dns.setDefaultResultOrder("ipv4first");
+net.setDefaultAutoSelectFamily(false);
 
 const SHUTDOWN_GRACE_MS = 3_000;
 const WATCHDOG_INTERVAL_MS = 2_000;


### PR DESCRIPTION
## Problem

Connections to `us.posthog.com` fail when Tailscale is enabled. The root cause was traced to IPv6 `EHOSTUNREACH` errors during Node `fetch`. PostHog's many-address ELB times out the connect when IPv6 is unreachable (e.g. via Tailscale), because Node's "Happy Eyeballs" family racing abandons each IPv4 attempt before it can complete. Setting `ipv4first` alone is not sufficient to resolve this.

## Reproduction

With **Tailscale enabled**, attempt to **log in** (against `us.posthog.com` — *not* a local `localhost` PostHog, which is loopback and unaffected). The login fails because the main-process OAuth token call is a Node `fetch` to PostHog's ELB, which times out. The same failure then affects the agent, auth-proxy and MCP proxy (all outbound Node `fetch` from the workspace-server child), making the app effectively unusable.

The underlying network failure can be reproduced directly:

```bash
# With Tailscale enabled — fails with AggregateError [ETIMEDOUT] after ~2s:
node -e '
const u="https://us.posthog.com/_health"; const t=Date.now();
fetch(u,{method:"HEAD",signal:AbortSignal.timeout(8000)})
  .then(r=>console.log("OK",r.status,Date.now()-t+"ms"))
  .catch(e=>console.log("FAIL",e.name,Date.now()-t+"ms"));'

# The same call succeeds once family autoselection is disabled (the fix in this PR):
node --no-network-family-autoselection --dns-result-order=ipv4first -e '
const u="https://us.posthog.com/_health"; const t=Date.now();
fetch(u,{method:"HEAD",signal:AbortSignal.timeout(8000)})
  .then(r=>console.log("OK",r.status,Date.now()-t+"ms"))
  .catch(e=>console.log("FAIL",e.name,Date.now()-t+"ms"));'
```

## Changes

- **`apps/code/src/main/bootstrap.ts`**: Disable Happy Eyeballs via `net.setDefaultAutoSelectFamily(false)` in the Electron main bootstrap, complementing the existing `dns.setDefaultResultOrder(\"ipv4first\")` call. Added an explanatory comment about why `ipv4first` alone is insufficient.
- **`packages/workspace-server/src/serve.ts`**: Mirror the same network configuration (`dns.setDefaultResultOrder(\"ipv4first\")` + `net.setDefaultAutoSelectFamily(false)`) in the workspace-server entrypoint, since this child process makes all outbound HTTPS calls to PostHog and the gateway.

> **TL;DR** Force IPv4 and disable Node's Happy Eyeballs family selection in both the Electron main process and the workspace-server entrypoint, fixing connection timeouts to PostHog's ELB when IPv6 is unreachable (e.g. under Tailscale).

## How did you test this?

- Reproduced the failure by logging in with Tailscale enabled against `us.posthog.com` (see Reproduction above) — login failed with IPv6 `EHOSTUNREACH` / `ETIMEDOUT` errors before the fix and succeeds after it.
- Confirmed the underlying `node -e` repro fails with default settings and succeeds with `--no-network-family-autoselection --dns-result-order=ipv4first`.
- Typecheck + lint pass; connectivity service unit tests pass (16/16).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*