### PR TITLE
fix(inbox): forward reviewer search query to the server

### DIFF
--- a/packages/ui/src/features/inbox/components/SuggestedReviewersSection.tsx
+++ b/packages/ui/src/features/inbox/components/SuggestedReviewersSection.tsx
@@ -103,6 +103,7 @@ function SuggestedReviewersBody({
   const { data: availableReviewers, isFetching } =
     useInboxAvailableSuggestedReviewers({
       enabled: !!client && addOpen,
+      query: deferredQuery,
     });
 
   const addableOptions = useMemo(() => {


### PR DESCRIPTION
## Problem

Assigning a reviewer in the Inbox only surfaced people whose first name fell in roughly the first half of the alphabet (up to ~"M"), and typing a name that came later returned "No users found" — even for someone who is definitely in the org. This blocked assigning a large set of teammates as reviewers.

## Changes

The Add-reviewer popover called `useInboxAvailableSuggestedReviewers` with no `query` and then filtered the result **client-side**. The backend `available_reviewers` endpoint returns only the first 100 users sorted by first name, so anyone after the cutoff was never in the fetched set and couldn't be found by searching.

This forwards the popover's `deferredQuery` into the hook so the search hits the server, which filters *before* applying its 100-row cap — making any teammate findable by typing their name. The hook already plumbs the query through its query key and into the API call; this just passes it in.

Note: this is the frontend half. The backend `[:100]` cap (in `PostHog/posthog` `products/signals/backend/views.py`) still truncates the default unsearched list and should be revisited separately.

## How did you test this?

Not run — `node_modules` isn't installed in this environment, so the workspace typecheck can't resolve. The change only passes a `string` into an options field already typed as `query?: string`, and the hook already handles query forwarding and cache-keying.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1781901413265679?thread_ts=1781901413.265679&cid=C09G8Q32R6F)*
