### PR TITLE
fix: include fingerprints in error tracking issue links

### DIFF
--- a/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -688,11 +688,13 @@ function SessionRecordingVideo({
 
 function ErrorTrackingSignalCard({
   signal,
+  extra,
   verified,
   codePaths,
   dataQueried,
 }: {
   signal: Signal;
+  extra: ErrorTrackingExtra;
   verified?: boolean;
   codePaths?: string[];
   dataQueried?: string;
@@ -700,7 +702,11 @@ function ErrorTrackingSignalCard({
   const projectId = useAuthStateValue((s) => s.currentProjectId);
   const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
   const issueUrl = signal.source_id
-    ? errorTrackingIssueUrl(signal.source_id, { projectId, cloudRegion })
+    ? errorTrackingIssueUrl(signal.source_id, {
+        projectId,
+        cloudRegion,
+        fingerprint: extra.fingerprint,
+      })
     : null;
 
   return (
@@ -904,6 +910,7 @@ export function SignalCard({
     content = (
       <ErrorTrackingSignalCard
         signal={signal}
+        extra={extra}
         verified={verified}
         codePaths={codePaths}
         dataQueried={dataQueried}

--- a/packages/ui/src/utils/posthogLinks.test.ts
+++ b/packages/ui/src/utils/posthogLinks.test.ts
@@ -1,0 +1,31 @@
+import { errorTrackingIssueUrl } from "@posthog/ui/utils/posthogLinks";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/utils/urls", () => ({
+  getPostHogUrl: (path: string) => `https://us.posthog.com${path}`,
+}));
+
+describe("errorTrackingIssueUrl", () => {
+  it("links to the issue when no fingerprint is provided", () => {
+    expect(
+      errorTrackingIssueUrl("issue id/with?chars", {
+        projectId: 123,
+        cloudRegion: "us",
+      }),
+    ).toBe(
+      "https://us.posthog.com/project/123/error_tracking/issue%20id%2Fwith%3Fchars",
+    );
+  });
+
+  it("includes a fingerprint query parameter for merged issue redirects", () => {
+    expect(
+      errorTrackingIssueUrl("old-issue-id", {
+        projectId: 123,
+        cloudRegion: "us",
+        fingerprint: "fp/value with spaces&eq=1",
+      }),
+    ).toBe(
+      "https://us.posthog.com/project/123/error_tracking/old-issue-id?fingerprint=fp%2Fvalue%20with%20spaces%26eq%3D1",
+    );
+  });
+});

--- a/packages/ui/src/utils/posthogLinks.ts
+++ b/packages/ui/src/utils/posthogLinks.ts
@@ -7,6 +7,10 @@ export interface LinkOverrides {
   cloudRegion?: CloudRegion | null;
 }
 
+export interface ErrorTrackingIssueLinkOverrides extends LinkOverrides {
+  fingerprint?: string | null;
+}
+
 function resolveProjectId(override?: number | null): number | null {
   if (override != null) return override;
   return useAuthStore.getState().authState.currentProjectId ?? null;
@@ -78,10 +82,12 @@ export function skillUrl(
 
 export function errorTrackingIssueUrl(
   issueId: string,
-  overrides?: LinkOverrides,
+  overrides?: ErrorTrackingIssueLinkOverrides,
 ): string | null {
-  return withProjectId(
-    (pid) => `/project/${pid}/error_tracking/${encodeURIComponent(issueId)}`,
-    overrides,
-  );
+  return withProjectId((pid) => {
+    const path = `/project/${pid}/error_tracking/${encodeURIComponent(issueId)}`;
+    return overrides?.fingerprint
+      ? `${path}?fingerprint=${encodeURIComponent(overrides.fingerprint)}`
+      : path;
+  }, overrides);
 }


### PR DESCRIPTION
## Summary

Adds the error-tracking fingerprint to PostHog issue links emitted from Signals in Code.

## Why

Signals can point at an older error-tracking issue id after issue merging or automerging. PostHog can redirect merged issues when the fingerprint is present, so Code should preserve that fingerprint in the generated link.

## Changes

- Extend the error-tracking issue URL helper with an optional fingerprint query parameter.
- Pass the validated error-tracking signal fingerprint into the View issue link.
- Add focused URL-helper coverage for encoded issue IDs and fingerprints.

## Validation

- pnpm build:deps
- pnpm --filter @posthog/ui exec vitest run src/utils/posthogLinks.test.ts
- pnpm --filter @posthog/ui typecheck
- pnpm typecheck
- autoreview on HEAD: clean, no accepted or actionable findings
