### PR TITLE
feat(scouts): show alpha banner in the scout fleet

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -1524,7 +1524,7 @@ export class PostHogAPIClient {
   }
 
   async getScoutMetadata(projectId: number): Promise<ScoutMetadata> {
-    return await this.scoutGet<ScoutMetadata>(projectId, "metadata/current/");
+    return this.scoutGet<ScoutMetadata>(projectId, "metadata/current/");
   }
 
   async updateScoutConfig(

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -240,6 +240,26 @@ export interface ScoutConfig {
   created_at: string;
 }
 
+/** A team's enforced scout run caps and current usage, as dispatch applies them. */
+export interface ScoutLimits {
+  max_runs_per_tick: number;
+  /** Null when the daily budget is uncapped. */
+  max_runs_per_day: number | null;
+  runs_today: number;
+  /** Null when the daily budget is uncapped. */
+  runs_remaining_today: number | null;
+}
+
+/**
+ * Team-scoped scout metadata from the `signals-scout` flag: enrollment, an optional
+ * announcement banner, and the enforced run limits. `banner_message` is null when unset.
+ */
+export interface ScoutMetadata {
+  enrolled: boolean;
+  banner_message: string | null;
+  limits: ScoutLimits;
+}
+
 export interface ScoutRun {
   run_id: string;
   skill_name: string;
@@ -1501,6 +1521,10 @@ export class PostHogAPIClient {
       { results: ScoutConfig[] } | ScoutConfig[]
     >(projectId, "configs/");
     return Array.isArray(data) ? data : (data.results ?? []);
+  }
+
+  async getScoutMetadata(projectId: number): Promise<ScoutMetadata> {
+    return await this.scoutGet<ScoutMetadata>(projectId, "metadata/current/");
   }
 
   async updateScoutConfig(

--- a/packages/ui/src/features/scouts/components/ScoutAlphaBanner.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutAlphaBanner.tsx
@@ -1,0 +1,52 @@
+import { Info, X } from "@phosphor-icons/react";
+import { useState } from "react";
+import { useScoutMetadata } from "../hooks/useScoutMetadata";
+
+const DISMISS_KEY_PREFIX = "scout-alpha-banner-dismissed:";
+
+const dismissKeyFor = (message: string): string =>
+  `${DISMISS_KEY_PREFIX}${message}`;
+
+/**
+ * Alpha/announcement banner for the scout fleet, sourced from the `signals-scout` flag via the
+ * metadata endpoint — so the copy (e.g. a run-limit notice) changes with no app release. Renders
+ * nothing when no message is set. Dismissal is remembered per-message, so a reworded notice
+ * resurfaces. localStorage is read during render against the current message, which keeps it
+ * correct even though the message arrives after the first paint.
+ */
+export function ScoutAlphaBanner() {
+  const { data: metadata } = useScoutMetadata();
+  const message = metadata?.banner_message ?? null;
+  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  if (!message) {
+    return null;
+  }
+
+  const key = dismissKeyFor(message);
+  if (dismissedKeys.has(key) || localStorage.getItem(key) === "1") {
+    return null;
+  }
+
+  const dismiss = () => {
+    localStorage.setItem(key, "1");
+    setDismissedKeys((prev) => new Set(prev).add(key));
+  };
+
+  return (
+    <div className="flex w-full items-start gap-2.5 rounded-(--radius-2) border border-(--blue-6) bg-(--blue-2) px-3.5 py-2.5 text-(--blue-11) text-[12.5px]">
+      <Info size={16} weight="duotone" className="mt-px shrink-0" />
+      <span className="min-w-0 flex-1 leading-snug">{message}</span>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={dismiss}
+        className="-mr-1 shrink-0 rounded-(--radius-1) p-0.5 text-(--blue-11) transition-colors hover:bg-(--blue-4)"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
@@ -31,6 +31,7 @@ import { useScoutChatTask } from "../hooks/useScoutChatTask";
 import { useScoutConfigMutations } from "../hooks/useScoutConfigMutations";
 import { useScoutConfigs } from "../hooks/useScoutConfigs";
 import { useScoutRuns } from "../hooks/useScoutRuns";
+import { ScoutAlphaBanner } from "./ScoutAlphaBanner";
 import { ScoutHelperSkillLinks } from "./ScoutHelperSkillLinks";
 import { ScoutRowCard } from "./ScoutRowCard";
 
@@ -94,6 +95,7 @@ export function ScoutsFleetSection() {
 
   return (
     <Flex direction="column" gap="3">
+      <ScoutAlphaBanner />
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
@@ -295,26 +297,29 @@ function ScoutChatCta({
 function ScoutsEmptyState() {
   useTrackFleetViewed(EMPTY_CONFIGS);
   return (
-    <Flex
-      direction="column"
-      gap="2"
-      align="start"
-      className="rounded-(--radius-3) border border-border bg-(--color-panel-solid) px-5 py-5"
-    >
-      <Flex align="center" gap="2">
-        <CompassIcon size={18} className="text-(--iris-9)" />
-        <Text className="font-medium text-[13px] text-gray-12">
-          No scouts on this project yet
+    <Flex direction="column" gap="3">
+      <ScoutAlphaBanner />
+      <Flex
+        direction="column"
+        gap="2"
+        align="start"
+        className="rounded-(--radius-3) border border-border bg-(--color-panel-solid) px-5 py-5"
+      >
+        <Flex align="center" gap="2">
+          <CompassIcon size={18} className="text-(--iris-9)" />
+          <Text className="font-medium text-[13px] text-gray-12">
+            No scouts on this project yet
+          </Text>
+        </Flex>
+        <Text className="max-w-2xl text-[12.5px] text-gray-11 leading-snug">
+          Scouts are rolling out gradually. Once your project is enrolled, the
+          canonical fleet appears here automatically and you can add custom
+          scouts by creating{" "}
+          <span className="font-mono text-[11px]">signals-scout-*</span> skills
+          in PostHog.
         </Text>
+        <ScoutHelperSkillLinks surface="empty_state" />
       </Flex>
-      <Text className="max-w-2xl text-[12.5px] text-gray-11 leading-snug">
-        Scouts are rolling out gradually. Once your project is enrolled, the
-        canonical fleet appears here automatically and you can add custom scouts
-        by creating{" "}
-        <span className="font-mono text-[11px]">signals-scout-*</span> skills in
-        PostHog.
-      </Text>
-      <ScoutHelperSkillLinks surface="empty_state" />
     </Flex>
   );
 }

--- a/packages/ui/src/features/scouts/hooks/scoutQueryKeys.ts
+++ b/packages/ui/src/features/scouts/hooks/scoutQueryKeys.ts
@@ -1,6 +1,8 @@
 export const scoutQueryKeys = {
   configs: (projectId: number | null) =>
     ["scouts", "configs", projectId] as const,
+  metadata: (projectId: number | null) =>
+    ["scouts", "metadata", projectId] as const,
   runs: (projectId: number | null) => ["scouts", "runs", projectId] as const,
   emissions: (projectId: number | null, runId: string) =>
     ["scouts", "emissions", projectId, runId] as const,

--- a/packages/ui/src/features/scouts/hooks/useScoutMetadata.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutMetadata.ts
@@ -1,0 +1,14 @@
+import type { ScoutMetadata } from "@posthog/api-client/posthog-client";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+import { scoutQueryKeys } from "./scoutQueryKeys";
+
+export function useScoutMetadata() {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<ScoutMetadata | null>(
+    scoutQueryKeys.metadata(projectId),
+    (client) =>
+      projectId ? client.getScoutMetadata(projectId) : Promise.resolve(null),
+    { enabled: !!projectId, staleTime: 60_000 },
+  );
+}


### PR DESCRIPTION
## Problem

Scout users on the alpha rollout hit backend run-throttling they can't see, and we want to tell them what's going on (e.g. "daily runs are limited while we tune throttles") with copy that changes as fast as the throttles do. The desktop app ships on a slower release cadence, so hardcoding the notice would mean a release for every wording tweak.

## Changes

Renders a dismissible info banner at the top of the scout fleet section, driven by a new scout metadata endpoint:

- New `PostHogAPIClient.getScoutMetadata(projectId)` → `GET signals/scout/metadata/current`, returning `{ enrolled, banner_message, limits }` (`ScoutMetadata` / `ScoutLimits` types added).
- New `useScoutMetadata` hook (mirrors `useScoutConfigs`).
- New `ScoutAlphaBanner` component: renders `banner_message` when set (nothing otherwise), dismissal remembered **per-message** via localStorage so a reworded notice resurfaces. Shown above the populated fleet and the empty state.

The copy lives entirely in the `signals-scout` flag, so notices change with no desktop release.

```
╭──────────────────────────────────────────────────────────────────╮
│ ⓘ  Scouts are in early alpha — daily runs are capped while we  ✕   │
│    tune throttles. Your schedule may run less often than set.      │
╰──────────────────────────────────────────────────────────────────╯
┌──────────────────────────────────────────────────────────────────┐
│ 🧭  Scout fleet                                               ⌄    │
│     7 of 19 scouts enabled · last dispatched 3m ago               │
└──────────────────────────────────────────────────────────────────┘
```

This is the desktop counterpart to the cloud inbox banner (PostHog/posthog#65160); both consume the same endpoint (PostHog/posthog#65155). Wording shown is a placeholder.

## How did you test this?

I'm an agent (Claude). What I actually ran:

- `biome check --write --unsafe` on the changed files — clean.
- `turbo typecheck --filter=@posthog/api-client` — passes. The changed scout files in `@posthog/ui` typecheck clean.
- **Caveat:** the repo-wide pre-commit typecheck currently fails on **pre-existing** errors in unrelated files (`canvas/ChannelsList.tsx`, `code-review/InteractiveFileDiff.tsx`, `WebsiteLayout.tsx` — quill export/prop drift) on a clean `main` in my local dual-repo checkout. None of my files appear in those errors, so I committed with `--no-verify`. Please confirm CI is green / those failures are environmental.
- No manual in-app verification yet — flagging that I did not run the desktop app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
