### PR TITLE
feat(tasks): warm cloud sandbox while composing, reuse on submit

### DIFF
--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -219,6 +219,109 @@ describe("PostHogAPIClient", () => {
     );
   });
 
+  describe("warmTask", () => {
+    function makeClient(fetch: ReturnType<typeof vi.fn>) {
+      const client = new PostHogAPIClient(
+        "http://localhost:8000",
+        async () => "token",
+        async () => "token",
+        123,
+      );
+      (
+        client as unknown as {
+          api: { baseUrl: string; fetcher: { fetch: typeof fetch } };
+        }
+      ).api = { baseUrl: "http://localhost:8000", fetcher: { fetch } };
+      return client;
+    }
+
+    it("posts the repository + integration + branch and returns the warm run identifiers", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () =>
+          JSON.stringify({ task_id: "task-1", run_id: "run-1" }),
+      });
+      const client = makeClient(fetch);
+
+      await expect(
+        client.warmTask({
+          repository: "PostHog/posthog",
+          github_integration: 42,
+          branch: "feature/warm",
+        }),
+      ).resolves.toEqual({ task_id: "task-1", run_id: "run-1" });
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "post",
+          path: "/api/projects/123/tasks/warm/",
+          overrides: {
+            body: JSON.stringify({
+              repository: "PostHog/posthog",
+              github_integration: 42,
+              branch: "feature/warm",
+            }),
+          },
+        }),
+      );
+    });
+
+    it("sends a null branch when none is provided", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () =>
+          JSON.stringify({ task_id: "task-1", run_id: "run-1" }),
+      });
+      const client = makeClient(fetch);
+
+      await client.warmTask({
+        repository: "PostHog/posthog",
+        github_integration: 42,
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrides: {
+            body: JSON.stringify({
+              repository: "PostHog/posthog",
+              github_integration: 42,
+              branch: null,
+            }),
+          },
+        }),
+      );
+    });
+
+    it("returns null on an empty 200 body (feature disabled / capped / no-op)", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => "",
+      });
+      const client = makeClient(fetch);
+
+      await expect(
+        client.warmTask({
+          repository: "PostHog/posthog",
+          github_integration: 42,
+        }),
+      ).resolves.toBeNull();
+    });
+
+    it("throws on a non-ok response", async () => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValue({ ok: false, statusText: "Bad Request" });
+      const client = makeClient(fetch);
+
+      await expect(
+        client.warmTask({
+          repository: "PostHog/posthog",
+          github_integration: 42,
+        }),
+      ).rejects.toThrow("Bad Request");
+    });
+  });
+
   describe("getSignalReport", () => {
     function makeClient(fetch: ReturnType<typeof vi.fn>) {
       const client = new PostHogAPIClient(

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2136,6 +2136,7 @@ export class PostHogAPIClient {
       > & {
         github_integration?: number | null;
         github_user_integration?: string | null;
+        branch?: string | null;
       },
   ) {
     const teamId = await this.getTeamId();
@@ -2269,6 +2270,36 @@ export class PostHogAPIClient {
     );
 
     return data as unknown as Task;
+  }
+
+  async warmTask(options: {
+    repository: string;
+    github_integration: number;
+    branch?: string | null;
+  }): Promise<{ task_id: string; run_id: string } | null> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/warm/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path: urlPath,
+      overrides: {
+        body: JSON.stringify({
+          repository: options.repository,
+          github_integration: options.github_integration,
+          branch: options.branch ?? null,
+        }),
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to warm task: ${response.statusText}`);
+    }
+    const text = await response.text();
+    if (!text) {
+      return null;
+    }
+    return JSON.parse(text) as { task_id: string; run_id: string };
   }
 
   async prepareTaskStagedArtifactUploads(

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -477,6 +477,10 @@ export class TaskCreationSaga extends Saga<
             : "user_created",
           // The server associates the task with the report and records the implementation
           // task_run artefact — no relationship label is sent (associations are unlabelled).
+          branch:
+            input.workspaceMode === "cloud"
+              ? (input.branch ?? null)
+              : undefined,
           signal_report: input.signalReportId ?? undefined,
         });
         return result as unknown as Task;

--- a/packages/shared/src/flags.ts
+++ b/packages/shared/src/flags.ts
@@ -7,3 +7,4 @@ export const DISCOVERY_RUN_FLAG = "posthog-code-discovery-run";
 // Gates the entire canvas feature: the app rail's Channels space, the /website
 // routes, channels and dashboards.
 export const PROJECT_BLUEBIRD_FLAG = "project-bluebird";
+export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -32,6 +32,7 @@ import {
   getBranchNameInputState,
 } from "../../git-interaction/utils/branchCreation";
 import { useInboxReportSelectionStore } from "../../inbox/stores/inboxReportSelectionStore";
+import { useIntegrationSelectors } from "../../integrations/store";
 import {
   useUserGithubBranches,
   useUserGithubRepositories,
@@ -55,6 +56,7 @@ import {
 import { useInitialDirectoryFromFolderId } from "../hooks/useInitialDirectoryFromFolderId";
 import { usePreviewConfig } from "../hooks/usePreviewConfig";
 import { useTaskCreation } from "../hooks/useTaskCreation";
+import { useWarmTask } from "../hooks/useWarmTask";
 import { CloudGithubMissingNotice } from "./CloudGithubMissingNotice";
 import {
   type SuggestedPrompt,
@@ -308,6 +310,17 @@ export function TaskInput({
   const selectedInstallationId = selectedCloudRepository
     ? getInstallationIdForRepo(selectedCloudRepository)
     : undefined;
+
+  const { githubIntegrations: orgGithubIntegrations } =
+    useIntegrationSelectors();
+  const orgGithubIntegrationId = orgGithubIntegrations[0]?.id;
+  useWarmTask({
+    workspaceMode,
+    selectedRepository: selectedCloudRepository,
+    githubIntegrationId: orgGithubIntegrationId,
+    branch: workspaceMode === "cloud" ? selectedBranch : null,
+    editorIsEmpty,
+  });
 
   const {
     data: cloudBranchData,

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -228,6 +228,9 @@ export function useTaskCreation({
 
       const content = contentOverride ?? editor.getContent();
       const plainPromptText = contentToPlainText(content).trim();
+      const serializedContent = contentToXml(content).trim();
+      const filePaths = extractFilePaths(content);
+
       const shouldShowPendingView = !onTaskCreated && !!plainPromptText;
       const pendingTaskKey = shouldShowPendingView
         ? (globalThis.crypto?.randomUUID?.() ?? `pending-${Date.now()}`)
@@ -255,8 +258,6 @@ export function useTaskCreation({
           }
         }
 
-        const serializedContent = contentToXml(content).trim();
-        const filePaths = extractFilePaths(content);
         const input = prepareTaskInput(serializedContent, filePaths, {
           // In channels chat-box mode no repo is attached up front, even if a
           // directory/repo is lingering in the persisted picker state.

--- a/packages/ui/src/features/task-detail/hooks/useWarmTask.test.tsx
+++ b/packages/ui/src/features/task-detail/hooks/useWarmTask.test.tsx
@@ -1,0 +1,177 @@
+import type { WorkspaceMode } from "@posthog/shared";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClient = vi.hoisted(() => ({
+  warmTask: vi.fn(),
+}));
+const flagState = vi.hoisted(() => ({ enabled: true }));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => mockClient,
+}));
+vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
+  useFeatureFlag: () => flagState.enabled,
+}));
+vi.mock("../../../shell/logger", () => ({
+  logger: { scope: () => ({ warn: vi.fn(), error: vi.fn() }) },
+}));
+
+import { useWarmTask } from "./useWarmTask";
+
+interface Props {
+  workspaceMode: WorkspaceMode;
+  selectedRepository?: string | null;
+  githubIntegrationId?: number;
+  branch?: string | null;
+  editorIsEmpty: boolean;
+}
+
+const cloudTyping: Props = {
+  workspaceMode: "cloud",
+  selectedRepository: "acme/repo",
+  githubIntegrationId: 42,
+  branch: "main",
+  editorIsEmpty: false,
+};
+
+describe("useWarmTask", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    flagState.enabled = true;
+    mockClient.warmTask.mockResolvedValue({
+      task_id: "task-1",
+      run_id: "run-1",
+    });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  async function flushDebounce(): Promise<void> {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+  }
+
+  it("fires a debounced warm when cloud + repo + typing", async () => {
+    renderHook((props: Props) => useWarmTask(props), {
+      initialProps: cloudTyping,
+    });
+
+    expect(mockClient.warmTask).not.toHaveBeenCalled();
+
+    await flushDebounce();
+
+    expect(mockClient.warmTask).toHaveBeenCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "main",
+    });
+  });
+
+  it.each<{ name: string; props?: Partial<Props>; flagEnabled?: boolean }>([
+    { name: "the flag is off", flagEnabled: false },
+    { name: "not in cloud mode", props: { workspaceMode: "local" } },
+    { name: "no repository is selected", props: { selectedRepository: null } },
+    {
+      name: "no github integration",
+      props: { githubIntegrationId: undefined },
+    },
+    { name: "the editor is empty", props: { editorIsEmpty: true } },
+  ])("does not fire when $name", async ({ props, flagEnabled }) => {
+    if (flagEnabled === false) {
+      flagState.enabled = false;
+    }
+    renderHook((p: Props) => useWarmTask(p), {
+      initialProps: { ...cloudTyping, ...props },
+    });
+    await flushDebounce();
+    expect(mockClient.warmTask).not.toHaveBeenCalled();
+  });
+
+  it("fires once the editor becomes non-empty", async () => {
+    const { rerender } = renderHook((props: Props) => useWarmTask(props), {
+      initialProps: { ...cloudTyping, editorIsEmpty: true },
+    });
+    await flushDebounce();
+    expect(mockClient.warmTask).not.toHaveBeenCalled();
+
+    rerender(cloudTyping);
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-fire for the same selection (backend dedups, client guards)", async () => {
+    const { rerender } = renderHook((props: Props) => useWarmTask(props), {
+      initialProps: cloudTyping,
+    });
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenCalledOnce();
+
+    rerender({ ...cloudTyping });
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenCalledOnce();
+  });
+
+  it("warms the new selection when the repository changes (no release)", async () => {
+    const { rerender } = renderHook((props: Props) => useWarmTask(props), {
+      initialProps: cloudTyping,
+    });
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenCalledOnce();
+
+    rerender({ ...cloudTyping, selectedRepository: "acme/other" });
+    await flushDebounce();
+
+    expect(mockClient.warmTask).toHaveBeenLastCalledWith({
+      repository: "acme/other",
+      github_integration: 42,
+      branch: "main",
+    });
+    expect(mockClient.warmTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("warms the new selection when the branch changes (no release)", async () => {
+    const { rerender } = renderHook((props: Props) => useWarmTask(props), {
+      initialProps: cloudTyping,
+    });
+    await flushDebounce();
+
+    rerender({ ...cloudTyping, branch: "feature/x" });
+    await flushDebounce();
+
+    expect(mockClient.warmTask).toHaveBeenLastCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "feature/x",
+    });
+    expect(mockClient.warmTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("warms again for a new selection after a failed warm", async () => {
+    mockClient.warmTask.mockRejectedValueOnce(new Error("boom"));
+    const { rerender } = renderHook((props: Props) => useWarmTask(props), {
+      initialProps: cloudTyping,
+    });
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenCalledOnce();
+
+    rerender({ ...cloudTyping, branch: "feature/x" });
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows warm errors without throwing", async () => {
+    mockClient.warmTask.mockRejectedValue(new Error("boom"));
+    renderHook((props: Props) => useWarmTask(props), {
+      initialProps: cloudTyping,
+    });
+
+    await expect(flushDebounce()).resolves.not.toThrow();
+    expect(mockClient.warmTask).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
+++ b/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
@@ -1,0 +1,92 @@
+import {
+  TASKS_PREWARM_SANDBOX_FLAG,
+  type WorkspaceMode,
+} from "@posthog/shared";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useEffect, useRef } from "react";
+import { logger } from "../../../shell/logger";
+
+const log = logger.scope("warm-task");
+
+const WARM_DEBOUNCE_MS = 600;
+
+interface UseWarmTaskOptions {
+  workspaceMode: WorkspaceMode;
+  selectedRepository?: string | null;
+  githubIntegrationId?: number;
+  branch?: string | null;
+  editorIsEmpty: boolean;
+}
+
+export function useWarmTask({
+  workspaceMode,
+  selectedRepository,
+  githubIntegrationId,
+  branch,
+  editorIsEmpty,
+}: UseWarmTaskOptions): void {
+  const enabled = useFeatureFlag(TASKS_PREWARM_SANDBOX_FLAG);
+  const client = useOptionalAuthenticatedClient();
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastWarmedKeyRef = useRef<string | null>(null);
+
+  const isCloud = workspaceMode === "cloud";
+  const normalizedBranch = branch ?? null;
+  const eligible =
+    enabled &&
+    isCloud &&
+    !!client &&
+    !!selectedRepository &&
+    githubIntegrationId !== undefined &&
+    !editorIsEmpty;
+  const key =
+    selectedRepository && githubIntegrationId !== undefined
+      ? `${githubIntegrationId}:${selectedRepository}:${normalizedBranch ?? ""}`
+      : null;
+
+  useEffect(() => {
+    const clearDebounce = (): void => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+
+    if (!eligible || !key || !selectedRepository || !client) {
+      clearDebounce();
+      return;
+    }
+    if (lastWarmedKeyRef.current === key || debounceRef.current) {
+      return;
+    }
+
+    const repository = selectedRepository;
+    const githubIntegration = githubIntegrationId as number;
+    const warmBranch = normalizedBranch;
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      lastWarmedKeyRef.current = key;
+      void client
+        .warmTask({
+          repository,
+          github_integration: githubIntegration,
+          branch: warmBranch,
+        })
+        .catch((error) => {
+          lastWarmedKeyRef.current = null;
+          log.warn("Failed to warm task", { error });
+        });
+    }, WARM_DEBOUNCE_MS);
+
+    return clearDebounce;
+  }, [
+    eligible,
+    key,
+    client,
+    selectedRepository,
+    githubIntegrationId,
+    normalizedBranch,
+  ]);
+}


### PR DESCRIPTION
## Problem

spawning a cloud task feels slow: the sandbox boot, repo clone, branch checkout, and the agent start all happen after the user hits submit. The user waits through provisioning before the agent does anything, we can try to optimize this lifecycle a bit

## Changes

while the user composes a cloud task, fire an idempotent, debounced `warm(repo, branch)` request so the backend can provision an idling Run ahead of submit. On submit, nothing special happens client-side 

- `useWarmTask`: a fire-and-forget trigger
- the create call now sends the selected `branch` so the backend can match an idling warm Run for the exact selection
