### PR TITLE
fix(inbox): use archive icon for archive action

### DIFF
--- a/packages/ui/src/features/inbox/components/PullRequestCard.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestCard.tsx
@@ -1,4 +1,4 @@
-import { ThumbsDownIcon } from "@phosphor-icons/react";
+import { ArchiveIcon } from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import {
   deriveHeadline,
@@ -154,7 +154,7 @@ export function PullRequestCard({
               onDismiss();
             }}
           >
-            <ThumbsDownIcon size={14} />
+            <ArchiveIcon size={14} />
           </UiButton>
           <Button
             type="button"

--- a/packages/ui/src/features/inbox/components/ReportCard.tsx
+++ b/packages/ui/src/features/inbox/components/ReportCard.tsx
@@ -1,7 +1,7 @@
 import {
+  ArchiveIcon,
   ArrowCounterClockwiseIcon,
   LightningIcon,
-  ThumbsDownIcon,
 } from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import {
@@ -288,7 +288,7 @@ export function ReportCard(props: ReportCardProps) {
                     props.onDismiss();
                   }}
                 >
-                  <ThumbsDownIcon size={14} />
+                  <ArchiveIcon size={14} />
                 </UiButton>
                 <Button
                   type="button"

--- a/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
+++ b/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
@@ -1,4 +1,4 @@
-import { ThumbsDownIcon } from "@phosphor-icons/react";
+import { ArchiveIcon } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import { isDismissalReasonSnooze } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
@@ -53,7 +53,7 @@ export function useInboxReportDismissAction(report: SignalReport): {
         disabled={isPending}
         onClick={() => setOpen(true)}
       >
-        {isPending ? <Spinner size="1" /> : <ThumbsDownIcon size={12} />}
+        {isPending ? <Spinner size="1" /> : <ArchiveIcon size={12} />}
       </Button>
     </Tooltip>
   );


### PR DESCRIPTION
## Problem

In the Self-driving Inbox, the action to archive a report shows a 👎 thumbs-down icon. The action was renamed to "Archive", but the icon was never swapped — a thumbs-down reads as "I didn't like this / recommend less" rather than "archive this report". Reported in Slack.

## Changes

Swap `ThumbsDownIcon` for `ArchiveIcon` (same `@phosphor-icons/react` package, already used elsewhere in the inbox) on the three archive affordances:
- `ReportCard` archive button
- `PullRequestCard` archive button
- `useInboxReportDismissAction` detail-screen archive button

## How did you test this?

Verified no `ThumbsDownIcon` references remain in the inbox UI. Did not run the full typecheck (dependencies not installed in this environment); the change is a like-for-like icon swap using an import already present in the package.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1782138251197239?thread_ts=1782138251.197239&cid=C09G8Q32R6F)*
