### PR TITLE
feat(inbox): remove PR auto-start threshold setting

### DIFF
--- a/packages/core/src/inbox/signalSourceService.test.ts
+++ b/packages/core/src/inbox/signalSourceService.test.ts
@@ -127,16 +127,6 @@ describe("SignalSourceService.toggleSource", () => {
   });
 });
 
-describe("SignalSourceService.updateUserAutonomyPriority", () => {
-  it("deletes the config when priority is null", async () => {
-    const client = fakeClient();
-    const service = new SignalSourceService();
-    await service.updateUserAutonomyPriority(client, null);
-    expect(client.deleteSignalUserAutonomyConfig).toHaveBeenCalledTimes(1);
-    expect(client.updateSignalUserAutonomyConfig).not.toHaveBeenCalled();
-  });
-});
-
 describe("SignalSourceService.buildSlackNotificationBody", () => {
   it("only writes passed keys translated to snake_case", () => {
     const service = new SignalSourceService();

--- a/packages/core/src/inbox/signalSourceService.ts
+++ b/packages/core/src/inbox/signalSourceService.ts
@@ -371,19 +371,6 @@ export class SignalSourceService {
     });
   }
 
-  async updateUserAutonomyPriority(
-    client: PostHogAPIClient,
-    priority: string | null,
-  ): Promise<void> {
-    if (priority === null) {
-      await client.deleteSignalUserAutonomyConfig();
-      return;
-    }
-    await client.updateSignalUserAutonomyConfig({
-      autostart_priority: priority,
-    });
-  }
-
   buildSlackNotificationBody(updates: {
     integrationId?: number | null;
     channel?: string | null;

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -740,10 +740,7 @@ export interface SignalSourceConnectedProperties {
 }
 
 // Agents page events (the `/code/agents` configuration surface)
-export type AgentsActionType =
-  | "run_setup_agent"
-  | "change_autostart_priority"
-  | "open_mcp_servers";
+export type AgentsActionType = "run_setup_agent" | "open_mcp_servers";
 
 export interface AgentsViewedProperties {
   /** Whether code access (GitHub) is connected — gates responder configuration. */
@@ -760,8 +757,6 @@ export interface AgentsViewedProperties {
 
 export interface AgentsActionProperties {
   action_type: AgentsActionType;
-  /** New threshold for `change_autostart_priority` (P0–P4, or null for "Never"). */
-  autostart_priority?: string | null;
   /** Whether `run_setup_agent` successfully created the setup task. */
   success?: boolean;
 }

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -13,7 +13,6 @@ import { useService } from "@posthog/di/react";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS, getCloudUrlFromRegion } from "@posthog/shared";
 import { SELF_DRIVING_SETUP_TASK_FLAG } from "@posthog/shared/constants";
-import type { SignalReportPriority } from "@posthog/shared/types";
 import { useTrackAgentsViewed } from "@posthog/ui/features/agents/hooks/useTrackAgentsViewed";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
@@ -34,7 +33,6 @@ import {
   useUserRepositoryIntegration,
 } from "@posthog/ui/features/integrations/useIntegrations";
 import { ScoutsFleetSection } from "@posthog/ui/features/scouts/components/ScoutsFleetSection";
-import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOptionSelect";
 import { GitHubIntegrationSection } from "@posthog/ui/features/settings/sections/GitHubIntegrationSection";
 import { SlackInboxNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackInboxNotificationsSettings";
 import {
@@ -52,24 +50,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { toast as sonnerToast } from "sonner";
-
-const AUTOSTART_PRIORITY_OPTIONS: {
-  value: SignalReportPriority;
-  label: string;
-}[] = [
-  { value: "P0", label: "P0 – Critical only" },
-  { value: "P1", label: "P1 – High and above" },
-  { value: "P2", label: "P2 – Medium and above" },
-  { value: "P3", label: "P3 – Low and above" },
-  { value: "P4", label: "P4 – All priorities" },
-];
-
-const NEVER_AUTOSTART_VALUE = "__never__";
-
-const USER_AUTOSTART_OPTIONS: { value: string; label: string }[] = [
-  { value: NEVER_AUTOSTART_VALUE, label: "Never – review everything first" },
-  ...AUTOSTART_PRIORITY_OPTIONS,
-];
 
 const AUTONOMY_SETUP_PROMPT = `Set up PostHog Self-driving for this product.
 
@@ -101,7 +81,6 @@ export function ConfigureAgentsSection() {
     handleSetupCancel,
     userAutonomyConfig,
     userAutonomyConfigLoading,
-    handleUpdateUserAutonomyPriority,
     evaluationsUrl,
   } = useSignalSourceManager();
   const { hasGithubIntegration, isLoadingIntegrations } =
@@ -113,8 +92,6 @@ export function ConfigureAgentsSection() {
   } = useIntegrations();
   const isLoadingSlack = isLoadingIntegrations || isLoadingSlackIntegrations;
   const showSetupTask = useFeatureFlag(SELF_DRIVING_SETUP_TASK_FLAG);
-  const userAutostartPriority =
-    userAutonomyConfig?.autostart_priority ?? NEVER_AUTOSTART_VALUE;
 
   // Derive from the query data, not the store-backed `hasGithubIntegration`: the
   // store is hydrated by a passive effect that lags the query by a render, so the
@@ -226,47 +203,6 @@ export function ConfigureAgentsSection() {
           showHeader={false}
           showTopBorder={false}
         />
-      </Subsection>
-
-      <Subsection
-        title="Auto-start"
-        description="Self-driving can start coding tasks automatically when a report is immediately actionable and assigned to you."
-      >
-        <Flex
-          align="center"
-          justify="between"
-          gap="4"
-          className="rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-4 py-3.5"
-        >
-          <Flex direction="column" gap="1" className="min-w-0">
-            <Text className="font-medium text-[13px] text-gray-12">
-              Your PR auto-start threshold
-            </Text>
-            <Text className="max-w-xl text-[12px] text-gray-11 leading-snug">
-              Reports at or above this priority can start an implementation task
-              for you. The backend deduplicates per report, and these runs count
-              toward usage.
-            </Text>
-          </Flex>
-          {userAutonomyConfigLoading ? (
-            <Box className="h-8 w-[260px] shrink-0 animate-pulse rounded bg-(--gray-3)" />
-          ) : (
-            <SettingsOptionSelect
-              value={userAutostartPriority}
-              options={USER_AUTOSTART_OPTIONS}
-              ariaLabel="PR auto-start threshold"
-              className="min-w-[260px] max-w-[300px]"
-              onValueChange={(value) => {
-                const priority = value === NEVER_AUTOSTART_VALUE ? null : value;
-                track(ANALYTICS_EVENTS.AGENTS_ACTION, {
-                  action_type: "change_autostart_priority",
-                  autostart_priority: priority,
-                });
-                void handleUpdateUserAutonomyPriority(priority);
-              }}
-            />
-          )}
-        </Flex>
       </Subsection>
 
       <Subsection

--- a/packages/ui/src/features/inbox/hooks/useSignalSourceManager.ts
+++ b/packages/ui/src/features/inbox/hooks/useSignalSourceManager.ts
@@ -47,8 +47,6 @@ export function useSignalSourceManager() {
     // User autonomy
     userAutonomyConfig,
     userAutonomyConfigLoading,
-    handleUpdateUserAutonomyPriority:
-      userAutonomyMutations.handleUpdateUserAutonomyPriority,
     handleUpdateSlackNotifications:
       userAutonomyMutations.handleUpdateSlackNotifications,
   };

--- a/packages/ui/src/features/inbox/hooks/useSignalUserAutonomyMutations.ts
+++ b/packages/ui/src/features/inbox/hooks/useSignalUserAutonomyMutations.ts
@@ -18,37 +18,11 @@ export interface SlackNotificationUpdates {
 
 /**
  * Mutations that write to the per-user Self-driving autonomy config:
- * autostart priority override and Slack notification preferences. Reads come
- * from `useSignalUserAutonomyConfig`.
+ * Slack notification preferences. Reads come from `useSignalUserAutonomyConfig`.
  */
 export function useSignalUserAutonomyMutations() {
   const client = useAuthenticatedClient();
   const queryClient = useQueryClient();
-
-  const handleUpdateUserAutonomyPriority = useCallback(
-    async (priority: string | null) => {
-      if (!client) return;
-      try {
-        if (priority === null) {
-          await client.deleteSignalUserAutonomyConfig();
-        } else {
-          await client.updateSignalUserAutonomyConfig({
-            autostart_priority: priority,
-          });
-        }
-        await queryClient.invalidateQueries({
-          queryKey: USER_AUTONOMY_QUERY_KEY,
-        });
-      } catch (error: unknown) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to update autonomy setting";
-        toast.error(message);
-      }
-    },
-    [client, queryClient],
-  );
 
   const handleUpdateSlackNotifications = useCallback(
     async (updates: SlackNotificationUpdates) => {
@@ -120,7 +94,6 @@ export function useSignalUserAutonomyMutations() {
   );
 
   return {
-    handleUpdateUserAutonomyPriority,
     handleUpdateSlackNotifications,
   };
 }

--- a/packages/ui/src/features/settings/sections/SignalSourcesSettings.tsx
+++ b/packages/ui/src/features/settings/sections/SignalSourcesSettings.tsx
@@ -1,5 +1,4 @@
-import { ArrowRightIcon, GithubLogoIcon } from "@phosphor-icons/react";
-import type { SignalReportPriority } from "@posthog/shared/domain-types";
+import { ArrowRightIcon } from "@phosphor-icons/react";
 import { DataSourceSetup } from "@posthog/ui/features/inbox/components/DataSourceSetup";
 import {
   SignalSourceToggles,
@@ -8,26 +7,10 @@ import {
 import { useSignalSourceManager } from "@posthog/ui/features/inbox/hooks/useSignalSourceManager";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
-import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOptionSelect";
 import { AutostartBaseBranchesSettings } from "@posthog/ui/features/settings/sections/AutostartBaseBranchesSettings";
 import { GitHubIntegrationSection } from "@posthog/ui/features/settings/sections/GitHubIntegrationSection";
 import { SlackInboxNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackInboxNotificationsSettings";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
-
-const PRIORITY_OPTIONS: { value: SignalReportPriority; label: string }[] = [
-  { value: "P0", label: "P0 — Critical only" },
-  { value: "P1", label: "P1 — High and above" },
-  { value: "P2", label: "P2 — Medium and above" },
-  { value: "P3", label: "P3 — Low and above" },
-  { value: "P4", label: "P4 — All priorities" },
-];
-
-const NEVER_VALUE = "__never__";
-
-const USER_PRIORITY_OPTIONS: { value: string; label: string }[] = [
-  { value: NEVER_VALUE, label: "Never – opt out of auto-assigned tasks" },
-  ...PRIORITY_OPTIONS,
-];
 
 interface SignalSourcesSettingsProps {
   /** Slack channel combobox is inside a Radix modal dialog (Inbox configuration). */
@@ -53,9 +36,6 @@ export function SignalSourcesSettings({
     handleSetup,
     handleSetupComplete,
     handleSetupCancel,
-    userAutonomyConfig,
-    userAutonomyConfigLoading,
-    handleUpdateUserAutonomyPriority,
     teamConfig,
     teamConfigLoading,
     handleUpdateAutostartBaseBranches,
@@ -63,9 +43,6 @@ export function SignalSourcesSettings({
 
   const { hasGithubIntegration, isLoadingIntegrations } =
     useRepositoryIntegration();
-
-  const userPriorityValue =
-    userAutonomyConfig?.autostart_priority ?? NEVER_VALUE;
 
   return (
     <Flex direction="column" gap="4">
@@ -116,43 +93,6 @@ export function SignalSourcesSettings({
           </Box>
         </Tooltip>
       )}
-      <Flex
-        direction="column"
-        gap="2"
-        pt="3"
-        style={{ borderTop: "1px dashed var(--gray-5)" }}
-      >
-        <Flex direction="column" gap="1">
-          <Flex align="center" gap="2">
-            <Box className="shrink-0 text-(--gray-11)">
-              <GithubLogoIcon size={16} />
-            </Box>
-            <Text className="font-medium text-(--gray-12) text-sm">
-              Your PR auto-start threshold
-            </Text>
-          </Flex>
-          <Text className="text-(--gray-11) text-[13px]">
-            Automatically start tasks assigned to you for reports at or above
-            this priority. These count toward your usage. Choose
-            &quot;Never&quot; to opt out.
-          </Text>
-        </Flex>
-        {userAutonomyConfigLoading ? (
-          <Box className="h-[32px] w-[260px] animate-pulse rounded bg-gray-3" />
-        ) : (
-          <SettingsOptionSelect
-            value={userPriorityValue}
-            options={USER_PRIORITY_OPTIONS}
-            ariaLabel="PR auto-start threshold"
-            className="min-w-[260px] max-w-[300px]"
-            onValueChange={(value) =>
-              void handleUpdateUserAutonomyPriority(
-                value === NEVER_VALUE ? null : value,
-              )
-            }
-          />
-        )}
-      </Flex>
       <AutostartBaseBranchesSettings
         branches={teamConfig?.autostart_base_branches ?? {}}
         onChange={(next) => void handleUpdateAutostartBaseBranches(next)}


### PR DESCRIPTION
## Problem

The PR auto-start threshold is becoming a fixed **P4** default managed entirely by the PostHog Cloud backend. With that change, the per-user "auto-start threshold" control in PostHog Code no longer has anything to configure, so it should be removed.

This is the PostHog Code half of a two-repo change; the backend default flip (P2 → P4), the data backfill, and hiding the equivalent web inbox UI land in posthog/posthog.

## Changes

- Remove the **"Your PR auto-start threshold"** select from both surfaces that rendered it: `ConfigureAgentsSection` (the `/code/agents` page) and the Settings → Signals section (`SignalSourcesSettings`).
- Remove the now-dead handler chain it drove: `handleUpdateUserAutonomyPriority` (mutation hook + source-manager re-export), the unused `SignalSourceService.updateUserAutonomyPriority` method and its test, and the `change_autostart_priority` analytics action type/property.
- Left untouched: Slack notification settings and the per-repo **auto-start base branches** config, which share the same backend objects but are separate features.

## How did you test this?

- `pnpm --filter @posthog/core --filter @posthog/ui --filter @posthog/shared typecheck` — passes
- `pnpm --filter @posthog/core test -- signalSourceService` — 1657 passed
- `biome lint` on all changed files — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1782143458211459)*
