### PR TITLE
Stop mirroring bundled skills into the shared ~/.agents/skills dir

### DIFF
--- a/packages/workspace-server/src/services/posthog-plugin/README.md
+++ b/packages/workspace-server/src/services/posthog-plugin/README.md
@@ -40,7 +40,7 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 **On startup:**
 1. Creates `{userData}/plugins/posthog/` (the runtime plugin dir)
 2. Assembles it: copies `plugin.json` from bundled, merges bundled skills + any previously-downloaded remote skills
-3. Syncs skills to `$HOME/.agents/skills/` for Codex
+3. Mirrors the user's own skills out to `$HOME/.agents/skills/` for Codex (see below)
 4. Starts a 30-minute interval timer
 5. Kicks off the first async download
 
@@ -49,7 +49,7 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 2. Extracts to a temp dir via `unzip`
 3. Atomically swaps into `{userData}/skills/`
 4. Re-assembles the runtime plugin dir
-5. Re-syncs to Codex
+5. Re-mirrors the user's own skills to Codex
 6. On failure: logs a warning, keeps existing skills, retries next interval
 
 **`getPluginPath()`** — called by `AgentService` when starting sessions:
@@ -57,9 +57,11 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 - Prod → `{userData}/plugins/posthog/` (with downloaded updates)
 - Fallback → bundled path
 
-### Codex Sync
+### Codex Mirror
 
-After every assembly, skills are copied to `$HOME/.agents/skills/` so that Codex sessions also pick them up.
+`$HOME/.agents/skills/` is a shared, cross-agent skills directory that other tools (e.g. Codex) also read. To avoid bloating that shared location — and inflating other agents' context — PostHog Code **only mirrors the user's own skills** (`$HOME/.claude/skills/`) there, never the bundled PostHog catalog. The bundled catalog lives in the app-private runtime plugin dir and is loaded only by PostHog Code's own sessions.
+
+`mirrorUserSkillsToCodex` (in `codex-mirror.ts`) runs on startup, after each 30-minute update, and after any user skill mutation. It is collision-safe: it tracks the names it wrote in `.posthog-mirror.json` and never overwrites a skill it didn't put there; mirrors whose source skill is deleted are removed.
 
 ## Dev Workflow
 

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
@@ -90,7 +90,6 @@ import type { IAppMeta } from "@posthog/platform/app-meta";
 import type { IBundledResources } from "@posthog/platform/bundled-resources";
 import type { IStoragePaths } from "@posthog/platform/storage-paths";
 import { PosthogPluginService } from "./posthog-plugin";
-import { syncCodexSkills } from "./update-skills-saga";
 
 /** Expose private members for testing without `as any`. */
 interface TestablePluginService {
@@ -105,7 +104,6 @@ const RUNTIME_SKILLS_DIR = "/mock/userData/skills";
 const BUNDLED_PLUGIN_DIR = "/mock/appPath/.vite/build/plugins/posthog";
 const BUNDLED_PLUGIN_DIR_PACKAGED =
   "/mock/appPath.unpacked/.vite/build/plugins/posthog";
-const CODEX_SKILLS_DIR = "/mock/home/.agents/skills";
 
 function mockFetchResponse(ok: boolean, status = 200) {
   return {
@@ -461,25 +459,6 @@ describe("PosthogPluginService", () => {
         ? vol.readdirSync("/mock/tmp")
         : [];
       expect(tmpEntries).toHaveLength(0);
-    });
-  });
-
-  describe("syncCodexSkills", () => {
-    it("copies skill directories to Codex dir", async () => {
-      setupBundledPlugin();
-
-      await syncCodexSkills(BUNDLED_PLUGIN_DIR, CODEX_SKILLS_DIR);
-
-      expect(
-        vol.readFileSync(`${CODEX_SKILLS_DIR}/shipped-skill/SKILL.md`, "utf-8"),
-      ).toBe("# Shipped");
-    });
-
-    it("skips if effective skills dir does not exist", async () => {
-      // No skills dir anywhere
-      await syncCodexSkills("/nonexistent", CODEX_SKILLS_DIR);
-
-      expect(vol.existsSync(CODEX_SKILLS_DIR)).toBe(false);
     });
   });
 

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
@@ -24,11 +24,7 @@ import { TypedEventEmitter } from "@posthog/shared";
 import { inject, injectable, postConstruct, preDestroy } from "inversify";
 import { getUserSkillsDir } from "../skills/skill-discovery";
 import { getCodexSkillsDir, mirrorUserSkillsToCodex } from "./codex-mirror";
-import {
-  overlayDownloadedSkills,
-  syncCodexSkills,
-  UpdateSkillsSaga,
-} from "./update-skills-saga";
+import { overlayDownloadedSkills, UpdateSkillsSaga } from "./update-skills-saga";
 
 const SKILLS_ZIP_URL = process.env.SKILLS_ZIP_URL ?? "";
 const CONTEXT_MILL_ZIP_URL = process.env.CONTEXT_MILL_ZIP_URL ?? "";
@@ -99,7 +95,6 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
     // Overlay any previously-downloaded skills on top of the runtime plugin
     await overlayDownloadedSkills(this.runtimeSkillsDir, this.runtimePluginDir);
 
-    await syncCodexSkills(this.getPluginPath(), CODEX_SKILLS_DIR);
     await this.mirrorUserSkills();
 
     // Start periodic updates
@@ -167,8 +162,6 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
       const result = await saga.run({
         runtimeSkillsDir: this.runtimeSkillsDir,
         runtimePluginDir: this.runtimePluginDir,
-        pluginPath: this.getPluginPath(),
-        codexSkillsDir: CODEX_SKILLS_DIR,
         tempDir,
         skillsZipUrl: SKILLS_ZIP_URL,
         contextMillZipUrl: CONTEXT_MILL_ZIP_URL,

--- a/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
@@ -38,40 +38,9 @@ export async function overlayDownloadedSkills(
   }
 }
 
-/**
- * Syncs skills from the effective plugin dir to `codexSkillsDir` for Codex.
- */
-export async function syncCodexSkills(
-  pluginPath: string,
-  codexSkillsDir: string,
-): Promise<void> {
-  const effectiveSkillsDir = join(pluginPath, "skills");
-  if (!existsSync(effectiveSkillsDir)) {
-    return;
-  }
-
-  try {
-    await mkdir(codexSkillsDir, { recursive: true });
-
-    const entries = await readdir(effectiveSkillsDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const src = join(effectiveSkillsDir, entry.name);
-        const dest = join(codexSkillsDir, entry.name);
-        await rm(dest, { recursive: true, force: true });
-        await cp(src, dest, { recursive: true });
-      }
-    }
-  } catch {
-    // Fire-and-forget — don't block startup or updates on Codex sync
-  }
-}
-
 export interface UpdateSkillsInput {
   runtimeSkillsDir: string;
   runtimePluginDir: string;
-  pluginPath: string;
-  codexSkillsDir: string;
   tempDir: string;
   skillsZipUrl: string;
   contextMillZipUrl: string;
@@ -184,17 +153,6 @@ export class UpdateSkillsSaga extends Saga<
         );
       } catch (err) {
         this.log.warn("Failed to overlay skills", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    });
-
-    // Step 6: sync codex skills (non-fatal)
-    await this.readOnlyStep("sync-codex-skills", async () => {
-      try {
-        await syncCodexSkills(input.pluginPath, input.codexSkillsDir);
-      } catch (err) {
-        this.log.warn("Failed to sync codex skills", {
           error: err instanceof Error ? err.message : String(err),
         });
       }


### PR DESCRIPTION
## Why

A user reported that PostHog Code "installed around 100 skills into the global `.agents` directory without notifying me" and that their tokens in other coding agents started burning faster. **This was accurate.**

`~/.agents/skills` is a *shared, cross-agent* skills directory — other tools (e.g. Codex) read it too. `syncCodexSkills` was copying our **entire bundled PostHog catalog (~100 skills)** into it:

- on **every app startup** (`PosthogPluginService.initialize`), and
- at the end of **every 30-minute skills update** (`UpdateSkillsSaga`),

unconditionally (`rm` + `cp` per skill), with **no collision guard, no state tracking, no cleanup, and no notification**. That silently bloated users' global skills dir and inflated *other* agents' context on every session — the direct cause of the "tokens burning faster" report.

This is distinct from the explicit marketplace/team "Install" flows (gated on a click, write to `~/.claude/skills`, toast on success) — those are fine.

## What

Remove `syncCodexSkills` entirely. Now **only the user's own skills** (`~/.claude/skills`) are mirrored out, via the existing collision-safe `mirrorUserSkillsToCodex`:
- tracks the names it wrote in `.posthog-mirror.json`,
- never overwrites a skill it didn't create,
- removes mirrors when the source skill is deleted.

The bundled catalog stays in the app-private runtime plugin dir and is loaded only by PostHog Code's own sessions — it never needed to be in the shared dir.

### Files
- `posthog-plugin.ts` — drop the `syncCodexSkills` import + startup call; remove now-unused saga inputs (`pluginPath`, `codexSkillsDir`).
- `update-skills-saga.ts` — delete the `syncCodexSkills` function, the `sync-codex-skills` saga step, and the unused input fields.
- `posthog-plugin.test.ts` — remove the obsolete `syncCodexSkills` tests and the unused `CODEX_SKILLS_DIR` constant.
- `README.md` — rewrite the "Codex Sync" section as "Codex Mirror", documenting that only user skills are mirrored, and why.

## Verification
- `codex-mirror` + `posthog-plugin` test suites: **31/31 pass**.
- Biome lint on changed files: clean.
- Typecheck: no errors in changed files.

## Follow-up (not in this PR)
Users on an affected build still have ~100 bundled skills sitting in `~/.agents/skills`. This change stops new writes but does **not** retroactively clean up already-mirrored bundled skills — they were never tracked in `.posthog-mirror.json`, so we can't safely distinguish them from the user's own. A one-time cleanup migration could be added if we want to claw those back.