### PR TITLE
fix(agent): attribute every PR a run creates, not just the first

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1281,15 +1281,33 @@ describe("AgentServer HTTP Mode", () => {
       expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);
     });
 
-    it("attributes only the first when two distinct recent PRs race", async () => {
-      // Both fetch as recent; without the post-await guard each would attribute.
+    it("attributes the most recent PR when a run opens several, in detection order", async () => {
+      // output.pr_url holds one value; the latest PR the run created is the useful one.
       const s = setup(justNow());
       const second = "https://github.com/PostHog/posthog.com/pull/17765";
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       s.maybeAttachCreatedPr(payload, terminalUpdate(second));
       await flush();
-      expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);
+      expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(2);
+      expect(s.posthogAPI.updateTaskRun).toHaveBeenLastCalledWith("t", "r", {
+        output: { pr_url: second },
+      });
+      expect(s.detectedPrUrl).toBe(second);
+    });
+
+    it("does not let an older PR the run only viewed overwrite the one it created", async () => {
+      const s = createServer() as unknown as PrTestServer;
+      s.posthogAPI = { updateTaskRun: vi.fn(async () => ({})) };
+      const viewed = "https://github.com/PostHog/posthog.com/pull/1";
+      // The created PR reads as recent; the later, merely-viewed PR reads as old.
+      s.fetchPrCreatedAt = vi.fn(async (url: string) =>
+        url === PR_URL ? justNow() : longAgo,
+      );
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      s.maybeAttachCreatedPr(payload, terminalUpdate(viewed));
+      await flush();
       expect(s.detectedPrUrl).toBe(PR_URL);
+      expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1296,10 +1296,9 @@ describe("AgentServer HTTP Mode", () => {
     });
 
     it("does not let an older PR the run only viewed overwrite the one it created", async () => {
-      const s = createServer() as unknown as PrTestServer;
-      s.posthogAPI = { updateTaskRun: vi.fn(async () => ({})) };
       const viewed = "https://github.com/PostHog/posthog.com/pull/1";
       // The created PR reads as recent; the later, merely-viewed PR reads as old.
+      const s = setup(justNow());
       s.fetchPrCreatedAt = vi.fn(async (url: string) =>
         url === PR_URL ? justNow() : longAgo,
       );

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -253,8 +253,8 @@ export class AgentServer {
   private questionRelayedToSlack = false;
   private adapterEmittedTurnComplete = false;
   private detectedPrUrl: string | null = null;
-  // Reset per session. `evaluatedPrUrls` dedupes the GitHub lookup per URL; the chain
-  // serializes attributions so when a run opens several PRs the most recent one wins.
+  // Reset per session. `evaluatedPrUrls` dedupes per URL; `prAttributionChain` serializes
+  // attributions so the most recently created PR in a run wins.
   private readonly evaluatedPrUrls = new Set<string>();
   private prAttributionChain: Promise<void> = Promise.resolve();
   private lastReportedBranch: string | null = null;
@@ -2400,8 +2400,7 @@ ${signedCommitInstructions}
     const prUrl = findPrUrl(JSON.stringify(update));
     if (!prUrl || this.evaluatedPrUrls.has(prUrl)) return;
     this.evaluatedPrUrls.add(prUrl);
-    // Serialize attributions so detection order is preserved when a run opens several PRs:
-    // output.pr_url is a single value, and the most recently created PR is the useful one.
+    // Chain so attributions run in detection order; later PRs overwrite earlier ones.
     this.prAttributionChain = this.prAttributionChain
       .catch(() => {})
       .then(() => this.attachPrIfCreatedThisRun(payload, prUrl));
@@ -2426,8 +2425,7 @@ ${signedCommitInstructions}
       return;
     }
 
-    // Only PRs created during this run — never one the agent merely viewed. This also keeps an
-    // older viewed PR from overwriting the one this run just created.
+    // Only attribute PRs created during this run, not ones the agent merely viewed.
     if (!wasCreatedRecently(createdAt, Date.now())) return;
 
     this.detectedPrUrl = prUrl;

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -253,9 +253,10 @@ export class AgentServer {
   private questionRelayedToSlack = false;
   private adapterEmittedTurnComplete = false;
   private detectedPrUrl: string | null = null;
-  // Reset per session. `evaluatedPrUrls` dedupes the GitHub lookup per URL.
-  private prAttributed = false;
+  // Reset per session. `evaluatedPrUrls` dedupes the GitHub lookup per URL; the chain
+  // serializes attributions so when a run opens several PRs the most recent one wins.
   private readonly evaluatedPrUrls = new Set<string>();
+  private prAttributionChain: Promise<void> = Promise.resolve();
   private lastReportedBranch: string | null = null;
   private resumeState: ResumeState | null = null;
   // Guards against concurrent session initialization. autoInitializeSession() and
@@ -1081,8 +1082,8 @@ export class AgentServer {
       runId: payload.run_id,
     });
 
-    this.prAttributed = false;
     this.evaluatedPrUrls.clear();
+    this.prAttributionChain = Promise.resolve();
 
     this.session = {
       payload,
@@ -2395,18 +2396,23 @@ ${signedCommitInstructions}
     payload: JwtPayload,
     update: Record<string, unknown> | undefined,
   ): void {
-    if (this.prAttributed || !update) return;
+    if (!update) return;
     const prUrl = findPrUrl(JSON.stringify(update));
     if (!prUrl || this.evaluatedPrUrls.has(prUrl)) return;
     this.evaluatedPrUrls.add(prUrl);
-    void this.attachPrIfCreatedThisRun(payload, prUrl);
+    // Serialize attributions so detection order is preserved when a run opens several PRs:
+    // output.pr_url is a single value, and the most recently created PR is the useful one.
+    this.prAttributionChain = this.prAttributionChain
+      .catch(() => {})
+      .then(() => this.attachPrIfCreatedThisRun(payload, prUrl));
   }
 
   private async attachPrIfCreatedThisRun(
     payload: JwtPayload,
     prUrl: string,
   ): Promise<void> {
-    if (this.prAttributed) return;
+    // Already the attributed PR (e.g. seeded from a Slack notification, or re-detected).
+    if (prUrl === this.detectedPrUrl) return;
 
     let createdAt: string | null;
     try {
@@ -2420,11 +2426,10 @@ ${signedCommitInstructions}
       return;
     }
 
+    // Only PRs created during this run — never one the agent merely viewed. This also keeps an
+    // older viewed PR from overwriting the one this run just created.
     if (!wasCreatedRecently(createdAt, Date.now())) return;
-    // Re-check after the await: another URL may have attributed while we waited.
-    if (this.prAttributed) return;
 
-    this.prAttributed = true;
     this.detectedPrUrl = prUrl;
 
     try {


### PR DESCRIPTION
## Why

PR attribution was **single-shot**: once a run recorded one `output.pr_url`, the `prAttributed` flag suppressed all further detections. A run that opened a second PR — or replaced an early PR with a later one — kept pointing at the stale first URL, and the Home tab / sidebar followed it.

## What

Retire the single-shot. Attributions now serialize through a chain so detection order is preserved, and the **most recently created PR wins** (`output.pr_url` holds a single value, and the latest PR the run opened is the useful one).

The `wasCreatedRecently` guard still ensures only PRs *created during this run* are attributed — so an older PR the agent merely **viewed** can never overwrite the one it created. `evaluatedPrUrls` still dedupes the GitHub lookup per URL.

## Pairs with
posthog/posthog#65168 — branch-based PR discovery in the code-workstreams pipeline. Between the agent reporting the latest PR and the pipeline discovering PRs by pushed branch, a run's PRs surface even when a single `output.pr_url` can't hold them all.

## Tests
`packages/agent/src/server/agent-server.test.ts` — flipped the old "only the first wins" test to assert the latest-PR-wins behavior (in detection order), and added a test that an older *viewed* PR doesn't overwrite the one the run created. **78/78 pass**; tsc + biome clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*