### PR TITLE
feat(canvas): tool-permission prompts on canvas + browser-style nav

### DIFF
--- a/packages/ui/src/features/canvas/freeform/CanvasPermissionDialog.tsx
+++ b/packages/ui/src/features/canvas/freeform/CanvasPermissionDialog.tsx
@@ -8,6 +8,7 @@ import {
   useModeConfigOptionForTask,
   usePendingPermissionsForTask,
 } from "@posthog/ui/features/sessions/useSession";
+import { toast } from "@posthog/ui/primitives/toast";
 import { Dialog, VisuallyHidden } from "@radix-ui/themes";
 import { useCallback, useMemo } from "react";
 
@@ -38,18 +39,26 @@ export function CanvasPermissionDialog({ taskId }: { taskId: string }) {
       answers?: Record<string, string>,
     ) => {
       if (!firstPendingPermission) return;
-      const plan = await sessionService.resolvePermissionSelection(
-        taskId,
-        firstPendingPermission,
-        optionId,
-        modeOption,
-        customInput,
-        answers,
-      );
-      // "Type here to tell the agent…" with no custom-input option attached is
-      // re-sent as a steering prompt, same as the task view.
-      if (plan.resendPromptText) {
-        await sessionService.sendPrompt(taskId, plan.resendPromptText);
+      try {
+        const plan = await sessionService.resolvePermissionSelection(
+          taskId,
+          firstPendingPermission,
+          optionId,
+          modeOption,
+          customInput,
+          answers,
+        );
+        // "Type here to tell the agent…" with no custom-input option attached
+        // is re-sent as a steering prompt, same as the task view. The response
+        // is already resolved by here, so a send failure must be surfaced —
+        // otherwise the user's text is silently dropped.
+        if (plan.resendPromptText) {
+          await sessionService.sendPrompt(taskId, plan.resendPromptText);
+        }
+      } catch (error) {
+        toast.error("Couldn't send your response to the agent", {
+          description: error instanceof Error ? error.message : String(error),
+        });
       }
     },
     [firstPendingPermission, taskId, modeOption, sessionService],
@@ -57,10 +66,16 @@ export function CanvasPermissionDialog({ taskId }: { taskId: string }) {
 
   const handleCancel = useCallback(async () => {
     if (!firstPendingPermission) return;
-    await sessionService.cancelPermissionAndPrompt(
-      taskId,
-      firstPendingPermission.toolCallId,
-    );
+    try {
+      await sessionService.cancelPermissionAndPrompt(
+        taskId,
+        firstPendingPermission.toolCallId,
+      );
+    } catch (error) {
+      toast.error("Couldn't cancel the request", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
   }, [firstPendingPermission, taskId, sessionService]);
 
   const open = !!firstPendingPermission;

--- a/packages/ui/src/features/canvas/freeform/CanvasPermissionDialog.tsx
+++ b/packages/ui/src/features/canvas/freeform/CanvasPermissionDialog.tsx
@@ -1,0 +1,95 @@
+import {
+  SESSION_SERVICE,
+  type SessionService,
+} from "@posthog/core/sessions/sessionService";
+import { useService } from "@posthog/di/react";
+import { PermissionSelector } from "@posthog/ui/features/permissions/PermissionSelector";
+import {
+  useModeConfigOptionForTask,
+  usePendingPermissionsForTask,
+} from "@posthog/ui/features/sessions/useSession";
+import { Dialog, VisuallyHidden } from "@radix-ui/themes";
+import { useCallback, useMemo } from "react";
+
+// Surfaces a generating canvas's pending permission request (e.g. an MCP tool
+// approval) right on the canvas screen, so the user never has to open the task
+// to unblock it. Reuses the task view's PermissionSelector + the same
+// SessionService response path; the request itself lives in the global session
+// store, populated by the gen task's live session — which is exactly the
+// session that keeps the canvas in its "generating" state. When no request is
+// pending the dialog stays closed.
+export function CanvasPermissionDialog({ taskId }: { taskId: string }) {
+  const sessionService = useService<SessionService>(SESSION_SERVICE);
+  const pendingPermissions = usePendingPermissionsForTask(taskId);
+  const modeOption = useModeConfigOptionForTask(taskId);
+
+  // The session log resolves one request at a time (oldest first); mirror that.
+  const firstPendingPermission = useMemo(() => {
+    const entries = Array.from(pendingPermissions.entries());
+    if (entries.length === 0) return null;
+    const [toolCallId, permission] = entries[0];
+    return { ...permission, toolCallId };
+  }, [pendingPermissions]);
+
+  const handleSelect = useCallback(
+    async (
+      optionId: string,
+      customInput?: string,
+      answers?: Record<string, string>,
+    ) => {
+      if (!firstPendingPermission) return;
+      const plan = await sessionService.resolvePermissionSelection(
+        taskId,
+        firstPendingPermission,
+        optionId,
+        modeOption,
+        customInput,
+        answers,
+      );
+      // "Type here to tell the agent…" with no custom-input option attached is
+      // re-sent as a steering prompt, same as the task view.
+      if (plan.resendPromptText) {
+        await sessionService.sendPrompt(taskId, plan.resendPromptText);
+      }
+    },
+    [firstPendingPermission, taskId, modeOption, sessionService],
+  );
+
+  const handleCancel = useCallback(async () => {
+    if (!firstPendingPermission) return;
+    await sessionService.cancelPermissionAndPrompt(
+      taskId,
+      firstPendingPermission.toolCallId,
+    );
+  }, [firstPendingPermission, taskId, sessionService]);
+
+  const open = !!firstPendingPermission;
+
+  return (
+    <Dialog.Root open={open}>
+      <Dialog.Content
+        maxWidth="560px"
+        // Require an explicit choice: outside clicks don't dismiss; Esc rejects
+        // the request (PermissionSelector's own Esc also routes to onCancel).
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => {
+          e.preventDefault();
+          void handleCancel();
+        }}
+      >
+        <VisuallyHidden>
+          <Dialog.Title>Canvas needs your approval</Dialog.Title>
+        </VisuallyHidden>
+        {firstPendingPermission && (
+          <PermissionSelector
+            toolCall={firstPendingPermission.toolCall}
+            options={firstPendingPermission.options}
+            onSelect={handleSelect}
+            onCancel={handleCancel}
+          />
+        )}
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -37,6 +37,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useMemo, useState } from "react";
 import { CanvasFramePlaceholder } from "./CanvasFramePlaceholder";
+import { CanvasPermissionDialog } from "./CanvasPermissionDialog";
 import { FreeformGenerateBar } from "./FreeformGenerateBar";
 import { handleFreeformDataRequest } from "./freeformDataBridge";
 import { useCanvasNavigation, useHomeCanvasReset } from "./useHomeCanvasView";
@@ -201,6 +202,11 @@ export function FreeformCanvasView({
 
   return (
     <Flex height="100%" overflow="hidden">
+      {/* A generating canvas can pause on a tool-permission request; surface it
+          here so the user can approve without opening the underlying task. */}
+      {interactive && genTaskId && (
+        <CanvasPermissionDialog taskId={genTaskId} />
+      )}
       <Flex direction="column" className="flex-1 bg-gray-1" overflow="hidden">
         {interactive && (
           <Flex

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -113,8 +113,10 @@ function RootLayout() {
   const canGoBack = useCanGoBack();
   // Forward availability isn't exposed by the router (and history.length counts
   // pre-app entries, so it can't be compared to __TSR_index). Track the newest
-  // index we've reached: a PUSH/REPLACE wipes the forward stack and becomes the
-  // new newest; BACK/GO move us below it. Forward is live while we're below it.
+  // index we've reached: only a PUSH wipes the forward stack, so it resets the
+  // newest to the current index. REPLACE mutates the current entry in place
+  // (index unchanged, forward entries intact) and BACK/GO just move within the
+  // existing stack, so both keep the max. Forward is live while below it.
   const historyIndex = useRouterState({
     select: (s) => s.location.state.__TSR_index,
   });
@@ -123,9 +125,7 @@ function RootLayout() {
     return router.history.subscribe(({ location, action }) => {
       const idx = location.state.__TSR_index;
       setNewestIndex((prev) =>
-        action.type === "PUSH" || action.type === "REPLACE"
-          ? idx
-          : Math.max(prev, idx),
+        action.type === "PUSH" ? idx : Math.max(prev, idx),
       );
     });
   }, [router]);

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -1,4 +1,8 @@
-import { ArrowSquareOut } from "@phosphor-icons/react";
+import {
+  ArrowSquareOut,
+  CaretLeftIcon,
+  CaretRightIcon,
+} from "@phosphor-icons/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
 import {
@@ -53,7 +57,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   createRootRoute,
   Outlet,
+  useCanGoBack,
   useNavigate,
+  useRouter,
   useRouterState,
 } from "@tanstack/react-router";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
@@ -103,6 +109,27 @@ export const Route = createRootRoute({
 function RootLayout() {
   const view = useAppView();
   const navigate = useNavigate();
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+  // Forward availability isn't exposed by the router (and history.length counts
+  // pre-app entries, so it can't be compared to __TSR_index). Track the newest
+  // index we've reached: a PUSH/REPLACE wipes the forward stack and becomes the
+  // new newest; BACK/GO move us below it. Forward is live while we're below it.
+  const historyIndex = useRouterState({
+    select: (s) => s.location.state.__TSR_index,
+  });
+  const [newestIndex, setNewestIndex] = useState(historyIndex);
+  useEffect(() => {
+    return router.history.subscribe(({ location, action }) => {
+      const idx = location.state.__TSR_index;
+      setNewestIndex((prev) =>
+        action.type === "PUSH" || action.type === "REPLACE"
+          ? idx
+          : Math.max(prev, idx),
+      );
+    });
+  }, [router]);
+  const canGoForward = historyIndex < newestIndex;
 
   // Feedback modal shown in the Channels title bar. Opened directly by "Leave
   // feedback" (mode "feedback"), or as an intercept before navigating away —
@@ -263,6 +290,24 @@ function RootLayout() {
             <LogosLandscape code={false} />
           </Box>
           <Flex align="center" gap="2" className="no-drag">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              aria-label="Back"
+              disabled={!canGoBack}
+              onClick={() => router.history.back()}
+            >
+              <CaretLeftIcon size={14} />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              aria-label="Forward"
+              disabled={!canGoForward}
+              onClick={() => router.history.forward()}
+            >
+              <CaretRightIcon size={14} />
+            </Button>
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
## What

<img width="1508" height="944" alt="image" src="https://github.com/user-attachments/assets/1ccfeb10-f9f0-495d-bf71-c2775e88fd75" />

<img width="438" height="139" alt="image" src="https://github.com/user-attachments/assets/671d0174-7de9-4ad4-bf0c-b69161d1a263" />


Two canvas UX fixes that came out of debugging a canvas stuck on "Generating".

### 1. Surface tool-permission prompts on the canvas
A generating freeform canvas can pause on an agent tool-permission request (e.g. an MCP call like `posthog - Read pull-requests`). The prompt only rendered in the task view, so on the canvas the user just saw an endless "Generating" with no way to unblock without hunting down the task.

`CanvasPermissionDialog` now surfaces the pending request as a dialog right on the canvas, reusing the task view's `PermissionSelector` and the **same** `SessionService` response path:
- Yes / Yes, always allow / "Type here to tell the agent…" / cancel
- The request lives in the global session store (populated by the gen task's live session), so no extra wiring — it shows whenever a request is pending and closes itself once resolved.
- Outside-click won't dismiss (forces an explicit choice); Esc rejects, matching the task view.

### 2. Browser-style back/forward in the Channels title bar
Two `variant="outline"` icon buttons to the right of the logo.
- Back uses `useCanGoBack()`.
- Forward availability is tracked via a history subscription (the newest `__TSR_index` reached), since the router exposes no `canGoForward` and `history.length` counts pre-app entries — both buttons disable correctly when there's nowhere to go.

## Notes
- The underlying "stuck on Generating" root cause (a local ACP session stays `connected` after the turn ends) was **already fixed on main** via `canvasGenerationStatus.ts` keying on `isPromptPending`. This PR builds on that and doesn't touch the generation-state derivation.
- The permission dialog stays correct while paused on a request: the turn is still in flight (`isPromptPending`), so the canvas reads as generating and the dialog fires.

## Test plan
- [ ] `pnpm --filter @posthog/ui typecheck` ✅
- [ ] Generate a canvas that triggers an MCP permission prompt → dialog appears on the canvas; approving continues generation without opening the task.
- [ ] In the Channels space, navigate around → back/forward enable/disable like a browser; clicking moves through history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)