### PR TITLE
fix(sidebar): clip collapsed sidebar so nav can't overflow page

### DIFF
--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -68,6 +68,11 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
         width: open ? `${width}px` : "0",
         minWidth: open ? `${width}px` : "0",
         maxWidth: open ? `${width}px` : "0",
+        // Clip the full-width inner content when collapsed so the nav can't paint
+        // outside the zero-width box and overlap the page (e.g. inbox/agents,
+        // which leave that region transparent). Keep overflow visible when open
+        // so the resize handle, positioned just outside the edge, stays clickable.
+        overflow: open ? "visible" : "hidden",
         transition: isResizing ? "none" : "width 0.2s ease-in-out",
         borderLeft: !isLeft && open ? "1px solid var(--border)" : "none",
         borderRight: isLeft && open ? "1px solid var(--border)" : "none",

--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -68,10 +68,6 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
         width: open ? `${width}px` : "0",
         minWidth: open ? `${width}px` : "0",
         maxWidth: open ? `${width}px` : "0",
-        // Clip the full-width inner content when collapsed so the nav can't paint
-        // outside the zero-width box and overlap the page (e.g. inbox/agents,
-        // which leave that region transparent). Keep overflow visible when open
-        // so the resize handle, positioned just outside the edge, stays clickable.
         overflow: open ? "visible" : "hidden",
         transition: isResizing ? "none" : "width 0.2s ease-in-out",
         borderLeft: !isLeft && open ? "1px solid var(--border)" : "none",

--- a/packages/ui/src/shell/HeaderRow.tsx
+++ b/packages/ui/src/shell/HeaderRow.tsx
@@ -27,7 +27,7 @@ import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
-import { isWindows } from "@posthog/ui/utils/platform";
+import { isMac, isWindows } from "@posthog/ui/utils/platform";
 import { Box, Flex } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
@@ -164,6 +164,12 @@ function BluebirdButton() {
 export const HEADER_HEIGHT = 36;
 const COLLAPSED_WIDTH = 110;
 const WINDOWS_TITLEBAR_INSET = 140;
+// On macOS the native close/minimize/zoom buttons sit at the top-left
+// (trafficLightPosition x:12, ~64px wide). When the sidebar is collapsed the
+// left header section shrinks and its right-justified controls would slide
+// under those buttons, so reserve room for them. When the sidebar is open the
+// section is already wide enough that the controls clear the traffic lights.
+const MACOS_TRAFFIC_LIGHT_INSET = 70;
 
 export function HeaderRow() {
   const content = useHeaderStore((state) => state.content);
@@ -209,8 +215,10 @@ export function HeaderRow() {
         px="2"
         pr="3"
         style={{
-          width: sidebarOpen ? `${sidebarWidth}px` : `${COLLAPSED_WIDTH}px`,
-          minWidth: `${COLLAPSED_WIDTH}px`,
+          width: sidebarOpen
+            ? `${sidebarWidth}px`
+            : `${COLLAPSED_WIDTH + (isMac ? MACOS_TRAFFIC_LIGHT_INSET : 0)}px`,
+          minWidth: `${COLLAPSED_WIDTH + (isMac ? MACOS_TRAFFIC_LIGHT_INSET : 0)}px`,
           transition: isResizing ? "none" : "width 0.2s ease-in-out",
         }}
         className="relative h-full gap-2 border-r border-r-(--gray-6)"

--- a/packages/ui/src/shell/HeaderRow.tsx
+++ b/packages/ui/src/shell/HeaderRow.tsx
@@ -164,11 +164,6 @@ function BluebirdButton() {
 export const HEADER_HEIGHT = 36;
 const COLLAPSED_WIDTH = 110;
 const WINDOWS_TITLEBAR_INSET = 140;
-// On macOS the native close/minimize/zoom buttons sit at the top-left
-// (trafficLightPosition x:12, ~64px wide). When the sidebar is collapsed the
-// left header section shrinks and its right-justified controls would slide
-// under those buttons, so reserve room for them. When the sidebar is open the
-// section is already wide enough that the controls clear the traffic lights.
 const MACOS_TRAFFIC_LIGHT_INSET = 70;
 
 export function HeaderRow() {


### PR DESCRIPTION
## Problem

The navbar stayed full-width when collapsed on the **inbox** and **agents** screens, while it collapsed correctly elsewhere. Reported in Slack by the team.

## Changes

The sidebar collapses by setting its outer container's `width`/`minWidth`/`maxWidth` to `0` (`ResizableSidebar.tsx`), but that container never clipped its overflow — the inner `Flex` is still rendered at the full `${width}px`, so the nav painted *outside* the zero-width box and overlapped the page to its right.

On most screens the adjacent page content (`<Box flexGrow="1">`, rendered after the sidebar in the DOM) paints an opaque background over the overflow, hiding it. Inbox (`InboxView`) and agents (`AgentBuilderDockLayout`) leave that top-left region transparent, so the overflowing nav showed through — the "wide" collapsed nav.

Fix: clip the outer container's overflow when collapsed. Overflow stays `visible` when open so the resize handle, positioned just outside the edge, remains clickable.

## How did you test this?

Not run locally (dependencies aren't installed in this environment). Change is a one-line conditional style; behavior should be verified by collapsing the sidebar on the inbox and agents screens and confirming the nav is fully hidden, and that the resize handle still works when expanded.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1782233086950929?thread_ts=1782233086.950929&cid=C09G8Q32R6F)*