### PR TITLE
feat(settings): add slot machine mode easter egg

### DIFF
--- a/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -8,6 +8,7 @@ import {
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { DiffStatsChip } from "./DiffStatsChip";
+import { SlotMachineLever } from "./SlotMachineLever";
 
 interface SessionFooterProps {
   task?: Task;
@@ -80,6 +81,7 @@ export function SessionFooter({
                 ({queuedCount} queued)
               </Text>
             )}
+            <SlotMachineLever spinning={Boolean(isPromptPending)} />
           </Flex>
           {rightSide}
         </Flex>

--- a/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
+++ b/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
@@ -20,9 +20,8 @@ interface SlotMachineLeverProps {
 }
 
 /**
- * A fun easter egg (gated behind the `slotMachineMode` setting): a tiny
- * slot machine whose reels spin while a task runs. Pull the lever to kick off
- * an extra spin — every agent run is a gamble. Three hedgehogs is the jackpot.
+ * Easter egg gated behind the `slotMachineMode` setting: a tiny slot machine
+ * whose reels spin while a task runs. Three hedgehogs is the jackpot.
  */
 export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
   const enabled = useSettingsStore((state) => state.slotMachineMode);
@@ -43,8 +42,6 @@ export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
     };
   }, []);
 
-  // Cycle the reels rapidly while spinning, then let them rest on their last
-  // values once the run (or manual pull) finishes.
   useEffect(() => {
     if (!isSpinning) return;
     const id = setInterval(() => {
@@ -69,46 +66,40 @@ export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
 
   if (!enabled) return null;
 
-  const jackpot =
-    !isSpinning &&
-    reels[0] === reels[1] &&
-    reels[1] === reels[2] &&
-    reels[0] === "🦔";
+  const jackpot = !isSpinning && reels.every((symbol) => symbol === "🦔");
 
   return (
-    <Tooltip content="Pull to gamble on your task 🎰">
+    <Flex
+      align="center"
+      gap="1"
+      className="shrink-0 select-none"
+      style={{ WebkitUserSelect: "none" }}
+    >
       <Flex
         align="center"
         gap="1"
-        className="shrink-0 select-none"
-        style={{ WebkitUserSelect: "none" }}
+        className={`rounded-sm border border-gray-6 bg-gray-2 px-1 py-[1px] ${
+          jackpot ? "animate-pulse" : ""
+        }`}
       >
-        {/* Reels */}
-        <Flex
-          align="center"
-          gap="1"
-          className={`rounded-sm border border-gray-6 bg-gray-2 px-1 py-[1px] ${
-            jackpot ? "animate-pulse" : ""
-          }`}
-        >
-          {reels.map((symbol, index) => (
-            <motion.span
-              // biome-ignore lint/suspicious/noArrayIndexKey: fixed 3-reel layout
-              key={index}
-              animate={isSpinning ? { y: [-1, 1, -1] } : { y: 0 }}
-              transition={
-                isSpinning
-                  ? { duration: 0.18, repeat: Infinity, ease: "linear" }
-                  : { type: "spring", stiffness: 500, damping: 18 }
-              }
-              className="w-[14px] text-center text-[12px] leading-none"
-            >
-              {symbol}
-            </motion.span>
-          ))}
-        </Flex>
+        {reels.map((symbol, index) => (
+          <motion.span
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed 3-reel layout
+            key={index}
+            animate={isSpinning ? { y: [-1, 1, -1] } : { y: 0 }}
+            transition={
+              isSpinning
+                ? { duration: 0.18, repeat: Infinity, ease: "linear" }
+                : { type: "spring", stiffness: 500, damping: 18 }
+            }
+            className="w-[14px] text-center text-[12px] leading-none"
+          >
+            {symbol}
+          </motion.span>
+        ))}
+      </Flex>
 
-        {/* Lever */}
+      <Tooltip content="Pull to gamble on your task 🎰">
         <button
           type="button"
           onClick={pull}
@@ -120,13 +111,11 @@ export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
             style={{ originY: 1, originX: 0.5 }}
             className="flex h-full flex-col items-center"
           >
-            {/* Knob */}
             <Box className="h-[6px] w-[6px] rounded-full bg-red-9" />
-            {/* Shaft */}
             <Box className="w-[2px] flex-1 bg-gray-8" />
           </motion.div>
         </button>
-      </Flex>
-    </Tooltip>
+      </Tooltip>
+    </Flex>
   );
 }

--- a/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
+++ b/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
@@ -1,7 +1,7 @@
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { Box, Flex, Tooltip } from "@radix-ui/themes";
 import { motion, useAnimationControls } from "framer-motion";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Reel faces. The hedgehog is the jackpot symbol. */
 const REEL_SYMBOLS = ["🍒", "🍋", "🔔", "⭐", "💎", "7️⃣", "🦔"] as const;
@@ -29,8 +29,19 @@ export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
   const [reels, setReels] = useState<[string, string, string]>(randomReels);
   const [pullSpin, setPullSpin] = useState(false);
   const lever = useAnimationControls();
+  const pullSpinTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isSpinning = enabled && (spinning || pullSpin);
+
+  // Clear any pending pull-spin timer on unmount so it doesn't fire against
+  // stale state after the session ends.
+  useEffect(() => {
+    return () => {
+      if (pullSpinTimeout.current !== null) {
+        clearTimeout(pullSpinTimeout.current);
+      }
+    };
+  }, []);
 
   // Cycle the reels rapidly while spinning, then let them rest on their last
   // values once the run (or manual pull) finishes.
@@ -48,7 +59,12 @@ export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
       transition: { duration: 0.55, times: [0, 0.32, 1], ease: "easeInOut" },
     });
     setPullSpin(true);
-    setTimeout(() => setPullSpin(false), 800);
+    // Restart the timer on each pull so rapid clicks keep the reels spinning
+    // until 800ms after the most recent press.
+    if (pullSpinTimeout.current !== null) {
+      clearTimeout(pullSpinTimeout.current);
+    }
+    pullSpinTimeout.current = setTimeout(() => setPullSpin(false), 800);
   }, [lever]);
 
   if (!enabled) return null;

--- a/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
+++ b/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
@@ -1,0 +1,116 @@
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { Box, Flex, Tooltip } from "@radix-ui/themes";
+import { motion, useAnimationControls } from "framer-motion";
+import { useCallback, useEffect, useState } from "react";
+
+/** Reel faces. The hedgehog is the jackpot symbol. */
+const REEL_SYMBOLS = ["🍒", "🍋", "🔔", "⭐", "💎", "7️⃣", "🦔"] as const;
+
+function randomSymbol(): string {
+  return REEL_SYMBOLS[Math.floor(Math.random() * REEL_SYMBOLS.length)];
+}
+
+function randomReels(): [string, string, string] {
+  return [randomSymbol(), randomSymbol(), randomSymbol()];
+}
+
+interface SlotMachineLeverProps {
+  /** Whether the agent is actively generating — the reels spin while it is. */
+  spinning: boolean;
+}
+
+/**
+ * A fun easter egg (gated behind the `slotMachineMode` setting): a tiny
+ * slot machine whose reels spin while a task runs. Pull the lever to kick off
+ * an extra spin — every agent run is a gamble. Three hedgehogs is the jackpot.
+ */
+export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
+  const enabled = useSettingsStore((state) => state.slotMachineMode);
+  const [reels, setReels] = useState<[string, string, string]>(randomReels);
+  const [pullSpin, setPullSpin] = useState(false);
+  const lever = useAnimationControls();
+
+  const isSpinning = enabled && (spinning || pullSpin);
+
+  // Cycle the reels rapidly while spinning, then let them rest on their last
+  // values once the run (or manual pull) finishes.
+  useEffect(() => {
+    if (!isSpinning) return;
+    const id = setInterval(() => {
+      setReels(randomReels());
+    }, 90);
+    return () => clearInterval(id);
+  }, [isSpinning]);
+
+  const pull = useCallback(() => {
+    void lever.start({
+      rotate: [0, 26, 0],
+      transition: { duration: 0.55, times: [0, 0.32, 1], ease: "easeInOut" },
+    });
+    setPullSpin(true);
+    setTimeout(() => setPullSpin(false), 800);
+  }, [lever]);
+
+  if (!enabled) return null;
+
+  const jackpot =
+    !isSpinning &&
+    reels[0] === reels[1] &&
+    reels[1] === reels[2] &&
+    reels[0] === "🦔";
+
+  return (
+    <Tooltip content="Pull to gamble on your task 🎰">
+      <Flex
+        align="center"
+        gap="1"
+        className="shrink-0 select-none"
+        style={{ WebkitUserSelect: "none" }}
+      >
+        {/* Reels */}
+        <Flex
+          align="center"
+          gap="1"
+          className={`rounded-sm border border-gray-6 bg-gray-2 px-1 py-[1px] ${
+            jackpot ? "animate-pulse" : ""
+          }`}
+        >
+          {reels.map((symbol, index) => (
+            <motion.span
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed 3-reel layout
+              key={index}
+              animate={isSpinning ? { y: [-1, 1, -1] } : { y: 0 }}
+              transition={
+                isSpinning
+                  ? { duration: 0.18, repeat: Infinity, ease: "linear" }
+                  : { type: "spring", stiffness: 500, damping: 18 }
+              }
+              className="w-[14px] text-center text-[12px] leading-none"
+            >
+              {symbol}
+            </motion.span>
+          ))}
+        </Flex>
+
+        {/* Lever */}
+        <button
+          type="button"
+          onClick={pull}
+          aria-label="Pull the slot machine lever"
+          className="relative flex h-[18px] w-[10px] items-center justify-center"
+        >
+          <motion.div
+            animate={lever}
+            style={{ originY: 1, originX: 0.5 }}
+            className="flex h-full flex-col items-center"
+          >
+            {/* Knob */}
+            <Box className="h-[6px] w-[6px] rounded-full bg-red-9" />
+            {/* Shaft */}
+            <Box className="w-[2px] flex-1 bg-gray-8" />
+          </motion.div>
+        </button>
+      </Flex>
+    </Tooltip>
+  );
+}

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -620,7 +620,7 @@ export function GeneralSettings() {
 
       <SettingRow
         label="Slot machine mode 🎰"
-        description="Show a pull-able slot machine lever while a task is running. Every run is a gamble — pull the handle and watch the reels spin."
+        description="Show a pull-able slot machine lever while a task is running. Every run is a gamble. Pull the handle and watch the reels spin."
         noBorder
       >
         <Switch

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -89,6 +89,7 @@ export function GeneralSettings() {
     sendMessagesWith,
     conversationCollapseMode,
     hedgehogMode,
+    slotMachineMode,
     setDesktopNotifications,
     setDockBadgeNotifications,
     setDockBounceNotifications,
@@ -102,6 +103,7 @@ export function GeneralSettings() {
     setSendMessagesWith,
     setConversationCollapseMode,
     setHedgehogMode,
+    setSlotMachineMode,
   } = useSettingsStore();
 
   // Sync toggle off if the user denied notification permission at the OS level
@@ -260,6 +262,18 @@ export function GeneralSettings() {
       setHedgehogMode(checked);
     },
     [hedgehogMode, setHedgehogMode],
+  );
+
+  const handleSlotMachineModeChange = useCallback(
+    (checked: boolean) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "slot_machine_mode",
+        new_value: checked,
+        old_value: slotMachineMode,
+      });
+      setSlotMachineMode(checked);
+    },
+    [slotMachineMode, setSlotMachineMode],
   );
 
   const accountUrl = buildPostHogUrl("/settings/user", cloudRegion);
@@ -596,14 +610,22 @@ export function GeneralSettings() {
         Fun
       </Text>
 
-      <SettingRow
-        label="Hedgehog mode"
-        description={<HedgehogDescription />}
-        noBorder
-      >
+      <SettingRow label="Hedgehog mode" description={<HedgehogDescription />}>
         <Switch
           checked={hedgehogMode}
           onCheckedChange={handleHedgehogModeChange}
+          size="1"
+        />
+      </SettingRow>
+
+      <SettingRow
+        label="Slot machine mode 🎰"
+        description="Show a pull-able slot machine lever while a task is running. Every run is a gamble — pull the handle and watch the reels spin."
+        noBorder
+      >
+        <Switch
+          checked={slotMachineMode}
+          onCheckedChange={handleSlotMachineModeChange}
           size="1"
         />
       </SettingRow>

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -126,6 +126,7 @@ describe("feature settingsStore cloud selections", () => {
   it.each([
     ["lastUsedWorkspaceMode", "local", "cloud"],
     ["debugLogsCloudRuns", false, true],
+    ["slotMachineMode", false, true],
   ] as const)("rehydrates %s", async (field, initial, persisted) => {
     getItem.mockResolvedValue(
       JSON.stringify({ state: { [field]: persisted }, version: 0 }),

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -140,8 +140,10 @@ interface SettingsStore {
 
   // Experimental / misc
   hedgehogMode: boolean;
+  slotMachineMode: boolean;
   mcpAppsDisabledServers: string[];
   setHedgehogMode: (enabled: boolean) => void;
+  setSlotMachineMode: (enabled: boolean) => void;
   setMcpAppsDisabledServers: (servers: string[]) => void;
 
   // Onboarding hints
@@ -262,8 +264,10 @@ export const useSettingsStore = create<SettingsStore>()(
 
       // Experimental / misc
       hedgehogMode: false,
+      slotMachineMode: false,
       mcpAppsDisabledServers: [],
       setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
+      setSlotMachineMode: (enabled) => set({ slotMachineMode: enabled }),
       setMcpAppsDisabledServers: (servers) =>
         set({ mcpAppsDisabledServers: servers }),
 
@@ -348,6 +352,7 @@ export const useSettingsStore = create<SettingsStore>()(
 
         // Experimental / misc
         hedgehogMode: state.hedgehogMode,
+        slotMachineMode: state.slotMachineMode,
         mcpAppsDisabledServers: state.mcpAppsDisabledServers,
 
         // Onboarding hints


### PR DESCRIPTION
## Problem

Andy asked for a slot machine handle in the PostHog Code UI when running tasks. Charles wanted it shipped as a fun settings easter egg.

## Changes

- New **Slot machine mode** toggle in the Fun section of General settings (off by default, persisted alongside Hedgehog mode).
- When enabled, a tiny slot machine renders next to the generating indicator in the session footer *while a task is actively running*. The reels spin for the duration of the run, and you can pull the lever for an extra spin. Three hedgehogs 🦔🦔🦔 is the jackpot.
- Self-contained `SlotMachineLever` component (framer-motion for the lever pull + reel jitter); self-gates on the setting so it has zero effect unless opted in.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — passes.
- `biome check` on all changed files — clean.
- Did not drive the running app to watch the animation live.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C04JN5NNMPF/p1782208294796059?thread_ts=1782208294.796059&cid=C04JN5NNMPF)*
