### PR TITLE
feat(canvas): start CONTEXT.md and canvas generation repo-less

### DIFF
--- a/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -27,16 +27,9 @@ import {
   useFolderInstructionsMutations,
   useFolderInstructionsVersions,
 } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
-import {
-  type GenerateContextTarget,
-  useGenerateContext,
-} from "@posthog/ui/features/canvas/hooks/useGenerateContext";
+import { useGenerateContext } from "@posthog/ui/features/canvas/hooks/useGenerateContext";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
-import { FolderPicker } from "@posthog/ui/features/folder-picker/FolderPicker";
-import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
-import { useUserRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
-import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { track } from "@posthog/ui/shell/analytics";
@@ -461,11 +454,10 @@ function EmptyState({
   );
 }
 
-type GenMode = "local" | "cloud";
-
-// Lets the user pick a local repo or a connected GitHub repo (cloud), then kicks
-// off a normal task that explores the code + PostHog data and publishes
-// CONTEXT.md via the MCP. Reuses the same pickers as the task input bar.
+// Kicks off a repo-less task that explores PostHog data (and a repo, if the
+// agent decides it needs one) and publishes CONTEXT.md via the MCP. The user no
+// longer picks a folder/repo up front — the agent attaches one lazily and asks
+// to clarify if it can't find the right one.
 function GenerateWithAgent({
   channelId,
   channelName,
@@ -476,131 +468,25 @@ function GenerateWithAgent({
   regenerate: boolean;
 }) {
   const { generate, isStarting } = useGenerateContext(channelId, channelName);
-  const lastUsedRunMode = useSettingsStore((s) => s.lastUsedRunMode);
 
-  // Fire generate_started, then kick off the generation task. Wrapping here
-  // covers both the local and cloud sub-pickers in one place.
-  const trackedGenerate = (target: GenerateContextTarget) => {
+  const onGenerate = () => {
     track(ANALYTICS_EVENTS.CONTEXT_ACTION, {
       action_type: "generate_started",
       channel_id: channelId,
-      execution_type: target.mode,
     });
-    return generate(target);
+    void generate();
   };
 
-  const [picking, setPicking] = useState(false);
-  const [genMode, setGenMode] = useState<GenMode>(
-    lastUsedRunMode === "cloud" ? "cloud" : "local",
-  );
-
-  if (!picking) {
-    return (
-      <QuillButton
-        variant="outline"
-        size="default"
-        onClick={() => setPicking(true)}
-      >
-        <SparkleIcon size={14} />
-        {regenerate ? "Generate again" : "Generate with agent"}
-      </QuillButton>
-    );
-  }
-
   return (
-    <Flex direction="column" align="center" gap="2">
-      <SegmentedControl.Root
-        size="1"
-        value={genMode}
-        onValueChange={(v) => setGenMode(v as GenMode)}
-      >
-        <SegmentedControl.Item value="local">Local</SegmentedControl.Item>
-        <SegmentedControl.Item value="cloud">Cloud</SegmentedControl.Item>
-      </SegmentedControl.Root>
-      {genMode === "local" ? (
-        <GenerateLocal generate={trackedGenerate} isStarting={isStarting} />
-      ) : (
-        <GenerateCloud generate={trackedGenerate} isStarting={isStarting} />
-      )}
-    </Flex>
-  );
-}
-
-interface GenerateSubProps {
-  generate: (target: GenerateContextTarget) => Promise<string | null>;
-  isStarting: boolean;
-}
-
-function GenerateLocal({ generate, isStarting }: GenerateSubProps) {
-  const [repoPath, setRepoPath] = useState("");
-  return (
-    <Flex align="center" gap="2">
-      <FolderPicker value={repoPath} onChange={setRepoPath} />
-      <Button
-        size="2"
-        variant="solid"
-        disabled={!repoPath || isStarting}
-        onClick={() => {
-          if (repoPath) void generate({ mode: "local", repoPath });
-        }}
-      >
-        {isStarting ? <Spinner size="1" /> : <SparkleIcon size={14} />}
-        Generate
-      </Button>
-    </Flex>
-  );
-}
-
-function GenerateCloud({ generate, isStarting }: GenerateSubProps) {
-  const {
-    repositories,
-    getUserIntegrationIdForRepo,
-    isLoadingRepos,
-    hasGithubIntegration,
-  } = useUserRepositoryIntegration();
-  const lastUsedCloudRepository = useSettingsStore(
-    (s) => s.lastUsedCloudRepository,
-  );
-  const [repo, setRepo] = useState<string | null>(
-    lastUsedCloudRepository ?? null,
-  );
-  const integrationId = repo ? getUserIntegrationIdForRepo(repo) : undefined;
-
-  if (!hasGithubIntegration && !isLoadingRepos) {
-    return (
-      <Text className="text-[12px] text-gray-10">
-        Connect GitHub to generate in the cloud.
-      </Text>
-    );
-  }
-
-  return (
-    <Flex align="center" gap="2">
-      <GitHubRepoPicker
-        value={repo}
-        onChange={setRepo}
-        repositories={repositories}
-        isLoading={isLoadingRepos}
-        size="2"
-      />
-      <Button
-        size="2"
-        variant="solid"
-        disabled={!repo || !integrationId || isStarting}
-        onClick={() => {
-          if (repo && integrationId) {
-            void generate({
-              mode: "cloud",
-              repository: repo,
-              githubUserIntegrationId: integrationId,
-            });
-          }
-        }}
-      >
-        {isStarting ? <Spinner size="1" /> : <SparkleIcon size={14} />}
-        Generate
-      </Button>
-    </Flex>
+    <QuillButton
+      variant="outline"
+      size="default"
+      disabled={isStarting}
+      onClick={onGenerate}
+    >
+      {isStarting ? <Spinner size="1" /> : <SparkleIcon size={14} />}
+      {regenerate ? "Generate again" : "Generate with agent"}
+    </QuillButton>
   );
 }
 

--- a/packages/ui/src/features/canvas/contextPrompt.ts
+++ b/packages/ui/src/features/canvas/contextPrompt.ts
@@ -1,8 +1,8 @@
 // Builds the prompt for the task that generates a channel's CONTEXT.md. The
-// task runs as a normal agent task in the channel's repo, so the agent has full
-// tools; this is the task's content (its first user message). CONTEXT.md is not
-// a file on disk — it lives in PostHog — so the agent must publish the result
-// via the PostHog MCP rather than writing a file.
+// task runs as a normal repo-less agent task (no repo picked up front), so the
+// agent has full tools; this is the task's content (its first user message).
+// CONTEXT.md is not a file on disk — it lives in PostHog — so the agent must
+// publish the result via the PostHog MCP rather than writing a file.
 export function buildContextGenerationPrompt(input: {
   channelName: string;
   channelId: string;
@@ -15,8 +15,10 @@ work in "${channelName}": what it is, key files, conventions, gotchas, and the
 PostHog resources that relate to it.
 
 Investigate two sources:
-1. This repository — use Read, Grep, and Glob to find code, directories, and
-   config related to "${channelName}" (conventions, key files, gotchas).
+1. The relevant repository — use Read, Grep, and Glob to find code, directories,
+   and config related to "${channelName}" (conventions, key files, gotchas). No
+   repo is attached up front: if one isn't already available and you can't infer
+   which to use, ask the user which repository to look at before continuing.
 2. PostHog — use the PostHog MCP to find data related to "${channelName}" in
    this project: feature flags, experiments, surveys, notebooks, insights, web
    analytics, and persons. Operate only on this project.

--- a/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
@@ -1,28 +1,12 @@
 import { SparkleIcon } from "@phosphor-icons/react";
-import {
-  type GenerateCanvasTarget,
-  useGenerateFreeformCanvas,
-} from "@posthog/ui/features/canvas/hooks/useGenerateFreeformCanvas";
-import { FolderPicker } from "@posthog/ui/features/folder-picker/FolderPicker";
-import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
-import { useUserRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
-import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
-import {
-  Button,
-  Flex,
-  SegmentedControl,
-  Spinner,
-  Text,
-  TextArea,
-} from "@radix-ui/themes";
-import { useState } from "react";
-
-type GenMode = "local" | "cloud";
+import { useGenerateFreeformCanvas } from "@posthog/ui/features/canvas/hooks/useGenerateFreeformCanvas";
+import { Button, Flex, Spinner, TextArea } from "@radix-ui/themes";
 
 // Composer that kicks off freeform canvas generation as a dedicated task: the
-// user describes what they want, picks a local repo or a connected GitHub repo
-// (cloud), and the agent builds + publishes the canvas. Used both for the first
-// build (empty canvas) and for follow-up edits (currentCode passed in).
+// user describes what they want and the agent builds + publishes the canvas. No
+// repo is picked up front — the agent attaches one lazily only if it needs it.
+// Used both for the first build (empty canvas) and for follow-up edits
+// (currentCode passed in).
 export function FreeformGenerateBar({
   dashboardId,
   channelId,
@@ -52,18 +36,14 @@ export function FreeformGenerateBar({
     channelName,
     templateId,
   });
-  const lastUsedRunMode = useSettingsStore((s) => s.lastUsedRunMode);
   const draft = value;
   const setDraft = onValueChange;
-  const [genMode, setGenMode] = useState<GenMode>(
-    lastUsedRunMode === "cloud" ? "cloud" : "local",
-  );
   const isEdit = !!currentCode?.trim();
 
-  const run = async (target: GenerateCanvasTarget) => {
+  const run = async () => {
     const instruction = draft.trim();
     if (!instruction) return;
-    const taskId = await generate(target, { instruction, currentCode });
+    const taskId = await generate({ instruction, currentCode });
     if (taskId) {
       setDraft("");
       onStarted?.(taskId);
@@ -87,109 +67,17 @@ export function FreeformGenerateBar({
         rows={3}
         disabled={isStarting}
       />
-      <SegmentedControl.Root
-        size="1"
-        value={genMode}
-        onValueChange={(v) => setGenMode(v as GenMode)}
-      >
-        <SegmentedControl.Item value="local">Local</SegmentedControl.Item>
-        <SegmentedControl.Item value="cloud">Cloud</SegmentedControl.Item>
-      </SegmentedControl.Root>
-      {genMode === "local" ? (
-        <GenerateLocal
-          run={run}
-          isStarting={isStarting}
-          disabled={!draft.trim()}
-          label={isEdit ? "Edit" : "Generate"}
-        />
-      ) : (
-        <GenerateCloud
-          run={run}
-          isStarting={isStarting}
-          disabled={!draft.trim()}
-          label={isEdit ? "Edit" : "Generate"}
-        />
-      )}
-    </Flex>
-  );
-}
-
-interface SubProps {
-  run: (target: GenerateCanvasTarget) => void;
-  isStarting: boolean;
-  disabled: boolean;
-  label: string;
-}
-
-function GenerateLocal({ run, isStarting, disabled, label }: SubProps) {
-  const [repoPath, setRepoPath] = useState("");
-  return (
-    <Flex align="center" gap="2">
-      <FolderPicker value={repoPath} onChange={setRepoPath} />
-      <Button
-        size="2"
-        variant="solid"
-        disabled={!repoPath || disabled || isStarting}
-        onClick={() => {
-          if (repoPath) run({ mode: "local", repoPath });
-        }}
-      >
-        {isStarting ? <Spinner size="1" /> : <SparkleIcon size={14} />}
-        {label}
-      </Button>
-    </Flex>
-  );
-}
-
-function GenerateCloud({ run, isStarting, disabled, label }: SubProps) {
-  const {
-    repositories,
-    getUserIntegrationIdForRepo,
-    isLoadingRepos,
-    hasGithubIntegration,
-  } = useUserRepositoryIntegration();
-  const lastUsedCloudRepository = useSettingsStore(
-    (s) => s.lastUsedCloudRepository,
-  );
-  const [repo, setRepo] = useState<string | null>(
-    lastUsedCloudRepository ?? null,
-  );
-  const integrationId = repo ? getUserIntegrationIdForRepo(repo) : undefined;
-
-  if (!hasGithubIntegration && !isLoadingRepos) {
-    return (
-      <Text className="text-[12px] text-gray-10">
-        Connect GitHub to generate in the cloud.
-      </Text>
-    );
-  }
-
-  return (
-    <Flex align="center" gap="2">
-      <GitHubRepoPicker
-        value={repo}
-        onChange={setRepo}
-        repositories={repositories}
-        isLoading={isLoadingRepos}
-        size="2"
-      />
-      <Button
-        size="2"
-        variant="solid"
-        disabled={!repo || !integrationId || disabled || isStarting}
-        onClick={() => {
-          if (repo && integrationId) {
-            run({
-              mode: "cloud",
-              repository: repo,
-              githubUserIntegrationId: integrationId,
-            });
-          }
-        }}
-      >
-        {isStarting ? <Spinner size="1" /> : <SparkleIcon size={14} />}
-        {label}
-      </Button>
+      <Flex align="center" justify="end" gap="2">
+        <Button
+          size="2"
+          variant="solid"
+          disabled={!draft.trim() || isStarting}
+          onClick={() => void run()}
+        >
+          {isStarting ? <Spinner size="1" /> : <SparkleIcon size={14} />}
+          {isEdit ? "Edit" : "Generate"}
+        </Button>
+      </Flex>
     </Flex>
   );
 }

--- a/packages/ui/src/features/canvas/freeformPrompt.ts
+++ b/packages/ui/src/features/canvas/freeformPrompt.ts
@@ -1,8 +1,9 @@
 import { freeformSystemPromptFor } from "@posthog/core/canvas/canvasTemplates";
 
 // Builds the prompt for the task that generates a freeform (React) canvas. Like
-// CONTEXT.md generation, this runs as a normal agent task in the channel's repo,
-// so the agent has the default system prompt — the freeform authoring contract
+// CONTEXT.md generation, this runs as a normal repo-less agent task (no repo
+// picked up front), so the agent has the default system prompt — the freeform
+// authoring contract
 // (imports, the `ph` data shim, Quill/style rules) therefore has to live in the
 // task's content (its first user message). The canvas is not a file on disk — it
 // lives in PostHog — so the agent publishes the result via the PostHog MCP tool

--- a/packages/ui/src/features/canvas/hooks/useGenerateContext.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateContext.ts
@@ -3,86 +3,75 @@ import {
   type TaskService,
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
+import { useHostTRPC } from "@posthog/host-router/react";
 import { buildContextGenerationPrompt } from "@posthog/ui/features/canvas/contextPrompt";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useFolderGenerationTaskMutation } from "@posthog/ui/features/canvas/hooks/useFolderGenerationTask";
 import { useCreateTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
 import { toast } from "@posthog/ui/primitives/toast";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 
-// Where the generation task runs: a local clone or a connected GitHub repo
-// (cloud sandbox). Cloud needs the user-integration id; both omit the branch
-// (defaults).
-export type GenerateContextTarget =
-  | { mode: "local"; repoPath: string }
-  | {
-      mode: "cloud";
-      repository: string;
-      githubUserIntegrationId: string;
-      branch?: string | null;
-    };
-
-// Kicks off CONTEXT.md generation as a normal task (local or cloud) in the
-// channel's repo. The task is filed to the channel and recorded server-side as
-// the channel's generation task so every user's CONTEXT.md view can track it.
+// Kicks off CONTEXT.md generation as a repo-less task. The user no longer picks
+// a folder/repo up front — the agent decides at runtime whether it needs one and
+// asks the user to clarify if it can't find the right one. The task runs in a
+// per-task scratch dir (local), is filed to the channel, and recorded
+// server-side as the channel's generation task so every user's CONTEXT.md view
+// can track it.
 export function useGenerateContext(channelId: string, channelName: string) {
   const taskService = useService<TaskService>(TASK_SERVICE);
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
   const { invalidateTasks } = useCreateTask();
   const { fileTask } = useChannelTaskMutations();
   const { set: setGenerationTask } = useFolderGenerationTaskMutation(channelId);
   const [isStarting, setIsStarting] = useState(false);
 
-  const generate = useCallback(
-    async (target: GenerateContextTarget): Promise<string | null> => {
-      setIsStarting(true);
-      try {
-        const base = {
+  const generate = useCallback(async (): Promise<string | null> => {
+    setIsStarting(true);
+    try {
+      const result = await taskService.createTask(
+        {
           content: buildContextGenerationPrompt({ channelName, channelId }),
           taskDescription: `Generate CONTEXT.md for #${channelName}`,
-        };
-        const result = await taskService.createTask(
-          target.mode === "cloud"
-            ? {
-                ...base,
-                repository: target.repository,
-                githubUserIntegrationId: target.githubUserIntegrationId,
-                workspaceMode: "cloud",
-                branch: target.branch ?? null,
-              }
-            : {
-                ...base,
-                repoPath: target.repoPath,
-                workspaceMode: "local",
-              },
-          (output) => invalidateTasks(output.task),
-        );
+          workspaceMode: "local",
+          allowNoRepo: true,
+        },
+        (output) => invalidateTasks(output.task),
+      );
 
-        if (!result.success) {
-          toast.error("Couldn't start CONTEXT.md generation", {
-            description: result.error,
-          });
-          return null;
-        }
-
-        const task = result.data.task;
-        // File into the channel + record as the (shared) generation task. Both
-        // are best-effort: a failure here shouldn't undo a started task.
-        void fileTask(channelId, task.id, task.title).catch(() => {});
-        void setGenerationTask(task.id).catch(() => {});
-        return task.id;
-      } finally {
-        setIsStarting(false);
+      if (!result.success) {
+        toast.error("Couldn't start CONTEXT.md generation", {
+          description: result.error,
+        });
+        return null;
       }
-    },
-    [
-      taskService,
-      invalidateTasks,
-      fileTask,
-      setGenerationTask,
-      channelId,
-      channelName,
-    ],
-  );
+
+      const task = result.data.task;
+      // File into the channel + record as the (shared) generation task. Both
+      // are best-effort: a failure here shouldn't undo a started task.
+      void fileTask(channelId, task.id, task.title).catch(() => {});
+      void setGenerationTask(task.id).catch(() => {});
+      // Repo-less tasks create no workspace row, so the usual workspace.create
+      // invalidation never fires — refresh the cache so the task view resolves
+      // its scratch cwd instead of showing the repo-picker prompt.
+      void queryClient.invalidateQueries({
+        queryKey: trpc.workspace.getAll.queryKey(),
+      });
+      return task.id;
+    } finally {
+      setIsStarting(false);
+    }
+  }, [
+    taskService,
+    trpc,
+    queryClient,
+    invalidateTasks,
+    fileTask,
+    setGenerationTask,
+    channelId,
+    channelName,
+  ]);
 
   return { generate, isStarting };
 }

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -12,6 +12,7 @@ import {
   isPlaceholderCanvasName,
   useDashboardMutations,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
 import { useCreateTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
 import { toast } from "@posthog/ui/primitives/toast";
 import { useQueryClient } from "@tanstack/react-query";
@@ -42,6 +43,10 @@ export function useGenerateFreeformCanvas(args: {
   const { invalidateTasks } = useCreateTask();
   const { fileTask } = useChannelTaskMutations();
   const { setGenerationTask, renameDashboard } = useDashboardMutations();
+  // The channel's CONTEXT.md, passed to the agent as optional background so the
+  // generated canvas starts with the shared context. Absent/empty is fine.
+  const { data: instructions } = useFolderInstructions(channelId);
+  const channelContext = instructions?.content;
   const [isStarting, setIsStarting] = useState(false);
 
   const generate = useCallback(
@@ -64,6 +69,8 @@ export function useGenerateFreeformCanvas(args: {
             taskDescription: `Generate canvas "${name}"`,
             workspaceMode: "local",
             allowNoRepo: true,
+            channelContext,
+            channelName,
           },
           (output) => invalidateTasks(output.task),
         );
@@ -117,6 +124,7 @@ export function useGenerateFreeformCanvas(args: {
       name,
       channelName,
       templateId,
+      channelContext,
     ],
   );
 

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -5,27 +5,26 @@ import {
   type TaskService,
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
+import { useHostTRPC } from "@posthog/host-router/react";
 import { buildFreeformGenerationPrompt } from "@posthog/ui/features/canvas/freeformPrompt";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import {
   isPlaceholderCanvasName,
   useDashboardMutations,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
-import type { GenerateContextTarget } from "@posthog/ui/features/canvas/hooks/useGenerateContext";
 import { useCreateTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
 import { toast } from "@posthog/ui/primitives/toast";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 
-// Where the canvas-generation task runs: a local clone or a connected GitHub
-// repo (cloud). Same shape as CONTEXT.md generation — canvas gen doesn't read
-// repo code, but the task system is repo-bound, so it runs in the channel repo.
-export type { GenerateContextTarget as GenerateCanvasTarget } from "@posthog/ui/features/canvas/hooks/useGenerateContext";
-
-// Kicks off freeform canvas generation as a normal task (local or cloud), files
-// it to the channel, and records it as the canvas's generation task (in the
-// canvas's meta) so every client's canvas view tracks the in-flight run. The
-// agent publishes the result via the `desktop-file-system-canvas-partial-update`
-// MCP tool — mirrors useGenerateContext.
+// Kicks off freeform canvas generation as a repo-less task, files it to the
+// channel, and records it as the canvas's generation task (in the canvas's meta)
+// so every client's canvas view tracks the in-flight run. Canvas generation
+// reads PostHog data via the MCP rather than repo code, so no repo is selected
+// up front — the agent attaches one lazily only if it decides it needs one. The
+// task runs in a per-task scratch dir (local) and the agent publishes the result
+// via the `desktop-file-system-canvas-partial-update` MCP tool — mirrors
+// useGenerateContext.
 export function useGenerateFreeformCanvas(args: {
   dashboardId: string;
   channelId: string;
@@ -38,43 +37,34 @@ export function useGenerateFreeformCanvas(args: {
   const titleGenerator = useService<TitleGeneratorService>(
     TITLE_GENERATOR_SERVICE,
   );
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
   const { invalidateTasks } = useCreateTask();
   const { fileTask } = useChannelTaskMutations();
   const { setGenerationTask, renameDashboard } = useDashboardMutations();
   const [isStarting, setIsStarting] = useState(false);
 
   const generate = useCallback(
-    async (
-      target: GenerateContextTarget,
-      opts: { instruction: string; currentCode?: string },
-    ): Promise<string | null> => {
+    async (opts: {
+      instruction: string;
+      currentCode?: string;
+    }): Promise<string | null> => {
       setIsStarting(true);
       try {
-        const base = {
-          content: buildFreeformGenerationPrompt({
-            dashboardId,
-            name,
-            channelName,
-            templateId,
-            instruction: opts.instruction,
-            currentCode: opts.currentCode,
-          }),
-          taskDescription: `Generate canvas "${name}"`,
-        };
         const result = await taskService.createTask(
-          target.mode === "cloud"
-            ? {
-                ...base,
-                repository: target.repository,
-                githubUserIntegrationId: target.githubUserIntegrationId,
-                workspaceMode: "cloud",
-                branch: target.branch ?? null,
-              }
-            : {
-                ...base,
-                repoPath: target.repoPath,
-                workspaceMode: "local",
-              },
+          {
+            content: buildFreeformGenerationPrompt({
+              dashboardId,
+              name,
+              channelName,
+              templateId,
+              instruction: opts.instruction,
+              currentCode: opts.currentCode,
+            }),
+            taskDescription: `Generate canvas "${name}"`,
+            workspaceMode: "local",
+            allowNoRepo: true,
+          },
           (output) => invalidateTasks(output.task),
         );
 
@@ -90,6 +80,12 @@ export function useGenerateFreeformCanvas(args: {
         // are best-effort: a failure here shouldn't undo a started task.
         void fileTask(channelId, task.id, task.title).catch(() => {});
         void setGenerationTask(dashboardId, task.id).catch(() => {});
+        // Repo-less tasks create no workspace row, so the usual workspace.create
+        // invalidation never fires — refresh the cache so the task view resolves
+        // its scratch cwd instead of showing the repo-picker prompt.
+        void queryClient.invalidateQueries({
+          queryKey: trpc.workspace.getAll.queryKey(),
+        });
         // Auto-name a still-unnamed canvas from its generation prompt, using the
         // same helper model that names tasks. Best-effort: a failure (or a user
         // who already named the canvas) leaves the existing title untouched.
@@ -110,6 +106,8 @@ export function useGenerateFreeformCanvas(args: {
     [
       taskService,
       titleGenerator,
+      trpc,
+      queryClient,
       invalidateTasks,
       fileTask,
       setGenerationTask,


### PR DESCRIPTION
## Problem

Canvas and CONTEXT.md generation tasks forced the user to select a folder (local) or a repo (cloud) before they could start. That requirement is no longer needed — the agent knows how to handle repo-less tasks now, attaching a repo lazily and asking the user to clarify if it can't find the right one.

**Why:** Picking a repo up front is friction for generation tasks that mostly read PostHog data, and the agent can now figure out (or ask about) the repo at runtime.

## Changes

- Both generation flows now create a **repo-less local task** (scratch dir) via the existing `allowNoRepo` path, mirroring the channels new-task chat box. The created task's workspace cache is invalidated so its view resolves the scratch cwd instead of showing the repo-picker prompt.
- The local/cloud segmented control and the folder/repo pickers are removed from the CONTEXT.md **"Generate with agent"** control and the canvas **generate bar** — each is now a single Generate button.
- The CONTEXT.md prompt notes no repo is attached up front and tells the agent to ask which repo to use when it can't infer one.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — passes
- `biome check` on changed files — clean
- `vitest run src/features/canvas` — 17 tests pass

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*