### PR TITLE
Add inline rename to canvas right-click menu in Bluebird nav

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -818,6 +818,7 @@ export type DashboardActionType =
   | "open"
   | "create"
   | "delete"
+  | "rename"
   | "save"
   | "fork"
   | "edit_toggle"

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -85,6 +85,7 @@ import {
   usePrefetchDashboards,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { TaskIcon } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
+import { HeaderTitleEditor } from "@posthog/ui/features/task-detail/HeaderTitleEditor";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
@@ -382,7 +383,7 @@ function ChildRow({
 }
 
 // A single saved canvas under a channel — navigates to its detail view, with a
-// right-click menu to delete it.
+// right-click menu to rename (inline) or delete it.
 function DashboardRow({
   channelId,
   dashboard,
@@ -394,8 +395,35 @@ function DashboardRow({
 }) {
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-  const { deleteDashboard, isDeleting } = useDashboardMutations();
+  const { deleteDashboard, isDeleting, renameDashboard } =
+    useDashboardMutations();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+
+  const onRename = async (next: string) => {
+    setRenaming(false);
+    try {
+      await renameDashboard(dashboard.id, next);
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "rename",
+        surface: "sidebar",
+        channel_id: channelId,
+        dashboard_id: dashboard.id,
+        success: true,
+      });
+    } catch (error) {
+      track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+        action_type: "rename",
+        surface: "sidebar",
+        channel_id: channelId,
+        dashboard_id: dashboard.id,
+        success: false,
+      });
+      toast.error("Couldn't rename canvas", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
 
   const onDelete = async () => {
     try {
@@ -431,6 +459,22 @@ function DashboardRow({
     }
   };
 
+  // While renaming, swap the row for an inline editor that saves on Enter/blur.
+  if (renaming) {
+    return (
+      <div className="flex w-full items-start gap-2 px-2 py-1">
+        <span className="mt-px shrink-0">
+          {iconForTemplate(dashboard.templateId)}
+        </span>
+        <HeaderTitleEditor
+          initialTitle={dashboard.name}
+          onSubmit={onRename}
+          onCancel={() => setRenaming(false)}
+        />
+      </div>
+    );
+  }
+
   return (
     <>
       <ContextMenu>
@@ -463,6 +507,11 @@ function DashboardRow({
           <TooltipContent side="right">{dashboard.name}</TooltipContent>
         </Tooltip>
         <ContextMenuContent>
+          <ContextMenuItem onClick={() => setRenaming(true)}>
+            <PencilSimpleIcon size={14} />
+            Rename…
+          </ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem
             variant="destructive"
             disabled={isDeleting}

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -399,9 +399,17 @@ function DashboardRow({
     useDashboardMutations();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
+  // The name typed on a failed rename, kept so the retry keeps the user's text.
+  const [renameDraft, setRenameDraft] = useState<string | null>(null);
+  // Bumped on failure to remount the editor, resetting its one-shot submit guard.
+  const [renameAttempt, setRenameAttempt] = useState(0);
+
+  const closeRename = () => {
+    setRenaming(false);
+    setRenameDraft(null);
+  };
 
   const onRename = async (next: string) => {
-    setRenaming(false);
     try {
       await renameDashboard(dashboard.id, next);
       track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
@@ -411,7 +419,11 @@ function DashboardRow({
         dashboard_id: dashboard.id,
         success: true,
       });
+      closeRename();
     } catch (error) {
+      // Keep the editor open with the typed text so the rename can be retried.
+      setRenameDraft(next);
+      setRenameAttempt((n) => n + 1);
       track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
         action_type: "rename",
         surface: "sidebar",
@@ -467,9 +479,10 @@ function DashboardRow({
           {iconForTemplate(dashboard.templateId)}
         </span>
         <HeaderTitleEditor
-          initialTitle={dashboard.name}
+          key={renameAttempt}
+          initialTitle={renameDraft ?? dashboard.name}
           onSubmit={onRename}
-          onCancel={() => setRenaming(false)}
+          onCancel={closeRename}
         />
       </div>
     );

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -85,8 +85,8 @@ import {
   usePrefetchDashboards,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { TaskIcon } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
-import { HeaderTitleEditor } from "@posthog/ui/features/task-detail/HeaderTitleEditor";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
+import { HeaderTitleEditor } from "@posthog/ui/features/task-detail/HeaderTitleEditor";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
 import { toast } from "@posthog/ui/primitives/toast";
@@ -507,7 +507,10 @@ function DashboardRow({
           <TooltipContent side="right">{dashboard.name}</TooltipContent>
         </Tooltip>
         <ContextMenuContent>
-          <ContextMenuItem onClick={() => setRenaming(true)}>
+          <ContextMenuItem
+            disabled={isDeleting}
+            onClick={() => setRenaming(true)}
+          >
             <PencilSimpleIcon size={14} />
             Rename…
           </ContextMenuItem>


### PR DESCRIPTION

https://github.com/user-attachments/assets/f6d83fdb-80ed-4577-9496-06d4d201d9b9


## Problem

In the Project Bluebird channel nav, there was no way to rename a saved canvas without opening it. You could only delete it from the right-click menu.

**Why:** Raquel asked for a quick way to rename a canvas straight from the nav — right-click → rename, edit in place, save on blur/Enter.

## Changes

- Added a **"Rename…"** item to a canvas row's right-click menu in the channel sidebar (`ChannelsList.tsx`). Selecting it turns the row into an inline editor (reusing the existing `HeaderTitleEditor`), saving on Enter or click-away and cancelling on Escape.
- Wired the save to the existing `dashboards.rename` mutation and added a `"rename"` `DashboardActionType` for analytics (success + failure), with an error toast — mirroring the existing delete flow.

## How did you test this?

Not yet manually verified in the running app. The change reuses existing rename plumbing (`renameDashboard` / `dashboards.rename`, already used for auto-naming and the breadcrumb rename) and follows the row's existing delete pattern. A full typecheck wasn't run in this environment (dependencies not installed in the clone).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*