### PR TITLE
feat(sidebar): show inbox unread badge as a red dot

### DIFF
--- a/packages/ui/src/features/sidebar/components/items/SidebarCountBadge.tsx
+++ b/packages/ui/src/features/sidebar/components/items/SidebarCountBadge.tsx
@@ -7,11 +7,8 @@ export function SidebarCountBadge({ count, title }: SidebarCountBadgeProps) {
   if (count <= 0) return null;
   return (
     <span
-      className="ml-2 inline-flex shrink-0 items-center justify-center rounded-full bg-(--red-9) p-1 font-medium text-[10px] leading-none"
-      style={{ color: "white" }}
+      className="ml-2 inline-flex h-2 w-2 shrink-0 rounded-full bg-(--red-9)"
       title={title}
-    >
-      {count > 99 ? "99+" : count}
-    </span>
+    />
   );
 }


### PR DESCRIPTION
## Problem

The inbox unread badge in the navbar showed a raw count, including a "99+" overflow. A big, odd number (e.g. 126 PRs) is discouraging rather than helpful — it actively pushes people away from opening the inbox.

## Changes

The badge is now just a small red dot whenever the unread count is greater than zero, instead of rendering the number / "99+".

## How did you test this?

Not tested beyond the code change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782296094653799?thread_ts=1782296094.653799&cid=C09SK2PAGKF)*
