### PR TITLE
Show only ready PRs in the inbox Pull requests tab

### DIFF
--- a/packages/core/src/inbox/reportFiltering.ts
+++ b/packages/core/src/inbox/reportFiltering.ts
@@ -22,6 +22,15 @@ export const INBOX_PIPELINE_STATUS_FILTER =
  */
 export const INBOX_DISMISSED_STATUS_FILTER = "suppressed";
 
+/**
+ * Status filter for the Pull requests tab's list and count. Only `ready` PRs —
+ * a Responder draft awaiting review — are surfaced; PRs that have already been
+ * merged/closed (`resolved`) or are still running drop off so the tab and its
+ * count reflect only actionable work the user can act on. Keeps the count
+ * honest about what the list actually shows.
+ */
+export const INBOX_PULL_REQUEST_STATUS_FILTER = "ready";
+
 /** Polling interval for inbox queries while the Electron window is focused. */
 export const INBOX_REFETCH_INTERVAL_MS = 3000;
 

--- a/packages/core/src/inbox/reportMembership.test.ts
+++ b/packages/core/src/inbox/reportMembership.test.ts
@@ -123,11 +123,11 @@ describe("tabFilters", () => {
       ).toBe(false);
     });
 
-    it("returns false for a resolved (merged/closed) PR", () => {
+    it("returns false for a PR whose report is no longer ready", () => {
       expect(
         isPullRequestReport(
           fakeReport({
-            status: "resolved",
+            status: "candidate",
             implementation_pr_url: "https://gh/p/1",
           }),
         ),
@@ -198,11 +198,11 @@ describe("tabFilters", () => {
       ).toBe(false);
     });
 
-    it("excludes resolved (merged/closed) PRs rather than surfacing them as Reports", () => {
+    it("excludes any PR-bearing report rather than surfacing it as a Report", () => {
       expect(
         isReportTabReport(
           fakeReport({
-            status: "resolved",
+            status: "candidate",
             implementation_pr_url: "https://gh/p/1",
           }),
         ),

--- a/packages/core/src/inbox/reportMembership.test.ts
+++ b/packages/core/src/inbox/reportMembership.test.ts
@@ -104,17 +104,44 @@ describe("inbox scope", () => {
 
 describe("tabFilters", () => {
   describe("isPullRequestReport", () => {
-    it("returns true when implementation_pr_url is set", () => {
+    it("returns true when a ready report has an implementation PR", () => {
       expect(
         isPullRequestReport(
-          fakeReport({ implementation_pr_url: "https://gh/p/1" }),
+          fakeReport({
+            status: "ready",
+            implementation_pr_url: "https://gh/p/1",
+          }),
         ),
       ).toBe(true);
     });
 
     it("returns false when implementation_pr_url is null", () => {
       expect(
-        isPullRequestReport(fakeReport({ implementation_pr_url: null })),
+        isPullRequestReport(
+          fakeReport({ status: "ready", implementation_pr_url: null }),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for a resolved (merged/closed) PR", () => {
+      expect(
+        isPullRequestReport(
+          fakeReport({
+            status: "resolved",
+            implementation_pr_url: "https://gh/p/1",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for a still-running PR", () => {
+      expect(
+        isPullRequestReport(
+          fakeReport({
+            status: "in_progress",
+            implementation_pr_url: "https://gh/p/1",
+          }),
+        ),
       ).toBe(false);
     });
 
@@ -167,6 +194,17 @@ describe("tabFilters", () => {
       expect(
         isReportTabReport(
           fakeReport({ implementation_pr_url: "https://gh/p/1" }),
+        ),
+      ).toBe(false);
+    });
+
+    it("excludes resolved (merged/closed) PRs rather than surfacing them as Reports", () => {
+      expect(
+        isReportTabReport(
+          fakeReport({
+            status: "resolved",
+            implementation_pr_url: "https://gh/p/1",
+          }),
         ),
       ).toBe(false);
     });

--- a/packages/core/src/inbox/reportMembership.ts
+++ b/packages/core/src/inbox/reportMembership.ts
@@ -120,9 +120,14 @@ export function isInboxDetailPath(pathname: string): boolean {
   return INBOX_DETAIL_PATH_RE.test(pathname);
 }
 
-/** PR tab membership: Responder shipped a draft PR and the report is still in-inbox. */
+/**
+ * PR tab membership: Responder shipped a draft PR and it is `ready` for review.
+ * PRs that have already been merged/closed (`resolved`) or are still running
+ * are excluded so the tab — and its count — only show actionable PRs, matching
+ * the PostHog Cloud inbox.
+ */
 export function isPullRequestReport(report: SignalReport): boolean {
-  return !!report.implementation_pr_url && !isExcludedFromInbox(report);
+  return report.status === "ready" && !!report.implementation_pr_url;
 }
 
 // ── Runs-tab partitioning ─────────────────────────────────────────────────
@@ -217,7 +222,10 @@ export function orderedRunsTabReports(reports: SignalReport[]): SignalReport[] {
 export function isReportTabReport(report: SignalReport): boolean {
   if (isExcludedFromInbox(report)) return false;
   if (report.status === "failed") return false; // failed runs live in the Runs tab only
-  if (isPullRequestReport(report)) return false;
+  // Any report carrying a PR belongs to the Pull requests tab, even once it has
+  // been merged/closed (`resolved`) — those just drop out of the inbox here
+  // rather than reappearing as a Report.
+  if (report.implementation_pr_url) return false;
   if (isAgentRunReport(report)) return false;
   return true;
 }

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -4,6 +4,7 @@ import {
   buildSuggestedReviewerFilterParam,
   filterReportsBySearch,
   INBOX_PIPELINE_STATUS_FILTER,
+  INBOX_PULL_REQUEST_STATUS_FILTER,
   INBOX_REFETCH_INTERVAL_MS,
 } from "@posthog/core/inbox/reportFiltering";
 import {
@@ -80,7 +81,11 @@ export function useInboxAllReports(options?: {
 
   const query = useInboxReportsInfinite(
     {
-      status: INBOX_PIPELINE_STATUS_FILTER,
+      // The Pull requests tab shows only `ready` PRs (active review work),
+      // matching its count query and the PostHog Cloud inbox.
+      status: pullRequestsOnly
+        ? INBOX_PULL_REQUEST_STATUS_FILTER
+        : INBOX_PIPELINE_STATUS_FILTER,
       has_implementation_pr: pullRequestsOnly ? true : undefined,
       ordering: buildSignalReportListOrdering(sortField, sortDirection),
       source_product:
@@ -110,7 +115,7 @@ export function useInboxAllReports(options?: {
   // returns the real total regardless of page size.
   const pullRequestCountQuery = useInboxReports(
     {
-      status: INBOX_PIPELINE_STATUS_FILTER,
+      status: INBOX_PULL_REQUEST_STATUS_FILTER,
       has_implementation_pr: true,
       // Mirror the list query's active filters so the badge matches the tab
       // body. These are empty when `ignoreFilters` is set (sidebar usage), so


### PR DESCRIPTION
## Problem

The inbox Pull requests tab listed and counted PRs of every status, so merged/closed (`resolved`) PRs piled up alongside active ones. A user saw 4 PR reports when only 1 was actually actionable — the other 3 were already-merged PRs. The count should reflect only what's worth acting on.

(Supersedes #2757, which aligned Code with Cloud by *showing* resolved PRs — wrong direction. Cloud is being changed to match this instead.)

## Changes

Restrict the Pull requests tab's list **and** its count to `ready` PRs (a Responder draft awaiting review):

- `isPullRequestReport` now requires `status === "ready"`.
- The list query (`pullRequestsOnly`) and the count query use a new `INBOX_PULL_REQUEST_STATUS_FILTER = "ready"`.
- `isReportTabReport` excludes any report carrying a PR (including resolved/merged), so done PRs drop out of the inbox rather than reappearing as a Report.

Resolved/merged and still-running PRs no longer inflate the tab or its badge. The Reports and Runs tabs are unchanged.

## How did you test this?

- Updated/added unit tests in `reportMembership.test.ts` (ready PR shown; resolved and in-progress PRs excluded; resolved PRs kept out of Reports).
- Ran `vitest run src/inbox/reportMembership.test.ts src/inbox/reportFiltering.test.ts src/inbox/engagement.test.ts` — 64 tests pass.
- Biome check clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781789565853999?thread_ts=1781789565.853999&cid=C09SK2PAGKF)*
