### PR TITLE
perf(branch-selector): cache branches longer and prefetch without validateRepo waterfall

### DIFF
--- a/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
@@ -151,7 +151,9 @@ export function BranchSelector({
         directoryPath: repoPath as string,
       }),
       enabled: !isCloudMode && !!repoPath,
-      staleTime: 60_000,
+      staleTime: 5 * 60_000,
+      gcTime: 30 * 60_000,
+      refetchOnWindowFocus: false,
     });
 
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;

--- a/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
@@ -151,9 +151,8 @@ export function BranchSelector({
         directoryPath: repoPath as string,
       }),
       enabled: !isCloudMode && !!repoPath,
-      staleTime: 5 * 60_000,
-      gcTime: 30 * 60_000,
-      refetchOnWindowFocus: false,
+      staleTime: Infinity,
+      gcTime: 10 * 60_000,
     });
 
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;

--- a/packages/ui/src/features/git-interaction/useGitQueries.ts
+++ b/packages/ui/src/features/git-interaction/useGitQueries.ts
@@ -109,9 +109,8 @@ export function useGitQueries(
   useQuery(
     trpc.git.getAllBranches.queryOptions(input, {
       enabled,
-      staleTime: 5 * 60_000,
-      gcTime: 30 * 60_000,
-      refetchOnWindowFocus: false,
+      staleTime: Infinity,
+      gcTime: 10 * 60_000,
     }),
   );
 

--- a/packages/ui/src/features/git-interaction/useGitQueries.ts
+++ b/packages/ui/src/features/git-interaction/useGitQueries.ts
@@ -108,9 +108,10 @@ export function useGitQueries(
 
   useQuery(
     trpc.git.getAllBranches.queryOptions(input, {
-      enabled: repoEnabled,
-      ...GIT_QUERY_DEFAULTS,
-      staleTime: 60_000,
+      enabled,
+      staleTime: 5 * 60_000,
+      gcTime: 30 * 60_000,
+      refetchOnWindowFocus: false,
     }),
   );
 


### PR DESCRIPTION
## Summary

Fixes #2488 - the branch selector is slow every time it is opened.

* **Long-lived branch cache**: Set `getAllBranches` to `staleTime: Infinity` and `gcTime: 10 min`. Branch lists are treated as fresh indefinitely and remain in the React Query cache for 10 minutes after the component unmounts (e.g. when switching tasks), making repeat opens instant.
* **Rely on git invalidation instead of timers**: Branches are invalidated by the existing git file watcher via `invalidateGitBranchQueries` whenever `.git` state changes. This means correctness is driven by actual repository changes (e.g. branch create/delete/switch) rather than arbitrary cache-expiry timers.
* **Background fetch / no waterfall**: In `useGitQueries`, drop the `repoEnabled` gate on `getAllBranches` (use `enabled` directly) so branch fetching starts in parallel with `validateRepo` rather than waiting for it to complete. Wherever `useGitQueries` is mounted (ChangesPanel, ReviewPage, etc.), branches are already being fetched before the user opens the dropdown. `getAllBranches` already catches errors and returns `[]`, so eagerly fetching is safe.

### Why these cache settings?

Branch lists change relatively infrequently, and we already have a file watcher that invalidates branch queries whenever the underlying git state changes. Because correctness is handled by invalidation, there is little value in periodically marking branch data as stale and refetching it.

Using `staleTime: Infinity` gives a simpler model: branch data remains fresh until the git watcher says otherwise. The 10-minute `gcTime` allows cached branch lists to survive normal task switching while still eventually releasing memory.

## Test plan

* [ ] Open a task with a local repo, click branch selector: first open loads, subsequent opens are instant
* [ ] Navigate to a different task and back within 10 minutes: branch list is instant (served from cache)
* [ ] Create or delete a branch from the terminal: file watcher fires and branch list updates when reopened
* [ ] Confirm branch fetching starts immediately when the page loads rather than waiting for `validateRepo` to complete
