### PR TITLE
fix(inbox): stop dropping PR reports the badge counts

### DIFF
--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -7,12 +7,10 @@ import {
   INBOX_REFETCH_INTERVAL_MS,
 } from "@posthog/core/inbox/reportFiltering";
 import {
-  computeInboxTabCounts,
   INBOX_SCOPE_FOR_YOU,
   isExcludedFromInbox,
   isPullRequestReport,
   isReportTabReport,
-  matchesReviewerScope,
   parseTeammateInboxScope,
 } from "@posthog/core/inbox/reportMembership";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
@@ -134,16 +132,21 @@ export function useInboxAllReports(options?: {
   const pullRequestTotal = pullRequestCountQuery.data?.count ?? 0;
 
   const scopedReports = useMemo(() => {
-    const byScope = ignoreScope
-      ? query.allReports
-      : query.allReports.filter((r) => matchesReviewerScope(r, scope));
+    // Reviewer scope is applied server-side via `suggested_reviewers` (see the
+    // infinite query above), so the loaded reports are already scoped. We must
+    // NOT re-filter here on the serialized `is_suggested_reviewer` boolean: the
+    // server's `suggested_reviewers` filter and that boolean can disagree (the
+    // boolean is recomputed at read time from GitHub-identity links and is
+    // `false` for some reports the filter still matches — notably failed runs).
+    // A client recheck would drop those reports from the list while the count
+    // badge — which trusts the same server filter — keeps counting them,
+    // producing a positive PR badge over an empty list.
     return searchQuery.trim()
-      ? filterReportsBySearch(byScope, searchQuery)
-      : byScope;
-  }, [query.allReports, scope, searchQuery, ignoreScope]);
+      ? filterReportsBySearch(query.allReports, searchQuery)
+      : query.allReports;
+  }, [query.allReports, searchQuery]);
 
   const counts = useMemo(() => {
-    const loaded = computeInboxTabCounts(query.allReports, scope);
     // The list is an infinite query that only holds the pages loaded so far
     // (100 per page), so the loaded-derived Reports count caps at the page size
     // and reads as a misleading "100". Reports is the dominant bucket, so derive
@@ -151,15 +154,17 @@ export function useInboxAllReports(options?: {
     // minus the non-report items the total also includes. PRs use the true
     // `pullRequestTotal` (also a real backend count), so PRs sitting past the
     // loaded page don't inflate Reports.
+    //
+    // Reviewer scope is already applied server-side, so every loaded report is
+    // in scope — no client `is_suggested_reviewer` recheck here either, to keep
+    // the Reports count consistent with the same server filter the totals use.
     const loadedOtherNonReport = query.allReports.filter(
       (r) =>
-        matchesReviewerScope(r, scope) &&
         !isExcludedFromInbox(r) &&
         !isReportTabReport(r) &&
         !isPullRequestReport(r),
     ).length;
     return {
-      ...loaded,
       // True backend counts, unaffected by the list's page-size cap.
       pulls: pullRequestTotal,
       reports: Math.max(
@@ -167,7 +172,7 @@ export function useInboxAllReports(options?: {
         query.totalCount - pullRequestTotal - loadedOtherNonReport,
       ),
     };
-  }, [query.allReports, query.totalCount, scope, pullRequestTotal]);
+  }, [query.allReports, query.totalCount, pullRequestTotal]);
 
   return {
     ...query,

--- a/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -132,32 +132,18 @@ export function useInboxAllReports(options?: {
   const pullRequestTotal = pullRequestCountQuery.data?.count ?? 0;
 
   const scopedReports = useMemo(() => {
-    // Reviewer scope is applied server-side via `suggested_reviewers` (see the
-    // infinite query above), so the loaded reports are already scoped. We must
-    // NOT re-filter here on the serialized `is_suggested_reviewer` boolean: the
-    // server's `suggested_reviewers` filter and that boolean can disagree (the
-    // boolean is recomputed at read time from GitHub-identity links and is
-    // `false` for some reports the filter still matches — notably failed runs).
-    // A client recheck would drop those reports from the list while the count
-    // badge — which trusts the same server filter — keeps counting them,
-    // producing a positive PR badge over an empty list.
+    // Reviewer scope is already applied server-side via `suggested_reviewers`.
+    // Don't re-filter on the `is_suggested_reviewer` boolean — it can disagree
+    // with that filter, dropping reports the count badge still counts.
     return searchQuery.trim()
       ? filterReportsBySearch(query.allReports, searchQuery)
       : query.allReports;
   }, [query.allReports, searchQuery]);
 
   const counts = useMemo(() => {
-    // The list is an infinite query that only holds the pages loaded so far
-    // (100 per page), so the loaded-derived Reports count caps at the page size
-    // and reads as a misleading "100". Reports is the dominant bucket, so derive
-    // its true size from the backend total `count` (unaffected by the page cap)
-    // minus the non-report items the total also includes. PRs use the true
-    // `pullRequestTotal` (also a real backend count), so PRs sitting past the
-    // loaded page don't inflate Reports.
-    //
-    // Reviewer scope is already applied server-side, so every loaded report is
-    // in scope — no client `is_suggested_reviewer` recheck here either, to keep
-    // the Reports count consistent with the same server filter the totals use.
+    // Derive Reports from the backend total (the loaded list caps at the page
+    // size), subtracting PRs and the other non-report items the total includes.
+    // Scope is server-side, so no client reviewer recheck here either.
     const loadedOtherNonReport = query.allReports.filter(
       (r) =>
         !isExcludedFromInbox(r) &&


### PR DESCRIPTION
## Problem

Peter reported the Inbox showing **1 PR in the badge/tab but an empty Pull requests list**. The "For you" badge and the "For you" list scope by reviewer two different ways, and those disagree:

- The badge count (`pullRequestCountQuery`) trusts the server-side `suggested_reviewers` filter.
- The list (`scopedReports`) started from the same server-filtered query but then re-applied a client-side recheck requiring `report.is_suggested_reviewer === true`.

The server's `suggested_reviewers` filter and the serialized `is_suggested_reviewer` boolean don't agree — the boolean is recomputed at read time from GitHub-identity links and comes back `false` for some reports the filter still matches (notably `failed` runs). Reproduced against live data: filtering PR reports by my own UUID returns 79, but 20 of them serialize `is_suggested_reviewer: false`. So a report can be counted in the badge yet dropped from the list — a positive PR badge over an empty list.

## Changes

- `useInboxAllReports`: drop the redundant client-side `matchesReviewerScope` recheck from `scopedReports` and from the Reports-count derivation. Reviewer scope is already applied server-side via `suggested_reviewers`, so the loaded reports are in scope; rechecking on the serialized boolean only introduced drift between the badge and the list.

This only affects the "For you" / teammate scopes (on "Entire project" the recheck was already a no-op). A smaller, separate gap remains by design — the count query doesn't apply the client-side search box (which also matches report `id`), so an active search can still show badge > list; left out to keep this fix focused.

## How did you test this?

- Reproduced the underlying mismatch against live data via the inbox reports API (`has_implementation_pr=true` + `suggested_reviewers=<uuid>` returns reports with `is_suggested_reviewer: false`).
- Biome lint clean on the changed file. (Repo `node_modules` not installed in this environment, so a full typecheck/test run wasn't possible here.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781859084648939?thread_ts=1781859084.648939&cid=C09SK2PAGKF)*
