### PR TITLE
fix(review): scroll clicked file into view in cloud and remote reviews

### DIFF
--- a/packages/ui/src/features/task-detail/components/ChangesPanel.tsx
+++ b/packages/ui/src/features/task-detail/components/ChangesPanel.tsx
@@ -56,6 +56,7 @@ interface ChangesPanelProps {
 interface ChangedFileItemProps {
   file: ChangedFile;
   taskId: string;
+  fileKey: string;
   isActive: boolean;
   repoPath?: string;
   mainRepoPath?: string;
@@ -91,6 +92,7 @@ function CompactIconButton({
 function ChangedFileItem({
   file,
   taskId,
+  fileKey,
   isActive,
   repoPath,
   mainRepoPath,
@@ -115,8 +117,6 @@ function ChangedFileItem({
   const fileName = file.path.split("/").pop() || file.path;
   const fullPath = repoPath ? `${repoPath}/${file.path}` : file.path;
   const indicator = getStatusIndicator(file.status);
-
-  const fileKey = makeFileKey(file.staged, file.path);
 
   const handleClick = () => {
     track(ANALYTICS_EVENTS.FILE_DIFF_VIEWED, {
@@ -318,6 +318,7 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
         key={file.path}
         file={file}
         taskId={taskId}
+        fileKey={file.path}
         isActive={activeFilePath === file.path}
         depth={depth}
       />
@@ -452,6 +453,7 @@ function LocalWorkingTreeChangesPanel({
           key={key}
           file={file}
           taskId={taskId}
+          fileKey={key}
           repoPath={repoPath}
           isActive={activeFilePath === key}
           mainRepoPath={workspace?.folderPath}
@@ -538,18 +540,16 @@ function RemoteChangesList({
   );
 
   const renderFile = useCallback(
-    (file: ChangedFile, depth: number) => {
-      const key = makeFileKey(file.staged, file.path);
-      return (
-        <ChangedFileItem
-          key={key}
-          file={file}
-          taskId={taskId}
-          isActive={activeFilePath === key}
-          depth={depth}
-        />
-      );
-    },
+    (file: ChangedFile, depth: number) => (
+      <ChangedFileItem
+        key={file.path}
+        file={file}
+        taskId={taskId}
+        fileKey={file.path}
+        isActive={activeFilePath === file.path}
+        depth={depth}
+      />
+    ),
     [taskId, activeFilePath],
   );
 


### PR DESCRIPTION
## Problem

In a task's **Changes** sidebar (file explorer) alongside the review diff pane, clicking a file is supposed to scroll that file's diff into view. This was broken for **cloud tasks** and **branch/PR (remote) reviews** — clicking did nothing.

### Root cause

Sidebar click → `requestScrollToFile(taskId, key)` → `ReviewShell` looks up `itemIndexByFilePath.get(key)` and scrolls. If the lookup misses, it silently returns.

The sidebar and diff list disagreed on the key:

| Source | Diff-list `scrollKey` | Sidebar click key | Match? |
| --- | --- | --- | --- |
| Local working tree | `makeFileKey(staged, path)` | `makeFileKey(...)` | ✅ |
| Branch / PR (remote) | `file.path` (raw) | `makeFileKey(...)` → `unstaged:path` | ❌ |
| Cloud | `file.path` (raw) | `makeFileKey(...)` → `unstaged:path` | ❌ |

The same mismatch also broke the sidebar active-file highlight for remote reviews.

## Fix

Before

https://github.com/user-attachments/assets/ad3d6937-af1e-4310-b939-0aa8e432ca87



After

https://github.com/user-attachments/assets/c28bf5b9-ec1a-4bb1-ac51-5b34f304b5e2



Pass the diff list's `scrollKey` into the shared `ChangedFileItem` per source instead of always computing `makeFileKey` internally:
- Cloud & remote panels → raw `file.path` (and remote `isActive` now compares the raw path too)
- Local working tree → keep `makeFileKey(staged, path)` (needs the prefix to disambiguate a path that is both staged and unstaged)

Single-file change in `ChangesPanel.tsx`; review pages, builders, and the navigation store already key consistently on `scrollKey`.

## Verification

- `pnpm --filter @posthog/ui typecheck` — clean (confirms the new required `fileKey` prop at every call site)
- `biome lint` on the changed file — clean
- Manual: click a file in the Changes sidebar for cloud / branch / PR reviews → diff scrolls into view and the row highlights; local working tree unchanged.