### PR TITLE
fix(sessions): drop redundant generic "PostHog" resource chip

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -57,6 +57,7 @@ import {
 } from "../../enrichment/file-enricher";
 import {
   classifyPostHogExecCall,
+  isUnclassifiedPostHogSubTool,
   POSTHOG_PRODUCTS,
   type PostHogProductId,
 } from "../../posthog-products";
@@ -2005,6 +2006,12 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
    *  any newly-seen product so the client's persistent list can update live. */
   private createOnPostHogResourceUsed() {
     return (subTool: string, commandText?: string) => {
+      // Surface PostHog calls whose domain we don't recognize yet, so the gap
+      // can be closed in `DOMAIN_PRODUCT` rather than the call silently
+      // surfacing no chip. Deliberately-suppressed admin domains don't log.
+      if (isUnclassifiedPostHogSubTool(subTool)) {
+        this.logger.debug("Unclassified PostHog MCP sub-tool", { subTool });
+      }
       this.recordSessionResources(
         classifyPostHogExecCall(subTool, commandText),
       );

--- a/packages/agent/src/posthog-products.test.ts
+++ b/packages/agent/src/posthog-products.test.ts
@@ -3,6 +3,7 @@ import {
   classifyPostHogExecCall,
   classifyPostHogSqlQuery,
   classifyPostHogSubTool,
+  isUnclassifiedPostHogSubTool,
   POSTHOG_PRODUCTS,
   type PostHogProductId,
 } from "./posthog-products";
@@ -20,6 +21,23 @@ describe("classifyPostHogSubTool", () => {
     ["cdp-functions-list", "cdp"],
     ["insight-create", "product_analytics"],
   ])("maps resource sub-tool %s to %s", (subTool, product) => {
+    expect(classifyPostHogSubTool(subTool)).toBe(product);
+  });
+
+  // Domains whose canonical token differs from the longer per-sub-tool name we
+  // used to key on — these previously fell through to the generic fallback.
+  it.each([
+    ["llma-evaluation-list", "llm_analytics"],
+    ["llma-clustering-get", "llm_analytics"],
+    ["llma-trace-get", "llm_analytics"],
+    ["notebook-create", "product_analytics"],
+    ["cdp-function-update", "cdp"],
+    ["cdp-function-templates-list", "cdp"],
+    ["external-data-schemas-list", "data_warehouse"],
+    ["event-definition-list", "product_analytics"],
+    ["web-analytics-weekly-digest-get", "web_analytics"],
+    ["vision-scanners-create", "session_replay"],
+  ])("maps newly-covered sub-tool %s to %s", (subTool, product) => {
     expect(classifyPostHogSubTool(subTool)).toBe(product);
   });
 
@@ -89,6 +107,35 @@ describe("classifyPostHogSubTool", () => {
     for (const id of ids) {
       expect(POSTHOG_PRODUCTS[id]).toBeDefined();
     }
+  });
+});
+
+describe("isUnclassifiedPostHogSubTool", () => {
+  it.each(["brand-new-thing-list", "totally-made-up-get"])(
+    "flags genuinely-unknown domain %s",
+    (subTool) => {
+      expect(isUnclassifiedPostHogSubTool(subTool)).toBe(true);
+    },
+  );
+
+  it.each([
+    // Mapped product domains.
+    "experiment-list",
+    "llma-evaluation-list",
+    "vision-scanners-create",
+    // Deliberately-suppressed admin/meta domains — recognized, not unknown.
+    "project-get",
+    "docs-search",
+    "tasks-list",
+    // Special-cased call shapes.
+    "query-trends",
+    "execute-sql",
+    "activity-log-list",
+    // Empty input.
+    "",
+    "   ",
+  ])("does not flag recognized or special-cased call %j", (subTool) => {
+    expect(isUnclassifiedPostHogSubTool(subTool)).toBe(false);
   });
 });
 

--- a/packages/agent/src/posthog-products.test.ts
+++ b/packages/agent/src/posthog-products.test.ts
@@ -69,8 +69,8 @@ describe("classifyPostHogSubTool", () => {
     },
   );
 
-  it("falls back to the generic product for unrecognized domains", () => {
-    expect(classifyPostHogSubTool("brand-new-thing-list")).toBe("posthog");
+  it("returns null for unrecognized domains rather than a generic chip", () => {
+    expect(classifyPostHogSubTool("brand-new-thing-list")).toBeNull();
   });
 
   it.each(["", "   "])("returns null for empty input %j", (subTool) => {

--- a/packages/agent/src/posthog-products.test.ts
+++ b/packages/agent/src/posthog-products.test.ts
@@ -24,8 +24,8 @@ describe("classifyPostHogSubTool", () => {
     expect(classifyPostHogSubTool(subTool)).toBe(product);
   });
 
-  // Domains whose canonical token differs from the longer per-sub-tool name we
-  // used to key on — these previously fell through to the generic fallback.
+  // Domains that previously fell through to the generic fallback — keyed on a
+  // longer per-sub-tool name than the canonical token, or missing entirely.
   it.each([
     ["llma-evaluation-list", "llm_analytics"],
     ["llma-clustering-get", "llm_analytics"],
@@ -35,6 +35,7 @@ describe("classifyPostHogSubTool", () => {
     ["cdp-function-templates-list", "cdp"],
     ["external-data-schemas-list", "data_warehouse"],
     ["event-definition-list", "product_analytics"],
+    ["custom-property-definitions-list", "product_analytics"],
     ["web-analytics-weekly-digest-get", "web_analytics"],
     ["vision-scanners-create", "session_replay"],
   ])("maps newly-covered sub-tool %s to %s", (subTool, product) => {
@@ -123,6 +124,7 @@ describe("isUnclassifiedPostHogSubTool", () => {
     "experiment-list",
     "llma-evaluation-list",
     "vision-scanners-create",
+    "custom-property-definitions-list",
     // Deliberately-suppressed admin/meta domains — recognized, not unknown.
     "project-get",
     "docs-search",

--- a/packages/agent/src/posthog-products.ts
+++ b/packages/agent/src/posthog-products.ts
@@ -53,22 +53,21 @@ const DOMAIN_PRODUCT: Record<string, PostHogProductId | null> = {
   "visual-review": "session_replay",
   // Surveys
   survey: "surveys",
-  // LLM analytics
+  // Session replay (Replay Vision)
+  vision: "session_replay",
+  // LLM analytics. `llm` covers `llm-total-costs`; `llma` covers the whole
+  // `llma-*` family (evaluation, clustering, prompt, sentiment, trace, …) in
+  // one token rather than one entry per sub-tool.
   llm: "llm_analytics",
-  "llma-evaluation-judge-models": "llm_analytics",
-  "llma-personal-spend": "llm_analytics",
-  "llma-tagger-test-hog": "llm_analytics",
+  llma: "llm_analytics",
   "agent-feedback": "llm_analytics",
-  // Data warehouse
-  "external-data-sources": "data_warehouse",
-  "external-data-schemas": "data_warehouse",
-  "external-data-sync-logs": "data_warehouse",
+  // Data warehouse. `external-data` covers sources/schemas/sync-logs.
+  "external-data": "data_warehouse",
   "read-data-warehouse-schema": "data_warehouse",
   "read-data-schema": "data_warehouse",
   "batch-export": "data_warehouse",
-  // Data pipelines (CDP)
-  "cdp-functions": "cdp",
-  "cdp-function-templates": "cdp",
+  // Data pipelines (CDP). `cdp-function` covers `cdp-function-templates` too.
+  "cdp-function": "cdp",
   "hog-flows-logs": "cdp",
   "hog-flows-metrics": "cdp",
   workflows: "cdp",
@@ -78,7 +77,7 @@ const DOMAIN_PRODUCT: Record<string, PostHogProductId | null> = {
   // SQL
   "execute-sql": "sql",
   // Web analytics
-  "web-analytics-weekly-digest": "web_analytics",
+  "web-analytics": "web_analytics",
   // Product analytics
   insight: "product_analytics",
   dashboard: "product_analytics",
@@ -86,12 +85,13 @@ const DOMAIN_PRODUCT: Record<string, PostHogProductId | null> = {
   cohorts: "product_analytics",
   persons: "product_analytics",
   annotation: "product_analytics",
+  "event-definition": "product_analytics",
   endpoint: "product_analytics",
   view: "product_analytics",
   "usage-metrics": "product_analytics",
   subscriptions: "product_analytics",
   alert: "product_analytics",
-  notebooks: "product_analytics",
+  notebook: "product_analytics",
   // Admin / meta / introspection — recognized but not surfaced.
   project: null,
   user: null,
@@ -350,15 +350,45 @@ export function classifyPostHogSubTool(
     return classifyQuery(name.slice("query-".length));
   }
 
-  // Longest matching domain wins so `feature-flag` beats a hypothetical
-  // `feature` and multi-word domains aren't shadowed by shorter prefixes.
+  const best = matchDomain(name);
+  if (best === null) return null;
+  return DOMAIN_PRODUCT[best];
+}
+
+/**
+ * Best (longest) matching known domain for a sub-tool name, or `null` if none
+ * match. Longest wins so `feature-flag` beats a hypothetical `feature` and
+ * multi-word domains aren't shadowed by shorter prefixes.
+ */
+function matchDomain(name: string): string | null {
   let best: string | null = null;
   for (const [domain, re] of DOMAIN_PATTERNS) {
     if (re.test(name)) {
       if (best === null || domain.length > best.length) best = domain;
     }
   }
+  return best;
+}
 
-  if (best === null) return null;
-  return DOMAIN_PRODUCT[best];
+/**
+ * True when a `call` sub-tool is a PostHog resource call we don't recognize at
+ * all: not a query/execute-sql/activity-log call and matching no known domain,
+ * so it surfaces no product chip. Distinct from a domain we deliberately
+ * suppress (project, docs-search, …), which is recognized and returns `null` on
+ * purpose. Lets callers log genuinely-unknown calls so `DOMAIN_PRODUCT` can be
+ * expanded deliberately instead of silently dropping them.
+ */
+export function isUnclassifiedPostHogSubTool(subTool: string): boolean {
+  const name = subTool.trim().toLowerCase();
+  if (!name) return false;
+  if (name === "query" || name.startsWith("query-")) return false;
+  if (name === "execute-sql" || name === "execute_sql") return false;
+  if (
+    name === "activity-log" ||
+    name.startsWith("activity-log-") ||
+    name.startsWith("advanced-activity-logs")
+  ) {
+    return false;
+  }
+  return matchDomain(name) === null;
 }

--- a/packages/agent/src/posthog-products.ts
+++ b/packages/agent/src/posthog-products.ts
@@ -86,6 +86,7 @@ const DOMAIN_PRODUCT: Record<string, PostHogProductId | null> = {
   persons: "product_analytics",
   annotation: "product_analytics",
   "event-definition": "product_analytics",
+  "custom-property-definition": "product_analytics",
   endpoint: "product_analytics",
   view: "product_analytics",
   "usage-metrics": "product_analytics",
@@ -292,6 +293,28 @@ function classifyPostHogActivityLog(commandText: string): PostHogProductId[] {
   return [...products];
 }
 
+/* Call shapes classified by their arguments rather than the domain map:
+ * `query-<type>` by query type, `execute-sql` by the SQL it runs, activity-log
+ * reads by their `scope`. Single source of truth shared by the classifiers and
+ * `isUnclassifiedPostHogSubTool`, so a new special case added to one can't be
+ * missed by the other. Each takes an already trimmed+lowercased name. */
+
+function isQueryCall(name: string): boolean {
+  return name === "query" || name.startsWith("query-");
+}
+
+function isExecuteSqlCall(name: string): boolean {
+  return name === "execute-sql" || name === "execute_sql";
+}
+
+function isActivityLogCall(name: string): boolean {
+  return (
+    name === "activity-log" ||
+    name.startsWith("activity-log-") ||
+    name.startsWith("advanced-activity-logs")
+  );
+}
+
 /**
  * Classify an executed MCP exec `call` into the products it touched. For
  * `execute-sql` the query text is inspected so the call is attributed to the
@@ -308,15 +331,11 @@ export function classifyPostHogExecCall(
   commandText?: string,
 ): PostHogProductId[] {
   const name = subTool.trim().toLowerCase();
-  if (name === "execute-sql" || name === "execute_sql") {
+  if (isExecuteSqlCall(name)) {
     const fromTables = commandText ? classifyPostHogSqlQuery(commandText) : [];
     return fromTables.length > 0 ? fromTables : ["sql"];
   }
-  if (
-    name === "activity-log" ||
-    name.startsWith("activity-log-") ||
-    name.startsWith("advanced-activity-logs")
-  ) {
+  if (isActivityLogCall(name)) {
     return commandText ? classifyPostHogActivityLog(commandText) : [];
   }
   const product = classifyPostHogSubTool(subTool);
@@ -346,7 +365,7 @@ export function classifyPostHogSubTool(
   const name = subTool.trim().toLowerCase();
   if (!name) return null;
 
-  if (name === "query" || name.startsWith("query-")) {
+  if (isQueryCall(name)) {
     return classifyQuery(name.slice("query-".length));
   }
 
@@ -381,13 +400,7 @@ function matchDomain(name: string): string | null {
 export function isUnclassifiedPostHogSubTool(subTool: string): boolean {
   const name = subTool.trim().toLowerCase();
   if (!name) return false;
-  if (name === "query" || name.startsWith("query-")) return false;
-  if (name === "execute-sql" || name === "execute_sql") return false;
-  if (
-    name === "activity-log" ||
-    name.startsWith("activity-log-") ||
-    name.startsWith("advanced-activity-logs")
-  ) {
+  if (isQueryCall(name) || isExecuteSqlCall(name) || isActivityLogCall(name)) {
     return false;
   }
   return matchDomain(name) === null;

--- a/packages/agent/src/posthog-products.ts
+++ b/packages/agent/src/posthog-products.ts
@@ -28,8 +28,6 @@ export const POSTHOG_PRODUCTS = {
   logs: "Logs",
   apm: "APM",
   sql: "SQL",
-  /** Generic fallback for a recognized-PostHog call we don't classify yet. */
-  posthog: "PostHog",
 } as const;
 
 export type PostHogProductId = keyof typeof POSTHOG_PRODUCTS;
@@ -38,7 +36,8 @@ export type PostHogProductId = keyof typeof POSTHOG_PRODUCTS;
  * Domain prefix → product, or `null` for admin/meta/introspection domains we
  * deliberately do not surface (listing projects, reading the activity log,
  * managing tasks, searching docs, …). A sub-tool whose domain is absent here
- * falls back to the generic `posthog` product rather than disappearing.
+ * surfaces nothing — every chip in the bar is already a PostHog resource, so a
+ * generic "PostHog" fallback chip would be redundant.
  */
 const DOMAIN_PRODUCT: Record<string, PostHogProductId | null> = {
   // Experiments
@@ -337,8 +336,9 @@ function classifyQuery(type: string): PostHogProductId | null {
 
 /**
  * Map a PostHog MCP `call` sub-tool (e.g. `feature-flag-update`, `query-trends`)
- * to a product id. Returns `null` when the sub-tool is an admin/meta domain we
- * deliberately don't surface, or when the name is empty.
+ * to a product id. Returns `null` when the name is empty, or when the domain is
+ * one we don't surface — either a known admin/meta domain or an unrecognized
+ * one (no point in a generic "PostHog" chip inside a PostHog-resources bar).
  */
 export function classifyPostHogSubTool(
   subTool: string,
@@ -359,6 +359,6 @@ export function classifyPostHogSubTool(
     }
   }
 
-  if (best === null) return "posthog";
+  if (best === null) return null;
   return DOMAIN_PRODUCT[best];
 }

--- a/packages/ui/src/features/sessions/components/SessionResourcesBar.tsx
+++ b/packages/ui/src/features/sessions/components/SessionResourcesBar.tsx
@@ -41,7 +41,6 @@ const PRODUCT_ICON: Record<PostHogProductId, ComponentType<IconProps>> = {
   logs: FileTextIcon,
   apm: GaugeIcon,
   sql: TableIcon,
-  posthog: SparkleIcon,
 };
 
 /**
@@ -63,7 +62,6 @@ const PRODUCT_DOC_URL: Partial<Record<PostHogProductId, string>> = {
   cdp: "https://posthog.com/docs/cdp",
   logs: "https://posthog.com/docs/logs",
   sql: "https://posthog.com/docs/sql",
-  posthog: "https://posthog.com/docs",
 };
 
 interface SessionResourcesBarProps {


### PR DESCRIPTION
## Problem

In a session's "PostHog resources used" bar, one chip just said **PostHog**. As Matt flagged in the thread: inside a bar literally titled "PostHog resources used", a chip that says "PostHog" is redundant.

It was the generic fallback (`posthog` product id) the MCP sub-tool classifier returned whenever a call's domain wasn't recognized. Digging into *what* was actually hitting that fallback surfaced two further problems:

- **No visibility** — an unrecognized call fell to the fallback silently, with nothing logged, so we had no way to know which sub-tools were landing there.
- **Real coverage gaps** — several `DOMAIN_PRODUCT` keys were written more specifically than the actual MCP domain token (e.g. `notebooks` vs `notebook`, `cdp-functions` vs `cdp-function`, `llma-personal-spend` vs the `llma-*` family). Legitimate product calls were being mis-bucketed into the fallback instead of showing their real product chip.

## Changes

- Removed the generic `posthog` product id. Unrecognized domains now classify as `null` and surface nothing — matching how known admin/meta domains already behave. The exhaustive `Record<PostHogProductId, …>` types compile-enforced dropping its icon/docs-URL entries in `SessionResourcesBar`.
- Added `isUnclassifiedPostHogSubTool` + a debug log in the agent, so genuinely-unknown PostHog sub-tools become visible and `DOMAIN_PRODUCT` can be expanded deliberately. Deliberately-suppressed admin domains (project, docs-search, …) don't log.
- Closed domain-map gaps so real product calls resolve to the right chip: consolidated the whole `llma-*` family → AI observability, fixed `notebook` / `cdp-function` / `external-data` / `web-analytics`, and added `event-definition` (Product analytics) and `vision` (Replay Vision → Session replay).

No frontend screenshot — the only UI effect is *removing* a chip that should never have rendered.

## How did you test this?

- `pnpm --filter @posthog/agent test posthog-products` — 82 passing (incl. new coverage for the fixed domains and the new predicate)
- `pnpm --filter @posthog/agent --filter @posthog/ui typecheck` — clean
- `biome lint` on the changed files — clean
- (Note: the rest of `@posthog/agent`'s suite has pre-existing failures on `main` unrelated to this change — stale `@posthog/shared` / `@posthog/git` dist artifacts.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1782318999010019?thread_ts=1782318999.010019&cid=C09G8Q32R6F)*
