### PR TITLE
feat(mobile): warm cloud sandbox while composing (port #2869)

### DIFF
--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -62,6 +62,7 @@ import { Pill } from "@/features/tasks/composer/Pill";
 import { RepositoryPickerInline } from "@/features/tasks/composer/RepositoryPickerInline";
 import { SelectSheet } from "@/features/tasks/composer/SelectSheet";
 import { useUserIntegrations } from "@/features/tasks/hooks/useUserIntegrations";
+import { useWarmTask } from "@/features/tasks/hooks/useWarmTask";
 import {
   generatePendingTaskKey,
   pendingTaskPromptStoreApi,
@@ -374,6 +375,15 @@ export default function NewTaskScreen() {
   const canSubmit =
     hasContent && isRepositorySelectionComplete(selection) && !creating;
   const showReasoningPill = modelSupportsReasoning(model);
+
+  // Best-effort prewarm; failures are swallowed. `selection.integrationId` is
+  // the GitHub installation id, not a PostHog integration id — the backend
+  // resolves the integration from the repository, so this only keys the warm.
+  useWarmTask({
+    repository: selection.repository,
+    githubIntegrationId: selection.integrationId,
+    composerIsEmpty: !hasContent,
+  });
 
   if (isLoading && hasGithubIntegration === null) {
     return (

--- a/apps/mobile/src/features/tasks/api.ts
+++ b/apps/mobile/src/features/tasks/api.ts
@@ -302,6 +302,41 @@ export async function runTaskAutomation(
   return await parseJsonResponse<TaskAutomation>(response);
 }
 
+export async function warmTask(options: {
+  repository: string;
+  github_integration: number;
+  branch?: string | null;
+}): Promise<{ task_id: string; run_id: string } | null> {
+  const baseUrl = getBaseUrl();
+  const projectId = getProjectId();
+
+  const response = await authedFetch(
+    `${baseUrl}/api/projects/${projectId}/tasks/warm/`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        repository: options.repository,
+        github_integration: options.github_integration,
+        branch: options.branch ?? null,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      "Failed to warm task",
+    );
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  return JSON.parse(text) as { task_id: string; run_id: string };
+}
+
 export async function createTask(options: CreateTaskOptions): Promise<Task> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();

--- a/apps/mobile/src/features/tasks/api.warm.test.ts
+++ b/apps/mobile/src/features/tasks/api.warm.test.ts
@@ -56,15 +56,15 @@ describe("warmTask", () => {
     );
   });
 
-  it("defaults a missing branch to null", async () => {
-    mockFetch.mockResolvedValueOnce(new Response("", { status: 200 }));
+  it("serializes a missing branch as null", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task_id: "task-1", run_id: "run-1" }), {
+        status: 200,
+      }),
+    );
 
-    const result = await warmTask({
-      repository: "posthog/posthog",
-      github_integration: 7,
-    });
+    await warmTask({ repository: "posthog/posthog", github_integration: 7 });
 
-    expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledWith(
       "https://app.posthog.test/api/projects/42/tasks/warm/",
       expect.objectContaining({
@@ -75,6 +75,17 @@ describe("warmTask", () => {
         }),
       }),
     );
+  });
+
+  it("returns null when the response body is empty", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("", { status: 200 }));
+
+    const result = await warmTask({
+      repository: "posthog/posthog",
+      github_integration: 7,
+    });
+
+    expect(result).toBeNull();
   });
 
   it("throws an HttpError on a failed response", async () => {

--- a/apps/mobile/src/features/tasks/api.warm.test.ts
+++ b/apps/mobile/src/features/tasks/api.warm.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("expo/fetch", () => ({
+  fetch: mockFetch,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getBaseUrl: () => "https://app.posthog.test",
+  getProjectId: () => 42,
+  authedFetch: (url: string, init?: RequestInit) =>
+    mockFetch(url, {
+      ...init,
+      headers: {
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
+        ...((init?.headers as Record<string, string> | undefined) ?? {}),
+      },
+    }),
+}));
+
+import { HttpError, warmTask } from "./api";
+
+describe("warmTask", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("posts the warm request with the backend contract", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task_id: "task-1", run_id: "run-1" }), {
+        status: 200,
+      }),
+    );
+
+    const result = await warmTask({
+      repository: "posthog/posthog",
+      github_integration: 7,
+      branch: "main",
+    });
+
+    expect(result).toEqual({ task_id: "task-1", run_id: "run-1" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://app.posthog.test/api/projects/42/tasks/warm/",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          repository: "posthog/posthog",
+          github_integration: 7,
+          branch: "main",
+        }),
+      }),
+    );
+  });
+
+  it("defaults a missing branch to null", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("", { status: 200 }));
+
+    const result = await warmTask({
+      repository: "posthog/posthog",
+      github_integration: 7,
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://app.posthog.test/api/projects/42/tasks/warm/",
+      expect.objectContaining({
+        body: JSON.stringify({
+          repository: "posthog/posthog",
+          github_integration: 7,
+          branch: null,
+        }),
+      }),
+    );
+  });
+
+  it("throws an HttpError on a failed response", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("nope", { status: 500 }));
+
+    await expect(
+      warmTask({ repository: "posthog/posthog", github_integration: 7 }),
+    ).rejects.toBeInstanceOf(HttpError);
+  });
+});

--- a/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
+++ b/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
@@ -1,0 +1,176 @@
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockWarmTask } = vi.hoisted(() => ({ mockWarmTask: vi.fn() }));
+const flagState = vi.hoisted(() => ({ enabled: true as boolean }));
+
+vi.mock("posthog-react-native", () => ({
+  useFeatureFlag: () => flagState.enabled,
+}));
+vi.mock("@/features/tasks/api", () => ({
+  warmTask: mockWarmTask,
+}));
+vi.mock("@/lib/logger", () => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    scope: () => mockLogger,
+  };
+  return { logger: mockLogger };
+});
+
+import { useWarmTask } from "./useWarmTask";
+
+interface Props {
+  repository?: string | null;
+  githubIntegrationId?: number | null;
+  branch?: string | null;
+  composerIsEmpty: boolean;
+}
+
+const composing: Props = {
+  repository: "acme/repo",
+  githubIntegrationId: 42,
+  branch: "main",
+  composerIsEmpty: false,
+};
+
+function render(initial: Props) {
+  let current = initial;
+  function Wrapper() {
+    useWarmTask(current);
+    return null;
+  }
+  let renderer: ReactTestRenderer | null = null;
+  act(() => {
+    renderer = create(createElement(Wrapper));
+  });
+  return {
+    rerender: (next: Props) => {
+      current = next;
+      act(() => {
+        renderer?.update(createElement(Wrapper));
+      });
+    },
+  };
+}
+
+async function flushDebounce(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(600);
+  });
+}
+
+describe("useWarmTask", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    flagState.enabled = true;
+    mockWarmTask.mockResolvedValue({ task_id: "task-1", run_id: "run-1" });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("fires a debounced warm when repo selected + composing", async () => {
+    render(composing);
+    expect(mockWarmTask).not.toHaveBeenCalled();
+
+    await flushDebounce();
+
+    expect(mockWarmTask).toHaveBeenCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "main",
+    });
+  });
+
+  it.each<{ name: string; props?: Partial<Props>; flagEnabled?: boolean }>([
+    { name: "the flag is off", flagEnabled: false },
+    { name: "no repository is selected", props: { repository: null } },
+    { name: "no github integration", props: { githubIntegrationId: null } },
+    { name: "the composer is empty", props: { composerIsEmpty: true } },
+  ])("does not fire when $name", async ({ props, flagEnabled }) => {
+    if (flagEnabled === false) {
+      flagState.enabled = false;
+    }
+    render({ ...composing, ...props });
+    await flushDebounce();
+    expect(mockWarmTask).not.toHaveBeenCalled();
+  });
+
+  it("fires once the composer becomes non-empty", async () => {
+    const { rerender } = render({ ...composing, composerIsEmpty: true });
+    await flushDebounce();
+    expect(mockWarmTask).not.toHaveBeenCalled();
+
+    rerender(composing);
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-fire for the same selection", async () => {
+    const { rerender } = render(composing);
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenCalledOnce();
+
+    rerender({ ...composing });
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenCalledOnce();
+  });
+
+  it("warms the new selection when the repository changes", async () => {
+    const { rerender } = render(composing);
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenCalledOnce();
+
+    rerender({ ...composing, repository: "acme/other" });
+    await flushDebounce();
+
+    expect(mockWarmTask).toHaveBeenLastCalledWith({
+      repository: "acme/other",
+      github_integration: 42,
+      branch: "main",
+    });
+    expect(mockWarmTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("warms the new selection when the branch changes", async () => {
+    const { rerender } = render(composing);
+    await flushDebounce();
+
+    rerender({ ...composing, branch: "feature/x" });
+    await flushDebounce();
+
+    expect(mockWarmTask).toHaveBeenLastCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "feature/x",
+    });
+    expect(mockWarmTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("warms again for a new selection after a failed warm", async () => {
+    mockWarmTask.mockRejectedValueOnce(new Error("boom"));
+    const { rerender } = render(composing);
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenCalledOnce();
+
+    rerender({ ...composing, branch: "feature/x" });
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows warm errors without throwing", async () => {
+    mockWarmTask.mockRejectedValue(new Error("boom"));
+    render(composing);
+
+    await expect(flushDebounce()).resolves.not.toThrow();
+    expect(mockWarmTask).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
+++ b/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
@@ -114,46 +114,57 @@ describe("useWarmTask", () => {
     expect(mockWarmTask).toHaveBeenCalledOnce();
   });
 
-  it("does not re-fire for the same selection", async () => {
+  it("does not re-fire for the same key after the composer empties and refills", async () => {
     const { rerender } = render(composing);
     await flushDebounce();
     expect(mockWarmTask).toHaveBeenCalledOnce();
 
-    rerender({ ...composing });
+    // Toggling `composerIsEmpty` flips `eligible` (a dep), so the effect
+    // re-runs with the same key — the `lastWarmedKeyRef` guard, not React's
+    // bail-out, is what blocks a second warm.
+    rerender({ ...composing, composerIsEmpty: true });
+    await flushDebounce();
+    rerender({ ...composing, composerIsEmpty: false });
     await flushDebounce();
     expect(mockWarmTask).toHaveBeenCalledOnce();
   });
 
-  it("warms the new selection when the repository changes", async () => {
-    const { rerender } = render(composing);
-    await flushDebounce();
-    expect(mockWarmTask).toHaveBeenCalledOnce();
+  it.each<{
+    name: string;
+    change: Partial<Props>;
+    expectedRepository: string;
+    expectedBranch: string;
+  }>([
+    {
+      name: "repository",
+      change: { repository: "acme/other" },
+      expectedRepository: "acme/other",
+      expectedBranch: "main",
+    },
+    {
+      name: "branch",
+      change: { branch: "feature/x" },
+      expectedRepository: "acme/repo",
+      expectedBranch: "feature/x",
+    },
+  ])(
+    "warms the new selection when the $name changes",
+    async ({ change, expectedRepository, expectedBranch }) => {
+      const { rerender } = render(composing);
+      await flushDebounce();
+      expect(mockWarmTask).toHaveBeenCalledOnce();
 
-    rerender({ ...composing, repository: "acme/other" });
-    await flushDebounce();
+      rerender({ ...composing, ...change });
+      await flushDebounce();
 
-    expect(mockWarmTask).toHaveBeenLastCalledWith({
-      repository: "acme/other",
-      github_integration: 42,
-      branch: "main",
-    });
-    expect(mockWarmTask).toHaveBeenCalledTimes(2);
-  });
-
-  it("warms the new selection when the branch changes", async () => {
-    const { rerender } = render(composing);
-    await flushDebounce();
-
-    rerender({ ...composing, branch: "feature/x" });
-    await flushDebounce();
-
-    expect(mockWarmTask).toHaveBeenLastCalledWith({
-      repository: "acme/repo",
-      github_integration: 42,
-      branch: "feature/x",
-    });
-    expect(mockWarmTask).toHaveBeenCalledTimes(2);
-  });
+      expect(mockWarmTask).toHaveBeenLastCalledWith({
+        repository: expectedRepository,
+        github_integration: 42,
+        branch: expectedBranch,
+      });
+      expect(mockWarmTask).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("warms again for a new selection after a failed warm", async () => {
     mockWarmTask.mockRejectedValueOnce(new Error("boom"));

--- a/apps/mobile/src/features/tasks/hooks/useWarmTask.ts
+++ b/apps/mobile/src/features/tasks/hooks/useWarmTask.ts
@@ -1,0 +1,74 @@
+import { TASKS_PREWARM_SANDBOX_FLAG } from "@posthog/shared";
+import { useFeatureFlag } from "posthog-react-native";
+import { useEffect, useRef } from "react";
+import { warmTask } from "@/features/tasks/api";
+import { logger } from "@/lib/logger";
+
+const log = logger.scope("warm-task");
+
+const WARM_DEBOUNCE_MS = 600;
+
+interface UseWarmTaskOptions {
+  repository?: string | null;
+  githubIntegrationId?: number | null;
+  branch?: string | null;
+  composerIsEmpty: boolean;
+}
+
+export function useWarmTask({
+  repository,
+  githubIntegrationId,
+  branch,
+  composerIsEmpty,
+}: UseWarmTaskOptions): void {
+  const enabled = useFeatureFlag(TASKS_PREWARM_SANDBOX_FLAG);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastWarmedKeyRef = useRef<string | null>(null);
+
+  const normalizedBranch = branch ?? null;
+  const eligible =
+    !!enabled &&
+    !!repository &&
+    githubIntegrationId != null &&
+    !composerIsEmpty;
+  const key =
+    repository && githubIntegrationId != null
+      ? `${githubIntegrationId}:${repository}:${normalizedBranch ?? ""}`
+      : null;
+
+  useEffect(() => {
+    const clearDebounce = (): void => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+
+    if (!eligible || !key || !repository || githubIntegrationId == null) {
+      clearDebounce();
+      return;
+    }
+    if (lastWarmedKeyRef.current === key || debounceRef.current) {
+      return;
+    }
+
+    const repo = repository;
+    const githubIntegration = githubIntegrationId;
+    const warmBranch = normalizedBranch;
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      lastWarmedKeyRef.current = key;
+      void warmTask({
+        repository: repo,
+        github_integration: githubIntegration,
+        branch: warmBranch,
+      }).catch((error) => {
+        lastWarmedKeyRef.current = null;
+        log.warn("Failed to warm task", error);
+      });
+    }, WARM_DEBOUNCE_MS);
+
+    return clearDebounce;
+  }, [eligible, key, repository, githubIntegrationId, normalizedBranch]);
+}


### PR DESCRIPTION
## Summary

Ports the desktop "warm cloud sandbox while composing" behaviour (#2869) to the mobile app. When a user is composing a new cloud task, the app pre-warms a cloud sandbox in the background (debounced) so it's ready on submit, reducing perceived start latency. Gated behind the `tasks-prewarm-sandbox` feature flag.

## Changes

- **`apps/mobile/src/features/tasks/api.ts`** — new `warmTask({ repository, github_integration, branch })` that POSTs to `/api/projects/{teamId}/tasks/warm/`, matching the existing mobile task API conventions (auth, `HttpError`, base-url/project-id).
- **`apps/mobile/src/features/tasks/hooks/useWarmTask.ts`** (new) — when the flag is on, debounces ~600ms and calls `warmTask` once per unique `{githubIntegration}:{repository}:{branch}` key while the composer is non-empty. Tracks the last-warmed key in a ref to dedupe, and clears it on failure so it can retry. Mobile is cloud-only, so the desktop `workspaceMode` gate is dropped.
- **`apps/mobile/src/app/task/index.tsx`** — wires the hook into the new-task composer using the existing repository selection and composer-empty state. The flag is read via `useFeatureFlag` from `posthog-react-native`; the flag constant is imported from `@posthog/shared`.

## Tests

- `api.warm.test.ts` — request shape, branch defaulting, error handling.
- `hooks/useWarmTask.test.tsx` — warms once per key; skips when flag off / no repo / no integration / empty composer; re-warms on repo/branch change; retries after failure; swallows errors.

All 14 tests pass; Biome and `tsc` are clean over the touched files.