### PR TITLE
feat(mobile): add steer and queue messaging modes (port #2663)

### DIFF
--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -19,6 +19,10 @@ import { FloatingSettingsHeader } from "@/features/settings/components/FloatingS
 import { SettingsRow } from "@/features/settings/components/SettingsRow";
 import { SettingsSection } from "@/features/settings/components/SettingsSection";
 import { SelectSheet } from "@/features/tasks/composer/SelectSheet";
+import {
+  type MessagingMode,
+  useMessagingModeStore,
+} from "@/features/tasks/stores/messagingModeStore";
 import { playCompletionSound } from "@/features/tasks/utils/sounds";
 import { useScreenInsets } from "@/hooks/useScreenInsets";
 import { logger } from "@/lib/logger";
@@ -71,6 +75,23 @@ const TASK_MODE_OPTIONS = [
   },
 ] as const;
 
+const MESSAGING_MODE_OPTIONS: ReadonlyArray<{
+  value: MessagingMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "queue",
+    label: "Queue",
+    description: "Hold messages until the current turn finishes",
+  },
+  {
+    value: "steer",
+    label: "Steer",
+    description: "Interrupt the current turn and send right away",
+  },
+];
+
 const REASONING_EFFORT_OPTIONS: ReadonlyArray<{
   value: DefaultReasoningEffort;
   label: string;
@@ -109,6 +130,10 @@ function volumeLabel(volume: number): string {
 
 function taskModeLabel(mode: InitialTaskMode): string {
   return TASK_MODE_OPTIONS.find((o) => o.value === mode)?.label ?? "Plan";
+}
+
+function messagingModeLabel(mode: MessagingMode): string {
+  return MESSAGING_MODE_OPTIONS.find((o) => o.value === mode)?.label ?? "Queue";
 }
 
 function reasoningEffortLabel(effort: DefaultReasoningEffort): string {
@@ -161,6 +186,10 @@ export default function SettingsScreen() {
   const setDefaultReasoningEffort = usePreferencesStore(
     (s) => s.setDefaultReasoningEffort,
   );
+  const defaultMessagingMode = useMessagingModeStore((s) => s.defaultMode);
+  const setDefaultMessagingMode = useMessagingModeStore(
+    (s) => s.setDefaultMode,
+  );
   const decidedCount = useDismissedReportsStore(
     (s) => s.dismissedIds.length + s.acceptedIds.length,
   );
@@ -173,6 +202,7 @@ export default function SettingsScreen() {
   const [taskModeSheetOpen, setTaskModeSheetOpen] = useState(false);
   const [reasoningEffortSheetOpen, setReasoningEffortSheetOpen] =
     useState(false);
+  const [messagingModeSheetOpen, setMessagingModeSheetOpen] = useState(false);
   const [projectSheetOpen, setProjectSheetOpen] = useState(false);
 
   // The selected project's name. Prefer the names fetched for the scoped teams
@@ -349,11 +379,24 @@ export default function SettingsScreen() {
             label="Default effort level"
             description="Reasoning effort to pre-fill on new tasks"
             onPress={() => setReasoningEffortSheetOpen(true)}
-            showDivider={false}
             rightSlot={
               <>
                 <Text className="text-[14px] text-gray-11">
                   {reasoningEffortLabel(defaultReasoningEffort)}
+                </Text>
+                <CaretRight size={14} color={themeColors.gray[10]} />
+              </>
+            }
+          />
+          <SettingsRow
+            label="Messaging mode"
+            description="What happens when you send while a turn is running"
+            onPress={() => setMessagingModeSheetOpen(true)}
+            showDivider={false}
+            rightSlot={
+              <>
+                <Text className="text-[14px] text-gray-11">
+                  {messagingModeLabel(defaultMessagingMode)}
                 </Text>
                 <CaretRight size={14} color={themeColors.gray[10]} />
               </>
@@ -606,6 +649,19 @@ export default function SettingsScreen() {
         }
         onClose={() => setReasoningEffortSheetOpen(false)}
         options={REASONING_EFFORT_OPTIONS.map((option) => ({
+          value: option.value,
+          label: option.label,
+          description: option.description,
+        }))}
+      />
+
+      <SelectSheet
+        open={messagingModeSheetOpen}
+        title="Messaging mode"
+        value={defaultMessagingMode}
+        onChange={(value) => setDefaultMessagingMode(value as MessagingMode)}
+        onClose={() => setMessagingModeSheetOpen(false)}
+        options={MESSAGING_MODE_OPTIONS.map((option) => ({
           value: option.value,
           label: option.label,
           description: option.description,

--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -31,7 +31,13 @@ import {
   type ReasoningEffort,
 } from "@/features/tasks/composer/options";
 import { TaskChatComposer } from "@/features/tasks/composer/TaskChatComposer";
+import {
+  useMessagingMode,
+  useQueuedCount,
+  useToggleMessagingMode,
+} from "@/features/tasks/hooks/useMessagingMode";
 import { taskKeys } from "@/features/tasks/hooks/useTasks";
+import { useMessageQueueStore } from "@/features/tasks/stores/messageQueueStore";
 import {
   pendingTaskPromptStoreApi,
   usePendingTaskPrompt,
@@ -41,7 +47,11 @@ import { useTaskStore } from "@/features/tasks/stores/taskStore";
 import type { Task } from "@/features/tasks/types";
 import { getSessionActivityPhase } from "@/features/tasks/utils/sessionActivity";
 import { useScreenInsets } from "@/hooks/useScreenInsets";
-import { useActiveTaskAnalyticsContext } from "@/lib/analytics";
+import {
+  ANALYTICS_EVENTS,
+  useActiveTaskAnalyticsContext,
+  useAnalytics,
+} from "@/lib/analytics";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
@@ -81,6 +91,7 @@ export default function TaskDetailScreen() {
     disconnectFromTask,
     sendPrompt,
     cancelPrompt,
+    sendInterrupting,
     sendPermissionResponse,
     setConfigOption,
     getSessionForTask,
@@ -146,6 +157,11 @@ export default function TaskDetailScreen() {
   const composerModel = composerConfig?.model ?? DEFAULT_MODEL;
   const composerReasoning: ReasoningEffort =
     composerConfig?.reasoning ?? DEFAULT_REASONING;
+
+  const messagingMode = useMessagingMode(taskId);
+  const queuedCount = useQueuedCount(taskId);
+  const toggleMessagingMode = useToggleMessagingMode(taskId);
+  const analytics = useAnalytics();
 
   const { height } = useReanimatedKeyboardAnimation();
 
@@ -309,6 +325,20 @@ export default function TaskDetailScreen() {
     ],
   );
 
+  const trackPromptSent = useCallback(
+    (text: string, isSteer: boolean) => {
+      if (!taskId) return;
+      analytics.track(ANALYTICS_EVENTS.PROMPT_SENT, {
+        task_id: taskId,
+        is_initial: false,
+        execution_type: "cloud",
+        prompt_length_chars: text.length,
+        is_steer: isSteer,
+      });
+    },
+    [taskId, analytics],
+  );
+
   const handleSendPrompt = useCallback(
     (text: string, attachments: PendingAttachment[]) => {
       if (!taskId) return;
@@ -319,15 +349,41 @@ export default function TaskDetailScreen() {
         return;
       }
 
-      sendPrompt(taskId, text, attachments).catch((err) => {
+      const onSendFailed = (err: unknown) => {
         log.error("Failed to send prompt", err);
         Alert.alert(
           "Failed to send",
           "Your message could not be delivered. Please try again.",
         );
-      });
+      };
+
+      // A turn is running. Queue holds the message locally until it ends;
+      // Steer interrupts the turn and resends right away.
+      if (session?.isPromptPending) {
+        if (messagingMode === "queue") {
+          useMessageQueueStore.getState().enqueue(taskId, text, attachments);
+          return;
+        }
+        sendInterrupting(taskId, text, attachments)
+          .then(() => trackPromptSent(text, true))
+          .catch(onSendFailed);
+        return;
+      }
+
+      sendPrompt(taskId, text, attachments)
+        .then(() => trackPromptSent(text, false))
+        .catch(onSendFailed);
     },
-    [taskId, sendPrompt, session?.terminalStatus, handleSendAfterTerminal],
+    [
+      taskId,
+      sendPrompt,
+      sendInterrupting,
+      session?.terminalStatus,
+      session?.isPromptPending,
+      messagingMode,
+      handleSendAfterTerminal,
+      trackPromptSent,
+    ],
   );
 
   const handleModeChange = useCallback(
@@ -577,6 +633,9 @@ export default function TaskDetailScreen() {
             onModeChange={handleModeChange}
             onModelChange={handleModelChange}
             onReasoningChange={handleReasoningChange}
+            messagingMode={messagingMode}
+            queuedCount={queuedCount}
+            onToggleMessagingMode={toggleMessagingMode}
           />
         </Animated.View>
       </Animated.View>

--- a/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
+++ b/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
@@ -2,6 +2,7 @@ import * as Haptics from "expo-haptics";
 import {
   ArrowUp,
   BrainIcon,
+  Lightning,
   Microphone,
   PaperclipIcon,
   PauseIcon,
@@ -9,6 +10,7 @@ import {
   Robot,
   ShieldCheck,
   Sparkle,
+  Stack,
   Stop,
 } from "phosphor-react-native";
 import {
@@ -31,6 +33,7 @@ import {
 import { useVoiceRecording } from "@/features/chat";
 import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
+import type { MessagingMode } from "../stores/messagingModeStore";
 import { AttachmentSheet } from "./attachments/AttachmentSheet";
 import { AttachmentsBar } from "./attachments/AttachmentsBar";
 import {
@@ -72,6 +75,10 @@ interface TaskChatComposerProps {
   onModeChange: (mode: ExecutionMode) => void;
   onModelChange: (model: string) => void;
   onReasoningChange: (reasoning: ReasoningEffort) => void;
+  /** Steer vs Queue behaviour for messages sent while a turn is running. */
+  messagingMode: MessagingMode;
+  queuedCount: number;
+  onToggleMessagingMode: () => void;
 }
 
 function modeIcon(mode: ExecutionMode, color: string, size = 14): ReactNode {
@@ -154,6 +161,9 @@ export function TaskChatComposer({
   onModeChange,
   onModelChange,
   onReasoningChange,
+  messagingMode,
+  queuedCount,
+  onToggleMessagingMode,
 }: TaskChatComposerProps) {
   const themeColors = useThemeColors();
   const [message, setMessage] = useState(() => initialMessage ?? "");
@@ -229,6 +239,18 @@ export function TaskChatComposer({
     onStop?.();
   };
 
+  const isSteer = messagingMode === "steer";
+  const messagingModeLabel = isSteer
+    ? "Steer"
+    : queuedCount > 0
+      ? `Queue (${queuedCount})`
+      : "Queue";
+
+  const handleToggleMessagingMode = () => {
+    Haptics.selectionAsync();
+    onToggleMessagingMode();
+  };
+
   return (
     <>
       <View className="px-3">
@@ -288,6 +310,23 @@ export function TaskChatComposer({
                   paddingRight: 4,
                 }}
               >
+                <Pill
+                  icon={
+                    isSteer ? (
+                      <Lightning
+                        size={14}
+                        color={themeColors.accent[11]}
+                        weight="fill"
+                      />
+                    ) : (
+                      <Stack size={14} color={themeColors.gray[11]} />
+                    )
+                  }
+                  label={messagingModeLabel}
+                  accent={isSteer}
+                  onPress={handleToggleMessagingMode}
+                />
+
                 <Pill
                   icon={modeIcon(
                     mode,

--- a/apps/mobile/src/features/tasks/hooks/useMessagingMode.ts
+++ b/apps/mobile/src/features/tasks/hooks/useMessagingMode.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import { useMessageQueueStore } from "../stores/messageQueueStore";
+import {
+  type MessagingMode,
+  useMessagingModeStore,
+} from "../stores/messagingModeStore";
+import { useTaskSessionStore } from "../stores/taskSessionStore";
+
+/** Effective mode for a task: per-task override, else the global default. */
+export function useMessagingMode(taskId: string | undefined): MessagingMode {
+  return useMessagingModeStore((s) => s.getEffectiveMode(taskId));
+}
+
+export function useQueuedCount(taskId: string | undefined): number {
+  return useMessageQueueStore((s) => (taskId ? s.getQueue(taskId).length : 0));
+}
+
+/**
+ * Toggle the per-task messaging mode. Switching to Steer flushes any buffered
+ * messages into the current turn so nothing stays stuck in a queue the user
+ * just turned off.
+ */
+export function useToggleMessagingMode(taskId: string | undefined): () => void {
+  const mode = useMessagingMode(taskId);
+  return useCallback(() => {
+    if (!taskId) return;
+    const next: MessagingMode = mode === "steer" ? "queue" : "steer";
+    useMessagingModeStore.getState().setMode(taskId, next);
+    if (next === "steer") {
+      void useTaskSessionStore.getState().flushQueuedMessages(taskId);
+    }
+  }, [taskId, mode]);
+}

--- a/apps/mobile/src/features/tasks/stores/messageQueueStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/messageQueueStore.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PendingAttachment } from "../composer/attachments/types";
+import {
+  combineQueuedMessages,
+  type QueuedMessage,
+  useMessageQueueStore,
+} from "./messageQueueStore";
+
+function image(id: string): PendingAttachment {
+  return {
+    kind: "image",
+    id,
+    uri: `file://${id}.png`,
+    fileName: `${id}.png`,
+    mimeType: "image/png",
+  };
+}
+
+describe("messageQueueStore", () => {
+  beforeEach(() => {
+    useMessageQueueStore.setState({ queuesByTaskId: {} }, false);
+  });
+
+  it("enqueues messages in FIFO order", () => {
+    const { enqueue, getQueue } = useMessageQueueStore.getState();
+    enqueue("t1", "first", []);
+    enqueue("t1", "second", []);
+    enqueue("t1", "third", []);
+    expect(getQueue("t1").map((m) => m.content)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("keeps separate queues per task", () => {
+    const { enqueue, getQueue } = useMessageQueueStore.getState();
+    enqueue("t1", "a", []);
+    enqueue("t2", "b", []);
+    expect(getQueue("t1").map((m) => m.content)).toEqual(["a"]);
+    expect(getQueue("t2").map((m) => m.content)).toEqual(["b"]);
+  });
+
+  it("drains the queue in order and clears it", () => {
+    const { enqueue, drain, getQueue } = useMessageQueueStore.getState();
+    enqueue("t1", "a", []);
+    enqueue("t1", "b", []);
+    expect(drain("t1").map((m) => m.content)).toEqual(["a", "b"]);
+    expect(getQueue("t1")).toEqual([]);
+    // A second drain on the emptied queue is a no-op.
+    expect(drain("t1")).toEqual([]);
+  });
+
+  it("prepends restored messages at the head (failed-flush rollback)", () => {
+    const { enqueue, drain, prepend, getQueue } =
+      useMessageQueueStore.getState();
+    enqueue("t1", "a", []);
+    enqueue("t1", "b", []);
+    const drained = drain("t1");
+
+    // A new message arrives while the flush is in flight.
+    enqueue("t1", "c", []);
+    // Flush failed — the drained messages go back ahead of the newcomer.
+    prepend("t1", drained);
+
+    expect(getQueue("t1").map((m) => m.content)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("combineQueuedMessages", () => {
+  function msg(
+    content: string,
+    attachments: PendingAttachment[],
+  ): QueuedMessage {
+    return { content, attachments };
+  }
+
+  it("joins text in order with a blank line and concatenates attachments", () => {
+    const result = combineQueuedMessages([
+      msg("first", [image("one")]),
+      msg("second", []),
+      msg("third", [image("two"), image("three")]),
+    ]);
+    expect(result.text).toBe("first\n\nsecond\n\nthird");
+    expect(result.attachments.map((a) => a.id)).toEqual([
+      "one",
+      "two",
+      "three",
+    ]);
+  });
+
+  it("handles an empty list", () => {
+    expect(combineQueuedMessages([])).toEqual({ text: "", attachments: [] });
+  });
+});

--- a/apps/mobile/src/features/tasks/stores/messageQueueStore.ts
+++ b/apps/mobile/src/features/tasks/stores/messageQueueStore.ts
@@ -1,0 +1,68 @@
+import { create } from "zustand";
+import type { PendingAttachment } from "../composer/attachments/types";
+
+export interface QueuedMessage {
+  content: string;
+  attachments: PendingAttachment[];
+}
+
+const EMPTY: QueuedMessage[] = [];
+
+interface MessageQueueState {
+  queuesByTaskId: Record<string, QueuedMessage[]>;
+  enqueue: (
+    taskId: string,
+    content: string,
+    attachments: PendingAttachment[],
+  ) => void;
+  /** Remove and return every queued message for a task, in FIFO order. */
+  drain: (taskId: string) => QueuedMessage[];
+  /** Restore messages at the head of the queue, e.g. after a failed flush. */
+  prepend: (taskId: string, messages: QueuedMessage[]) => void;
+  getQueue: (taskId: string) => QueuedMessage[];
+}
+
+export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
+  queuesByTaskId: {},
+  enqueue: (taskId, content, attachments) =>
+    set((state) => ({
+      queuesByTaskId: {
+        ...state.queuesByTaskId,
+        [taskId]: [
+          ...(state.queuesByTaskId[taskId] ?? []),
+          { content, attachments },
+        ],
+      },
+    })),
+  drain: (taskId) => {
+    const queued = get().queuesByTaskId[taskId] ?? EMPTY;
+    if (queued.length === 0) return EMPTY;
+    set((state) => {
+      const { [taskId]: _drained, ...rest } = state.queuesByTaskId;
+      return { queuesByTaskId: rest };
+    });
+    return queued;
+  },
+  prepend: (taskId, messages) =>
+    set((state) => ({
+      queuesByTaskId: {
+        ...state.queuesByTaskId,
+        [taskId]: [...messages, ...(state.queuesByTaskId[taskId] ?? [])],
+      },
+    })),
+  getQueue: (taskId) => get().queuesByTaskId[taskId] ?? EMPTY,
+}));
+
+/**
+ * Combine buffered messages into a single prompt, preserving the order they
+ * were typed: texts join with a blank line, attachments concatenate.
+ */
+export function combineQueuedMessages(messages: QueuedMessage[]): {
+  text: string;
+  attachments: PendingAttachment[];
+} {
+  return {
+    text: messages.map((m) => m.content).join("\n\n"),
+    attachments: messages.flatMap((m) => m.attachments),
+  };
+}

--- a/apps/mobile/src/features/tasks/stores/messagingModeStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/messagingModeStore.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useMessagingModeStore } from "./messagingModeStore";
+
+const INITIAL_STATE = useMessagingModeStore.getState();
+
+describe("messagingModeStore", () => {
+  beforeEach(() => {
+    useMessagingModeStore.setState(
+      { ...INITIAL_STATE, modesByTaskId: {}, defaultMode: "queue" },
+      true,
+    );
+  });
+
+  it("defaults to Queue", () => {
+    expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
+      "queue",
+    );
+  });
+
+  it("falls back to the global default when a task has no override", () => {
+    useMessagingModeStore.getState().setDefaultMode("steer");
+    expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
+      "steer",
+    );
+  });
+
+  it("prefers a per-task override over the global default", () => {
+    useMessagingModeStore.getState().setDefaultMode("steer");
+    useMessagingModeStore.getState().setMode("t1", "queue");
+    expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
+      "queue",
+    );
+    // A different task still resolves to the global default.
+    expect(useMessagingModeStore.getState().getEffectiveMode("t2")).toBe(
+      "steer",
+    );
+  });
+
+  it("treats an undefined taskId as the global default", () => {
+    useMessagingModeStore.getState().setDefaultMode("steer");
+    expect(useMessagingModeStore.getState().getEffectiveMode(undefined)).toBe(
+      "steer",
+    );
+  });
+});

--- a/apps/mobile/src/features/tasks/stores/messagingModeStore.ts
+++ b/apps/mobile/src/features/tasks/stores/messagingModeStore.ts
@@ -1,0 +1,43 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export type MessagingMode = "queue" | "steer";
+
+interface MessagingModeState {
+  /** Per-task overrides. Absent entries fall back to `defaultMode`. */
+  modesByTaskId: Record<string, MessagingMode>;
+  defaultMode: MessagingMode;
+  setMode: (taskId: string, mode: MessagingMode) => void;
+  setDefaultMode: (mode: MessagingMode) => void;
+  getEffectiveMode: (taskId: string | undefined) => MessagingMode;
+}
+
+export const useMessagingModeStore = create<MessagingModeState>()(
+  persist(
+    (set, get) => ({
+      modesByTaskId: {},
+      defaultMode: "queue",
+      setMode: (taskId, mode) =>
+        set((state) => ({
+          modesByTaskId: { ...state.modesByTaskId, [taskId]: mode },
+        })),
+      setDefaultMode: (defaultMode) => set({ defaultMode }),
+      getEffectiveMode: (taskId) => {
+        const state = get();
+        return (
+          (taskId ? state.modesByTaskId[taskId] : undefined) ??
+          state.defaultMode
+        );
+      },
+    }),
+    {
+      name: "messaging-mode-storage",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        modesByTaskId: state.modesByTaskId,
+        defaultMode: state.defaultMode,
+      }),
+    },
+  ),
+);

--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
@@ -30,6 +30,10 @@ import {
 import { convertStoredEntriesToEvents } from "../utils/parseSessionLogs";
 import { playMeepSound } from "../utils/sounds";
 import { useAttachmentEchoStore } from "./attachmentEchoStore";
+import {
+  combineQueuedMessages,
+  useMessageQueueStore,
+} from "./messageQueueStore";
 
 const log = logger.scope("task-session-store");
 
@@ -306,6 +310,13 @@ interface TaskSessionStore {
     },
   ) => Promise<void>;
   cancelPrompt: (taskId: string) => Promise<boolean>;
+  /** Send a prompt now, interrupting the running turn first if one is live. */
+  sendInterrupting: (
+    taskId: string,
+    prompt: string,
+    attachments?: PendingAttachment[],
+  ) => Promise<void>;
+  flushQueuedMessages: (taskId: string) => Promise<void>;
   setConfigOption: (
     taskId: string,
     configId: string,
@@ -328,6 +339,9 @@ interface TaskSessionStore {
 
 const watchHandles = new Map<string, WatchCloudTaskHandle>();
 const connectAttempts = new Set<string>();
+// Guards against a turn-end batch and a mode toggle racing to flush the same
+// queue twice.
+const flushingTasks = new Set<string>();
 
 function mapTerminalStatus(
   status: string | undefined | null,
@@ -749,6 +763,37 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
     }
   },
 
+  sendInterrupting: async (taskId, prompt, attachments) => {
+    // The cloud has no mid-turn inject, so steering interrupts the running
+    // turn and resends as a fresh prompt.
+    if (get().getSessionForTask(taskId)?.isPromptPending) {
+      await get().cancelPrompt(taskId);
+    }
+    await get().sendPrompt(taskId, prompt, attachments);
+  },
+
+  flushQueuedMessages: async (taskId: string) => {
+    if (flushingTasks.has(taskId)) return;
+    flushingTasks.add(taskId);
+    try {
+      const drained = useMessageQueueStore.getState().drain(taskId);
+      if (drained.length === 0) return;
+
+      const { text, attachments } = combineQueuedMessages(drained);
+      try {
+        await get().sendInterrupting(taskId, text, attachments);
+      } catch (err) {
+        log.warn("Failed to flush queued messages, restoring queue", {
+          taskId,
+          error: err,
+        });
+        useMessageQueueStore.getState().prepend(taskId, drained);
+      }
+    } finally {
+      flushingTasks.delete(taskId);
+    }
+  },
+
   getSessionForTask: (taskId: string) => {
     return Object.values(get().sessions).find((s) => s.taskId === taskId);
   },
@@ -855,6 +900,7 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
       );
 
       const wasAwaitingPing = existing?.awaitingPing ?? false;
+      const wasPromptPending = existing?.isPromptPending ?? false;
 
       set((state) => {
         const current = state.sessions[taskRunId];
@@ -958,6 +1004,26 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
           taskRunId,
           kind: "task_failed",
         });
+      }
+
+      // Turn just ended on a live delta — drain any queued messages the user
+      // buffered while it was running. Deferred a tick so the store state is
+      // committed before the flush reads it.
+      const after = get().sessions[taskRunId];
+      if (
+        !isSnapshot &&
+        wasPromptPending &&
+        after &&
+        !after.isPromptPending &&
+        after.status === "connected" &&
+        useMessageQueueStore.getState().getQueue(after.taskId).length > 0
+      ) {
+        const flushTaskId = after.taskId;
+        setTimeout(() => {
+          get()
+            .flushQueuedMessages(flushTaskId)
+            .catch((err) => log.warn("Queue flush failed", err));
+        }, 0);
       }
     }
 

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -15,6 +15,7 @@ export const ANALYTICS_EVENTS = {
   SIGN_IN_STARTED: "Sign in started",
   SIGN_IN_COMPLETED: "Sign in completed",
   SIGN_IN_FAILED: "Sign in failed",
+  PROMPT_SENT: "Prompt sent",
 } as const;
 
 export type SignInMethod = "oauth" | "dev_api_key" | "qr_scan";
@@ -162,6 +163,15 @@ export interface InboxReportActionProperties {
   suggested_reviewer_uuid?: string;
 }
 
+export interface PromptSentProperties {
+  task_id: string;
+  is_initial: boolean;
+  execution_type: "cloud";
+  prompt_length_chars: number;
+  /** True when the message interrupted a running turn (Steer mode). */
+  is_steer: boolean;
+}
+
 export type EventPropertyMap = {
   [ANALYTICS_EVENTS.INBOX_VIEWED]: InboxViewedProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_OPENED]: InboxReportOpenedProperties;
@@ -171,6 +181,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.SIGN_IN_STARTED]: SignInStartedProperties;
   [ANALYTICS_EVENTS.SIGN_IN_COMPLETED]: SignInCompletedProperties;
   [ANALYTICS_EVENTS.SIGN_IN_FAILED]: SignInFailedProperties;
+  [ANALYTICS_EVENTS.PROMPT_SENT]: PromptSentProperties;
 };
 
 export interface Analytics {

--- a/apps/mobile/src/test/setup.ts
+++ b/apps/mobile/src/test/setup.ts
@@ -107,6 +107,7 @@ vi.mock("phosphor-react-native", async () => {
     ShieldCheck: icon("ShieldCheck"),
     Sparkle: icon("Sparkle"),
     SpeakerHigh: icon("SpeakerHigh"),
+    Stack: icon("Stack"),
     Stop: icon("Stop"),
     StopIcon: icon("StopIcon"),
     Terminal: icon("Terminal"),


### PR DESCRIPTION
Ports the desktop **Steer & Queue messaging modes** (#2663) to the React Native / Expo mobile app.

## What this adds

A per-task **messaging mode** toggle controlling what happens when you send a message while a session turn is still running:

- **Queue** (default): messages are held locally while a turn is running, then flushed as a single combined prompt — in the order they were typed — once the turn ends.
- **Steer**: the message interrupts the running turn and is resent right away. Mobile is cloud-only and has no native mid-turn inject, so Steer maps to **interrupt-and-resend** (cancel the live turn via the existing cloud `cancel` command, then resend as a fresh prompt).

## Changes

- **`messagingModeStore`** — persisted per-task mode override plus a global default (defaults to Queue), mirroring the desktop store but using the app's `zustand + persist + AsyncStorage` pattern.
- **`messageQueueStore`** — lightweight in-memory queue with `enqueue` / `drain` / `prepend` and a pure `combineQueuedMessages` helper (FIFO order preserved, attachments concatenated).
- **`taskSessionStore`** — a single `sendInterrupting` chokepoint for interrupt-and-resend, and an auto-flush that drains the queue when a turn ends. Failed flushes roll the messages back onto the head of the queue.
- **`TaskChatComposer`** — a touch-friendly toggle pill showing the current mode and the queued count (`Queue (3)`).
- **Settings** — a global "Messaging mode" default.
- **Analytics** — sends emit a `Prompt sent` event carrying `is_steer`.

All changes are confined to `apps/mobile`; no desktop or shared package code is touched.

## Testing

- Unit tests for the mode store (override vs global default resolution) and the queue store (FIFO ordering, drain-clears, failed-flush rollback ordering, combine ordering).
- `vitest run` — 41 files / 280 tests pass.
- Typecheck and Biome lint clean on the touched files.