### PR TITLE
fix(auth): preserve restoring auth state

### DIFF
--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -305,7 +305,7 @@ describe("AuthService", () => {
     );
   });
 
-  it("completes bootstrap anonymously when the stored-session restore hangs", async () => {
+  it("keeps bootstrap restoring when the stored-session restore hangs", async () => {
     vi.useFakeTimers();
     try {
       seedStoredSession({ selectedProjectId: 42 });
@@ -318,8 +318,8 @@ describe("AuthService", () => {
       await initPromise;
 
       expect(service.getState()).toMatchObject({
-        status: "anonymous",
-        bootstrapComplete: true,
+        status: "restoring",
+        bootstrapComplete: false,
         cloudRegion: "us",
         currentProjectId: 42,
       });
@@ -345,7 +345,7 @@ describe("AuthService", () => {
       await vi.advanceTimersByTimeAsync(20_001);
       await initPromise;
 
-      expect(service.getState().status).toBe("anonymous");
+      expect(service.getState().status).toBe("restoring");
 
       resolveRefresh(
         mockTokenResponse({
@@ -360,6 +360,44 @@ describe("AuthService", () => {
         bootstrapComplete: true,
         currentProjectId: 42,
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shares the in-flight bootstrap refresh with token callers after the deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      seedStoredSession({ selectedProjectId: 42 });
+      stubAuthFetch();
+      let resolveRefresh!: (value: unknown) => void;
+      oauthFlow.refreshToken.mockReturnValue(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+      const initPromise = service.initialize();
+      await vi.advanceTimersByTimeAsync(20_001);
+      await initPromise;
+
+      expect(service.getState().status).toBe("restoring");
+
+      const tokenPromise = service.getValidAccessToken();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+
+      resolveRefresh(
+        mockTokenResponse({
+          accessToken: "late-access-token",
+          refreshToken: "late-refresh-token",
+        }),
+      );
+
+      await expect(tokenPromise).resolves.toMatchObject({
+        accessToken: "late-access-token",
+      });
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
@@ -512,7 +550,7 @@ describe("AuthService", () => {
       seedStoredSession({ selectedProjectId: 42 });
       vi.mocked(connectivity.getStatus).mockReturnValue({ isOnline: false });
       await service.initialize();
-      expect(service.getState().status).toBe("anonymous");
+      expect(service.getState().status).toBe("restoring");
 
       vi.mocked(connectivity.getStatus).mockReturnValue({ isOnline: true });
       oauthFlow.refreshToken.mockResolvedValue(mockTokenResponse());
@@ -640,7 +678,7 @@ describe("AuthService", () => {
       expect(sessionPort.getCurrent()).toBeNull();
     });
 
-    it("does not retry on unknown_error", async () => {
+    it("keeps restoring after a non-retryable unknown_error", async () => {
       seedStoredSession();
       oauthFlow.refreshToken.mockResolvedValue({
         success: false,
@@ -650,7 +688,7 @@ describe("AuthService", () => {
 
       await service.initialize();
 
-      expect(service.getState().status).toBe("anonymous");
+      expect(service.getState().status).toBe("restoring");
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
     });
 
@@ -664,7 +702,7 @@ describe("AuthService", () => {
 
       await service.initialize();
 
-      expect(service.getState().status).toBe("anonymous");
+      expect(service.getState().status).toBe("restoring");
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(3);
     });
   });

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -746,12 +746,6 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     });
     await this.syncAuthenticatedSession(session);
   }
-  private async refreshAndSyncSession(
-    input: StoredSessionInput,
-  ): Promise<void> {
-    const session = await this.refreshSession(input);
-    await this.syncAuthenticatedSession(session);
-  }
   private async syncAuthenticatedSession(
     session: InMemorySession,
   ): Promise<void> {
@@ -978,10 +972,14 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     if (!stored) return;
     if (stored.scopeVersion < OAUTH_SCOPE_VERSION) return;
 
-    const storedSession = this.resolveStoredSession();
-    if (!storedSession) return;
+    if (!this.resolveStoredSession()) return;
 
-    this.recoveryPromise = this.refreshAndSyncSession(storedSession)
+    // Route through ensureValidSession so a refresh already in flight (e.g. the
+    // background bootstrap restore past its deadline) is shared instead of
+    // kicking a second concurrent token refresh that would burn the same
+    // rotating refresh token twice.
+    this.recoveryPromise = this.ensureValidSession()
+      .then(() => undefined)
       .catch((error) => {
         this.logger.warn("Session recovery failed", { error });
       })

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -421,37 +421,53 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       return;
     }
 
+    this.setRestoringState(storedSession);
+
     try {
-      const restore = this.refreshAndSyncSession(storedSession);
+      const restore = this.ensureValidSession().then(() => undefined);
       const outcome = await withTimeout(restore, AUTH_BOOTSTRAP_DEADLINE_MS);
       if (outcome.result === "timeout") {
         this.logger.warn(
-          "Auth bootstrap exceeded deadline; completing anonymously and restoring in the background",
+          "Auth bootstrap exceeded deadline; keeping stored session in restoring state",
         );
-        // Keep awaiting so a late success still upgrades state; swallow rejection.
         restore.catch((error) => {
           this.logger.warn("Background auth restore failed after deadline", {
             error,
           });
+          this.handleStoredSessionRestoreFailure(storedSession);
         });
-        this.completeBootstrapAnonymously(storedSession);
       }
     } catch (error) {
       this.logger.warn("Failed to restore stored auth session", { error });
-      this.completeBootstrapAnonymously(storedSession);
+      this.handleStoredSessionRestoreFailure(storedSession);
     }
   }
-  private completeBootstrapAnonymously(
-    storedSession: StoredSessionInput,
-  ): void {
-    // Stored session stays on disk so connectivity/resume recovery can retry.
+
+  private setRestoringState(storedSession: StoredSessionInput): void {
     this.session = null;
-    this.setAnonymousState({
-      bootstrapComplete: true,
+    this.updateState({
+      status: "restoring",
+      bootstrapComplete: false,
       cloudRegion: storedSession.cloudRegion,
+      orgProjectsMap: {},
+      currentOrgId: null,
       currentProjectId: storedSession.selectedProjectId,
+      hasCodeAccess: null,
+      needsScopeReauth: false,
     });
   }
+
+  private handleStoredSessionRestoreFailure(
+    storedSession: StoredSessionInput,
+  ): void {
+    // Refresh-token auth errors clear the stored session and publish a real
+    // anonymous state from refreshSession. Transient/offline failures keep the
+    // stored session on disk, so consumers must not treat them as logout.
+    if (this.authSession.getCurrent()) {
+      this.setRestoringState(storedSession);
+    }
+  }
+
   private async ensureValidSession(
     forceRefresh = false,
   ): Promise<InMemorySession> {
@@ -469,13 +485,17 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
 
     const sessionInput = this.getSessionInputForRefresh();
 
-    this.refreshPromise = this.refreshSession(sessionInput).finally(() => {
+    const refreshAndSync = async (): Promise<InMemorySession> => {
+      const session = await this.refreshSession(sessionInput);
+      await this.syncAuthenticatedSession(session);
+      return session;
+    };
+
+    this.refreshPromise = refreshAndSync().finally(() => {
       this.refreshPromise = null;
     });
 
-    const session = await this.refreshPromise;
-    await this.syncAuthenticatedSession(session);
-    return session;
+    return this.refreshPromise;
   }
 
   private getSessionInputForRefresh(): StoredSessionInput {

--- a/packages/core/src/auth/schemas.ts
+++ b/packages/core/src/auth/schemas.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 import { cloudRegion, type oAuthTokenResponse } from "./oauth.schemas";
 
-export const authStatusSchema = z.enum(["anonymous", "authenticated"]);
+export const authStatusSchema = z.enum([
+  "anonymous",
+  "restoring",
+  "authenticated",
+]);
 export type AuthStatus = z.infer<typeof authStatusSchema>;
 
 export const orgProjectsSchema = z.object({

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -3745,6 +3745,16 @@ export class SessionService {
     }
   }
 
+  public countQueuedCloudMessages(): number {
+    const sessions = this.d.store.getSessions();
+    let count = 0;
+    for (const session of Object.values(sessions)) {
+      if (!session.isCloud) continue;
+      count += session.messageQueue.length;
+    }
+    return count;
+  }
+
   public updateSessionTaskTitle(taskId: string, taskTitle: string): void {
     const session = this.d.store.getSessionByTaskId(taskId);
     if (!session) return;

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -92,6 +92,10 @@ const LOCAL_SESSION_RECOVERY_FAILED_MESSAGE =
 const GITHUB_AUTHORIZATION_REQUIRED_CODE = "github_authorization_required";
 const AUTO_RETRY_MAX_ATTEMPTS = 2;
 const AUTO_RETRY_DELAY_MS = 10_000;
+// A local connect can start while a stored-session auth restore is still in
+// flight past its bootstrap deadline. Cap how many retry delays we hold the
+// session in "connecting" waiting for that restore before surfacing an error.
+const AUTH_RESTORE_MAX_RETRY_WAITS = 6;
 
 class GitHubAuthorizationRequiredForCloudHandoffError extends Error {
   constructor(
@@ -666,23 +670,41 @@ export class SessionService {
 
       let lastRetryMessage = message;
       let wentOffline = false;
-      for (let attempt = 1; attempt <= AUTO_RETRY_MAX_ATTEMPTS; attempt++) {
+      let restoringWaits = 0;
+      let attempt = 0;
+      while (attempt < AUTO_RETRY_MAX_ATTEMPTS) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, AUTO_RETRY_DELAY_MS),
+        );
+        if (!this.d.getIsOnline()) {
+          this.d.log.warn("Skipping retry — device went offline", { taskId });
+          wentOffline = true;
+          break;
+        }
+
+        // A stored-session auth restore can outlast its bootstrap deadline and
+        // settle in the background. While it is still restoring, keep the
+        // session connecting and wait rather than calling clearSessionError
+        // (which tears the session down) and burning the retry budget into a
+        // permanent error. Bounded so a wedged restore still surfaces an error.
+        if (
+          restoringWaits < AUTH_RESTORE_MAX_RETRY_WAITS &&
+          (await this.getAuthCredentialsStatus()).kind === "restoring"
+        ) {
+          restoringWaits++;
+          this.d.log.info("Auth still restoring; keeping session connecting", {
+            taskId,
+            restoringWaits,
+          });
+          continue;
+        }
+
+        attempt++;
         this.d.log.warn("Auto-retrying failed connection", {
           taskId,
           attempt,
           delayMs: AUTO_RETRY_DELAY_MS,
         });
-        await new Promise((resolve) =>
-          setTimeout(resolve, AUTO_RETRY_DELAY_MS),
-        );
-        if (!this.d.getIsOnline()) {
-          this.d.log.warn("Skipping retry — device went offline", {
-            taskId,
-            attempt,
-          });
-          wentOffline = true;
-          break;
-        }
         try {
           await this.clearSessionError(taskId, repoPath);
           return;

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2170,12 +2170,11 @@ export class SessionService {
 
     const authStatus = await this.getAuthCredentialsStatus();
     if (authStatus.kind === "restoring") {
-      this.d.store.enqueueMessage(session.taskId, transport.promptText, prompt);
-      this.d.log.info("Cloud message queued (auth restoring)", {
-        taskId: session.taskId,
-        queueLength: session.messageQueue.length + 1,
-      });
-      return { stopReason: "queued" };
+      return this.queueRestoringCloudPrompt(
+        session,
+        prompt,
+        "Cloud message queued (auth restoring)",
+      );
     }
 
     const cloudCommandAuth = await this.getCloudCommandAuth();
@@ -2320,6 +2319,13 @@ export class SessionService {
           session.status === "connected");
       if (!canSendNow || session.isPromptPending) return;
 
+      // Draining while auth is still restoring would route through the restoring
+      // gate in sendCloudPrompt, re-enqueueing a single merged prompt and losing
+      // the original message boundaries. The auth-restored flush re-runs this
+      // once credentials are ready.
+      const authStatus = await this.getAuthCredentialsStatus();
+      if (authStatus.kind === "restoring") return;
+
       const drained = this.d.store.dequeueMessages(taskId);
       const combined = this.d.h.combineQueuedCloudPrompts(drained);
       if (!combined) return;
@@ -2351,13 +2357,11 @@ export class SessionService {
   ): Promise<{ stopReason: string }> {
     const authStatus = await this.getAuthCredentialsStatus();
     if (authStatus.kind === "restoring") {
-      const transport = this.d.h.getCloudPromptTransport(prompt);
-      this.d.store.enqueueMessage(session.taskId, transport.promptText, prompt);
-      this.d.log.info("Cloud resume queued (auth restoring)", {
-        taskId: session.taskId,
-        queueLength: session.messageQueue.length + 1,
-      });
-      return { stopReason: "queued" };
+      return this.queueRestoringCloudPrompt(
+        session,
+        prompt,
+        "Cloud resume queued (auth restoring)",
+      );
     }
     if (authStatus.kind !== "ready") {
       throw new Error("Authentication required for cloud commands");
@@ -2899,8 +2903,11 @@ export class SessionService {
     if (session?.initialPrompt?.length) {
       const { taskTitle, initialPrompt } = session;
       await this.teardownSession(session.taskRunId);
-      const auth = await this.getAuthCredentials();
-      if (!auth) {
+      const authStatus = await this.getAuthCredentialsStatus();
+      if (authStatus.kind === "restoring") {
+        throw new Error("Authentication is still restoring. Please wait.");
+      }
+      if (authStatus.kind !== "ready") {
         throw new Error(
           "Unable to reach server. Please check your connection.",
         );
@@ -2909,7 +2916,7 @@ export class SessionService {
         taskId,
         taskTitle,
         repoPath,
-        auth,
+        authStatus.auth,
         initialPrompt,
       );
       return;
@@ -2957,10 +2964,14 @@ export class SessionService {
     }
     this.unsubscribeFromChannel(taskRunId);
 
-    const auth = await this.getAuthCredentials();
-    if (!auth) {
+    const authStatus = await this.getAuthCredentialsStatus();
+    if (authStatus.kind === "restoring") {
+      throw new Error("Authentication is still restoring. Please wait.");
+    }
+    if (authStatus.kind !== "ready") {
       throw new Error("Unable to reach server. Please check your connection.");
     }
+    const auth = authStatus.auth;
 
     const prefetchedLogs = await this.fetchSessionLogs(logUrl, taskRunId);
 
@@ -4253,6 +4264,8 @@ export class SessionService {
 
   private async getAuthCredentialsStatus(): Promise<AuthCredentialsStatus> {
     const authState = await this.d.fetchAuthState();
+    // `bootstrapComplete === false` also covers the pre-initialize window where
+    // status is still the default "anonymous" but auth has not resolved yet.
     if (
       authState.status === "restoring" ||
       authState.bootstrapComplete === false
@@ -4270,9 +4283,18 @@ export class SessionService {
     return { kind: "ready", auth: { apiHost, projectId, client } };
   }
 
-  private async getAuthCredentials(): Promise<AuthCredentials | null> {
-    const authStatus = await this.getAuthCredentialsStatus();
-    return authStatus.kind === "ready" ? authStatus.auth : null;
+  private queueRestoringCloudPrompt(
+    session: AgentSession,
+    prompt: string | ContentBlock[],
+    reason: string,
+  ): { stopReason: "queued" } {
+    const transport = this.d.h.getCloudPromptTransport(prompt);
+    this.d.store.enqueueMessage(session.taskId, transport.promptText, prompt);
+    this.d.log.info(reason, {
+      taskId: session.taskId,
+      queueLength: session.messageQueue.length + 1,
+    });
+    return { stopReason: "queued" };
   }
 
   private parseLogContent(content: string): ParsedSessionLogs {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -92,9 +92,6 @@ const LOCAL_SESSION_RECOVERY_FAILED_MESSAGE =
 const GITHUB_AUTHORIZATION_REQUIRED_CODE = "github_authorization_required";
 const AUTO_RETRY_MAX_ATTEMPTS = 2;
 const AUTO_RETRY_DELAY_MS = 10_000;
-// A local connect can start while a stored-session auth restore is still in
-// flight past its bootstrap deadline. Cap how many retry delays we hold the
-// session in "connecting" waiting for that restore before surfacing an error.
 const AUTH_RESTORE_MAX_RETRY_WAITS = 6;
 
 class GitHubAuthorizationRequiredForCloudHandoffError extends Error {
@@ -682,11 +679,8 @@ export class SessionService {
           break;
         }
 
-        // A stored-session auth restore can outlast its bootstrap deadline and
-        // settle in the background. While it is still restoring, keep the
-        // session connecting and wait rather than calling clearSessionError
-        // (which tears the session down) and burning the retry budget into a
-        // permanent error. Bounded so a wedged restore still surfaces an error.
+        // Wait out an in-flight restore instead of spending a retry on
+        // clearSessionError, which tears the connecting session down.
         if (
           restoringWaits < AUTH_RESTORE_MAX_RETRY_WAITS &&
           (await this.getAuthCredentialsStatus()).kind === "restoring"

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -274,6 +274,11 @@ interface AuthCredentials {
   client: AuthClient;
 }
 
+type AuthCredentialsStatus =
+  | { kind: "ready"; auth: AuthCredentials }
+  | { kind: "restoring" }
+  | { kind: "missing" };
+
 export interface ConnectParams {
   task: Task;
   repoPath: string;
@@ -529,7 +534,11 @@ export class SessionService {
     }
 
     try {
-      const auth = await this.getAuthCredentials();
+      const authStatus = await this.getAuthCredentialsStatus();
+      if (authStatus.kind === "restoring") {
+        throw new Error("Authentication is still restoring. Please wait.");
+      }
+      const auth = authStatus.kind === "ready" ? authStatus.auth : null;
       const route = routeLocalConnect({
         hasAuth: auth !== null,
         latestRunId: latestRun?.id,
@@ -2159,13 +2168,21 @@ export class SessionService {
       return { stopReason: "queued" };
     }
 
-    const [auth, cloudCommandAuth] = await Promise.all([
-      this.getAuthCredentials(),
-      this.getCloudCommandAuth(),
-    ]);
-    if (!auth || !cloudCommandAuth) {
+    const authStatus = await this.getAuthCredentialsStatus();
+    if (authStatus.kind === "restoring") {
+      this.d.store.enqueueMessage(session.taskId, transport.promptText, prompt);
+      this.d.log.info("Cloud message queued (auth restoring)", {
+        taskId: session.taskId,
+        queueLength: session.messageQueue.length + 1,
+      });
+      return { stopReason: "queued" };
+    }
+
+    const cloudCommandAuth = await this.getCloudCommandAuth();
+    if (authStatus.kind !== "ready" || !cloudCommandAuth) {
       throw new Error("Authentication required for cloud commands");
     }
+    const { auth } = authStatus;
 
     this.watchCloudTask(
       session.taskId,
@@ -2332,10 +2349,21 @@ export class SessionService {
     session: AgentSession,
     prompt: string | ContentBlock[],
   ): Promise<{ stopReason: string }> {
-    const authCredentials = await this.getAuthCredentials();
-    if (!authCredentials) {
+    const authStatus = await this.getAuthCredentialsStatus();
+    if (authStatus.kind === "restoring") {
+      const transport = this.d.h.getCloudPromptTransport(prompt);
+      this.d.store.enqueueMessage(session.taskId, transport.promptText, prompt);
+      this.d.log.info("Cloud resume queued (auth restoring)", {
+        taskId: session.taskId,
+        queueLength: session.messageQueue.length + 1,
+      });
+      return { stopReason: "queued" };
+    }
+    if (authStatus.kind !== "ready") {
       throw new Error("Authentication required for cloud commands");
     }
+    const authCredentials = authStatus.auth;
+
     const auth = await this.getCloudCommandAuth();
     if (!auth) {
       throw new Error("Authentication required for cloud commands");
@@ -4215,16 +4243,28 @@ export class SessionService {
 
   // --- Helper Methods ---
 
-  private async getAuthCredentials(): Promise<AuthCredentials | null> {
+  private async getAuthCredentialsStatus(): Promise<AuthCredentialsStatus> {
     const authState = await this.d.fetchAuthState();
+    if (
+      authState.status === "restoring" ||
+      authState.bootstrapComplete === false
+    ) {
+      return { kind: "restoring" };
+    }
+
     const apiHost = authState.cloudRegion
       ? getCloudUrlFromRegion(authState.cloudRegion)
       : null;
     const projectId = authState.currentProjectId;
     const client = this.d.createAuthenticatedClient(authState);
 
-    if (!apiHost || !projectId || !client) return null;
-    return { apiHost, projectId, client };
+    if (!apiHost || !projectId || !client) return { kind: "missing" };
+    return { kind: "ready", auth: { apiHost, projectId, client } };
+  }
+
+  private async getAuthCredentials(): Promise<AuthCredentials | null> {
+    const authStatus = await this.getAuthCredentialsStatus();
+    return authStatus.kind === "ready" ? authStatus.auth : null;
   }
 
   private parseLogContent(content: string): ParsedSessionLogs {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -3704,6 +3704,14 @@ export class SessionService {
     }
   }
 
+  public flushQueuedCloudMessagesAfterAuthRestored(): void {
+    const sessions = this.d.store.getSessions();
+    for (const session of Object.values(sessions)) {
+      if (!session.isCloud || session.messageQueue.length === 0) continue;
+      this.scheduleCloudQueueFlush(session.taskId, "auth_restored");
+    }
+  }
+
   public updateSessionTaskTitle(taskId: string, taskTitle: string): void {
     const session = this.d.store.getSessionByTaskId(taskId);
     if (!session) return;

--- a/packages/ui/src/features/auth/auth.contribution.ts
+++ b/packages/ui/src/features/auth/auth.contribution.ts
@@ -1,3 +1,7 @@
+import {
+  SESSION_SERVICE,
+  type SessionService,
+} from "@posthog/core/sessions/sessionService";
 import type { Contribution } from "@posthog/di/contribution";
 import {
   HOST_TRPC_CLIENT,
@@ -17,11 +21,18 @@ export class AuthContribution implements Contribution {
   constructor(
     @inject(HOST_TRPC_CLIENT)
     private readonly hostClient: HostTrpcClient,
+    @inject(SESSION_SERVICE)
+    private readonly sessionService: SessionService,
   ) {}
 
   async start(): Promise<void> {
     this.hostClient.auth.onStateChanged.subscribe(undefined, {
-      onData: (state) => useAuthStore.getState().setAuthState(state),
+      onData: (state) => {
+        useAuthStore.getState().setAuthState(state);
+        if (state.status === "authenticated") {
+          this.sessionService.flushQueuedCloudMessagesAfterAuthRestored();
+        }
+      },
     });
 
     const outcome = await withTimeout(
@@ -30,6 +41,9 @@ export class AuthContribution implements Contribution {
     );
     if (outcome.result === "success") {
       useAuthStore.getState().setAuthState(outcome.value);
+      if (outcome.value.status === "authenticated") {
+        this.sessionService.flushQueuedCloudMessagesAfterAuthRestored();
+      }
     } else {
       log.warn(
         "Initial auth state query timed out; relying on state subscription",

--- a/packages/ui/src/features/auth/auth.contribution.ts
+++ b/packages/ui/src/features/auth/auth.contribution.ts
@@ -50,9 +50,6 @@ export class AuthContribution implements Contribution {
     }
   }
 
-  // Cloud prompts can queue while auth is restoring. Flush them once auth
-  // resolves, or tell the user to sign back in if the restore ended in logout
-  // so their queued messages are not silently stranded.
   private syncCloudQueueForAuthState(state: AuthState): void {
     if (state.status === "authenticated") {
       this.sessionService.flushQueuedCloudMessagesAfterAuthRestored();

--- a/packages/ui/src/features/auth/auth.contribution.ts
+++ b/packages/ui/src/features/auth/auth.contribution.ts
@@ -1,3 +1,4 @@
+import type { AuthState } from "@posthog/core/auth/schemas";
 import {
   SESSION_SERVICE,
   type SessionService,
@@ -8,6 +9,7 @@ import {
   type HostTrpcClient,
 } from "@posthog/host-router/client";
 import { withTimeout } from "@posthog/shared";
+import { toast } from "@posthog/ui/primitives/toast";
 import { logger } from "@posthog/ui/shell/logger";
 import { inject, injectable } from "inversify";
 import { useAuthStore } from "./store";
@@ -15,6 +17,7 @@ import { useAuthStore } from "./store";
 const log = logger.scope("auth-contribution");
 // boot() starts contributions serially, so a stuck host query must not wedge it.
 const INITIAL_STATE_TIMEOUT_MS = 10_000;
+const STRANDED_CLOUD_QUEUE_TOAST_ID = "stranded-cloud-queue";
 
 @injectable()
 export class AuthContribution implements Contribution {
@@ -29,9 +32,7 @@ export class AuthContribution implements Contribution {
     this.hostClient.auth.onStateChanged.subscribe(undefined, {
       onData: (state) => {
         useAuthStore.getState().setAuthState(state);
-        if (state.status === "authenticated") {
-          this.sessionService.flushQueuedCloudMessagesAfterAuthRestored();
-        }
+        this.syncCloudQueueForAuthState(state);
       },
     });
 
@@ -41,12 +42,31 @@ export class AuthContribution implements Contribution {
     );
     if (outcome.result === "success") {
       useAuthStore.getState().setAuthState(outcome.value);
-      if (outcome.value.status === "authenticated") {
-        this.sessionService.flushQueuedCloudMessagesAfterAuthRestored();
-      }
+      this.syncCloudQueueForAuthState(outcome.value);
     } else {
       log.warn(
         "Initial auth state query timed out; relying on state subscription",
+      );
+    }
+  }
+
+  // Cloud prompts can queue while auth is restoring. Flush them once auth
+  // resolves, or tell the user to sign back in if the restore ended in logout
+  // so their queued messages are not silently stranded.
+  private syncCloudQueueForAuthState(state: AuthState): void {
+    if (state.status === "authenticated") {
+      this.sessionService.flushQueuedCloudMessagesAfterAuthRestored();
+      return;
+    }
+
+    if (state.status === "anonymous") {
+      const pending = this.sessionService.countQueuedCloudMessages();
+      if (pending === 0) return;
+      const noun = pending === 1 ? "message" : "messages";
+      const pronoun = pending === 1 ? "it" : "them";
+      toast.error(
+        `You were signed out with ${pending} unsent cloud ${noun}. Sign in to send ${pronoun}.`,
+        { id: STRANDED_CLOUD_QUEUE_TOAST_ID },
       );
     }
   }

--- a/packages/ui/src/features/auth/useAuthSession.ts
+++ b/packages/ui/src/features/auth/useAuthSession.ts
@@ -39,13 +39,15 @@ function useAuthSubscriptionSync(): void {
   }, [hostClient]);
 }
 
-function useAuthIdentitySync(
-  authIdentity: string | null,
-  cloudRegion: "us" | "eu" | "dev" | null,
-): void {
+function useAuthIdentitySync(authState: AuthState): void {
+  const authIdentity = getAuthIdentity(authState);
+  const cloudRegion = authState.cloudRegion;
   const hostClient = useHostTRPCClient();
   useEffect(() => {
     if (!authIdentity) {
+      if (!authState.bootstrapComplete || authState.status === "restoring") {
+        return;
+      }
       resetUser();
       void hostClient.analytics.resetUser.mutate();
       clearAuthScopedQueries();
@@ -56,7 +58,13 @@ function useAuthIdentitySync(
     }
 
     useAuthUiStateStore.getState().clearStaleRegion();
-  }, [authIdentity, cloudRegion, hostClient]);
+  }, [
+    authIdentity,
+    authState.bootstrapComplete,
+    authState.status,
+    cloudRegion,
+    hostClient,
+  ]);
 }
 
 function useAuthAnalyticsIdentity(
@@ -124,7 +132,7 @@ export function useAuthSession() {
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
 
   useAuthSubscriptionSync();
-  useAuthIdentitySync(authIdentity, authState.cloudRegion);
+  useAuthIdentitySync(authState);
   useAuthAnalyticsIdentity(authIdentity, authState, currentUser);
   useSeatSync(authIdentity, billingEnabled);
 

--- a/packages/ui/src/features/sessions/components/VirtualizedList.tsx
+++ b/packages/ui/src/features/sessions/components/VirtualizedList.tsx
@@ -243,7 +243,7 @@ function VirtualizedListInner<T>(
       <div
         ref={parentRef}
         onScroll={handleScroll}
-        className="scroll-mask-8 flex-1 overflow-auto"
+        className="scroll-mask-8 flex-1 overflow-y-auto overflow-x-hidden"
         style={{ scrollbarGutter: "stable" }}
       >
         <div

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -3763,6 +3763,52 @@ describe("SessionService", () => {
       }
     });
 
+    it("does not drain the cloud queue while auth is still restoring", async () => {
+      vi.useFakeTimers();
+      try {
+        const service = getSessionService();
+        const prompt: ContentBlock[] = [{ type: "text", text: "hold this" }];
+        const queuedMessage = {
+          id: "queue-1",
+          content: "hold this",
+          rawPrompt: prompt,
+          queuedAt: 1700000000,
+        };
+        const session = createMockSession({
+          isCloud: true,
+          cloudStatus: "in_progress",
+          status: "connected",
+          isPromptPending: false,
+          messageQueue: [queuedMessage],
+        });
+        mockSessionStoreSetters.getSessions.mockReturnValue({
+          "run-123": session,
+        });
+        mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
+        mockSessionStoreSetters.dequeueMessages.mockReturnValue([
+          queuedMessage,
+        ]);
+        mockAuth.fetchAuthState.mockResolvedValue({
+          status: "restoring",
+          bootstrapComplete: false,
+          cloudRegion: "us",
+          orgProjectsMap: {},
+          currentOrgId: null,
+          currentProjectId: 123,
+          hasCodeAccess: null,
+          needsScopeReauth: false,
+        });
+
+        service.flushQueuedCloudMessagesAfterAuthRestored();
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(mockSessionStoreSetters.dequeueMessages).not.toHaveBeenCalled();
+        expect(mockTrpcCloudTask.sendCommand.mutate).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not pin isPromptPending when queueing during sandbox boot", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -3713,6 +3713,56 @@ describe("SessionService", () => {
       expect(mockTrpcCloudTask.sendCommand.mutate).not.toHaveBeenCalled();
     });
 
+    it("flushes cloud prompt queued during auth restore after auth is restored", async () => {
+      vi.useFakeTimers();
+      try {
+        const service = getSessionService();
+        const prompt: ContentBlock[] = [{ type: "text", text: "hold this" }];
+        const queuedMessage = {
+          id: "queue-1",
+          content: "hold this",
+          rawPrompt: prompt,
+          queuedAt: 1700000000,
+        };
+        const session = createMockSession({
+          isCloud: true,
+          cloudStatus: "in_progress",
+          status: "connected",
+          isPromptPending: false,
+          messageQueue: [queuedMessage],
+        });
+        mockSessionStoreSetters.getSessions.mockReturnValue({
+          "run-123": session,
+        });
+        mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
+        mockSessionStoreSetters.dequeueMessages.mockReturnValue([
+          queuedMessage,
+        ]);
+        mockTrpcCloudTask.sendCommand.mutate.mockResolvedValue({
+          success: true,
+          result: { queued: true },
+        });
+
+        service.flushQueuedCloudMessagesAfterAuthRestored();
+        await vi.advanceTimersByTimeAsync(0);
+
+        await vi.waitFor(() => {
+          expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+              taskId: "task-123",
+              runId: "run-123",
+              method: "user_message",
+            }),
+          );
+        });
+        expect(mockSessionStoreSetters.dequeueMessages).toHaveBeenCalledWith(
+          "task-123",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not pin isPromptPending when queueing during sandbox boot", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -617,7 +617,7 @@ describe("SessionService", () => {
       );
     });
 
-    it("keeps the session connecting when auth is still restoring", async () => {
+    it("keeps the session connecting while auth restores, then recovers", async () => {
       vi.useFakeTimers();
       try {
         const service = getSessionService();
@@ -653,6 +653,26 @@ describe("SessionService", () => {
           }),
         );
         expect(mockTrpcAgent.start.mutate).not.toHaveBeenCalled();
+
+        // Past the old 2-attempt / 20s window: still restoring, so the session
+        // must stay connecting instead of being torn down or flipped to error.
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(clearSpy).not.toHaveBeenCalled();
+        expect(mockSessionStoreSetters.updateSession).not.toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ status: "error" }),
+        );
+
+        mockAuth.fetchAuthState.mockResolvedValue({
+          status: "authenticated",
+          bootstrapComplete: true,
+          cloudRegion: "us",
+          orgProjectsMap: {},
+          currentOrgId: null,
+          currentProjectId: 123,
+          hasCodeAccess: true,
+          needsScopeReauth: false,
+        });
 
         await vi.advanceTimersByTimeAsync(10_000);
         await promise;

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -654,8 +654,6 @@ describe("SessionService", () => {
         );
         expect(mockTrpcAgent.start.mutate).not.toHaveBeenCalled();
 
-        // Past the old 2-attempt / 20s window: still restoring, so the session
-        // must stay connecting instead of being torn down or flipped to error.
         await vi.advanceTimersByTimeAsync(30_000);
         expect(clearSpy).not.toHaveBeenCalled();
         expect(mockSessionStoreSetters.updateSession).not.toHaveBeenCalledWith(

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -3829,6 +3829,32 @@ describe("SessionService", () => {
       }
     });
 
+    it("counts queued messages across cloud sessions only", () => {
+      const service = getSessionService();
+      const queued = (id: string) => ({
+        id,
+        content: "queued",
+        rawPrompt: [{ type: "text", text: "queued" }] as ContentBlock[],
+        queuedAt: 1700000000,
+      });
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-cloud-a": createMockSession({
+          isCloud: true,
+          messageQueue: [queued("a1"), queued("a2")],
+        }),
+        "run-local": createMockSession({
+          isCloud: false,
+          messageQueue: [queued("l1")],
+        }),
+        "run-cloud-empty": createMockSession({
+          isCloud: true,
+          messageQueue: [],
+        }),
+      });
+
+      expect(service.countQueuedCloudMessages()).toBe(2);
+    });
+
     it("does not pin isPromptPending when queueing during sandbox boot", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -390,6 +390,7 @@ describe("SessionService", () => {
     mockSettingsState.customInstructions = "";
     mockGetIsOnline.mockReturnValue(true);
     mockGetConfigOptionByCategory.mockReturnValue(undefined);
+    mockBuildAuthenticatedClient.mockReturnValue(mockAuthenticatedClient);
     mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(undefined);
     mockSessionStoreSetters.getSessions.mockReturnValue({});
     mockAuth.fetchAuthState.mockResolvedValue({
@@ -614,6 +615,52 @@ describe("SessionService", () => {
           errorMessage: expect.stringContaining("Authentication required"),
         }),
       );
+    });
+
+    it("keeps the session connecting when auth is still restoring", async () => {
+      vi.useFakeTimers();
+      try {
+        const service = getSessionService();
+        const clearSpy = vi
+          .spyOn(service, "clearSessionError")
+          .mockResolvedValue(undefined);
+        const initialPrompt: ContentBlock[] = [
+          { type: "text", text: "do the thing" },
+        ];
+
+        mockAuth.fetchAuthState.mockResolvedValue({
+          status: "restoring",
+          bootstrapComplete: false,
+          cloudRegion: "us",
+          orgProjectsMap: {},
+          currentOrgId: null,
+          currentProjectId: 123,
+          hasCodeAccess: null,
+          needsScopeReauth: false,
+        });
+
+        const promise = service.connectToTask({
+          task: createMockTask(),
+          repoPath: "/repo",
+          initialPrompt,
+        });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(mockSessionStoreSetters.setSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: "connecting",
+            initialPrompt,
+          }),
+        );
+        expect(mockTrpcAgent.start.mutate).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        await promise;
+
+        expect(clearSpy).toHaveBeenCalledWith("task-123", "/repo");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     describe("auto-retry on connect failure", () => {
@@ -3631,6 +3678,39 @@ describe("SessionService", () => {
 
       expect(result.stopReason).toBe("queued");
       expect(mockTrpcCloudTask.retry.mutate).not.toHaveBeenCalled();
+    });
+
+    it("queues cloud prompt while auth is still restoring", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          isCloud: true,
+          cloudStatus: "in_progress",
+          status: "connected",
+          isPromptPending: false,
+        }),
+      );
+      mockAuth.fetchAuthState.mockResolvedValue({
+        status: "restoring",
+        bootstrapComplete: false,
+        cloudRegion: "us",
+        orgProjectsMap: {},
+        currentOrgId: null,
+        currentProjectId: 123,
+        hasCodeAccess: null,
+        needsScopeReauth: false,
+      });
+
+      const prompt: ContentBlock[] = [{ type: "text", text: "hold this" }];
+      const result = await service.sendPrompt("task-123", prompt);
+
+      expect(result.stopReason).toBe("queued");
+      expect(mockSessionStoreSetters.enqueueMessage).toHaveBeenCalledWith(
+        "task-123",
+        "hold this",
+        prompt,
+      );
+      expect(mockTrpcCloudTask.sendCommand.mutate).not.toHaveBeenCalled();
     });
 
     it("does not pin isPromptPending when queueing during sandbox boot", async () => {


### PR DESCRIPTION
## Summary
- add an explicit auth restoring state for stored-session bootstrap timeouts instead of publishing anonymous
- share the bootstrap refresh through the normal refresh promise so token callers do not start a second rotating-token refresh
- keep UI identity/query state intact while auth is restoring and queue/retry sessions instead of dropping prompts on transient auth state

## What went wrong
This is the regression from `e9630bd91 fix(auth): stop a hung token refresh from wedging bootstrap (#2582)`.

That PR correctly noticed that a hung token refresh could wedge bootstrap forever. The bad part was the recovery behavior: after the 20s bootstrap deadline, we marked auth as `anonymous` with `bootstrapComplete: true` while intentionally leaving the stored session on disk so a late background restore could still recover.

That created a poisonous in-between state. The user still had a real stored refresh token, selected project, and region, but every consumer saw a completed anonymous bootstrap. From there:
- the UI identity sync treated it as a logout, reset analytics, cleared auth-scoped queries, and preserved only stale region/project hints
- project lookups saw no authenticated org/project map, so sessions and project UI degraded into empty or `(unknown)` state
- local session connect treated auth as missing, wrote a hard `Authentication required` error session, and then would not naturally recover because errored sessions short-circuit reconnect paths
- cloud prompting checked auth before optimistic insertion; while auth looked anonymous it threw `Authentication required for cloud commands`, which surfaced to users as prompts disappearing or empty generations
- `getValidAccessToken()` could start a second refresh after the timeout because bootstrap refresh was not stored in `refreshPromise`; with rotating refresh tokens, that made the transient window worse because two refreshes could race with the same token

So #2582 traded a visible bootstrap hang for a transient fake logout. Because that fake logout was marked complete, the rest of the app did exactly what it was told and cleared state / failed prompts.

## Why this fixes it
Stored-session restore now has three states instead of two:
- `authenticated`: refresh and sync succeeded
- `anonymous`: there is no usable stored session, or the server rejected the refresh token with a real auth error
- `restoring`: there is still a stored session, but refresh/bootstrap is slow, offline, or transiently failing

While `restoring`, we keep bootstrap incomplete, do not clear auth-scoped UI/query state, do not call host analytics reset, do not create permanent local auth-error sessions, and queue cloud prompts/resumes instead of dropping them. The bootstrap refresh also goes through the normal shared refresh promise, so token callers cannot kick off a competing refresh with the same rotating token.

## Test plan
- pnpm --filter @posthog/core test -- auth.test.ts
- pnpm --filter @posthog/ui test -- sessionServiceHost.test.ts
- pnpm --filter @posthog/core typecheck
- pnpm --filter @posthog/ui typecheck
- pnpm exec biome lint packages/core/src/auth packages/core/src/sessions/sessionService.ts packages/ui/src/features/auth/useAuthSession.ts packages/ui/src/features/sessions/sessionServiceHost.test.ts
- pre-commit: biome check --write --unsafe and pnpm typecheck