### PR TITLE
feat(task-input): cache cloud repositories so picker renders instantly

### DIFF
--- a/packages/core/src/integrations/repositories.test.ts
+++ b/packages/core/src/integrations/repositories.test.ts
@@ -4,11 +4,17 @@ import {
   combineRepositoryPicker,
   combineUserGithubRepositories,
   getIntegrationIdForRepo,
+  isEmptyRepositoryMap,
   isRepoInIntegration,
   normalizeRepoKey,
+  type RepositoryCacheAction,
   type RepositoryQueryResult,
+  resolveEffectiveUserRepositoryMap,
+  resolveUserRepositoryCacheAction,
+  sameUserRepositoryMap,
   type TeamRepositoriesResult,
   type UserRepositoriesResult,
+  type UserRepositoryCacheInputs,
   type UserRepositoryIntegrationRef,
 } from "./repositories";
 
@@ -105,5 +111,171 @@ describe("repo key helpers", () => {
     expect(isRepoInIntegration({}, "")).toBe(true);
     expect(isRepoInIntegration({ "a/x": 1 }, "A/X")).toBe(true);
     expect(isRepoInIntegration({}, "a/x")).toBe(false);
+  });
+});
+
+const ref: UserRepositoryIntegrationRef = {
+  userIntegrationId: "u1",
+  installationId: "i1",
+};
+
+describe("isEmptyRepositoryMap", () => {
+  it("detects empty and non-empty maps", () => {
+    expect(isEmptyRepositoryMap({})).toBe(true);
+    expect(isEmptyRepositoryMap({ "a/x": ref })).toBe(false);
+  });
+});
+
+describe("sameUserRepositoryMap", () => {
+  it("compares by content, not reference", () => {
+    expect(
+      sameUserRepositoryMap({ "a/x": { ...ref } }, { "a/x": { ...ref } }),
+    ).toBe(true);
+  });
+
+  it("differs on size, missing keys or changed refs", () => {
+    expect(sameUserRepositoryMap({ "a/x": ref }, {})).toBe(false);
+    expect(sameUserRepositoryMap({ "a/x": ref }, { "a/y": ref })).toBe(false);
+    expect(
+      sameUserRepositoryMap(
+        { "a/x": ref },
+        { "a/x": { userIntegrationId: "u2", installationId: "i1" } },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveUserRepositoryCacheAction", () => {
+  const cases: Array<{
+    name: string;
+    inputs: UserRepositoryCacheInputs;
+    expected: RepositoryCacheAction;
+  }> = [
+    {
+      name: "skips while integrations are pending",
+      inputs: {
+        integrationsPending: true,
+        reposPending: false,
+        hasIntegrations: true,
+        liveRepositoryMap: { "a/x": ref },
+        cachedRepositoryMap: {},
+      },
+      expected: "skip",
+    },
+    {
+      name: "clears when there are no integrations and a cache exists",
+      inputs: {
+        integrationsPending: false,
+        reposPending: false,
+        hasIntegrations: false,
+        liveRepositoryMap: {},
+        cachedRepositoryMap: { "a/x": ref },
+      },
+      expected: "clear",
+    },
+    {
+      name: "skips clearing when there are no integrations and no cache",
+      inputs: {
+        integrationsPending: false,
+        reposPending: false,
+        hasIntegrations: false,
+        liveRepositoryMap: {},
+        cachedRepositoryMap: {},
+      },
+      expected: "skip",
+    },
+    {
+      name: "skips while repos are pending",
+      inputs: {
+        integrationsPending: false,
+        reposPending: true,
+        hasIntegrations: true,
+        liveRepositoryMap: {},
+        cachedRepositoryMap: { "a/x": ref },
+      },
+      expected: "skip",
+    },
+    {
+      name: "skips an empty live map so a failed fetch keeps the cache",
+      inputs: {
+        integrationsPending: false,
+        reposPending: false,
+        hasIntegrations: true,
+        liveRepositoryMap: {},
+        cachedRepositoryMap: { "a/x": ref },
+      },
+      expected: "skip",
+    },
+    {
+      name: "skips when live data equals the cache by content",
+      inputs: {
+        integrationsPending: false,
+        reposPending: false,
+        hasIntegrations: true,
+        liveRepositoryMap: { "a/x": { ...ref } },
+        cachedRepositoryMap: { "a/x": { ...ref } },
+      },
+      expected: "skip",
+    },
+    {
+      name: "writes when live data differs from the cache",
+      inputs: {
+        integrationsPending: false,
+        reposPending: false,
+        hasIntegrations: true,
+        liveRepositoryMap: { "a/y": ref },
+        cachedRepositoryMap: { "a/x": ref },
+      },
+      expected: "write",
+    },
+  ];
+
+  it.each(cases)("$name", ({ inputs, expected }) => {
+    expect(resolveUserRepositoryCacheAction(inputs)).toBe(expected);
+  });
+});
+
+describe("resolveEffectiveUserRepositoryMap", () => {
+  const cached = { "a/y": ref };
+  const live = { "a/x": ref };
+
+  it("uses live data when not loading even if a cache exists", () => {
+    const result = resolveEffectiveUserRepositoryMap({
+      liveLoading: false,
+      liveRepositoryMap: {},
+      cachedRepositoryMap: cached,
+    });
+    expect(result.servingFromCache).toBe(false);
+    expect(result.effectiveRepositoryMap).toEqual({});
+  });
+
+  it("serves the cache while loading with an empty live map", () => {
+    const result = resolveEffectiveUserRepositoryMap({
+      liveLoading: true,
+      liveRepositoryMap: {},
+      cachedRepositoryMap: cached,
+    });
+    expect(result.servingFromCache).toBe(true);
+    expect(result.effectiveRepositoryMap).toBe(cached);
+  });
+
+  it("prefers live data once it arrives mid-load", () => {
+    const result = resolveEffectiveUserRepositoryMap({
+      liveLoading: true,
+      liveRepositoryMap: live,
+      cachedRepositoryMap: cached,
+    });
+    expect(result.servingFromCache).toBe(false);
+    expect(result.effectiveRepositoryMap).toBe(live);
+  });
+
+  it("does not serve from cache when both maps are empty", () => {
+    const result = resolveEffectiveUserRepositoryMap({
+      liveLoading: true,
+      liveRepositoryMap: {},
+      cachedRepositoryMap: {},
+    });
+    expect(result.servingFromCache).toBe(false);
+    expect(result.effectiveRepositoryMap).toEqual({});
   });
 });

--- a/packages/core/src/integrations/repositories.test.ts
+++ b/packages/core/src/integrations/repositories.test.ts
@@ -156,6 +156,7 @@ describe("resolveUserRepositoryCacheAction", () => {
       inputs: {
         integrationsPending: true,
         reposPending: false,
+        reposErrored: false,
         hasIntegrations: true,
         liveRepositoryMap: { "a/x": ref },
         cachedRepositoryMap: {},
@@ -167,6 +168,7 @@ describe("resolveUserRepositoryCacheAction", () => {
       inputs: {
         integrationsPending: false,
         reposPending: false,
+        reposErrored: false,
         hasIntegrations: false,
         liveRepositoryMap: {},
         cachedRepositoryMap: { "a/x": ref },
@@ -178,6 +180,7 @@ describe("resolveUserRepositoryCacheAction", () => {
       inputs: {
         integrationsPending: false,
         reposPending: false,
+        reposErrored: false,
         hasIntegrations: false,
         liveRepositoryMap: {},
         cachedRepositoryMap: {},
@@ -189,6 +192,7 @@ describe("resolveUserRepositoryCacheAction", () => {
       inputs: {
         integrationsPending: false,
         reposPending: true,
+        reposErrored: false,
         hasIntegrations: true,
         liveRepositoryMap: {},
         cachedRepositoryMap: { "a/x": ref },
@@ -196,13 +200,38 @@ describe("resolveUserRepositoryCacheAction", () => {
       expected: "skip",
     },
     {
-      name: "skips an empty live map so a failed fetch keeps the cache",
+      name: "keeps the cache when an errored fetch returns empty",
       inputs: {
         integrationsPending: false,
         reposPending: false,
+        reposErrored: true,
         hasIntegrations: true,
         liveRepositoryMap: {},
         cachedRepositoryMap: { "a/x": ref },
+      },
+      expected: "skip",
+    },
+    {
+      name: "clears a stale cache when a clean fetch returns empty",
+      inputs: {
+        integrationsPending: false,
+        reposPending: false,
+        reposErrored: false,
+        hasIntegrations: true,
+        liveRepositoryMap: {},
+        cachedRepositoryMap: { "a/x": ref },
+      },
+      expected: "clear",
+    },
+    {
+      name: "skips when a clean empty fetch matches an empty cache",
+      inputs: {
+        integrationsPending: false,
+        reposPending: false,
+        reposErrored: false,
+        hasIntegrations: true,
+        liveRepositoryMap: {},
+        cachedRepositoryMap: {},
       },
       expected: "skip",
     },
@@ -211,6 +240,7 @@ describe("resolveUserRepositoryCacheAction", () => {
       inputs: {
         integrationsPending: false,
         reposPending: false,
+        reposErrored: false,
         hasIntegrations: true,
         liveRepositoryMap: { "a/x": { ...ref } },
         cachedRepositoryMap: { "a/x": { ...ref } },
@@ -222,6 +252,7 @@ describe("resolveUserRepositoryCacheAction", () => {
       inputs: {
         integrationsPending: false,
         reposPending: false,
+        reposErrored: false,
         hasIntegrations: true,
         liveRepositoryMap: { "a/y": ref },
         cachedRepositoryMap: { "a/x": ref },

--- a/packages/core/src/integrations/repositories.ts
+++ b/packages/core/src/integrations/repositories.ts
@@ -155,3 +155,89 @@ export function isRepoInIntegration(
 ): boolean {
   return !repoKey || normalizeRepoKey(repoKey) in repositoryMap;
 }
+
+export function isEmptyRepositoryMap(map: Record<string, unknown>): boolean {
+  return Object.keys(map).length === 0;
+}
+
+export function sameUserRepositoryMap(
+  a: Record<string, UserRepositoryIntegrationRef>,
+  b: Record<string, UserRepositoryIntegrationRef>,
+): boolean {
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every((key) => {
+    const left = a[key];
+    const right = b[key];
+    return (
+      !!right &&
+      left.userIntegrationId === right.userIntegrationId &&
+      left.installationId === right.installationId
+    );
+  });
+}
+
+export type RepositoryCacheAction = "write" | "clear" | "skip";
+
+export interface UserRepositoryCacheInputs {
+  integrationsPending: boolean;
+  reposPending: boolean;
+  hasIntegrations: boolean;
+  liveRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
+  cachedRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
+}
+
+/**
+ * Decides how the persisted cold-start cache should track the live repository
+ * map: write fresh data, clear stale data, or leave the cache untouched.
+ */
+export function resolveUserRepositoryCacheAction({
+  integrationsPending,
+  reposPending,
+  hasIntegrations,
+  liveRepositoryMap,
+  cachedRepositoryMap,
+}: UserRepositoryCacheInputs): RepositoryCacheAction {
+  if (integrationsPending) return "skip";
+  if (!hasIntegrations) {
+    return isEmptyRepositoryMap(cachedRepositoryMap) ? "skip" : "clear";
+  }
+  if (reposPending) return "skip";
+  // A transient empty or failed fetch must not clobber the last-known-good
+  // cache, so only overwrite when fresh data exists and actually differs.
+  if (isEmptyRepositoryMap(liveRepositoryMap)) return "skip";
+  if (sameUserRepositoryMap(liveRepositoryMap, cachedRepositoryMap)) {
+    return "skip";
+  }
+  return "write";
+}
+
+export interface EffectiveUserRepositoryMap {
+  effectiveRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
+  servingFromCache: boolean;
+}
+
+/**
+ * Picks the map the picker should render: the cached map stands in only while
+ * the live queries are loading and have produced nothing yet.
+ */
+export function resolveEffectiveUserRepositoryMap({
+  liveLoading,
+  liveRepositoryMap,
+  cachedRepositoryMap,
+}: {
+  liveLoading: boolean;
+  liveRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
+  cachedRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
+}): EffectiveUserRepositoryMap {
+  const servingFromCache =
+    liveLoading &&
+    isEmptyRepositoryMap(liveRepositoryMap) &&
+    !isEmptyRepositoryMap(cachedRepositoryMap);
+  return {
+    effectiveRepositoryMap: servingFromCache
+      ? cachedRepositoryMap
+      : liveRepositoryMap,
+    servingFromCache,
+  };
+}

--- a/packages/core/src/integrations/repositories.ts
+++ b/packages/core/src/integrations/repositories.ts
@@ -182,6 +182,7 @@ export type RepositoryCacheAction = "write" | "clear" | "skip";
 export interface UserRepositoryCacheInputs {
   integrationsPending: boolean;
   reposPending: boolean;
+  reposErrored: boolean;
   hasIntegrations: boolean;
   liveRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
   cachedRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
@@ -194,6 +195,7 @@ export interface UserRepositoryCacheInputs {
 export function resolveUserRepositoryCacheAction({
   integrationsPending,
   reposPending,
+  reposErrored,
   hasIntegrations,
   liveRepositoryMap,
   cachedRepositoryMap,
@@ -203,9 +205,13 @@ export function resolveUserRepositoryCacheAction({
     return isEmptyRepositoryMap(cachedRepositoryMap) ? "skip" : "clear";
   }
   if (reposPending) return "skip";
-  // A transient empty or failed fetch must not clobber the last-known-good
-  // cache, so only overwrite when fresh data exists and actually differs.
-  if (isEmptyRepositoryMap(liveRepositoryMap)) return "skip";
+  if (isEmptyRepositoryMap(liveRepositoryMap)) {
+    // A failed fetch can return an empty map, so keep the last-known-good
+    // cache instead of clobbering it. A genuinely empty result clears the
+    // stale cache so a removed repo does not flash on the next cold start.
+    if (reposErrored) return "skip";
+    return isEmptyRepositoryMap(cachedRepositoryMap) ? "skip" : "clear";
+  }
   if (sameUserRepositoryMap(liveRepositoryMap, cachedRepositoryMap)) {
     return "skip";
   }

--- a/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/packages/ui/src/features/integrations/useIntegrations.ts
@@ -407,10 +407,12 @@ export function useUserRepositoryIntegration() {
 
   // Persist the freshly loaded map so the picker has data on the next cold
   // start, and clear it once the user has no integrations.
+  const reposErrored = failedInstallationIds.length > 0;
   useEffect(() => {
     const action = resolveUserRepositoryCacheAction({
       integrationsPending,
       reposPending,
+      reposErrored,
       hasIntegrations: githubIntegrations.length > 0,
       liveRepositoryMap: repositoryMap,
       cachedRepositoryMap,
@@ -423,6 +425,7 @@ export function useUserRepositoryIntegration() {
   }, [
     integrationsPending,
     reposPending,
+    reposErrored,
     githubIntegrations.length,
     repositoryMap,
     cachedRepositoryMap,

--- a/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/packages/ui/src/features/integrations/useIntegrations.ts
@@ -12,7 +12,10 @@ import {
   combineUserGithubRepositories,
   getIntegrationIdForRepo,
   getRepoEntry,
+  isEmptyRepositoryMap,
   isRepoInIntegration,
+  resolveEffectiveUserRepositoryMap,
+  resolveUserRepositoryCacheAction,
   type UserRepositoryIntegrationRef,
 } from "@posthog/core/integrations/repositories";
 import type { RepositoriesService } from "@posthog/core/integrations/repositoriesService";
@@ -402,22 +405,21 @@ export function useUserRepositoryIntegration() {
     failedInstallationIds,
   } = useAllUserGithubRepositories(githubIntegrations);
 
-  // Keep the persisted cache in sync with the freshly fetched map so the next
-  // cold start can render the picker without waiting on the network. Clear the
-  // cache when the user has no integrations; otherwise only write once
-  // everything has loaded so partial data never overwrites a good cache.
+  // Persist the freshly loaded map so the picker has data on the next cold
+  // start, and clear it once the user has no integrations.
   useEffect(() => {
-    if (integrationsPending) return;
-    if (githubIntegrations.length === 0) {
-      if (Object.keys(cachedRepositoryMap).length > 0) {
-        setCachedRepositoryMap({});
-      }
-      return;
+    const action = resolveUserRepositoryCacheAction({
+      integrationsPending,
+      reposPending,
+      hasIntegrations: githubIntegrations.length > 0,
+      liveRepositoryMap: repositoryMap,
+      cachedRepositoryMap,
+    });
+    if (action === "write") {
+      setCachedRepositoryMap(repositoryMap);
+    } else if (action === "clear") {
+      setCachedRepositoryMap({});
     }
-    if (reposPending) return;
-    if (Object.keys(repositoryMap).length === 0) return;
-    if (repositoryMap === cachedRepositoryMap) return;
-    setCachedRepositoryMap(repositoryMap);
   }, [
     integrationsPending,
     reposPending,
@@ -428,16 +430,12 @@ export function useUserRepositoryIntegration() {
   ]);
 
   const liveLoading = integrationsPending || reposPending;
-  const servingFromCache =
-    liveLoading &&
-    Object.keys(repositoryMap).length === 0 &&
-    Object.keys(cachedRepositoryMap).length > 0;
-
-  // Serve the cached map while the live queries load so the picker renders the
-  // last-used repo immediately on a cold start instead of a spinner.
-  const effectiveRepositoryMap = servingFromCache
-    ? cachedRepositoryMap
-    : repositoryMap;
+  const { effectiveRepositoryMap, servingFromCache } =
+    resolveEffectiveUserRepositoryMap({
+      liveLoading,
+      liveRepositoryMap: repositoryMap,
+      cachedRepositoryMap,
+    });
 
   const repositories = useMemo(
     () => Object.keys(effectiveRepositoryMap),
@@ -489,7 +487,7 @@ export function useUserRepositoryIntegration() {
     refreshRepositories,
     hasGithubIntegration:
       githubIntegrations.length > 0 ||
-      (integrationsPending && Object.keys(cachedRepositoryMap).length > 0),
+      (integrationsPending && !isEmptyRepositoryMap(cachedRepositoryMap)),
     failedInstallationIds,
     reposByInstallationId,
   };

--- a/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/packages/ui/src/features/integrations/useIntegrations.ts
@@ -29,6 +29,7 @@ import {
   useIntegrationSelectors,
   useIntegrationStore,
 } from "@posthog/ui/features/integrations/store";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useAuthenticatedInfiniteQuery } from "@posthog/ui/hooks/useAuthenticatedInfiniteQuery";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useDebounce } from "@posthog/ui/primitives/hooks/useDebounce";
@@ -387,6 +388,13 @@ export function useUserRepositoryIntegration() {
     useUserGithubIntegrations();
   const [isRefreshingRepos, setIsRefreshingRepos] = useState(false);
 
+  const cachedRepositoryMap = useSettingsStore(
+    (state) => state.cachedCloudRepositoryMap,
+  );
+  const setCachedRepositoryMap = useSettingsStore(
+    (state) => state.setCachedCloudRepositoryMap,
+  );
+
   const {
     repositoryMap,
     reposByInstallationId,
@@ -394,25 +402,63 @@ export function useUserRepositoryIntegration() {
     failedInstallationIds,
   } = useAllUserGithubRepositories(githubIntegrations);
 
+  // Keep the persisted cache in sync with the freshly fetched map so the next
+  // cold start can render the picker without waiting on the network. Clear the
+  // cache when the user has no integrations; otherwise only write once
+  // everything has loaded so partial data never overwrites a good cache.
+  useEffect(() => {
+    if (integrationsPending) return;
+    if (githubIntegrations.length === 0) {
+      if (Object.keys(cachedRepositoryMap).length > 0) {
+        setCachedRepositoryMap({});
+      }
+      return;
+    }
+    if (reposPending) return;
+    if (Object.keys(repositoryMap).length === 0) return;
+    if (repositoryMap === cachedRepositoryMap) return;
+    setCachedRepositoryMap(repositoryMap);
+  }, [
+    integrationsPending,
+    reposPending,
+    githubIntegrations.length,
+    repositoryMap,
+    cachedRepositoryMap,
+    setCachedRepositoryMap,
+  ]);
+
+  const liveLoading = integrationsPending || reposPending;
+  const servingFromCache =
+    liveLoading &&
+    Object.keys(repositoryMap).length === 0 &&
+    Object.keys(cachedRepositoryMap).length > 0;
+
+  // Serve the cached map while the live queries load so the picker renders the
+  // last-used repo immediately on a cold start instead of a spinner.
+  const effectiveRepositoryMap = servingFromCache
+    ? cachedRepositoryMap
+    : repositoryMap;
+
   const repositories = useMemo(
-    () => Object.keys(repositoryMap),
-    [repositoryMap],
+    () => Object.keys(effectiveRepositoryMap),
+    [effectiveRepositoryMap],
   );
 
   const getUserIntegrationIdForRepo = useCallback(
     (repoKey: string) =>
-      getRepoEntry(repositoryMap, repoKey)?.userIntegrationId,
-    [repositoryMap],
+      getRepoEntry(effectiveRepositoryMap, repoKey)?.userIntegrationId,
+    [effectiveRepositoryMap],
   );
 
   const getInstallationIdForRepo = useCallback(
-    (repoKey: string) => getRepoEntry(repositoryMap, repoKey)?.installationId,
-    [repositoryMap],
+    (repoKey: string) =>
+      getRepoEntry(effectiveRepositoryMap, repoKey)?.installationId,
+    [effectiveRepositoryMap],
   );
 
   const repoInIntegration = useCallback(
-    (repoKey: string) => isRepoInIntegration(repositoryMap, repoKey),
-    [repositoryMap],
+    (repoKey: string) => isRepoInIntegration(effectiveRepositoryMap, repoKey),
+    [effectiveRepositoryMap],
   );
 
   const refreshRepositories = useCallback(async () => {
@@ -438,10 +484,12 @@ export function useUserRepositoryIntegration() {
     getUserIntegrationIdForRepo,
     getInstallationIdForRepo,
     isRepoInIntegration: repoInIntegration,
-    isLoadingRepos: integrationsPending || reposPending,
-    isRefreshingRepos,
+    isLoadingRepos: liveLoading && !servingFromCache,
+    isRefreshingRepos: isRefreshingRepos || servingFromCache,
     refreshRepositories,
-    hasGithubIntegration: githubIntegrations.length > 0,
+    hasGithubIntegration:
+      githubIntegrations.length > 0 ||
+      (integrationsPending && Object.keys(cachedRepositoryMap).length > 0),
     failedInstallationIds,
     reposByInstallationId,
   };

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -20,6 +20,7 @@ describe("feature settingsStore cloud selections", () => {
     useSettingsStore.setState({
       allowBypassPermissions: false,
       lastUsedCloudRepository: null,
+      cachedCloudRepositoryMap: {},
     });
   });
 
@@ -55,6 +56,56 @@ describe("feature settingsStore cloud selections", () => {
     expect(useSettingsStore.getState().lastUsedCloudRepository).toBe(
       "posthog/posthog",
     );
+  });
+
+  it("persists the cached cloud repository map", async () => {
+    useSettingsStore.getState().setCachedCloudRepositoryMap({
+      "posthog/posthog": {
+        userIntegrationId: "user-1",
+        installationId: "install-1",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(setItem).toHaveBeenCalled();
+    });
+
+    const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
+    const persisted = JSON.parse(lastCall[1]);
+
+    expect(persisted.state.cachedCloudRepositoryMap).toEqual({
+      "posthog/posthog": {
+        userIntegrationId: "user-1",
+        installationId: "install-1",
+      },
+    });
+  });
+
+  it("rehydrates the cached cloud repository map", async () => {
+    getItem.mockResolvedValue(
+      JSON.stringify({
+        state: {
+          cachedCloudRepositoryMap: {
+            "posthog/code": {
+              userIntegrationId: "user-2",
+              installationId: "install-2",
+            },
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    useSettingsStore.setState({ cachedCloudRepositoryMap: {} });
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().cachedCloudRepositoryMap).toEqual({
+      "posthog/code": {
+        userIntegrationId: "user-2",
+        installationId: "install-2",
+      },
+    });
   });
 
   it("rehydrates the unsafe mode toggle", async () => {

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -1,3 +1,4 @@
+import type { UserRepositoryIntegrationRef } from "@posthog/core/integrations/repositories";
 import type { ExecutionMode, WorkspaceMode } from "@posthog/shared";
 import {
   COLLAPSE_MODE_DEFAULT,
@@ -66,6 +67,7 @@ interface SettingsStore {
   lastUsedModel: string | null;
   lastUsedReasoningEffort: string | null;
   lastUsedCloudRepository: string | null;
+  cachedCloudRepositoryMap: Record<string, UserRepositoryIntegrationRef>;
   lastUsedEnvironments: Record<string, string>;
   defaultInitialTaskMode: DefaultInitialTaskMode;
   lastUsedInitialTaskMode: ExecutionMode;
@@ -80,6 +82,9 @@ interface SettingsStore {
   setLastUsedModel: (model: string) => void;
   setLastUsedReasoningEffort: (effort: string) => void;
   setLastUsedCloudRepository: (repo: string | null) => void;
+  setCachedCloudRepositoryMap: (
+    map: Record<string, UserRepositoryIntegrationRef>,
+  ) => void;
   setLastUsedEnvironment: (
     repoPath: string,
     environmentId: string | null,
@@ -163,6 +168,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedModel: null,
       lastUsedReasoningEffort: null,
       lastUsedCloudRepository: null,
+      cachedCloudRepositoryMap: {},
       lastUsedEnvironments: {},
       defaultInitialTaskMode: "plan",
       lastUsedInitialTaskMode: "plan",
@@ -179,6 +185,8 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ lastUsedReasoningEffort: effort }),
       setLastUsedCloudRepository: (repo) =>
         set({ lastUsedCloudRepository: repo }),
+      setCachedCloudRepositoryMap: (map) =>
+        set({ cachedCloudRepositoryMap: map }),
       setLastUsedEnvironment: (repoPath, environmentId) =>
         set((state) => {
           const next = { ...state.lastUsedEnvironments };
@@ -303,6 +311,7 @@ export const useSettingsStore = create<SettingsStore>()(
         lastUsedModel: state.lastUsedModel,
         lastUsedReasoningEffort: state.lastUsedReasoningEffort,
         lastUsedCloudRepository: state.lastUsedCloudRepository,
+        cachedCloudRepositoryMap: state.cachedCloudRepositoryMap,
         lastUsedEnvironments: state.lastUsedEnvironments,
         defaultInitialTaskMode: state.defaultInitialTaskMode,
         lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,


### PR DESCRIPTION
## Problem

Clicking **New task** in the sidebar shows a "Loading repos..." spinner in the GitHub repo picker on a cold start, even though the answer is almost always the last repo you picked. The picker waits on a full integrations and per-installation repo fetch from PostHog before it can render or validate the selection. React Query keeps the list warm within a session, but nothing survives an app restart, so every cold start pays for that round trip.

This re-implements the approach from #2206 (closed during the package-split refactor in #2442) on the current `packages/core` + `packages/ui` architecture. The mobile app already does this via its own `repositoryCacheStore`; desktop and web did not.

## Changes

- `settingsStore`: new persisted field `cachedCloudRepositoryMap` (repo name to `{ userIntegrationId, installationId }`) plus a setter, added to `partialize` so it survives restarts. The value type reuses `UserRepositoryIntegrationRef` from `@posthog/core`.
- `useUserRepositoryIntegration`:
  - Writes the freshly loaded map to the cache once integrations and repos have settled, and skips the write when the content reference is unchanged.
  - Clears the cache when the user has no GitHub integrations.
  - Serves the cached map as a stand-in while the live queries load and the live map is still empty, so the picker renders the last-used repo immediately.
  - Reports the cold-start window as a background refresh (`isRefreshingRepos`) instead of a blocking load (`isLoadingRepos`), and keeps `hasGithubIntegration` true while integrations load on a warm cache so the picker does not flip to local mode.

No picker component changes are needed: the existing selection validation and cleanup effect already run against whatever the hook returns, so a cached repo that turns out to be gone still clears once live data lands.

## How did you test this?

Automated, run in this worktree:

- `turbo typecheck --filter=@posthog/ui`: passes (the pre-commit hook also ran `pnpm typecheck` clean).
- `@posthog/ui` unit tests: 769 passed, including 2 new `settingsStore` tests covering persist and rehydrate of `cachedCloudRepositoryMap`.
- `biome check` on the 3 changed files: clean.

I did not manually drive the running Electron app for this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
