### PR TITLE
Show resolved PRs in the inbox Pull requests tab

### DIFF
--- a/packages/core/src/inbox/reportFiltering.ts
+++ b/packages/core/src/inbox/reportFiltering.ts
@@ -7,10 +7,14 @@ import type {
 
 /**
  * Comma-separated statuses for the inbox query. We pull `failed` so the Runs
- * tab can surface failed runs in its Recently finished section.
+ * tab can surface failed runs in its Recently finished section, and `resolved`
+ * so the Pull requests tab can surface PRs that have already been merged/closed
+ * — matching the PostHog Cloud inbox, which shows every status except
+ * `suppressed`/`deleted`. The Reports tab keeps `resolved` out via its own
+ * `isReportTabReport` predicate.
  */
 export const INBOX_PIPELINE_STATUS_FILTER =
-  "potential,candidate,in_progress,ready,pending_input,failed";
+  "potential,candidate,in_progress,ready,pending_input,failed,resolved";
 
 /** Polling interval for inbox queries while the Electron window is focused. */
 export const INBOX_REFETCH_INTERVAL_MS = 3000;

--- a/packages/core/src/inbox/reportMembership.test.ts
+++ b/packages/core/src/inbox/reportMembership.test.ts
@@ -109,6 +109,17 @@ describe("tabFilters", () => {
         ),
       ).toBe(false);
     });
+
+    it("keeps resolved PRs in the Pull requests tab (matches Cloud)", () => {
+      expect(
+        isPullRequestReport(
+          fakeReport({
+            implementation_pr_url: "https://gh/p/1",
+            status: "resolved",
+          }),
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("isExcludedFromInbox", () => {
@@ -170,6 +181,14 @@ describe("tabFilters", () => {
       expect(
         isReportTabReport(
           fakeReport({ status: "pending_input", implementation_pr_url: null }),
+        ),
+      ).toBe(false);
+    });
+
+    it("excludes resolved reports (done work, only shown in the Pull requests tab)", () => {
+      expect(
+        isReportTabReport(
+          fakeReport({ status: "resolved", implementation_pr_url: null }),
         ),
       ).toBe(false);
     });

--- a/packages/core/src/inbox/reportMembership.ts
+++ b/packages/core/src/inbox/reportMembership.ts
@@ -194,6 +194,7 @@ export function orderedRunsTabReports(reports: SignalReport[]): SignalReport[] {
 export function isReportTabReport(report: SignalReport): boolean {
   if (isExcludedFromInbox(report)) return false;
   if (report.status === "failed") return false; // failed runs live in the Runs tab only
+  if (report.status === "resolved") return false; // resolved work is done; only surfaces in the Pull requests tab when it has a PR
   if (isPullRequestReport(report)) return false;
   if (isAgentRunReport(report)) return false;
   return true;


### PR DESCRIPTION
## Problem

The Code desktop inbox showed a different PR count than the PostHog Cloud inbox for the same user (Andy saw 4 PR reports in Cloud but only 1 in the Code app). Investigation ([session writeup](https://github.com/posthog/claude-sessions/blob/main/sessions/andrewm4894/20260618-143732.md#whats-actually-going-on)) found it's not a sync bug — both read the same backend. The Code inbox query excludes the `resolved` status, so merged/closed PRs drop off the Pull requests tab, while Cloud's pulls view shows every status except `suppressed`/`deleted` and keeps them.

## Changes

Align the Pull requests tab with Cloud:

- Add `resolved` to `INBOX_PIPELINE_STATUS_FILTER` so resolved PRs are fetched and surface in the Pull requests tab and its count badge.
- Exclude `resolved` from `isReportTabReport` so resolved reports stay out of the Reports tab (matching Cloud, where Reports is `ready,pending_input` only, and preserving current Code behavior). The Runs tab is unaffected — `resolved` isn't a queued/live/finished run status.

## How did you test this?

- Added unit tests in `reportMembership.test.ts`: a resolved PR is kept in the Pull requests tab, and a resolved non-PR report is excluded from the Reports tab.
- Ran `vitest run src/inbox/reportMembership.test.ts src/inbox/reportFiltering.test.ts` — 48 tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781789565853999?thread_ts=1781789565.853999&cid=C09SK2PAGKF)*
