### PR TITLE
fix(inbox): keep detail back link pointing at the tab you came from

### DIFF
--- a/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
+++ b/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
@@ -8,6 +8,10 @@ import { Button } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
+import {
+  type InboxBackTarget,
+  useInboxBackTarget,
+} from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxRestoreReport } from "@posthog/ui/features/inbox/hooks/useInboxRestoreReport";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 import { Spinner } from "@radix-ui/themes";
@@ -35,28 +39,44 @@ export function DismissedReportDetail({
   reportId,
   cachedReport = null,
 }: DismissedReportDetailProps) {
+  // Follow the user's path in: if they archived a report while viewing it, the
+  // redirect here recorded its origin (Reports / Pulls / Runs) so the back link
+  // returns there. Arriving directly (deep link, Archive-tab click, refresh)
+  // falls back to "Back to archive".
+  const back = useInboxBackTarget({
+    to: "/code/inbox/dismissed",
+    label: "Back to archive",
+  });
   return (
     <InboxReportDetailGate
       reportId={reportId}
       cachedReport={cachedReport}
       backTo="/code/inbox/dismissed"
       backLabel="Back to archive"
+      backLinkTo={back.to}
+      backLinkLabel={back.label}
       missingCopy="This report couldn't be found. It may have been deleted."
     >
-      {(report) => <DismissedReportDetailContent report={report} />}
+      {(report) => <DismissedReportDetailContent report={report} back={back} />}
     </InboxReportDetailGate>
   );
 }
 
-function DismissedReportDetailContent({ report }: { report: SignalReport }) {
+function DismissedReportDetailContent({
+  report,
+  back,
+}: {
+  report: SignalReport;
+  back: InboxBackTarget;
+}) {
   // Resolved reports are terminal (their PR already merged) — nothing to
   // restore, so only suppressed reports get a Restore action.
   const canRestore = report.status === "suppressed";
   return (
     <InboxDetailFrame
       report={report}
-      backTo="/code/inbox/dismissed"
-      backLabel="Back to archive"
+      backTo={back.to}
+      backLabel={back.label}
       fallbackTitle="Untitled report"
       showDismiss={false}
       primaryAction={

--- a/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -18,6 +18,7 @@ import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components
 import { SignalReportStatusBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportStatusBadge";
 import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
 import { hasKnownSourceProduct } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
+import type { InboxListRoute } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import { useInboxReportSignals } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
@@ -27,7 +28,7 @@ import type { ComponentType, ReactNode } from "react";
 interface InboxDetailFrameProps {
   report: SignalReport;
   /** List route for the back-link (e.g. "/code/inbox/pulls"). */
-  backTo: "/code/inbox/pulls" | "/code/inbox/reports" | "/code/inbox/dismissed";
+  backTo: InboxListRoute;
   backLabel: string;
   /**
    * Whether to render the Dismiss button + dialog. Off for already-dismissed

--- a/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
@@ -6,6 +6,7 @@ import {
 import { Spinner } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBackLink";
+import type { InboxListRoute } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxReportById } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import {
   type InboxDetailTab,
@@ -18,12 +19,17 @@ import { type ReactNode, useEffect } from "react";
 interface InboxReportDetailGateProps {
   reportId: string;
   cachedReport?: SignalReport | null;
-  backTo:
-    | "/code/inbox/pulls"
-    | "/code/inbox/reports"
-    | "/code/inbox/runs"
-    | "/code/inbox/dismissed";
+  backTo: InboxListRoute;
   backLabel: string;
+  /**
+   * Where the missing-report shell's back link points, when it should differ
+   * from `backTo`. The Archive detail sets these to the recorded origin so the
+   * link follows the user's path in, while `backTo` stays the route identity
+   * that drives the status↔route redirect and engagement tracking below.
+   * Defaults to `backTo`/`backLabel`.
+   */
+  backLinkTo?: string;
+  backLinkLabel?: string;
   missingCopy: string;
   children: (report: SignalReport) => ReactNode;
 }
@@ -57,6 +63,8 @@ export function InboxReportDetailGate({
   cachedReport = null,
   backTo,
   backLabel,
+  backLinkTo,
+  backLinkLabel,
   missingCopy,
   children,
 }: InboxReportDetailGateProps) {
@@ -110,8 +118,16 @@ export function InboxReportDetailGate({
       to: redirectTo,
       params: { reportId: redirectReportId },
       replace: true,
+      // Carry where we came from into the Archive route so its back link reads
+      // "Back to reports/pulls/runs" rather than "Back to archive". This branch
+      // only fires from a non-Archive route, so `backTo` is the pipeline origin
+      // the user is returning to.
+      state:
+        redirectTo === "/code/inbox/dismissed/$reportId"
+          ? { inboxBackOrigin: { to: backTo, label: backLabel } }
+          : undefined,
     });
-  }, [redirectTo, redirectReportId, navigate]);
+  }, [redirectTo, redirectReportId, navigate, backTo, backLabel]);
 
   if ((isLoading && !resolvedReport) || statusUnconfirmed) {
     return (
@@ -139,7 +155,10 @@ export function InboxReportDetailGate({
           gap="3"
           className="border-(--gray-5) border-b px-6 py-6"
         >
-          <DetailBackLink to={backTo} label={backLabel} />
+          <DetailBackLink
+            to={backLinkTo ?? backTo}
+            label={backLinkLabel ?? backLabel}
+          />
           <Text className="text-[13px] text-gray-11">{missingCopy}</Text>
         </Flex>
       </Flex>

--- a/packages/ui/src/features/inbox/hooks/useInboxBackTarget.test.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxBackTarget.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { asInboxBackTarget } from "./useInboxBackTarget";
+
+describe("asInboxBackTarget", () => {
+  it.each([
+    ["reports origin", { to: "/code/inbox/reports", label: "Back to reports" }],
+    ["pulls origin", { to: "/code/inbox/pulls", label: "Back to pull requests" }],
+    ["runs origin", { to: "/code/inbox/runs", label: "Back to runs" }],
+    [
+      "archive origin",
+      { to: "/code/inbox/dismissed", label: "Back to archive" },
+    ],
+  ])("accepts a valid %s", (_label, value) => {
+    expect(asInboxBackTarget(value)).toEqual(value);
+  });
+
+  it.each([
+    ["undefined (no history state)", undefined],
+    ["null", null],
+    ["a non-object", "reports"],
+    ["a route outside the inbox", { to: "/code/tasks", label: "Back" }],
+    ["a non-list inbox route", { to: "/code/inbox/reports/abc", label: "Back" }],
+    ["a missing label", { to: "/code/inbox/reports" }],
+    ["an empty label", { to: "/code/inbox/reports", label: "" }],
+    ["a missing route", { label: "Back to reports" }],
+    ["a non-string route", { to: 7, label: "Back" }],
+  ])("rejects %s and falls back", (_label, value) => {
+    expect(asInboxBackTarget(value)).toBeNull();
+  });
+});

--- a/packages/ui/src/features/inbox/hooks/useInboxBackTarget.test.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxBackTarget.test.ts
@@ -4,7 +4,10 @@ import { asInboxBackTarget } from "./useInboxBackTarget";
 describe("asInboxBackTarget", () => {
   it.each([
     ["reports origin", { to: "/code/inbox/reports", label: "Back to reports" }],
-    ["pulls origin", { to: "/code/inbox/pulls", label: "Back to pull requests" }],
+    [
+      "pulls origin",
+      { to: "/code/inbox/pulls", label: "Back to pull requests" },
+    ],
     ["runs origin", { to: "/code/inbox/runs", label: "Back to runs" }],
     [
       "archive origin",
@@ -19,7 +22,10 @@ describe("asInboxBackTarget", () => {
     ["null", null],
     ["a non-object", "reports"],
     ["a route outside the inbox", { to: "/code/tasks", label: "Back" }],
-    ["a non-list inbox route", { to: "/code/inbox/reports/abc", label: "Back" }],
+    [
+      "a non-list inbox route",
+      { to: "/code/inbox/reports/abc", label: "Back" },
+    ],
     ["a missing label", { to: "/code/inbox/reports" }],
     ["an empty label", { to: "/code/inbox/reports", label: "" }],
     ["a missing route", { label: "Back to reports" }],

--- a/packages/ui/src/features/inbox/hooks/useInboxBackTarget.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxBackTarget.ts
@@ -1,0 +1,61 @@
+import { useLocation } from "@tanstack/react-router";
+
+/** List routes an inbox detail screen's back link can return to. */
+export type InboxListRoute =
+  | "/code/inbox/pulls"
+  | "/code/inbox/reports"
+  | "/code/inbox/runs"
+  | "/code/inbox/dismissed";
+
+/**
+ * Where a detail screen's back link should go. The Archive redirect records the
+ * origin here so a report archived while open keeps "Back to reports" (or pulls
+ * / runs) instead of flipping to "Back to archive" the moment its status
+ * changes. The back link follows the path the user took in, not the report's
+ * current state.
+ */
+export interface InboxBackTarget {
+  to: InboxListRoute;
+  label: string;
+}
+
+// Carried in history state across the status↔route redirect; declared here so
+// `navigate({ state })` and `useLocation().state` stay typed.
+declare module "@tanstack/react-router" {
+  interface HistoryState {
+    inboxBackOrigin?: InboxBackTarget;
+  }
+}
+
+const INBOX_LIST_ROUTES = new Set<InboxListRoute>([
+  "/code/inbox/pulls",
+  "/code/inbox/reports",
+  "/code/inbox/runs",
+  "/code/inbox/dismissed",
+]);
+
+/**
+ * Validate untyped history state before trusting it: it may have come from an
+ * older app version, a hand-edited URL, or a corrupted entry.
+ */
+export function asInboxBackTarget(value: unknown): InboxBackTarget | null {
+  if (!value || typeof value !== "object") return null;
+  const { to, label } = value as Record<string, unknown>;
+  if (typeof label !== "string" || label.length === 0) return null;
+  if (typeof to !== "string" || !INBOX_LIST_ROUTES.has(to as InboxListRoute)) {
+    return null;
+  }
+  return { to: to as InboxListRoute, label };
+}
+
+/**
+ * Resolves a detail screen's back link: the origin recorded when the status↔route
+ * redirect carried us here, or `fallback` when we arrived directly (deep link,
+ * tab click, or a page refresh that dropped the history state).
+ */
+export function useInboxBackTarget(fallback: InboxBackTarget): InboxBackTarget {
+  const origin = useLocation({
+    select: (location) => location.state.inboxBackOrigin,
+  });
+  return asInboxBackTarget(origin) ?? fallback;
+}

--- a/packages/ui/src/features/inbox/hooks/useInboxBackTarget.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxBackTarget.ts
@@ -1,11 +1,14 @@
 import { useLocation } from "@tanstack/react-router";
 
+const INBOX_LIST_ROUTE_VALUES = [
+  "/code/inbox/pulls",
+  "/code/inbox/reports",
+  "/code/inbox/runs",
+  "/code/inbox/dismissed",
+] as const;
+
 /** List routes an inbox detail screen's back link can return to. */
-export type InboxListRoute =
-  | "/code/inbox/pulls"
-  | "/code/inbox/reports"
-  | "/code/inbox/runs"
-  | "/code/inbox/dismissed";
+export type InboxListRoute = (typeof INBOX_LIST_ROUTE_VALUES)[number];
 
 /**
  * Where a detail screen's back link should go. The Archive redirect records the
@@ -27,12 +30,7 @@ declare module "@tanstack/react-router" {
   }
 }
 
-const INBOX_LIST_ROUTES = new Set<InboxListRoute>([
-  "/code/inbox/pulls",
-  "/code/inbox/reports",
-  "/code/inbox/runs",
-  "/code/inbox/dismissed",
-]);
+const INBOX_LIST_ROUTES = new Set<InboxListRoute>(INBOX_LIST_ROUTE_VALUES);
 
 /**
  * Validate untyped history state before trusting it: it may have come from an


### PR DESCRIPTION
## Problem

After archiving a report while viewing it, the back button flipped from **"Back to reports"** to **"Back to archive"**. The usual flow is: open Reports → open a report → maybe archive → go back. So you'd expect to land back in Reports, not Archive.

This wasn't a label being swapped — the architecture flips it implicitly. Archiving sets the report's status to `suppressed`, and `InboxReportDetailGate` redirects (`replace: true`) from `/code/inbox/reports/$reportId` to `/code/inbox/dismissed/$reportId`. That route mounts `DismissedReportDetail`, which hard-codes `backTo="/code/inbox/dismissed"` / "Back to archive". So the back link followed the report's *new state* instead of the path you took in.

The redirect is load-bearing (it keeps archived reports off the triage view), so it's kept — but it now **remembers where you came from**.

## Change

- **New `useInboxBackTarget` hook** — owns the `InboxListRoute` / `InboxBackTarget` types, augments TanStack Router's `HistoryState` with an `inboxBackOrigin` field, and resolves the back link from history state (validating the untyped state at the boundary), with a fallback.
- **`InboxReportDetailGate`** — stamps the origin (`{ to, label }`, always a pipeline route at that point) into navigation `state` on the to-Archive redirect. Gains optional display-only `backLinkTo`/`backLinkLabel`; `backTo` stays the route identity that drives the redirect and engagement tracking.
- **`DismissedReportDetail`** — reads the recorded origin and uses it for both the missing-shell link and the header link; defaults to "Back to archive".
- **`InboxDetailFrame`** — `backTo` widened to the shared `InboxListRoute` union.
- **Unit test** for the history-state validator.

## Behavior

| Path in | Back link |
| --- | --- |
| Reports → open → archive | **Back to reports** → Reports list |
| Pulls → open → archive | **Back to pull requests** |
| Runs → open → archive | **Back to runs** |
| Archive tab / deep link / refresh | **Back to archive** (fallback) |

## Verification

⚠️ I could **not** run `pnpm typecheck`/tests locally — the sandbox's network is throttled to single-digit KiB/s and `pnpm install` gets OOM-killed before `@tanstack/react-router` and `vitest` are installed. Verified by manual review. Two things worth a CI/reviewer eye:
- The `declare module "@tanstack/react-router" { interface HistoryState }` augmentation (documented TanStack v1 pattern; mirrors the existing `Register` augmentation in `router.ts`).
- `useLocation({ select })` typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)