### PR TITLE
fix(models): default thinking level to high when no effort is set

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
@@ -9,6 +9,7 @@ type SdkQueryHandle = {
   interrupt: ReturnType<typeof vi.fn>;
   setModel: ReturnType<typeof vi.fn>;
   setMcpServers: ReturnType<typeof vi.fn>;
+  applyFlagSettings: ReturnType<typeof vi.fn>;
   supportedCommands: ReturnType<typeof vi.fn>;
   initializationResult: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -26,6 +27,7 @@ function makeQueryHandle(): SdkQueryHandle {
     interrupt: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue(undefined),
     setMcpServers: vi.fn().mockResolvedValue(undefined),
+    applyFlagSettings: vi.fn().mockResolvedValue(undefined),
     supportedCommands: vi.fn().mockResolvedValue([]),
     initializationResult: vi.fn().mockImplementation(() => nextInitPromise),
     close: vi.fn(),

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -110,8 +110,10 @@ import {
   resolveInitialModelId,
 } from "./session/model-config";
 import {
+  DEFAULT_EFFORT,
   DEFAULT_MODEL,
   getEffortOptions,
+  resolveEffortForModel,
   resolveModelPreference,
   supports1MContext,
   supportsMcpInjection,
@@ -1918,6 +1920,18 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       await this.session.query.setModel(resolvedSdkModel);
     }
 
+    // Keep thinking enabled by default for effort-capable models (see
+    // DEFAULT_EFFORT).
+    const resolvedEffort = resolveEffortForModel(resolvedModelId, effort);
+    if (resolvedEffort && resolvedEffort !== effort) {
+      this.session.effort = resolvedEffort;
+      this.session.queryOptions.effort = resolvedEffort;
+      await this.session.query.applyFlagSettings({
+        // @ts-expect-error SDK Settings.effortLevel omits "max" but runtime accepts it
+        effortLevel: resolvedEffort,
+      });
+    }
+
     if (supports1MContext(resolvedModelId)) {
       options.betas = ["context-1m-2025-08-07"];
     }
@@ -1935,7 +1949,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     const configOptions = this.buildConfigOptions(
       permissionMode,
       modelOptions,
-      effort ?? "medium",
+      this.session.effort ?? DEFAULT_EFFORT,
     );
     session.configOptions = configOptions;
 
@@ -2041,7 +2055,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       currentModelId: string;
       options: SessionConfigSelectOption[];
     },
-    currentEffort: EffortLevel = "medium",
+    currentEffort: EffortLevel = DEFAULT_EFFORT,
   ): SessionConfigOption[] {
     const modeOptions = getAvailableModes().map((mode) => ({
       value: mode.id,
@@ -2109,11 +2123,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     const rawCurrentValue = existingEffort?.currentValue;
     const currentValue =
-      typeof rawCurrentValue === "string" ? rawCurrentValue : "high";
+      typeof rawCurrentValue === "string" ? rawCurrentValue : DEFAULT_EFFORT;
     const isValidValue = effortOptions.some((o) => o.value === currentValue);
-    const resolvedValue = isValidValue ? currentValue : "high";
+    const resolvedValue = isValidValue ? currentValue : DEFAULT_EFFORT;
 
-    if (resolvedValue !== currentValue && this.session.effort) {
+    // Set the default when none is chosen yet (see DEFAULT_EFFORT), or re-apply
+    // when the prior level is invalid for the newly selected model.
+    if (!this.session.effort || resolvedValue !== currentValue) {
       this.session.effort = resolvedValue as EffortLevel;
       this.session.queryOptions.effort = resolvedValue as EffortLevel;
       void this.session.query.applyFlagSettings({

--- a/packages/agent/src/adapters/claude/session/models.test.ts
+++ b/packages/agent/src/adapters/claude/session/models.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_EFFORT,
   getEffortOptions,
+  resolveEffortForModel,
   resolveModelPreference,
   supports1MContext,
   supportsEffort,
@@ -62,6 +64,31 @@ describe("model capability flags", () => {
   it("keeps deprecated Haiku sessions excluded from MCP injection", () => {
     expect(supportsMcpInjection("claude-haiku-4-5")).toBe(false);
   });
+});
+
+describe("resolveEffortForModel", () => {
+  it("defaults the thinking level to high", () => {
+    expect(DEFAULT_EFFORT).toBe("high");
+  });
+
+  it.each([
+    // No explicit effort: effort-capable models fall back to the default.
+    ["claude-fable-5", undefined, "high"],
+    ["claude-opus-4-8", undefined, "high"],
+    ["claude-opus-4-7", undefined, "high"],
+    ["claude-sonnet-4-6", undefined, "high"],
+    // Models without effort support stay unset (SDK disables thinking).
+    ["claude-haiku-4-5", undefined, undefined],
+    ["claude-opus-4-6", undefined, undefined],
+    // An explicit choice is always honored, including on adaptive-only models.
+    ["claude-opus-4-8", "low", "low"],
+    ["claude-fable-5", "max", "max"],
+  ] as const)(
+    "resolveEffortForModel(%s, %s) === %s",
+    (modelId, effort, expected) => {
+      expect(resolveEffortForModel(modelId, effort)).toBe(expected);
+    },
+  );
 });
 
 describe("getEffortOptions", () => {

--- a/packages/agent/src/adapters/claude/session/models.ts
+++ b/packages/agent/src/adapters/claude/session/models.ts
@@ -1,4 +1,11 @@
+import type { EffortLevel } from "../types";
+
 export const DEFAULT_MODEL = "opus";
+
+// Default thinking level when the user hasn't picked one. Adaptive-only models
+// like claude-fable-5 reject the SDK's no-effort `thinking: { type: "disabled" }`
+// shape, so effort-capable models default to high to keep thinking enabled.
+export const DEFAULT_EFFORT: EffortLevel = "high";
 
 const GATEWAY_TO_SDK_MODEL: Record<string, string> = {
   "claude-opus-4-7": "opus",
@@ -36,6 +43,14 @@ const MODELS_WITH_XHIGH_EFFORT = new Set([
 
 export function supportsEffort(modelId: string): boolean {
   return MODELS_WITH_EFFORT.has(modelId);
+}
+
+export function resolveEffortForModel(
+  modelId: string,
+  effort: EffortLevel | undefined,
+): EffortLevel | undefined {
+  if (effort) return effort;
+  return supportsEffort(modelId) ? DEFAULT_EFFORT : undefined;
 }
 
 export function supportsXhighEffort(modelId: string): boolean {


### PR DESCRIPTION
## Problem

Users who pick **claude-fable-5** hit hard failures whenever a generation runs without a configured effort/thinking level (8 users and 142 failed generations on 06-11 alone, invisible to error monitoring since `$ai_http_status=None`).

fable-5 only supports adaptive thinking and rejects the SDK's default `thinking: { type: "disabled" }` with `invalid_request_error: "thinking.type.disabled" is not supported for this model`. The effort level only reaches the SDK when present, so a fable-5 session with no effort set lets the SDK default to disabled thinking, which fable-5 rejects outright.

Same issue as #2618. This PR takes a different approach: instead of scoping a `medium` default to fable-5 behind a `requiresAdaptiveThinking` flag, it makes **high** the default thinking level for every effort-capable model. That keeps thinking enabled by default and removes the disabled-thinking request shape that fable-5 rejects.

## Changes

- Add `DEFAULT_EFFORT` (`"high"`) and a `resolveEffortForModel` helper in `session/models.ts`. The helper honors an explicit effort, falls back to high for effort-capable models, and leaves models without effort support (e.g. haiku) unset so they keep disabled thinking.
- In `claude-agent.ts` `createSession`, after the gateway `modelId` is resolved, apply the default effort via `applyFlagSettings` when the user has not chosen one. Gating on the resolved id (not the raw setting) means the default also applies to the default model and aliases, not just explicit fable-5 picks.
- Fix the mid-session model-switch path (`rebuildEffortConfigOption`): when switching to an effort-capable model with no explicit effort, apply the default to the live query instead of only updating the display. This closes the same fable-5 failure when the model is changed from the picker, which #2618 left open.
- Default the effort config display and the `buildConfigOptions` fallback to high so the UI matches the request shape.

## How did you test this?

- Added parameterized unit tests in `models.test.ts`: `resolveEffortForModel` (effort-capable models default to high; haiku/opus-4-6 stay unset; explicit effort is honored, including `max` on fable-5) and `DEFAULT_EFFORT === "high"`.
- Updated the `claude-agent.resume-model.test.ts` query mock to include `applyFlagSettings` (the real SDK query exposes it; the mock did not).
- Ran `pnpm --filter @posthog/agent exec vitest run src/adapters/claude src/server` — 486 tests pass.
- `pnpm --filter @posthog/agent typecheck` passes; `biome check` clean on changed files; `node scripts/check-host-boundaries.mjs` shows no new violations.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
