### PR TITLE
Sort channel tasks by last updated in the channels nav

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -653,17 +653,22 @@ function ChannelSection({
   // Order by each task's own last-updated time (most recent first) so a
   // channel surfaces what's actively moving, rather than the order tasks were
   // filed. `filedTasks` arrives sorted by filing time; this re-sorts by the
-  // task's `updated_at`, falling back to 0 when a task isn't loaded.
-  const taskUpdatedAt = (taskId: string): number => {
-    const updatedAt = tasks?.find((t) => t.id === taskId)?.updated_at;
-    return updatedAt ? Date.parse(updatedAt) : 0;
-  };
+  // task's `updated_at`. A single id→ms map keeps both the membership filter
+  // and the sort O(1) per item; `|| 0` guards against a malformed date
+  // (`Date.parse` → NaN) and a task that isn't loaded.
+  const taskUpdatedAtMs = new Map(
+    tasks?.map((t) => [t.id, Date.parse(t.updated_at) || 0]) ?? [],
+  );
   const visibleFiledTasks = filedTasks
     .filter(
       ({ taskId }) =>
-        !archivedTaskIds.has(taskId) && tasks?.some((t) => t.id === taskId),
+        !archivedTaskIds.has(taskId) && taskUpdatedAtMs.has(taskId),
     )
-    .sort((a, b) => taskUpdatedAt(b.taskId) - taskUpdatedAt(a.taskId));
+    .sort(
+      (a, b) =>
+        (taskUpdatedAtMs.get(b.taskId) ?? 0) -
+        (taskUpdatedAtMs.get(a.taskId) ?? 0),
+    );
   const displayedFiledTasks = visibleFiledTasks.slice(0, taskLimit);
   const hiddenTaskCount = visibleFiledTasks.length - displayedFiledTasks.length;
   // Reveal one more batch, capped at the remaining count.

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -650,10 +650,20 @@ function ChannelSection({
   // Tasks are private to each user. A task filed by someone else won't be in
   // `tasks` (it isn't shared with me), so hide it rather than rendering an
   // "Untitled task" placeholder. Also drop archived tasks.
-  const visibleFiledTasks = filedTasks.filter(
-    ({ taskId }) =>
-      !archivedTaskIds.has(taskId) && tasks?.some((t) => t.id === taskId),
-  );
+  // Order by each task's own last-updated time (most recent first) so a
+  // channel surfaces what's actively moving, rather than the order tasks were
+  // filed. `filedTasks` arrives sorted by filing time; this re-sorts by the
+  // task's `updated_at`, falling back to 0 when a task isn't loaded.
+  const taskUpdatedAt = (taskId: string): number => {
+    const updatedAt = tasks?.find((t) => t.id === taskId)?.updated_at;
+    return updatedAt ? Date.parse(updatedAt) : 0;
+  };
+  const visibleFiledTasks = filedTasks
+    .filter(
+      ({ taskId }) =>
+        !archivedTaskIds.has(taskId) && tasks?.some((t) => t.id === taskId),
+    )
+    .sort((a, b) => taskUpdatedAt(b.taskId) - taskUpdatedAt(a.taskId));
   const displayedFiledTasks = visibleFiledTasks.slice(0, taskLimit);
   const hiddenTaskCount = visibleFiledTasks.length - displayedFiledTasks.length;
   // Reveal one more batch, capped at the remaining count.


### PR DESCRIPTION
## Problem

In the channels (bluebird) nav, the tasks filed under each channel were ordered by when they were filed, not by recent activity — so a channel didn't surface what was actively moving at the top.

**Why:** requested so each channel's task list reflects the most recently updated tasks first.

## Changes

`ChannelSection` in `ChannelsList.tsx` now sorts each channel's visible filed tasks by the task's own `updated_at` (most recent first), instead of inheriting the server's filing-time (`createdAt`) order. The sort lives in the component because that's where the filed-task FS rows are already joined against the live task list (which carries `updated_at`); the server's `channelTasksService.list` only has the filing-time on each row.

## How did you test this?

Static review only. The change is a sort over already-typed records using the existing `Task.updated_at` field. I did not run the test suite or typecheck — `node_modules` isn't installed in this environment, so the existing `pnpm typecheck` failures are unrelated (missing-module noise) and none reference the changed file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*