### PR TITLE
feat(agent-applications): session search matches conversation text

### DIFF
--- a/packages/shared/src/agent-platform-types.ts
+++ b/packages/shared/src/agent-platform-types.ts
@@ -470,7 +470,7 @@ export interface AgentSessionsListParams {
   agent_user_id?: string;
   created_after?: string;
   created_before?: string;
-  /** Case-insensitive server-side match over the session id and external key. */
+  /** Case-insensitive server-side match over the conversation text, id, and external key. */
   search?: string;
 }
 

--- a/packages/ui/src/features/agent-applications/components/AgentSessionsPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentSessionsPane.tsx
@@ -103,7 +103,7 @@ export function AgentSessionsPane({ idOrSlug }: { idOrSlug: string }) {
               type="search"
               value={queryInput}
               onChange={(e) => changeQuery(e.currentTarget.value)}
-              placeholder="Search by id or external key…"
+              placeholder="Search conversations…"
               aria-label="Search sessions"
               className="h-8 w-full rounded-(--radius-2) border border-border bg-(--color-panel-solid) pr-2 pl-8 text-[12.5px]"
             />


### PR DESCRIPTION
Frontend counterpart to PostHog/posthog#65764 (the persisted `search_text` digest that makes session search cover transcripts).

The session search box already sends `?search=`; that PR makes the backend match the conversation text (not just id / external_key). This aligns the UI copy:

- Placeholder: `Search by id or external key…` → **`Search conversations…`**
- `AgentSessionsListParams.search` doc updated to mention the conversation text.

No behaviour change on this side — purely the copy/doc that was narrowed when transcript search was deferred for scale. Merge alongside (or after) #65764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
