### PR TITLE
feat(agent): forward ai_stage as a gateway trace property

### DIFF
--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -7,6 +7,7 @@ interface TestableServer {
     isInternal?: boolean;
     originProduct?: Task["origin_product"] | null;
     signalReportId?: string | null;
+    aiStage?: string | null;
     taskId?: string | null;
     taskRunId?: string | null;
     taskUserId?: number | null;
@@ -143,6 +144,7 @@ describe("AgentServer.configureEnvironment", () => {
       isInternal: true,
       originProduct: "signal_report",
       signalReportId: "report-123",
+      aiStage: "research",
       taskId: "task-abc",
       taskRunId: "run-xyz",
       taskUserId: 42,
@@ -154,12 +156,22 @@ describe("AgentServer.configureEnvironment", () => {
         "x-posthog-property-task_origin_product: signal_report",
         "x-posthog-property-task_internal: true",
         "x-posthog-property-signal_report_id: report-123",
+        "x-posthog-property-ai_stage: research",
         "x-posthog-property-task_id: task-abc",
         "x-posthog-property-task_run_id: run-xyz",
         "x-posthog-property-task_user_id: 42",
         "x-posthog-property-task_title: Fix the bug",
       ].join("\n"),
     );
+  });
+
+  it("omits ai_stage from ANTHROPIC_CUSTOM_HEADERS when not provided", () => {
+    buildServer("background").configureEnvironment({
+      isInternal: false,
+      taskId: "task-abc",
+    });
+
+    expect(process.env.ANTHROPIC_CUSTOM_HEADERS).not.toContain("ai_stage");
   });
 
   // A signals_scout title is multi-line; it must not inject extra header lines.

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -938,6 +938,7 @@ export class AgentServer {
       isInternal: preTask?.internal === true,
       originProduct: preTask?.origin_product,
       signalReportId: preTask?.signal_report,
+      aiStage: getTaskRunStateString(preTaskRun, "ai_stage"),
       taskId: payload.task_id,
       taskRunId: payload.run_id,
       taskUserId: payload.user_id,
@@ -2006,6 +2007,7 @@ ${signedCommitInstructions}
     isInternal = false,
     originProduct,
     signalReportId,
+    aiStage,
     taskId,
     taskRunId,
     taskUserId,
@@ -2014,6 +2016,7 @@ ${signedCommitInstructions}
     isInternal?: boolean;
     originProduct?: Task["origin_product"] | null;
     signalReportId?: string | null;
+    aiStage?: string | null;
     taskId?: string | null;
     taskRunId?: string | null;
     taskUserId?: number | null;
@@ -2039,6 +2042,7 @@ ${signedCommitInstructions}
       task_origin_product: originProduct,
       task_internal: isInternal,
       signal_report_id: signalReportId,
+      ai_stage: aiStage,
       task_id: taskId,
       task_run_id: taskRunId,
       task_user_id: taskUserId,


### PR DESCRIPTION
## Problem

The signals agentic research runs (repo selection + report research) execute inside the sandbox agent, whose LLM calls route through the gateway tagged `ai_product=signals`. They carried `signal_report_id` (for the research run) but no `ai_stage`, so the spend couldn't be broken down by pipeline stage the way the rest of the signals pipeline can.

## Changes

`configureEnvironment` now reads `ai_stage` from the task run state (`getTaskRunStateString(preTaskRun, "ai_stage")`) and includes it in the `buildGatewayPropertyHeaders` bag, so it's forwarded as an `x-posthog-property-ai_stage` header on the agent's Anthropic calls. The gateway lifts it onto the `$ai_generation` event.

The producing side — setting `TaskRun.state["ai_stage"]` to `"research"` / `"repo_selection"` and extending `signal_report_id` to the repo-selection run — is in the companion PostHog/posthog PR (#64367).

## How did you test this?

I'm an agent (PostHog Slack app). I ran locally:
- `vitest run` on `agent-server.configure-environment.test.ts` — 16 passed, including a new assertion that `ai_stage` is forwarded and one that it's omitted when absent.
- `tsc --noEmit` typecheck on `@posthog/agent` — clean.
- `biome check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?