### PR TITLE
fix(tasks): detect PR on local task's current branch

### DIFF
--- a/packages/workspace-server/src/services/git/task-pr-status.test.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.test.ts
@@ -92,74 +92,94 @@ describe("TaskPrStatusService revalidation PR detection", () => {
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
   });
 
-  it("detects a PR on a local task's current branch even with no linked branch", async () => {
-    workspaceService.getWorkspace.mockResolvedValue({
-      mode: "local",
-      worktreePath: null,
-      folderPath: "/repo",
-      linkedBranch: null,
-    });
-    gitService.getPrStatus.mockResolvedValue({
-      prExists: true,
-      prState: "open",
-      prUrl: "https://github.com/acme/repo/pull/7",
-      isDraft: false,
-    });
-
-    await service.getTaskPrStatus("task-local", null);
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(gitService.getPrStatus).toHaveBeenCalledWith("/repo");
-    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-local", {
-      prUrl: "https://github.com/acme/repo/pull/7",
-      prState: "open",
-    });
-    expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
+  it.each([
+    {
+      name: "detects a PR on a local task's current branch with no linked branch",
       taskId: "task-local",
-      prUrl: "https://github.com/acme/repo/pull/7",
-      prState: "open",
-    });
-  });
+      workspace: { mode: "local", worktreePath: null, folderPath: "/repo" },
+      prStatus: {
+        prExists: true,
+        prState: "open",
+        prUrl: "https://github.com/acme/repo/pull/7",
+        isDraft: false,
+      },
+      diffStats: { filesChanged: 0 },
+      expectedRepoPath: "/repo",
+      expectDiffStatsCalled: false,
+      expectedCache: {
+        prUrl: "https://github.com/acme/repo/pull/7",
+        prState: "open",
+      },
+      expectedEmit: {
+        prUrl: "https://github.com/acme/repo/pull/7",
+        prState: "open",
+      },
+    },
+    {
+      name: "caches no PR for a local task whose branch has none, without checking diff",
+      taskId: "task-local",
+      workspace: { mode: "local", worktreePath: null, folderPath: "/repo" },
+      prStatus: { prExists: false },
+      diffStats: { filesChanged: 0 },
+      expectedRepoPath: "/repo",
+      expectDiffStatsCalled: false,
+      expectedCache: { prUrl: null, prState: null },
+      expectedEmit: null,
+    },
+    {
+      name: "still reports a worktree task's local diff when no PR exists",
+      taskId: "task-wt",
+      workspace: { mode: "worktree", worktreePath: "/wt", folderPath: null },
+      prStatus: { prExists: false },
+      diffStats: { filesChanged: 3 },
+      expectedRepoPath: "/wt",
+      expectDiffStatsCalled: true,
+      expectedCache: { prUrl: null, prState: null },
+      expectedEmit: null,
+    },
+  ])(
+    "$name",
+    async ({
+      taskId,
+      workspace,
+      prStatus,
+      diffStats,
+      expectedRepoPath,
+      expectDiffStatsCalled,
+      expectedCache,
+      expectedEmit,
+    }) => {
+      workspaceService.getWorkspace.mockResolvedValue({
+        ...workspace,
+        linkedBranch: null,
+      });
+      gitService.getPrStatus.mockResolvedValue(prStatus);
+      gitService.getDiffStats.mockResolvedValue(diffStats);
 
-  it("caches no PR for a local task whose branch has none, without checking diff", async () => {
-    workspaceService.getWorkspace.mockResolvedValue({
-      mode: "local",
-      worktreePath: null,
-      folderPath: "/repo",
-      linkedBranch: null,
-    });
-    gitService.getPrStatus.mockResolvedValue({ prExists: false });
+      await service.getTaskPrStatus(taskId, null);
+      await new Promise((resolve) => setImmediate(resolve));
 
-    await service.getTaskPrStatus("task-local", null);
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(gitService.getPrStatus).toHaveBeenCalledWith("/repo");
-    expect(gitService.getDiffStats).not.toHaveBeenCalled();
-    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-local", {
-      prUrl: null,
-      prState: null,
-    });
-  });
-
-  it("still reports a worktree task's local diff when no PR exists", async () => {
-    workspaceService.getWorkspace.mockResolvedValue({
-      mode: "worktree",
-      worktreePath: "/wt",
-      folderPath: null,
-      linkedBranch: null,
-    });
-    gitService.getPrStatus.mockResolvedValue({ prExists: false });
-    gitService.getDiffStats.mockResolvedValue({ filesChanged: 3 });
-    gitService.getGitSyncStatus.mockResolvedValue({ aheadOfDefault: 0 });
-
-    await service.getTaskPrStatus("task-wt", null);
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(gitService.getPrStatus).toHaveBeenCalledWith("/wt");
-    expect(gitService.getDiffStats).toHaveBeenCalledWith("/wt");
-    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-wt", {
-      prUrl: null,
-      prState: null,
-    });
-  });
+      expect(gitService.getPrStatus).toHaveBeenCalledWith(expectedRepoPath);
+      if (expectDiffStatsCalled) {
+        expect(gitService.getDiffStats).toHaveBeenCalledWith(expectedRepoPath);
+      } else {
+        expect(gitService.getDiffStats).not.toHaveBeenCalled();
+      }
+      expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith(
+        taskId,
+        expectedCache,
+      );
+      if (expectedEmit) {
+        expect(workspaceService.emit).toHaveBeenCalledWith(
+          "taskPrInfoChanged",
+          {
+            taskId,
+            ...expectedEmit,
+          },
+        );
+      } else {
+        expect(workspaceService.emit).not.toHaveBeenCalled();
+      }
+    },
+  );
 });

--- a/packages/workspace-server/src/services/git/task-pr-status.test.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.test.ts
@@ -51,3 +51,115 @@ describe("TaskPrStatusService.getTaskPrStatus (missing worktree directory)", () 
     expect(gitService.getDiffStats).not.toHaveBeenCalled();
   });
 });
+
+describe("TaskPrStatusService revalidation PR detection", () => {
+  let service: TaskPrStatusService;
+  let gitService: {
+    getPrStatus: ReturnType<typeof vi.fn>;
+    getDiffStats: ReturnType<typeof vi.fn>;
+    getGitSyncStatus: ReturnType<typeof vi.fn>;
+    getPrUrlForBranch: ReturnType<typeof vi.fn>;
+    getPrDetailsByUrl: ReturnType<typeof vi.fn>;
+  };
+  let workspaceService: {
+    getWorkspace: ReturnType<typeof vi.fn>;
+    emit: ReturnType<typeof vi.fn>;
+  };
+  let workspaceRepo: {
+    findByTaskId: ReturnType<typeof vi.fn>;
+    updatePrCache: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    gitService = {
+      getPrStatus: vi.fn(),
+      getDiffStats: vi.fn().mockResolvedValue({ filesChanged: 0 }),
+      getGitSyncStatus: vi.fn().mockResolvedValue({ aheadOfDefault: 0 }),
+      getPrUrlForBranch: vi.fn(),
+      getPrDetailsByUrl: vi.fn(),
+    };
+    workspaceService = { getWorkspace: vi.fn(), emit: vi.fn() };
+    workspaceRepo = {
+      findByTaskId: vi.fn().mockReturnValue({ prUrl: null, prState: null }),
+      updatePrCache: vi.fn(),
+    };
+    service = new TaskPrStatusService(
+      gitService as unknown as GitService,
+      workspaceRepo as unknown as IWorkspaceRepository,
+      workspaceService as unknown as WorkspaceService,
+    );
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+  });
+
+  it("detects a PR on a local task's current branch even with no linked branch", async () => {
+    workspaceService.getWorkspace.mockResolvedValue({
+      mode: "local",
+      worktreePath: null,
+      folderPath: "/repo",
+      linkedBranch: null,
+    });
+    gitService.getPrStatus.mockResolvedValue({
+      prExists: true,
+      prState: "open",
+      prUrl: "https://github.com/acme/repo/pull/7",
+      isDraft: false,
+    });
+
+    await service.getTaskPrStatus("task-local", null);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(gitService.getPrStatus).toHaveBeenCalledWith("/repo");
+    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-local", {
+      prUrl: "https://github.com/acme/repo/pull/7",
+      prState: "open",
+    });
+    expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
+      taskId: "task-local",
+      prUrl: "https://github.com/acme/repo/pull/7",
+      prState: "open",
+    });
+  });
+
+  it("caches no PR for a local task whose branch has none, without checking diff", async () => {
+    workspaceService.getWorkspace.mockResolvedValue({
+      mode: "local",
+      worktreePath: null,
+      folderPath: "/repo",
+      linkedBranch: null,
+    });
+    gitService.getPrStatus.mockResolvedValue({ prExists: false });
+
+    await service.getTaskPrStatus("task-local", null);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(gitService.getPrStatus).toHaveBeenCalledWith("/repo");
+    expect(gitService.getDiffStats).not.toHaveBeenCalled();
+    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-local", {
+      prUrl: null,
+      prState: null,
+    });
+  });
+
+  it("still reports a worktree task's local diff when no PR exists", async () => {
+    workspaceService.getWorkspace.mockResolvedValue({
+      mode: "worktree",
+      worktreePath: "/wt",
+      folderPath: null,
+      linkedBranch: null,
+    });
+    gitService.getPrStatus.mockResolvedValue({ prExists: false });
+    gitService.getDiffStats.mockResolvedValue({ filesChanged: 3 });
+    gitService.getGitSyncStatus.mockResolvedValue({ aheadOfDefault: 0 });
+
+    await service.getTaskPrStatus("task-wt", null);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(gitService.getPrStatus).toHaveBeenCalledWith("/wt");
+    expect(gitService.getDiffStats).toHaveBeenCalledWith("/wt");
+    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-wt", {
+      prUrl: null,
+      prState: null,
+    });
+  });
+});

--- a/packages/workspace-server/src/services/git/task-pr-status.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.ts
@@ -156,8 +156,8 @@ export class TaskPrStatusService {
       return { prUrl: null, prState: null, hasDiff: false };
     }
 
-    if (worktreePath) {
-      const prStatus = await this.gitService.getPrStatus(worktreePath);
+    if (repoPath) {
+      const prStatus = await this.gitService.getPrStatus(repoPath);
       if (prStatus.prExists && prStatus.prState) {
         return {
           prUrl: prStatus.prUrl,
@@ -170,16 +170,19 @@ export class TaskPrStatusService {
         };
       }
 
-      const [diffStats, syncStatus] = await Promise.all([
-        this.gitService.getDiffStats(worktreePath),
-        this.gitService.getGitSyncStatus(worktreePath),
-      ]);
+      // Only worktree tasks track local diff/ahead state as a PR-less signal.
+      if (worktreePath) {
+        const [diffStats, syncStatus] = await Promise.all([
+          this.gitService.getDiffStats(worktreePath),
+          this.gitService.getGitSyncStatus(worktreePath),
+        ]);
 
-      const hasDiff =
-        (diffStats?.filesChanged ?? 0) > 0 ||
-        (syncStatus?.aheadOfDefault ?? 0) > 0;
+        const hasDiff =
+          (diffStats?.filesChanged ?? 0) > 0 ||
+          (syncStatus?.aheadOfDefault ?? 0) > 0;
 
-      return { prUrl: null, prState: null, hasDiff };
+        return { prUrl: null, prState: null, hasDiff };
+      }
     }
 
     return { prUrl: null, prState: null, hasDiff: false };


### PR DESCRIPTION
## Problem

A regression: when a user starts a task on `main` (local mode) and the agent later checks out a feature branch and opens a PR, the PR was **not reliably linked** to the task — no PR button in the top-right, and the task looked like it had no branch or PR.

## Root cause

The PR button and the sidebar PR dot are kept current by `TaskPrStatusService.computeTaskPrStatus` — the periodically-revalidated "safety net" that persists the cached `prUrl`/`prState` and emits `taskPrInfoChanged` to the renderer. This cache is the reliable backstop when the other two paths (agent file-activity branch-linking and `gh`-based PR detection) are stale or empty.

For a **local** task with no linked branch, that function bailed to "no PR":

```ts
const repoPath = worktreePath ?? (folderPath || null);
...
if (linkedBranch && repoPath) { ... }   // skipped — no linked branch
if (worktreePath) { ... getPrStatus(worktreePath) ... }  // skipped — local tasks have no worktreePath
return { prUrl: null, prState: null, hasDiff: false };   // local task always lands here
```

The PR-detection fallback was gated on `worktreePath`, which is `null` for local tasks (only `folderPath` is set). So the branch that actually had the PR was never inspected, and the button depended entirely on the fragile, timing-sensitive paths (whose lookups cache "no PR" before the PR exists and only re-poll on an interval) — hence "not always."

## Fix

Split the fallback so PR detection runs against `repoPath` (`worktreePath ?? folderPath`), while the worktree-only `hasDiff` signal stays gated on `worktreePath`:

- **Worktree tasks:** `repoPath === worktreePath`, so behavior is identical.
- **Local tasks:** `getPrStatus(folderPath)` now runs, detects the PR on the repo's current branch, persists it via `updatePrCache`, and emits `taskPrInfoChanged` → the header PR button and sidebar dot light up.

## Tests

Added 3 tests (local-task-with-PR, local-task-without-PR, worktree-unchanged) alongside the existing one — **4/4 pass**. Typecheck and Biome are clean.