### PR TITLE
fix(mobile): tiebreak priority sort by newest first (port #2787)

### DIFF
--- a/apps/mobile/src/features/inbox/utils.test.ts
+++ b/apps/mobile/src/features/inbox/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type {
   AvailableSuggestedReviewer,
   SignalReport,
+  SignalReportOrderingField,
   SignalReportStatus,
   SuggestedReviewer,
 } from "./types";
@@ -9,6 +10,7 @@ import {
   buildInboxViewedProperties,
   buildPriorityFilterParam,
   buildReviewerOptions,
+  buildSignalReportListOrdering,
   dismissalReasonLabel,
   formatSignalReportSummaryMarkdown,
   isArchivedReport,
@@ -338,6 +340,46 @@ describe("reviewerMatchesAvailable", () => {
   ])("$name", ({ reviewer, expected }) => {
     expect(reviewerMatchesAvailable(reviewer, makeAvailable())).toBe(expected);
   });
+});
+
+describe("buildSignalReportListOrdering", () => {
+  it.each([
+    {
+      field: "priority" as SignalReportOrderingField,
+      direction: "desc" as const,
+      expected: "status,-is_suggested_reviewer,-priority,-created_at",
+    },
+    {
+      field: "priority" as SignalReportOrderingField,
+      direction: "asc" as const,
+      expected: "status,-is_suggested_reviewer,priority,-created_at",
+    },
+    {
+      field: "signal_count" as SignalReportOrderingField,
+      direction: "desc" as const,
+      expected: "status,-is_suggested_reviewer,-signal_count",
+    },
+    {
+      field: "total_weight" as SignalReportOrderingField,
+      direction: "asc" as const,
+      expected: "status,-is_suggested_reviewer,total_weight",
+    },
+    {
+      field: "created_at" as SignalReportOrderingField,
+      direction: "desc" as const,
+      expected: "status,-is_suggested_reviewer,-created_at",
+    },
+    {
+      field: "updated_at" as SignalReportOrderingField,
+      direction: "asc" as const,
+      expected: "status,-is_suggested_reviewer,updated_at",
+    },
+  ])(
+    "orders $field $direction as $expected",
+    ({ field, direction, expected }) => {
+      expect(buildSignalReportListOrdering(field, direction)).toBe(expected);
+    },
+  );
 });
 
 describe("buildPriorityFilterParam", () => {

--- a/apps/mobile/src/features/inbox/utils.ts
+++ b/apps/mobile/src/features/inbox/utils.ts
@@ -86,13 +86,16 @@ export function inboxStatusLabel(status: SignalReportStatus): string {
  * 1. Status rank (ready first)
  * 2. Suggested reviewer (current user first)
  * 3. User-selected field
+ *
+ * Priority is a coarse 5-bucket rank, so ties are broken by newest first.
  */
 export function buildSignalReportListOrdering(
   field: SignalReportOrderingField,
   direction: "asc" | "desc",
 ): string {
   const fieldKey = direction === "desc" ? `-${field}` : field;
-  return `status,-is_suggested_reviewer,${fieldKey}`;
+  const tiebreak = field === "priority" ? ",-created_at" : "";
+  return `status,-is_suggested_reviewer,${fieldKey}${tiebreak}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Ports desktop PR #2787 (`fix(inbox): tiebreak priority sort by newest first`) to the React Native / Expo mobile app.

Priority is a coarse 5-bucket rank (P0–P4); without a secondary sort, reports within the same priority tier came back in arbitrary order on mobile. This appends a `-created_at` (newest first) tiebreak to the signal report list `ordering` param **when sorting by priority**, so the ordering string becomes e.g. `status,-is_suggested_reviewer,-priority,-created_at`. The existing `status` and `-is_suggested_reviewer` prefixes are unchanged, and non-priority sort fields are unaffected.

## Changes

- `apps/mobile/src/features/inbox/utils.ts` — add the `-created_at` tiebreak in `buildSignalReportListOrdering` for the `priority` field only.
- `apps/mobile/src/features/inbox/utils.test.ts` — parameterized tests across all ordering fields and both directions, asserting the tiebreak is present for priority and absent for other fields.

## Testing

- `vitest run src/features/inbox/utils.test.ts` — 37 passing.
- Lint clean on changed files; no new typecheck errors introduced.

Scope is limited to `apps/mobile`; no changes to `apps/code` or `packages/*`.