### PR TITLE
fix(mobile): show error reason on failed tool calls (port #2830)

### DIFF
--- a/apps/mobile/src/features/chat/components/ToolMessage.test.tsx
+++ b/apps/mobile/src/features/chat/components/ToolMessage.test.tsx
@@ -56,22 +56,25 @@ const base: ToolMessageProps = {
 };
 
 describe("ToolMessage posthog-exec error reason", () => {
-  it("shows the captured error output for a failed call when expanded", () => {
+  it("hides output in the collapsed state for a failed call", () => {
     const renderer = render(base);
     expect(tree(renderer)).not.toContain(ERROR_OUTPUT);
-    expand(renderer);
-    expect(tree(renderer)).toContain(ERROR_OUTPUT);
   });
 
-  it("still shows output for a completed call when expanded", () => {
-    const renderer = render({ ...base, status: "completed" });
-    expand(renderer);
-    expect(tree(renderer)).toContain(ERROR_OUTPUT);
-  });
-
-  it("does not show output while the call is still running", () => {
-    const renderer = render({ ...base, status: "running" });
-    expand(renderer);
-    expect(tree(renderer)).not.toContain(ERROR_OUTPUT);
-  });
+  it.each<[ToolMessageProps["status"], boolean]>([
+    ["error", true],
+    ["completed", true],
+    ["running", false],
+  ])(
+    "status=%s → output visible after expand: %s",
+    (status, expectVisible) => {
+      const renderer = render({ ...base, status });
+      expand(renderer);
+      if (expectVisible) {
+        expect(tree(renderer)).toContain(ERROR_OUTPUT);
+      } else {
+        expect(tree(renderer)).not.toContain(ERROR_OUTPUT);
+      }
+    },
+  );
 });

--- a/apps/mobile/src/features/chat/components/ToolMessage.test.tsx
+++ b/apps/mobile/src/features/chat/components/ToolMessage.test.tsx
@@ -65,16 +65,13 @@ describe("ToolMessage posthog-exec error reason", () => {
     ["error", true],
     ["completed", true],
     ["running", false],
-  ])(
-    "status=%s → output visible after expand: %s",
-    (status, expectVisible) => {
-      const renderer = render({ ...base, status });
-      expand(renderer);
-      if (expectVisible) {
-        expect(tree(renderer)).toContain(ERROR_OUTPUT);
-      } else {
-        expect(tree(renderer)).not.toContain(ERROR_OUTPUT);
-      }
-    },
-  );
+  ])("status=%s → output visible after expand: %s", (status, expectVisible) => {
+    const renderer = render({ ...base, status });
+    expand(renderer);
+    if (expectVisible) {
+      expect(tree(renderer)).toContain(ERROR_OUTPUT);
+    } else {
+      expect(tree(renderer)).not.toContain(ERROR_OUTPUT);
+    }
+  });
 });

--- a/apps/mobile/src/features/chat/components/ToolMessage.test.tsx
+++ b/apps/mobile/src/features/chat/components/ToolMessage.test.tsx
@@ -1,0 +1,77 @@
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { ToolMessage, type ToolMessageProps } from "./ToolMessage";
+
+vi.mock("expo-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+vi.mock("@/features/mcp/components/McpAppHost", () => ({
+  McpAppHost: () => null,
+}));
+
+vi.mock("@/lib/syntax-highlight", () => ({
+  getColorForClass: () => null,
+  highlightCode: () => null,
+  languageFromPath: () => null,
+}));
+
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({
+    gray: { 8: "#888888", 9: "#999999", 11: "#bbbbbb", 12: "#cccccc" },
+    accent: { 3: "#eef", 9: "#3366ff", contrast: "#ffffff" },
+    status: { success: "#00aa00", error: "#cc0000" },
+  }),
+}));
+
+function render(props: ToolMessageProps) {
+  let renderer: ReturnType<typeof create> | null = null;
+  act(() => {
+    renderer = create(createElement(ToolMessage, props));
+  });
+  if (!renderer) throw new Error("Renderer not created");
+  return renderer as ReturnType<typeof create>;
+}
+
+function expand(renderer: ReturnType<typeof create>) {
+  const pressable = renderer.root.findAll(
+    (n) => typeof n.props?.onPress === "function",
+  )[0];
+  act(() => {
+    pressable.props.onPress();
+  });
+}
+
+function tree(renderer: ReturnType<typeof create>): string {
+  return JSON.stringify(renderer.toJSON());
+}
+
+const ERROR_OUTPUT = "Error: query failed: invalid HogQL syntax near token";
+
+const base: ToolMessageProps = {
+  toolName: "exec",
+  rawToolName: "mcp__posthog__exec",
+  status: "error",
+  args: { command: "call query-run {}" },
+  result: ERROR_OUTPUT,
+};
+
+describe("ToolMessage posthog-exec error reason", () => {
+  it("shows the captured error output for a failed call when expanded", () => {
+    const renderer = render(base);
+    expect(tree(renderer)).not.toContain(ERROR_OUTPUT);
+    expand(renderer);
+    expect(tree(renderer)).toContain(ERROR_OUTPUT);
+  });
+
+  it("still shows output for a completed call when expanded", () => {
+    const renderer = render({ ...base, status: "completed" });
+    expand(renderer);
+    expect(tree(renderer)).toContain(ERROR_OUTPUT);
+  });
+
+  it("does not show output while the call is still running", () => {
+    const renderer = render({ ...base, status: "running" });
+    expand(renderer);
+    expect(tree(renderer)).not.toContain(ERROR_OUTPUT);
+  });
+});

--- a/apps/mobile/src/features/chat/components/ToolMessage.tsx
+++ b/apps/mobile/src/features/chat/components/ToolMessage.tsx
@@ -963,6 +963,9 @@ export function ToolMessage({
     const outputText = resultText ? stripAnsi(resultText) : null;
     const hasOutput = !!outputText?.trim();
     const isExpandable = !!fullInput || hasOutput;
+    // Surface output for failures too — otherwise a failed call shows "Failed"
+    // with no reason, even though the error text lives in the result content.
+    const showOutput = (isCompleted || isFailed) && hasOutput;
 
     return (
       <View className={`px-4 py-1 ${isRunning ? "bg-accent-3/30" : ""}`}>
@@ -1016,7 +1019,7 @@ export function ToolMessage({
           </View>
         )}
 
-        {isOpen && isCompleted && hasOutput && outputText && (
+        {isOpen && showOutput && outputText && (
           <View className="mt-1.5 ml-5 rounded border border-gray-6 bg-gray-2 px-2 py-1.5">
             <Text
               className="font-mono text-[11px] text-gray-11 leading-4"


### PR DESCRIPTION
Ports desktop PR #2830 (`fix(sessions): show the error reason on failed tool calls`) to the React Native / Expo mobile app.

## Problem

In `apps/mobile/.../chat/components/ToolMessage.tsx`, the posthog-exec / MCP tool-call branch gated its output panel behind a **completed-only** status:

```ts
{isOpen && isCompleted && hasOutput && outputText && ( ... )}
```

So when a tool call had `status === "error"`, the captured error text (which the agent layer already writes into the result content) stayed hidden even when the user expanded the row — the same bug #2830 fixed on desktop.

## Fix

Ungate the output panel so it renders for **failed** calls too:

```ts
const showOutput = (isCompleted || isFailed) && hasOutput;
...
{isOpen && showOutput && outputText && ( ... )}
```

This brings the posthog-exec branch in line with the `execute` and `read` branches, which already render output regardless of status. The loading/pending states are unchanged.

`McpAppHost` already forwards the result for both `"completed"` and `"error"` status into the WebView, so no change was needed there.

## Scope

- Changes are confined to `apps/mobile`. No `apps/code` or `packages/*` files touched.

## Tests

Added `ToolMessage.test.tsx` asserting:
- a failed posthog-exec call surfaces its captured error output when expanded;
- a completed call still shows output (no regression);
- a running call shows no output.

## Verification

- `pnpm test` (mobile): 43 files / 299 tests pass.
- `biome check` (lint): clean.
- `tsc --noEmit`: no new errors introduced (changed files type-clean).