### PR TITLE
feat(agent-applications): searchable/paged agents list + UI polish

### DIFF
--- a/packages/ui/src/features/agent-applications/agent-builder/AgentBuilderDockLayout.tsx
+++ b/packages/ui/src/features/agent-applications/agent-builder/AgentBuilderDockLayout.tsx
@@ -11,6 +11,11 @@ import { useAgentBuilderStore } from "./agentBuilderStore";
  * disabled, the content renders unchanged with no dock or affordance. Hidden by
  * default; toggled via the edge affordance, the dock's hide button, or
  * Cmd/Ctrl+I. Panel sizes persist (`autoSaveId`).
+ *
+ * The content panel is always mounted in the same tree position; only the dock
+ * panel + resize handle toggle. Keeping the content's React identity stable
+ * across show/hide means panes don't remount — so per-pane state (the memory
+ * file you had open, a sessions filter, scroll position) survives toggling.
  */
 export function AgentBuilderDockLayout({ children }: { children: ReactNode }) {
   const enabled = useFeatureFlag(AGENT_PLATFORM_FLAG);
@@ -43,12 +48,9 @@ export function AgentBuilderDockLayout({ children }: { children: ReactNode }) {
     return <>{children}</>;
   }
 
-  // Collapsed: render content unchanged. The open affordance lives in the
+  // The content panel stays mounted whether the dock is open or not; only the
+  // dock panel + handle render conditionally. The open affordance lives in the
   // agents page headers (AgentBuilderHeaderControls); Cmd/Ctrl+Shift+I toggles.
-  if (!visible) {
-    return <>{children}</>;
-  }
-
   return (
     <PanelGroup
       direction="horizontal"
@@ -56,6 +58,7 @@ export function AgentBuilderDockLayout({ children }: { children: ReactNode }) {
       className="h-full min-h-0"
     >
       <Panel
+        id="agents-content"
         order={1}
         defaultSize={68}
         minSize={40}
@@ -63,16 +66,21 @@ export function AgentBuilderDockLayout({ children }: { children: ReactNode }) {
       >
         {children}
       </Panel>
-      <PanelResizeHandle className="w-px bg-(--gray-5) transition-colors hover:bg-(--gray-7) data-[resize-handle-state=drag]:bg-(--accent-9)" />
-      <Panel
-        order={2}
-        defaultSize={32}
-        minSize={22}
-        maxSize={48}
-        className="flex min-h-0 flex-col"
-      >
-        <AgentBuilderDock />
-      </Panel>
+      {visible ? (
+        <>
+          <PanelResizeHandle className="w-px bg-(--gray-5) transition-colors hover:bg-(--gray-7) data-[resize-handle-state=drag]:bg-(--accent-9)" />
+          <Panel
+            id="agents-dock"
+            order={2}
+            defaultSize={32}
+            minSize={22}
+            maxSize={48}
+            className="flex min-h-0 flex-col"
+          >
+            <AgentBuilderDock />
+          </Panel>
+        </>
+      ) : null}
     </PanelGroup>
   );
 }

--- a/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
@@ -2,6 +2,7 @@ import {
   ArrowSquareOutIcon,
   CaretRightIcon,
   LockKeyIcon,
+  MagnifyingGlassIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
 import type {
@@ -10,10 +11,11 @@ import type {
 } from "@posthog/shared/agent-platform-types";
 import { AgentsTabLayout } from "@posthog/ui/features/agents/components/AgentsTabLayout";
 import { Badge } from "@posthog/ui/primitives/Badge";
+import { Button } from "@posthog/ui/primitives/Button";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { Flex, Text } from "@radix-ui/themes";
 import { Link } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useAuthStateValue } from "../../auth/store";
 import { useAgentAnalytics } from "../hooks/useAgentAnalytics";
 import { useAgentApplications } from "../hooks/useAgentApplications";
@@ -24,11 +26,15 @@ import { AgentAnalyticsKpiStrip } from "./AgentAnalyticsView";
 import { AgentDetailEmptyState } from "./AgentDetailLayout";
 import { AgentFleetLiveSessionsPanel } from "./AgentFleetLiveSessionsPanel";
 
+type StatusFilter = "all" | "live" | "drafts";
+
+/** Agents per page in the fleet list. */
+const PAGE_SIZE = 8;
+
 /**
  * The Applications tab. Renders the deployed-agent fleet as the primary
- * surface, with operational / activity / live-now panels appearing below the
- * list only when they have something to say. A quiet fleet still feels like a
- * launchpad: just the agents, sectioned LIVE vs DRAFTS.
+ * surface: a searchable, status-filtered, paged list with the 7-day activity
+ * strip pinned at the top and operational / live-now panels below.
  */
 export function AgentApplicationsListView() {
   const region = useAuthStateValue((s) => s.cloudRegion);
@@ -56,62 +62,68 @@ export function AgentApplicationsListView() {
     return map;
   }, [analytics]);
 
-  // Split LIVE vs DRAFT so the operational view foregrounds what's serving
-  // traffic; drafts dim and section below.
-  const { liveApps, draftApps } = useMemo(() => {
-    const live: AgentApplication[] = [];
-    const draft: AgentApplication[] = [];
-    for (const app of applications ?? []) {
-      if (app.live_revision != null) live.push(app);
-      else draft.push(app);
-    }
-    return { liveApps: live, draftApps: draft };
-  }, [applications]);
+  // Live agents sort ahead of drafts so the operational view foregrounds what's
+  // serving traffic. Search + status filter + paging keep a large fleet
+  // navigable.
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [page, setPage] = useState(0);
+
+  const allApps = useMemo(() => applications ?? [], [applications]);
+  const liveCount = useMemo(
+    () => allApps.filter((a) => a.live_revision != null).length,
+    [allApps],
+  );
+  const draftCount = allApps.length - liveCount;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allApps
+      .filter((app) => {
+        if (status === "live" && app.live_revision == null) return false;
+        if (status === "drafts" && app.live_revision != null) return false;
+        if (!q) return true;
+        return (
+          app.name.toLowerCase().includes(q) ||
+          (app.slug?.toLowerCase().includes(q) ?? false) ||
+          (app.description?.toLowerCase().includes(q) ?? false)
+        );
+      })
+      .sort(
+        (a, b) =>
+          Number(b.live_revision != null) - Number(a.live_revision != null),
+      );
+  }, [allApps, status, query]);
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount - 1);
+  const pageItems = filtered.slice(
+    safePage * PAGE_SIZE,
+    safePage * PAGE_SIZE + PAGE_SIZE,
+  );
+
+  function changeStatus(next: StatusFilter) {
+    setStatus(next);
+    setPage(0);
+  }
+
+  function changeQuery(next: string) {
+    setQuery(next);
+    setPage(0);
+  }
+
+  const statusFilters: { id: StatusFilter; label: string; count: number }[] = [
+    { id: "all", label: "All", count: allApps.length },
+    { id: "live", label: "Live", count: liveCount },
+    { id: "drafts", label: "Drafts", count: draftCount },
+  ];
 
   return (
     <AgentsTabLayout activeTab="applications">
       <Flex direction="column" gap="6">
-        <section>
-          {isLoading ? (
-            <ApplicationsSkeleton />
-          ) : isError ? (
-            <AgentDetailEmptyState
-              title="Couldn't load applications"
-              description={
-                error instanceof Error
-                  ? error.message
-                  : "The agent platform API returned an error."
-              }
-            />
-          ) : !applications || applications.length === 0 ? (
-            <AgentDetailEmptyState
-              title="No agents yet"
-              description="Deployed agents on the agent platform will show up here."
-            />
-          ) : (
-            <Flex direction="column" gap="5">
-              <AgentsSection
-                label="Live"
-                apps={liveApps}
-                statsById={statsById}
-              />
-              {draftApps.length > 0 ? (
-                <AgentsSection
-                  label="Drafts"
-                  apps={draftApps}
-                  statsById={statsById}
-                  dimmed
-                />
-              ) : null}
-            </Flex>
-          )}
-        </section>
-
-        <OperationalStrip pendingCount={pendingCount} />
-
         {hasAnalytics ? (
           <section>
-            <Flex align="center" justify="between" className="mb-3">
+            <Flex align="center" justify="between" gap="3" className="mb-3">
               <Text className="font-semibold text-[13px] text-gray-12">
                 Activity · last 7 days
               </Text>
@@ -119,7 +131,7 @@ export function AgentApplicationsListView() {
                 <button
                   type="button"
                   onClick={() => openExternalUrl(aiObservabilityUrl)}
-                  className="inline-flex items-center gap-1 text-[12px] text-gray-11 no-underline hover:text-gray-12"
+                  className="inline-flex shrink-0 items-center gap-1 text-[12px] text-gray-11 no-underline hover:text-gray-12"
                 >
                   Open in AI observability
                   <ArrowSquareOutIcon size={12} />
@@ -133,48 +145,127 @@ export function AgentApplicationsListView() {
           </section>
         ) : null}
 
+        <section>
+          {isLoading ? (
+            <ApplicationsSkeleton />
+          ) : isError ? (
+            <AgentDetailEmptyState
+              title="Couldn't load applications"
+              description={
+                error instanceof Error
+                  ? error.message
+                  : "The agent platform API returned an error."
+              }
+            />
+          ) : allApps.length === 0 ? (
+            <AgentDetailEmptyState
+              title="No agents yet"
+              description="Deployed agents on the agent platform will show up here."
+            />
+          ) : (
+            <Flex direction="column" gap="3">
+              <Flex align="center" justify="between" gap="3" wrap="wrap">
+                <div className="relative min-w-0 flex-1 sm:max-w-xs">
+                  <MagnifyingGlassIcon
+                    size={13}
+                    className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 text-gray-10"
+                  />
+                  <input
+                    type="search"
+                    value={query}
+                    onChange={(e) => changeQuery(e.currentTarget.value)}
+                    placeholder="Search agents…"
+                    aria-label="Search agents"
+                    className="h-8 w-full rounded-(--radius-2) border border-border bg-(--color-panel-solid) pr-2 pl-8 text-[12.5px]"
+                  />
+                </div>
+                <Flex gap="2" wrap="wrap" className="shrink-0">
+                  {statusFilters.map((f) => (
+                    <button
+                      key={f.id}
+                      type="button"
+                      onClick={() => changeStatus(f.id)}
+                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12px] ${
+                        status === f.id
+                          ? "border-(--accent-7) bg-(--accent-3) text-gray-12"
+                          : "border-border text-gray-11 hover:border-(--gray-7)"
+                      }`}
+                    >
+                      {f.label}
+                      <span className="text-[11px] text-gray-10 tabular-nums">
+                        {f.count}
+                      </span>
+                    </button>
+                  ))}
+                </Flex>
+              </Flex>
+
+              {pageItems.length === 0 ? (
+                <AgentDetailEmptyState
+                  title="No matching agents"
+                  description="No agents match your search and filters."
+                />
+              ) : (
+                <Flex direction="column" gap="2">
+                  {pageItems.map((app) => (
+                    <ApplicationRow
+                      key={app.id}
+                      application={app}
+                      stats={statsById.get(app.id)}
+                    />
+                  ))}
+                </Flex>
+              )}
+
+              {filtered.length > 0 ? (
+                <Flex
+                  align="center"
+                  justify="between"
+                  gap="3"
+                  wrap="wrap"
+                  className="pt-1"
+                >
+                  <Text className="text-[11px] text-gray-10 tabular-nums">
+                    Showing {safePage * PAGE_SIZE + 1}–
+                    {safePage * PAGE_SIZE + pageItems.length} of{" "}
+                    {filtered.length}
+                  </Text>
+                  {pageCount > 1 ? (
+                    <Flex align="center" gap="2">
+                      <Button
+                        variant="soft"
+                        size="1"
+                        disabled={safePage === 0}
+                        onClick={() => setPage((p) => Math.max(0, p - 1))}
+                      >
+                        Previous
+                      </Button>
+                      <Text className="text-[11px] text-gray-10 tabular-nums">
+                        {safePage + 1} / {pageCount}
+                      </Text>
+                      <Button
+                        variant="soft"
+                        size="1"
+                        disabled={safePage >= pageCount - 1}
+                        onClick={() =>
+                          setPage((p) => Math.min(pageCount - 1, p + 1))
+                        }
+                      >
+                        Next
+                      </Button>
+                    </Flex>
+                  ) : null}
+                </Flex>
+              ) : null}
+            </Flex>
+          )}
+        </section>
+
+        <OperationalStrip pendingCount={pendingCount} />
+
         <AgentFleetLiveSessionsPanel />
       </Flex>
     </AgentsTabLayout>
-  );
-}
-
-/** A labeled group of agent rows; `dimmed` softens drafts so live agents
- * dominate the visual hierarchy. */
-function AgentsSection({
-  label,
-  apps,
-  statsById,
-  dimmed,
-}: {
-  label: string;
-  apps: AgentApplication[];
-  statsById: Map<string, AgentAnalyticsAgentRow>;
-  dimmed?: boolean;
-}) {
-  if (apps.length === 0) return null;
-  return (
-    <Flex direction="column" gap="2">
-      <Flex align="center" gap="2">
-        <Text className="text-[11px] text-gray-10 uppercase tracking-wide">
-          {label}
-        </Text>
-        <Text className="text-[11px] text-gray-9 tabular-nums">
-          {apps.length}
-        </Text>
-      </Flex>
-      <div className={dimmed ? "opacity-70" : undefined}>
-        <Flex direction="column" gap="2">
-          {apps.map((app) => (
-            <ApplicationRow
-              key={app.id}
-              application={app}
-              stats={statsById.get(app.id)}
-            />
-          ))}
-        </Flex>
-      </div>
-    </Flex>
   );
 }
 

--- a/packages/ui/src/features/agent-applications/components/AgentApprovalsPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentApprovalsPane.tsx
@@ -43,8 +43,8 @@ export function AgentApprovalsPane({
     : null;
 
   const filters = (
-    <Flex align="center" justify="between" gap="3">
-      <Flex gap="1.5" wrap="wrap">
+    <Flex align="center" justify="between" gap="3" wrap="wrap">
+      <Flex gap="2" wrap="wrap" className="min-w-0">
         {APPROVAL_FILTERS.map((f) => (
           <button
             key={f.id}

--- a/packages/ui/src/features/agent-applications/components/AgentDetailLayout.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentDetailLayout.tsx
@@ -173,22 +173,24 @@ export function AgentDetailLayout({
             {application.description}
           </Text>
         ) : null}
-        <Flex gap="1" className="-mb-px">
-          {TABS.map((tab) => (
-            <Link
-              key={tab.id}
-              to={tab.to}
-              params={{ idOrSlug }}
-              className={`border-b-2 px-3 pb-2.5 text-[12.5px] no-underline ${
-                tab.id === activeTab
-                  ? "border-(--accent-9) font-medium text-gray-12"
-                  : "border-transparent text-gray-11 hover:text-gray-12"
-              }`}
-            >
-              {tab.label}
-            </Link>
-          ))}
-        </Flex>
+        <div className="scrollbar-overlay -mb-px">
+          <Flex gap="1" className="w-max">
+            {TABS.map((tab) => (
+              <Link
+                key={tab.id}
+                to={tab.to}
+                params={{ idOrSlug }}
+                className={`shrink-0 whitespace-nowrap border-b-2 px-3 pb-2.5 text-[12.5px] no-underline ${
+                  tab.id === activeTab
+                    ? "border-(--accent-9) font-medium text-gray-12"
+                    : "border-transparent text-gray-11 hover:text-gray-12"
+                }`}
+              >
+                {tab.label}
+              </Link>
+            ))}
+          </Flex>
+        </div>
       </Flex>
 
       {(() => {

--- a/packages/ui/src/features/agent-applications/components/AgentFleetApprovalsPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentFleetApprovalsPane.tsx
@@ -74,8 +74,8 @@ export function AgentFleetApprovalsPane({
   useSetAgentBuilderPage({ kind: "agent-list" });
 
   const filters = (
-    <Flex align="center" justify="between" gap="3">
-      <Flex gap="1.5" wrap="wrap">
+    <Flex align="center" justify="between" gap="3" wrap="wrap">
+      <Flex gap="2" wrap="wrap" className="min-w-0">
         {APPROVAL_FILTERS.map((f) => (
           <button
             key={f.id}

--- a/packages/ui/src/features/agent-applications/components/AgentMemoryPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentMemoryPane.tsx
@@ -28,7 +28,7 @@ export function AgentMemoryPane({ idOrSlug }: { idOrSlug: string }) {
   return (
     <AgentDetailLayout idOrSlug={idOrSlug} activeTab="memory" fill>
       <Flex direction="column" className="h-full min-h-0">
-        <Flex gap="1" className="shrink-0 border-(--gray-5) border-b px-4 py-2">
+        <Flex gap="2" className="shrink-0 border-(--gray-5) border-b px-4 py-2">
           {(["files", "tables"] as const).map((v) => (
             <button
               key={v}

--- a/packages/ui/src/features/agent-applications/components/AgentSessionsPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentSessionsPane.tsx
@@ -64,8 +64,8 @@ export function AgentSessionsPane({ idOrSlug }: { idOrSlug: string }) {
   return (
     <AgentDetailLayout idOrSlug={idOrSlug} activeTab="sessions">
       <Flex direction="column" gap="4">
-        <Flex align="center" justify="between" gap="3">
-          <Flex gap="1.5" wrap="wrap">
+        <Flex align="center" gap="3" wrap="wrap">
+          <Flex gap="2" wrap="wrap" className="min-w-0 flex-1">
             {FILTERS.map((f) => (
               <button
                 key={f.id}
@@ -81,13 +81,13 @@ export function AgentSessionsPane({ idOrSlug }: { idOrSlug: string }) {
               </button>
             ))}
           </Flex>
-          <Flex align="center" gap="3" className="shrink-0">
+          <Flex align="center" gap="3" wrap="wrap" className="min-w-0 shrink-0">
             {users.length > 0 ? (
               <select
                 value={userId}
                 onChange={(e) => changeUser(e.target.value)}
                 aria-label="Filter by user"
-                className="rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-2 py-1 text-[12px] text-gray-12"
+                className="min-w-0 max-w-full rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-2 py-1 text-[12px] text-gray-12"
               >
                 <option value="all">All users</option>
                 {users.map((u) => (


### PR DESCRIPTION
## Summary

General fixes and enhancements across the **agent-applications** UI. Targets `agent-builder-cross-project-approvals` (not `main`) since the whole agent-applications feature lives on that branch — so this diff is just the UI changes.

- **Activity first** — moved the 7-day Activity KPI strip to the **top** of the Applications view, above the fleet list.
- **Agents list: search + filter + paging** — added a search box (matches name / slug / description), status filter pills (**All / Live / Drafts** with counts), and client-side paging (8/page, Prev / Next + "Showing X–Y of Z"). Live agents sort ahead of drafts; new "No matching agents" empty state for filtered-to-empty.
- **Pill spacing** — filter pills were `gap="1.5"`, which isn't a valid Radix space token (rendered ~0 gap → bunched). Bumped pill groups to `gap="2"` across sessions, approvals, fleet approvals, and the memory files/tables toggle.
- **Responsive sessions toolbar** — the filter/search row now wraps so the user `<select>` + refresh no longer overflow on narrow widths (select gets `min-w-0 max-w-full`). Same wrap applied to the approvals toolbars.
- **Memory keeps focus on dock toggle** — toggling the agent builder dock used to swap the layout between bare `children` and a `PanelGroup`, remounting the entire `/code/agents` subtree and resetting the memory pane's selected file. The content panel is now **always mounted**; only the dock panel + resize handle toggle. This also preserves sessions filters and scroll position across toggles.
- **Scrollable detail tabs** — the 8-tab agent detail bar is now horizontally scrollable (`scrollbar-overlay`, thin auto-hiding bar) when the pane is too narrow. Left the top-level Scouts/Applications bar alone — 2 short tabs that won't overflow, and its underline uses per-tab `-mb-px` that `overflow-y:hidden` would clip.

## Files

- `AgentApplicationsListView.tsx` — activity-first reorder + search/filter/paging
- `AgentBuilderDockLayout.tsx` — keep content panel mounted across dock toggle
- `AgentDetailLayout.tsx` — scrollable tab bar
- `AgentSessionsPane.tsx`, `AgentApprovalsPane.tsx`, `AgentFleetApprovalsPane.tsx`, `AgentMemoryPane.tsx` — pill spacing + responsive toolbars

## Test plan

- [x] `biome check` (lint + format) — clean
- [x] `tsc --noEmit` for `@posthog/ui` (via `turbo typecheck`, deps built) — passes
- [ ] Manual: search/filter/page the agents list; toggle the dock on the Memory tab and confirm the open file stays selected; narrow the window and confirm the sessions toolbar wraps and the detail tabs scroll

> Static verification only (lint + typecheck); not yet driven in the running Electron app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)