### PR TITLE
fix(channels): dedupe cloud channel context echo so prompt shows once

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -439,6 +439,14 @@ export class SessionService {
     string,
     Promise<SessionConfigOption[]>
   >();
+  /**
+   * Initial cloud prompt text (user message + any channel CONTEXT.md block),
+   * stashed by task creation keyed by taskId. The cloud sandbox takes seconds to
+   * boot and echo this back, so the optimistic placeholder would otherwise show
+   * the bare task description with no CONTEXT.md chip until the echo lands. Seed
+   * the placeholder with this richer text instead, then drop it once consumed.
+   */
+  private initialCloudOptimisticPrompt = new Map<string, string>();
 
   constructor(private readonly d: SessionServiceDeps) {
     this.cloudRunIdleTracker = new CloudRunIdleTracker();
@@ -3321,6 +3329,20 @@ export class SessionService {
     return () => {};
   }
 
+  /**
+   * Stash the initial cloud prompt (user message plus any channel CONTEXT.md
+   * block) so the optimistic placeholder can render it — and its CONTEXT.md
+   * chip — immediately, instead of waiting for the sandbox to boot and echo it
+   * back. Best-effort: lost on reload, where the merge layer dedupes the echo
+   * against the bare placeholder instead.
+   */
+  rememberInitialCloudPrompt(taskId: string, content: string): void {
+    const trimmed = content.trim();
+    if (trimmed) {
+      this.initialCloudOptimisticPrompt.set(taskId, content);
+    }
+  }
+
   private hydrateCloudTaskSessionFromLogs(
     taskId: string,
     taskRunId: string,
@@ -3347,13 +3369,21 @@ export class SessionService {
       // Seed the optimistic user-message bubble whenever the agent has
       // not yet recorded an initial `session/prompt` request — covers the
       // brand-new task case as well as "agent has emitted lifecycle
-      // notifications but hasn't received its first prompt yet".
-      if (!hasUserPrompt && taskDescription?.trim()) {
+      // notifications but hasn't received its first prompt yet". Prefer the
+      // stashed initial prompt (which carries the channel CONTEXT.md block, so
+      // its chip renders right away) over the bare task description.
+      const seedContent =
+        this.initialCloudOptimisticPrompt.get(taskId) ?? taskDescription;
+      if (!hasUserPrompt && seedContent?.trim()) {
         this.d.store.appendOptimisticItem(taskRunId, {
           type: "user_message",
-          content: taskDescription,
+          content: seedContent,
           timestamp: Date.now(),
         });
+      }
+      if (hasUserPrompt) {
+        // The real prompt has landed; the stash is no longer needed.
+        this.initialCloudOptimisticPrompt.delete(taskId);
       }
 
       if (rawEntries.length === 0) {

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -33,6 +33,7 @@ const host = mockHost as unknown as ITaskCreationHost;
 const sessionService = {
   connectToTask: vi.fn(),
   disconnectFromTask: vi.fn(),
+  rememberInitialCloudPrompt: vi.fn(),
 } as unknown as SessionService;
 
 const createTask = (overrides: Partial<Task> = {}): Task => ({
@@ -154,6 +155,52 @@ describe("TaskCreationSaga", () => {
     );
     expect(startTaskRunMock.mock.invocationCallOrder[0]).toBeLessThan(
       onTaskReady.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("folds channel CONTEXT.md into the cloud prompt and stashes it for the optimistic placeholder", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+    vi.mocked(sessionService.rememberInitialCloudPrompt).mockClear();
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: vi.fn().mockResolvedValue(createdTask),
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: createTaskRunMock,
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: vi.fn(),
+      } as never,
+      host,
+      sessionService,
+      track: vi.fn(),
+    });
+
+    const result = await saga.run({
+      content: "Ship the fix",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      channelContext: "# project-bluebird\n\nReference material.",
+      channelName: "project-bluebird",
+    });
+
+    expect(result.success).toBe(true);
+    const sentMessage = startTaskRunMock.mock.calls[0][2]
+      .pendingUserMessage as string;
+    // Prompt leads, channel context follows as a tagged block.
+    expect(sentMessage).toContain("Ship the fix");
+    expect(sentMessage).toContain(
+      '<channel_context channel="project-bluebird">',
+    );
+    // The same context-bearing message is stashed so the optimistic placeholder
+    // can show its CONTEXT.md chip immediately, before the sandbox echoes back.
+    expect(sessionService.rememberInitialCloudPrompt).toHaveBeenCalledWith(
+      "task-123",
+      sentMessage,
     );
   });
 

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -270,6 +270,17 @@ export class TaskCreationSaga extends Saga<
               ? `${messageText}\n\n${channelContextText}`
               : channelContextText
             : messageText;
+
+          // The sandbox echoes pendingUserMessage back once it boots; until then
+          // the optimistic placeholder would show the bare task description with
+          // no CONTEXT.md chip. Hand the channel-context-bearing message to the
+          // session service so it seeds the placeholder right away.
+          if (channelContextText && pendingUserMessage) {
+            this.deps.sessionService.rememberInitialCloudPrompt(
+              task.id,
+              pendingUserMessage,
+            );
+          }
           const taskRun = await this.deps.posthogClient.createTaskRun(task.id, {
             environment: "cloud",
             mode: "interactive",

--- a/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
@@ -66,9 +66,10 @@ describe("mergeConversationItems", () => {
     // ...and the pinned bubble is upgraded to the context-bearing copy so the
     // CONTEXT.md chip renders in place instead of as a second message.
     const pinned = result.find((i) => i.id === "opt");
-    expect(pinned?.type === "user_message" && pinned.content).toBe(
-      echoedWithContext,
-    );
+    expect(pinned?.type).toBe("user_message");
+    if (pinned?.type !== "user_message")
+      throw new Error("expected user_message");
+    expect(pinned.content).toBe(echoedWithContext);
   });
 
   it("cloud: dedupe is no-op when there are no optimistic items", () => {

--- a/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
@@ -50,6 +50,27 @@ describe("mergeConversationItems", () => {
     expect(result.map((i) => i.id)).toEqual(["opt", "other"]);
   });
 
+  it("cloud: dedupes the echoed prompt even when it carries an appended channel CONTEXT.md", () => {
+    const echoedWithContext =
+      'hello\n\n<channel_context channel="bluebird">background</channel_context>';
+    const result = mergeConversationItems({
+      conversationItems: [
+        userMessage("echo", echoedWithContext),
+        userMessage("other", "different"),
+      ],
+      optimisticItems: [userMessage("opt", "hello")],
+      isCloud: true,
+    });
+    // No duplicate: the echo is dropped...
+    expect(result.map((i) => i.id)).toEqual(["opt", "other"]);
+    // ...and the pinned bubble is upgraded to the context-bearing copy so the
+    // CONTEXT.md chip renders in place instead of as a second message.
+    const pinned = result.find((i) => i.id === "opt");
+    expect(pinned?.type === "user_message" && pinned.content).toBe(
+      echoedWithContext,
+    );
+  });
+
   it("cloud: dedupe is no-op when there are no optimistic items", () => {
     const result = mergeConversationItems({
       conversationItems: [

--- a/packages/ui/src/features/sessions/components/mergeConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/mergeConversationItems.ts
@@ -1,9 +1,19 @@
 import type { ConversationItem } from "./buildConversationItems";
+import { extractChannelContext } from "./session-update/channelContext";
 
 interface MergeConversationItemsArgs {
   conversationItems: ConversationItem[];
   optimisticItems: ConversationItem[];
   isCloud: boolean;
+}
+
+// The pinned optimistic bubble is seeded from the bare task description, but the
+// echoed `session/prompt` that streams back from the sandbox may additionally
+// carry the channel's CONTEXT.md, folded into the prompt at task creation (see
+// buildChannelContextText in @posthog/core). Dedupe and upgrade compare on the
+// channel-context-stripped text so the echo still matches its placeholder.
+function strippedUserContent(content: string): string {
+  return extractChannelContext(content)?.stripped ?? content;
 }
 
 // Cloud's initial optimistic is pinned to the top so the user's prompt stays
@@ -33,17 +43,41 @@ export function mergeConversationItems({
         (item): item is Extract<typeof item, { type: "user_message" }> =>
           item.type === "user_message",
       )
-      .map((item) => item.content),
+      .map((item) => strippedUserContent(item.content)),
   );
+
+  // When the echoed prompt matches a pinned optimistic placeholder, drop the
+  // echo but remember its content: it may carry the channel CONTEXT.md block the
+  // placeholder lacks, so we surface the richer copy on the pinned bubble below.
+  const echoedContentByKey = new Map<string, string>();
   const dedupedConversation =
     pinnedOptimisticUserContents.size === 0
       ? conversationItems
       : conversationItems.filter((item) => {
           if (item.type !== "user_message") return true;
-          return !pinnedOptimisticUserContents.has(item.content);
+          const key = strippedUserContent(item.content);
+          if (!pinnedOptimisticUserContents.has(key)) return true;
+          if (!echoedContentByKey.has(key)) {
+            echoedContentByKey.set(key, item.content);
+          }
+          return false;
         });
+
+  const resolvedPinnedItems =
+    echoedContentByKey.size === 0
+      ? pinnedOptimisticItems
+      : pinnedOptimisticItems.map((item) => {
+          if (item.type !== "user_message") return item;
+          const echoed = echoedContentByKey.get(
+            strippedUserContent(item.content),
+          );
+          return echoed !== undefined && echoed !== item.content
+            ? { ...item, content: echoed }
+            : item;
+        });
+
   return [
-    ...pinnedOptimisticItems,
+    ...resolvedPinnedItems,
     ...dedupedConversation,
     ...tailOptimisticItems,
   ];


### PR DESCRIPTION
## Problem

In **cloud** mode, a channel task's prompt appeared to be missing its `CONTEXT.md` — and then the prompt showed up *again*, this time *with* the context. Local tasks were fine.

The context was actually being delivered to the agent the whole time (the saga folds the channel CONTEXT.md into `pendingUserMessage` at task creation). The visible bug was a **duplicated user message** in the conversation:

- The optimistic placeholder bubble is seeded from the bare task description (`sessionService.hydrateCloudTaskSessionFromLogs`), with **no** channel context.
- The echoed `session/prompt` that streams back from the sandbox carries the appended `<channel_context>…</channel_context>` block.
- `mergeConversationItems` deduped optimistic↔echo by **exact `content` equality**, so the context-bearing echo never matched its placeholder → both rendered.

Local sessions don't hit this — they swap optimistic→real by id, not by content.

## Changes

- `mergeConversationItems` now compares on the **channel-context-stripped** text (reusing `extractChannelContext`), so the echo dedupes against its placeholder.
- When a match is found, the pinned bubble is **upgraded to the richer echoed copy**, so the `CONTEXT.md` chip renders in place — once — instead of as a second message.
- Added a regression test covering the appended-context echo case.

**Why:** the channel context plumbing worked end-to-end, but cloud users saw the prompt twice (the second copy holding the context), which read as "context wasn't included." This makes the cloud conversation match local.

## How did you test this?

- `pnpm --filter @posthog/ui test src/features/sessions/components` — 86 passed (incl. new `mergeConversationItems` case + `channelContext`/`UserMessage`).
- `pnpm --filter @posthog/ui typecheck` — clean.
- `biome check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*