### PR TITLE
feat(canvas): add Leave feedback survey modal to Channels view

### DIFF
--- a/apps/web/src/web-container.ts
+++ b/apps/web/src/web-container.ts
@@ -76,6 +76,7 @@ container.bind(ANALYTICS_TRACKER).toConstantValue({
   identifyUser: () => {},
   setUserGroups: () => {},
   resetUser: () => {},
+  captureSurveyResponse: () => {},
 });
 container.bind(IMPERATIVE_QUERY_CLIENT).toConstantValue(queryClient);
 

--- a/packages/ui/src/features/canvas/components/FeedbackModal.test.tsx
+++ b/packages/ui/src/features/canvas/components/FeedbackModal.test.tsx
@@ -25,21 +25,21 @@ describe("FeedbackModal", () => {
     captureSurveyResponse.mockReset();
   });
 
-  it("shows a Skip button when opened via Go back to Code", () => {
-    renderModal("leaving");
-    expect(screen.getByRole("button", { name: "Skip" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Cancel" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows a Cancel button when opened via Leave feedback", () => {
-    renderModal("feedback");
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Skip" }),
-    ).not.toBeInTheDocument();
-  });
+  it.each([
+    { mode: "leaving" as const, expected: "Skip", missing: "Cancel" },
+    { mode: "feedback" as const, expected: "Cancel", missing: "Skip" },
+  ])(
+    "shows the $expected secondary button in $mode mode",
+    ({ mode, expected, missing }) => {
+      renderModal(mode);
+      expect(
+        screen.getByRole("button", { name: expected }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: missing }),
+      ).not.toBeInTheDocument();
+    },
+  );
 
   it("disables submit until text is entered", async () => {
     const user = userEvent.setup();

--- a/packages/ui/src/features/canvas/components/FeedbackModal.test.tsx
+++ b/packages/ui/src/features/canvas/components/FeedbackModal.test.tsx
@@ -1,0 +1,81 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { captureSurveyResponse } = vi.hoisted(() => ({
+  captureSurveyResponse: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/shell/analytics", () => ({ captureSurveyResponse }));
+
+import { FeedbackModal, type FeedbackModalMode } from "./FeedbackModal";
+
+function renderModal(mode: FeedbackModalMode | null, onFinished = vi.fn()) {
+  render(
+    <Theme>
+      <FeedbackModal mode={mode} onFinished={onFinished} />
+    </Theme>,
+  );
+  return onFinished;
+}
+
+describe("FeedbackModal", () => {
+  beforeEach(() => {
+    captureSurveyResponse.mockReset();
+  });
+
+  it("shows a Skip button when opened via Go back to Code", () => {
+    renderModal("leaving");
+    expect(screen.getByRole("button", { name: "Skip" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a Cancel button when opened via Leave feedback", () => {
+    renderModal("feedback");
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Skip" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables submit until text is entered", async () => {
+    const user = userEvent.setup();
+    renderModal("feedback");
+    const submit = screen.getByRole("button", { name: "Send feedback" });
+    // The quill Button signals disabled state via aria-disabled, not the native attr.
+    expect(submit).toHaveAttribute("aria-disabled", "true");
+
+    await user.type(screen.getByPlaceholderText("Share your feedback"), "hi");
+    expect(submit).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("captures the trimmed response and finishes on submit", async () => {
+    const user = userEvent.setup();
+    const onFinished = renderModal("leaving");
+
+    await user.type(
+      screen.getByPlaceholderText("Share your feedback"),
+      "  great work  ",
+    );
+    await user.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    expect(captureSurveyResponse).toHaveBeenCalledTimes(1);
+    expect(captureSurveyResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ response: "great work" }),
+    );
+    expect(onFinished).toHaveBeenCalledTimes(1);
+  });
+
+  it("finishes without capturing when skipped", async () => {
+    const user = userEvent.setup();
+    const onFinished = renderModal("leaving");
+
+    await user.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(captureSurveyResponse).not.toHaveBeenCalled();
+    expect(onFinished).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/features/canvas/components/FeedbackModal.tsx
+++ b/packages/ui/src/features/canvas/components/FeedbackModal.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -13,7 +14,7 @@ import {
 } from "@posthog/ui/features/canvas/feedbackSurvey";
 import { captureSurveyResponse } from "@posthog/ui/shell/analytics";
 import { TextArea } from "@radix-ui/themes";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export type FeedbackModalMode = "feedback" | "leaving";
 
@@ -32,23 +33,6 @@ export interface FeedbackModalProps {
  */
 export function FeedbackModal({ mode, onFinished }: FeedbackModalProps) {
   const open = mode !== null;
-  const [value, setValue] = useState("");
-
-  // Reset the textarea every time the modal opens.
-  useEffect(() => {
-    if (open) setValue("");
-  }, [open]);
-
-  const handleSubmit = () => {
-    const response = value.trim();
-    if (!response) return;
-    captureSurveyResponse({
-      surveyId: FEEDBACK_SURVEY_ID,
-      questionId: FEEDBACK_SURVEY_QUESTION_ID,
-      response,
-    });
-    onFinished();
-  };
 
   return (
     <Dialog
@@ -66,6 +50,39 @@ export function FeedbackModal({ mode, onFinished }: FeedbackModalProps) {
             change.
           </DialogDescription>
         </DialogHeader>
+        {/* Mounted only while open so the textarea resets on each open without
+            syncing state to the `mode` prop in an effect. */}
+        {mode !== null && (
+          <FeedbackModalForm mode={mode} onFinished={onFinished} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FeedbackModalForm({
+  mode,
+  onFinished,
+}: {
+  mode: FeedbackModalMode;
+  onFinished: () => void;
+}) {
+  const [value, setValue] = useState("");
+
+  const handleSubmit = () => {
+    const response = value.trim();
+    if (!response) return;
+    captureSurveyResponse({
+      surveyId: FEEDBACK_SURVEY_ID,
+      questionId: FEEDBACK_SURVEY_QUESTION_ID,
+      response,
+    });
+    onFinished();
+  };
+
+  return (
+    <>
+      <DialogBody>
         <TextArea
           value={value}
           onChange={(event) => setValue(event.target.value)}
@@ -74,20 +91,20 @@ export function FeedbackModal({ mode, onFinished }: FeedbackModalProps) {
           maxLength={4000}
           autoFocus
         />
-        <DialogFooter>
-          <Button variant="outline" size="sm" onClick={onFinished}>
-            {mode === "leaving" ? "Skip" : "Cancel"}
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            disabled={value.trim().length === 0}
-            onClick={handleSubmit}
-          >
-            Send feedback
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      </DialogBody>
+      <DialogFooter>
+        <Button variant="outline" size="sm" onClick={onFinished}>
+          {mode === "leaving" ? "Skip" : "Cancel"}
+        </Button>
+        <Button
+          variant="primary"
+          size="sm"
+          disabled={value.trim().length === 0}
+          onClick={handleSubmit}
+        >
+          Send feedback
+        </Button>
+      </DialogFooter>
+    </>
   );
 }

--- a/packages/ui/src/features/canvas/components/FeedbackModal.tsx
+++ b/packages/ui/src/features/canvas/components/FeedbackModal.tsx
@@ -1,0 +1,93 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@posthog/quill";
+import {
+  FEEDBACK_SURVEY_ID,
+  FEEDBACK_SURVEY_QUESTION_ID,
+} from "@posthog/ui/features/canvas/feedbackSurvey";
+import { captureSurveyResponse } from "@posthog/ui/shell/analytics";
+import { TextArea } from "@radix-ui/themes";
+import { useEffect, useState } from "react";
+
+export type FeedbackModalMode = "feedback" | "leaving";
+
+export interface FeedbackModalProps {
+  /** `null` closes the modal. `"leaving"` shows a Skip button, `"feedback"` a Cancel button. */
+  mode: FeedbackModalMode | null;
+  /** Called after the response is submitted, and when the modal is skipped/cancelled/dismissed. */
+  onFinished: () => void;
+}
+
+/**
+ * Feedback modal for the Channels space. Submitting records the text as a
+ * PostHog survey response (see {@link FEEDBACK_SURVEY_ID}). The secondary button
+ * reads "Skip" when opened by "Go back to Code" (`mode === "leaving"`) and
+ * "Cancel" when opened by "Leave feedback".
+ */
+export function FeedbackModal({ mode, onFinished }: FeedbackModalProps) {
+  const open = mode !== null;
+  const [value, setValue] = useState("");
+
+  // Reset the textarea every time the modal opens.
+  useEffect(() => {
+    if (open) setValue("");
+  }, [open]);
+
+  const handleSubmit = () => {
+    const response = value.trim();
+    if (!response) return;
+    captureSurveyResponse({
+      surveyId: FEEDBACK_SURVEY_ID,
+      questionId: FEEDBACK_SURVEY_QUESTION_ID,
+      response,
+    });
+    onFinished();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        // Esc / outside-click dismiss behaves like the secondary button.
+        if (!isOpen) onFinished();
+      }}
+    >
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Leave feedback</DialogTitle>
+          <DialogDescription>
+            How's the Channels experience? Tell us what's working and what you'd
+            change.
+          </DialogDescription>
+        </DialogHeader>
+        <TextArea
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="Share your feedback"
+          rows={4}
+          maxLength={4000}
+          autoFocus
+        />
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={onFinished}>
+            {mode === "leaving" ? "Skip" : "Cancel"}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={value.trim().length === 0}
+            onClick={handleSubmit}
+          >
+            Send feedback
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/features/canvas/components/FeedbackModal.tsx
+++ b/packages/ui/src/features/canvas/components/FeedbackModal.tsx
@@ -7,13 +7,13 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Textarea,
 } from "@posthog/quill";
 import {
   FEEDBACK_SURVEY_ID,
   FEEDBACK_SURVEY_QUESTION_ID,
 } from "@posthog/ui/features/canvas/feedbackSurvey";
 import { captureSurveyResponse } from "@posthog/ui/shell/analytics";
-import { TextArea } from "@radix-ui/themes";
 import { useState } from "react";
 
 export type FeedbackModalMode = "feedback" | "leaving";
@@ -83,7 +83,7 @@ function FeedbackModalForm({
   return (
     <>
       <DialogBody>
-        <TextArea
+        <Textarea
           value={value}
           onChange={(event) => setValue(event.target.value)}
           placeholder="Share your feedback"

--- a/packages/ui/src/features/canvas/feedbackSurvey.ts
+++ b/packages/ui/src/features/canvas/feedbackSurvey.ts
@@ -1,0 +1,8 @@
+// PostHog survey backing the Channels "Leave feedback" modal. Created via the
+// MCP in project 2 ("PostHog App + Website") and launched so it collects
+// responses. Responses are sent client-side as a `survey sent` event and only
+// attach to this survey if the app reports to the same project.
+// https://us.posthog.com/project/2/surveys/019ee235-2e3b-0000-64b3-5f2efa487452
+export const FEEDBACK_SURVEY_ID = "019ee235-2e3b-0000-64b3-5f2efa487452";
+export const FEEDBACK_SURVEY_QUESTION_ID =
+  "d1b5bf40-c255-434f-8799-d4ca13873d74";

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -8,6 +8,10 @@ import {
 } from "@posthog/shared";
 import { UsageLimitModal } from "@posthog/ui/features/billing/UsageLimitModal";
 import { ChannelsSidebar } from "@posthog/ui/features/canvas/components/ChannelsSidebar";
+import {
+  FeedbackModal,
+  type FeedbackModalMode,
+} from "@posthog/ui/features/canvas/components/FeedbackModal";
 import { CommandMenu } from "@posthog/ui/features/command/CommandMenu";
 import { KeyboardShortcutsSheet } from "@posthog/ui/features/command/KeyboardShortcutsSheet";
 import { useNewTaskDeepLink } from "@posthog/ui/features/deep-links/useNewTaskDeepLink";
@@ -90,6 +94,18 @@ export const Route = createRootRoute({
 function RootLayout() {
   const view = useAppView();
   const navigate = useNavigate();
+
+  // Feedback modal shown in the Channels title bar. Opened directly by "Leave
+  // feedback" (mode "feedback") or as an intercept before "Go back to Code"
+  // (mode "leaving", which routes to /code once submitted or skipped).
+  const [feedbackMode, setFeedbackMode] = useState<FeedbackModalMode | null>(
+    null,
+  );
+  const handleFeedbackFinished = () => {
+    const wasLeaving = feedbackMode === "leaving";
+    setFeedbackMode(null);
+    if (wasLeaving) navigate({ to: "/code" });
+  };
   const {
     isOpen: commandMenuOpen,
     setOpen: setCommandMenuOpen,
@@ -214,15 +230,22 @@ function RootLayout() {
           <Box className="h-[14px] w-[26px] overflow-hidden [&>svg]:h-[14px] [&>svg]:w-auto">
             <LogosLandscape code={false} />
           </Box>
-          <div className="no-drag">
+          <Flex align="center" gap="2" className="no-drag">
             <Button
               variant="outline"
               size="sm"
-              onClick={() => navigate({ to: "/code" })}
+              onClick={() => setFeedbackMode("leaving")}
             >
               Go back to Code
             </Button>
-          </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setFeedbackMode("feedback")}
+            >
+              Leave feedback
+            </Button>
+          </Flex>
         </Flex>
         <Flex flexGrow="1" overflow="hidden">
           <ChannelsSidebar />
@@ -245,6 +268,7 @@ function RootLayout() {
         />
         {billingEnabled && <UsageLimitModal />}
         <RemoteBranchCheckoutDialog />
+        <FeedbackModal mode={feedbackMode} onFinished={handleFeedbackFinished} />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>
             <TanStackDevtools />

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -268,7 +268,10 @@ function RootLayout() {
         />
         {billingEnabled && <UsageLimitModal />}
         <RemoteBranchCheckoutDialog />
-        <FeedbackModal mode={feedbackMode} onFinished={handleFeedbackFinished} />
+        <FeedbackModal
+          mode={feedbackMode}
+          onFinished={handleFeedbackFinished}
+        />
         {import.meta.env.DEV && (
           <Suspense fallback={null}>
             <TanStackDevtools />

--- a/packages/ui/src/shell/analytics.ts
+++ b/packages/ui/src/shell/analytics.ts
@@ -30,6 +30,11 @@ export interface AnalyticsTracker {
   identifyUser(userId: string, properties?: UserIdentifyProperties): void;
   setUserGroups(user: AnalyticsUserGroups): void;
   resetUser(): void;
+  captureSurveyResponse(params: {
+    surveyId: string;
+    questionId: string;
+    response: string;
+  }): void;
 }
 
 export const ANALYTICS_TRACKER = Symbol.for("posthog.ui.AnalyticsTracker");
@@ -73,4 +78,14 @@ export function setUserGroups(user: AnalyticsUserGroups): void {
 
 export function resetUser(): void {
   resolveService<AnalyticsTracker>(ANALYTICS_TRACKER).resetUser();
+}
+
+export function captureSurveyResponse(params: {
+  surveyId: string;
+  questionId: string;
+  response: string;
+}): void {
+  resolveService<AnalyticsTracker>(ANALYTICS_TRACKER).captureSurveyResponse(
+    params,
+  );
 }

--- a/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -219,6 +219,34 @@ export function track<K extends keyof EventPropertyMap>(
 }
 
 /**
+ * Record a survey response via posthog-js's `survey sent` event. The survey
+ * must already exist (and be launched) in the project the app reports to, or
+ * the response will not attach to it.
+ */
+export function captureSurveyResponse({
+  surveyId,
+  questionId,
+  response,
+}: {
+  surveyId: string;
+  questionId: string;
+  response: string;
+}) {
+  if (!isInitialized) {
+    return;
+  }
+
+  posthog.capture("survey sent", {
+    $survey_id: surveyId,
+    $survey_questions: [{ id: questionId }],
+    // Newer ingestion keys responses by question id; `$survey_response` is the
+    // legacy single-question key. Send both so the response attaches either way.
+    [`$survey_response_${questionId}`]: response,
+    $survey_response: response,
+  });
+}
+
+/**
  * Build tool metadata for analytics on permission requests
  */
 export function buildPermissionToolMetadata(
@@ -318,6 +346,7 @@ export const posthogAnalyticsTracker: AnalyticsTracker = {
   identifyUser,
   setUserGroups,
   resetUser,
+  captureSurveyResponse,
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds a **"Leave feedback"** button next to "Go back to Code" in the project-bluebird **Channels** title bar, and routes "Go back to Code" through the same modal first.

1. **Leave feedback** → opens a modal with a text box; submitting records the text as a **PostHog survey response**.
2. **Go back to Code** → opens the same modal as a gentle intercept. The user can **Skip** (the secondary button reads "Skip" only in this flow; it reads "Cancel" when opened via "Leave feedback"). After submit *or* skip, the user is routed back to `/code`. In the "Leave feedback" flow, submit/cancel just closes — no navigation.

## How it works

- Survey responses are sent via posthog-js's `"survey sent"` event, routed through the existing `AnalyticsTracker` seam (new `captureSurveyResponse` method) so feature code never imports posthog-js directly.
- The backing survey is an `api`-type single-open-question survey created + launched in PostHog. Its IDs are stored in `packages/ui/src/features/canvas/feedbackSurvey.ts`:
  - Survey: [`019ee235-2e3b-0000-64b3-5f2efa487452`](https://us.posthog.com/project/2/surveys/019ee235-2e3b-0000-64b3-5f2efa487452) (us.posthog.com project 2)

## Files

- `features/canvas/components/FeedbackModal.tsx` *(new)* — quill `Dialog` + Radix `TextArea`; Skip/Cancel labeling driven by mode; submit disabled until text entered.
- `features/canvas/feedbackSurvey.ts` *(new)* — survey/question ID constants.
- `shell/analytics.ts` + `shell/posthogAnalyticsImpl.ts` — `captureSurveyResponse` on the analytics tracker.
- `router/routes/__root.tsx` — buttons + modal wiring in the channels branch.
- `apps/web/src/web-container.ts` — no-op `captureSurveyResponse` for the web stub tracker.

## ⚠️ Note on the survey project

The survey lives in **us.posthog.com project 2**, but the desktop app's analytics host is build-time configured (`VITE_POSTHOG_API_HOST`, default `internal-c.posthog.com`). `survey sent` events only attach to this survey if the running build reports to project 2. Confirm via `surveys-responses-list` once a build pointed there exercises the flow.

## Test plan

- [x] `@posthog/ui`, `@posthog/web`, `@posthog/code` typecheck
- [x] Biome lint clean on all touched files (no `noRestrictedImports` violations)
- [x] New `FeedbackModal.test.tsx` (5 tests) + existing `posthogAnalyticsImpl` tests (11) pass
- [ ] Manual: in `/website`, both buttons render; "Leave feedback" shows **Cancel** and stays on Channels; "Go back to Code" shows **Skip** and routes to `/code` on submit/skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
