### PR TITLE
Add model selection to freeform canvas generation

### DIFF
--- a/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
@@ -1,6 +1,9 @@
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useGenerateFreeformCanvas } from "@posthog/ui/features/canvas/hooks/useGenerateFreeformCanvas";
-import { Button, Flex, Spinner, TextArea } from "@radix-ui/themes";
+import { flattenSelectOptions } from "@posthog/ui/features/sessions/sessionStore";
+import { usePreviewConfig } from "@posthog/ui/features/task-detail/hooks/usePreviewConfig";
+import { Button, Flex, Select, Spinner, TextArea } from "@radix-ui/themes";
+import { useMemo, useState } from "react";
 
 // Composer that kicks off freeform canvas generation as a dedicated task: the
 // user describes what they want and the agent builds + publishes the canvas. No
@@ -40,10 +43,36 @@ export function FreeformGenerateBar({
   const setDraft = onValueChange;
   const isEdit = !!currentCode?.trim();
 
+  // Model picker for the generation task. We default to Sonnet (faster) so we
+  // can compare its canvas output against the gateway default (Opus). Options
+  // come from the same preview-config query the task input uses, so only models
+  // the gateway actually offers are selectable.
+  const { modelOption } = usePreviewConfig("claude");
+  const modelOptions = useMemo(() => {
+    const raw =
+      modelOption?.type === "select"
+        ? flattenSelectOptions(modelOption.options)
+        : [];
+    // ACP config values are string | boolean | number; model ids are always
+    // strings, so narrow to those and drop anything unexpected.
+    return raw.flatMap((m) =>
+      typeof m.value === "string" ? [{ value: m.value, name: m.name }] : [],
+    );
+  }, [modelOption]);
+  const defaultModel = useMemo(() => {
+    const sonnet = modelOptions.find((m) => m.value.includes("sonnet"));
+    const current = modelOption?.currentValue;
+    return (
+      sonnet?.value ?? (typeof current === "string" ? current : undefined)
+    );
+  }, [modelOptions, modelOption]);
+  const [selectedModel, setSelectedModel] = useState<string | undefined>();
+  const model = selectedModel ?? defaultModel;
+
   const run = async () => {
     const instruction = draft.trim();
     if (!instruction) return;
-    const taskId = await generate({ instruction, currentCode });
+    const taskId = await generate({ instruction, currentCode, model });
     if (taskId) {
       setDraft("");
       onStarted?.(taskId);
@@ -67,7 +96,26 @@ export function FreeformGenerateBar({
         rows={3}
         disabled={isStarting}
       />
-      <Flex align="center" justify="end" gap="2">
+      <Flex align="center" justify="between" gap="2">
+        {modelOptions.length > 0 ? (
+          <Select.Root
+            size="1"
+            value={model}
+            onValueChange={setSelectedModel}
+            disabled={isStarting}
+          >
+            <Select.Trigger variant="soft" aria-label="Generation model" />
+            <Select.Content>
+              {modelOptions.map((m) => (
+                <Select.Item key={m.value} value={m.value}>
+                  {m.name}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        ) : (
+          <span />
+        )}
         <Button
           size="2"
           variant="solid"

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -53,6 +53,9 @@ export function useGenerateFreeformCanvas(args: {
     async (opts: {
       instruction: string;
       currentCode?: string;
+      // Which model the generation task runs on. Omitted falls back to the
+      // gateway default; the generate bar defaults this to Sonnet for speed.
+      model?: string;
     }): Promise<string | null> => {
       setIsStarting(true);
       try {
@@ -71,6 +74,7 @@ export function useGenerateFreeformCanvas(args: {
             allowNoRepo: true,
             channelContext,
             channelName,
+            model: opts.model,
           },
           (output) => invalidateTasks(output.task),
         );


### PR DESCRIPTION
## Problem

The freeform canvas generation bar currently uses a fixed model for generation tasks. We need to allow users to select which Claude model to use, defaulting to Sonnet for faster generation while still supporting other available models from the gateway.

## Changes

- Added a model picker dropdown to `FreeformGenerateBar` that displays available Claude models from the preview-config query
- Defaults to Sonnet model if available, otherwise falls back to the gateway default
- Only shows models that the gateway actually offers (via `flattenSelectOptions`)
- Updated `useGenerateFreeformCanvas` hook to accept and pass through an optional `model` parameter to the generation task
- Reorganized the button layout to accommodate the new model selector on the left with action buttons on the right

The model selection is disabled while generation is in progress and respects the same preview-config that the task input uses, ensuring consistency.

## How did you test this?

N/A - This is a UI feature addition that integrates with existing preview-config infrastructure. The model parameter is optional and falls back to gateway defaults when not specified.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

https://claude.ai/code/session_01K7TJ3A76WVYdhbGBdxy5Pz