### PR TITLE
feat(code-review): collapse resolved and outdated PR comment threads

### DIFF
--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -18,7 +18,13 @@ import { Button } from "@posthog/quill";
 import type { PrReviewComment } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import { Avatar, Badge, Box, Flex, Text } from "@radix-ui/themes";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import type { PluggableList } from "unified";
@@ -44,6 +50,25 @@ function toPreview(body: string): string {
     .replace(/[#>*_`~-]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function ToggleCaret({
+  collapsed,
+  onToggle,
+}: {
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={collapsed ? "Expand thread" : "Collapse thread"}
+      className="-ml-0.5 flex shrink-0 cursor-pointer items-center rounded p-0.5 text-[var(--gray-10)] hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
+    >
+      {collapsed ? <CaretRight size={14} /> : <CaretDown size={14} />}
+    </button>
+  );
 }
 
 interface ThreadActionBarProps {
@@ -177,10 +202,12 @@ function CommentBody({
   comment,
   showLineAbove = false,
   showLineBelow = false,
+  leading,
 }: {
   comment: PrReviewComment;
   showLineAbove?: boolean;
   showLineBelow?: boolean;
+  leading?: ReactNode;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -214,6 +241,7 @@ function CommentBody({
       </div>
       <div className="min-w-0 flex-1 pt-1.5 pb-1.5">
         <Flex align="center" gap="2" className="mb-0.5">
+          {leading}
           <Text className="font-medium text-[13px] text-[var(--gray-12)]">
             {comment.user.login}
           </Text>
@@ -353,65 +381,68 @@ export function PrCommentThread({
     if (!success) setIsResolved(!next);
   }, [isResolved, nodeId, resolve]);
 
+  const toggleCollapsed = useCallback(
+    () => setIsCollapsed((prev) => !prev),
+    [],
+  );
+  const hasBadges = isResolved || isFileLevel || isOutdated;
+
   return (
     <div className="px-3 py-1.5" style={{ contain: "inline-size" }}>
       <div
         data-pr-comment-thread=""
         className={`overflow-hidden whitespace-normal rounded-md border border-[var(--gray-5)] bg-[var(--gray-2)] px-2.5 py-2 font-sans ${isResolved ? "opacity-60" : ""}`}
       >
-        <Flex align="center" gap="1" className={isCollapsed ? "" : "mb-1.5"}>
-          <button
-            type="button"
-            onClick={() => setIsCollapsed((prev) => !prev)}
-            aria-label={isCollapsed ? "Expand thread" : "Collapse thread"}
-            className="-ml-0.5 flex shrink-0 cursor-pointer items-center rounded p-0.5 text-[var(--gray-10)] hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
-          >
-            {isCollapsed ? <CaretRight size={14} /> : <CaretDown size={14} />}
-          </button>
-          {isResolved && (
-            <Badge color="green" size="1" variant="soft">
-              <CheckCircle size={12} weight="fill" />
-              Resolved
-            </Badge>
-          )}
-          {isFileLevel && (
-            <Badge color="gray" size="1" variant="soft">
-              <File size={12} />
-              File comment
-            </Badge>
-          )}
-          {isOutdated && (
-            <Badge color="yellow" size="1" variant="soft">
-              <WarningCircle size={12} weight="fill" />
-              Outdated
-            </Badge>
-          )}
-          {isCollapsed && (
-            <button
-              type="button"
-              onClick={() => setIsCollapsed(false)}
-              className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
-            >
-              <Text className="shrink-0 font-medium text-[13px] text-[var(--gray-12)]">
-                {comments[0]?.user.login}
-              </Text>
-              <Text className="min-w-0 flex-1 truncate text-[13px] text-[var(--gray-10)]">
-                {toPreview(comments[0]?.body ?? "")}
-              </Text>
-              {comments.length > 1 && (
-                <Badge
-                  color="gray"
-                  size="1"
-                  variant="soft"
-                  className="shrink-0"
-                >
-                  <ChatCircle size={11} />
-                  {comments.length}
-                </Badge>
-              )}
-            </button>
-          )}
-        </Flex>
+        {(isCollapsed || hasBadges) && (
+          <Flex align="center" gap="1" className={isCollapsed ? "" : "mb-1.5"}>
+            {isCollapsed && (
+              <ToggleCaret collapsed onToggle={toggleCollapsed} />
+            )}
+            {isResolved && (
+              <Badge color="green" size="1" variant="soft">
+                <CheckCircle size={12} weight="fill" />
+                Resolved
+              </Badge>
+            )}
+            {isFileLevel && (
+              <Badge color="gray" size="1" variant="soft">
+                <File size={12} />
+                File comment
+              </Badge>
+            )}
+            {isOutdated && (
+              <Badge color="yellow" size="1" variant="soft">
+                <WarningCircle size={12} weight="fill" />
+                Outdated
+              </Badge>
+            )}
+            {isCollapsed && (
+              <button
+                type="button"
+                onClick={() => setIsCollapsed(false)}
+                className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+              >
+                <Text className="shrink-0 font-medium text-[13px] text-[var(--gray-12)]">
+                  {comments[0]?.user.login}
+                </Text>
+                <Text className="min-w-0 flex-1 truncate text-[13px] text-[var(--gray-10)]">
+                  {toPreview(comments[0]?.body ?? "")}
+                </Text>
+                {comments.length > 1 && (
+                  <Badge
+                    color="gray"
+                    size="1"
+                    variant="soft"
+                    className="shrink-0"
+                  >
+                    <ChatCircle size={11} />
+                    {comments.length}
+                  </Badge>
+                )}
+              </button>
+            )}
+          </Flex>
+        )}
 
         {!isCollapsed &&
           comments.map((comment, index) => (
@@ -420,6 +451,11 @@ export function PrCommentThread({
               comment={comment}
               showLineAbove={index > 0}
               showLineBelow={index < comments.length - 1 || !!pendingReply}
+              leading={
+                index === 0 ? (
+                  <ToggleCaret collapsed={false} onToggle={toggleCollapsed} />
+                ) : undefined
+              }
             />
           ))}
 

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -417,7 +417,7 @@ export function PrCommentThread({
       >
         <div className="flex gap-1">
           {/* Caret lives in a fixed gutter so it stays put when toggling. */}
-          <div className="shrink-0 pt-1.5">
+          <div className="shrink-0 pt-2.5">
             <ToggleCaret collapsed={isCollapsed} onToggle={toggleCollapsed} />
           </div>
 

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -202,12 +202,12 @@ function CommentBody({
   comment,
   showLineAbove = false,
   showLineBelow = false,
-  leading,
+  badges,
 }: {
   comment: PrReviewComment;
   showLineAbove?: boolean;
   showLineBelow?: boolean;
-  leading?: ReactNode;
+  badges?: ReactNode;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -241,13 +241,13 @@ function CommentBody({
       </div>
       <div className="min-w-0 flex-1 pt-1.5 pb-1.5">
         <Flex align="center" gap="2" className="mb-0.5">
-          {leading}
           <Text className="font-medium text-[13px] text-[var(--gray-12)]">
             {comment.user.login}
           </Text>
           <Text className="text-[13px] text-[var(--gray-9)]">
             {formatRelativeTimeShort(comment.created_at)}
           </Text>
+          {badges}
         </Flex>
         <Box
           ref={contentRef}
@@ -385,7 +385,29 @@ export function PrCommentThread({
     () => setIsCollapsed((prev) => !prev),
     [],
   );
-  const hasBadges = isResolved || isFileLevel || isOutdated;
+
+  const badges = (
+    <>
+      {isResolved && (
+        <Badge color="green" size="1" variant="soft">
+          <CheckCircle size={12} weight="fill" />
+          Resolved
+        </Badge>
+      )}
+      {isFileLevel && (
+        <Badge color="gray" size="1" variant="soft">
+          <File size={12} />
+          File comment
+        </Badge>
+      )}
+      {isOutdated && (
+        <Badge color="yellow" size="1" variant="soft">
+          <WarningCircle size={12} weight="fill" />
+          Outdated
+        </Badge>
+      )}
+    </>
+  );
 
   return (
     <div className="px-3 py-1.5" style={{ contain: "inline-size" }}>
@@ -393,35 +415,20 @@ export function PrCommentThread({
         data-pr-comment-thread=""
         className={`overflow-hidden whitespace-normal rounded-md border border-[var(--gray-5)] bg-[var(--gray-2)] px-2.5 py-2 font-sans ${isResolved ? "opacity-60" : ""}`}
       >
-        {(isCollapsed || hasBadges) && (
-          <Flex align="center" gap="1" className={isCollapsed ? "" : "mb-1.5"}>
-            {isCollapsed && (
-              <ToggleCaret collapsed onToggle={toggleCollapsed} />
-            )}
-            {isResolved && (
-              <Badge color="green" size="1" variant="soft">
-                <CheckCircle size={12} weight="fill" />
-                Resolved
-              </Badge>
-            )}
-            {isFileLevel && (
-              <Badge color="gray" size="1" variant="soft">
-                <File size={12} />
-                File comment
-              </Badge>
-            )}
-            {isOutdated && (
-              <Badge color="yellow" size="1" variant="soft">
-                <WarningCircle size={12} weight="fill" />
-                Outdated
-              </Badge>
-            )}
-            {isCollapsed && (
+        <div className="flex gap-1">
+          {/* Caret lives in a fixed gutter so it stays put when toggling. */}
+          <div className="shrink-0 pt-1.5">
+            <ToggleCaret collapsed={isCollapsed} onToggle={toggleCollapsed} />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            {isCollapsed ? (
               <button
                 type="button"
-                onClick={() => setIsCollapsed(false)}
-                className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+                onClick={toggleCollapsed}
+                className="flex w-full min-w-0 cursor-pointer items-center gap-1.5 py-1.5 text-left"
               >
+                {badges}
                 <Text className="shrink-0 font-medium text-[13px] text-[var(--gray-12)]">
                   {comments[0]?.user.login}
                 </Text>
@@ -440,66 +447,68 @@ export function PrCommentThread({
                   </Badge>
                 )}
               </button>
-            )}
-          </Flex>
-        )}
+            ) : (
+              <>
+                {comments.map((comment, index) => (
+                  <CommentBody
+                    key={comment.id}
+                    comment={comment}
+                    showLineAbove={index > 0}
+                    showLineBelow={
+                      index < comments.length - 1 || !!pendingReply
+                    }
+                    badges={index === 0 ? badges : undefined}
+                  />
+                ))}
 
-        {!isCollapsed &&
-          comments.map((comment, index) => (
-            <CommentBody
-              key={comment.id}
-              comment={comment}
-              showLineAbove={index > 0}
-              showLineBelow={index < comments.length - 1 || !!pendingReply}
-              leading={
-                index === 0 ? (
-                  <ToggleCaret collapsed={false} onToggle={toggleCollapsed} />
-                ) : undefined
-              }
-            />
-          ))}
+                {pendingReply && (
+                  <div className="flex gap-2 opacity-50">
+                    <div className="flex flex-col items-center">
+                      <div className="h-1.5 w-0.5 rounded-full bg-[var(--gray-5)]" />
+                      <Avatar
+                        size="1"
+                        radius="full"
+                        fallback=""
+                        className="shrink-0"
+                      />
+                    </div>
+                    <div className="min-w-0 flex-1 pt-1.5 pb-1.5">
+                      <Flex align="center" gap="2" className="mb-0.5">
+                        <Text className="font-medium text-[13px] text-[var(--gray-12)]">
+                          Sending...
+                        </Text>
+                      </Flex>
+                      <div className="text-[13px] text-[var(--gray-11)] leading-relaxed">
+                        <MarkdownRenderer
+                          content={pendingReply}
+                          rehypePlugins={ghRehypePlugins}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
 
-        {!isCollapsed && pendingReply && (
-          <div className="flex gap-2 opacity-50">
-            <div className="flex flex-col items-center">
-              <div className="h-1.5 w-0.5 rounded-full bg-[var(--gray-5)]" />
-              <Avatar size="1" radius="full" fallback="" className="shrink-0" />
-            </div>
-            <div className="min-w-0 flex-1 pt-1.5 pb-1.5">
-              <Flex align="center" gap="2" className="mb-0.5">
-                <Text className="font-medium text-[13px] text-[var(--gray-12)]">
-                  Sending...
-                </Text>
-              </Flex>
-              <div className="text-[13px] text-[var(--gray-11)] leading-relaxed">
-                <MarkdownRenderer
-                  content={pendingReply}
-                  rehypePlugins={ghRehypePlugins}
+                <ThreadActionBar
+                  prUrl={prUrl}
+                  taskId={taskId}
+                  filePath={filePath}
+                  endLine={endLine}
+                  side={side}
+                  comments={comments}
+                  isResolved={isResolved}
+                  onResolveToggle={handleResolveToggle}
+                  showReplyBox={showReplyBox}
+                  pendingReply={pendingReply}
+                  onShowReplyBox={() => setShowReplyBox(true)}
+                  onHideReplyBox={() => setShowReplyBox(false)}
+                  onSubmitReply={handleReplySubmit}
+                  onKeyDown={handleKeyDown}
+                  textareaRefCallback={setTextareaRefCallback}
                 />
-              </div>
-            </div>
+              </>
+            )}
           </div>
-        )}
-
-        {!isCollapsed && (
-          <ThreadActionBar
-            prUrl={prUrl}
-            taskId={taskId}
-            filePath={filePath}
-            endLine={endLine}
-            side={side}
-            comments={comments}
-            isResolved={isResolved}
-            onResolveToggle={handleResolveToggle}
-            showReplyBox={showReplyBox}
-            pendingReply={pendingReply}
-            onShowReplyBox={() => setShowReplyBox(true)}
-            onHideReplyBox={() => setShowReplyBox(false)}
-            onSubmitReply={handleReplySubmit}
-            onKeyDown={handleKeyDown}
-            textareaRefCallback={setTextareaRefCallback}
-          />
-        )}
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -403,7 +403,7 @@ export function PrCommentThread({
               type="button"
               onClick={toggleCollapsed}
               aria-label={isCollapsed ? "Expand thread" : "Collapse thread"}
-              className="-ml-0.5 flex shrink-0 cursor-pointer items-center rounded p-0.5 text-[var(--gray-10)] transition-colors hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
+              className="-ml-0.5 before:-inset-2 relative flex shrink-0 cursor-pointer items-center rounded p-0.5 text-[var(--gray-10)] transition-colors before:absolute before:content-[''] hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
             >
               <CaretRight
                 size={14}

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -52,25 +52,6 @@ function toPreview(body: string): string {
     .trim();
 }
 
-function ToggleCaret({
-  collapsed,
-  onToggle,
-}: {
-  collapsed: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-label={collapsed ? "Expand thread" : "Collapse thread"}
-      className="-ml-0.5 flex shrink-0 cursor-pointer items-center rounded p-0.5 text-[var(--gray-10)] hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
-    >
-      {collapsed ? <CaretRight size={14} /> : <CaretDown size={14} />}
-    </button>
-  );
-}
-
 interface ThreadActionBarProps {
   prUrl: string | null;
   taskId: string;
@@ -418,11 +399,23 @@ export function PrCommentThread({
         <div className="flex gap-1">
           {/* Caret lives in a fixed gutter so it stays put when toggling. */}
           <div className="shrink-0 pt-2.5">
-            <ToggleCaret collapsed={isCollapsed} onToggle={toggleCollapsed} />
+            <button
+              type="button"
+              onClick={toggleCollapsed}
+              aria-label={isCollapsed ? "Expand thread" : "Collapse thread"}
+              className="-ml-0.5 flex shrink-0 cursor-pointer items-center rounded p-0.5 text-[var(--gray-10)] transition-colors hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
+            >
+              <CaretRight
+                size={14}
+                className={`transition-transform duration-200 ${
+                  isCollapsed ? "" : "rotate-90"
+                }`}
+              />
+            </button>
           </div>
 
           <div className="min-w-0 flex-1">
-            {isCollapsed ? (
+            {isCollapsed && (
               <button
                 type="button"
                 onClick={toggleCollapsed}
@@ -447,8 +440,15 @@ export function PrCommentThread({
                   </Badge>
                 )}
               </button>
-            ) : (
-              <>
+            )}
+
+            {/* Grid-rows trick animates the body height open/closed smoothly. */}
+            <div
+              className={`grid transition-[grid-template-rows] duration-200 ease-out ${
+                isCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]"
+              }`}
+            >
+              <div className="overflow-hidden">
                 {comments.map((comment, index) => (
                   <CommentBody
                     key={comment.id}
@@ -505,8 +505,8 @@ export function PrCommentThread({
                   onKeyDown={handleKeyDown}
                   textareaRefCallback={setTextareaRefCallback}
                 />
-              </>
-            )}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowCounterClockwise,
   CaretDown,
+  CaretRight,
   CaretUp,
   ChatCircle,
   CheckCircle,
@@ -33,6 +34,16 @@ const ghRehypePlugins: PluggableList = [
 ];
 
 const MAX_COMMENT_HEIGHT = 120;
+
+/** Strip markdown noise to a single-line preview for the collapsed header. */
+function toPreview(body: string): string {
+  return body
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/[#>*_`~-]/g, " ")
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
 interface ThreadActionBarProps {
   prUrl: string | null;
@@ -278,6 +289,10 @@ export function PrCommentThread({
   const [showReplyBox, setShowReplyBox] = useState(false);
   const [pendingReply, setPendingReply] = useState<string | null>(null);
   const [isResolved, setIsResolved] = useState(initialIsResolved);
+  // Resolved/outdated threads add up — start them collapsed.
+  const [isCollapsed, setIsCollapsed] = useState(
+    initialIsResolved || isOutdated,
+  );
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
@@ -343,39 +358,71 @@ export function PrCommentThread({
         data-pr-comment-thread=""
         className={`overflow-hidden whitespace-normal rounded-md border border-[var(--gray-5)] bg-[var(--gray-2)] px-2.5 py-2 font-sans ${isResolved ? "opacity-60" : ""}`}
       >
-        {(isResolved || isOutdated || isFileLevel) && (
-          <Flex align="center" gap="1" className="mb-1.5">
-            {isResolved && (
-              <Badge color="green" size="1" variant="soft">
-                <CheckCircle size={12} weight="fill" />
-                Resolved
-              </Badge>
-            )}
-            {isFileLevel && (
-              <Badge color="gray" size="1" variant="soft">
-                <File size={12} />
-                File comment
-              </Badge>
-            )}
-            {isOutdated && (
-              <Badge color="yellow" size="1" variant="soft">
-                <WarningCircle size={12} weight="fill" />
-                Outdated
-              </Badge>
-            )}
-          </Flex>
-        )}
+        <Flex align="center" gap="1" className={isCollapsed ? "" : "mb-1.5"}>
+          <button
+            type="button"
+            onClick={() => setIsCollapsed((prev) => !prev)}
+            aria-label={isCollapsed ? "Expand thread" : "Collapse thread"}
+            className="-ml-0.5 flex shrink-0 cursor-pointer items-center rounded p-0.5 text-[var(--gray-10)] hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
+          >
+            {isCollapsed ? <CaretRight size={14} /> : <CaretDown size={14} />}
+          </button>
+          {isResolved && (
+            <Badge color="green" size="1" variant="soft">
+              <CheckCircle size={12} weight="fill" />
+              Resolved
+            </Badge>
+          )}
+          {isFileLevel && (
+            <Badge color="gray" size="1" variant="soft">
+              <File size={12} />
+              File comment
+            </Badge>
+          )}
+          {isOutdated && (
+            <Badge color="yellow" size="1" variant="soft">
+              <WarningCircle size={12} weight="fill" />
+              Outdated
+            </Badge>
+          )}
+          {isCollapsed && (
+            <button
+              type="button"
+              onClick={() => setIsCollapsed(false)}
+              className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+            >
+              <Text className="shrink-0 font-medium text-[13px] text-[var(--gray-12)]">
+                {comments[0]?.user.login}
+              </Text>
+              <Text className="min-w-0 flex-1 truncate text-[13px] text-[var(--gray-10)]">
+                {toPreview(comments[0]?.body ?? "")}
+              </Text>
+              {comments.length > 1 && (
+                <Badge
+                  color="gray"
+                  size="1"
+                  variant="soft"
+                  className="shrink-0"
+                >
+                  <ChatCircle size={11} />
+                  {comments.length}
+                </Badge>
+              )}
+            </button>
+          )}
+        </Flex>
 
-        {comments.map((comment, index) => (
-          <CommentBody
-            key={comment.id}
-            comment={comment}
-            showLineAbove={index > 0}
-            showLineBelow={index < comments.length - 1 || !!pendingReply}
-          />
-        ))}
+        {!isCollapsed &&
+          comments.map((comment, index) => (
+            <CommentBody
+              key={comment.id}
+              comment={comment}
+              showLineAbove={index > 0}
+              showLineBelow={index < comments.length - 1 || !!pendingReply}
+            />
+          ))}
 
-        {pendingReply && (
+        {!isCollapsed && pendingReply && (
           <div className="flex gap-2 opacity-50">
             <div className="flex flex-col items-center">
               <div className="h-1.5 w-0.5 rounded-full bg-[var(--gray-5)]" />
@@ -397,23 +444,25 @@ export function PrCommentThread({
           </div>
         )}
 
-        <ThreadActionBar
-          prUrl={prUrl}
-          taskId={taskId}
-          filePath={filePath}
-          endLine={endLine}
-          side={side}
-          comments={comments}
-          isResolved={isResolved}
-          onResolveToggle={handleResolveToggle}
-          showReplyBox={showReplyBox}
-          pendingReply={pendingReply}
-          onShowReplyBox={() => setShowReplyBox(true)}
-          onHideReplyBox={() => setShowReplyBox(false)}
-          onSubmitReply={handleReplySubmit}
-          onKeyDown={handleKeyDown}
-          textareaRefCallback={setTextareaRefCallback}
-        />
+        {!isCollapsed && (
+          <ThreadActionBar
+            prUrl={prUrl}
+            taskId={taskId}
+            filePath={filePath}
+            endLine={endLine}
+            side={side}
+            comments={comments}
+            isResolved={isResolved}
+            onResolveToggle={handleResolveToggle}
+            showReplyBox={showReplyBox}
+            pendingReply={pendingReply}
+            onShowReplyBox={() => setShowReplyBox(true)}
+            onHideReplyBox={() => setShowReplyBox(false)}
+            onSubmitReply={handleReplySubmit}
+            onKeyDown={handleKeyDown}
+            textareaRefCallback={setTextareaRefCallback}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -39,8 +39,9 @@ const MAX_COMMENT_HEIGHT = 120;
 function toPreview(body: string): string {
   return body
     .replace(/```[\s\S]*?```/g, " ")
-    .replace(/[#>*_`~-]/g, " ")
     .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[#>*_`~-]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
 }


### PR DESCRIPTION
## Summary

Makes PR comment threads collapsible to cut down on visual noise from resolved and outdated discussions.

https://github.com/user-attachments/assets/3e543289-f372-4919-aa2d-6fbc64f021da


- Adds a caret toggle button to each thread header.
- **Resolved** and **outdated** threads now start collapsed by default.
- When collapsed, the header shows a compact preview: the first comment's author, a single-line markdown-stripped preview of the body (via a new `toPreview` helper), and a reply-count badge when the thread has more than one comment.
- When collapsed, the comment bodies, pending reply, and `ThreadActionBar` are hidden; expanding restores the full thread.

## Test plan

- Open a PR review with resolved/outdated threads and confirm they render collapsed with the preview header.
- Toggle the caret to expand/collapse; confirm bodies, pending replies, and the action bar show/hide accordingly.
- Confirm active (unresolved, in-range) threads still default to expanded.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*