### PR TITLE
fix(auth): treat transient code-access checks as indeterminate, not denied

### DIFF
--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -151,6 +151,9 @@ describe("AuthService", () => {
         string,
         { name: string; projects: { id: number; name: string }[] }
       >;
+      // Overrides the /api/code/invites/check-access/ response (defaults to
+      // granting access). May throw to simulate a network error.
+      checkAccess?: () => Response;
     } = {},
   ) => {
     const accountKey = options.accountKey ?? "user-1";
@@ -186,6 +189,9 @@ describe("AuthService", () => {
           } as unknown as Response;
         }
 
+        if (options.checkAccess) {
+          return options.checkAccess();
+        }
         return {
           ok: true,
           json: vi.fn().mockResolvedValue({ has_access: true }),
@@ -1344,35 +1350,6 @@ describe("AuthService", () => {
   });
 
   describe("code access resilience", () => {
-    // A fetch stub whose user/org endpoints always succeed, so only the
-    // check-access endpoint's behaviour varies between tests.
-    const authFetchWithCheck = (checkAccess: () => Response) =>
-      vi.fn(async (input: string | Request) => {
-        const url = typeof input === "string" ? input : input.url;
-
-        if (url.includes("/api/users/@me/")) {
-          return {
-            ok: true,
-            json: vi.fn().mockResolvedValue({
-              uuid: "user-1",
-              organization: { id: "org-1" },
-            }),
-          } as unknown as Response;
-        }
-
-        if (/\/api\/organizations\/([^/]+)\/$/.test(url)) {
-          return {
-            ok: true,
-            json: vi.fn().mockResolvedValue({
-              name: "Org 1",
-              teams: [{ id: 42, name: "Project 42" }],
-            }),
-          } as unknown as Response;
-        }
-
-        return checkAccess();
-      }) as unknown as typeof fetch;
-
     const okBody = (body: unknown): Response =>
       ({
         ok: true,
@@ -1415,7 +1392,7 @@ describe("AuthService", () => {
         expected: null,
       },
     ])("$name", async ({ checkAccess, expected }) => {
-      vi.stubGlobal("fetch", authFetchWithCheck(checkAccess));
+      stubAuthFetch({ checkAccess });
 
       await service.initialize();
 
@@ -1424,60 +1401,52 @@ describe("AuthService", () => {
       expect(state.hasCodeAccess).toBe(expected);
     });
 
-    it("keeps a confirmed grant when a later check fails with a network error", async () => {
-      let failCheck = false;
-      vi.stubGlobal(
-        "fetch",
-        authFetchWithCheck(() => {
-          if (failCheck) throw new Error("network down");
-          return okBody({ has_access: true });
-        }),
-      );
+    // A transient blip on a later check must not be mistaken for a revoked
+    // invite — a previously confirmed grant stays granted.
+    it.each([
+      {
+        name: "a network error",
+        fail: (): Response => {
+          throw new Error("network down");
+        },
+      },
+      {
+        name: "a 401",
+        fail: (): Response =>
+          ({
+            ok: false,
+            status: 401,
+            json: vi.fn().mockResolvedValue({}),
+          }) as unknown as Response,
+      },
+    ])(
+      "keeps a confirmed grant when a later check hits $name",
+      async ({ fail }) => {
+        let shouldFail = false;
+        stubAuthFetch({
+          checkAccess: () =>
+            shouldFail ? fail() : okBody({ has_access: true }),
+        });
 
-      await service.initialize();
-      expect(service.getState().hasCodeAccess).toBe(true);
+        await service.initialize();
+        expect(service.getState().hasCodeAccess).toBe(true);
 
-      failCheck = true;
-      await service.refreshAccessToken();
+        shouldFail = true;
+        await service.refreshAccessToken();
 
-      // A transient blip must not be mistaken for a revoked invite.
-      expect(service.getState().hasCodeAccess).toBe(true);
-    });
-
-    it("keeps a confirmed grant when a later check returns 401", async () => {
-      let unauthorized = false;
-      vi.stubGlobal(
-        "fetch",
-        authFetchWithCheck(() =>
-          unauthorized
-            ? ({
-                ok: false,
-                status: 401,
-                json: vi.fn().mockResolvedValue({}),
-              } as unknown as Response)
-            : okBody({ has_access: true }),
-        ),
-      );
-
-      await service.initialize();
-      expect(service.getState().hasCodeAccess).toBe(true);
-
-      unauthorized = true;
-      await service.refreshAccessToken();
-
-      expect(service.getState().hasCodeAccess).toBe(true);
-    });
+        expect(service.getState().hasCodeAccess).toBe(true);
+      },
+    );
 
     it("recovers within the retry loop when a later attempt succeeds", async () => {
       let attempts = 0;
-      vi.stubGlobal(
-        "fetch",
-        authFetchWithCheck(() => {
+      stubAuthFetch({
+        checkAccess: () => {
           attempts += 1;
           if (attempts === 1) throw new Error("transient");
           return okBody({ has_access: true });
-        }),
-      );
+        },
+      });
 
       await service.initialize();
 

--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -1389,18 +1389,39 @@ describe("AuthService", () => {
       );
     });
 
-    it("denies access when the server explicitly reports no access", async () => {
-      vi.stubGlobal(
-        "fetch",
-        authFetchWithCheck(() => okBody({ has_access: false })),
-      );
+    // null (not false) for an inconclusive check: the UI shows "Checking
+    // access…" rather than the invite screen, and the next sync re-checks.
+    it.each([
+      {
+        name: "grants access when the server reports has_access true",
+        checkAccess: () => okBody({ has_access: true }),
+        expected: true,
+      },
+      {
+        name: "denies access when the server explicitly reports no access",
+        checkAccess: () => okBody({ has_access: false }),
+        expected: false,
+      },
+      {
+        name: "stays indeterminate when the check throws",
+        checkAccess: () => {
+          throw new Error("network down");
+        },
+        expected: null,
+      },
+      {
+        name: "stays indeterminate on a 2xx response without a has_access flag",
+        checkAccess: () => okBody({}),
+        expected: null,
+      },
+    ])("$name", async ({ checkAccess, expected }) => {
+      vi.stubGlobal("fetch", authFetchWithCheck(checkAccess));
 
       await service.initialize();
 
-      expect(service.getState()).toMatchObject({
-        status: "authenticated",
-        hasCodeAccess: false,
-      });
+      const state = service.getState();
+      expect(state.status).toBe("authenticated");
+      expect(state.hasCodeAccess).toBe(expected);
     });
 
     it("keeps a confirmed grant when a later check fails with a network error", async () => {
@@ -1447,32 +1468,21 @@ describe("AuthService", () => {
       expect(service.getState().hasCodeAccess).toBe(true);
     });
 
-    it("stays indeterminate (never auto-denies) when the check is inconclusive", async () => {
+    it("recovers within the retry loop when a later attempt succeeds", async () => {
+      let attempts = 0;
       vi.stubGlobal(
         "fetch",
         authFetchWithCheck(() => {
-          throw new Error("network down");
+          attempts += 1;
+          if (attempts === 1) throw new Error("transient");
+          return okBody({ has_access: true });
         }),
       );
 
       await service.initialize();
 
-      const state = service.getState();
-      expect(state.status).toBe("authenticated");
-      // null, not false: the UI shows "Checking access…" rather than the
-      // invite screen, and the next sync re-checks.
-      expect(state.hasCodeAccess).toBeNull();
-    });
-
-    it("ignores a 2xx response without an explicit has_access flag", async () => {
-      vi.stubGlobal(
-        "fetch",
-        authFetchWithCheck(() => okBody({})),
-      );
-
-      await service.initialize();
-
-      expect(service.getState().hasCodeAccess).toBeNull();
+      expect(service.getState().hasCodeAccess).toBe(true);
+      expect(attempts).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -1353,18 +1353,20 @@ describe("AuthService", () => {
         if (url.includes("/api/users/@me/")) {
           return {
             ok: true,
-            json: vi
-              .fn()
-              .mockResolvedValue({ uuid: "user-1", organization: { id: "org-1" } }),
+            json: vi.fn().mockResolvedValue({
+              uuid: "user-1",
+              organization: { id: "org-1" },
+            }),
           } as unknown as Response;
         }
 
         if (/\/api\/organizations\/([^/]+)\/$/.test(url)) {
           return {
             ok: true,
-            json: vi
-              .fn()
-              .mockResolvedValue({ name: "Org 1", teams: [{ id: 42, name: "Project 42" }] }),
+            json: vi.fn().mockResolvedValue({
+              name: "Org 1",
+              teams: [{ id: 42, name: "Project 42" }],
+            }),
           } as unknown as Response;
         }
 
@@ -1372,7 +1374,10 @@ describe("AuthService", () => {
       }) as unknown as typeof fetch;
 
     const okBody = (body: unknown): Response =>
-      ({ ok: true, json: vi.fn().mockResolvedValue(body) }) as unknown as Response;
+      ({
+        ok: true,
+        json: vi.fn().mockResolvedValue(body),
+      }) as unknown as Response;
 
     beforeEach(() => {
       seedStoredSession();

--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -1366,8 +1366,6 @@ describe("AuthService", () => {
       );
     });
 
-    // null (not false) for an inconclusive check: the UI shows "Checking
-    // access…" rather than the invite screen, and the next sync re-checks.
     it.each([
       {
         name: "grants access when the server reports has_access true",
@@ -1401,8 +1399,6 @@ describe("AuthService", () => {
       expect(state.hasCodeAccess).toBe(expected);
     });
 
-    // A transient blip on a later check must not be mistaken for a revoked
-    // invite — a previously confirmed grant stays granted.
     it.each([
       {
         name: "a network error",

--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -1342,4 +1342,132 @@ describe("AuthService", () => {
       expect(redeemCallCount).toBe(2);
     });
   });
+
+  describe("code access resilience", () => {
+    // A fetch stub whose user/org endpoints always succeed, so only the
+    // check-access endpoint's behaviour varies between tests.
+    const authFetchWithCheck = (checkAccess: () => Response) =>
+      vi.fn(async (input: string | Request) => {
+        const url = typeof input === "string" ? input : input.url;
+
+        if (url.includes("/api/users/@me/")) {
+          return {
+            ok: true,
+            json: vi
+              .fn()
+              .mockResolvedValue({ uuid: "user-1", organization: { id: "org-1" } }),
+          } as unknown as Response;
+        }
+
+        if (/\/api\/organizations\/([^/]+)\/$/.test(url)) {
+          return {
+            ok: true,
+            json: vi
+              .fn()
+              .mockResolvedValue({ name: "Org 1", teams: [{ id: 42, name: "Project 42" }] }),
+          } as unknown as Response;
+        }
+
+        return checkAccess();
+      }) as unknown as typeof fetch;
+
+    const okBody = (body: unknown): Response =>
+      ({ ok: true, json: vi.fn().mockResolvedValue(body) }) as unknown as Response;
+
+    beforeEach(() => {
+      seedStoredSession();
+      oauthFlow.refreshToken.mockResolvedValue(
+        mockTokenResponse({
+          accessToken: "access-token",
+          refreshToken: "rotated-refresh-token",
+        }),
+      );
+    });
+
+    it("denies access when the server explicitly reports no access", async () => {
+      vi.stubGlobal(
+        "fetch",
+        authFetchWithCheck(() => okBody({ has_access: false })),
+      );
+
+      await service.initialize();
+
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        hasCodeAccess: false,
+      });
+    });
+
+    it("keeps a confirmed grant when a later check fails with a network error", async () => {
+      let failCheck = false;
+      vi.stubGlobal(
+        "fetch",
+        authFetchWithCheck(() => {
+          if (failCheck) throw new Error("network down");
+          return okBody({ has_access: true });
+        }),
+      );
+
+      await service.initialize();
+      expect(service.getState().hasCodeAccess).toBe(true);
+
+      failCheck = true;
+      await service.refreshAccessToken();
+
+      // A transient blip must not be mistaken for a revoked invite.
+      expect(service.getState().hasCodeAccess).toBe(true);
+    });
+
+    it("keeps a confirmed grant when a later check returns 401", async () => {
+      let unauthorized = false;
+      vi.stubGlobal(
+        "fetch",
+        authFetchWithCheck(() =>
+          unauthorized
+            ? ({
+                ok: false,
+                status: 401,
+                json: vi.fn().mockResolvedValue({}),
+              } as unknown as Response)
+            : okBody({ has_access: true }),
+        ),
+      );
+
+      await service.initialize();
+      expect(service.getState().hasCodeAccess).toBe(true);
+
+      unauthorized = true;
+      await service.refreshAccessToken();
+
+      expect(service.getState().hasCodeAccess).toBe(true);
+    });
+
+    it("stays indeterminate (never auto-denies) when the check is inconclusive", async () => {
+      vi.stubGlobal(
+        "fetch",
+        authFetchWithCheck(() => {
+          throw new Error("network down");
+        }),
+      );
+
+      await service.initialize();
+
+      const state = service.getState();
+      expect(state.status).toBe("authenticated");
+      // null, not false: the UI shows "Checking access…" rather than the
+      // invite screen, and the next sync re-checks.
+      expect(state.hasCodeAccess).toBeNull();
+    });
+
+    it("ignores a 2xx response without an explicit has_access flag", async () => {
+      vi.stubGlobal(
+        "fetch",
+        authFetchWithCheck(() => okBody({})),
+      );
+
+      await service.initialize();
+
+      expect(service.getState().hasCodeAccess).toBeNull();
+    });
+  });
 });

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -71,6 +71,13 @@ interface TokenResponseOptions {
   selectedProjectId: number | null;
 }
 
+// A Code invite access check is only authoritative when the server gives a
+// clear yes/no. Anything else (offline, network error, timeout, non-2xx, or an
+// unparseable body) is "indeterminate" and must not be mistaken for a denial.
+type CodeAccessOutcome =
+  | { kind: "resolved"; hasAccess: boolean }
+  | { kind: "indeterminate" };
+
 @injectable()
 export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private state: AuthState = {
@@ -910,26 +917,93 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       return;
     }
 
-    try {
-      const apiHost = getCloudUrlFromRegion(this.session.cloudRegion);
-      const response = await this.executeAuthenticatedFetch(
-        fetch,
-        `${apiHost}/api/code/invites/check-access/`,
-        {},
-        this.session.accessToken,
-      );
-      const data = (await response.json().catch(() => ({}))) as {
-        has_access?: boolean;
-      };
+    const outcome = await this.checkCodeAccess(this.session);
 
-      this.updateState({ hasCodeAccess: data.has_access === true });
-    } catch (error) {
-      this.logger.warn("Failed to update code access state", { error });
-      this.updateState({ hasCodeAccess: false });
+    if (outcome.kind === "resolved") {
+      this.updateState({ hasCodeAccess: outcome.hasAccess });
+      return;
     }
+
+    // Indeterminate: a network blip, timeout, or transient/unauthorized
+    // response is not proof that the invite was revoked, so it must not clobber
+    // a known value and strand the user on the invite screen. Keep whatever we
+    // already know — a confirmed `true` stays `true`; a still-unknown `null`
+    // stays `null` (the UI keeps showing "Checking access…") — and let the next
+    // session sync re-check.
+    this.logger.warn(
+      "Code access check was inconclusive; keeping previous value",
+      { hasCodeAccess: this.state.hasCodeAccess },
+    );
+  }
+  /**
+   * Resolves Code invite access for the given session.
+   *
+   * Only a successful (2xx) response carrying an explicit boolean `has_access`
+   * is authoritative. Offline status, network errors, timeouts, non-2xx
+   * responses (including a 401/403 from an unexpectedly rejected token), and
+   * unparseable or incomplete bodies are all treated as indeterminate and
+   * retried with backoff, so a transient failure never masquerades as a denied
+   * invite. The freshly synced access token is used directly rather than
+   * routing through `authenticatedFetch`, because this runs inside the
+   * bootstrap/refresh flow where re-entering the token-refresh machinery would
+   * deadlock.
+   */
+  private async checkCodeAccess(
+    session: InMemorySession,
+  ): Promise<CodeAccessOutcome> {
+    const url = `${getCloudUrlFromRegion(session.cloudRegion)}/api/code/invites/check-access/`;
+
+    for (
+      let attempt = 0;
+      attempt < AuthService.CODE_ACCESS_MAX_ATTEMPTS;
+      attempt++
+    ) {
+      if (!this.connectivity.getStatus().isOnline) {
+        return { kind: "indeterminate" };
+      }
+
+      try {
+        const response = await this.executeAuthenticatedFetch(
+          fetch,
+          url,
+          {},
+          session.accessToken,
+        );
+
+        if (response.ok) {
+          const data = (await response.json().catch(() => null)) as {
+            has_access?: unknown;
+          } | null;
+          if (data && typeof data.has_access === "boolean") {
+            return { kind: "resolved", hasAccess: data.has_access };
+          }
+          this.logger.warn("Code access response missing has_access flag", {
+            status: response.status,
+          });
+        } else {
+          this.logger.warn("Code access check returned non-OK status", {
+            status: response.status,
+          });
+        }
+      } catch (error) {
+        this.logger.warn("Code access check request failed", {
+          error,
+          attempt,
+        });
+      }
+
+      const isLastAttempt =
+        attempt === AuthService.CODE_ACCESS_MAX_ATTEMPTS - 1;
+      if (!isLastAttempt) {
+        await sleepWithBackoff(attempt, AuthService.REFRESH_BACKOFF);
+      }
+    }
+
+    return { kind: "indeterminate" };
   }
   private static readonly REFRESH_MAX_ATTEMPTS = 3;
   private static readonly ORG_FETCH_MAX_ATTEMPTS = 3;
+  private static readonly CODE_ACCESS_MAX_ATTEMPTS = 3;
   private static readonly ORG_RECOVERY_MAX_ATTEMPTS = 5;
   private static readonly REFRESH_BACKOFF: BackoffOptions = {
     initialDelayMs: 1_000,

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -71,13 +71,6 @@ interface TokenResponseOptions {
   selectedProjectId: number | null;
 }
 
-// A Code invite access check is only authoritative when the server gives a
-// clear yes/no. Anything else (offline, network error, timeout, non-2xx, or an
-// unparseable body) is "indeterminate" and must not be mistaken for a denial.
-type CodeAccessOutcome =
-  | { kind: "resolved"; hasAccess: boolean }
-  | { kind: "indeterminate" };
-
 @injectable()
 export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private state: AuthState = {
@@ -917,40 +910,31 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       return;
     }
 
-    const outcome = await this.checkCodeAccess(this.session);
+    const hasAccess = await this.checkCodeAccess(this.session);
 
-    if (outcome.kind === "resolved") {
-      this.updateState({ hasCodeAccess: outcome.hasAccess });
+    if (hasAccess !== null) {
+      this.updateState({ hasCodeAccess: hasAccess });
       return;
     }
 
-    // Indeterminate: a network blip, timeout, or transient/unauthorized
-    // response is not proof that the invite was revoked, so it must not clobber
-    // a known value and strand the user on the invite screen. Keep whatever we
-    // already know — a confirmed `true` stays `true`; a still-unknown `null`
-    // stays `null` (the UI keeps showing "Checking access…") — and let the next
-    // session sync re-check.
+    // Indeterminate: a transient/unauthorized failure isn't proof the invite
+    // was revoked, so keep the prior value and let the next sync re-check.
     this.logger.warn(
       "Code access check was inconclusive; keeping previous value",
       { hasCodeAccess: this.state.hasCodeAccess },
     );
   }
   /**
-   * Resolves Code invite access for the given session.
-   *
-   * Only a successful (2xx) response carrying an explicit boolean `has_access`
-   * is authoritative. Offline status, network errors, timeouts, non-2xx
-   * responses (including a 401/403 from an unexpectedly rejected token), and
-   * unparseable or incomplete bodies are all treated as indeterminate and
-   * retried with backoff, so a transient failure never masquerades as a denied
-   * invite. The freshly synced access token is used directly rather than
-   * routing through `authenticatedFetch`, because this runs inside the
-   * bootstrap/refresh flow where re-entering the token-refresh machinery would
-   * deadlock.
+   * Resolves Code invite access. Only a 2xx response with an explicit boolean
+   * `has_access` is authoritative; everything else (offline, network error,
+   * non-2xx, malformed body) is indeterminate, retried with backoff, then
+   * returned as `null` so the caller keeps the prior value. Uses the synced
+   * token directly rather than `authenticatedFetch`, which would re-enter the
+   * refresh flow this runs inside and deadlock.
    */
   private async checkCodeAccess(
     session: InMemorySession,
-  ): Promise<CodeAccessOutcome> {
+  ): Promise<boolean | null> {
     const url = `${getCloudUrlFromRegion(session.cloudRegion)}/api/code/invites/check-access/`;
 
     for (
@@ -959,7 +943,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       attempt++
     ) {
       if (!this.connectivity.getStatus().isOnline) {
-        return { kind: "indeterminate" };
+        return null;
       }
 
       try {
@@ -975,7 +959,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
             has_access?: unknown;
           } | null;
           if (data && typeof data.has_access === "boolean") {
-            return { kind: "resolved", hasAccess: data.has_access };
+            return data.has_access;
           }
           this.logger.warn("Code access response missing has_access flag", {
             status: response.status,
@@ -994,12 +978,11 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
 
       const isLastAttempt =
         attempt === AuthService.CODE_ACCESS_MAX_ATTEMPTS - 1;
-      if (!isLastAttempt) {
-        await sleepWithBackoff(attempt, AuthService.REFRESH_BACKOFF);
-      }
+      if (isLastAttempt) break;
+      await sleepWithBackoff(attempt, AuthService.REFRESH_BACKOFF);
     }
 
-    return { kind: "indeterminate" };
+    return null;
   }
   private static readonly REFRESH_MAX_ATTEMPTS = 3;
   private static readonly ORG_FETCH_MAX_ATTEMPTS = 3;

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -924,6 +924,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       { hasCodeAccess: this.state.hasCodeAccess },
     );
   }
+
   /**
    * Resolves Code invite access. Only a 2xx response with an explicit boolean
    * `has_access` is authoritative; everything else (offline, network error,


### PR DESCRIPTION
## Problem

The invite-code screen is gated by an in-memory `hasCodeAccess` flag that is re-fetched from `GET /api/code/invites/check-access/` every time the session syncs. `updateCodeAccessFromSession` treated **any** non-success as "not invited":

- a transient throw (network blip, timeout) → `hasCodeAccess: false`
- a non-`true` body (e.g. `{}` returned by a 401) → `hasCodeAccess: false`

This check re-runs mid-session on every token refresh, 401-retry, system sleep/wake, and network reconnect (via `syncAuthenticatedSession`). So a single transient blip — an expired token at check time, a flaky network moment, a slow API response — overwrote a previously-valid `true` with `false`, and `App.tsx` immediately rendered the invite screen. Restarting "fixed" it because init re-ran the check and it succeeded.

In short: a recoverable error was being treated as a hard lockout, and the flag had no indeterminate state to fall back on.

## Fix

Introduce a discriminated `CodeAccessOutcome` (`resolved` vs `indeterminate`) and split the logic into a `checkCodeAccess(session)` helper:

1. **Only an authoritative answer changes state.** `false` (invite screen) is set *only* on a clean 2xx response carrying an explicit boolean `has_access`. A genuinely non-invited user (`{ has_access: false }`) still correctly sees the invite screen.
2. **Everything else is indeterminate and preserves the prior value.** Offline status, network errors, timeouts, non-2xx (incl. 401/403), and unparseable/incomplete bodies no longer clobber a known value — a confirmed `true` stays `true`, a pending `null` stays `null` (UI keeps showing "Checking access…") — and the next sync re-checks.
3. **Transient failures self-heal within the sync** via a bounded retry (`CODE_ACCESS_MAX_ATTEMPTS = 3`) using the existing `sleepWithBackoff` + `REFRESH_BACKOFF`, with a fast exit when offline.

### Deliberate non-change

I considered routing through `authenticatedFetch` (which does 401-refresh-and-retry), but that path calls `getValidAccessToken → initialize()` / `ensureValidSession`, and this method runs *inside* the bootstrap/refresh flow — re-entering that machinery would await an in-flight promise from within itself and **deadlock**. Because `syncAuthenticatedSession` always passes a freshly-minted token, a 401 here is anomalous and is handled as indeterminate (preserve + retry) rather than via a re-entrant refresh. This reasoning is documented in the method's docstring.

## Tests

Adds a `code access resilience` block (5 cases): explicit denial → `false`; network failure on re-check → keeps `true`; 401 on re-check → keeps `true`; inconclusive restore → stays `null` (never auto-denies); 2xx without `has_access` → stays `null`. All 41 auth tests pass; `biome lint` and `pnpm --filter @posthog/core typecheck` are clean.

> Part 1 of a stack. A follow-up PR builds the broader connectivity UX (persistent banner + reconnecting state, consistent git-action gating, auto-reconnect) that this fix is one instance of.