### PR TITLE
feat(channels): unify header breadcrumb + quill Empty states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ await boot(container);
 - Use path aliases and package public exports. Avoid deep relative imports.
 - No barrel files (`index.ts`).
 - Use Tailwind first. Keep classes sorted. Use inline `style` only for runtime values, library configuration, or CSS variables.
+- Empty/placeholder/loading screens (canvas and elsewhere) are a `@posthog/quill` `<Empty>` (`EmptyHeader` → `EmptyMedia variant="icon"` → `EmptyTitle` → `EmptyDescription`, then `EmptyContent` for CTAs). Don't hand-roll the centered Flex + dashed icon box. CTAs are quill `Button`s: primary action `variant="primary"`, secondary `variant="outline"`, `size="default"`. For a link CTA use `render={<Link … />}` (Base UI), not `asChild`.
 - Abort controllers before awaiting cleanup that depends on them.
 
 See [docs/conventions.md](./docs/conventions.md).

--- a/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
@@ -1,0 +1,77 @@
+import { HashIcon } from "@phosphor-icons/react";
+import { HeaderTitleEditor } from "@posthog/ui/features/task-detail/HeaderTitleEditor";
+import { Flex, Text } from "@radix-ui/themes";
+import { type ReactNode, useState } from "react";
+
+interface ChannelBreadcrumbProps {
+  /** The channel (root) segment label. */
+  channelName: string;
+  /** Optional leading icon for the leaf segment (e.g. a canvas's tier icon). */
+  leafIcon?: ReactNode;
+  /** The trailing (current page) segment label. */
+  leafLabel: string;
+  /**
+   * When provided, the leaf becomes inline-editable: double-click to rename,
+   * Enter or blur to submit, Escape to cancel. Receives the trimmed new value.
+   */
+  onRename?: (next: string) => void;
+  /** Right-aligned slot pushed to the far end of the bar (e.g. an opener). */
+  trailing?: ReactNode;
+}
+
+// "# channel / leaf" header breadcrumb shared across channel scenes (CONTEXT.md,
+// new + existing tasks, canvases). The leaf can carry a tier icon and, when
+// onRename is given, edits inline using the same editor as task titles.
+export function ChannelBreadcrumb({
+  channelName,
+  leafIcon,
+  leafLabel,
+  onRename,
+  trailing,
+}: ChannelBreadcrumbProps) {
+  const [editing, setEditing] = useState(false);
+
+  return (
+    <Flex align="center" justify="between" gap="2" className="w-full min-w-0">
+      <Flex align="center" gap="2" className="min-w-0">
+        <div className="flex items-center gap-1">
+          <HashIcon
+            size={12}
+            className="mt-px shrink-0 text-muted-foreground/80"
+          />
+          <Text
+            className="min-w-0 truncate whitespace-nowrap font-medium text-[13px]"
+            title={channelName}
+          >
+            {channelName}
+          </Text>
+        </div>
+        <Text className="shrink-0 text-[13px] text-muted-foreground/20">/</Text>
+        <div className="flex items-center gap-1.5">
+          {leafIcon && (
+            <span className="flex shrink-0 text-primary">{leafIcon}</span>
+          )}
+          {editing && onRename ? (
+            <HeaderTitleEditor
+              initialTitle={leafLabel}
+              onSubmit={(next) => {
+                setEditing(false);
+                onRename(next);
+              }}
+              onCancel={() => setEditing(false)}
+            />
+          ) : (
+            <Text
+              truncate
+              className="no-drag min-w-0 whitespace-nowrap text-[13px]"
+              onDoubleClick={onRename ? () => setEditing(true) : undefined}
+            >
+              {leafLabel}
+            </Text>
+          )}
+        </div>
+      </Flex>
+      {trailing}
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
@@ -1,4 +1,5 @@
 import { HashIcon } from "@phosphor-icons/react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
 import { HeaderTitleEditor } from "@posthog/ui/features/task-detail/HeaderTitleEditor";
 import { Flex, Text } from "@radix-ui/themes";
 import { type ReactNode, useState } from "react";
@@ -49,7 +50,7 @@ export function ChannelBreadcrumb({
         <Text className="shrink-0 text-[13px] text-muted-foreground/20">/</Text>
         <div className="flex items-center gap-1.5">
           {leafIcon && (
-            <span className="flex shrink-0 text-primary">{leafIcon}</span>
+            <span className="mt-px flex shrink-0 text-primary">{leafIcon}</span>
           )}
           {editing && onRename ? (
             <HeaderTitleEditor
@@ -61,13 +62,22 @@ export function ChannelBreadcrumb({
               onCancel={() => setEditing(false)}
             />
           ) : (
-            <Text
-              truncate
-              className="no-drag min-w-0 whitespace-nowrap text-[13px]"
-              onDoubleClick={onRename ? () => setEditing(true) : undefined}
-            >
-              {leafLabel}
-            </Text>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Text
+                    truncate
+                    className="no-drag min-w-0 whitespace-nowrap text-[13px]"
+                    onDoubleClick={
+                      onRename ? () => setEditing(true) : undefined
+                    }
+                  />
+                }
+              >
+                {leafLabel}
+              </TooltipTrigger>
+              <TooltipContent>{leafLabel}</TooltipContent>
+            </Tooltip>
           )}
         </div>
       </Flex>

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -2,10 +2,8 @@ import {
   ArchiveIcon,
   CaretDownIcon,
   ChartBarIcon,
-  ChartLineIcon,
   CodeIcon,
   DotsThreeIcon,
-  FileIcon,
   FileTextIcon,
   FolderIcon,
   HashIcon,
@@ -57,6 +55,7 @@ import type { Task } from "@posthog/shared/domain-types";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
 import { CreateChannelModal } from "@posthog/ui/features/canvas/components/CreateChannelModal";
+import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import {
   NewCanvasDialog,
   trackAndCreateCanvas,
@@ -98,20 +97,6 @@ import { hostClient } from "../hostClient";
 // Cap how many tasks each channel shows by default; the rest hide behind a
 // "View more" button so a busy channel doesn't dominate the sidebar.
 const MAX_VISIBLE_TASKS_PER_CHANNEL = 5;
-
-// A canvas's leading icon, chosen from its template so the tree reads at a
-// glance: bar chart for dashboards, line chart for web-analytics, plain file for
-// blank canvases.
-function iconForTemplate(templateId: string): ReactNode {
-  switch (templateId) {
-    case "web-analytics":
-      return <ChartLineIcon size={16} className="text-gray-9" />;
-    case "blank":
-      return <FileIcon size={16} className="text-gray-9" />;
-    default:
-      return <ChartBarIcon size={16} className="text-gray-9" />;
-  }
-}
 
 // Short "x ago" stamp for an item's subtitle. Coarse on purpose — the sidebar
 // just needs recency at a glance, not a precise duration.

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -811,6 +811,10 @@ function ChannelSection({
     hiddenTaskCount,
     MAX_VISIBLE_TASKS_PER_CHANNEL,
   );
+  const hasChildren =
+    dashboards.length > 0 ||
+    displayedFiledTasks.length > 0 ||
+    hiddenTaskCount > 0;
 
   return (
     <Box
@@ -961,64 +965,66 @@ function ChannelSection({
         </div>
         {/* Children hang off a vertical guide line, like a tree. The folder
             variant's own inset is removed so the guide line controls indent. */}
-        <CollapsibleContent className="px-0">
-          <Flex
-            direction="column"
-            gap="px"
-            className="mt-px ml-[11px] border-gray-6 border-l pl-2 empty:hidden"
-          >
-            {dashboards.map((d) => (
-              <DashboardRow
-                key={d.id}
-                channelId={channel.id}
-                dashboard={d}
-                active={pathname === `${base}/dashboards/${d.id}`}
-              />
-            ))}
-            {displayedFiledTasks.map(({ id: channelTaskId, taskId }) => {
-              const task = tasks?.find((t) => t.id === taskId);
-              const title = task?.title || "Untitled task";
-              return (
-                <TaskRow
-                  key={channelTaskId}
-                  channelTaskId={channelTaskId}
+        {hasChildren && (
+          <CollapsibleContent className="px-0">
+            <Flex
+              direction="column"
+              gap="px"
+              className="mt-px ml-[11px] border-gray-6 border-l pl-2 empty:hidden"
+            >
+              {dashboards.map((d) => (
+                <DashboardRow
+                  key={d.id}
                   channelId={channel.id}
-                  taskId={taskId}
-                  task={task}
-                  title={title}
-                  active={pathname === `${base}/tasks/${taskId}`}
-                  onClick={() =>
-                    navigate({
-                      to: "/website/$channelId/tasks/$taskId",
-                      params: { channelId: channel.id, taskId },
-                    })
-                  }
-                  channels={channels}
+                  dashboard={d}
+                  active={pathname === `${base}/dashboards/${d.id}`}
                 />
-              );
-            })}
-            {hiddenTaskCount > 0 && (
-              <Button
-                variant="default"
-                size="default"
-                onClick={() => {
-                  track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-                    action_type: "view_more_tasks",
-                    surface: "sidebar",
-                    channel_id: channel.id,
-                  });
-                  setTaskLimit((n) => n + MAX_VISIBLE_TASKS_PER_CHANNEL);
-                }}
-                className="w-full min-w-0 justify-start gap-2 text-[13px] text-gray-10"
-              >
-                <span className="inline-flex size-[14px] shrink-0 items-center justify-center">
-                  <CaretDownIcon size={12} />
-                </span>
-                View {nextBatchCount} more
-              </Button>
-            )}
-          </Flex>
-        </CollapsibleContent>
+              ))}
+              {displayedFiledTasks.map(({ id: channelTaskId, taskId }) => {
+                const task = tasks?.find((t) => t.id === taskId);
+                const title = task?.title || "Untitled task";
+                return (
+                  <TaskRow
+                    key={channelTaskId}
+                    channelTaskId={channelTaskId}
+                    channelId={channel.id}
+                    taskId={taskId}
+                    task={task}
+                    title={title}
+                    active={pathname === `${base}/tasks/${taskId}`}
+                    onClick={() =>
+                      navigate({
+                        to: "/website/$channelId/tasks/$taskId",
+                        params: { channelId: channel.id, taskId },
+                      })
+                    }
+                    channels={channels}
+                  />
+                );
+              })}
+              {hiddenTaskCount > 0 && (
+                <Button
+                  variant="default"
+                  size="default"
+                  onClick={() => {
+                    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                      action_type: "view_more_tasks",
+                      surface: "sidebar",
+                      channel_id: channel.id,
+                    });
+                    setTaskLimit((n) => n + MAX_VISIBLE_TASKS_PER_CHANNEL);
+                  }}
+                  className="w-full min-w-0 justify-start gap-2 text-[13px] text-gray-10"
+                >
+                  <span className="inline-flex size-[14px] shrink-0 items-center justify-center">
+                    <CaretDownIcon size={12} />
+                  </span>
+                  View {nextBatchCount} more
+                </Button>
+              )}
+            </Flex>
+          </CollapsibleContent>
+        )}
       </Collapsible>
       {/* One modal for both the dropdown and context-menu "Rename" actions. */}
       <RenameChannelModal
@@ -1103,7 +1109,7 @@ export function ChannelsList() {
     <TooltipProvider delay={600}>
       <Flex direction="column" gap="px" className="px-2 pb-2">
         <Box className="py-1.5">
-          <Separator />
+          <Separator className="bg-border" />
         </Box>
 
         {starred.length > 0 && (

--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -154,7 +154,7 @@ export function ChannelsSidebar() {
       setIsResizing={setIsResizing}
       side="left"
     >
-      <Flex direction="column" className="h-full bg-gray-2">
+      <Flex direction="column" className="h-full bg-chrome">
         {/* Workspace switcher — a compact bordered button. The title bar above
             provides the window-drag region and stoplight clearance. */}
         <Box className="shrink-0 p-2 pb-0">
@@ -172,7 +172,7 @@ export function ChannelsSidebar() {
 
         {/* Settings pinned to the bottom. Settings is a full-page route, so this
             leaves the Channels space rather than highlighting in place. */}
-        <Box className="shrink-0 p-2 pt-0">
+        <Box className="shrink-0 border-border border-t p-2">
           <SidebarItem
             depth={0}
             icon={<GearSixIcon size={16} />}

--- a/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
+++ b/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
@@ -67,8 +67,8 @@ export function CanvasTemplateList({
             );
           }}
         >
-          <span className="font-medium text-gray-12">{t.name}</span>
-          <span className="font-normal text-gray-10 text-xs [text-wrap:initial]">
+          <span className="font-medium">{t.name}</span>
+          <span className="font-normal text-muted-foreground/80 text-xs [text-wrap:initial]">
             {t.description}
           </span>
         </Button>
@@ -101,7 +101,7 @@ export function NewCanvasDialog({
             generating UI.
           </DialogDescription>
         </DialogHeader>
-        <DialogBody className="[&_*[data-slot=scroll-area-viewport]]:py-0">
+        <DialogBody className="[&_*[data-slot=scroll-area-viewport]]:px-2 [&_*[data-slot=scroll-area-viewport]]:py-px">
           <CanvasTemplateList
             channelId={channelId}
             surface={surface}

--- a/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -6,6 +6,15 @@ import {
 } from "@phosphor-icons/react";
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Button as QuillButton,
+} from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
@@ -417,53 +426,47 @@ function EmptyState({
   onCreate: () => void;
 }) {
   return (
-    <Flex
-      direction="column"
-      align="center"
-      gap="4"
-      className="mx-auto max-w-[440px] py-16 text-center"
-    >
-      <Box className="rounded-lg border border-gray-6 border-dashed p-4">
-        <FileTextIcon size={28} className="text-gray-8" />
-      </Box>
-      <Flex direction="column" gap="2" align="center">
-        <Text className="font-medium text-[14px] text-gray-12">
-          No CONTEXT.md yet
-        </Text>
-        <Text className="text-[13px] text-gray-10 leading-relaxed">
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <FileTextIcon size={28} />
+        </EmptyMedia>
+        <EmptyTitle>No CONTEXT.md yet</EmptyTitle>
+        <EmptyDescription>
           CONTEXT.md tells agents the specific details they need to know when
           working in <strong>{channelName}</strong> — conventions, gotchas, key
           files, and anything else that isn't obvious from the code.
-        </Text>
-      </Flex>
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        {stoppedTaskId ? (
+          <Callout.Root color="amber" size="1" className="w-full text-left">
+            <Callout.Text>
+              The previous generation in task{" "}
+              <Link
+                to="/website/$channelId/tasks/$taskId"
+                params={{ channelId, taskId: stoppedTaskId }}
+                className="font-medium text-amber-11 underline"
+              >
+                {shortTaskId(stoppedTaskId)}
+              </Link>{" "}
+              stopped before writing a CONTEXT.md. You can generate again.
+            </Callout.Text>
+          </Callout.Root>
+        ) : null}
 
-      {stoppedTaskId ? (
-        <Callout.Root color="amber" size="1" className="w-full text-left">
-          <Callout.Text>
-            The previous generation in task{" "}
-            <Link
-              to="/website/$channelId/tasks/$taskId"
-              params={{ channelId, taskId: stoppedTaskId }}
-              className="font-medium text-amber-11 underline"
-            >
-              {shortTaskId(stoppedTaskId)}
-            </Link>{" "}
-            stopped before writing a CONTEXT.md. You can generate again.
-          </Callout.Text>
-        </Callout.Root>
-      ) : null}
-
-      <Flex align="center" gap="3">
-        <Button size="2" variant="solid" onClick={onCreate}>
-          Create CONTEXT.md
-        </Button>
-        <GenerateWithAgent
-          channelId={channelId}
-          channelName={channelName}
-          regenerate={!!stoppedTaskId}
-        />
-      </Flex>
-    </Flex>
+        <Flex align="center" gap="3">
+          <QuillButton variant="primary" size="default" onClick={onCreate}>
+            Create
+          </QuillButton>
+          <GenerateWithAgent
+            channelId={channelId}
+            channelName={channelName}
+            regenerate={!!stoppedTaskId}
+          />
+        </Flex>
+      </EmptyContent>
+    </Empty>
   );
 }
 
@@ -502,10 +505,14 @@ function GenerateWithAgent({
 
   if (!picking) {
     return (
-      <Button size="2" variant="soft" onClick={() => setPicking(true)}>
+      <QuillButton
+        variant="outline"
+        size="default"
+        onClick={() => setPicking(true)}
+      >
         <SparkleIcon size={14} />
         {regenerate ? "Generate again" : "Generate with agent"}
-      </Button>
+      </QuillButton>
     );
   }
 

--- a/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,6 +1,5 @@
 import {
   FileTextIcon,
-  HashIcon,
   SparkleIcon,
   SpinnerGapIcon,
 } from "@phosphor-icons/react";
@@ -17,6 +16,7 @@ import {
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { ChannelBreadcrumb } from "@posthog/ui/features/canvas/components/ChannelBreadcrumb";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import {
   useFolderGenerationTask,
@@ -166,20 +166,11 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
   const channelName = channel?.name ?? "Channel";
   const headerContent = useMemo(
     () => (
-      <Flex align="center" gap="2" className="w-full min-w-0">
-        <HashIcon size={12} className="shrink-0 text-gray-10" />
-        <Text
-          className="truncate whitespace-nowrap font-medium text-[13px]"
-          title={channelName}
-        >
-          {channelName}
-        </Text>
-        <Text className="shrink-0 text-[13px] text-gray-9">/</Text>
-        <FileTextIcon size={12} className="shrink-0 text-gray-10" />
-        <Text className="shrink-0 whitespace-nowrap text-[13px] text-gray-11">
-          CONTEXT.md
-        </Text>
-      </Flex>
+      <ChannelBreadcrumb
+        channelName={channelName}
+        leafIcon={<FileTextIcon size={12} />}
+        leafLabel="CONTEXT.md"
+      />
     ),
     [channelName],
   );
@@ -623,30 +614,31 @@ function GeneratingState({
   taskId: string;
 }) {
   return (
-    <Flex
-      direction="column"
-      align="center"
-      gap="4"
-      className="mx-auto max-w-[440px] py-16 text-center"
-    >
-      <Box className="rounded-lg border border-gray-6 border-dashed p-3">
-        <SpinnerGapIcon size={18} className="animate-spin text-accent-9" />
-      </Box>
-      <Flex direction="column" gap="1" align="center">
-        <Text className="font-medium text-[14px] text-gray-12">Generating</Text>
-        <Text className="text-[13px] text-gray-10">
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <SpinnerGapIcon size={18} className="animate-spin text-accent-9" />
+        </EmptyMedia>
+        <EmptyTitle>Generating</EmptyTitle>
+        <EmptyDescription>
           An agent is writing this CONTEXT.md.
-        </Text>
-      </Flex>
-      <Button size="2" variant="soft" asChild>
-        <Link
-          to="/website/$channelId/tasks/$taskId"
-          params={{ channelId, taskId }}
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <QuillButton
+          variant="primary"
+          size="default"
+          render={
+            <Link
+              to="/website/$channelId/tasks/$taskId"
+              params={{ channelId, taskId }}
+            />
+          }
         >
           View task
-        </Link>
-      </Button>
-    </Flex>
+        </QuillButton>
+      </EmptyContent>
+    </Empty>
   );
 }
 

--- a/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -229,7 +229,7 @@ export function WebsiteLayout() {
           align="center"
           justify="end"
           gap="2"
-          className="h-10 shrink-0 border-gray-6 border-b px-3"
+          className="h-10 shrink-0 border-border border-b px-3"
         >
           {isDashboardDetail && channelId && dashboardId ? (
             <FreeformEditControls

--- a/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -1,7 +1,10 @@
 import { GitForkIcon, PencilSimpleIcon, XIcon } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { ChannelBreadcrumb } from "@posthog/ui/features/canvas/components/ChannelBreadcrumb";
+import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { NewCanvasMenu } from "@posthog/ui/features/canvas/components/NewCanvasMenu";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import {
   useDashboard,
   useDashboardMutations,
@@ -17,13 +20,14 @@ import {
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
-import { Box, Flex, Text } from "@radix-ui/themes";
+import { Box, Flex } from "@radix-ui/themes";
 import {
   Outlet,
   useNavigate,
   useParams,
   useRouterState,
 } from "@tanstack/react-router";
+import type { ReactNode } from "react";
 
 function threadIdFor(dashboardId: string): string {
   return `dashboard:${dashboardId}`;
@@ -173,8 +177,40 @@ function FreeformEditControls({
   );
 }
 
-// Canvas toolbar + content outlet for the Website space (channel-scoped). No
-// breadcrumb row — a single toolbar carries the data controls and actions.
+// "# channel / canvas" breadcrumb for a single canvas, with the leaf inline-
+// renamable and a tier icon (dashboard / web-analytics / freeform app).
+function CanvasBreadcrumb({
+  channelName,
+  dashboardId,
+  trailing,
+}: {
+  channelName: string;
+  dashboardId: string;
+  trailing?: ReactNode;
+}) {
+  const { dashboard } = useDashboard(dashboardId);
+  const { renameDashboard } = useDashboardMutations();
+  const name = dashboard?.name ?? "Canvas";
+
+  return (
+    <ChannelBreadcrumb
+      channelName={channelName}
+      leafIcon={iconForTemplate(dashboard?.templateId ?? "", {
+        size: 12,
+        // No color here: the breadcrumb's leaf <span> owns the icon color so it
+        // can be styled in one place.
+        className: "",
+      })}
+      leafLabel={name}
+      onRename={(next) => void renameDashboard(dashboardId, next)}
+      trailing={trailing}
+    />
+  );
+}
+
+// Canvas toolbar + content outlet for the Website space (channel-scoped). A
+// single toolbar carries the channel breadcrumb (left) and data controls /
+// actions (right).
 export function WebsiteLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const params = useParams({ strict: false });
@@ -189,6 +225,11 @@ export function WebsiteLayout() {
   const dashboardId = params.dashboardId;
   const base = channelId ? `/website/${channelId}` : "/website";
 
+  const { channels } = useChannels();
+  const channelName = channelId
+    ? (channels.find((c) => c.id === channelId)?.name ?? "Channel")
+    : "Channel";
+
   const isDashboardDetail = Boolean(channelId && dashboardId);
   // The dashboards grid (a channel with no sub-view selected).
   const isDashboardsGrid = Boolean(channelId) && pathname === base;
@@ -197,48 +238,49 @@ export function WebsiteLayout() {
   // canvas (so Edit lives here too).
   const showToolbar =
     Boolean(channelId) && (isDashboardsGrid || isDashboardDetail);
-  // The channel's new-task screen (no header store content of its own).
-  const isNewTask = Boolean(channelId) && pathname === `${base}/new`;
 
   return (
     <Flex direction="column" height="100%" overflow="hidden">
-      {/* Title bar for non-canvas views (no breadcrumbs): channel-scoped task
-          detail and channel context push their title into the header store;
-          channel-less mirrored pages (Home, Skills, …) do too. The new-task
-          screen has no header content, so label it explicitly. Hidden when the
-          canvas toolbar is showing (grid / a single canvas). */}
-      {!showToolbar && (headerContent || isNewTask) && (
+      {/* Title bar for non-canvas views: every channel scene (task detail,
+          new task, CONTEXT.md) pushes its "# channel / leaf" breadcrumb into
+          the header store, as do channel-less mirrored pages (Home, Skills, …).
+          Hidden when the canvas toolbar is showing (grid / a single canvas). */}
+      {!showToolbar && headerContent && (
         <Flex
           align="center"
           gap="2"
           className="h-10 shrink-0 border-gray-6 border-b px-3"
         >
-          {headerContent ?? (
-            <Text size="2" weight="medium" className="text-gray-12">
-              New task
-            </Text>
-          )}
+          {headerContent}
         </Flex>
       )}
 
-      {/* Single canvas toolbar (no breadcrumb row): canvas actions (Edit /
-          Save as fork / New canvas) on the right. Freeform canvases own their
-          own date control in-app (Quill DateTimePicker). */}
-      {showToolbar && (
+      {/* Single canvas toolbar: the "# channel / canvas" breadcrumb (left) and
+          canvas actions (Edit / Save as fork / New canvas) on the right.
+          Freeform canvases own their own date control in-app (DateTimePicker). */}
+      {showToolbar && channelId && (
         <Flex
           align="center"
-          justify="end"
-          gap="2"
           className="h-10 shrink-0 border-border border-b px-3"
         >
-          {isDashboardDetail && channelId && dashboardId ? (
-            <FreeformEditControls
-              channelId={channelId}
+          {isDashboardDetail && dashboardId ? (
+            <CanvasBreadcrumb
+              channelName={channelName}
               dashboardId={dashboardId}
+              trailing={
+                <FreeformEditControls
+                  channelId={channelId}
+                  dashboardId={dashboardId}
+                />
+              }
             />
-          ) : isDashboardsGrid && channelId ? (
-            <NewCanvasMenu channelId={channelId} />
-          ) : null}
+          ) : (
+            <ChannelBreadcrumb
+              channelName={channelName}
+              leafLabel="Canvases"
+              trailing={<NewCanvasMenu channelId={channelId} />}
+            />
+          )}
         </Flex>
       )}
       <Box flexGrow="1" overflow="hidden">

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -1,19 +1,21 @@
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
+import { ChannelBreadcrumb } from "@posthog/ui/features/canvas/components/ChannelBreadcrumb";
 import { ChannelContextPanel } from "@posthog/ui/features/canvas/components/ChannelContextPanel";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
 import { TaskInput } from "@posthog/ui/features/task-detail/components/TaskInput";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Flex } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 // A channel's "New task" view. Reuses /code's TaskInput, but routes the created
 // task into the channel (/website/$channelId/tasks/$id) instead of /code, and
@@ -25,6 +27,20 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
   const { fileTask } = useChannelTaskMutations();
   const { channels } = useChannels();
   const channelName = channels.find((c) => c.id === channelId)?.name;
+
+  // Surface the channel breadcrumb in the shared header, same as the other
+  // channel scenes ("# channel / New task").
+  useSetHeaderContent(
+    useMemo(
+      () => (
+        <ChannelBreadcrumb
+          channelName={channelName ?? "Channel"}
+          leafLabel="New task"
+        />
+      ),
+      [channelName],
+    ),
+  );
   // The channel's CONTEXT.md, passed to the agent as optional background so
   // tasks created here start with the shared context. Absent/empty is fine.
   const { data: instructions } = useFolderInstructions(channelId);

--- a/packages/ui/src/features/canvas/components/canvasTemplateIcon.tsx
+++ b/packages/ui/src/features/canvas/components/canvasTemplateIcon.tsx
@@ -1,16 +1,16 @@
 import {
   ChartBarIcon,
   ChartLineIcon,
-  CodeIcon,
   FileIcon,
+  ShapesIcon,
 } from "@phosphor-icons/react";
 import { FREEFORM_TEMPLATE_ID } from "@posthog/core/canvas/freeformSchemas";
 import type { ReactNode } from "react";
 
 // A canvas's leading icon, chosen from its template so the tree and header read
 // at a glance: bar chart for json-render dashboards, line chart for web
-// analytics, code for the generic freeform React/HTML app, plain file for blank
-// canvases.
+// analytics, shapes for the generic freeform canvas (until it's classified as
+// something more specific), plain file for blank canvases.
 export function iconForTemplate(
   templateId: string,
   opts?: { size?: number; className?: string },
@@ -23,7 +23,7 @@ export function iconForTemplate(
     case "blank":
       return <FileIcon size={size} className={className} />;
     case FREEFORM_TEMPLATE_ID:
-      return <CodeIcon size={size} className={className} />;
+      return <ShapesIcon size={size} className={className} />;
     default:
       return <ChartBarIcon size={size} className={className} />;
   }

--- a/packages/ui/src/features/canvas/components/canvasTemplateIcon.tsx
+++ b/packages/ui/src/features/canvas/components/canvasTemplateIcon.tsx
@@ -1,0 +1,30 @@
+import {
+  ChartBarIcon,
+  ChartLineIcon,
+  CodeIcon,
+  FileIcon,
+} from "@phosphor-icons/react";
+import { FREEFORM_TEMPLATE_ID } from "@posthog/core/canvas/freeformSchemas";
+import type { ReactNode } from "react";
+
+// A canvas's leading icon, chosen from its template so the tree and header read
+// at a glance: bar chart for json-render dashboards, line chart for web
+// analytics, code for the generic freeform React/HTML app, plain file for blank
+// canvases.
+export function iconForTemplate(
+  templateId: string,
+  opts?: { size?: number; className?: string },
+): ReactNode {
+  const size = opts?.size ?? 16;
+  const className = opts?.className ?? "text-gray-9";
+  switch (templateId) {
+    case "web-analytics":
+      return <ChartLineIcon size={size} className={className} />;
+    case "blank":
+      return <FileIcon size={size} className={className} />;
+    case FREEFORM_TEMPLATE_ID:
+      return <CodeIcon size={size} className={className} />;
+    default:
+      return <ChartBarIcon size={size} className={className} />;
+  }
+}

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowUUpLeftIcon,
   ArrowUUpRightIcon,
+  ShapesIcon,
   SpinnerGapIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
@@ -251,23 +252,19 @@ export function FreeformCanvasView({
             ) : showGeneratingState ? (
               <GeneratingState channelId={channelId} taskId={genTaskId ?? ""} />
             ) : (
-              <Flex
-                direction="column"
-                align="center"
-                justify="center"
-                height="100%"
-                gap="1"
-                className="px-6 text-center"
-              >
-                <Text size="3" weight="bold" className="text-gray-12">
-                  Freeform canvas
-                </Text>
-                <Text size="2" className="text-gray-10">
-                  {interactive
-                    ? "Describe the canvas below to build it with an agent."
-                    : "This canvas is empty. Hit Edit to build it with an agent."}
-                </Text>
-              </Flex>
+              <Empty className="h-full">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <ShapesIcon size={24} />
+                  </EmptyMedia>
+                  <EmptyTitle>Freeform canvas</EmptyTitle>
+                  <EmptyDescription>
+                    {interactive
+                      ? "Describe the canvas below to build it with an agent."
+                      : "This canvas is empty. Hit Edit to build it with an agent."}
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
             )}
           </ScrollArea>
         </Box>

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -6,7 +6,15 @@ import {
 } from "@phosphor-icons/react";
 import type { CanvasAnalyticsConfig } from "@posthog/core/canvas/freeformSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
-import { Button } from "@posthog/quill";
+import {
+  Button,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@posthog/quill";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import {
@@ -293,33 +301,30 @@ function GeneratingState({
   taskId: string;
 }) {
   return (
-    <Flex
-      direction="column"
-      align="center"
-      justify="center"
-      height="100%"
-      gap="4"
-      className="mx-auto max-w-[440px] px-6 text-center"
-    >
-      <Box className="rounded-lg border border-gray-6 border-dashed p-3">
-        <SpinnerGapIcon size={18} className="animate-spin text-accent-9" />
-      </Box>
-      <Flex direction="column" gap="1" align="center">
-        <Text className="font-medium text-[14px] text-gray-12">Generating</Text>
-        <Text className="text-[13px] text-gray-10">
-          An agent is building this canvas.
-        </Text>
-      </Flex>
+    <Empty className="h-full">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <SpinnerGapIcon size={18} className="animate-spin text-accent-9" />
+        </EmptyMedia>
+        <EmptyTitle>Generating</EmptyTitle>
+        <EmptyDescription>An agent is building this canvas.</EmptyDescription>
+      </EmptyHeader>
       {taskId && (
-        <RadixButton size="2" variant="soft" asChild>
-          <Link
-            to="/website/$channelId/tasks/$taskId"
-            params={{ channelId, taskId }}
+        <EmptyContent>
+          <Button
+            variant="primary"
+            size="default"
+            render={
+              <Link
+                to="/website/$channelId/tasks/$taskId"
+                params={{ channelId, taskId }}
+              />
+            }
           >
             View task
-          </Link>
-        </RadixButton>
+          </Button>
+        </EmptyContent>
       )}
-    </Flex>
+    </Empty>
   );
 }

--- a/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -5,6 +5,7 @@ import { useHotkeys, useHotkeysContext } from "react-hotkeys-hook";
 import { useBlurOnEscape } from "../../../hooks/useBlurOnEscape";
 import { useSetHeaderContent } from "../../../hooks/useSetHeaderContent";
 import { logger } from "../../../shell/logger";
+import { ChannelBreadcrumb } from "../../canvas/components/ChannelBreadcrumb";
 import { CloudReviewPage } from "../../code-review/components/CloudReviewPage";
 import { ReviewPage } from "../../code-review/components/ReviewPage";
 import { useReviewNavigationStore } from "../../code-review/reviewNavigationStore";
@@ -28,9 +29,18 @@ const log = logger.scope("task-detail");
 
 interface TaskDetailProps {
   task: Task;
+  /**
+   * When the task is opened inside a channel, the channel name to prefix the
+   * header title with as a "# channel / title" breadcrumb. Omitted for the
+   * plain Code task view.
+   */
+  channelName?: string;
 }
 
-export function TaskDetail({ task: initialTask }: TaskDetailProps) {
+export function TaskDetail({
+  task: initialTask,
+  channelName,
+}: TaskDetailProps) {
   const taskId = initialTask.id;
 
   const { task } = useTaskData({ taskId, initialTask });
@@ -104,32 +114,47 @@ export function TaskDetail({ task: initialTask }: TaskDetailProps) {
   const handleTitleEditCancel = useCallback(() => {
     setIsEditingTitle(false);
   }, []);
+  const trailing = openTargetPath ? (
+    <ExternalAppsOpener targetPath={openTargetPath} />
+  ) : null;
   const headerContent = useMemo(
-    () => (
-      <Flex align="center" justify="between" gap="2" width="100%">
-        {isEditingTitle ? (
-          <HeaderTitleEditor
-            initialTitle={task.title}
-            onSubmit={handleTitleEditSubmit}
-            onCancel={handleTitleEditCancel}
-          />
-        ) : (
-          <Tooltip content={task.title} side="bottom" delayDuration={300}>
-            <Text
-              truncate
-              className="no-drag min-w-0 font-medium text-[13px]"
-              onDoubleClick={() => setIsEditingTitle(true)}
-            >
-              {task.title}
-            </Text>
-          </Tooltip>
-        )}
-        {openTargetPath && <ExternalAppsOpener targetPath={openTargetPath} />}
-      </Flex>
-    ),
+    () =>
+      // Inside a channel, prefix the editable title with the channel
+      // breadcrumb ("# channel / title"); the plain Code view keeps the bare
+      // title. Both share the same inline-rename editor.
+      channelName ? (
+        <ChannelBreadcrumb
+          channelName={channelName}
+          leafLabel={task.title}
+          onRename={handleTitleEditSubmit}
+          trailing={trailing}
+        />
+      ) : (
+        <Flex align="center" justify="between" gap="2" width="100%">
+          {isEditingTitle ? (
+            <HeaderTitleEditor
+              initialTitle={task.title}
+              onSubmit={handleTitleEditSubmit}
+              onCancel={handleTitleEditCancel}
+            />
+          ) : (
+            <Tooltip content={task.title} side="bottom" delayDuration={300}>
+              <Text
+                truncate
+                className="no-drag min-w-0 font-medium text-[13px]"
+                onDoubleClick={() => setIsEditingTitle(true)}
+              >
+                {task.title}
+              </Text>
+            </Tooltip>
+          )}
+          {trailing}
+        </Flex>
+      ),
     [
+      channelName,
       task.title,
-      openTargetPath,
+      trailing,
       isEditingTitle,
       handleTitleEditSubmit,
       handleTitleEditCancel,

--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -69,10 +69,10 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
         minWidth: open ? `${width}px` : "0",
         maxWidth: open ? `${width}px` : "0",
         transition: isResizing ? "none" : "width 0.2s ease-in-out",
-        borderLeft: !isLeft && open ? "1px solid var(--gray-6)" : "none",
-        borderRight: isLeft && open ? "1px solid var(--gray-6)" : "none",
+        borderLeft: !isLeft && open ? "1px solid var(--border)" : "none",
+        borderRight: isLeft && open ? "1px solid var(--border)" : "none",
       }}
-      className="relative h-full shrink-0 overflow-hidden"
+      className="relative h-full shrink-0"
     >
       <Flex
         direction="column"
@@ -86,13 +86,15 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
       {open && (
         <Box
           onMouseDown={handleMouseDown}
-          className="no-drag absolute top-0 bottom-0 w-[4px] cursor-col-resize bg-transparent"
+          className="no-drag group absolute top-0 bottom-0 flex w-2 cursor-col-resize justify-center bg-transparent"
           style={{
             left: isLeft ? undefined : 0,
-            right: isLeft ? 0 : undefined,
+            right: isLeft ? -5 : undefined,
             zIndex: 100,
           }}
-        />
+        >
+          <span className="h-full w-px bg-transparent transition-colors delay-100 duration-150 ease-out group-hover:bg-primary" />
+        </Box>
       )}
     </Box>
   );

--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -88,7 +88,7 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
           onMouseDown={handleMouseDown}
           className="no-drag group absolute top-0 bottom-0 flex w-2 cursor-col-resize justify-center bg-transparent"
           style={{
-            left: isLeft ? undefined : 0,
+            left: isLeft ? undefined : -5,
             right: isLeft ? -5 : undefined,
             zIndex: 100,
           }}

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -251,7 +251,7 @@ function RootLayout() {
 
   if (isChannelsSpace) {
     return (
-      <Flex direction="column" height="100vh" className="bg-gray-2">
+      <Flex direction="column" height="100vh" className="bg-chrome">
         {/* Full-width title bar: a window-drag region carrying the PostHog
             mark. The left padding clears the macOS stoplights. */}
         <Flex align="center" gap="3" className="drag h-10 shrink-0 pl-[78px]">
@@ -302,8 +302,8 @@ function RootLayout() {
           <ChannelsSidebar />
           {/* Content sits in a bordered, rounded card inset from the window
               edges — the framed pane from the design. */}
-          <Box flexGrow="1" className="overflow-hidden pr-2 pb-2">
-            <Box className="h-full overflow-hidden rounded-sm border border-gray-6 bg-gray-1">
+          <Box flexGrow="1" className="overflow-hidden">
+            <Box className="h-full overflow-hidden rounded-tl-sm border-border border-t border-l bg-background">
               <Outlet />
             </Box>
           </Box>

--- a/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
+++ b/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
@@ -1,4 +1,5 @@
 import type { Task } from "@posthog/shared/domain-types";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { TaskDetail } from "@posthog/ui/features/task-detail/components/TaskDetail";
 import {
   getCachedTask,
@@ -19,10 +20,12 @@ export const Route = createFileRoute("/website/$channelId/tasks/$taskId")({
 });
 
 function ChannelTaskDetailRoute() {
-  const { taskId } = Route.useParams();
+  const { channelId, taskId } = Route.useParams();
   const loaderTask = Route.useLoaderData();
   const { data: tasks } = useTasks();
   const fromList = tasks?.find((t) => t.id === taskId);
+  const { channels } = useChannels();
+  const channelName = channels.find((c) => c.id === channelId)?.name;
 
   const { data: fetched } = useQuery({
     ...taskDetailQuery(taskId),
@@ -35,5 +38,11 @@ function ChannelTaskDetailRoute() {
     return <RoutePending />;
   }
 
-  return <TaskDetail key={task.id} task={task} />;
+  return (
+    <TaskDetail
+      key={task.id}
+      task={task}
+      channelName={channelName ?? "Channel"}
+    />
+  );
 }


### PR DESCRIPTION
Unifies the channel header into one breadcrumb and standardizes canvas/context placeholder screens on quill `<Empty>`.


<img width="1197" height="944" alt="image" src="https://github.com/user-attachments/assets/38e74da2-c586-4c7d-a8fa-760a1f456c83" />


## Changes

- Add `ChannelBreadcrumb` primitive — `# channel / leaf`, with optional leaf icon, optional inline rename (reuses `HeaderTitleEditor`), and an optional trailing slot.
- Use the breadcrumb on **CONTEXT.md** — `# channel / 📄 CONTEXT.md`.
- Use the breadcrumb on **new task** — `# channel / New task`, pushed via the header store; remove the hardcoded "New task" label in `WebsiteLayout`.
- Use the breadcrumb on **existing task** — `TaskDetail` gains optional `channelName`; channel-scoped tasks render `# channel / <title>` with inline rename preserved. Plain Code task view unchanged.
- Use the breadcrumb on **canvas detail** — `# channel / <tier icon> <name>`, inline-renamable via `renameDashboard`; the canvas grid shows `# channel / Canvases`.
- Extract tier-icon logic into a shared `iconForTemplate` (`canvasTemplateIcon.tsx`); reuse it in `ChannelsList`.
- Breadcrumb leaf `<span>` owns the icon color (icons no longer bake in `text-gray-9`), so color is styled in one place.
- Render the breadcrumb leaf tooltip trigger as the `Text` itself (Base UI `render`) so its default `<button>` doesn't push the label down.
- Use `ShapesIcon` for generic freeform canvases (until classified as something more specific); bar = json dashboard, line = web-analytics, file = blank.
- Convert canvas "Generating" + CONTEXT.md generating/empty screens to quill `<Empty>` with primary/outline `Button`s.
- Convert the empty freeform canvas screen to quill `<Empty>` (no CTAs).
- Document the convention in `AGENTS.md`: empty/placeholder/loading screens are `<Empty>` with quill primary/outline buttons; link CTAs use `render={<Link/>}` (Base UI), not `asChild`.

## Notes
- quill `Button` is Base UI — no `asChild`; link buttons use `render`.
- Typecheck + biome clean (pre-commit hook green). Not yet driven in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)