### PR TITLE
Keep skills out of shared global dirs; merge per-session

### DIFF
--- a/packages/agent/src/adapters/codex/spawn.test.ts
+++ b/packages/agent/src/adapters/codex/spawn.test.ts
@@ -74,3 +74,29 @@ describe("spawnCodexProcess developer instructions", () => {
     expect(args).toContain('developer_instructions="a\\\\b\\n\\"c"');
   });
 });
+
+describe("spawnCodexProcess codex home", () => {
+  it("sets CODEX_HOME on the child env when provided", () => {
+    spawnMock.mockClear();
+    spawnMock.mockReturnValue(makeFakeChild());
+
+    spawnCodexProcess({
+      logger: new Logger({ debug: false }),
+      codexHome: "/data/codex-home",
+    });
+
+    const env = spawnMock.mock.calls[0][2].env;
+    expect(env.CODEX_HOME).toBe("/data/codex-home");
+  });
+
+  it("does not inject CODEX_HOME when not provided", () => {
+    spawnMock.mockClear();
+    spawnMock.mockReturnValue(makeFakeChild());
+
+    spawnCodexProcess({ logger: new Logger({ debug: false }) });
+
+    // Inherits the ambient value (if any) without the adapter adding its own.
+    const env = spawnMock.mock.calls[0][2].env;
+    expect(env.CODEX_HOME).toBe(process.env.CODEX_HOME);
+  });
+});

--- a/packages/agent/src/adapters/codex/spawn.ts
+++ b/packages/agent/src/adapters/codex/spawn.ts
@@ -19,11 +19,6 @@ export interface CodexProcessOptions {
    */
   developerInstructions?: string;
   binaryPath?: string;
-  /**
-   * Private CODEX_HOME for this process. codex-acp scans `$CODEX_HOME/skills`
-   * (for PostHog's bundled + Claude skills) on top of `$HOME/.agents/skills`
-   * (the user's own Codex skills), so this never touches the shared dir.
-   */
   codexHome?: string;
   logger?: Logger;
   processCallbacks?: ProcessSpawnedCallback;

--- a/packages/agent/src/adapters/codex/spawn.ts
+++ b/packages/agent/src/adapters/codex/spawn.ts
@@ -19,6 +19,12 @@ export interface CodexProcessOptions {
    */
   developerInstructions?: string;
   binaryPath?: string;
+  /**
+   * Private CODEX_HOME for this process. codex-acp scans `$CODEX_HOME/skills`
+   * (for PostHog's bundled + Claude skills) on top of `$HOME/.agents/skills`
+   * (the user's own Codex skills), so this never touches the shared dir.
+   */
+  codexHome?: string;
   logger?: Logger;
   processCallbacks?: ProcessSpawnedCallback;
   settings?: CodexSettings;
@@ -120,6 +126,10 @@ export function spawnCodexProcess(options: CodexProcessOptions): CodexProcess {
 
   if (options.apiKey) {
     env.POSTHOG_GATEWAY_API_KEY = options.apiKey;
+  }
+
+  if (options.codexHome) {
+    env.CODEX_HOME = options.codexHome;
   }
 
   const { command, args } = findCodexBinary(options);

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -134,6 +134,7 @@ export class Agent {
               apiBaseUrl: `${gatewayConfig.gatewayUrl}/v1`,
               apiKey: gatewayConfig.apiKey,
               binaryPath: options.codexBinaryPath,
+              codexHome: options.codexHome,
               model: sanitizedModel,
               reasoningEffort: options.reasoningEffort,
               developerInstructions: options.developerInstructions,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -53,6 +53,12 @@ export interface TaskExecutionOptions {
   model?: string;
   gatewayUrl?: string;
   codexBinaryPath?: string;
+  /**
+   * Codex-only. Private CODEX_HOME for the spawned codex-acp process, holding
+   * PostHog's bundled + the user's Claude skills, so Codex sessions get them
+   * without writing to the shared `~/.agents/skills`.
+   */
+  codexHome?: string;
   reasoningEffort?: EffortLevel;
   /**
    * Codex-only. Appended on top of the model's base prompt via the Codex

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -53,11 +53,6 @@ export interface TaskExecutionOptions {
   model?: string;
   gatewayUrl?: string;
   codexBinaryPath?: string;
-  /**
-   * Codex-only. Private CODEX_HOME for the spawned codex-acp process, holding
-   * PostHog's bundled + the user's Claude skills, so Codex sessions get them
-   * without writing to the shared `~/.agents/skills`.
-   */
   codexHome?: string;
   reasoningEffort?: EffortLevel;
   /**

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -67,7 +67,7 @@ import { PROCESS_TRACKING_SERVICE } from "../process-tracking/identifiers";
 import type { ProcessTrackingService } from "../process-tracking/process-tracking";
 import { loadSessionEnvOverrides } from "../session-env/loader";
 import type { AgentAuthAdapter, McpToolInstallations } from "./auth-adapter";
-import { prepareCodexHome } from "./codex-home";
+import { cleanupCodexHome, prepareCodexHome } from "./codex-home";
 import { discoverExternalPlugins } from "./discover-plugins";
 import {
   AGENT_AUTH_ADAPTER,
@@ -690,14 +690,23 @@ When creating pull requests, add the following footer at the end of the PR descr
         "skills",
       );
 
-      const codexHome =
-        adapter === "codex"
-          ? await prepareCodexHome({
-              appDataPath: this.storagePaths.appDataPath,
-              bundledSkillsDir,
-              log: this.log,
-            })
-          : undefined;
+      let codexHome: string | undefined;
+      if (adapter === "codex") {
+        try {
+          codexHome = await prepareCodexHome({
+            appDataPath: this.storagePaths.appDataPath,
+            taskRunId,
+            bundledSkillsDir,
+            log: this.log,
+          });
+        } catch (err) {
+          // A skills-prep failure must not kill the session; Codex falls back
+          // to its default home and the user's own ~/.agents/skills.
+          this.log.warn("Failed to prepare codex home", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
 
       const acpConnection = await agent.run(taskId, taskRunId, {
         adapter,
@@ -1428,6 +1437,10 @@ For git operations while detached:
       } catch {
         this.log.debug("Agent cleanup failed", { taskRunId });
       }
+
+      await cleanupCodexHome(this.storagePaths.appDataPath, taskRunId).catch(
+        () => this.log.debug("Codex home cleanup failed", { taskRunId }),
+      );
 
       this.sessions.delete(taskRunId);
 

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -67,6 +67,7 @@ import { PROCESS_TRACKING_SERVICE } from "../process-tracking/identifiers";
 import type { ProcessTrackingService } from "../process-tracking/process-tracking";
 import { loadSessionEnvOverrides } from "../session-env/loader";
 import type { AgentAuthAdapter, McpToolInstallations } from "./auth-adapter";
+import { prepareCodexHome } from "./codex-home";
 import { discoverExternalPlugins } from "./discover-plugins";
 import {
   AGENT_AUTH_ADAPTER,
@@ -684,11 +685,24 @@ When creating pull requests, add the following footer at the end of the PR descr
         systemPromptOverride,
       );
 
+      const codexHome =
+        adapter === "codex"
+          ? await prepareCodexHome({
+              appDataPath: this.storagePaths.appDataPath,
+              bundledSkillsDir: join(
+                this.posthogPluginService.getPluginPath(),
+                "skills",
+              ),
+              log: this.log,
+            })
+          : undefined;
+
       const acpConnection = await agent.run(taskId, taskRunId, {
         adapter,
         gatewayUrl: proxyUrl,
         codexBinaryPath:
           adapter === "codex" ? this.getCodexBinaryPath() : undefined,
+        codexHome,
         model,
         reasoningEffort: adapter === "codex" ? effort : undefined,
         developerInstructions:
@@ -781,6 +795,10 @@ When creating pull requests, add the following footer at the end of the PR descr
           {
             userDataDir: this.storagePaths.appDataPath,
             repoPath,
+            bundledSkillsDir: join(
+              this.posthogPluginService.getPluginPath(),
+              "skills",
+            ),
           },
           this.log,
         );

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -685,14 +685,16 @@ When creating pull requests, add the following footer at the end of the PR descr
         systemPromptOverride,
       );
 
+      const bundledSkillsDir = join(
+        this.posthogPluginService.getPluginPath(),
+        "skills",
+      );
+
       const codexHome =
         adapter === "codex"
           ? await prepareCodexHome({
               appDataPath: this.storagePaths.appDataPath,
-              bundledSkillsDir: join(
-                this.posthogPluginService.getPluginPath(),
-                "skills",
-              ),
+              bundledSkillsDir,
               log: this.log,
             })
           : undefined;
@@ -795,10 +797,7 @@ When creating pull requests, add the following footer at the end of the PR descr
           {
             userDataDir: this.storagePaths.appDataPath,
             repoPath,
-            bundledSkillsDir: join(
-              this.posthogPluginService.getPluginPath(),
-              "skills",
-            ),
+            bundledSkillsDir,
           },
           this.log,
         );

--- a/packages/workspace-server/src/services/agent/codex-home.test.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.test.ts
@@ -12,9 +12,15 @@ vi.mock("node:os", async (importOriginal) => {
   return { ...actual, homedir, default: { ...actual, homedir } };
 });
 
-import { prepareCodexHome } from "./codex-home";
+import {
+  cleanupCodexHome,
+  getCodexHomeDir,
+  prepareCodexHome,
+} from "./codex-home";
 
 const noopLog = { debug() {}, info() {}, warn() {}, error() {} };
+
+const taskRunId = "run-1";
 
 let root: string;
 let appDataPath: string;
@@ -48,11 +54,12 @@ describe("prepareCodexHome", () => {
 
     const codexHome = await prepareCodexHome({
       appDataPath,
+      taskRunId,
       bundledSkillsDir,
       log: noopLog,
     });
 
-    expect(codexHome).toBe(path.join(appDataPath, "codex-home"));
+    expect(codexHome).toBe(path.join(appDataPath, "codex-home", taskRunId));
     const skillsDir = path.join(codexHome, "skills");
     expect(existsSync(path.join(skillsDir, "query-data", "SKILL.md"))).toBe(
       true,
@@ -66,6 +73,7 @@ describe("prepareCodexHome", () => {
 
     const codexHome = await prepareCodexHome({
       appDataPath,
+      taskRunId,
       bundledSkillsDir,
       log: noopLog,
     });
@@ -84,6 +92,7 @@ describe("prepareCodexHome", () => {
 
     const codexHome = await prepareCodexHome({
       appDataPath,
+      taskRunId,
       bundledSkillsDir,
       log: noopLog,
     });
@@ -95,12 +104,18 @@ describe("prepareCodexHome", () => {
 
   it("rebuilds the skills dir, dropping stale links", async () => {
     await createSkill(bundledSkillsDir, "first");
-    await prepareCodexHome({ appDataPath, bundledSkillsDir, log: noopLog });
+    await prepareCodexHome({
+      appDataPath,
+      taskRunId,
+      bundledSkillsDir,
+      log: noopLog,
+    });
 
     await rm(path.join(bundledSkillsDir, "first"), { recursive: true });
     await createSkill(bundledSkillsDir, "second");
     const codexHome = await prepareCodexHome({
       appDataPath,
+      taskRunId,
       bundledSkillsDir,
       log: noopLog,
     });
@@ -108,5 +123,48 @@ describe("prepareCodexHome", () => {
     const skillsDir = path.join(codexHome, "skills");
     expect(existsSync(path.join(skillsDir, "first"))).toBe(false);
     expect(existsSync(path.join(skillsDir, "second"))).toBe(true);
+  });
+
+  it("gives each task run an isolated dir, so concurrent runs never share", async () => {
+    await createSkill(bundledSkillsDir, "query-data");
+
+    const [homeA, homeB] = await Promise.all([
+      prepareCodexHome({
+        appDataPath,
+        taskRunId: "run-a",
+        bundledSkillsDir,
+        log: noopLog,
+      }),
+      prepareCodexHome({
+        appDataPath,
+        taskRunId: "run-b",
+        bundledSkillsDir,
+        log: noopLog,
+      }),
+    ]);
+
+    expect(homeA).not.toBe(homeB);
+    expect(existsSync(path.join(homeA, "skills", "query-data"))).toBe(true);
+    expect(existsSync(path.join(homeB, "skills", "query-data"))).toBe(true);
+  });
+
+  it("cleanupCodexHome removes the run's dir and is a no-op when absent", async () => {
+    await createSkill(bundledSkillsDir, "query-data");
+    const codexHome = await prepareCodexHome({
+      appDataPath,
+      taskRunId,
+      bundledSkillsDir,
+      log: noopLog,
+    });
+    expect(existsSync(codexHome)).toBe(true);
+
+    await cleanupCodexHome(appDataPath, taskRunId);
+    expect(existsSync(codexHome)).toBe(false);
+    expect(existsSync(getCodexHomeDir(appDataPath, taskRunId))).toBe(false);
+
+    // Second call on a now-absent dir must not throw.
+    await expect(
+      cleanupCodexHome(appDataPath, taskRunId),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/workspace-server/src/services/agent/codex-home.test.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { mkdir, mkdtemp, readlink, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testHome = vi.hoisted(() => ({ dir: "" }));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  const homedir = () => testHome.dir;
+  return { ...actual, homedir, default: { ...actual, homedir } };
+});
+
+import { prepareCodexHome } from "./codex-home";
+
+const noopLog = { debug() {}, info() {}, warn() {}, error() {} };
+
+let root: string;
+let appDataPath: string;
+let bundledSkillsDir: string;
+let userSkillsDir: string;
+
+async function createSkill(dir: string, name: string, body = `# ${name}`) {
+  await mkdir(path.join(dir, name), { recursive: true });
+  await writeFile(path.join(dir, name, "SKILL.md"), body);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "codex-home-test-"));
+  testHome.dir = path.join(root, "home");
+  appDataPath = path.join(root, "appdata");
+  bundledSkillsDir = path.join(root, "bundled", "skills");
+  userSkillsDir = path.join(testHome.dir, ".claude", "skills");
+  await mkdir(appDataPath, { recursive: true });
+  await mkdir(bundledSkillsDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("prepareCodexHome", () => {
+  it("links bundled and user Claude skills into <appData>/codex-home/skills", async () => {
+    await createSkill(bundledSkillsDir, "query-data");
+    await createSkill(userSkillsDir, "my-skill");
+
+    const codexHome = await prepareCodexHome({
+      appDataPath,
+      bundledSkillsDir,
+      log: noopLog,
+    });
+
+    expect(codexHome).toBe(path.join(appDataPath, "codex-home"));
+    const skillsDir = path.join(codexHome, "skills");
+    expect(existsSync(path.join(skillsDir, "query-data", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(skillsDir, "my-skill", "SKILL.md"))).toBe(true);
+  });
+
+  it("lets the bundled catalog win on a name collision", async () => {
+    await createSkill(bundledSkillsDir, "dup", "bundled body");
+    await createSkill(userSkillsDir, "dup", "user body");
+
+    const codexHome = await prepareCodexHome({
+      appDataPath,
+      bundledSkillsDir,
+      log: noopLog,
+    });
+
+    const linked = await readlink(path.join(codexHome, "skills", "dup"));
+    expect(readFileSync(path.join(linked, "SKILL.md"), "utf-8")).toBe(
+      "bundled body",
+    );
+  });
+
+  it("symlinks the user's ~/.codex/config.toml when present", async () => {
+    const codexConfigDir = path.join(testHome.dir, ".codex");
+    await mkdir(codexConfigDir, { recursive: true });
+    const configPath = path.join(codexConfigDir, "config.toml");
+    await writeFile(configPath, 'model = "gpt-5-codex"\n');
+
+    const codexHome = await prepareCodexHome({
+      appDataPath,
+      bundledSkillsDir,
+      log: noopLog,
+    });
+
+    const link = path.join(codexHome, "config.toml");
+    expect(existsSync(link)).toBe(true);
+    expect(await readlink(link)).toBe(realpathSync(configPath));
+  });
+
+  it("rebuilds the skills dir, dropping stale links", async () => {
+    await createSkill(bundledSkillsDir, "first");
+    await prepareCodexHome({ appDataPath, bundledSkillsDir, log: noopLog });
+
+    await rm(path.join(bundledSkillsDir, "first"), { recursive: true });
+    await createSkill(bundledSkillsDir, "second");
+    const codexHome = await prepareCodexHome({
+      appDataPath,
+      bundledSkillsDir,
+      log: noopLog,
+    });
+
+    const skillsDir = path.join(codexHome, "skills");
+    expect(existsSync(path.join(skillsDir, "first"))).toBe(false);
+    expect(existsSync(path.join(skillsDir, "second"))).toBe(true);
+  });
+});

--- a/packages/workspace-server/src/services/agent/codex-home.test.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.test.ts
@@ -167,4 +167,24 @@ describe("prepareCodexHome", () => {
       cleanupCodexHome(appDataPath, taskRunId),
     ).resolves.toBeUndefined();
   });
+
+  it("rejects an unsafe taskRunId instead of escaping the codex-home dir", async () => {
+    const outside = path.join(appDataPath, "keep-me");
+    await createSkill(outside, "precious");
+
+    for (const badId of ["", ".", "..", "../../escape", "nested/evil"]) {
+      expect(() => getCodexHomeDir(appDataPath, badId)).toThrow();
+      await expect(
+        prepareCodexHome({
+          appDataPath,
+          taskRunId: badId,
+          bundledSkillsDir,
+          log: noopLog,
+        }),
+      ).rejects.toThrow();
+      await expect(cleanupCodexHome(appDataPath, badId)).rejects.toThrow();
+    }
+
+    expect(existsSync(path.join(outside, "precious", "SKILL.md"))).toBe(true);
+  });
 });

--- a/packages/workspace-server/src/services/agent/codex-home.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.ts
@@ -1,7 +1,11 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { findSkillDirs, getUserSkillsDir } from "../skills/skill-discovery";
+import {
+  findSkillDirs,
+  getUserSkillsDir,
+  linkSkillsInto,
+} from "../skills/skill-discovery";
 import type { AgentScopedLogger } from "./ports";
 
 /**
@@ -34,28 +38,13 @@ export async function prepareCodexHome(options: {
   const sources = [options.bundledSkillsDir, getUserSkillsDir()];
   const linked = new Set<string>();
   for (const sourceDir of sources) {
-    const names = await findSkillDirs(sourceDir);
-    await Promise.all(
-      names.map(async (name) => {
-        if (linked.has(name)) return;
-        linked.add(name);
-        try {
-          const realSrc = await fs.promises.realpath(
-            path.join(sourceDir, name),
-          );
-          await fs.promises.symlink(realSrc, path.join(skillsDir, name));
-        } catch (err) {
-          linked.delete(name);
-          options.log.warn("Failed to link skill into codex home", {
-            skillName: name,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }),
+    const names = (await findSkillDirs(sourceDir)).filter(
+      (name) => !linked.has(name),
     );
+    const ok = await linkSkillsInto(skillsDir, sourceDir, names, options.log);
+    for (const name of ok) linked.add(name);
   }
 
-  // Keep the user's real Codex config in effect for our sessions.
   const configLink = path.join(codexHome, "config.toml");
   await fs.promises.rm(configLink, { force: true });
   const userConfig = path.join(os.homedir(), ".codex", "config.toml");

--- a/packages/workspace-server/src/services/agent/codex-home.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.ts
@@ -9,6 +9,32 @@ import {
 import type { AgentScopedLogger } from "./ports";
 
 /**
+ * Resolves a task run's private CODEX_HOME directory. Each run gets its own so
+ * concurrent Codex sessions never share — and never race to rebuild — the same
+ * skills directory.
+ */
+export function getCodexHomeDir(
+  appDataPath: string,
+  taskRunId: string,
+): string {
+  return path.join(appDataPath, "codex-home", taskRunId);
+}
+
+/**
+ * Removes a task run's private CODEX_HOME. Safe for any adapter — a no-op when
+ * the directory was never created.
+ */
+export async function cleanupCodexHome(
+  appDataPath: string,
+  taskRunId: string,
+): Promise<void> {
+  await fs.promises.rm(getCodexHomeDir(appDataPath, taskRunId), {
+    recursive: true,
+    force: true,
+  });
+}
+
+/**
  * Builds a private CODEX_HOME for PostHog Code's own Codex sessions, so they
  * load the bundled PostHog catalog and the user's `~/.claude/skills` — without
  * ever writing into the shared cross-agent `~/.agents/skills`.
@@ -23,13 +49,14 @@ import type { AgentScopedLogger } from "./ports";
  */
 export async function prepareCodexHome(options: {
   appDataPath: string;
+  taskRunId: string;
   bundledSkillsDir: string;
   log: AgentScopedLogger;
 }): Promise<string> {
-  const codexHome = path.join(options.appDataPath, "codex-home");
+  const codexHome = getCodexHomeDir(options.appDataPath, options.taskRunId);
   const skillsDir = path.join(codexHome, "skills");
 
-  // Rebuild the skills dir from scratch each spawn so removed skills don't linger.
+  // Start from a clean skills dir; a retried run reuses the same taskRunId.
   await fs.promises.rm(skillsDir, { recursive: true, force: true });
   await fs.promises.mkdir(skillsDir, { recursive: true });
 

--- a/packages/workspace-server/src/services/agent/codex-home.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.ts
@@ -56,7 +56,7 @@ export async function prepareCodexHome(options: {
   const codexHome = getCodexHomeDir(options.appDataPath, options.taskRunId);
   const skillsDir = path.join(codexHome, "skills");
 
-  // Start from a clean skills dir; a retried run reuses the same taskRunId.
+  // A retried run reuses its taskRunId, so wipe any stale links before rebuilding.
   await fs.promises.rm(skillsDir, { recursive: true, force: true });
   await fs.promises.mkdir(skillsDir, { recursive: true });
 

--- a/packages/workspace-server/src/services/agent/codex-home.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.ts
@@ -1,0 +1,76 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { findSkillDirs, getUserSkillsDir } from "../skills/skill-discovery";
+import type { AgentScopedLogger } from "./ports";
+
+/**
+ * Builds a private CODEX_HOME for PostHog Code's own Codex sessions, so they
+ * load the bundled PostHog catalog and the user's `~/.claude/skills` — without
+ * ever writing into the shared cross-agent `~/.agents/skills`.
+ *
+ * codex-acp scans `$CODEX_HOME/skills` plus `$HOME/.agents/skills`. By pointing
+ * CODEX_HOME at this app-private dir we feed our skills through the former while
+ * the user's own Codex skills still load from the latter (it is keyed off
+ * `$HOME`, not `$CODEX_HOME`). The user's real `~/.codex/config.toml` is
+ * symlinked in so their Codex configuration still applies.
+ *
+ * Returns the CODEX_HOME path to hand to the spawned process.
+ */
+export async function prepareCodexHome(options: {
+  appDataPath: string;
+  bundledSkillsDir: string;
+  log: AgentScopedLogger;
+}): Promise<string> {
+  const codexHome = path.join(options.appDataPath, "codex-home");
+  const skillsDir = path.join(codexHome, "skills");
+
+  // Rebuild the skills dir from scratch each spawn so removed skills don't linger.
+  await fs.promises.rm(skillsDir, { recursive: true, force: true });
+  await fs.promises.mkdir(skillsDir, { recursive: true });
+
+  // Bundled catalog first, then the user's Claude skills. Bundled wins on a
+  // name collision so the curated catalog is never shadowed.
+  const sources = [options.bundledSkillsDir, getUserSkillsDir()];
+  const linked = new Set<string>();
+  for (const sourceDir of sources) {
+    const names = await findSkillDirs(sourceDir);
+    await Promise.all(
+      names.map(async (name) => {
+        if (linked.has(name)) return;
+        linked.add(name);
+        try {
+          const realSrc = await fs.promises.realpath(
+            path.join(sourceDir, name),
+          );
+          await fs.promises.symlink(realSrc, path.join(skillsDir, name));
+        } catch (err) {
+          linked.delete(name);
+          options.log.warn("Failed to link skill into codex home", {
+            skillName: name,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
+  }
+
+  // Keep the user's real Codex config in effect for our sessions.
+  const configLink = path.join(codexHome, "config.toml");
+  await fs.promises.rm(configLink, { force: true });
+  const userConfig = path.join(os.homedir(), ".codex", "config.toml");
+  if (fs.existsSync(userConfig)) {
+    try {
+      await fs.promises.symlink(
+        await fs.promises.realpath(userConfig),
+        configLink,
+      );
+    } catch (err) {
+      options.log.warn("Failed to link codex config into codex home", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return codexHome;
+}

--- a/packages/workspace-server/src/services/agent/codex-home.ts
+++ b/packages/workspace-server/src/services/agent/codex-home.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import {
   findSkillDirs,
   getUserSkillsDir,
+  isSafePathSegment,
   linkSkillsInto,
 } from "../skills/skill-discovery";
 import type { AgentScopedLogger } from "./ports";
@@ -17,6 +18,9 @@ export function getCodexHomeDir(
   appDataPath: string,
   taskRunId: string,
 ): string {
+  if (!isSafePathSegment(taskRunId)) {
+    throw new Error(`Unsafe taskRunId: ${JSON.stringify(taskRunId)}`);
+  }
   return path.join(appDataPath, "codex-home", taskRunId);
 }
 

--- a/packages/workspace-server/src/services/agent/discover-plugins.test.ts
+++ b/packages/workspace-server/src/services/agent/discover-plugins.test.ts
@@ -426,4 +426,68 @@ describe("discoverExternalPlugins", () => {
       expect(result[2]?.path).toMatch(/repo-skills-/);
     });
   });
+
+  describe("codex skills", () => {
+    const CODEX_SKILLS_DIR = "/mock/home/.agents/skills";
+
+    it("discovers the user's codex skills as a synthetic plugin", async () => {
+      createSkillDir(CODEX_SKILLS_DIR, "codex-skill");
+
+      const result = await discoverExternalPlugins({
+        userDataDir: USER_DATA_DIR,
+      });
+
+      expect(result).toEqual([
+        { type: "local", path: `${USER_DATA_DIR}/plugins/codex-skills` },
+      ]);
+      const pluginJson = JSON.parse(
+        vol.readFileSync(
+          `${USER_DATA_DIR}/plugins/codex-skills/plugin.json`,
+          "utf-8",
+        ) as string,
+      );
+      expect(pluginJson.description).toBe("User Codex skills");
+    });
+
+    it("excludes codex skills whose name matches a user skill", async () => {
+      createSkillDir(USER_SKILLS_DIR, "shared");
+      createSkillDir(CODEX_SKILLS_DIR, "shared");
+      createSkillDir(CODEX_SKILLS_DIR, "codex-only");
+
+      await discoverExternalPlugins({ userDataDir: USER_DATA_DIR });
+
+      const entries = vol.readdirSync(
+        `${USER_DATA_DIR}/plugins/codex-skills/skills`,
+      );
+      expect(entries).toEqual(["codex-only"]);
+    });
+
+    it("excludes codex skills whose name matches a bundled skill", async () => {
+      const bundledSkillsDir = "/mock/bundled/skills";
+      createSkillDir(bundledSkillsDir, "query-data");
+      createSkillDir(CODEX_SKILLS_DIR, "query-data");
+      createSkillDir(CODEX_SKILLS_DIR, "codex-only");
+
+      await discoverExternalPlugins({
+        userDataDir: USER_DATA_DIR,
+        bundledSkillsDir,
+      });
+
+      const entries = vol.readdirSync(
+        `${USER_DATA_DIR}/plugins/codex-skills/skills`,
+      );
+      expect(entries).toEqual(["codex-only"]);
+    });
+
+    it("omits the codex plugin entirely when every name collides", async () => {
+      createSkillDir(USER_SKILLS_DIR, "dup");
+      createSkillDir(CODEX_SKILLS_DIR, "dup");
+
+      const result = await discoverExternalPlugins({
+        userDataDir: USER_DATA_DIR,
+      });
+
+      expect(result.some((p) => p.path.endsWith("/codex-skills"))).toBe(false);
+    });
+  });
 });

--- a/packages/workspace-server/src/services/agent/discover-plugins.ts
+++ b/packages/workspace-server/src/services/agent/discover-plugins.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { SdkPluginConfig } from "@anthropic-ai/claude-agent-sdk";
+import { getCodexSkillsDir } from "../posthog-plugin/codex-mirror";
 import {
   findSkillDirs,
   getMarketplaceInstallPaths,
@@ -12,6 +13,11 @@ import type { AgentScopedLogger } from "./ports";
 interface DiscoverPluginsOptions {
   userDataDir: string;
   repoPath?: string;
+  /**
+   * The bundled PostHog skills dir (`<plugin>/skills`). Used only to dedupe the
+   * user's Codex skills against names PostHog Code already provides.
+   */
+  bundledSkillsDir?: string;
 }
 
 const noopLogger: AgentScopedLogger = {
@@ -25,15 +31,49 @@ export async function discoverExternalPlugins(
   options: DiscoverPluginsOptions,
   log: AgentScopedLogger = noopLogger,
 ): Promise<SdkPluginConfig[]> {
-  const [globalSkills, marketplacePlugins, repoSkills] = await Promise.all([
-    discoverUserSkills(options.userDataDir, log),
-    discoverMarketplacePlugins(),
-    options.repoPath
-      ? discoverRepoSkills(options.userDataDir, options.repoPath, log)
-      : Promise.resolve([]),
-  ]);
+  const [globalSkills, marketplacePlugins, repoSkills, codexSkills] =
+    await Promise.all([
+      discoverUserSkills(options.userDataDir, log),
+      discoverMarketplacePlugins(),
+      options.repoPath
+        ? discoverRepoSkills(options.userDataDir, options.repoPath, log)
+        : Promise.resolve([]),
+      discoverCodexSkills(options.userDataDir, options.bundledSkillsDir, log),
+    ]);
 
-  return [...globalSkills, ...marketplacePlugins, ...repoSkills];
+  return [
+    ...globalSkills,
+    ...marketplacePlugins,
+    ...repoSkills,
+    ...codexSkills,
+  ];
+}
+
+/**
+ * Surfaces the user's own Codex skills (`~/.agents/skills`) in Claude sessions
+ * too — the symmetric half of the cross-harness merge. Names already provided
+ * by PostHog Code (bundled catalog) or the user's `~/.claude/skills` are
+ * skipped so a skill never loads twice under different plugins.
+ */
+async function discoverCodexSkills(
+  userDataDir: string,
+  bundledSkillsDir: string | undefined,
+  log: AgentScopedLogger,
+): Promise<SdkPluginConfig[]> {
+  const [userNames, bundledNames] = await Promise.all([
+    findSkillDirs(path.join(os.homedir(), ".claude", "skills")),
+    bundledSkillsDir ? findSkillDirs(bundledSkillsDir) : Promise.resolve([]),
+  ]);
+  const exclude = new Set([...userNames, ...bundledNames]);
+
+  return buildSyntheticPlugin(
+    getCodexSkillsDir(),
+    path.join(userDataDir, "plugins", "codex-skills"),
+    "codex-skills",
+    "User Codex skills",
+    log,
+    exclude,
+  );
 }
 
 async function discoverUserSkills(
@@ -81,9 +121,13 @@ async function buildSyntheticPlugin(
   name: string,
   description: string,
   log: AgentScopedLogger,
+  exclude?: Set<string>,
 ): Promise<SdkPluginConfig[]> {
   try {
-    const skillDirs = await findSkillDirs(sourceSkillsDir);
+    const allSkillDirs = await findSkillDirs(sourceSkillsDir);
+    const skillDirs = exclude
+      ? allSkillDirs.filter((skillName) => !exclude.has(skillName))
+      : allSkillDirs;
     if (skillDirs.length === 0) {
       return [];
     }

--- a/packages/workspace-server/src/services/agent/discover-plugins.ts
+++ b/packages/workspace-server/src/services/agent/discover-plugins.ts
@@ -1,12 +1,13 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import type { SdkPluginConfig } from "@anthropic-ai/claude-agent-sdk";
 import { getCodexSkillsDir } from "../posthog-plugin/codex-mirror";
 import {
   findSkillDirs,
   getMarketplaceInstallPaths,
+  getUserSkillsDir,
+  linkSkillsInto,
 } from "../skills/skill-discovery";
 import type { AgentScopedLogger } from "./ports";
 
@@ -61,7 +62,7 @@ async function discoverCodexSkills(
   log: AgentScopedLogger,
 ): Promise<SdkPluginConfig[]> {
   const [userNames, bundledNames] = await Promise.all([
-    findSkillDirs(path.join(os.homedir(), ".claude", "skills")),
+    findSkillDirs(getUserSkillsDir()),
     bundledSkillsDir ? findSkillDirs(bundledSkillsDir) : Promise.resolve([]),
   ]);
   const exclude = new Set([...userNames, ...bundledNames]);
@@ -81,7 +82,7 @@ async function discoverUserSkills(
   log: AgentScopedLogger,
 ): Promise<SdkPluginConfig[]> {
   return buildSyntheticPlugin(
-    path.join(os.homedir(), ".claude", "skills"),
+    getUserSkillsDir(),
     path.join(userDataDir, "plugins", "user-skills"),
     "user-skills",
     "User Claude skills",
@@ -154,21 +155,7 @@ async function buildSyntheticPlugin(
       // ignore
     }
 
-    await Promise.all(
-      skillDirs.map(async (skillName) => {
-        const src = path.join(sourceSkillsDir, skillName);
-        const dest = path.join(syntheticSkillsDir, skillName);
-        try {
-          const realSrc = await fs.promises.realpath(src);
-          await fs.promises.symlink(realSrc, dest);
-        } catch (err) {
-          log.warn("Failed to symlink skill", {
-            skillName,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }),
-    );
+    await linkSkillsInto(syntheticSkillsDir, sourceSkillsDir, skillDirs, log);
 
     return [{ type: "local", path: pluginDir }];
   } catch (err) {

--- a/packages/workspace-server/src/services/agent/discover-plugins.ts
+++ b/packages/workspace-server/src/services/agent/discover-plugins.ts
@@ -126,9 +126,9 @@ async function buildSyntheticPlugin(
 ): Promise<SdkPluginConfig[]> {
   try {
     const allSkillDirs = await findSkillDirs(sourceSkillsDir);
-    const skillDirs = exclude
-      ? allSkillDirs.filter((skillName) => !exclude.has(skillName))
-      : allSkillDirs;
+    const skillDirs = allSkillDirs.filter(
+      (skillName) => !exclude?.has(skillName),
+    );
     if (skillDirs.length === 0) {
       return [];
     }

--- a/packages/workspace-server/src/services/posthog-plugin/README.md
+++ b/packages/workspace-server/src/services/posthog-plugin/README.md
@@ -40,7 +40,7 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 **On startup:**
 1. Creates `{userData}/plugins/posthog/` (the runtime plugin dir)
 2. Assembles it: copies `plugin.json` from bundled, merges bundled skills + any previously-downloaded remote skills
-3. Syncs skills to `$HOME/.agents/skills/` for Codex
+3. Mirrors the user's own skills out to `$HOME/.agents/skills/` for Codex (see below)
 4. Starts a 30-minute interval timer
 5. Kicks off the first async download
 
@@ -49,7 +49,7 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 2. Extracts to a temp dir via `unzip`
 3. Atomically swaps into `{userData}/skills/`
 4. Re-assembles the runtime plugin dir
-5. Re-syncs to Codex
+5. Re-mirrors the user's own skills to Codex
 6. On failure: logs a warning, keeps existing skills, retries next interval
 
 **`getPluginPath()`** — called by `AgentService` when starting sessions:
@@ -57,9 +57,11 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 - Prod → `{userData}/plugins/posthog/` (with downloaded updates)
 - Fallback → bundled path
 
-### Codex Sync
+### Codex Mirror
 
-After every assembly, skills are copied to `$HOME/.agents/skills/` so that Codex sessions also pick them up.
+`$HOME/.agents/skills/` is a shared, cross-agent skills directory that other tools (e.g. Codex) also read. To avoid bloating that shared location — and inflating other agents' context — PostHog Code **only mirrors the user's own skills** (`$HOME/.claude/skills/`) there, never the bundled PostHog catalog. The bundled catalog lives in the app-private runtime plugin dir and is loaded only by PostHog Code's own sessions.
+
+`mirrorUserSkillsToCodex` (in `codex-mirror.ts`) runs on startup, after each 30-minute update, and after any user skill mutation. It is collision-safe: it tracks the names it wrote in `.posthog-mirror.json` and never overwrites a skill it didn't put there; mirrors whose source skill is deleted are removed.
 
 ## Dev Workflow
 

--- a/packages/workspace-server/src/services/posthog-plugin/README.md
+++ b/packages/workspace-server/src/services/posthog-plugin/README.md
@@ -40,7 +40,7 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 **On startup:**
 1. Creates `{userData}/plugins/posthog/` (the runtime plugin dir)
 2. Assembles it: copies `plugin.json` from bundled, merges bundled skills + any previously-downloaded remote skills
-3. Mirrors the user's own skills out to `$HOME/.agents/skills/` for Codex (see below)
+3. One-time: cleans up skills earlier builds copied into `$HOME/.agents/skills/` (see below)
 4. Starts a 30-minute interval timer
 5. Kicks off the first async download
 
@@ -49,19 +49,21 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 2. Extracts to a temp dir via `unzip`
 3. Atomically swaps into `{userData}/skills/`
 4. Re-assembles the runtime plugin dir
-5. Re-mirrors the user's own skills to Codex
-6. On failure: logs a warning, keeps existing skills, retries next interval
+5. On failure: logs a warning, keeps existing skills, retries next interval
 
 **`getPluginPath()`** — called by `AgentService` when starting sessions:
 - Dev mode → bundled path (Vite already merged everything)
 - Prod → `{userData}/plugins/posthog/` (with downloaded updates)
 - Fallback → bundled path
 
-### Codex Mirror
+### Cross-harness skills (no global writes)
 
-`$HOME/.agents/skills/` is a shared, cross-agent skills directory that other tools (e.g. Codex) also read. To avoid bloating that shared location — and inflating other agents' context — PostHog Code **only mirrors the user's own skills** (`$HOME/.claude/skills/`) there, never the bundled PostHog catalog. The bundled catalog lives in the app-private runtime plugin dir and is loaded only by PostHog Code's own sessions.
+`$HOME/.agents/skills/` is a shared, cross-agent skills directory that other tools (e.g. standalone Codex) also read. PostHog Code **never writes skills there.** It only reads it, to surface the user's own Codex skills in the Skills tab. The "use your skills in any harness" merge happens per-session, scoped to the process PostHog Code spawns:
 
-`mirrorUserSkillsToCodex` (in `codex-mirror.ts`) runs on startup, after each 30-minute update, and after any user skill mutation. It is collision-safe: it tracks the names it wrote in `.posthog-mirror.json` and never overwrites a skill it didn't put there; mirrors whose source skill is deleted are removed.
+- **Claude sessions** load the user's Codex skills (`$HOME/.agents/skills`) as an extra synthetic plugin — see `discover-plugins.ts` (`discoverCodexSkills`), deduped against the bundled catalog and `$HOME/.claude/skills`.
+- **Codex sessions** get a private `CODEX_HOME` (`{userData}/codex-home`) whose `skills/` holds the bundled catalog + the user's `$HOME/.claude/skills` — see `codex-home.ts` (`prepareCodexHome`). codex-acp scans `$CODEX_HOME/skills` plus `$HOME/.agents/skills`, so the user's own Codex skills still load while ours stay app-private.
+
+**One-time cleanup.** Earlier builds copied skills into the shared `$HOME/.agents/skills/` (the bundled catalog via `syncCodexSkills`, and the user's skills via an automatic mirror). `cleanupLegacyCodexMirror` (in `codex-mirror.ts`) removes those leftovers once per install so the directory becomes the user's own again. It only deletes skills it can prove we wrote: names tracked in `.posthog-mirror.json`, and bundled-catalog copies whose `SKILL.md` is byte-identical to ours (so a user's own same-named skill is never deleted).
 
 ## Dev Workflow
 

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.test.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.test.ts
@@ -1,16 +1,12 @@
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  addMirroredName,
-  mirrorUserSkillsToCodex,
-  readCodexMirrorState,
-} from "./codex-mirror";
+import { cleanupLegacyCodexMirror, readCodexMirrorState } from "./codex-mirror";
 
 let root: string;
-let userDir: string;
+let bundledDir: string;
 let codexDir: string;
 
 async function createSkill(dir: string, name: string, body = `# ${name}`) {
@@ -20,79 +16,67 @@ async function createSkill(dir: string, name: string, body = `# ${name}`) {
 
 beforeEach(async () => {
   root = await mkdtemp(path.join(tmpdir(), "codex-mirror-test-"));
-  userDir = path.join(root, "user-skills");
+  bundledDir = path.join(root, "bundled-skills");
   codexDir = path.join(root, "codex-skills");
-  await mkdir(userDir, { recursive: true });
+  await mkdir(bundledDir, { recursive: true });
 });
 
 afterEach(async () => {
   await rm(root, { recursive: true, force: true });
 });
 
-describe("mirrorUserSkillsToCodex", () => {
-  it("copies user skills into the codex dir and records them", async () => {
-    await createSkill(userDir, "alpha");
-    await createSkill(userDir, "beta");
+describe("cleanupLegacyCodexMirror", () => {
+  it("removes tracked mirror copies and deletes the state file", async () => {
+    await createSkill(codexDir, "alpha", "mirrored copy");
+    await createSkill(codexDir, "beta", "mirrored copy");
+    await writeFile(
+      path.join(codexDir, ".posthog-mirror.json"),
+      JSON.stringify({ version: 1, mirrored: ["alpha", "beta"] }),
+    );
 
-    await mirrorUserSkillsToCodex(userDir, codexDir);
+    const removed = await cleanupLegacyCodexMirror(codexDir, bundledDir);
 
-    expect(
-      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
-    ).toBe("# alpha");
-    expect(existsSync(path.join(codexDir, "beta", "SKILL.md"))).toBe(true);
-    const state = await readCodexMirrorState(codexDir);
-    expect(state.mirrored.sort()).toEqual(["alpha", "beta"]);
-  });
-
-  it("never overwrites a codex skill we did not put there", async () => {
-    await mkdir(codexDir, { recursive: true });
-    await createSkill(codexDir, "alpha", "codex original");
-    await createSkill(userDir, "alpha", "user version");
-
-    await mirrorUserSkillsToCodex(userDir, codexDir);
-
-    expect(
-      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
-    ).toBe("codex original");
-    const state = await readCodexMirrorState(codexDir);
-    expect(state.mirrored).toEqual([]);
-  });
-
-  it("overwrites skills we previously mirrored and carries edits out", async () => {
-    await createSkill(userDir, "alpha", "v1");
-    await mirrorUserSkillsToCodex(userDir, codexDir);
-
-    await writeFile(path.join(userDir, "alpha", "SKILL.md"), "v2");
-    await mirrorUserSkillsToCodex(userDir, codexDir);
-
-    expect(
-      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
-    ).toBe("v2");
-  });
-
-  it("removes mirrors whose source skill is gone", async () => {
-    await createSkill(userDir, "alpha");
-    await mirrorUserSkillsToCodex(userDir, codexDir);
-
-    await rm(path.join(userDir, "alpha"), { recursive: true });
-    await mirrorUserSkillsToCodex(userDir, codexDir);
-
+    expect(removed.sort()).toEqual(["alpha", "beta"]);
     expect(existsSync(path.join(codexDir, "alpha"))).toBe(false);
-    expect((await readCodexMirrorState(codexDir)).mirrored).toEqual([]);
+    expect(existsSync(path.join(codexDir, "beta"))).toBe(false);
+    expect(existsSync(path.join(codexDir, ".posthog-mirror.json"))).toBe(false);
   });
 
-  it("takes ownership of an imported skill via addMirroredName", async () => {
-    // Codex-authored skill, imported to user skills (import records the name).
-    await mkdir(codexDir, { recursive: true });
-    await createSkill(codexDir, "alpha", "codex original");
-    await createSkill(userDir, "alpha", "imported then edited");
-    await addMirroredName(codexDir, "alpha");
+  it("removes bundled-catalog copies with identical SKILL.md", async () => {
+    await createSkill(bundledDir, "query-data", "bundled body");
+    await createSkill(codexDir, "query-data", "bundled body");
 
-    await mirrorUserSkillsToCodex(userDir, codexDir);
+    const removed = await cleanupLegacyCodexMirror(codexDir, bundledDir);
 
-    expect(
-      await readFile(path.join(codexDir, "alpha", "SKILL.md"), "utf-8"),
-    ).toBe("imported then edited");
+    expect(removed).toEqual(["query-data"]);
+    expect(existsSync(path.join(codexDir, "query-data"))).toBe(false);
+  });
+
+  it("keeps a user's own skill that shares a bundled name but differs", async () => {
+    await createSkill(bundledDir, "query-data", "bundled body");
+    await createSkill(codexDir, "query-data", "the user's own different body");
+
+    const removed = await cleanupLegacyCodexMirror(codexDir, bundledDir);
+
+    expect(removed).toEqual([]);
+    expect(existsSync(path.join(codexDir, "query-data"))).toBe(true);
+  });
+
+  it("keeps untracked, non-bundled codex skills", async () => {
+    await createSkill(codexDir, "my-codex-skill", "wholly the user's");
+
+    const removed = await cleanupLegacyCodexMirror(codexDir, bundledDir);
+
+    expect(removed).toEqual([]);
+    expect(existsSync(path.join(codexDir, "my-codex-skill"))).toBe(true);
+  });
+
+  it("returns nothing when the codex dir does not exist", async () => {
+    const removed = await cleanupLegacyCodexMirror(
+      path.join(root, "missing"),
+      bundledDir,
+    );
+    expect(removed).toEqual([]);
   });
 });
 

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.test.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.test.ts
@@ -78,6 +78,24 @@ describe("cleanupLegacyCodexMirror", () => {
     );
     expect(removed).toEqual([]);
   });
+
+  it("never deletes the codex dir or its parent from unsafe mirror names", async () => {
+    await createSkill(codexDir, "keep-me", "the user's own");
+    await writeFile(
+      path.join(codexDir, ".posthog-mirror.json"),
+      JSON.stringify({
+        version: 1,
+        mirrored: ["", ".", "..", "../../escape", "nested/evil"],
+      }),
+    );
+
+    const removed = await cleanupLegacyCodexMirror(codexDir, bundledDir);
+
+    expect(removed).toEqual([]);
+    expect(existsSync(root)).toBe(true);
+    expect(existsSync(codexDir)).toBe(true);
+    expect(existsSync(path.join(codexDir, "keep-me"))).toBe(true);
+  });
 });
 
 describe("readCodexMirrorState", () => {
@@ -92,6 +110,21 @@ describe("readCodexMirrorState", () => {
     expect(await readCodexMirrorState(codexDir)).toEqual({
       version: 1,
       mirrored: [],
+    });
+  });
+
+  it("drops unsafe entries that could escape the codex dir", async () => {
+    await mkdir(codexDir, { recursive: true });
+    await writeFile(
+      path.join(codexDir, ".posthog-mirror.json"),
+      JSON.stringify({
+        version: 1,
+        mirrored: ["good", "", ".", "..", "nested/evil", "back\\slash", 42],
+      }),
+    );
+    expect(await readCodexMirrorState(codexDir)).toEqual({
+      version: 1,
+      mirrored: ["good"],
     });
   });
 });

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { findSkillDirs } from "../skills/skill-discovery";
+import { findSkillDirs, isSafePathSegment } from "../skills/skill-discovery";
 
 const MIRROR_STATE_FILE = ".posthog-mirror.json";
 
@@ -22,23 +22,6 @@ export function getCodexSkillsDir(): string {
   return path.join(os.homedir(), ".agents", "skills");
 }
 
-/**
- * A mirror entry names a single skill directory we copied. Reject anything that
- * is not a plain segment ("", ".", "..", or a path containing a separator) so a
- * corrupt or hand-edited state file can never widen the recursive delete in
- * cleanup to the codex dir itself or its parent.
- */
-function isSafeMirrorName(name: unknown): name is string {
-  return (
-    typeof name === "string" &&
-    name.length > 0 &&
-    name !== "." &&
-    name !== ".." &&
-    !name.includes("/") &&
-    !name.includes("\\")
-  );
-}
-
 export async function readCodexMirrorState(
   codexDir: string,
 ): Promise<CodexMirrorState> {
@@ -53,7 +36,7 @@ export async function readCodexMirrorState(
     }
     return {
       version: 1,
-      mirrored: data.mirrored.filter(isSafeMirrorName),
+      mirrored: data.mirrored.filter(isSafePathSegment),
     };
   } catch {
     return { version: 1, mirrored: [] };

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
@@ -22,6 +22,23 @@ export function getCodexSkillsDir(): string {
   return path.join(os.homedir(), ".agents", "skills");
 }
 
+/**
+ * A mirror entry names a single skill directory we copied. Reject anything that
+ * is not a plain segment ("", ".", "..", or a path containing a separator) so a
+ * corrupt or hand-edited state file can never widen the recursive delete in
+ * cleanup to the codex dir itself or its parent.
+ */
+function isSafeMirrorName(name: unknown): name is string {
+  return (
+    typeof name === "string" &&
+    name.length > 0 &&
+    name !== "." &&
+    name !== ".." &&
+    !name.includes("/") &&
+    !name.includes("\\")
+  );
+}
+
 export async function readCodexMirrorState(
   codexDir: string,
 ): Promise<CodexMirrorState> {
@@ -36,7 +53,7 @@ export async function readCodexMirrorState(
     }
     return {
       version: 1,
-      mirrored: data.mirrored.filter((n) => typeof n === "string"),
+      mirrored: data.mirrored.filter(isSafeMirrorName),
     };
   } catch {
     return { version: 1, mirrored: [] };

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
@@ -109,7 +109,7 @@ export async function cleanupLegacyCodexMirror(
     }),
   );
 
-  // 3. Drop the legacy mirror-state file; nothing maintains it anymore.
+  // 3. Drop the legacy mirror-state file.
   await fs.promises.rm(path.join(codexDir, MIRROR_STATE_FILE), { force: true });
 
   return [...removed];

--- a/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/codex-mirror.ts
@@ -11,6 +11,13 @@ export interface CodexMirrorState {
   mirrored: string[];
 }
 
+/**
+ * The shared, cross-agent skills directory that Codex (and other tools) read.
+ * PostHog Code never writes skills here — it only reads it to surface the
+ * user's own Codex skills in the Skills tab. Bundled and Claude skills reach
+ * Codex sessions through a private CODEX_HOME instead, so this directory stays
+ * the user's own.
+ */
 export function getCodexSkillsDir(): string {
   return path.join(os.homedir(), ".agents", "skills");
 }
@@ -36,84 +43,74 @@ export async function readCodexMirrorState(
   }
 }
 
-export async function writeCodexMirrorState(
-  codexDir: string,
-  state: CodexMirrorState,
-): Promise<void> {
-  await fs.promises.mkdir(codexDir, { recursive: true });
-  await fs.promises.writeFile(
-    path.join(codexDir, MIRROR_STATE_FILE),
-    `${JSON.stringify(state, null, 2)}\n`,
-    "utf-8",
-  );
-}
-
-/** Marks a codex skill as ours, so future mirrors may overwrite it. */
-export async function addMirroredName(
-  codexDir: string,
-  name: string,
-): Promise<void> {
-  const state = await readCodexMirrorState(codexDir);
-  if (!state.mirrored.includes(name)) {
-    state.mirrored.push(name);
-    await writeCodexMirrorState(codexDir, state);
+async function readSkillManifest(skillDir: string): Promise<Buffer | null> {
+  try {
+    return await fs.promises.readFile(path.join(skillDir, "SKILL.md"));
+  } catch {
+    return null;
   }
 }
 
 /**
- * One-way mirror, ours out: copies every user skill into the Codex skills
- * dir so skills created, edited, or installed in PostHog Code work in Codex
- * sessions too.
+ * One-time cleanup of the skills earlier builds copied into the shared
+ * ~/.agents/skills directory (the bundled catalog via the old `syncCodexSkills`,
+ * and the user's own skills via the old mirror). Both are gone now; this
+ * removes their leftovers so the directory is the user's own again.
  *
- * Safety rule: never overwrite a skill in ~/.agents/skills we didn't put
- * there. Colliding names are skipped — the collision surfaces in the Skills
- * tab as a shadowing warning. Mirrors whose source skill is gone are
- * removed (it's a mirror, not an archive).
+ * Safety: only deletes skills we can prove we wrote.
+ * - Names recorded in `.posthog-mirror.json` were copies of the user's
+ *   `~/.claude/skills`; the originals still live there, so the copy is safe to drop.
+ * - A bundled-catalog leftover is identified by an exact name match against the
+ *   current bundled skills *and* a byte-identical `SKILL.md`. The content check
+ *   guarantees we never delete a user's own Codex skill that merely shares a name.
+ *
+ * Returns the directory names that were removed.
  */
-export async function mirrorUserSkillsToCodex(
-  userSkillsDir: string,
+export async function cleanupLegacyCodexMirror(
   codexDir: string,
-): Promise<void> {
-  const state = await readCodexMirrorState(codexDir);
-  const previouslyMirrored = new Set(state.mirrored);
-  const userNames = await findSkillDirs(userSkillsDir);
-  await fs.promises.mkdir(codexDir, { recursive: true });
+  bundledSkillsDir: string,
+): Promise<string[]> {
+  if (!fs.existsSync(codexDir)) {
+    return [];
+  }
 
-  const copied = await Promise.all(
-    userNames.map(async (name) => {
+  const removed = new Set<string>();
+
+  const remove = async (name: string): Promise<void> => {
+    await fs.promises.rm(path.join(codexDir, name), {
+      recursive: true,
+      force: true,
+    });
+    removed.add(name);
+  };
+
+  // 1. Tracked copies of the user's own skills.
+  const state = await readCodexMirrorState(codexDir);
+  for (const name of state.mirrored) {
+    if (fs.existsSync(path.join(codexDir, name))) {
+      await remove(name);
+    }
+  }
+
+  // 2. Bundled-catalog copies: same name and byte-identical SKILL.md.
+  const bundledNames = await findSkillDirs(bundledSkillsDir);
+  await Promise.all(
+    bundledNames.map(async (name) => {
+      if (removed.has(name)) return;
       const target = path.join(codexDir, name);
-      if (fs.existsSync(target) && !previouslyMirrored.has(name)) {
-        return null;
-      }
-      await fs.promises.rm(target, { recursive: true, force: true });
-      try {
-        // dereference: mirrored skills must be self-contained.
-        await fs.promises.cp(path.join(userSkillsDir, name), target, {
-          recursive: true,
-          dereference: true,
-        });
-        return name;
-      } catch {
-        // Skip unreadable skills (e.g. broken symlinks); drop the partial copy.
-        await fs.promises.rm(target, { recursive: true, force: true });
-        return null;
+      if (!fs.existsSync(target)) return;
+      const [bundled, present] = await Promise.all([
+        readSkillManifest(path.join(bundledSkillsDir, name)),
+        readSkillManifest(target),
+      ]);
+      if (bundled && present && bundled.equals(present)) {
+        await remove(name);
       }
     }),
   );
 
-  await Promise.all(
-    [...previouslyMirrored]
-      .filter((name) => !userNames.includes(name))
-      .map((name) =>
-        fs.promises.rm(path.join(codexDir, name), {
-          recursive: true,
-          force: true,
-        }),
-      ),
-  );
+  // 3. Drop the legacy mirror-state file; nothing maintains it anymore.
+  await fs.promises.rm(path.join(codexDir, MIRROR_STATE_FILE), { force: true });
 
-  await writeCodexMirrorState(codexDir, {
-    version: 1,
-    mirrored: copied.filter((name): name is string => name !== null),
-  });
+  return [...removed];
 }

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
@@ -90,7 +90,6 @@ import type { IAppMeta } from "@posthog/platform/app-meta";
 import type { IBundledResources } from "@posthog/platform/bundled-resources";
 import type { IStoragePaths } from "@posthog/platform/storage-paths";
 import { PosthogPluginService } from "./posthog-plugin";
-import { syncCodexSkills } from "./update-skills-saga";
 
 /** Expose private members for testing without `as any`. */
 interface TestablePluginService {
@@ -105,7 +104,6 @@ const RUNTIME_SKILLS_DIR = "/mock/userData/skills";
 const BUNDLED_PLUGIN_DIR = "/mock/appPath/.vite/build/plugins/posthog";
 const BUNDLED_PLUGIN_DIR_PACKAGED =
   "/mock/appPath.unpacked/.vite/build/plugins/posthog";
-const CODEX_SKILLS_DIR = "/mock/home/.agents/skills";
 
 function mockFetchResponse(ok: boolean, status = 200) {
   return {
@@ -461,25 +459,6 @@ describe("PosthogPluginService", () => {
         ? vol.readdirSync("/mock/tmp")
         : [];
       expect(tmpEntries).toHaveLength(0);
-    });
-  });
-
-  describe("syncCodexSkills", () => {
-    it("copies skill directories to Codex dir", async () => {
-      setupBundledPlugin();
-
-      await syncCodexSkills(BUNDLED_PLUGIN_DIR, CODEX_SKILLS_DIR);
-
-      expect(
-        vol.readFileSync(`${CODEX_SKILLS_DIR}/shipped-skill/SKILL.md`, "utf-8"),
-      ).toBe("# Shipped");
-    });
-
-    it("skips if effective skills dir does not exist", async () => {
-      // No skills dir anywhere
-      await syncCodexSkills("/nonexistent", CODEX_SKILLS_DIR);
-
-      expect(vol.existsSync(CODEX_SKILLS_DIR)).toBe(false);
     });
   });
 

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
@@ -24,11 +24,7 @@ import { TypedEventEmitter } from "@posthog/shared";
 import { inject, injectable, postConstruct, preDestroy } from "inversify";
 import { getUserSkillsDir } from "../skills/skill-discovery";
 import { getCodexSkillsDir, mirrorUserSkillsToCodex } from "./codex-mirror";
-import {
-  overlayDownloadedSkills,
-  syncCodexSkills,
-  UpdateSkillsSaga,
-} from "./update-skills-saga";
+import { overlayDownloadedSkills, UpdateSkillsSaga } from "./update-skills-saga";
 
 const SKILLS_ZIP_URL = process.env.SKILLS_ZIP_URL ?? "";
 const CONTEXT_MILL_ZIP_URL = process.env.CONTEXT_MILL_ZIP_URL ?? "";
@@ -99,7 +95,6 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
     // Overlay any previously-downloaded skills on top of the runtime plugin
     await overlayDownloadedSkills(this.runtimeSkillsDir, this.runtimePluginDir);
 
-    await syncCodexSkills(this.getPluginPath(), CODEX_SKILLS_DIR);
     await this.mirrorUserSkills();
 
     // Start periodic updates
@@ -167,8 +162,6 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
       const result = await saga.run({
         runtimeSkillsDir: this.runtimeSkillsDir,
         runtimePluginDir: this.runtimePluginDir,
-        pluginPath: this.getPluginPath(),
-        codexSkillsDir: CODEX_SKILLS_DIR,
         tempDir,
         skillsZipUrl: SKILLS_ZIP_URL,
         contextMillZipUrl: CONTEXT_MILL_ZIP_URL,

--- a/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.ts
@@ -22,15 +22,16 @@ import {
 } from "@posthog/platform/storage-paths";
 import { TypedEventEmitter } from "@posthog/shared";
 import { inject, injectable, postConstruct, preDestroy } from "inversify";
-import { getUserSkillsDir } from "../skills/skill-discovery";
-import { getCodexSkillsDir, mirrorUserSkillsToCodex } from "./codex-mirror";
-import { overlayDownloadedSkills, UpdateSkillsSaga } from "./update-skills-saga";
+import { cleanupLegacyCodexMirror, getCodexSkillsDir } from "./codex-mirror";
+import {
+  overlayDownloadedSkills,
+  UpdateSkillsSaga,
+} from "./update-skills-saga";
 
 const SKILLS_ZIP_URL = process.env.SKILLS_ZIP_URL ?? "";
 const CONTEXT_MILL_ZIP_URL = process.env.CONTEXT_MILL_ZIP_URL ?? "";
 const UPDATE_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
-const CODEX_SKILLS_DIR = getCodexSkillsDir();
-const USER_SKILLS_DIR = getUserSkillsDir();
+const CODEX_CLEANUP_MARKER = ".codex-mirror-cleanup-done";
 
 interface PosthogPluginEvents {
   skillsUpdated: true;
@@ -95,7 +96,7 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
     // Overlay any previously-downloaded skills on top of the runtime plugin
     await overlayDownloadedSkills(this.runtimeSkillsDir, this.runtimePluginDir);
 
-    await this.mirrorUserSkills();
+    await this.cleanupLegacyCodexMirrorOnce();
 
     // Start periodic updates
     this.intervalId = setInterval(() => {
@@ -109,15 +110,28 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
   }
 
   /**
-   * Mirrors the user's skills out to Codex ("bring your skills, use them
-   * anywhere"). Never fatal: a broken mirror must not affect the official
-   * skills pipeline or the mutation that triggered it.
+   * Removes the skills earlier builds copied into the shared ~/.agents/skills
+   * directory (bundled catalog + user-skill mirror), so the directory becomes
+   * the user's own again. Runs at most once per install; never fatal.
    */
-  async mirrorUserSkills(): Promise<void> {
+  private async cleanupLegacyCodexMirrorOnce(): Promise<void> {
+    const marker = join(this.storagePaths.appDataPath, CODEX_CLEANUP_MARKER);
+    if (existsSync(marker)) {
+      return;
+    }
     try {
-      await mirrorUserSkillsToCodex(USER_SKILLS_DIR, CODEX_SKILLS_DIR);
+      const removed = await cleanupLegacyCodexMirror(
+        getCodexSkillsDir(),
+        join(this.getPluginPath(), "skills"),
+      );
+      if (removed.length > 0) {
+        this.log.info("Cleaned legacy mirrored skills from ~/.agents/skills", {
+          count: removed.length,
+        });
+      }
+      await writeFile(marker, `${new Date().toISOString()}\n`);
     } catch (err) {
-      this.log.warn("Mirroring user skills to Codex failed", { error: err });
+      this.log.warn("Codex mirror cleanup failed", { error: err });
     }
   }
 
@@ -169,7 +183,6 @@ export class PosthogPluginService extends TypedEventEmitter<PosthogPluginEvents>
       });
 
       if (result.success) {
-        await this.mirrorUserSkills();
         this.emit("skillsUpdated", true);
       } else {
         this.log.warn("Skills update failed", {

--- a/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
+++ b/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
@@ -38,40 +38,9 @@ export async function overlayDownloadedSkills(
   }
 }
 
-/**
- * Syncs skills from the effective plugin dir to `codexSkillsDir` for Codex.
- */
-export async function syncCodexSkills(
-  pluginPath: string,
-  codexSkillsDir: string,
-): Promise<void> {
-  const effectiveSkillsDir = join(pluginPath, "skills");
-  if (!existsSync(effectiveSkillsDir)) {
-    return;
-  }
-
-  try {
-    await mkdir(codexSkillsDir, { recursive: true });
-
-    const entries = await readdir(effectiveSkillsDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const src = join(effectiveSkillsDir, entry.name);
-        const dest = join(codexSkillsDir, entry.name);
-        await rm(dest, { recursive: true, force: true });
-        await cp(src, dest, { recursive: true });
-      }
-    }
-  } catch {
-    // Fire-and-forget — don't block startup or updates on Codex sync
-  }
-}
-
 export interface UpdateSkillsInput {
   runtimeSkillsDir: string;
   runtimePluginDir: string;
-  pluginPath: string;
-  codexSkillsDir: string;
   tempDir: string;
   skillsZipUrl: string;
   contextMillZipUrl: string;
@@ -184,17 +153,6 @@ export class UpdateSkillsSaga extends Saga<
         );
       } catch (err) {
         this.log.warn("Failed to overlay skills", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    });
-
-    // Step 6: sync codex skills (non-fatal)
-    await this.readOnlyStep("sync-codex-skills", async () => {
-      try {
-        await syncCodexSkills(input.pluginPath, input.codexSkillsDir);
-      } catch (err) {
-        this.log.warn("Failed to sync codex skills", {
           error: err instanceof Error ? err.message : String(err),
         });
       }

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
@@ -12,7 +12,6 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 import { existsSync } from "node:fs";
-import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import {
   collectSkillFiles,
   findSkillDirPrefix,
@@ -21,10 +20,7 @@ import {
 } from "./skills-marketplace";
 
 function makeService(): SkillsMarketplaceService {
-  const plugin = {
-    mirrorUserSkills: async () => {},
-  } as unknown as PosthogPluginService;
-  return new SkillsMarketplaceService(plugin);
+  return new SkillsMarketplaceService();
 }
 
 let root: string;

--- a/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -2,10 +2,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { SKILL_EXISTS_MARKER } from "@posthog/shared";
 import type { Unzipped } from "fflate";
-import { inject, injectable } from "inversify";
+import { injectable } from "inversify";
 import { unzipAsync } from "../posthog-plugin/extract-zip";
-import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
-import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import { getUserSkillsDir, isProbablyText } from "../skills/skill-discovery";
 import { validateSkillDirName } from "../skills/skills";
 import {
@@ -110,11 +108,6 @@ export function collectSkillFiles(
 export class SkillsMarketplaceService {
   private archives = new Map<string, CachedArchive>();
 
-  constructor(
-    @inject(POSTHOG_PLUGIN_SERVICE)
-    private readonly plugin: PosthogPluginService,
-  ) {}
-
   async search(query: string): Promise<MarketplaceSearchOutput> {
     const trimmed = query.trim();
     if (trimmed.length < 2) return { results: [] };
@@ -197,8 +190,6 @@ export class SkillsMarketplaceService {
     const state = await readInstalledState();
     state.installed[ref.skillId] = { repo: ref.source };
     await writeInstalledState(state);
-
-    void this.plugin.mirrorUserSkills().catch(() => {});
 
     return { path: target };
   }

--- a/packages/workspace-server/src/services/skills/skill-discovery.ts
+++ b/packages/workspace-server/src/services/skills/skill-discovery.ts
@@ -25,6 +25,23 @@ export function getUserSkillsDir(): string {
   return path.join(os.homedir(), ".claude", "skills");
 }
 
+/**
+ * True when `value` is a single path segment safe to join onto a trusted
+ * directory. Rejects "", ".", "..", and anything containing a separator, so a
+ * value from a state file or an RPC boundary can never widen a `path.join`
+ * into a sibling or parent directory (and a recursive delete along with it).
+ */
+export function isSafePathSegment(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value !== "." &&
+    value !== ".." &&
+    !value.includes("/") &&
+    !value.includes("\\")
+  );
+}
+
 /** Heuristic: content with NUL bytes in the first 4 KiB is binary. */
 export function isProbablyText(bytes: Uint8Array): boolean {
   return !bytes.subarray(0, 4096).includes(0);

--- a/packages/workspace-server/src/services/skills/skill-discovery.ts
+++ b/packages/workspace-server/src/services/skills/skill-discovery.ts
@@ -52,6 +52,37 @@ export async function findSkillDirs(
     .map((e) => e.name);
 }
 
+/**
+ * Symlinks each named skill from `sourceDir` into `targetDir`, resolving the
+ * real path first so the link works even when the source is itself a symlink.
+ * Failures are logged and skipped. Returns the names that were linked.
+ */
+export async function linkSkillsInto(
+  targetDir: string,
+  sourceDir: string,
+  skillNames: string[],
+  log: { warn: (message: string, meta?: Record<string, unknown>) => void },
+): Promise<string[]> {
+  const linked: string[] = [];
+  await Promise.all(
+    skillNames.map(async (skillName) => {
+      try {
+        const realSrc = await fs.promises.realpath(
+          path.join(sourceDir, skillName),
+        );
+        await fs.promises.symlink(realSrc, path.join(targetDir, skillName));
+        linked.push(skillName);
+      } catch (err) {
+        log.warn("Failed to symlink skill", {
+          skillName,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }),
+  );
+  return linked;
+}
+
 export async function getMarketplaceInstallPaths(): Promise<string[]> {
   const installedPath = path.join(
     os.homedir(),

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -219,6 +219,18 @@ describe("codex skills", () => {
     expect(codexSkills[0]?.editable).toBe(false);
   });
 
+  it("hides a codex skill already imported into the user skills dir", async () => {
+    await mkdir(codexHome.dir, { recursive: true });
+    await createSkill(userSkillsHome.dir, "shared-skill");
+    await createSkill(codexHome.dir, "shared-skill");
+    await createSkill(codexHome.dir, "codex-only");
+
+    const skills = await makeService().listSkills();
+    const codexSkills = skills.filter((s) => s.source === "codex");
+
+    expect(codexSkills.map((s) => s.name)).toEqual(["codex-only"]);
+  });
+
   it("imports a codex skill into the user skills dir", async () => {
     await mkdir(codexHome.dir, { recursive: true });
     await createSkill(codexHome.dir, "codex-only");

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -30,7 +30,6 @@ let repoSkillsDir: string;
 function makeService(): SkillsService {
   const plugin = {
     getPluginPath: () => pluginPath,
-    mirrorUserSkills: async () => {},
   } as unknown as PosthogPluginService;
   const folders = {
     getFolders: async () => [{ path: folderPath, name: "my-repo" }],
@@ -220,7 +219,7 @@ describe("codex skills", () => {
     expect(codexSkills[0]?.editable).toBe(false);
   });
 
-  it("imports a codex skill into the user skills dir and takes mirror ownership", async () => {
+  it("imports a codex skill into the user skills dir", async () => {
     await mkdir(codexHome.dir, { recursive: true });
     await createSkill(codexHome.dir, "codex-only");
     const service = makeService();
@@ -233,14 +232,10 @@ describe("codex skills", () => {
     expect(result.path).toBe(target);
     const content = await service.readSkillFile(target, "SKILL.md");
     expect(content).toContain("codex-only");
-
-    const state = JSON.parse(
-      await (await import("node:fs/promises")).readFile(
-        path.join(codexHome.dir, ".posthog-mirror.json"),
-        "utf-8",
-      ),
+    // The original Codex skill is left untouched — we copy, never mirror back.
+    expect(existsSync(path.join(codexHome.dir, "codex-only", "SKILL.md"))).toBe(
+      true,
     );
-    expect(state.mirrored).toContain("codex-only");
   });
 
   it("rejects importing paths outside the codex skills dir", async () => {

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -187,8 +187,7 @@ export class SkillsService {
 
   /**
    * Imports a Codex-authored skill into ~/.claude/skills, after which it is
-   * an ordinary editable user skill. The mirror takes ownership of the Codex
-   * copy so future syncs carry edits back without clobbering or duplicating.
+   * an ordinary editable user skill. The original Codex copy is left untouched.
    */
   async importCodexSkill(
     skillPath: string,

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -6,7 +6,6 @@ import { WATCHER_SERVICE } from "../../di/tokens";
 import type { FoldersService } from "../folders/folders";
 import { FOLDERS_SERVICE } from "../folders/identifiers";
 import {
-  addMirroredName,
   getCodexSkillsDir,
   readCodexMirrorState,
 } from "../posthog-plugin/codex-mirror";
@@ -61,11 +60,6 @@ export class SkillsService {
     @inject(WATCHER_SERVICE)
     private readonly watcher: WatcherService,
   ) {}
-
-  /** Fire-and-forget Codex mirror after local mutations. */
-  private queueCodexMirror(): void {
-    void this.plugin.mirrorUserSkills().catch(() => {});
-  }
 
   async listSkills(): Promise<SkillInfo[]> {
     const roots = await this.getSkillRoots();
@@ -125,7 +119,6 @@ export class SkillsService {
       serializeSkillMarkdown({ name, description: "" }, SKILL_MD_TEMPLATE_BODY),
       "utf-8",
     );
-    this.queueCodexMirror();
     return { path: skillPath };
   }
 
@@ -147,7 +140,6 @@ export class SkillsService {
       content,
       "utf-8",
     );
-    this.queueCodexMirror();
   }
 
   async saveSkillFile(
@@ -159,7 +151,6 @@ export class SkillsService {
     const target = resolveSkillFilePath(skillDir, filePath);
     await fs.promises.mkdir(path.dirname(target), { recursive: true });
     await fs.promises.writeFile(target, content, "utf-8");
-    this.queueCodexMirror();
   }
 
   async renameSkillFile(
@@ -178,7 +169,6 @@ export class SkillsService {
     }
     await fs.promises.mkdir(path.dirname(to), { recursive: true });
     await fs.promises.rename(from, to);
-    this.queueCodexMirror();
   }
 
   async deleteSkillFile(skillPath: string, filePath: string): Promise<void> {
@@ -188,13 +178,11 @@ export class SkillsService {
       throw new Error("SKILL.md cannot be deleted");
     }
     await fs.promises.rm(target, { force: true });
-    this.queueCodexMirror();
   }
 
   async deleteSkill(skillPath: string): Promise<void> {
     const skillDir = await this.resolveWritableSkillDir(skillPath);
     await fs.promises.rm(skillDir, { recursive: true, force: true });
-    this.queueCodexMirror();
   }
 
   /**
@@ -231,8 +219,6 @@ export class SkillsService {
       recursive: true,
       dereference: true,
     });
-    await addMirroredName(codexRoot, name);
-    this.queueCodexMirror();
     return { path: target };
   }
 
@@ -339,7 +325,6 @@ export class SkillsService {
       await fs.promises.rm(staging, { recursive: true, force: true });
       throw error;
     }
-    this.queueCodexMirror();
     return { path: target };
   }
 

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -515,9 +515,10 @@ async function waitForDir(dir: string, signal?: AbortSignal): Promise<boolean> {
 }
 
 /**
- * Hides Codex copies we are responsible for: bundled skills synced by the
- * official pipeline and user skills mirrored out. What remains is genuinely
- * the user's Codex-only skills.
+ * Hides Codex copies already represented elsewhere in the list: a bundled skill
+ * synced there by the old pipeline, a legacy mirror copy, or a skill the user
+ * has imported into their own `~/.claude/skills`. What remains is genuinely the
+ * user's Codex-only skills.
  */
 function dedupeCodexSkills(
   skills: SkillInfo[],
@@ -526,13 +527,18 @@ function dedupeCodexSkills(
   const bundledNames = new Set(
     skills.filter((s) => s.source === "bundled").map((s) => s.name),
   );
+  const userDirNames = new Set(
+    skills.filter((s) => s.source === "user").map((s) => path.basename(s.path)),
+  );
   return skills.filter((skill) => {
     if (skill.source !== "codex") return true;
-    // The mirror state stores directory names; frontmatter names only
-    // matter for the bundled copies, which keep theirs verbatim.
+    const dirName = path.basename(skill.path);
+    // The mirror state and the user's own skills are matched by directory name;
+    // bundled copies keep their frontmatter name verbatim, so match those by it.
     return (
       !bundledNames.has(skill.name) &&
-      !mirroredNames.has(path.basename(skill.path))
+      !mirroredNames.has(dirName) &&
+      !userDirNames.has(dirName)
     );
   });
 }


### PR DESCRIPTION
## Why

A user reported that PostHog Code "installed around 100 skills into the global `.agents` directory without notifying me," and that their tokens in *other* coding agents started burning faster. **This was accurate.**

`~/.agents/skills` is a *shared, cross-agent* skills directory — other tools (e.g. standalone Codex) read it too. We were writing into it automatically:
- `syncCodexSkills` copied our **entire bundled PostHog catalog (~100 skills)** into it on every app startup and every 30-minute skills update — unconditionally, with no collision guard, no cleanup, and no notification.
- The user-skills mirror also pushed the user's **Claude** skills into the shared dir, leaking them into their standalone Codex.

Both inflated *other* agents' context on every session — the direct cause of the "tokens burning faster elsewhere" report.

## Principle

**PostHog Code writes nothing into the user's global, cross-agent skill dirs** (`~/.agents/skills`, `~/.claude/skills`). Those stay pristine: standalone Codex sees only Codex skills, standalone Claude sees only Claude skills. The "use your skills anywhere" merge happens **only inside PostHog Code's own spawned agent sessions**, scoped to the child process.

## What

- **`codex-mirror`** — stop mirroring outward entirely. Add a **one-time cleanup** that removes the entries we previously wrote to `~/.agents/skills` (tracked in `.posthog-mirror.json`), clawing back the bloat on already-affected builds.
- **`codex-home`** (new) — give the spawned `codex-acp` a **private `CODEX_HOME`** whose `skills/` root is populated (via symlink) with the bundled PostHog catalog + the user's `~/.claude/skills`. `$CODEX_HOME/skills` is a real scanned skill root, so our Codex sessions reach full parity **without touching the shared dir**. The user's own `~/.agents/skills` is still scanned (it's keyed off `$HOME`, not `$CODEX_HOME`), so their Codex skills keep working. `codexHome` is threaded through `agent` → `spawn`.
- **`discover-plugins`** — Claude sessions now also load the user's **Codex** skills (`~/.agents/skills`) as a session-scoped synthetic plugin, deduped against the bundled catalog and `~/.claude/skills`.
- **`skills` / `skills-marketplace`** — drop the now-dead automatic mirror triggers and the unused plugin dependency.

## Verification

- **Empirically validated against the real `codex-acp` v0.14.0 binary** (built from codex-rs `2808a4d`) using a local ACP + model-capture harness:
  - bundled + Claude skills load from the private `CODEX_HOME/skills` (symlinked),
  - the user's own Codex skills still load from `~/.agents/skills`,
  - **nothing** is written to the shared `~/.agents/skills`.
- Unit tests: 135+ across the touched suites pass (`codex-mirror`, `posthog-plugin`, `skills`, `skills-marketplace`, `discover-plugins`, `codex-home`, `spawn`).
- Biome lint clean; both touched packages (`@posthog/agent`, `@posthog/workspace-server`) typecheck.

---

Supersedes #2755 (which contained only the initial minimal fix; this PR includes that commit plus the full per-session design).
