### PR TITLE
feat(scouts): show scout finding tags on the emission card

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -327,6 +327,8 @@ export interface ScoutEmission {
   weight: number;
   confidence: number;
   severity: string | null;
+  /** Slug tags the scout attached to this finding (lowercase kebab-case, e.g. `cost-spike`). */
+  tags: string[];
   source_id: string;
   emitted_at: string;
 }

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -328,7 +328,7 @@ export interface ScoutEmission {
   confidence: number;
   severity: string | null;
   /** Slug tags the scout attached to this finding (lowercase kebab-case, e.g. `cost-spike`). */
-  tags: string[];
+  tags?: string[];
   source_id: string;
   emitted_at: string;
 }

--- a/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
@@ -7,7 +7,7 @@ import { ANALYTICS_EVENTS } from "@posthog/shared";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { track } from "@posthog/ui/shell/analytics";
-import { Box, Flex, Text } from "@radix-ui/themes";
+import { Badge, Box, Flex, Text } from "@radix-ui/themes";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { SeverityBadge } from "./ScoutBadges";
 import { ScoutLinkedReportChip } from "./ScoutLinkedReportChip";
@@ -91,6 +91,21 @@ export function ScoutEmissionCard({
       >
         <MarkdownRenderer content={emission.description} />
       </Box>
+      {emission.tags?.length ? (
+        <Flex gap="1" mt="2" wrap="wrap">
+          {emission.tags.map((tag) => (
+            <Badge
+              key={tag}
+              variant="soft"
+              color="gray"
+              size="1"
+              className="text-[11px]"
+            >
+              {tag}
+            </Badge>
+          ))}
+        </Flex>
+      ) : null}
       {expanded ? (
         <Flex
           align="center"


### PR DESCRIPTION
## Problem

Scouts attach category tags (lowercase kebab-case slugs like `kafka`, `latency-regression`, `cost-spike`) to every finding they emit. These already render on the finding card in the **report detail view** (`SignalCard`), but the **scout detail page** emission cards don't show them — even though the data is in the API response. The tags are a quick at-a-glance signal of what a finding is about, so it's worth surfacing them when browsing a scout's emissions too.

This mirrors the equivalent change in the main `posthog/posthog` repo (PostHog/posthog#65543), keeping the desktop app's scout page consistent with the web inbox.

## Changes

- Added the missing `tags: string[]` field to the `ScoutEmission` interface in `packages/api-client`. The backend `SignalScoutEmissionSerializer` already returns `tags`; the hand-maintained client type just wasn't declaring it, so the data was arriving and being dropped.
- Rendered a tag-chip row in `ScoutEmissionCard`, directly under the description, reusing the same Radix `Badge variant="soft" color="gray" size="1"` styling the report `SignalCard` already uses for tags — so the two surfaces look consistent. The row is omitted when a finding has no tags, and renders in both collapsed and expanded states.

No backend changes — purely surfacing data that was already returned.

## How did you test this?

I'm an agent (Claude Code). I did not run the app manually. Automated checks run:

- `biome check` on both edited files — clean, no fixes needed.
- `turbo typecheck --filter=@posthog/ui --filter=@posthog/api-client` — all tasks pass.
- Confirmed via `grep` that the backend serializer's `Meta.fields` includes `tags`, so the new client type matches the actual response.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy investigated the scout-driven tags feature, confirmed via the data warehouse that tags are emitted on ~100% of finding rows with a healthy vocabulary, then asked to surface them on the scout emission card here after landing the same change in the web app. We chose chips under the description (rather than inline in the confidence header) to mirror the existing report `SignalCard` and avoid crowding the header — findings average ~4 tags, capped at 10.

Tools: Claude Code (Opus 4.8), Explore subagents for code navigation.
