### PR TITLE
fix(canvas): pin freeform iframe to parent height with internal scroll

### DIFF
--- a/packages/core/src/canvas/freeformSchemas.ts
+++ b/packages/core/src/canvas/freeformSchemas.ts
@@ -245,13 +245,6 @@ export const canvasToHostMessageSchema = z.discriminatedUnion("type", [
     channel: z.literal(CANVAS_CHANNEL),
     type: z.literal("rendered"),
   }),
-  // The iframe reporting its content height so the host can size it without
-  // an inner scrollbar.
-  z.object({
-    channel: z.literal(CANVAS_CHANNEL),
-    type: z.literal("resize"),
-    height: z.number(),
-  }),
   // A request to navigate the host app. Fire-and-forget (no id/response). The
   // `nav` payload is the allowlist above — the host drops anything that doesn't
   // parse, so the iframe can only reach the four sanctioned destinations.

--- a/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
@@ -185,8 +185,8 @@ function FreeformPreview({ code }: { code?: string }) {
             style={{
               transform: `scale(${PREVIEW_SCALE})`,
               width: `${100 / PREVIEW_SCALE}%`,
-              // Fixed tall content height so the scaled iframe has something to
-              // fill before its first resize message arrives; the frame clips it.
+              // Fixed tall preview height for the scaled iframe to fill (the
+              // iframe is h-full); the frame clips whatever overflows.
               height: 600,
             }}
           >

--- a/packages/ui/src/features/canvas/freeform/CanvasFrameHost.tsx
+++ b/packages/ui/src/features/canvas/freeform/CanvasFrameHost.tsx
@@ -34,9 +34,9 @@ export function CanvasFrameHost() {
           left: rect?.left ?? 0,
           width: rect?.width ?? 0,
           height: rect?.height ?? 0,
-          // The slot owns scroll: the iframe grows to its content height and this
-          // box scrolls it, so scroll position survives in the warm frame.
-          overflow: active ? "auto" : "hidden",
+          // The iframe fills this slot exactly and scrolls its own content
+          // internally, so the wrapper only clips — it never scrolls.
+          overflow: "hidden",
           visibility: active ? "visible" : "hidden",
           pointerEvents: active ? "auto" : "none",
         };

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
@@ -13,7 +13,6 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
 } from "react";
 import { buildSandboxDocument, type SandboxMode } from "./sandboxRuntime";
 
@@ -68,7 +67,6 @@ export function FreeformCanvas({
   refreshKey = 0,
 }: FreeformCanvasProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = useState<number | null>(null);
   // The canvas mirrors the host's light/dark theme. Passed via `init` (not the
   // srcDoc) so a theme switch updates the running canvas in place, like `code`.
   const theme = useThemeStore((s) => (s.isDarkMode ? "dark" : "light"));
@@ -136,7 +134,7 @@ export function FreeformCanvas({
   // Subscribed once for the component's life; reads latest props via the ref.
   // Layout effect (not passive): the listener must be attached during commit,
   // before the browser yields to the iframe's load task — otherwise the iframe's
-  // one-shot "ready" (and early data-request/error/resize) can fire before the
+  // one-shot "ready" (and early data-request/error) can fire before the
   // listener exists and be lost, leaving the canvas blank on a cold first open.
   useLayoutEffect(() => {
     const post = (msg: HostToCanvasMessage) => {
@@ -179,9 +177,6 @@ export function FreeformCanvas({
           break;
         case "rendered":
           latest.current.onRendered?.();
-          break;
-        case "resize":
-          setHeight(msg.height);
           break;
         case "navigate":
           // msg.nav is already allowlist-validated by safeParse below.
@@ -256,8 +251,7 @@ export function FreeformCanvas({
       }}
       // bg tracks the host theme so there's no white flash in dark mode before
       // the iframe paints; the canvas body uses the same --background token.
-      className="w-full border-0 bg-background"
-      style={{ height: height ? `${height}px` : "100%", minHeight: "100%" }}
+      className="h-full w-full border-0 bg-background"
     />
   );
 }

--- a/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -206,16 +206,6 @@ export function buildSandboxDocument(
       ),
     );
 
-    // --- size reporting so the host can grow the iframe (no inner scrollbar) ---
-    const reportSize = () => {
-      const h = document.documentElement.scrollHeight;
-      post({ type: "resize", height: h });
-    };
-    // Observe size ONCE for the iframe's life. mount() runs on every streamed
-    // code snapshot, so creating the observer there would leak one per snapshot
-    // and multiply resize messages.
-    new ResizeObserver(reportSize).observe(document.documentElement);
-
     let root = null;
     // mount() is async and is called once per streamed code snapshot, so several
     // runs overlap on their awaits. Without ordering, a slower EARLIER (partial,
@@ -268,11 +258,10 @@ export function buildSandboxDocument(
         root.render(
           React.createElement(Boundary, null, React.createElement(Comp)),
         );
-        // Let layout settle, then report success + size.
+        // Let layout settle, then report success.
         requestAnimationFrame(() => {
           if (seq !== mountSeq) return;
           post({ type: "rendered" });
-          reportSize();
         });
       } catch (err) {
         // Only the latest snapshot reports — a superseded partial's parse error
@@ -314,7 +303,9 @@ ${FREEFORM_QUILL_CSS_URLS.map(
 ).join("\n")}
 <style>
   *, *::before, *::after { box-sizing: border-box; }
-  html, body { margin: 0; padding: 0; }
+  /* Fill the iframe viewport exactly so overflow scrolls on the iframe's own root
+     scroller — the iframe is pinned to its parent's height and never grows it. */
+  html, body { margin: 0; padding: 0; height: 100%; }
   /* Track the theme via Quill's tokens (set on :root / .dark) so the page chrome
      flips with the host theme; fall back to light if the tokens haven't loaded. */
   body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; color: var(--foreground, #111); background: var(--background, #fff); }


### PR DESCRIPTION
## Problem

In the project-bluebird Channels canvas, the freeform dashboard iframe didn't size to its container. It auto-grew to fit its content height and an outer host box did the scrolling, so a tall dashboard could push the Website-space chrome around instead of scrolling within its own pane.

**Why:** the iframe should take up the height of its parent and no more — content should scroll *inside* the iframe, while the iframe itself doesn't grow or scroll the outer page.

## Changes

Flipped the sizing model so the iframe is pinned to its parent's height and owns its own scroll:

- **FreeformCanvas** — removed the `height` state and the `resize` message handler; the `<iframe>` is now `h-full` and fills its slot exactly.
- **sandboxRuntime** — removed the `ResizeObserver`/`reportSize` machinery; `html, body` now fill the viewport (`height: 100%`) so overflow scrolls on the iframe's native root scroller.
- **CanvasFrameHost** — the slot wrapper always clips (`overflow: hidden`) rather than scrolling.
- **freeformSchemas** — dropped the now-dead `resize` canvas→host message variant.

## How did you test this?

- `@posthog/core` + `@posthog/ui` typecheck — clean
- `@posthog/core` unit tests — 1704 passed
- Biome lint on `packages/core/src/canvas` and `packages/ui/src/features/canvas` — clean

Not done: in-app visual confirmation in the running Electron app (scrollbar inside the iframe, Website chrome static).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
