### PR TITLE
feat(canvas): toast when a backgrounded canvas generation finishes

### DIFF
--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -17,8 +17,10 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
-import { isTerminalStatus } from "@posthog/shared/domain-types";
-import { isCanvasGenerationRunning } from "@posthog/ui/features/canvas/freeform/canvasGenerationStatus";
+import {
+  isCanvasGenerating,
+  isCanvasGenerationRunning,
+} from "@posthog/ui/features/canvas/freeform/canvasGenerationStatus";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import {
   useFreeformChatStore,
@@ -114,24 +116,14 @@ export function FreeformCanvasView({
     session: genSession,
   });
   // Whether the agent is actively producing the canvas right now. Drives the
-  // "Generating…" UI (notice, composer, undo/redo). A local session stays
-  // "connected" after its single generation prompt completes, so key off the
-  // pending prompt, not the connection — otherwise the notice never clears. A
-  // terminal run record always wins so a stuck session can't strand the notice.
-  const isGenerating = (() => {
-    if (!genTaskId) return false;
-    if (genTaskLoading) return true;
-    if (genTask?.latest_run?.environment === "cloud") {
-      const cloudStatus =
-        genSession?.cloudStatus ?? genTask?.latest_run?.status ?? null;
-      return !isTerminalStatus(cloudStatus);
-    }
-    if (isTerminalStatus(genTask?.latest_run?.status)) return false;
-    return (
-      genSession?.status === "connecting" ||
-      genSession?.isPromptPending === true
-    );
-  })();
+  // "Generating…" UI (notice, composer, undo/redo). Shares the tested helper
+  // with the completion-toast watcher so both read the same signal.
+  const isGenerating = isCanvasGenerating({
+    genTaskId,
+    genTaskLoading,
+    latestRun: genTask?.latest_run,
+    session: genSession,
+  });
 
   // Poll the record while the session is alive so a just-published canvas
   // appears (the publish lands while the prompt is still pending).

--- a/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
+++ b/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
@@ -1,10 +1,25 @@
 import type { AgentSession } from "@posthog/shared";
 import type { TaskRun, TaskRunStatus } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
-import { isCanvasGenerationRunning } from "./canvasGenerationStatus";
+import {
+  hasCanvasGenerationStarted,
+  isCanvasGenerating,
+  isCanvasGenerationRunning,
+  resolveCanvasGenerationStatus,
+} from "./canvasGenerationStatus";
 
 type Run = Pick<TaskRun, "environment" | "status">;
-type Session = Pick<AgentSession, "status" | "cloudStatus">;
+type Session = Pick<AgentSession, "status" | "cloudStatus" | "isPromptPending">;
+type GenSession = Session;
+
+const genSession = (
+  status: AgentSession["status"],
+  opts?: { cloudStatus?: TaskRunStatus; isPromptPending?: boolean },
+): GenSession => ({
+  status,
+  cloudStatus: opts?.cloudStatus,
+  isPromptPending: opts?.isPromptPending ?? false,
+});
 
 const run = (environment: "local" | "cloud", status: TaskRunStatus): Run => ({
   environment,
@@ -13,7 +28,7 @@ const run = (environment: "local" | "cloud", status: TaskRunStatus): Run => ({
 const session = (
   status: AgentSession["status"],
   cloudStatus?: TaskRunStatus,
-): Session => ({ status, cloudStatus });
+): Session => ({ status, cloudStatus, isPromptPending: false });
 
 describe("isCanvasGenerationRunning", () => {
   it("is not running when there is no generation task", () => {
@@ -115,5 +130,138 @@ describe("isCanvasGenerationRunning", () => {
         session: sess,
       }),
     ).toBe(expected);
+  });
+});
+
+describe("isCanvasGenerating", () => {
+  it("is not generating without a task, and assumes generating while loading", () => {
+    expect(
+      isCanvasGenerating({
+        genTaskId: null,
+        genTaskLoading: false,
+        latestRun: undefined,
+        session: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      isCanvasGenerating({
+        genTaskId: "t1",
+        genTaskLoading: true,
+        latestRun: undefined,
+        session: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it.each<[string, Run, GenSession | undefined, boolean]>([
+    ["cloud in_progress", run("cloud", "in_progress"), undefined, true],
+    [
+      "cloud cloudStatus completed clears it",
+      run("cloud", "in_progress"),
+      genSession("connected", { cloudStatus: "completed" }),
+      false,
+    ],
+    // Local: keys off the pending prompt, NOT the connection — a session that
+    // lingers connected after the prompt finishes is no longer generating.
+    [
+      "local prompt pending",
+      run("local", "in_progress"),
+      genSession("connected", { isPromptPending: true }),
+      true,
+    ],
+    [
+      "local connected but prompt settled",
+      run("local", "in_progress"),
+      genSession("connected", { isPromptPending: false }),
+      false,
+    ],
+    [
+      "local still connecting",
+      run("local", "in_progress"),
+      genSession("connecting"),
+      true,
+    ],
+    [
+      "local terminal run record wins",
+      run("local", "completed"),
+      genSession("connected", { isPromptPending: true }),
+      false,
+    ],
+  ])("%s", (_label, latestRun, sess, expected) => {
+    expect(
+      isCanvasGenerating({
+        genTaskId: "t1",
+        genTaskLoading: false,
+        latestRun,
+        session: sess,
+      }),
+    ).toBe(expected);
+  });
+});
+
+describe("hasCanvasGenerationStarted", () => {
+  it.each<[string, Run | undefined, GenSession | undefined, boolean]>([
+    // The create→connect gap: task exists, no live session, not yet in_progress.
+    ["not started yet", run("local", "queued"), undefined, false],
+    [
+      "local prompt pending",
+      run("local", "queued"),
+      genSession("connected", { isPromptPending: true }),
+      true,
+    ],
+    [
+      "local session connecting",
+      run("local", "queued"),
+      genSession("connecting"),
+      true,
+    ],
+    ["run in_progress", run("local", "in_progress"), undefined, true],
+    // A session that lingers connected after the prompt settled still counts as
+    // started — it's the arming latch, not the running signal.
+    [
+      "local connected, prompt settled",
+      run("local", "completed"),
+      genSession("connected", { isPromptPending: false }),
+      true,
+    ],
+    ["cloud in_progress", run("cloud", "in_progress"), undefined, true],
+    ["cloud queued", run("cloud", "queued"), undefined, true],
+    ["cloud not_started", run("cloud", "not_started"), undefined, false],
+  ])("%s", (_label, latestRun, sess, expected) => {
+    expect(hasCanvasGenerationStarted({ latestRun, session: sess })).toBe(
+      expected,
+    );
+  });
+});
+
+describe("resolveCanvasGenerationStatus", () => {
+  it.each<[string, Run | undefined, GenSession | undefined, string]>([
+    ["local completed", run("local", "completed"), undefined, "completed"],
+    ["local failed", run("local", "failed"), undefined, "failed"],
+    ["local cancelled", run("local", "cancelled"), undefined, "cancelled"],
+    // A local run that finished via the session before its record flipped
+    // terminal still counts as a successful completion.
+    [
+      "local non-terminal record",
+      run("local", "in_progress"),
+      undefined,
+      "completed",
+    ],
+    [
+      "cloud reads cloudStatus first",
+      run("cloud", "in_progress"),
+      genSession("connected", { cloudStatus: "failed" }),
+      "failed",
+    ],
+    [
+      "cloud falls back to run record",
+      run("cloud", "completed"),
+      undefined,
+      "completed",
+    ],
+  ])("%s", (_label, latestRun, sess, expected) => {
+    expect(resolveCanvasGenerationStatus({ latestRun, session: sess })).toBe(
+      expected,
+    );
   });
 });

--- a/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
+++ b/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
@@ -1,5 +1,9 @@
 import type { AgentSession } from "@posthog/shared";
-import { isTerminalStatus, type TaskRun } from "@posthog/shared/domain-types";
+import {
+  isTerminalStatus,
+  type TaskRun,
+  type TaskRunStatus,
+} from "@posthog/shared/domain-types";
 
 export interface CanvasGenerationStatusInput {
   /** The canvas's in-flight generation task id, or null if none. */
@@ -9,8 +13,15 @@ export interface CanvasGenerationStatusInput {
   /** The task's latest run record (carries environment + persisted status). */
   latestRun: Pick<TaskRun, "environment" | "status"> | undefined;
   /** The live ACP session for the task, if one is connected in this client. */
-  session: Pick<AgentSession, "status" | "cloudStatus"> | undefined;
+  session:
+    | Pick<AgentSession, "status" | "cloudStatus" | "isPromptPending">
+    | undefined;
 }
+
+export type CanvasTerminalStatus = Extract<
+  TaskRunStatus,
+  "completed" | "failed" | "cancelled"
+>;
 
 // Whether a canvas generation task is still actively running.
 //
@@ -40,4 +51,74 @@ export function isCanvasGenerationRunning({
   // stuck live session, so it can never strand the canvas on "Generating".
   if (isTerminalStatus(latestRun?.status)) return false;
   return session?.status === "connecting" || session?.status === "connected";
+}
+
+// Whether the agent is ACTIVELY producing the canvas right now. This is the
+// signal that drives the "Generating…" UI and the completion toast, and it's
+// finer-grained than isCanvasGenerationRunning: a local ACP session lingers
+// "connected" after its single generation prompt finishes, so here a local run
+// keys off the pending prompt rather than the connection — the signal clears the
+// moment generation actually ends, not whenever the session disconnects.
+export function isCanvasGenerating({
+  genTaskId,
+  genTaskLoading,
+  latestRun,
+  session,
+}: CanvasGenerationStatusInput): boolean {
+  if (!genTaskId) return false;
+  if (genTaskLoading) return true;
+
+  if (latestRun?.environment === "cloud") {
+    const cloudStatus = session?.cloudStatus ?? latestRun.status ?? null;
+    return !isTerminalStatus(cloudStatus);
+  }
+
+  if (isTerminalStatus(latestRun?.status)) return false;
+  return session?.status === "connecting" || session?.isPromptPending === true;
+}
+
+// Whether there's concrete evidence the generation run has actually started, as
+// opposed to merely having been created. The completion-toast watcher arms on
+// this so the brief gap between creating the task and its live session
+// connecting — during which the local "generating" signal momentarily reads
+// false — can never be mistaken for a finished run.
+export function hasCanvasGenerationStarted({
+  latestRun,
+  session,
+}: {
+  latestRun: Pick<TaskRun, "environment" | "status"> | undefined;
+  session:
+    | Pick<AgentSession, "status" | "cloudStatus" | "isPromptPending">
+    | undefined;
+}): boolean {
+  if (session?.isPromptPending) return true;
+  if (session?.status === "connecting" || session?.status === "connected") {
+    return true;
+  }
+  if (latestRun?.status === "in_progress") return true;
+  if (latestRun?.environment === "cloud") {
+    const status = session?.cloudStatus ?? latestRun?.status;
+    return status === "in_progress" || status === "queued";
+  }
+  return false;
+}
+
+// The terminal status to report once generation has finished. Cloud runs carry
+// it on the live session's cloudStatus (falling back to the persisted run);
+// local runs read the persisted run record. Anything that isn't an explicit
+// failure/cancellation is treated as a successful completion — a local run whose
+// record hasn't flipped terminal yet still finished by producing its canvas.
+export function resolveCanvasGenerationStatus({
+  latestRun,
+  session,
+}: {
+  latestRun: Pick<TaskRun, "environment" | "status"> | undefined;
+  session: Pick<AgentSession, "cloudStatus"> | undefined;
+}): CanvasTerminalStatus {
+  const status =
+    latestRun?.environment === "cloud"
+      ? (session?.cloudStatus ?? latestRun?.status)
+      : latestRun?.status;
+  if (status === "failed" || status === "cancelled") return status;
+  return "completed";
 }

--- a/packages/ui/src/features/canvas/freeform/useCanvasGenerationToasts.ts
+++ b/packages/ui/src/features/canvas/freeform/useCanvasGenerationToasts.ts
@@ -1,0 +1,153 @@
+import {
+  type CanvasTerminalStatus,
+  hasCanvasGenerationStarted,
+  isCanvasGenerating,
+  resolveCanvasGenerationStatus,
+} from "@posthog/ui/features/canvas/freeform/canvasGenerationStatus";
+import { useCanvasGenerationTrackerStore } from "@posthog/ui/features/canvas/stores/canvasGenerationTrackerStore";
+import { useSessionStore } from "@posthog/ui/features/sessions/sessionStore";
+import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { toast } from "@posthog/ui/primitives/toast";
+import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
+import { useQueries } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+
+// Poll cadence for the run status of a tracked generation task. Matches the
+// canvas record poll in FreeformCanvasView so the toast and the in-view state
+// land together.
+const POLL_MS = 4000;
+
+// Surface a finished canvas generation as an application toast with a link back
+// to the canvas.
+function surfaceCanvasGenerationToast(t: {
+  channelId: string;
+  dashboardId: string;
+  name: string;
+  status: CanvasTerminalStatus;
+}): void {
+  const name = t.name.trim() || "Canvas";
+  const action = {
+    label: "View canvas",
+    onClick: () => navigateToChannelDashboard(t.channelId, t.dashboardId),
+  };
+
+  if (t.status === "completed") {
+    toast.success(`${name} is ready`, {
+      description: "Generation finished.",
+      duration: 8000,
+      action,
+    });
+  } else if (t.status === "failed") {
+    toast.error(`${name} generation failed`, {
+      description: "The agent couldn't finish building this canvas.",
+      action,
+    });
+  }
+  // "cancelled" is user-initiated — stay silent.
+}
+
+// Watches every canvas generation started in this client (registered in the
+// tracker store) and fires a toast — with a link to the canvas — the moment each
+// one stops generating. Mounted on the persistent channel layout so it keeps
+// watching after the user navigates to another canvas: the whole point is to
+// call them back when a backgrounded generation lands.
+//
+// Completion is read from the same signal the canvas view uses (isCanvasGenerating:
+// the live ACP session for local runs, cloudStatus for cloud) rather than the
+// dashboard's generationTaskId, which is never cleared for freeform canvases.
+export function useCanvasGenerationToasts(): void {
+  const tracked = useCanvasGenerationTrackerStore((s) => s.tracked);
+  const untrack = useCanvasGenerationTrackerStore((s) => s.untrack);
+
+  const taskIds = useMemo(() => Object.keys(tracked), [tracked]);
+
+  const details = useQueries({
+    queries: taskIds.map((id) => ({
+      ...taskDetailQuery(id),
+      refetchInterval: POLL_MS,
+    })),
+  });
+
+  // The live ACP sessions — for local runs this, not the run record, is what
+  // tells us generation has actually finished.
+  const sessions = useSessionStore((s) => s.sessions);
+  const taskIdIndex = useSessionStore((s) => s.taskIdIndex);
+
+  // Compute the "still generating?" signal per tracked task each render.
+  const states = taskIds.map((id, i) => {
+    const runId = taskIdIndex[id];
+    const session = runId ? sessions[runId] : undefined;
+    const latestRun = details[i]?.data?.latest_run;
+    const generating = isCanvasGenerating({
+      genTaskId: id,
+      genTaskLoading: details[i]?.isLoading ?? false,
+      latestRun,
+      session,
+    });
+    return { id, generating, latestRun, session };
+  });
+
+  // A stable signature so the transition effect only runs on real changes.
+  const sig = states
+    .map(
+      (s) =>
+        `${s.id}:${s.generating ? 1 : 0}:${s.latestRun?.status ?? ""}:${s.session?.status ?? ""}:${s.session?.cloudStatus ?? ""}:${s.session?.isPromptPending ? 1 : 0}`,
+    )
+    .join("|");
+
+  const statesRef = useRef(states);
+  statesRef.current = states;
+  // Tasks we've confirmed actually started running — only an armed task can
+  // toast on finishing, so the create→connect gap can't fire a false toast.
+  const armedRef = useRef<Set<string>>(new Set());
+  // Tasks already toasted, so a re-run can never double-fire.
+  const toastedRef = useRef<Set<string>>(new Set());
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sig is the trigger; states/store are read fresh (states via ref) when it changes.
+  useEffect(() => {
+    for (const st of statesRef.current) {
+      if (
+        hasCanvasGenerationStarted({
+          latestRun: st.latestRun,
+          session: st.session,
+        })
+      ) {
+        armedRef.current.add(st.id);
+      }
+
+      // A task only toasts once it has demonstrably run and is no longer
+      // generating.
+      if (
+        !armedRef.current.has(st.id) ||
+        st.generating ||
+        toastedRef.current.has(st.id)
+      ) {
+        continue;
+      }
+
+      toastedRef.current.add(st.id);
+      const entry = useCanvasGenerationTrackerStore.getState().tracked[st.id];
+      if (entry) {
+        surfaceCanvasGenerationToast({
+          channelId: entry.channelId,
+          dashboardId: entry.dashboardId,
+          name: entry.name,
+          status: resolveCanvasGenerationStatus({
+            latestRun: st.latestRun,
+            session: st.session,
+          }),
+        });
+      }
+      // Stop tracking (and polling) this task now that it's done.
+      untrack(st.id);
+    }
+  }, [sig, untrack]);
+}
+
+// Renders nothing; exists only to host useCanvasGenerationToasts so the frequent
+// session-driven re-renders it subscribes to stay isolated here instead of
+// re-rendering whatever layout mounts it.
+export function CanvasGenerationToaster(): null {
+  useCanvasGenerationToasts();
+  return null;
+}

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -13,6 +13,7 @@ import {
   useDashboardMutations,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
+import { useCanvasGenerationTrackerStore } from "@posthog/ui/features/canvas/stores/canvasGenerationTrackerStore";
 import { useCreateTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
 import { toast } from "@posthog/ui/primitives/toast";
 import { useQueryClient } from "@tanstack/react-query";
@@ -87,6 +88,11 @@ export function useGenerateFreeformCanvas(args: {
         // are best-effort: a failure here shouldn't undo a started task.
         void fileTask(channelId, task.id, task.title).catch(() => {});
         void setGenerationTask(dashboardId, task.id).catch(() => {});
+        // Track this run so a toast (with a link back here) fires when it
+        // finishes, even after the user navigates to another canvas.
+        useCanvasGenerationTrackerStore
+          .getState()
+          .track({ taskId: task.id, dashboardId, channelId, name });
         // Repo-less tasks create no workspace row, so the usual workspace.create
         // invalidation never fires — refresh the cache so the task view resolves
         // its scratch cwd instead of showing the repo-picker prompt.
@@ -101,7 +107,14 @@ export function useGenerateFreeformCanvas(args: {
             .generateCanvasName(opts.instruction)
             .then(async (generated) => {
               const title = generated?.trim();
-              if (title) await renameDashboard(dashboardId, title);
+              if (title) {
+                await renameDashboard(dashboardId, title);
+                // Keep the tracked generation's name in sync so its completion
+                // toast reads the real title, not "Untitled canvas".
+                useCanvasGenerationTrackerStore
+                  .getState()
+                  .updateName(task.id, title);
+              }
             })
             .catch(() => {});
         }

--- a/packages/ui/src/features/canvas/stores/canvasGenerationTrackerStore.ts
+++ b/packages/ui/src/features/canvas/stores/canvasGenerationTrackerStore.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+// A freeform canvas generation we kicked off in this client and want to toast
+// about when it finishes. Registered at start (not derived from the dashboard
+// record, whose generationTaskId is never cleared), so the watcher only ever
+// announces generations the user actually started this session — never a stale
+// association on reload.
+export interface TrackedCanvasGeneration {
+  taskId: string;
+  dashboardId: string;
+  channelId: string;
+  name: string;
+}
+
+interface CanvasGenerationTrackerState {
+  // Keyed by taskId.
+  tracked: Record<string, TrackedCanvasGeneration>;
+  track: (entry: TrackedCanvasGeneration) => void;
+  // Keep the display name fresh when a freshly-created canvas is auto-renamed
+  // from its prompt after generation has already started.
+  updateName: (taskId: string, name: string) => void;
+  untrack: (taskId: string) => void;
+}
+
+export const useCanvasGenerationTrackerStore =
+  create<CanvasGenerationTrackerState>((set) => ({
+    tracked: {},
+    track: (entry) =>
+      set((s) => ({ tracked: { ...s.tracked, [entry.taskId]: entry } })),
+    updateName: (taskId, name) =>
+      set((s) =>
+        s.tracked[taskId]
+          ? {
+              tracked: {
+                ...s.tracked,
+                [taskId]: { ...s.tracked[taskId], name },
+              },
+            }
+          : s,
+      ),
+    untrack: (taskId) =>
+      set((s) => {
+        if (!s.tracked[taskId]) return s;
+        const { [taskId]: _removed, ...rest } = s.tracked;
+        return { tracked: rest };
+      }),
+  }));

--- a/packages/ui/src/primitives/toast.tsx
+++ b/packages/ui/src/primitives/toast.tsx
@@ -124,7 +124,12 @@ export const toast = {
 
   error: (
     title: ReactNode,
-    options?: { description?: string; id?: string | number; duration?: number },
+    options?: {
+      description?: string;
+      id?: string | number;
+      duration?: number;
+      action?: ToastAction;
+    },
   ) => {
     return sonnerToast.custom(
       (id) => (
@@ -133,6 +138,7 @@ export const toast = {
           type="error"
           title={title}
           description={options?.description}
+          action={options?.action}
         />
       ),
       { id: options?.id, duration: options?.duration ?? 5000 },

--- a/packages/ui/src/shell/App.tsx
+++ b/packages/ui/src/shell/App.tsx
@@ -11,6 +11,7 @@ import { InviteCodeScreen } from "@posthog/ui/features/auth/components/InviteCod
 import { ScopeReauthPrompt } from "@posthog/ui/features/auth/components/ScopeReauthPrompt";
 import { useAuthSession } from "@posthog/ui/features/auth/useAuthSession";
 import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
+import { CanvasGenerationToaster } from "@posthog/ui/features/canvas/freeform/useCanvasGenerationToasts";
 import { AddDirectoryDialog } from "@posthog/ui/features/folder-picker/AddDirectoryDialog";
 import { OnboardingFlow } from "@posthog/ui/features/onboarding/components/OnboardingFlow";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
@@ -160,6 +161,10 @@ function App() {
         transition={{ duration: 0.5, delay: showTransition ? 0.5 : 0 }}
       >
         <RouterProvider router={router} />
+        {/* Surfaces a toast when a backgrounded canvas generation finishes,
+            from anywhere in the app. Sibling of the router so it stays mounted
+            across every route (not just the canvas space). Renders null. */}
+        <CanvasGenerationToaster />
       </motion.div>
     );
   };


### PR DESCRIPTION
## What

<img width="405" height="178" alt="image" src="https://github.com/user-attachments/assets/d8f52294-0758-4029-82be-3856a908a9e1" />

--- 

<img width="271" height="120" alt="Screenshot 2026-06-24 at 16 41 01" src="https://github.com/user-attachments/assets/ceccd55b-808f-4ad9-a2d2-9c12803be077" />


Surfaces a global application toast — with a **View canvas** link — the moment a freeform canvas generation finishes, so the user is called back to it from **anywhere in the app**, not just while sitting on the canvas.

- **Tracking** is in-memory, registered at generation start (`canvasGenerationTrackerStore`), rather than the dashboard's `generationTaskId` (which is never cleared for freeform canvases).
- **Completion detection** reuses the same signal the canvas view uses — `isCanvasGenerating` (live ACP session `isPromptPending` for local runs, `cloudStatus` for cloud). Extracted into tested helpers and shared with `FreeformCanvasView`, removing its duplicated inline logic.
- **Armed latch** (`hasCanvasGenerationStarted`): a task can only toast after concrete "has started running" evidence, so the brief create→connect gap can't fire a false completion.
- **Mount point**: `CanvasGenerationToaster` (renders `null`) is a sibling of `<RouterProvider>` in `App.tsx`, so it stays mounted across every route. `toast.error` extended to carry an action link.

Toast: `completed` → success "X is ready" + View canvas; `failed` → error + link; `cancelled` → silent.

## Testing

- 33 unit tests across the status helpers (local-session, cloud, create→connect race, status resolution).
- Full canvas suite green, typecheck + lint clean.

## Known limitation

Tracks generations started in **this client session** — a quit/reload mid-generation, or another client's generation, won't toast. Persisting that needs a backend "recently completed" signal (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)