### PR TITLE
feat(inbox): add Load more button to paginate report lists

### DIFF
--- a/packages/ui/src/features/inbox/components/DismissedTab.tsx
+++ b/packages/ui/src/features/inbox/components/DismissedTab.tsx
@@ -67,7 +67,7 @@ export function DismissedTab() {
       <InboxLoadMore
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
-        onLoadMore={() => void fetchNextPage()}
+        onLoadMore={() => void fetchNextPage({ cancelRefetch: false })}
       />
     </Flex>
   );

--- a/packages/ui/src/features/inbox/components/DismissedTab.tsx
+++ b/packages/ui/src/features/inbox/components/DismissedTab.tsx
@@ -7,6 +7,7 @@ import {
   EmptyTitle,
 } from "@posthog/quill";
 import { CardSkeleton } from "@posthog/ui/features/inbox/components/CardSkeleton";
+import { InboxLoadMore } from "@posthog/ui/features/inbox/components/InboxLoadMore";
 import { ReportCard } from "@posthog/ui/features/inbox/components/ReportCard";
 import { useInboxDismissedReports } from "@posthog/ui/features/inbox/hooks/useInboxDismissedReports";
 import { useInboxRestoreReport } from "@posthog/ui/features/inbox/hooks/useInboxRestoreReport";
@@ -19,7 +20,8 @@ import { Flex } from "@radix-ui/themes";
  * a read-only detail view (summary + evidence) — no triage affordances.
  */
 export function DismissedTab() {
-  const { reports, isLoading } = useInboxDismissedReports();
+  const { reports, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useInboxDismissedReports();
   const restore = useInboxRestoreReport();
   const restoringId = restore.isPending ? restore.variables : null;
 
@@ -62,6 +64,11 @@ export function DismissedTab() {
           isRestorePending={restoringId === report.id}
         />
       ))}
+      <InboxLoadMore
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => void fetchNextPage()}
+      />
     </Flex>
   );
 }

--- a/packages/ui/src/features/inbox/components/InboxLoadMore.tsx
+++ b/packages/ui/src/features/inbox/components/InboxLoadMore.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@posthog/ui/primitives/Button";
+import { Flex } from "@radix-ui/themes";
+
+/**
+ * "Load more" control for the paginated inbox tabs. The report lists are backed
+ * by an infinite query (page size 100) but nothing advanced it, so tabs capped
+ * at the first page. This renders the next-page trigger below the list.
+ *
+ * `hasNextPage` from React Query is `boolean | undefined`; render nothing until
+ * there's a confirmed next page.
+ */
+export function InboxLoadMore({
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: {
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}) {
+  if (!hasNextPage) return null;
+
+  return (
+    <Flex justify="center" className="py-2">
+      <Button
+        type="button"
+        variant="soft"
+        color="gray"
+        loading={isFetchingNextPage}
+        disabled={isFetchingNextPage}
+        onClick={onLoadMore}
+      >
+        Load more
+      </Button>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/inbox/components/InboxReportListTab.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportListTab.tsx
@@ -18,6 +18,7 @@ import {
   type DismissReportDialogResult,
 } from "@posthog/ui/features/inbox/components/DismissReportDialog";
 import { InboxBulkSelectionBar } from "@posthog/ui/features/inbox/components/InboxBulkSelectionBar";
+import { InboxLoadMore } from "@posthog/ui/features/inbox/components/InboxLoadMore";
 import { InboxSearchFilterBar } from "@posthog/ui/features/inbox/components/InboxSearchFilterBar";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import {
@@ -97,7 +98,14 @@ export function InboxReportListTab({
   CardListWrapper,
   pullRequestsOnly = false,
 }: InboxReportListTabProps) {
-  const { scopedReports, allReports, isLoading } = useInboxAllReports({
+  const {
+    scopedReports,
+    allReports,
+    isLoading,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInboxAllReports({
     pullRequestsOnly,
   });
   const scope = useInboxReviewerScopeStore((s) => s.scope);
@@ -177,7 +185,7 @@ export function InboxReportListTab({
           />
         ) : null}
 
-        {matchingReports.length === 0 ? (
+        {matchingReports.length === 0 && !hasNextPage ? (
           <Empty className="mx-auto max-w-md py-16">
             <EmptyHeader>
               <EmptyMedia variant="icon">
@@ -188,28 +196,40 @@ export function InboxReportListTab({
             </EmptyHeader>
           </Empty>
         ) : (
-          <CardListContainer
-            reports={matchingReports}
-            Wrapper={CardListWrapper}
-          >
-            <Flex direction="column" gap="3">
-              {matchingReports.map((report) => (
-                <Card
-                  key={report.id}
-                  report={report}
-                  isSelected={isReportSelected(report.id)}
-                  onRowClick={(event) => handleReportClick(report.id, event)}
-                  onDismiss={() => setDismissReport(report)}
-                  dismissDisabledReason={
-                    suppressDisabledByReportId.get(report.id) ?? null
-                  }
-                  isDismissPending={
-                    dismissReport?.id === report.id && dismissMutationPending
-                  }
-                />
-              ))}
-            </Flex>
-          </CardListContainer>
+          <>
+            {matchingReports.length > 0 && (
+              <CardListContainer
+                reports={matchingReports}
+                Wrapper={CardListWrapper}
+              >
+                <Flex direction="column" gap="3">
+                  {matchingReports.map((report) => (
+                    <Card
+                      key={report.id}
+                      report={report}
+                      isSelected={isReportSelected(report.id)}
+                      onRowClick={(event) =>
+                        handleReportClick(report.id, event)
+                      }
+                      onDismiss={() => setDismissReport(report)}
+                      dismissDisabledReason={
+                        suppressDisabledByReportId.get(report.id) ?? null
+                      }
+                      isDismissPending={
+                        dismissReport?.id === report.id &&
+                        dismissMutationPending
+                      }
+                    />
+                  ))}
+                </Flex>
+              </CardListContainer>
+            )}
+            <InboxLoadMore
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              onLoadMore={() => void fetchNextPage()}
+            />
+          </>
         )}
       </Flex>
 

--- a/packages/ui/src/features/inbox/components/InboxReportListTab.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportListTab.tsx
@@ -227,7 +227,7 @@ export function InboxReportListTab({
             <InboxLoadMore
               hasNextPage={hasNextPage}
               isFetchingNextPage={isFetchingNextPage}
-              onLoadMore={() => void fetchNextPage()}
+              onLoadMore={() => void fetchNextPage({ cancelRefetch: false })}
             />
           </>
         )}


### PR DESCRIPTION
## Problem

The inbox report tabs cap at 100 reports. With ~500 reports you can't scroll past the first 100 — the rest never load.

The lists are backed by an infinite query (`useInboxReportsInfinite`, page size 100) and the pagination plumbing was already in place (`getNextPageParam`, `fetchNextPage`, `hasNextPage`), but **nothing ever called `fetchNextPage()`** — there was no infinite-scroll sentinel and no Load more button. So only page 1 ever loaded.

## Change

- **New** `InboxLoadMore.tsx` — a reusable button (quill `Button`, spinner while fetching) that renders only when there's a confirmed next page and calls `fetchNextPage()` on click.
- Wired into the flat-list tabs:
  - `InboxReportListTab.tsx` — shared shell for the **Reports** and **Pull requests** tabs.
  - `DismissedTab.tsx` — the **Archive** tab.
- Relaxed the shared shell's empty-state to `matchingReports.length === 0 && !hasNextPage`, so a first page containing no predicate-matching items (e.g. all PRs/runs) offers Load more instead of a misleading "nothing here".

Each click loads the next 100; the button disappears once `loaded >= count`.

## Out of scope

The **Runs** tab is intentionally left out — it's not a flat list. It partitions into queued/live/finished with its own show-all toggles (capped at 10 each), and runs are a small, recent set near the top of the order. Can follow up if it turns out to need it.

## Testing

- `pnpm --filter @posthog/ui typecheck` ✅
- `pnpm biome check` on changed files ✅
- `pnpm --filter @posthog/ui test inbox` → 836 passed ✅