### PR TITLE
feat(slot-machine): pull a real lever to send when slot machine mode is on

### DIFF
--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -4,6 +4,7 @@ import { ArrowUp, Stop } from "@phosphor-icons/react";
 import { InputGroup, InputGroupAddon, InputGroupButton } from "@posthog/quill";
 import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { cycleModeOption } from "@posthog/ui/features/sessions/sessionStore";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { hasOpenOverlay } from "@posthog/ui/utils/overlay";
 import { Flex, Text, Tooltip } from "@radix-ui/themes";
 import { EditorContent } from "@tiptap/react";
@@ -17,6 +18,7 @@ import { useTiptapEditor } from "../tiptap/useTiptapEditor";
 import type { EditorHandle } from "../types";
 import { AttachmentMenu } from "./AttachmentMenu";
 import { AttachmentsBar } from "./AttachmentsBar";
+import { SlotMachineSubmit } from "./SlotMachineSubmit";
 
 export type { EditorHandle };
 
@@ -107,6 +109,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
   ) => {
     const focusRequested = useDraftStore((s) => s.focusRequested[sessionId]);
     const clearFocusRequest = useDraftStore((s) => s.actions.clearFocusRequest);
+    const slotMachineMode = useSettingsStore((s) => s.slotMachineMode);
     const { data: skills } = useSkills();
 
     const {
@@ -278,13 +281,17 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       e.stopPropagation();
     }, []);
 
-    const handleSubmitClick = (e: React.MouseEvent) => {
-      e.stopPropagation();
+    const doSubmit = useCallback(() => {
       if (onSubmitClick) {
         onSubmitClick();
       } else {
         submit();
       }
+    }, [onSubmitClick, submit]);
+
+    const handleSubmitClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      doSubmit();
     };
 
     const submitBlocked = submitDisabledExternal || isEmpty;
@@ -292,92 +299,100 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       submitTooltipOverride ??
       (submitBlocked ? "Enter a message" : "Send message");
 
-    const submitButton =
-      isLoading && onCancel ? (
-        <Tooltip content="Stop">
-          <InputGroupButton
-            variant="destructive"
-            size="icon-sm"
-            onClick={onCancel}
-            aria-label="Stop"
-          >
-            <Stop size={14} weight="fill" />
-          </InputGroupButton>
-        </Tooltip>
-      ) : (
-        <Tooltip content={submitTooltip}>
-          <InputGroupButton
-            variant="primary"
-            size="icon-sm"
-            onClick={handleSubmitClick}
-            disabled={submitBlocked}
-            aria-label="Send message"
-            {...(tourTarget && { "data-tour": `${tourTarget}-submit` })}
-          >
-            <ArrowUp size={14} weight="bold" />
-          </InputGroupButton>
-        </Tooltip>
-      );
+    // Stop takes priority over everything: you cancel a run, you don't gamble
+    // on it. With slot machine mode on, the send affordance moves out to the
+    // pull-lever mounted beside the composer, so the toolbar slot is empty.
+    const inStopMode = isLoading && !!onCancel;
+    const submitButton = inStopMode ? (
+      <Tooltip content="Stop">
+        <InputGroupButton
+          variant="destructive"
+          size="icon-sm"
+          onClick={onCancel}
+          aria-label="Stop"
+        >
+          <Stop size={14} weight="fill" />
+        </InputGroupButton>
+      </Tooltip>
+    ) : slotMachineMode ? null : (
+      <Tooltip content={submitTooltip}>
+        <InputGroupButton
+          variant="primary"
+          size="icon-sm"
+          onClick={handleSubmitClick}
+          disabled={submitBlocked}
+          aria-label="Send message"
+          {...(tourTarget && { "data-tour": `${tourTarget}-submit` })}
+        >
+          <ArrowUp size={14} weight="bold" />
+        </InputGroupButton>
+      </Tooltip>
+    );
 
     return (
       <Flex direction="column" gap="1">
-        <InputGroup
-          onClick={handleContainerClick}
-          onContextMenu={handleContextMenu}
-          className={`h-auto cursor-text bg-card ${isBashMode ? "ring-1 ring-blue-9" : "focus-within:ring-1 focus-within:ring-purple-9"}`}
-          {...(tourTarget && {
-            "data-tour": `${tourTarget}-editor`,
-            "data-tour-ready": !isEmpty ? "true" : undefined,
-          })}
-        >
-          {attachments.length > 0 && (
-            <InputGroupAddon align="block-start">
-              <AttachmentsBar
-                attachments={attachments}
-                onRemove={removeAttachment}
-              />
-            </InputGroupAddon>
-          )}
-          <div
-            className={clsx(
-              "cli-editor-scroll relative min-h-[50px] w-full flex-1 overflow-y-auto px-2 py-2 text-[14px]",
-              editorHeight === "large" ? "max-h-[45vh]" : "max-h-[200px]",
-            )}
+        <Flex gap="2" align="stretch">
+          <InputGroup
+            onClick={handleContainerClick}
+            onContextMenu={handleContextMenu}
+            className={`h-auto flex-1 cursor-text bg-card ${isBashMode ? "ring-1 ring-blue-9" : "focus-within:ring-1 focus-within:ring-purple-9"}`}
+            {...(tourTarget && {
+              "data-tour": `${tourTarget}-editor`,
+              "data-tour-ready": !isEmpty ? "true" : undefined,
+            })}
           >
-            <EditorContent editor={editor} />
-          </div>
-          <InputGroupAddon align="block-end" className="p-1">
-            <AttachmentMenu
-              disabled={disabled}
-              repoPath={repoPath}
-              taskId={taskId}
-              onAddAttachment={addAttachment}
-              onAttachFiles={onAttachFiles}
-              onInsertChip={insertChip}
-              onRemoveChip={removeChipById}
-            />
-            {modeOption && onModeChange && (
-              <ModeSelector
-                modeOption={modeOption}
-                onChange={onModeChange}
-                allowBypassPermissions={allowBypassPermissions}
+            {attachments.length > 0 && (
+              <InputGroupAddon align="block-start">
+                <AttachmentsBar
+                  attachments={attachments}
+                  onRemove={removeAttachment}
+                />
+              </InputGroupAddon>
+            )}
+            <div
+              className={clsx(
+                "cli-editor-scroll relative min-h-[50px] w-full flex-1 overflow-y-auto px-2 py-2 text-[14px]",
+                editorHeight === "large" ? "max-h-[45vh]" : "max-h-[200px]",
+              )}
+            >
+              <EditorContent editor={editor} />
+            </div>
+            <InputGroupAddon align="block-end" className="p-1">
+              <AttachmentMenu
                 disabled={disabled}
+                repoPath={repoPath}
+                taskId={taskId}
+                onAddAttachment={addAttachment}
+                onAttachFiles={onAttachFiles}
+                onInsertChip={insertChip}
+                onRemoveChip={removeChipById}
               />
-            )}
-            {modelSelector && <span>{modelSelector}</span>}
-            {reasoningSelector && <span>{reasoningSelector}</span>}
-            {messagingModeToggle && <span>{messagingModeToggle}</span>}
-            {isBashMode && (
-              <Text className="font-mono text-(--blue-9) text-[13px]">
-                ! bash
-              </Text>
-            )}
-            <span className="ml-auto flex items-center gap-1">
-              {historyButton}
-              {submitButton}
-            </span>
-          </InputGroupAddon>
-        </InputGroup>
+              {modeOption && onModeChange && (
+                <ModeSelector
+                  modeOption={modeOption}
+                  onChange={onModeChange}
+                  allowBypassPermissions={allowBypassPermissions}
+                  disabled={disabled}
+                />
+              )}
+              {modelSelector && <span>{modelSelector}</span>}
+              {reasoningSelector && <span>{reasoningSelector}</span>}
+              {messagingModeToggle && <span>{messagingModeToggle}</span>}
+              {isBashMode && (
+                <Text className="font-mono text-(--blue-9) text-[13px]">
+                  ! bash
+                </Text>
+              )}
+              <span className="ml-auto flex items-center gap-1">
+                {historyButton}
+                {submitButton}
+              </span>
+            </InputGroupAddon>
+          </InputGroup>
+          {slotMachineMode && !inStopMode && (
+            <SlotMachineSubmit disabled={submitBlocked} onSubmit={doSubmit} />
+          )}
+        </Flex>
       </Flex>
     );
   },

--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -390,7 +390,11 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
             </InputGroupAddon>
           </InputGroup>
           {slotMachineMode && !inStopMode && (
-            <SlotMachineSubmit disabled={submitBlocked} onSubmit={doSubmit} />
+            <SlotMachineSubmit
+              disabled={submitBlocked}
+              onSubmit={doSubmit}
+              tourTarget={tourTarget}
+            />
           )}
         </Flex>
       </Flex>

--- a/packages/ui/src/features/message-editor/components/SlotMachineSubmit.tsx
+++ b/packages/ui/src/features/message-editor/components/SlotMachineSubmit.tsx
@@ -1,0 +1,69 @@
+import { Tooltip } from "@radix-ui/themes";
+import { motion, useAnimationControls } from "framer-motion";
+import { useCallback } from "react";
+
+interface SlotMachineSubmitProps {
+  /** Blocks the pull and greys out the handle (empty editor / external block). */
+  disabled: boolean;
+  /** Fires the prompt. Called on the lever's downswing. */
+  onSubmit: () => void;
+}
+
+/**
+ * A real slot-machine arm mounted to the right of the composer. Stands in for
+ * the send button while the `slotMachineMode` easter egg is enabled — pull the
+ * lever to fire your prompt. Every run is a gamble. 🎰
+ */
+export function SlotMachineSubmit({
+  disabled,
+  onSubmit,
+}: SlotMachineSubmitProps) {
+  const lever = useAnimationControls();
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (disabled) return;
+      // Swing the arm down and let it spring back, firing the prompt on the
+      // downswing so the send feels like the pull caused it.
+      void lever.start({
+        rotate: [0, 72, 0],
+        transition: {
+          duration: 0.55,
+          times: [0, 0.4, 1],
+          ease: ["easeIn", "easeOut"],
+        },
+      });
+      onSubmit();
+    },
+    [disabled, lever, onSubmit],
+  );
+
+  return (
+    <Tooltip
+      content={disabled ? "Enter a message" : "Pull to gamble on your task 🎰"}
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled}
+        aria-label="Pull the slot machine lever to send"
+        className="group relative flex w-9 shrink-0 cursor-pointer items-end justify-center self-stretch disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {/* Housing the arm pivots out of, bolted to the side of the machine. */}
+        <span className="-translate-x-1/2 absolute bottom-0 left-1/2 h-3 w-5 rounded-t-[3px] bg-gradient-to-b from-gray-7 to-gray-9 shadow-sm" />
+        <span className="-translate-x-1/2 absolute bottom-[5px] left-1/2 h-[3px] w-[3px] rounded-full bg-gray-11" />
+
+        {/* The arm: a chrome shaft topped with the red ball, pivoting at base. */}
+        <motion.span
+          animate={lever}
+          style={{ originX: 0.5, originY: 1 }}
+          className="relative z-10 mb-[7px] flex flex-col items-center"
+        >
+          <span className="h-[14px] w-[14px] rounded-full bg-gradient-to-br from-red-8 to-red-10 shadow-[0_1px_2px_rgba(0,0,0,0.35),inset_0_1px_1px_rgba(255,255,255,0.5)] group-hover:from-red-7 group-hover:to-red-9" />
+          <span className="h-[26px] w-[4px] rounded-full bg-gradient-to-r from-gray-8 via-gray-6 to-gray-9" />
+        </motion.span>
+      </button>
+    </Tooltip>
+  );
+}

--- a/packages/ui/src/features/message-editor/components/SlotMachineSubmit.tsx
+++ b/packages/ui/src/features/message-editor/components/SlotMachineSubmit.tsx
@@ -12,6 +12,12 @@ interface SlotMachineSubmitProps {
   disabled: boolean;
   /** Fires the prompt. Called on the lever's downswing. */
   onSubmit: () => void;
+  /**
+   * Tour anchor prefix. When set, the lever carries `data-tour="<target>-submit"`
+   * so the create-first-task tour's submit step can still find and advance off
+   * it while slot machine mode is enabled.
+   */
+  tourTarget?: string;
 }
 
 /**
@@ -22,6 +28,7 @@ interface SlotMachineSubmitProps {
 export function SlotMachineSubmit({
   disabled,
   onSubmit,
+  tourTarget,
 }: SlotMachineSubmitProps) {
   const lever = useAnimationControls();
   const submitTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -67,6 +74,7 @@ export function SlotMachineSubmit({
         disabled={disabled}
         aria-label="Pull the slot machine lever to send"
         className="group relative flex w-9 shrink-0 cursor-pointer items-end justify-center self-stretch disabled:cursor-not-allowed disabled:opacity-40"
+        {...(tourTarget && { "data-tour": `${tourTarget}-submit` })}
       >
         {/* Housing the arm pivots out of, bolted to the side of the machine. */}
         <span className="-translate-x-1/2 absolute bottom-0 left-1/2 h-3 w-5 rounded-t-[3px] bg-gradient-to-b from-gray-7 to-gray-9 shadow-sm" />

--- a/packages/ui/src/features/message-editor/components/SlotMachineSubmit.tsx
+++ b/packages/ui/src/features/message-editor/components/SlotMachineSubmit.tsx
@@ -1,6 +1,11 @@
 import { Tooltip } from "@radix-ui/themes";
 import { motion, useAnimationControls } from "framer-motion";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
+
+// The arm reaches the bottom of its swing at ~270ms (0.45 of the 0.6s tween).
+// Fire the prompt there so the pull visibly completes before submitting flips
+// the composer into loading and unmounts the lever.
+const SUBMIT_DELAY_MS = 260;
 
 interface SlotMachineSubmitProps {
   /** Blocks the pull and greys out the handle (empty editor / external block). */
@@ -19,22 +24,35 @@ export function SlotMachineSubmit({
   onSubmit,
 }: SlotMachineSubmitProps) {
   const lever = useAnimationControls();
+  const submitTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Don't leave a pending submit timer to fire after the lever unmounts.
+  useEffect(() => {
+    return () => {
+      if (submitTimeout.current !== null) {
+        clearTimeout(submitTimeout.current);
+      }
+    };
+  }, []);
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
       if (disabled) return;
-      // Swing the arm down and let it spring back, firing the prompt on the
-      // downswing so the send feels like the pull caused it.
+      // Swing the arm down and let it spring back. The submit is deferred to
+      // the bottom of the swing so the pull plays out before the prompt fires.
       void lever.start({
         rotate: [0, 72, 0],
         transition: {
-          duration: 0.55,
-          times: [0, 0.4, 1],
+          duration: 0.6,
+          times: [0, 0.45, 1],
           ease: ["easeIn", "easeOut"],
         },
       });
-      onSubmit();
+      if (submitTimeout.current !== null) {
+        clearTimeout(submitTimeout.current);
+      }
+      submitTimeout.current = setTimeout(onSubmit, SUBMIT_DELAY_MS);
     },
     [disabled, lever, onSubmit],
   );

--- a/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
+++ b/packages/ui/src/features/sessions/components/SlotMachineLever.tsx
@@ -1,10 +1,24 @@
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
-import { Box, Flex, Tooltip } from "@radix-ui/themes";
-import { motion, useAnimationControls } from "framer-motion";
+import { fireFrom } from "@posthog/ui/primitives/confetti";
+import { motion } from "framer-motion";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Reel faces. The hedgehog is the jackpot symbol. */
 const REEL_SYMBOLS = ["🍒", "🍋", "🔔", "⭐", "💎", "7️⃣", "🦔"] as const;
+
+/** How often spinning reels swap faces, in ms. */
+const SPIN_INTERVAL_MS = 80;
+
+/**
+ * When a run ends, the reels don't stop dead — they decelerate and lock one at
+ * a time, left to right, at these offsets (ms) so you can watch the result land.
+ */
+const LAND_STAGGER_MS = [320, 640, 980] as const;
+
+/** Odds the landed result is a forced triple-hedgehog jackpot. The house is generous. */
+const JACKPOT_RATE = 0.2;
+
+const JACKPOT_RESULT: [string, string, string] = ["🦔", "🦔", "🦔"];
 
 function randomSymbol(): string {
   return REEL_SYMBOLS[Math.floor(Math.random() * REEL_SYMBOLS.length)];
@@ -14,108 +28,141 @@ function randomReels(): [string, string, string] {
   return [randomSymbol(), randomSymbol(), randomSymbol()];
 }
 
+/** Decide where the reels land once a run finishes. */
+function rollResult(): [string, string, string] {
+  if (Math.random() < JACKPOT_RATE) return [...JACKPOT_RESULT];
+  return randomReels();
+}
+
 interface SlotMachineLeverProps {
   /** Whether the agent is actively generating — the reels spin while it is. */
   spinning: boolean;
 }
 
 /**
- * Easter egg gated behind the `slotMachineMode` setting: a tiny slot machine
- * whose reels spin while a task runs. Three hedgehogs is the jackpot.
+ * Easter egg gated behind the `slotMachineMode` setting: a tiny slot machine in
+ * the session footer. The reels spin while a task runs, then decelerate and
+ * lock one reel at a time when it finishes so you can see what you got. Three
+ * hedgehogs is the jackpot — and pays out in confetti.
  */
 export function SlotMachineLever({ spinning }: SlotMachineLeverProps) {
   const enabled = useSettingsStore((state) => state.slotMachineMode);
   const [reels, setReels] = useState<[string, string, string]>(randomReels);
-  const [pullSpin, setPullSpin] = useState(false);
-  const lever = useAnimationControls();
-  const pullSpinTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Which reels are still spinning. They lock left-to-right as a run lands.
+  const [active, setActive] = useState<[boolean, boolean, boolean]>([
+    false,
+    false,
+    false,
+  ]);
+  const [jackpot, setJackpot] = useState(false);
+  const reelBoxRef = useRef<HTMLDivElement>(null);
+  const landTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  // Tracks whether the reels were spinning, so we only run the landing sequence
+  // after a real run (not on mount, when `spinning` starts out false).
+  const wasSpinning = useRef(false);
 
-  const isSpinning = enabled && (spinning || pullSpin);
-
-  // Clear any pending pull-spin timer on unmount so it doesn't fire against
-  // stale state after the session ends.
-  useEffect(() => {
-    return () => {
-      if (pullSpinTimeout.current !== null) {
-        clearTimeout(pullSpinTimeout.current);
-      }
-    };
+  const clearLandTimers = useCallback(() => {
+    for (const timer of landTimers.current) {
+      clearTimeout(timer);
+    }
+    landTimers.current = [];
   }, []);
 
-  useEffect(() => {
-    if (!isSpinning) return;
-    const id = setInterval(() => {
-      setReels(randomReels());
-    }, 90);
-    return () => clearInterval(id);
-  }, [isSpinning]);
+  // Clear pending land timers on unmount so they don't fire against stale state.
+  useEffect(() => clearLandTimers, [clearLandTimers]);
 
-  const pull = useCallback(() => {
-    void lever.start({
-      rotate: [0, 26, 0],
-      transition: { duration: 0.55, times: [0, 0.32, 1], ease: "easeInOut" },
-    });
-    setPullSpin(true);
-    // Restart the timer on each pull so rapid clicks keep the reels spinning
-    // until 800ms after the most recent press.
-    if (pullSpinTimeout.current !== null) {
-      clearTimeout(pullSpinTimeout.current);
+  // Start spinning when a run begins; decelerate and land when it ends.
+  useEffect(() => {
+    if (!enabled) return;
+    if (spinning) {
+      clearLandTimers();
+      setJackpot(false);
+      wasSpinning.current = true;
+      setActive([true, true, true]);
+      return;
     }
-    pullSpinTimeout.current = setTimeout(() => setPullSpin(false), 800);
-  }, [lever]);
+    if (!wasSpinning.current) return;
+    wasSpinning.current = false;
+
+    const result = rollResult();
+    LAND_STAGGER_MS.forEach((delay, index) => {
+      const timer = setTimeout(() => {
+        setReels((prev) => {
+          const next: [string, string, string] = [...prev];
+          next[index] = result[index];
+          return next;
+        });
+        setActive((prev) => {
+          const next: [boolean, boolean, boolean] = [...prev];
+          next[index] = false;
+          return next;
+        });
+        // Last reel just locked — pay out if it's three hedgehogs.
+        if (index === LAND_STAGGER_MS.length - 1) {
+          const won = result.every((symbol) => symbol === "🦔");
+          if (won) {
+            setJackpot(true);
+            if (reelBoxRef.current) {
+              fireFrom(reelBoxRef.current, {
+                particleCount: 60,
+                spread: 80,
+                startVelocity: 28,
+              });
+            }
+          }
+        }
+      }, delay);
+      landTimers.current.push(timer);
+    });
+  }, [spinning, enabled, clearLandTimers]);
+
+  // Randomise only the reels that are still spinning.
+  useEffect(() => {
+    if (!active.some(Boolean)) return;
+    const id = setInterval(() => {
+      setReels(
+        (prev) =>
+          prev.map((symbol, i) => (active[i] ? randomSymbol() : symbol)) as [
+            string,
+            string,
+            string,
+          ],
+      );
+    }, SPIN_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [active]);
 
   if (!enabled) return null;
 
-  const jackpot = !isSpinning && reels.every((symbol) => symbol === "🦔");
-
   return (
-    <Flex
-      align="center"
-      gap="1"
-      className="shrink-0 select-none"
+    <motion.div
+      ref={reelBoxRef}
+      animate={
+        jackpot ? { scale: [1, 1.25, 1], rotate: [0, -4, 4, 0] } : { scale: 1 }
+      }
+      transition={jackpot ? { duration: 0.6, ease: "easeInOut" } : undefined}
+      className={`flex shrink-0 select-none items-center gap-1 rounded-sm border px-1 py-[1px] ${
+        jackpot
+          ? "border-yellow-7 bg-yellow-3 shadow-[0_0_8px_rgba(245,190,42,0.7)]"
+          : "border-gray-6 bg-gray-2"
+      }`}
       style={{ WebkitUserSelect: "none" }}
     >
-      <Flex
-        align="center"
-        gap="1"
-        className={`rounded-sm border border-gray-6 bg-gray-2 px-1 py-[1px] ${
-          jackpot ? "animate-pulse" : ""
-        }`}
-      >
-        {reels.map((symbol, index) => (
-          <motion.span
-            // biome-ignore lint/suspicious/noArrayIndexKey: fixed 3-reel layout
-            key={index}
-            animate={isSpinning ? { y: [-1, 1, -1] } : { y: 0 }}
-            transition={
-              isSpinning
-                ? { duration: 0.18, repeat: Infinity, ease: "linear" }
-                : { type: "spring", stiffness: 500, damping: 18 }
-            }
-            className="w-[14px] text-center text-[12px] leading-none"
-          >
-            {symbol}
-          </motion.span>
-        ))}
-      </Flex>
-
-      <Tooltip content="Pull to gamble on your task 🎰">
-        <button
-          type="button"
-          onClick={pull}
-          aria-label="Pull the slot machine lever"
-          className="relative flex h-[18px] w-[10px] items-center justify-center"
+      {reels.map((symbol, index) => (
+        <motion.span
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed 3-reel layout
+          key={index}
+          animate={active[index] ? { y: [-1, 1, -1] } : { y: 0 }}
+          transition={
+            active[index]
+              ? { duration: 0.16, repeat: Infinity, ease: "linear" }
+              : { type: "spring", stiffness: 500, damping: 18 }
+          }
+          className="w-[14px] text-center text-[12px] leading-none"
         >
-          <motion.div
-            animate={lever}
-            style={{ originY: 1, originX: 0.5 }}
-            className="flex h-full flex-col items-center"
-          >
-            <Box className="h-[6px] w-[6px] rounded-full bg-red-9" />
-            <Box className="w-[2px] flex-1 bg-gray-8" />
-          </motion.div>
-        </button>
-      </Tooltip>
-    </Flex>
+          {symbol}
+        </motion.span>
+      ))}
+    </motion.div>
   );
 }


### PR DESCRIPTION
## What

Builds on the slot machine mode easter egg (#2853). When **Slot machine mode 🎰** is enabled (Settings → General):

1. **Pull a real lever to send.** The orange `↑` send button in the prompt composer is replaced with an actual mounted slot-machine arm to the right of the input. Pull the handle to fire your prompt — the arm swings through its full arc before the prompt submits.
2. **The footer reels land instead of vanishing.** While a task runs the reels spin; when it finishes they decelerate and lock one reel at a time (left → right) and hold the result so you can see what you got.
3. **Jackpot pays out.** The result is rolled at a 20% jackpot rate — triple hedgehog fires confetti and a glowing pop.

## Why

The original easter egg crammed a tiny lever into the `icon-sm` send button (an unreadable blob), and the footer reels stopped dead on a random frame with no satisfying landing. This makes the whole loop legible: pull the lever → reels spin → reels decelerate and land → jackpot celebration.

## Details

- **`SlotMachineSubmit`** (new): a red domed knob + chrome shaft pivoting out of a housing, mounted beside the composer. The submit is deferred to the bottom of the ~0.6s downswing so the pull visibly plays out before submitting flips the composer into loading and unmounts the lever. Stop still takes priority while a task runs; the lever only shows in send mode. Disabled (empty editor) greys it out.
- **`SlotMachineLever`** (footer): per-reel spin state; on run end, staggered timers lock each reel and settle it with a spring. 20% forced-jackpot roll; wins fire `fireFrom()` confetti (respects `prefers-reduced-motion`) plus a gold glow/pop. The redundant mini footer handle is removed.
- Default behaviour (slot machine mode off) is unchanged — normal `↑` send button, no layout change.

## Test plan

- [ ] Settings → General → enable **Slot machine mode 🎰**
- [ ] Pull the composer lever to send a prompt; the arm visibly swings before the task starts
- [ ] Footer reels spin during the run, then decelerate and lock left→right, holding the result
- [ ] Roughly 1 in 5 runs lands triple-hedgehog → confetti + gold pop
- [ ] Empty editor greys out the lever; while running, the toolbar shows Stop (no lever)
- [ ] Disabling the setting restores the normal `↑` send button and removes the reels