### PR TITLE
feat(bluebird): open channel CONTEXT.md from new-task chip

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -796,6 +796,7 @@ export type ChannelActionType =
   | "edit_context_open"
   | "new_task_open"
   | "new_task_suggestion"
+  | "view_context"
   | "file_task"
   | "unfile_task"
   | "archive_task"

--- a/packages/ui/src/features/canvas/components/ChannelContextPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelContextPanel.test.tsx
@@ -31,22 +31,32 @@ function renderPanel(
 }
 
 describe("ChannelContextPanel", () => {
-  it("renders the channel-qualified CONTEXT.md title and body", () => {
+  it.each([
+    {
+      channelName: "project-bluebird",
+      expectedTitle: "#project-bluebird CONTEXT.md",
+    },
+    { channelName: undefined, expectedTitle: "CONTEXT.md" },
+  ])(
+    "renders title '$expectedTitle' for channelName=$channelName",
+    ({ channelName, expectedTitle }) => {
+      render(
+        <Theme>
+          <ChannelContextPanel
+            channelName={channelName}
+            body="body"
+            onClose={vi.fn()}
+          />
+        </Theme>,
+      );
+      expect(screen.getByText(expectedTitle)).toBeInTheDocument();
+    },
+  );
+
+  it("renders the markdown body", () => {
     renderPanel();
-    expect(
-      screen.getByText("#project-bluebird CONTEXT.md"),
-    ).toBeInTheDocument();
     expect(screen.getByText("Heading")).toBeInTheDocument();
     expect(screen.getByText("context")).toBeInTheDocument();
-  });
-
-  it("omits the channel prefix when no name is given", () => {
-    render(
-      <Theme>
-        <ChannelContextPanel body="body" onClose={vi.fn()} />
-      </Theme>,
-    );
-    expect(screen.getByText("CONTEXT.md")).toBeInTheDocument();
   });
 
   it("calls onClose when the close button is clicked", async () => {

--- a/packages/ui/src/features/canvas/components/ChannelContextPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelContextPanel.test.tsx
@@ -1,0 +1,60 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+// Radix's ScrollArea observes resizes; jsdom lacks ResizeObserver.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+import { ChannelContextPanel } from "./ChannelContextPanel";
+
+function renderPanel(
+  props?: Partial<Parameters<typeof ChannelContextPanel>[0]>,
+) {
+  const onClose = props?.onClose ?? vi.fn();
+  render(
+    <Theme>
+      <ChannelContextPanel
+        channelName={props?.channelName ?? "project-bluebird"}
+        body={props?.body ?? "# Heading\n\nSome **context** body."}
+        onClose={onClose}
+      />
+    </Theme>,
+  );
+  return onClose;
+}
+
+describe("ChannelContextPanel", () => {
+  it("renders the channel-qualified CONTEXT.md title and body", () => {
+    renderPanel();
+    expect(
+      screen.getByText("#project-bluebird CONTEXT.md"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Heading")).toBeInTheDocument();
+    expect(screen.getByText("context")).toBeInTheDocument();
+  });
+
+  it("omits the channel prefix when no name is given", () => {
+    render(
+      <Theme>
+        <ChannelContextPanel body="body" onClose={vi.fn()} />
+      </Theme>,
+    );
+    expect(screen.getByText("CONTEXT.md")).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = renderPanel();
+    await user.click(
+      screen.getByRole("button", { name: "Close context panel" }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/features/canvas/components/ChannelContextPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelContextPanel.tsx
@@ -1,0 +1,57 @@
+import { X } from "@phosphor-icons/react";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { Box, Flex, ScrollArea, Text, Tooltip } from "@radix-ui/themes";
+
+interface ChannelContextPanelProps {
+  channelName?: string;
+  body: string;
+  onClose: () => void;
+}
+
+// Side-panel preview of a channel's CONTEXT.md, opened from the new-task chip.
+// Mirrors ChannelContextTab's read-only markdown render, but adds its own header
+// + close button since it lives in a ResizableSidebar rather than a task tab.
+export function ChannelContextPanel({
+  channelName,
+  body,
+  onClose,
+}: ChannelContextPanelProps) {
+  return (
+    <Flex direction="column" className="h-full min-w-0">
+      <Flex
+        align="center"
+        justify="between"
+        gap="2"
+        className="shrink-0 border-gray-6 border-b px-4 py-2"
+      >
+        <Text
+          size="2"
+          weight="medium"
+          className="min-w-0 truncate text-gray-12"
+        >
+          {channelName ? `#${channelName} ` : ""}CONTEXT.md
+        </Text>
+        <Tooltip content="Close">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close context panel"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-gray-10 hover:bg-gray-4 hover:text-gray-12"
+          >
+            <X size={14} />
+          </button>
+        </Tooltip>
+      </Flex>
+      <ScrollArea type="auto" scrollbars="vertical" className="min-h-0 flex-1">
+        <Box p="4">
+          <Text className="mb-3 block text-[12px] text-gray-9">
+            Included with new tasks in this channel as background context.
+          </Text>
+          <Box className="text-[13px]">
+            <MarkdownRenderer content={body} />
+          </Box>
+        </Box>
+      </ScrollArea>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
@@ -81,14 +81,25 @@ describe("WebsiteNewTask context panel", () => {
     expect(
       screen.getByText("#project-bluebird CONTEXT.md"),
     ).toBeInTheDocument();
-    expect(track).toHaveBeenCalledWith(
-      "Channel action",
+    const viewContextCalls = () =>
+      track.mock.calls.filter(
+        ([, props]) => props?.action_type === "view_context",
+      );
+    expect(viewContextCalls()).toHaveLength(1);
+    expect(viewContextCalls()[0][1]).toEqual(
       expect.objectContaining({
         action_type: "view_context",
         surface: "new_task",
         channel_id: "chan-1",
       }),
     );
+
+    // Clicking again closes the panel and must NOT re-track view_context.
+    await user.click(screen.getByRole("button", { name: "context-chip" }));
+    expect(
+      screen.queryByText("#project-bluebird CONTEXT.md"),
+    ).not.toBeInTheDocument();
+    expect(viewContextCalls()).toHaveLength(1);
   });
 
   it("leaves the chip non-interactive when the channel has no CONTEXT.md", () => {

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
@@ -1,0 +1,99 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Radix's ScrollArea (in the context panel) observes resizes; jsdom lacks it.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+const { track, useFolderInstructions } = vi.hoisted(() => ({
+  track: vi.fn(),
+  useFolderInstructions: vi.fn(),
+}));
+
+// TaskInput is a huge hook-heavy component; stub it down to just the surface
+// this test cares about — a button that fires onContextChipClick when wired.
+vi.mock("@posthog/ui/features/task-detail/components/TaskInput", () => ({
+  TaskInput: ({ onContextChipClick }: { onContextChipClick?: () => void }) => (
+    <button
+      type="button"
+      disabled={!onContextChipClick}
+      onClick={onContextChipClick}
+    >
+      context-chip
+    </button>
+  ),
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({
+    channels: [{ id: "chan-1", name: "project-bluebird" }],
+  }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelTasks", () => ({
+  useChannelTaskMutations: () => ({ fileTask: vi.fn() }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useFolderInstructions", () => ({
+  useFolderInstructions,
+}));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ setQueryData: vi.fn() }),
+}));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+
+import { WebsiteNewTask } from "./WebsiteNewTask";
+
+function renderNewTask() {
+  render(
+    <Theme>
+      <WebsiteNewTask channelId="chan-1" />
+    </Theme>,
+  );
+}
+
+describe("WebsiteNewTask context panel", () => {
+  beforeEach(() => {
+    track.mockReset();
+    useFolderInstructions.mockReset();
+  });
+
+  it("opens the context panel and tracks view_context when the chip is clicked", async () => {
+    const user = userEvent.setup();
+    useFolderInstructions.mockReturnValue({
+      data: { content: "# Channel context\n\nBackground." },
+    });
+    renderNewTask();
+
+    // Panel starts closed.
+    expect(
+      screen.queryByText("#project-bluebird CONTEXT.md"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "context-chip" }));
+
+    expect(
+      screen.getByText("#project-bluebird CONTEXT.md"),
+    ).toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith(
+      "Channel action",
+      expect.objectContaining({
+        action_type: "view_context",
+        surface: "new_task",
+        channel_id: "chan-1",
+      }),
+    );
+  });
+
+  it("leaves the chip non-interactive when the channel has no CONTEXT.md", () => {
+    useFolderInstructions.mockReturnValue({ data: undefined });
+    renderNewTask();
+    expect(screen.getByRole("button", { name: "context-chip" })).toBeDisabled();
+  });
+});

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -1,16 +1,19 @@
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
+import { ChannelContextPanel } from "@posthog/ui/features/canvas/components/ChannelContextPanel";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
 import { TaskInput } from "@posthog/ui/features/task-detail/components/TaskInput";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
+import { Flex } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 // A channel's "New task" view. Reuses /code's TaskInput, but routes the created
 // task into the channel (/website/$channelId/tasks/$id) instead of /code, and
@@ -25,6 +28,23 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
   // The channel's CONTEXT.md, passed to the agent as optional background so
   // tasks created here start with the shared context. Absent/empty is fine.
   const { data: instructions } = useFolderInstructions(channelId);
+  const channelContext = instructions?.content;
+
+  // Right-side preview of the CONTEXT.md, opened from the composer's chip so the
+  // user can read what will be sent before submitting (mirrors the post-submit
+  // context tab). Local view state — no panel-layout store exists pre-submit.
+  const [contextPanelOpen, setContextPanelOpen] = useState(false);
+  const [contextPanelWidth, setContextPanelWidth] = useState(360);
+  const [contextPanelResizing, setContextPanelResizing] = useState(false);
+
+  const handleContextChipClick = useCallback(() => {
+    setContextPanelOpen((open) => !open);
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "view_context",
+      surface: "new_task",
+      channel_id: channelId,
+    });
+  }, [channelId]);
 
   const onTaskCreated = useCallback(
     (task: Task) => {
@@ -62,20 +82,43 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
   );
 
   return (
-    <TaskInput
-      onTaskCreated={onTaskCreated}
-      channelContext={instructions?.content}
-      channelName={channelName}
-      allowNoRepo
-      suggestions={CHANNEL_TASK_SUGGESTIONS}
-      onSuggestionSelect={(label) =>
-        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-          action_type: "new_task_suggestion",
-          surface: "new_task",
-          channel_id: channelId,
-          suggestion_label: label,
-        })
-      }
-    />
+    <Flex className="h-full min-w-0 flex-1">
+      <div className="min-w-0 flex-1">
+        <TaskInput
+          onTaskCreated={onTaskCreated}
+          channelContext={channelContext}
+          channelName={channelName}
+          allowNoRepo
+          suggestions={CHANNEL_TASK_SUGGESTIONS}
+          onSuggestionSelect={(label) =>
+            track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+              action_type: "new_task_suggestion",
+              surface: "new_task",
+              channel_id: channelId,
+              suggestion_label: label,
+            })
+          }
+          onContextChipClick={
+            channelContext ? handleContextChipClick : undefined
+          }
+        />
+      </div>
+      <ResizableSidebar
+        open={contextPanelOpen && !!channelContext}
+        width={contextPanelWidth}
+        setWidth={setContextPanelWidth}
+        isResizing={contextPanelResizing}
+        setIsResizing={setContextPanelResizing}
+        side="right"
+      >
+        {contextPanelOpen && channelContext ? (
+          <ChannelContextPanel
+            channelName={channelName}
+            body={channelContext}
+            onClose={() => setContextPanelOpen(false)}
+          />
+        ) : null}
+      </ResizableSidebar>
+    </Flex>
   );
 }

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -38,13 +38,18 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
   const [contextPanelResizing, setContextPanelResizing] = useState(false);
 
   const handleContextChipClick = useCallback(() => {
-    setContextPanelOpen((open) => !open);
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-      action_type: "view_context",
-      surface: "new_task",
-      channel_id: channelId,
-    });
-  }, [channelId]);
+    const nextOpen = !contextPanelOpen;
+    setContextPanelOpen(nextOpen);
+    // Only count opening the panel, not closing it, so an open→close→open
+    // cycle doesn't inflate the metric.
+    if (nextOpen) {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "view_context",
+        surface: "new_task",
+        channel_id: channelId,
+      });
+    }
+  }, [channelId, contextPanelOpen]);
 
   const onTaskCreated = useCallback(
     (task: Task) => {

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -94,6 +94,13 @@ interface TaskInputProps {
    * effect on the fill behaviour.
    */
   onSuggestionSelect?: (label: string) => void;
+  /**
+   * Called when the channel CONTEXT.md chip is clicked (not its dismiss × ).
+   * When provided, the chip's icon+label becomes a button — the channels
+   * new-task screen uses it to open the CONTEXT.md in a side panel. Without it
+   * the chip is non-interactive (only dismissable).
+   */
+  onContextChipClick?: () => void;
 }
 
 export function TaskInput({
@@ -110,6 +117,7 @@ export function TaskInput({
   allowNoRepo,
   suggestions,
   onSuggestionSelect,
+  onContextChipClick,
 }: TaskInputProps = {}) {
   const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
   const trpc = useHostTRPC();
@@ -921,10 +929,27 @@ export function TaskInput({
               <div className="-mt-px mx-2 flex select-none flex-wrap items-center gap-1.5 rounded-b-md border border-gray-6 border-t-0 bg-gray-2 px-2 py-1 text-[12px] text-gray-11">
                 <span className="shrink-0 text-gray-10">Using:</span>
                 <span className="inline-flex items-center gap-1 rounded-[var(--radius-1)] bg-[var(--gray-a3)] px-1.5 py-px font-medium text-[var(--gray-11)]">
-                  <FileText size={12} />
-                  <span className="truncate">
-                    {channelName ? `#${channelName} ` : ""}CONTEXT.md
-                  </span>
+                  {onContextChipClick ? (
+                    <Tooltip content="View this context">
+                      <button
+                        type="button"
+                        onClick={onContextChipClick}
+                        className="inline-flex min-w-0 items-center gap-1 rounded text-[var(--gray-11)] hover:text-gray-12"
+                      >
+                        <FileText size={12} />
+                        <span className="truncate">
+                          {channelName ? `#${channelName} ` : ""}CONTEXT.md
+                        </span>
+                      </button>
+                    </Tooltip>
+                  ) : (
+                    <>
+                      <FileText size={12} />
+                      <span className="truncate">
+                        {channelName ? `#${channelName} ` : ""}CONTEXT.md
+                      </span>
+                    </>
+                  )}
                   <Tooltip content="Don't include this context">
                     <button
                       type="button"


### PR DESCRIPTION
## Problem

In a channel's new-task composer (project-bluebird), the `Using: #<channel> CONTEXT.md` chip could only be dismissed (×) — there was no way to see what the CONTEXT.md actually contains before submitting. After submit you can open the context tab to read it; this brings the same affordance to the composer.

**Why:** users wanted to review the channel context that will be attached to a task *before* sending it, not only afterward.

## Changes

- **`TaskInput`**: new optional `onContextChipClick` prop turns the chip's icon+label into a button (tooltip "View this context"). The × dismiss is unchanged, and the other `TaskInput` callers are unaffected.
- **`ChannelContextPanel`** (new): read-only markdown panel with a header + close button, mirroring `ChannelContextTab`.
- **`WebsiteNewTask`**: wires the chip to a right-side `ResizableSidebar` panel; content is mounted only while open, and the chip stays non-interactive when the channel has no CONTEXT.md.
- **analytics-events**: added a `view_context` `ChannelActionType`, tracked on chip click.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` and `@posthog/shared` typecheck — clean
- Biome lint on all touched files — clean
- New Vitest suites (5 tests, all passing): `ChannelContextPanel` (title/body/no-prefix/close) and `WebsiteNewTask` (chip → panel opens + `view_context` tracked; chip disabled when no context)

Not done: manual run of the Electron app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
