### PR TITLE
fix(styles): use semantic colors for plan markdown styling

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -475,13 +475,13 @@ body {
     "Berkeley Mono", "JetBrains Mono", "Monaco", "Menlo", "Ubuntu Mono",
     "Courier New", monospace;
   font-size: 12px;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--blue-a5);
   padding: 0 4px;
   border-radius: 4px;
 }
 
 .plan-markdown pre {
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--blue-a3);
   padding: 8px 10px;
   border-radius: 6px;
   overflow-x: auto;
@@ -504,7 +504,7 @@ body {
 
 .plan-markdown th,
 .plan-markdown td {
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--blue-a6);
   padding: 4px 6px;
   text-align: left;
   vertical-align: top;
@@ -513,7 +513,7 @@ body {
 .plan-markdown blockquote {
   margin: 8px 0 12px;
   padding-left: 10px;
-  border-left: 2px solid rgba(255, 255, 255, 0.3);
+  border-left: 2px solid var(--blue-a6);
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
## TL;DR

Replace hardcoded rgba colors with semantic color variables in plan markdown styling to ensure consistent visibility and appropriate contrast in both light and dark modes.

## Problem

Plan highlighting lacks proper contrast and visibility across different color schemes. The hardcoded `rgba(0, 0, 0, ...)` and `rgba(255, 255, 255, ...)` values don't adapt well to light and dark modes, resulting in unclear highlighting and jarring visual presentation.

## Changes

Before:

<img width="3692" height="2544" alt="CleanShot 2026-06-24 at 10 24 30@2x" src="https://github.com/user-attachments/assets/155e9cb0-bd5e-4e1f-9fc5-de6c04025188" />
<img width="3730" height="2640" alt="CleanShot 2026-06-24 at 10 24 40@2x" src="https://github.com/user-attachments/assets/033775a3-9c10-4dd1-a1b1-c637032c3c0d" />

After

<img width="1490" height="1686" alt="CleanShot 2026-06-24 at 10 22 59@2x" src="https://github.com/user-attachments/assets/b8c5b1cd-dd76-40d3-8b0e-09c4e9aa5da8" />
<img width="1588" height="1756" alt="CleanShot 2026-06-24 at 10 23 11@2x" src="https://github.com/user-attachments/assets/f25b1944-a3d1-49be-af93-d67cf7277f24" />

- Replace `background: rgba(0, 0, 0, 0.2)` with `var(--blue-a5)` for code inline background
- Replace `background: rgba(0, 0, 0, 0.25)` with `var(--blue-a3)` for pre-formatted code block background
- Replace `border: 1px solid rgba(255, 255, 255, 0.2)` with `var(--blue-a6)` for table cell borders
- Replace `border-left: 2px solid rgba(255, 255, 255, 0.3)` with `var(--blue-a6)` for blockquote left border

## How did you test this?

Visual inspection of plan markdown rendering in both light and dark modes to verify improved contrast and consistent visibility.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*