### PR TITLE
feat(mobile): render signal report activity log (port #2557)

### DIFF
--- a/apps/mobile/src/app/inbox/[...id].tsx
+++ b/apps/mobile/src/app/inbox/[...id].tsx
@@ -33,6 +33,7 @@ import {
   type DismissReportResult,
   DismissReportSheet,
 } from "@/features/inbox/components/DismissReportSheet";
+import { ReportActivity } from "@/features/inbox/components/ReportActivity";
 import { SignalCard } from "@/features/inbox/components/SignalCard";
 import {
   type ReviewerActionExtra,
@@ -568,6 +569,9 @@ export default function ReportDetailScreen() {
         {signalsQuery.isLoading && (
           <Text className="text-[12px] text-gray-9">Loading signals…</Text>
         )}
+
+        {/* Activity log */}
+        <ReportActivity reportId={report.id} artefacts={artefacts} />
       </ScrollView>
 
       <View

--- a/apps/mobile/src/features/inbox/activityLog.test.ts
+++ b/apps/mobile/src/features/inbox/activityLog.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  attributionLabel,
+  parseDiffLines,
+  selectActivityArtefacts,
+  shortSha,
+  taskRunLabel,
+} from "./activityLog";
+import type { ReportArtefact } from "./types";
+
+function commit(id: string, createdAt: string): ReportArtefact {
+  return {
+    id,
+    type: "commit",
+    created_at: createdAt,
+    content: {
+      repository: "posthog/posthog",
+      branch: "main",
+      commit_sha: "abcdef1234567890",
+      message: "fix",
+    },
+  };
+}
+
+function taskRun(id: string, createdAt: string): ReportArtefact {
+  return {
+    id,
+    type: "task_run",
+    created_at: createdAt,
+    content: { task_id: "t1", product: "signals", type: "research" },
+  };
+}
+
+describe("selectActivityArtefacts", () => {
+  it("keeps only commit and task_run, sorted oldest-first", () => {
+    const artefacts: ReportArtefact[] = [
+      taskRun("b", "2026-01-02T00:00:00Z"),
+      {
+        id: "x",
+        type: "note",
+        created_at: "2026-01-03T00:00:00Z",
+        content: {},
+      },
+      commit("a", "2026-01-01T00:00:00Z"),
+    ];
+
+    expect(selectActivityArtefacts(artefacts).map((a) => a.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("returns an empty list when there is no activity", () => {
+    const artefacts: ReportArtefact[] = [
+      {
+        id: "x",
+        type: "note",
+        created_at: "2026-01-01T00:00:00Z",
+        content: {},
+      },
+    ];
+    expect(selectActivityArtefacts(artefacts)).toEqual([]);
+  });
+});
+
+describe("shortSha", () => {
+  it("truncates to 12 characters", () => {
+    expect(shortSha("abcdef1234567890")).toBe("abcdef123456");
+  });
+});
+
+describe("taskRunLabel", () => {
+  it("maps known signals task types to friendly labels", () => {
+    expect(taskRunLabel({ product: "signals", type: "repo_selection" })).toBe(
+      "Repo selection",
+    );
+  });
+
+  it("humanizes unknown identifiers", () => {
+    expect(taskRunLabel({ product: "custom", type: "code-review" })).toBe(
+      "Code review",
+    );
+  });
+});
+
+describe("attributionLabel", () => {
+  it("prefers the user's first name", () => {
+    expect(
+      attributionLabel({ created_by: { first_name: "Ada", email: "a@b.co" } }),
+    ).toBe("Ada");
+  });
+
+  it("falls back to email then agent then null", () => {
+    expect(attributionLabel({ created_by: { email: "a@b.co" } })).toBe(
+      "a@b.co",
+    );
+    expect(attributionLabel({ task_id: "t1" })).toBe("agent");
+    expect(attributionLabel({})).toBeNull();
+  });
+});
+
+describe("parseDiffLines", () => {
+  it("classifies added, removed, hunk and context lines", () => {
+    const lines = parseDiffLines(
+      ["@@ -1 +1 @@", "+added", "-removed", " ctx", "+++ b/f", "--- a/f"].join(
+        "\n",
+      ),
+    );
+    expect(lines.map((l) => l.kind)).toEqual([
+      "hunk",
+      "add",
+      "del",
+      "context",
+      "context",
+      "context",
+    ]);
+  });
+});

--- a/apps/mobile/src/features/inbox/activityLog.test.ts
+++ b/apps/mobile/src/features/inbox/activityLog.test.ts
@@ -70,32 +70,46 @@ describe("shortSha", () => {
 });
 
 describe("taskRunLabel", () => {
-  it("maps known signals task types to friendly labels", () => {
-    expect(taskRunLabel({ product: "signals", type: "repo_selection" })).toBe(
+  it.each([
+    [
+      "maps known signals task type to friendly label",
+      "signals",
+      "repo_selection",
       "Repo selection",
-    );
-  });
-
-  it("humanizes unknown identifiers", () => {
-    expect(taskRunLabel({ product: "custom", type: "code-review" })).toBe(
+    ],
+    [
+      "humanizes unknown signals task type",
+      "signals",
+      "unknown_op",
+      "Unknown op",
+    ],
+    [
+      "humanizes identifiers for other products",
+      "custom",
+      "code-review",
       "Code review",
-    );
+    ],
+  ] as const)("%s", (_desc, product, type, expected) => {
+    expect(taskRunLabel({ product, type })).toBe(expected);
   });
 });
 
 describe("attributionLabel", () => {
-  it("prefers the user's first name", () => {
-    expect(
-      attributionLabel({ created_by: { first_name: "Ada", email: "a@b.co" } }),
-    ).toBe("Ada");
-  });
-
-  it("falls back to email then agent then null", () => {
-    expect(attributionLabel({ created_by: { email: "a@b.co" } })).toBe(
+  it.each([
+    [
+      "prefers first name over email",
+      { created_by: { first_name: "Ada", email: "a@b.co" } },
+      "Ada",
+    ],
+    [
+      "falls back to email when first name is absent",
+      { created_by: { email: "a@b.co" } },
       "a@b.co",
-    );
-    expect(attributionLabel({ task_id: "t1" })).toBe("agent");
-    expect(attributionLabel({})).toBeNull();
+    ],
+    ["returns 'agent' when only task_id is set", { task_id: "t1" }, "agent"],
+    ["returns null when no attribution is present", {}, null],
+  ] as const)("%s", (_desc, input, expected) => {
+    expect(attributionLabel(input)).toBe(expected);
   });
 });
 

--- a/apps/mobile/src/features/inbox/activityLog.ts
+++ b/apps/mobile/src/features/inbox/activityLog.ts
@@ -1,0 +1,82 @@
+import type { ReportArtefact } from "./types";
+
+export type ActivityArtefact = Extract<
+  ReportArtefact,
+  { type: "commit" | "task_run" }
+>;
+
+export function selectActivityArtefacts(
+  artefacts: ReportArtefact[],
+): ActivityArtefact[] {
+  return artefacts
+    .filter(
+      (a): a is ActivityArtefact =>
+        a.type === "commit" || a.type === "task_run",
+    )
+    .sort((a, b) => a.created_at.localeCompare(b.created_at));
+}
+
+export function shortSha(sha: string): string {
+  return sha.slice(0, 12);
+}
+
+const SIGNALS_TYPE_LABELS: Record<string, string> = {
+  research: "Research",
+  implementation: "Implementation",
+  repo_selection: "Repo selection",
+};
+
+function humanizeIdentifier(value: string): string {
+  const spaced = value.replace(/[_-]+/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function taskRunLabel(content: {
+  product: string;
+  type: string;
+}): string {
+  if (content.product === "signals") {
+    return (
+      SIGNALS_TYPE_LABELS[content.type] ?? humanizeIdentifier(content.type)
+    );
+  }
+  return humanizeIdentifier(content.type);
+}
+
+export function attributionLabel(artefact: {
+  created_by?: { first_name?: string; email: string } | null;
+  task_id?: string | null;
+}): string | null {
+  if (artefact.created_by) {
+    return artefact.created_by.first_name?.trim() || artefact.created_by.email;
+  }
+  if (artefact.task_id) {
+    return "agent";
+  }
+  return null;
+}
+
+type DiffLineKind = "add" | "del" | "hunk" | "context";
+
+interface DiffLine {
+  text: string;
+  kind: DiffLineKind;
+}
+
+export function parseDiffLines(diff: string): DiffLine[] {
+  return diff
+    .replace(/\n$/, "")
+    .split("\n")
+    .map((text) => {
+      if (text.startsWith("+") && !text.startsWith("+++")) {
+        return { text, kind: "add" as const };
+      }
+      if (text.startsWith("-") && !text.startsWith("---")) {
+        return { text, kind: "del" as const };
+      }
+      if (text.startsWith("@@")) {
+        return { text, kind: "hunk" as const };
+      }
+      return { text, kind: "context" as const };
+    });
+}

--- a/apps/mobile/src/features/inbox/api.ts
+++ b/apps/mobile/src/features/inbox/api.ts
@@ -8,6 +8,7 @@ const log = logger.scope("inbox-api");
 import type {
   AvailableSuggestedReviewer,
   AvailableSuggestedReviewersResponse,
+  CommitDiffResponse,
   ReportArtefact,
   SignalProcessingStateResponse,
   SignalReport,
@@ -174,6 +175,33 @@ export async function getSignalReportArtefacts(
   const data = await response.json();
   const results: ReportArtefact[] = data.results ?? [];
   return { results, count: data.count ?? results.length };
+}
+
+/** Fetch a commit artefact's diff against its parent (lazily, on demand). */
+export async function getCommitDiff(
+  reportId: string,
+  artefactId: string,
+): Promise<CommitDiffResponse> {
+  const baseUrl = getBaseUrl();
+  const projectId = getProjectId();
+
+  const response = await authedFetch(
+    `${baseUrl}/api/projects/${projectId}/signals/reports/${reportId}/artefacts/${artefactId}/diff/`,
+  );
+
+  if (!response.ok) {
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      "Couldn’t load the diff",
+    );
+  }
+
+  const data = await response.json();
+  return {
+    diff: typeof data.diff === "string" ? data.diff : "",
+    truncated: data.truncated === true,
+  };
 }
 
 /** Replace the content of a report artefact (full PUT, not a partial update). */

--- a/apps/mobile/src/features/inbox/components/ArtefactCommit.tsx
+++ b/apps/mobile/src/features/inbox/components/ArtefactCommit.tsx
@@ -1,0 +1,80 @@
+import { Text } from "@components/text";
+import { CaretDown, CaretRight } from "phosphor-react-native";
+import { useState } from "react";
+import { ActivityIndicator, Pressable, View } from "react-native";
+import { useThemeColors } from "@/lib/theme";
+import { shortSha } from "../activityLog";
+import { useCommitDiff } from "../hooks/useInboxReports";
+import type { CommitContent } from "../types";
+import { DiffBlock } from "./DiffBlock";
+
+export function ArtefactCommit({
+  reportId,
+  artefactId,
+  content,
+}: {
+  reportId: string;
+  artefactId: string;
+  content: CommitContent;
+}) {
+  const themeColors = useThemeColors();
+  const [expanded, setExpanded] = useState(false);
+  const diffQuery = useCommitDiff(reportId, artefactId, expanded);
+
+  return (
+    <View>
+      <Text className="text-[13px] text-gray-12">{content.message}</Text>
+      <Text className="font-mono text-[11px] text-gray-9">
+        {shortSha(content.commit_sha)} · {content.repository}@{content.branch}
+      </Text>
+      {content.note?.trim() ? (
+        <Text className="mt-0.5 text-[12px] text-gray-11">{content.note}</Text>
+      ) : null}
+
+      <Pressable
+        onPress={() => setExpanded((v) => !v)}
+        hitSlop={6}
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        className="mt-1.5 flex-row items-center gap-1 self-start py-1 active:opacity-60"
+      >
+        {expanded ? (
+          <CaretDown size={12} color={themeColors.gray[11]} />
+        ) : (
+          <CaretRight size={12} color={themeColors.gray[11]} />
+        )}
+        <Text className="text-[12px] text-gray-11">
+          {expanded ? "Hide diff" : "View diff"}
+        </Text>
+      </Pressable>
+
+      {expanded ? (
+        <View className="mt-1.5">
+          {diffQuery.isLoading ? (
+            <View className="flex-row items-center gap-2">
+              <ActivityIndicator size="small" color={themeColors.gray[9]} />
+              <Text className="text-[12px] text-gray-9">Fetching diff…</Text>
+            </View>
+          ) : diffQuery.isError ? (
+            <Text className="text-[12px] text-status-error">
+              Couldn’t load the diff.
+            </Text>
+          ) : diffQuery.data?.diff.trim() ? (
+            <>
+              <DiffBlock diff={diffQuery.data.diff} />
+              {diffQuery.data.truncated ? (
+                <Text className="mt-1 text-[11px] text-gray-9">
+                  Diff truncated — too large to display in full.
+                </Text>
+              ) : null}
+            </>
+          ) : (
+            <Text className="text-[12px] text-gray-9">
+              No changes recorded for this commit.
+            </Text>
+          )}
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/inbox/components/ArtefactTaskRun.tsx
+++ b/apps/mobile/src/features/inbox/components/ArtefactTaskRun.tsx
@@ -1,0 +1,49 @@
+import { Text } from "@components/text";
+import { useRouter } from "expo-router";
+import { CaretRight } from "phosphor-react-native";
+import { Pressable, View } from "react-native";
+import { useTask } from "@/features/tasks";
+import { useThemeColors } from "@/lib/theme";
+import { taskRunLabel } from "../activityLog";
+import type { TaskRunArtefactContent } from "../types";
+
+export function ArtefactTaskRun({
+  content,
+}: {
+  content: TaskRunArtefactContent;
+}) {
+  const router = useRouter();
+  const themeColors = useThemeColors();
+  const taskQuery = useTask(content.task_id);
+
+  const task = taskQuery.data;
+  const label = taskRunLabel(content);
+  const status = task?.latest_run?.status;
+
+  return (
+    <Pressable
+      onPress={() => router.push(`/task/${content.task_id}`)}
+      hitSlop={4}
+      accessibilityRole="button"
+      className="flex-row items-center gap-2 py-1 active:opacity-60"
+    >
+      <View className="rounded bg-gray-4 px-1.5 py-0.5">
+        <Text className="font-medium text-[11px] text-gray-11">{label}</Text>
+      </View>
+      <Text
+        className="min-w-0 flex-1 text-[13px] text-gray-12"
+        numberOfLines={1}
+      >
+        {taskQuery.isLoading
+          ? "Loading task…"
+          : (task?.title ?? content.task_id)}
+      </Text>
+      {status ? (
+        <View className="rounded bg-gray-4 px-1.5 py-0.5">
+          <Text className="text-[11px] text-gray-11">{status}</Text>
+        </View>
+      ) : null}
+      <CaretRight size={14} color={themeColors.gray[9]} />
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/features/inbox/components/DiffBlock.tsx
+++ b/apps/mobile/src/features/inbox/components/DiffBlock.tsx
@@ -1,0 +1,34 @@
+import { Text } from "@components/text";
+import { ScrollView, View } from "react-native";
+import { parseDiffLines } from "../activityLog";
+
+const LINE_CLASS: Record<string, string> = {
+  add: "bg-status-success/15 text-status-success",
+  del: "bg-status-error/15 text-status-error",
+  hunk: "text-gray-9",
+  context: "text-gray-12",
+};
+
+export function DiffBlock({ diff }: { diff: string }) {
+  const lines = parseDiffLines(diff);
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator
+      className="max-h-72 rounded-lg border border-gray-6 bg-gray-2"
+    >
+      <View className="p-2">
+        {lines.map((line, i) => (
+          <Text
+            // biome-ignore lint/suspicious/noArrayIndexKey: stable parse output, never reorders
+            key={i}
+            className={`font-mono text-[11px] leading-[16px] ${LINE_CLASS[line.kind]}`}
+          >
+            {line.text || " "}
+          </Text>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/features/inbox/components/ReportActivity.tsx
+++ b/apps/mobile/src/features/inbox/components/ReportActivity.tsx
@@ -1,0 +1,89 @@
+import { Text } from "@components/text";
+import { ClockCounterClockwise } from "phosphor-react-native";
+import { useMemo } from "react";
+import { View } from "react-native";
+import { formatRelativeTime } from "@/lib/format";
+import { useThemeColors } from "@/lib/theme";
+import {
+  type ActivityArtefact,
+  attributionLabel,
+  selectActivityArtefacts,
+} from "../activityLog";
+import type { ReportArtefact } from "../types";
+import { ArtefactCommit } from "./ArtefactCommit";
+import { ArtefactTaskRun } from "./ArtefactTaskRun";
+
+function ArtefactRow({
+  reportId,
+  artefact,
+}: {
+  reportId: string;
+  artefact: ActivityArtefact;
+}) {
+  const attribution = attributionLabel(artefact);
+  const timestampMs = Date.parse(artefact.created_at);
+
+  return (
+    <View className="rounded-xl border border-gray-6 bg-gray-1 p-3">
+      <View className="mb-1.5 flex-row items-center gap-2">
+        <Text className="font-medium text-[12px] text-gray-12">
+          {artefact.type === "commit" ? "Commit pushed" : "Task run"}
+        </Text>
+        <View className="flex-1" />
+        {attribution ? (
+          <Text className="text-[11px] text-gray-9">by {attribution}</Text>
+        ) : null}
+        {!Number.isNaN(timestampMs) ? (
+          <Text className="text-[11px] text-gray-9">
+            {formatRelativeTime(timestampMs)}
+          </Text>
+        ) : null}
+      </View>
+      {artefact.type === "commit" ? (
+        <ArtefactCommit
+          reportId={reportId}
+          artefactId={artefact.id}
+          content={artefact.content}
+        />
+      ) : (
+        <ArtefactTaskRun content={artefact.content} />
+      )}
+    </View>
+  );
+}
+
+export function ReportActivity({
+  reportId,
+  artefacts,
+}: {
+  reportId: string;
+  artefacts: ReportArtefact[];
+}) {
+  const themeColors = useThemeColors();
+  const activity = useMemo(
+    () => selectActivityArtefacts(artefacts),
+    [artefacts],
+  );
+
+  if (activity.length === 0) return null;
+
+  return (
+    <View className="mb-4">
+      <View className="mb-2 flex-row items-center gap-1.5">
+        <ClockCounterClockwise size={14} color={themeColors.gray[12]} />
+        <Text className="font-semibold text-[14px] text-gray-12">
+          Activity ({activity.length})
+        </Text>
+      </View>
+      <View className="gap-2">
+        {activity.map((artefact) => (
+          <ArtefactRow
+            key={artefact.id}
+            reportId={reportId}
+            artefact={artefact}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
+++ b/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
@@ -4,6 +4,7 @@ import {
   type DismissSignalReportInput,
   dismissSignalReport,
   getAvailableSuggestedReviewers,
+  getCommitDiff,
   getSignalProcessingState,
   getSignalReport,
   getSignalReportArtefacts,
@@ -19,6 +20,7 @@ import {
 import { useInboxFilterStore } from "../stores/inboxFilterStore";
 import type {
   AvailableSuggestedReviewersResponse,
+  CommitDiffResponse,
   SignalProcessingStateResponse,
   SignalReport,
   SignalReportArtefactsResponse,
@@ -47,6 +49,8 @@ export const inboxKeys = {
     [...inboxKeys.all, reportId, "artefacts"] as const,
   signals: (reportId: string) =>
     [...inboxKeys.all, reportId, "signals"] as const,
+  commitDiff: (reportId: string, artefactId: string) =>
+    [...inboxKeys.all, reportId, "artefacts", artefactId, "diff"] as const,
   processingState: ["inbox", "signal-processing-state"] as const,
 };
 
@@ -164,6 +168,27 @@ export function useInboxReportArtefacts(reportId: string | null) {
       return getSignalReportArtefacts(reportId);
     },
     enabled: !!projectId && !!oauthAccessToken && !!reportId,
+    // The log is a live work record — agents append artefacts while a report
+    // is open, so refresh it gently rather than trusting the default staleTime.
+    staleTime: 10_000,
+    refetchInterval: 20_000,
+  });
+}
+
+export function useCommitDiff(
+  reportId: string,
+  artefactId: string,
+  enabled: boolean,
+) {
+  const { projectId, oauthAccessToken } = useAuthStore();
+
+  return useQuery<CommitDiffResponse>({
+    queryKey: inboxKeys.commitDiff(reportId, artefactId),
+    queryFn: () => getCommitDiff(reportId, artefactId),
+    // A commit's diff is immutable, so only fetch once expanded and never retry.
+    enabled: enabled && !!projectId && !!oauthAccessToken,
+    staleTime: 5 * 60_000,
+    retry: false,
   });
 }
 

--- a/apps/mobile/src/features/inbox/types.ts
+++ b/apps/mobile/src/features/inbox/types.ts
@@ -145,32 +145,58 @@ export interface SuggestedReviewerWriteEntry {
   github_name?: string;
 }
 
+export interface ArtefactUser {
+  uuid?: string;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface CommitContent {
+  repository: string;
+  branch: string;
+  commit_sha: string;
+  message: string;
+  note?: string | null;
+}
+
+export interface TaskRunArtefactContent {
+  task_id: string;
+  product: string;
+  type: string;
+}
+
+export interface CommitDiffResponse {
+  diff: string;
+  truncated: boolean;
+}
+
+/**
+ * Fields shared by every artefact row. `created_by` / `task_id` carry
+ * attribution: at most one is set — `created_by` for user writes, `task_id`
+ * for agent writes, neither for system writes.
+ */
+interface BaseArtefact {
+  id: string;
+  created_at: string;
+  created_by?: ArtefactUser | null;
+  task_id?: string | null;
+}
+
 export type ReportArtefact =
-  | {
-      id: string;
+  | (BaseArtefact & {
       type: "priority_judgment";
-      created_at: string;
       content: PriorityJudgmentContent;
-    }
-  | {
-      id: string;
+    })
+  | (BaseArtefact & {
       type: "actionability_judgment";
-      created_at: string;
       content: ActionabilityJudgmentContent;
-    }
-  | {
-      id: string;
-      type: "signal_finding";
-      created_at: string;
-      content: SignalFindingContent;
-    }
-  | SuggestedReviewersArtefact
-  | {
-      id: string;
-      type: string;
-      created_at: string;
-      content: unknown;
-    };
+    })
+  | (BaseArtefact & { type: "signal_finding"; content: SignalFindingContent })
+  | (BaseArtefact & { type: "commit"; content: CommitContent })
+  | (BaseArtefact & { type: "task_run"; content: TaskRunArtefactContent })
+  | (BaseArtefact & SuggestedReviewersArtefact)
+  | (BaseArtefact & { type: string; content: unknown });
 
 export interface SignalReportArtefactsResponse {
   results: ReportArtefact[];


### PR DESCRIPTION
## Summary

Ports desktop PR #2557 (_feat(inbox): render the signal report artefact log_) to the **React Native / Expo mobile app**. Adds a native **Activity** section to the signal report detail screen that renders the report's work-log artefacts — commits the agent pushed and task runs it spawned — in chronological order, with inline diffs.

Desktop-only artefact types that already have dedicated mobile sections (judgments, suggested reviewers, signal findings) are unchanged; this fills the gap for the activity timeline.

## What's included

- **Activity section** (`ReportActivity`) appended to the report detail screen, rendering `commit` and `task_run` artefacts oldest-first under a clock-icon header with an entry count.
- **Commits** (`ArtefactCommit`): message, short SHA, `repo@branch`, optional note, and a collapsible **View diff** toggle that lazily fetches the commit-vs-parent diff. Diffs render in a horizontally-scrollable, `+`/`-` colour-coded block sized for small screens, with a truncation notice.
- **Task runs** (`ArtefactTaskRun`): humanized type label, task title + run status, tapping navigates to the task detail screen (the mobile-appropriate adaptation of desktop's inline logs panel).
- **Types**: mobile-local `commit` / `task_run` artefact variants with attribution fields (`created_by` / `task_id`), plus `CommitContent`, `TaskRunArtefactContent`, `CommitDiffResponse`, matching the server shapes in `packages/shared`.
- **API + hooks**: `getCommitDiff` (throws `HttpError`, consistent with the file) and `useCommitDiff` (enabled-gated, immutable diff so `staleTime: 5m`, no retry). The artefacts query now polls gently (20s) so the log stays live while a report is open.
- **Pure helpers** (`activityLog.ts`): `selectActivityArtefacts`, `parseDiffLines`, `taskRunLabel`, `attributionLabel`, `shortSha` — covered by colocated Vitest unit tests.

## Scope

Implemented in `apps/mobile` only. No changes to `apps/code`, `packages/ui`, `packages/core`, or `packages/shared`.

## Testing

- `pnpm --filter @posthog/mobile test` — 43 files / 304 tests pass (includes new `activityLog.test.ts`).
- `tsc --noEmit` — no errors in the changed files.
- `biome check` — clean.