### PR TITLE
feat(tasks): bundle local skills into sha256-verified zip artifacts

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -6,6 +6,7 @@ import type {
   PrAuthorshipMode,
   SeatData,
   StoredLogEntry,
+  TaskRunArtifactMetadata,
 } from "@posthog/shared";
 import {
   DISMISSAL_REASON_OPTIONS,
@@ -432,10 +433,11 @@ export class FolderInstructionsConflictError extends Error {
 
 export interface TaskArtifactUploadRequest {
   name: string;
-  type: "user_attachment";
+  type: "user_attachment" | "skill_bundle";
   size: number;
   content_type?: string;
   source?: string;
+  metadata?: TaskRunArtifactMetadata;
 }
 
 export interface DirectUploadPresignedPost {
@@ -457,6 +459,7 @@ export interface FinalizedTaskArtifactUpload {
   source?: string;
   size?: number;
   content_type?: string;
+  metadata?: TaskArtifactUploadRequest["metadata"];
   storage_path: string;
   uploaded_at?: string;
 }
@@ -2361,6 +2364,7 @@ export class PostHogAPIClient {
             type: artifact.type,
             source: artifact.source,
             content_type: artifact.content_type,
+            metadata: artifact.metadata,
             storage_path: artifact.storage_path,
           })),
         }),
@@ -2436,6 +2440,7 @@ export class PostHogAPIClient {
             type: artifact.type,
             source: artifact.source,
             content_type: artifact.content_type,
+            metadata: artifact.metadata,
             storage_path: artifact.storage_path,
           })),
         }),

--- a/packages/core/src/sessions/cloudArtifactIdentifiers.ts
+++ b/packages/core/src/sessions/cloudArtifactIdentifiers.ts
@@ -1,9 +1,15 @@
+import type {
+  TaskRunArtifactMetadata,
+  UploadableSkillSource,
+} from "@posthog/shared";
+
 export interface CloudArtifactUploadRequest {
   name: string;
-  type: "user_attachment";
+  type: "user_attachment" | "skill_bundle";
   size: number;
   content_type?: string;
   source?: string;
+  metadata?: TaskRunArtifactMetadata;
 }
 
 export interface CloudArtifactPresignedPost {
@@ -41,9 +47,32 @@ export interface CloudArtifactClient {
   ): Promise<FinalizedCloudArtifact[]>;
 }
 
+export interface CloudSkillBundleRef {
+  name: string;
+  source: UploadableSkillSource;
+  path: string;
+}
+
+export interface LocalSkillBundle {
+  name: string;
+  source: UploadableSkillSource;
+  fileName: string;
+  contentType: "application/zip";
+  contentBase64: string;
+  contentSha256: string;
+  size: number;
+}
+
+export type BundleLocalSkill = (
+  skillBundleRef: CloudSkillBundleRef,
+) => Promise<LocalSkillBundle>;
+
 export const CLOUD_ARTIFACT_SERVICE = Symbol.for(
   "posthog.core.sessions.cloudArtifactService",
 );
 export const CLOUD_ARTIFACT_READ_FILE_AS_BASE64 = Symbol.for(
   "posthog.core.sessions.cloudArtifactReadFileAsBase64",
+);
+export const CLOUD_ARTIFACT_BUNDLE_LOCAL_SKILL = Symbol.for(
+  "posthog.core.sessions.cloudArtifactBundleLocalSkill",
 );

--- a/packages/host-router/src/routers/skills.router.ts
+++ b/packages/host-router/src/routers/skills.router.ts
@@ -1,6 +1,8 @@
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
 import { SKILLS_SERVICE } from "@posthog/workspace-server/services/skills/identifiers";
 import {
+  bundleLocalSkillInput,
+  bundleLocalSkillOutput,
   createSkillInput,
   deleteSkillFileInput,
   deleteSkillInput,
@@ -35,6 +37,12 @@ export const skillsRouter = router({
     .output(listSkillsOutput)
     .query(({ ctx }) =>
       ctx.container.get<SkillsService>(SKILLS_SERVICE).listSkills(),
+    ),
+  bundleLocal: publicProcedure
+    .input(bundleLocalSkillInput)
+    .output(bundleLocalSkillOutput)
+    .query(({ ctx, input }) =>
+      ctx.container.get<SkillsService>(SKILLS_SERVICE).bundleLocalSkill(input),
     ),
   contents: publicProcedure
     .input(skillContentsInput)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -169,6 +169,7 @@ export type {
   SkillFileEntry,
   SkillInfo,
   SkillSource,
+  UploadableSkillSource,
 } from "./skills";
 export { SKILL_EXISTS_MARKER, stripFrontmatter } from "./skills";
 export type {
@@ -176,6 +177,7 @@ export type {
   PostHogAPIConfig,
   TaskRun,
   TaskRunArtifact,
+  TaskRunArtifactMetadata,
   TaskRunEnvironment,
   TaskRunStatus,
 } from "./task";

--- a/packages/shared/src/skills.ts
+++ b/packages/shared/src/skills.ts
@@ -1,4 +1,5 @@
 export type SkillSource = "bundled" | "user" | "repo" | "marketplace" | "codex";
+export type UploadableSkillSource = Exclude<SkillSource, "bundled">;
 
 export interface SkillInfo {
   name: string;

--- a/packages/shared/src/task.ts
+++ b/packages/shared/src/task.ts
@@ -1,4 +1,6 @@
 // PostHog Task model (matches PostHog Code's OpenAPI schema)
+import type { UploadableSkillSource } from "./skills";
+
 export interface Task {
   id: string;
   task_number?: number;
@@ -37,7 +39,16 @@ export type ArtifactType =
   | "reference"
   | "output"
   | "artifact"
-  | "user_attachment";
+  | "user_attachment"
+  | "skill_bundle";
+
+export interface TaskRunArtifactMetadata {
+  skill_name: string;
+  skill_source: UploadableSkillSource;
+  content_sha256: string;
+  bundle_format: "zip";
+  schema_version: number;
+}
 
 export interface TaskRunArtifact {
   id?: string;
@@ -46,6 +57,7 @@ export interface TaskRunArtifact {
   source?: string;
   size?: number;
   content_type?: string;
+  metadata?: TaskRunArtifactMetadata;
   storage_path?: string;
   uploaded_at?: string;
 }

--- a/packages/workspace-server/src/services/skills/schemas.ts
+++ b/packages/workspace-server/src/services/skills/schemas.ts
@@ -118,9 +118,28 @@ export const installTeamSkillInput = z.object({
 export type ExportedSkill = z.infer<typeof exportSkillOutput>;
 export type InstallTeamSkillInput = z.infer<typeof installTeamSkillInput>;
 
+export const bundleLocalSkillInput = z.object({
+  name: z.string().min(1),
+  source: z.enum(["user", "repo", "marketplace", "codex"]),
+  path: z.string().min(1),
+});
+
+export const bundleLocalSkillOutput = z.object({
+  name: z.string(),
+  source: z.enum(["user", "repo", "marketplace", "codex"]),
+  fileName: z.string(),
+  contentType: z.literal("application/zip"),
+  contentBase64: z.string(),
+  contentSha256: z.string(),
+  size: z.number().int().positive(),
+});
+
+export type BundleLocalSkillInput = z.infer<typeof bundleLocalSkillInput>;
+export type BundleLocalSkillOutput = z.infer<typeof bundleLocalSkillOutput>;
 export type SkillInfo = z.infer<typeof skillInfo>;
 export type SkillScope = z.infer<typeof skillScope>;
 export type CreateSkillInput = z.infer<typeof createSkillInput>;
 export type SkillSource = z.infer<typeof skillSource>;
 export type SkillFileEntry = z.infer<typeof skillFileEntry>;
 export type SkillContents = z.infer<typeof skillContentsOutput>;
+export type UploadableSkillSource = BundleLocalSkillInput["source"];

--- a/packages/workspace-server/src/services/skills/skill-bundler.ts
+++ b/packages/workspace-server/src/services/skills/skill-bundler.ts
@@ -1,0 +1,173 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { strToU8, zipSync } from "fflate";
+import type { BundleLocalSkillOutput, UploadableSkillSource } from "./schemas";
+
+const SKILL_BUNDLE_MAX_BYTES = 30 * 1024 * 1024;
+const SKILL_BUNDLE_MAX_FILES = 1000;
+const IGNORED_ENTRIES = new Set([
+  ".DS_Store",
+  ".git",
+  "node_modules",
+  "__pycache__",
+]);
+
+function toZipPath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+function getSafeSkillFileName(name: string): string {
+  const safeName = path.basename(name).replace(/[^\w.-]/g, "_");
+  return safeName.length > 0 ? safeName : "skill";
+}
+
+async function assertSkillRoot(skillPath: string): Promise<string> {
+  const root = await fs.promises.realpath(path.resolve(skillPath));
+  const skillMdPath = path.join(root, "SKILL.md");
+  const stat = await fs.promises.stat(skillMdPath);
+  if (!stat.isFile()) {
+    throw new Error("Local skill bundle must contain a SKILL.md file");
+  }
+  return root;
+}
+
+function isInsideRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    Boolean(relative) &&
+    !relative.startsWith("..") &&
+    !path.isAbsolute(relative)
+  );
+}
+
+interface SkillFileAccumulator {
+  files: Record<string, Uint8Array>;
+  totalBytes: number;
+}
+
+async function addSkillFile(
+  acc: SkillFileAccumulator,
+  relativePath: string,
+  sourcePath: string,
+  size: number,
+): Promise<void> {
+  if (Object.keys(acc.files).length >= SKILL_BUNDLE_MAX_FILES) {
+    throw new Error(
+      `Local skill bundle contains more than ${SKILL_BUNDLE_MAX_FILES} files`,
+    );
+  }
+  if (acc.totalBytes + size > SKILL_BUNDLE_MAX_BYTES) {
+    throw new Error("Local skill bundle exceeds the 30MB cloud run limit");
+  }
+  const content = await fs.promises.readFile(sourcePath);
+  acc.files[toZipPath(relativePath)] = new Uint8Array(content);
+  acc.totalBytes += content.byteLength;
+}
+
+async function collectSkillFiles(
+  root: string,
+  currentDir: string,
+  acc: SkillFileAccumulator,
+): Promise<void> {
+  const entries = await fs.promises.readdir(currentDir, {
+    withFileTypes: true,
+  });
+
+  for (const entry of entries) {
+    if (IGNORED_ENTRIES.has(entry.name)) {
+      continue;
+    }
+
+    const absolutePath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(root, absolutePath);
+    if (
+      !relativePath ||
+      relativePath.startsWith("..") ||
+      path.isAbsolute(relativePath)
+    ) {
+      continue;
+    }
+
+    if (entry.isSymbolicLink()) {
+      const realPath = await fs.promises
+        .realpath(absolutePath)
+        .catch(() => null);
+      if (!realPath || !isInsideRoot(root, realPath)) {
+        continue;
+      }
+      const stat = await fs.promises.stat(realPath);
+      if (!stat.isFile()) {
+        continue;
+      }
+      await addSkillFile(acc, relativePath, realPath, stat.size);
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      await collectSkillFiles(root, absolutePath, acc);
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const stat = await fs.promises.stat(absolutePath);
+    await addSkillFile(acc, relativePath, absolutePath, stat.size);
+  }
+}
+
+export async function bundleLocalSkill({
+  name,
+  source,
+  skillPath,
+}: {
+  name: string;
+  source: UploadableSkillSource;
+  skillPath: string;
+}): Promise<BundleLocalSkillOutput> {
+  const root = await assertSkillRoot(skillPath);
+  const acc: SkillFileAccumulator = { files: {}, totalBytes: 0 };
+  await collectSkillFiles(root, root, acc);
+  const files = acc.files;
+  const fileNames = Object.keys(files).sort();
+
+  if (!files["SKILL.md"]) {
+    throw new Error("Local skill bundle must contain a SKILL.md file");
+  }
+
+  const manifest = {
+    schema_version: 1,
+    name,
+    source,
+  };
+
+  const zipInput: Record<string, Uint8Array> = {};
+  for (const fileName of fileNames) {
+    zipInput[fileName] = files[fileName];
+  }
+  zipInput["posthog-skill-bundle.json"] = strToU8(JSON.stringify(manifest));
+
+  const zipped = zipSync(zipInput, { level: 6 });
+  if (zipped.byteLength > SKILL_BUNDLE_MAX_BYTES) {
+    throw new Error(
+      "Local skill bundle archive exceeds the 30MB cloud run limit",
+    );
+  }
+
+  const contentSha256 = crypto
+    .createHash("sha256")
+    .update(zipped)
+    .digest("hex");
+
+  return {
+    name,
+    source,
+    fileName: `${getSafeSkillFileName(name)}.zip`,
+    contentType: "application/zip",
+    contentBase64: Buffer.from(zipped).toString("base64"),
+    contentSha256,
+    size: zipped.byteLength,
+  };
+}

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -14,6 +14,8 @@ import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import type { WatcherService } from "../watcher/service";
 import { parseSkillFrontmatter } from "./parse-skill-frontmatter";
 import type {
+  BundleLocalSkillInput,
+  BundleLocalSkillOutput,
   CreateSkillInput,
   ExportedSkill,
   InstallTeamSkillInput,
@@ -21,6 +23,7 @@ import type {
   SkillInfo,
   SkillSource,
 } from "./schemas";
+import { bundleLocalSkill } from "./skill-bundler";
 import {
   getMarketplaceInstallPaths,
   getUserSkillsDir,
@@ -484,6 +487,16 @@ export class SkillsService {
       throw new Error("Access denied: not a known skill directory");
     }
     return resolved;
+  }
+
+  bundleLocalSkill(
+    input: BundleLocalSkillInput,
+  ): Promise<BundleLocalSkillOutput> {
+    return bundleLocalSkill({
+      name: input.name,
+      source: input.source,
+      skillPath: input.path,
+    });
   }
 }
 


### PR DESCRIPTION
## Problem

for cloud tasks, local skill invocations only sent the slash command text. User-local and repo-local skills were available in the local editor but not in the cloud sandbox

## Changes

- let's bundle uploadable local skills into zip artifacts with SHA-256 metadata and send them through the existing cloud artifact upload flow.

- install `skill_bundle` artifacts in the agent server before prompt delivery, inject the bundled skill instructions for the invoked turn, and suppress the raw slash command from the model-facing prompt so local skills behave like actual skills rather than unsupported commands

- refresh slash command metadata when a follow-up command is submitted, so newly created local skills can be selected and invoked without starting a brand-new task.

closes https://github.com/PostHog/code/issues/2260
