### PR TITLE
feat(updates): update modal, auto-download setting, changelog

### DIFF
--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -164,6 +164,7 @@ import type { ExternalAppsPreferences } from "@posthog/workspace-server/services
 import { foldersModule } from "@posthog/workspace-server/services/folders/folders.module";
 import { GitService } from "@posthog/workspace-server/services/git/service";
 import { TaskPrStatusService } from "@posthog/workspace-server/services/git/task-pr-status";
+import { githubReleasesModule } from "@posthog/workspace-server/services/github-releases/github-releases.module";
 import {
   HANDOFF_GIT_GATEWAY,
   HANDOFF_LOG_GATEWAY,
@@ -589,6 +590,7 @@ container.load(posthogPluginModule);
 container.bind(MAIN_POSTHOG_PLUGIN_SERVICE).toService(POSTHOG_PLUGIN_SERVICE);
 container.load(skillsModule);
 container.load(skillsMarketplaceModule);
+container.load(githubReleasesModule);
 container.load(onboardingImportModule);
 container.load(claudeCliSessionsModule);
 container.load(additionalDirectoriesModule);

--- a/apps/code/src/main/platform-adapters/electron-updater.ts
+++ b/apps/code/src/main/platform-adapters/electron-updater.ts
@@ -1,14 +1,39 @@
-import type { IUpdater } from "@posthog/platform/updater";
+import type {
+  IUpdater,
+  UpdateAvailableInfo,
+  UpdateDownloadProgress,
+} from "@posthog/platform/updater";
 import { app } from "electron";
 import log from "electron-log/main";
-import { autoUpdater, type UpdateInfo } from "electron-updater";
+import {
+  autoUpdater,
+  type ProgressInfo,
+  type UpdateInfo,
+} from "electron-updater";
 import { injectable } from "inversify";
+
+function normalizeReleaseNotes(
+  notes: UpdateInfo["releaseNotes"],
+): string | null {
+  if (!notes) return null;
+  if (typeof notes === "string") return notes;
+  const joined = notes
+    .map((n) => n.note ?? "")
+    .filter((n) => n.length > 0)
+    .join("\n\n");
+  return joined.length > 0 ? joined : null;
+}
 
 @injectable()
 export class ElectronUpdater implements IUpdater {
   constructor() {
     autoUpdater.logger = log;
     autoUpdater.disableDifferentialDownload = true;
+    // Default to manual download; the "Download updates automatically" setting
+    // flips this via setAutoDownload(). A downloaded update always installs on the
+    // next quit, with an in-app Restart button for immediate install.
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = true;
   }
 
   public isSupported(): boolean {
@@ -23,8 +48,16 @@ export class ElectronUpdater implements IUpdater {
     void autoUpdater.checkForUpdates();
   }
 
+  public download(): void {
+    void autoUpdater.downloadUpdate();
+  }
+
   public quitAndInstall(): void {
     autoUpdater.quitAndInstall(false, true);
+  }
+
+  public setAutoDownload(enabled: boolean): void {
+    autoUpdater.autoDownload = enabled;
   }
 
   public onCheckStart(handler: () => void): () => void {
@@ -32,10 +65,32 @@ export class ElectronUpdater implements IUpdater {
     return () => autoUpdater.off("checking-for-update", handler);
   }
 
-  public onUpdateAvailable(handler: () => void): () => void {
-    const l = (_info: UpdateInfo) => handler();
+  public onUpdateAvailable(
+    handler: (info: UpdateAvailableInfo) => void,
+  ): () => void {
+    const l = (info: UpdateInfo) =>
+      handler({
+        version: info.version,
+        releaseNotes: normalizeReleaseNotes(info.releaseNotes),
+        releaseDate: info.releaseDate,
+        releaseName: info.releaseName,
+      });
     autoUpdater.on("update-available", l);
     return () => autoUpdater.off("update-available", l);
+  }
+
+  public onDownloadProgress(
+    handler: (progress: UpdateDownloadProgress) => void,
+  ): () => void {
+    const l = (info: ProgressInfo) =>
+      handler({
+        percent: info.percent,
+        bytesPerSecond: info.bytesPerSecond,
+        transferred: info.transferred,
+        total: info.total,
+      });
+    autoUpdater.on("download-progress", l);
+    return () => autoUpdater.off("download-progress", l);
   }
 
   public onUpdateDownloaded(handler: (version: string) => void): () => void {

--- a/apps/code/src/main/platform-adapters/electron-updater.ts
+++ b/apps/code/src/main/platform-adapters/electron-updater.ts
@@ -45,11 +45,11 @@ export class ElectronUpdater implements IUpdater {
   }
 
   public check(): void {
-    void autoUpdater.checkForUpdates();
+    void autoUpdater.checkForUpdates().catch(() => undefined);
   }
 
   public download(): void {
-    void autoUpdater.downloadUpdate();
+    void autoUpdater.downloadUpdate().catch(() => undefined);
   }
 
   public quitAndInstall(): void {

--- a/apps/code/src/main/platform-adapters/electron-updater.ts
+++ b/apps/code/src/main/platform-adapters/electron-updater.ts
@@ -24,6 +24,12 @@ function normalizeReleaseNotes(
   return joined.length > 0 ? joined : null;
 }
 
+function pickDownloadSize(files: UpdateInfo["files"]): number | null {
+  if (!files?.length) return null;
+  const sizes = files.map((file) => file.size ?? 0).filter((size) => size > 0);
+  return sizes.length > 0 ? Math.max(...sizes) : null;
+}
+
 @injectable()
 export class ElectronUpdater implements IUpdater {
   constructor() {
@@ -74,6 +80,7 @@ export class ElectronUpdater implements IUpdater {
         releaseNotes: normalizeReleaseNotes(info.releaseNotes),
         releaseDate: info.releaseDate,
         releaseName: info.releaseName,
+        sizeBytes: pickDownloadSize(info.files),
       });
     autoUpdater.on("update-available", l);
     return () => autoUpdater.off("update-available", l);

--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -21,6 +21,7 @@ import { foldersRouter } from "@posthog/host-router/routers/folders.router";
 import { fsRouter } from "@posthog/host-router/routers/fs.router";
 import { gitRouter } from "@posthog/host-router/routers/git.router";
 import { githubIntegrationRouter } from "@posthog/host-router/routers/github-integration.router";
+import { githubReleasesRouter } from "@posthog/host-router/routers/github-releases.router";
 import { handoffRouter } from "@posthog/host-router/routers/handoff.router";
 import { linearIntegrationRouter } from "@posthog/host-router/routers/linear-integration.router";
 import { llmGatewayRouter } from "@posthog/host-router/routers/llm-gateway.router";
@@ -72,6 +73,7 @@ export const trpcRouter = router({
   fs: fsRouter,
   git: gitRouter,
   githubIntegration: githubIntegrationRouter,
+  githubReleases: githubReleasesRouter,
   handoff: handoffRouter,
   linearIntegration: linearIntegrationRouter,
   llmGateway: llmGatewayRouter,

--- a/apps/code/src/renderer/platform-adapters/updates.ts
+++ b/apps/code/src/renderer/platform-adapters/updates.ts
@@ -6,12 +6,15 @@ import {
   updateStore,
 } from "@posthog/core/updates/updateStore";
 import { resolveService } from "@posthog/di/container";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import {
   UPDATES_CLIENT,
   type UpdatesClient,
 } from "@posthog/ui/features/updates/updatesClient";
+import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
 import { toast } from "@posthog/ui/primitives/toast";
 import { logger } from "@posthog/ui/shell/logger";
+import { hostTrpcClient } from "@renderer/trpc/client";
 
 const log = logger.scope("updates-host");
 
@@ -44,11 +47,8 @@ void client
   .getStatus()
   .then((status) => {
     const update = deriveUpdateUiStatus(status, store().status);
-    if (update?.status) {
-      store().setStatus(update.status);
-    }
-    if (update && "version" in update) {
-      store().setVersion(update.version ?? null);
+    if (update) {
+      store().applyStatusUpdate(update);
     }
   })
   .catch((error: unknown) => {
@@ -58,11 +58,8 @@ void client
 client.onStatus({
   onData: (status) => {
     const update = deriveUpdateUiStatus(status, store().status);
-    if (update?.status) {
-      store().setStatus(update.status);
-    }
-    if (update && "version" in update) {
-      store().setVersion(update.version ?? null);
+    if (update) {
+      store().applyStatusUpdate(update);
     }
 
     const outcome = resolveMenuCheckFromStatus(
@@ -119,3 +116,48 @@ client.onCheckFromMenu({
     log.error("Update menu check subscription error", { error });
   },
 });
+
+// Bridge the "download updates automatically" preference to the core updater.
+let lastSyncedAutoDownload: boolean | null = null;
+function syncAutoDownload(enabled: boolean): void {
+  if (enabled === lastSyncedAutoDownload) return;
+  lastSyncedAutoDownload = enabled;
+  void hostTrpcClient.updates.setAutoDownload
+    .mutate({ enabled })
+    .catch((error: unknown) =>
+      log.error("Failed to sync auto-download preference", { error }),
+    );
+}
+
+// Auto-show "What's New" once on the first launch after the version changes.
+function maybeShowWhatsNew(): void {
+  void hostTrpcClient.os.getAppVersion
+    .query()
+    .then((currentVersion) => {
+      const settings = useSettingsStore.getState();
+      const lastSeen = settings.lastSeenChangelogVersion;
+      if (lastSeen && lastSeen !== currentVersion) {
+        useWhatsNewStore.getState().open();
+      }
+      if (lastSeen !== currentVersion) {
+        settings.setLastSeenChangelogVersion(currentVersion);
+      }
+    })
+    .catch((error: unknown) =>
+      log.error("Failed to evaluate What's New", { error }),
+    );
+}
+
+function onSettingsReady(): void {
+  syncAutoDownload(useSettingsStore.getState().downloadUpdatesAutomatically);
+  useSettingsStore.subscribe((state) =>
+    syncAutoDownload(state.downloadUpdatesAutomatically),
+  );
+  maybeShowWhatsNew();
+}
+
+if (useSettingsStore.persist.hasHydrated()) {
+  onSettingsReady();
+} else {
+  useSettingsStore.persist.onFinishHydration(onSettingsReady);
+}

--- a/packages/core/src/updates/schemas.ts
+++ b/packages/core/src/updates/schemas.ts
@@ -16,10 +16,16 @@ export const checkForUpdatesOutput = z.object({
 export const updatesStatusOutput = z.object({
   checking: z.boolean(),
   downloading: z.boolean().optional(),
+  available: z.boolean().optional(),
   upToDate: z.boolean().optional(),
   updateReady: z.boolean().optional(),
   installing: z.boolean().optional(),
   version: z.string().optional(),
+  availableVersion: z.string().optional(),
+  releaseNotes: z.string().nullable().optional(),
+  releaseDate: z.string().optional(),
+  downloadPercent: z.number().optional(),
+  bytesPerSecond: z.number().optional(),
   error: z.string().optional(),
 });
 

--- a/packages/core/src/updates/schemas.ts
+++ b/packages/core/src/updates/schemas.ts
@@ -26,6 +26,7 @@ export const updatesStatusOutput = z.object({
   releaseDate: z.string().optional(),
   downloadPercent: z.number().optional(),
   bytesPerSecond: z.number().optional(),
+  downloadSizeBytes: z.number().nullable().optional(),
   error: z.string().optional(),
 });
 

--- a/packages/core/src/updates/updateStore.test.ts
+++ b/packages/core/src/updates/updateStore.test.ts
@@ -27,7 +27,14 @@ describe("deriveUpdateUiStatus", () => {
   it("maps checking + downloading to downloading", () => {
     expect(
       deriveUpdateUiStatus({ checking: true, downloading: true }, "idle"),
-    ).toEqual({ status: "downloading" });
+    ).toEqual({
+      status: "downloading",
+      availableVersion: null,
+      releaseNotes: null,
+      releaseDate: null,
+      downloadPercent: null,
+      bytesPerSecond: null,
+    });
   });
 
   it("maps checking to checking", () => {

--- a/packages/core/src/updates/updateStore.test.ts
+++ b/packages/core/src/updates/updateStore.test.ts
@@ -34,6 +34,7 @@ describe("deriveUpdateUiStatus", () => {
       releaseDate: null,
       downloadPercent: null,
       bytesPerSecond: null,
+      downloadSizeBytes: null,
     });
   });
 

--- a/packages/core/src/updates/updateStore.ts
+++ b/packages/core/src/updates/updateStore.ts
@@ -17,6 +17,7 @@ interface UpdateState {
   releaseDate: string | null;
   downloadPercent: number | null;
   bytesPerSecond: number | null;
+  downloadSizeBytes: number | null;
   isEnabled: boolean;
   menuCheckPending: boolean;
 
@@ -36,6 +37,7 @@ export const updateStore = createStore<UpdateState>((set) => ({
   releaseDate: null,
   downloadPercent: null,
   bytesPerSecond: null,
+  downloadSizeBytes: null,
   isEnabled: false,
   menuCheckPending: false,
 
@@ -68,6 +70,10 @@ export const updateStore = createStore<UpdateState>((set) => ({
         update.bytesPerSecond !== undefined
           ? update.bytesPerSecond
           : state.bytesPerSecond,
+      downloadSizeBytes:
+        update.downloadSizeBytes !== undefined
+          ? update.downloadSizeBytes
+          : state.downloadSizeBytes,
     })),
 }));
 
@@ -84,6 +90,7 @@ export interface UpdateStatusUpdate {
   releaseDate?: string | null;
   downloadPercent?: number | null;
   bytesPerSecond?: number | null;
+  downloadSizeBytes?: number | null;
 }
 
 export function deriveUpdateUiStatus(
@@ -106,6 +113,7 @@ export function deriveUpdateUiStatus(
       releaseDate: payload.releaseDate ?? null,
       downloadPercent: payload.downloadPercent ?? null,
       bytesPerSecond: payload.bytesPerSecond ?? null,
+      downloadSizeBytes: payload.downloadSizeBytes ?? null,
     };
   }
 
@@ -115,6 +123,7 @@ export function deriveUpdateUiStatus(
       availableVersion: payload.availableVersion ?? null,
       releaseNotes: payload.releaseNotes ?? null,
       releaseDate: payload.releaseDate ?? null,
+      downloadSizeBytes: payload.downloadSizeBytes ?? null,
     };
   }
 

--- a/packages/core/src/updates/updateStore.ts
+++ b/packages/core/src/updates/updateStore.ts
@@ -3,6 +3,7 @@ import { createStore } from "zustand/vanilla";
 
 export type UpdateUiStatus =
   | "idle"
+  | "available"
   | "checking"
   | "downloading"
   | "ready"
@@ -11,6 +12,11 @@ export type UpdateUiStatus =
 interface UpdateState {
   status: UpdateUiStatus;
   version: string | null;
+  availableVersion: string | null;
+  releaseNotes: string | null;
+  releaseDate: string | null;
+  downloadPercent: number | null;
+  bytesPerSecond: number | null;
   isEnabled: boolean;
   menuCheckPending: boolean;
 
@@ -19,11 +25,17 @@ interface UpdateState {
   setEnabled: (isEnabled: boolean) => void;
   setMenuCheckPending: (menuCheckPending: boolean) => void;
   setReady: (version: string | null) => void;
+  applyStatusUpdate: (update: UpdateStatusUpdate) => void;
 }
 
 export const updateStore = createStore<UpdateState>((set) => ({
   status: "idle",
   version: null,
+  availableVersion: null,
+  releaseNotes: null,
+  releaseDate: null,
+  downloadPercent: null,
+  bytesPerSecond: null,
   isEnabled: false,
   menuCheckPending: false,
 
@@ -32,6 +44,31 @@ export const updateStore = createStore<UpdateState>((set) => ({
   setEnabled: (isEnabled) => set({ isEnabled }),
   setMenuCheckPending: (menuCheckPending) => set({ menuCheckPending }),
   setReady: (version) => set({ status: "ready", version }),
+  applyStatusUpdate: (update) =>
+    set((state) => ({
+      status: update.status ?? state.status,
+      version: update.version !== undefined ? update.version : state.version,
+      availableVersion:
+        update.availableVersion !== undefined
+          ? update.availableVersion
+          : state.availableVersion,
+      releaseNotes:
+        update.releaseNotes !== undefined
+          ? update.releaseNotes
+          : state.releaseNotes,
+      releaseDate:
+        update.releaseDate !== undefined
+          ? update.releaseDate
+          : state.releaseDate,
+      downloadPercent:
+        update.downloadPercent !== undefined
+          ? update.downloadPercent
+          : state.downloadPercent,
+      bytesPerSecond:
+        update.bytesPerSecond !== undefined
+          ? update.bytesPerSecond
+          : state.bytesPerSecond,
+    })),
 }));
 
 export const getUpdateUiStatus = () => updateStore.getState().status;
@@ -42,6 +79,11 @@ export const getMenuCheckPending = () =>
 export interface UpdateStatusUpdate {
   status?: UpdateUiStatus;
   version?: string | null;
+  availableVersion?: string | null;
+  releaseNotes?: string | null;
+  releaseDate?: string | null;
+  downloadPercent?: number | null;
+  bytesPerSecond?: number | null;
 }
 
 export function deriveUpdateUiStatus(
@@ -57,7 +99,23 @@ export function deriveUpdateUiStatus(
   }
 
   if (payload.checking && payload.downloading) {
-    return { status: "downloading" };
+    return {
+      status: "downloading",
+      availableVersion: payload.availableVersion ?? null,
+      releaseNotes: payload.releaseNotes ?? null,
+      releaseDate: payload.releaseDate ?? null,
+      downloadPercent: payload.downloadPercent ?? null,
+      bytesPerSecond: payload.bytesPerSecond ?? null,
+    };
+  }
+
+  if (payload.available) {
+    return {
+      status: "available",
+      availableVersion: payload.availableVersion ?? null,
+      releaseNotes: payload.releaseNotes ?? null,
+      releaseDate: payload.releaseDate ?? null,
+    };
   }
 
   if (payload.checking) {

--- a/packages/core/src/updates/updates.test.ts
+++ b/packages/core/src/updates/updates.test.ts
@@ -722,6 +722,54 @@ describe("UpdatesService", () => {
     });
   });
 
+  describe("available update guards", () => {
+    it("does not re-check or clear the banner on periodic checks while available", async () => {
+      await initializeService(service);
+
+      updaterHandlers.updateAvailable?.({
+        version: "v2.0.0",
+        releaseNotes: "Notes",
+      });
+      expect(service.getStatus()).toMatchObject({
+        available: true,
+        availableVersion: "v2.0.0",
+      });
+
+      const statusHandler = vi.fn();
+      service.on(UpdatesEvent.Status, statusHandler);
+      mockUpdater.check.mockClear();
+
+      const result = service.checkForUpdates("periodic");
+
+      expect(result).toEqual({ success: true });
+      expect(mockUpdater.check).not.toHaveBeenCalled();
+      expect(statusHandler).not.toHaveBeenCalled();
+      expect(service.getStatus()).toMatchObject({
+        available: true,
+        availableVersion: "v2.0.0",
+      });
+    });
+
+    it("starts the download when auto-download is enabled while available", async () => {
+      await initializeService(service);
+
+      updaterHandlers.updateAvailable?.({
+        version: "v2.0.0",
+        releaseNotes: null,
+      });
+      expect(service.getStatus()).toMatchObject({ available: true });
+
+      mockUpdater.download.mockClear();
+      service.setAutoDownloadEnabled(true);
+
+      expect(mockUpdater.download).toHaveBeenCalled();
+      expect(service.getStatus()).toMatchObject({
+        downloading: true,
+        availableVersion: "v2.0.0",
+      });
+    });
+  });
+
   describe("check timeout", () => {
     beforeEach(async () => {
       await initializeService(service);

--- a/packages/core/src/updates/updates.test.ts
+++ b/packages/core/src/updates/updates.test.ts
@@ -1,3 +1,7 @@
+import type {
+  UpdateAvailableInfo,
+  UpdateDownloadProgress,
+} from "@posthog/platform/updater";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdatesEvent } from "./schemas";
 
@@ -13,7 +17,8 @@ const {
 } = vi.hoisted(() => {
   const updaterHandlers: {
     checkStart: (() => void) | null;
-    updateAvailable: (() => void) | null;
+    updateAvailable: ((info: UpdateAvailableInfo) => void) | null;
+    downloadProgress: ((progress: UpdateDownloadProgress) => void) | null;
     noUpdate: (() => void) | null;
     updateDownloaded: ((version: string) => void) | null;
     error: ((error: Error) => void) | null;
@@ -21,6 +26,7 @@ const {
   } = {
     checkStart: null,
     updateAvailable: null,
+    downloadProgress: null,
     noUpdate: null,
     updateDownloaded: null,
     error: null,
@@ -37,10 +43,18 @@ const {
         updaterHandlers.checkStart = h;
         return () => {};
       }),
-      onUpdateAvailable: vi.fn((h: () => void) => {
+      onUpdateAvailable: vi.fn((h: (info: UpdateAvailableInfo) => void) => {
         updaterHandlers.updateAvailable = h;
         return () => {};
       }),
+      onDownloadProgress: vi.fn(
+        (h: (progress: UpdateDownloadProgress) => void) => {
+          updaterHandlers.downloadProgress = h;
+          return () => {};
+        },
+      ),
+      download: vi.fn(),
+      setAutoDownload: vi.fn(),
       onNoUpdate: vi.fn((h: () => void) => {
         updaterHandlers.noUpdate = h;
         return () => {};
@@ -656,14 +670,54 @@ describe("UpdatesService", () => {
       });
     });
 
-    it("returns downloading status while an update is downloading", async () => {
+    it("returns available status when an update is found", async () => {
       await initializeService(service);
 
-      updaterHandlers.updateAvailable?.();
+      updaterHandlers.updateAvailable?.({
+        version: "v2.0.0",
+        releaseNotes: "Notes",
+      });
 
       expect(service.getStatus()).toEqual({
+        checking: false,
+        available: true,
+        availableVersion: "v2.0.0",
+        releaseNotes: "Notes",
+      });
+    });
+
+    it("auto-downloads and returns downloading status when enabled", async () => {
+      await initializeService(service);
+      service.setAutoDownloadEnabled(true);
+
+      updaterHandlers.updateAvailable?.({
+        version: "v2.0.0",
+        releaseNotes: null,
+      });
+
+      expect(mockUpdater.download).toHaveBeenCalled();
+      expect(service.getStatus()).toMatchObject({
         checking: true,
         downloading: true,
+        availableVersion: "v2.0.0",
+      });
+    });
+
+    it("downloads on requestDownload and reaches ready", async () => {
+      await initializeService(service);
+
+      updaterHandlers.updateAvailable?.({
+        version: "v2.0.0",
+        releaseNotes: null,
+      });
+      service.requestDownload();
+      expect(mockUpdater.download).toHaveBeenCalled();
+      expect(service.getStatus()).toMatchObject({ downloading: true });
+
+      updaterHandlers.updateDownloaded?.("v2.0.0");
+      expect(service.getStatus()).toMatchObject({
+        updateReady: true,
+        version: "v2.0.0",
       });
     });
   });

--- a/packages/core/src/updates/updates.ts
+++ b/packages/core/src/updates/updates.ts
@@ -8,7 +8,12 @@ import {
   type IMainWindow,
   MAIN_WINDOW_SERVICE,
 } from "@posthog/platform/main-window";
-import { type IUpdater, UPDATER_SERVICE } from "@posthog/platform/updater";
+import {
+  type IUpdater,
+  UPDATER_SERVICE,
+  type UpdateAvailableInfo,
+  type UpdateDownloadProgress,
+} from "@posthog/platform/updater";
 import {
   type SagaLogger,
   TypedEventEmitter,
@@ -28,6 +33,7 @@ type CheckSource = "user" | "periodic";
 type UpdateState =
   | "idle"
   | "checking"
+  | "available"
   | "downloading"
   | "ready"
   | "installing"
@@ -82,6 +88,10 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
   private lastError: string | null = null;
   private initialized = false;
   private unsubscribes: Array<() => void> = [];
+  private availableInfo: UpdateAvailableInfo | null = null;
+  private downloadProgress: UpdateDownloadProgress | null = null;
+  private autoDownloadEnabled = false;
+  private lastProgressEmit = 0;
 
   get hasUpdateReady(): boolean {
     return this.isUpdateStaged();
@@ -112,13 +122,43 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
     this.emit(UpdatesEvent.CheckFromMenu, true);
   }
 
+  setAutoDownloadEnabled(enabled: boolean): void {
+    this.autoDownloadEnabled = enabled;
+    if (this.isEnabled) {
+      this.updater.setAutoDownload(enabled);
+    }
+    this.log.info("Auto-download preference updated", { enabled });
+  }
+
+  requestDownload(): void {
+    if (this.state !== "available") {
+      this.log.warn("requestDownload called but no update is available", {
+        state: this.state,
+      });
+      return;
+    }
+    this.transitionTo("downloading", {
+      reason: "user requested download",
+      incomingVersion: this.availableInfo?.version ?? null,
+    });
+    this.log.info("Downloading update...", {
+      version: this.availableInfo?.version,
+    });
+    this.updater.download();
+    this.emitStatus(this.downloadingStatusPayload());
+  }
+
   getStatus(): UpdatesStatusPayload {
     if (this.state === "checking") {
       return { checking: true };
     }
 
+    if (this.state === "available") {
+      return this.availableStatusPayload();
+    }
+
     if (this.state === "downloading") {
-      return { checking: true, downloading: true };
+      return this.downloadingStatusPayload();
     }
 
     if (this.isUpdateStaged()) {
@@ -238,7 +278,12 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
     this.unsubscribes.push(
       this.updater.onError((error) => this.handleError(error)),
       this.updater.onCheckStart(() => this.log.info("Checking for updates...")),
-      this.updater.onUpdateAvailable(() => this.handleUpdateAvailable()),
+      this.updater.onUpdateAvailable((info) =>
+        this.handleUpdateAvailable(info),
+      ),
+      this.updater.onDownloadProgress((progress) =>
+        this.handleDownloadProgress(progress),
+      ),
       this.updater.onNoUpdate(() => this.handleNoUpdate()),
       this.updater.onUpdateDownloaded((releaseName) =>
         this.handleUpdateDownloaded(releaseName),
@@ -259,6 +304,28 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       updateReady: true,
       installing: this.state === "installing",
       version: this.downloadedVersion ?? undefined,
+    };
+  }
+
+  private availableStatusPayload(): UpdatesStatusPayload {
+    return {
+      checking: false,
+      available: true,
+      availableVersion: this.availableInfo?.version,
+      releaseNotes: this.availableInfo?.releaseNotes ?? undefined,
+      releaseDate: this.availableInfo?.releaseDate,
+    };
+  }
+
+  private downloadingStatusPayload(): UpdatesStatusPayload {
+    return {
+      checking: true,
+      downloading: true,
+      availableVersion: this.availableInfo?.version,
+      releaseNotes: this.availableInfo?.releaseNotes ?? undefined,
+      releaseDate: this.availableInfo?.releaseDate,
+      downloadPercent: this.downloadProgress?.percent,
+      bytesPerSecond: this.downloadProgress?.bytesPerSecond,
     };
   }
 
@@ -289,7 +356,7 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
     }
   }
 
-  private handleUpdateAvailable(): void {
+  private handleUpdateAvailable(info: UpdateAvailableInfo): void {
     if (this.isUpdateStaged()) {
       this.log.info(
         "Ignoring update-available because an update is already staged",
@@ -301,9 +368,42 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
     }
 
     this.clearCheckTimeout();
-    this.transitionTo("downloading", { reason: "update available" });
-    this.log.info("Update available, downloading...");
-    this.emitStatus({ checking: true, downloading: true });
+    this.availableInfo = info;
+    this.downloadProgress = null;
+
+    if (this.autoDownloadEnabled) {
+      this.transitionTo("downloading", {
+        reason: "update available (auto-download)",
+        incomingVersion: info.version,
+      });
+      this.log.info("Update available, auto-downloading...", {
+        version: info.version,
+      });
+      this.updater.download();
+      this.emitStatus(this.downloadingStatusPayload());
+      return;
+    }
+
+    this.transitionTo("available", {
+      reason: "update available",
+      incomingVersion: info.version,
+    });
+    this.log.info("Update available, awaiting user download", {
+      version: info.version,
+    });
+    this.emitStatus(this.availableStatusPayload());
+  }
+
+  private handleDownloadProgress(progress: UpdateDownloadProgress): void {
+    if (this.state !== "downloading") {
+      return;
+    }
+    this.downloadProgress = progress;
+    const now = Date.now();
+    if (now - this.lastProgressEmit >= 400 || progress.percent >= 100) {
+      this.lastProgressEmit = now;
+      this.emitStatus(this.downloadingStatusPayload());
+    }
   }
 
   private handleNoUpdate(): void {

--- a/packages/core/src/updates/updates.ts
+++ b/packages/core/src/updates/updates.ts
@@ -326,6 +326,7 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       availableVersion: this.availableInfo?.version,
       releaseNotes: this.availableInfo?.releaseNotes ?? undefined,
       releaseDate: this.availableInfo?.releaseDate,
+      downloadSizeBytes: this.availableInfo?.sizeBytes ?? undefined,
     };
   }
 
@@ -338,6 +339,7 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       releaseDate: this.availableInfo?.releaseDate,
       downloadPercent: this.downloadProgress?.percent,
       bytesPerSecond: this.downloadProgress?.bytesPerSecond,
+      downloadSizeBytes: this.availableInfo?.sizeBytes ?? undefined,
     };
   }
 

--- a/packages/core/src/updates/updates.ts
+++ b/packages/core/src/updates/updates.ts
@@ -128,6 +128,10 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       this.updater.setAutoDownload(enabled);
     }
     this.log.info("Auto-download preference updated", { enabled });
+
+    if (enabled && this.state === "available") {
+      this.requestDownload();
+    }
   }
 
   requestDownload(): void {
@@ -196,6 +200,14 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
         this.emitStatus(this.stagedStatusPayload());
       }
 
+      return { success: true };
+    }
+
+    if (source === "periodic" && this.state === "available") {
+      this.logStateTransition(this.state, {
+        source,
+        reason: "periodic check skipped because an update is already available",
+      });
       return { success: true };
     }
 

--- a/packages/host-router/src/router.ts
+++ b/packages/host-router/src/router.ts
@@ -22,6 +22,7 @@ import { foldersRouter } from "./routers/folders.router";
 import { fsRouter } from "./routers/fs.router";
 import { gitRouter } from "./routers/git.router";
 import { githubIntegrationRouter } from "./routers/github-integration.router";
+import { githubReleasesRouter } from "./routers/github-releases.router";
 import { handoffRouter } from "./routers/handoff.router";
 import { linearIntegrationRouter } from "./routers/linear-integration.router";
 import { llmGatewayRouter } from "./routers/llm-gateway.router";
@@ -70,6 +71,7 @@ export const hostRouter = router({
   git: gitRouter,
   handoff: handoffRouter,
   githubIntegration: githubIntegrationRouter,
+  githubReleases: githubReleasesRouter,
   linearIntegration: linearIntegrationRouter,
   llmGateway: llmGatewayRouter,
   logs: logsRouter,

--- a/packages/host-router/src/routers/github-releases.router.ts
+++ b/packages/host-router/src/routers/github-releases.router.ts
@@ -1,0 +1,14 @@
+import { publicProcedure, router } from "@posthog/host-trpc/trpc";
+import type { GitHubReleasesService } from "@posthog/workspace-server/services/github-releases/github-releases";
+import { GITHUB_RELEASES_SERVICE } from "@posthog/workspace-server/services/github-releases/identifiers";
+import { listReleasesOutput } from "@posthog/workspace-server/services/github-releases/schemas";
+
+export const githubReleasesRouter = router({
+  list: publicProcedure
+    .output(listReleasesOutput)
+    .query(({ ctx }) =>
+      ctx.container
+        .get<GitHubReleasesService>(GITHUB_RELEASES_SERVICE)
+        .listReleases(),
+    ),
+});

--- a/packages/host-router/src/routers/updates.router.ts
+++ b/packages/host-router/src/routers/updates.router.ts
@@ -9,6 +9,7 @@ import {
 } from "@posthog/core/updates/schemas";
 import type { UpdatesService } from "@posthog/core/updates/updates";
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
+import { z } from "zod";
 
 function subscribe<K extends keyof UpdatesEvents>(event: K) {
   return publicProcedure.subscription(async function* ({ ctx, signal }) {
@@ -40,6 +41,18 @@ export const updatesRouter = router({
     const service = ctx.container.get<UpdatesService>(UPDATES_SERVICE);
     return service.installUpdate();
   }),
+
+  download: publicProcedure.mutation(({ ctx }) => {
+    ctx.container.get<UpdatesService>(UPDATES_SERVICE).requestDownload();
+  }),
+
+  setAutoDownload: publicProcedure
+    .input(z.object({ enabled: z.boolean() }))
+    .mutation(({ ctx, input }) => {
+      ctx.container
+        .get<UpdatesService>(UPDATES_SERVICE)
+        .setAutoDownloadEnabled(input.enabled);
+    }),
 
   onReady: subscribe(UpdatesEvent.Ready),
   onStatus: subscribe(UpdatesEvent.Status),

--- a/packages/platform/src/updater.ts
+++ b/packages/platform/src/updater.ts
@@ -1,9 +1,28 @@
+export interface UpdateAvailableInfo {
+  version: string;
+  releaseNotes: string | null;
+  releaseDate?: string;
+  releaseName?: string | null;
+}
+
+export interface UpdateDownloadProgress {
+  percent: number;
+  bytesPerSecond: number;
+  transferred: number;
+  total: number;
+}
+
 export interface IUpdater {
   isSupported(): boolean;
   check(): void;
+  download(): void;
   quitAndInstall(): void;
+  setAutoDownload(enabled: boolean): void;
   onCheckStart(handler: () => void): () => void;
-  onUpdateAvailable(handler: () => void): () => void;
+  onUpdateAvailable(handler: (info: UpdateAvailableInfo) => void): () => void;
+  onDownloadProgress(
+    handler: (progress: UpdateDownloadProgress) => void,
+  ): () => void;
   onUpdateDownloaded(handler: (version: string) => void): () => void;
   onNoUpdate(handler: () => void): () => void;
   onError(handler: (error: Error) => void): () => void;

--- a/packages/platform/src/updater.ts
+++ b/packages/platform/src/updater.ts
@@ -3,6 +3,7 @@ export interface UpdateAvailableInfo {
   releaseNotes: string | null;
   releaseDate?: string;
   releaseName?: string | null;
+  sizeBytes?: number | null;
 }
 
 export interface UpdateDownloadProgress {

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -35,13 +35,23 @@ export function GeneralSettings() {
   const theme = useThemeStore((state) => state.theme);
   const setTheme = useThemeStore((state) => state.setTheme);
   // Power state
-  const { preventSleepWhileRunning, setPreventSleepWhileRunning } =
-    useSettingsStore();
+  const {
+    preventSleepWhileRunning,
+    setPreventSleepWhileRunning,
+    downloadUpdatesAutomatically,
+    setDownloadUpdatesAutomatically,
+  } = useSettingsStore();
   const { data: serverPreventSleep } = useQuery(
     hostTRPC.sleep.getEnabled.queryOptions(),
   );
   const preventSleepMutation = useMutation(
     hostTRPC.sleep.setEnabled.mutationOptions(),
+  );
+  const { data: updatesEnabled } = useQuery(
+    hostTRPC.updates.isEnabled.queryOptions(),
+  );
+  const autoDownloadMutation = useMutation(
+    hostTRPC.updates.setAutoDownload.mutationOptions(),
   );
 
   useEffect(() => {
@@ -61,6 +71,19 @@ export function GeneralSettings() {
       preventSleepMutation.mutate({ enabled: checked });
     },
     [setPreventSleepWhileRunning, preventSleepMutation],
+  );
+
+  const handleAutoDownloadChange = useCallback(
+    (checked: boolean) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "download_updates_automatically",
+        new_value: checked,
+        old_value: !checked,
+      });
+      setDownloadUpdatesAutomatically(checked);
+      autoDownloadMutation.mutate({ enabled: checked });
+    },
+    [setDownloadUpdatesAutomatically, autoDownloadMutation],
   );
 
   // Chat state
@@ -429,6 +452,27 @@ export function GeneralSettings() {
           size="1"
         />
       </SettingRow>
+
+      {updatesEnabled?.enabled ? (
+        <>
+          {/* Updates */}
+          <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">
+            Updates
+          </Text>
+
+          <SettingRow
+            label="Download updates automatically"
+            description="Download new versions in the background and install them on the next quit. When off, you choose when to download each update."
+            noBorder
+          >
+            <Switch
+              checked={downloadUpdatesAutomatically}
+              onCheckedChange={handleAutoDownloadChange}
+              size="1"
+            />
+          </SettingRow>
+        </>
+      ) : null}
 
       {/* Fun */}
       <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -50,9 +50,6 @@ export function GeneralSettings() {
   const { data: updatesEnabled } = useQuery(
     hostTRPC.updates.isEnabled.queryOptions(),
   );
-  const autoDownloadMutation = useMutation(
-    hostTRPC.updates.setAutoDownload.mutationOptions(),
-  );
 
   useEffect(() => {
     if (serverPreventSleep !== undefined) {
@@ -81,9 +78,8 @@ export function GeneralSettings() {
         old_value: !checked,
       });
       setDownloadUpdatesAutomatically(checked);
-      autoDownloadMutation.mutate({ enabled: checked });
     },
-    [setDownloadUpdatesAutomatically, autoDownloadMutation],
+    [setDownloadUpdatesAutomatically],
   );
 
   // Chat state

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -35,20 +35,13 @@ export function GeneralSettings() {
   const theme = useThemeStore((state) => state.theme);
   const setTheme = useThemeStore((state) => state.setTheme);
   // Power state
-  const {
-    preventSleepWhileRunning,
-    setPreventSleepWhileRunning,
-    downloadUpdatesAutomatically,
-    setDownloadUpdatesAutomatically,
-  } = useSettingsStore();
+  const { preventSleepWhileRunning, setPreventSleepWhileRunning } =
+    useSettingsStore();
   const { data: serverPreventSleep } = useQuery(
     hostTRPC.sleep.getEnabled.queryOptions(),
   );
   const preventSleepMutation = useMutation(
     hostTRPC.sleep.setEnabled.mutationOptions(),
-  );
-  const { data: updatesEnabled } = useQuery(
-    hostTRPC.updates.isEnabled.queryOptions(),
   );
 
   useEffect(() => {
@@ -68,18 +61,6 @@ export function GeneralSettings() {
       preventSleepMutation.mutate({ enabled: checked });
     },
     [setPreventSleepWhileRunning, preventSleepMutation],
-  );
-
-  const handleAutoDownloadChange = useCallback(
-    (checked: boolean) => {
-      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
-        setting_name: "download_updates_automatically",
-        new_value: checked,
-        old_value: !checked,
-      });
-      setDownloadUpdatesAutomatically(checked);
-    },
-    [setDownloadUpdatesAutomatically],
   );
 
   // Chat state
@@ -448,27 +429,6 @@ export function GeneralSettings() {
           size="1"
         />
       </SettingRow>
-
-      {updatesEnabled?.enabled ? (
-        <>
-          {/* Updates */}
-          <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">
-            Updates
-          </Text>
-
-          <SettingRow
-            label="Download updates automatically"
-            description="Download new versions in the background and install them on the next quit. When off, you choose when to download each update."
-            noBorder
-          >
-            <Switch
-              checked={downloadUpdatesAutomatically}
-              onCheckedChange={handleAutoDownloadChange}
-              size="1"
-            />
-          </SettingRow>
-        </>
-      ) : null}
 
       {/* Fun */}
       <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">

--- a/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
+++ b/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
@@ -1,9 +1,12 @@
 import { CheckCircle, XCircle } from "@phosphor-icons/react";
 import { deriveUpdateStatus } from "@posthog/core/settings/updateStatus";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { ANALYTICS_EVENTS } from "@posthog/shared";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { logger } from "@posthog/ui/shell/logger";
-import { Badge, Button, Flex, Spinner, Text } from "@radix-ui/themes";
+import { Badge, Button, Flex, Spinner, Switch, Text } from "@radix-ui/themes";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useSubscription } from "@trpc/tanstack-react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -13,6 +16,15 @@ const log = logger.scope("updates-settings");
 export function UpdatesSettings() {
   const trpc = useHostTRPC();
   const { data: appVersion } = useQuery(trpc.os.getAppVersion.queryOptions());
+  const { data: updatesEnabled } = useQuery(
+    trpc.updates.isEnabled.queryOptions(),
+  );
+  const downloadUpdatesAutomatically = useSettingsStore(
+    (state) => state.downloadUpdatesAutomatically,
+  );
+  const setDownloadUpdatesAutomatically = useSettingsStore(
+    (state) => state.setDownloadUpdatesAutomatically,
+  );
   const [checkingForUpdates, setCheckingForUpdates] = useState(false);
   const [updatesDisabled, setUpdatesDisabled] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<{
@@ -60,6 +72,18 @@ export function UpdatesSettings() {
     }
   }, [checkUpdatesMutation]);
 
+  const handleAutoDownloadChange = useCallback(
+    (checked: boolean) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "download_updates_automatically",
+        new_value: checked,
+        old_value: !checked,
+      });
+      setDownloadUpdatesAutomatically(checked);
+    },
+    [setDownloadUpdatesAutomatically],
+  );
+
   useEffect(() => {
     if (!hasCheckedRef.current) {
       hasCheckedRef.current = true;
@@ -88,6 +112,19 @@ export function UpdatesSettings() {
           {appVersion || "Loading..."}
         </Badge>
       </SettingRow>
+
+      {updatesEnabled?.enabled ? (
+        <SettingRow
+          label="Download updates automatically"
+          description="Download new versions in the background and install them on the next quit. When off, you choose when to download each update."
+        >
+          <Switch
+            checked={downloadUpdatesAutomatically}
+            onCheckedChange={handleAutoDownloadChange}
+            size="1"
+          />
+        </SettingRow>
+      ) : null}
 
       <SettingRow
         label="Check for updates"

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -142,9 +142,13 @@ interface SettingsStore {
   hedgehogMode: boolean;
   slotMachineMode: boolean;
   mcpAppsDisabledServers: string[];
+  downloadUpdatesAutomatically: boolean;
+  lastSeenChangelogVersion: string | null;
   setHedgehogMode: (enabled: boolean) => void;
   setSlotMachineMode: (enabled: boolean) => void;
   setMcpAppsDisabledServers: (servers: string[]) => void;
+  setDownloadUpdatesAutomatically: (enabled: boolean) => void;
+  setLastSeenChangelogVersion: (version: string | null) => void;
 
   // Onboarding hints
   hints: Record<string, HintState>;
@@ -272,8 +276,14 @@ export const useSettingsStore = create<SettingsStore>()(
       hedgehogMode: false,
       slotMachineMode: false,
       mcpAppsDisabledServers: [],
+      downloadUpdatesAutomatically: false,
+      lastSeenChangelogVersion: null,
       setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
       setSlotMachineMode: (enabled) => set({ slotMachineMode: enabled }),
+      setDownloadUpdatesAutomatically: (enabled) =>
+        set({ downloadUpdatesAutomatically: enabled }),
+      setLastSeenChangelogVersion: (version) =>
+        set({ lastSeenChangelogVersion: version }),
       setMcpAppsDisabledServers: (servers) =>
         set({ mcpAppsDisabledServers: servers }),
 
@@ -360,6 +370,8 @@ export const useSettingsStore = create<SettingsStore>()(
         hedgehogMode: state.hedgehogMode,
         slotMachineMode: state.slotMachineMode,
         mcpAppsDisabledServers: state.mcpAppsDisabledServers,
+        downloadUpdatesAutomatically: state.downloadUpdatesAutomatically,
+        lastSeenChangelogVersion: state.lastSeenChangelogVersion,
 
         // Onboarding hints
         hints: state.hints,

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -276,7 +276,7 @@ export const useSettingsStore = create<SettingsStore>()(
       hedgehogMode: false,
       slotMachineMode: false,
       mcpAppsDisabledServers: [],
-      downloadUpdatesAutomatically: false,
+      downloadUpdatesAutomatically: true,
       lastSeenChangelogVersion: null,
       setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
       setSlotMachineMode: (enabled) => set({ slotMachineMode: enabled }),

--- a/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -6,6 +6,7 @@ import {
   DiscordLogo,
   FolderSimple,
   Gear,
+  Gift,
   Info,
   Keyboard,
   Plus,
@@ -50,6 +51,7 @@ import {
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useProjects } from "@posthog/ui/features/projects/useProjects";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { isMac } from "@posthog/ui/utils/platform";
 import { getPostHogUrl } from "@posthog/ui/utils/urls";
@@ -160,6 +162,11 @@ export function ProjectSwitcher({
 
   const handleDiscord = () => {
     openExternalUrl(EXTERNAL_LINKS.discord);
+    setPopoverOpen(false);
+  };
+
+  const handleViewChangelog = () => {
+    useWhatsNewStore.getState().open();
     setPopoverOpen(false);
   };
 
@@ -332,6 +339,11 @@ export function ProjectSwitcher({
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
+
+            <DropdownMenuItem onClick={handleViewChangelog}>
+              <Gift size={14} className="text-gray-11" />
+              View changelog
+            </DropdownMenuItem>
 
             <DropdownMenuItem onClick={handleSettings}>
               <Gear size={14} className="text-gray-11" />

--- a/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -310,6 +310,11 @@ export function ProjectSwitcher({
               <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
             </DropdownMenuItem>
 
+            <DropdownMenuItem onClick={handleViewChangelog}>
+              <Gift size={14} className="text-gray-11" />
+              View changelog
+            </DropdownMenuItem>
+
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <Info size={14} className="text-gray-11" />
@@ -339,11 +344,6 @@ export function ProjectSwitcher({
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
-
-            <DropdownMenuItem onClick={handleViewChangelog}>
-              <Gift size={14} className="text-gray-11" />
-              View changelog
-            </DropdownMenuItem>
 
             <DropdownMenuItem onClick={handleSettings}>
               <Gear size={14} className="text-gray-11" />

--- a/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -1,12 +1,10 @@
 import { ArrowsClockwise, Gift, Spinner } from "@phosphor-icons/react";
-import { useHostTRPC } from "@posthog/host-router/react";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
   useInstallUpdate,
   useUpdateView,
 } from "@posthog/ui/features/updates/updateStore";
 import { Box } from "@radix-ui/themes";
-import { useMutation } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
 
 interface UpdateBannerProps {
@@ -18,10 +16,6 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
     useUpdateView();
   const installUpdate = useInstallUpdate();
   const openModal = useUpdateModalStore((state) => state.open);
-  const hostTRPC = useHostTRPC();
-  const downloadMutation = useMutation(
-    hostTRPC.updates.download.mutationOptions(),
-  );
 
   const isVisible =
     isEnabled &&
@@ -109,8 +103,10 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
                     onClick={openModal}
                     className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
                   >
-                    <span className="font-medium">Update available</span>
-                    <span className="text-[11px] text-[var(--green-a11)]">
+                    <span className="truncate font-medium">
+                      Update available
+                    </span>
+                    <span className="truncate text-[11px] text-[var(--green-a11)]">
                       {availableVersion
                         ? `Version ${availableVersion}`
                         : "View details"}
@@ -118,11 +114,10 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
                   </button>
                   <button
                     type="button"
-                    className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)] disabled:opacity-60"
-                    onClick={() => downloadMutation.mutate(undefined)}
-                    disabled={downloadMutation.isPending}
+                    onClick={openModal}
+                    className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2.5 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
                   >
-                    Download
+                    View
                   </button>
                 </div>
               </BannerCard>

--- a/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -1,4 +1,5 @@
 import { ArrowsClockwise, Gift, Spinner } from "@phosphor-icons/react";
+import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
   useInstallUpdate,
   useUpdateView,
@@ -11,12 +12,20 @@ interface UpdateBannerProps {
 }
 
 export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
-  const { status, version, isEnabled } = useUpdateView();
+  const { status, version, availableVersion, downloadPercent } =
+    useUpdateView();
+  const { isEnabled } = useUpdateView();
   const installUpdate = useInstallUpdate();
+  const openModal = useUpdateModalStore((state) => state.open);
 
   const isVisible =
     isEnabled &&
-    (status === "downloading" || status === "ready" || status === "installing");
+    (status === "available" ||
+      status === "downloading" ||
+      status === "ready" ||
+      status === "installing");
+
+  const percent = Math.round(downloadPercent ?? 0);
 
   if (variant === "compact") {
     return (
@@ -28,11 +37,26 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
             exit={{ opacity: 0, x: -8 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
           >
+            {status === "available" && (
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-2 border border-(--green-a5) bg-(--green-a3) px-2.5 py-1 font-medium text-(--green-11) text-[13px] transition-colors hover:bg-(--green-a4)"
+                onClick={openModal}
+              >
+                <Gift size={14} weight="duotone" />
+                <span>Update available</span>
+              </button>
+            )}
+
             {status === "downloading" && (
-              <div className="flex items-center gap-1.5 text-(--green-11) text-[13px] opacity-70">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 text-(--green-11) text-[13px] opacity-70"
+                onClick={openModal}
+              >
                 <Spinner size={14} className="animate-spin" />
-                <span>Downloading update...</span>
-              </div>
+                <span>Downloading update... {percent}%</span>
+              </button>
             )}
 
             {status === "ready" && (
@@ -43,8 +67,7 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
               >
                 <Gift size={14} weight="duotone" />
                 <span>
-                  {version ? `${version} available` : "Update available"} —
-                  Restart
+                  {version ? `${version} ready` : "Update ready"} — Restart
                 </span>
               </button>
             )}
@@ -72,62 +95,97 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
           className="shrink-0 overflow-hidden"
         >
           <AnimatePresence mode="wait">
+            {status === "available" && (
+              <BannerCard key="available">
+                <button
+                  type="button"
+                  onClick={openModal}
+                  className="flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-left text-[13px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a4)]"
+                >
+                  <Gift size={20} weight="duotone" className="shrink-0" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="font-medium">Update available</span>
+                    <span className="text-[11px] text-[var(--green-a11)]">
+                      {availableVersion
+                        ? `Version ${availableVersion}`
+                        : "Click to view details"}
+                    </span>
+                  </div>
+                </button>
+              </BannerCard>
+            )}
+
             {status === "downloading" && (
-              <BannerContent key="downloading">
-                <Spinner size={16} className="animate-spin" />
-                <span>Downloading update...</span>
-              </BannerContent>
+              <BannerCard key="downloading">
+                <button
+                  type="button"
+                  onClick={openModal}
+                  className="flex w-full flex-col gap-1.5 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]"
+                >
+                  <div className="flex w-full items-center justify-between">
+                    <span className="font-medium">Downloading update...</span>
+                    <span className="text-[11px] text-[var(--green-a11)]">
+                      {percent}%
+                    </span>
+                  </div>
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--green-a4)]">
+                    <div
+                      className="h-full rounded-full bg-[var(--green-9)] transition-all"
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+                </button>
+              </BannerCard>
             )}
 
             {status === "ready" && (
-              <motion.div
-                key="ready"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.15 }}
-              >
-                <Box className="p-2">
-                  <div className="flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
-                    <motion.div
-                      className="shrink-0"
-                      animate={{
-                        rotate: [0, -12, 12, -8, 8, -4, 0],
-                      }}
-                      transition={{
-                        duration: 0.6,
-                        repeat: Infinity,
-                        repeatDelay: 4,
-                        ease: "easeInOut",
-                      }}
-                    >
-                      <Gift size={20} weight="duotone" />
-                    </motion.div>
-                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                      <span className="font-medium">
-                        {version ? `${version} ready` : "Update ready"}
-                      </span>
-                      <span className="text-[11px] text-[var(--green-a11)]">
-                        Restart to apply
-                      </span>
-                    </div>
-                    <button
-                      type="button"
-                      className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
-                      onClick={() => void installUpdate()}
-                    >
-                      Restart
-                    </button>
-                  </div>
-                </Box>
-              </motion.div>
+              <BannerCard key="ready">
+                <div className="flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
+                  <motion.div
+                    className="shrink-0"
+                    animate={{ rotate: [0, -12, 12, -8, 8, -4, 0] }}
+                    transition={{
+                      duration: 0.6,
+                      repeat: Infinity,
+                      repeatDelay: 4,
+                      ease: "easeInOut",
+                    }}
+                  >
+                    <Gift size={20} weight="duotone" />
+                  </motion.div>
+                  <button
+                    type="button"
+                    onClick={openModal}
+                    className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
+                  >
+                    <span className="font-medium">
+                      {version ? `${version} ready` : "Update ready"}
+                    </span>
+                    <span className="text-[11px] text-[var(--green-a11)]">
+                      Restart to apply
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
+                    onClick={() => void installUpdate()}
+                  >
+                    Restart
+                  </button>
+                </div>
+              </BannerCard>
             )}
 
             {status === "installing" && (
-              <BannerContent key="installing">
-                <ArrowsClockwise size={16} className="shrink-0 animate-spin" />
-                <span className="font-medium">Restarting...</span>
-              </BannerContent>
+              <BannerCard key="installing">
+                <div className="flex w-full items-center gap-2 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
+                  <ArrowsClockwise
+                    size={16}
+                    className="shrink-0 animate-spin"
+                  />
+                  <span className="font-medium">Restarting...</span>
+                </div>
+              </BannerCard>
             )}
           </AnimatePresence>
         </motion.div>
@@ -136,22 +194,15 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
   );
 }
 
-function BannerContent({
-  children,
-  ...props
-}: { children: React.ReactNode } & React.ComponentProps<typeof motion.div>) {
+function BannerCard({ children }: { children: React.ReactNode }) {
   return (
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.15 }}
-      className="p-2"
-      {...props}
     >
-      <div className="flex items-center gap-2 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
-        {children}
-      </div>
+      <Box className="p-2">{children}</Box>
     </motion.div>
   );
 }

--- a/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -12,9 +12,8 @@ interface UpdateBannerProps {
 }
 
 export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
-  const { status, version, availableVersion, downloadPercent } =
+  const { status, version, availableVersion, downloadPercent, isEnabled } =
     useUpdateView();
-  const { isEnabled } = useUpdateView();
   const installUpdate = useInstallUpdate();
   const openModal = useUpdateModalStore((state) => state.open);
 

--- a/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -1,10 +1,12 @@
 import { ArrowsClockwise, Gift, Spinner } from "@phosphor-icons/react";
+import { useHostTRPC } from "@posthog/host-router/react";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
   useInstallUpdate,
   useUpdateView,
 } from "@posthog/ui/features/updates/updateStore";
 import { Box } from "@radix-ui/themes";
+import { useMutation } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
 
 interface UpdateBannerProps {
@@ -16,6 +18,10 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
     useUpdateView();
   const installUpdate = useInstallUpdate();
   const openModal = useUpdateModalStore((state) => state.open);
+  const hostTRPC = useHostTRPC();
+  const downloadMutation = useMutation(
+    hostTRPC.updates.download.mutationOptions(),
+  );
 
   const isVisible =
     isEnabled &&
@@ -96,21 +102,29 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
           <AnimatePresence mode="wait">
             {status === "available" && (
               <BannerCard key="available">
-                <button
-                  type="button"
-                  onClick={openModal}
-                  className="flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-left text-[13px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a4)]"
-                >
+                <div className="flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
                   <Gift size={20} weight="duotone" className="shrink-0" />
-                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <button
+                    type="button"
+                    onClick={openModal}
+                    className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
+                  >
                     <span className="font-medium">Update available</span>
                     <span className="text-[11px] text-[var(--green-a11)]">
                       {availableVersion
                         ? `Version ${availableVersion}`
-                        : "Click to view details"}
+                        : "View details"}
                     </span>
-                  </div>
-                </button>
+                  </button>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)] disabled:opacity-60"
+                    onClick={() => downloadMutation.mutate(undefined)}
+                    disabled={downloadMutation.isPending}
+                  >
+                    Download
+                  </button>
+                </div>
               </BannerCard>
             )}
 

--- a/packages/ui/src/features/updates/ReleaseNotesSections.tsx
+++ b/packages/ui/src/features/updates/ReleaseNotesSections.tsx
@@ -1,0 +1,33 @@
+import type { CategorizedNotes } from "@posthog/ui/features/updates/releaseNotes";
+import { Flex } from "@radix-ui/themes";
+
+function ReleaseSection({ title, items }: { title: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <Flex direction="column" gap="1">
+      <span className="font-medium text-[11px] text-gray-10 uppercase tracking-wide">
+        {title}
+      </span>
+      <ul className="m-0 flex list-none flex-col gap-1.5 p-0">
+        {items.map((item) => (
+          <li
+            key={`${title}-${item}`}
+            className="flex gap-2 text-[13px] text-gray-12 leading-relaxed"
+          >
+            <span className="mt-px select-none text-gray-9">•</span>
+            <span className="min-w-0">{item}</span>
+          </li>
+        ))}
+      </ul>
+    </Flex>
+  );
+}
+
+export function ReleaseNotesSections({ notes }: { notes: CategorizedNotes }) {
+  return (
+    <Flex direction="column" gap="3">
+      <ReleaseSection title="Improved" items={notes.improved} />
+      <ReleaseSection title="Fixed" items={notes.fixed} />
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -15,6 +15,7 @@ import {
   IconButton,
   Progress,
   ScrollArea,
+  Skeleton,
   Text,
 } from "@radix-ui/themes";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -29,6 +30,20 @@ function formatSize(bytes: number | null): string {
   const mb = bytes / (1024 * 1024);
   if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
   return `${Math.round(mb)} MB`;
+}
+
+function ReleaseNotesSkeleton() {
+  return (
+    <Flex direction="column" gap="3">
+      {["improved", "fixed"].map((key) => (
+        <Flex key={key} direction="column" gap="2">
+          <Skeleton width="56px" height="12px" />
+          <Skeleton width="90%" height="14px" />
+          <Skeleton width="80%" height="14px" />
+        </Flex>
+      ))}
+    </Flex>
+  );
 }
 
 export function UpdateAvailableModal() {
@@ -48,7 +63,7 @@ export function UpdateAvailableModal() {
   const downloadMutation = useMutation(
     hostTRPC.updates.download.mutationOptions(),
   );
-  const { data: releasesData } = useQuery({
+  const { data: releasesData, isLoading: isLoadingReleases } = useQuery({
     ...hostTRPC.githubReleases.list.queryOptions(),
     enabled: isOpen,
   });
@@ -100,7 +115,7 @@ export function UpdateAvailableModal() {
             </Dialog.Close>
           </Flex>
 
-          {hasParsedNotes || rawNotes ? (
+          {hasParsedNotes || rawNotes || isLoadingReleases ? (
             <Flex direction="column" gap="2">
               <Text
                 size="1"
@@ -110,19 +125,23 @@ export function UpdateAvailableModal() {
               >
                 Release notes
               </Text>
-              <ScrollArea
-                type="auto"
-                scrollbars="vertical"
-                style={{ maxHeight: 240 }}
-              >
-                <div className="pr-3">
-                  {hasParsedNotes && parsedNotes ? (
-                    <ReleaseNotesSections notes={parsedNotes} />
-                  ) : rawNotes ? (
-                    <MarkdownRenderer content={rawNotes} />
-                  ) : null}
-                </div>
-              </ScrollArea>
+              {hasParsedNotes || rawNotes ? (
+                <ScrollArea
+                  type="auto"
+                  scrollbars="vertical"
+                  style={{ maxHeight: 240 }}
+                >
+                  <div className="pr-3">
+                    {hasParsedNotes && parsedNotes ? (
+                      <ReleaseNotesSections notes={parsedNotes} />
+                    ) : rawNotes ? (
+                      <MarkdownRenderer content={rawNotes} />
+                    ) : null}
+                  </div>
+                </ScrollArea>
+              ) : (
+                <ReleaseNotesSkeleton />
+              )}
             </Flex>
           ) : null}
 
@@ -141,6 +160,9 @@ export function UpdateAvailableModal() {
           ) : null}
 
           <Flex justify="end" align="center" gap="2" mt="1">
+            <Button variant="soft" color="gray" size="2" onClick={close}>
+              Later
+            </Button>
             {isReady ? (
               <Button size="2" onClick={() => void installUpdate()}>
                 Restart to update

--- a/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -126,7 +126,10 @@ export function UpdateAvailableModal() {
                 Downloading...
               </Button>
             ) : (
-              <Button onClick={() => downloadMutation.mutate(undefined)}>
+              <Button
+                onClick={() => downloadMutation.mutate(undefined)}
+                disabled={downloadMutation.isPending}
+              >
                 <ArrowDown size={16} />
                 Download Update
               </Button>

--- a/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowDown,
-  ArrowRight,
-  ArrowsClockwise,
-  Gift,
-} from "@phosphor-icons/react";
+import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
@@ -15,9 +10,9 @@ import {
 } from "@posthog/ui/features/updates/updateStore";
 import {
   Button,
-  Code,
   Dialog,
   Flex,
+  IconButton,
   Progress,
   ScrollArea,
   Text,
@@ -50,9 +45,6 @@ export function UpdateAvailableModal() {
   } = useUpdateView();
   const installUpdate = useInstallUpdate();
   const hostTRPC = useHostTRPC();
-  const { data: currentVersion } = useQuery(
-    hostTRPC.os.getAppVersion.queryOptions(),
-  );
   const downloadMutation = useMutation(
     hostTRPC.updates.download.mutationOptions(),
   );
@@ -88,16 +80,9 @@ export function UpdateAvailableModal() {
     >
       <Dialog.Content maxWidth="440px">
         <Flex direction="column" gap="4">
-          <Flex align="center" gap="3">
-            <Flex
-              align="center"
-              justify="center"
-              className="size-10 shrink-0 rounded-full bg-accent-3 text-accent-11"
-            >
-              <Gift size={22} weight="duotone" />
-            </Flex>
-            <Flex direction="column">
-              <Dialog.Title className="mb-0" size="4">
+          <Flex justify="between" align="start" gap="3">
+            <Flex direction="column" gap="1">
+              <Dialog.Title className="mb-0">
                 {isReady ? "Update ready" : "Update available"}
               </Dialog.Title>
               <Dialog.Description>
@@ -108,22 +93,12 @@ export function UpdateAvailableModal() {
                 </Text>
               </Dialog.Description>
             </Flex>
+            <Dialog.Close>
+              <IconButton variant="ghost" color="gray" aria-label="Close">
+                <X size={16} />
+              </IconButton>
+            </Dialog.Close>
           </Flex>
-
-          {currentVersion ? (
-            <Flex
-              align="center"
-              justify="center"
-              gap="3"
-              className="rounded-3 border border-gray-5 bg-gray-2 px-3 py-2.5"
-            >
-              <Code variant="soft" color="gray">
-                {currentVersion}
-              </Code>
-              <ArrowRight size={14} className="shrink-0 text-gray-9" />
-              <Code variant="soft">{targetVersion ?? "latest"}</Code>
-            </Flex>
-          ) : null}
 
           {hasParsedNotes || rawNotes ? (
             <Flex direction="column" gap="2">
@@ -166,17 +141,12 @@ export function UpdateAvailableModal() {
           ) : null}
 
           <Flex justify="end" align="center" gap="2" mt="1">
-            <Button variant="soft" color="gray" size="2" onClick={close}>
-              Later
-            </Button>
             {isReady ? (
               <Button size="2" onClick={() => void installUpdate()}>
-                <ArrowsClockwise size={16} />
                 Restart to update
               </Button>
             ) : isDownloading ? (
               <Button size="2" disabled>
-                <ArrowsClockwise size={16} className="animate-spin" />
                 Downloading...
               </Button>
             ) : (
@@ -185,7 +155,6 @@ export function UpdateAvailableModal() {
                 onClick={() => downloadMutation.mutate(undefined)}
                 disabled={downloadMutation.isPending}
               >
-                <ArrowDown size={16} />
                 Download update
               </Button>
             )}

--- a/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -1,0 +1,139 @@
+import { ArrowDown, ArrowsClockwise } from "@phosphor-icons/react";
+import { useHostTRPC } from "@posthog/host-router/react";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
+import {
+  useInstallUpdate,
+  useUpdateView,
+} from "@posthog/ui/features/updates/updateStore";
+import {
+  Button,
+  Code,
+  Dialog,
+  Flex,
+  Progress,
+  ScrollArea,
+  Text,
+} from "@radix-ui/themes";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+function formatSpeed(bytesPerSecond: number | null): string {
+  if (!bytesPerSecond || bytesPerSecond <= 0) return "";
+  return `${(bytesPerSecond / (1024 * 1024)).toFixed(1)} MB/s`;
+}
+
+export function UpdateAvailableModal() {
+  const isOpen = useUpdateModalStore((state) => state.isOpen);
+  const close = useUpdateModalStore((state) => state.close);
+  const {
+    status,
+    version,
+    availableVersion,
+    releaseNotes,
+    downloadPercent,
+    bytesPerSecond,
+  } = useUpdateView();
+  const installUpdate = useInstallUpdate();
+  const hostTRPC = useHostTRPC();
+  const { data: currentVersion } = useQuery(
+    hostTRPC.os.getAppVersion.queryOptions(),
+  );
+  const downloadMutation = useMutation(
+    hostTRPC.updates.download.mutationOptions(),
+  );
+
+  const targetVersion = version ?? availableVersion;
+  const percent = Math.round(downloadPercent ?? 0);
+  const isDownloading = status === "downloading";
+  const isReady = status === "ready" || status === "installing";
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      <Dialog.Content maxWidth="460px">
+        <Flex direction="column" gap="3">
+          <Flex direction="column" gap="1">
+            <Dialog.Title className="mb-0">Update Available</Dialog.Title>
+            <Dialog.Description>
+              <Text color="gray" size="2">
+                {targetVersion
+                  ? `PostHog Code ${targetVersion} is ready`
+                  : "A new version is ready"}
+              </Text>
+            </Dialog.Description>
+          </Flex>
+
+          {currentVersion ? (
+            <Flex
+              align="center"
+              gap="2"
+              className="rounded-3 border border-gray-5 bg-gray-2 px-3 py-2"
+            >
+              <Text size="2" color="gray">
+                You're currently on version
+              </Text>
+              <Code variant="soft">{currentVersion}</Code>
+            </Flex>
+          ) : null}
+
+          {releaseNotes ? (
+            <Flex direction="column" gap="1">
+              <Text size="2" weight="medium" color="gray">
+                Release notes
+              </Text>
+              <ScrollArea
+                type="auto"
+                scrollbars="vertical"
+                style={{ maxHeight: 240 }}
+              >
+                <div className="pr-3">
+                  <MarkdownRenderer content={releaseNotes} />
+                </div>
+              </ScrollArea>
+            </Flex>
+          ) : null}
+
+          {isDownloading ? (
+            <Flex direction="column" gap="1">
+              <Flex justify="between">
+                <Text size="1" color="gray">
+                  Downloading... {percent}%
+                </Text>
+                <Text size="1" color="gray">
+                  {formatSpeed(bytesPerSecond)}
+                </Text>
+              </Flex>
+              <Progress value={percent} size="2" />
+            </Flex>
+          ) : null}
+
+          <Flex justify="end" align="center" gap="3" mt="1">
+            <Button variant="ghost" color="gray" onClick={close}>
+              Later
+            </Button>
+            {isReady ? (
+              <Button onClick={() => void installUpdate()}>
+                <ArrowsClockwise size={16} />
+                Restart to update
+              </Button>
+            ) : isDownloading ? (
+              <Button disabled>
+                <ArrowsClockwise size={16} className="animate-spin" />
+                Downloading...
+              </Button>
+            ) : (
+              <Button onClick={() => downloadMutation.mutate(undefined)}>
+                <ArrowDown size={16} />
+                Download Update
+              </Button>
+            )}
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -29,6 +29,13 @@ function formatSpeed(bytesPerSecond: number | null): string {
   return `${(bytesPerSecond / (1024 * 1024)).toFixed(1)} MB/s`;
 }
 
+function formatSize(bytes: number | null): string {
+  if (!bytes || bytes <= 0) return "";
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
+  return `${Math.round(mb)} MB`;
+}
+
 export function UpdateAvailableModal() {
   const isOpen = useUpdateModalStore((state) => state.isOpen);
   const close = useUpdateModalStore((state) => state.close);
@@ -39,6 +46,7 @@ export function UpdateAvailableModal() {
     releaseNotes,
     downloadPercent,
     bytesPerSecond,
+    downloadSizeBytes,
   } = useUpdateView();
   const installUpdate = useInstallUpdate();
   const hostTRPC = useHostTRPC();
@@ -55,6 +63,7 @@ export function UpdateAvailableModal() {
 
   const targetVersion = version ?? availableVersion;
   const percent = Math.round(downloadPercent ?? 0);
+  const sizeLabel = formatSize(downloadSizeBytes);
   const isDownloading = status === "downloading";
   const isReady = status === "ready" || status === "installing";
 
@@ -94,7 +103,7 @@ export function UpdateAvailableModal() {
               <Dialog.Description>
                 <Text color="gray" size="2">
                   {targetVersion
-                    ? `PostHog Code ${targetVersion}`
+                    ? `PostHog Code ${targetVersion}${sizeLabel ? ` · ${sizeLabel}` : ""}`
                     : "A new version is available"}
                 </Text>
               </Dialog.Description>

--- a/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -1,6 +1,13 @@
-import { ArrowDown, ArrowsClockwise } from "@phosphor-icons/react";
+import {
+  ArrowDown,
+  ArrowRight,
+  ArrowsClockwise,
+  Gift,
+} from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
+import { parseReleaseNotes } from "@posthog/ui/features/updates/releaseNotes";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
   useInstallUpdate,
@@ -41,11 +48,27 @@ export function UpdateAvailableModal() {
   const downloadMutation = useMutation(
     hostTRPC.updates.download.mutationOptions(),
   );
+  const { data: releasesData } = useQuery({
+    ...hostTRPC.githubReleases.list.queryOptions(),
+    enabled: isOpen,
+  });
 
   const targetVersion = version ?? availableVersion;
   const percent = Math.round(downloadPercent ?? 0);
   const isDownloading = status === "downloading";
   const isReady = status === "ready" || status === "installing";
+
+  const releases = releasesData?.releases ?? [];
+  const latestRelease = releases.find((r) => !r.isPrerelease) ?? releases[0];
+  const noteRelease =
+    releases.find((r) => r.version === targetVersion) ?? latestRelease;
+  const rawNotes = noteRelease?.notes?.trim()
+    ? noteRelease.notes
+    : releaseNotes;
+  const parsedNotes = rawNotes ? parseReleaseNotes(rawNotes) : null;
+  const hasParsedNotes =
+    !!parsedNotes &&
+    (parsedNotes.improved.length > 0 || parsedNotes.fixed.length > 0);
 
   return (
     <Dialog.Root
@@ -54,35 +77,53 @@ export function UpdateAvailableModal() {
         if (!open) close();
       }}
     >
-      <Dialog.Content maxWidth="460px">
-        <Flex direction="column" gap="3">
-          <Flex direction="column" gap="1">
-            <Dialog.Title className="mb-0">Update Available</Dialog.Title>
-            <Dialog.Description>
-              <Text color="gray" size="2">
-                {targetVersion
-                  ? `PostHog Code ${targetVersion} is ready`
-                  : "A new version is ready"}
-              </Text>
-            </Dialog.Description>
+      <Dialog.Content maxWidth="440px">
+        <Flex direction="column" gap="4">
+          <Flex align="center" gap="3">
+            <Flex
+              align="center"
+              justify="center"
+              className="size-10 shrink-0 rounded-full bg-accent-3 text-accent-11"
+            >
+              <Gift size={22} weight="duotone" />
+            </Flex>
+            <Flex direction="column">
+              <Dialog.Title className="mb-0" size="4">
+                {isReady ? "Update ready" : "Update available"}
+              </Dialog.Title>
+              <Dialog.Description>
+                <Text color="gray" size="2">
+                  {targetVersion
+                    ? `PostHog Code ${targetVersion}`
+                    : "A new version is available"}
+                </Text>
+              </Dialog.Description>
+            </Flex>
           </Flex>
 
           {currentVersion ? (
             <Flex
               align="center"
-              gap="2"
-              className="rounded-3 border border-gray-5 bg-gray-2 px-3 py-2"
+              justify="center"
+              gap="3"
+              className="rounded-3 border border-gray-5 bg-gray-2 px-3 py-2.5"
             >
-              <Text size="2" color="gray">
-                You're currently on version
-              </Text>
-              <Code variant="soft">{currentVersion}</Code>
+              <Code variant="soft" color="gray">
+                {currentVersion}
+              </Code>
+              <ArrowRight size={14} className="shrink-0 text-gray-9" />
+              <Code variant="soft">{targetVersion ?? "latest"}</Code>
             </Flex>
           ) : null}
 
-          {releaseNotes ? (
-            <Flex direction="column" gap="1">
-              <Text size="2" weight="medium" color="gray">
+          {hasParsedNotes || rawNotes ? (
+            <Flex direction="column" gap="2">
+              <Text
+                size="1"
+                weight="medium"
+                color="gray"
+                className="uppercase tracking-wide"
+              >
                 Release notes
               </Text>
               <ScrollArea
@@ -91,7 +132,11 @@ export function UpdateAvailableModal() {
                 style={{ maxHeight: 240 }}
               >
                 <div className="pr-3">
-                  <MarkdownRenderer content={releaseNotes} />
+                  {hasParsedNotes && parsedNotes ? (
+                    <ReleaseNotesSections notes={parsedNotes} />
+                  ) : rawNotes ? (
+                    <MarkdownRenderer content={rawNotes} />
+                  ) : null}
                 </div>
               </ScrollArea>
             </Flex>
@@ -111,27 +156,28 @@ export function UpdateAvailableModal() {
             </Flex>
           ) : null}
 
-          <Flex justify="end" align="center" gap="3" mt="1">
-            <Button variant="ghost" color="gray" onClick={close}>
+          <Flex justify="end" align="center" gap="2" mt="1">
+            <Button variant="soft" color="gray" size="2" onClick={close}>
               Later
             </Button>
             {isReady ? (
-              <Button onClick={() => void installUpdate()}>
+              <Button size="2" onClick={() => void installUpdate()}>
                 <ArrowsClockwise size={16} />
                 Restart to update
               </Button>
             ) : isDownloading ? (
-              <Button disabled>
+              <Button size="2" disabled>
                 <ArrowsClockwise size={16} className="animate-spin" />
                 Downloading...
               </Button>
             ) : (
               <Button
+                size="2"
                 onClick={() => downloadMutation.mutate(undefined)}
                 disabled={downloadMutation.isPending}
               >
                 <ArrowDown size={16} />
-                Download Update
+                Download update
               </Button>
             )}
           </Flex>

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -26,7 +26,7 @@ export function WhatsNewModal() {
   const isOpen = useWhatsNewStore((state) => state.isOpen);
   const close = useWhatsNewStore((state) => state.close);
   const hostTRPC = useHostTRPC();
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     ...hostTRPC.githubReleases.list.queryOptions(),
     enabled: isOpen,
   });
@@ -59,7 +59,8 @@ export function WhatsNewModal() {
           </Flex>
         ) : isError ? (
           <Text color="gray" size="2">
-            Could not load releases. Please try again later.
+            Could not load releases:{" "}
+            {error instanceof Error ? error.message : String(error)}
           </Text>
         ) : releases.length === 0 ? (
           <Text color="gray" size="2">

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -1,5 +1,6 @@
 import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
 import {
   groupReleases,
   mergeReleaseNotes,
@@ -15,28 +16,6 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
-
-function ReleaseSection({ title, items }: { title: string; items: string[] }) {
-  if (items.length === 0) return null;
-  return (
-    <Flex direction="column" gap="1">
-      <span className="font-medium text-[11px] text-gray-10 uppercase tracking-wide">
-        {title}
-      </span>
-      <ul className="m-0 flex list-none flex-col gap-1.5 p-0">
-        {items.map((item) => (
-          <li
-            key={`${title}-${item}`}
-            className="flex gap-2 text-[13px] text-gray-12 leading-relaxed"
-          >
-            <span className="mt-px select-none text-gray-9">•</span>
-            <span className="min-w-0">{item}</span>
-          </li>
-        ))}
-      </ul>
-    </Flex>
-  );
-}
 
 function ChangelogSkeleton() {
   return (
@@ -155,10 +134,7 @@ export function WhatsNewModal() {
                         No notable changes.
                       </Text>
                     ) : (
-                      <Flex direction="column" gap="3">
-                        <ReleaseSection title="Improved" items={improved} />
-                        <ReleaseSection title="Fixed" items={fixed} />
-                      </Flex>
+                      <ReleaseNotesSections notes={{ improved, fixed }} />
                     )}
                   </Flex>
                 );

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -1,5 +1,8 @@
 import { useHostTRPC } from "@posthog/host-router/react";
-import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import {
+  groupReleases,
+  mergeReleaseNotes,
+} from "@posthog/ui/features/updates/releaseNotes";
 import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
 import {
   Badge,
@@ -11,22 +14,33 @@ import {
 } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
 
-function formatDate(date: string | null): string {
-  if (!date) return "";
-  const parsed = new Date(date);
-  if (Number.isNaN(parsed.getTime())) return "";
-  return parsed.toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+function ReleaseSection({ title, items }: { title: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <Flex direction="column" gap="1">
+      <span className="font-medium text-[11px] text-gray-10 uppercase tracking-wide">
+        {title}
+      </span>
+      <ul className="m-0 flex list-none flex-col gap-1.5 p-0">
+        {items.map((item) => (
+          <li
+            key={`${title}-${item}`}
+            className="flex gap-2 text-[13px] text-gray-12 leading-relaxed"
+          >
+            <span className="mt-px select-none text-gray-9">•</span>
+            <span className="min-w-0">{item}</span>
+          </li>
+        ))}
+      </ul>
+    </Flex>
+  );
 }
 
 export function WhatsNewModal() {
   const isOpen = useWhatsNewStore((state) => state.isOpen);
   const close = useWhatsNewStore((state) => state.close);
   const hostTRPC = useHostTRPC();
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     ...hostTRPC.githubReleases.list.queryOptions(),
     enabled: isOpen,
   });
@@ -34,7 +48,7 @@ export function WhatsNewModal() {
     hostTRPC.os.getAppVersion.queryOptions(),
   );
 
-  const releases = data?.releases ?? [];
+  const groups = groupReleases(data?.releases ?? []);
 
   return (
     <Dialog.Root
@@ -59,47 +73,68 @@ export function WhatsNewModal() {
           </Flex>
         ) : isError ? (
           <Text color="gray" size="2">
-            Could not load releases:{" "}
-            {error instanceof Error ? error.message : String(error)}
+            Could not load releases. Please try again later.
           </Text>
-        ) : releases.length === 0 ? (
+        ) : groups.length === 0 ? (
           <Text color="gray" size="2">
             No releases found.
           </Text>
         ) : (
           <ScrollArea
-            type="auto"
+            type="scroll"
             scrollbars="vertical"
             style={{ maxHeight: "60vh" }}
           >
             <Flex direction="column" gap="5" className="pr-3">
-              {releases.map((release, index) => (
-                <Flex key={release.version} direction="column" gap="2">
-                  <Flex align="center" justify="between" gap="2">
-                    <Flex align="center" gap="2">
+              {groups.map((group, index) => {
+                const { improved, fixed } = mergeReleaseNotes(group.releases);
+                const containsCurrent = currentVersion
+                  ? group.releases.some(
+                      (release) => release.version === currentVersion,
+                    )
+                  : false;
+                return (
+                  <Flex
+                    key={group.key}
+                    direction="column"
+                    gap="3"
+                    className={
+                      index > 0 ? "border-gray-6 border-t pt-5" : undefined
+                    }
+                  >
+                    <Flex align="center" justify="between" gap="2">
                       <Text weight="bold" size="3">
-                        {release.name}
+                        {group.label}
                       </Text>
-                      {index === 0 ? <Badge color="green">Latest</Badge> : null}
-                      {currentVersion === release.version ? (
+                      <Flex align="center" gap="2">
+                        {group.isLatest ? (
+                          <Badge color="green">Latest</Badge>
+                        ) : null}
+                        {containsCurrent ? (
+                          <Badge color="gray" variant="outline">
+                            Current
+                          </Badge>
+                        ) : null}
                         <Badge color="gray" variant="soft">
-                          Current
+                          {group.releases.length === 1
+                            ? group.releases[0].name
+                            : `${group.releases.length} releases`}
                         </Badge>
-                      ) : null}
+                      </Flex>
                     </Flex>
-                    <Text size="1" color="gray">
-                      {formatDate(release.date)}
-                    </Text>
+                    {improved.length === 0 && fixed.length === 0 ? (
+                      <Text size="2" color="gray">
+                        No notable changes.
+                      </Text>
+                    ) : (
+                      <Flex direction="column" gap="3">
+                        <ReleaseSection title="Improved" items={improved} />
+                        <ReleaseSection title="Fixed" items={fixed} />
+                      </Flex>
+                    )}
                   </Flex>
-                  {release.notes ? (
-                    <MarkdownRenderer content={release.notes} />
-                  ) : (
-                    <Text size="2" color="gray">
-                      No release notes.
-                    </Text>
-                  )}
-                </Flex>
-              ))}
+                );
+              })}
             </Flex>
           </ScrollArea>
         )}

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -1,3 +1,4 @@
+import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
   groupReleases,
@@ -8,6 +9,7 @@ import {
   Badge,
   Dialog,
   Flex,
+  IconButton,
   ScrollArea,
   Spinner,
   Text,
@@ -58,13 +60,20 @@ export function WhatsNewModal() {
       }}
     >
       <Dialog.Content maxWidth="640px">
-        <Flex direction="column" gap="1" mb="3">
-          <Dialog.Title className="mb-0">What's New</Dialog.Title>
-          <Dialog.Description>
-            <Text color="gray" size="2">
-              Release history and recent improvements
-            </Text>
-          </Dialog.Description>
+        <Flex justify="between" align="start" gap="3" mb="3">
+          <Flex direction="column" gap="1">
+            <Dialog.Title className="mb-0">What's New</Dialog.Title>
+            <Dialog.Description>
+              <Text color="gray" size="2">
+                Release history and recent improvements
+              </Text>
+            </Dialog.Description>
+          </Flex>
+          <Dialog.Close>
+            <IconButton variant="ghost" color="gray" aria-label="Close">
+              <X size={16} />
+            </IconButton>
+          </Dialog.Close>
         </Flex>
 
         {isLoading ? (

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -1,0 +1,108 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
+import {
+  Badge,
+  Dialog,
+  Flex,
+  ScrollArea,
+  Spinner,
+  Text,
+} from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
+
+function formatDate(date: string | null): string {
+  if (!date) return "";
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function WhatsNewModal() {
+  const isOpen = useWhatsNewStore((state) => state.isOpen);
+  const close = useWhatsNewStore((state) => state.close);
+  const hostTRPC = useHostTRPC();
+  const { data, isLoading, isError } = useQuery({
+    ...hostTRPC.githubReleases.list.queryOptions(),
+    enabled: isOpen,
+  });
+  const { data: currentVersion } = useQuery(
+    hostTRPC.os.getAppVersion.queryOptions(),
+  );
+
+  const releases = data?.releases ?? [];
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      <Dialog.Content maxWidth="640px">
+        <Flex direction="column" gap="1" mb="3">
+          <Dialog.Title className="mb-0">What's New</Dialog.Title>
+          <Dialog.Description>
+            <Text color="gray" size="2">
+              Release history and recent improvements
+            </Text>
+          </Dialog.Description>
+        </Flex>
+
+        {isLoading ? (
+          <Flex align="center" justify="center" py="6">
+            <Spinner />
+          </Flex>
+        ) : isError ? (
+          <Text color="gray" size="2">
+            Could not load releases. Please try again later.
+          </Text>
+        ) : releases.length === 0 ? (
+          <Text color="gray" size="2">
+            No releases found.
+          </Text>
+        ) : (
+          <ScrollArea
+            type="auto"
+            scrollbars="vertical"
+            style={{ maxHeight: "60vh" }}
+          >
+            <Flex direction="column" gap="5" className="pr-3">
+              {releases.map((release, index) => (
+                <Flex key={release.version} direction="column" gap="2">
+                  <Flex align="center" justify="between" gap="2">
+                    <Flex align="center" gap="2">
+                      <Text weight="bold" size="3">
+                        {release.name}
+                      </Text>
+                      {index === 0 ? <Badge color="green">Latest</Badge> : null}
+                      {currentVersion === release.version ? (
+                        <Badge color="gray" variant="soft">
+                          Current
+                        </Badge>
+                      ) : null}
+                    </Flex>
+                    <Text size="1" color="gray">
+                      {formatDate(release.date)}
+                    </Text>
+                  </Flex>
+                  {release.notes ? (
+                    <MarkdownRenderer content={release.notes} />
+                  ) : (
+                    <Text size="2" color="gray">
+                      No release notes.
+                    </Text>
+                  )}
+                </Flex>
+              ))}
+            </Flex>
+          </ScrollArea>
+        )}
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -11,7 +11,7 @@ import {
   Flex,
   IconButton,
   ScrollArea,
-  Spinner,
+  Skeleton,
   Text,
 } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
@@ -34,6 +34,27 @@ function ReleaseSection({ title, items }: { title: string; items: string[] }) {
           </li>
         ))}
       </ul>
+    </Flex>
+  );
+}
+
+function ChangelogSkeleton() {
+  return (
+    <Flex direction="column" gap="5">
+      {["a", "b", "c"].map((key) => (
+        <Flex key={key} direction="column" gap="3">
+          <Flex align="center" justify="between" gap="2">
+            <Skeleton width="150px" height="22px" />
+            <Skeleton width="72px" height="22px" />
+          </Flex>
+          <Flex direction="column" gap="2">
+            <Skeleton width="64px" height="12px" />
+            <Skeleton width="82%" height="14px" />
+            <Skeleton width="68%" height="14px" />
+            <Skeleton width="74%" height="14px" />
+          </Flex>
+        </Flex>
+      ))}
     </Flex>
   );
 }
@@ -77,9 +98,7 @@ export function WhatsNewModal() {
         </Flex>
 
         {isLoading ? (
-          <Flex align="center" justify="center" py="6">
-            <Spinner />
-          </Flex>
+          <ChangelogSkeleton />
         ) : isError ? (
           <Text color="gray" size="2">
             Could not load releases. Please try again later.

--- a/packages/ui/src/features/updates/releaseNotes.test.ts
+++ b/packages/ui/src/features/updates/releaseNotes.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupReleases,
+  mergeReleaseNotes,
+  parseReleaseNotes,
+} from "./releaseNotes";
+
+describe("parseReleaseNotes", () => {
+  it("keeps change bullets, strips prefix + attribution, splits fix vs rest", () => {
+    const notes = [
+      "## What's Changed",
+      "* feat(canvas): right-click a canvas by @alice in https://github.com/PostHog/code/pull/1",
+      "* fix(inbox): point link to docs by @bob in https://github.com/PostHog/code/pull/2",
+      '* Add "PostHog Web" button by @carol in https://github.com/PostHog/code/pull/3',
+      "* @newbie made their first contribution in https://example.com",
+      "**Full Changelog**: https://github.com/PostHog/code/compare/v1...v2",
+    ].join("\n");
+
+    expect(parseReleaseNotes(notes)).toEqual({
+      improved: ["Right-click a canvas", 'Add "PostHog Web" button'],
+      fixed: ["Point link to docs"],
+    });
+  });
+});
+
+describe("mergeReleaseNotes", () => {
+  it("merges across releases and dedupes", () => {
+    const releases = [
+      { name: "v2", version: "2", date: null, notes: "* fix: a\n* feat: b" },
+      { name: "v1", version: "1", date: null, notes: "* fix: a\n* feat: c" },
+    ];
+    expect(mergeReleaseNotes(releases)).toEqual({
+      improved: ["B", "C"],
+      fixed: ["A"],
+    });
+  });
+});
+
+describe("groupReleases", () => {
+  const now = Date.parse("2026-06-20T12:00:00Z");
+  const mk = (name: string, date: string) => ({
+    name,
+    version: name.replace(/^v/, ""),
+    date,
+    notes: "",
+  });
+
+  it("buckets recent releases by day and older ones by week", () => {
+    const groups = groupReleases(
+      [
+        mk("v0.55.14", "2026-06-20T12:00:00Z"),
+        mk("v0.55.13", "2026-06-19T12:00:00Z"),
+        mk("v0.55.12", "2026-06-19T09:00:00Z"),
+        mk("v0.55.5", "2026-06-12T12:00:00Z"),
+        mk("v0.55.4", "2026-06-10T12:00:00Z"),
+      ],
+      now,
+      3,
+    );
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0].key.startsWith("day-")).toBe(true);
+    expect(groups[0].releases).toHaveLength(1);
+    expect(groups[0].isLatest).toBe(true);
+    expect(groups[1].key.startsWith("day-")).toBe(true);
+    expect(groups[1].releases).toHaveLength(2);
+    expect(groups[2].key.startsWith("week-")).toBe(true);
+    expect(groups[2].releases).toHaveLength(2);
+  });
+});

--- a/packages/ui/src/features/updates/releaseNotes.ts
+++ b/packages/ui/src/features/updates/releaseNotes.ts
@@ -72,19 +72,21 @@ function dayLabel(date: Date): string {
   });
 }
 
-function weekLabel(date: Date): string {
+function mondayOf(date: Date): Date {
   const monday = new Date(date);
   monday.setDate(date.getDate() - ((date.getDay() + 6) % 7));
-  return `Week of ${monday.toLocaleDateString(undefined, {
+  return monday;
+}
+
+function weekLabel(date: Date): string {
+  return `Week of ${mondayOf(date).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
   })}`;
 }
 
 function weekKey(date: Date): string {
-  const monday = new Date(date);
-  monday.setDate(date.getDate() - ((date.getDay() + 6) % 7));
-  return `week-${monday.toDateString()}`;
+  return `week-${mondayOf(date).toDateString()}`;
 }
 
 // Groups newest-first releases: each of the last `recentDays` days is its own
@@ -95,10 +97,9 @@ export function groupReleases(
   recentDays: number = RECENT_DAYS,
 ): ReleaseGroup[] {
   const recentCutoff = now - recentDays * DAY_MS;
-  const order: string[] = [];
   const map = new Map<string, ReleaseGroup>();
 
-  releases.forEach((release, index) => {
+  for (const release of releases) {
     const time = release.date ? Date.parse(release.date) : Number.NaN;
     const dated = !Number.isNaN(time);
     let key: string;
@@ -118,12 +119,15 @@ export function groupReleases(
 
     let group = map.get(key);
     if (!group) {
-      group = { key, label, releases: [], isLatest: index === 0 };
+      group = { key, label, releases: [], isLatest: false };
       map.set(key, group);
-      order.push(key);
     }
     group.releases.push(release);
-  });
+  }
 
-  return order.map((key) => map.get(key) as ReleaseGroup);
+  const groups = Array.from(map.values());
+  if (groups.length > 0) {
+    groups[0].isLatest = true;
+  }
+  return groups;
 }

--- a/packages/ui/src/features/updates/releaseNotes.ts
+++ b/packages/ui/src/features/updates/releaseNotes.ts
@@ -1,0 +1,129 @@
+export interface CategorizedNotes {
+  improved: string[];
+  fixed: string[];
+}
+
+export interface ReleaseLike {
+  name: string;
+  version: string;
+  notes: string;
+  date: string | null;
+}
+
+export interface ReleaseGroup {
+  key: string;
+  label: string;
+  releases: ReleaseLike[];
+  isLatest: boolean;
+}
+
+// Recent releases stay broken out by day; anything older is bucketed by week so
+// the timeline stays scannable when we ship a lot.
+export const RECENT_DAYS = 3;
+const DAY_MS = 86_400_000;
+
+// Release notes are GitHub auto-generated: a "What's Changed" bullet list of PR
+// titles (conventional-commit prefixed), plus contributor and "Full Changelog"
+// noise. Keep only the change bullets, strip the prefix and "by @user in <pr>"
+// attribution, and bucket `fix` into Fixed and everything else into Improved.
+export function parseReleaseNotes(notes: string): CategorizedNotes {
+  const improved: string[] = [];
+  const fixed: string[] = [];
+  for (const rawLine of notes.split("\n")) {
+    const bullet = rawLine.trim().match(/^[-*•]\s+(.*)$/);
+    if (!bullet) continue;
+    let text = bullet[1].trim();
+    if (text.startsWith("@")) continue; // "New Contributors" lines
+    text = text.replace(/\s+by\s+@\S+\s+in\s+\S+.*$/i, "").trim();
+    const conventional = text.match(/^([a-z]+)(?:\([^)]*\))?!?:\s*(.*)$/i);
+    let isFix = false;
+    if (conventional) {
+      isFix = conventional[1].toLowerCase() === "fix";
+      text = conventional[2].trim();
+    } else {
+      isFix = /^fix(ed|es)?\b/i.test(text);
+    }
+    if (text.length === 0) continue;
+    text = text.charAt(0).toUpperCase() + text.slice(1);
+    (isFix ? fixed : improved).push(text);
+  }
+  return { improved, fixed };
+}
+
+export function mergeReleaseNotes(releases: ReleaseLike[]): CategorizedNotes {
+  const improved: string[] = [];
+  const fixed: string[] = [];
+  for (const release of releases) {
+    const parsed = parseReleaseNotes(release.notes);
+    improved.push(...parsed.improved);
+    fixed.push(...parsed.fixed);
+  }
+  return {
+    improved: Array.from(new Set(improved)),
+    fixed: Array.from(new Set(fixed)),
+  };
+}
+
+function dayLabel(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function weekLabel(date: Date): string {
+  const monday = new Date(date);
+  monday.setDate(date.getDate() - ((date.getDay() + 6) % 7));
+  return `Week of ${monday.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })}`;
+}
+
+function weekKey(date: Date): string {
+  const monday = new Date(date);
+  monday.setDate(date.getDate() - ((date.getDay() + 6) % 7));
+  return `week-${monday.toDateString()}`;
+}
+
+// Groups newest-first releases: each of the last `recentDays` days is its own
+// group; everything older is grouped into its calendar week.
+export function groupReleases(
+  releases: ReleaseLike[],
+  now: number = Date.now(),
+  recentDays: number = RECENT_DAYS,
+): ReleaseGroup[] {
+  const recentCutoff = now - recentDays * DAY_MS;
+  const order: string[] = [];
+  const map = new Map<string, ReleaseGroup>();
+
+  releases.forEach((release, index) => {
+    const time = release.date ? Date.parse(release.date) : Number.NaN;
+    const dated = !Number.isNaN(time);
+    let key: string;
+    let label: string;
+    if (dated && time >= recentCutoff) {
+      const date = new Date(time);
+      key = `day-${date.toDateString()}`;
+      label = dayLabel(date);
+    } else if (dated) {
+      const date = new Date(time);
+      key = weekKey(date);
+      label = weekLabel(date);
+    } else {
+      key = "earlier";
+      label = "Earlier";
+    }
+
+    let group = map.get(key);
+    if (!group) {
+      group = { key, label, releases: [], isLatest: index === 0 };
+      map.set(key, group);
+      order.push(key);
+    }
+    group.releases.push(release);
+  });
+
+  return order.map((key) => map.get(key) as ReleaseGroup);
+}

--- a/packages/ui/src/features/updates/updateModalStore.ts
+++ b/packages/ui/src/features/updates/updateModalStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface UpdateModalStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useUpdateModalStore = create<UpdateModalStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/packages/ui/src/features/updates/updateModalStore.ts
+++ b/packages/ui/src/features/updates/updateModalStore.ts
@@ -1,13 +1,3 @@
-import { create } from "zustand";
+import { createDialogStore } from "@posthog/ui/utils/createDialogStore";
 
-interface UpdateModalStore {
-  isOpen: boolean;
-  open: () => void;
-  close: () => void;
-}
-
-export const useUpdateModalStore = create<UpdateModalStore>((set) => ({
-  isOpen: false,
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
-}));
+export const useUpdateModalStore = createDialogStore();

--- a/packages/ui/src/features/updates/updateStore.ts
+++ b/packages/ui/src/features/updates/updateStore.ts
@@ -16,6 +16,10 @@ const log = logger.scope("update-store");
 interface UpdateView {
   status: UpdateUiStatus;
   version: string | null;
+  availableVersion: string | null;
+  releaseNotes: string | null;
+  downloadPercent: number | null;
+  bytesPerSecond: number | null;
   isEnabled: boolean;
 }
 
@@ -23,6 +27,10 @@ export function useUpdateView(): UpdateView {
   return useStore(updateStore, (state) => ({
     status: state.status,
     version: state.version,
+    availableVersion: state.availableVersion,
+    releaseNotes: state.releaseNotes,
+    downloadPercent: state.downloadPercent,
+    bytesPerSecond: state.bytesPerSecond,
     isEnabled: state.isEnabled,
   }));
 }

--- a/packages/ui/src/features/updates/updateStore.ts
+++ b/packages/ui/src/features/updates/updateStore.ts
@@ -20,6 +20,7 @@ interface UpdateView {
   releaseNotes: string | null;
   downloadPercent: number | null;
   bytesPerSecond: number | null;
+  downloadSizeBytes: number | null;
   isEnabled: boolean;
 }
 
@@ -31,6 +32,7 @@ export function useUpdateView(): UpdateView {
     releaseNotes: state.releaseNotes,
     downloadPercent: state.downloadPercent,
     bytesPerSecond: state.bytesPerSecond,
+    downloadSizeBytes: state.downloadSizeBytes,
     isEnabled: state.isEnabled,
   }));
 }

--- a/packages/ui/src/features/updates/whatsNewStore.ts
+++ b/packages/ui/src/features/updates/whatsNewStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface WhatsNewStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useWhatsNewStore = create<WhatsNewStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/packages/ui/src/features/updates/whatsNewStore.ts
+++ b/packages/ui/src/features/updates/whatsNewStore.ts
@@ -1,13 +1,3 @@
-import { create } from "zustand";
+import { createDialogStore } from "@posthog/ui/utils/createDialogStore";
 
-interface WhatsNewStore {
-  isOpen: boolean;
-  open: () => void;
-  close: () => void;
-}
-
-export const useWhatsNewStore = create<WhatsNewStore>((set) => ({
-  isOpen: false,
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
-}));
+export const useWhatsNewStore = createDialogStore();

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -42,6 +42,8 @@ import { ExistingWorktreeDialog } from "@posthog/ui/features/task-detail/compone
 import { RemoteBranchCheckoutDialog } from "@posthog/ui/features/task-detail/components/RemoteBranchCheckoutDialog";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { TourOverlay } from "@posthog/ui/features/tour/components/TourOverlay";
+import { UpdateAvailableModal } from "@posthog/ui/features/updates/UpdateAvailableModal";
+import { WhatsNewModal } from "@posthog/ui/features/updates/WhatsNewModal";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import LogosLandscape from "@posthog/ui/primitives/Logo";
 import { useAppView } from "@posthog/ui/router/useAppView";
@@ -391,6 +393,8 @@ function RootLayout() {
           onToggleShortcutsSheet={toggleShortcutsSheet}
         />
         {billingEnabled && <UsageLimitModal />}
+        <UpdateAvailableModal />
+        <WhatsNewModal />
         <RemoteBranchCheckoutDialog />
         <FeedbackModal
           mode={feedbackMode}
@@ -421,6 +425,8 @@ function RootLayout() {
           onToggleShortcutsSheet={toggleShortcutsSheet}
         />
         {billingEnabled && <UsageLimitModal />}
+        <UpdateAvailableModal />
+        <WhatsNewModal />
         <RemoteBranchCheckoutDialog />
         <ExistingWorktreeDialog />
         {import.meta.env.DEV && (
@@ -465,6 +471,8 @@ function RootLayout() {
         />
         <TourOverlay />
         {billingEnabled && <UsageLimitModal />}
+        <UpdateAvailableModal />
+        <WhatsNewModal />
         <RemoteBranchCheckoutDialog />
         {approvalDeepLink.pending ? (
           <DeepLinkApprovalModal

--- a/packages/ui/src/utils/createDialogStore.ts
+++ b/packages/ui/src/utils/createDialogStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+export interface DialogStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export function createDialogStore() {
+  return create<DialogStore>((set) => ({
+    isOpen: false,
+    open: () => set({ isOpen: true }),
+    close: () => set({ isOpen: false }),
+  }));
+}

--- a/packages/workspace-server/src/services/github-releases/github-releases.module.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.module.ts
@@ -1,0 +1,7 @@
+import { ContainerModule } from "inversify";
+import { GitHubReleasesService } from "./github-releases";
+import { GITHUB_RELEASES_SERVICE } from "./identifiers";
+
+export const githubReleasesModule = new ContainerModule(({ bind }) => {
+  bind(GITHUB_RELEASES_SERVICE).to(GitHubReleasesService).inSingletonScope();
+});

--- a/packages/workspace-server/src/services/github-releases/github-releases.test.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubReleasesService } from "./github-releases";
+
+const sampleReleases = [
+  {
+    tag_name: "v1.2.0",
+    name: "v1.2.0",
+    body: "## Notes\n- thing",
+    draft: false,
+    prerelease: false,
+    published_at: "2026-06-20T00:00:00Z",
+    html_url: "https://github.com/PostHog/code/releases/tag/v1.2.0",
+  },
+  {
+    tag_name: "v1.1.0",
+    name: "",
+    body: null,
+    draft: false,
+    prerelease: true,
+    published_at: "2026-06-10T00:00:00Z",
+    html_url: "https://github.com/PostHog/code/releases/tag/v1.1.0",
+  },
+  {
+    tag_name: "v1.3.0-draft",
+    name: "draft",
+    body: "x",
+    draft: true,
+    prerelease: false,
+    published_at: null,
+    html_url: "https://github.com/PostHog/code/releases/tag/v1.3.0-draft",
+  },
+];
+
+describe("GitHubReleasesService", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => sampleReleases,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("maps releases, strips the v prefix and drops drafts", async () => {
+    const service = new GitHubReleasesService();
+    const { releases } = await service.listReleases();
+
+    expect(releases).toHaveLength(2);
+    expect(releases[0]).toEqual({
+      version: "1.2.0",
+      name: "v1.2.0",
+      notes: "## Notes\n- thing",
+      date: "2026-06-20T00:00:00Z",
+      isPrerelease: false,
+      htmlUrl: "https://github.com/PostHog/code/releases/tag/v1.2.0",
+    });
+    // empty name falls back to the tag; null body becomes an empty string
+    expect(releases[1]).toMatchObject({
+      version: "1.1.0",
+      name: "v1.1.0",
+      notes: "",
+      isPrerelease: true,
+    });
+  });
+
+  it("caches results within the TTL", async () => {
+    const service = new GitHubReleasesService();
+    await service.listReleases();
+    await service.listReleases();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on non-ok responses", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    const service = new GitHubReleasesService();
+    await expect(service.listReleases()).rejects.toThrow();
+  });
+});

--- a/packages/workspace-server/src/services/github-releases/github-releases.test.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.test.ts
@@ -81,4 +81,18 @@ describe("GitHubReleasesService", () => {
     const service = new GitHubReleasesService();
     await expect(service.listReleases()).rejects.toThrow();
   });
+
+  it("serves stale cache when a later refetch fails", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
+    const service = new GitHubReleasesService();
+    const first = await service.listReleases();
+
+    nowSpy.mockReturnValue(11 * 60_000);
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    const second = await service.listReleases();
+
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
 });

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -1,0 +1,45 @@
+import { injectable } from "inversify";
+import { githubReleasesApiResponse, type ListReleasesOutput } from "./schemas";
+
+const RELEASES_URL =
+  "https://api.github.com/repos/PostHog/code/releases?per_page=30";
+const CACHE_TTL_MS = 10 * 60_000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+@injectable()
+export class GitHubReleasesService {
+  private cache: { fetchedAt: number; data: ListReleasesOutput } | null = null;
+
+  async listReleases(): Promise<ListReleasesOutput> {
+    if (this.cache && Date.now() - this.cache.fetchedAt < CACHE_TTL_MS) {
+      return this.cache.data;
+    }
+
+    const response = await fetch(RELEASES_URL, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub releases fetch failed: ${response.status}`);
+    }
+
+    const parsed = githubReleasesApiResponse.parse(await response.json());
+    const releases = parsed
+      .filter((release) => !release.draft)
+      .map((release) => ({
+        version: release.tag_name.replace(/^v/, ""),
+        name:
+          release.name && release.name.length > 0
+            ? release.name
+            : release.tag_name,
+        notes: release.body ?? "",
+        date: release.published_at,
+        isPrerelease: release.prerelease,
+        htmlUrl: release.html_url,
+      }));
+
+    const data: ListReleasesOutput = { releases };
+    this.cache = { fetchedAt: Date.now(), data };
+    return data;
+  }
+}

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -15,31 +15,38 @@ export class GitHubReleasesService {
       return this.cache.data;
     }
 
-    const response = await fetch(RELEASES_URL, {
-      headers: { Accept: "application/vnd.github+json" },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      throw new Error(`GitHub releases fetch failed: ${response.status}`);
+    try {
+      const response = await fetch(RELEASES_URL, {
+        headers: { Accept: "application/vnd.github+json" },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(`GitHub releases fetch failed: ${response.status}`);
+      }
+
+      const parsed = githubReleasesApiResponse.parse(await response.json());
+      const releases = parsed
+        .filter((release) => !release.draft)
+        .map((release) => ({
+          version: release.tag_name.replace(/^v/, ""),
+          name:
+            release.name && release.name.length > 0
+              ? release.name
+              : release.tag_name,
+          notes: release.body ?? "",
+          date: release.published_at,
+          isPrerelease: release.prerelease,
+          htmlUrl: release.html_url,
+        }));
+
+      const data: ListReleasesOutput = { releases };
+      this.cache = { fetchedAt: Date.now(), data };
+      return data;
+    } catch (error) {
+      if (this.cache) {
+        return this.cache.data;
+      }
+      throw error;
     }
-
-    const parsed = githubReleasesApiResponse.parse(await response.json());
-    const releases = parsed
-      .filter((release) => !release.draft)
-      .map((release) => ({
-        version: release.tag_name.replace(/^v/, ""),
-        name:
-          release.name && release.name.length > 0
-            ? release.name
-            : release.tag_name,
-        notes: release.body ?? "",
-        date: release.published_at,
-        isPrerelease: release.prerelease,
-        htmlUrl: release.html_url,
-      }));
-
-    const data: ListReleasesOutput = { releases };
-    this.cache = { fetchedAt: Date.now(), data };
-    return data;
   }
 }

--- a/packages/workspace-server/src/services/github-releases/identifiers.ts
+++ b/packages/workspace-server/src/services/github-releases/identifiers.ts
@@ -1,0 +1,3 @@
+export const GITHUB_RELEASES_SERVICE = Symbol.for(
+  "posthog.workspace.githubReleasesService",
+);

--- a/packages/workspace-server/src/services/github-releases/schemas.ts
+++ b/packages/workspace-server/src/services/github-releases/schemas.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const githubReleaseApiItem = z.object({
+  tag_name: z.string(),
+  name: z.string().nullable(),
+  body: z.string().nullable(),
+  draft: z.boolean(),
+  prerelease: z.boolean(),
+  published_at: z.string().nullable(),
+  html_url: z.string(),
+});
+
+export const githubReleasesApiResponse = z.array(githubReleaseApiItem);
+
+export const releaseItem = z.object({
+  version: z.string(),
+  name: z.string(),
+  notes: z.string(),
+  date: z.string().nullable(),
+  isPrerelease: z.boolean(),
+  htmlUrl: z.string(),
+});
+
+export const listReleasesOutput = z.object({
+  releases: z.array(releaseItem),
+});
+
+export type ReleaseItem = z.infer<typeof releaseItem>;
+export type ListReleasesOutput = z.infer<typeof listReleasesOutput>;


### PR DESCRIPTION
## Problem

The move to electron-updater gave us a new set of primitives that were previously unavailable to us: checking for an update without downloading it, byte-level download progress, an explicit download trigger, install-on-quit and release notes at check time. The old experience used none of them. Updates downloaded silently, and the only UI was a bottom-left banner with a "Restart" button that appeared once the download had already finished. There was no opt-in download, no release notes, no progress and no way to browse the changelog.

## Changes

Three user-facing additions, built on those primitives:

- Update modal. Updates no longer auto-download by default. The bottom-left banner becomes a passive "Update available" that opens a modal showing the release notes (rendered markdown), your current version and a Download button with a live progress bar (percent and MB/s). You can close the modal while the download runs and the banner mirrors the progress; when it finishes the action becomes "Restart to update".
- "Download updates automatically" setting in General (default off). When on, updates download in the background and install on the next quit, with the Restart button still available for an immediate install. The renderer pushes the preference to the core updater through a new `updates.setAutoDownload` procedure.
- "View changelog" in the project switcher opens a "What's New" modal: a timeline of GitHub releases fetched by a new `GitHubReleasesService` (in workspace-server, public `GET /repos/PostHog/code/releases`, Zod-parsed and cached). The current version is marked, and the modal auto-shows once on the first launch after an update installs (tracked with a persisted `lastSeenChangelogVersion`).

Plumbing: `IUpdater` gains `download()`, `onDownloadProgress()` and `setAutoDownload()`, and `onUpdateAvailable` now carries the release notes. The electron-updater adapter sets `autoDownload` to false and `autoInstallOnAppQuit` to true and wires the `download-progress` event. `UpdatesService` gains an "available" state, download progress and the auto-download decision, and the status payload plus the renderer stores carry the new fields.

Auto-update stays macOS and Windows only; the What's New changelog works on every platform.

Stacked on #2817.

## How did you test this?

- `pnpm typecheck` (22 of 22), `pnpm lint` and `pnpm build` all pass.
- `pnpm test` passes. New unit tests cover the `UpdatesService` transitions (available, then requestDownload, then downloading, then ready, plus the auto-download branch) with a faked `IUpdater`, and the `GitHubReleasesService` mapping, caching and error handling with a faked fetch.
- Driving the live modal and banner states in the packaged app over CDP is a follow-up.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
