### PR TITLE
docs: add Secretive commit-signing troubleshooting entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ We love contributions big and small. See [CONTRIBUTING.md](./CONTRIBUTING.md) to
 
 ## Troubleshooting
 
-See [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) for common issues (black screen, Electron install failures, native module crashes, etc.).
+See [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) for common issues (black screen, Electron install failures, native module crashes, Secretive commit signing, etc.).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -185,13 +185,19 @@ The usual cause is **not** that the key is missing — it's that the shell runni
 
 ### Fix
 
-Point `SSH_AUTH_SOCK` at Secretive's socket. Find the exact path (Secretive also shows it in-app under its setup screen):
+**Quick setup — paste this.** It locates Secretive's socket and adds `SSH_AUTH_SOCK` to your **user-global** `~/.claude/settings.json`, merging with whatever's already there so every agent shell picks it up regardless of how the app was launched (needs `jq`; if you don't have it, do the manual edit below instead):
+
+```bash
+SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"; [ -S "$SOCK" ] || echo "⚠️  No Secretive socket at $SOCK — open Secretive → Setup and copy the path it shows"; mkdir -p ~/.claude; f=~/.claude/settings.json; [ -s "$f" ] || echo '{}' > "$f"; tmp=$(mktemp) && jq --arg s "$SOCK" '.env = (.env // {}) + {SSH_AUTH_SOCK: $s}' "$f" > "$tmp" && mv "$tmp" "$f" && echo "updated $f:" && cat "$f"
+```
+
+**Or set it by hand.** Find the socket path (Secretive also shows it in-app under its setup screen):
 
 ```bash
 ls "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 ```
 
-For agent-driven commits, set it in your **user-global** `~/.claude/settings.json` so every agent shell has it regardless of how the app was launched:
+and add it to `~/.claude/settings.json`:
 
 ```json
 {
@@ -201,18 +207,21 @@ For agent-driven commits, set it in your **user-global** `~/.claude/settings.jso
 }
 ```
 
-For commits you run in a terminal, also export it from your shell profile (`~/.zshrc`):
+Either way, for commits you run in a terminal yourself, also export it from your shell profile (`~/.zshrc`):
 
 ```bash
 export SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 ```
 
-Then verify the agent can actually serve the key (this should print your Secretive public key) and that a signed commit goes through:
+Then verify the agent can serve the key (this prints your Secretive public key) and that a signed commit goes through. Run it inside a git repo, and note the single `export` so the socket applies to *both* commands — not just `ssh-add`:
 
 ```bash
-SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ssh-add -L
+export SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+ssh-add -L
 git commit --allow-empty -m "test signing" && git log --show-signature -1
 ```
+
+> **Note:** Claude Code reads `env` at session start, so restart the app (or start a new session) after editing `~/.claude/settings.json` for the change to take effect.
 
 Two things `SSH_AUTH_SOCK` can't fix, because only the machine owner controls them:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -185,7 +185,7 @@ The usual cause is **not** that the key is missing — it's that the shell runni
 
 ### Fix
 
-**Quick setup — paste this.** It locates Secretive's socket and adds `SSH_AUTH_SOCK` to your **user-global** `~/.claude/settings.json`, merging with whatever's already there so every agent shell picks it up regardless of how the app was launched (needs `jq`; if you don't have it, do the manual edit below instead):
+**Quick setup — paste this.** Adds `SSH_AUTH_SOCK` to your `~/.claude/settings.json` (merging with anything already there) so every agent shell picks it up. Needs `jq`; otherwise use the manual edit below:
 
 ```bash
 SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"; [ -S "$SOCK" ] || echo "⚠️  No Secretive socket at $SOCK — open Secretive → Setup and copy the path it shows"; mkdir -p ~/.claude; f=~/.claude/settings.json; [ -s "$f" ] || echo '{}' > "$f"; tmp=$(mktemp) && jq --arg s "$SOCK" '.env = (.env // {}) + {SSH_AUTH_SOCK: $s}' "$f" > "$tmp" && mv "$tmp" "$f" && echo "updated $f:" && cat "$f"
@@ -213,7 +213,7 @@ Either way, for commits you run in a terminal yourself, also export it from your
 export SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 ```
 
-Then verify the agent can serve the key (this prints your Secretive public key) and that a signed commit goes through. Run it inside a git repo, and note the single `export` so the socket applies to *both* commands — not just `ssh-add`:
+Then verify it works, from inside a git repo — this prints your Secretive public key, then a signed commit:
 
 ```bash
 export SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
@@ -227,7 +227,3 @@ Two things `SSH_AUTH_SOCK` can't fix, because only the machine owner controls th
 
 - **Keep the Mac unlocked** while agents commit — the Secure Enclave is unavailable while the screen is locked.
 - For fully unattended signing, **turn off "Require Authentication before use"** for that key in the Secretive app (the trade-off is no per-signature Touch ID). Leave it on and you'll have to approve each commit's Touch ID prompt.
-
-### Why this isn't a repo-level setting
-
-It's tempting to put `SSH_AUTH_SOCK` in the repo's checked-in `.claude/settings.json`, but that path is macOS- and Secretive-specific. Forcing it on everyone would clobber the working SSH agent of Linux/CI runs and any contributor who doesn't use Secretive. Keep it in your per-machine `~/.claude/settings.json` (or shell profile) instead.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -169,3 +169,56 @@ Packages: -198
 ```
 
 This is cosmetic noise — nothing is broken. It's caused by `node-linker=hoisted` in `.npmrc`, which gives us a flat `node_modules` layout (required for Electron). With hoisted mode, pnpm reorganizes the flat layout on each install and reports the churn as packages added/removed. The packages aren't actually disappearing. Safe to ignore.
+
+## Commit signing fails with Secretive ("private key not available")
+
+We require signed commits, and many of us sign via [Secretive](https://github.com/maxgoedjen/secretive) (SSH keys held in the macOS Secure Enclave). A commit — most often one an agent like Claude Code or Codex runs for you — fails with something like:
+
+```
+error: Load key "...": agent refused operation
+fatal: failed to write commit object
+```
+
+or a tool reports that "the Secretive SSH agent doesn't have the matching private key available."
+
+The usual cause is **not** that the key is missing — it's that the shell running `git commit` can't reach Secretive's agent socket. Git signs commits with `ssh-keygen -Y sign`, which finds the agent **only** through the `SSH_AUTH_SOCK` environment variable. It does **not** read `~/.ssh/config`'s `IdentityAgent`. A GUI-launched app (or an agent shell spawned from one) often doesn't inherit `SSH_AUTH_SOCK`, so signing fails intermittently even though Secretive is running and your terminal commits fine.
+
+### Fix
+
+Point `SSH_AUTH_SOCK` at Secretive's socket. Find the exact path (Secretive also shows it in-app under its setup screen):
+
+```bash
+ls "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+```
+
+For agent-driven commits, set it in your **user-global** `~/.claude/settings.json` so every agent shell has it regardless of how the app was launched:
+
+```json
+{
+  "env": {
+    "SSH_AUTH_SOCK": "/Users/<you>/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+  }
+}
+```
+
+For commits you run in a terminal, also export it from your shell profile (`~/.zshrc`):
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+```
+
+Then verify the agent can actually serve the key (this should print your Secretive public key) and that a signed commit goes through:
+
+```bash
+SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ssh-add -L
+git commit --allow-empty -m "test signing" && git log --show-signature -1
+```
+
+Two things `SSH_AUTH_SOCK` can't fix, because only the machine owner controls them:
+
+- **Keep the Mac unlocked** while agents commit — the Secure Enclave is unavailable while the screen is locked.
+- For fully unattended signing, **turn off "Require Authentication before use"** for that key in the Secretive app (the trade-off is no per-signature Touch ID). Leave it on and you'll have to approve each commit's Touch ID prompt.
+
+### Why this isn't a repo-level setting
+
+It's tempting to put `SSH_AUTH_SOCK` in the repo's checked-in `.claude/settings.json`, but that path is macOS- and Secretive-specific. Forcing it on everyone would clobber the working SSH agent of Linux/CI runs and any contributor who doesn't use Secretive. Keep it in your per-machine `~/.claude/settings.json` (or shell profile) instead.


### PR DESCRIPTION
## What

Adds a troubleshooting entry for the recurring **Secretive commit-signing failure** — the "the matching private key isn't available / agent refused operation" error people hit when signing commits via SSH, most often during agent-driven commits.

## Why

The failure is intermittent and confusing because the key isn't actually missing. git signs commits with `ssh-keygen -Y sign`, which locates the agent **only** through the `SSH_AUTH_SOCK` environment variable — it does **not** read `~/.ssh/config`'s `IdentityAgent`. A GUI-launched app (or an agent shell spawned from one) often doesn't inherit `SSH_AUTH_SOCK`, so signing fails even though Secretive is running and terminal commits work fine.

## Changes

- **`docs/TROUBLESHOOTING.md`** — new entry with the per-machine fix (point `SSH_AUTH_SOCK` at Secretive's socket via `~/.claude/settings.json` `env` and/or the shell profile), verify commands, and the two machine-owner caveats (Mac must be unlocked; turn off per-use auth for unattended signing). Includes a note on why this is intentionally **not** a repo-level setting — a macOS-only path in the shared `.claude/settings.json` would clobber Linux/CI and non-Secretive contributors.
- **`README.md`** — adds "Secretive commit signing" to the troubleshooting pointer for discoverability.

Docs-only; no code or config behavior changes.