### PR TITLE
fix(inbox): Give Inbox-generated report PRs a backlink

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1404,7 +1404,10 @@ describe("AgentServer HTTP Mode", () => {
       expect(prompt).toContain("gh pr create --draft");
       expect(prompt).toContain("Generated-By: PostHog Code");
       expect(prompt).toContain("Task-Id: test-task-id");
-      expect(prompt).toContain("Created with [PostHog Code]");
+      // Slack-origin PRs are attributed to PostHog, not the PostHog Code app.
+      expect(prompt).toContain(
+        "Created with [PostHog](https://posthog.com?ref=pr)",
+      );
       // PR template detection (repo first, org `.github` fallback)
       expect(prompt).toContain(".github/pull_request_template.md");
       expect(prompt).toContain("org's `.github` repo");
@@ -1656,11 +1659,12 @@ describe("AgentServer HTTP Mode", () => {
           // brevity
           expect(prompt).toContain("Keep the PR description brief");
           expect(prompt).toContain("do NOT enumerate every change");
-          // plain footer, no Slack link
+          // plain footer, no Slack link; Slack-origin PRs are branded "PostHog"
           expect(prompt).toContain(
-            "*Created with [PostHog Code](https://posthog.com/code?ref=pr)*",
+            "*Created with [PostHog](https://posthog.com?ref=pr)*",
           );
           expect(prompt).not.toContain("from a [Slack thread]");
+          expect(prompt).not.toContain("PostHog Code](https://posthog.com");
         } finally {
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         }
@@ -1676,7 +1680,7 @@ describe("AgentServer HTTP Mode", () => {
             "https://posthog.slack.com/archives/C123/p456",
           );
           expect(prompt).toContain(
-            "*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C123/p456)*",
+            "*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C123/p456)*",
           );
           // The Why bullet no longer carries the thread link.
           expect(prompt).not.toContain(
@@ -1698,7 +1702,7 @@ describe("AgentServer HTTP Mode", () => {
             "http://localhost:8000/project/1/inbox/rep_1",
           );
           expect(prompt).toContain(
-            "*Created with [PostHog Code](https://posthog.com/code?ref=pr) from an [inbox report](http://localhost:8000/project/1/inbox/rep_1)*",
+            "*Created with [PostHog](https://posthog.com?ref=pr) from an [inbox report](http://localhost:8000/project/1/inbox/rep_1)*",
           );
           expect(prompt).not.toContain("Slack thread");
         } finally {
@@ -1751,7 +1755,7 @@ describe("AgentServer HTTP Mode", () => {
             "https://posthog.slack.com/archives/C123/p456",
           );
           expect(prompt).toContain(
-            "*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C123/p456)*",
+            "*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C123/p456)*",
           );
         } finally {
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -204,11 +204,13 @@ interface TestableServer {
   buildCloudSystemPrompt(
     prUrl?: string | null,
     slackThreadUrl?: string | null,
+    inboxReportUrl?: string | null,
   ): string;
   buildDetectedPrContext(prUrl: string): string;
   buildSessionSystemPrompt(
     prUrl?: string | null,
     slackThreadUrl?: string | null,
+    inboxReportUrl?: string | null,
   ): string | { append: string };
   buildCodexInstructions(systemPrompt: string | { append: string }): string;
   getRuntimeAdapter(): "claude" | "codex";
@@ -1680,6 +1682,42 @@ describe("AgentServer HTTP Mode", () => {
           expect(prompt).not.toContain(
             "this task started from a Slack thread, also link it",
           );
+        } finally {
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        }
+      });
+
+      it("embeds the inbox report link in the footer for a signal_report run", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "signal_report";
+        try {
+          const prompt = (
+            createServer() as unknown as TestableServer
+          ).buildCloudSystemPrompt(
+            null,
+            null,
+            "http://localhost:8000/project/1/inbox/rep_1",
+          );
+          expect(prompt).toContain(
+            "*Created with [PostHog Code](https://posthog.com/code?ref=pr) from an [inbox report](http://localhost:8000/project/1/inbox/rep_1)*",
+          );
+          expect(prompt).not.toContain("Slack thread");
+        } finally {
+          delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
+        }
+      });
+
+      it("prefers the Slack thread link over the inbox report link when both are present", () => {
+        process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
+        try {
+          const prompt = (
+            createServer() as unknown as TestableServer
+          ).buildCloudSystemPrompt(
+            null,
+            "https://posthog.slack.com/archives/C123/p456",
+            "http://localhost:8000/project/1/inbox/rep_1",
+          );
+          expect(prompt).toContain("from a [Slack thread]");
+          expect(prompt).not.toContain("from an [inbox report]");
         } finally {
           delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         }

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1717,16 +1717,22 @@ export class AgentServer {
   }
 
   /**
+   * Automated, PostHog-branded origins: the Slack app and the Self-driving
+   * inbox. These both auto-publish by default and attribute their PRs to
+   * "PostHog" rather than the PostHog Code desktop app.
+   */
+  private isAutomatedOrigin(): boolean {
+    const origin = this.getCloudInteractionOrigin();
+    return origin === "slack" || origin === "signal_report";
+  }
+
+  /**
    * Automated-origin cloud runs auto-publish by default. Every other origin is
    * review-first unless the user explicitly asks, and createPr=false always
    * disables publishing.
    */
   private shouldAutoPublishCloudChanges(): boolean {
-    const origin = this.getCloudInteractionOrigin();
-    return (
-      (origin === "slack" || origin === "signal_report") &&
-      this.config.createPr !== false
-    );
+    return this.isAutomatedOrigin() && this.config.createPr !== false;
   }
 
   private buildDetectedPrContext(prUrl: string): string {
@@ -1824,11 +1830,17 @@ we want:
   Task-Id: ${taskId}`;
 
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.`;
+    // Slack- and inbox-originated PRs are attributed to PostHog, not the
+    // PostHog Code desktop app — they come from the Slack app / Self-driving
+    // inbox, which users know as "PostHog".
+    const createdWith = this.isAutomatedOrigin()
+      ? "Created with [PostHog](https://posthog.com?ref=pr)"
+      : "Created with [PostHog Code](https://posthog.com/code?ref=pr)";
     const prFooter = slackThreadUrl
-      ? `*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](${slackThreadUrl})*`
+      ? `*${createdWith} from a [Slack thread](${slackThreadUrl})*`
       : inboxReportUrl
-        ? `*Created with [PostHog Code](https://posthog.com/code?ref=pr) from an [inbox report](${inboxReportUrl})*`
-        : `*Created with [PostHog Code](https://posthog.com/code?ref=pr)*`;
+        ? `*${createdWith} from an [inbox report](${inboxReportUrl})*`
+        : `*${createdWith}*`;
 
     if (prUrl) {
       if (!shouldAutoCreatePr) {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -961,10 +961,19 @@ export class AgentServer {
       "slack_thread_url",
     );
 
+    // Web backlink to the inbox report that spawned this task, so the
+    // auto-generated PR can point back at it. Built from the same pieces as the
+    // report's `_posthogUrl`: <apiUrl>/project/<projectId>/inbox/<reportId>.
+    const signalReportId = preTask?.signal_report;
+    const inboxReportUrl = signalReportId
+      ? `${this.config.apiUrl.replace(/\/$/, "")}/project/${this.config.projectId}/inbox/${signalReportId}`
+      : null;
+
     const runtimeAdapter = this.getRuntimeAdapter();
     const sessionSystemPrompt = this.buildSessionSystemPrompt(
       prUrl,
       slackThreadUrl,
+      inboxReportUrl,
     );
     const codexInstructions =
       runtimeAdapter === "codex"
@@ -1640,8 +1649,13 @@ export class AgentServer {
   private buildSessionSystemPrompt(
     prUrl?: string | null,
     slackThreadUrl?: string | null,
+    inboxReportUrl?: string | null,
   ): string | { append: string } {
-    const cloudAppend = this.buildCloudSystemPrompt(prUrl, slackThreadUrl);
+    const cloudAppend = this.buildCloudSystemPrompt(
+      prUrl,
+      slackThreadUrl,
+      inboxReportUrl,
+    );
     const userPrompt = this.config.claudeCode?.systemPrompt;
 
     // String override: combine user prompt with cloud instructions
@@ -1737,6 +1751,7 @@ export class AgentServer {
   private buildCloudSystemPrompt(
     prUrl?: string | null,
     slackThreadUrl?: string | null,
+    inboxReportUrl?: string | null,
   ): string {
     const taskId = this.config.taskId;
     const shouldAutoCreatePr = this.shouldAutoPublishCloudChanges();
@@ -1811,7 +1826,9 @@ we want:
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.`;
     const prFooter = slackThreadUrl
       ? `*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](${slackThreadUrl})*`
-      : `*Created with [PostHog Code](https://posthog.com/code?ref=pr)*`;
+      : inboxReportUrl
+        ? `*Created with [PostHog Code](https://posthog.com/code?ref=pr) from an [inbox report](${inboxReportUrl})*`
+        : `*Created with [PostHog Code](https://posthog.com/code?ref=pr)*`;
 
     if (prUrl) {
       if (!shouldAutoCreatePr) {

--- a/packages/core/src/inbox/reportActions.test.ts
+++ b/packages/core/src/inbox/reportActions.test.ts
@@ -5,51 +5,49 @@ import {
 } from "./reportActions";
 
 describe("buildCreatePrReportPrompt", () => {
-  it.each([
-    { isDevBuild: false, expectedScheme: "posthog-code" },
-    { isDevBuild: true, expectedScheme: "posthog-code-dev" },
-  ])(
-    "uses the $expectedScheme deeplink scheme when isDevBuild=$isDevBuild",
-    ({ isDevBuild, expectedScheme }) => {
-      const prompt = buildCreatePrReportPrompt({
-        reportId: "abc123",
-        isDevBuild,
-      });
-      expect(prompt).toContain(`${expectedScheme}://inbox/abc123`);
-    },
-  );
-
-  it("references the inbox MCP tools so the agent fetches the detail itself", () => {
+  it("embeds the report web URL as a clickable backlink when provided", () => {
     const prompt = buildCreatePrReportPrompt({
       reportId: "abc123",
-      isDevBuild: false,
+      reportUrl: "https://us.posthog.com/project/2/inbox/abc123",
     });
+    expect(prompt).toContain(
+      "([inbox item](https://us.posthog.com/project/2/inbox/abc123))",
+    );
+  });
+
+  it("never embeds a posthog-code:// deep link", () => {
+    const prompt = buildCreatePrReportPrompt({
+      reportId: "abc123",
+      reportUrl: "https://us.posthog.com/project/2/inbox/abc123",
+    });
+    expect(prompt).not.toContain("posthog-code://");
+  });
+
+  it("omits the inline link when no report URL is known", () => {
+    const prompt = buildCreatePrReportPrompt({ reportId: "abc123" });
+    expect(prompt).not.toContain("([inbox item]");
+    expect(prompt).toContain("Act on PostHog inbox report abc123.");
+  });
+
+  it("references the inbox MCP tools so the agent fetches the detail itself", () => {
+    const prompt = buildCreatePrReportPrompt({ reportId: "abc123" });
     expect(prompt).toContain("inbox MCP tools");
   });
 
   it("asks the agent to open a PR", () => {
-    const prompt = buildCreatePrReportPrompt({
-      reportId: "abc123",
-      isDevBuild: false,
-    });
+    const prompt = buildCreatePrReportPrompt({ reportId: "abc123" });
     expect(prompt).toMatch(/open a PR/i);
   });
 
   it("tells the agent to continue an existing linked PR instead of opening a duplicate", () => {
-    const prompt = buildCreatePrReportPrompt({
-      reportId: "abc123",
-      isDevBuild: false,
-    });
+    const prompt = buildCreatePrReportPrompt({ reportId: "abc123" });
     expect(prompt).toContain("implementation_pr_url");
     expect(prompt).toMatch(/gh pr checkout/i);
     expect(prompt).toMatch(/do not open a second PR/i);
   });
 
   it("tells the agent to stop rather than guess if the report can't be fetched", () => {
-    const prompt = buildCreatePrReportPrompt({
-      reportId: "abc123",
-      isDevBuild: false,
-    });
+    const prompt = buildCreatePrReportPrompt({ reportId: "abc123" });
     expect(prompt).toMatch(/can't fetch the report/i);
     expect(prompt).toMatch(/instead of guessing/i);
   });
@@ -57,7 +55,6 @@ describe("buildCreatePrReportPrompt", () => {
   it("appends user feedback when provided", () => {
     const prompt = buildCreatePrReportPrompt({
       reportId: "abc123",
-      isDevBuild: false,
       feedback: "Use the v2 endpoint, not v1.",
     });
     expect(prompt).toMatch(/Additional feedback from the user/i);
@@ -69,13 +66,9 @@ describe("buildCreatePrReportPrompt", () => {
     { label: "empty string", feedback: "" },
     { label: "whitespace only", feedback: "   " },
   ])("omits the feedback section when feedback is $label", ({ feedback }) => {
-    const base = buildCreatePrReportPrompt({
-      reportId: "abc123",
-      isDevBuild: false,
-    });
+    const base = buildCreatePrReportPrompt({ reportId: "abc123" });
     const prompt = buildCreatePrReportPrompt({
       reportId: "abc123",
-      isDevBuild: false,
       feedback,
     });
     expect(prompt).toBe(base);

--- a/packages/core/src/inbox/reportActions.ts
+++ b/packages/core/src/inbox/reportActions.ts
@@ -1,8 +1,5 @@
 import { buildDiscussReportPrompt as buildSharedDiscussReportPrompt } from "@posthog/shared";
-import {
-  buildInboxDeeplink,
-  getDeeplinkProtocol,
-} from "@posthog/shared/deeplink";
+import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import type { SignalReport } from "@posthog/shared/types";
 
 /**
@@ -27,17 +24,27 @@ export function canCreateImplementationPr(report: SignalReport): boolean {
 
 interface BuildCreatePrReportPromptOptions {
   reportId: string;
-  isDevBuild: boolean;
+  /**
+   * Canonical web URL of the report
+   * (`https://<region>.posthog.com/project/<projectId>/inbox/<reportId>`).
+   * Embedded as a clickable backlink so the agent can reference the report from
+   * the cloud PR. Prefer this over the desktop `posthog-code://` deep link,
+   * which isn't navigable from GitHub or Slack. Omitted when the region/project
+   * aren't known.
+   */
+  reportUrl?: string | null;
   feedback?: string;
 }
 
 export function buildCreatePrReportPrompt({
   reportId,
-  isDevBuild,
+  reportUrl,
   feedback,
 }: BuildCreatePrReportPromptOptions): string {
-  const reportLink = `${getDeeplinkProtocol(isDevBuild)}://inbox/${reportId}`;
-  const base = `Act on PostHog inbox report ${reportId} ([inbox item](${reportLink})). Use the inbox MCP tools to fetch the report, its contributing findings, any suggested reviewers, and any implementation PR already linked to it; investigate the root cause; and implement the fix.\n\nIf the report already has a linked implementation PR (check the report's \`implementation_pr_url\`) and it is still open, you are iterating on existing work: check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to that same PR. Do NOT open a second PR for the same fix. Otherwise, open a PR. Only open a separate PR alongside an existing one when the user's feedback clearly asks for a distinct change.\n\nIf you can't fetch the report, stop and report that instead of guessing what it contains.`;
+  const reportRef = reportUrl
+    ? `${reportId} ([inbox item](${reportUrl}))`
+    : reportId;
+  const base = `Act on PostHog inbox report ${reportRef}. Use the inbox MCP tools to fetch the report, its contributing findings, any suggested reviewers, and any implementation PR already linked to it; investigate the root cause; and implement the fix.\n\nIf the report already has a linked implementation PR (check the report's \`implementation_pr_url\`) and it is still open, you are iterating on existing work: check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to that same PR. Do NOT open a second PR for the same fix. Otherwise, open a PR. Only open a separate PR alongside an existing one when the user's feedback clearly asks for a distinct change.\n\nIf you can't fetch the report, stop and report that instead of guessing what it contains.`;
   const trimmedFeedback = feedback?.trim();
   if (!trimmedFeedback) return base;
   return `${base}\n\nAdditional feedback from the user (take this into account, including any questions raised in the report thread):\n${trimmedFeedback}`;

--- a/packages/core/src/inbox/signalReportTaskService.ts
+++ b/packages/core/src/inbox/signalReportTaskService.ts
@@ -9,6 +9,7 @@ import {
   TASK_SERVICE,
   type TaskService,
 } from "../task-detail/taskService";
+import { buildPostHogUrl } from "../settings/posthogUrl";
 import { REPORT_MODEL_RESOLVER, type ReportModelResolver } from "./identifiers";
 import {
   buildCreatePrReportPrompt,
@@ -25,6 +26,7 @@ export interface CreateSignalReportTaskInput {
   cloudRepository: string | null;
   githubUserIntegrationId: string | null;
   cloudRegion: CloudRegion | null;
+  projectId?: number | null;
   adapter: "claude" | "codex";
   modelOverride?: string | null;
   reasoningLevel?: string;
@@ -90,7 +92,16 @@ export class SignalReportTaskService {
           })
         : buildCreatePrReportPrompt({
             reportId: input.reportId,
-            isDevBuild: input.isDevBuild,
+            // Web URL rather than a `posthog-code://` deep link: the prompt runs
+            // in a cloud task and may be echoed into the PR, where only an https
+            // link works.
+            reportUrl:
+              input.projectId != null
+                ? buildPostHogUrl(
+                    `/project/${input.projectId}/inbox/${input.reportId}`,
+                    input.cloudRegion,
+                  )
+                : null,
             feedback: input.feedback,
           });
 

--- a/packages/core/src/inbox/signalReportTaskService.ts
+++ b/packages/core/src/inbox/signalReportTaskService.ts
@@ -4,12 +4,12 @@ import {
   type TaskCreationOutput,
 } from "@posthog/shared";
 import { inject, injectable } from "inversify";
+import { buildPostHogUrl } from "../settings/posthogUrl";
 import {
   type CreateTaskResult,
   TASK_SERVICE,
   type TaskService,
 } from "../task-detail/taskService";
-import { buildPostHogUrl } from "../settings/posthogUrl";
 import { REPORT_MODEL_RESOLVER, type ReportModelResolver } from "./identifiers";
 import {
   buildCreatePrReportPrompt,

--- a/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
+++ b/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
@@ -1,5 +1,7 @@
 import { buildCreatePrReportPrompt } from "@posthog/core/inbox/reportActions";
+import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
 import type { TaskCreationInput } from "@posthog/core/task-detail/taskService";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
   type InboxCloudTaskInputContext,
   useInboxCloudTaskRunner,
@@ -45,6 +47,8 @@ export function useCreatePrReport({
 }: UseCreatePrReportOptions): UseCreatePrReportReturn {
   const { data: teamConfig } = useSignalTeamConfig();
   const baseBranchOverrides = teamConfig?.autostart_base_branches ?? null;
+  const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
+  const projectId = useAuthStateValue((s) => s.currentProjectId);
 
   // Holds the steering text for the in-flight run. `buildInput` is invoked
   // synchronously inside `run()`, so the ref is always current when read; a ref
@@ -53,9 +57,18 @@ export function useCreatePrReport({
 
   const buildInput = useCallback(
     (ctx: InboxCloudTaskInputContext): TaskCreationInput => {
+      // Web URL rather than a `posthog-code://` deep link: the prompt runs in a
+      // cloud task and may be echoed into the PR, where only an https link works.
+      const reportUrl =
+        projectId != null
+          ? buildPostHogUrl(
+              `/project/${projectId}/inbox/${reportId}`,
+              cloudRegion,
+            )
+          : null;
       const prompt = buildCreatePrReportPrompt({
         reportId,
-        isDevBuild: import.meta.env.DEV,
+        reportUrl,
         feedback: feedbackRef.current,
       });
       const targetRepo = ctx.cloudRepository.toLowerCase();
@@ -80,7 +93,7 @@ export function useCreatePrReport({
         signalReportId: reportId,
       };
     },
-    [baseBranchOverrides, reportId],
+    [baseBranchOverrides, reportId, cloudRegion, projectId],
   );
 
   const analyticsExtras = useMemo(


### PR DESCRIPTION
## Problem

These auto-generated "act on an inbox report" PRs had two link issues Rafa flagged:

1. The original prompt embedded a desktop `posthog-code://inbox/<reportId>` deep link, which GitHub/Slack don't render as a navigable link - so it shows up broken.
2. `signal_report`-origin PRs had no backlink to the report that generated them.

## Changes

- `buildCreatePrReportPrompt` now embeds the report's canonical **web** URL (`https://<region>.posthog.com/project/<id>/inbox/<reportId>`) instead of the desktop deep link. Callers (`useCreatePrReport`, `SignalReportTaskService`) build it from the current region + project ID.
- The cloud PR footer now includes a deterministic `from an [inbox report](…)` backlink for signal_report-origin runs, mirroring the existing `from a [Slack thread](…)` footer.

## How did you test this?

Updated unit tests for the new prompt shape and the footer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1782307374692799?thread_ts=1782307374.692799&cid=C09G8Q32R6F)*