### PR TITLE
fix(inbox): remove Scouts source toggle now that scouts are always-on

### DIFF
--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -58,10 +58,9 @@ Inspect the connected PostHog project and repository, figure out which Self-driv
 const log = logger.scope("agents-setup-task");
 
 /**
- * Source products that count as Responders on this page. `displayValues` also
- * carries the legacy `signals_scout` toggle, but scouts render separately in
- * `ScoutsFleetSection` and are excluded from the responder roster — so they must
- * not inflate the responder counts in `AGENTS_VIEWED`.
+ * Source products that count as Responders on this page. Filtering
+ * `displayValues` through this set keeps non-responder sources out of the
+ * responder counts in `AGENTS_VIEWED`.
  */
 const RESPONDER_SOURCE_PRODUCTS = new Set<ResponderAgentSource>(
   RESPONDER_AGENT_GROUPS.flatMap((group) =>
@@ -100,8 +99,7 @@ export function ConfigureAgentsSection() {
   const trackedHasGithubIntegration = classifyIntegrations(
     integrationsData ?? [],
   ).hasGithubIntegration;
-  // Count only Responder sources; `displayValues` also includes `signals_scout`,
-  // which renders separately and would otherwise inflate the responder counts.
+  // Count only Responder sources so non-responder inputs don't inflate counts.
   const responderEntries = Object.entries(displayValues).filter(([source]) =>
     RESPONDER_SOURCE_PRODUCTS.has(source as ResponderAgentSource),
   );

--- a/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -4,7 +4,6 @@ import {
   BugIcon,
   ChatsIcon,
   CircleNotchIcon,
-  CompassIcon,
   GithubLogoIcon,
   KanbanIcon,
   TicketIcon,
@@ -20,7 +19,6 @@ import { memo, useCallback } from "react";
 export interface SignalSourceValues {
   session_replay: boolean;
   error_tracking: boolean;
-  signals_scout: boolean;
   github: boolean;
   linear: boolean;
   zendesk: boolean;
@@ -300,10 +298,6 @@ export function SignalSourceToggles({
     (checked: boolean) => onToggle("conversations", checked),
     [onToggle],
   );
-  const toggleScouts = useCallback(
-    (checked: boolean) => onToggle("signals_scout", checked),
-    [onToggle],
-  );
   const togglePgAnalyze = useCallback(
     (checked: boolean) => onToggle("pganalyze", checked),
     [onToggle],
@@ -360,18 +354,6 @@ export function SignalSourceToggles({
                 />
               ) : undefined
             }
-          />
-          <SignalSourceToggleCard
-            icon={<CompassIcon size={20} />}
-            label="Scouts"
-            labelSuffix={<Badge color="orange">Beta</Badge>}
-            description="Scheduled agents that sweep this project and surface findings"
-            checked={value.signals_scout}
-            onCheckedChange={toggleScouts}
-            disabled={disabled}
-            syncStatus={sourceStates?.signals_scout?.syncStatus}
-            docsUrl="https://posthog.com/blog/self-driving-product"
-            docsLabel="Scouts"
           />
           {evaluationsUrl && (
             <EvaluationsSection evaluationsUrl={evaluationsUrl} />

--- a/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
+++ b/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
@@ -15,11 +15,10 @@ type SourceType = SignalSourceConfig["source_type"];
 type SetupSourceProduct = "github" | "linear" | "zendesk" | "pganalyze";
 
 const SOURCE_TYPE_MAP: Record<
-  Exclude<SourceProduct, "error_tracking" | "llm_analytics">,
+  Exclude<SourceProduct, "error_tracking" | "llm_analytics" | "signals_scout">,
   SourceType
 > = {
   session_replay: "session_analysis_cluster",
-  signals_scout: "cross_source_issue",
   github: "issue",
   linear: "issue",
   zendesk: "ticket",
@@ -36,7 +35,6 @@ const ERROR_TRACKING_SOURCE_TYPES: SourceType[] = [
 const SOURCE_LABELS: Record<keyof SignalSourceValues, string> = {
   session_replay: "Session replay",
   error_tracking: "Error tracking",
-  signals_scout: "Scouts",
   github: "GitHub Issues",
   linear: "Linear Issues",
   zendesk: "Zendesk Tickets",
@@ -57,7 +55,6 @@ const DATA_WAREHOUSE_SOURCES: Record<
 const ALL_SOURCE_PRODUCTS: (keyof SignalSourceValues)[] = [
   "session_replay",
   "error_tracking",
-  "signals_scout",
   "github",
   "linear",
   "zendesk",
@@ -77,7 +74,6 @@ function computeValues(
   const result: SignalSourceValues = {
     session_replay: false,
     error_tracking: false,
-    signals_scout: false,
     github: false,
     linear: false,
     zendesk: false,
@@ -316,7 +312,7 @@ export function useSignalSourceToggles() {
                 SOURCE_TYPE_MAP[
                   product as Exclude<
                     SourceProduct,
-                    "error_tracking" | "llm_analytics"
+                    "error_tracking" | "llm_analytics" | "signals_scout"
                   >
                 ],
               enabled: true,


### PR DESCRIPTION
## What

Removes the **Scouts** source toggle from the Self-driving sources UI (shown in **Settings → Signal sources**, rendered by `SignalSourceToggles`).

## Why

[PostHog/posthog#65673](https://github.com/PostHog/posthog/pull/65673) removes the per-team "Surface findings in your inbox" toggle for scouts and makes scout findings **fail-open**: a missing `SignalSourceConfig` row now means *enabled* (mirroring the existing always-on pattern for LLM analytics and Replay Vision). Data migration `0049` flips any existing explicit-off rows back on so previously-disabled teams aren't stranded.

Since the cloud backend no longer gates scouts on a config row, the matching client toggle should go too. Leaving it in place would:
- let the client keep writing explicit `signals_scout` config rows the backend is actively retiring, and
- misleadingly read **off** for teams that never had a row (the old `computeValues` default).

## Scope

Enable/disable **toggle only**. `signals_scout` remains a first-class source product everywhere else, per the inbox `CLAUDE.md` note:
- report filtering — `filterOptions.tsx`
- `SOURCE_PRODUCT_META` / `source-product-icons.tsx`
- `SignalCard` scout-name display

Per-scout enable switches in the **scouts fleet** UI (`/api/projects/{id}/signals/scout/`) are a separate control and are **unaffected**.

## Changes

- `SignalSourceToggles.tsx` — drop the Scouts `SignalSourceToggleCard`, its `toggleScouts` callback, the `signals_scout` field on `SignalSourceValues`, and the now-unused `CompassIcon` import.
- `useSignalSourceToggles.ts` — drop `signals_scout` from `SOURCE_TYPE_MAP`, `SOURCE_LABELS`, `ALL_SOURCE_PRODUCTS`, and the `computeValues` default; add it to the `SOURCE_TYPE_MAP` key `Exclude` (scouts are no longer created via this path).
- `ConfigureAgentsSection.tsx` — refresh two comments that referenced the removed toggle; responder-count logic is unchanged (the `RESPONDER_SOURCE_PRODUCTS` filter already excluded scouts).

## Notes / sequencing

Core `signalSourceService.ts` already excluded `signals_scout` from its source-type map, so no core change was needed. Ideally this merges **after** PostHog/posthog#65673 is deployed so users relying on an explicit-on row don't lose the toggle while the backend still honors off-rows.

Typecheck + Biome clean on the changed files; no tests referenced the toggle.