### PR TITLE
perf(renderer): stop refetching every query on window focus

### DIFF
--- a/apps/code/src/renderer/utils/queryClient.test.ts
+++ b/apps/code/src/renderer/utils/queryClient.test.ts
@@ -63,6 +63,14 @@ describe("getCachedTask", () => {
   });
 });
 
+describe("defaultOptions", () => {
+  it("defaults refetchOnWindowFocus to false so returning to the app does not refetch every query", () => {
+    expect(queryClient.getDefaultOptions().queries?.refetchOnWindowFocus).toBe(
+      false,
+    );
+  });
+});
+
 describe("focusManager", () => {
   it("flips focus state on window focus/blur events", () => {
     window.dispatchEvent(new Event("blur"));

--- a/apps/code/src/renderer/utils/queryClient.ts
+++ b/apps/code/src/renderer/utils/queryClient.ts
@@ -10,10 +10,12 @@ export const queryClient = new QueryClient({
   },
 });
 
-// Electron renderers stay visible when the BrowserWindow loses OS focus, so
-// `document.visibilitychange` (TanStack's default signal) never fires on
-// app-switch. Listen to window `focus`/`blur` as well so refetchOnWindowFocus
-// actually triggers when the user returns from an external browser.
+// Electron renderers stay "visible" when the BrowserWindow loses OS focus, so
+// `document.visibilitychange` (TanStack's default focus signal) never fires on
+// app-switch. Track window `focus`/`blur` so `focusManager` knows when the app
+// is backgrounded and pauses `refetchInterval` polling for the queries that
+// don't set `refetchIntervalInBackground`. Refetch-on-focus is off (see
+// `defaultOptions` above); this listener exists only for the polling gate.
 focusManager.setEventListener((handleFocus) => {
   if (typeof window === "undefined") return;
 

--- a/apps/code/src/renderer/utils/queryClient.ts
+++ b/apps/code/src/renderer/utils/queryClient.ts
@@ -5,7 +5,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5,
-      refetchOnWindowFocus: true,
+      refetchOnWindowFocus: false,
     },
   },
 });

--- a/packages/ui/src/shell/App.tsx
+++ b/packages/ui/src/shell/App.tsx
@@ -59,7 +59,6 @@ function App() {
     client: authenticatedClient,
     enabled:
       isAuthenticated && hasCompletedOnboarding && hasCodeAccess === true,
-    refetchOnWindowFocus: "always",
   });
   const currentOrg = currentUser?.organization;
   const needsAiApproval =

--- a/packages/ui/src/shell/App.tsx
+++ b/packages/ui/src/shell/App.tsx
@@ -59,6 +59,7 @@ function App() {
     client: authenticatedClient,
     enabled:
       isAuthenticated && hasCompletedOnboarding && hasCodeAccess === true,
+    refetchOnWindowFocus: "always",
   });
   const currentOrg = currentUser?.organization;
   const needsAiApproval =


### PR DESCRIPTION
## Problem

Returning to PostHog Code (alt-tab back into the window) froze the UI: the renderer pegged the main thread at 100%+ while the main process sat idle at ~2%.

`apps/code/src/renderer/utils/queryClient.ts` set `refetchOnWindowFocus: true` globally, and a `focusManager` listener deliberately maps window `focus`/`blur` to refetch (Electron renderers stay "visible" on app-switch, so `visibilitychange` alone never fires). So **every active query refetched the instant you returned to the app** — a synchronous refetch-and-re-render burst, worst after being away >5min when every query is also stale.

## Change

- Default `refetchOnWindowFocus` to `false` in the renderer query client. This kills the storm; data still refreshes via tRPC subscriptions and the file watcher, and the inbox hooks already set `false` per-query.
- Correct the `focusManager` listener comment: it is **not** removed (it still gates `refetchInterval` background-poll pausing, which TanStack ties to focus state), but its comment no longer claims to drive focus-refetch.

`currentUser` keeps its `refetchOnWindowFocus: "always"` override (unchanged from main) so the AI-approval gate still clears on return — that is one cheap query, not the storm.

## Measurement

Captured against the running dev app over CDP (React commit hook + `longtask` observer, focus synthesized to reproduce "return to app"):

| per focus event | before | after (global flip) | idle baseline |
| --- | --- | --- | --- |
| React commits | 12 | 2-4 | 4 / 5s |
| long tasks | 1 | 0 | 0 |
| main thread blocked | 53-73ms | 0ms | 0ms |
| commit work | ~125ms | 11-28ms | - |

(With `currentUser` keeping `"always"`, expect ~1 extra query refetch + a small commit per focus — still far below the original 12-commit storm.)

## Follow-ups (separate PRs)

- #2799 — debounce/coalesce file-watcher query invalidations.
- Streaming render perf (CodePreview editor recreation, tool-view memoization) — pending a live streaming trace before touching render code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)