### PR TITLE
perf(task-detail): cache cloud diff stats by content identity

### DIFF
--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -62,6 +62,61 @@ describe("extractCloudToolChangedFiles", () => {
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe("src/app.ts");
   });
+
+  it.each([
+    {
+      name: "new file counts all lines as added",
+      kind: "write" as const,
+      oldText: undefined,
+      newText: "a\nb\nc",
+      added: 3,
+      removed: 0,
+    },
+    {
+      name: "modified file counts added and removed",
+      kind: "edit" as const,
+      oldText: "a\nb\nc",
+      newText: "a\nB\nc\nd",
+      added: 2,
+      removed: 1,
+    },
+    {
+      name: "pure removal counts removed only",
+      kind: "edit" as const,
+      oldText: "a\nb\nc",
+      newText: "a",
+      added: 0,
+      removed: 2,
+    },
+  ])("diff stats: $name", ({ kind, oldText, newText, added, removed }) => {
+    const calls = makeToolCalls(
+      toolCall({
+        toolCallId: "tc",
+        kind,
+        locations: [{ path: "src/f.ts" }],
+        content: diffContent("src/f.ts", newText, oldText),
+      }),
+    );
+    const [file] = extractCloudToolChangedFiles(calls);
+    expect(file.linesAdded).toBe(added);
+    expect(file.linesRemoved).toBe(removed);
+  });
+
+  it("returns identical stats when the same diff object is reused (cache)", () => {
+    const content = diffContent("src/f.ts", "a\nB\nc", "a\nb\nc");
+    const first = extractCloudToolChangedFiles(
+      makeToolCalls(
+        toolCall({ kind: "edit", locations: [{ path: "src/f.ts" }], content }),
+      ),
+    );
+    const second = extractCloudToolChangedFiles(
+      makeToolCalls(
+        toolCall({ kind: "edit", locations: [{ path: "src/f.ts" }], content }),
+      ),
+    );
+    expect(second[0].linesAdded).toBe(first[0].linesAdded);
+    expect(second[0].linesRemoved).toBe(first[0].linesRemoved);
+  });
 });
 
 describe("extractCloudFileContent", () => {

--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  cachedDiffStats,
   extractCloudFileContent,
   extractCloudToolChangedFiles,
   type ParsedToolCall,
 } from "./cloudToolChanges";
+
+function diffObj(
+  newText: string,
+  oldText: string,
+): NonNullable<Parameters<typeof cachedDiffStats>[0]> {
+  return { type: "diff", path: "src/f.ts", newText, oldText };
+}
 
 function toolCall(overrides: Partial<ParsedToolCall>): ParsedToolCall {
   return {
@@ -102,20 +110,15 @@ describe("extractCloudToolChangedFiles", () => {
     expect(file.linesRemoved).toBe(removed);
   });
 
-  it("returns identical stats when the same diff object is reused (cache)", () => {
-    const content = diffContent("src/f.ts", "a\nB\nc", "a\nb\nc");
-    const first = extractCloudToolChangedFiles(
-      makeToolCalls(
-        toolCall({ kind: "edit", locations: [{ path: "src/f.ts" }], content }),
-      ),
-    );
-    const second = extractCloudToolChangedFiles(
-      makeToolCalls(
-        toolCall({ kind: "edit", locations: [{ path: "src/f.ts" }], content }),
-      ),
-    );
-    expect(second[0].linesAdded).toBe(first[0].linesAdded);
-    expect(second[0].linesRemoved).toBe(first[0].linesRemoved);
+  it("memoizes diff stats by diff-object identity", () => {
+    const diff = diffObj("a\nB\nc", "a\nb\nc");
+    const first = cachedDiffStats(diff);
+    expect(cachedDiffStats(diff)).toBe(first);
+
+    const distinctButEqual = diffObj("a\nB\nc", "a\nb\nc");
+    const recomputed = cachedDiffStats(distinctButEqual);
+    expect(recomputed).not.toBe(first);
+    expect(recomputed).toEqual(first);
   });
 });
 

--- a/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.ts
@@ -143,7 +143,7 @@ const diffStatsCache = new WeakMap<
   { added?: number; removed?: number }
 >();
 
-function cachedDiffStats(
+export function cachedDiffStats(
   diff: Extract<ToolCallContent, { type: "diff" }> | undefined,
 ): { added?: number; removed?: number } {
   if (!diff) return {};

--- a/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.ts
@@ -138,6 +138,22 @@ function getDiffStats(
   return { added, removed };
 }
 
+const diffStatsCache = new WeakMap<
+  Extract<ToolCallContent, { type: "diff" }>,
+  { added?: number; removed?: number }
+>();
+
+function cachedDiffStats(
+  diff: Extract<ToolCallContent, { type: "diff" }> | undefined,
+): { added?: number; removed?: number } {
+  if (!diff) return {};
+  const cached = diffStatsCache.get(diff);
+  if (cached) return cached;
+  const stats = getDiffStats(diff.oldText, diff.newText);
+  diffStatsCache.set(diff, stats);
+  return stats;
+}
+
 export interface CloudEventSummary {
   toolCalls: Map<string, ParsedToolCall>;
 }
@@ -266,7 +282,7 @@ export function extractCloudToolChangedFiles(
         status: "deleted",
       };
     } else {
-      const diffStats = getDiffStats(diff?.oldText, diff?.newText);
+      const diffStats = cachedDiffStats(diff);
       file = {
         path,
         status: kind === "write" && !diff?.oldText ? "added" : "modified",


### PR DESCRIPTION
## Problem

Opening a large **cloud** task froze the renderer (100% CPU, no loaders — synchronous work). `extractCloudToolChangedFiles` line-diffs every changed file via `getDiffStats`, and it re-runs whenever the session `events` array changes identity. A big session log loads/streams in chunks, so **every changed file was re-diffed on every chunk** — O(files × updates).

Found by loading a production database (766 workspaces, 5.9 GB of logs, biggest single conversation 449 MB / 203k events) into a dev instance and CPU-profiling task loads over CDP. `getDiffStats` was the single biggest frame — **28% / ~2,088ms** on the worst load.

## Change

The diff content objects are stable across these recomputes (they're the session events' own objects), so cache `getDiffStats` results in a `WeakMap` keyed on the diff object. Repeated recomputes become O(new diffs) instead of O(all files). Output is unchanged — the cache only avoids recompute.

## Measurement

Same CDP profile, before/after:
- `getDiffStats`: **~2,088ms (28% of the worst load) → ~0** (dropped out of the hot path entirely).
- A representative large cloud task: **4,101ms → 1,282ms** blocked main-thread time on load.

A parameterised test pins the diff-stat values (added/removed across new/modified/removal) and that reusing the same diff object returns identical results.

## Scope

This is the **cloud-conversation** half of the freeze. The **sidebar** half (re-rendering all task rows on navigation) is a separate PR (memoizing `TaskRow`). Residual cost on the most extreme 449 MB task is now diffuse (log parsing, file-search indexing) with no single dominant frame — a possible future follow-up is incrementalizing `buildCloudEventSummary`, but the dominant freeze is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)