### PR TITLE
fix(auth): keep a failed session restore from wedging bootstrap

### DIFF
--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -305,7 +305,7 @@ describe("AuthService", () => {
     );
   });
 
-  it("keeps bootstrap restoring when the stored-session restore hangs", async () => {
+  it("completes bootstrap but stays restoring when the stored-session restore hangs", async () => {
     vi.useFakeTimers();
     try {
       seedStoredSession({ selectedProjectId: 42 });
@@ -317,9 +317,12 @@ describe("AuthService", () => {
       await vi.advanceTimersByTimeAsync(20_001);
       await initPromise;
 
+      // bootstrapComplete flips true at the deadline so the renderer leaves the
+      // boot gate; status stays restoring so a late success still upgrades and
+      // the stored session is not treated as a logout.
       expect(service.getState()).toMatchObject({
         status: "restoring",
-        bootstrapComplete: false,
+        bootstrapComplete: true,
         cloudRegion: "us",
         currentProjectId: 42,
       });

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -421,15 +421,20 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       return;
     }
 
-    this.setRestoringState(storedSession);
+    this.setRestoringState(storedSession, false);
 
     try {
       const restore = this.ensureValidSession().then(() => undefined);
       const outcome = await withTimeout(restore, AUTH_BOOTSTRAP_DEADLINE_MS);
       if (outcome.result === "timeout") {
         this.logger.warn(
-          "Auth bootstrap exceeded deadline; keeping stored session in restoring state",
+          "Auth bootstrap exceeded deadline; completing bootstrap while the restore continues in the background",
         );
+        // A stored session that is merely slow to refresh must not strand the
+        // renderer on the boot screen. Complete bootstrap but stay "restoring"
+        // so a late success still upgrades and consumers don't treat the delay
+        // as a logout.
+        this.completeBootstrapWhileRestoring(storedSession);
         restore.catch((error) => {
           this.logger.warn("Background auth restore failed after deadline", {
             error,
@@ -443,11 +448,14 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     }
   }
 
-  private setRestoringState(storedSession: StoredSessionInput): void {
+  private setRestoringState(
+    storedSession: StoredSessionInput,
+    bootstrapComplete: boolean,
+  ): void {
     this.session = null;
     this.updateState({
       status: "restoring",
-      bootstrapComplete: false,
+      bootstrapComplete,
       cloudRegion: storedSession.cloudRegion,
       orgProjectsMap: {},
       currentOrgId: null,
@@ -457,15 +465,23 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     });
   }
 
+  private completeBootstrapWhileRestoring(
+    storedSession: StoredSessionInput,
+  ): void {
+    // Only meaningful while the stored session is still on disk: a rejected
+    // refresh token clears it and publishes a real anonymous state instead.
+    // Transient/offline failures keep the session, so stay "restoring" (no
+    // logout side effects) but flip bootstrapComplete so the renderer leaves
+    // the boot gate rather than stranding on the loading screen.
+    if (this.authSession.getCurrent()) {
+      this.setRestoringState(storedSession, true);
+    }
+  }
+
   private handleStoredSessionRestoreFailure(
     storedSession: StoredSessionInput,
   ): void {
-    // Refresh-token auth errors clear the stored session and publish a real
-    // anonymous state from refreshSession. Transient/offline failures keep the
-    // stored session on disk, so consumers must not treat them as logout.
-    if (this.authSession.getCurrent()) {
-      this.setRestoringState(storedSession);
-    }
+    this.completeBootstrapWhileRestoring(storedSession);
   }
 
   private async ensureValidSession(


### PR DESCRIPTION
## Problem

On boot with a stored session, if the token refresh fails transiently (offline, or the backend returns a 5xx) auth bootstrap stays in the `restoring` state with `bootstrapComplete: false`. The renderer gates the whole app on `bootstrapComplete` (`App.tsx` shows `BootstrapFallback` until it flips true), so it sits on the loading spinner and after 25s shows "PostHog is taking longer than expected to start". There is no escape until the backend recovers and the user reloads.

This reproduces on every boot whenever the configured backend is unreachable. It surfaced in local dev with `VITE_POSTHOG_API_HOST` pointing at a local PostHog that was returning 502 on `/oauth/token/`, but it hits any offline or degraded-network boot with a saved session.

Regression from #2767 ("preserve restoring auth state"), which replaced the prior `completeBootstrapAnonymously()` (it set `bootstrapComplete: true` so the renderer could proceed) with a restoring state that never completes bootstrap. #2582 had originally fixed this same wedge.

## Changes

`packages/core/src/auth/auth.ts`:

- After the bootstrap deadline (`AUTH_BOOTSTRAP_DEADLINE_MS` timeout) or a restore failure, complete bootstrap (`bootstrapComplete: true`) while keeping `status: "restoring"`. The renderer leaves the boot gate, a late background refresh still upgrades to `authenticated` via `syncAuthenticatedSession`, and the stored session stays on disk so the blip is not treated as a logout (no identity reset, no "signed out" toast, queued cloud messages preserved).
- `setRestoringState` now takes an explicit `bootstrapComplete` flag. The initial restoring state (before the deadline) stays `false` so a fast refresh resolves before any UI shows. A new `completeBootstrapWhileRestoring` helper does the post-deadline transition and is shared by the timeout and failure paths (guarded on the stored session still being present, since a rejected refresh token clears it and publishes a real anonymous state instead).

`status: "restoring"` is unchanged, so the existing restoring-state consumers (cloud-message queue suppression in `auth.contribution.ts`, identity-reset suppression in `useAuthSession.ts`) keep working.

## How did you test this?

- `packages/core` auth vitest: 36 passed. Updated the "stored-session restore hangs" test to assert `bootstrapComplete: true` after the deadline (status stays `restoring`); the late-success and shared-refresh tests still pass unchanged.
- `pnpm typecheck` (ran via the pre-commit hook) passed.
- Reproduced live against the running dev app: with the backend returning 502 on `/oauth/token/`, the renderer was stuck on "PostHog is taking longer than expected to start". After the fix built into the running main bundle (verified the live `.vite/build` bundle contained the change), the app leaves the boot gate instead of stranding.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
