### PR TITLE
fix(canvas): don't flash empty state while canvas is loading

### DIFF
--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -71,7 +71,7 @@ export function FreeformCanvasView({
   // The generation-task association lives in the canvas record's meta. Poll it
   // while a task is running so the published code + the cleared association show
   // up without a manual refresh (WebsiteDashboard re-syncs the working copy).
-  const { data: dashboard } = useQuery(
+  const { data: dashboard, isLoading: dashboardLoading } = useQuery(
     trpc.dashboards.get.queryOptions(
       { id: dashboardId },
       { enabled: !!dashboardId, staleTime: 4000 },
@@ -198,6 +198,13 @@ export function FreeformCanvasView({
 
   const showCanvas = !!code;
   const showGeneratingState = isGenerating && !code;
+  // Don't flash the empty state while the record is still resolving: the working
+  // copy (`code`) is only seeded from the record by WebsiteDashboard once the
+  // `dashboards.get` query lands, so until the record is fetched — or in the gap
+  // before a record that already has code syncs into the thread — treat the
+  // canvas as loading, not empty.
+  const showLoadingState =
+    !code && !isGenerating && (dashboardLoading || !!dashboard?.code);
   const showComposer = interactive && !isGenerating;
 
   return (
@@ -317,6 +324,8 @@ export function FreeformCanvasView({
                   channelId={channelId}
                   taskId={genTaskId ?? ""}
                 />
+              ) : showLoadingState ? (
+                <LoadingState />
               ) : (
                 <Empty className="h-full">
                   <EmptyHeader>
@@ -352,6 +361,21 @@ export function FreeformCanvasView({
         )}
       </Flex>
     </Flex>
+  );
+}
+
+// Shown while the canvas record is still loading, so a canvas that actually has
+// content doesn't flash the empty state before its code syncs into the thread.
+function LoadingState() {
+  return (
+    <Empty className="h-full">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <SpinnerGapIcon size={18} className="animate-spin text-accent-9" />
+        </EmptyMedia>
+        <EmptyTitle>Loading canvas</EmptyTitle>
+      </EmptyHeader>
+    </Empty>
   );
 }
 

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -196,15 +196,19 @@ export function FreeformCanvasView({
     );
   };
 
-  const showCanvas = !!code;
-  const showGeneratingState = isGenerating && !code;
-  // Don't flash the empty state while the record is still resolving: the working
-  // copy (`code`) is only seeded from the record by WebsiteDashboard once the
-  // `dashboards.get` query lands, so until the record is fetched — or in the gap
-  // before a record that already has code syncs into the thread — treat the
-  // canvas as loading, not empty.
-  const showLoadingState =
-    !code && !isGenerating && (dashboardLoading || !!dashboard?.code);
+  // The working copy (`code`) is only seeded from the record by WebsiteDashboard
+  // once `dashboards.get` lands, so fall back to the record's stored code to
+  // bridge the gap before that seed runs — the seeded value is identical, so a
+  // canvas with content renders right away instead of flashing the empty state.
+  // Deriving from the record rather than waiting on the seed also means a seed
+  // that never runs can't strand the canvas on a spinner.
+  const renderCode = code || dashboard?.code || "";
+  const showCanvas = !!renderCode;
+  const showGeneratingState = isGenerating && !renderCode;
+  // While the record is still being fetched we don't yet know whether the canvas
+  // has content, so show a spinner instead of the empty state. Bounded by the
+  // query, so it resolves once the fetch settles.
+  const showLoadingState = !renderCode && !isGenerating && dashboardLoading;
   const showComposer = interactive && !isGenerating;
 
   return (
@@ -309,7 +313,7 @@ export function FreeformCanvasView({
             <Box className="h-full w-full">
               <CanvasFramePlaceholder
                 dashboardId={dashboardId}
-                code={code}
+                code={renderCode}
                 analytics={analytics}
                 onDataRequest={onDataRequest}
                 onError={onError}
@@ -353,7 +357,7 @@ export function FreeformCanvasView({
               channelName={channelName}
               name={dashboard?.name ?? "Canvas"}
               templateId={dashboard?.templateId}
-              currentCode={code || undefined}
+              currentCode={renderCode || undefined}
               value={draft}
               onValueChange={setDraft}
             />


### PR DESCRIPTION
## Problem

When viewing a canvas that has content, it briefly flashes "This canvas is empty…" before the canvas loads in. The empty-state message keyed only on the working-copy `code` being empty, with no guard for the record still being fetched from the server.

**Why:** A non-empty canvas shouldn't show an "empty" message just because the result hasn't come back from the server yet.

## Changes

In `FreeformCanvasView`, gate the empty state on the record actually being loaded:

- Capture the `dashboards.get` record's `isLoading` (the query was already running).
- Show a loading spinner while the record is still fetching, or in the one-render gap before a record that already has `code` syncs into the thread.
- The "This canvas is empty…" message now only appears once the record has loaded and genuinely has no code.

The loading state is a quill `<Empty>` with the same spinner the generating state uses.

## How did you test this?

- Typechecked the canvas feature (`@posthog/ui`) — no errors in the changed file.
- Biome lint clean on the edited file.

(Note: full repo typecheck has pre-existing errors from unbuilt sibling packages, unrelated to this change.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
