### PR TITLE
Instrument project-bluebird (Channels space) with analytics events

### DIFF
--- a/packages/core/src/canvas/canvasAnalytics.test.ts
+++ b/packages/core/src/canvas/canvasAnalytics.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCanvasPromptProps,
+  buildContextSaveProps,
+  dashboardIdFromThread,
+} from "./canvasAnalytics";
+
+describe("dashboardIdFromThread", () => {
+  it("strips the dashboard: prefix", () => {
+    expect(dashboardIdFromThread("dashboard:abc-123")).toBe("abc-123");
+  });
+
+  it("leaves an unprefixed id untouched", () => {
+    expect(dashboardIdFromThread("abc-123")).toBe("abc-123");
+  });
+});
+
+describe("buildCanvasPromptProps", () => {
+  it("resolves dashboard id and prompt length for a free-typed prompt", () => {
+    expect(
+      buildCanvasPromptProps({
+        surface: "json",
+        threadId: "dashboard:d1",
+        text: "hello",
+        fromSuggestion: false,
+      }),
+    ).toEqual({
+      surface: "json",
+      dashboard_id: "d1",
+      from_suggestion: false,
+      prompt_length_chars: 5,
+    });
+  });
+
+  it("flags suggestion-driven prompts", () => {
+    const props = buildCanvasPromptProps({
+      surface: "freeform",
+      threadId: "dashboard:d2",
+      text: "build a chart",
+      fromSuggestion: true,
+    });
+    expect(props.from_suggestion).toBe(true);
+    expect(props.surface).toBe("freeform");
+  });
+
+  it("passes through the ask_agent_to_fix intent and omits it otherwise", () => {
+    const withIntent = buildCanvasPromptProps({
+      surface: "freeform",
+      threadId: "dashboard:d3",
+      text: "fix it",
+      fromSuggestion: false,
+      intent: "ask_agent_to_fix",
+    });
+    expect(withIntent.intent).toBe("ask_agent_to_fix");
+
+    const withoutIntent = buildCanvasPromptProps({
+      surface: "freeform",
+      threadId: "dashboard:d3",
+      text: "fix it",
+      fromSuggestion: false,
+    });
+    expect(withoutIntent).not.toHaveProperty("intent");
+  });
+});
+
+describe("buildContextSaveProps", () => {
+  it("marks the first version when there are no existing instructions", () => {
+    expect(
+      buildContextSaveProps({
+        channelId: "c1",
+        hasInstructions: false,
+        success: true,
+      }),
+    ).toEqual({
+      action_type: "save_version",
+      channel_id: "c1",
+      is_first_version: true,
+      success: true,
+    });
+  });
+
+  it("marks an update when instructions already exist", () => {
+    const props = buildContextSaveProps({
+      channelId: "c1",
+      hasInstructions: true,
+      success: false,
+    });
+    expect(props.is_first_version).toBe(false);
+    expect(props.success).toBe(false);
+  });
+});

--- a/packages/core/src/canvas/canvasAnalytics.test.ts
+++ b/packages/core/src/canvas/canvasAnalytics.test.ts
@@ -64,28 +64,24 @@ describe("buildCanvasPromptProps", () => {
 });
 
 describe("buildContextSaveProps", () => {
-  it("marks the first version when there are no existing instructions", () => {
-    expect(
-      buildContextSaveProps({
-        channelId: "c1",
-        hasInstructions: false,
-        success: true,
-      }),
-    ).toEqual({
-      action_type: "save_version",
-      channel_id: "c1",
-      is_first_version: true,
-      success: true,
-    });
-  });
-
-  it("marks an update when instructions already exist", () => {
-    const props = buildContextSaveProps({
-      channelId: "c1",
-      hasInstructions: true,
-      success: false,
-    });
-    expect(props.is_first_version).toBe(false);
-    expect(props.success).toBe(false);
-  });
+  // is_first_version is the negation of hasInstructions; success passes through
+  // independently. The table covers both inputs against both outcomes.
+  it.each([
+    { hasInstructions: false, success: true, is_first_version: true },
+    { hasInstructions: true, success: true, is_first_version: false },
+    { hasInstructions: false, success: false, is_first_version: true },
+    { hasInstructions: true, success: false, is_first_version: false },
+  ])(
+    "hasInstructions=$hasInstructions success=$success → is_first_version=$is_first_version",
+    ({ hasInstructions, success, is_first_version }) => {
+      expect(
+        buildContextSaveProps({ channelId: "c1", hasInstructions, success }),
+      ).toEqual({
+        action_type: "save_version",
+        channel_id: "c1",
+        is_first_version,
+        success,
+      });
+    },
+  );
 });

--- a/packages/core/src/canvas/canvasAnalytics.ts
+++ b/packages/core/src/canvas/canvasAnalytics.ts
@@ -1,0 +1,48 @@
+import type {
+  CanvasPromptSentProperties,
+  CanvasPromptSurface,
+  ContextActionProperties,
+} from "@posthog/shared/analytics-events";
+
+/** The dashboardId a canvas thread persists to ("dashboard:<id>" → "<id>"). */
+export function dashboardIdFromThread(threadId: string): string {
+  return threadId.replace(/^dashboard:/, "");
+}
+
+/**
+ * Build the properties for a `CANVAS_PROMPT_SENT` event. Resolves the
+ * dashboard id from the thread id, measures the prompt length, and folds in
+ * the suggestion / intent context.
+ */
+export function buildCanvasPromptProps(opts: {
+  surface: CanvasPromptSurface;
+  threadId: string;
+  text: string;
+  fromSuggestion: boolean;
+  intent?: "ask_agent_to_fix";
+}): CanvasPromptSentProperties {
+  return {
+    surface: opts.surface,
+    dashboard_id: dashboardIdFromThread(opts.threadId),
+    from_suggestion: opts.fromSuggestion,
+    prompt_length_chars: opts.text.length,
+    ...(opts.intent ? { intent: opts.intent } : {}),
+  };
+}
+
+/**
+ * Build the properties for a `save_version` `CONTEXT_ACTION` event. A channel
+ * with no published instructions yet is publishing its first version.
+ */
+export function buildContextSaveProps(opts: {
+  channelId: string;
+  hasInstructions: boolean;
+  success: boolean;
+}): ContextActionProperties {
+  return {
+    action_type: "save_version",
+    channel_id: opts.channelId,
+    is_first_version: !opts.hasInstructions,
+    success: opts.success,
+  };
+}

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -1195,9 +1195,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.SUBSCRIPTION_CANCELLED]: SubscriptionCancelledProperties;
 
   // Project Bluebird (Channels) events
-  [ANALYTICS_EVENTS.CHANNELS_SPACE_VIEWED]:
-    | ChannelsSpaceViewedProperties
-    | undefined;
+  [ANALYTICS_EVENTS.CHANNELS_SPACE_VIEWED]: ChannelsSpaceViewedProperties;
   [ANALYTICS_EVENTS.CHANNEL_ACTION]: ChannelActionProperties;
   [ANALYTICS_EVENTS.DASHBOARD_ACTION]: DashboardActionProperties;
   [ANALYTICS_EVENTS.CANVAS_PROMPT_SENT]: CanvasPromptSentProperties;

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -211,6 +211,8 @@ export interface FolderRegisteredProperties {
 // Navigation events
 export interface CommandMenuActionProperties {
   action_type: CommandMenuAction;
+  /** Channel acted on for the bluebird `open-channel` / `open-task` actions. */
+  channel_id?: string;
 }
 
 export interface SkillButtonTriggeredProperties {
@@ -764,6 +766,119 @@ export interface AgentsActionProperties {
   success?: boolean;
 }
 
+// ── Project Bluebird / Channels (Website) space events ──
+
+/** Where within the Channels space an interaction originated. */
+export type ChannelsSurface =
+  | "header_button"
+  | "title_bar"
+  | "nav"
+  | "sidebar"
+  | "command_menu"
+  | "new_task"
+  | "dashboards_grid"
+  | "canvas"
+  | "context";
+
+export type ChannelActionType =
+  | "enter_space"
+  | "leave_space"
+  | "leave_feedback"
+  | "nav_click"
+  | "open_channel"
+  | "collapse_channel"
+  | "view_more_tasks"
+  | "create"
+  | "rename"
+  | "delete"
+  | "star"
+  | "unstar"
+  | "edit_context_open"
+  | "new_task_open"
+  | "new_task_suggestion"
+  | "file_task"
+  | "unfile_task"
+  | "archive_task"
+  | "open_task";
+
+export interface ChannelActionProperties {
+  action_type: ChannelActionType;
+  surface: ChannelsSurface;
+  /** The channel acted on, when one is in scope. */
+  channel_id?: string;
+  /** For file/unfile/archive/open task actions. */
+  task_id?: string;
+  /** For file_task: destination channel when different from `channel_id`. */
+  target_channel_id?: string;
+  /** For nav_click: which destination ("home"|"inbox"|"canvas"|"agents"|"files"|"settings"). */
+  nav_target?: string;
+  /** For new_task_suggestion: the starter-prompt card label. */
+  suggestion_label?: string;
+  /** Whether the underlying mutation resolved successfully. */
+  success?: boolean;
+}
+
+export type DashboardActionType =
+  | "open"
+  | "create"
+  | "delete"
+  | "save"
+  | "fork"
+  | "edit_toggle"
+  | "revert"
+  | "refresh"
+  | "poll_mode_change"
+  | "date_range_apply";
+
+export interface DashboardActionProperties {
+  action_type: DashboardActionType;
+  surface: ChannelsSurface;
+  channel_id?: string;
+  dashboard_id?: string;
+  /** The canvas render kind. */
+  kind?: "json-render" | "freeform";
+  /** Template chosen on create. */
+  template_id?: string;
+  /** edit_toggle: the state being entered. */
+  editing?: boolean;
+  /** poll_mode_change: the new value ("static"|"10s"|"10min"). */
+  poll_mode?: string;
+  /** date_range_apply: the named range, when not custom. */
+  range_name?: string;
+  /** Whether the underlying mutation resolved successfully. */
+  success?: boolean;
+}
+
+export type CanvasPromptSurface = "json" | "freeform";
+
+export interface CanvasPromptSentProperties {
+  surface: CanvasPromptSurface;
+  dashboard_id?: string;
+  /** True when sent via a suggestion chip rather than free-typed. */
+  from_suggestion: boolean;
+  /** "ask_agent_to_fix" for the freeform self-repair path; absent otherwise. */
+  intent?: "ask_agent_to_fix";
+  prompt_length_chars: number;
+}
+
+export type ContextActionType = "save_version" | "generate_started" | "discard";
+
+export interface ContextActionProperties {
+  action_type: ContextActionType;
+  channel_id: string;
+  /** generate_started only. */
+  execution_type?: "local" | "cloud";
+  /** save_version: whether this created the first version vs. an update. */
+  is_first_version?: boolean;
+  success?: boolean;
+}
+
+export interface ChannelsSpaceViewedProperties {
+  /** Total channels visible when the space mounts. */
+  channel_count: number;
+  starred_count: number;
+}
+
 // Subscription / billing events
 
 export type UpgradePromptShownSurface = "usage_limit_modal" | "upgrade_dialog";
@@ -936,6 +1051,13 @@ export const ANALYTICS_EVENTS = {
   CLOUD_TASK_USAGE_BLOCKED: "Cloud task usage blocked",
   SUBSCRIPTION_STARTED: "Subscription started",
   SUBSCRIPTION_CANCELLED: "Subscription cancelled",
+
+  // Project Bluebird (Channels) events
+  CHANNELS_SPACE_VIEWED: "Channels space viewed",
+  CHANNEL_ACTION: "Channel action",
+  DASHBOARD_ACTION: "Dashboard action",
+  CANVAS_PROMPT_SENT: "Canvas prompt sent",
+  CONTEXT_ACTION: "Context action",
 } as const;
 
 // Event property mapping
@@ -1071,4 +1193,13 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.CLOUD_TASK_USAGE_BLOCKED]: CloudTaskUsageBlockedProperties;
   [ANALYTICS_EVENTS.SUBSCRIPTION_STARTED]: SubscriptionStartedProperties;
   [ANALYTICS_EVENTS.SUBSCRIPTION_CANCELLED]: SubscriptionCancelledProperties;
+
+  // Project Bluebird (Channels) events
+  [ANALYTICS_EVENTS.CHANNELS_SPACE_VIEWED]:
+    | ChannelsSpaceViewedProperties
+    | undefined;
+  [ANALYTICS_EVENTS.CHANNEL_ACTION]: ChannelActionProperties;
+  [ANALYTICS_EVENTS.DASHBOARD_ACTION]: DashboardActionProperties;
+  [ANALYTICS_EVENTS.CANVAS_PROMPT_SENT]: CanvasPromptSentProperties;
+  [ANALYTICS_EVENTS.CONTEXT_ACTION]: ContextActionProperties;
 };

--- a/packages/ui/src/features/canvas/components/CanvasChat.tsx
+++ b/packages/ui/src/features/canvas/components/CanvasChat.tsx
@@ -4,6 +4,7 @@ import { buildCanvasPromptProps } from "@posthog/core/canvas/canvasAnalytics";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useCanvasTemplates } from "@posthog/ui/features/canvas/hooks/useCanvasTemplates";
+import { useFromSuggestion } from "@posthog/ui/features/canvas/hooks/useFromSuggestion";
 import {
   useCanvasChatStore,
   useCanvasThread,
@@ -27,13 +28,11 @@ export function CanvasChat({ threadId }: { threadId: string }) {
   const [draft, setDraft] = useState("");
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  // True once a suggestion chip seeded the composer, until the user types over
-  // it — so the eventual send is attributed to the suggestion.
-  const fromSuggestionRef = useRef(false);
+  const fromSuggestion = useFromSuggestion();
 
   // Drop a suggestion into the composer and focus it (ready to edit or send).
   const fillSuggestion = (text: string) => {
-    fromSuggestionRef.current = true;
+    fromSuggestion.mark();
     setDraft(text);
     inputRef.current?.focus();
   };
@@ -53,10 +52,9 @@ export function CanvasChat({ threadId }: { threadId: string }) {
         surface: "json",
         threadId,
         text,
-        fromSuggestion: fromSuggestionRef.current,
+        fromSuggestion: fromSuggestion.consume(),
       }),
     );
-    fromSuggestionRef.current = false;
     setDraft("");
     void send(threadId, text);
   };
@@ -151,7 +149,7 @@ export function CanvasChat({ threadId }: { threadId: string }) {
             placeholder="Build a canvas of…"
             value={draft}
             onChange={(e) => {
-              fromSuggestionRef.current = false;
+              fromSuggestion.clear();
               setDraft(e.target.value);
             }}
             onKeyDown={(e) => {

--- a/packages/ui/src/features/canvas/components/CanvasChat.tsx
+++ b/packages/ui/src/features/canvas/components/CanvasChat.tsx
@@ -1,11 +1,14 @@
 import { isNonEmptySpec } from "@json-render/core";
 import { PaperPlaneRightIcon, SpinnerGapIcon } from "@phosphor-icons/react";
+import { buildCanvasPromptProps } from "@posthog/core/canvas/canvasAnalytics";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useCanvasTemplates } from "@posthog/ui/features/canvas/hooks/useCanvasTemplates";
 import {
   useCanvasChatStore,
   useCanvasThread,
 } from "@posthog/ui/features/canvas/stores/canvasChatStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex, ScrollArea, Text, TextArea } from "@radix-ui/themes";
 import { useEffect, useRef, useState } from "react";
 
@@ -24,9 +27,13 @@ export function CanvasChat({ threadId }: { threadId: string }) {
   const [draft, setDraft] = useState("");
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  // True once a suggestion chip seeded the composer, until the user types over
+  // it — so the eventual send is attributed to the suggestion.
+  const fromSuggestionRef = useRef(false);
 
   // Drop a suggestion into the composer and focus it (ready to edit or send).
   const fillSuggestion = (text: string) => {
+    fromSuggestionRef.current = true;
     setDraft(text);
     inputRef.current?.focus();
   };
@@ -40,6 +47,16 @@ export function CanvasChat({ threadId }: { threadId: string }) {
   const submit = () => {
     const text = draft.trim();
     if (!text || isStreaming) return;
+    track(
+      ANALYTICS_EVENTS.CANVAS_PROMPT_SENT,
+      buildCanvasPromptProps({
+        surface: "json",
+        threadId,
+        text,
+        fromSuggestion: fromSuggestionRef.current,
+      }),
+    );
+    fromSuggestionRef.current = false;
     setDraft("");
     void send(threadId, text);
   };
@@ -133,7 +150,10 @@ export function CanvasChat({ threadId }: { threadId: string }) {
             className="flex-1"
             placeholder="Build a canvas of…"
             value={draft}
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(e) => {
+              fromSuggestionRef.current = false;
+              setDraft(e.target.value);
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -37,6 +37,7 @@ import {
   MenuLabel,
   Separator,
 } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
@@ -65,9 +66,10 @@ import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { AlertDialog, Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { hostClient } from "../hostClient";
 
 // Cap how many tasks each channel shows by default; the rest hide behind a
@@ -140,11 +142,23 @@ function ChannelMenu({
 
       await deleteChannel(channel.id);
       removeStar();
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "delete",
+        surface: "sidebar",
+        channel_id: channel.id,
+        success: true,
+      });
       // If we're inside the channel being deleted, fall back to the index.
       if (pathname.startsWith(`/website/${channel.id}`)) {
         void navigate({ to: "/website" });
       }
     } catch (error) {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "delete",
+        surface: "sidebar",
+        channel_id: channel.id,
+        success: false,
+      });
       toast.error("Couldn't delete channel", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -176,18 +190,32 @@ function ChannelMenu({
           sideOffset={4}
           className="w-auto min-w-fit"
         >
-          <DropdownMenuItem onClick={() => toggleStar()}>
+          <DropdownMenuItem
+            onClick={() => {
+              track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                action_type: isStarred ? "unstar" : "star",
+                surface: "sidebar",
+                channel_id: channel.id,
+              });
+              toggleStar();
+            }}
+          >
             <StarIcon size={14} weight={isStarred ? "fill" : "regular"} />
             {isStarred ? "Unstar channel" : "Star channel"}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
-            onClick={() =>
+            onClick={() => {
+              track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                action_type: "edit_context_open",
+                surface: "sidebar",
+                channel_id: channel.id,
+              });
               navigate({
                 to: "/website/$channelId/context",
                 params: { channelId: channel.id },
-              })
-            }
+              });
+            }}
           >
             <FileTextIcon size={14} />
             Edit CONTEXT.md
@@ -274,6 +302,14 @@ function DashboardRow({
   const onDelete = async () => {
     try {
       await deleteDashboard(dashboard.id);
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "delete",
+        surface: "sidebar",
+        channel_id: channelId,
+        dashboard_id: dashboard.id,
+        kind: dashboard.kind,
+        success: true,
+      });
       // Deleting destroys the canvas, including any child routes under it, so
       // match the whole subtree (mirrors ChannelMenu.onDelete).
       if (
@@ -285,6 +321,14 @@ function DashboardRow({
         });
       }
     } catch (error) {
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "delete",
+        surface: "sidebar",
+        channel_id: channelId,
+        dashboard_id: dashboard.id,
+        kind: dashboard.kind,
+        success: false,
+      });
       toast.error("Couldn't delete canvas", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -303,12 +347,20 @@ function DashboardRow({
                   title={dashboard.name}
                   subtitle={`updated ${relativeTime(dashboard.updatedAt)}`}
                   active={active}
-                  onClick={() =>
+                  onClick={() => {
+                    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+                      action_type: "open",
+                      surface: "sidebar",
+                      channel_id: channelId,
+                      dashboard_id: dashboard.id,
+                      kind: dashboard.kind,
+                      template_id: dashboard.templateId,
+                    });
                     navigate({
                       to: "/website/$channelId/dashboards/$dashboardId",
                       params: { channelId, dashboardId: dashboard.id },
-                    })
-                  }
+                    });
+                  }}
                 />
               </Box>
             }
@@ -422,7 +474,23 @@ function TaskRow({
   const onFileTo = async (targetChannelId: string) => {
     try {
       await fileTask(targetChannelId, taskId, title);
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "file_task",
+        surface: "sidebar",
+        channel_id: channelId,
+        target_channel_id: targetChannelId,
+        task_id: taskId,
+        success: true,
+      });
     } catch (error) {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "file_task",
+        surface: "sidebar",
+        channel_id: channelId,
+        target_channel_id: targetChannelId,
+        task_id: taskId,
+        success: false,
+      });
       toast.error("Couldn't file task", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -432,7 +500,21 @@ function TaskRow({
   const onArchive = async () => {
     try {
       await archiveTask({ taskId });
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "archive_task",
+        surface: "sidebar",
+        channel_id: channelId,
+        task_id: taskId,
+        success: true,
+      });
     } catch (error) {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "archive_task",
+        surface: "sidebar",
+        channel_id: channelId,
+        task_id: taskId,
+        success: false,
+      });
       toast.error("Couldn't archive task", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -442,6 +524,13 @@ function TaskRow({
   const onRemove = async () => {
     try {
       await unfileTask(channelTaskId);
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "unfile_task",
+        surface: "sidebar",
+        channel_id: channelId,
+        task_id: taskId,
+        success: true,
+      });
       if (pathname === `/website/${channelId}/tasks/${taskId}`) {
         void navigate({
           to: "/website/$channelId",
@@ -449,6 +538,13 @@ function TaskRow({
         });
       }
     } catch (error) {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "unfile_task",
+        surface: "sidebar",
+        channel_id: channelId,
+        task_id: taskId,
+        success: false,
+      });
       toast.error("Couldn't remove task from channel", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -538,6 +634,11 @@ function ChannelSection({
   }, [isActive]);
   // Toggle expansion; collapsing also resets back to the first batch of tasks.
   const toggleOpen = () => {
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: open ? "collapse_channel" : "open_channel",
+      surface: "sidebar",
+      channel_id: channel.id,
+    });
     setOpen((o) => !o);
     if (open) setTaskLimit(MAX_VISIBLE_TASKS_PER_CHANNEL);
   };
@@ -601,12 +702,17 @@ function ChannelSection({
               variant="outline"
               size="icon-xs"
               aria-label={`New task in ${channel.name}`}
-              onClick={() =>
+              onClick={() => {
+                track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                  action_type: "new_task_open",
+                  surface: "sidebar",
+                  channel_id: channel.id,
+                });
                 navigate({
                   to: "/website/$channelId/new",
                   params: { channelId: channel.id },
-                })
-              }
+                });
+              }}
               className={cn(
                 "transition-opacity group-hover:border-border",
                 menuOpen
@@ -665,9 +771,14 @@ function ChannelSection({
             <Button
               variant="default"
               size="default"
-              onClick={() =>
-                setTaskLimit((n) => n + MAX_VISIBLE_TASKS_PER_CHANNEL)
-              }
+              onClick={() => {
+                track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                  action_type: "view_more_tasks",
+                  surface: "sidebar",
+                  channel_id: channel.id,
+                });
+                setTaskLimit((n) => n + MAX_VISIBLE_TASKS_PER_CHANNEL);
+              }}
               className="w-full min-w-0 justify-start gap-2 text-[13px] text-gray-10"
             >
               <span className="inline-flex size-[14px] shrink-0 items-center justify-center">
@@ -692,6 +803,19 @@ export function ChannelsList() {
 
   const starred = channels.filter((c) => starredRefToShortcutId.has(c.path));
   const others = channels.filter((c) => !starredRefToShortcutId.has(c.path));
+
+  // Fire CHANNELS_SPACE_VIEWED once per space mount, after channels first load
+  // (so the counts are accurate). The sidebar stays mounted while navigating
+  // between channels, so this naturally fires once per entry into the space.
+  const viewedTrackedRef = useRef(false);
+  useEffect(() => {
+    if (isLoading || viewedTrackedRef.current) return;
+    viewedTrackedRef.current = true;
+    track(ANALYTICS_EVENTS.CHANNELS_SPACE_VIEWED, {
+      channel_count: channels.length,
+      starred_count: starred.length,
+    });
+  }, [isLoading, channels.length, starred.length]);
 
   return (
     <>

--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -6,6 +6,7 @@ import {
   SquaresFourIcon,
   TrayIcon,
 } from "@phosphor-icons/react";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { HOME_TAB_FLAG } from "@posthog/shared/constants";
 import { ChannelsList } from "@posthog/ui/features/canvas/components/ChannelsList";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
@@ -20,8 +21,19 @@ import {
   navigateToWebsiteHome,
 } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
+import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex } from "@radix-ui/themes";
 import { useRouterState } from "@tanstack/react-router";
+
+// Fire a nav_click event, then run the destination's navigation.
+function trackNav(navTarget: string, navigate: () => void) {
+  track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    action_type: "nav_click",
+    surface: "nav",
+    nav_target: navTarget,
+  });
+  navigate();
+}
 
 // Non-canvas /website mirrors (Home, Files, etc.) — used to tell whether the
 // current /website route is a canvas surface (channels index / a channel / a
@@ -65,7 +77,7 @@ function ChannelsNav() {
           }
           label="Home"
           isActive={view.type === "home"}
-          onClick={navigateToWebsiteHome}
+          onClick={() => trackNav("home", navigateToWebsiteHome)}
         />
       )}
       <SidebarItem
@@ -78,7 +90,7 @@ function ChannelsNav() {
         }
         label="Global Inbox"
         isActive={view.type === "inbox"}
-        onClick={navigateToInbox}
+        onClick={() => trackNav("inbox", navigateToInbox)}
       />
       <SidebarItem
         depth={0}
@@ -90,7 +102,7 @@ function ChannelsNav() {
         }
         label="Canvas"
         isActive={isCanvasActive}
-        onClick={navigateToCanvas}
+        onClick={() => trackNav("canvas", navigateToCanvas)}
       />
       <SidebarItem
         depth={0}
@@ -102,7 +114,7 @@ function ChannelsNav() {
         }
         label="Agents"
         isActive={view.type === "agents"}
-        onClick={navigateToAgents}
+        onClick={() => trackNav("agents", navigateToAgents)}
       />
       <SidebarItem
         depth={0}
@@ -114,7 +126,7 @@ function ChannelsNav() {
         }
         label="Files"
         isActive={view.type === "skills"}
-        onClick={navigateToSkills}
+        onClick={() => trackNav("files", navigateToSkills)}
       />
     </Flex>
   );
@@ -147,7 +159,7 @@ export function ChannelsSidebar() {
           depth={0}
           icon={<GearSixIcon size={16} />}
           label="Settings"
-          onClick={() => openSettings()}
+          onClick={() => trackNav("settings", () => openSettings())}
         />
       </Box>
     </Flex>

--- a/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -1,8 +1,10 @@
 import { HashIcon, XIcon } from "@phosphor-icons/react";
 import { validateChannelName } from "@posthog/core/canvas/channelName";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { Dialog, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
@@ -40,12 +42,23 @@ export function CreateChannelModal({
     if (!trimmed || validationError || isCreating) return;
     try {
       const channel = await createChannel(trimmed);
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "create",
+        surface: "sidebar",
+        channel_id: channel.id,
+        success: true,
+      });
       onOpenChange(false);
       void navigate({
         to: "/website/$channelId",
         params: { channelId: channel.id },
       });
     } catch (error) {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "create",
+        surface: "sidebar",
+        success: false,
+      });
       toast.error("Couldn't create channel", {
         description: error instanceof Error ? error.message : String(error),
       });

--- a/packages/ui/src/features/canvas/components/DashboardDateRangeControl.tsx
+++ b/packages/ui/src/features/canvas/components/DashboardDateRangeControl.tsx
@@ -12,6 +12,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import {
   formatRangeLabel,
   liveWindow,
@@ -25,6 +26,7 @@ import {
   useCanvasThread,
 } from "@posthog/ui/features/canvas/stores/canvasChatStore";
 import { useIsDashboardEditing } from "@posthog/ui/features/canvas/stores/dashboardEditStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { useMemo, useState } from "react";
 
 function threadIdFor(dashboardId: string): string {
@@ -41,8 +43,10 @@ function threadIdFor(dashboardId: string): string {
 // the label shows the human-readable window.
 export function DashboardDateRangeControl({
   dashboardId,
+  channelId,
 }: {
   dashboardId: string;
+  channelId?: string;
 }) {
   const editing = useIsDashboardEditing(dashboardId);
   const threadId = threadIdFor(dashboardId);
@@ -76,6 +80,14 @@ export function DashboardDateRangeControl({
 
   const onApply = (next: DateTimeValue) => {
     setOpen(false);
+    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+      action_type: "date_range_apply",
+      surface: "canvas",
+      channel_id: channelId,
+      dashboard_id: dashboardId,
+      range_name: next.range.name,
+      editing,
+    });
     const range: DashboardDateRange = {
       name: next.range.name,
       from: next.start.getTime(),

--- a/packages/ui/src/features/canvas/components/DashboardRefreshControl.tsx
+++ b/packages/ui/src/features/canvas/components/DashboardRefreshControl.tsx
@@ -11,8 +11,10 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useRefreshDashboard } from "@posthog/ui/features/canvas/hooks/useRefreshDashboard";
 import { useIsDashboardEditing } from "@posthog/ui/features/canvas/stores/dashboardEditStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useState } from "react";
 
 const POLL_OPTIONS = { "10s": 10_000, "10min": 600_000 } as const;
@@ -32,8 +34,10 @@ function formatCountdown(intervalMs: number, secondsLeft: number): string {
 // is paused while the dashboard is being edited so the data stays put.
 export function DashboardRefreshControl({
   dashboardId,
+  channelId,
 }: {
   dashboardId: string;
+  channelId?: string;
 }) {
   const editing = useIsDashboardEditing(dashboardId);
   const { refresh, isRefreshing } = useRefreshDashboard(dashboardId);
@@ -81,7 +85,15 @@ export function DashboardRefreshControl({
         variant="outline"
         size="sm"
         disabled={isRefreshing}
-        onClick={() => void refresh()}
+        onClick={() => {
+          track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+            action_type: "refresh",
+            surface: "canvas",
+            channel_id: channelId,
+            dashboard_id: dashboardId,
+          });
+          void refresh();
+        }}
       >
         <ArrowClockwiseIcon
           size={14}
@@ -105,7 +117,16 @@ export function DashboardRefreshControl({
         >
           <DropdownMenuRadioGroup
             value={mode}
-            onValueChange={(value) => setMode(value as RefreshMode)}
+            onValueChange={(value) => {
+              track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+                action_type: "poll_mode_change",
+                surface: "canvas",
+                channel_id: channelId,
+                dashboard_id: dashboardId,
+                poll_mode: value,
+              });
+              setMode(value as RefreshMode);
+            }}
           >
             <DropdownMenuRadioItem value="static">Static</DropdownMenuRadioItem>
             <DropdownMenuGroup>

--- a/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
+++ b/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
@@ -9,9 +9,26 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useCanvasTemplates } from "@posthog/ui/features/canvas/hooks/useCanvasTemplates";
 import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
+
+// Fire the "create" DASHBOARD_ACTION, then create + open the canvas.
+function trackAndCreate(
+  channelId: string | undefined,
+  templateId: string | undefined,
+  create: () => void,
+) {
+  track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+    action_type: "create",
+    surface: "dashboards_grid",
+    channel_id: channelId,
+    template_id: templateId,
+  });
+  create();
+}
 
 // "New canvas" entry point: opens a dialog to pick a template (Dashboard,
 // Blank, …); the chosen template's agent context drives how the canvas is
@@ -33,7 +50,9 @@ export function NewCanvasMenu({
         variant={variant}
         size="sm"
         className="no-drag"
-        onClick={() => void createAndOpen()}
+        onClick={() =>
+          trackAndCreate(channelId, undefined, () => void createAndOpen())
+        }
       >
         <PlusIcon size={14} />
         New canvas
@@ -67,7 +86,11 @@ export function NewCanvasMenu({
               className="h-auto w-full flex-col items-start gap-0.5 whitespace-normal py-3 text-left"
               onClick={() => {
                 setOpen(false);
-                void createAndOpen({ templateId: t.id });
+                trackAndCreate(
+                  channelId,
+                  t.id,
+                  () => void createAndOpen({ templateId: t.id }),
+                );
               }}
             >
               <span className="font-medium text-gray-12">{t.name}</span>

--- a/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
+++ b/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
@@ -1,9 +1,11 @@
 import { HashIcon, XIcon } from "@phosphor-icons/react";
 import { validateChannelName } from "@posthog/core/canvas/channelName";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Channel } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { Dialog, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
 
@@ -38,8 +40,20 @@ export function RenameChannelModal({
     if (!trimmed || unchanged || validationError || isRenaming) return;
     try {
       await renameChannel(channel.id, trimmed);
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "rename",
+        surface: "sidebar",
+        channel_id: channel.id,
+        success: true,
+      });
       onOpenChange(false);
     } catch (error) {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "rename",
+        surface: "sidebar",
+        channel_id: channel.id,
+        success: false,
+      });
       toast.error("Couldn't rename channel", {
         description: error instanceof Error ? error.message : String(error),
       });

--- a/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -5,6 +5,8 @@ import {
   SpinnerGapIcon,
 } from "@phosphor-icons/react";
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
+import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import {
@@ -28,6 +30,7 @@ import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { track } from "@posthog/ui/shell/analytics";
 import {
   Box,
   Button,
@@ -181,9 +184,17 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
         // concurrency check; otherwise we send the version we started from.
         baseVersion: latest?.version ?? 0,
       });
+      track(
+        ANALYTICS_EVENTS.CONTEXT_ACTION,
+        buildContextSaveProps({ channelId, hasInstructions, success: true }),
+      );
       setHasDraft(false);
       setMode("rendered");
     } catch {
+      track(
+        ANALYTICS_EVENTS.CONTEXT_ACTION,
+        buildContextSaveProps({ channelId, hasInstructions, success: false }),
+      );
       // Errors surface through `publishError` below; nothing to do here.
     }
   };
@@ -473,6 +484,17 @@ function GenerateWithAgent({
   const { generate, isStarting } = useGenerateContext(channelId, channelName);
   const lastUsedRunMode = useSettingsStore((s) => s.lastUsedRunMode);
 
+  // Fire generate_started, then kick off the generation task. Wrapping here
+  // covers both the local and cloud sub-pickers in one place.
+  const trackedGenerate = (target: GenerateContextTarget) => {
+    track(ANALYTICS_EVENTS.CONTEXT_ACTION, {
+      action_type: "generate_started",
+      channel_id: channelId,
+      execution_type: target.mode,
+    });
+    return generate(target);
+  };
+
   const [picking, setPicking] = useState(false);
   const [genMode, setGenMode] = useState<GenMode>(
     lastUsedRunMode === "cloud" ? "cloud" : "local",
@@ -498,9 +520,9 @@ function GenerateWithAgent({
         <SegmentedControl.Item value="cloud">Cloud</SegmentedControl.Item>
       </SegmentedControl.Root>
       {genMode === "local" ? (
-        <GenerateLocal generate={generate} isStarting={isStarting} />
+        <GenerateLocal generate={trackedGenerate} isStarting={isStarting} />
       ) : (
-        <GenerateCloud generate={generate} isStarting={isStarting} />
+        <GenerateCloud generate={trackedGenerate} isStarting={isStarting} />
       )}
     </Flex>
   );

--- a/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
@@ -15,6 +15,7 @@ import {
   Text,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { NewCanvasMenu } from "@posthog/ui/features/canvas/components/NewCanvasMenu";
 import { FreeformCanvas } from "@posthog/ui/features/canvas/freeform/FreeformCanvas";
 import { handleFreeformDataRequest } from "@posthog/ui/features/canvas/freeform/freeformDataBridge";
@@ -27,6 +28,7 @@ import {
 import { useSeedShowcase } from "@posthog/ui/features/canvas/hooks/useSeedShowcase";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { ErrorBoundary } from "@posthog/ui/shell/ErrorBoundary";
 import { Box, Flex, Grid } from "@radix-ui/themes";
 import { Link } from "@tanstack/react-router";
@@ -119,6 +121,16 @@ const DashboardCard = memo(function DashboardCard({
         to="/website/$channelId/dashboards/$dashboardId"
         params={{ channelId, dashboardId: summary.id }}
         className="no-underline"
+        onClick={() =>
+          track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+            action_type: "open",
+            surface: "dashboards_grid",
+            channel_id: channelId,
+            dashboard_id: summary.id,
+            kind: summary.kind,
+            template_id: summary.templateId,
+          })
+        }
       >
         <Card className="gap-0 overflow-hidden p-0">
           {isFreeform ? (
@@ -146,7 +158,12 @@ const DashboardCard = memo(function DashboardCard({
       </Link>
       {/* Sibling of the Link (not nested) so opening the menu or deleting never
           navigates into the dashboard. */}
-      <DashboardCardMenu id={summary.id} name={summary.name} />
+      <DashboardCardMenu
+        id={summary.id}
+        name={summary.name}
+        channelId={channelId}
+        kind={summary.kind}
+      />
     </Box>
   );
 });
@@ -246,16 +263,45 @@ function FreeformPreview({ code }: { code?: string }) {
   );
 }
 
-function DashboardCardMenu({ id, name }: { id: string; name: string }) {
+function DashboardCardMenu({
+  id,
+  name,
+  channelId,
+  kind,
+}: {
+  id: string;
+  name: string;
+  channelId: string;
+  kind: DashboardSummary["kind"];
+}) {
   const [open, setOpen] = useState(false);
   const { deleteDashboard, isDeleting } = useDashboardMutations();
 
   const onDelete = () => {
-    deleteDashboard(id).catch((error) => {
-      toast.error("Couldn't delete canvas", {
-        description: error instanceof Error ? error.message : String(error),
+    deleteDashboard(id)
+      .then(() => {
+        track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+          action_type: "delete",
+          surface: "dashboards_grid",
+          channel_id: channelId,
+          dashboard_id: id,
+          kind,
+          success: true,
+        });
+      })
+      .catch((error) => {
+        track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+          action_type: "delete",
+          surface: "dashboards_grid",
+          channel_id: channelId,
+          dashboard_id: id,
+          kind,
+          success: false,
+        });
+        toast.error("Couldn't delete canvas", {
+          description: error instanceof Error ? error.message : String(error),
+        });
       });
-    });
   };
 
   return (

--- a/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -6,6 +6,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { DashboardDateRangeControl } from "@posthog/ui/features/canvas/components/DashboardDateRangeControl";
 import { DashboardRefreshControl } from "@posthog/ui/features/canvas/components/DashboardRefreshControl";
 import { NewCanvasMenu } from "@posthog/ui/features/canvas/components/NewCanvasMenu";
@@ -27,6 +28,7 @@ import {
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import {
@@ -72,15 +74,30 @@ function DashboardEditControls({
     if (!dirty) return;
     // The h1 title is the dashboard's name: sync it to the file on every save so
     // renaming the canvas title renames the saved dashboard.
-    saveDashboard(
-      dashboardId,
-      liveSpec,
-      dashboardTitleFromSpec(liveSpec),
-    ).catch((error) => {
-      toast.error("Couldn't save dashboard", {
-        description: error instanceof Error ? error.message : String(error),
+    saveDashboard(dashboardId, liveSpec, dashboardTitleFromSpec(liveSpec))
+      .then(() => {
+        track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+          action_type: "save",
+          surface: "canvas",
+          channel_id: channelId,
+          dashboard_id: dashboardId,
+          kind: "json-render",
+          success: true,
+        });
+      })
+      .catch((error) => {
+        track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+          action_type: "save",
+          surface: "canvas",
+          channel_id: channelId,
+          dashboard_id: dashboardId,
+          kind: "json-render",
+          success: false,
+        });
+        toast.error("Couldn't save dashboard", {
+          description: error instanceof Error ? error.message : String(error),
+        });
       });
-    });
   };
 
   const onFork = async () => {
@@ -90,12 +107,28 @@ function DashboardEditControls({
         dashboardTitleFromSpec(liveSpec) ?? dashboard?.name ?? "Canvas";
       const name = `${title} (fork)`;
       const record = await createDashboard(channelId, name, liveSpec);
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "fork",
+        surface: "canvas",
+        channel_id: channelId,
+        dashboard_id: dashboardId,
+        kind: "json-render",
+        success: true,
+      });
       setEditing(record.id, true);
       void navigate({
         to: "/website/$channelId/dashboards/$dashboardId",
         params: { channelId, dashboardId: record.id },
       });
     } catch (error) {
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "fork",
+        surface: "canvas",
+        channel_id: channelId,
+        dashboard_id: dashboardId,
+        kind: "json-render",
+        success: false,
+      });
       toast.error("Couldn't fork dashboard", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -103,6 +136,14 @@ function DashboardEditControls({
   };
 
   const onToggleEdit = () => {
+    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+      action_type: "edit_toggle",
+      surface: "canvas",
+      channel_id: channelId,
+      dashboard_id: dashboardId,
+      kind: "json-render",
+      editing: !editing,
+    });
     if (editing) {
       // Cancel: drop unsaved edits. Resetting the thread clears the live spec so
       // re-entering edit re-seeds from the saved dashboard; the file is untouched.
@@ -194,12 +235,28 @@ function FreeformEditControls({
         versions,
         currentVersionId ?? undefined,
       );
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "fork",
+        surface: "canvas",
+        channel_id: channelId,
+        dashboard_id: dashboardId,
+        kind: "freeform",
+        success: true,
+      });
       setEditing(record.id, true);
       void navigate({
         to: "/website/$channelId/dashboards/$dashboardId",
         params: { channelId, dashboardId: record.id },
       });
     } catch (error) {
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "fork",
+        surface: "canvas",
+        channel_id: channelId,
+        dashboard_id: dashboardId,
+        kind: "freeform",
+        success: false,
+      });
       toast.error("Couldn't fork canvas", {
         description: error instanceof Error ? error.message : String(error),
       });
@@ -221,7 +278,16 @@ function FreeformEditControls({
             <Button
               variant="primary"
               size="sm"
-              onClick={() => revert(threadId)}
+              onClick={() => {
+                track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+                  action_type: "revert",
+                  surface: "canvas",
+                  channel_id: channelId,
+                  dashboard_id: dashboardId,
+                  kind: "freeform",
+                });
+                revert(threadId);
+              }}
             >
               Revert to this version
             </Button>
@@ -249,7 +315,17 @@ function FreeformEditControls({
         variant="outline"
         size="sm"
         data-selected={editing}
-        onClick={() => setEditing(dashboardId, !editing)}
+        onClick={() => {
+          track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+            action_type: "edit_toggle",
+            surface: "canvas",
+            channel_id: channelId,
+            dashboard_id: dashboardId,
+            kind: "freeform",
+            editing: !editing,
+          });
+          setEditing(dashboardId, !editing);
+        }}
       >
         {editing ? (
           <XIcon size={14} />
@@ -344,12 +420,18 @@ export function WebsiteLayout() {
             {/* Shown in edit too: changing it directs the agent's next build at
                 the chosen window (refresh in view, prompt hint in edit). */}
             {isDashboardDetail && dashboardId && isDataTemplate && (
-              <DashboardDateRangeControl dashboardId={dashboardId} />
+              <DashboardDateRangeControl
+                dashboardId={dashboardId}
+                channelId={channelId}
+              />
             )}
           </Flex>
           <Flex align="center" gap="2">
             {isDashboardDetail && dashboardId && isDataTemplate && !editing && (
-              <DashboardRefreshControl dashboardId={dashboardId} />
+              <DashboardRefreshControl
+                dashboardId={dashboardId}
+                channelId={channelId}
+              />
             )}
             {isDashboardDetail && channelId && dashboardId ? (
               dashboard?.kind === "freeform" ? (

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -1,3 +1,4 @@
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
@@ -6,6 +7,7 @@ import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFold
 import { TaskInput } from "@posthog/ui/features/task-detail/components/TaskInput";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
@@ -29,11 +31,28 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
       // Seed the detail cache so the destination route resolves instantly
       // (mirrors openTask), then file to the channel + navigate.
       queryClient.setQueryData(taskDetailQuery(task.id).queryKey, task);
-      void fileTask(channelId, task.id, task.title).catch((error: unknown) => {
-        toast.error("Couldn't file task to channel", {
-          description: error instanceof Error ? error.message : String(error),
+      void fileTask(channelId, task.id, task.title)
+        .then(() => {
+          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+            action_type: "file_task",
+            surface: "new_task",
+            channel_id: channelId,
+            task_id: task.id,
+            success: true,
+          });
+        })
+        .catch((error: unknown) => {
+          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+            action_type: "file_task",
+            surface: "new_task",
+            channel_id: channelId,
+            task_id: task.id,
+            success: false,
+          });
+          toast.error("Couldn't file task to channel", {
+            description: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
       void navigate({
         to: "/website/$channelId/tasks/$taskId",
         params: { channelId, taskId: task.id },
@@ -49,6 +68,14 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
       channelName={channelName}
       allowNoRepo
       suggestions={CHANNEL_TASK_SUGGESTIONS}
+      onSuggestionSelect={(label) =>
+        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          action_type: "new_task_suggestion",
+          surface: "new_task",
+          channel_id: channelId,
+          suggestion_label: label,
+        })
+      }
     />
   );
 }

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -3,13 +3,16 @@ import {
   ArrowUUpRightIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
+import { buildCanvasPromptProps } from "@posthog/core/canvas/canvasAnalytics";
 import type { CanvasAnalyticsConfig } from "@posthog/core/canvas/freeformSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import {
   useFreeformChatStore,
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { ErrorBoundary } from "@posthog/ui/shell/ErrorBoundary";
 import { Flex, ScrollArea, Text } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
@@ -79,10 +82,18 @@ export function FreeformCanvasView({
   // Q7 self-repair: hand the runtime error back to the agent to fix.
   const askAgentToFix = () => {
     if (!runtimeError) return;
-    void send(
-      threadId,
-      `The app threw a runtime error: "${runtimeError}". Fix it and rewrite the whole file.`,
+    const text = `The app threw a runtime error: "${runtimeError}". Fix it and rewrite the whole file.`;
+    track(
+      ANALYTICS_EVENTS.CANVAS_PROMPT_SENT,
+      buildCanvasPromptProps({
+        surface: "freeform",
+        threadId,
+        text,
+        fromSuggestion: false,
+        intent: "ask_agent_to_fix",
+      }),
     );
+    void send(threadId, text);
   };
 
   return (

--- a/packages/ui/src/features/canvas/freeform/FreeformChat.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformChat.tsx
@@ -3,6 +3,7 @@ import { buildCanvasPromptProps } from "@posthog/core/canvas/canvasAnalytics";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useCanvasTemplates } from "@posthog/ui/features/canvas/hooks/useCanvasTemplates";
+import { useFromSuggestion } from "@posthog/ui/features/canvas/hooks/useFromSuggestion";
 import {
   useFreeformChatStore,
   useFreeformThread,
@@ -25,12 +26,10 @@ export function FreeformChat({ threadId }: { threadId: string }) {
   const [draft, setDraft] = useState("");
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  // True once a suggestion chip seeded the composer, until the user types over
-  // it — so the eventual send is attributed to the suggestion.
-  const fromSuggestionRef = useRef(false);
+  const fromSuggestion = useFromSuggestion();
 
   const fillSuggestion = (text: string) => {
-    fromSuggestionRef.current = true;
+    fromSuggestion.mark();
     setDraft(text);
     inputRef.current?.focus();
   };
@@ -50,10 +49,9 @@ export function FreeformChat({ threadId }: { threadId: string }) {
         surface: "freeform",
         threadId,
         text,
-        fromSuggestion: fromSuggestionRef.current,
+        fromSuggestion: fromSuggestion.consume(),
       }),
     );
-    fromSuggestionRef.current = false;
     setDraft("");
     void send(threadId, text);
   };
@@ -148,7 +146,7 @@ export function FreeformChat({ threadId }: { threadId: string }) {
             placeholder="Build an app that…"
             value={draft}
             onChange={(e) => {
-              fromSuggestionRef.current = false;
+              fromSuggestion.clear();
               setDraft(e.target.value);
             }}
             onKeyDown={(e) => {

--- a/packages/ui/src/features/canvas/freeform/FreeformChat.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformChat.tsx
@@ -1,10 +1,13 @@
 import { PaperPlaneRightIcon, SpinnerGapIcon } from "@phosphor-icons/react";
+import { buildCanvasPromptProps } from "@posthog/core/canvas/canvasAnalytics";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useCanvasTemplates } from "@posthog/ui/features/canvas/hooks/useCanvasTemplates";
 import {
   useFreeformChatStore,
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex, ScrollArea, Text, TextArea } from "@radix-ui/themes";
 import { useEffect, useRef, useState } from "react";
 
@@ -22,8 +25,12 @@ export function FreeformChat({ threadId }: { threadId: string }) {
   const [draft, setDraft] = useState("");
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  // True once a suggestion chip seeded the composer, until the user types over
+  // it — so the eventual send is attributed to the suggestion.
+  const fromSuggestionRef = useRef(false);
 
   const fillSuggestion = (text: string) => {
+    fromSuggestionRef.current = true;
     setDraft(text);
     inputRef.current?.focus();
   };
@@ -37,6 +44,16 @@ export function FreeformChat({ threadId }: { threadId: string }) {
   const submit = () => {
     const text = draft.trim();
     if (!text || isStreaming) return;
+    track(
+      ANALYTICS_EVENTS.CANVAS_PROMPT_SENT,
+      buildCanvasPromptProps({
+        surface: "freeform",
+        threadId,
+        text,
+        fromSuggestion: fromSuggestionRef.current,
+      }),
+    );
+    fromSuggestionRef.current = false;
     setDraft("");
     void send(threadId, text);
   };
@@ -130,7 +147,10 @@ export function FreeformChat({ threadId }: { threadId: string }) {
             className="flex-1"
             placeholder="Build an app that…"
             value={draft}
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(e) => {
+              fromSuggestionRef.current = false;
+              setDraft(e.target.value);
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();

--- a/packages/ui/src/features/canvas/hooks/useFromSuggestion.ts
+++ b/packages/ui/src/features/canvas/hooks/useFromSuggestion.ts
@@ -1,0 +1,33 @@
+import { useRef } from "react";
+
+export interface FromSuggestionTracker {
+  /** A suggestion chip seeded the composer. */
+  mark: () => void;
+  /** The user typed over the seeded prompt. */
+  clear: () => void;
+  /** Read the flag for the outgoing prompt and reset it. */
+  consume: () => boolean;
+}
+
+// Tracks whether the composer's current draft was seeded by a suggestion chip,
+// so the eventual send can be attributed to it. Shared by the canvas and
+// freeform chat panels, which drive the same attribution. The flag is a ref
+// (not state) — it never needs to trigger a re-render.
+export function useFromSuggestion(): FromSuggestionTracker {
+  const ref = useRef(false);
+  // Stable object identity across renders so it's safe in deps/handlers.
+  const api = useRef<FromSuggestionTracker>({
+    mark: () => {
+      ref.current = true;
+    },
+    clear: () => {
+      ref.current = false;
+    },
+    consume: () => {
+      const value = ref.current;
+      ref.current = false;
+      return value;
+    },
+  });
+  return api.current;
+}

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -60,6 +60,8 @@ type Command = {
   keywords?: string;
   icon: React.ReactNode;
   action: CommandMenuAction;
+  /** Channel in scope for the bluebird open-channel / open-task actions. */
+  channelId?: string;
   onRun: () => void;
 };
 
@@ -282,6 +284,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
             keywords: channel?.name,
             icon: <TaskCommandIcon task={task} />,
             action: "open-task" as CommandMenuAction,
+            channelId: bluebirdEnabled ? channel?.id : undefined,
             onRun: () => {
               closeSettingsDialog();
               // Bluebird: a task filed to a channel opens in the channel-
@@ -310,6 +313,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
           keywords: "channel",
           icon: <HashIcon size={12} className="text-gray-11" />,
           action: "open-channel" as CommandMenuAction,
+          channelId: channel.id,
           onRun: () => {
             closeSettingsDialog();
             navigateToChannel(channel.id);
@@ -334,7 +338,10 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     if (id === null) return;
     const cmd = allCommands.find((c) => c.id === id);
     if (!cmd) return;
-    track(ANALYTICS_EVENTS.COMMAND_MENU_ACTION, { action_type: cmd.action });
+    track(ANALYTICS_EVENTS.COMMAND_MENU_ACTION, {
+      action_type: cmd.action,
+      channel_id: cmd.channelId,
+    });
     cmd.onRun();
     onOpenChange(false);
     setQuery("");

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -88,6 +88,12 @@ interface TaskInputProps {
    * composer. Channels-only — omitted on the /code new-task screen.
    */
   suggestions?: SuggestedPrompt[];
+  /**
+   * Called when a starter-prompt suggestion card is clicked, with the card's
+   * label. Optional analytics hook for the channels new-task screen; has no
+   * effect on the fill behaviour.
+   */
+  onSuggestionSelect?: (label: string) => void;
 }
 
 export function TaskInput({
@@ -103,6 +109,7 @@ export function TaskInput({
   channelName,
   allowNoRepo,
   suggestions,
+  onSuggestionSelect,
 }: TaskInputProps = {}) {
   const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
   const trpc = useHostTRPC();
@@ -964,6 +971,7 @@ export function TaskInput({
                           key={suggestion.label}
                           suggestion={suggestion}
                           onSelect={() => {
+                            onSuggestionSelect?.(suggestion.label);
                             // Use pending content (not setContent) so the
                             // multi-line template — intro + "User input:" fill-in
                             // lines — keeps its line breaks; focuses at the end.

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -262,14 +262,26 @@ function RootLayout() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setFeedbackMode("leaving")}
+              onClick={() => {
+                track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                  action_type: "leave_space",
+                  surface: "title_bar",
+                });
+                setFeedbackMode("leaving");
+              }}
             >
               Go back to Code
             </Button>
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setFeedbackMode("feedback")}
+              onClick={() => {
+                track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                  action_type: "leave_feedback",
+                  surface: "title_bar",
+                });
+                setFeedbackMode("feedback");
+              }}
             >
               Leave feedback
             </Button>

--- a/packages/ui/src/shell/HeaderRow.tsx
+++ b/packages/ui/src/shell/HeaderRow.tsx
@@ -1,6 +1,7 @@
 import { Cloud, Spinner } from "@phosphor-icons/react";
 import { Button as QuillButton } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useDiffStatsToggle } from "@posthog/ui/features/code-review/hooks/useDiffStatsToggle";
@@ -24,6 +25,7 @@ import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { useAppView } from "@posthog/ui/router/useAppView";
+import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
 import { isWindows } from "@posthog/ui/utils/platform";
 import { Box, Flex } from "@radix-ui/themes";
@@ -145,7 +147,13 @@ function BluebirdButton() {
       <QuillButton
         variant="outline"
         size="sm"
-        onClick={() => navigate({ to: "/website" })}
+        onClick={() => {
+          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+            action_type: "enter_space",
+            surface: "header_button",
+          });
+          navigate({ to: "/website" });
+        }}
       >
         Bluebird
       </QuillButton>


### PR DESCRIPTION
## Problem

Project Bluebird (the **Channels / Website space**, gated behind `project-bluebird`) is a beta feature shipped to an email allowlist. Its CONTEXT.md mandates that *"all features should be instrumented with events,"* and there's already a usage dashboard waiting for data — but almost none of the bluebird surfaces emitted analytics. Only the feedback-survey submit was tracked; the command menu fired generic events without channel context.

**Why:** we need to measure adoption and usage of the Channels space — who enters it, and what they do with channels, dashboards/canvases, the canvas agent, and CONTEXT.md.

## Changes

Six new events in `packages/shared/src/analytics-events.ts`, following the codebase's existing grouped `*_ACTION { action_type, surface }` + `*_VIEWED` convention (mirrors `AGENTS_ACTION` / `SCOUT_ACTION` / `INBOX_REPORT_ACTION`):

- **`CHANNELS_SPACE_VIEWED`** — fired once on entering the space, with channel/star counts.
- **`CHANNEL_ACTION`** — enter/leave space, nav clicks, channel CRUD (create/rename/delete/star), filing/archiving/removing tasks, starter suggestion-cards.
- **`DASHBOARD_ACTION`** — open/create/save/fork/delete, edit toggle, date-range apply, manual refresh, poll-mode change.
- **`CANVAS_PROMPT_SENT`** — canvas-agent prompts (json + freeform), with `from_suggestion` / `ask_agent_to_fix` intent.
- **`CONTEXT_ACTION`** — CONTEXT.md save + agent generation (local/cloud).
- Enriched the existing **`COMMAND_MENU_ACTION`** with `channel_id`.

Events fire at call sites via the standard `track()` helper and **degrade to a no-op on the web host** (its `ANALYTICS_TRACKER` is stubbed). Pure prop-builders live in `@posthog/core` (`canvas/canvasAnalytics.ts`) with unit tests, following the onboarding/inbox precedent. Low-signal interactions (undo/redo, the 10s/10min poll-tick refresh) are intentionally left untracked to avoid noise.

## How did you test this?

- `pnpm --filter @posthog/shared --filter @posthog/core --filter @posthog/ui typecheck` — clean.
- `pnpm --filter @posthog/core test canvasAnalytics` — 7 passing (new helper tests).
- `pnpm --filter @posthog/ui test` — full suite green (785 passing), incl. existing canvas/command/task-detail tests.
- `biome check` / `lint` on all changed files — clean (incl. core `noRestrictedImports`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*