### PR TITLE
fix(channels): pin nav links so only the channel tree scrolls

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -161,10 +161,10 @@ export function ChannelsSidebar() {
           <ProjectSwitcher triggerVariant="button" />
         </Box>
 
-        {/* The whole nav (links + channel tree) scrolls as one — only the switcher
-            above and Settings below stay pinned. */}
+        {/* The global nav links stay pinned below the switcher; only the channel
+            tree scrolls when it overflows. */}
+        <ChannelsNav />
         <Box className="scroll-mask-4 min-h-0 flex-1 overflow-y-auto">
-          <ChannelsNav />
           <ChannelsList />
         </Box>
 


### PR DESCRIPTION
## Problem

In the Project Bluebird (Channels) sidebar, when the nav content is taller than the screen the **entire** nav scrolls — the top-level links (Home, Global Inbox, Canvas, Agents, Files) scroll away along with the channel tree. Those links should stay put; only the channels area should scroll.

## Changes

In `ChannelsSidebar`, the global nav links and the channel tree shared a single `overflow-y-auto` container. Moved `ChannelsNav` out of that container so it stays pinned (it already has `shrink-0`), leaving only `ChannelsList` inside the scroll region. The workspace switcher and Settings remain pinned as before.

## How did you test this?

Not run locally — this is a CSS/JSX layout change moving one component out of the scroll container. No tests were added or run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
