### PR TITLE
Show update prompt in Bluebird channels nav

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -13,6 +13,7 @@ import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFla
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { ProjectSwitcher } from "@posthog/ui/features/sidebar/components/ProjectSwitcher";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { UpdateBanner } from "@posthog/ui/features/sidebar/components/UpdateBanner";
 import {
   navigateToAgents,
   navigateToCanvas,
@@ -151,6 +152,11 @@ export function ChannelsSidebar() {
         <ChannelsNav />
         <ChannelsList />
       </Box>
+
+      {/* Update prompt pinned above Settings, mirroring the Code-mode sidebar
+          (SidebarContent) so a ready update is offered in this space too. The
+          banner renders nothing unless an update is downloading/ready. */}
+      <UpdateBanner />
 
       {/* Settings pinned to the bottom. Settings is a full-page route, so this
           leaves the Channels space rather than highlighting in place. */}

--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -153,9 +153,6 @@ export function ChannelsSidebar() {
         <ChannelsList />
       </Box>
 
-      {/* Update prompt pinned above Settings, mirroring the Code-mode sidebar
-          (SidebarContent) so a ready update is offered in this space too. The
-          banner renders nothing unless an update is downloading/ready. */}
       <UpdateBanner />
 
       {/* Settings pinned to the bottom. Settings is a full-page route, so this


### PR DESCRIPTION
## Problem

The "update available / restart" prompt (`UpdateBanner`) shows in the Code-mode nav but not in the Bluebird (Channels / Website space) nav, which renders its own chrome. A user living in the Channels space would never be offered a ready update.

**Why:** Make the update prompt that shows in the Code-mode nav also show up in the Bluebird nav.

## Changes

Render `<UpdateBanner />` in `ChannelsSidebar`, pinned just above the Settings button — the closest mirror of where Code mode places it in `SidebarContent`. The component is self-contained (reads update state from the store via hooks) and renders nothing unless an update is downloading/ready/installing, so there's no behavioral change when no update is pending.

## How did you test this?

Not run. The shallow clone has no installed dependencies, so a package typecheck can't resolve modules. The change reuses the exact import path and self-contained component already used by the Code-mode `SidebarContent`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*