### PR TITLE
fix(canvas): keep bluebird Home nav in the Channels space

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -13,9 +13,9 @@ import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem
 import {
   navigateToAgents,
   navigateToCanvas,
-  navigateToHome,
   navigateToInbox,
   navigateToSkills,
+  navigateToWebsiteHome,
 } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { Box, Flex } from "@radix-ui/themes";
@@ -32,8 +32,10 @@ const NON_CANVAS_WEBSITE_PREFIXES = [
 ];
 
 // The global nav brought over from the Code app — a single icon+label row each,
-// no rail. These are app-wide destinations (they leave the Channels space for
-// the corresponding Code view); the channel tree below is channel browsing.
+// no rail. Home points at the /website/home mirror so it stays in the Channels
+// space (same shared HomeView, channels chrome kept); the other rows are
+// app-wide destinations that leave the Channels space for the Code view. The
+// channel tree below is channel browsing.
 function ChannelsNav() {
   const view = useAppView();
   // Active on the canvas surfaces: the channels index, a channel, or a canvas —
@@ -59,7 +61,7 @@ function ChannelsNav() {
         }
         label="Home"
         isActive={view.type === "home"}
-        onClick={navigateToHome}
+        onClick={navigateToWebsiteHome}
       />
       <SidebarItem
         depth={0}

--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -6,7 +6,9 @@ import {
   SquaresFourIcon,
   TrayIcon,
 } from "@phosphor-icons/react";
+import { HOME_TAB_FLAG } from "@posthog/shared/constants";
 import { ChannelsList } from "@posthog/ui/features/canvas/components/ChannelsList";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { ProjectSwitcher } from "@posthog/ui/features/sidebar/components/ProjectSwitcher";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
@@ -38,6 +40,7 @@ const NON_CANVAS_WEBSITE_PREFIXES = [
 // channel tree below is channel browsing.
 function ChannelsNav() {
   const view = useAppView();
+  const homeTabEnabled = useFeatureFlag(HOME_TAB_FLAG);
   // Active on the canvas surfaces: the channels index, a channel, or a canvas —
   // any /website route that isn't one of the cross-app mirrors above.
   const isCanvasActive = useRouterState({
@@ -51,18 +54,20 @@ function ChannelsNav() {
   });
   return (
     <Flex direction="column" className="shrink-0 gap-px px-2 py-2">
-      <SidebarItem
-        depth={0}
-        icon={
-          <HouseIcon
-            size={16}
-            weight={view.type === "home" ? "fill" : "regular"}
-          />
-        }
-        label="Home"
-        isActive={view.type === "home"}
-        onClick={navigateToWebsiteHome}
-      />
+      {homeTabEnabled && (
+        <SidebarItem
+          depth={0}
+          icon={
+            <HouseIcon
+              size={16}
+              weight={view.type === "home" ? "fill" : "regular"}
+            />
+          }
+          label="Home"
+          isActive={view.type === "home"}
+          onClick={navigateToWebsiteHome}
+        />
+      )}
       <SidebarItem
         depth={0}
         icon={


### PR DESCRIPTION
## What

Clicking **Home** in the project-bluebird (Channels) left nav navigated to `/code/home`, which leaves the Channels space and swaps the whole view back to the Code app. This points the Home item at the existing `/website/home` mirror route so it renders the same shared `HomeView` while keeping the channels chrome.

## How

The supporting infrastructure already existed:
- `routes/website/home.tsx` — `/website/home` route rendering the **same** `HomeView` as `/code/home` (single source of truth).
- `useAppView` maps both `/code/home` and `/website/home` to `type: "home"`, so active-state highlighting works.
- `__root.tsx` keeps the channels chrome (`isChannelsSpace`) for any `/website/*` path.
- `navigateToWebsiteHome()` already exists in `navigationBridge.ts`.

The only missing wiring was the sidebar click. This PR:
- Swaps the Home item's `onClick` from `navigateToHome` (`/code/home`) → `navigateToWebsiteHome` (`/website/home`) in `ChannelsSidebar.tsx`.
- Updates the import and the nav-block comment (Home now stays in-space; Inbox/Agents/Files still leave it).

## Result

One `HomeView` component, rendered under both `/code/home` and `/website/home`. Clicking Home in the bluebird sidebar now stays within the Channels view instead of switching the whole app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)