### PR TITLE
feat(mobile): steer and discard queued messages (port #2768)

### DIFF
--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -30,6 +30,7 @@ import {
   modelSupportsReasoning,
   type ReasoningEffort,
 } from "@/features/tasks/composer/options";
+import { QueuedMessagesDock } from "@/features/tasks/composer/QueuedMessagesDock";
 import { TaskChatComposer } from "@/features/tasks/composer/TaskChatComposer";
 import {
   useMessagingMode,
@@ -37,7 +38,10 @@ import {
   useToggleMessagingMode,
 } from "@/features/tasks/hooks/useMessagingMode";
 import { taskKeys } from "@/features/tasks/hooks/useTasks";
-import { useMessageQueueStore } from "@/features/tasks/stores/messageQueueStore";
+import {
+  type QueuedMessage,
+  useMessageQueueStore,
+} from "@/features/tasks/stores/messageQueueStore";
 import {
   pendingTaskPromptStoreApi,
   usePendingTaskPrompt,
@@ -96,6 +100,7 @@ export default function TaskDetailScreen() {
     setConfigOption,
     getSessionForTask,
     setFocusedTaskId,
+    steerQueuedMessage,
   } = useTaskSessionStore();
 
   useEffect(() => {
@@ -386,6 +391,47 @@ export default function TaskDetailScreen() {
     ],
   );
 
+  const [restoredDraft, setRestoredDraft] = useState<{
+    text: string;
+    attachments: PendingAttachment[];
+  }>();
+
+  const handleSteerQueued = useCallback(
+    (message: QueuedMessage) => {
+      if (!taskId) return;
+      steerQueuedMessage(taskId, message.id)
+        .then(() => trackPromptSent(message.content, true))
+        .catch((err) => {
+          log.error("Failed to steer queued message", err);
+          Alert.alert(
+            "Couldn't steer",
+            "This message is still queued. Please try again.",
+          );
+        });
+    },
+    [taskId, steerQueuedMessage, trackPromptSent],
+  );
+
+  const handleReturnQueuedToComposer = useCallback(
+    (message: QueuedMessage) => {
+      if (!taskId) return;
+      useMessageQueueStore.getState().remove(taskId, message.id);
+      setRestoredDraft({
+        text: message.content,
+        attachments: message.attachments,
+      });
+    },
+    [taskId],
+  );
+
+  const handleDiscardQueued = useCallback(
+    (message: QueuedMessage) => {
+      if (!taskId) return;
+      useMessageQueueStore.getState().remove(taskId, message.id);
+    },
+    [taskId],
+  );
+
   const handleModeChange = useCallback(
     (value: ExecutionMode) => {
       if (!taskId) return;
@@ -619,8 +665,22 @@ export default function TaskDetailScreen() {
             last message can never sit behind the input. Stays visible on
             terminal runs so the user can send a follow-up that resumes. */}
         <Animated.View style={inputContainerStyle}>
+          {taskId ? (
+            <QueuedMessagesDock
+              taskId={taskId}
+              canSteer={
+                !!session?.isPromptPending &&
+                !session?.isCompacting &&
+                !session?.terminalStatus
+              }
+              onSteer={handleSteerQueued}
+              onReturnToComposer={handleReturnQueuedToComposer}
+              onDiscard={handleDiscardQueued}
+            />
+          ) : null}
           <TaskChatComposer
             onSend={handleSendPrompt}
+            restoredDraft={restoredDraft}
             onStop={handleStop}
             isUserTurn={!(session?.isPromptPending ?? true)}
             placeholder={

--- a/apps/mobile/src/features/tasks/composer/QueuedMessagesDock.tsx
+++ b/apps/mobile/src/features/tasks/composer/QueuedMessagesDock.tsx
@@ -1,0 +1,156 @@
+import { Text } from "@components/text";
+import {
+  Lightning,
+  PaperclipIcon,
+  PencilSimple,
+  Stack,
+  Trash,
+} from "phosphor-react-native";
+import { type ReactNode, useState } from "react";
+import { Pressable, View } from "react-native";
+import { SheetContainer } from "@/components/SheetContainer";
+import { useThemeColors } from "@/lib/theme";
+import {
+  type QueuedMessage,
+  useMessageQueueStore,
+} from "../stores/messageQueueStore";
+
+interface QueuedMessagesDockProps {
+  taskId: string;
+  canSteer: boolean;
+  onSteer: (message: QueuedMessage) => void;
+  onReturnToComposer: (message: QueuedMessage) => void;
+  onDiscard: (message: QueuedMessage) => void;
+}
+
+function previewText(message: QueuedMessage): string {
+  if (message.content.trim().length > 0) return message.content;
+  const count = message.attachments.length;
+  return count === 1 ? "1 attachment" : `${count} attachments`;
+}
+
+export function QueuedMessagesDock({
+  taskId,
+  canSteer,
+  onSteer,
+  onReturnToComposer,
+  onDiscard,
+}: QueuedMessagesDockProps) {
+  const themeColors = useThemeColors();
+  const queued = useMessageQueueStore((s) => s.queuesByTaskId[taskId]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  if (!queued || queued.length === 0) return null;
+  const active = queued.find((m) => m.id === activeId) ?? null;
+
+  return (
+    <>
+      <View className="gap-1 px-3 pb-2">
+        {queued.map((message) => (
+          <Pressable
+            key={message.id}
+            onPress={() => setActiveId(message.id)}
+            accessibilityRole="button"
+            accessibilityLabel="Queued message actions"
+            className="flex-row items-center gap-2 rounded-xl border border-gray-6 bg-card px-3 py-2 active:opacity-70"
+          >
+            <Stack size={14} color={themeColors.gray[10]} />
+            <Text numberOfLines={1} className="flex-1 text-[13px] text-gray-11">
+              {previewText(message)}
+            </Text>
+            {message.attachments.length > 0 ? (
+              <PaperclipIcon size={13} color={themeColors.gray[9]} />
+            ) : null}
+            <Text className="text-[11px] text-gray-9">Queued</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <SheetContainer open={active !== null} onClose={() => setActiveId(null)}>
+        {active ? (
+          <>
+            <View className="px-4 pt-2 pb-3">
+              <Text numberOfLines={3} className="text-[14px] text-gray-12">
+                {previewText(active)}
+              </Text>
+            </View>
+            {canSteer ? (
+              <ActionRow
+                icon={
+                  <Lightning
+                    size={18}
+                    color={themeColors.accent[11]}
+                    weight="fill"
+                  />
+                }
+                label="Steer now"
+                description="Interrupt the current turn and send this now"
+                onPress={() => {
+                  onSteer(active);
+                  setActiveId(null);
+                }}
+              />
+            ) : null}
+            <ActionRow
+              icon={<PencilSimple size={18} color={themeColors.gray[11]} />}
+              label="Edit in composer"
+              description="Pull it back into the composer to revise"
+              onPress={() => {
+                onReturnToComposer(active);
+                setActiveId(null);
+              }}
+            />
+            <ActionRow
+              icon={<Trash size={18} color={themeColors.status.error} />}
+              label="Discard"
+              destructive
+              onPress={() => {
+                onDiscard(active);
+                setActiveId(null);
+              }}
+            />
+          </>
+        ) : null}
+      </SheetContainer>
+    </>
+  );
+}
+
+function ActionRow({
+  icon,
+  label,
+  description,
+  destructive = false,
+  onPress,
+}: {
+  icon: ReactNode;
+  label: string;
+  description?: string;
+  destructive?: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      className="flex-row items-center gap-3 px-4 py-3 active:bg-gray-2"
+    >
+      <View className="h-5 w-5 shrink-0 items-center justify-center">
+        {icon}
+      </View>
+      <View className="min-w-0 flex-1">
+        <Text
+          className={`font-medium text-[15px] ${
+            destructive ? "text-status-error" : "text-gray-12"
+          }`}
+        >
+          {label}
+        </Text>
+        {description ? (
+          <Text className="mt-0.5 text-[12px] text-gray-10">{description}</Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
+++ b/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
@@ -79,6 +79,8 @@ interface TaskChatComposerProps {
   messagingMode: MessagingMode;
   queuedCount: number;
   onToggleMessagingMode: () => void;
+  /** A queued message pulled back for editing; pass a fresh object to restore. */
+  restoredDraft?: { text: string; attachments: PendingAttachment[] };
 }
 
 function modeIcon(mode: ExecutionMode, color: string, size = 14): ReactNode {
@@ -164,6 +166,7 @@ export function TaskChatComposer({
   messagingMode,
   queuedCount,
   onToggleMessagingMode,
+  restoredDraft,
 }: TaskChatComposerProps) {
   const themeColors = useThemeColors();
   const [message, setMessage] = useState(() => initialMessage ?? "");
@@ -174,6 +177,12 @@ export function TaskChatComposer({
     if (!initialMessage) return;
     setMessage(initialMessage);
   }, [initialMessage]);
+
+  useEffect(() => {
+    if (!restoredDraft) return;
+    setMessage(restoredDraft.text);
+    setAttachments(restoredDraft.attachments);
+  }, [restoredDraft]);
 
   const appendTranscript = useCallback((transcript: string) => {
     setMessage((prev) => (prev ? `${prev} ${transcript}` : transcript));

--- a/apps/mobile/src/features/tasks/stores/messageQueueStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/messageQueueStore.test.ts
@@ -65,6 +65,32 @@ describe("messageQueueStore", () => {
 
     expect(getQueue("t1").map((m) => m.content)).toEqual(["a", "b", "c"]);
   });
+
+  it("removes exactly the targeted message and leaves the rest", () => {
+    const { enqueue, remove, getQueue } = useMessageQueueStore.getState();
+    enqueue("t1", "a", []);
+    enqueue("t1", "b", []);
+    enqueue("t1", "c", []);
+    const target = getQueue("t1")[1];
+
+    remove("t1", target.id);
+
+    expect(getQueue("t1").map((m) => m.content)).toEqual(["a", "c"]);
+  });
+
+  it("clears the queue entry once the last message is removed", () => {
+    const { enqueue, remove, getQueue } = useMessageQueueStore.getState();
+    enqueue("t1", "only", []);
+    remove("t1", getQueue("t1")[0].id);
+    expect(getQueue("t1")).toEqual([]);
+  });
+
+  it("ignores removal of an unknown id", () => {
+    const { enqueue, remove, getQueue } = useMessageQueueStore.getState();
+    enqueue("t1", "a", []);
+    remove("t1", "nope");
+    expect(getQueue("t1").map((m) => m.content)).toEqual(["a"]);
+  });
 });
 
 describe("combineQueuedMessages", () => {
@@ -72,7 +98,7 @@ describe("combineQueuedMessages", () => {
     content: string,
     attachments: PendingAttachment[],
   ): QueuedMessage {
-    return { content, attachments };
+    return { id: content, content, attachments };
   }
 
   it("joins text in order with a blank line and concatenates attachments", () => {

--- a/apps/mobile/src/features/tasks/stores/messageQueueStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/messageQueueStore.test.ts
@@ -66,23 +66,24 @@ describe("messageQueueStore", () => {
     expect(getQueue("t1").map((m) => m.content)).toEqual(["a", "b", "c"]);
   });
 
-  it("removes exactly the targeted message and leaves the rest", () => {
+  it.each([
+    {
+      name: "removes exactly the targeted message",
+      contents: ["a", "b", "c"],
+      removeIndex: 1,
+      expected: ["a", "c"],
+    },
+    {
+      name: "clears the entry once the last message is removed",
+      contents: ["only"],
+      removeIndex: 0,
+      expected: [],
+    },
+  ])("$name", ({ contents, removeIndex, expected }) => {
     const { enqueue, remove, getQueue } = useMessageQueueStore.getState();
-    enqueue("t1", "a", []);
-    enqueue("t1", "b", []);
-    enqueue("t1", "c", []);
-    const target = getQueue("t1")[1];
-
-    remove("t1", target.id);
-
-    expect(getQueue("t1").map((m) => m.content)).toEqual(["a", "c"]);
-  });
-
-  it("clears the queue entry once the last message is removed", () => {
-    const { enqueue, remove, getQueue } = useMessageQueueStore.getState();
-    enqueue("t1", "only", []);
-    remove("t1", getQueue("t1")[0].id);
-    expect(getQueue("t1")).toEqual([]);
+    for (const content of contents) enqueue("t1", content, []);
+    remove("t1", getQueue("t1")[removeIndex].id);
+    expect(getQueue("t1").map((m) => m.content)).toEqual(expected);
   });
 
   it("ignores removal of an unknown id", () => {

--- a/apps/mobile/src/features/tasks/stores/messageQueueStore.ts
+++ b/apps/mobile/src/features/tasks/stores/messageQueueStore.ts
@@ -2,11 +2,18 @@ import { create } from "zustand";
 import type { PendingAttachment } from "../composer/attachments/types";
 
 export interface QueuedMessage {
+  id: string;
   content: string;
   attachments: PendingAttachment[];
 }
 
 const EMPTY: QueuedMessage[] = [];
+
+let queueIdCounter = 0;
+function nextQueueId(): string {
+  queueIdCounter += 1;
+  return `queue-${queueIdCounter}`;
+}
 
 interface MessageQueueState {
   queuesByTaskId: Record<string, QueuedMessage[]>;
@@ -19,6 +26,8 @@ interface MessageQueueState {
   drain: (taskId: string) => QueuedMessage[];
   /** Restore messages at the head of the queue, e.g. after a failed flush. */
   prepend: (taskId: string, messages: QueuedMessage[]) => void;
+  /** Drop a single queued message by id. */
+  remove: (taskId: string, messageId: string) => void;
   getQueue: (taskId: string) => QueuedMessage[];
 }
 
@@ -30,7 +39,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
         ...state.queuesByTaskId,
         [taskId]: [
           ...(state.queuesByTaskId[taskId] ?? []),
-          { content, attachments },
+          { id: nextQueueId(), content, attachments },
         ],
       },
     })),
@@ -50,6 +59,20 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
         [taskId]: [...messages, ...(state.queuesByTaskId[taskId] ?? [])],
       },
     })),
+  remove: (taskId, messageId) =>
+    set((state) => {
+      const queue = state.queuesByTaskId[taskId];
+      if (!queue) return state;
+      const next = queue.filter((m) => m.id !== messageId);
+      if (next.length === queue.length) return state;
+      if (next.length === 0) {
+        const { [taskId]: _emptied, ...rest } = state.queuesByTaskId;
+        return { queuesByTaskId: rest };
+      }
+      return {
+        queuesByTaskId: { ...state.queuesByTaskId, [taskId]: next },
+      };
+    }),
   getQueue: (taskId) => get().queuesByTaskId[taskId] ?? EMPTY,
 }));
 

--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("expo-haptics", () => ({
+  impactAsync: vi.fn(),
+  notificationAsync: vi.fn(),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium" },
+  NotificationFeedbackType: { Success: "success" },
+}));
+vi.mock("../lib/cloudTaskStream", () => ({ watchCloudTask: vi.fn() }));
+vi.mock("../composer/attachments/buildCloudPrompt", () => ({
+  buildCloudPromptBlocks: vi.fn(() => Promise.resolve([])),
+}));
+vi.mock("../utils/sounds", () => ({
+  playMeepSound: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/features/notifications/lib/notifications", () => ({
+  presentLocalNotification: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("../api", () => ({
+  CloudCommandError: class CloudCommandError extends Error {},
+  getTask: vi.fn(),
+  runTaskInCloud: vi.fn(),
+  sendCloudCommand: vi.fn(),
+}));
+
+import { useMessageQueueStore } from "./messageQueueStore";
+import { type TaskSession, useTaskSessionStore } from "./taskSessionStore";
+
+function seedSession(overrides: Partial<TaskSession> = {}): void {
+  const session: TaskSession = {
+    taskRunId: "run-1",
+    taskId: "t1",
+    events: [],
+    status: "connected",
+    isPromptPending: true,
+    ...overrides,
+  };
+  useTaskSessionStore.setState({ sessions: { "run-1": session } });
+}
+
+describe("steerQueuedMessage", () => {
+  beforeEach(() => {
+    useMessageQueueStore.setState({ queuesByTaskId: {} }, false);
+    useTaskSessionStore.setState({ sessions: {} });
+  });
+
+  it("removes the message and resends it as a steer", async () => {
+    seedSession();
+    const sendInterrupting = vi.fn(() => Promise.resolve());
+    useTaskSessionStore.setState({ sendInterrupting });
+
+    useMessageQueueStore.getState().enqueue("t1", "first", []);
+    useMessageQueueStore.getState().enqueue("t1", "second", []);
+    const target = useMessageQueueStore.getState().getQueue("t1")[0];
+
+    await useTaskSessionStore.getState().steerQueuedMessage("t1", target.id);
+
+    expect(sendInterrupting).toHaveBeenCalledWith("t1", "first", []);
+    expect(
+      useMessageQueueStore
+        .getState()
+        .getQueue("t1")
+        .map((m) => m.content),
+    ).toEqual(["second"]);
+  });
+
+  it("rolls the message back onto the head when the resend fails", async () => {
+    seedSession();
+    const sendInterrupting = vi.fn(() => Promise.reject(new Error("boom")));
+    useTaskSessionStore.setState({ sendInterrupting });
+
+    useMessageQueueStore.getState().enqueue("t1", "first", []);
+    useMessageQueueStore.getState().enqueue("t1", "second", []);
+    const target = useMessageQueueStore.getState().getQueue("t1")[0];
+
+    await expect(
+      useTaskSessionStore.getState().steerQueuedMessage("t1", target.id),
+    ).rejects.toThrow("boom");
+
+    expect(
+      useMessageQueueStore
+        .getState()
+        .getQueue("t1")
+        .map((m) => m.content),
+    ).toEqual(["first", "second"]);
+  });
+
+  it("no-ops while the session is compacting", async () => {
+    seedSession({ isCompacting: true });
+    const sendInterrupting = vi.fn(() => Promise.resolve());
+    useTaskSessionStore.setState({ sendInterrupting });
+
+    useMessageQueueStore.getState().enqueue("t1", "first", []);
+    const target = useMessageQueueStore.getState().getQueue("t1")[0];
+
+    await useTaskSessionStore.getState().steerQueuedMessage("t1", target.id);
+
+    expect(sendInterrupting).not.toHaveBeenCalled();
+    expect(
+      useMessageQueueStore
+        .getState()
+        .getQueue("t1")
+        .map((m) => m.content),
+    ).toEqual(["first"]);
+  });
+
+  it("no-ops for an unknown message id", async () => {
+    seedSession();
+    const sendInterrupting = vi.fn(() => Promise.resolve());
+    useTaskSessionStore.setState({ sendInterrupting });
+
+    useMessageQueueStore.getState().enqueue("t1", "first", []);
+
+    await useTaskSessionStore.getState().steerQueuedMessage("t1", "missing");
+
+    expect(sendInterrupting).not.toHaveBeenCalled();
+    expect(useMessageQueueStore.getState().getQueue("t1")).toHaveLength(1);
+  });
+});

--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.test.ts
@@ -23,6 +23,7 @@ vi.mock("../api", () => ({
   sendCloudCommand: vi.fn(),
 }));
 
+import type { CloudTaskUpdatePayload, StoredLogEntry } from "../types";
 import { useMessageQueueStore } from "./messageQueueStore";
 import { type TaskSession, useTaskSessionStore } from "./taskSessionStore";
 
@@ -115,5 +116,64 @@ describe("steerQueuedMessage", () => {
 
     expect(sendInterrupting).not.toHaveBeenCalled();
     expect(useMessageQueueStore.getState().getQueue("t1")).toHaveLength(1);
+  });
+
+  it("no-ops when no turn is running", async () => {
+    seedSession({ isPromptPending: false });
+    const sendInterrupting = vi.fn(() => Promise.resolve());
+    useTaskSessionStore.setState({ sendInterrupting });
+
+    useMessageQueueStore.getState().enqueue("t1", "first", []);
+    const target = useMessageQueueStore.getState().getQueue("t1")[0];
+
+    await useTaskSessionStore.getState().steerQueuedMessage("t1", target.id);
+
+    expect(sendInterrupting).not.toHaveBeenCalled();
+    expect(useMessageQueueStore.getState().getQueue("t1")).toHaveLength(1);
+  });
+});
+
+describe("compaction tracking from the log stream", () => {
+  beforeEach(() => {
+    useTaskSessionStore.setState({ sessions: {} });
+  });
+
+  function statusEntry(isComplete: boolean): StoredLogEntry {
+    return {
+      type: "notification",
+      notification: {
+        method: "_posthog/status",
+        params: { status: "compacting", isComplete },
+      },
+    };
+  }
+
+  function logsUpdate(entries: StoredLogEntry[]): CloudTaskUpdatePayload {
+    return {
+      kind: "logs",
+      taskId: "t1",
+      runId: "run-1",
+      newEntries: entries,
+      totalEntryCount: entries.length,
+    };
+  }
+
+  it("sets isCompacting on a compacting status and clears it on the boundary", () => {
+    seedSession({ isCompacting: false });
+    const store = useTaskSessionStore.getState();
+
+    store._handleCloudUpdate("run-1", logsUpdate([statusEntry(false)]));
+    expect(store.getSessionForTask("t1")?.isCompacting).toBe(true);
+
+    store._handleCloudUpdate(
+      "run-1",
+      logsUpdate([
+        {
+          type: "notification",
+          notification: { method: "_posthog/compact_boundary" },
+        },
+      ]),
+    );
+    expect(store.getSessionForTask("t1")?.isCompacting).toBe(false);
   });
 });

--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
@@ -160,6 +160,8 @@ interface BatchAnalysis {
   hasVisibleAgentOutput: boolean;
   externalUserMessageCount: number;
   agentMessageFinalized: boolean;
+  // Latest compaction state seen in the batch (undefined = no change).
+  compacting?: boolean;
 }
 
 function analyzeEntries(
@@ -173,6 +175,7 @@ function analyzeEntries(
   let hasVisibleAgentOutput = false;
   let externalUserMessageCount = 0;
   let agentMessageFinalized = false;
+  let compacting: boolean | undefined;
 
   for (const entry of entries) {
     const method = entry.notification?.method;
@@ -190,6 +193,18 @@ function analyzeEntries(
       if (method === "_posthog/error") {
         hasTurnFailed = true;
       }
+    }
+
+    if (method === "_posthog/status") {
+      const params = entry.notification?.params as
+        | { status?: string; isComplete?: boolean }
+        | undefined;
+      if (params?.status === "compacting") {
+        compacting = !params.isComplete;
+      }
+    }
+    if (method === "_posthog/compact_boundary") {
+      compacting = false;
     }
 
     if (
@@ -222,6 +237,7 @@ function analyzeEntries(
     hasVisibleAgentOutput,
     externalUserMessageCount,
     agentMessageFinalized,
+    compacting,
   };
 }
 
@@ -284,6 +300,10 @@ export interface TaskSession {
   // here so the response can be routed back to the awaiting tool call.
   cloudPermissionRequestIds?: Record<string, string>;
   pendingPermissions?: Record<string, CloudPendingPermissionRequest>;
+  // True while the agent is compacting context. Steering cancels and resends
+  // the running turn, which would abort an in-flight compaction, so queued
+  // messages are held until compaction ends.
+  isCompacting?: boolean;
 }
 
 interface TaskSessionStore {
@@ -317,6 +337,8 @@ interface TaskSessionStore {
     attachments?: PendingAttachment[],
   ) => Promise<void>;
   flushQueuedMessages: (taskId: string) => Promise<void>;
+  /** Drop one queued message and resend it now as a steer (interrupt + resend). */
+  steerQueuedMessage: (taskId: string, messageId: string) => Promise<void>;
   setConfigOption: (
     taskId: string,
     configId: string,
@@ -794,6 +816,32 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
     }
   },
 
+  steerQueuedMessage: async (taskId: string, messageId: string) => {
+    const session = get().getSessionForTask(taskId);
+    // Steering mid-compaction would abort the compaction; leave the message
+    // queued so it drains normally once compaction ends.
+    if (!session || session.isCompacting) return;
+
+    const message = useMessageQueueStore
+      .getState()
+      .getQueue(taskId)
+      .find((m) => m.id === messageId);
+    if (!message) return;
+
+    useMessageQueueStore.getState().remove(taskId, messageId);
+    try {
+      await get().sendInterrupting(
+        taskId,
+        message.content,
+        message.attachments,
+      );
+    } catch (err) {
+      // Restore at the head so a failed steer never silently drops the message.
+      useMessageQueueStore.getState().prepend(taskId, [message]);
+      throw err;
+    }
+  },
+
   getSessionForTask: (taskId: string) => {
     return Object.values(get().sessions).find((s) => s.taskId === taskId);
   },
@@ -951,6 +999,7 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
               isPromptPending: nextIsPromptPending,
               awaitingPing: nextAwaitingPing,
               awaitingAgentOutput: nextAwaitingAgentOutput,
+              isCompacting: analysis.compacting ?? current.isCompacting,
               localUserEchoes: echoSet.size > 0 ? echoSet : undefined,
               lastEventAt: events.length > 0 ? Date.now() : current.lastEventAt,
             },

--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
@@ -818,9 +818,10 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
 
   steerQueuedMessage: async (taskId: string, messageId: string) => {
     const session = get().getSessionForTask(taskId);
-    // Steering mid-compaction would abort the compaction; leave the message
-    // queued so it drains normally once compaction ends.
-    if (!session || session.isCompacting) return;
+    // Steering only makes sense against a live turn. Mid-compaction it would
+    // abort the compaction; with no turn running there is nothing to interrupt
+    // and the message drains via the normal turn-end flush.
+    if (!session || !session.isPromptPending || session.isCompacting) return;
 
     const message = useMessageQueueStore
       .getState()


### PR DESCRIPTION
## Problem

Mobile already lets you queue follow-up messages while a cloud task is running (#2752), but a queued message could only be **counted** — there was no way to act on one. This ports the desktop queued-message management from #2768 to the mobile app, using native mobile interaction instead of the desktop dock layout.

## Changes

- **Queued messages dock** — queued messages now render as compact rows pinned above the composer. Tapping a row opens a bottom-sheet (`SheetContainer`) with the available actions.
- **Steer now** — drops the message from the queue and resends it as a steer (cloud interrupt + resend via `sendInterrupting`). Rolls the message back onto the **head** of the queue if the resend fails so it is never silently lost, and **no-ops while the task is compacting** (steering would abort the in-flight compaction). Only offered while a turn is live.
- **Edit in composer** — pulls the message (text + attachments) back into `TaskChatComposer` to revise before re-sending.
- **Discard** — removes a single queued message by id.
- Queued messages now carry a stable `id`, and the session tracks `isCompacting` from the cloud `_posthog/status` / `_posthog/compact_boundary` stream so steer can be gated.

No desktop/shared code was changed.

## Tests

- `messageQueueStore.test.ts` — discard removes exactly the targeted message, clears the entry when empty, and ignores unknown ids.
- `taskSessionStore.test.ts` — steer removes + resends, rolls back onto the head on failure, and no-ops during compaction / for unknown ids.

Full mobile suite (`pnpm test`), `pnpm lint`, and typecheck pass.

## How did you test this?

Unit tests for the queue-mutation and steer logic; lint + typecheck clean.