### PR TITLE
fix(agent): bill signals scouts and all signal-report tasks to signals product

### DIFF
--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -127,14 +127,25 @@ describe("AgentServer.configureEnvironment", () => {
     );
   });
 
-  it("does not tag as signals when origin_product is 'signal_report' but the task is not internal", () => {
+  it("tags as signals when origin_product is 'signal_report' even if the task is not internal", () => {
     buildServer("background").configureEnvironment({
       isInternal: false,
       originProduct: "signal_report",
     });
 
     expect(process.env.LLM_GATEWAY_URL).toBe(
-      "https://gateway.us.posthog.com/posthog_code",
+      "https://gateway.us.posthog.com/signals",
+    );
+  });
+
+  it("tags as signals for scout runs (origin_product 'signals_scout'), internal or not", () => {
+    buildServer("background").configureEnvironment({
+      isInternal: false,
+      originProduct: "signals_scout",
+    });
+
+    expect(process.env.LLM_GATEWAY_URL).toBe(
+      "https://gateway.us.posthog.com/signals",
     );
   });
 

--- a/packages/agent/src/utils/gateway.test.ts
+++ b/packages/agent/src/utils/gateway.test.ts
@@ -17,7 +17,7 @@ describe("resolveGatewayProduct", () => {
     {
       isInternal: false,
       originProduct: "signal_report",
-      expected: "posthog_code",
+      expected: "signals",
     },
     {
       isInternal: true,
@@ -30,6 +30,16 @@ describe("resolveGatewayProduct", () => {
       expected: "background_agents",
     },
     { isInternal: true, originProduct: "signal_report", expected: "signals" },
+    {
+      isInternal: false,
+      originProduct: "signals_scout",
+      expected: "signals",
+    },
+    {
+      isInternal: true,
+      originProduct: "signals_scout",
+      expected: "signals",
+    },
   ] as const)(
     "isInternal=$isInternal originProduct=$originProduct -> $expected",
     ({ isInternal, originProduct, expected }) => {

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -14,9 +14,6 @@ export function resolveGatewayProduct({
   if (originProduct === "slack") {
     return "slack_app";
   }
-  // Signals-originated work bills to the signals product regardless of whether
-  // the run is internal: signal-report tasks and headless scout runs both count
-  // against signals.
   if (originProduct === "signal_report" || originProduct === "signals_scout") {
     return "signals";
   }

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -14,8 +14,14 @@ export function resolveGatewayProduct({
   if (originProduct === "slack") {
     return "slack_app";
   }
+  // Signals-originated work bills to the signals product regardless of whether
+  // the run is internal: signal-report tasks and headless scout runs both count
+  // against signals. (`signals_scout` is the scout origin product.)
+  if (originProduct === "signal_report" || originProduct === "signals_scout") {
+    return "signals";
+  }
   if (isInternal) {
-    return originProduct === "signal_report" ? "signals" : "background_agents";
+    return "background_agents";
   }
   return "posthog_code";
 }

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -16,7 +16,7 @@ export function resolveGatewayProduct({
   }
   // Signals-originated work bills to the signals product regardless of whether
   // the run is internal: signal-report tasks and headless scout runs both count
-  // against signals. (`signals_scout` is the scout origin product.)
+  // against signals.
   if (originProduct === "signal_report" || originProduct === "signals_scout") {
     return "signals";
   }

--- a/packages/shared/src/task.ts
+++ b/packages/shared/src/task.ts
@@ -12,7 +12,7 @@ export interface Task {
     | "support_queue"
     | "session_summaries"
     | "signal_report"
-    | "signals_scout" // Headless Signals scout that proactively emits signals
+    | "signals_scout"
     | "slack";
   signal_report?: string | null; // Inbox report UUID when origin_product is "signal_report"
   github_integration?: number | null;

--- a/packages/shared/src/task.ts
+++ b/packages/shared/src/task.ts
@@ -12,6 +12,7 @@ export interface Task {
     | "support_queue"
     | "session_summaries"
     | "signal_report"
+    | "signals_scout" // Headless Signals scout that proactively emits signals
     | "slack";
   signal_report?: string | null; // Inbox report UUID when origin_product is "signal_report"
   github_integration?: number | null;


### PR DESCRIPTION
## Problem

LLM usage from the Signals product wasn't fully attributed to the `signals` gateway product. Only *internal* signal-report tasks routed to `signals`; non-internal signal-report tasks fell through to `posthog_code`, and headless scout runs (`origin_product = signals_scout`) weren't routed to `signals` at all.

## Changes

`resolveGatewayProduct` now routes any signals-originated work to the `signals` gateway product regardless of the internal flag:

- `signal_report` tasks → `signals` (previously only when internal)
- `signals_scout` (headless scout runs) → `signals` (new)

`Task["origin_product"]` in `@posthog/shared` gains the `signals_scout` member to match the backend `OriginProduct` enum (`products/tasks/backend/models.py`), where the scout origin product is `signals_scout`.

## How did you test this?

Ran the affected unit tests:
`pnpm --filter @posthog/agent exec vitest run src/utils/gateway.test.ts src/server/agent-server.configure-environment.test.ts` — 41 passing, including new cases for non-internal `signal_report` and both internal/non-internal `signals_scout`. Also ran `tsc --noEmit` on the agent package and biome on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1781719189479519)*
