### PR TITLE
test: exercise CI with deliberate type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Found a bug or have feedback? [Open an issue](https://github.com/PostHog/code/is
 
 # PostHog Code
 
+<!-- CI test comment: verifying the pipeline picks up changes on this branch -->
+
 This is the monorepo for PostHog Code apps and the agent framework that powers them.
 
 ## Development

--- a/packages/host-router/src/ports/connectivity-client.ts
+++ b/packages/host-router/src/ports/connectivity-client.ts
@@ -7,3 +7,6 @@ export const CONNECTIVITY_CLIENT = Symbol.for(
 export interface HostConnectivityClient {
   connectivity: WorkspaceClient["connectivity"];
 }
+
+// CI test: deliberate type error to verify the pipeline fails as expected.
+const _ciTestBrokenValue: number = "this is not a number";


### PR DESCRIPTION
Test PR to verify the CI pipeline.

## Changes
- Added a test comment to the README.
- Added a deliberate TypeScript type error in `packages/host-router/src/ports/connectivity-client.ts` so the typecheck job fails.

This is intentionally broken to confirm CI reports failures as expected. **Do not merge** — will be reverted/closed once CI behavior is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)