### PR TITLE
fix(canvas): render first canvas on cold open via race-free iframe init

### DIFF
--- a/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
@@ -5,7 +5,14 @@ import {
   type HostToCanvasMessage,
 } from "@posthog/core/canvas/freeformSchemas";
 import { logger } from "@posthog/ui/shell/logger";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { buildSandboxDocument, type SandboxMode } from "./sandboxRuntime";
 
 const log = logger.scope("freeform-canvas");
@@ -105,12 +112,16 @@ export function FreeformCanvas({
   // reload it re-announces "ready", so mark it not-ready until then. Ref write
   // only — no state update, no extra render.
   // biome-ignore lint/correctness/useExhaustiveDependencies: srcDoc identity tracks a reload.
-  useEffect(() => {
+  useLayoutEffect(() => {
     readyRef.current = false;
   }, [srcDoc]);
 
   // Subscribed once for the component's life; reads latest props via the ref.
-  useEffect(() => {
+  // Layout effect (not passive): the listener must be attached during commit,
+  // before the browser yields to the iframe's load task — otherwise the iframe's
+  // one-shot "ready" (and early data-request/error/resize) can fire before the
+  // listener exists and be lost, leaving the canvas blank on a cold first open.
+  useLayoutEffect(() => {
     const post = (msg: HostToCanvasMessage) => {
       iframeRef.current?.contentWindow?.postMessage(msg, "*");
     };
@@ -192,6 +203,14 @@ export function FreeformCanvas({
       // isolation boundary).
       sandbox="allow-scripts"
       srcDoc={srcDoc}
+      // Race-free init: by `load`, the iframe's module bootstrap has executed
+      // (so its message listener is registered and "ready" already posted), so
+      // posting init here reliably delivers the code — even if the one-shot
+      // "ready" message was missed. Re-posting is idempotent (mountSeq dedupes).
+      onLoad={() => {
+        readyRef.current = true;
+        postInit();
+      }}
       className="w-full border-0 bg-white"
       style={{ height: height ? `${height}px` : "100%", minHeight: "100%" }}
     />


### PR DESCRIPTION
## Problem

When you click to view a canvas, it renders **blank**. Opening a *different* canvas works, and going back to the first one then renders it. Only the **first canvas of a session** is affected.

## Root cause

A lossy one-shot handshake between the host and the sandboxed canvas iframe:

- The iframe bootstrap (`sandboxRuntime.ts`) posts a single `"ready"` message when its module finishes.
- The host listened for `"ready"` in a **passive `useEffect`** and only then posted `init` — the message carrying the canvas `code`. Until `init`, the iframe shows nothing. No retry, no ack.
- Passive effects run *after paint*; the iframe's srcDoc parse + module exec is also async after commit. They race. On a **cold** first open the route chunk loads lazily and the main thread is busy, so the listener attaches late and the iframe's one-shot `"ready"` fires first → **missed → blank forever**.
- Warm navigations win the race (chunk cached), so subsequent canvases work. Each canvas remounts a fresh iframe, so readiness isn't shared — only the cold first open loses.

## Fix

All in `packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx`:

1. **Drive `init` from the iframe `load` event** — by `load`, the bootstrap module has executed (listener registered, `"ready"` posted), so posting `init` here reliably delivers the code regardless of message timing. Re-posting is idempotent (`mountSeq` dedupes in the iframe).
2. **Attach the host `message` listener via `useLayoutEffect`** — runs during commit, before the browser yields to the iframe load task. Also prevents early `data-request`/`error`/`resize` messages from being dropped.
3. Switch the `srcDoc`-reset effect to `useLayoutEffect` for consistent ordering on reload.

> Note: `key={dashboardId}` was a tempting "stale instance" fix but is wrong — the bug is on *fresh mount*, not instance reuse; keying would make every navigation a cold mount and worse.

## Testing

- Cold reload → click first canvas → renders immediately (previously blank). ✅
- Second canvas + back to first → both render. ✅
- Hard-refresh directly on a canvas URL → renders. ✅
- Edit-mode generation / analytics-driven srcDoc reload still re-deliver code on `load`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*