### PR TITLE
chore(diagnostics): Instrument agent no-response failures

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1126,7 +1126,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         this.session.settingsManager.dispose();
         this.session.input.end();
         throw RequestError.internalError(
-          undefined,
+          { details: msg },
           "The Claude Agent process exited unexpectedly. Please start a new session.",
         );
       }
@@ -1825,10 +1825,12 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     // Kick off SDK initialization for new sessions so it runs concurrently
     // with the model config fetch below (the gateway REST call is independent).
+    const initStartedAt = Date.now();
     const initPromise = !isResume
       ? withTimeout(q.initializationResult(), SESSION_VALIDATION_TIMEOUT_MS)
       : undefined;
 
+    const modelConfigStartedAt = Date.now();
     const [rawModelOptions] = await Promise.all([
       this.getModelConfigOptions(
         settingsManager.getSettings().model || meta?.model || undefined,
@@ -1843,6 +1845,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           ]
         : []),
     ]);
+    const modelConfigMs = Date.now() - modelConfigStartedAt;
 
     // Restrict the model list to the user's `availableModels` allowlist
     // from settings.json so config UI and downstream resolution stay
@@ -1867,6 +1870,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         session.knownSlashCommands = collectKnownSlashCommands(
           initResult.value.commands,
         );
+        this.logger.info("Session initialized", {
+          sessionId,
+          taskId,
+          taskRunId: meta?.taskRunId,
+          modelConfigMs,
+          initMs: Date.now() - initStartedAt,
+        });
       } catch (err) {
         settingsManager.dispose();
         this.terminateQuery(q, abortController);
@@ -1874,6 +1884,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           sessionId,
           taskId,
           taskRunId: meta?.taskRunId,
+          modelConfigMs,
+          initMs: Date.now() - initStartedAt,
           error: err instanceof Error ? err.message : String(err),
         });
         throw err;

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1817,7 +1817,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
             sessionId,
             taskId,
             taskRunId: meta?.taskRunId,
-            error: err instanceof Error ? err.message : String(err),
+            errorDetail: serializeError(err),
           },
         );
         throw err;

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -42,6 +42,7 @@ import {
   type SDKUserMessage,
   type SlashCommand,
 } from "@anthropic-ai/claude-agent-sdk";
+import { serializeError } from "@posthog/shared";
 import { v7 as uuidv7 } from "uuid";
 import packageJson from "../../../package.json" with { type: "json" };
 import {
@@ -1830,7 +1831,6 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       ? withTimeout(q.initializationResult(), SESSION_VALIDATION_TIMEOUT_MS)
       : undefined;
 
-    const modelConfigStartedAt = Date.now();
     const [rawModelOptions] = await Promise.all([
       this.getModelConfigOptions(
         settingsManager.getSettings().model || meta?.model || undefined,
@@ -1845,7 +1845,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           ]
         : []),
     ]);
-    const modelConfigMs = Date.now() - modelConfigStartedAt;
+    const modelConfigMs = Date.now() - initStartedAt;
 
     // Restrict the model list to the user's `availableModels` allowlist
     // from settings.json so config UI and downstream resolution stay
@@ -1886,7 +1886,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           taskRunId: meta?.taskRunId,
           modelConfigMs,
           initMs: Date.now() - initStartedAt,
-          error: err instanceof Error ? err.message : String(err),
+          errorDetail: serializeError(err),
         });
         throw err;
       }

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -300,7 +300,7 @@ function buildSpawnWrapper(
     child.stderr?.on("data", (data: Buffer) => {
       const msg = data.toString().trim();
       if (msg && logger) {
-        logger.debug(`[claude-code:${child.pid}] stderr: ${msg}`);
+        logger.warn(`[claude-code:${child.pid}] stderr: ${msg}`);
       }
     });
 

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { serializeError } from "@posthog/shared";
 import type { SessionContext } from "./otel-log-writer";
 import type { PostHogAPIClient } from "./posthog-api";
 import type { StoredNotification } from "./types";
@@ -221,7 +222,8 @@ export class SessionLogWriter {
           {
             taskId: session.context.taskId,
             runId: session.context.runId,
-            error,
+            maxRetries: SessionLogWriter.MAX_FLUSH_RETRIES,
+            errorDetail: serializeError(error),
           },
         );
         this.retryCounts.set(sessionId, 0);

--- a/packages/agent/src/utils/streams.ts
+++ b/packages/agent/src/utils/streams.ts
@@ -1,5 +1,6 @@
 import type { Readable, Writable } from "node:stream";
 import { ReadableStream, WritableStream } from "node:stream/web";
+import { serializeError } from "@posthog/shared";
 import type { Logger } from "./logger";
 
 export class Pushable<T> implements AsyncIterable<T> {
@@ -147,8 +148,7 @@ export function createTappedWritableStream(
         // Stream may be closed if subprocess crashed - log but don't throw
         droppedWriteCount++;
         logger?.error("ACP write error", {
-          error: err instanceof Error ? err.message : String(err),
-          errorName: err instanceof Error ? err.name : undefined,
+          errorDetail: serializeError(err),
           messageCount,
           droppedWriteCount,
           droppedBytes: chunk.byteLength,

--- a/packages/agent/src/utils/streams.ts
+++ b/packages/agent/src/utils/streams.ts
@@ -148,6 +148,7 @@ export function createTappedWritableStream(
         droppedWriteCount++;
         logger?.error("ACP write error", {
           error: err instanceof Error ? err.message : String(err),
+          errorName: err instanceof Error ? err.name : undefined,
           messageCount,
           droppedWriteCount,
           droppedBytes: chunk.byteLength,

--- a/packages/agent/src/utils/streams.ts
+++ b/packages/agent/src/utils/streams.ts
@@ -122,7 +122,8 @@ export function createTappedWritableStream(
   const { onMessage, logger } = options;
   const decoder = new TextDecoder();
   let buffer = "";
-  let _messageCount = 0;
+  let messageCount = 0;
+  let droppedWriteCount = 0;
 
   return new WritableStream({
     async write(chunk: Uint8Array) {
@@ -133,7 +134,7 @@ export function createTappedWritableStream(
 
       for (const line of lines) {
         if (!line.trim()) continue;
-        _messageCount++;
+        messageCount++;
 
         onMessage(line);
       }
@@ -144,7 +145,13 @@ export function createTappedWritableStream(
         writer.releaseLock();
       } catch (err) {
         // Stream may be closed if subprocess crashed - log but don't throw
-        logger?.error("ACP write error", err);
+        droppedWriteCount++;
+        logger?.error("ACP write error", {
+          error: err instanceof Error ? err.message : String(err),
+          messageCount,
+          droppedWriteCount,
+          droppedBytes: chunk.byteLength,
+        });
       }
     },
     async close() {

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -8,7 +8,7 @@ import {
   type IAnalytics,
 } from "@posthog/platform/analytics";
 import type { StoredLogEntry } from "@posthog/shared";
-import { TypedEventEmitter } from "@posthog/shared";
+import { serializeError, TypedEventEmitter } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { inject, injectable, preDestroy } from "inversify";
 import type { CloudTaskPermissionRequestUpdate } from "./cloud-task-types";
@@ -106,6 +106,9 @@ interface WatcherState {
   lastErrorMessage: string | null;
   lastBranch: string | null;
   lastStatusUpdatedAt: string | null;
+  connStartedAt: number;
+  connSentLastEventId: string | null;
+  connDataEventsReceived: number;
   isBootstrapping: boolean;
   hasEmittedSnapshot: boolean;
   bufferedLogBatches: StoredLogEntry[][];
@@ -155,6 +158,16 @@ function isPermissionRequestEvent(
     data !== null &&
     (data as { type?: string }).type === "permission_request" &&
     typeof (data as { requestId?: string }).requestId === "string"
+  );
+}
+
+function isKeepaliveEvent(event: SseEvent): boolean {
+  return (
+    event.event === "keepalive" ||
+    (typeof event.data === "object" &&
+      event.data !== null &&
+      "type" in event.data &&
+      event.data.type === "keepalive")
   );
 }
 
@@ -432,6 +445,9 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       lastErrorMessage: null,
       lastBranch: null,
       lastStatusUpdatedAt: null,
+      connStartedAt: 0,
+      connSentLastEventId: null,
+      connDataEventsReceived: 0,
       isBootstrapping: false,
       hasEmittedSnapshot: false,
       bufferedLogBatches: [],
@@ -620,10 +636,15 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     const controller = new AbortController();
     watcher.sseAbortController = controller;
 
+    watcher.connStartedAt = 0;
+    watcher.connSentLastEventId = watcher.lastEventId;
+    watcher.connDataEventsReceived = 0;
+    const startLatest = Boolean(options?.startLatest && !watcher.lastEventId);
+
     const url = new URL(
       `${watcher.apiHost}/api/projects/${watcher.teamId}/tasks/${watcher.taskId}/runs/${watcher.runId}/stream/`,
     );
-    if (options?.startLatest && !watcher.lastEventId) {
+    if (startLatest) {
       url.searchParams.set("start", "latest");
     }
     const headers: Record<string, string> = {
@@ -643,6 +664,9 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     // failed reconnect attempt (see SSE_HEALTHY_CONNECTION_MS).
     let connectedAt = 0;
     let streamWasEstablished = false;
+    let bytesReceived = 0;
+    let eventsReceived = 0;
+    let dataEventsReceived = 0;
 
     try {
       const response = await this.auth.authenticatedFetch(url.toString(), {
@@ -661,6 +685,21 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
       connectedAt = Date.now();
       streamWasEstablished = true;
+      watcher.connStartedAt = connectedAt;
+
+      this.log.info("Cloud task SSE connected", {
+        key,
+        sentLastEventId: watcher.connSentLastEventId,
+        startLatest,
+        status: response.status,
+        server: response.headers.get("server"),
+        via: response.headers.get("via"),
+        cfRay: response.headers.get("cf-ray"),
+        cfCacheStatus: response.headers.get("cf-cache-status"),
+        xAccelBuffering: response.headers.get("x-accel-buffering"),
+        contentType: response.headers.get("content-type"),
+        requestId: response.headers.get("x-request-id"),
+      });
 
       const reader = response.body.getReader();
 
@@ -674,9 +713,14 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
           continue;
         }
 
+        bytesReceived += value.byteLength;
         const chunk = decoder.decode(value, { stream: true });
         const events = parser.parse(chunk);
         for (const event of events) {
+          eventsReceived += 1;
+          if (event.event !== "error" && !isKeepaliveEvent(event)) {
+            dataEventsReceived += 1;
+          }
           this.handleSseEvent(key, event);
         }
       }
@@ -692,6 +736,14 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
         return;
       }
 
+      this.log.info("Cloud task stream closed cleanly", {
+        key,
+        connectionDurationMs: connectedAt ? Date.now() - connectedAt : 0,
+        bytesReceived,
+        eventsReceived,
+        dataEventsReceived,
+        lastEventId: this.watchers.get(key)?.lastEventId ?? null,
+      });
       await this.handleStreamCompletion(key, { reconnectIfNonTerminal: true });
     } catch (error) {
       this.flushLogBatch(key);
@@ -729,8 +781,20 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       this.log.warn("Cloud task stream error", {
         key,
         error: errorMessage,
+        errorDetail: serializeError(error),
         wasHealthyStream,
         isBackendError,
+        streamWasEstablished,
+        connectionDurationMs: streamWasEstablished
+          ? Date.now() - connectedAt
+          : 0,
+        bytesReceived,
+        eventsReceived,
+        dataEventsReceived,
+        lastEventId: watcher?.lastEventId ?? null,
+        reconnectAttempts: watcher?.reconnectAttempts ?? 0,
+        streamErrorAttempts: watcher?.streamErrorAttempts ?? 0,
+        cumulativeReconnectAttempts: watcher?.cumulativeReconnectAttempts ?? 0,
       });
       await this.handleStreamCompletion(key, {
         reconnectIfNonTerminal: true,
@@ -766,13 +830,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     // data.
     watcher.reconnectAttempts = 0;
 
-    if (
-      event.event === "keepalive" ||
-      (typeof event.data === "object" &&
-        event.data !== null &&
-        "type" in event.data &&
-        event.data.type === "keepalive")
-    ) {
+    if (isKeepaliveEvent(event)) {
       return;
     }
 
@@ -780,6 +838,15 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     // and cumulative budgets too.
     watcher.streamErrorAttempts = 0;
     watcher.cumulativeReconnectAttempts = 0;
+
+    watcher.connDataEventsReceived += 1;
+    if (watcher.connDataEventsReceived === 1 && watcher.connSentLastEventId) {
+      this.log.info("Cloud task SSE resumed", {
+        key,
+        resumedFrom: watcher.connSentLastEventId,
+        firstEventIdAfterResume: event.id ?? null,
+      });
+    }
 
     if (isTaskRunStateEvent(event.data)) {
       if (this.applyTaskRunState(watcher, event.data)) {
@@ -992,6 +1059,18 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     const watcher = this.watchers.get(key);
     if (!watcher) return;
 
+    this.log.warn("Cloud task watcher failed", {
+      key,
+      errorTitle: error.title,
+      retryable: error.retryable,
+      status: watcher.lastStatus,
+      wasBootstrapping: watcher.isBootstrapping,
+      reconnectAttempts: watcher.reconnectAttempts,
+      cumulativeReconnectAttempts: watcher.cumulativeReconnectAttempts,
+      totalEntryCount: watcher.totalEntryCount,
+      lastEventId: watcher.lastEventId,
+    });
+
     this.analytics.track(ANALYTICS_EVENTS.CLOUD_STREAM_DISCONNECTED, {
       task_id: watcher.taskId,
       run_id: watcher.runId,
@@ -1173,12 +1252,32 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       this.log.warn("Cloud task stream ended before terminal status", {
         key,
         status: watcher.lastStatus,
+        stage: watcher.lastStage,
+        stateChanged,
+        lastEventId: watcher.lastEventId,
+        sentLastEventId: watcher.connSentLastEventId,
+        connDataEventsReceived: watcher.connDataEventsReceived,
+        reconnectAttempts: watcher.reconnectAttempts,
+        streamErrorAttempts: watcher.streamErrorAttempts,
+        cumulativeReconnectAttempts: watcher.cumulativeReconnectAttempts,
       });
       this.scheduleReconnect(key, options.reconnectError, {
         countAttempt: options.countReconnectAttempt ?? false,
       });
       return;
     }
+
+    this.log.info("Cloud task terminal stop", {
+      key,
+      status: watcher.lastStatus,
+      reachedViaError: options.reconnectError !== undefined,
+      lastEventId: watcher.lastEventId,
+      sentLastEventId: watcher.connSentLastEventId,
+      totalEntryCount: watcher.totalEntryCount,
+      connDataEventsReceived: watcher.connDataEventsReceived,
+      connDurationMs:
+        watcher.connStartedAt !== 0 ? Date.now() - watcher.connStartedAt : 0,
+    });
 
     // Always emit the latest status before stopping. Terminal states are
     // intentionally deferred until stream completion; clean EOFs can also mean

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -732,14 +732,13 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
         return;
       }
 
-      const closed = this.watchers.get(key);
       this.log.info("Cloud task stream closed cleanly", {
         key,
         connectionDurationMs: connectedAt ? Date.now() - connectedAt : 0,
         bytesReceived,
         eventsReceived,
-        dataEventsReceived: closed?.connDataEventsReceived ?? 0,
-        lastEventId: closed?.lastEventId ?? null,
+        dataEventsReceived: watcher.connDataEventsReceived,
+        lastEventId: watcher.lastEventId,
       });
       await this.handleStreamCompletion(key, { reconnectIfNonTerminal: true });
     } catch (error) {

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -734,7 +734,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
       this.log.info("Cloud task stream closed cleanly", {
         key,
-        connectionDurationMs: connectedAt ? Date.now() - connectedAt : 0,
+        connectionDurationMs: Date.now() - connectedAt,
         bytesReceived,
         eventsReceived,
         dataEventsReceived: watcher.connDataEventsReceived,

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -666,7 +666,6 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     let streamWasEstablished = false;
     let bytesReceived = 0;
     let eventsReceived = 0;
-    let dataEventsReceived = 0;
 
     try {
       const response = await this.auth.authenticatedFetch(url.toString(), {
@@ -718,9 +717,6 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
         const events = parser.parse(chunk);
         for (const event of events) {
           eventsReceived += 1;
-          if (event.event !== "error" && !isKeepaliveEvent(event)) {
-            dataEventsReceived += 1;
-          }
           this.handleSseEvent(key, event);
         }
       }
@@ -736,13 +732,14 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
         return;
       }
 
+      const closed = this.watchers.get(key);
       this.log.info("Cloud task stream closed cleanly", {
         key,
         connectionDurationMs: connectedAt ? Date.now() - connectedAt : 0,
         bytesReceived,
         eventsReceived,
-        dataEventsReceived,
-        lastEventId: this.watchers.get(key)?.lastEventId ?? null,
+        dataEventsReceived: closed?.connDataEventsReceived ?? 0,
+        lastEventId: closed?.lastEventId ?? null,
       });
       await this.handleStreamCompletion(key, { reconnectIfNonTerminal: true });
     } catch (error) {
@@ -790,7 +787,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
           : 0,
         bytesReceived,
         eventsReceived,
-        dataEventsReceived,
+        dataEventsReceived: watcher?.connDataEventsReceived ?? 0,
         lastEventId: watcher?.lastEventId ?? null,
         reconnectAttempts: watcher?.reconnectAttempts ?? 0,
         streamErrorAttempts: watcher?.streamErrorAttempts ?? 0,

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -361,6 +361,28 @@ export function isPermissionRequestAlreadySurfaced(
   );
 }
 
+function classifyTurnEventKind(
+  msg: AcpMessage["message"],
+): "text" | "output" | "other" {
+  if (!("method" in msg) || msg.method !== "session/update") return "other";
+  const update = (msg as { params?: { update?: Record<string, unknown> } })
+    .params?.update;
+  if (!update) return "other";
+  const sessionUpdate = update.sessionUpdate;
+  if (sessionUpdate === "agent_message_chunk") {
+    const content = update.content as { type?: string } | undefined;
+    return content?.type === "text" ? "text" : "output";
+  }
+  if (
+    sessionUpdate === "agent_thought_chunk" ||
+    sessionUpdate === "tool_call" ||
+    sessionUpdate === "tool_call_update"
+  ) {
+    return "output";
+  }
+  return "other";
+}
+
 export class SessionService {
   private connectingTasks = new Map<string, Promise<void>>();
   private reconcilingTasks = new Set<string>();
@@ -398,6 +420,10 @@ export class SessionService {
   private cloudLogGapReconciler: CloudLogGapReconciler;
   /** Maps toolCallId → cloud requestId for routing permission responses */
   private cloudPermissionRequestIds = new Map<string, string>();
+  private liveTurnContent = new Map<
+    string,
+    { startedAtTs: number; agentTextChunks: number; agentOutputEvents: number }
+  >();
   private idleKilledSubscription: { unsubscribe: () => void } | null = null;
   /**
    * Cached preview-config-options responses keyed by `${apiHost}::${adapter}`.
@@ -1220,6 +1246,7 @@ export class SessionService {
     subscription?.event.unsubscribe();
     subscription?.permission?.unsubscribe();
     this.subscriptions.delete(taskRunId);
+    this.liveTurnContent.delete(taskRunId);
   }
 
   /**
@@ -1247,6 +1274,7 @@ export class SessionService {
     this.localRepoPaths.clear();
     this.localRecoveryAttempts.clear();
     this.cloudPermissionRequestIds.clear();
+    this.liveTurnContent.clear();
     this.cloudLogGapReconciler.clear();
     this.dispatchingCloudQueues.clear();
     this.scheduledCloudQueueFlushes.clear();
@@ -1270,6 +1298,31 @@ export class SessionService {
     return false;
   }
 
+  private finalizeTurnContent(
+    taskRunId: string,
+    trigger: "stop_reason" | "turn_complete",
+    endedAtTs: number,
+  ): void {
+    const tally = this.liveTurnContent.get(taskRunId);
+    if (!tally) return;
+    this.liveTurnContent.delete(taskRunId);
+    const session = this.d.store.getSessions()[taskRunId];
+    const payload = {
+      taskRunId,
+      taskId: session?.taskId,
+      isCloud: session?.isCloud ?? false,
+      trigger,
+      agentTextChunks: tally.agentTextChunks,
+      agentOutputEvents: tally.agentOutputEvents,
+      durationMs: Math.max(0, endedAtTs - tally.startedAtTs),
+    };
+    if (tally.agentTextChunks === 0 && tally.agentOutputEvents === 0) {
+      this.d.log.warn("Turn completed with no agent output", payload);
+    } else {
+      this.d.log.debug("Turn completed", payload);
+    }
+  }
+
   private updatePromptStateFromEvents(
     taskRunId: string,
     events: AcpMessage[],
@@ -1283,6 +1336,14 @@ export class SessionService {
       if (this.isSteerMessage(msg)) {
         continue;
       }
+      const turnTally = isLive
+        ? this.liveTurnContent.get(taskRunId)
+        : undefined;
+      if (turnTally) {
+        const kind = classifyTurnEventKind(msg);
+        if (kind === "text") turnTally.agentTextChunks += 1;
+        else if (kind === "output") turnTally.agentOutputEvents += 1;
+      }
       if (isJsonRpcRequest(msg) && msg.method === "session/prompt") {
         this.d.store.updateSession(taskRunId, {
           isPromptPending: true,
@@ -1290,6 +1351,13 @@ export class SessionService {
           pausedDurationMs: 0,
           currentPromptId: msg.id,
         });
+        if (isLive) {
+          this.liveTurnContent.set(taskRunId, {
+            startedAtTs: acpMsg.ts,
+            agentTextChunks: 0,
+            agentOutputEvents: 0,
+          });
+        }
         const promptSession = this.d.store.getSessions()[taskRunId];
         if (promptSession?.isCloud) {
           this.cloudRunIdleTracker.markBusy(promptSession);
@@ -1319,6 +1387,9 @@ export class SessionService {
           promptStartedAt: null,
           currentPromptId: null,
         });
+        if (isLive) {
+          this.finalizeTurnContent(taskRunId, "stop_reason", acpMsg.ts);
+        }
       }
       if (isTurnCompleteEvent(acpMsg)) {
         // Local sessions use the JSON-RPC response as the canonical turn-done
@@ -1341,6 +1412,7 @@ export class SessionService {
               );
             }
             this.d.taskViewedApi.markActivity(session.taskId);
+            this.finalizeTurnContent(taskRunId, "turn_complete", acpMsg.ts);
           }
         }
       }

--- a/packages/shared/src/errors.test.ts
+++ b/packages/shared/src/errors.test.ts
@@ -144,4 +144,30 @@ describe("serializeError", () => {
     expect(serializeError(42)).toEqual({ message: "42" });
     expect(serializeError(null)).toEqual({ message: "null" });
   });
+
+  it("captures a numeric code", () => {
+    expect(serializeError({ message: "x", code: 42 })).toEqual({
+      message: "x",
+      code: 42,
+    });
+  });
+
+  it("does not follow the cause chain at maxDepth 0", () => {
+    const err = new Error("top", { cause: new Error("inner") });
+    expect(serializeError(err, 0)).toEqual({ name: "Error", message: "top" });
+  });
+
+  it("omits name for a plain object without one", () => {
+    expect(serializeError({ message: "foo", code: "ENOENT" })).toEqual({
+      message: "foo",
+      code: "ENOENT",
+    });
+  });
+
+  it("returns only name and message for a bare Error", () => {
+    expect(serializeError(new Error("x"))).toEqual({
+      name: "Error",
+      message: "x",
+    });
+  });
 });

--- a/packages/shared/src/errors.test.ts
+++ b/packages/shared/src/errors.test.ts
@@ -6,6 +6,7 @@ import {
   isNotAuthenticatedError,
   isRateLimitError,
   NotAuthenticatedError,
+  serializeError,
 } from "./errors";
 
 describe("NotAuthenticatedError", () => {
@@ -101,5 +102,46 @@ describe("isFatalSessionError", () => {
 
   it("returns false for ordinary recoverable errors", () => {
     expect(isFatalSessionError("temporary network blip")).toBe(false);
+  });
+});
+
+describe("serializeError", () => {
+  it("captures name, message and code from an Error", () => {
+    const err = Object.assign(new TypeError("boom"), { code: "ERR_X" });
+    expect(serializeError(err)).toEqual({
+      name: "TypeError",
+      message: "boom",
+      code: "ERR_X",
+    });
+  });
+
+  it("walks the cause chain (the undici 'terminated' shape)", () => {
+    const cause = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    const err = new TypeError("terminated", { cause });
+    expect(serializeError(err)).toEqual({
+      name: "TypeError",
+      message: "terminated",
+      cause: {
+        name: "Error",
+        message: "other side closed",
+        code: "UND_ERR_SOCKET",
+      },
+    });
+  });
+
+  it("bounds depth to avoid runaway or cyclic chains", () => {
+    const cyclic: { message: string; cause?: unknown } = { message: "a" };
+    cyclic.cause = cyclic;
+    const result = serializeError(cyclic, 2);
+    expect(result.cause?.cause?.message).toBe("a");
+    expect(result.cause?.cause?.cause).toBeUndefined();
+  });
+
+  it("handles non-Error inputs", () => {
+    expect(serializeError("plain string")).toEqual({ message: "plain string" });
+    expect(serializeError(42)).toEqual({ message: "42" });
+    expect(serializeError(null)).toEqual({ message: "null" });
   });
 });

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -29,6 +29,49 @@ export function getErrorMessage(error: unknown): string {
   return "";
 }
 
+export interface SerializedError {
+  name?: string;
+  message: string;
+  code?: string | number;
+  cause?: SerializedError;
+}
+
+/**
+ * Flatten an error and its `cause` chain into a plain, log-friendly object.
+ * undici surfaces the real socket-level reason for `TypeError: terminated`
+ * (e.g. ECONNRESET, UND_ERR_SOCKET, UND_ERR_HEADERS_TIMEOUT) on `error.cause`,
+ * which a bare `error.message` throws away. Depth-bounded to avoid cycles.
+ */
+export function serializeError(error: unknown, maxDepth = 5): SerializedError {
+  if (typeof error === "object" && error !== null) {
+    const source = error as {
+      name?: unknown;
+      message?: unknown;
+      code?: unknown;
+      cause?: unknown;
+    };
+    const result: SerializedError = {
+      message:
+        typeof source.message === "string"
+          ? source.message
+          : error instanceof Error
+            ? error.message
+            : String(error),
+    };
+    if (typeof source.name === "string") {
+      result.name = source.name;
+    }
+    if (typeof source.code === "string" || typeof source.code === "number") {
+      result.code = source.code;
+    }
+    if (source.cause != null && maxDepth > 0) {
+      result.cause = serializeError(source.cause, maxDepth - 1);
+    }
+    return result;
+  }
+  return { message: String(error) };
+}
+
 export function isAuthError(error: unknown): boolean {
   const message = getErrorMessage(error).toLowerCase();
   if (!message) return false;

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -36,12 +36,6 @@ export interface SerializedError {
   cause?: SerializedError;
 }
 
-/**
- * Flatten an error and its `cause` chain into a plain, log-friendly object.
- * undici surfaces the real socket-level reason for `TypeError: terminated`
- * (e.g. ECONNRESET, UND_ERR_SOCKET, UND_ERR_HEADERS_TIMEOUT) on `error.cause`,
- * which a bare `error.message` throws away. Depth-bounded to avoid cycles.
- */
 export function serializeError(error: unknown, maxDepth = 5): SerializedError {
   if (typeof error === "object" && error !== null) {
     const source = error as {

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -46,11 +46,7 @@ export function serializeError(error: unknown, maxDepth = 5): SerializedError {
     };
     const result: SerializedError = {
       message:
-        typeof source.message === "string"
-          ? source.message
-          : error instanceof Error
-            ? error.message
-            : String(error),
+        typeof source.message === "string" ? source.message : String(error),
     };
     if (typeof source.name === "string") {
       result.name = source.name;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -49,6 +49,8 @@ export {
   isNotAuthenticatedError,
   isRateLimitError,
   NotAuthenticatedError,
+  type SerializedError,
+  serializeError,
 } from "./errors";
 export type { ExecutionMode } from "./exec-types";
 export * from "./flags";

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -55,6 +55,7 @@ import {
 import {
   type AcpMessage,
   isAuthError,
+  serializeError,
   TypedEventEmitter,
 } from "@posthog/shared";
 import { inject, injectable, preDestroy } from "inversify";
@@ -946,7 +947,17 @@ When creating pull requests, add the following footer at the end of the PR descr
       const action = isReconnect ? "reconnect" : "create";
       this.log.error(
         `Failed to ${action} session${isRetry ? " after retry" : ""}${detailSuffix}`,
-        err,
+        {
+          taskRunId,
+          taskId,
+          sessionId: config.sessionId,
+          adapter: config.adapter,
+          model: config.model,
+          isRetry,
+          code: (err as { code?: unknown }).code,
+          data: (err as { data?: unknown }).data,
+          errorDetail: serializeError(err),
+        },
       );
       // Non-auth reconnect failure on first attempt: fall back to a fresh session.
       // If this was already an auth retry (isRetry=true), we've exhausted retries
@@ -954,6 +965,8 @@ When creating pull requests, add the following footer at the end of the PR descr
       if (isReconnect && !isRetry) {
         this.log.warn("Reconnect failed, falling back to new session", {
           taskRunId,
+          taskId,
+          sessionId: config.sessionId,
         });
         config.sessionId = undefined;
         return this.getOrCreateSession(config, false, false);

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -1384,6 +1384,14 @@ For git operations while detached:
   private async cleanupSession(taskRunId: string): Promise<void> {
     const session = this.sessions.get(taskRunId);
     if (session) {
+      if (session.promptPending || session.inFlightMcpToolCalls.size > 0) {
+        this.log.warn("Cleaning up session with in-flight work", {
+          taskRunId,
+          taskId: session.taskId,
+          promptPending: session.promptPending,
+          inFlightMcpToolCalls: session.inFlightMcpToolCalls.size,
+        });
+      }
       this.cancelInFlightMcpToolCalls(session);
       this.sleepService.release(taskRunId);
       try {

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -954,7 +954,6 @@ When creating pull requests, add the following footer at the end of the PR descr
           adapter: config.adapter,
           model: config.model,
           isRetry,
-          code: (err as { code?: unknown }).code,
           data: (err as { data?: unknown }).data,
           errorDetail: serializeError(err),
         },

--- a/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
+++ b/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
@@ -4,8 +4,12 @@ import {
   type RootLogger,
   type ScopedLogger,
 } from "@posthog/di/logger";
+import { serializeError } from "@posthog/shared";
 import { inject, injectable } from "inversify";
-import { streamBodyToResponse } from "../proxy-stream/proxy-stream";
+import {
+  type StreamProgress,
+  streamBodyToResponse,
+} from "../proxy-stream/proxy-stream";
 import { AUTH_PROXY_AUTH } from "./identifiers";
 import type { AuthProxyAuth } from "./ports";
 
@@ -178,8 +182,12 @@ export class AuthProxyService {
     options: RequestInit,
     res: http.ServerResponse,
   ): Promise<void> {
+    const startedAt = Date.now();
+    const progress: StreamProgress = { bytesWritten: 0 };
+    let status = 0;
     try {
       const response = await this.auth.authenticatedFetch(url, options);
+      status = response.status;
 
       const responseHeaders: Record<string, string> = {};
       const stripHeaders = new Set([
@@ -194,14 +202,39 @@ export class AuthProxyService {
 
       res.writeHead(response.status, responseHeaders);
 
-      await streamBodyToResponse(response.body, res);
+      await streamBodyToResponse(response.body, res, progress);
+
+      this.log.info("Auth proxy forward completed", {
+        url,
+        method: options.method,
+        status,
+        durationMs: Date.now() - startedAt,
+        bytesStreamed: progress.bytesWritten,
+      });
     } catch (err) {
+      // headersSent distinguishes a pre-response failure (connection setup)
+      // from a mid-stream termination (the body died after status was sent).
+      // With durationMs + bytesStreamed this reveals whether an upstream
+      // timeout is cutting streamed LLM responses, and serializeError surfaces
+      // the real undici socket cause (ECONNRESET, UND_ERR_SOCKET) behind the
+      // generic "terminated" message.
       if (options.signal?.aborted) {
         this.log.debug("Upstream fetch aborted after client disconnect", {
           url,
+          durationMs: Date.now() - startedAt,
+          bytesStreamed: progress.bytesWritten,
         });
       } else {
-        this.log.error("Proxy forward error", { url, err });
+        this.log.error("Proxy forward error", {
+          url,
+          method: options.method,
+          status,
+          headersSent: res.headersSent,
+          durationMs: Date.now() - startedAt,
+          bytesStreamed: progress.bytesWritten,
+          err,
+          errorDetail: serializeError(err),
+        });
       }
       if (!res.headersSent) {
         res.writeHead(502);

--- a/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
+++ b/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
@@ -212,12 +212,6 @@ export class AuthProxyService {
         bytesStreamed: progress.bytesWritten,
       });
     } catch (err) {
-      // headersSent distinguishes a pre-response failure (connection setup)
-      // from a mid-stream termination (the body died after status was sent).
-      // With durationMs + bytesStreamed this reveals whether an upstream
-      // timeout is cutting streamed LLM responses, and serializeError surfaces
-      // the real undici socket cause (ECONNRESET, UND_ERR_SOCKET) behind the
-      // generic "terminated" message.
       if (options.signal?.aborted) {
         this.log.debug("Upstream fetch aborted after client disconnect", {
           url,

--- a/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
+++ b/packages/workspace-server/src/services/auth-proxy/auth-proxy.ts
@@ -232,7 +232,7 @@ export class AuthProxyService {
           headersSent: res.headersSent,
           durationMs: Date.now() - startedAt,
           bytesStreamed: progress.bytesWritten,
-          err,
+          stack: err instanceof Error ? err.stack : undefined,
           errorDetail: serializeError(err),
         });
       }

--- a/packages/workspace-server/src/services/proxy-stream/proxy-stream.test.ts
+++ b/packages/workspace-server/src/services/proxy-stream/proxy-stream.test.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { streamBodyToResponse } from "./proxy-stream";
+import { type StreamProgress, streamBodyToResponse } from "./proxy-stream";
 
 describe("streamBodyToResponse", () => {
   let server: http.Server | undefined;
@@ -74,5 +74,56 @@ describe("streamBodyToResponse", () => {
     await vi.waitFor(() => {
       expect(cancelled).toBe(true);
     });
+  });
+
+  it("counts streamed bytes into progress", async () => {
+    const progress: StreamProgress = { bytesWritten: 0 };
+    const payload = "data: one\n\ndata: two\n\n";
+    const url = await serve((res) => {
+      res.writeHead(200);
+      void streamBodyToResponse(new Response(payload).body, res, progress);
+    });
+
+    await fetch(url).then((r) => r.text());
+
+    await vi.waitFor(() => {
+      expect(progress.bytesWritten).toBe(
+        new TextEncoder().encode(payload).byteLength,
+      );
+    });
+  });
+
+  it("accumulates bytes across multiple chunks", async () => {
+    const progress: StreamProgress = { bytesWritten: 0 };
+    const url = await serve((res) => {
+      res.writeHead(200);
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of ["aaaa", "bbbbbb", "cc"]) {
+            controller.enqueue(new TextEncoder().encode(chunk));
+          }
+          controller.close();
+        },
+      });
+      void streamBodyToResponse(body, res, progress);
+    });
+
+    await fetch(url).then((r) => r.text());
+
+    await vi.waitFor(() => {
+      expect(progress.bytesWritten).toBe(12);
+    });
+  });
+
+  it("leaves progress at zero for a null body", async () => {
+    const progress: StreamProgress = { bytesWritten: 0 };
+    const url = await serve((res) => {
+      res.writeHead(200);
+      void streamBodyToResponse(null, res, progress);
+    });
+
+    await fetch(url).then((r) => r.text());
+
+    expect(progress.bytesWritten).toBe(0);
   });
 });

--- a/packages/workspace-server/src/services/proxy-stream/proxy-stream.ts
+++ b/packages/workspace-server/src/services/proxy-stream/proxy-stream.ts
@@ -1,5 +1,9 @@
 import type http from "node:http";
 
+export interface StreamProgress {
+  bytesWritten: number;
+}
+
 function waitForDrainOrClose(res: http.ServerResponse): Promise<void> {
   return new Promise<void>((resolve) => {
     const settle = () => {
@@ -21,6 +25,7 @@ function waitForDrainOrClose(res: http.ServerResponse): Promise<void> {
 export async function streamBodyToResponse(
   body: ReadableStream<Uint8Array> | null,
   res: http.ServerResponse,
+  progress?: StreamProgress,
 ): Promise<void> {
   if (!body) {
     res.end();
@@ -35,6 +40,9 @@ export async function streamBodyToResponse(
     if (done) {
       res.end();
       return;
+    }
+    if (progress) {
+      progress.bytesWritten += value.byteLength;
     }
     if (!res.write(value)) {
       await waitForDrainOrClose(res);


### PR DESCRIPTION
## Problem

People intermittently get no response from the agent, transient and seemingly random, on both local and cloud tasks. The current logs don't capture the cause: undici's generic "terminated" hides the real socket reason, cloud SSE streams drop without naming the terminating hop, and local session-init failures surface only as opaque "Internal error".

## Changes

1. Add `serializeError` to `@posthog/shared` to flatten an error and its `.cause` chain, surfacing the real undici socket reason (ECONNRESET, UND_ERR_SOCKET) behind "terminated"
2. Instrument cloud SSE streams: connect-time response headers (server, via, cf-ray, x-accel-buffering), resume detection, per-connection counters, connection durations
3. Enrich the local LLM auth-proxy: error cause, `headersSent`, duration, bytes streamed, plus a per-request completion baseline
4. De-opaque local agent session create/reconnect failures (real cause, code, session context) and add session-init phase timing (`modelConfigMs` vs `initMs`)
5. Surface Claude CLI stderr and a "turn completed with no agent output" warning
6. Add tests for `serializeError` and the proxy byte-counting

## How did you test this?

Manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
