### PR TITLE
feat(ui): make code blocks distinct from comment background

### DIFF
--- a/packages/ui/src/primitives/CodeBlock.tsx
+++ b/packages/ui/src/primitives/CodeBlock.tsx
@@ -44,7 +44,7 @@ export function CodeBlock({ children, size = "1" }: CodeBlockProps) {
   return (
     <div className="group relative">
       <pre
-        className={`m-0 mb-3 overflow-x-auto whitespace-pre rounded-(--radius-2) border border-(--gray-4) bg-(--gray-2) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
+        className={`m-0 mb-3 overflow-x-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
       >
         {children}
       </pre>


### PR DESCRIPTION
## Problem

Code blocks rendered inside comment/finding bodies blended into the cards wrapping them. The shared `CodeBlock` primitive used a `gray-2` fill — the same color as the PR comment card around it — with a faint `gray-4` border, so fenced code blocks were nearly indistinguishable from the surrounding comment.

## Changes

Before:
<img width="2652" height="698" alt="CleanShot 2026-06-23 at 16 20 21@2x" src="https://github.com/user-attachments/assets/9521233e-3bbc-4722-a1db-faa0dbdf69bb" />

After:
<img width="2620" height="668" alt="CleanShot 2026-06-23 at 16 20 10@2x" src="https://github.com/user-attachments/assets/db7b3cd2-bec1-47f9-8d2b-3decbadac4db" />


- Bumped the `<pre>` fill from `gray-2` to `gray-3` and the border from `gray-4` to `gray-6`, so code blocks read as a distinct, slightly recessed panel.
- Single-file change to the shared `CodeBlock` primitive — PR comment threads, scout emission cards, and signal cards all benefit at once.
- `gray-3`/`gray-6` are mode-aware Radix steps, so light and dark mode both stay correct.

## How did you test this?

- Ran `pnpm --filter @posthog/ui typecheck` — passes.
- Did not visually verify in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*