### PR TITLE
fix(sessions): show the error reason on failed tool calls

### DIFF
--- a/packages/ui/src/features/mcp-apps/components/McpToolView.test.tsx
+++ b/packages/ui/src/features/mcp-apps/components/McpToolView.test.tsx
@@ -1,0 +1,52 @@
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { McpToolView } from "./McpToolView";
+
+const ERROR_MARKER = "Sentinel error reason for testing";
+const OUTPUT_MARKER = "Sentinel success output for testing";
+
+function makeToolCall(overrides: Partial<ToolCall> = {}): ToolCall {
+  return {
+    toolCallId: "tc-1",
+    title: "posthog",
+    kind: "other",
+    status: "completed",
+    rawInput: { foo: "bar" },
+    ...overrides,
+  };
+}
+
+function textContent(text: string): NonNullable<ToolCall["content"]> {
+  return [{ type: "content", content: { type: "text", text } }];
+}
+
+function renderView(toolCall: ToolCall) {
+  return render(
+    <Theme>
+      <McpToolView toolCall={toolCall} mcpToolName="posthog__query" expanded />
+    </Theme>,
+  );
+}
+
+describe("McpToolView", () => {
+  it("renders the error reason when the tool call failed", () => {
+    renderView(
+      makeToolCall({ status: "failed", content: textContent(ERROR_MARKER) }),
+    );
+
+    expect(screen.getByText(ERROR_MARKER)).toBeInTheDocument();
+  });
+
+  it("still renders output when the tool call completed", () => {
+    renderView(
+      makeToolCall({
+        status: "completed",
+        content: textContent(OUTPUT_MARKER),
+      }),
+    );
+
+    expect(screen.getByText(OUTPUT_MARKER)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/features/mcp-apps/components/McpToolView.tsx
+++ b/packages/ui/src/features/mcp-apps/components/McpToolView.tsx
@@ -56,7 +56,9 @@ export function McpToolView({
 
   const output = stripCodeFences(getContentText(content) ?? "");
   const hasOutput = output.trim().length > 0;
-  const showOutput = isComplete && hasOutput;
+  // Surface output for failures too, otherwise a failed call shows "(Failed)"
+  // with no reason — the error text lives in `content`.
+  const showOutput = (isComplete || isFailed) && hasOutput;
 
   const body =
     fullInput || showOutput ? (

--- a/packages/ui/src/features/sessions/components/session-update/ToolCallView.test.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ToolCallView.test.tsx
@@ -2,7 +2,7 @@ import type { ToolCall } from "@posthog/ui/features/sessions/types";
 import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { McpToolView } from "./McpToolView";
+import { ToolCallView } from "./ToolCallView";
 
 const ERROR_MARKER = "Sentinel error reason for testing";
 const OUTPUT_MARKER = "Sentinel success output for testing";
@@ -10,7 +10,7 @@ const OUTPUT_MARKER = "Sentinel success output for testing";
 function makeToolCall(overrides: Partial<ToolCall> = {}): ToolCall {
   return {
     toolCallId: "tc-1",
-    title: "posthog",
+    title: "do_something",
     kind: "other",
     status: "completed",
     rawInput: { foo: "bar" },
@@ -25,12 +25,12 @@ function textContent(text: string): NonNullable<ToolCall["content"]> {
 function renderView(toolCall: ToolCall) {
   return render(
     <Theme>
-      <McpToolView toolCall={toolCall} mcpToolName="posthog__query" expanded />
+      <ToolCallView toolCall={toolCall} expanded />
     </Theme>,
   );
 }
 
-describe("McpToolView", () => {
+describe("ToolCallView", () => {
   it.each([
     { status: "failed" as const, marker: ERROR_MARKER },
     { status: "completed" as const, marker: OUTPUT_MARKER },

--- a/packages/ui/src/features/sessions/components/session-update/ToolCallView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ToolCallView.tsx
@@ -103,7 +103,9 @@ export function ToolCallView({
 
   const output = stripCodeFences(getContentText(content) ?? "");
   const hasOutput = output.trim().length > 0;
-  const showOutput = isComplete && hasOutput;
+  // Surface output for failures too, otherwise a failed call shows "(Failed)"
+  // with no reason — the error text lives in `content`.
+  const showOutput = (isComplete || isFailed) && hasOutput;
 
   const body =
     fullInput || showOutput ? (


### PR DESCRIPTION
## Problem

When a tool call failed, the row showed `… (Failed)` but never the reason why — even when the row was expanded. This was reported for MCP tool calls but affected the generic tool view too.

## Changes

The error text is already captured into the tool call's `content` (the agent layer writes it there), but two render components gated the output panel behind completed-only status:

```ts
const showOutput = isComplete && hasOutput; // isComplete === status === "completed"
```

On a failed call `isComplete` is `false`, so the error content was read and then dropped before reaching the DOM. (`ExecuteToolView` already rendered output unconditionally, which is why Bash failures *did* surface their output — only `McpToolView` and the generic `ToolCallView` had the bug.)

The fix lets output through on failure too in both views:

```ts
const showOutput = (isComplete || isFailed) && hasOutput;
```

- `packages/ui/src/features/mcp-apps/components/McpToolView.tsx`
- `packages/ui/src/features/sessions/components/session-update/ToolCallView.tsx`

Behavior is otherwise unchanged: rows stay collapsed-by-default, so the reason appears once the failed row is expanded (consistent with the existing convention). Auto-expanding failures is a reasonable follow-up if we want the reason visible without a click.

## How did you test this?

- Added `McpToolView.test.tsx` — asserts a failed MCP call renders its error reason, and that completed calls still render their output. Both pass (`vitest run`, 2/2).
- `biome check` clean on the three changed files.
- `tsc --noEmit` produces no errors in any of the changed files (remaining repo-wide errors are pre-existing, from unbuilt sibling packages on a fresh checkout).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
