### PR TITLE
Make freeform canvases respond to light/dark theme

### DIFF
--- a/packages/core/src/canvas/canvasTemplates.ts
+++ b/packages/core/src/canvas/canvasTemplates.ts
@@ -56,6 +56,12 @@ const FREEFORM_STYLE = [
   "- You may use inline `style` objects, `@posthog/quill` components, or a `<style>` block in your JSX. Write real, specific copy — never lorem ipsum.",
   "- Build ANYTHING the user asks: dashboards, tools, forms, reports, small apps. Keep it self-contained in the one file.",
   "",
+  "THEME (light / dark) — the canvas renders in the user's current PostHog theme, and that can switch at runtime. The host puts a `.dark` class on the document root in dark mode (exactly like the main app), so your styles MUST adapt to both:",
+  "- Prefer `@posthog/quill` components and the design tokens — they already flip between light and dark automatically, so you get correct theming for free.",
+  "- For any custom styling, derive colors from the Quill CSS variables — e.g. `var(--background)`, `var(--foreground)`, `var(--card)`, `var(--card-foreground)`, `var(--border)`, `var(--muted-foreground)`, `var(--primary)` — or the matching Tailwind token utilities (`bg-background`, `text-foreground`, `bg-card`, `border-border`, `text-muted-foreground`). These all track the theme.",
+  "- NEVER hardcode a light-only color (e.g. `#fff`, `#111`, `color: black`, `background: white`) — it looks broken in the other theme. If you must special-case dark mode, use the `dark:` Tailwind variant (e.g. `className=\"bg-white dark:bg-zinc-900\"`), which is wired to the `.dark` class.",
+  "- recharts strokes/fills must use the token CSS variables too (e.g. `stroke=\"var(--primary)\"`, grid/axis in `var(--border)` / `var(--muted-foreground)`) so charts adapt as well.",
+  "",
   "Do NOT write files, edit code on disk, or run shell commands. Your entire app is the single fenced tsx block in your reply.",
 ];
 

--- a/packages/core/src/canvas/canvasTemplates.ts
+++ b/packages/core/src/canvas/canvasTemplates.ts
@@ -59,8 +59,8 @@ const FREEFORM_STYLE = [
   "THEME (light / dark) — the canvas renders in the user's current PostHog theme, and that can switch at runtime. The host puts a `.dark` class on the document root in dark mode (exactly like the main app), so your styles MUST adapt to both:",
   "- Prefer `@posthog/quill` components and the design tokens — they already flip between light and dark automatically, so you get correct theming for free.",
   "- For any custom styling, derive colors from the Quill CSS variables — e.g. `var(--background)`, `var(--foreground)`, `var(--card)`, `var(--card-foreground)`, `var(--border)`, `var(--muted-foreground)`, `var(--primary)` — or the matching Tailwind token utilities (`bg-background`, `text-foreground`, `bg-card`, `border-border`, `text-muted-foreground`). These all track the theme.",
-  "- NEVER hardcode a light-only color (e.g. `#fff`, `#111`, `color: black`, `background: white`) — it looks broken in the other theme. If you must special-case dark mode, use the `dark:` Tailwind variant (e.g. `className=\"bg-white dark:bg-zinc-900\"`), which is wired to the `.dark` class.",
-  "- recharts strokes/fills must use the token CSS variables too (e.g. `stroke=\"var(--primary)\"`, grid/axis in `var(--border)` / `var(--muted-foreground)`) so charts adapt as well.",
+  '- NEVER hardcode a light-only color (e.g. `#fff`, `#111`, `color: black`, `background: white`) — it looks broken in the other theme. If you must special-case dark mode, use the `dark:` Tailwind variant (e.g. `className="bg-white dark:bg-zinc-900"`), which is wired to the `.dark` class.',
+  '- recharts strokes/fills must use the token CSS variables too (e.g. `stroke="var(--primary)"`, grid/axis in `var(--border)` / `var(--muted-foreground)`) so charts adapt as well.',
   "",
   "Do NOT write files, edit code on disk, or run shell commands. Your entire app is the single fenced tsx block in your reply.",
 ];

--- a/packages/core/src/canvas/dashboardSchemas.ts
+++ b/packages/core/src/canvas/dashboardSchemas.ts
@@ -91,6 +91,12 @@ export const saveFreeformInput = z.object({
 
 export const dashboardIdInput = z.object({ id: z.string().min(1) });
 
+// Rename a canvas (changes the last path segment, i.e. its display title).
+export const renameDashboardInput = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+});
+
 // Set (or clear, when taskId is null) the canvas's generation-task association.
 // Stored in the row's meta so every client polling the canvas sees the run.
 export const setGenerationTaskInput = z.object({

--- a/packages/core/src/canvas/dashboardsService.test.ts
+++ b/packages/core/src/canvas/dashboardsService.test.ts
@@ -59,3 +59,49 @@ describe("DashboardsService.list", () => {
     expect(result[0]).toMatchObject({ name: "Newer", channelId: "chan-1" });
   });
 });
+
+// Fake exposing getEntry (resolves the row to rename) + fetch (the PATCH).
+function fakeFsForRename(entry: FsEntryBase) {
+  const fetch = vi.fn(async (_path: string, init?: RequestInit) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      ...entry,
+      path: JSON.parse((init?.body as string) ?? "{}").path ?? entry.path,
+    }),
+  }));
+  const fs = {
+    getEntry: async () => entry,
+    fetch,
+  };
+  return { fs: fs as unknown as DesktopFsClient, fetch };
+}
+
+describe("DashboardsService.rename", () => {
+  it("PATCHes a new last path segment built from the name", async () => {
+    const entry = dashboardRow("d1", "Untitled canvas", "chan-1", 100);
+    const { fs, fetch } = fakeFsForRename(entry);
+    const service = new DashboardsService(fs, {} as never);
+
+    const result = await service.rename({ id: "d1", name: "Churn by plan" });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, init] = fetch.mock.calls[0];
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse((init?.body as string) ?? "{}").path).toBe(
+      "Channels/chan-1/Churn by plan",
+    );
+    expect(result.name).toBe("Churn by plan");
+  });
+
+  it("no-ops (no fetch) when the name resolves to the same path", async () => {
+    const entry = dashboardRow("d1", "Same name", "chan-1", 100);
+    const { fs, fetch } = fakeFsForRename(entry);
+    const service = new DashboardsService(fs, {} as never);
+
+    const result = await service.rename({ id: "d1", name: "Same name" });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.name).toBe("Same name");
+  });
+});

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -195,6 +195,25 @@ export class DashboardsService {
     return toRecord((await res.json()) as FsEntry);
   }
 
+  // Rename a canvas by rewriting the last path segment (the title). Touches only
+  // the path, leaving meta (code/versions/etc.) intact — used to auto-name a
+  // freshly-created canvas from its generation prompt.
+  async rename(input: { id: string; name: string }): Promise<DashboardRecord> {
+    const entry = await this.getEntry(input.id);
+    if (!entry) throw new Error("Dashboard not found");
+    const parent = parentPath(entry.path);
+    const next = sanitizeSegment(input.name);
+    const newPath = parent ? `${parent}/${next}` : next;
+    if (newPath === entry.path) return toRecord(entry);
+    const res = await this.fs.fetch(`${encodeURIComponent(input.id)}/`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: newPath }),
+    });
+    if (!res.ok) throw new Error(`Failed to rename canvas (${res.status})`);
+    return toRecord((await res.json()) as FsEntry);
+  }
+
   async delete(id: string): Promise<void> {
     const res = await this.fs.fetch(`${encodeURIComponent(id)}/`, {
       method: "DELETE",

--- a/packages/core/src/canvas/freeformSchemas.ts
+++ b/packages/core/src/canvas/freeformSchemas.ts
@@ -138,6 +138,13 @@ export const canvasAnalyticsConfigSchema = z.object({
 });
 export type CanvasAnalyticsConfig = z.infer<typeof canvasAnalyticsConfigSchema>;
 
+// The light/dark appearance the host wants the canvas to render in. Mirrors the
+// host's resolved theme (system preference already collapsed to light/dark).
+// The iframe toggles a `.dark` class on its document root from this — the same
+// mechanism the main app uses — so Quill's CSS tokens and `dark:` utilities flip.
+export const canvasThemeSchema = z.enum(["light", "dark"]);
+export type CanvasTheme = z.infer<typeof canvasThemeSchema>;
+
 // host -> iframe
 export const hostToCanvasMessageSchema = z.discriminatedUnion("type", [
   // First frame: hand the iframe its source + the run mode. The iframe does not
@@ -151,6 +158,9 @@ export const hostToCanvasMessageSchema = z.discriminatedUnion("type", [
     mode: z.enum(["edit", "view"]),
     // Present when analytics/replay should run in the iframe. Absent = no capture.
     analytics: canvasAnalyticsConfigSchema.optional(),
+    // The appearance to render in. Re-sent (like `code`) when the host theme
+    // changes, so the canvas tracks light/dark live. Absent = light.
+    theme: canvasThemeSchema.optional(),
   }),
   // Reply to a data-request, correlated by `id`.
   z.object({

--- a/packages/core/src/canvas/services.ts
+++ b/packages/core/src/canvas/services.ts
@@ -43,6 +43,7 @@ export interface IDashboardsService {
     id: string;
     taskId: string | null;
   }): Promise<DashboardRecord>;
+  rename(input: { id: string; name: string }): Promise<DashboardRecord>;
   delete(id: string): Promise<void>;
 }
 

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -64,6 +64,31 @@ Title examples:
 
 Never include any explanation outside the TITLE and SUMMARY lines.`;
 
+// Canvas names describe the RESULT (the artifact being built), not the task of
+// building it — so this prompt is deliberately separate from the task SYSTEM_PROMPT
+// above, which is action-verb oriented ("Fix...", "Create..."). Don't merge them.
+const CANVAS_NAME_SYSTEM_PROMPT = `You name a data canvas (a small dashboard/chart app) from a description of what to build. Output ONLY the name, on a single line, with nothing else.
+
+The name describes the RESULT — the thing the canvas shows — as a short noun phrase. It is NOT a description of the task of building it.
+
+Rules:
+- 2-5 words, fewer is better. No trailing punctuation.
+- Describe what the canvas shows, never the action. NEVER start with a verb like Create, Make, Build, Add, Generate, Show, Display.
+- Use sentence case (capitalize only the first word and proper nouns).
+- Keep exact: event names, property names, numbers, filenames.
+- Never wrap the name in quotes.
+- Only output "Untitled canvas" if the input is completely empty/missing.
+
+Examples:
+- "Make a canvas with one chart showing the number of users who performed signed_up events over the last 30 days." → Signed_up users
+- "Build a dashboard of weekly revenue broken down by plan" → Weekly revenue by plan
+- "Show me a funnel from pageview to purchase" → Pageview to purchase funnel
+- "create a chart of daily active users" → Daily active users
+- "retention curve for new signups" → New signup retention
+- "a table of the top 10 pages by views this week" → Top pages by views
+
+Never include any explanation — output only the name.`;
+
 export interface TitleAndSummary {
   title: string;
   summary: string;
@@ -154,6 +179,35 @@ export class TitleGeneratorService {
       return { title, summary };
     } catch (error) {
       this.log.error("Failed to generate title and summary", { error });
+      return null;
+    }
+  }
+
+  // Name a canvas from its generation prompt — a short noun phrase describing
+  // the result (e.g. "Signed_up users"), not the task of building it. Separate
+  // from generateTitleAndSummary so the task-title behaviour is untouched.
+  async generateCanvasName(content: string): Promise<string | null> {
+    try {
+      const result = await this.llmGateway.prompt(
+        [
+          {
+            role: "user",
+            content: `Name the canvas described below. Do NOT build it, respond to it, or help with it — output ONLY the name.\n\n<description>\n${content}\n</description>\n\nOutput the name now:`,
+          },
+        ],
+        { system: CANVAS_NAME_SYSTEM_PROMPT, model: HELPER_GATEWAY_MODEL },
+      );
+
+      const name = result.content
+        .trim()
+        .split("\n")[0]
+        .replace(/^["']|["']$/g, "")
+        .trim()
+        .slice(0, 255);
+
+      return name || null;
+    } catch (error) {
+      this.log.error("Failed to generate canvas name", { error });
       return null;
     }
   }

--- a/packages/host-router/src/routers/dashboards.router.ts
+++ b/packages/host-router/src/routers/dashboards.router.ts
@@ -4,6 +4,7 @@ import {
   dashboardRecordSchema,
   dashboardSummarySchema,
   listDashboardsInput,
+  renameDashboardInput,
   saveFreeformInput,
   setGenerationTaskInput,
 } from "@posthog/core/canvas/dashboardSchemas";
@@ -48,6 +49,12 @@ export const dashboardsRouter = router({
       ctx.container
         .get<IDashboardsService>(DASHBOARDS_SERVICE)
         .setGenerationTask(input),
+    ),
+  rename: publicProcedure
+    .input(renameDashboardInput)
+    .output(dashboardRecordSchema)
+    .mutation(({ ctx, input }) =>
+      ctx.container.get<IDashboardsService>(DASHBOARDS_SERVICE).rename(input),
     ),
   delete: publicProcedure
     .input(dashboardIdInput)

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
@@ -5,6 +5,7 @@ import {
   type HostToCanvasMessage,
 } from "@posthog/core/canvas/freeformSchemas";
 import { logger } from "@posthog/ui/shell/logger";
+import { useThemeStore } from "@posthog/ui/shell/themeStore";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { buildSandboxDocument, type SandboxMode } from "./sandboxRuntime";
 
@@ -53,6 +54,9 @@ export function FreeformCanvas({
 }: FreeformCanvasProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState<number | null>(null);
+  // The canvas mirrors the host's light/dark theme. Passed via `init` (not the
+  // srcDoc) so a theme switch updates the running canvas in place, like `code`.
+  const theme = useThemeStore((s) => (s.isDarkMode ? "dark" : "light"));
   // Whether the iframe has announced it's ready for `init`. A ref, not state: it
   // only gates an imperative postMessage and is never shown on screen, so it
   // shouldn't trigger re-renders.
@@ -77,6 +81,7 @@ export function FreeformCanvas({
     code,
     mode,
     analytics,
+    theme,
   });
   latest.current = {
     onDataRequest,
@@ -85,6 +90,7 @@ export function FreeformCanvas({
     code,
     mode,
     analytics,
+    theme,
   };
 
   const postInit = useCallback(() => {
@@ -96,6 +102,7 @@ export function FreeformCanvas({
         code: p.code,
         mode: p.mode,
         analytics: p.analytics,
+        theme: p.theme,
       },
       "*",
     );
@@ -178,10 +185,10 @@ export function FreeformCanvas({
   useEffect(() => {
     if (!readyRef.current) return;
     iframeRef.current?.contentWindow?.postMessage(
-      { channel: "posthog-canvas", type: "init", code, mode, analytics },
+      { channel: "posthog-canvas", type: "init", code, mode, analytics, theme },
       "*",
     );
-  }, [code, mode, analytics]);
+  }, [code, mode, analytics, theme]);
 
   return (
     <iframe
@@ -192,7 +199,9 @@ export function FreeformCanvas({
       // isolation boundary).
       sandbox="allow-scripts"
       srcDoc={srcDoc}
-      className="w-full border-0 bg-white"
+      // bg tracks the host theme so there's no white flash in dark mode before
+      // the iframe paints; the canvas body uses the same --background token.
+      className="w-full border-0 bg-background"
       style={{ height: height ? `${height}px` : "100%", minHeight: "100%" }}
     />
   );

--- a/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -55,6 +55,10 @@ export function buildSandboxDocument(
   // calendar's \`bg-fill-hover\`, \`bg-fill-selected\`), so every token Quill maps
   // must be here or the component renders half-styled.
   corePlugins: { preflight: false },
+  // Drive \`dark:\` utilities off the \`.dark\` class (which the host toggles via
+  // the init theme), NOT prefers-color-scheme — so the canvas follows the user's
+  // PostHog theme, matching the main app, even when it differs from the OS.
+  darkMode: "class",
   plugins: [
     // Quill authors for Tailwind v4; \`not-disabled:\` is a v4 variant the Play
     // CDN (v3) lacks. The calendar uses \`not-disabled:hover:bg-fill-hover\`, so
@@ -165,6 +169,13 @@ export function buildSandboxDocument(
       }
     };
 
+    // --- theme: mirror the host's light/dark by toggling \`.dark\` on the root,
+    // exactly as the main app does. Quill's CSS tokens (:root / .dark) and the
+    // \`dark:\` Tailwind utilities both key off this class, so the whole canvas
+    // flips. Re-applied on every init, so a host theme change updates live.
+    const applyTheme = (theme) =>
+      document.documentElement.classList.toggle("dark", theme === "dark");
+
     // --- error reporting (feeds the host's self-repair loop) ---
     const reportError = (message, stack) =>
       post({ type: "error", message: String(message ?? "Unknown error"), stack });
@@ -257,6 +268,7 @@ export function buildSandboxDocument(
       const d = e.data;
       if (!d || d.channel !== CHANNEL) return;
       if (d.type === "init") {
+        applyTheme(d.theme);
         if (d.analytics) void bootAnalytics(d.analytics);
         void mount(d.code);
       } else if (d.type === "data-response") {
@@ -283,7 +295,9 @@ ${FREEFORM_QUILL_CSS_URLS.map(
 <style>
   *, *::before, *::after { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
-  body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; color: #111; background: #fff; }
+  /* Track the theme via Quill's tokens (set on :root / .dark) so the page chrome
+     flips with the host theme; fall back to light if the tokens haven't loaded. */
+  body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; color: var(--foreground, #111); background: var(--background, #fff); }
   #root { min-height: 100vh; }
 </style>
 </head>

--- a/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -13,6 +13,17 @@ import { useCallback } from "react";
 
 const log = logger.scope("dashboards");
 
+// Default name for a canvas created without one. Also the marker we use to
+// detect a still-unnamed canvas worth auto-naming from its generation prompt.
+export const UNTITLED_CANVAS_NAME = "Untitled canvas";
+
+// True when a canvas name is a placeholder (never user-chosen), so auto-naming
+// from a generation prompt is safe and won't clobber a real title.
+export function isPlaceholderCanvasName(name: string): boolean {
+  const trimmed = name.trim();
+  return trimmed === UNTITLED_CANVAS_NAME || trimmed === "Untitled dashboard";
+}
+
 /** Saved canvases for a channel (file-backed freeform React apps). */
 export function useDashboards(channelId: string | undefined): {
   dashboards: DashboardSummary[];
@@ -86,6 +97,9 @@ export function useDashboardMutations() {
       onSuccess: invalidate,
     }),
   );
+  const rename = useMutation(
+    trpc.dashboards.rename.mutationOptions({ onSuccess: invalidate }),
+  );
 
   return {
     createDashboard: (channelId: string, name: string, templateId?: string) =>
@@ -95,6 +109,10 @@ export function useDashboardMutations() {
     // meta so every client polling the canvas sees the in-flight generation.
     setGenerationTask: (id: string, taskId: string | null) =>
       setGenerationTask.mutateAsync({ id, taskId }),
+    // Rename a canvas (changes its display title). Used to auto-name a freshly
+    // created canvas from its generation prompt.
+    renameDashboard: (id: string, name: string) =>
+      rename.mutateAsync({ id, name }),
     // Explicitly persist a freeform canvas's current code + history (autosave
     // already runs each turn; this is the manual Save affordance).
     saveFreeformDashboard: (
@@ -143,7 +161,7 @@ export function useCreateAndOpenDashboard(
     async (opts) => {
       if (!channelId) return;
       const templateId = opts?.templateId ?? "freeform";
-      const name = opts?.name ?? "Untitled canvas";
+      const name = opts?.name ?? UNTITLED_CANVAS_NAME;
       try {
         const record = await createDashboard(channelId, name, templateId);
         setEditing(record.id, true);

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -95,9 +95,9 @@ export function useGenerateFreeformCanvas(args: {
         // who already named the canvas) leaves the existing title untouched.
         if (isPlaceholderCanvasName(name)) {
           void titleGenerator
-            .generateTitleAndSummary(opts.instruction)
-            .then(async (res) => {
-              const title = res?.title?.trim();
+            .generateCanvasName(opts.instruction)
+            .then(async (generated) => {
+              const title = generated?.trim();
               if (title) await renameDashboard(dashboardId, title);
             })
             .catch(() => {});

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -1,3 +1,5 @@
+import { TITLE_GENERATOR_SERVICE } from "@posthog/core/sessions/titleGeneratorIdentifiers";
+import type { TitleGeneratorService } from "@posthog/core/sessions/titleGeneratorService";
 import {
   TASK_SERVICE,
   type TaskService,
@@ -5,7 +7,10 @@ import {
 import { useService } from "@posthog/di/react";
 import { buildFreeformGenerationPrompt } from "@posthog/ui/features/canvas/freeformPrompt";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
-import { useDashboardMutations } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import {
+  isPlaceholderCanvasName,
+  useDashboardMutations,
+} from "@posthog/ui/features/canvas/hooks/useDashboards";
 import type { GenerateContextTarget } from "@posthog/ui/features/canvas/hooks/useGenerateContext";
 import { useCreateTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
 import { toast } from "@posthog/ui/primitives/toast";
@@ -30,9 +35,12 @@ export function useGenerateFreeformCanvas(args: {
 }) {
   const { dashboardId, channelId, name, channelName, templateId } = args;
   const taskService = useService<TaskService>(TASK_SERVICE);
+  const titleGenerator = useService<TitleGeneratorService>(
+    TITLE_GENERATOR_SERVICE,
+  );
   const { invalidateTasks } = useCreateTask();
   const { fileTask } = useChannelTaskMutations();
-  const { setGenerationTask } = useDashboardMutations();
+  const { setGenerationTask, renameDashboard } = useDashboardMutations();
   const [isStarting, setIsStarting] = useState(false);
 
   const generate = useCallback(
@@ -82,6 +90,18 @@ export function useGenerateFreeformCanvas(args: {
         // are best-effort: a failure here shouldn't undo a started task.
         void fileTask(channelId, task.id, task.title).catch(() => {});
         void setGenerationTask(dashboardId, task.id).catch(() => {});
+        // Auto-name a still-unnamed canvas from its generation prompt, using the
+        // same helper model that names tasks. Best-effort: a failure (or a user
+        // who already named the canvas) leaves the existing title untouched.
+        if (isPlaceholderCanvasName(name)) {
+          void titleGenerator
+            .generateTitleAndSummary(opts.instruction)
+            .then(async (res) => {
+              const title = res?.title?.trim();
+              if (title) await renameDashboard(dashboardId, title);
+            })
+            .catch(() => {});
+        }
         return task.id;
       } finally {
         setIsStarting(false);
@@ -89,9 +109,11 @@ export function useGenerateFreeformCanvas(args: {
     },
     [
       taskService,
+      titleGenerator,
       invalidateTasks,
       fileTask,
       setGenerationTask,
+      renameDashboard,
       dashboardId,
       channelId,
       name,


### PR DESCRIPTION
## Problem

Agents building freeform canvases (project-bluebird) couldn't make them respond to the user's light/dark preference. Canvases render in a sandboxed iframe and we already inject code into it for event tracking and query fetching — but not the theme — so a canvas always rendered light regardless of the user's PostHog theme.

**Why:** so agent-built canvases match the rest of the app and adapt to the user's light/dark preference.

## Changes

- Inject the host's resolved theme into the iframe on the `init` message (next to `code`/`analytics`), and toggle the `.dark` class on the iframe root — the same mechanism the main app uses, so Quill tokens and `dark:` utilities flip. Re-sent on theme change, so a running canvas updates in place without reload.
- Update the freeform agent prompt to instruct the canvas to adapt to both themes (prefer Quill components/tokens, use CSS variables / token utilities, never hardcode light-only colors, theme recharts via tokens).
- Set `darkMode: "class"` in the in-iframe Tailwind config and switch the sandbox body + iframe backgrounds to theme tokens (avoids a white flash in dark mode).

## How did you test this?

- `@biomejs/biome lint` on the changed canvas dirs — clean.
- `@posthog/core` and `@posthog/ui` typecheck — no errors in the canvas/freeform/themeStore files I touched (remaining errors are pre-existing unbuilt-dependency noise in this environment).
- `@posthog/core` unit tests — all pass.
- Not yet verified visually in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
