### PR TITLE
feat(thread): tooltips explaining collapsed tool-call chip icons

### DIFF
--- a/packages/ui/src/features/sessions/components/new-thread/ToolCallGroupChip.tsx
+++ b/packages/ui/src/features/sessions/components/new-thread/ToolCallGroupChip.tsx
@@ -1,8 +1,12 @@
 import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 import type { GroupSummary } from "@posthog/ui/features/sessions/components/new-thread/buildThreadGroups";
-import { motion as motionConfig } from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
+import {
+  labelForIconKey,
+  motion as motionConfig,
+} from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
 import { ToolRow } from "@posthog/ui/features/sessions/components/session-update/ToolRow";
 import { DotsCircleSpinner } from "@posthog/ui/primitives/DotsCircleSpinner";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { motion, useReducedMotion } from "framer-motion";
 import type { ReactNode } from "react";
 
@@ -69,7 +73,11 @@ export function ToolCallGroupChip({
           !expanded && summary.icons.length > 0 ? (
             <span className="ml-1 flex shrink-0 items-center gap-1.5 text-gray-9">
               {summary.icons.map(({ Icon, key }) => (
-                <Icon key={key} size={13} />
+                <Tooltip key={key} content={labelForIconKey(key)}>
+                  <span className="flex items-center">
+                    <Icon size={13} />
+                  </span>
+                </Tooltip>
               ))}
             </span>
           ) : null

--- a/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
+++ b/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
@@ -4,6 +4,7 @@ import {
   buildDoneLabel,
   type CollapseMode,
   type GroupCounts,
+  type GroupIconKey,
   grouping,
   iconForToolKind,
   MCP_ICON,
@@ -12,7 +13,7 @@ import {
 
 export interface GroupIconEntry {
   Icon: Icon;
-  key: string;
+  key: GroupIconKey;
 }
 
 export interface GroupSummary {
@@ -125,7 +126,7 @@ function summarize(items: ConversationItem[]): GroupSummary {
   const icons: GroupIconEntry[] = [];
   const seenIcons = new Set<string>();
 
-  const addIcon = (Icon: Icon, key: string) => {
+  const addIcon = (Icon: Icon, key: GroupIconKey) => {
     if (seenIcons.has(key) || icons.length >= grouping.maxIconsInChip) return;
     seenIcons.add(key);
     icons.push({ Icon, key });

--- a/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
+++ b/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
@@ -141,6 +141,25 @@ export function iconForToolKind(kind: CodeToolKind | null | undefined): Icon {
 export const SUBAGENT_ICON: Icon = Robot;
 export const MCP_ICON: Icon = PuzzlePiece;
 
+/** Human-readable label for a chip icon, keyed by its `GroupIconEntry.key`. */
+const ICON_KEY_LABELS: Record<string, string> = {
+  subagent: "Spawned a subagent",
+  mcp: "Called an MCP tool",
+  "kind:read": "Read files",
+  "kind:edit": "Edited files",
+  "kind:delete": "Deleted files",
+  "kind:move": "Moved files",
+  "kind:search": "Searched the codebase",
+  "kind:execute": "Ran terminal commands",
+  "kind:think": "Thought through the problem",
+  "kind:fetch": "Fetched a web page",
+  "kind:question": "Asked a question",
+};
+
+export function labelForIconKey(key: string): string {
+  return ICON_KEY_LABELS[key] ?? "Ran other tools";
+}
+
 // ---------- Motion ----------
 
 /**

--- a/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
+++ b/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
@@ -141,8 +141,15 @@ export function iconForToolKind(kind: CodeToolKind | null | undefined): Icon {
 export const SUBAGENT_ICON: Icon = Robot;
 export const MCP_ICON: Icon = PuzzlePiece;
 
+/** The closed set of `GroupIconEntry.key` values a chip icon can carry. */
+export type GroupIconKey =
+  | "subagent"
+  | "mcp"
+  | `kind:${CodeToolKind}`
+  | "kind:other";
+
 /** Human-readable label for a chip icon, keyed by its `GroupIconEntry.key`. */
-const ICON_KEY_LABELS: Record<string, string> = {
+const ICON_KEY_LABELS: Partial<Record<GroupIconKey, string>> = {
   subagent: "Spawned a subagent",
   mcp: "Called an MCP tool",
   "kind:read": "Read files",
@@ -156,7 +163,7 @@ const ICON_KEY_LABELS: Record<string, string> = {
   "kind:question": "Asked a question",
 };
 
-export function labelForIconKey(key: string): string {
+export function labelForIconKey(key: GroupIconKey): string {
   return ICON_KEY_LABELS[key] ?? "Ran other tools";
 }
 


### PR DESCRIPTION
Problem:
- robot had mini icons to explain the type of work it did, but it wasn't always clear what exactly that work was.

- Adds hover tooltips to each icon in a collapsed tool-call chip, explaining what it means (terminal → "Ran terminal commands", robot → "Spawned a subagent", etc.)
- `conversationThreadConfig.ts`: new `labelForIconKey(key)` label map
- `ToolCallGroupChip.tsx`: wrap each icon in the existing `Tooltip` primitive

<img width="784" height="218" alt="CleanShot 2026-06-17 at 14 51 31@2x" src="https://github.com/user-attachments/assets/8dea9935-161e-46ae-991d-710339685849" />
<img width="716" height="246" alt="CleanShot 2026-06-17 at 14 51 40@2x" src="https://github.com/user-attachments/assets/70a137b9-5d5e-492f-9fb8-707500999e13" />


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*