### PR TITLE
fix(sidebar): preselect cloud repository when creating task from repo group

### DIFF
--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -280,6 +280,13 @@ export function TaskListView({
               );
               const groupFolderId =
                 folder?.id ?? group.tasks.find((t) => t.folderId)?.folderId;
+              // Cloud-only repository groups have no registered local folder.
+              // Their group id is the normalized `owner/repo` key; detect them
+              // via a parsed repository (which carries an organization) so we
+              // can preselect the cloud repo instead of opening a blank input.
+              const cloudRepository = group.tasks.find(
+                (t) => t.repository?.organization,
+              )?.repository?.fullPath;
               return (
                 <DraggableFolder key={group.id} id={group.id} index={index}>
                   <SidebarSection
@@ -293,6 +300,10 @@ export function TaskListView({
                     onNewTask={() => {
                       if (groupFolderId) {
                         openTaskInput(groupFolderId);
+                      } else if (cloudRepository) {
+                        openTaskInput({
+                          initialCloudRepository: cloudRepository,
+                        });
                       } else {
                         openTaskInput();
                       }


### PR DESCRIPTION
## Summary

In the tasks sidebar (grouped by repository), clicking the **+** to the right of a repository name to create a new task did not preselect that repository in the main view when running in cloud mode — it opened a blank task input.

## Root cause

`onNewTask` only handled the local-folder case via `groupFolderId`. Cloud-only repository groups have no registered local folder and their tasks carry no `folderId`, so `groupFolderId` was `undefined` and the handler fell through to `openTaskInput()` with no arguments, selecting nothing.

## Fix

Detect cloud repository groups via their parsed `repository` (which carries an `organization` and a normalized `owner/repo` `fullPath`) and route them through the existing `initialCloudRepository` prefill path. That path already switches `workspaceMode` to `"cloud"` and calls `setSelectedRepository(...)`, so the correct repo is now preselected. Local-folder groups take precedence and are unchanged; the empty fallback only remains for the genuinely-unidentifiable "Other" bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)