### PR TITLE
fix(canvas): generate canvases in auto mode instead of accept-edits

### DIFF
--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -67,6 +67,8 @@ export function useGenerateFreeformCanvas(args: {
               currentCode: opts.currentCode,
             }),
             taskDescription: `Generate canvas "${name}"`,
+            // Unattended generation: run in auto mode so it doesn't stall on edit-approval prompts.
+            executionMode: "auto" as const,
             workspaceMode: "local",
             allowNoRepo: true,
             channelContext,


### PR DESCRIPTION
## Problem

When you generate a canvas (project bluebird), the generation agent runs in **accept-edits** mode and stalls on edit-approval prompts. Canvas generation is unattended — you describe the canvas and the agent builds + publishes it — so blocking on per-edit approvals is just friction.

## Cause

`useGenerateFreeformCanvas` created its task without setting `executionMode`. With no mode passed, it fell through to the agent's default (`acceptEdits`), which auto-accepts edits but still prompts on other tool calls.

## Fix

Default canvas generation to **auto** mode (the model-classifier mode that approves/denies prompts itself), so generation runs unattended without stalling. One line on the existing `createTask` input; flows through both local and cloud run paths in the task-creation saga.

## Testing

- `pnpm --filter @posthog/ui typecheck` passes
- biome lint clean
- Pre-commit full typecheck passed

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*