### PR TITLE
fix(inbox): continue existing PR when iterating on a report

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1406,6 +1406,27 @@ describe("AgentServer HTTP Mode", () => {
       delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
     });
 
+    it.each([
+      { label: "Slack", origin: "slack" },
+      { label: "signal_report", origin: "signal_report" },
+    ])(
+      "guards the auto-PR prompt against duplicating an existing PR on $label-origin runs",
+      ({ origin }) => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = origin;
+        const s = createServer();
+        const prompt = (
+          s as unknown as TestableServer
+        ).buildCloudSystemPrompt();
+        // Still the new-PR branch...
+        expect(prompt).toContain("gh pr create --draft");
+        // ...but tells the agent to continue an existing linked PR instead of duplicating.
+        expect(prompt).toContain("implementation_pr_url");
+        expect(prompt).toContain("gh pr checkout <url>");
+        expect(prompt).toMatch(/do not open a second PR/i);
+        delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+      },
+    );
+
     it("returns PR-update prompt for existing PRs on Slack-origin runs", () => {
       process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
       const s = createServer();

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1902,7 +1902,7 @@ ${signedCommitInstructions}
     return `${identityInstructions}
 # Cloud Task Execution
 
-If this work already has an open pull request — for example, the inbox report you fetched already links an implementation PR (its \`implementation_pr_url\`), or the thread references an earlier PR for the same fix — do NOT open a second PR. Check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to it with the \`git_signed_commit\` tool (if the branch is behind its base, call \`git_signed_merge\` first). Only open a new, separate PR when the change is genuinely distinct from the existing one.
+If the work you are being asked to do already has an open pull request — for example, the inbox report you fetched links an implementation PR (its \`implementation_pr_url\`), or this same thread already produced a PR that you are now being asked to revise — do NOT open a second PR. Check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to it with the \`git_signed_commit\` tool (if the branch is behind its base, call \`git_signed_merge\` first). A PR is only the one to continue if it is for this same request; if the thread merely mentions an unrelated or older PR, ignore it. Only open a new, separate PR when the change is genuinely distinct from the existing one.
 
 Otherwise, after completing the requested changes:
 1. Pick a new branch name prefixed with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`)

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1902,7 +1902,9 @@ ${signedCommitInstructions}
     return `${identityInstructions}
 # Cloud Task Execution
 
-After completing the requested changes:
+If this work already has an open pull request — for example, the inbox report you fetched already links an implementation PR (its \`implementation_pr_url\`), or the thread references an earlier PR for the same fix — do NOT open a second PR. Check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to it with the \`git_signed_commit\` tool (if the branch is behind its base, call \`git_signed_merge\` first). Only open a new, separate PR when the change is genuinely distinct from the existing one.
+
+Otherwise, after completing the requested changes:
 1. Pick a new branch name prefixed with \`posthog-code/\` (e.g. \`posthog-code/fix-login-redirect\`)
 2. Stage your changes with \`git add\`, then call the \`git_signed_commit\` tool with \`branch\` set to that name and a clear \`message\` (do NOT use \`git commit\`/\`git push\` — they are blocked). The tool creates the branch on the remote and a signed commit on it.
 3. Before opening the PR, prepare the body:

--- a/packages/core/src/inbox/reportActions.test.ts
+++ b/packages/core/src/inbox/reportActions.test.ts
@@ -35,6 +35,16 @@ describe("buildCreatePrReportPrompt", () => {
     expect(prompt).toMatch(/open a PR/i);
   });
 
+  it("tells the agent to continue an existing linked PR instead of opening a duplicate", () => {
+    const prompt = buildCreatePrReportPrompt({
+      reportId: "abc123",
+      isDevBuild: false,
+    });
+    expect(prompt).toContain("implementation_pr_url");
+    expect(prompt).toMatch(/gh pr checkout/i);
+    expect(prompt).toMatch(/do not open a second PR/i);
+  });
+
   it("tells the agent to stop rather than guess if the report can't be fetched", () => {
     const prompt = buildCreatePrReportPrompt({
       reportId: "abc123",

--- a/packages/core/src/inbox/reportActions.ts
+++ b/packages/core/src/inbox/reportActions.ts
@@ -37,7 +37,7 @@ export function buildCreatePrReportPrompt({
   feedback,
 }: BuildCreatePrReportPromptOptions): string {
   const reportLink = `${getDeeplinkProtocol(isDevBuild)}://inbox/${reportId}`;
-  const base = `Act on PostHog inbox report ${reportId} ([inbox item](${reportLink})). Use the inbox MCP tools to fetch the report, its contributing findings, and any suggested reviewers; investigate the root cause; implement the fix; and open a PR. If you can't fetch the report, stop and report that instead of guessing what it contains.`;
+  const base = `Act on PostHog inbox report ${reportId} ([inbox item](${reportLink})). Use the inbox MCP tools to fetch the report, its contributing findings, any suggested reviewers, and any implementation PR already linked to it; investigate the root cause; and implement the fix.\n\nIf the report already has a linked implementation PR (check the report's \`implementation_pr_url\`) and it is still open, you are iterating on existing work: check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to that same PR. Do NOT open a second PR for the same fix. Otherwise, open a PR. Only open a separate PR alongside an existing one when the user's feedback clearly asks for a distinct change.\n\nIf you can't fetch the report, stop and report that instead of guessing what it contains.`;
   const trimmedFeedback = feedback?.trim();
   if (!trimmedFeedback) return base;
   return `${base}\n\nAdditional feedback from the user (take this into account, including any questions raised in the report thread):\n${trimmedFeedback}`;


### PR DESCRIPTION
## Problem

Re-tagging an inbox report (e.g. from the #signals Slack channel) that already has a linked PR starts a fresh agent run. A fresh run had no `slack_notified_pr_url` in its TaskRun state, so the agent fell into the "create a new branch / `gh pr create --draft`" path and opened a **duplicate PR** — it never consulted the report's own `implementation_pr_url`. Reported via Slack feedback; the intended workflow is for follow-up instructions on a report to continue the existing PR.

**Why:** Users iterating on an already-PR'd report were getting a second PR for the same fix instead of new commits on the existing one.

## Changes

- `buildCreatePrReportPrompt` now tells the agent to fetch any linked implementation PR and, if one is open, `gh pr checkout` it and commit to that branch instead of opening a duplicate.
- The cloud auto-publish system prompt (`buildCloudSystemPrompt`) gains the same guard, so `signal_report`/Slack runs continue an existing PR even when the user prompt is built server-side. A genuinely distinct change can still get its own PR.

## How did you test this?

- `pnpm --filter @posthog/core test reportActions` — 18 tests pass, including a new case asserting the continue-existing-PR guidance.
- Typechecked the touched packages and ran Biome lint on the changed files (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1782299209260959)*
