### PR TITLE
feat(git-interaction): add copy branch name button to PR actions menu

### DIFF
--- a/packages/core/src/git/router-schemas.ts
+++ b/packages/core/src/git/router-schemas.ts
@@ -383,6 +383,7 @@ export const getPrDetailsByUrlOutput = z.object({
   state: z.string(),
   merged: z.boolean(),
   draft: z.boolean(),
+  headRefName: z.string().nullable(),
 });
 export type PrDetailsByUrlOutput = z.infer<typeof getPrDetailsByUrlOutput>;
 

--- a/packages/host-router/src/routers/git.router.ts
+++ b/packages/host-router/src/routers/git.router.ts
@@ -509,7 +509,14 @@ export const gitRouter = router({
       ).git.getPrDetailsByUrl.query({
         prUrl: input.prUrl,
       });
-      return result ?? { state: "unknown", merged: false, draft: false };
+      return (
+        result ?? {
+          state: "unknown",
+          merged: false,
+          draft: false,
+          headRefName: null,
+        }
+      );
     }),
 
   updatePrByUrl: publicProcedure

--- a/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
+++ b/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowsClockwise,
   CloudArrowUp,
+  Copy,
   Eye,
   GitBranch,
   GitCommit,
@@ -20,6 +21,7 @@ import type { PrActionType } from "@posthog/shared";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { Button, DropdownMenu, Flex, Spinner, Text } from "@radix-ui/themes";
 import { ChevronDown } from "lucide-react";
+import { toast } from "sonner";
 import { Tooltip } from "../../../primitives/Tooltip";
 import { useLocalRepoPath } from "../../workspace/useLocalRepoPath";
 import { getPrActionIcon } from "../prIcon";
@@ -78,7 +80,7 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
   const prUrl = useTaskPrUrl(taskId, isCloud);
 
   const {
-    meta: { state: prState, merged, draft },
+    meta: { state: prState, merged, draft, headRefName },
   } = usePrDetails(prUrl);
   const { execute: executePrAction, isPending: isPrActionPending } =
     usePrActions(prUrl);
@@ -107,6 +109,7 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
             prState={pr.state}
             merged={merged}
             draft={draft}
+            branchName={headRefName}
             isPrPending={isPrActionPending}
             gitItems={gitItems}
             onGitSelect={gitActions.openAction}
@@ -208,6 +211,7 @@ interface PrBadgeControlProps {
   prState: string;
   merged: boolean;
   draft: boolean;
+  branchName: string | null;
   isPrPending: boolean;
   gitItems: GitMenuAction[];
   onGitSelect: (id: GitMenuActionId) => void;
@@ -219,6 +223,7 @@ function PrBadgeControl({
   prState,
   merged,
   draft,
+  branchName,
   isPrPending,
   gitItems,
   onGitSelect,
@@ -226,7 +231,18 @@ function PrBadgeControl({
 }: PrBadgeControlProps) {
   const config = getPrVisualConfig(prState, merged, draft);
   const lifecycleItems = config.actions;
-  const hasDropdown = gitItems.length + lifecycleItems.length > 0;
+  const hasMenuItems = gitItems.length + lifecycleItems.length > 0;
+  const hasDropdown = hasMenuItems || !!branchName;
+
+  const copyBranchName = async () => {
+    if (!branchName) return;
+    try {
+      await navigator.clipboard.writeText(branchName);
+      toast.success("Branch name copied");
+    } catch {
+      toast.error("Couldn't copy branch name");
+    }
+  };
 
   return (
     <Flex align="center" gap="0">
@@ -280,6 +296,17 @@ function PrBadgeControl({
                 </Flex>
               </DropdownMenu.Item>
             ))}
+            {branchName && (
+              <>
+                {hasMenuItems && <DropdownMenu.Separator />}
+                <DropdownMenu.Item onSelect={copyBranchName}>
+                  <Flex align="center" gap="2">
+                    <Copy size={12} weight="bold" />
+                    <Text size="1">Copy branch name</Text>
+                  </Flex>
+                </DropdownMenu.Item>
+              </>
+            )}
           </DropdownMenu.Content>
         </DropdownMenu.Root>
       )}

--- a/packages/ui/src/features/git-interaction/usePrActions.ts
+++ b/packages/ui/src/features/git-interaction/usePrActions.ts
@@ -18,7 +18,10 @@ export function usePrActions(prUrl: string | null) {
         toast.success(PR_ACTION_LABELS[variables.action]);
         queryClient.setQueryData(
           trpc.git.getPrDetailsByUrl.queryKey({ prUrl: variables.prUrl }),
-          getOptimisticPrState(variables.action),
+          (prev) => ({
+            ...getOptimisticPrState(variables.action),
+            headRefName: prev?.headRefName ?? null,
+          }),
         );
         // The inbox Pulls list reads PR status from the batched
         // `getPrDiffStatsBatch` query (separate cache, 5-min staleTime), so

--- a/packages/ui/src/features/git-interaction/usePrDetails.ts
+++ b/packages/ui/src/features/git-interaction/usePrDetails.ts
@@ -55,6 +55,7 @@ export function usePrDetails(
       state: metaQuery.data?.state ?? null,
       merged: metaQuery.data?.merged ?? false,
       draft: metaQuery.data?.draft ?? false,
+      headRefName: metaQuery.data?.headRefName ?? null,
       isLoading: metaQuery.isLoading,
     },
     commentThreads,

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -302,6 +302,7 @@ export const getPrDetailsByUrlOutput = z.object({
   state: z.string(),
   merged: z.boolean(),
   draft: z.boolean(),
+  headRefName: z.string().nullable(),
 });
 
 export type PrDetailsByUrlOutput = z.infer<typeof getPrDetailsByUrlOutput>;

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -930,7 +930,7 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         "api",
         `repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`,
         "--jq",
-        "{state,merged,draft}",
+        "{state,merged,draft,headRefName: .head.ref}",
       ]);
 
       if (result.exitCode !== 0) {
@@ -941,6 +941,7 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         state: string;
         merged: boolean;
         draft: boolean;
+        headRefName: string | null;
       };
 
       return data;


### PR DESCRIPTION
## Problem

When i have multiple cloud tasks running, often i get the cloud task to make a PR so i can then copy the branch locally to test.

Branch names aren't surfaced on the cloud tasks, so i have to into the PR, click copy branch name and then come back. I dont want to leave PHC

## What

- Adds **Copy branch name** to the PR actions dropdown menu

<img width="464" height="300" alt="CleanShot 2026-06-24 at 10 39 56@2x" src="https://github.com/user-attachments/assets/37cb2274-99a6-4b26-8043-2ed3bcbf7ec3" />


## How

- Fetch `head.ref` from GitHub in `getPrDetailsByUrl`, threaded through as nullable `headRefName`
- New dropdown item copies it to the clipboard with a success/error toast
- Only shows when a branch name is available

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*