### PR TITLE
test(updates): macOS auto-update E2E test pipeline with real install + relaunch

### DIFF
--- a/.claude/skills/test-electron-app/SKILL.md
+++ b/.claude/skills/test-electron-app/SKILL.md
@@ -50,17 +50,18 @@ pnpm build:deps                        # turbo build of @posthog/code deps
 tail -f /dev/null | pnpm dev:code      # run in the background; leave it running
 ```
 
-`pnpm dev:code` is `electron-forge start -- --remote-debugging-port=9222` — just
-the app, no TUI and no watch rebuilders (fine for screenshotting/interacting).
+`pnpm dev:code` is `pnpm --filter code start`, i.e. `electron-vite dev --watch` — just
+the app, no `phrocs` TUI; it watches and rebuilds main/preload and hot-reloads the
+renderer (fine for screenshotting/interacting). The CDP port (`:9222`) is opened by
+the app itself in dev (the `remote-debugging-port` switch in
+`apps/code/src/main/bootstrap.ts`), not by a CLI flag.
 
-**The `tail -f /dev/null |` is required, do not drop it.** `electron-forge start`
-runs an interactive "type `rs` to restart" stdin reader. With no stdin it hits
-EOF immediately, treats that as quit, tears down the Electron window, and exits
-**0** before the CDP port ever opens — so the app looks like it launched
-("✔ Launched Electron app") and then silently vanishes. Piping from
-`tail -f /dev/null` gives it a stdin that never closes, so it stays up. A
-pseudo-TTY via `script` does **not** help: `script` forwards the EOF (`^D`) and
-the app still quits.
+The `tail -f /dev/null |` prefix is a harmless guard and no longer strictly required.
+The old `electron-forge start` ran an interactive "type `rs` to restart" stdin reader
+that hit EOF in a no-stdin shell, treated it as quit, and tore the Electron window
+down before the CDP port ever opened. `electron-vite dev` has no such reader, so a
+backgrounded `pnpm dev:code` with no stdin stays up on its own; keeping the pipe does
+no harm.
 
 Then wait for the port and connect (poll, don't sleep blindly):
 
@@ -113,7 +114,7 @@ rm -f /tmp/posthog-dev-lastuse
 ```
 
 Group-killing the launcher (`kill -TERM -PGID`) takes down `tail`, `pnpm`,
-`electron-forge` and Electron together, so nothing — not even the
+`electron-vite` and Electron together, so nothing — not even the
 `tail -f /dev/null` stdin pipe — lingers. Matching `remote-debugging-port=9222`
 hits only your dev instance (prod has no debug port and a separate
 `posthog-code-dev` profile), so it never touches the user's app. Verify with
@@ -212,11 +213,12 @@ PostHog Code orchestrates the agent, so the usual loop is: **prod** (the install
 - **Connection refused on :9222:** the app isn't running with the debug flag.
   Start it (see *Launching the app yourself* for the headless recipe). Verify the
   port: `lsof -i :9222` or `curl -s localhost:9222/json/version`.
-- **App launches then immediately exits 0; CDP never opens:** you started it with
-  no stdin (background / no TTY) and `electron-forge` quit on stdin EOF. Relaunch
-  with `tail -f /dev/null | pnpm dev:code` so stdin never closes (see *Launching
-  the app yourself*). Note `pnpm dev` cannot run headlessly at all — its `phrocs`
-  TUI needs a TTY; use `pnpm dev:code`.
+- **App launches then immediately exits; CDP never opens:** the old `electron-forge`
+  "quit on stdin EOF" behavior is gone under `electron-vite`, so the
+  `tail -f /dev/null |` prefix is optional and not the fix here. This is now usually a
+  build error, the single-instance lock (another dev instance running) or a crash —
+  check the `pnpm dev:code` output. Note `pnpm dev` cannot run headlessly at all — its
+  `phrocs` TUI needs a TTY; use `pnpm dev:code`.
 - **Snapshot is empty / wrong window:** you're on the wrong target. Run
   `agent-browser tab` and switch to the "PostHog Code" page.
 - **Can't type into an input:** try `agent-browser keyboard type "text"` (types at

--- a/.github/workflows/code-build-test.yml
+++ b/.github/workflows/code-build-test.yml
@@ -90,6 +90,12 @@ jobs:
           pnpm --filter @posthog/enricher run build
           pnpm --filter @posthog/agent run build
 
+      # build/Assets.car is gitignored; regenerate it so the packaged app ships
+      # the liquid-glass icon (the script falls back to .icns if actool fails).
+      - name: Compile macOS liquid-glass icon
+        working-directory: apps/code
+        run: bash scripts/compile-glass-icon.sh
+
       - name: Build app
         env:
           MATRIX_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -143,6 +143,12 @@ jobs:
       - name: Build agent package
         run: pnpm --filter @posthog/agent run build
 
+      # build/Assets.car is gitignored; regenerate it on the runner so the packaged
+      # app ships the liquid-glass icon (the script falls back to .icns if actool fails).
+      - name: Compile macOS liquid-glass icon
+        working-directory: apps/code
+        run: bash scripts/compile-glass-icon.sh
+
       - name: Build release artifacts
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
@@ -235,6 +241,9 @@ jobs:
       NODE_ENV: production
       VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
       VITE_POSTHOG_API_HOST: ${{ secrets.VITE_POSTHOG_API_HOST }}
+      POSTHOG_SOURCEMAP_API_KEY: ${{ secrets.POSTHOG_SOURCEMAP_API_KEY }}
+      POSTHOG_ENV_ID: ${{ secrets.POSTHOG_ENV_ID }}
+      POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
     steps:
       - name: Get app token
         id: app-token
@@ -349,6 +358,9 @@ jobs:
       NODE_ENV: production
       VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
       VITE_POSTHOG_API_HOST: ${{ secrets.VITE_POSTHOG_API_HOST }}
+      POSTHOG_SOURCEMAP_API_KEY: ${{ secrets.POSTHOG_SOURCEMAP_API_KEY }}
+      POSTHOG_ENV_ID: ${{ secrets.POSTHOG_ENV_ID }}
+      POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
     steps:
       - name: Get app token
         id: app-token

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -89,16 +89,28 @@ jobs:
       - name: Run macOS update E2E
         working-directory: apps/code
         env:
-          RUN_UPDATE_E2E: "1"
-        run: pnpm exec playwright test --config=tests/e2e/playwright.config.ts tests/e2e/tests/update.spec.ts
+          PLAYWRIGHT_JSON_OUTPUT_NAME: out/update-report.json
+        run: |
+          pnpm exec playwright test --config=tests/e2e/playwright.update.config.ts
+          node -e '
+            const r = require("./out/update-report.json");
+            const s = r.stats || {};
+            console.log("update e2e stats:", JSON.stringify(s));
+            if (s.expected !== 1 || s.skipped || s.unexpected || s.flaky) {
+              console.error("FAIL: expected exactly one passing update test");
+              process.exit(1);
+            }
+          '
 
-      - name: Upload report and logs on failure
-        if: failure()
+      - name: Upload report and logs
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: update-e2e-macos
           path: |
-            apps/code/playwright-report/
             apps/code/playwright-results/
+            apps/code/out/update-report.json
             /Users/runner/.posthog-code/logs/
+            /Users/runner/Library/Caches/com.posthog.array.ShipIt/
+          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -89,11 +89,11 @@ jobs:
       - name: Run macOS update E2E
         working-directory: apps/code
         env:
-          PLAYWRIGHT_JSON_OUTPUT_NAME: out/update-report.json
+          PLAYWRIGHT_JSON_OUTPUT_NAME: ${{ github.workspace }}/apps/code/out/update-report.json
         run: |
           pnpm exec playwright test --config=tests/e2e/playwright.update.config.ts
           node -e '
-            const r = require("./out/update-report.json");
+            const r = require(process.env.GITHUB_WORKSPACE + "/apps/code/out/update-report.json");
             const s = r.stats || {};
             console.log("update e2e stats:", JSON.stringify(s));
             if (s.expected !== 1 || s.skipped || s.unexpected || s.flaky) {

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -5,6 +5,12 @@ name: Code Update E2E (macOS)
 # through download -> install -> Squirrel.Mac swap -> relaunch and assert the
 # installed app became 2.0.0. Nightly and on demand only, never on PRs: it builds
 # twice and exercises a real install, so it is too slow and too flaky for the gate.
+#
+# Two legs run against the same new (2.0.0) feed:
+#   1. electron-builder -> electron-builder: the forward-compatibility baseline.
+#   2. Forge -> electron-builder: a real Electron Forge build (v0.55.132, the last
+#      Forge release, what users run today) updating via the genuine built-in
+#      Squirrel.Mac client to the electron-builder build we ship now.
 
 on:
   # Temporary: also run on this branch so the harness can be exercised on the PR.
@@ -108,36 +114,63 @@ jobs:
             }
           '
 
-      - name: Render update proof summary
+      # Forge -> electron-builder leg. Built after the baseline leg so a flake in
+      # the (riskier) old-build step can never mask the baseline result.
+      - name: Build old Forge app (v0.55.132)
+        working-directory: apps/code
+        run: bash scripts/dev-update/build-old-forge.sh
+
+      - name: Run macOS Forge to builder update E2E
+        working-directory: apps/code
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: ${{ github.workspace }}/apps/code/out/update-forge-report.json
+        run: |
+          pnpm exec playwright test --config=tests/e2e/playwright.update-forge.config.ts
+          node -e '
+            const r = require(process.env.GITHUB_WORKSPACE + "/apps/code/out/update-forge-report.json");
+            const s = r.stats || {};
+            console.log("forge update e2e stats:", JSON.stringify(s));
+            if (s.expected !== 1 || s.skipped || s.unexpected || s.flaky) {
+              console.error("FAIL: expected exactly one passing forge update test");
+              process.exit(1);
+            }
+          '
+
+      - name: Render update proof summaries
         if: always()
         working-directory: apps/code
         run: |
           node -e '
             const fs = require("fs");
-            const p = "out/update-proof/proof.json";
-            if (!fs.existsSync(p)) { console.log("no proof file was written"); process.exit(0); }
-            const d = JSON.parse(fs.readFileSync(p, "utf8"));
-            const cell = (v) => v === undefined || v === null ? "-" : String(v).replace(/\|/g, "\\|").replace(/\n/g, " ");
-            const rows = [
-              ["Result", d.result],
-              ["Old version", d.oldVersion],
-              ["New version", d.newVersion],
-              ["Booted on", d.bootedOn],
-              ["Feed offered", d.feedAvailableVersion],
-              ["Downloaded", d.downloaded],
-              ["Bundle after swap", d.bundleVersionAfterSwap],
-              ["Auto-relaunched exe", d.autoRelaunchedExecutable],
-              ["Fresh launch version", d.freshLaunchVersion],
-              ["ShipIt cache", d.shipItExists ? (d.shipItEntries || []).join(", ") : "missing"],
-              ["Failed step", d.failedStep],
-              ["Error", d.error],
-              ["Finished", d.finishedAt],
+            const proofs = [
+              ["out/update-proof/proof.json", "macOS auto-update proof (builder -> builder)"],
+              ["out/update-proof-forge/proof.json", "macOS auto-update proof (Forge -> builder)"],
             ];
-            const md = ["## macOS auto-update proof: " + d.result, "", "| Check | Value |", "| --- | --- |"]
-              .concat(rows.map((r) => "| " + r[0] + " | " + cell(r[1]) + " |"))
-              .join("\n");
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + "\n");
-            console.log(md);
+            const cell = (v) => v === undefined || v === null ? "-" : String(v).replace(/\|/g, "\\|").replace(/\n/g, " ");
+            for (const [p, title] of proofs) {
+              if (!fs.existsSync(p)) { console.log("no proof file at " + p); continue; }
+              const d = JSON.parse(fs.readFileSync(p, "utf8"));
+              const rows = [
+                ["Result", d.result],
+                ["Old version", d.oldVersion],
+                ["New version", d.newVersion],
+                ["Booted on", d.bootedOn],
+                ["Feed offered", d.feedAvailableVersion],
+                ["Downloaded", d.downloaded],
+                ["Bundle after swap", d.bundleVersionAfterSwap],
+                ["Auto-relaunched exe", d.autoRelaunchedExecutable],
+                ["Fresh launch version", d.freshLaunchVersion],
+                ["ShipIt cache", d.shipItExists ? (d.shipItEntries || []).join(", ") : "missing"],
+                ["Failed step", d.failedStep],
+                ["Error", d.error],
+                ["Finished", d.finishedAt],
+              ];
+              const md = ["## " + title + ": " + d.result, "", "| Check | Value |", "| --- | --- |"]
+                .concat(rows.map((r) => "| " + r[0] + " | " + cell(r[1]) + " |"))
+                .join("\n");
+              fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + "\n\n");
+              console.log(md);
+            }
           '
 
       - name: Upload proof, report and logs
@@ -147,7 +180,9 @@ jobs:
           name: update-e2e-macos
           path: |
             apps/code/out/update-proof/
+            apps/code/out/update-proof-forge/
             apps/code/out/update-report.json
+            apps/code/out/update-forge-report.json
             apps/code/playwright-results/
             /Users/runner/.posthog-code/logs/
             /Users/runner/Library/Caches/com.posthog.array.ShipIt/
@@ -171,5 +206,14 @@ jobs:
         with:
           name: update-new-build-2.0.0
           path: apps/code/out/dev-update-feed/
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload old Forge build (v0.55.132)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: update-old-forge-build-1.0.0
+          path: apps/code/out/old-forge/
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -102,15 +102,68 @@ jobs:
             }
           '
 
-      - name: Upload report and logs
+      - name: Render update proof summary
+        if: always()
+        working-directory: apps/code
+        run: |
+          node -e '
+            const fs = require("fs");
+            const p = "out/update-proof/proof.json";
+            if (!fs.existsSync(p)) { console.log("no proof file was written"); process.exit(0); }
+            const d = JSON.parse(fs.readFileSync(p, "utf8"));
+            const cell = (v) => v === undefined || v === null ? "-" : String(v).replace(/\|/g, "\\|").replace(/\n/g, " ");
+            const rows = [
+              ["Result", d.result],
+              ["Old version", d.oldVersion],
+              ["New version", d.newVersion],
+              ["Booted on", d.bootedOn],
+              ["Feed offered", d.feedAvailableVersion],
+              ["Downloaded", d.downloaded],
+              ["Bundle after swap", d.bundleVersionAfterSwap],
+              ["Auto-relaunched exe", d.autoRelaunchedExecutable],
+              ["Fresh launch version", d.freshLaunchVersion],
+              ["ShipIt cache", d.shipItExists ? (d.shipItEntries || []).join(", ") : "missing"],
+              ["Failed step", d.failedStep],
+              ["Error", d.error],
+              ["Finished", d.finishedAt],
+            ];
+            const md = ["## macOS auto-update proof: " + d.result, "", "| Check | Value |", "| --- | --- |"]
+              .concat(rows.map((r) => "| " + r[0] + " | " + cell(r[1]) + " |"))
+              .join("\n");
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + "\n");
+            console.log(md);
+          '
+
+      - name: Upload proof, report and logs
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: update-e2e-macos
           path: |
-            apps/code/playwright-results/
+            apps/code/out/update-proof/
             apps/code/out/update-report.json
+            apps/code/playwright-results/
             /Users/runner/.posthog-code/logs/
             /Users/runner/Library/Caches/com.posthog.array.ShipIt/
           if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload old build (1.0.0)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: update-old-build-1.0.0
+          path: |
+            apps/code/out/PostHog-Code-1.0.0-arm64-mac.zip
+            apps/code/out/PostHog-Code-1.0.0-arm64-mac.zip.blockmap
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload new build feed (2.0.0)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: update-new-build-2.0.0
+          path: apps/code/out/dev-update-feed/
+          if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -1,0 +1,102 @@
+name: Code Update E2E (macOS)
+
+# Real macOS auto-update end to end: build a signed old (1.0.0) app and a signed
+# new (2.0.0) feed, serve the feed on localhost, then drive a packaged build
+# through download -> install -> Squirrel.Mac swap -> relaunch and assert the
+# installed app became 2.0.0. Nightly and on demand only, never on PRs: it builds
+# twice and exercises a real install, so it is too slow and too flaky for the gate.
+
+on:
+  # Temporary: also run on this branch so the harness can be exercised on the PR.
+  # Remove this push trigger once merged; nightly + dispatch is the steady state.
+  push:
+    branches:
+      - test/macos-auto-update-e2e
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: code-update-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-e2e-macos:
+    runs-on: macos-15
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
+      NODE_ENV: production
+      npm_config_arch: arm64
+      npm_config_platform: darwin
+      VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
+      VITE_POSTHOG_API_HOST: ${{ secrets.VITE_POSTHOG_API_HOST }}
+      # Sign both builds with the same identity so Squirrel.Mac accepts the swap.
+      # Notarization is skipped: it is a Gatekeeper concern, not what the in-place
+      # update verifies, and locally built bundles carry no quarantine attribute.
+      CSC_LINK: ${{ secrets.APPLE_CODESIGN_CERT_BASE64 }}
+      CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      SKIP_NOTARIZE: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_TWIG_APP_ASSETS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_TWIG_APP_ASSETS_REGION }}
+          mask-aws-account-id: true
+          unset-current-credentials: true
+
+      - name: Download BerkeleyMono fonts from S3
+        run: aws s3 cp s3://${{ secrets.AWS_TWIG_APP_ASSETS_BUCKET }}/fonts/BerkeleyMono/ apps/code/assets/fonts/BerkeleyMono/ --recursive
+
+      - name: Build workspace packages
+        run: |
+          pnpm --filter @posthog/electron-trpc run build
+          pnpm --filter @posthog/platform run build
+          pnpm --filter @posthog/shared run build
+          pnpm --filter @posthog/git run build
+          pnpm --filter @posthog/enricher run build
+          pnpm --filter @posthog/agent run build
+
+      - name: Build old + new update pair
+        working-directory: apps/code
+        run: bash scripts/dev-update/build-pair.sh
+
+      - name: Install Playwright
+        run: pnpm --filter code exec playwright install
+
+      - name: Run macOS update E2E
+        working-directory: apps/code
+        run: pnpm exec playwright test --config=tests/e2e/playwright.config.ts tests/e2e/tests/update.spec.ts
+
+      - name: Upload report and logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: update-e2e-macos
+          path: |
+            apps/code/playwright-report/
+            apps/code/playwright-results/
+            /Users/runner/.posthog-code/logs/
+          retention-days: 7

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -148,9 +148,11 @@ jobs:
       # (a full build) instead of a confusing swap failure in the Forge leg.
       - name: Build old Forge app if not cached
         working-directory: apps/code
+        env:
+          CACHE_HIT: ${{ steps.forge-cache.outputs.cache-hit }}
         run: |
           APP="out/old-forge/PostHog Code.app"
-          if [ "${{ steps.forge-cache.outputs.cache-hit }}" = "true" ] && codesign --verify --strict "$APP" 2>/dev/null; then
+          if [ "$CACHE_HIT" = "true" ] && codesign --verify --strict "$APP" 2>/dev/null; then
             echo "Reusing cached Forge app with a valid signature"
             codesign --verify --strict --verbose=2 "$APP"
           else

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -68,6 +68,22 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
+      - name: Cache Electron binary
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/Library/Caches/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            electron-${{ runner.os }}-
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -114,11 +130,33 @@ jobs:
             }
           '
 
-      # Forge -> electron-builder leg. Built after the baseline leg so a flake in
-      # the (riskier) old-build step can never mask the baseline result.
-      - name: Build old Forge app (v0.55.132)
+      # Forge -> electron-builder leg. The old Forge app is a fixed pinned build
+      # (cb0ca68db), byte-identical on every run, so cache it and skip the ~11 min
+      # rebuild that dominates this job. The key tracks the build script, which
+      # pins the ref; bump the script to force a rebuild. Built after the baseline
+      # leg so a flake in the (riskier) old-build step can never mask the baseline.
+      - name: Cache old Forge app (v0.55.132)
+        id: forge-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: apps/code/out/old-forge
+          key: forge-app-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/code/scripts/dev-update/build-old-forge.sh') }}
+
+      # Reuse the cached app only if its signature still verifies, otherwise rebuild.
+      # This makes a missing or tar-corrupted restore degrade to today's behaviour
+      # (a full build) instead of a confusing swap failure in the Forge leg.
+      - name: Build old Forge app if not cached
         working-directory: apps/code
-        run: bash scripts/dev-update/build-old-forge.sh
+        run: |
+          APP="out/old-forge/PostHog Code.app"
+          if [ "${{ steps.forge-cache.outputs.cache-hit }}" = "true" ] && codesign --verify --strict "$APP" 2>/dev/null; then
+            echo "Reusing cached Forge app with a valid signature"
+            codesign --verify --strict --verbose=2 "$APP"
+          else
+            echo "No usable cached Forge app; building from the pinned ref"
+            rm -rf out/old-forge
+            bash scripts/dev-update/build-old-forge.sh
+          fi
 
       - name: Run macOS Forge to builder update E2E
         working-directory: apps/code

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -9,9 +9,15 @@ name: Code Update E2E (macOS)
 on:
   # Temporary: also run on this branch so the harness can be exercised on the PR.
   # Remove this push trigger once merged; nightly + dispatch is the steady state.
+  # Docs and the local-only run-from-ci helper do not affect CI, so skip rebuilds
+  # for those and use workflow_dispatch / the nightly schedule on demand instead.
   push:
     branches:
       - test/macos-auto-update-e2e
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "apps/code/scripts/dev-update/run-from-ci.sh"
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Run macOS update E2E
         working-directory: apps/code
+        env:
+          RUN_UPDATE_E2E: "1"
         run: pnpm exec playwright test --config=tests/e2e/playwright.config.ts tests/e2e/tests/update.spec.ts
 
       - name: Upload report and logs on failure

--- a/.github/workflows/code-update-e2e.yml
+++ b/.github/workflows/code-update-e2e.yml
@@ -24,6 +24,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "apps/code/scripts/dev-update/run-from-ci.sh"
+      - "apps/code/scripts/dev-update/run-from-ci-forge.sh"
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:
@@ -247,11 +248,34 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      # upload-artifact follows symlinks and repacks them as real files, which
+      # breaks the framework layout and the code signature. ditto -c -k preserves
+      # both, so the pulled zip extracts to a bundle Squirrel still accepts (the
+      # same way the baseline old app travels). run-from-ci-forge.sh consumes this.
+      - name: Package old Forge app for upload
+        if: always()
+        working-directory: apps/code
+        run: |
+          APP="out/old-forge/PostHog Code.app"
+          ZIP="out/PostHog-Code-forge-1.0.0-arm64-mac.zip"
+          if [ ! -d "$APP" ]; then
+            echo "no Forge app to package (an earlier step likely failed); skipping"
+            exit 0
+          fi
+          ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
+          # Prove the zip round-trips to a still-valid signature, so the artifact
+          # run-from-ci-forge.sh pulls is usable and not silently corrupt.
+          VERIFY_DIR="$(mktemp -d)"
+          ditto -x -k "$ZIP" "$VERIFY_DIR"
+          codesign --verify --strict "$VERIFY_DIR/PostHog Code.app"
+          rm -rf "$VERIFY_DIR"
+          echo "OK: packaged Forge app zip verifies"
+
       - name: Upload old Forge build (v0.55.132)
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: update-old-forge-build-1.0.0
-          path: apps/code/out/old-forge/
+          path: apps/code/out/PostHog-Code-forge-1.0.0-arm64-mac.zip
           if-no-files-found: warn
           retention-days: 7

--- a/apps/code/README.md
+++ b/apps/code/README.md
@@ -68,7 +68,7 @@ pnpm build-native
 
 ### Auto Updates & Releases
 
-PostHog Code uses Electron's built-in `autoUpdater` pointed at the public `update.electronjs.org` service for `PostHog/code`. Every time a non-draft GitHub release is published with the platform archives, packaged apps will automatically download and install the newest version on macOS and Windows.
+PostHog Code auto-updates on macOS and Windows. Current builds use `electron-updater`, which reads the `latest-mac.yml` and `latest.yml` manifests published with each non-draft GitHub release and downloads the matching archive. Builds made by the old Electron Forge toolchain (`v0.55.x` and earlier) take a single bridge update through the public `update.electronjs.org` service, which serves the same GitHub releases to their built-in Squirrel client, and become `electron-updater` clients from the next launch. See [docs/UPDATES.md](../../docs/UPDATES.md) and [docs/AUTO-UPDATE-TESTING.md](../../docs/AUTO-UPDATE-TESTING.md).
 
 There are three ways a release can fire:
 

--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -6,7 +6,7 @@
   "main": ".vite/build/bootstrap.js",
   "versionHash": "dynamic",
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=22.12.0",
     "pnpm": ">=9.0.0"
   },
   "scripts": {

--- a/apps/code/scripts/dev-update/build-old-forge.sh
+++ b/apps/code/scripts/dev-update/build-old-forge.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Build the LAST Electron Forge release (v0.55.132 / cb0ca68db) as the "old"
+# side of the Forge -> electron-builder auto-update E2E.
+#
+# The point of this test is the genuine built-in Squirrel.Mac client that real
+# users are running today. That client only exists in a real Forge build, so the
+# old app must be built from the pinned Forge commit, not rebuilt with
+# electron-builder. We:
+#   1. Check the pinned tag out into an isolated git worktree.
+#   2. Apply a one-line env seam so the old build asks our local feed instead of
+#      update.electronjs.org (POSTHOG_E2E_UPDATE_HOST). Nothing else in the
+#      download/verify/swap path changes.
+#   3. Force the version to 1.0.0 so the feed's 2.0.0 is strictly greater.
+#   4. Build + sign with the SAME identity the new build uses, so the designated
+#      requirement Squirrel checks matches and the swap is allowed.
+#   5. Allow http to loopback (the built-in autoUpdater uses NSURLSession, which
+#      enforces ATS) and re-seal the bundle.
+#   6. Copy the signed app to apps/code/out/old-forge for the spec.
+#
+# Run from anywhere; paths are resolved from this script. Needs the same signing
+# env the new build uses (CSC_LINK / CSC_KEY_PASSWORD) and full git history
+# (actions/checkout fetch-depth: 0).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"          # apps/code
+REPO_ROOT="$(cd "$APP_DIR/../.." && pwd)"
+
+OLD_REF="${OLD_FORGE_REF:-cb0ca68db}"               # v0.55.132, last Forge release
+OLD_VERSION="${OLD_VERSION:-1.0.0}"
+WORKTREE="${OLD_FORGE_WORKTREE:-$REPO_ROOT/.old-forge-worktree}"
+OUT_APP_DIR="$APP_DIR/out/old-forge"
+DEST_APP="$OUT_APP_DIR/PostHog Code.app"
+
+export SKIP_NOTARIZE=1
+export HUSKY=0
+
+log() { printf '\n==> %s\n' "$*"; }
+
+cleanup_worktree() {
+  git -C "$REPO_ROOT" worktree remove --force "$WORKTREE" 2>/dev/null || true
+  rm -rf "$WORKTREE"
+}
+
+log "old Forge ref: $OLD_REF (version $OLD_VERSION)"
+
+# 1. Isolated worktree at the pinned tag. Separate node_modules + build output,
+#    so the current branch checkout is untouched.
+cleanup_worktree
+git -C "$REPO_ROOT" worktree add --force --detach "$WORKTREE" "$OLD_REF"
+trap cleanup_worktree EXIT
+
+# 2. The env seam: SERVER_HOST honours POSTHOG_E2E_UPDATE_HOST.
+UPDATES_TS="$WORKTREE/packages/core/src/updates/updates.ts"
+[ -f "$UPDATES_TS" ] || { echo "FAIL: $UPDATES_TS not found at $OLD_REF"; exit 1; }
+perl -0pi -e 's{SERVER_HOST = "https://update\.electronjs\.org"}{SERVER_HOST = process.env.POSTHOG_E2E_UPDATE_HOST ?? "https://update.electronjs.org"}' "$UPDATES_TS"
+grep -q 'POSTHOG_E2E_UPDATE_HOST' "$UPDATES_TS" || { echo "FAIL: env seam not applied to $UPDATES_TS"; exit 1; }
+log "env seam applied: $(grep -n 'SERVER_HOST =' "$UPDATES_TS")"
+
+# 3. Force the old version so the feed's 2.0.0 is strictly greater.
+node -e 'const f=process.argv[1];const fs=require("fs");const p=JSON.parse(fs.readFileSync(f,"utf8"));p.version=process.argv[2];fs.writeFileSync(f,JSON.stringify(p,null,2)+"\n")' \
+  "$WORKTREE/apps/code/package.json" "$OLD_VERSION"
+log "forced version: $(node -e 'console.log(require(process.argv[1]).version)' "$WORKTREE/apps/code/package.json")"
+
+# 4. Reuse the fonts the workflow already fetched into the main checkout.
+if [ -d "$APP_DIR/assets/fonts/BerkeleyMono" ]; then
+  mkdir -p "$WORKTREE/apps/code/assets/fonts"
+  ditto "$APP_DIR/assets/fonts/BerkeleyMono" "$WORKTREE/apps/code/assets/fonts/BerkeleyMono"
+  log "copied BerkeleyMono fonts into the worktree"
+fi
+
+# 5. Signing identity. Forge's osxSign resolves the identity by NAME from a
+#    keychain (unlike electron-builder, which consumes CSC_LINK directly), so
+#    import the shared cert into a temp keychain and derive the identity name.
+if [ -z "${APPLE_CODESIGN_IDENTITY:-}" ] && [ -n "${CSC_LINK:-}" ]; then
+  KEYCHAIN="${RUNNER_TEMP:-/tmp}/old-forge-sign.keychain-db"
+  KEYCHAIN_PW="old-forge-temp-pw"
+  CERT_P12="${RUNNER_TEMP:-/tmp}/old-forge-cert.p12"
+  security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+  security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+  security set-keychain-settings -lut 21600 "$KEYCHAIN"
+  security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+  echo "$CSC_LINK" | base64 --decode > "$CERT_P12"
+  security import "$CERT_P12" -k "$KEYCHAIN" -P "${CSC_KEY_PASSWORD:-}" -T /usr/bin/codesign
+  security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+  EXISTING_KEYCHAINS="$(security list-keychains -d user | sed -e 's/"//g' -e 's/^[[:space:]]*//')"
+  # shellcheck disable=SC2086
+  security list-keychains -d user -s "$KEYCHAIN" $EXISTING_KEYCHAINS
+  APPLE_CODESIGN_IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" | sed -n 's/.*"\(.*\)".*/\1/p' | head -1)"
+  export APPLE_CODESIGN_IDENTITY
+  rm -f "$CERT_P12"
+fi
+[ -n "${APPLE_CODESIGN_IDENTITY:-}" ] || {
+  echo "FAIL: no signing identity. Squirrel only swaps a signed bundle whose"
+  echo "      designated requirement matches; set CSC_LINK / CSC_KEY_PASSWORD"
+  echo "      or APPLE_CODESIGN_IDENTITY."
+  exit 1
+}
+log "signing identity: $APPLE_CODESIGN_IDENTITY"
+
+# 6. Build + sign the old Forge app (turbo build of deps, then forge package).
+cd "$WORKTREE"
+log "installing worktree dependencies"
+# The old tree may carry a lockfile from an older pnpm; fall back if the current
+# pnpm refuses it frozen. The worktree is disposable, so a relaxed install is fine.
+pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+log "building workspace dependencies"
+pnpm build:deps
+log "packaging the Forge app"
+pnpm --filter code package
+
+BUILT_APP="$WORKTREE/apps/code/out/PostHog Code-darwin-arm64/PostHog Code.app"
+[ -d "$BUILT_APP" ] || {
+  echo "FAIL: forge package did not produce $BUILT_APP"
+  ls -la "$WORKTREE/apps/code/out" 2>/dev/null || true
+  exit 1
+}
+
+# 7. Allow http to loopback so the built-in autoUpdater (NSURLSession) can reach
+#    our local feed, then re-sign the OUTER bundle with the same identity +
+#    entitlements. Editing Info.plist invalidates only the outer seal; nested
+#    code keeps its valid signatures, so the designated requirement is unchanged.
+PLIST="$BUILT_APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :NSAppTransportSecurity dict" "$PLIST" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :NSAppTransportSecurity:NSAllowsLocalNetworking bool true" "$PLIST" 2>/dev/null \
+  || /usr/libexec/PlistBuddy -c "Set :NSAppTransportSecurity:NSAllowsLocalNetworking true" "$PLIST"
+codesign --force --options runtime --timestamp=none \
+  --entitlements "$WORKTREE/apps/code/build/entitlements.mac.plist" \
+  --sign "$APPLE_CODESIGN_IDENTITY" "$BUILT_APP"
+codesign --verify --strict --verbose=2 "$BUILT_APP"
+
+# 8. Hand the signed app to the location the spec expects.
+rm -rf "$OUT_APP_DIR"
+mkdir -p "$OUT_APP_DIR"
+ditto "$BUILT_APP" "$DEST_APP"
+
+log "old Forge app ready: $DEST_APP"
+log "bundle version: $(plutil -extract CFBundleShortVersionString raw "$DEST_APP/Contents/Info.plist")"

--- a/apps/code/scripts/dev-update/build-pair.sh
+++ b/apps/code/scripts/dev-update/build-pair.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Build a signed OLD (1.0.0) app to run plus a signed NEW (2.0.0) feed for the
+# macOS auto-update E2E. Real signing needs CSC_LINK (set in CI); locally it uses
+# whatever identity electron-builder finds. Run from apps/code.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+OLD_VERSION="${OLD_VERSION:-1.0.0}"
+NEW_VERSION="${NEW_VERSION:-2.0.0}"
+FEED_DIR="out/dev-update-feed"
+
+export SKIP_NOTARIZE="${SKIP_NOTARIZE:-1}"
+
+echo "==> electron-vite build"
+pnpm exec electron-vite build
+
+echo "==> build NEW $NEW_VERSION (feed artifacts)"
+pnpm exec electron-builder build --mac zip --arm64 \
+  -c.extraMetadata.version="$NEW_VERSION" --config electron-builder.ts
+
+rm -rf "$FEED_DIR"
+mkdir -p "$FEED_DIR"
+cp "out/PostHog-Code-${NEW_VERSION}-arm64-mac.zip" "$FEED_DIR/"
+cp "out/PostHog-Code-${NEW_VERSION}-arm64-mac.zip.blockmap" "$FEED_DIR/"
+cp "out/latest-mac.yml" "$FEED_DIR/"
+
+echo "==> build OLD $OLD_VERSION (runnable app left in out/mac-arm64)"
+pnpm exec electron-builder build --mac zip --arm64 \
+  -c.extraMetadata.version="$OLD_VERSION" --config electron-builder.ts
+
+echo "==> feed=$FEED_DIR"
+echo "==> app=out/mac-arm64/PostHog Code.app ($OLD_VERSION)"

--- a/apps/code/scripts/dev-update/build-pair.sh
+++ b/apps/code/scripts/dev-update/build-pair.sh
@@ -16,7 +16,7 @@ echo "==> electron-vite build"
 pnpm exec electron-vite build
 
 echo "==> build NEW $NEW_VERSION (feed artifacts)"
-pnpm exec electron-builder build --mac zip --arm64 \
+pnpm exec electron-builder build --mac zip --arm64 --publish never \
   -c.extraMetadata.version="$NEW_VERSION" --config electron-builder.ts
 
 rm -rf "$FEED_DIR"
@@ -26,7 +26,7 @@ cp "out/PostHog-Code-${NEW_VERSION}-arm64-mac.zip.blockmap" "$FEED_DIR/"
 cp "out/latest-mac.yml" "$FEED_DIR/"
 
 echo "==> build OLD $OLD_VERSION (runnable app left in out/mac-arm64)"
-pnpm exec electron-builder build --mac zip --arm64 \
+pnpm exec electron-builder build --mac zip --arm64 --publish never \
   -c.extraMetadata.version="$OLD_VERSION" --config electron-builder.ts
 
 echo "==> feed=$FEED_DIR"

--- a/apps/code/scripts/dev-update/run-from-ci-forge.sh
+++ b/apps/code/scripts/dev-update/run-from-ci-forge.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# One command to try the Forge -> electron-builder macOS auto-update locally
+# against the CI-signed builds, no local signing. It downloads the old Forge
+# (v0.55.132, versioned 1.0.0) app and the new (2.0.0) feed from the latest green
+# Code Update E2E run, serves the feed, and launches the Forge app pointed at it.
+# Its genuine built-in Squirrel.Mac client checks the feed, downloads 2.0.0, and
+# on restart swaps + relaunches into 2.0.0 -- the path real Forge users take.
+#
+# Squirrel verifies signatures cryptographically, so the CI-signed pair updates
+# here without the cert being in your keychain.
+#
+# Usage:
+#   bash scripts/dev-update/run-from-ci-forge.sh [run-id]
+#   AUTOMATED=1 bash scripts/dev-update/run-from-ci-forge.sh   # run the Playwright spec instead
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+command -v gh >/dev/null || {
+  echo "gh (GitHub CLI) is required and must be authenticated" >&2
+  exit 1
+}
+
+if pgrep -x "PostHog Code" >/dev/null; then
+  echo "PostHog Code is already running. Quit it first; the test build shares its single-instance lock and data dir." >&2
+  exit 1
+fi
+
+RUN_ID="${1:-$(gh run list --workflow=code-update-e2e.yml --status success -L 1 --json databaseId -q '.[0].databaseId')}"
+[[ -n "$RUN_ID" ]] || {
+  echo "no successful Code Update E2E run found; pass a run id explicitly" >&2
+  exit 1
+}
+echo "==> using CI run $RUN_ID"
+
+TMP="$(mktemp -d)"
+cleanup() {
+  [[ -n "${SERVE_PID:-}" ]] && kill "$SERVE_PID" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+echo "==> downloading signed builds from CI"
+gh run download "$RUN_ID" -n update-old-forge-build-1.0.0 -D "$TMP/old"
+gh run download "$RUN_ID" -n update-new-build-2.0.0 -D "$TMP/new"
+
+OLD_ZIP="$(find "$TMP/old" -name '*.zip' | head -1)"
+FEED_YML="$(find "$TMP/new" -name latest-mac.yml | head -1)"
+[[ -n "$OLD_ZIP" ]] || {
+  echo "old Forge app zip not found in artifact" >&2
+  exit 1
+}
+[[ -n "$FEED_YML" ]] || {
+  echo "latest-mac.yml not found in new build artifact" >&2
+  exit 1
+}
+
+echo "==> old Forge 1.0.0 app -> out/old-forge"
+rm -rf out/old-forge && mkdir -p out/old-forge
+ditto -x -k "$OLD_ZIP" out/old-forge
+xattr -dr com.apple.quarantine "out/old-forge/PostHog Code.app" 2>/dev/null || true
+
+# The Squirrel swap only completes if the running app's signature is intact, so
+# fail loudly here rather than time out mid-swap if the artifact arrived corrupt.
+echo "==> verifying the CI signature survived transport"
+codesign --verify --strict "out/old-forge/PostHog Code.app" || {
+  echo "old Forge app failed signature verification; the Squirrel swap will not complete" >&2
+  exit 1
+}
+
+echo "==> new 2.0.0 feed -> out/dev-update-feed"
+rm -rf out/dev-update-feed && mkdir -p out/dev-update-feed
+cp "$(dirname "$FEED_YML")"/* out/dev-update-feed/
+
+if [[ "${AUTOMATED:-}" == "1" ]]; then
+  echo "==> running the automated Forge update test"
+  pnpm exec playwright test --config=tests/e2e/playwright.update-forge.config.ts
+  exit $?
+fi
+
+PORT="${PORT:-8788}"
+node scripts/dev-update/serve.mjs out/dev-update-feed "$PORT" &
+SERVE_PID=$!
+
+APP_LOG="out/run-from-ci-forge-app.log"
+echo
+echo "==> launching Forge PostHog Code 1.0.0 (feed http://127.0.0.1:$PORT)"
+echo "    Its built-in Squirrel.Mac client downloads 2.0.0 in the background."
+echo "    When prompted, click Restart (or quit and reopen) to apply the swap."
+echo "    It relaunches into 2.0.0. Quit the app (or Ctrl+C) to finish."
+echo "    App output: $APP_LOG   update log: ~/.posthog-code/logs/main.log"
+echo
+POSTHOG_E2E_UPDATE_HOST="http://127.0.0.1:$PORT" \
+  "out/old-forge/PostHog Code.app/Contents/MacOS/PostHog Code" >"$APP_LOG" 2>&1 || true
+
+echo "==> app exited; cleaning up"

--- a/apps/code/scripts/dev-update/run-from-ci.sh
+++ b/apps/code/scripts/dev-update/run-from-ci.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# One command to try the macOS auto-update flow locally against the CI-signed
+# builds, no local signing. It downloads the old (1.0.0) app and the new (2.0.0)
+# feed from the latest green Code Update E2E run, serves the feed, and opens the
+# old app pointed at it. In the app: open the update banner, click Download, then
+# Restart, and watch the real Squirrel swap + relaunch into 2.0.0.
+#
+# Squirrel verifies signatures cryptographically, so the CI-signed pair updates
+# here without the cert being in your keychain.
+#
+# Usage:
+#   bash scripts/dev-update/run-from-ci.sh [run-id]
+#   AUTOMATED=1 bash scripts/dev-update/run-from-ci.sh   # run the Playwright spec instead
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+command -v gh >/dev/null || {
+  echo "gh (GitHub CLI) is required and must be authenticated" >&2
+  exit 1
+}
+
+if pgrep -x "PostHog Code" >/dev/null; then
+  echo "PostHog Code is already running. Quit it first; the test build shares its single-instance lock and data dir." >&2
+  exit 1
+fi
+
+RUN_ID="${1:-$(gh run list --workflow=code-update-e2e.yml --status success -L 1 --json databaseId -q '.[0].databaseId')}"
+[[ -n "$RUN_ID" ]] || {
+  echo "no successful Code Update E2E run found; pass a run id explicitly" >&2
+  exit 1
+}
+echo "==> using CI run $RUN_ID"
+
+TMP="$(mktemp -d)"
+cleanup() {
+  [[ -n "${SERVE_PID:-}" ]] && kill "$SERVE_PID" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+echo "==> downloading signed builds from CI"
+gh run download "$RUN_ID" -n update-old-build-1.0.0 -D "$TMP/old"
+gh run download "$RUN_ID" -n update-new-build-2.0.0 -D "$TMP/new"
+
+OLD_ZIP="$(find "$TMP/old" -name 'PostHog-Code-*-arm64-mac.zip' | head -1)"
+FEED_YML="$(find "$TMP/new" -name latest-mac.yml | head -1)"
+[[ -n "$OLD_ZIP" ]] || {
+  echo "old build zip not found in artifact" >&2
+  exit 1
+}
+[[ -n "$FEED_YML" ]] || {
+  echo "latest-mac.yml not found in new build artifact" >&2
+  exit 1
+}
+
+echo "==> old 1.0.0 app -> out/mac-arm64"
+rm -rf out/mac-arm64 && mkdir -p out/mac-arm64
+ditto -x -k "$OLD_ZIP" out/mac-arm64
+xattr -dr com.apple.quarantine "out/mac-arm64/PostHog Code.app" 2>/dev/null || true
+
+echo "==> new 2.0.0 feed -> out/dev-update-feed"
+rm -rf out/dev-update-feed && mkdir -p out/dev-update-feed
+cp "$(dirname "$FEED_YML")"/* out/dev-update-feed/
+
+if [[ "${AUTOMATED:-}" == "1" ]]; then
+  echo "==> running the automated update test"
+  pnpm exec playwright test --config=tests/e2e/playwright.update.config.ts
+  exit $?
+fi
+
+PORT="${PORT:-8788}"
+node scripts/dev-update/serve.mjs out/dev-update-feed "$PORT" &
+SERVE_PID=$!
+
+APP_LOG="out/run-from-ci-app.log"
+echo
+echo "==> launching PostHog Code 1.0.0 (feed http://127.0.0.1:$PORT)"
+echo "    In the app: open the update banner, click Download, then Restart."
+echo "    It swaps and relaunches into 2.0.0. Quit the app (or Ctrl+C) to finish."
+echo "    App output: $APP_LOG   update log: ~/.posthog-code/logs/main.log"
+echo
+POSTHOG_E2E_UPDATE_FEED="http://127.0.0.1:$PORT" \
+  "out/mac-arm64/PostHog Code.app/Contents/MacOS/PostHog Code" >"$APP_LOG" 2>&1 || true
+
+echo "==> app exited; cleaning up"

--- a/apps/code/scripts/dev-update/serve.mjs
+++ b/apps/code/scripts/dev-update/serve.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Dependency-free static file server for the auto-update feed. Serves a directory
+// (latest-mac.yml + zip + blockmap) over HTTP with Range support, which the macOS
+// updater needs. Used by the update E2E and for local manual testing.
+//
+// Usage: node serve.mjs <dir> [port]
+import { createReadStream, statSync } from "node:fs";
+import { createServer } from "node:http";
+import { extname, join, normalize } from "node:path";
+
+const root = process.argv[2];
+const port = Number(process.argv[3] ?? 8080);
+
+if (!root) {
+  console.error("Usage: serve.mjs <dir> [port]");
+  process.exit(1);
+}
+
+const CONTENT_TYPES = {
+  ".yml": "text/yaml; charset=utf-8",
+  ".yaml": "text/yaml; charset=utf-8",
+  ".zip": "application/zip",
+  ".blockmap": "application/octet-stream",
+  ".json": "application/json; charset=utf-8",
+};
+
+const server = createServer((req, res) => {
+  const urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
+  const safePath = normalize(urlPath).replace(/^(\.\.[/\\])+/, "");
+  const filePath = join(root, safePath);
+
+  let stat;
+  try {
+    stat = statSync(filePath);
+  } catch {
+    res.writeHead(404);
+    res.end("Not found");
+    return;
+  }
+  if (!stat.isFile()) {
+    res.writeHead(404);
+    res.end("Not found");
+    return;
+  }
+
+  const type = CONTENT_TYPES[extname(filePath)] ?? "application/octet-stream";
+  const range = req.headers.range;
+
+  if (range) {
+    const match = /bytes=(\d*)-(\d*)/.exec(range);
+    const start = match?.[1] ? Number(match[1]) : 0;
+    const end = match?.[2] ? Number(match[2]) : stat.size - 1;
+    res.writeHead(206, {
+      "Content-Type": type,
+      "Content-Range": `bytes ${start}-${end}/${stat.size}`,
+      "Accept-Ranges": "bytes",
+      "Content-Length": end - start + 1,
+    });
+    createReadStream(filePath, { start, end }).pipe(res);
+    return;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": type,
+    "Content-Length": stat.size,
+    "Accept-Ranges": "bytes",
+  });
+  createReadStream(filePath).pipe(res);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`update feed: http://127.0.0.1:${port} serving ${root}`);
+});

--- a/apps/code/scripts/dev-update/serve.mjs
+++ b/apps/code/scripts/dev-update/serve.mjs
@@ -48,8 +48,15 @@ const server = createServer((req, res) => {
 
   if (range) {
     const match = /bytes=(\d*)-(\d*)/.exec(range);
-    const start = match?.[1] ? Number(match[1]) : 0;
-    const end = match?.[2] ? Number(match[2]) : stat.size - 1;
+    let start = 0;
+    let end = stat.size - 1;
+    if (match?.[1]) {
+      start = Number(match[1]);
+      if (match[2]) end = Number(match[2]);
+    } else if (match?.[2]) {
+      // Suffix range (bytes=-N): the last N bytes of the file.
+      start = Math.max(0, stat.size - Number(match[2]));
+    }
     res.writeHead(206, {
       "Content-Type": type,
       "Content-Range": `bytes ${start}-${end}/${stat.size}`,

--- a/apps/code/scripts/dev-update/serve.mjs
+++ b/apps/code/scripts/dev-update/serve.mjs
@@ -3,8 +3,13 @@
 // (latest-mac.yml + zip + blockmap) over HTTP with Range support, which the macOS
 // updater needs. Used by the update E2E and for local manual testing.
 //
+// It also answers the Squirrel.Mac JSON feed that the LEGACY built-in autoUpdater
+// expects (what shipped Forge builds run), so the same feed dir drives both the
+// new electron-updater client and the old built-in one. See the Forge -> builder
+// update E2E (tests/e2e/tests/update-forge.spec.ts).
+//
 // Usage: node serve.mjs <dir> [port]
-import { createReadStream, statSync } from "node:fs";
+import { createReadStream, readFileSync, statSync } from "node:fs";
 import { createServer } from "node:http";
 import { extname, join, normalize } from "node:path";
 
@@ -24,8 +29,68 @@ const CONTENT_TYPES = {
   ".json": "application/json; charset=utf-8",
 };
 
+// The legacy built-in autoUpdater (Squirrel.Mac) GETs
+// /<owner>/<repo>/darwin-<arch>/<currentVersion> and expects 204 when current,
+// or 200 + { url } pointing at the zip to install. update.electronjs.org served
+// exactly this shape; we reproduce it locally from the feed's latest-mac.yml.
+const SQUIRREL_FEED_RE = /\/darwin-(?:arm64|x64)\/([0-9][^/]*)\/?$/;
+const PUB_DATE = "2020-01-01T00:00:00Z";
+
+// Read the version + zip the feed offers, staying dependency-free (no YAML lib).
+function readFeedMeta() {
+  try {
+    const yml = readFileSync(join(root, "latest-mac.yml"), "utf8");
+    const version = /^version:\s*(.+)$/m.exec(yml)?.[1]?.trim();
+    const zip = /(?:url|path):\s*(\S+\.zip)\b/m.exec(yml)?.[1]?.trim();
+    if (version && zip) return { version, zip };
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function compareSemver(a, b) {
+  const pa = a.split(/[.+-]/).map(Number);
+  const pb = b.split(/[.+-]/).map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff) return diff > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
 const server = createServer((req, res) => {
   const urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
+
+  const squirrel = SQUIRREL_FEED_RE.exec(urlPath);
+  if (squirrel) {
+    const meta = readFeedMeta();
+    if (!meta) {
+      res.writeHead(503);
+      res.end("feed metadata missing");
+      return;
+    }
+    const currentVersion = squirrel[1];
+    if (compareSemver(meta.version, currentVersion) <= 0) {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    const host = req.headers.host ?? `127.0.0.1:${port}`;
+    const body = JSON.stringify({
+      url: `http://${host}/${meta.zip}`,
+      name: meta.version,
+      notes: "",
+      pub_date: PUB_DATE,
+    });
+    res.writeHead(200, {
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Length": Buffer.byteLength(body),
+    });
+    res.end(body);
+    return;
+  }
+
   const safePath = normalize(urlPath).replace(/^(\.\.[/\\])+/, "");
   const filePath = join(root, safePath);
 

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -381,6 +381,19 @@ app.whenReady().then(async () => {
   container.bind(FS_SERVICE).toService(MAIN_FS_SERVICE);
   await initializeServices();
   initializeDeepLinks();
+
+  if (process.env.POSTHOG_E2E_UPDATE_FEED) {
+    const updates = container.get<UpdatesService>(MAIN_TOKENS.UpdatesService);
+    Object.assign(globalThis, {
+      __e2eUpdates: {
+        check: () => updates.checkForUpdates(),
+        download: () => updates.requestDownload(),
+        install: () => updates.installUpdate(),
+        status: () => updates.getStatus(),
+      },
+    });
+    log.info("E2E update hook installed on globalThis.__e2eUpdates");
+  }
 });
 
 app.on("window-all-closed", () => {

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -383,7 +383,7 @@ app.whenReady().then(async () => {
   initializeDeepLinks();
 
   if (process.env.POSTHOG_E2E_UPDATE_FEED) {
-    const updates = container.get<UpdatesService>(MAIN_TOKENS.UpdatesService);
+    const updates = container.get<UpdatesService>(UPDATES_SERVICE);
     Object.assign(globalThis, {
       __e2eUpdates: {
         check: () => updates.checkForUpdates(),

--- a/apps/code/src/main/platform-adapters/electron-updater.ts
+++ b/apps/code/src/main/platform-adapters/electron-updater.ts
@@ -40,6 +40,14 @@ export class ElectronUpdater implements IUpdater {
     // next quit, with an in-app Restart button for immediate install.
     autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = true;
+
+    // E2E only: redirect the updater at a local feed so a packaged build can be
+    // driven through a real download and install against test artifacts. The env
+    // var is never set in production.
+    const e2eFeedUrl = process.env.POSTHOG_E2E_UPDATE_FEED;
+    if (e2eFeedUrl) {
+      autoUpdater.setFeedURL({ provider: "generic", url: e2eFeedUrl });
+    }
   }
 
   public isSupported(): boolean {

--- a/apps/code/tests/e2e/fixtures/update.ts
+++ b/apps/code/tests/e2e/fixtures/update.ts
@@ -1,5 +1,11 @@
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -17,10 +23,37 @@ export const SHIPIT_DIR = path.join(
   "Library/Caches/com.posthog.array.ShipIt",
 );
 
+export const PROOF_DIR = path.join(OUT_DIR, "update-proof");
+const PROOF_FILE = path.join(PROOF_DIR, "proof.json");
+
 const SERVE_SCRIPT = path.join(
   __dirname,
   "../../../scripts/dev-update/serve.mjs",
 );
+
+// A single legible record of the update, written on pass and fail, that the
+// workflow turns into a run-page summary and uploads as the proof artifact.
+export type UpdateProof = {
+  result: "PASS" | "FAIL";
+  oldVersion: string;
+  newVersion: string;
+  bootedOn?: string;
+  feedAvailableVersion?: string;
+  downloaded?: boolean;
+  bundleVersionAfterSwap?: string;
+  autoRelaunchedExecutable?: string;
+  freshLaunchVersion?: string;
+  shipItExists?: boolean;
+  shipItEntries?: string[];
+  failedStep?: string;
+  error?: string;
+  finishedAt?: string;
+};
+
+export function writeProof(proof: UpdateProof): void {
+  mkdirSync(PROOF_DIR, { recursive: true });
+  writeFileSync(PROOF_FILE, `${JSON.stringify(proof, null, 2)}\n`);
+}
 
 // Copy the pristine built app into a disposable run dir so the in-place update
 // swap never mutates the build output, which lets a retry start from 1.0.0

--- a/apps/code/tests/e2e/fixtures/update.ts
+++ b/apps/code/tests/e2e/fixtures/update.ts
@@ -78,6 +78,31 @@ export function isAppRunning(): boolean {
   }
 }
 
+// Executable paths of the running main app processes (not helpers). Used to prove
+// Squirrel's auto-relaunched process is running from the swapped bundle.
+export function runningAppExecutables(): string[] {
+  let pids: string[];
+  try {
+    pids = execFileSync("pgrep", ["-x", "PostHog Code"], { encoding: "utf8" })
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+  return pids
+    .map((pid) => {
+      try {
+        return execFileSync("ps", ["-p", pid, "-o", "comm="], {
+          encoding: "utf8",
+        }).trim();
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+}
+
 export function killApp(): void {
   try {
     execFileSync("pkill", ["-x", "PostHog Code"]);

--- a/apps/code/tests/e2e/fixtures/update.ts
+++ b/apps/code/tests/e2e/fixtures/update.ts
@@ -17,6 +17,20 @@ export const RUN_DIR = path.join(OUT_DIR, "e2e-update-run");
 export const RUN_APP = path.join(RUN_DIR, "PostHog Code.app");
 export const RUN_APP_BIN = path.join(RUN_APP, "Contents/MacOS/PostHog Code");
 
+// The "old" side of the Forge -> electron-builder test: a real Electron Forge
+// build (v0.55.132) produced by scripts/dev-update/build-old-forge.sh. It runs
+// the genuine built-in Squirrel.Mac client, against the same 2.0.0 feed.
+export const FORGE_PRISTINE_APP = path.join(
+  OUT_DIR,
+  "old-forge/PostHog Code.app",
+);
+export const FORGE_RUN_DIR = path.join(OUT_DIR, "e2e-update-forge-run");
+export const FORGE_RUN_APP = path.join(FORGE_RUN_DIR, "PostHog Code.app");
+export const FORGE_RUN_APP_BIN = path.join(
+  FORGE_RUN_APP,
+  "Contents/MacOS/PostHog Code",
+);
+
 export const MAIN_LOG = path.join(homedir(), ".posthog-code/logs/main.log");
 export const SHIPIT_DIR = path.join(
   homedir(),
@@ -25,6 +39,9 @@ export const SHIPIT_DIR = path.join(
 
 export const PROOF_DIR = path.join(OUT_DIR, "update-proof");
 const PROOF_FILE = path.join(PROOF_DIR, "proof.json");
+
+export const FORGE_PROOF_DIR = path.join(OUT_DIR, "update-proof-forge");
+const FORGE_PROOF_FILE = path.join(FORGE_PROOF_DIR, "proof.json");
 
 const SERVE_SCRIPT = path.join(
   __dirname,
@@ -55,6 +72,11 @@ export function writeProof(proof: UpdateProof): void {
   writeFileSync(PROOF_FILE, `${JSON.stringify(proof, null, 2)}\n`);
 }
 
+export function writeForgeProof(proof: UpdateProof): void {
+  mkdirSync(FORGE_PROOF_DIR, { recursive: true });
+  writeFileSync(FORGE_PROOF_FILE, `${JSON.stringify(proof, null, 2)}\n`);
+}
+
 // Copy the pristine built app into a disposable run dir so the in-place update
 // swap never mutates the build output, which lets a retry start from 1.0.0
 // again. ditto preserves the code signature that Squirrel.Mac verifies.
@@ -62,6 +84,12 @@ export function prepareRunApp(): void {
   rmSync(RUN_DIR, { recursive: true, force: true });
   mkdirSync(RUN_DIR, { recursive: true });
   execFileSync("ditto", [PRISTINE_APP, RUN_APP]);
+}
+
+export function prepareForgeRunApp(): void {
+  rmSync(FORGE_RUN_DIR, { recursive: true, force: true });
+  mkdirSync(FORGE_RUN_DIR, { recursive: true });
+  execFileSync("ditto", [FORGE_PRISTINE_APP, FORGE_RUN_APP]);
 }
 
 export function startFeedServer(port: number): ChildProcess {
@@ -89,6 +117,13 @@ export function readMainLog(): string {
   } catch {
     return "";
   }
+}
+
+// Both legs swap the same bundle id, so they share one ShipIt cache dir. Clear it
+// before a run that asserts on it, so its presence afterward is attributable to
+// that run's swap and not a leftover from the other leg.
+export function resetShipItCache(): void {
+  rmSync(SHIPIT_DIR, { recursive: true, force: true });
 }
 
 // Squirrel.Mac's ShipIt helper performs the in-place swap and leaves its cache

--- a/apps/code/tests/e2e/fixtures/update.ts
+++ b/apps/code/tests/e2e/fixtures/update.ts
@@ -1,0 +1,74 @@
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+
+const OUT_DIR = path.join(__dirname, "../../../out");
+
+export const PRISTINE_APP = path.join(OUT_DIR, "mac-arm64/PostHog Code.app");
+export const FEED_DIR = path.join(OUT_DIR, "dev-update-feed");
+export const RUN_DIR = path.join(OUT_DIR, "e2e-update-run");
+export const RUN_APP = path.join(RUN_DIR, "PostHog Code.app");
+export const RUN_APP_BIN = path.join(RUN_APP, "Contents/MacOS/PostHog Code");
+
+const SERVE_SCRIPT = path.join(
+  __dirname,
+  "../../../scripts/dev-update/serve.mjs",
+);
+
+// Copy the pristine built app into a disposable run dir so the in-place update
+// swap never mutates the build output, which lets a retry start from 1.0.0
+// again. ditto preserves the code signature that Squirrel.Mac verifies.
+export function prepareRunApp(): void {
+  rmSync(RUN_DIR, { recursive: true, force: true });
+  mkdirSync(RUN_DIR, { recursive: true });
+  execFileSync("ditto", [PRISTINE_APP, RUN_APP]);
+}
+
+export function startFeedServer(port: number): ChildProcess {
+  return spawn("node", [SERVE_SCRIPT, FEED_DIR, String(port)], {
+    stdio: "inherit",
+  });
+}
+
+export function readBundleVersion(appPath: string): string {
+  return execFileSync(
+    "plutil",
+    [
+      "-extract",
+      "CFBundleShortVersionString",
+      "raw",
+      path.join(appPath, "Contents/Info.plist"),
+    ],
+    { encoding: "utf8" },
+  ).trim();
+}
+
+export function isAppRunning(): boolean {
+  try {
+    execFileSync("pgrep", ["-x", "PostHog Code"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function killApp(): void {
+  try {
+    execFileSync("pkill", ["-x", "PostHog Code"]);
+  } catch {
+    // nothing running, fine
+  }
+}
+
+export async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms: ${message}`);
+}

--- a/apps/code/tests/e2e/fixtures/update.ts
+++ b/apps/code/tests/e2e/fixtures/update.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 
 const OUT_DIR = path.join(__dirname, "../../../out");
@@ -9,6 +10,12 @@ export const FEED_DIR = path.join(OUT_DIR, "dev-update-feed");
 export const RUN_DIR = path.join(OUT_DIR, "e2e-update-run");
 export const RUN_APP = path.join(RUN_DIR, "PostHog Code.app");
 export const RUN_APP_BIN = path.join(RUN_APP, "Contents/MacOS/PostHog Code");
+
+export const MAIN_LOG = path.join(homedir(), ".posthog-code/logs/main.log");
+export const SHIPIT_DIR = path.join(
+  homedir(),
+  "Library/Caches/com.posthog.array.ShipIt",
+);
 
 const SERVE_SCRIPT = path.join(
   __dirname,
@@ -41,6 +48,25 @@ export function readBundleVersion(appPath: string): string {
     ],
     { encoding: "utf8" },
   ).trim();
+}
+
+export function readMainLog(): string {
+  try {
+    return readFileSync(MAIN_LOG, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+// Squirrel.Mac's ShipIt helper performs the in-place swap and leaves its cache
+// under ~/Library/Caches/<bundleId>.ShipIt, which is direct evidence the install
+// went through Squirrel rather than anything the test did itself.
+export function shipItEvidence(): { exists: boolean; entries: string[] } {
+  try {
+    return { exists: true, entries: readdirSync(SHIPIT_DIR) };
+  } catch {
+    return { exists: false, entries: [] };
+  }
 }
 
 export function isAppRunning(): boolean {

--- a/apps/code/tests/e2e/playwright.config.ts
+++ b/apps/code/tests/e2e/playwright.config.ts
@@ -5,6 +5,9 @@ const isCI = !!process.env.CI;
 export default defineConfig({
   testDir: "./tests",
   testMatch: "**/*.spec.ts",
+  // The update spec needs a signed feed; it runs only via
+  // playwright.update.config.ts, never in the general suite.
+  testIgnore: "**/update.spec.ts",
   timeout: 60000,
   retries: isCI ? 2 : 0,
   // Must run serially - Electron app has single instance lock
@@ -19,6 +22,7 @@ export default defineConfig({
     {
       name: "electron",
       testMatch: "**/*.spec.ts",
+      testIgnore: "**/update.spec.ts",
     },
   ],
 });

--- a/apps/code/tests/e2e/playwright.config.ts
+++ b/apps/code/tests/e2e/playwright.config.ts
@@ -5,9 +5,9 @@ const isCI = !!process.env.CI;
 export default defineConfig({
   testDir: "./tests",
   testMatch: "**/*.spec.ts",
-  // The update spec needs a signed feed; it runs only via
-  // playwright.update.config.ts, never in the general suite.
-  testIgnore: "**/update.spec.ts",
+  // The update specs need a signed feed; they run only via their dedicated
+  // configs (playwright.update*.config.ts), never in the general suite.
+  testIgnore: "**/update*.spec.ts",
   timeout: 60000,
   retries: isCI ? 2 : 0,
   // Must run serially - Electron app has single instance lock
@@ -22,7 +22,7 @@ export default defineConfig({
     {
       name: "electron",
       testMatch: "**/*.spec.ts",
-      testIgnore: "**/update.spec.ts",
+      testIgnore: "**/update*.spec.ts",
     },
   ],
 });

--- a/apps/code/tests/e2e/playwright.update-forge.config.ts
+++ b/apps/code/tests/e2e/playwright.update-forge.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/test";
+
+// Dedicated config for the Forge -> electron-builder auto-update E2E. The general
+// suite excludes update*.spec.ts by path, so this only runs here and cannot
+// silently skip. retries are 0 so a broken swap surfaces immediately. In CI the
+// JSON reporter lets the workflow assert exactly one test actually ran.
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/update-forge.spec.ts",
+  timeout: 60000,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["json"]] : [["list"]],
+  outputDir: "../playwright-results",
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+});

--- a/apps/code/tests/e2e/playwright.update.config.ts
+++ b/apps/code/tests/e2e/playwright.update.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/test";
+
+// Dedicated config for the macOS auto-update E2E. The general suite excludes this
+// spec by path (see testIgnore in playwright.config.ts), so it only runs here and
+// cannot silently skip. retries are 0 so a broken swap surfaces immediately. In
+// CI the JSON reporter lets the workflow assert exactly one test actually ran.
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/update.spec.ts",
+  timeout: 60000,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["json"]] : [["list"]],
+  outputDir: "../playwright-results",
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+});

--- a/apps/code/tests/e2e/tests/update-forge.spec.ts
+++ b/apps/code/tests/e2e/tests/update-forge.spec.ts
@@ -1,0 +1,208 @@
+import { existsSync } from "node:fs";
+import {
+  type ElectronApplication,
+  _electron as electron,
+  expect,
+  test,
+} from "@playwright/test";
+import {
+  FEED_DIR,
+  FORGE_PRISTINE_APP,
+  FORGE_RUN_APP,
+  FORGE_RUN_APP_BIN,
+  FORGE_RUN_DIR,
+  isAppRunning,
+  killApp,
+  prepareForgeRunApp,
+  readBundleVersion,
+  resetShipItCache,
+  runningAppExecutables,
+  SHIPIT_DIR,
+  shipItEvidence,
+  startFeedServer,
+  type UpdateProof,
+  waitUntil,
+  writeForgeProof,
+} from "../fixtures/update";
+
+const FEED_PORT = 8789;
+const FEED_URL = `http://127.0.0.1:${FEED_PORT}`;
+const OLD_VERSION = "1.0.0";
+const NEW_VERSION = "2.0.0";
+
+// The "old" build here is a real Electron Forge release (v0.55.132), built by
+// scripts/dev-update/build-old-forge.sh. It runs the genuine built-in Squirrel.Mac
+// client (electron.autoUpdater) that shipped to users, not electron-updater. This
+// proves a Forge build in the field auto-updates to the electron-builder build we
+// ship now. The old build reaches the local feed via the POSTHOG_E2E_UPDATE_HOST
+// env seam baked in at build time, so its own boot check drives the download.
+test.describe("Forge -> electron-builder auto-update", () => {
+  // Runs only via playwright.update-forge.config.ts; the general e2e suite
+  // excludes update*.spec.ts by path, so there is no env gate that could
+  // silently skip it.
+  test.skip(process.platform !== "darwin", "macOS-only update flow");
+
+  test("legacy Squirrel.Mac build updates to the electron-builder build", async () => {
+    test.setTimeout(5 * 60_000);
+
+    const proof: UpdateProof = {
+      result: "FAIL",
+      oldVersion: OLD_VERSION,
+      newVersion: NEW_VERSION,
+    };
+    let feed: ReturnType<typeof startFeedServer> | undefined;
+    let app: ElectronApplication | undefined;
+    let updated: ElectronApplication | undefined;
+
+    try {
+      proof.failedStep = "preconditions";
+      expect(
+        existsSync(FORGE_PRISTINE_APP),
+        `missing old Forge app at ${FORGE_PRISTINE_APP}; run scripts/dev-update/build-old-forge.sh`,
+      ).toBe(true);
+      expect(
+        existsSync(FEED_DIR),
+        `missing feed at ${FEED_DIR}; run scripts/dev-update/build-pair.sh`,
+      ).toBe(true);
+
+      killApp();
+      // Isolate the ShipIt evidence from the baseline leg, which swaps the same
+      // bundle id earlier in the same CI job.
+      resetShipItCache();
+      prepareForgeRunApp();
+      feed = startFeedServer(FEED_PORT);
+
+      // Phase 1: launch the old Forge build pointed at the local feed and let its
+      // own updater drive the real check + download.
+      proof.failedStep = "launch";
+      app = await electron.launch({
+        executablePath: FORGE_RUN_APP_BIN,
+        args: [],
+        env: {
+          ...process.env,
+          ELECTRON_DISABLE_GPU: "1",
+          POSTHOG_E2E_UPDATE_HOST: FEED_URL,
+        },
+      });
+
+      // Prove we actually start on the old Forge version, so the swap is real.
+      proof.failedStep = "start-version";
+      const startVersion = await app.evaluate(({ app: a }) => a.getVersion());
+      proof.bootedOn = startVersion;
+      expect(startVersion, "old app should boot on the Forge version").toBe(
+        OLD_VERSION,
+      );
+
+      // Wait for the genuine built-in Squirrel.Mac client to download the update.
+      // The app's UpdatesService checks on boot (against our local feed) and the
+      // built-in autoUpdater auto-downloads, so update-downloaded fires without a
+      // separate download step. We only observe it.
+      proof.failedStep = "download";
+      const downloadedName = await app.evaluate(
+        ({ autoUpdater }) =>
+          new Promise<string>((resolve, reject) => {
+            const timer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    "built-in autoUpdater did not download an update within 180s",
+                  ),
+                ),
+              180_000,
+            );
+            autoUpdater.on("error", (err) => {
+              clearTimeout(timer);
+              reject(err);
+            });
+            autoUpdater.on(
+              "update-downloaded",
+              (_event, _releaseNotes, releaseName) => {
+                clearTimeout(timer);
+                resolve(releaseName ?? "");
+              },
+            );
+          }),
+      );
+      proof.feedAvailableVersion = downloadedName || NEW_VERSION;
+      proof.downloaded = true;
+      console.log(`Squirrel.Mac downloaded: ${downloadedName}`);
+
+      // Drive the install on the genuine client and wait for it to quit.
+      proof.failedStep = "install-and-swap";
+      const closed = app.waitForEvent("close");
+      void app
+        .evaluate(({ autoUpdater }) => autoUpdater.quitAndInstall())
+        .catch(() => undefined);
+      await closed;
+
+      // Phase 2: prove the bundle swapped and a fresh launch is the new version.
+      await waitUntil(
+        () => readBundleVersion(FORGE_RUN_APP) === NEW_VERSION,
+        120_000,
+        "bundle was not swapped to the new version",
+      );
+      proof.bundleVersionAfterSwap = readBundleVersion(FORGE_RUN_APP);
+
+      // Squirrel relaunches the installed app (isForceRunAfter=true); confirm the
+      // auto-relaunched process actually came up from the swapped bundle.
+      proof.failedStep = "auto-relaunch";
+      await waitUntil(
+        () =>
+          runningAppExecutables().some((exe) => exe.includes(FORGE_RUN_DIR)),
+        60_000,
+        "Squirrel did not auto-relaunch the updated app",
+      );
+      proof.autoRelaunchedExecutable = runningAppExecutables().find((exe) =>
+        exe.includes(FORGE_RUN_DIR),
+      );
+      console.log(
+        `Auto-relaunched from swapped bundle: ${proof.autoRelaunchedExecutable}`,
+      );
+
+      killApp();
+      await waitUntil(
+        () => !isAppRunning(),
+        30_000,
+        "relaunched instance did not exit",
+      );
+
+      proof.failedStep = "fresh-launch";
+      updated = await electron.launch({
+        executablePath: FORGE_RUN_APP_BIN,
+        args: [],
+        env: { ...process.env, ELECTRON_DISABLE_GPU: "1" },
+      });
+      const version = await updated.evaluate(({ app: a }) => a.getVersion());
+      proof.freshLaunchVersion = version;
+      expect(version).toBe(NEW_VERSION);
+      await updated.close();
+
+      // Mechanism evidence: Squirrel.Mac's ShipIt is what performed the in-place
+      // swap, so its cache is direct proof the genuine client did the install.
+      proof.failedStep = "evidence";
+      const shipIt = shipItEvidence();
+      proof.shipItExists = shipIt.exists;
+      proof.shipItEntries = shipIt.entries;
+      console.log(
+        `Squirrel ShipIt cache: exists=${shipIt.exists} entries=[${shipIt.entries.join(", ")}]`,
+      );
+      expect(
+        shipIt.exists,
+        `no Squirrel ShipIt cache at ${SHIPIT_DIR}; the swap was not performed by Squirrel`,
+      ).toBe(true);
+
+      proof.failedStep = undefined;
+      proof.result = "PASS";
+    } catch (err) {
+      proof.error = err instanceof Error ? err.message : String(err);
+      throw err;
+    } finally {
+      await app?.close().catch(() => {});
+      await updated?.close().catch(() => {});
+      feed?.kill();
+      killApp();
+      proof.finishedAt = new Date().toISOString();
+      writeForgeProof(proof);
+    }
+  });
+});

--- a/apps/code/tests/e2e/tests/update.spec.ts
+++ b/apps/code/tests/e2e/tests/update.spec.ts
@@ -64,6 +64,8 @@ test.describe("macOS auto-update", () => {
       newVersion: NEW_VERSION,
     };
     let feed: ReturnType<typeof startFeedServer> | undefined;
+    let app: ElectronApplication | undefined;
+    let updated: ElectronApplication | undefined;
 
     try {
       proof.failedStep = "preconditions";
@@ -81,7 +83,7 @@ test.describe("macOS auto-update", () => {
 
       // Phase 1: drive the real download + install on the old build.
       proof.failedStep = "launch";
-      const app = await electron.launch({
+      app = await electron.launch({
         executablePath: RUN_APP_BIN,
         args: [],
         env: {
@@ -167,7 +169,7 @@ test.describe("macOS auto-update", () => {
       );
 
       proof.failedStep = "fresh-launch";
-      const updated = await electron.launch({
+      updated = await electron.launch({
         executablePath: RUN_APP_BIN,
         args: [],
         env: { ...process.env, ELECTRON_DISABLE_GPU: "1" },
@@ -205,6 +207,8 @@ test.describe("macOS auto-update", () => {
       proof.error = err instanceof Error ? err.message : String(err);
       throw err;
     } finally {
+      await app?.close().catch(() => {});
+      await updated?.close().catch(() => {});
       feed?.kill();
       killApp();
       proof.finishedAt = new Date().toISOString();

--- a/apps/code/tests/e2e/tests/update.spec.ts
+++ b/apps/code/tests/e2e/tests/update.spec.ts
@@ -14,6 +14,9 @@ import {
   RUN_APP,
   RUN_APP_BIN,
   readBundleVersion,
+  readMainLog,
+  SHIPIT_DIR,
+  shipItEvidence,
   startFeedServer,
   waitUntil,
 } from "../fixtures/update";
@@ -40,15 +43,13 @@ type Hooked = typeof globalThis & { __e2eUpdates: E2eHook };
 
 const FEED_PORT = 8788;
 const FEED_URL = `http://127.0.0.1:${FEED_PORT}`;
+const OLD_VERSION = "1.0.0";
 const NEW_VERSION = "2.0.0";
 
 test.describe("macOS auto-update", () => {
-  // Runs only in the dedicated code-update-e2e workflow, which builds the signed
-  // feed first. The general e2e suite has no feed, so it skips this spec.
-  test.skip(
-    process.platform !== "darwin" || process.env.RUN_UPDATE_E2E !== "1",
-    "macOS-only; set RUN_UPDATE_E2E=1 (needs scripts/dev-update/build-pair.sh)",
-  );
+  // Runs only via playwright.update.config.ts; the general e2e suite excludes
+  // this file by path, so there is no env gate that could silently skip it.
+  test.skip(process.platform !== "darwin", "macOS-only update flow");
 
   test("downloads, installs and relaunches into the new version", async () => {
     test.setTimeout(5 * 60_000);
@@ -86,6 +87,12 @@ test.describe("macOS auto-update", () => {
           },
         )
         .toBe("object");
+
+      // Prove we actually start on the old version, so the swap is real.
+      const startVersion = await app.evaluate(({ app: a }) => a.getVersion());
+      expect(startVersion, "run app should start on the old version").toBe(
+        OLD_VERSION,
+      );
 
       await app.evaluate(() => (globalThis as Hooked).__e2eUpdates.check());
       await pollStatus(
@@ -130,6 +137,25 @@ test.describe("macOS auto-update", () => {
       const version = await updated.evaluate(({ app: a }) => a.getVersion());
       expect(version).toBe(NEW_VERSION);
       await updated.close();
+
+      // Mechanism evidence: our updater drove a real download and install, and
+      // Squirrel.Mac's ShipIt is what performed the in-place swap.
+      const mainLog = readMainLog();
+      expect(
+        mainLog,
+        "main.log missing the completed-download marker",
+      ).toContain("Update downloaded, awaiting user confirmation");
+      expect(mainLog, "main.log missing the install marker").toContain(
+        "Installing update and restarting",
+      );
+      const shipIt = shipItEvidence();
+      console.log(
+        `Squirrel ShipIt cache: exists=${shipIt.exists} entries=[${shipIt.entries.join(", ")}]`,
+      );
+      expect(
+        shipIt.exists,
+        `no Squirrel ShipIt cache at ${SHIPIT_DIR}; the swap was not performed by Squirrel`,
+      ).toBe(true);
     } finally {
       feed.kill();
     }

--- a/apps/code/tests/e2e/tests/update.spec.ts
+++ b/apps/code/tests/e2e/tests/update.spec.ts
@@ -13,8 +13,10 @@ import {
   prepareRunApp,
   RUN_APP,
   RUN_APP_BIN,
+  RUN_DIR,
   readBundleVersion,
   readMainLog,
+  runningAppExecutables,
   SHIPIT_DIR,
   shipItEvidence,
   startFeedServer,
@@ -122,6 +124,18 @@ test.describe("macOS auto-update", () => {
         120_000,
         "bundle was not swapped to the new version",
       );
+
+      // Squirrel relaunches the installed app (isForceRunAfter=true); confirm the
+      // auto-relaunched process actually came up running from the swapped bundle.
+      await waitUntil(
+        () => runningAppExecutables().some((exe) => exe.includes(RUN_DIR)),
+        60_000,
+        "Squirrel did not auto-relaunch the updated app",
+      );
+      console.log(
+        `Auto-relaunched from swapped bundle: ${runningAppExecutables().join(", ")}`,
+      );
+
       killApp();
       await waitUntil(
         () => !isAppRunning(),

--- a/apps/code/tests/e2e/tests/update.spec.ts
+++ b/apps/code/tests/e2e/tests/update.spec.ts
@@ -20,7 +20,9 @@ import {
   SHIPIT_DIR,
   shipItEvidence,
   startFeedServer,
+  type UpdateProof,
   waitUntil,
+  writeProof,
 } from "../fixtures/update";
 
 type UpdateStatus = {
@@ -56,20 +58,29 @@ test.describe("macOS auto-update", () => {
   test("downloads, installs and relaunches into the new version", async () => {
     test.setTimeout(5 * 60_000);
 
-    expect(
-      existsSync(PRISTINE_APP),
-      `missing built app at ${PRISTINE_APP}; run scripts/dev-update/build-pair.sh`,
-    ).toBe(true);
-    expect(
-      existsSync(FEED_DIR),
-      `missing feed at ${FEED_DIR}; run scripts/dev-update/build-pair.sh`,
-    ).toBe(true);
-
-    prepareRunApp();
-    const feed = startFeedServer(FEED_PORT);
+    const proof: UpdateProof = {
+      result: "FAIL",
+      oldVersion: OLD_VERSION,
+      newVersion: NEW_VERSION,
+    };
+    let feed: ReturnType<typeof startFeedServer> | undefined;
 
     try {
+      proof.failedStep = "preconditions";
+      expect(
+        existsSync(PRISTINE_APP),
+        `missing built app at ${PRISTINE_APP}; run scripts/dev-update/build-pair.sh`,
+      ).toBe(true);
+      expect(
+        existsSync(FEED_DIR),
+        `missing feed at ${FEED_DIR}; run scripts/dev-update/build-pair.sh`,
+      ).toBe(true);
+
+      prepareRunApp();
+      feed = startFeedServer(FEED_PORT);
+
       // Phase 1: drive the real download + install on the old build.
+      proof.failedStep = "launch";
       const app = await electron.launch({
         executablePath: RUN_APP_BIN,
         args: [],
@@ -91,25 +102,32 @@ test.describe("macOS auto-update", () => {
         .toBe("object");
 
       // Prove we actually start on the old version, so the swap is real.
+      proof.failedStep = "start-version";
       const startVersion = await app.evaluate(({ app: a }) => a.getVersion());
+      proof.bootedOn = startVersion;
       expect(startVersion, "run app should start on the old version").toBe(
         OLD_VERSION,
       );
 
+      proof.failedStep = "update-available";
       await app.evaluate(() => (globalThis as Hooked).__e2eUpdates.check());
       await pollStatus(
         app,
         (s) => s.available === true && s.availableVersion === NEW_VERSION,
         "update never became available",
       );
+      proof.feedAvailableVersion = NEW_VERSION;
 
+      proof.failedStep = "download";
       await app.evaluate(() => (globalThis as Hooked).__e2eUpdates.download());
       await pollStatus(
         app,
         (s) => s.updateReady === true,
         "update never finished downloading",
       );
+      proof.downloaded = true;
 
+      proof.failedStep = "install-and-swap";
       const closed = app.waitForEvent("close");
       void app
         .evaluate(() => {
@@ -124,16 +142,21 @@ test.describe("macOS auto-update", () => {
         120_000,
         "bundle was not swapped to the new version",
       );
+      proof.bundleVersionAfterSwap = readBundleVersion(RUN_APP);
 
       // Squirrel relaunches the installed app (isForceRunAfter=true); confirm the
       // auto-relaunched process actually came up running from the swapped bundle.
+      proof.failedStep = "auto-relaunch";
       await waitUntil(
         () => runningAppExecutables().some((exe) => exe.includes(RUN_DIR)),
         60_000,
         "Squirrel did not auto-relaunch the updated app",
       );
+      proof.autoRelaunchedExecutable = runningAppExecutables().find((exe) =>
+        exe.includes(RUN_DIR),
+      );
       console.log(
-        `Auto-relaunched from swapped bundle: ${runningAppExecutables().join(", ")}`,
+        `Auto-relaunched from swapped bundle: ${proof.autoRelaunchedExecutable}`,
       );
 
       killApp();
@@ -143,17 +166,20 @@ test.describe("macOS auto-update", () => {
         "relaunched instance did not exit",
       );
 
+      proof.failedStep = "fresh-launch";
       const updated = await electron.launch({
         executablePath: RUN_APP_BIN,
         args: [],
         env: { ...process.env, ELECTRON_DISABLE_GPU: "1" },
       });
       const version = await updated.evaluate(({ app: a }) => a.getVersion());
+      proof.freshLaunchVersion = version;
       expect(version).toBe(NEW_VERSION);
       await updated.close();
 
       // Mechanism evidence: our updater drove a real download and install, and
       // Squirrel.Mac's ShipIt is what performed the in-place swap.
+      proof.failedStep = "evidence";
       const mainLog = readMainLog();
       expect(
         mainLog,
@@ -163,6 +189,8 @@ test.describe("macOS auto-update", () => {
         "Installing update and restarting",
       );
       const shipIt = shipItEvidence();
+      proof.shipItExists = shipIt.exists;
+      proof.shipItEntries = shipIt.entries;
       console.log(
         `Squirrel ShipIt cache: exists=${shipIt.exists} entries=[${shipIt.entries.join(", ")}]`,
       );
@@ -170,8 +198,17 @@ test.describe("macOS auto-update", () => {
         shipIt.exists,
         `no Squirrel ShipIt cache at ${SHIPIT_DIR}; the swap was not performed by Squirrel`,
       ).toBe(true);
+
+      proof.failedStep = undefined;
+      proof.result = "PASS";
+    } catch (err) {
+      proof.error = err instanceof Error ? err.message : String(err);
+      throw err;
     } finally {
-      feed.kill();
+      feed?.kill();
+      killApp();
+      proof.finishedAt = new Date().toISOString();
+      writeProof(proof);
     }
   });
 });

--- a/apps/code/tests/e2e/tests/update.spec.ts
+++ b/apps/code/tests/e2e/tests/update.spec.ts
@@ -43,7 +43,12 @@ const FEED_URL = `http://127.0.0.1:${FEED_PORT}`;
 const NEW_VERSION = "2.0.0";
 
 test.describe("macOS auto-update", () => {
-  test.skip(process.platform !== "darwin", "macOS-only update flow");
+  // Runs only in the dedicated code-update-e2e workflow, which builds the signed
+  // feed first. The general e2e suite has no feed, so it skips this spec.
+  test.skip(
+    process.platform !== "darwin" || process.env.RUN_UPDATE_E2E !== "1",
+    "macOS-only; set RUN_UPDATE_E2E=1 (needs scripts/dev-update/build-pair.sh)",
+  );
 
   test("downloads, installs and relaunches into the new version", async () => {
     test.setTimeout(5 * 60_000);

--- a/apps/code/tests/e2e/tests/update.spec.ts
+++ b/apps/code/tests/e2e/tests/update.spec.ts
@@ -1,0 +1,150 @@
+import { existsSync } from "node:fs";
+import {
+  type ElectronApplication,
+  _electron as electron,
+  expect,
+  test,
+} from "@playwright/test";
+import {
+  FEED_DIR,
+  isAppRunning,
+  killApp,
+  PRISTINE_APP,
+  prepareRunApp,
+  RUN_APP,
+  RUN_APP_BIN,
+  readBundleVersion,
+  startFeedServer,
+  waitUntil,
+} from "../fixtures/update";
+
+type UpdateStatus = {
+  checking?: boolean;
+  available?: boolean;
+  availableVersion?: string;
+  downloading?: boolean;
+  downloadPercent?: number;
+  updateReady?: boolean;
+};
+
+// Installed on globalThis by main/index.ts when POSTHOG_E2E_UPDATE_FEED is set.
+// The cast is erased at compile time, so the evaluate closures serialize to plain
+// globalThis access in the main process.
+type E2eHook = {
+  check: () => void;
+  download: () => void;
+  install: () => Promise<unknown>;
+  status: () => UpdateStatus;
+};
+type Hooked = typeof globalThis & { __e2eUpdates: E2eHook };
+
+const FEED_PORT = 8788;
+const FEED_URL = `http://127.0.0.1:${FEED_PORT}`;
+const NEW_VERSION = "2.0.0";
+
+test.describe("macOS auto-update", () => {
+  test.skip(process.platform !== "darwin", "macOS-only update flow");
+
+  test("downloads, installs and relaunches into the new version", async () => {
+    test.setTimeout(5 * 60_000);
+
+    expect(
+      existsSync(PRISTINE_APP),
+      `missing built app at ${PRISTINE_APP}; run scripts/dev-update/build-pair.sh`,
+    ).toBe(true);
+    expect(
+      existsSync(FEED_DIR),
+      `missing feed at ${FEED_DIR}; run scripts/dev-update/build-pair.sh`,
+    ).toBe(true);
+
+    prepareRunApp();
+    const feed = startFeedServer(FEED_PORT);
+
+    try {
+      // Phase 1: drive the real download + install on the old build.
+      const app = await electron.launch({
+        executablePath: RUN_APP_BIN,
+        args: [],
+        env: {
+          ...process.env,
+          ELECTRON_DISABLE_GPU: "1",
+          POSTHOG_E2E_UPDATE_FEED: FEED_URL,
+        },
+      });
+
+      await expect
+        .poll(
+          () => app.evaluate(() => typeof (globalThis as Hooked).__e2eUpdates),
+          {
+            timeout: 30_000,
+            message: "update hook was never installed",
+          },
+        )
+        .toBe("object");
+
+      await app.evaluate(() => (globalThis as Hooked).__e2eUpdates.check());
+      await pollStatus(
+        app,
+        (s) => s.available === true && s.availableVersion === NEW_VERSION,
+        "update never became available",
+      );
+
+      await app.evaluate(() => (globalThis as Hooked).__e2eUpdates.download());
+      await pollStatus(
+        app,
+        (s) => s.updateReady === true,
+        "update never finished downloading",
+      );
+
+      const closed = app.waitForEvent("close");
+      void app
+        .evaluate(() => {
+          void (globalThis as Hooked).__e2eUpdates.install();
+        })
+        .catch(() => undefined);
+      await closed;
+
+      // Phase 2: prove the bundle swapped and a fresh launch is the new version.
+      await waitUntil(
+        () => readBundleVersion(RUN_APP) === NEW_VERSION,
+        120_000,
+        "bundle was not swapped to the new version",
+      );
+      killApp();
+      await waitUntil(
+        () => !isAppRunning(),
+        30_000,
+        "relaunched instance did not exit",
+      );
+
+      const updated = await electron.launch({
+        executablePath: RUN_APP_BIN,
+        args: [],
+        env: { ...process.env, ELECTRON_DISABLE_GPU: "1" },
+      });
+      const version = await updated.evaluate(({ app: a }) => a.getVersion());
+      expect(version).toBe(NEW_VERSION);
+      await updated.close();
+    } finally {
+      feed.kill();
+    }
+  });
+});
+
+async function pollStatus(
+  app: ElectronApplication,
+  predicate: (status: UpdateStatus) => boolean,
+  message: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        predicate(
+          await app.evaluate(() =>
+            (globalThis as Hooked).__e2eUpdates.status(),
+          ),
+        ),
+      { timeout: 120_000, message },
+    )
+    .toBe(true);
+}

--- a/docs/AUTO-UPDATE-TESTING.md
+++ b/docs/AUTO-UPDATE-TESTING.md
@@ -25,7 +25,7 @@ The flow under test: a packaged old build checks a local feed, downloads a newer
 | `apps/code/scripts/dev-update/serve.mjs` | Dependency-free, range-capable static server for the feed |
 | `apps/code/tests/e2e/tests/update.spec.ts` | Two-phase Playwright test: drive download and install, then assert the swap and relaunch |
 | `POSTHOG_E2E_UPDATE_FEED` env | When set, the updater points at this URL instead of GitHub (gated, inert in production) |
-| `RUN_UPDATE_E2E` env | When set to `1`, the Playwright spec actually runs; otherwise it skips |
+| `apps/code/tests/e2e/playwright.update.config.ts` | Dedicated Playwright config; the only place the update spec runs |
 | `globalThis.__e2eUpdates` | Set in the main process when `POSTHOG_E2E_UPDATE_FEED` is present; lets the test drive `check` / `download` / `install` / `status` |
 
 ## 1. Build the pair
@@ -52,11 +52,11 @@ This takes a few minutes and may prompt for keychain access to sign.
 The spec starts its own feed server, copies the `1.0.0` app to a disposable run dir (so a rerun starts clean), drives the full flow and asserts the relaunched app is `2.0.0`.
 
 ```bash
-RUN_UPDATE_E2E=1 pnpm --filter code exec playwright test \
-  --config=tests/e2e/playwright.config.ts tests/e2e/tests/update.spec.ts
+pnpm --filter code exec playwright test \
+  --config=tests/e2e/playwright.update.config.ts
 ```
 
-Without `RUN_UPDATE_E2E=1` the spec skips, which is why the general e2e suite ignores it.
+The spec runs only through this dedicated config. The general e2e suite excludes it by path (`testIgnore` in `playwright.config.ts`), so it never runs there without a feed.
 
 ## 2b. Run it manually (real UI)
 
@@ -97,7 +97,7 @@ A manual run swaps `out/mac-arm64` in place, so rerun `build-pair.sh` (or just t
 gh workflow run "Code Update E2E (macOS)"
 ```
 
-It builds the pair, serves the feed and runs `update.spec.ts` with `RUN_UPDATE_E2E=1`.
+It builds the pair, runs the spec via `playwright.update.config.ts`, and asserts exactly one test actually ran, so a missing feed or a silent skip fails the job. The main log and the Squirrel ShipIt cache are uploaded as artifacts on every run.
 
 ## Cleanup
 

--- a/docs/AUTO-UPDATE-TESTING.md
+++ b/docs/AUTO-UPDATE-TESTING.md
@@ -143,6 +143,18 @@ pnpm --filter code exec playwright test \
 
 The old Forge app lands at `apps/code/out/old-forge/PostHog Code.app`. The spec copies it to a disposable run dir, so a rerun starts from `1.0.0` again without rebuilding.
 
+### Or: against the CI-signed Forge build (no local signing, no 9-minute build)
+
+The Forge counterpart to `run-from-ci.sh`. It pulls the CI-signed Forge `1.0.0` app and the `2.0.0` feed from the latest green run, verifies the signature survived transport, serves the feed, and launches the Forge app so its built-in Squirrel.Mac client drives the real update:
+
+```bash
+bash apps/code/scripts/dev-update/run-from-ci-forge.sh
+# a specific run:         bash apps/code/scripts/dev-update/run-from-ci-forge.sh <run-id>
+# automated spec instead: AUTOMATED=1 bash apps/code/scripts/dev-update/run-from-ci-forge.sh
+```
+
+Needs `gh` authenticated and your normal PostHog Code quit. The CI job uploads the Forge app as a `ditto` zip (`update-old-forge-build-1.0.0`) so its symlinks and code signature survive the artifact round-trip; a plain directory upload would break both and the swap would fail.
+
 ## CI
 
 `code-update-e2e.yml` runs both specs nightly on `macos-15` with the real signing secrets, and on demand:

--- a/docs/AUTO-UPDATE-TESTING.md
+++ b/docs/AUTO-UPDATE-TESTING.md
@@ -14,7 +14,7 @@ The flow under test: a packaged old build checks a local feed, downloads a newer
 
 - A packaged build (not `pnpm dev`). Auto-update only runs when `app.isPackaged` is true.
 - For the full install and relaunch: a Developer ID signing identity. Squirrel.Mac only swaps a bundle whose signature matches the running app's designated requirement, so both builds must be signed with the same identity. Set `CSC_LINK` / `CSC_KEY_PASSWORD`, or have a Developer ID cert in your login keychain.
-  - Without a matching identity you can still watch check, available, download and ready. The final swap is the part that needs the signature.
+  - Without a matching identity you can still watch check, available, download and ready, but the final swap needs the signature. If you can't sign locally, skip the local build and pull the CI-signed pair instead (see below).
 - Notarization is intentionally skipped (`SKIP_NOTARIZE=1`). It is a Gatekeeper concern for first launch of a downloaded app, not what the in-place update verifies, and a locally built bundle carries no quarantine attribute.
 
 ## The harness
@@ -28,7 +28,7 @@ The flow under test: a packaged old build checks a local feed, downloads a newer
 | `apps/code/tests/e2e/playwright.update.config.ts` | Dedicated Playwright config; the only place the update spec runs |
 | `globalThis.__e2eUpdates` | Set in the main process when `POSTHOG_E2E_UPDATE_FEED` is present; lets the test drive `check` / `download` / `install` / `status` |
 
-## 1. Build the pair
+## Build the pair locally
 
 ```bash
 bash apps/code/scripts/dev-update/build-pair.sh
@@ -46,6 +46,31 @@ OLD_VERSION=1.0.0 NEW_VERSION=2.0.0 bash apps/code/scripts/dev-update/build-pair
 ```
 
 This takes a few minutes and may prompt for keychain access to sign.
+
+## Or: pull a signed pair from CI (no local signing)
+
+If you don't have a Developer ID cert, `build-pair.sh` produces unsigned builds and the swap won't complete. The nightly run signs both with PostHog's identity and uploads them as two separate artifacts. Squirrel verifies signatures cryptographically (it does not need the cert in your keychain), so the pulled pair updates locally just like a real release.
+
+Drop them into the same paths the local build produces, then use the run sections below unchanged:
+
+```bash
+# latest green run
+RUN=$(gh run list --workflow=code-update-e2e.yml --status success -L 1 \
+  --json databaseId -q '.[0].databaseId')
+
+# old 1.0.0 app -> apps/code/out/mac-arm64/PostHog Code.app
+gh run download "$RUN" -n update-old-build-1.0.0 -D /tmp/upd-old
+rm -rf apps/code/out/mac-arm64 && mkdir -p apps/code/out/mac-arm64
+ditto -x -k "/tmp/upd-old/PostHog-Code-1.0.0-arm64-mac.zip" apps/code/out/mac-arm64
+# harmless if already clear; needed only if you downloaded via the browser
+xattr -dr com.apple.quarantine "apps/code/out/mac-arm64/PostHog Code.app"
+
+# new 2.0.0 feed -> apps/code/out/dev-update-feed/
+rm -rf apps/code/out/dev-update-feed
+gh run download "$RUN" -n update-new-build-2.0.0 -D apps/code/out/dev-update-feed
+```
+
+The builds are signed but not notarized, so launch by the binary path (the manual section does this); `open`-ing the `.app` may trip Gatekeeper.
 
 ## 2a. Run it automated (Playwright)
 
@@ -97,7 +122,7 @@ A manual run swaps `out/mac-arm64` in place, so rerun `build-pair.sh` (or just t
 gh workflow run "Code Update E2E (macOS)"
 ```
 
-It builds the pair, runs the spec via `playwright.update.config.ts`, and asserts exactly one test actually ran, so a missing feed or a silent skip fails the job. The main log and the Squirrel ShipIt cache are uploaded as artifacts on every run.
+It builds the pair, runs the spec via `playwright.update.config.ts`, and asserts exactly one test actually ran, so a missing feed or a silent skip fails the job. Every run renders a proof summary on the run page and uploads, on pass or fail: the proof manifest, main log and Squirrel ShipIt cache (artifact `update-e2e-macos`), plus the two signed builds as their own artifacts (`update-old-build-1.0.0`, `update-new-build-2.0.0`) you can pull as shown above.
 
 ## Cleanup
 

--- a/docs/AUTO-UPDATE-TESTING.md
+++ b/docs/AUTO-UPDATE-TESTING.md
@@ -47,30 +47,17 @@ OLD_VERSION=1.0.0 NEW_VERSION=2.0.0 bash apps/code/scripts/dev-update/build-pair
 
 This takes a few minutes and may prompt for keychain access to sign.
 
-## Or: pull a signed pair from CI (no local signing)
+## Or: one command, against the CI-signed pair (no local signing)
 
-If you don't have a Developer ID cert, `build-pair.sh` produces unsigned builds and the swap won't complete. The nightly run signs both with PostHog's identity and uploads them as two separate artifacts. Squirrel verifies signatures cryptographically (it does not need the cert in your keychain), so the pulled pair updates locally just like a real release.
-
-Drop them into the same paths the local build produces, then use the run sections below unchanged:
+If you don't have a Developer ID cert, `build-pair.sh` produces unsigned builds and the swap won't complete. Instead run one script: it pulls the signed pair from the latest green run, serves the feed, and opens the old app pointed at it. Squirrel verifies signatures cryptographically (it does not need the cert in your keychain), so the CI-signed pair updates locally just like a real release.
 
 ```bash
-# latest green run
-RUN=$(gh run list --workflow=code-update-e2e.yml --status success -L 1 \
-  --json databaseId -q '.[0].databaseId')
-
-# old 1.0.0 app -> apps/code/out/mac-arm64/PostHog Code.app
-gh run download "$RUN" -n update-old-build-1.0.0 -D /tmp/upd-old
-rm -rf apps/code/out/mac-arm64 && mkdir -p apps/code/out/mac-arm64
-ditto -x -k "/tmp/upd-old/PostHog-Code-1.0.0-arm64-mac.zip" apps/code/out/mac-arm64
-# harmless if already clear; needed only if you downloaded via the browser
-xattr -dr com.apple.quarantine "apps/code/out/mac-arm64/PostHog Code.app"
-
-# new 2.0.0 feed -> apps/code/out/dev-update-feed/
-rm -rf apps/code/out/dev-update-feed
-gh run download "$RUN" -n update-new-build-2.0.0 -D apps/code/out/dev-update-feed
+bash apps/code/scripts/dev-update/run-from-ci.sh
+# a specific run:         bash apps/code/scripts/dev-update/run-from-ci.sh <run-id>
+# automated spec instead: AUTOMATED=1 bash apps/code/scripts/dev-update/run-from-ci.sh
 ```
 
-The builds are signed but not notarized, so launch by the binary path (the manual section does this); `open`-ing the `.app` may trip Gatekeeper.
+Needs the GitHub CLI (`gh`) authenticated, and your normal PostHog Code must be quit (the test build shares its single-instance lock and data dir). The app opens on `1.0.0` with an update available; click Download, then Restart, and it swaps and relaunches into `2.0.0`.
 
 ## 2a. Run it automated (Playwright)
 

--- a/docs/AUTO-UPDATE-TESTING.md
+++ b/docs/AUTO-UPDATE-TESTING.md
@@ -10,6 +10,11 @@ Auto-update is macOS and Windows only (`isSupported` in `apps/code/src/main/plat
 
 The flow under test: a packaged old build checks a local feed, downloads a newer build, and Squirrel.Mac swaps the app bundle in place and relaunches into the new version.
 
+Two legs run against the same `2.0.0` feed:
+
+- **electron-builder to electron-builder**: the forward-compatibility baseline. A `1.0.0` electron-builder build updates to the `2.0.0` electron-builder build using `electron-updater`.
+- **Forge to electron-builder**: a real Electron Forge build (the last Forge release, `v0.55.132`) updates to the `2.0.0` electron-builder build using the genuine built-in Squirrel.Mac client. This is the case real users are in: their app was made by Forge, and we need it to pick up the electron-builder builds we ship now. See [The Forge to electron-builder leg](#the-forge-to-electron-builder-leg).
+
 ## What you need
 
 - A packaged build (not `pnpm dev`). Auto-update only runs when `app.isPackaged` is true.
@@ -21,12 +26,15 @@ The flow under test: a packaged old build checks a local feed, downloads a newer
 
 | Piece | Role |
 | --- | --- |
-| `apps/code/scripts/dev-update/build-pair.sh` | Builds a signed `2.0.0` feed plus a runnable signed `1.0.0` app |
-| `apps/code/scripts/dev-update/serve.mjs` | Dependency-free, range-capable static server for the feed |
-| `apps/code/tests/e2e/tests/update.spec.ts` | Two-phase Playwright test: drive download and install, then assert the swap and relaunch |
-| `POSTHOG_E2E_UPDATE_FEED` env | When set, the updater points at this URL instead of GitHub (gated, inert in production) |
-| `apps/code/tests/e2e/playwright.update.config.ts` | Dedicated Playwright config; the only place the update spec runs |
-| `globalThis.__e2eUpdates` | Set in the main process when `POSTHOG_E2E_UPDATE_FEED` is present; lets the test drive `check` / `download` / `install` / `status` |
+| `apps/code/scripts/dev-update/build-pair.sh` | Builds a signed `2.0.0` feed plus a runnable signed `1.0.0` app (the baseline leg) |
+| `apps/code/scripts/dev-update/build-old-forge.sh` | Builds the last Forge release (`v0.55.132`) as the signed `1.0.0` old app for the Forge leg |
+| `apps/code/scripts/dev-update/serve.mjs` | Dependency-free, range-capable static server. Serves the `electron-updater` manifest AND the Squirrel.Mac JSON feed the built-in updater expects |
+| `apps/code/tests/e2e/tests/update.spec.ts` | Baseline leg: drive `electron-updater` download and install, then assert the swap and relaunch |
+| `apps/code/tests/e2e/tests/update-forge.spec.ts` | Forge leg: let the old build's built-in Squirrel.Mac client download, drive install, then assert the swap and relaunch |
+| `POSTHOG_E2E_UPDATE_FEED` env | Baseline leg: when set, `electron-updater` points at this URL instead of GitHub (gated, inert in production) |
+| `POSTHOG_E2E_UPDATE_HOST` env | Forge leg: the one-line env seam baked into the old build so its built-in updater asks this host instead of `update.electronjs.org` |
+| `apps/code/tests/e2e/playwright.update.config.ts`, `playwright.update-forge.config.ts` | Dedicated Playwright configs; the only place each update spec runs |
+| `globalThis.__e2eUpdates` | Baseline leg only: set in the main process when `POSTHOG_E2E_UPDATE_FEED` is present; lets the test drive `check` / `download` / `install` / `status` |
 
 ## Build the pair locally
 
@@ -101,15 +109,51 @@ A manual run swaps `out/mac-arm64` in place, so rerun `build-pair.sh` (or just t
   tail -f ~/.posthog-code/logs/main.log
   ```
 
+## The Forge to electron-builder leg
+
+The baseline leg proves an electron-builder build updates to a newer electron-builder build. That is the future. It does not prove what every current user needs: their app was made by Electron Forge and runs the genuine built-in Squirrel.Mac client, not `electron-updater`. This leg covers that.
+
+### What it proves
+
+A real Forge build picks up an electron-builder build through its own updater, end to end: boot on the Forge `1.0.0`, the built-in client checks the local feed, downloads the `2.0.0` electron-builder zip, Squirrel.Mac swaps the bundle in place, relaunches, and the fresh launch is `2.0.0`. The swap only happens if the new bundle's code signature satisfies the running app's designated requirement, so signing parity is part of what is verified.
+
+### How the old build is produced
+
+`build-old-forge.sh` checks the last Forge release out into an isolated git worktree and builds it there, so the current branch checkout is untouched. The pinned commit is `cb0ca68db` (`v0.55.132`), the last release before the electron-builder migration. Override with `OLD_FORGE_REF` if needed.
+
+It is a genuine `electron-forge package` build, not a rebuild with electron-builder, because the whole point is the built-in Squirrel.Mac client that shipped to users. It is signed with the same identity the new build uses (Forge resolves the identity by name from a keychain, so the script imports `CSC_LINK` into a temp keychain and derives `APPLE_CODESIGN_IDENTITY`). Both Forge and electron-builder use bundle id `com.posthog.array`, so the designated requirements match and the swap is allowed.
+
+### Two seams the old build needs
+
+- **Feed host (`POSTHOG_E2E_UPDATE_HOST`)**: a one-line change applied in the worktree so the built-in updater's feed host honours the env var instead of being hardcoded to `update.electronjs.org`. Nothing in the download, verify or swap path changes. At test time the app's own boot check then drives the real download against the local feed, exactly as it would against `update.electronjs.org` in production.
+- **Local networking (ATS)**: the built-in updater uses `NSURLSession`, which enforces App Transport Security, so plain http to loopback is blocked by default. The script adds `NSAppTransportSecurity.NSAllowsLocalNetworking` to the packaged `Info.plist` and re-signs the bundle with the same identity and entitlements, so the designated requirement is unchanged. `electron-updater` (the baseline leg) uses its own Node HTTP client and is not subject to ATS, which is why only this leg needs it.
+
+`serve.mjs` answers the Squirrel.Mac feed shape (`GET /<owner>/<repo>/darwin-<arch>/<version>` returns `204` when current, or `200` + `{ url }` pointing at the new zip) in addition to the static `electron-updater` manifest. It self-configures from the feed's `latest-mac.yml`, so the same feed dir drives both legs.
+
+### Run it locally
+
+You need the same Developer ID signing setup as the baseline leg (`CSC_LINK` / `CSC_KEY_PASSWORD`, or an identity in a keychain), full git history, and the `2.0.0` feed from `build-pair.sh`:
+
+```bash
+bash apps/code/scripts/dev-update/build-pair.sh        # the 2.0.0 feed
+bash apps/code/scripts/dev-update/build-old-forge.sh   # the old Forge 1.0.0 app
+pnpm --filter code exec playwright test \
+  --config=tests/e2e/playwright.update-forge.config.ts
+```
+
+The old Forge app lands at `apps/code/out/old-forge/PostHog Code.app`. The spec copies it to a disposable run dir, so a rerun starts from `1.0.0` again without rebuilding.
+
 ## CI
 
-`code-update-e2e.yml` runs the same spec nightly on `macos-15` with the real signing secrets, and on demand:
+`code-update-e2e.yml` runs both specs nightly on `macos-15` with the real signing secrets, and on demand:
 
 ```bash
 gh workflow run "Code Update E2E (macOS)"
 ```
 
-It builds the pair, runs the spec via `playwright.update.config.ts`, and asserts exactly one test actually ran, so a missing feed or a silent skip fails the job. Every run renders a proof summary on the run page and uploads, on pass or fail: the proof manifest, main log and Squirrel ShipIt cache (artifact `update-e2e-macos`), plus the two signed builds as their own artifacts (`update-old-build-1.0.0`, `update-new-build-2.0.0`) you can pull as shown above.
+It builds the `2.0.0` feed and the baseline `1.0.0` app, runs the baseline spec via `playwright.update.config.ts`, then builds the old Forge `1.0.0` app and runs the Forge spec via `playwright.update-forge.config.ts`. Each leg asserts exactly one test actually ran, so a missing feed or a silent skip fails the job. The Forge leg runs after the baseline so a flake in the (riskier) old-build step can never mask the baseline result.
+
+Every run renders a proof summary per leg on the run page and uploads, on pass or fail: both proof manifests, main log and Squirrel ShipIt cache (artifact `update-e2e-macos`), plus the signed builds as their own artifacts (`update-old-build-1.0.0`, `update-new-build-2.0.0`, `update-old-forge-build-1.0.0`) you can pull as shown above.
 
 ## Cleanup
 

--- a/docs/AUTO-UPDATE-TESTING.md
+++ b/docs/AUTO-UPDATE-TESTING.md
@@ -1,0 +1,106 @@
+# Testing Auto-Update Locally
+
+This explains how to exercise the real auto-update flow (check, download, install, relaunch) on your own machine, against a local feed, without cutting a GitHub release. For how releases and versioning actually work in production, see [UPDATES.md](./UPDATES.md).
+
+The same harness runs nightly in CI (`.github/workflows/code-update-e2e.yml`) on a signed macOS build.
+
+## What this covers
+
+Auto-update is macOS and Windows only (`isSupported` in `apps/code/src/main/platform-adapters/electron-updater.ts`). This guide is macOS, which is where the harness and the nightly job run.
+
+The flow under test: a packaged old build checks a local feed, downloads a newer build, and Squirrel.Mac swaps the app bundle in place and relaunches into the new version.
+
+## What you need
+
+- A packaged build (not `pnpm dev`). Auto-update only runs when `app.isPackaged` is true.
+- For the full install and relaunch: a Developer ID signing identity. Squirrel.Mac only swaps a bundle whose signature matches the running app's designated requirement, so both builds must be signed with the same identity. Set `CSC_LINK` / `CSC_KEY_PASSWORD`, or have a Developer ID cert in your login keychain.
+  - Without a matching identity you can still watch check, available, download and ready. The final swap is the part that needs the signature.
+- Notarization is intentionally skipped (`SKIP_NOTARIZE=1`). It is a Gatekeeper concern for first launch of a downloaded app, not what the in-place update verifies, and a locally built bundle carries no quarantine attribute.
+
+## The harness
+
+| Piece | Role |
+| --- | --- |
+| `apps/code/scripts/dev-update/build-pair.sh` | Builds a signed `2.0.0` feed plus a runnable signed `1.0.0` app |
+| `apps/code/scripts/dev-update/serve.mjs` | Dependency-free, range-capable static server for the feed |
+| `apps/code/tests/e2e/tests/update.spec.ts` | Two-phase Playwright test: drive download and install, then assert the swap and relaunch |
+| `POSTHOG_E2E_UPDATE_FEED` env | When set, the updater points at this URL instead of GitHub (gated, inert in production) |
+| `RUN_UPDATE_E2E` env | When set to `1`, the Playwright spec actually runs; otherwise it skips |
+| `globalThis.__e2eUpdates` | Set in the main process when `POSTHOG_E2E_UPDATE_FEED` is present; lets the test drive `check` / `download` / `install` / `status` |
+
+## 1. Build the pair
+
+```bash
+bash apps/code/scripts/dev-update/build-pair.sh
+```
+
+This runs `electron-vite build` once, then builds twice with `electron-builder`:
+
+- The new `2.0.0` artifacts are copied to `apps/code/out/dev-update-feed/` (`latest-mac.yml`, the zip and its blockmap). This is the feed.
+- The old `1.0.0` app is left at `apps/code/out/mac-arm64/PostHog Code.app`. This is what you run.
+
+Override the versions if you want (`2.0.0` must be greater than `1.0.0`):
+
+```bash
+OLD_VERSION=1.0.0 NEW_VERSION=2.0.0 bash apps/code/scripts/dev-update/build-pair.sh
+```
+
+This takes a few minutes and may prompt for keychain access to sign.
+
+## 2a. Run it automated (Playwright)
+
+The spec starts its own feed server, copies the `1.0.0` app to a disposable run dir (so a rerun starts clean), drives the full flow and asserts the relaunched app is `2.0.0`.
+
+```bash
+RUN_UPDATE_E2E=1 pnpm --filter code exec playwright test \
+  --config=tests/e2e/playwright.config.ts tests/e2e/tests/update.spec.ts
+```
+
+Without `RUN_UPDATE_E2E=1` the spec skips, which is why the general e2e suite ignores it.
+
+## 2b. Run it manually (real UI)
+
+Serve the feed in one terminal:
+
+```bash
+node apps/code/scripts/dev-update/serve.mjs apps/code/out/dev-update-feed 8788
+```
+
+Launch the `1.0.0` app pointed at it in another terminal:
+
+```bash
+POSTHOG_E2E_UPDATE_FEED=http://127.0.0.1:8788 \
+  "apps/code/out/mac-arm64/PostHog Code.app/Contents/MacOS/PostHog Code"
+```
+
+The app checks on launch and the update banner shows `2.0.0` is available. Open it, click Download, watch progress, then Restart. The app quits, swaps and relaunches into `2.0.0`.
+
+A manual run swaps `out/mac-arm64` in place, so rerun `build-pair.sh` (or just the old build) to reset to `1.0.0` before testing again.
+
+## Verifying the result
+
+- Running version: open the in-app About, or read the bundle:
+  ```bash
+  plutil -extract CFBundleShortVersionString raw \
+    "apps/code/out/mac-arm64/PostHog Code.app/Contents/Info.plist"
+  ```
+- Update logs are in the main log:
+  ```bash
+  tail -f ~/.posthog-code/logs/main.log
+  ```
+
+## CI
+
+`code-update-e2e.yml` runs the same spec nightly on `macos-15` with the real signing secrets, and on demand:
+
+```bash
+gh workflow run "Code Update E2E (macOS)"
+```
+
+It builds the pair, serves the feed and runs `update.spec.ts` with `RUN_UPDATE_E2E=1`.
+
+## Cleanup
+
+```bash
+rm -rf apps/code/out/dev-update-feed apps/code/out/e2e-update-run
+```

--- a/packages/core/src/updates/updateStore.test.ts
+++ b/packages/core/src/updates/updateStore.test.ts
@@ -38,6 +38,40 @@ describe("deriveUpdateUiStatus", () => {
     });
   });
 
+  it("hydrates an available update", () => {
+    expect(
+      deriveUpdateUiStatus(
+        {
+          checking: false,
+          available: true,
+          availableVersion: "v2",
+          releaseNotes: "notes",
+          releaseDate: "2026-01-01",
+          downloadSizeBytes: 1234,
+        },
+        "idle",
+      ),
+    ).toEqual({
+      status: "available",
+      availableVersion: "v2",
+      releaseNotes: "notes",
+      releaseDate: "2026-01-01",
+      downloadSizeBytes: 1234,
+    });
+  });
+
+  it("defaults available fields to null when absent", () => {
+    expect(
+      deriveUpdateUiStatus({ checking: false, available: true }, "idle"),
+    ).toEqual({
+      status: "available",
+      availableVersion: null,
+      releaseNotes: null,
+      releaseDate: null,
+      downloadSizeBytes: null,
+    });
+  });
+
   it("maps checking to checking", () => {
     expect(deriveUpdateUiStatus({ checking: true }, "idle")).toEqual({
       status: "checking",

--- a/packages/ui/src/features/updates/releaseNotes.test.ts
+++ b/packages/ui/src/features/updates/releaseNotes.test.ts
@@ -67,4 +67,33 @@ describe("groupReleases", () => {
     expect(groups[2].key.startsWith("week-")).toBe(true);
     expect(groups[2].releases).toHaveLength(2);
   });
+
+  it("marks the newest stable release as latest, skipping a prerelease", () => {
+    const groups = groupReleases(
+      [
+        { ...mk("v0.56.0-beta.1", "2026-06-20T12:00:00Z"), isPrerelease: true },
+        mk("v0.55.14", "2026-06-19T12:00:00Z"),
+      ],
+      now,
+      3,
+    );
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].releases[0].name).toBe("v0.56.0-beta.1");
+    expect(groups[0].isLatest).toBe(false);
+    expect(groups[1].isLatest).toBe(true);
+  });
+
+  it("falls back to the newest group when every release is a prerelease", () => {
+    const groups = groupReleases(
+      [
+        { ...mk("v0.56.0-beta.2", "2026-06-20T12:00:00Z"), isPrerelease: true },
+        { ...mk("v0.56.0-beta.1", "2026-06-19T12:00:00Z"), isPrerelease: true },
+      ],
+      now,
+      3,
+    );
+
+    expect(groups[0].isLatest).toBe(true);
+  });
 });

--- a/packages/ui/src/features/updates/releaseNotes.ts
+++ b/packages/ui/src/features/updates/releaseNotes.ts
@@ -8,6 +8,7 @@ export interface ReleaseLike {
   version: string;
   notes: string;
   date: string | null;
+  isPrerelease?: boolean;
 }
 
 export interface ReleaseGroup {
@@ -98,6 +99,9 @@ export function groupReleases(
 ): ReleaseGroup[] {
   const recentCutoff = now - recentDays * DAY_MS;
   const map = new Map<string, ReleaseGroup>();
+  // The "Latest" badge should mark the newest stable release, not a prerelease
+  // that sorts first; UpdateAvailableModal applies the same skip-prerelease rule.
+  let latestStableGroup: ReleaseGroup | undefined;
 
   for (const release of releases) {
     const time = release.date ? Date.parse(release.date) : Number.NaN;
@@ -123,11 +127,15 @@ export function groupReleases(
       map.set(key, group);
     }
     group.releases.push(release);
+    if (!latestStableGroup && !release.isPrerelease) {
+      latestStableGroup = group;
+    }
   }
 
   const groups = Array.from(map.values());
-  if (groups.length > 0) {
-    groups[0].isLatest = true;
+  const latestGroup = latestStableGroup ?? groups[0];
+  if (latestGroup) {
+    latestGroup.isLatest = true;
   }
   return groups;
 }

--- a/scripts/rebuild-better-sqlite3-electron.mjs
+++ b/scripts/rebuild-better-sqlite3-electron.mjs
@@ -77,7 +77,9 @@ console.log(`better-sqlite3 built for Electron ${electronVersion}.`);
 // workspace-server's Node-ABI binary, which the DB unit tests load directly.
 const builtBinary = path.join(moduleDir, "build/Release/better_sqlite3.node");
 if (!existsSync(builtBinary)) {
-  throw new Error(`Expected built binary at ${builtBinary} but none was found.`);
+  throw new Error(
+    `Expected built binary at ${builtBinary} but none was found.`,
+  );
 }
 
 const rootVersion = JSON.parse(

--- a/scripts/rebuild-better-sqlite3-electron.mjs
+++ b/scripts/rebuild-better-sqlite3-electron.mjs
@@ -8,7 +8,14 @@
 // @electron/rebuild, whose CLI crashes on Node 26+ and whose module walker
 // cannot see pnpm's hoisted node_modules.
 import { execFileSync } from "node:child_process";
-import { rmSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -60,3 +67,45 @@ try {
   ]);
 }
 console.log(`better-sqlite3 built for Electron ${electronVersion}.`);
+
+// pnpm's hoisted layout gives every workspace package that directly depends on
+// better-sqlite3 its own physical copy. The rebuild above only touches the root
+// copy, but the bundled Electron main process resolves better-sqlite3 from
+// apps/code/node_modules first, so a stale binary there fails to load and
+// DatabaseService's @postConstruct initializer throws. Mirror the freshly built
+// binary into same-version nested copies. The version guard preserves
+// workspace-server's Node-ABI binary, which the DB unit tests load directly.
+const builtBinary = path.join(moduleDir, "build/Release/better_sqlite3.node");
+if (!existsSync(builtBinary)) {
+  throw new Error(`Expected built binary at ${builtBinary} but none was found.`);
+}
+
+const rootVersion = JSON.parse(
+  readFileSync(path.join(moduleDir, "package.json"), "utf8"),
+).version;
+
+const nestedModuleDirs = ["apps", "packages"].flatMap((group) => {
+  const groupDir = path.join(repoRoot, group);
+  if (!existsSync(groupDir)) return [];
+  return readdirSync(groupDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) =>
+      path.join(groupDir, entry.name, "node_modules/better-sqlite3"),
+    )
+    .filter((dir) => existsSync(path.join(dir, "package.json")));
+});
+
+for (const dir of nestedModuleDirs) {
+  const relDir = path.relative(repoRoot, dir);
+  const version = JSON.parse(
+    readFileSync(path.join(dir, "package.json"), "utf8"),
+  ).version;
+  if (version !== rootVersion) {
+    console.log(`Skipping ${relDir} (better-sqlite3 ${version}).`);
+    continue;
+  }
+  const dest = path.join(dir, "build/Release/better_sqlite3.node");
+  mkdirSync(path.dirname(dest), { recursive: true });
+  copyFileSync(builtBinary, dest);
+  console.log(`Synced Electron binary to ${relDir}.`);
+}


### PR DESCRIPTION
## Problem

The electron-builder + electron-updater migration gave us a real auto-update path (download, install, relaunch), but nothing tests it end to end. 

## Changes

Two tiny test-gated hooks in the main process, both inert unless `POSTHOG_E2E_UPDATE_FEED` is set (no production behavior change):
- `electron-updater.ts` points the updater at a local feed via `setFeedURL`. `disableDifferentialDownload`, `autoDownload`, `autoInstallOnAppQuit` and `isSupported` are untouched.
- `main/index.ts` exposes `globalThis.__e2eUpdates` (check/download/install/status) wired to the real `UpdatesService`.

Harness:
- `scripts/dev-update/serve.mjs`: dependency-free, range-capable static feed server.
- `scripts/dev-update/build-pair.sh`: builds a signed `2.0.0` feed and a runnable signed `1.0.0` app (`SKIP_NOTARIZE=1`).
- `tests/e2e/fixtures/update.ts`: `ditto` run-copy so a retry restarts from `1.0.0`, plist version read, pkill helpers.
- `tests/e2e/tests/update.spec.ts`: phase 1 drives download then install via the main-process hook; phase 2 waits for the on-disk bundle to swap, kills the auto-relaunched instance, then fresh-launches and asserts `app.getVersion()` is `2.0.0`.

CI: a dedicated `code-update-e2e.yml`, macOS only, reusing the existing `build-macos` steps and Apple signing secrets. It is not on the PR gate (nightly + `workflow_dispatch`); a temporary push trigger on this branch lets it run on the PR and is meant to be removed before merge.

The swap is signature-gated (Squirrel.Mac matches the designated requirement), which is why this runs in CI where the signing cert is present rather than as a local unit test. Notarization is skipped on purpose: it is a Gatekeeper concern, not what the in-place update verifies.

## How did you test this?

Ran locally:
- `pnpm --filter code typecheck` passes with the hooks.
- Biome clean on all new and changed files.
- `node --check serve.mjs` and `bash -n build-pair.sh` pass.
- The e2e tsconfig typechecks the two new e2e files (the only errors are pre-existing in `smoke.spec.ts`).

Not run locally: the full signed build plus end-to-end swap (two signed mac builds, needs the Developer ID cert). That runs in the new workflow on this branch via the temporary push trigger, which is the real validation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?