### PR TITLE
fix(nav): change Inbox label from Alpha to Beta

### DIFF
--- a/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
@@ -45,7 +45,7 @@ export function InboxItem({
           onClick={onClick}
           endContent={
             <>
-              <Badge variant="warning">Alpha</Badge>
+              <Badge variant="warning">Beta</Badge>
               <SidebarKbdHint keys={SHORTCUTS.INBOX} />
             </>
           }


### PR DESCRIPTION
## Problem

The Inbox in PostHog Code still showed an "Alpha" badge in the sidebar, but Inbox has graduated to beta.

## Changes

Changed the Inbox sidebar badge from "Alpha" to "Beta".

## How did you test this?

Not run — single-string label change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B98FCPT3N/p1782324278634359?thread_ts=1782324278.634359&cid=C0B98FCPT3N)*
