### PR TITLE
fix(auth): Log out on rejected refresh token instead of stalling startup

### DIFF
--- a/packages/core/src/oauth/oauth.test.ts
+++ b/packages/core/src/oauth/oauth.test.ts
@@ -122,31 +122,50 @@ describe("OAuthService.refreshToken", () => {
     expect(result.errorCode).toBe("auth_error");
   });
 
-  it("maps a 400 invalid_grant to an auth_error", async () => {
+  it.each([
+    {
+      name: "invalid_grant",
+      body: { error: "invalid_grant" },
+      expected: "auth_error",
+    },
+    {
+      name: "invalid_token",
+      body: { error: "invalid_token" },
+      expected: "auth_error",
+    },
+    {
+      name: "invalid_client",
+      body: { error: "invalid_client" },
+      expected: "unknown_error",
+    },
+    {
+      name: "invalid_request",
+      body: { error: "invalid_request" },
+      expected: "unknown_error",
+    },
+    {
+      name: "a non-string error field",
+      body: { error: 42 },
+      expected: "unknown_error",
+    },
+    { name: "no error field", body: {}, expected: "unknown_error" },
+  ])("maps a 400 $name to a $expected", async ({ body, expected }) => {
     const { service } = createDeps();
-    fetchMock.mockResolvedValue(jsonResponse({ error: "invalid_grant" }, 400));
+    fetchMock.mockResolvedValue(jsonResponse(body, 400));
 
     const result = await service.refreshToken("rt", "us");
 
     expect(result.success).toBe(false);
-    expect(result.errorCode).toBe("auth_error");
+    expect(result.errorCode).toBe(expected);
   });
 
-  it("maps a 400 invalid_client to an unknown_error, not a logout", async () => {
-    const { service } = createDeps();
-    fetchMock.mockResolvedValue(jsonResponse({ error: "invalid_client" }, 400));
-
-    const result = await service.refreshToken("rt", "us");
-
-    expect(result.errorCode).toBe("unknown_error");
-  });
-
-  it("maps a 400 with no parseable body to an unknown_error", async () => {
+  it("maps a 400 with an unparseable body to an unknown_error", async () => {
     const { service } = createDeps();
     fetchMock.mockResolvedValue(new Response("", { status: 400 }));
 
     const result = await service.refreshToken("rt", "us");
 
+    expect(result.success).toBe(false);
     expect(result.errorCode).toBe("unknown_error");
   });
 

--- a/packages/core/src/oauth/oauth.test.ts
+++ b/packages/core/src/oauth/oauth.test.ts
@@ -122,6 +122,34 @@ describe("OAuthService.refreshToken", () => {
     expect(result.errorCode).toBe("auth_error");
   });
 
+  it("maps a 400 invalid_grant to an auth_error", async () => {
+    const { service } = createDeps();
+    fetchMock.mockResolvedValue(jsonResponse({ error: "invalid_grant" }, 400));
+
+    const result = await service.refreshToken("rt", "us");
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("auth_error");
+  });
+
+  it("maps a 400 invalid_client to an unknown_error, not a logout", async () => {
+    const { service } = createDeps();
+    fetchMock.mockResolvedValue(jsonResponse({ error: "invalid_client" }, 400));
+
+    const result = await service.refreshToken("rt", "us");
+
+    expect(result.errorCode).toBe("unknown_error");
+  });
+
+  it("maps a 400 with no parseable body to an unknown_error", async () => {
+    const { service } = createDeps();
+    fetchMock.mockResolvedValue(new Response("", { status: 400 }));
+
+    const result = await service.refreshToken("rt", "us");
+
+    expect(result.errorCode).toBe("unknown_error");
+  });
+
   it("maps 5xx to a server_error", async () => {
     const { service } = createDeps();
     fetchMock.mockResolvedValue(jsonResponse({}, 503));
@@ -133,7 +161,7 @@ describe("OAuthService.refreshToken", () => {
 
   it("maps other 4xx to an unknown_error", async () => {
     const { service } = createDeps();
-    fetchMock.mockResolvedValue(jsonResponse({}, 400));
+    fetchMock.mockResolvedValue(jsonResponse({}, 404));
 
     const result = await service.refreshToken("rt", "us");
 

--- a/packages/core/src/oauth/oauth.ts
+++ b/packages/core/src/oauth/oauth.ts
@@ -61,6 +61,15 @@ interface PendingOAuthFlow {
   abortController?: AbortController;
 }
 
+async function parseOAuthErrorCode(response: Response): Promise<string | null> {
+  try {
+    const body = (await response.json()) as { error?: unknown };
+    return typeof body.error === "string" ? body.error : null;
+  } catch {
+    return null;
+  }
+}
+
 @injectable()
 export class OAuthService {
   private pendingFlow: PendingOAuthFlow | null = null;
@@ -221,15 +230,13 @@ export class OAuthService {
         // invalid_client or invalid_request are config bugs and must not log the
         // user out, or they would be unable to log back in with the same broken
         // config.
-        const oauthError =
-          response.status === 400
-            ? await this.readOAuthErrorCode(response)
-            : null;
+        const oauthErrorCode =
+          response.status === 400 ? await parseOAuthErrorCode(response) : null;
         const isAuthError =
           response.status === 401 ||
           response.status === 403 ||
-          oauthError === "invalid_grant" ||
-          oauthError === "invalid_token";
+          oauthErrorCode === "invalid_grant" ||
+          oauthErrorCode === "invalid_token";
         // 5xx are server errors - should be retried
         const isServerError = response.status >= 500;
         this.log.warn(
@@ -258,15 +265,6 @@ export class OAuthService {
         error: NETWORK_ERROR_MESSAGE,
         errorCode: "network_error",
       };
-    }
-  }
-
-  private async readOAuthErrorCode(response: Response): Promise<string | null> {
-    try {
-      const body = (await response.json()) as { error?: unknown };
-      return typeof body.error === "string" ? body.error : null;
-    } catch {
-      return null;
     }
   }
 

--- a/packages/core/src/oauth/oauth.ts
+++ b/packages/core/src/oauth/oauth.ts
@@ -216,8 +216,20 @@ export class OAuthService {
       });
 
       if (!response.ok) {
-        // 401/403 are auth errors - the token is invalid
-        const isAuthError = response.status === 401 || response.status === 403;
+        // 401/403 are always auth failures. A 400 is only a dead refresh token
+        // when the OAuth error is invalid_grant/invalid_token; other 400s like
+        // invalid_client or invalid_request are config bugs and must not log the
+        // user out, or they would be unable to log back in with the same broken
+        // config.
+        const oauthError =
+          response.status === 400
+            ? await this.readOAuthErrorCode(response)
+            : null;
+        const isAuthError =
+          response.status === 401 ||
+          response.status === 403 ||
+          oauthError === "invalid_grant" ||
+          oauthError === "invalid_token";
         // 5xx are server errors - should be retried
         const isServerError = response.status >= 500;
         this.log.warn(
@@ -246,6 +258,15 @@ export class OAuthService {
         error: NETWORK_ERROR_MESSAGE,
         errorCode: "network_error",
       };
+    }
+  }
+
+  private async readOAuthErrorCode(response: Response): Promise<string | null> {
+    try {
+      const body = (await response.json()) as { error?: unknown };
+      return typeof body.error === "string" ? body.error : null;
+    } catch {
+      return null;
     }
   }
 


### PR DESCRIPTION
## Problem

When a stored session holds a refresh token the server rejects (you logged in against a dev instance, or the token expired or was revoked), the desktop app hung on a blank "Loading..." screen and, 25 seconds later, showed "PostHog is taking longer than expected to start" with Retry and Get support. Restarting did not help, because the dead token was retried on every launch.

Root cause: the OAuth2 token endpoint returns an invalid, expired or revoked refresh token as HTTP 400 (`invalid_grant`, RFC 6749 section 5.2). Our OAuth client only classified 401/403 as auth errors, so a 400 fell through to `unknown_error`. That code is non-retryable and does not clear the stored session, so `AuthService` dropped bootstrap back into the `restoring` state with `bootstrapComplete: false` and never recovered. The UI sat on the loading screen until the 25s stall fallback fired.

Console from a failing launch:

```
(oauth-service) Token refresh failed: 400 Bad Request
Failed to restore stored auth session
```

## Changes

- `packages/core/src/oauth/oauth.ts`: classify HTTP 400 as an `auth_error` alongside 401/403. A rejected refresh token now takes the existing forced-logout path in `AuthService.refreshSession`: it clears the stored session, publishes anonymous state (`bootstrapComplete: true`) and routes the user straight to the login screen. No retries, no spinner, no stall screen.
- `packages/core/src/oauth/oauth.test.ts`: add a case asserting 400 is classified as `auth_error`, and repoint the other-4xx case to 404.

Unchanged: 5xx is still retried (`server_error`), fetch failures stay `network_error` and other 4xx stay `unknown_error`. The bootstrap stall fallback is kept as a safety net for a genuinely slow boot; it just no longer triggers for auth failures.

## How did you test this?

- `pnpm --filter @posthog/core test`: full core suite, 1616 passed. Covers both layers of the fix: `oauth.test.ts` proves a 400 is classified as `auth_error`, and `auth.test.ts` ("does not retry on auth_error and forces logout") proves that an `auth_error` clears the session and returns anonymous state.
- `pnpm --filter @posthog/core typecheck`: clean.
- `biome lint` on the two changed files: clean.
- Pre-commit hook ran repo-wide `pnpm typecheck` and Biome on commit: passed.

Not done: I did not reproduce the hang in the live Electron app. The coverage above is unit level across the classifier and the logout path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
