### PR TITLE
perf(sidebar): memoize TaskRow so navigation re-renders 2 rows, not all

### DIFF
--- a/packages/ui/src/features/sidebar/components/TaskListView.test.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.test.tsx
@@ -1,0 +1,111 @@
+import type { TaskData } from "@posthog/core/sidebar/sidebarData.types";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { renderCounts } = vi.hoisted(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  return { renderCounts: new Map<string, number>() };
+});
+
+vi.mock("@posthog/ui/features/sidebar/components/items/TaskItem", () => ({
+  TaskItem: ({ taskId }: { taskId: string }) => {
+    renderCounts.set(taskId, (renderCounts.get(taskId) ?? 0) + 1);
+    return null;
+  },
+}));
+
+vi.mock("@posthog/ui/features/workspace/useWorkspace", () => ({
+  useWorkspace: () => undefined,
+}));
+vi.mock("@posthog/ui/features/sidebar/useTaskPrStatus", () => ({
+  useTaskPrStatus: () => ({ prState: null, hasDiff: false }),
+}));
+vi.mock("@posthog/ui/features/sidebar/archivingTasksStore", () => ({
+  useArchivingTasksStore: (
+    selector: (s: { archivingTaskIds: Set<string> }) => unknown,
+  ) => selector({ archivingTaskIds: new Set<string>() }),
+}));
+vi.mock("@posthog/ui/features/folders/useFolders", () => ({
+  useFolders: () => ({ folders: [] }),
+}));
+vi.mock("@posthog/ui/router/useAppView", () => ({
+  useAppView: () => ({ type: "task-detail" }),
+}));
+vi.mock("@posthog/ui/router/useOpenTask", () => ({ openTaskInput: vi.fn() }));
+vi.mock("@posthog/ui/assets/hedgehogs", () => ({ builderHog: "" }));
+vi.mock("@posthog/ui/features/sidebar/sidebarStore", () => {
+  const state = {
+    organizeMode: "recent",
+    sortMode: "updated",
+    collapsedSections: new Set<string>(),
+    toggleSection: () => {},
+    loadMoreHistory: () => {},
+    resetHistoryVisibleCount: () => {},
+    folderOrder: [] as string[],
+    reorderFolders: () => {},
+  };
+  return {
+    useSidebarStore: Object.assign(
+      (selector: (s: typeof state) => unknown) => selector(state),
+      { getState: () => state },
+    ),
+  };
+});
+
+import { TaskListView } from "./TaskListView";
+
+function makeTask(i: number): TaskData {
+  return {
+    id: `task-${i}`,
+    title: `Task ${i}`,
+    createdAt: 1000 + i,
+    lastActivityAt: 1000 + i,
+    isGenerating: false,
+    isUnread: false,
+    isPinned: true,
+    needsPermission: false,
+    repository: null,
+    isSuspended: false,
+    folderPath: null,
+    cloudPrUrl: null,
+    branchName: null,
+    linkedBranch: null,
+  };
+}
+
+describe("TaskListView memoization", () => {
+  beforeEach(() => renderCounts.clear());
+
+  it("re-renders only the two affected rows when the active task changes", () => {
+    const tasks = Array.from({ length: 20 }, (_, i) => makeTask(i));
+    const props = {
+      pinnedTasks: tasks,
+      flatTasks: [],
+      groupedTasks: [],
+      editingTaskId: null,
+      selectedTaskIds: [],
+      hasMore: false,
+      onTaskClick: vi.fn(),
+      onTaskDoubleClick: vi.fn(),
+      onTaskContextMenu: vi.fn(),
+      onTaskArchive: vi.fn(),
+      onTaskTogglePin: vi.fn(),
+      onTaskEditSubmit: vi.fn(),
+      onTaskEditCancel: vi.fn(),
+    };
+
+    const { rerender } = render(
+      <TaskListView {...props} activeTaskId="task-0" />,
+    );
+    expect(renderCounts.size).toBe(20);
+
+    renderCounts.clear();
+    rerender(<TaskListView {...props} activeTaskId="task-1" />);
+
+    expect([...renderCounts.keys()].sort()).toEqual(["task-0", "task-1"]);
+  });
+});

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -59,13 +59,13 @@ const TaskRow = memo(function TaskRow({
   isSelected,
   hideHoverActions,
   isEditing,
-  onTaskClick,
-  onTaskDoubleClick,
-  onTaskContextMenu,
-  onTaskArchive,
-  onTaskTogglePin,
-  onTaskEditSubmit,
-  onTaskEditCancel,
+  onClick,
+  onDoubleClick,
+  onContextMenu,
+  onArchive,
+  onTogglePin,
+  onEditSubmit,
+  onEditCancel,
   timestamp,
   depth = 0,
 }: {
@@ -74,21 +74,21 @@ const TaskRow = memo(function TaskRow({
   isSelected: boolean;
   hideHoverActions: boolean;
   isEditing: boolean;
-  onTaskClick: (taskId: string, e: React.MouseEvent) => void;
-  onTaskDoubleClick: (taskId: string) => void;
-  onTaskContextMenu: (
+  onClick: (taskId: string, e: React.MouseEvent) => void;
+  onDoubleClick: (taskId: string) => void;
+  onContextMenu: (
     taskId: string,
     e: React.MouseEvent,
     isPinned: boolean,
   ) => void;
-  onTaskArchive: (taskId: string) => void;
-  onTaskTogglePin: (taskId: string) => void;
-  onTaskEditSubmit: (
+  onArchive: (taskId: string) => void;
+  onTogglePin: (taskId: string) => void;
+  onEditSubmit: (
     taskId: string,
     currentTitle: string,
     newTitle: string,
   ) => void;
-  onTaskEditCancel: () => void;
+  onEditCancel: () => void;
   timestamp: number;
   depth?: number;
 }) {
@@ -125,15 +125,13 @@ const TaskRow = memo(function TaskRow({
       hasDiff={hasDiff}
       prUrl={task.cloudPrUrl}
       timestamp={timestamp}
-      onClick={(e) => onTaskClick(task.id, e)}
-      onDoubleClick={() => onTaskDoubleClick(task.id)}
-      onContextMenu={(e) => onTaskContextMenu(task.id, e, task.isPinned)}
-      onArchive={() => onTaskArchive(task.id)}
-      onTogglePin={() => onTaskTogglePin(task.id)}
-      onEditSubmit={(newTitle) =>
-        onTaskEditSubmit(task.id, task.title, newTitle)
-      }
-      onEditCancel={onTaskEditCancel}
+      onClick={(e) => onClick(task.id, e)}
+      onDoubleClick={() => onDoubleClick(task.id)}
+      onContextMenu={(e) => onContextMenu(task.id, e, task.isPinned)}
+      onArchive={() => onArchive(task.id)}
+      onTogglePin={() => onTogglePin(task.id)}
+      onEditSubmit={(newTitle) => onEditSubmit(task.id, task.title, newTitle)}
+      onEditCancel={onEditCancel}
     />
   );
 });
@@ -212,13 +210,13 @@ export function TaskListView({
               isSelected={selectedIdSet.has(task.id)}
               hideHoverActions={hasMultiSelection}
               isEditing={editingTaskId === task.id}
-              onTaskClick={onTaskClick}
-              onTaskDoubleClick={onTaskDoubleClick}
-              onTaskContextMenu={onTaskContextMenu}
-              onTaskArchive={onTaskArchive}
-              onTaskTogglePin={onTaskTogglePin}
-              onTaskEditSubmit={onTaskEditSubmit}
-              onTaskEditCancel={onTaskEditCancel}
+              onClick={onTaskClick}
+              onDoubleClick={onTaskDoubleClick}
+              onContextMenu={onTaskContextMenu}
+              onArchive={onTaskArchive}
+              onTogglePin={onTaskTogglePin}
+              onEditSubmit={onTaskEditSubmit}
+              onEditCancel={onTaskEditCancel}
               timestamp={task[timestampKey]}
             />
           ))}
@@ -313,13 +311,13 @@ export function TaskListView({
                         isSelected={selectedIdSet.has(task.id)}
                         hideHoverActions={hasMultiSelection}
                         isEditing={editingTaskId === task.id}
-                        onTaskClick={onTaskClick}
-                        onTaskDoubleClick={onTaskDoubleClick}
-                        onTaskContextMenu={onTaskContextMenu}
-                        onTaskArchive={onTaskArchive}
-                        onTaskTogglePin={onTaskTogglePin}
-                        onTaskEditSubmit={onTaskEditSubmit}
-                        onTaskEditCancel={onTaskEditCancel}
+                        onClick={onTaskClick}
+                        onDoubleClick={onTaskDoubleClick}
+                        onContextMenu={onTaskContextMenu}
+                        onArchive={onTaskArchive}
+                        onTogglePin={onTaskTogglePin}
+                        onEditSubmit={onTaskEditSubmit}
+                        onEditCancel={onTaskEditCancel}
                         timestamp={task[timestampKey]}
                         depth={1}
                       />
@@ -343,13 +341,13 @@ export function TaskListView({
                   isSelected={selectedIdSet.has(task.id)}
                   hideHoverActions={hasMultiSelection}
                   isEditing={editingTaskId === task.id}
-                  onTaskClick={onTaskClick}
-                  onTaskDoubleClick={onTaskDoubleClick}
-                  onTaskContextMenu={onTaskContextMenu}
-                  onTaskArchive={onTaskArchive}
-                  onTaskTogglePin={onTaskTogglePin}
-                  onTaskEditSubmit={onTaskEditSubmit}
-                  onTaskEditCancel={onTaskEditCancel}
+                  onClick={onTaskClick}
+                  onDoubleClick={onTaskDoubleClick}
+                  onContextMenu={onTaskContextMenu}
+                  onArchive={onTaskArchive}
+                  onTogglePin={onTaskTogglePin}
+                  onEditSubmit={onTaskEditSubmit}
+                  onEditCancel={onTaskEditCancel}
                   timestamp={task[timestampKey]}
                 />
               ))}

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -22,7 +22,7 @@ import { useAppView } from "@posthog/ui/router/useAppView";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { Flex, Text } from "@radix-ui/themes";
 import { motion } from "framer-motion";
-import { Fragment, useCallback, useEffect, useMemo } from "react";
+import { Fragment, memo, useCallback, useEffect, useMemo } from "react";
 
 interface TaskListViewProps {
   pinnedTasks: TaskData[];
@@ -53,19 +53,19 @@ function SectionLabel({ label }: { label: string }) {
   return <MenuLabel className="flex items-center py-0">{label}</MenuLabel>;
 }
 
-function TaskRow({
+const TaskRow = memo(function TaskRow({
   task,
   isActive,
   isSelected,
   hideHoverActions,
   isEditing,
-  onClick,
-  onDoubleClick,
-  onContextMenu,
-  onArchive,
-  onTogglePin,
-  onEditSubmit,
-  onEditCancel,
+  onTaskClick,
+  onTaskDoubleClick,
+  onTaskContextMenu,
+  onTaskArchive,
+  onTaskTogglePin,
+  onTaskEditSubmit,
+  onTaskEditCancel,
   timestamp,
   depth = 0,
 }: {
@@ -74,13 +74,21 @@ function TaskRow({
   isSelected: boolean;
   hideHoverActions: boolean;
   isEditing: boolean;
-  onClick: (e: React.MouseEvent) => void;
-  onDoubleClick: () => void;
-  onContextMenu: (e: React.MouseEvent, isPinned: boolean) => void;
-  onArchive: () => void;
-  onTogglePin: () => void;
-  onEditSubmit: (newTitle: string) => void;
-  onEditCancel: () => void;
+  onTaskClick: (taskId: string, e: React.MouseEvent) => void;
+  onTaskDoubleClick: (taskId: string) => void;
+  onTaskContextMenu: (
+    taskId: string,
+    e: React.MouseEvent,
+    isPinned: boolean,
+  ) => void;
+  onTaskArchive: (taskId: string) => void;
+  onTaskTogglePin: (taskId: string) => void;
+  onTaskEditSubmit: (
+    taskId: string,
+    currentTitle: string,
+    newTitle: string,
+  ) => void;
+  onTaskEditCancel: () => void;
   timestamp: number;
   depth?: number;
 }) {
@@ -117,16 +125,18 @@ function TaskRow({
       hasDiff={hasDiff}
       prUrl={task.cloudPrUrl}
       timestamp={timestamp}
-      onClick={onClick}
-      onDoubleClick={onDoubleClick}
-      onContextMenu={(e) => onContextMenu(e, task.isPinned)}
-      onArchive={onArchive}
-      onTogglePin={onTogglePin}
-      onEditSubmit={onEditSubmit}
-      onEditCancel={onEditCancel}
+      onClick={(e) => onTaskClick(task.id, e)}
+      onDoubleClick={() => onTaskDoubleClick(task.id)}
+      onContextMenu={(e) => onTaskContextMenu(task.id, e, task.isPinned)}
+      onArchive={() => onTaskArchive(task.id)}
+      onTogglePin={() => onTaskTogglePin(task.id)}
+      onEditSubmit={(newTitle) =>
+        onTaskEditSubmit(task.id, task.title, newTitle)
+      }
+      onEditCancel={onTaskEditCancel}
     />
   );
-}
+});
 
 export function TaskListView({
   pinnedTasks,
@@ -202,17 +212,13 @@ export function TaskListView({
               isSelected={selectedIdSet.has(task.id)}
               hideHoverActions={hasMultiSelection}
               isEditing={editingTaskId === task.id}
-              onClick={(e) => onTaskClick(task.id, e)}
-              onDoubleClick={() => onTaskDoubleClick(task.id)}
-              onContextMenu={(e, isPinned) =>
-                onTaskContextMenu(task.id, e, isPinned)
-              }
-              onArchive={() => onTaskArchive(task.id)}
-              onTogglePin={() => onTaskTogglePin(task.id)}
-              onEditSubmit={(newTitle) =>
-                onTaskEditSubmit(task.id, task.title, newTitle)
-              }
-              onEditCancel={onTaskEditCancel}
+              onTaskClick={onTaskClick}
+              onTaskDoubleClick={onTaskDoubleClick}
+              onTaskContextMenu={onTaskContextMenu}
+              onTaskArchive={onTaskArchive}
+              onTaskTogglePin={onTaskTogglePin}
+              onTaskEditSubmit={onTaskEditSubmit}
+              onTaskEditCancel={onTaskEditCancel}
               timestamp={task[timestampKey]}
             />
           ))}
@@ -307,17 +313,13 @@ export function TaskListView({
                         isSelected={selectedIdSet.has(task.id)}
                         hideHoverActions={hasMultiSelection}
                         isEditing={editingTaskId === task.id}
-                        onClick={(e) => onTaskClick(task.id, e)}
-                        onDoubleClick={() => onTaskDoubleClick(task.id)}
-                        onContextMenu={(e, isPinned) =>
-                          onTaskContextMenu(task.id, e, isPinned)
-                        }
-                        onArchive={() => onTaskArchive(task.id)}
-                        onTogglePin={() => onTaskTogglePin(task.id)}
-                        onEditSubmit={(newTitle) =>
-                          onTaskEditSubmit(task.id, task.title, newTitle)
-                        }
-                        onEditCancel={onTaskEditCancel}
+                        onTaskClick={onTaskClick}
+                        onTaskDoubleClick={onTaskDoubleClick}
+                        onTaskContextMenu={onTaskContextMenu}
+                        onTaskArchive={onTaskArchive}
+                        onTaskTogglePin={onTaskTogglePin}
+                        onTaskEditSubmit={onTaskEditSubmit}
+                        onTaskEditCancel={onTaskEditCancel}
                         timestamp={task[timestampKey]}
                         depth={1}
                       />
@@ -341,17 +343,13 @@ export function TaskListView({
                   isSelected={selectedIdSet.has(task.id)}
                   hideHoverActions={hasMultiSelection}
                   isEditing={editingTaskId === task.id}
-                  onClick={(e) => onTaskClick(task.id, e)}
-                  onDoubleClick={() => onTaskDoubleClick(task.id)}
-                  onContextMenu={(e, isPinned) =>
-                    onTaskContextMenu(task.id, e, isPinned)
-                  }
-                  onArchive={() => onTaskArchive(task.id)}
-                  onTogglePin={() => onTaskTogglePin(task.id)}
-                  onEditSubmit={(newTitle) =>
-                    onTaskEditSubmit(task.id, task.title, newTitle)
-                  }
-                  onEditCancel={onTaskEditCancel}
+                  onTaskClick={onTaskClick}
+                  onTaskDoubleClick={onTaskDoubleClick}
+                  onTaskContextMenu={onTaskContextMenu}
+                  onTaskArchive={onTaskArchive}
+                  onTaskTogglePin={onTaskTogglePin}
+                  onTaskEditSubmit={onTaskEditSubmit}
+                  onTaskEditCancel={onTaskEditCancel}
                   timestamp={task[timestampKey]}
                 />
               ))}


### PR DESCRIPTION
when i'm using ph-code it regularly freezes

i copied my local prod app database into the dev instance and had the robot poke at it via CDP

-----

## Problem

The sidebar task list froze the UI on every task load with a real-scale dataset. `TaskRow` was not memoized, and each call site passed fresh inline closures (`onClick={(e) => onTaskClick(task.id, e)}`, ...), so an `activeTaskId` change on navigation re-rendered **every** row — and each row re-runs two queries (`useWorkspace`, `useTaskPrStatus`) plus a store subscription.

This was found by loading a **production database (766 workspaces, 5.9 GB of conversation logs)** into a dev instance and CPU-profiling task loads over CDP. It blocked the renderer main thread for **1–3.3s on every task load** — a hard freeze with no loaders, because it's synchronous render work, not async fetching. (Earlier theories — focus-refetch storms, file-watcher churn — were measured and ruled out; they never produced a long task.)

## Change

Memoize `TaskRow` and pass it the parent's already-`useCallback`'d handlers, binding `task.id` inside the row. Now an `activeTaskId` change re-renders only the two rows whose `isActive` flipped, instead of all of them. `TaskListView`'s external props are unchanged.

## Measurement

Blocked main-thread time on task load, 766-workspace dataset, same CDP harness before/after:

| task | before | after |
| --- | --- | --- |
| 1fbb7d49 | 2742ms | **539ms** |
| 4ebc00bf | 2361ms | **515ms** |
| 7f55577b | 3282ms | **665ms** |
| 0a06a281 | 2079ms | **347ms** |
| 1f9f73a8 | 942ms | **176ms** |
| be480903 | 984ms | **384ms** |

The measured drop confirms `task` object identity is stable enough for `memo` to bite.

## Scope / follow-ups

This fixes the **sidebar** half of the freeze (every task load). A second, independent cause remains for **large cloud conversations** — `buildCloudEventSummary`/`getDiffStats` (`@posthog/core/task-detail/cloudToolChanges`) reprocess the entire session event log on every update (O(n) per tick) — which I'm tackling separately. Virtualizing the sidebar list would further cut the first-mount cost but is a larger change; memoization captures the recurring re-render freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)