### PR TITLE
Make inbox sidebar badge follow active filters

### DIFF
--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -113,8 +113,8 @@ export function useInboxAllReports(options?: {
       status: INBOX_PIPELINE_STATUS_FILTER,
       has_implementation_pr: true,
       // Mirror the list query's active filters so the badge matches the tab
-      // body. These are empty when `ignoreFilters` is set (sidebar usage), so
-      // the count stays scope-only there.
+      // body. These are empty when `ignoreFilters` is set (e.g. the Runs tab),
+      // so the count stays scope-only there.
       source_product:
         sourceProductFilter.length > 0
           ? sourceProductFilter.join(",")

--- a/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
@@ -82,10 +82,11 @@ export function SidebarNavSection({
   const isMcpServersActive = view.type === "mcp-servers";
 
   // Open pull requests in the inbox — the main CTA, and the same count the inbox
-  // Pull requests tab shows, so the badge and the tab always agree.
-  // `ignoreFilters` keeps the badge stable against the inbox's filter chrome;
-  // scope still follows the user's For-you / project choice.
-  const { counts: inboxCounts } = useInboxAllReports({ ignoreFilters: true });
+  // Pull requests tab shows, so the badge and the tab always agree. The badge
+  // tracks the inbox's active source/priority/search filters (and the user's
+  // For-you / project scope) so it never shows a total that contradicts the
+  // filtered list the user is looking at.
+  const { counts: inboxCounts } = useInboxAllReports();
   const inboxPullRequestCount = inboxCounts.pulls;
 
   // Only subscribe to the task list when a parent hasn't already supplied the


### PR DESCRIPTION
## Problem

When a user filters the inbox by a specific source (e.g. Scouts), priority, or search, the inbox count badge on the left sidebar did not update — it kept showing the total pull-request count across all sources. That left the sidebar badge contradicting the count shown next to the Pull requests tab inside the inbox, which is confusing.

## Changes

The sidebar called `useInboxAllReports({ ignoreFilters: true })`, which hard-pinned the source/priority/search filters to empty. Dropping `ignoreFilters` makes the badge track the same filtered count the Pull requests tab shows, so the two always agree. Reviewer scope (For you / Entire project) already followed the user's choice and is unchanged.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — no type errors in the changed files (remaining errors are pre-existing unbuilt-dependency module-resolution issues unrelated to this change).
- Verified no existing tests assert the old sidebar-badge behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781778391586809?thread_ts=1781778391.586809&cid=C09SK2PAGKF)*
