### PR TITLE
feat(sessions): connect queued-message dock to the composer input

### DIFF
--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -63,6 +63,9 @@ export interface PromptInputProps {
   submitTooltipOverride?: string;
   editorHeight?: "default" | "large";
   tourTarget?: string;
+  // when a queued-message dock sits flush on top, square the input's top corners
+  // so the two boxes read as one connected unit
+  attachedTop?: boolean;
 }
 
 export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
@@ -102,6 +105,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       submitTooltipOverride,
       editorHeight = "default",
       tourTarget,
+      attachedTop = false,
     },
     ref,
   ) => {
@@ -324,7 +328,15 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
         <InputGroup
           onClick={handleContainerClick}
           onContextMenu={handleContextMenu}
-          className={`h-auto cursor-text bg-card ${isBashMode ? "ring-1 ring-blue-9" : "focus-within:ring-1 focus-within:ring-purple-9"}`}
+          className={clsx(
+            "h-auto cursor-text bg-card",
+            // input is rounded more than the queued-message dock above it; when a
+            // message is docked, square the top so the two boxes connect flush
+            attachedTop ? "rounded-b-xl! rounded-t-none!" : "rounded-xl!",
+            isBashMode
+              ? "ring-1 ring-blue-9"
+              : "focus-within:ring-1 focus-within:ring-purple-9",
+          )}
           {...(tourTarget && {
             "data-tour": `${tourTarget}-editor`,
             "data-tour-ready": !isEmpty ? "true" : undefined,

--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -332,7 +332,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
             "h-auto cursor-text bg-card",
             // input is rounded more than the queued-message dock above it; when a
             // message is docked, square the top so the two boxes connect flush
-            attachedTop ? "rounded-b-xl! rounded-t-none!" : "rounded-xl!",
+            attachedTop ? "rounded-t-none! rounded-b-xl!" : "rounded-xl!",
             isBashMode
               ? "ring-1 ring-blue-9"
               : "focus-within:ring-1 focus-within:ring-purple-9",

--- a/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
+++ b/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
@@ -35,10 +35,11 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
 
   return (
     <Flex direction="column" gap="1">
-      {queued.map((message) => (
+      {queued.map((message, index) => (
         <QueuedMessageView
           key={message.id}
           message={message}
+          connectedToInput={index === queued.length - 1}
           supportsNativeSteer={supportsNativeSteer}
           onSteer={
             isCompacting

--- a/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
+++ b/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
@@ -34,7 +34,7 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
   if (queued.length === 0) return null;
 
   return (
-    <Flex direction="column" gap="1" className="mb-1">
+    <Flex direction="column" gap="1">
       {queued.map((message) => (
         <QueuedMessageView
           key={message.id}

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -41,7 +41,10 @@ import {
   useShowRawLogs,
 } from "@posthog/ui/features/sessions/sessionViewStore";
 import type { Plan } from "@posthog/ui/features/sessions/types";
-import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
+import {
+  useQueuedMessagesForTask,
+  useSessionForTask,
+} from "@posthog/ui/features/sessions/useSession";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useIsWorkspaceCloudRun } from "@posthog/ui/features/workspace/useWorkspace";
 import { useConnectivity } from "@posthog/ui/hooks/useConnectivity";
@@ -169,6 +172,7 @@ export function SessionView({
   const thoughtOption = useThoughtLevelConfigOptionForTask(taskId);
   const adapter = useAdapterForTask(taskId);
   const toggleMessagingMode = useToggleMessagingMode(taskId);
+  const hasQueuedMessages = useQueuedMessagesForTask(taskId).length > 0;
   const { allowBypassPermissions } = useSettingsStore();
   const { isOnline } = useConnectivity();
   const currentModeId = modeOption?.currentValue;
@@ -606,6 +610,7 @@ export function SessionView({
                         {taskId && <QueuedMessagesDock taskId={taskId} />}
                         <PromptInput
                           ref={editorRef}
+                          attachedTop={hasQueuedMessages}
                           sessionId={sessionId}
                           placeholder="Type a message... @ to mention files, ! for bash mode, / for skills"
                           disabled={!isRunning && !handoffInProgress}

--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -30,7 +30,7 @@ export function QueuedMessageView({
     : "Interrupt the current turn and resend with this message.";
 
   return (
-    <Box className="rounded-lg border border-gray-5 bg-card px-3 py-2">
+    <Box className="rounded-t-md border border-gray-5 border-b-0 bg-card px-3 py-2">
       <Flex align="center" gap="2">
         <Stack size={14} className="shrink-0 text-gray-9" />
         <Box className="min-w-0 flex-1 font-medium text-[13px] text-gray-12 [&>*:last-child]:mb-0">

--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -6,6 +6,7 @@ import {
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import { Box, Flex, IconButton, Tooltip } from "@radix-ui/themes";
+import clsx from "clsx";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import type { QueuedMessage } from "../../sessionStore";
 import { hasFileMentions, parseFileMentions } from "./parseFileMentions";
@@ -16,6 +17,9 @@ interface QueuedMessageViewProps {
   onReturnToEditor?: () => void;
   onRemove?: () => void;
   supportsNativeSteer?: boolean;
+  // when this is the message sitting directly on the composer, square + open its
+  // bottom edge so it connects flush; otherwise it's a standalone rounded card
+  connectedToInput?: boolean;
 }
 
 export function QueuedMessageView({
@@ -24,13 +28,19 @@ export function QueuedMessageView({
   onReturnToEditor,
   onRemove,
   supportsNativeSteer = false,
+  connectedToInput = false,
 }: QueuedMessageViewProps) {
   const steerTooltip = supportsNativeSteer
     ? "Inject this message into the current turn at the next tool boundary."
     : "Interrupt the current turn and resend with this message.";
 
   return (
-    <Box className="rounded-t-md border border-gray-5 border-b-0 bg-card px-3 py-2">
+    <Box
+      className={clsx(
+        "border border-gray-5 bg-card px-3 py-2",
+        connectedToInput ? "rounded-t-md border-b-0" : "rounded-md",
+      )}
+    >
       <Flex align="center" gap="2">
         <Stack size={14} className="shrink-0 text-gray-9" />
         <Box className="min-w-0 flex-1 font-medium text-[13px] text-gray-12 [&>*:last-child]:mb-0">


### PR DESCRIPTION
## Problem

When steering, the queued message box sat a few pixels above the composer and was rounded *more* than the input — so it read as a separate, slightly mismatched card. Michael wanted the queued box to connect to the input at the bottom, rounded *less*, while the input gets rounded *more*.

## Changes

The queued-message dock now connects flush to the composer as one unit:
- **Queued box** (`QueuedMessageView`): `rounded-lg` → `rounded-t-md` with `border-b-0` — rounded less, only at the top, square bottom that shares a single seam line with the input.
- **Dock** (`QueuedMessagesDock`): dropped the `mb-1` gap so it sits flush on the composer.
- **Composer** (`PromptInput`): new optional `attachedTop` prop. The input is rounded more (`rounded-xl`) and squares its top corners (`rounded-b-xl rounded-t-none`) when a message is docked on top. `SessionView` passes `attachedTop` based on whether any messages are queued.

The `!` modifiers are needed because quill's `.quill-input-group` radius is imported unlayered and otherwise wins over Tailwind utilities.

## How did you test this?

Not run — dependencies aren't installed in this environment, so I couldn't run typecheck/lint or launch the app. Changes are CSS-class-only plus one optional prop with a default. Worth an eyeball in the running app (single queued message is the common case; multiple stacked messages keep the `gap-1` separation).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1782207142490019?thread_ts=1782207142.490019&cid=C09G8Q32R6F)*