### PR TITLE
refactor(scouts): classify origin from the API instead of a hardcoded list

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -235,6 +235,13 @@ export interface ScoutConfig {
    * absent entirely on backends predating the field.
    */
   description?: string;
+  /**
+   * Where the scout came from: "canonical" for a scout PostHog ships and
+   * maintains (seeded from products/signals/skills), "custom" for one a team
+   * hand-authored. The serializer defaults to "custom" when the skill is absent;
+   * the field itself is absent entirely on backends predating it.
+   */
+  scout_origin?: "canonical" | "custom";
   run_interval_minutes: number;
   last_run_at: string | null;
   created_at: string;

--- a/packages/core/src/scouts/scoutPresentation.test.ts
+++ b/packages/core/src/scouts/scoutPresentation.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeRunStatus,
   prettifyScoutSkillName,
   runDurationSeconds,
+  type ScoutOrigin,
   runMatchesFilter,
   type ScoutRunFilter,
   scoutRunOutcomeLabel,
@@ -77,15 +78,17 @@ describe("naming", () => {
     );
   });
 
-  it("reads scout origin from the config's scout_origin field", () => {
-    expect(getScoutOrigin({ scout_origin: "canonical" })).toBe("canonical");
-    expect(getScoutOrigin({ scout_origin: "custom" })).toBe("custom");
-  });
-
-  it("treats a missing scout_origin (older backends) as custom", () => {
-    expect(getScoutOrigin({})).toBe("custom");
-    expect(getScoutOrigin(null)).toBe("custom");
-    expect(getScoutOrigin(undefined)).toBe("custom");
+  it.each<
+    [Pick<ScoutConfig, "scout_origin"> | null | undefined, ScoutOrigin]
+  >([
+    [{ scout_origin: "canonical" }, "canonical"],
+    [{ scout_origin: "custom" }, "custom"],
+    // A missing field (older backends) or no config falls back to custom.
+    [{}, "custom"],
+    [null, "custom"],
+    [undefined, "custom"],
+  ])("getScoutOrigin(%o) returns %s", (input, expected) => {
+    expect(getScoutOrigin(input)).toBe(expected);
   });
 });
 

--- a/packages/core/src/scouts/scoutPresentation.test.ts
+++ b/packages/core/src/scouts/scoutPresentation.test.ts
@@ -77,9 +77,15 @@ describe("naming", () => {
     );
   });
 
-  it("classifies canonical vs custom scouts", () => {
-    expect(getScoutOrigin("signals-scout-error-tracking")).toBe("canonical");
-    expect(getScoutOrigin("signals-scout-react-performance")).toBe("custom");
+  it("reads scout origin from the config's scout_origin field", () => {
+    expect(getScoutOrigin({ scout_origin: "canonical" })).toBe("canonical");
+    expect(getScoutOrigin({ scout_origin: "custom" })).toBe("custom");
+  });
+
+  it("treats a missing scout_origin (older backends) as custom", () => {
+    expect(getScoutOrigin({})).toBe("custom");
+    expect(getScoutOrigin(null)).toBe("custom");
+    expect(getScoutOrigin(undefined)).toBe("custom");
   });
 });
 

--- a/packages/core/src/scouts/scoutPresentation.test.ts
+++ b/packages/core/src/scouts/scoutPresentation.test.ts
@@ -13,8 +13,8 @@ import {
   normalizeRunStatus,
   prettifyScoutSkillName,
   runDurationSeconds,
-  type ScoutOrigin,
   runMatchesFilter,
+  type ScoutOrigin,
   type ScoutRunFilter,
   scoutRunOutcomeLabel,
   scoutSkillNameFromSlug,
@@ -78,9 +78,7 @@ describe("naming", () => {
     );
   });
 
-  it.each<
-    [Pick<ScoutConfig, "scout_origin"> | null | undefined, ScoutOrigin]
-  >([
+  it.each<[Pick<ScoutConfig, "scout_origin"> | null | undefined, ScoutOrigin]>([
     [{ scout_origin: "canonical" }, "canonical"],
     [{ scout_origin: "custom" }, "custom"],
     // A missing field (older backends) or no config falls back to custom.

--- a/packages/core/src/scouts/scoutPresentation.ts
+++ b/packages/core/src/scouts/scoutPresentation.ts
@@ -4,34 +4,17 @@ import type { ScoutConfig, ScoutRun } from "@posthog/api-client/posthog-client";
 // (which cannot import core) and the UI share one slug implementation.
 export { scoutSkillNameFromSlug, scoutSkillSlug } from "@posthog/shared";
 
-/**
- * Canonical scouts shipped in the PostHog repo (products/signals/skills).
- * The configs endpoint does not yet distinguish canonical from hand-authored
- * skills (scouts-ui api gap 4); until it carries `seeded_by`, classify by
- * this known-name list.
- */
-export const CANONICAL_SCOUT_SKILLS = new Set<string>([
-  "signals-scout-general",
-  "signals-scout-anomaly-detection",
-  "signals-scout-ai-observability",
-  "signals-scout-csp-violations",
-  "signals-scout-data-pipelines",
-  "signals-scout-error-tracking",
-  "signals-scout-experiments",
-  "signals-scout-feature-flags",
-  "signals-scout-health-checks",
-  "signals-scout-logs",
-  "signals-scout-observability-gaps",
-  "signals-scout-revenue-analytics",
-  "signals-scout-session-replay",
-  "signals-scout-surveys",
-  "signals-scout-web-analytics",
-]);
-
 export type ScoutOrigin = "canonical" | "custom";
 
-export function getScoutOrigin(skillName: string): ScoutOrigin {
-  return CANONICAL_SCOUT_SKILLS.has(skillName) ? "canonical" : "custom";
+/**
+ * Origin comes straight from the configs endpoint's `scout_origin` field, which
+ * the backend computes from the skill's `seeded_by` metadata. Older backends
+ * omit the field; treat those scouts as custom.
+ */
+export function getScoutOrigin(
+  config: Pick<ScoutConfig, "scout_origin"> | null | undefined,
+): ScoutOrigin {
+  return config?.scout_origin === "canonical" ? "canonical" : "custom";
 }
 
 /** "signals-scout-error-tracking" → "Error tracking" */

--- a/packages/ui/src/features/scouts/components/ScoutBadges.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutBadges.tsx
@@ -2,8 +2,8 @@ import type { ScoutConfig } from "@posthog/api-client/posthog-client";
 import { getScoutOrigin } from "@posthog/core/scouts/scoutPresentation";
 import { Badge, Tooltip } from "@radix-ui/themes";
 
-export function ScoutOriginBadge({ skillName }: { skillName: string }) {
-  const origin = getScoutOrigin(skillName);
+export function ScoutOriginBadge({ config }: { config: ScoutConfig }) {
+  const origin = getScoutOrigin(config);
   return (
     <Tooltip
       content={

--- a/packages/ui/src/features/scouts/components/ScoutDetailView.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutDetailView.tsx
@@ -119,7 +119,7 @@ export function ScoutDetailView({
     viewTrackedFor.current = skillName;
     track(ANALYTICS_EVENTS.SCOUT_DETAIL_VIEWED, {
       skill_name: skillName,
-      scout_origin: getScoutOrigin(skillName),
+      scout_origin: getScoutOrigin(config),
       has_config: Boolean(config),
       enabled: config?.enabled ?? null,
       emit: config?.emit ?? null,

--- a/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
@@ -103,7 +103,7 @@ export function ScoutRowCard({
               </a>
             </Tooltip>
           ) : null}
-          <ScoutOriginBadge skillName={config.skill_name} />
+          <ScoutOriginBadge config={config} />
           <DryRunBadge config={config} />
           <Text className="whitespace-nowrap text-[11px] text-gray-10">
             {formatRunIntervalShort(config.run_interval_minutes)}

--- a/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
@@ -141,7 +141,7 @@ function useTrackFleetViewed(configs: ScoutConfig[]) {
       enabled_count: configs.filter((config) => config.enabled).length,
       dry_run_count: configs.filter((config) => !config.emit).length,
       custom_count: configs.filter(
-        (config) => getScoutOrigin(config.skill_name) === "custom",
+        (config) => getScoutOrigin(config) === "custom",
       ).length,
       is_empty: configs.length === 0,
     });

--- a/packages/ui/src/features/scouts/hooks/useScoutConfigMutations.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutConfigMutations.ts
@@ -28,7 +28,7 @@ function trackConfigChange(
     if (newValue === undefined) continue;
     track(ANALYTICS_EVENTS.SCOUT_CONFIG_CHANGED, {
       skill_name: previousConfig.skill_name,
-      scout_origin: getScoutOrigin(previousConfig.skill_name),
+      scout_origin: getScoutOrigin(previousConfig),
       setting,
       new_value: newValue,
       old_value: previousConfig[setting],


### PR DESCRIPTION
## What

The configs endpoint now returns a `scout_origin` (`"canonical"` | `"custom"`) field, computed server-side from the skill's `seeded_by` metadata against the canonical skills PostHog ships (`products/signals/skills/`). The serializer help text explicitly says to "use it to badge built-in vs custom scouts instead of a hardcoded name list."

This PR does exactly that: it deletes the hand-maintained `CANONICAL_SCOUT_SKILLS` set and reads the field directly.

## Why

The old list had to be hand-synced every time a new canonical scout shipped, and a scout added in production but missing from the list would silently mis-badge as "custom". The backend is now the source of truth.

## Changes

- `@posthog/api-client`: add optional `scout_origin?: "canonical" | "custom"` to the `ScoutConfig` interface (optional — backends predating the field omit it).
- `@posthog/core`: drop the 15-entry `CANONICAL_SCOUT_SKILLS` set; `getScoutOrigin` now takes a `ScoutConfig` and returns its `scout_origin`, defaulting to `"custom"` when absent (matching the serializer's own default).
- `@posthog/ui`: thread the config through the 4 consumers (`ScoutOriginBadge` now takes `config` not `skillName`, plus the fleet/detail/mutation analytics call sites).
- Tests updated to cover the field-based path, including the missing-field-defaults-to-custom case.

## Testing

- `@posthog/core` scout tests: 41 passed.
- Typecheck of `api-client` / `core` / `ui`: zero scout-related errors (pre-existing failures in `inbox/`, `canvas/`, `code-review/`, `shell/` are unrelated and present on `main`).
- Biome lint on touched files: clean, no `noRestrictedImports`.

Not yet verified against the live running app.