### PR TITLE
feat(mobile): add inbox Archive tab with restore (port #2704)

### DIFF
--- a/apps/mobile/src/app/(tabs)/inbox.tsx
+++ b/apps/mobile/src/app/(tabs)/inbox.tsx
@@ -2,13 +2,20 @@ import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ArchivedReportList } from "@/features/inbox/components/ArchivedReportList";
 import { FilterSheet } from "@/features/inbox/components/FilterSheet";
 import { FloatingInboxHeader } from "@/features/inbox/components/FloatingInboxHeader";
-import { InboxViewToggle } from "@/features/inbox/components/InboxViewToggle";
+import {
+  type InboxViewMode,
+  InboxViewToggle,
+} from "@/features/inbox/components/InboxViewToggle";
 import { ReportList } from "@/features/inbox/components/ReportList";
 import { ReviewerFilterSheet } from "@/features/inbox/components/ReviewerFilterSheet";
 import { TinderView } from "@/features/inbox/components/TinderView";
-import { useInboxReports } from "@/features/inbox/hooks/useInboxReports";
+import {
+  useArchivedReports,
+  useInboxReports,
+} from "@/features/inbox/hooks/useInboxReports";
 import {
   decidedIds,
   useDismissedReportsStore,
@@ -23,8 +30,6 @@ import { buildInboxViewedProperties } from "@/features/inbox/utils";
 import { useIntegrations } from "@/features/tasks/hooks/useIntegrations";
 import { ANALYTICS_EVENTS, useAnalytics } from "@/lib/analytics";
 
-type InboxViewMode = "list" | "tinder";
-
 export default function InboxScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -33,6 +38,7 @@ export default function InboxScreen() {
   const [filterOpen, setFilterOpen] = useState(false);
   const [reviewerOpen, setReviewerOpen] = useState(false);
   const [viewMode, setViewMode] = useState<InboxViewMode>("list");
+  const archived = useArchivedReports({ enabled: viewMode === "archive" });
   const reviewerFilterCount = useInboxFilterStore(
     (s) => s.suggestedReviewerFilter.length,
   );
@@ -134,6 +140,11 @@ export default function InboxScreen() {
           onReportPress={handleReportPress}
           contentInsetTop={headerHeight}
         />
+      ) : viewMode === "archive" ? (
+        <ArchivedReportList
+          onReportPress={handleReportPress}
+          contentInsetTop={headerHeight}
+        />
       ) : (
         <View style={{ paddingTop: headerHeight }} className="flex-1">
           <TinderView
@@ -145,8 +156,8 @@ export default function InboxScreen() {
       )}
 
       <FloatingInboxHeader
-        isFetching={isFetching}
-        hasError={!!error}
+        isFetching={viewMode === "archive" ? archived.isFetching : isFetching}
+        hasError={viewMode === "archive" ? !!archived.error : !!error}
         reviewerFilterCount={reviewerFilterCount}
         showFilters={viewMode === "list"}
         onReviewerPress={() => setReviewerOpen(true)}

--- a/apps/mobile/src/features/inbox/api.ts
+++ b/apps/mobile/src/features/inbox/api.ts
@@ -310,3 +310,30 @@ export async function dismissSignalReport(
 
   return await response.json();
 }
+
+/** Re-queue a dismissed report into the inbox via the `potential` transition. */
+export async function restoreSignalReport(
+  reportId: string,
+): Promise<SignalReport> {
+  const baseUrl = getBaseUrl();
+  const projectId = getProjectId();
+
+  const response = await authedFetch(
+    `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/state/`,
+    {
+      method: "POST",
+      body: JSON.stringify({ state: "potential" }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      errorText || "Failed to restore signal report",
+    );
+  }
+
+  return await response.json();
+}

--- a/apps/mobile/src/features/inbox/components/ArchivedReportList.tsx
+++ b/apps/mobile/src/features/inbox/components/ArchivedReportList.tsx
@@ -1,0 +1,219 @@
+import { Text } from "@components/text";
+import * as Haptics from "expo-haptics";
+import { ArrowCounterClockwise, Tray } from "phosphor-react-native";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  View,
+} from "react-native";
+import { useThemeColors } from "@/lib/theme";
+import { useArchivedReports, useRestoreReport } from "../hooks/useInboxReports";
+import type { SignalReport } from "../types";
+import { dismissalReasonLabel, formatReportTimestamp } from "../utils";
+
+interface ArchivedReportListProps {
+  onReportPress?: (report: SignalReport) => void;
+  contentInsetTop?: number;
+}
+
+type Feedback = { kind: "success" | "info" | "error"; text: string };
+
+interface ArchivedRowProps {
+  report: SignalReport;
+  onPress: (report: SignalReport) => void;
+  onRestore: (reportId: string) => void;
+  restoring: boolean;
+}
+
+const ArchivedRow = memo(function ArchivedRow({
+  report,
+  onPress,
+  onRestore,
+  restoring,
+}: ArchivedRowProps) {
+  const themeColors = useThemeColors();
+  const when = formatReportTimestamp(new Date(report.updated_at));
+  const reasonLabel = report.dismissal_reason
+    ? dismissalReasonLabel(report.dismissal_reason)
+    : null;
+
+  return (
+    <Pressable
+      onPress={() => onPress(report)}
+      className="flex-row items-start gap-2.5 border-gray-6 border-b px-3 py-2.5 active:bg-gray-3"
+    >
+      <View className="min-w-0 flex-1">
+        <Text
+          className="font-medium text-[14px] text-gray-12 leading-snug"
+          numberOfLines={2}
+          ellipsizeMode="tail"
+        >
+          {report.title ?? "Untitled signal"}
+        </Text>
+
+        <View className="mt-1 flex-row flex-wrap items-center gap-2">
+          <Text className="text-[11px] text-gray-9">Archived {when}</Text>
+          {reasonLabel ? (
+            <Text className="rounded bg-gray-3 px-1.5 py-0.5 text-[11px] text-gray-11">
+              {reasonLabel}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+
+      <Pressable
+        onPress={() => onRestore(report.id)}
+        disabled={restoring}
+        hitSlop={8}
+        accessibilityLabel="Restore report to inbox"
+        accessibilityRole="button"
+        className="flex-row items-center gap-1.5 self-center rounded-full border border-gray-6 px-3 py-1.5 active:bg-gray-3"
+      >
+        {restoring ? (
+          <ActivityIndicator size="small" color={themeColors.gray[11]} />
+        ) : (
+          <>
+            <ArrowCounterClockwise size={14} color={themeColors.gray[11]} />
+            <Text className="font-medium text-[12px] text-gray-11">
+              Restore
+            </Text>
+          </>
+        )}
+      </Pressable>
+    </Pressable>
+  );
+});
+
+export function ArchivedReportList({
+  onReportPress,
+  contentInsetTop = 0,
+}: ArchivedReportListProps) {
+  const { reports, isLoading, error, refetch } = useArchivedReports();
+  const themeColors = useThemeColors();
+  const restore = useRestoreReport();
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const feedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showFeedback = useCallback((next: Feedback) => {
+    setFeedback(next);
+    if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+    feedbackTimer.current = setTimeout(() => setFeedback(null), 4000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+    };
+  }, []);
+
+  const restoreMutate = restore.mutate;
+  const handleRestore = useCallback(
+    (reportId: string) => {
+      restoreMutate(reportId, {
+        onSuccess: (restored) => {
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+          showFeedback(
+            restored
+              ? { kind: "success", text: "Restored to inbox" }
+              : { kind: "info", text: "Already back in your inbox" },
+          );
+        },
+        onError: (err) => {
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+          showFeedback({
+            kind: "error",
+            text: err.message || "Failed to restore report",
+          });
+        },
+      });
+    },
+    [restoreMutate, showFeedback],
+  );
+
+  if (error) {
+    return (
+      <View className="flex-1 items-center justify-center p-6">
+        <Text className="mb-4 text-center text-status-error">{error}</Text>
+        <Pressable
+          onPress={() => refetch()}
+          className="rounded-lg bg-gray-3 px-4 py-2"
+        >
+          <Text className="text-gray-12">Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (isLoading && reports.length === 0) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator size="large" color={themeColors.accent[9]} />
+        <Text className="mt-4 text-gray-11">Loading archive...</Text>
+      </View>
+    );
+  }
+
+  if (reports.length === 0) {
+    return (
+      <View className="flex-1 items-center justify-center p-6">
+        <View className="mb-6 h-16 w-16 items-center justify-center rounded-full bg-gray-3">
+          <Tray size={28} color={themeColors.gray[10]} />
+        </View>
+        <Text className="mb-2 text-center font-semibold text-[16px] text-gray-12">
+          Archive is empty
+        </Text>
+        <Text className="text-center text-[13px] text-gray-11">
+          Reports you dismiss show up here.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1">
+      <FlatList
+        data={reports}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <ArchivedRow
+            report={item}
+            onPress={(report) => onReportPress?.(report)}
+            onRestore={handleRestore}
+            restoring={restore.isPending && restore.variables === item.id}
+          />
+        )}
+        refreshControl={
+          <RefreshControl
+            refreshing={isLoading}
+            onRefresh={() => refetch()}
+            tintColor={themeColors.accent[9]}
+            progressViewOffset={contentInsetTop}
+          />
+        }
+        contentContainerStyle={{
+          paddingTop: contentInsetTop,
+          paddingBottom: 100,
+        }}
+      />
+
+      {feedback ? (
+        <View
+          className={`absolute inset-x-4 bottom-24 rounded-xl px-4 py-3 shadow-lg ${
+            feedback.kind === "success"
+              ? "bg-status-success"
+              : feedback.kind === "error"
+                ? "bg-status-error"
+                : "bg-gray-12"
+          }`}
+        >
+          <Text className="text-center font-medium text-[14px] text-white">
+            {feedback.text}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/inbox/components/ArchivedReportList.tsx
+++ b/apps/mobile/src/features/inbox/components/ArchivedReportList.tsx
@@ -109,6 +109,11 @@ export function ArchivedReportList({
     };
   }, []);
 
+  const handlePress = useCallback(
+    (report: SignalReport) => onReportPress?.(report),
+    [onReportPress],
+  );
+
   const restoreMutate = restore.mutate;
   const handleRestore = useCallback(
     (reportId: string) => {
@@ -180,7 +185,7 @@ export function ArchivedReportList({
         renderItem={({ item }) => (
           <ArchivedRow
             report={item}
-            onPress={(report) => onReportPress?.(report)}
+            onPress={handlePress}
             onRestore={handleRestore}
             restoring={restore.isPending && restore.variables === item.id}
           />

--- a/apps/mobile/src/features/inbox/components/InboxViewToggle.tsx
+++ b/apps/mobile/src/features/inbox/components/InboxViewToggle.tsx
@@ -1,10 +1,16 @@
 import * as Haptics from "expo-haptics";
-import { Cards, ListBullets } from "phosphor-react-native";
+import { Archive, Cards, type Icon, ListBullets } from "phosphor-react-native";
 import { Pressable, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColors } from "@/lib/theme";
 
-type InboxViewMode = "list" | "tinder";
+export type InboxViewMode = "list" | "tinder" | "archive";
+
+const VIEW_MODES: { mode: InboxViewMode; icon: Icon; label: string }[] = [
+  { mode: "list", icon: ListBullets, label: "List view" },
+  { mode: "tinder", icon: Cards, label: "Card view" },
+  { mode: "archive", icon: Archive, label: "Archive" },
+];
 
 interface InboxViewToggleProps {
   mode: InboxViewMode;
@@ -12,8 +18,8 @@ interface InboxViewToggleProps {
 }
 
 /**
- * Floating pill toggle at the bottom of the inbox screen. Two icons — list
- * view and tinder/card view — with the active one highlighted.
+ * Floating pill toggle at the bottom of the inbox screen, with the active
+ * segment highlighted.
  */
 export function InboxViewToggle({ mode, onModeChange }: InboxViewToggleProps) {
   const insets = useSafeAreaInsets();
@@ -32,36 +38,27 @@ export function InboxViewToggle({ mode, onModeChange }: InboxViewToggleProps) {
       pointerEvents="box-none"
     >
       <View className="elevation-4 flex-row items-center overflow-hidden rounded-full border border-gray-6 bg-card shadow-lg">
-        <Pressable
-          onPress={() => handlePress("list")}
-          hitSlop={4}
-          className={`items-center justify-center rounded-full px-5 py-3 ${mode === "list" ? "bg-accent-9" : "active:bg-gray-3"}`}
-        >
-          <ListBullets
-            size={20}
-            weight={mode === "list" ? "bold" : "regular"}
-            color={
-              mode === "list"
-                ? themeColors.accent.contrast
-                : themeColors.gray[11]
-            }
-          />
-        </Pressable>
-        <Pressable
-          onPress={() => handlePress("tinder")}
-          hitSlop={4}
-          className={`items-center justify-center rounded-full px-5 py-3 ${mode === "tinder" ? "bg-accent-9" : "active:bg-gray-3"}`}
-        >
-          <Cards
-            size={20}
-            weight={mode === "tinder" ? "bold" : "regular"}
-            color={
-              mode === "tinder"
-                ? themeColors.accent.contrast
-                : themeColors.gray[11]
-            }
-          />
-        </Pressable>
+        {VIEW_MODES.map(({ mode: m, icon: IconCmp, label }) => {
+          const active = mode === m;
+          return (
+            <Pressable
+              key={m}
+              onPress={() => handlePress(m)}
+              hitSlop={4}
+              accessibilityLabel={label}
+              accessibilityRole="button"
+              className={`items-center justify-center rounded-full px-5 py-3 ${active ? "bg-accent-9" : "active:bg-gray-3"}`}
+            >
+              <IconCmp
+                size={20}
+                weight={active ? "bold" : "regular"}
+                color={
+                  active ? themeColors.accent.contrast : themeColors.gray[11]
+                }
+              />
+            </Pressable>
+          );
+        })}
       </View>
     </View>
   );

--- a/apps/mobile/src/features/inbox/components/ReportListRow.tsx
+++ b/apps/mobile/src/features/inbox/components/ReportListRow.tsx
@@ -1,10 +1,10 @@
 import { Text } from "@components/text";
-import { differenceInHours, format, formatDistanceToNow } from "date-fns";
 import { memo } from "react";
 import { Pressable, View } from "react-native";
 import { PrStatusBadge } from "@/features/tasks/components/PrStatusBadge";
 import { useThemeColors } from "@/lib/theme";
 import type { SignalReport } from "../types";
+import { formatReportTimestamp } from "../utils";
 
 interface ReportListRowProps {
   report: SignalReport;
@@ -34,12 +34,7 @@ const priorityColorMap: Record<string, string> = {
 
 function ReportListRowComponent({ report, onPress }: ReportListRowProps) {
   const themeColors = useThemeColors();
-  const updatedAt = new Date(report.updated_at);
-  const hoursSince = differenceInHours(new Date(), updatedAt);
-  const timeDisplay =
-    hoursSince < 24
-      ? formatDistanceToNow(updatedAt, { addSuffix: true })
-      : format(updatedAt, "MMM d");
+  const timeDisplay = formatReportTimestamp(new Date(report.updated_at));
 
   const dotKind = statusDotMap[report.status] ?? "muted";
   const dotColor =

--- a/apps/mobile/src/features/inbox/constants.ts
+++ b/apps/mobile/src/features/inbox/constants.ts
@@ -2,6 +2,9 @@
 export const INBOX_PIPELINE_STATUS_FILTER =
   "potential,candidate,in_progress,ready,pending_input";
 
+/** Status filter for the Archive view — reports the user has dismissed. */
+export const INBOX_DISMISSED_STATUS_FILTER = "suppressed";
+
 /** Polling interval for inbox queries (ms). */
 export const INBOX_REFETCH_INTERVAL_MS = 5_000;
 

--- a/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
+++ b/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
@@ -9,9 +9,13 @@ import {
   getSignalReportArtefacts,
   getSignalReportSignals,
   getSignalReports,
+  restoreSignalReport,
   updateSignalReportArtefact,
 } from "../api";
-import { INBOX_REFETCH_INTERVAL_MS } from "../constants";
+import {
+  INBOX_DISMISSED_STATUS_FILTER,
+  INBOX_REFETCH_INTERVAL_MS,
+} from "../constants";
 import { useInboxFilterStore } from "../stores/inboxFilterStore";
 import type {
   AvailableSuggestedReviewersResponse,
@@ -29,12 +33,15 @@ import {
   buildSignalReportListOrdering,
   buildStatusFilterParam,
   buildSuggestedReviewerFilterParam,
+  isArchivedReport,
 } from "../utils";
 
 export const inboxKeys = {
   all: ["inbox", "signal-reports"] as const,
   list: (params?: SignalReportsQueryParams) =>
     [...inboxKeys.all, "list", params ?? {}] as const,
+  archived: (params?: SignalReportsQueryParams) =>
+    [...inboxKeys.all, "archived", params ?? {}] as const,
   detail: (reportId: string) => [...inboxKeys.all, reportId, "detail"] as const,
   artefacts: (reportId: string) =>
     [...inboxKeys.all, reportId, "artefacts"] as const,
@@ -73,6 +80,30 @@ export function useInboxReports(options?: { enabled?: boolean }) {
     queryFn: () => getSignalReports(params),
     enabled: !!projectId && !!oauthAccessToken && (options?.enabled ?? true),
     refetchInterval: INBOX_REFETCH_INTERVAL_MS,
+  });
+
+  return {
+    reports: query.data?.results ?? [],
+    totalCount: query.data?.count ?? 0,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error?.message ?? null,
+    refetch: query.refetch,
+  };
+}
+
+export function useArchivedReports(options?: { enabled?: boolean }) {
+  const { projectId, oauthAccessToken } = useAuthStore();
+
+  const params: SignalReportsQueryParams = {
+    status: INBOX_DISMISSED_STATUS_FILTER,
+    ordering: buildSignalReportListOrdering("updated_at", "desc"),
+  };
+
+  const query = useQuery<SignalReportsResponse>({
+    queryKey: inboxKeys.archived(params),
+    queryFn: () => getSignalReports(params),
+    enabled: !!projectId && !!oauthAccessToken && (options?.enabled ?? true),
   });
 
   return {
@@ -202,6 +233,27 @@ export function useDismissReport(reportId: string) {
     mutationFn: (input) => dismissSignalReport(reportId, input),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: inboxKeys.detail(reportId) });
+      queryClient.invalidateQueries({ queryKey: inboxKeys.all });
+    },
+  });
+}
+
+export function useRestoreReport() {
+  const queryClient = useQueryClient();
+
+  // Resolves to whether the report was actually re-queued. Revalidate against
+  // the server first so a stale row can't silently reopen an already-active
+  // report.
+  return useMutation<boolean, Error, string>({
+    mutationFn: async (reportId) => {
+      const current = await getSignalReport(reportId);
+      if (current && !isArchivedReport(current)) {
+        return false;
+      }
+      await restoreSignalReport(reportId);
+      return true;
+    },
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: inboxKeys.all });
     },
   });

--- a/apps/mobile/src/features/inbox/types.ts
+++ b/apps/mobile/src/features/inbox/types.ts
@@ -1,3 +1,5 @@
+import type { DismissalReasonOptionValue } from "./constants";
+
 export type SignalReportStatus =
   | "potential"
   | "candidate"
@@ -29,6 +31,8 @@ export interface SignalReport {
   priority?: SignalReportPriority | null;
   actionability?: SignalReportActionability | null;
   already_addressed?: boolean | null;
+  dismissal_reason?: DismissalReasonOptionValue | null;
+  dismissal_note?: string | null;
   is_suggested_reviewer?: boolean;
   source_products?: string[];
   implementation_pr_url?: string | null;

--- a/apps/mobile/src/features/inbox/utils.test.ts
+++ b/apps/mobile/src/features/inbox/utils.test.ts
@@ -9,7 +9,9 @@ import {
   buildInboxViewedProperties,
   buildPriorityFilterParam,
   buildReviewerOptions,
+  dismissalReasonLabel,
   formatSignalReportSummaryMarkdown,
+  isArchivedReport,
   orderSuggestedReviewers,
   reviewerMatchesAvailable,
   toSuggestedReviewerWriteContent,
@@ -357,6 +359,27 @@ describe("buildPriorityFilterParam", () => {
     },
   ])("$name", ({ input, expected }) => {
     expect(buildPriorityFilterParam([...input])).toBe(expected);
+  });
+});
+
+describe("isArchivedReport", () => {
+  it.each([
+    { status: "suppressed" as SignalReportStatus, expected: true },
+    { status: "ready" as SignalReportStatus, expected: false },
+    { status: "potential" as SignalReportStatus, expected: false },
+    { status: "deleted" as SignalReportStatus, expected: false },
+  ])("is $expected for $status", ({ status, expected }) => {
+    expect(isArchivedReport({ status })).toBe(expected);
+  });
+});
+
+describe("dismissalReasonLabel", () => {
+  it.each([
+    { value: "analysis_wrong", expected: "Agent's analysis is wrong" },
+    { value: "other", expected: "Something else…" },
+    { value: "totally_unknown_code", expected: "totally_unknown_code" },
+  ])("maps $value", ({ value, expected }) => {
+    expect(dismissalReasonLabel(value)).toBe(expected);
   });
 });
 

--- a/apps/mobile/src/features/inbox/utils.ts
+++ b/apps/mobile/src/features/inbox/utils.ts
@@ -1,4 +1,6 @@
+import { differenceInHours, format, formatDistanceToNow } from "date-fns";
 import type { InboxViewedProperties } from "@/lib/analytics";
+import { DISMISSAL_REASON_OPTIONS } from "./constants";
 import type {
   AvailableSuggestedReviewer,
   SignalReport,
@@ -33,6 +35,27 @@ export function formatSignalReportSummaryMarkdown(content: string): string {
   }
 
   return result;
+}
+
+/** Relative time for the last day, absolute "MMM d" beyond it. */
+export function formatReportTimestamp(date: Date): string {
+  return differenceInHours(new Date(), date) < 24
+    ? formatDistanceToNow(date, { addSuffix: true })
+    : format(date, "MMM d");
+}
+
+/** A report is archived when it has been dismissed (suppressed). */
+export function isArchivedReport(
+  report: Pick<SignalReport, "status">,
+): boolean {
+  return report.status === "suppressed";
+}
+
+/** Human label for a persisted dismissal reason, falling back to the raw code. */
+export function dismissalReasonLabel(value: string): string {
+  return (
+    DISMISSAL_REASON_OPTIONS.find((o) => o.value === value)?.label ?? value
+  );
 }
 
 export function inboxStatusLabel(status: SignalReportStatus): string {


### PR DESCRIPTION
## Summary

Ports the desktop **Archive** (dismissed reports) inbox feature from #2704 to the **React Native / Expo app** (`apps/mobile`). Desktop code is untouched; this implements the equivalent natively, reusing existing mobile inbox patterns.

Previously the mobile inbox could dismiss reports but offered no way to view or restore them.

## What's included

- **Archive segment** added to the floating inbox view toggle (`InboxViewToggle`), alongside the existing list/card modes. Matches the existing mobile inbox UX rather than copying the desktop tab bar.
- **Dedicated query** (`useArchivedReports`) filtered to `status = suppressed`, ordered by `updated_at` desc (newest-dismissed first), reusing the existing mobile ordering helper. Suppressed reports stay excluded from the main pipeline query.
- **Restore action** per row (`useRestoreReport`): re-fetches the report and no-ops if it's no longer `suppressed`, otherwise issues the `potential` state transition, then invalidates the report caches so the report leaves Archive and re-enters the inbox. Success / no-op / failure are surfaced with an inline banner and haptics (the established mobile feedback pattern — `TinderView` does the same).
- **Dismissal reason** shown on each archived row via `dismissalReasonLabel`, falling back to the raw code for unknown values.

## Notes

- `@posthog/core` is not a mobile dependency and Metro only src-aliases the `@posthog/shared` root barrel, so the `suppressed` filter and `dismissalReasonLabel` are mirrored minimally in the mobile feature — consistent with how the app already mirrors `DISMISSAL_REASON_OPTIONS` and the core filter/ordering helpers.

## Tests

`apps/mobile/src/features/inbox/utils.test.ts` covers the suppressed-membership predicate (`isArchivedReport`) and the reason-label fallback (`dismissalReasonLabel`). The membership predicate also gates the restore no-op path.

- `pnpm --filter @posthog/mobile test` — inbox suite green (50 passing)
- `tsc --noEmit` — clean for touched files
- `biome check` — clean
