### PR TITLE
feat(channels): home canvas — host navigation + reset to default

### DIFF
--- a/packages/core/src/canvas/dashboardSchemas.ts
+++ b/packages/core/src/canvas/dashboardSchemas.ts
@@ -54,6 +54,10 @@ export const dashboardFileMetaSchema = z.object({
   // the FileSystem row has no updated_at column to sort the dashboards list by.
   createdAt: z.number().optional(),
   updatedAt: z.number().optional(),
+  // Channel folders only: the file-system id of the channel's home canvas (the
+  // auto-created freeform board shown when the channel name is clicked). Stored
+  // on the folder's meta because the FileSystem model has no column for it.
+  homeCanvasId: z.string().optional(),
 });
 export type DashboardFileMeta = z.infer<typeof dashboardFileMetaSchema>;
 
@@ -90,6 +94,10 @@ export const saveFreeformInput = z.object({
 });
 
 export const dashboardIdInput = z.object({ id: z.string().min(1) });
+
+export const ensureHomeCanvasInput = z.object({
+  channelId: z.string().min(1),
+});
 
 // Rename a canvas (changes the last path segment, i.e. its display title).
 export const renameDashboardInput = z.object({

--- a/packages/core/src/canvas/dashboardsService.test.ts
+++ b/packages/core/src/canvas/dashboardsService.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { DashboardsService } from "./dashboardsService";
 import type { DesktopFsClient, FsEntryBase } from "./desktopFsClient";
 
+// ensureHomeCanvas fetches the signed-in user's label via posthogApi; stub it so
+// the service doesn't reach the network in tests.
+vi.mock("./posthogApi", () => ({
+  fetchCurrentUser: vi.fn(async () => ({ label: "Tester" })),
+}));
+
 // A dashboard FS row carrying our payload under `meta`, as the backend returns it.
 function dashboardRow(
   id: string,
@@ -103,5 +109,179 @@ describe("DashboardsService.rename", () => {
 
     expect(fetch).not.toHaveBeenCalled();
     expect(result.name).toBe("Same name");
+  });
+});
+
+// A stateful fake exposing getEntry + fetch, enough for create/saveFreeform/PATCH.
+// POST "" assigns an id and stores the row; PATCH "<id>/" merges meta/path.
+function statefulFs(initial: Record<string, Record<string, unknown>>) {
+  const entries: Record<string, Record<string, unknown>> = { ...initial };
+  let seq = 0;
+  const fetch = vi.fn(
+    async (suffix: string, init?: { method?: string; body?: string }) => {
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(init.body) : undefined;
+      if (suffix === "" && method === "POST") {
+        const id = `new-${++seq}`;
+        const entry = {
+          id,
+          path: body.path,
+          type: body.type,
+          meta: body.meta ?? {},
+        };
+        entries[id] = entry;
+        return { ok: true, status: 200, json: async () => entry } as Response;
+      }
+      const id = decodeURIComponent(suffix.replace(/\/$/, ""));
+      const prev = entries[id] ?? { id, path: "", meta: {} };
+      const next = { ...prev };
+      if (body?.meta) next.meta = body.meta;
+      if (body?.path) next.path = body.path;
+      entries[id] = next;
+      return { ok: true, status: 200, json: async () => next } as Response;
+    },
+  );
+  const getEntry = vi.fn(async (id: string) => entries[id] ?? null);
+  const fs = { getEntry, fetch } as unknown as DesktopFsClient;
+  return { fs, fetch, entries };
+}
+
+describe("DashboardsService.ensureHomeCanvas", () => {
+  it("creates + seeds a freeform canvas and records it on the channel folder", async () => {
+    const { fs, entries } = statefulFs({
+      "chan-1": {
+        id: "chan-1",
+        path: "marketing",
+        type: "folder",
+        meta: {},
+      },
+    });
+    const service = new DashboardsService(fs, {} as never);
+
+    const record = await service.ensureHomeCanvas("chan-1");
+
+    // The freeform canvas was created under the channel folder.
+    expect(record.id).toBe("new-1");
+    expect(record.templateId).toBe("freeform");
+    expect(entries["new-1"]?.path).toBe("marketing/Home");
+
+    // Its seeded source queries the file_system system table and bakes both ids.
+    const meta = entries["new-1"]?.meta as { code?: string };
+    expect(meta.code).toContain("system.file_system");
+    expect(meta.code).toContain("chan-1");
+    expect(meta.code).toContain("new-1");
+
+    // The channel folder now points at the home canvas.
+    const folderMeta = entries["chan-1"]?.meta as { homeCanvasId?: string };
+    expect(folderMeta.homeCanvasId).toBe("new-1");
+  });
+
+  it("seeds source that transpiles as valid TSX", async () => {
+    const { fs, entries } = statefulFs({
+      "chan-1": { id: "chan-1", path: "marketing", type: "folder", meta: {} },
+    });
+    const service = new DashboardsService(fs, {} as never);
+
+    await service.ensureHomeCanvas("chan-1");
+    const code = (entries["new-1"]?.meta as { code?: string }).code ?? "";
+
+    // The sandbox transpiles the seeded code with Babel at runtime; mirror that
+    // here with esbuild so a syntax error is caught in CI, not in the iframe.
+    const { transform } = await import("esbuild");
+    await expect(
+      transform(code, { loader: "tsx", format: "esm" }),
+    ).resolves.toBeDefined();
+  });
+
+  it("is idempotent: returns the existing home canvas without creating another", async () => {
+    const { fs, fetch, entries } = statefulFs({
+      "chan-1": {
+        id: "chan-1",
+        path: "marketing",
+        type: "folder",
+        meta: { homeCanvasId: "home-x" },
+      },
+      "home-x": {
+        id: "home-x",
+        path: "marketing/Home",
+        type: "dashboard",
+        meta: {
+          channelId: "chan-1",
+          templateId: "freeform",
+          code: "// seeded",
+        },
+      },
+    });
+    const service = new DashboardsService(fs, {} as never);
+
+    const record = await service.ensureHomeCanvas("chan-1");
+
+    expect(record.id).toBe("home-x");
+    // No create/patch happened — the folder already had a live home canvas.
+    expect(fetch).not.toHaveBeenCalled();
+    expect(Object.keys(entries)).toEqual(["chan-1", "home-x"]);
+  });
+});
+
+describe("DashboardsService.resetHomeCanvas", () => {
+  it("appends a fresh default version without dropping history", async () => {
+    const { fs, entries } = statefulFs({
+      "chan-1": {
+        id: "chan-1",
+        path: "marketing",
+        type: "folder",
+        meta: { homeCanvasId: "home-x" },
+      },
+      "home-x": {
+        id: "home-x",
+        path: "marketing/Home",
+        type: "dashboard",
+        meta: {
+          channelId: "chan-1",
+          templateId: "freeform",
+          code: "// edited by the user",
+          versions: [{ id: "v1", code: "// edited by the user", createdAt: 1 }],
+          currentVersionId: "v1",
+        },
+      },
+    });
+    const service = new DashboardsService(fs, {} as never);
+
+    const record = await service.resetHomeCanvas("chan-1");
+
+    // The returned record carries the regenerated default source (queries the
+    // file_system table and bakes both ids), not the user's edit.
+    expect(record.id).toBe("home-x");
+    expect(record.code).toContain("system.file_system");
+    expect(record.code).toContain("chan-1");
+    expect(record.code).toContain("home-x");
+    expect(record.code).not.toContain("// edited by the user");
+
+    // History is preserved: the prior version stays and the default is appended
+    // as the new head, so Undo can restore the user's edit.
+    expect(record.versions?.map((v) => v.id)).toEqual([
+      "v1",
+      record.currentVersionId,
+    ]);
+    expect(record.currentVersionId).not.toBe("v1");
+    expect(record.versions?.at(-1)?.code).toBe(record.code);
+
+    // Persisted to the same canvas (no new canvas created).
+    expect(Object.keys(entries)).toEqual(["chan-1", "home-x"]);
+  });
+
+  it("creates a home canvas if the channel has none yet", async () => {
+    const { fs, entries } = statefulFs({
+      "chan-1": { id: "chan-1", path: "marketing", type: "folder", meta: {} },
+    });
+    const service = new DashboardsService(fs, {} as never);
+
+    const record = await service.resetHomeCanvas("chan-1");
+
+    expect(record.id).toBe("new-1");
+    expect(record.code).toContain("system.file_system");
+    expect(
+      (entries["chan-1"]?.meta as { homeCanvasId?: string }).homeCanvasId,
+    ).toBe("new-1");
   });
 });

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -11,12 +11,15 @@ import {
   type DesktopFsClient,
   type FsEntryBase,
 } from "./desktopFsClient";
-import type { FreeformVersion } from "./freeformSchemas";
+import { FREEFORM_TEMPLATE_ID, type FreeformVersion } from "./freeformSchemas";
 import { fetchCurrentUser } from "./posthogApi";
 
 // Desktop file-system "type" tag for a dashboard entry. Channels are `folder`
 // rows (depth 1); dashboards are these `dashboard` files nested beneath them.
 const DASHBOARD_TYPE = "dashboard";
+
+// Display name (canvas h1) of a channel's auto-created home canvas.
+const HOME_CANVAS_NAME = "Home";
 
 // Dashboard-specific shape on top of the shared FS row. Our payload rides in
 // `meta` — see DashboardFileMeta for what that blob holds.
@@ -214,6 +217,101 @@ export class DashboardsService {
     return toRecord((await res.json()) as FsEntry);
   }
 
+  // Ensure the channel has a home canvas: the freeform board shown when the
+  // channel name is clicked. Idempotent — if the channel folder's meta already
+  // points at a live canvas, return it; otherwise create one, seed its source,
+  // and record its id on the folder. Safe to call on channel create and lazily
+  // on first open (backfills channels made before home canvases existed).
+  async ensureHomeCanvas(channelId: string): Promise<DashboardRecord> {
+    const folder = await this.getEntry(channelId);
+    if (!folder) throw new Error("Channel not found");
+
+    // Resolve (or create) the canvas, then seed it. Each step is recorded before
+    // the next runs, so a failure mid-way leaves a retryable state rather than an
+    // orphan: if `create` succeeds but seeding throws, the folder already points
+    // at the canvas, so the next call reuses it (and seeds it below) instead of
+    // creating a second "Home".
+    const existingId = folder.meta?.homeCanvasId;
+    let record = existingId ? await this.get(existingId) : null;
+    if (!record) {
+      // The canvas's own id is baked into the code so it can exclude itself from
+      // the "Canvases" list; the channel id lets it resolve the (rename-safe)
+      // folder path at runtime.
+      record = await this.create({
+        channelId,
+        name: HOME_CANVAS_NAME,
+        templateId: FREEFORM_TEMPLATE_ID,
+      });
+      await this.setHomeCanvasId(channelId, record.id, folder);
+    }
+
+    // Seed the source if it isn't already (covers a prior create whose seed
+    // failed). A canvas that already has code is returned untouched.
+    if (!record.code) {
+      const code = buildHomeCanvasCode(channelId, record.id);
+      const version: FreeformVersion = {
+        id: `home-${record.id}`,
+        code,
+        createdAt: Date.now(),
+      };
+      record = await this.saveFreeform({
+        id: record.id,
+        code,
+        versions: [version],
+        currentVersionId: version.id,
+      });
+    }
+    return record;
+  }
+
+  // Rebuild a channel's home canvas from the default template, discarding edits.
+  // Non-destructive: the pre-reset source is kept as the prior version (so Undo
+  // restores it) and the regenerated default is appended as the new head. If the
+  // channel has no home canvas yet, this is just a create. Only valid for the
+  // home canvas — regular canvases have no "default" to reset to.
+  async resetHomeCanvas(channelId: string): Promise<DashboardRecord> {
+    const folder = await this.getEntry(channelId);
+    if (!folder) throw new Error("Channel not found");
+
+    const homeCanvasId = folder.meta?.homeCanvasId;
+    if (!homeCanvasId) return this.ensureHomeCanvas(channelId);
+    const record = await this.get(homeCanvasId);
+    if (!record) return this.ensureHomeCanvas(channelId);
+
+    const code = buildHomeCanvasCode(channelId, homeCanvasId);
+    const version: FreeformVersion = {
+      id: `reset-${homeCanvasId}-${Date.now()}`,
+      code,
+      createdAt: Date.now(),
+    };
+    return this.saveFreeform({
+      id: homeCanvasId,
+      code,
+      versions: [...(record.versions ?? []), version],
+      currentVersionId: version.id,
+    });
+  }
+
+  // Point a channel folder at its home canvas by writing homeCanvasId onto the
+  // folder's meta (preserving any existing meta keys).
+  private async setHomeCanvasId(
+    channelId: string,
+    homeCanvasId: string,
+    folder?: FsEntry | null,
+  ): Promise<void> {
+    const entry = folder ?? (await this.getEntry(channelId));
+    const prevMeta = entry?.meta ?? {};
+    const meta: DashboardFileMeta = { ...prevMeta, homeCanvasId };
+    const res = await this.fs.fetch(`${encodeURIComponent(channelId)}/`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ meta }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to set channel home canvas (${res.status})`);
+    }
+  }
+
   async delete(id: string): Promise<void> {
     const res = await this.fs.fetch(`${encodeURIComponent(id)}/`, {
       method: "DELETE",
@@ -231,6 +329,408 @@ export class DashboardsService {
     if (!entry) throw new Error("Channel not found");
     return entry.path;
   }
+}
+
+// The seeded React source for a channel's home canvas. It runs in the freeform
+// sandbox (null-origin iframe), so its only data avenue is `window.ph.query`
+// (HogQL). It reads three lists from the `system.file_system` HogQL table:
+//   - Canvases: this channel's `dashboard` rows (excluding the home canvas).
+//   - Inbox / to-dos: stubbed (no data source yet) with an assignee filter.
+//   - Tasks: this channel's filed `task` rows, newest first.
+// Each list shows a page at a time and loads more as its own box is scrolled.
+// Rows and the "New" buttons drive host routing via the allowlisted
+// `ph.navigate` bridge (toTask/toNewTask/toCanvas/toNewCanvas); the Inbox stub
+// stays a no-op until it has a data source. channelId is host-supplied, so the
+// canvas can only navigate within its own channel.
+// channelId is baked in (the path is resolved at runtime so renames are safe);
+// homeCanvasId lets the Canvases list exclude this board.
+function buildHomeCanvasCode(channelId: string, homeCanvasId: string): string {
+  const cid = JSON.stringify(channelId);
+  const hid = JSON.stringify(homeCanvasId);
+  return `import { useCallback, useEffect, useRef, useState } from "react";
+
+const CHANNEL_ID = ${cid};
+const HOME_CANVAS_ID = ${hid};
+const PAGE_SIZE = 10;
+
+const ph = (window as any).ph;
+
+// Single-quote a value for inlining into a HogQL string literal.
+function sql(v: string): string {
+  return "'" + String(v).replace(/'/g, "''") + "'";
+}
+
+function lastSegment(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}
+
+// Resolve the channel folder's current path from its stable id, so renaming the
+// channel doesn't break the lists (the path, not the id, scopes child rows).
+async function resolveChannelPath(): Promise<string> {
+  const res = await ph.query(
+    "SELECT path FROM system.file_system WHERE id = " + sql(CHANNEL_ID) + " LIMIT 1",
+  );
+  const rows = (res && res.results) || [];
+  return rows.length ? String(rows[0][0]) : "";
+}
+
+type Row = { id: string; title: string; ref: string | null; createdAt: string };
+
+// Paginated reader for the channel's filesystem rows of a given type, newest
+// first. Resolves the channel path once, then walks pages by offset.
+function useChannelRows(kind: "dashboard" | "task") {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+  const offsetRef = useRef(0);
+  const pathRef = useRef<string | null>(null);
+  const busyRef = useRef(false);
+
+  const loadMore = useCallback(async () => {
+    if (busyRef.current || done) return;
+    busyRef.current = true;
+    setLoading(true);
+    try {
+      if (pathRef.current === null) pathRef.current = await resolveChannelPath();
+      const prefix = pathRef.current + "/";
+      const exclude =
+        kind === "dashboard" ? " AND id != " + sql(HOME_CANVAS_ID) : "";
+      const query =
+        "SELECT id, path, ref, created_at FROM system.file_system" +
+        " WHERE type = " + sql(kind) +
+        " AND surface = 'desktop'" +
+        " AND startsWith(path, " + sql(prefix) + ")" +
+        exclude +
+        " ORDER BY created_at DESC LIMIT " + PAGE_SIZE +
+        " OFFSET " + offsetRef.current;
+      const res = await ph.query(query);
+      const batch: Row[] = ((res && res.results) || []).map((r: any[]) => ({
+        id: String(r[0]),
+        title: lastSegment(String(r[1])),
+        ref: r[2] == null ? null : String(r[2]),
+        createdAt: String(r[3]),
+      }));
+      offsetRef.current += batch.length;
+      setRows((prev) => prev.concat(batch));
+      if (batch.length < PAGE_SIZE) setDone(true);
+    } catch (err) {
+      // Stop paging on error (e.g. the system table isn't available yet) rather
+      // than spinning; the section just shows what it has.
+      setDone(true);
+    } finally {
+      busyRef.current = false;
+      setLoading(false);
+    }
+  }, [kind, done]);
+
+  useEffect(() => {
+    void loadMore();
+    // Load the first page once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { rows, loadMore, loading, done };
+}
+
+// A fixed-height, scrollable section card. A sentinel at the bottom (observed
+// against THIS box, not the page) fires onLoadMore as the user scrolls near the
+// end. Styled to match the PostHog Code app: greenish-gray neutrals, soft
+// shadow, ~16px radius, a per-section accent dot.
+function Section(props: {
+  title: string;
+  accent: string;
+  onNew: () => void;
+  loading: boolean;
+  done: boolean;
+  onLoadMore: () => void;
+  children: any;
+  // A "+ New" that isn't wired yet: disable it and explain via tooltip rather
+  // than offering a button that silently does nothing.
+  newDisabled?: boolean;
+  newTooltip?: string;
+}) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const root = scrollRef.current;
+    const target = sentinelRef.current;
+    if (!root || !target) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) props.onLoadMore();
+      },
+      { root, rootMargin: "120px" },
+    );
+    io.observe(target);
+    return () => io.disconnect();
+  }, [props.onLoadMore]);
+
+  return (
+    <section
+      style={{
+        flex: "1 1 0",
+        minWidth: 0,
+        maxWidth: 380,
+        height: 460,
+        display: "flex",
+        flexDirection: "column",
+        background: "#ffffff",
+        border: "1px solid #e4e5de",
+        borderRadius: 16,
+        overflow: "hidden",
+        boxShadow:
+          "0 1px 2px rgba(13,13,13,0.04), 0 12px 32px rgba(13,13,13,0.06)",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "14px 16px",
+          borderBottom: "1px solid #eceee8",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: 999,
+              background: props.accent,
+              boxShadow: "0 0 0 3px " + props.accent + "22",
+            }}
+          />
+          <h2
+            style={{
+              margin: 0,
+              fontSize: 15,
+              fontWeight: 600,
+              color: "#0d0d0d",
+              letterSpacing: "-0.01em",
+            }}
+          >
+            {props.title}
+          </h2>
+        </div>
+        <button
+          type="button"
+          className="ph-btn"
+          onClick={props.onNew}
+          disabled={props.newDisabled}
+          title={props.newTooltip}
+          style={{
+            fontSize: 12,
+            fontWeight: 500,
+            padding: "4px 10px",
+            borderRadius: 8,
+            border: "1px solid #d8dbd1",
+            background: "#f2f3ee",
+            color: "#3a4036",
+            cursor: props.newDisabled ? "not-allowed" : "pointer",
+            opacity: props.newDisabled ? 0.5 : 1,
+          }}
+        >
+          + New
+        </button>
+      </header>
+      <div ref={scrollRef} style={{ flex: 1, overflowY: "auto", padding: 8 }}>
+        {props.children}
+        {!props.done ? (
+          <div ref={sentinelRef} style={{ height: 1 }} />
+        ) : null}
+        {props.loading ? (
+          <div style={{ padding: 8, fontSize: 12, color: "#93998a" }}>Loading…</div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function ListRow(props: { title: string; meta?: string; onClick?: () => void }) {
+  return (
+    <div
+      className="ph-row"
+      role={props.onClick ? "button" : undefined}
+      tabIndex={props.onClick ? 0 : undefined}
+      onClick={props.onClick}
+      onKeyDown={(e) => {
+        if (props.onClick && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          props.onClick();
+        }
+      }}
+      style={{
+        padding: "8px 10px",
+        borderRadius: 8,
+        fontSize: 13,
+        color: "#3a4036",
+        display: "flex",
+        justifyContent: "space-between",
+        gap: 8,
+        cursor: props.onClick ? "pointer" : "default",
+      }}
+    >
+      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {props.title}
+      </span>
+      {props.meta ? (
+        <span style={{ color: "#93998a", fontSize: 11, flexShrink: 0 }}>{props.meta}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function Empty(props: { label: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "100%",
+        minHeight: 120,
+        alignItems: "center",
+        justifyContent: "center",
+        textAlign: "center",
+        padding: 16,
+        fontSize: 12,
+        color: "#a9af9f",
+      }}
+    >
+      {props.label}
+    </div>
+  );
+}
+
+function CanvasesSection() {
+  const { rows, loadMore, loading, done } = useChannelRows("dashboard");
+  return (
+    <Section
+      title="Canvases"
+      accent="#f54d00"
+      onNew={() => ph.navigate?.toNewCanvas()}
+      loading={loading}
+      done={done}
+      onLoadMore={loadMore}
+    >
+      {rows.length === 0 && done ? <Empty label="No canvases yet." /> : null}
+      {rows.map((r) => (
+        <ListRow key={r.id} title={r.title} onClick={() => ph.navigate?.toCanvas(r.id)} />
+      ))}
+    </Section>
+  );
+}
+
+function TasksSection() {
+  const { rows, loadMore, loading, done } = useChannelRows("task");
+  return (
+    <Section
+      title="Tasks"
+      accent="#f8be2a"
+      onNew={() => ph.navigate?.toNewTask()}
+      loading={loading}
+      done={done}
+      onLoadMore={loadMore}
+    >
+      {rows.length === 0 && done ? <Empty label="No tasks yet." /> : null}
+      {rows.map((r) => (
+        <ListRow
+          key={r.id}
+          title={r.title}
+          meta={r.createdAt.slice(0, 10)}
+          // A task row's file-system id is NOT the task id; the task id is the
+          // row's ref (ChannelTasksService files it as ref=taskId). Only rows
+          // with a ref are navigable.
+          onClick={r.ref ? () => ph.navigate?.toTask(r.ref as string) : undefined}
+        />
+      ))}
+    </Section>
+  );
+}
+
+// Inbox / to-dos: there's no data source for these yet, so this is a stub. The
+// assignee toggle and "New" button are placeholders the host will wire up later.
+function InboxSection() {
+  const [scope, setScope] = useState<"me" | "team">("me");
+  const accent = "#1d4aff";
+  return (
+    <Section title="Inbox" accent={accent} onNew={() => {}} loading={false} done={true} onLoadMore={() => {}} newDisabled={true} newTooltip="Coming soon">
+      <div style={{ display: "flex", gap: 6, padding: "2px 2px 10px" }}>
+        {(["me", "team"] as const).map((s) => {
+          const active = scope === s;
+          return (
+            <button
+              key={s}
+              type="button"
+              className="ph-btn"
+              onClick={() => setScope(s)}
+              style={{
+                fontSize: 12,
+                fontWeight: 500,
+                padding: "4px 10px",
+                borderRadius: 8,
+                border: "1px solid " + (active ? accent : "#d8dbd1"),
+                background: active ? accent + "14" : "#f2f3ee",
+                color: active ? accent : "#3a4036",
+                cursor: "pointer",
+              }}
+            >
+              {s === "me" ? "Assigned to me" : "Teammates"}
+            </button>
+          );
+        })}
+      </div>
+      <Empty label={"No " + (scope === "me" ? "items assigned to you" : "teammate items") + " yet."} />
+    </Section>
+  );
+}
+
+const STYLE_TEXT =
+  ".ph-btn{transition:background .15s ease,border-color .15s ease,color .15s ease}" +
+  ".ph-btn:hover{background:#eceee8;border-color:#cbd0c3}" +
+  ".ph-row{transition:background .12s ease}" +
+  ".ph-row:hover{background:#f2f3ee}" +
+  "*::-webkit-scrollbar{width:10px;height:10px}" +
+  "*::-webkit-scrollbar-thumb{background:#cbd0c3;border-radius:8px;border:2px solid transparent;background-clip:padding-box}" +
+  "*::-webkit-scrollbar-thumb:hover{background:#a9af9f;background-clip:padding-box}";
+
+export default function ChannelHome() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        boxSizing: "border-box",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 40,
+        background: "linear-gradient(180deg, #f4f5f0 0%, #eceee8 100%)",
+        fontFamily:
+          '"Open Runde", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+        color: "#3a4036",
+      }}
+    >
+      <style>{STYLE_TEXT}</style>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "stretch",
+          justifyContent: "center",
+          gap: 20,
+          width: "100%",
+          maxWidth: 1200,
+          flexWrap: "wrap",
+        }}
+      >
+        <CanvasesSection />
+        <InboxSection />
+        <TasksSection />
+      </div>
+    </div>
+  );
+}
+`;
 }
 
 // Build the renderer-facing record from a file-system row. The name is the last

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -476,8 +476,8 @@ function Section(props: {
         height: 460,
         display: "flex",
         flexDirection: "column",
-        background: "#ffffff",
-        border: "1px solid #e4e5de",
+        background: "var(--card-bg)",
+        border: "1px solid var(--card-border)",
         borderRadius: 16,
         overflow: "hidden",
         boxShadow:
@@ -490,7 +490,7 @@ function Section(props: {
           alignItems: "center",
           justifyContent: "space-between",
           padding: "14px 16px",
-          borderBottom: "1px solid #eceee8",
+          borderBottom: "1px solid var(--header-border)",
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -508,7 +508,7 @@ function Section(props: {
               margin: 0,
               fontSize: 15,
               fontWeight: 600,
-              color: "#0d0d0d",
+              color: "var(--title)",
               letterSpacing: "-0.01em",
             }}
           >
@@ -526,9 +526,9 @@ function Section(props: {
             fontWeight: 500,
             padding: "4px 10px",
             borderRadius: 8,
-            border: "1px solid #d8dbd1",
-            background: "#f2f3ee",
-            color: "#3a4036",
+            border: "1px solid var(--btn-border)",
+            background: "var(--btn-bg)",
+            color: "var(--btn-color)",
             cursor: props.newDisabled ? "not-allowed" : "pointer",
             opacity: props.newDisabled ? 0.5 : 1,
           }}
@@ -542,7 +542,7 @@ function Section(props: {
           <div ref={sentinelRef} style={{ height: 1 }} />
         ) : null}
         {props.loading ? (
-          <div style={{ padding: 8, fontSize: 12, color: "#93998a" }}>Loading…</div>
+          <div style={{ padding: 8, fontSize: 12, color: "var(--meta)" }}>Loading…</div>
         ) : null}
       </div>
     </section>
@@ -566,7 +566,7 @@ function ListRow(props: { title: string; meta?: string; onClick?: () => void }) 
         padding: "8px 10px",
         borderRadius: 8,
         fontSize: 13,
-        color: "#3a4036",
+        color: "var(--row-color)",
         display: "flex",
         justifyContent: "space-between",
         gap: 8,
@@ -577,7 +577,7 @@ function ListRow(props: { title: string; meta?: string; onClick?: () => void }) 
         {props.title}
       </span>
       {props.meta ? (
-        <span style={{ color: "#93998a", fontSize: 11, flexShrink: 0 }}>{props.meta}</span>
+        <span style={{ color: "var(--meta)", fontSize: 11, flexShrink: 0 }}>{props.meta}</span>
       ) : null}
     </div>
   );
@@ -595,7 +595,7 @@ function Empty(props: { label: string }) {
         textAlign: "center",
         padding: 16,
         fontSize: 12,
-        color: "#a9af9f",
+        color: "var(--empty)",
       }}
     >
       {props.label}
@@ -670,9 +670,9 @@ function InboxSection() {
                 fontWeight: 500,
                 padding: "4px 10px",
                 borderRadius: 8,
-                border: "1px solid " + (active ? accent : "#d8dbd1"),
-                background: active ? accent + "14" : "#f2f3ee",
-                color: active ? accent : "#3a4036",
+                border: "1px solid " + (active ? accent : "var(--btn-border)"),
+                background: active ? accent + "14" : "var(--btn-bg)",
+                color: active ? accent : "var(--btn-color)",
                 cursor: "pointer",
               }}
             >
@@ -686,14 +686,29 @@ function InboxSection() {
   );
 }
 
+// Colors are CSS variables so the canvas follows the user's PostHog theme. The
+// iframe loader toggles a \`dark\` class on <html> (sandboxRuntime.applyTheme);
+// \`html.dark\` overrides win on specificity, so every value flips with no JS.
 const STYLE_TEXT =
+  ":root{" +
+  "--bg-from:#f4f5f0;--bg-to:#eceee8;--card-bg:#ffffff;--card-border:#e4e5de;" +
+  "--header-border:#eceee8;--title:#0d0d0d;--btn-border:#d8dbd1;--btn-bg:#f2f3ee;" +
+  "--btn-color:#3a4036;--btn-hover-bg:#eceee8;--btn-hover-border:#cbd0c3;" +
+  "--row-color:#3a4036;--row-hover-bg:#f2f3ee;--meta:#93998a;--empty:#a9af9f;" +
+  "--page-color:#3a4036;--scroll-thumb:#cbd0c3;--scroll-thumb-hover:#a9af9f}" +
+  "html.dark{" +
+  "--bg-from:#1b1d1a;--bg-to:#141613;--card-bg:#202220;--card-border:#33362e;" +
+  "--header-border:#2b2e27;--title:#f3f4ef;--btn-border:#3a3e34;--btn-bg:#2a2d26;" +
+  "--btn-color:#d4d7cd;--btn-hover-bg:#34372f;--btn-hover-border:#474c3f;" +
+  "--row-color:#d4d7cd;--row-hover-bg:#2a2d26;--meta:#8a917e;--empty:#6f7567;" +
+  "--page-color:#d4d7cd;--scroll-thumb:#3a3e34;--scroll-thumb-hover:#4a4f42}" +
   ".ph-btn{transition:background .15s ease,border-color .15s ease,color .15s ease}" +
-  ".ph-btn:hover{background:#eceee8;border-color:#cbd0c3}" +
+  ".ph-btn:hover{background:var(--btn-hover-bg);border-color:var(--btn-hover-border)}" +
   ".ph-row{transition:background .12s ease}" +
-  ".ph-row:hover{background:#f2f3ee}" +
+  ".ph-row:hover{background:var(--row-hover-bg)}" +
   "*::-webkit-scrollbar{width:10px;height:10px}" +
-  "*::-webkit-scrollbar-thumb{background:#cbd0c3;border-radius:8px;border:2px solid transparent;background-clip:padding-box}" +
-  "*::-webkit-scrollbar-thumb:hover{background:#a9af9f;background-clip:padding-box}";
+  "*::-webkit-scrollbar-thumb{background:var(--scroll-thumb);border-radius:8px;border:2px solid transparent;background-clip:padding-box}" +
+  "*::-webkit-scrollbar-thumb:hover{background:var(--scroll-thumb-hover);background-clip:padding-box}";
 
 export default function ChannelHome() {
   return (
@@ -705,10 +720,11 @@ export default function ChannelHome() {
         alignItems: "center",
         justifyContent: "center",
         padding: 40,
-        background: "linear-gradient(180deg, #f4f5f0 0%, #eceee8 100%)",
+        background:
+          "linear-gradient(180deg, var(--bg-from) 0%, var(--bg-to) 100%)",
         fontFamily:
           '"Open Runde", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-        color: "#3a4036",
+        color: "var(--page-color)",
       }}
     >
       <style>{STYLE_TEXT}</style>

--- a/packages/core/src/canvas/freeformSchemas.ts
+++ b/packages/core/src/canvas/freeformSchemas.ts
@@ -183,6 +183,19 @@ export const hostToCanvasMessageSchema = z.discriminatedUnion("type", [
 ]);
 export type HostToCanvasMessage = z.infer<typeof hostToCanvasMessageSchema>;
 
+// The ONLY navigations a canvas may request of the host. The canvas runs
+// untrusted code in a null-origin iframe, so this nested union IS the security
+// allowlist: there is no free-form path/route field, only these four targets.
+// `channelId` is intentionally absent — the host supplies it from the loaded
+// record so the iframe can never pick the channel, only which task/dashboard.
+export const canvasNavIntentSchema = z.discriminatedUnion("target", [
+  z.object({ target: z.literal("task"), taskId: z.string().min(1) }),
+  z.object({ target: z.literal("new-task") }),
+  z.object({ target: z.literal("canvas"), dashboardId: z.string().min(1) }),
+  z.object({ target: z.literal("new-canvas") }),
+]);
+export type CanvasNavIntent = z.infer<typeof canvasNavIntentSchema>;
+
 // iframe -> host
 export const canvasToHostMessageSchema = z.discriminatedUnion("type", [
   // Iframe runtime is mounted and ready to receive `init`.
@@ -220,6 +233,14 @@ export const canvasToHostMessageSchema = z.discriminatedUnion("type", [
     channel: z.literal(CANVAS_CHANNEL),
     type: z.literal("resize"),
     height: z.number(),
+  }),
+  // A request to navigate the host app. Fire-and-forget (no id/response). The
+  // `nav` payload is the allowlist above — the host drops anything that doesn't
+  // parse, so the iframe can only reach the four sanctioned destinations.
+  z.object({
+    channel: z.literal(CANVAS_CHANNEL),
+    type: z.literal("navigate"),
+    nav: canvasNavIntentSchema,
   }),
 ]);
 export type CanvasToHostMessage = z.infer<typeof canvasToHostMessageSchema>;

--- a/packages/core/src/canvas/posthogApi.ts
+++ b/packages/core/src/canvas/posthogApi.ts
@@ -72,7 +72,14 @@ export async function runHogQLQuery(
   hogql: string,
   opts?: { refresh?: string },
 ): Promise<HogQLResult> {
-  return runQuery(authService, { kind: "HogQLQuery", query: hogql }, opts);
+  // `tags.productKey` attributes the query to a product so PostHog's
+  // query-tagging guard is satisfied (it hard-fails untagged ClickHouse queries
+  // in local dev). The desktop canvas/dashboard surfaces are the "max" product.
+  return runQuery(
+    authService,
+    { kind: "HogQLQuery", query: hogql, tags: { productKey: "max" } },
+    opts,
+  );
 }
 
 export interface CurrentUser {

--- a/packages/core/src/canvas/services.ts
+++ b/packages/core/src/canvas/services.ts
@@ -44,6 +44,11 @@ export interface IDashboardsService {
     taskId: string | null;
   }): Promise<DashboardRecord>;
   rename(input: { id: string; name: string }): Promise<DashboardRecord>;
+  // Idempotently create + seed a channel's home canvas, returning it.
+  ensureHomeCanvas(channelId: string): Promise<DashboardRecord>;
+  // Append a fresh template version to the home canvas (non-destructive; the
+  // prior version stays in history so the edit can be restored via undo).
+  resetHomeCanvas(channelId: string): Promise<DashboardRecord>;
   delete(id: string): Promise<void>;
 }
 

--- a/packages/host-router/src/routers/dashboards.router.ts
+++ b/packages/host-router/src/routers/dashboards.router.ts
@@ -3,6 +3,7 @@ import {
   dashboardIdInput,
   dashboardRecordSchema,
   dashboardSummarySchema,
+  ensureHomeCanvasInput,
   listDashboardsInput,
   renameDashboardInput,
   saveFreeformInput,
@@ -55,6 +56,22 @@ export const dashboardsRouter = router({
     .output(dashboardRecordSchema)
     .mutation(({ ctx, input }) =>
       ctx.container.get<IDashboardsService>(DASHBOARDS_SERVICE).rename(input),
+    ),
+  ensureHomeCanvas: publicProcedure
+    .input(ensureHomeCanvasInput)
+    .output(dashboardRecordSchema)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<IDashboardsService>(DASHBOARDS_SERVICE)
+        .ensureHomeCanvas(input.channelId),
+    ),
+  resetHomeCanvas: publicProcedure
+    .input(ensureHomeCanvasInput)
+    .output(dashboardRecordSchema)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<IDashboardsService>(DASHBOARDS_SERVICE)
+        .resetHomeCanvas(input.channelId),
     ),
   delete: publicProcedure
     .input(dashboardIdInput)

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -82,6 +82,7 @@ import {
   useCreateAndOpenDashboard,
   useDashboardMutations,
   useDashboards,
+  useOpenHomeCanvas,
   usePrefetchDashboards,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { TaskIcon } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
@@ -723,6 +724,7 @@ function ChannelSection({
   channels: Channel[];
 }) {
   const navigate = useNavigate();
+  const openHomeCanvas = useOpenHomeCanvas();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const { data: tasks } = useTasks();
   const archivedTaskIds = useArchivedTaskIds();
@@ -849,10 +851,7 @@ function ChannelSection({
                       surface: "sidebar",
                       channel_id: channel.id,
                     });
-                    navigate({
-                      to: "/website/$channelId",
-                      params: { channelId: channel.id },
-                    });
+                    void openHomeCanvas(channel);
                   }}
                   className="w-full min-w-0 justify-start ps-8 data-selected:bg-fill-selected data-selected:text-gray-12"
                 >

--- a/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -3,10 +3,10 @@ import { validateChannelName } from "@posthog/core/canvas/channelName";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useOpenHomeCanvas } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Dialog, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
-import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
 // Matches Slack's "Create a channel" naming constraint.
@@ -22,7 +22,7 @@ export function CreateChannelModal({
   onOpenChange,
 }: CreateChannelModalProps) {
   const { createChannel, isCreating } = useChannelMutations();
-  const navigate = useNavigate();
+  const openHomeCanvas = useOpenHomeCanvas();
   const [name, setName] = useState("");
 
   // Reset the field each time the modal opens so a previous draft never lingers.
@@ -40,18 +40,14 @@ export function CreateChannelModal({
 
   const submit = async () => {
     if (!trimmed || validationError || isCreating) return;
+    let channel: Awaited<ReturnType<typeof createChannel>>;
     try {
-      const channel = await createChannel(trimmed);
+      channel = await createChannel(trimmed);
       track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
         action_type: "create",
         surface: "sidebar",
         channel_id: channel.id,
         success: true,
-      });
-      onOpenChange(false);
-      void navigate({
-        to: "/website/$channelId",
-        params: { channelId: channel.id },
       });
     } catch (error) {
       track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
@@ -62,7 +58,12 @@ export function CreateChannelModal({
       toast.error("Couldn't create channel", {
         description: error instanceof Error ? error.message : String(error),
       });
+      return;
     }
+    onOpenChange(false);
+    // Create + seed the channel's home canvas and open it in the main pane. A
+    // freshly created channel has no homeCanvasId yet, so this creates one.
+    await openHomeCanvas(channel);
   };
 
   return (

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
@@ -1,5 +1,6 @@
 import {
   type CanvasAnalyticsConfig,
+  type CanvasNavIntent,
   type CanvasToHostMessage,
   canvasToHostMessageSchema,
   type HostToCanvasMessage,
@@ -34,6 +35,12 @@ export interface FreeformCanvasProps {
   /** Called once the canvas has rendered successfully (clears error state). */
   onRendered?: () => void;
   /**
+   * Called when the canvas requests a host navigation. The intent is already
+   * validated against the allowlist; this component stays channel-agnostic and
+   * just forwards it — the caller maps it to actual routing.
+   */
+  onNavigate?: (intent: CanvasNavIntent) => void;
+  /**
    * Bootstrap config for in-iframe posthog-js (analytics + session replay).
    * Absent = no capture/replay. Only the PUBLIC key is here; the private token
    * never crosses into the iframe.
@@ -56,6 +63,7 @@ export function FreeformCanvas({
   onDataRequest,
   onError,
   onRendered,
+  onNavigate,
   analytics,
   refreshKey = 0,
 }: FreeformCanvasProps) {
@@ -85,6 +93,7 @@ export function FreeformCanvas({
     onDataRequest,
     onError,
     onRendered,
+    onNavigate,
     code,
     mode,
     analytics,
@@ -94,6 +103,7 @@ export function FreeformCanvas({
     onDataRequest,
     onError,
     onRendered,
+    onNavigate,
     code,
     mode,
     analytics,
@@ -172,6 +182,10 @@ export function FreeformCanvas({
           break;
         case "resize":
           setHeight(msg.height);
+          break;
+        case "navigate":
+          // msg.nav is already allowlist-validated by safeParse below.
+          latest.current.onNavigate?.(msg.nav);
           break;
       }
     };

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -1,20 +1,31 @@
 import {
+  ArrowCounterClockwiseIcon,
   ArrowUUpLeftIcon,
   ArrowUUpRightIcon,
   SpinnerGapIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
-import type { CanvasAnalyticsConfig } from "@posthog/core/canvas/freeformSchemas";
+import type {
+  CanvasAnalyticsConfig,
+  CanvasNavIntent,
+} from "@posthog/core/canvas/freeformSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import {
   useFreeformChatStore,
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
 import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { toast } from "@posthog/ui/primitives/toast";
+import {
+  navigateToChannelDashboard,
+  navigateToChannelNewTask,
+  navigateToChannelTask,
+} from "@posthog/ui/router/navigationBridge";
 import { ErrorBoundary } from "@posthog/ui/shell/ErrorBoundary";
 import {
   Box,
@@ -23,7 +34,7 @@ import {
   ScrollArea,
   Text,
 } from "@radix-ui/themes";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useMemo, useState } from "react";
 import { FreeformCanvas } from "./FreeformCanvas";
@@ -53,6 +64,7 @@ export function FreeformCanvasView({
   const undo = useFreeformChatStore((s) => s.undo);
   const redo = useFreeformChatStore((s) => s.redo);
   const setRuntimeError = useFreeformChatStore((s) => s.setRuntimeError);
+  const syncFromRecord = useFreeformChatStore((s) => s.syncFromRecord);
 
   const trpc = useHostTRPC();
 
@@ -73,6 +85,42 @@ export function FreeformCanvasView({
     () => channels.find((c) => c.id === channelId)?.name ?? "",
     [channels, channelId],
   );
+
+  // Only the channel's home canvas has a "default" template to reset to; regular
+  // canvases start blank. Gate the Reset action on this being the home canvas.
+  const isHomeCanvas = channels.some(
+    (c) => c.id === channelId && c.homeCanvasId === dashboardId,
+  );
+  const [isResetting, setIsResetting] = useState(false);
+  const resetHome = useMutation(
+    trpc.dashboards.resetHomeCanvas.mutationOptions(),
+  );
+
+  // Rebuild the home canvas from the default template. The host appends the
+  // regenerated source as a new version and keeps the prior one for undo, so
+  // syncFromRecord adopts the fresh head and the edit stays recoverable.
+  const onResetToDefault = useCallback(async () => {
+    setIsResetting(true);
+    try {
+      const record = await resetHome.mutateAsync({ channelId });
+      syncFromRecord(threadId, {
+        code: record.code,
+        versions: record.versions,
+        currentVersionId: record.currentVersionId,
+        templateId: record.templateId,
+        context: record.context,
+      });
+      toast.success("Canvas reset to default", {
+        description: "Undo to restore your previous version.",
+      });
+    } catch (error) {
+      toast.error("Couldn't reset canvas", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setIsResetting(false);
+    }
+  }, [channelId, threadId, resetHome, syncFromRecord]);
 
   // Run status: cloud reports via cloudStatus / latest_run.status; local is tied
   // to the live ACP session. Assume running while the task record loads.
@@ -137,6 +185,30 @@ export function FreeformCanvasView({
     [threadId, setRuntimeError],
   );
 
+  // Maps the canvas's allowlisted nav intent to real routing. channelId is
+  // host-supplied here (never from the iframe), so the canvas can only move
+  // within its own channel. The switch is exhaustive over the intent union.
+  const createAndOpen = useCreateAndOpenDashboard(channelId);
+  const onNavigate = useCallback(
+    (intent: CanvasNavIntent) => {
+      switch (intent.target) {
+        case "task":
+          navigateToChannelTask(channelId, intent.taskId);
+          break;
+        case "new-task":
+          navigateToChannelNewTask(channelId);
+          break;
+        case "canvas":
+          navigateToChannelDashboard(channelId, intent.dashboardId);
+          break;
+        case "new-canvas":
+          void createAndOpen();
+          break;
+      }
+    },
+    [channelId, createAndOpen],
+  );
+
   // The edit composer's draft, lifted so self-repair can prefill it.
   const [draft, setDraft] = useState("");
   const askAgentToFix = () => {
@@ -182,6 +254,18 @@ export function FreeformCanvasView({
                 <Text size="1" className="ml-1 text-gray-9">
                   v{idx + 1}/{versions.length}
                 </Text>
+              )}
+              {isHomeCanvas && (
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="ml-1"
+                  disabled={isGenerating || isResetting}
+                  onClick={onResetToDefault}
+                >
+                  <ArrowCounterClockwiseIcon size={14} />
+                  {isResetting ? "Resetting…" : "Reset to default"}
+                </Button>
               )}
             </Flex>
             {isGenerating && genTaskId ? (
@@ -237,6 +321,7 @@ export function FreeformCanvasView({
                   onDataRequest={handleFreeformDataRequest}
                   onError={onError}
                   onRendered={onRendered}
+                  onNavigate={onNavigate}
                   analytics={analytics}
                 />
               </ErrorBoundary>

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -5,27 +5,17 @@ import {
   SpinnerGapIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
-import type {
-  CanvasAnalyticsConfig,
-  CanvasNavIntent,
-} from "@posthog/core/canvas/freeformSchemas";
+import type { CanvasAnalyticsConfig } from "@posthog/core/canvas/freeformSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
-import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import {
   useFreeformChatStore,
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
 import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
-import { toast } from "@posthog/ui/primitives/toast";
-import {
-  navigateToChannelDashboard,
-  navigateToChannelNewTask,
-  navigateToChannelTask,
-} from "@posthog/ui/router/navigationBridge";
 import { ErrorBoundary } from "@posthog/ui/shell/ErrorBoundary";
 import {
   Box,
@@ -34,12 +24,13 @@ import {
   ScrollArea,
   Text,
 } from "@radix-ui/themes";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useMemo, useState } from "react";
 import { FreeformCanvas } from "./FreeformCanvas";
 import { FreeformGenerateBar } from "./FreeformGenerateBar";
 import { handleFreeformDataRequest } from "./freeformDataBridge";
+import { useCanvasNavigation, useHomeCanvasReset } from "./useHomeCanvasView";
 
 // The dashboardId a thread is keyed on ("dashboard:<id>" → "<id>").
 function dashboardIdOf(threadId: string): string {
@@ -64,7 +55,6 @@ export function FreeformCanvasView({
   const undo = useFreeformChatStore((s) => s.undo);
   const redo = useFreeformChatStore((s) => s.redo);
   const setRuntimeError = useFreeformChatStore((s) => s.setRuntimeError);
-  const syncFromRecord = useFreeformChatStore((s) => s.syncFromRecord);
 
   const trpc = useHostTRPC();
 
@@ -86,41 +76,12 @@ export function FreeformCanvasView({
     [channels, channelId],
   );
 
-  // Only the channel's home canvas has a "default" template to reset to; regular
-  // canvases start blank. Gate the Reset action on this being the home canvas.
-  const isHomeCanvas = channels.some(
-    (c) => c.id === channelId && c.homeCanvasId === dashboardId,
-  );
-  const [isResetting, setIsResetting] = useState(false);
-  const resetHome = useMutation(
-    trpc.dashboards.resetHomeCanvas.mutationOptions(),
-  );
-
-  // Rebuild the home canvas from the default template. The host appends the
-  // regenerated source as a new version and keeps the prior one for undo, so
-  // syncFromRecord adopts the fresh head and the edit stays recoverable.
-  const onResetToDefault = useCallback(async () => {
-    setIsResetting(true);
-    try {
-      const record = await resetHome.mutateAsync({ channelId });
-      syncFromRecord(threadId, {
-        code: record.code,
-        versions: record.versions,
-        currentVersionId: record.currentVersionId,
-        templateId: record.templateId,
-        context: record.context,
-      });
-      toast.success("Canvas reset to default", {
-        description: "Undo to restore your previous version.",
-      });
-    } catch (error) {
-      toast.error("Couldn't reset canvas", {
-        description: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setIsResetting(false);
-    }
-  }, [channelId, threadId, resetHome, syncFromRecord]);
+  // The "Reset to default" affordance, shown only on a channel's home canvas.
+  const {
+    isHomeCanvas,
+    isResetting,
+    reset: onResetToDefault,
+  } = useHomeCanvasReset({ channelId, dashboardId, threadId });
 
   // Run status: cloud reports via cloudStatus / latest_run.status; local is tied
   // to the live ACP session. Assume running while the task record loads.
@@ -185,29 +146,8 @@ export function FreeformCanvasView({
     [threadId, setRuntimeError],
   );
 
-  // Maps the canvas's allowlisted nav intent to real routing. channelId is
-  // host-supplied here (never from the iframe), so the canvas can only move
-  // within its own channel. The switch is exhaustive over the intent union.
-  const createAndOpen = useCreateAndOpenDashboard(channelId);
-  const onNavigate = useCallback(
-    (intent: CanvasNavIntent) => {
-      switch (intent.target) {
-        case "task":
-          navigateToChannelTask(channelId, intent.taskId);
-          break;
-        case "new-task":
-          navigateToChannelNewTask(channelId);
-          break;
-        case "canvas":
-          navigateToChannelDashboard(channelId, intent.dashboardId);
-          break;
-        case "new-canvas":
-          void createAndOpen();
-          break;
-      }
-    },
-    [channelId, createAndOpen],
-  );
+  // Routes the canvas's allowlisted nav intents within this channel.
+  const onNavigate = useCanvasNavigation(channelId);
 
   // The edit composer's draft, lifted so self-repair can prefill it.
   const [draft, setDraft] = useState("");

--- a/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -139,6 +139,15 @@ export function buildSandboxDocument(
         }
         return call("capture", { event, properties: properties ?? {}, distinctId });
       },
+      // Navigate the host app. Fire-and-forget: the host validates the intent
+      // against its allowlist and routes within the current channel. The canvas
+      // cannot pick the channel or an arbitrary path — only these four targets.
+      navigate: {
+        toTask: (taskId) => post({ type: "navigate", nav: { target: "task", taskId } }),
+        toNewTask: () => post({ type: "navigate", nav: { target: "new-task" } }),
+        toCanvas: (dashboardId) => post({ type: "navigate", nav: { target: "canvas", dashboardId } }),
+        toNewCanvas: () => post({ type: "navigate", nav: { target: "new-canvas" } }),
+      },
     };
 
     // Boot posthog-js with the PUBLIC key the host passed in (never the read

--- a/packages/ui/src/features/canvas/freeform/useHomeCanvasView.ts
+++ b/packages/ui/src/features/canvas/freeform/useHomeCanvasView.ts
@@ -1,0 +1,98 @@
+import type { CanvasNavIntent } from "@posthog/core/canvas/freeformSchemas";
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { useFreeformChatStore } from "@posthog/ui/features/canvas/stores/freeformChatStore";
+import { toast } from "@posthog/ui/primitives/toast";
+import {
+  navigateToChannelDashboard,
+  navigateToChannelNewTask,
+  navigateToChannelTask,
+} from "@posthog/ui/router/navigationBridge";
+import { useMutation } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+
+/**
+ * Routes a canvas's allowlisted nav intent to real host navigation. channelId is
+ * host-supplied (never from the iframe), so the canvas can only move within its
+ * own channel. The returned callback switches exhaustively over the intent union.
+ */
+export function useCanvasNavigation(
+  channelId: string,
+): (intent: CanvasNavIntent) => void {
+  const createAndOpen = useCreateAndOpenDashboard(channelId);
+  return useCallback(
+    (intent: CanvasNavIntent) => {
+      switch (intent.target) {
+        case "task":
+          navigateToChannelTask(channelId, intent.taskId);
+          break;
+        case "new-task":
+          navigateToChannelNewTask(channelId);
+          break;
+        case "canvas":
+          navigateToChannelDashboard(channelId, intent.dashboardId);
+          break;
+        case "new-canvas":
+          void createAndOpen();
+          break;
+      }
+    },
+    [channelId, createAndOpen],
+  );
+}
+
+/**
+ * The home-canvas "Reset to default" affordance. Only a channel's home canvas has
+ * a default template to reset to, so `isHomeCanvas` gates the button. `reset`
+ * rebuilds it from the template (the host appends the regenerated source as a new
+ * version and keeps the prior one for undo) and adopts the fresh head into the
+ * thread via syncFromRecord, so the edit stays recoverable.
+ */
+export function useHomeCanvasReset(args: {
+  channelId: string;
+  dashboardId: string;
+  threadId: string;
+}): {
+  isHomeCanvas: boolean;
+  isResetting: boolean;
+  reset: () => Promise<void>;
+} {
+  const { channelId, dashboardId, threadId } = args;
+  const trpc = useHostTRPC();
+  const { channels } = useChannels();
+  const syncFromRecord = useFreeformChatStore((s) => s.syncFromRecord);
+  const resetMutation = useMutation(
+    trpc.dashboards.resetHomeCanvas.mutationOptions(),
+  );
+  const [isResetting, setIsResetting] = useState(false);
+
+  const isHomeCanvas = channels.some(
+    (c) => c.id === channelId && c.homeCanvasId === dashboardId,
+  );
+
+  const reset = useCallback(async () => {
+    setIsResetting(true);
+    try {
+      const record = await resetMutation.mutateAsync({ channelId });
+      syncFromRecord(threadId, {
+        code: record.code,
+        versions: record.versions,
+        currentVersionId: record.currentVersionId,
+        templateId: record.templateId,
+        context: record.context,
+      });
+      toast.success("Canvas reset to default", {
+        description: "Undo to restore your previous version.",
+      });
+    } catch (error) {
+      toast.error("Couldn't reset canvas", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setIsResetting(false);
+    }
+  }, [channelId, threadId, resetMutation, syncFromRecord]);
+
+  return { isHomeCanvas, isResetting, reset };
+}

--- a/packages/ui/src/features/canvas/hooks/useChannels.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannels.ts
@@ -17,11 +17,26 @@ export interface Channel {
    * channel, so the desktop shortcut links back to this exact folder.
    */
   path: string;
+  /**
+   * File-system id of the channel's home canvas, if one has been created.
+   * Stored on the folder row's `meta`; used to open the home canvas when the
+   * channel name is clicked. Absent on channels made before home canvases
+   * existed (those are backfilled lazily on first open).
+   */
+  homeCanvasId?: string;
 }
 
 function toChannel(fs: Schemas.FileSystem): Channel {
+  // The generated OpenAPI type declares `meta` as null, but the API returns our
+  // free-form blob at runtime; read homeCanvasId past the type.
+  const meta = fs.meta as { homeCanvasId?: string } | null | undefined;
   // Top-level channels have a single-segment path; strip any leading slash.
-  return { id: fs.id, name: fs.path.replace(/^\/+/, ""), path: fs.path };
+  return {
+    id: fs.id,
+    name: fs.path.replace(/^\/+/, ""),
+    path: fs.path,
+    homeCanvasId: meta?.homeCanvasId,
+  };
 }
 
 /** List the project's channels (top-level desktop file-system folders). */

--- a/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -100,6 +100,16 @@ export function useDashboardMutations() {
   const rename = useMutation(
     trpc.dashboards.rename.mutationOptions({ onSuccess: invalidate }),
   );
+  const ensureHome = useMutation(
+    trpc.dashboards.ensureHomeCanvas.mutationOptions({
+      onSuccess: () => {
+        invalidate();
+        // The folder now carries homeCanvasId; refresh the channel list so the
+        // sidebar/name-click can route straight to it next time.
+        void queryClient.invalidateQueries({ queryKey: ["canvas-channels"] });
+      },
+    }),
+  );
 
   return {
     createDashboard: (channelId: string, name: string, templateId?: string) =>
@@ -113,6 +123,10 @@ export function useDashboardMutations() {
     // created canvas from its generation prompt.
     renameDashboard: (id: string, name: string) =>
       rename.mutateAsync({ id, name }),
+    // Ensure a channel has its home canvas (creating + seeding it if absent).
+    // Idempotent server-side; returns the home canvas record.
+    ensureHomeCanvas: (channelId: string) =>
+      ensureHome.mutateAsync({ channelId }),
     // Explicitly persist a freeform canvas's current code + history (autosave
     // already runs each turn; this is the manual Save affordance).
     saveFreeformDashboard: (
@@ -147,6 +161,38 @@ export function useDashboardMutations() {
     isCreating: create.isPending,
     isDeleting: remove.isPending,
   };
+}
+
+/**
+ * Open a channel's home canvas in the main content pane. Uses the channel's
+ * known homeCanvasId when present; otherwise creates one on the fly (backfill
+ * for channels made before home canvases existed) before navigating.
+ */
+export function useOpenHomeCanvas(): (channel: {
+  id: string;
+  homeCanvasId?: string;
+}) => Promise<void> {
+  const navigate = useNavigate();
+  const { ensureHomeCanvas } = useDashboardMutations();
+
+  return useCallback(
+    async (channel) => {
+      try {
+        const dashboardId =
+          channel.homeCanvasId ?? (await ensureHomeCanvas(channel.id)).id;
+        await navigate({
+          to: "/website/$channelId/dashboards/$dashboardId",
+          params: { channelId: channel.id, dashboardId },
+        });
+      } catch (error) {
+        log.error("Failed to open home canvas", { error });
+        toast.error("Couldn't open channel home", {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    [navigate, ensureHomeCanvas],
+  );
 }
 
 /** Create an empty canvas in a channel, enter edit mode, and navigate to it. */

--- a/packages/ui/src/router/navigationBridge.ts
+++ b/packages/ui/src/router/navigationBridge.ts
@@ -46,6 +46,23 @@ export function navigateToChannelTask(channelId: string, taskId: string): void {
   });
 }
 
+export function navigateToChannelNewTask(channelId: string): void {
+  void getRouterOrNull()?.navigate({
+    to: "/website/$channelId/new",
+    params: { channelId },
+  });
+}
+
+export function navigateToChannelDashboard(
+  channelId: string,
+  dashboardId: string,
+): void {
+  void getRouterOrNull()?.navigate({
+    to: "/website/$channelId/dashboards/$dashboardId",
+    params: { channelId, dashboardId },
+  });
+}
+
 export function navigateToFolderSettings(folderId: string): void {
   void getRouterOrNull()?.navigate({
     to: "/folders/$folderId",


### PR DESCRIPTION
## What

Adds a per-channel **home canvas**: a freeform React board (rendered in a null-origin sandbox iframe) that lists the channel's canvases and tasks. This PR builds it up to be interactive.

### Home canvas (earlier commits)
- Auto-create a home canvas per channel; lazily backfill older channels.
- Read Canvases / Tasks / Inbox lists from the `system.file_system` HogQL table, tagged to the desktop surface.
- Horizontal section layout with PostHog styling.

### Canvas → app navigation (this work)
- New **allowlisted** `navigate` postMessage variant on the canvas↔host protocol. Its payload is a nested discriminated union — `task` | `new-task` | `canvas` | `new-canvas` — which **is** the security allowlist: no free-form path, and `channelId` is host-supplied, so an untrusted canvas can only route within its own channel.
- `window.ph.navigate.{toTask,toNewTask,toCanvas,toNewCanvas}` shim inside the iframe; `FreeformCanvas` forwards the validated intent via a channel-agnostic `onNavigate` prop; the channel-aware view maps it to `navigationBridge`.
- Wired the seeded template: clicking a task/canvas row or a "+ New" button now routes. Tasks navigate by `ref` (the real task id), not the file-system row id.

### Reset to default
- "Reset to default" button shown when editing the channel's home canvas. The host regenerates the default template, appends it as a new version (prior source kept as an undo step), and persists — non-destructive and recoverable via Undo.

## Security
- The intent union is the only navigation surface; the host drops anything that doesn't parse.
- `channelId` is never iframe-supplied; IDs flow into router params (escaped), never concatenated into paths.
- `FreeformCanvas` stays channel-agnostic so the allowlist mapping can't be bypassed.

## Notes
- The home canvas is seeded **once per channel** — channels created before a change keep their old template until **Reset to default** (or a fresh channel).
- Tasks only appear once filed to the channel (desktop FS row under the channel folder).

## Testing
- `@posthog/core`, `@posthog/host-router`, `@posthog/ui` typecheck clean for these changes.
- ⚠️ Whole-repo typecheck currently fails on 3 **pre-existing** errors unrelated to this PR (`WebsiteLayout.tsx` `loading` prop; `InteractiveFileDiff.tsx` `fileGap`).
- Manual: open a channel home canvas → click task/canvas rows and "+ New" buttons route correctly; edit the home canvas → "Reset to default" restores the template and Undo brings edits back.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*