### PR TITLE
feat(sessions): Dock queued messages with steer and discard actions

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2048,6 +2048,10 @@ export class SessionService {
   async steerQueuedMessage(taskId: string, messageId: string): Promise<void> {
     const session = this.d.store.getSessionByTaskId(taskId);
     if (!session) return;
+    // Steer falls through to the queue during compaction, which would re-enqueue
+    // the message as plain text and drop its rawPrompt. Leave it queued; it
+    // drains normally once compaction ends.
+    if (session.isCompacting) return;
     const message = session.messageQueue.find((m) => m.id === messageId);
     if (!message) return;
 

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2039,6 +2039,30 @@ export class SessionService {
   }
 
   /**
+   * Steer a single queued message into the running turn now: drop it from the
+   * queue and resend it as a steer. Native (Claude, local) injects at the next
+   * tool boundary; cloud/Codex interrupt and resend. The rest of the queue is
+   * left in place and drains when the turn ends. Rolls the message back onto
+   * the queue if the send fails so it is not silently lost.
+   */
+  async steerQueuedMessage(taskId: string, messageId: string): Promise<void> {
+    const session = this.d.store.getSessionByTaskId(taskId);
+    if (!session) return;
+    const message = session.messageQueue.find((m) => m.id === messageId);
+    if (!message) return;
+
+    this.d.store.removeQueuedMessage(taskId, messageId);
+    try {
+      await this.sendPrompt(taskId, message.rawPrompt ?? message.content, {
+        steer: true,
+      });
+    } catch (error) {
+      this.d.store.prependQueuedMessages(taskId, [message]);
+      throw error;
+    }
+  }
+
+  /**
    * Cancel the current prompt.
    */
   async cancelPrompt(taskId: string): Promise<boolean> {

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -261,10 +261,6 @@ export function ConversationView({
           return <TurnCancelledView interruptReason={item.interruptReason} />;
         case "user_shell_execute":
           return <UserShellExecuteView item={item} />;
-        case "queued":
-          // Queued messages render in the QueuedMessagesDock above the
-          // composer, not inline in the thread.
-          return null;
       }
     },
     [repoPath, taskId, slackThreadUrl, firstUserMessageId, initialItemIds],

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -25,7 +25,6 @@ import {
 } from "@posthog/ui/features/sessions/components/new-thread/buildThreadGroups";
 import { ToolCallGroupChip } from "@posthog/ui/features/sessions/components/new-thread/ToolCallGroupChip";
 import { SessionFooter } from "@posthog/ui/features/sessions/components/SessionFooter";
-import { QueuedMessageView } from "@posthog/ui/features/sessions/components/session-update/QueuedMessageView";
 import {
   type RenderItem,
   SessionUpdateView,
@@ -41,7 +40,6 @@ import { useContextUsage } from "@posthog/ui/features/sessions/hooks/useContextU
 import { useConversationItems } from "@posthog/ui/features/sessions/hooks/useConversationItems";
 import { useConversationSearch } from "@posthog/ui/features/sessions/hooks/useConversationSearch";
 import {
-  sessionStoreSetters,
   useOptimisticItemsForTask,
   usePendingPermissionsForTask,
   useQueuedMessagesForTask,
@@ -140,20 +138,10 @@ export function ConversationView({
 
   const pendingPermissions = usePendingPermissionsForTask(taskId ?? "");
   const pendingPermissionsCount = pendingPermissions.size;
-  const queuedMessages = useQueuedMessagesForTask(taskId);
+  const queuedCount = useQueuedMessagesForTask(taskId).length;
   const optimisticItems = useOptimisticItemsForTask(taskId);
   const session = useSessionForTask(taskId);
   const pausedDurationMs = session?.pausedDurationMs ?? 0;
-
-  const queuedItems = useMemo<Extract<ConversationItem, { type: "queued" }>[]>(
-    () =>
-      queuedMessages.map((msg) => ({
-        type: "queued" as const,
-        id: msg.id,
-        message: msg,
-      })),
-    [queuedMessages],
-  );
 
   const isCloud = session?.isCloud ?? false;
 
@@ -162,10 +150,9 @@ export function ConversationView({
       mergeConversationItems({
         conversationItems,
         optimisticItems,
-        queuedItems,
         isCloud,
       }),
-    [conversationItems, optimisticItems, queuedItems, isCloud],
+    [conversationItems, optimisticItems, isCloud],
   );
 
   // Fold each completed turn's tool-call work into a collapsible chip, and emit
@@ -275,20 +262,9 @@ export function ConversationView({
         case "user_shell_execute":
           return <UserShellExecuteView item={item} />;
         case "queued":
-          return (
-            <QueuedMessageView
-              message={item.message}
-              onRemove={
-                taskId
-                  ? () =>
-                      sessionStoreSetters.removeQueuedMessage(
-                        taskId,
-                        item.message.id,
-                      )
-                  : undefined
-              }
-            />
-          );
+          // Queued messages render in the QueuedMessagesDock above the
+          // composer, not inline in the thread.
+          return null;
       }
     },
     [repoPath, taskId, slackThreadUrl, firstUserMessageId, initialItemIds],
@@ -348,7 +324,7 @@ export function ConversationView({
             : null
         }
         lastStopReason={lastTurnInfo?.stopReason}
-        queuedCount={queuedMessages.length}
+        queuedCount={queuedCount}
         hasPendingPermission={pendingPermissionsCount > 0}
         pausedDurationMs={pausedDurationMs}
         isCompacting={isCompacting}

--- a/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
+++ b/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
@@ -1,0 +1,56 @@
+import {
+  SESSION_SERVICE,
+  type SessionService,
+} from "@posthog/core/sessions/sessionService";
+import { useService } from "@posthog/di/react";
+import { QueuedMessageView } from "@posthog/ui/features/sessions/components/session-update/QueuedMessageView";
+import {
+  useMessagingMode,
+  useSupportsNativeSteer,
+} from "@posthog/ui/features/sessions/hooks/useMessagingMode";
+import { useToggleMessagingMode } from "@posthog/ui/features/sessions/hooks/useToggleMessagingMode";
+import { sessionStoreSetters } from "@posthog/ui/features/sessions/sessionStore";
+import { useQueuedMessagesForTask } from "@posthog/ui/features/sessions/useSession";
+import { Flex } from "@radix-ui/themes";
+
+interface QueuedMessagesDockProps {
+  taskId: string;
+}
+
+/**
+ * Queued follow-ups pinned directly above the composer (outside the scrolling
+ * thread) with per-message actions: steer it into the running turn now, discard
+ * it, or turn queueing off for the task.
+ */
+export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
+  const queued = useQueuedMessagesForTask(taskId);
+  const sessionService = useService<SessionService>(SESSION_SERVICE);
+  const mode = useMessagingMode(taskId);
+  const turnOffQueueing = useToggleMessagingMode(taskId);
+  const supportsNativeSteer = useSupportsNativeSteer(taskId);
+
+  if (queued.length === 0) return null;
+
+  return (
+    <Flex direction="column" gap="1" className="mb-1">
+      {queued.map((message) => (
+        <QueuedMessageView
+          key={message.id}
+          message={message}
+          supportsNativeSteer={supportsNativeSteer}
+          onSteer={() => {
+            void sessionService
+              .steerQueuedMessage(taskId, message.id)
+              .catch(() => {
+                // Steer failed; the service already re-queued the message.
+              });
+          }}
+          onRemove={() =>
+            sessionStoreSetters.removeQueuedMessage(taskId, message.id)
+          }
+          onTurnOffQueueing={mode === "queue" ? turnOffQueueing : undefined}
+        />
+      ))}
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
+++ b/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
@@ -5,6 +5,7 @@ import {
 import { useService } from "@posthog/di/react";
 import { QueuedMessageView } from "@posthog/ui/features/sessions/components/session-update/QueuedMessageView";
 import { useSupportsNativeSteer } from "@posthog/ui/features/sessions/hooks/useMessagingMode";
+import { useReturnQueuedMessageToEditor } from "@posthog/ui/features/sessions/hooks/useReturnQueuedMessageToEditor";
 import { sessionStoreSetters } from "@posthog/ui/features/sessions/sessionStore";
 import { useQueuedMessagesForTask } from "@posthog/ui/features/sessions/useSession";
 import { Flex } from "@radix-ui/themes";
@@ -15,13 +16,14 @@ interface QueuedMessagesDockProps {
 
 /**
  * Queued follow-ups pinned directly above the composer (outside the scrolling
- * thread) with per-message actions: steer it into the running turn now, or
- * discard it.
+ * thread) with per-message actions: steer it into the running turn now, return
+ * it to the composer to re-read or edit, or discard it.
  */
 export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
   const queued = useQueuedMessagesForTask(taskId);
   const sessionService = useService<SessionService>(SESSION_SERVICE);
   const supportsNativeSteer = useSupportsNativeSteer(taskId);
+  const returnToEditor = useReturnQueuedMessageToEditor(taskId);
 
   if (queued.length === 0) return null;
 
@@ -39,6 +41,7 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
                 // Steer failed; the service already re-queued the message.
               });
           }}
+          onReturnToEditor={() => returnToEditor(message)}
           onRemove={() =>
             sessionStoreSetters.removeQueuedMessage(taskId, message.id)
           }

--- a/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
+++ b/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
@@ -6,8 +6,12 @@ import { useService } from "@posthog/di/react";
 import { QueuedMessageView } from "@posthog/ui/features/sessions/components/session-update/QueuedMessageView";
 import { useSupportsNativeSteer } from "@posthog/ui/features/sessions/hooks/useMessagingMode";
 import { useReturnQueuedMessageToEditor } from "@posthog/ui/features/sessions/hooks/useReturnQueuedMessageToEditor";
-import { sessionStoreSetters } from "@posthog/ui/features/sessions/sessionStore";
+import {
+  sessionStoreSetters,
+  useSessionForTask,
+} from "@posthog/ui/features/sessions/sessionStore";
 import { useQueuedMessagesForTask } from "@posthog/ui/features/sessions/useSession";
+import { toast } from "@posthog/ui/primitives/toast";
 import { Flex } from "@radix-ui/themes";
 
 interface QueuedMessagesDockProps {
@@ -24,6 +28,8 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
   const sessionService = useService<SessionService>(SESSION_SERVICE);
   const supportsNativeSteer = useSupportsNativeSteer(taskId);
   const returnToEditor = useReturnQueuedMessageToEditor(taskId);
+  // Steer can't inject mid-compaction, so it would be a silent no-op; hide it.
+  const isCompacting = useSessionForTask(taskId)?.isCompacting ?? false;
 
   if (queued.length === 0) return null;
 
@@ -34,13 +40,19 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
           key={message.id}
           message={message}
           supportsNativeSteer={supportsNativeSteer}
-          onSteer={() => {
-            void sessionService
-              .steerQueuedMessage(taskId, message.id)
-              .catch(() => {
-                // Steer failed; the service already re-queued the message.
-              });
-          }}
+          onSteer={
+            isCompacting
+              ? undefined
+              : () => {
+                  void sessionService
+                    .steerQueuedMessage(taskId, message.id)
+                    .catch(() => {
+                      toast.error(
+                        "Couldn't steer this message. It's still queued.",
+                      );
+                    });
+                }
+          }
           onReturnToEditor={() => returnToEditor(message)}
           onRemove={() =>
             sessionStoreSetters.removeQueuedMessage(taskId, message.id)

--- a/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
+++ b/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
@@ -4,11 +4,7 @@ import {
 } from "@posthog/core/sessions/sessionService";
 import { useService } from "@posthog/di/react";
 import { QueuedMessageView } from "@posthog/ui/features/sessions/components/session-update/QueuedMessageView";
-import {
-  useMessagingMode,
-  useSupportsNativeSteer,
-} from "@posthog/ui/features/sessions/hooks/useMessagingMode";
-import { useToggleMessagingMode } from "@posthog/ui/features/sessions/hooks/useToggleMessagingMode";
+import { useSupportsNativeSteer } from "@posthog/ui/features/sessions/hooks/useMessagingMode";
 import { sessionStoreSetters } from "@posthog/ui/features/sessions/sessionStore";
 import { useQueuedMessagesForTask } from "@posthog/ui/features/sessions/useSession";
 import { Flex } from "@radix-ui/themes";
@@ -19,14 +15,12 @@ interface QueuedMessagesDockProps {
 
 /**
  * Queued follow-ups pinned directly above the composer (outside the scrolling
- * thread) with per-message actions: steer it into the running turn now, discard
- * it, or turn queueing off for the task.
+ * thread) with per-message actions: steer it into the running turn now, or
+ * discard it.
  */
 export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
   const queued = useQueuedMessagesForTask(taskId);
   const sessionService = useService<SessionService>(SESSION_SERVICE);
-  const mode = useMessagingMode(taskId);
-  const turnOffQueueing = useToggleMessagingMode(taskId);
   const supportsNativeSteer = useSupportsNativeSteer(taskId);
 
   if (queued.length === 0) return null;
@@ -48,7 +42,6 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
           onRemove={() =>
             sessionStoreSetters.removeQueuedMessage(taskId, message.id)
           }
-          onTurnOffQueueing={mode === "queue" ? turnOffQueueing : undefined}
         />
       ))}
     </Flex>

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -23,6 +23,7 @@ import { DropZoneOverlay } from "@posthog/ui/features/sessions/components/DropZo
 import { ModelSelector } from "@posthog/ui/features/sessions/components/ModelSelector";
 import { PendingChatView } from "@posthog/ui/features/sessions/components/PendingChatView";
 import { PlanStatusBar } from "@posthog/ui/features/sessions/components/PlanStatusBar";
+import { QueuedMessagesDock } from "@posthog/ui/features/sessions/components/QueuedMessagesDock";
 import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components/ReasoningLevelSelector";
 import { RawLogsView } from "@posthog/ui/features/sessions/components/raw-logs/RawLogsView";
 import { SessionResourcesBar } from "@posthog/ui/features/sessions/components/SessionResourcesBar";
@@ -600,6 +601,7 @@ export function SessionView({
                             : { maxWidth: CHAT_CONTENT_MAX_WIDTH }
                         }
                       >
+                        {taskId && <QueuedMessagesDock taskId={taskId} />}
                         <PromptInput
                           ref={editorRef}
                           sessionId={sessionId}

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -19,7 +19,6 @@ import {
   parseGitActionMessage,
 } from "@posthog/ui/features/sessions/components/GitActionMessage";
 import type { UserShellExecute } from "@posthog/ui/features/sessions/components/session-update/UserShellExecuteView";
-import type { QueuedMessage } from "@posthog/ui/features/sessions/sessionStore";
 import type {
   SessionUpdate,
   ToolCall,
@@ -64,8 +63,7 @@ export type ConversationItem =
       turnId: string;
     }
   | { type: "turn_cancelled"; id: string; interruptReason?: string }
-  | UserShellExecute
-  | { type: "queued"; id: string; message: QueuedMessage };
+  | UserShellExecute;
 
 export interface LastTurnInfo {
   isComplete: boolean;

--- a/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
@@ -1,4 +1,3 @@
-import type { QueuedMessage } from "@posthog/ui/features/sessions/sessionStore";
 import { describe, expect, it } from "vitest";
 import type { ConversationItem } from "./buildConversationItems";
 import { mergeConversationItems } from "./mergeConversationItems";
@@ -11,45 +10,20 @@ function userMessage(
   return { type: "user_message", id, content, timestamp: 0, pinToTop };
 }
 
-function queuedItem(
-  id: string,
-  content: string,
-): Extract<ConversationItem, { type: "queued" }> {
-  const message: QueuedMessage = {
-    id,
-    content,
-    rawPrompt: [{ type: "text", text: content }],
-    queuedAt: 0,
-  };
-  return { type: "queued", id, message };
-}
-
 describe("mergeConversationItems", () => {
   it("local: appends optimistic at the chronological end", () => {
     const result = mergeConversationItems({
       conversationItems: [userMessage("a", "first")],
       optimisticItems: [userMessage("opt", "draft")],
-      queuedItems: [],
       isCloud: false,
     });
     expect(result.map((i) => i.id)).toEqual(["a", "opt"]);
-  });
-
-  it("local: queued items always come last", () => {
-    const result = mergeConversationItems({
-      conversationItems: [userMessage("a", "first")],
-      optimisticItems: [userMessage("opt", "draft")],
-      queuedItems: [queuedItem("q1", "later")],
-      isCloud: false,
-    });
-    expect(result.map((i) => i.id)).toEqual(["a", "opt", "q1"]);
   });
 
   it("local: does NOT dedupe — duplicate echoes are intentionally retained", () => {
     const result = mergeConversationItems({
       conversationItems: [userMessage("echo", "hello")],
       optimisticItems: [userMessage("opt", "hello")],
-      queuedItems: [],
       isCloud: false,
     });
     expect(result.map((i) => i.id)).toEqual(["echo", "opt"]);
@@ -59,7 +33,6 @@ describe("mergeConversationItems", () => {
     const result = mergeConversationItems({
       conversationItems: [userMessage("setup", "setup info")],
       optimisticItems: [userMessage("opt", "draft")],
-      queuedItems: [],
       isCloud: true,
     });
     expect(result.map((i) => i.id)).toEqual(["opt", "setup"]);
@@ -72,7 +45,6 @@ describe("mergeConversationItems", () => {
         userMessage("other", "different"),
       ],
       optimisticItems: [userMessage("opt", "hello")],
-      queuedItems: [],
       isCloud: true,
     });
     expect(result.map((i) => i.id)).toEqual(["opt", "other"]);
@@ -85,27 +57,15 @@ describe("mergeConversationItems", () => {
         userMessage("b", "second"),
       ],
       optimisticItems: [],
-      queuedItems: [],
       isCloud: true,
     });
     expect(result.map((i) => i.id)).toEqual(["a", "b"]);
-  });
-
-  it("cloud: queued items always come last", () => {
-    const result = mergeConversationItems({
-      conversationItems: [userMessage("setup", "setup")],
-      optimisticItems: [userMessage("opt", "draft")],
-      queuedItems: [queuedItem("q1", "later")],
-      isCloud: true,
-    });
-    expect(result.map((i) => i.id)).toEqual(["opt", "setup", "q1"]);
   });
 
   it("cloud: renders follow-up optimistic messages at the tail", () => {
     const result = mergeConversationItems({
       conversationItems: [userMessage("setup", "setup")],
       optimisticItems: [userMessage("opt", "follow up", false)],
-      queuedItems: [],
       isCloud: true,
     });
     expect(result.map((i) => i.id)).toEqual(["setup", "opt"]);
@@ -118,7 +78,6 @@ describe("mergeConversationItems", () => {
         userMessage("setup", "setup"),
       ],
       optimisticItems: [userMessage("opt", "repeat", false)],
-      queuedItems: [],
       isCloud: true,
     });
     expect(result.map((i) => i.id)).toEqual(["old", "setup", "opt"]);

--- a/packages/ui/src/features/sessions/components/mergeConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/mergeConversationItems.ts
@@ -1,11 +1,8 @@
 import type { ConversationItem } from "./buildConversationItems";
 
-type QueuedItem = Extract<ConversationItem, { type: "queued" }>;
-
 interface MergeConversationItemsArgs {
   conversationItems: ConversationItem[];
   optimisticItems: ConversationItem[];
-  queuedItems: QueuedItem[];
   isCloud: boolean;
 }
 
@@ -18,15 +15,10 @@ interface MergeConversationItemsArgs {
 export function mergeConversationItems({
   conversationItems,
   optimisticItems,
-  queuedItems,
   isCloud,
 }: MergeConversationItemsArgs): ConversationItem[] {
   if (!isCloud) {
-    const result: ConversationItem[] = [
-      ...conversationItems,
-      ...optimisticItems,
-    ];
-    return queuedItems.length > 0 ? [...result, ...queuedItems] : result;
+    return [...conversationItems, ...optimisticItems];
   }
 
   const pinnedOptimisticItems = optimisticItems.filter(
@@ -50,10 +42,9 @@ export function mergeConversationItems({
           if (item.type !== "user_message") return true;
           return !pinnedOptimisticUserContents.has(item.content);
         });
-  const result: ConversationItem[] = [
+  return [
     ...pinnedOptimisticItems,
     ...dedupedConversation,
     ...tailOptimisticItems,
   ];
-  return queuedItems.length > 0 ? [...result, ...queuedItems] : result;
 }

--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -1,4 +1,9 @@
-import { ArrowBendDownLeft, Stack, Trash } from "@phosphor-icons/react";
+import {
+  ArrowBendDownLeft,
+  ArrowUUpLeft,
+  Stack,
+  Trash,
+} from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import { Box, Flex, IconButton, Tooltip } from "@radix-ui/themes";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
@@ -8,6 +13,7 @@ import { hasFileMentions, parseFileMentions } from "./parseFileMentions";
 interface QueuedMessageViewProps {
   message: QueuedMessage;
   onSteer?: () => void;
+  onReturnToEditor?: () => void;
   onRemove?: () => void;
   supportsNativeSteer?: boolean;
 }
@@ -15,6 +21,7 @@ interface QueuedMessageViewProps {
 export function QueuedMessageView({
   message,
   onSteer,
+  onReturnToEditor,
   onRemove,
   supportsNativeSteer = false,
 }: QueuedMessageViewProps) {
@@ -46,6 +53,19 @@ export function QueuedMessageView({
                 <ArrowBendDownLeft size={12} />
                 <span>Steer</span>
               </Button>
+            </Tooltip>
+          )}
+          {onReturnToEditor && (
+            <Tooltip content="Edit in composer">
+              <IconButton
+                size="1"
+                variant="ghost"
+                color="gray"
+                aria-label="Return message to the composer"
+                onClick={onReturnToEditor}
+              >
+                <ArrowUUpLeft size={12} />
+              </IconButton>
             </Tooltip>
           )}
           {onRemove && (

--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -56,12 +56,12 @@ export function QueuedMessageView({
             </Tooltip>
           )}
           {onReturnToEditor && (
-            <Tooltip content="Edit in composer">
+            <Tooltip content="Return to editor">
               <IconButton
                 size="1"
                 variant="ghost"
                 color="gray"
-                aria-label="Return message to the composer"
+                aria-label="Return to editor"
                 onClick={onReturnToEditor}
               >
                 <ArrowUUpLeft size={12} />

--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -1,18 +1,6 @@
-import {
-  ArrowBendDownLeft,
-  DotsThree,
-  Stack,
-  Trash,
-} from "@phosphor-icons/react";
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@posthog/quill";
+import { ArrowBendDownLeft, Stack, Trash } from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
 import { Box, Flex, IconButton, Tooltip } from "@radix-ui/themes";
-import { useState } from "react";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import type { QueuedMessage } from "../../sessionStore";
 import { hasFileMentions, parseFileMentions } from "./parseFileMentions";
@@ -21,7 +9,6 @@ interface QueuedMessageViewProps {
   message: QueuedMessage;
   onSteer?: () => void;
   onRemove?: () => void;
-  onTurnOffQueueing?: () => void;
   supportsNativeSteer?: boolean;
 }
 
@@ -29,11 +16,8 @@ export function QueuedMessageView({
   message,
   onSteer,
   onRemove,
-  onTurnOffQueueing,
   supportsNativeSteer = false,
 }: QueuedMessageViewProps) {
-  const [menuOpen, setMenuOpen] = useState(false);
-
   const steerTooltip = supportsNativeSteer
     ? "Inject this message into the current turn at the next tool boundary."
     : "Interrupt the current turn and resend with this message.";
@@ -76,28 +60,6 @@ export function QueuedMessageView({
                 <Trash size={12} />
               </IconButton>
             </Tooltip>
-          )}
-          {onTurnOffQueueing && (
-            <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    type="button"
-                    variant="default"
-                    size="icon-xs"
-                    aria-label="More options"
-                  >
-                    <DotsThree size={16} weight="bold" />
-                  </Button>
-                }
-              />
-              <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
-                <DropdownMenuItem onClick={onTurnOffQueueing}>
-                  <Stack size={14} />
-                  Turn off queueing
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
           )}
         </Flex>
       </Flex>

--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -33,7 +33,7 @@ export function QueuedMessageView({
     <Box className="rounded-lg border border-gray-5 bg-card px-3 py-2">
       <Flex align="center" gap="2">
         <Stack size={14} className="shrink-0 text-gray-9" />
-        <Box className="min-w-0 flex-1 font-medium text-[13px] text-gray-12 [&>*:last-child]:mb-0 [&>*]:line-clamp-2">
+        <Box className="min-w-0 flex-1 font-medium text-[13px] text-gray-12 [&>*:last-child]:mb-0">
           {hasFileMentions(message.content) ? (
             parseFileMentions(message.content)
           ) : (

--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -1,48 +1,105 @@
-import { Clock, X } from "@phosphor-icons/react";
-import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
+import {
+  ArrowBendDownLeft,
+  DotsThree,
+  Stack,
+  Trash,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@posthog/quill";
+import { Box, Flex, IconButton, Tooltip } from "@radix-ui/themes";
+import { useState } from "react";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import type { QueuedMessage } from "../../sessionStore";
 import { hasFileMentions, parseFileMentions } from "./parseFileMentions";
 
 interface QueuedMessageViewProps {
   message: QueuedMessage;
+  onSteer?: () => void;
   onRemove?: () => void;
+  onTurnOffQueueing?: () => void;
+  supportsNativeSteer?: boolean;
 }
 
 export function QueuedMessageView({
   message,
+  onSteer,
   onRemove,
+  onTurnOffQueueing,
+  supportsNativeSteer = false,
 }: QueuedMessageViewProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const steerTooltip = supportsNativeSteer
+    ? "Inject this message into the current turn at the next tool boundary."
+    : "Interrupt the current turn and resend with this message.";
+
   return (
-    <Box
-      className="group relative border-l-2 border-dashed bg-gray-2 py-2 pr-2 pl-3 opacity-70"
-      style={{ borderColor: "var(--gray-8)" }}
-    >
-      <Flex justify="between" align="start" gap="2">
-        <Box className="min-w-0 flex-1 font-medium text-[13px] [&>*:last-child]:mb-0">
+    <Box className="rounded-lg border border-gray-5 bg-card px-3 py-2">
+      <Flex align="center" gap="2">
+        <Stack size={14} className="shrink-0 text-gray-9" />
+        <Box className="min-w-0 flex-1 font-medium text-[13px] text-gray-12 [&>*:last-child]:mb-0 [&>*]:line-clamp-2">
           {hasFileMentions(message.content) ? (
             parseFileMentions(message.content)
           ) : (
             <MarkdownRenderer content={message.content} />
           )}
         </Box>
-        {onRemove && (
-          <IconButton
-            size="1"
-            variant="ghost"
-            color="gray"
-            className="shrink-0 opacity-0 group-hover:opacity-100"
-            onClick={onRemove}
-          >
-            <X size={12} />
-          </IconButton>
-        )}
-      </Flex>
-      <Flex align="center" gap="1" mt="1">
-        <Clock size={12} className="text-gray-9" />
-        <Text color="gray" className="text-[13px]">
-          Queued
-        </Text>
+        <Flex align="center" gap="1" className="shrink-0">
+          {onSteer && (
+            <Tooltip content={steerTooltip}>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                aria-label="Steer this message"
+                onClick={onSteer}
+              >
+                <ArrowBendDownLeft size={12} />
+                <span>Steer</span>
+              </Button>
+            </Tooltip>
+          )}
+          {onRemove && (
+            <Tooltip content="Discard">
+              <IconButton
+                size="1"
+                variant="ghost"
+                color="gray"
+                aria-label="Discard queued message"
+                onClick={onRemove}
+              >
+                <Trash size={12} />
+              </IconButton>
+            </Tooltip>
+          )}
+          {onTurnOffQueueing && (
+            <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="icon-xs"
+                    aria-label="More options"
+                  >
+                    <DotsThree size={16} weight="bold" />
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
+                <DropdownMenuItem onClick={onTurnOffQueueing}>
+                  <Stack size={14} />
+                  Turn off queueing
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </Flex>
       </Flex>
     </Box>
   );

--- a/packages/ui/src/features/sessions/hooks/useReturnQueuedMessageToEditor.ts
+++ b/packages/ui/src/features/sessions/hooks/useReturnQueuedMessageToEditor.ts
@@ -1,4 +1,7 @@
-import type { EditorContent } from "@posthog/core/message-editor/content";
+import {
+  type EditorContent,
+  xmlToContent,
+} from "@posthog/core/message-editor/content";
 import {
   combineQueuedCloudPrompts,
   promptToQueuedEditorContent,
@@ -34,9 +37,10 @@ export function useReturnQueuedMessageToEditor(
           ? promptToQueuedEditorContent(combined)
           : null;
       } else {
-        pendingContent = {
-          segments: [{ type: "text", text: message.content }],
-        };
+        // Local queued content is the serialized form (text + `<file .../>`
+        // tags); parse it back into chip segments so attachments restore as
+        // chips, not raw XML.
+        pendingContent = xmlToContent(message.content);
       }
       if (!pendingContent) return;
 

--- a/packages/ui/src/features/sessions/hooks/useReturnQueuedMessageToEditor.ts
+++ b/packages/ui/src/features/sessions/hooks/useReturnQueuedMessageToEditor.ts
@@ -1,0 +1,49 @@
+import type { EditorContent } from "@posthog/core/message-editor/content";
+import {
+  combineQueuedCloudPrompts,
+  promptToQueuedEditorContent,
+} from "@posthog/core/sessions/cloudPrompt";
+import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
+import {
+  type QueuedMessage,
+  sessionStoreSetters,
+  useSessionForTask,
+} from "@posthog/ui/features/sessions/sessionStore";
+import { useCallback } from "react";
+
+/**
+ * Pull a queued message out of the queue and back into the composer so it can be
+ * re-read or edited before re-sending. Mirrors the cancel-to-composer restore:
+ * cloud keeps its rich payload (mentions, attachments) via the queued-cloud
+ * conversion; local restores the plain text it was queued with.
+ */
+export function useReturnQueuedMessageToEditor(
+  taskId: string | undefined,
+): (message: QueuedMessage) => void {
+  const { requestFocus, setPendingContent } = useDraftStore((s) => s.actions);
+  const isCloud = useSessionForTask(taskId)?.isCloud ?? false;
+
+  return useCallback(
+    (message: QueuedMessage) => {
+      if (!taskId) return;
+
+      let pendingContent: EditorContent | null;
+      if (isCloud) {
+        const combined = combineQueuedCloudPrompts([message]);
+        pendingContent = combined
+          ? promptToQueuedEditorContent(combined)
+          : null;
+      } else {
+        pendingContent = {
+          segments: [{ type: "text", text: message.content }],
+        };
+      }
+      if (!pendingContent) return;
+
+      sessionStoreSetters.removeQueuedMessage(taskId, message.id);
+      setPendingContent(taskId, pendingContent);
+      requestFocus(taskId);
+    },
+    [taskId, isCloud, requestFocus, setPendingContent],
+  );
+}

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -4302,6 +4302,49 @@ describe("SessionService", () => {
         mockSessionStoreSetters.prependQueuedMessages,
       ).toHaveBeenCalledWith("task-123", [queuedMessage]);
     });
+
+    it("is a no-op while compacting and keeps the queued message intact", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          adapter: "claude",
+          isPromptPending: true,
+          isCompacting: true,
+          messageQueue: [queuedMessage],
+        }),
+      );
+
+      await service.steerQueuedMessage("task-123", "q-1");
+
+      expect(
+        mockSessionStoreSetters.removeQueuedMessage,
+      ).not.toHaveBeenCalled();
+      expect(mockSessionStoreSetters.enqueueMessage).not.toHaveBeenCalled();
+      expect(mockTrpcAgent.prompt.mutate).not.toHaveBeenCalled();
+    });
+
+    it("resends the original rawPrompt blocks, not the plain-text content", async () => {
+      const service = getSessionService();
+      const rawPrompt: ContentBlock[] = [{ type: "text", text: "rich blocks" }];
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          adapter: "claude",
+          isPromptPending: true,
+          messageQueue: [
+            { id: "q-rich", content: "plain text", rawPrompt, queuedAt: 1 },
+          ],
+        }),
+      );
+      mockTrpcAgent.prompt.mutate.mockResolvedValue({ stopReason: "end_turn" });
+
+      await service.steerQueuedMessage("task-123", "q-rich");
+
+      expect(mockTrpcAgent.prompt.mutate).toHaveBeenCalledWith({
+        sessionId: "run-123",
+        prompt: [{ type: "text", text: "rich blocks" }],
+        steer: true,
+      });
+    });
   });
 
   describe("cancelPrompt", () => {

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -4228,6 +4228,82 @@ describe("SessionService", () => {
     });
   });
 
+  describe("steerQueuedMessage", () => {
+    const queuedMessage = {
+      id: "q-1",
+      content: "do the thing",
+      queuedAt: 1700000000,
+    };
+
+    it("removes the message and resends it as a native steer", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          adapter: "claude",
+          isPromptPending: true,
+          messageQueue: [
+            queuedMessage,
+            { id: "q-2", content: "keep me", queuedAt: 1700000001 },
+          ],
+        }),
+      );
+      mockTrpcAgent.prompt.mutate.mockResolvedValue({ stopReason: "end_turn" });
+
+      await service.steerQueuedMessage("task-123", "q-1");
+
+      expect(mockSessionStoreSetters.removeQueuedMessage).toHaveBeenCalledWith(
+        "task-123",
+        "q-1",
+      );
+      expect(mockTrpcAgent.prompt.mutate).toHaveBeenCalledWith({
+        sessionId: "run-123",
+        prompt: [{ type: "text", text: "do the thing" }],
+        steer: true,
+      });
+      expect(
+        mockSessionStoreSetters.prependQueuedMessages,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the message id is not queued", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          adapter: "claude",
+          isPromptPending: true,
+          messageQueue: [queuedMessage],
+        }),
+      );
+
+      await service.steerQueuedMessage("task-123", "missing");
+
+      expect(
+        mockSessionStoreSetters.removeQueuedMessage,
+      ).not.toHaveBeenCalled();
+      expect(mockTrpcAgent.prompt.mutate).not.toHaveBeenCalled();
+    });
+
+    it("rolls the message back onto the queue when the steer fails", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          adapter: "claude",
+          isPromptPending: true,
+          messageQueue: [queuedMessage],
+        }),
+      );
+      mockTrpcAgent.prompt.mutate.mockRejectedValue(new Error("steer failed"));
+
+      await expect(
+        service.steerQueuedMessage("task-123", "q-1"),
+      ).rejects.toThrow("steer failed");
+
+      expect(
+        mockSessionStoreSetters.prependQueuedMessages,
+      ).toHaveBeenCalledWith("task-123", [queuedMessage]);
+    });
+  });
+
   describe("cancelPrompt", () => {
     it("returns false if no session exists", async () => {
       const service = getSessionService();

--- a/packages/ui/src/features/sessions/utils/extractSearchableText.test.ts
+++ b/packages/ui/src/features/sessions/utils/extractSearchableText.test.ts
@@ -205,19 +205,6 @@ describe("extractSearchableText", () => {
     expect(extractSearchableText(item)).toBe("moving_to_worktree");
   });
 
-  it("extracts queued message content", () => {
-    const item: ConversationItem = {
-      type: "queued",
-      id: "14",
-      message: {
-        id: "q1",
-        content: "queued text",
-        queuedAt: 0,
-      },
-    };
-    expect(extractSearchableText(item)).toBe("queued text");
-  });
-
   it.each(["git_action", "skill_button_action", "git_action_result"] as const)(
     "returns empty string for %s items",
     (type) => {

--- a/packages/ui/src/features/sessions/utils/extractSearchableText.ts
+++ b/packages/ui/src/features/sessions/utils/extractSearchableText.ts
@@ -40,8 +40,6 @@ export function extractSearchableText(item: ConversationItem): string {
       ].join(" ");
     case "turn_cancelled":
       return item.interruptReason ?? "Interrupted by user";
-    case "queued":
-      return item.message.content;
     case "git_action":
     case "skill_button_action":
     case "git_action_result":


### PR DESCRIPTION
## Problem

Queued follow-ups were buried at the bottom of the scrolling thread with only a hover-only remove button, so you could not see them or act on them while the agent was working.

## Changes

1. Dock queued messages pinned directly above the composer, out of the scrolling thread
2. Per-message Steer: inject a single queued message into the running turn now (native injection for local Claude, interrupt-and-resend for cloud/Codex)
3. Discard a single queued message, or Turn off queueing from a "..." menu
4. New `SessionService.steerQueuedMessage` (resend as steer, rolls the message back onto the queue on failure)
5. Stop sourcing queued items into the conversation thread (footer "(N queued)" count preserved)

## How did you test this?

Manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?