### PR TITLE
fix(canvas): stop local generation stranding the canvas on "Generating"

### DIFF
--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -17,7 +17,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
-import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { isCanvasGenerationRunning } from "@posthog/ui/features/canvas/freeform/canvasGenerationStatus";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import {
   useFreeformChatStore,
@@ -91,26 +91,21 @@ export function FreeformCanvasView({
     reset: onResetToDefault,
   } = useHomeCanvasReset({ channelId, dashboardId, threadId });
 
-  // Run status: cloud reports via cloudStatus / latest_run.status; local is tied
-  // to the live ACP session. Assume running while the task record loads.
+  // Run status derivation (cloud vs local) lives in a pure, tested helper; a
+  // terminal run record always ends "running" so a stale session can't strand
+  // the canvas on "Generating".
   const { data: genTask, isLoading: genTaskLoading } = useQuery({
     ...taskDetailQuery(genTaskId ?? ""),
     enabled: !!genTaskId,
     refetchInterval: genTaskId ? 5000 : false,
   });
   const genSession = useSessionForTask(genTaskId ?? undefined);
-  const running = (() => {
-    if (!genTaskId) return false;
-    if (genTaskLoading) return true;
-    if (genTask?.latest_run?.environment === "cloud") {
-      const cloudStatus =
-        genSession?.cloudStatus ?? genTask?.latest_run?.status ?? null;
-      return !isTerminalStatus(cloudStatus);
-    }
-    return (
-      genSession?.status === "connecting" || genSession?.status === "connected"
-    );
-  })();
+  const running = isCanvasGenerationRunning({
+    genTaskId,
+    genTaskLoading,
+    latestRun: genTask?.latest_run,
+    session: genSession,
+  });
   const isGenerating = !!genTaskId && running;
 
   // Poll the record while generating so a just-published canvas appears.

--- a/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
+++ b/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
@@ -58,6 +58,19 @@ describe("isCanvasGenerationRunning", () => {
     ).toBe(expected);
   });
 
+  it("is running when loaded with no run record yet but a connected session", () => {
+    // A task whose first run hasn't been created falls through to the local
+    // path; isTerminalStatus(undefined) is false, so a live session decides.
+    expect(
+      isCanvasGenerationRunning({
+        genTaskId: "t1",
+        genTaskLoading: false,
+        latestRun: undefined,
+        session: session("connected"),
+      }),
+    ).toBe(true);
+  });
+
   it.each<[string, Run, Session | undefined, boolean]>([
     [
       "session connected",

--- a/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
+++ b/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
@@ -1,0 +1,106 @@
+import type { AgentSession } from "@posthog/shared";
+import type { TaskRun, TaskRunStatus } from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import { isCanvasGenerationRunning } from "./canvasGenerationStatus";
+
+type Run = Pick<TaskRun, "environment" | "status">;
+type Session = Pick<AgentSession, "status" | "cloudStatus">;
+
+const run = (environment: "local" | "cloud", status: TaskRunStatus): Run => ({
+  environment,
+  status,
+});
+const session = (
+  status: AgentSession["status"],
+  cloudStatus?: TaskRunStatus,
+): Session => ({ status, cloudStatus });
+
+describe("isCanvasGenerationRunning", () => {
+  it("is not running when there is no generation task", () => {
+    expect(
+      isCanvasGenerationRunning({
+        genTaskId: null,
+        genTaskLoading: false,
+        latestRun: undefined,
+        session: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("assumes running while the task record is still loading", () => {
+    expect(
+      isCanvasGenerationRunning({
+        genTaskId: "t1",
+        genTaskLoading: true,
+        latestRun: undefined,
+        session: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it.each<[string, Run, Session | undefined, boolean]>([
+    ["in_progress, no session", run("cloud", "in_progress"), undefined, true],
+    [
+      "session cloudStatus terminal overrides run record",
+      run("cloud", "in_progress"),
+      session("connected", "completed"),
+      false,
+    ],
+    ["run record terminal", run("cloud", "failed"), undefined, false],
+  ])("cloud: %s", (_label, latestRun, sess, expected) => {
+    expect(
+      isCanvasGenerationRunning({
+        genTaskId: "t1",
+        genTaskLoading: false,
+        latestRun,
+        session: sess,
+      }),
+    ).toBe(expected);
+  });
+
+  it.each<[string, Run, Session | undefined, boolean]>([
+    [
+      "session connected",
+      run("local", "in_progress"),
+      session("connected"),
+      true,
+    ],
+    [
+      "session connecting",
+      run("local", "in_progress"),
+      session("connecting"),
+      true,
+    ],
+    ["no live session", run("local", "in_progress"), undefined, false],
+    [
+      "session disconnected",
+      run("local", "in_progress"),
+      session("disconnected"),
+      false,
+    ],
+    // The regression: a terminal run record must stop "running" even if the
+    // live session is still (stale) reporting connected — otherwise the canvas
+    // is stranded on "Generating" forever.
+    [
+      "terminal run wins over stale connected session",
+      run("local", "completed"),
+      session("connected"),
+      false,
+    ],
+    [
+      "failed run wins over stale connected session",
+      run("local", "failed"),
+      session("connected"),
+      false,
+    ],
+  ])("local: %s", (_label, latestRun, sess, expected) => {
+    expect(
+      isCanvasGenerationRunning({
+        genTaskId: "t1",
+        genTaskLoading: false,
+        latestRun,
+        session: sess,
+      }),
+    ).toBe(expected);
+  });
+});

--- a/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
+++ b/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
@@ -1,0 +1,43 @@
+import type { AgentSession } from "@posthog/shared";
+import { isTerminalStatus, type TaskRun } from "@posthog/shared/domain-types";
+
+export interface CanvasGenerationStatusInput {
+  /** The canvas's in-flight generation task id, or null if none. */
+  genTaskId: string | null;
+  /** True while the task record is still loading for the first time. */
+  genTaskLoading: boolean;
+  /** The task's latest run record (carries environment + persisted status). */
+  latestRun: Pick<TaskRun, "environment" | "status"> | undefined;
+  /** The live ACP session for the task, if one is connected in this client. */
+  session: Pick<AgentSession, "status" | "cloudStatus"> | undefined;
+}
+
+// Whether a canvas generation task is still actively running.
+//
+// Cloud and local report progress through different channels:
+//   - cloud: status comes from the live session's `cloudStatus`, falling back to
+//     the persisted run record — running until that status is terminal.
+//   - local: progress is tied to the live ACP session (connecting/connected).
+//     But the session can go stale or stall without cleanly disconnecting, so a
+//     terminal run record (completed/failed/cancelled) ALWAYS wins — otherwise a
+//     hung session pins the canvas in the "Generating" state indefinitely.
+export function isCanvasGenerationRunning({
+  genTaskId,
+  genTaskLoading,
+  latestRun,
+  session,
+}: CanvasGenerationStatusInput): boolean {
+  if (!genTaskId) return false;
+  // Assume running while the task record is still loading.
+  if (genTaskLoading) return true;
+
+  if (latestRun?.environment === "cloud") {
+    const cloudStatus = session?.cloudStatus ?? latestRun?.status ?? null;
+    return !isTerminalStatus(cloudStatus);
+  }
+
+  // Local: a terminal run record means the run is done regardless of a stale or
+  // stuck live session, so it can never strand the canvas on "Generating".
+  if (isTerminalStatus(latestRun?.status)) return false;
+  return session?.status === "connecting" || session?.status === "connected";
+}

--- a/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
+++ b/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
@@ -32,7 +32,7 @@ export function isCanvasGenerationRunning({
   if (genTaskLoading) return true;
 
   if (latestRun?.environment === "cloud") {
-    const cloudStatus = session?.cloudStatus ?? latestRun?.status ?? null;
+    const cloudStatus = session?.cloudStatus ?? latestRun.status;
     return !isTerminalStatus(cloudStatus);
   }
 


### PR DESCRIPTION
## Problem

A freeform canvas generated by a **local** task could get stuck showing "Generating" forever — the "canvas keeps timing out" experience.

`FreeformCanvasView` derives its `running` state differently per environment:
- **cloud** falls back to the persisted run record and stops once `latest_run.status` (or the session `cloudStatus`) is terminal.
- **local** relied *only* on the live ACP session being `connecting`/`connected`.

So if a local session went stale or the agent stalled without cleanly disconnecting, `running` stayed `true`, `isGenerating` never cleared, and the canvas was pinned on the "Generating" empty state with no escape.

## Changes

- Extract the run-status derivation into a pure, unit-tested helper (`canvasGenerationStatus.ts`).
- Give the local path the same terminal-run guard cloud already has: a terminal run record (`completed` / `failed` / `cancelled`) always ends `running`, so a stuck/stale session can no longer strand the canvas. Cloud behavior is unchanged.

## How did you test this?

I'm an agent (PostHog Slack app). I did not drive the desktop app manually. I added `canvasGenerationStatus.test.ts` (11 cases, cloud + local, incl. the regression: a terminal run record must win over a stale `connected` session) — `vitest run` passes locally. `@posthog/ui` typecheck shows no errors in the changed files, and Biome check passes on them.

## Agent context

Investigated from a Slack thread: a user's self-driving canvas "errored out, then kept timing out." Traced his session — the canvas generation ran as a **local** repo-less task (`workspaceMode: "local"`), and the only frontend defect that matches an indefinite "Generating" state is the cloud/local asymmetry in the run-status derivation. The canvas's own runtime error renders in the `about:srcdoc` sandbox and isn't captured in our product analytics, so this targets the most likely stuck-state mechanism rather than a specific captured stack trace — worth a sanity check from whoever owns the freeform canvas.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B73C8480P/p1782219329449559?thread_ts=1782219329.449559&cid=C0B73C8480P)*
