### PR TITLE
fix(sidebar): always sort the "Other" section to the bottom

### DIFF
--- a/packages/core/src/sidebar/groupTasks.test.ts
+++ b/packages/core/src/sidebar/groupTasks.test.ts
@@ -299,4 +299,55 @@ describe("groupByRepository", () => {
       "acme/zeta",
     ]);
   });
+
+  it("sorts the 'other' group last in the alphabetical path", () => {
+    const tasks: TestTask[] = [
+      task("t1"),
+      task("t2", {
+        fullPath: "posthog/zeta",
+        name: "zeta",
+        organization: "PostHog",
+      }),
+      task("t3", {
+        fullPath: "posthog/alpha",
+        name: "alpha",
+        organization: "PostHog",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, []);
+
+    expect(groups.map((g) => g.id)).toEqual([
+      "posthog/alpha",
+      "posthog/zeta",
+      "other",
+    ]);
+  });
+
+  it("sorts the 'other' group last in the folder-order path", () => {
+    const tasks: TestTask[] = [
+      task("t1"),
+      task("t2", {
+        fullPath: "posthog/code",
+        name: "code",
+        organization: "PostHog",
+      }),
+      task("t3", {
+        fullPath: "posthog/posthog",
+        name: "posthog",
+        organization: "PostHog",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, [
+      "posthog/posthog",
+      "posthog/code",
+    ]);
+
+    expect(groups.map((g) => g.id)).toEqual([
+      "posthog/posthog",
+      "posthog/code",
+      "other",
+    ]);
+  });
 });

--- a/packages/core/src/sidebar/groupTasks.ts
+++ b/packages/core/src/sidebar/groupTasks.ts
@@ -88,11 +88,26 @@ export function groupByRepository<T extends GroupableTask>(
     }
   }
 
+  // The "other" group (tasks without a resolvable repository) always sorts to
+  // the bottom, regardless of the alphabetical or persisted folder order.
+  const pinOtherLast = (a: TaskGroup<T>, b: TaskGroup<T>): number | null => {
+    const aOther = a.id === "other";
+    const bOther = b.id === "other";
+    if (aOther && bOther) return 0;
+    if (aOther) return 1;
+    if (bOther) return -1;
+    return null;
+  };
+
   if (folderOrder.length === 0) {
-    return groups.sort((a, b) => a.name.localeCompare(b.name));
+    return groups.sort(
+      (a, b) => pinOtherLast(a, b) ?? a.name.localeCompare(b.name),
+    );
   }
 
   return groups.sort((a, b) => {
+    const pinned = pinOtherLast(a, b);
+    if (pinned !== null) return pinned;
     const aIndex = folderOrder.indexOf(a.id);
     const bIndex = folderOrder.indexOf(b.id);
     if (aIndex === -1 && bIndex === -1) {


### PR DESCRIPTION
## Summary

In the sidebar, the **Other** section (tasks without a resolvable repository) was being sorted alphabetically alongside the repository sections. It should always sit at the bottom.

This pins the `"other"` group to the bottom in both sort paths of `groupByRepository`:
- the alphabetical fallback (no persisted folder order)
- the persisted folder-order path

via a small `pinOtherLast` comparator helper.

## Testing

- Added two tests covering "Other" sorting last in both paths.
- `pnpm --filter @posthog/core test groupTasks` → 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)