### PR TITLE
fix(tasks): stop prewarm sandbox placeholders appearing as empty tasks

### DIFF
--- a/packages/shared/src/domain-types.test.ts
+++ b/packages/shared/src/domain-types.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isContentlessTask } from "./domain-types";
+
+describe("isContentlessTask", () => {
+  it.each([
+    { name: "empty strings", title: "", description: "" },
+    { name: "whitespace only", title: "   ", description: "\n\t " },
+    { name: "null fields", title: null, description: null },
+    { name: "undefined fields", title: undefined, description: undefined },
+  ])("returns true for a placeholder task ($name)", (task) => {
+    expect(isContentlessTask(task)).toBe(true);
+  });
+
+  it.each([
+    { name: "a description", title: "", description: "Fix the login bug" },
+    { name: "a title", title: "Fix the login bug", description: "" },
+    {
+      name: "a title and description",
+      title: "Fix the login bug",
+      description: "Fix the login bug",
+    },
+    { name: "padded content", title: "  Hi  ", description: "" },
+  ])("returns false when the task has content ($name)", (task) => {
+    expect(isContentlessTask(task)).toBe(false);
+  });
+});

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -76,14 +76,6 @@ export function isTerminalStatus(
   );
 }
 
-/**
- * A task with no prompt yet: neither a title nor a description. The
- * prewarm-sandbox feature creates an empty cloud task server-side to warm a
- * sandbox while the user is still typing, before any prompt is submitted. These
- * placeholders must not be surfaced as real user tasks (e.g. in the sidebar) —
- * a genuinely created task always carries the submitted prompt as its
- * description, so this never matches one.
- */
 export function isContentlessTask(task: {
   title?: string | null;
   description?: string | null;

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -76,6 +76,21 @@ export function isTerminalStatus(
   );
 }
 
+/**
+ * A task with no prompt yet: neither a title nor a description. The
+ * prewarm-sandbox feature creates an empty cloud task server-side to warm a
+ * sandbox while the user is still typing, before any prompt is submitted. These
+ * placeholders must not be surfaced as real user tasks (e.g. in the sidebar) —
+ * a genuinely created task always carries the submitted prompt as its
+ * description, so this never matches one.
+ */
+export function isContentlessTask(task: {
+  title?: string | null;
+  description?: string | null;
+}): boolean {
+  return !task.title?.trim() && !task.description?.trim();
+}
+
 export interface TaskRun {
   id: string;
   task: string; // Task ID

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -12,6 +12,7 @@ import {
   SYNC_CLOUD_TASKS_FLAG,
 } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { isContentlessTask } from "@posthog/shared/domain-types";
 import { DeepLinkApprovalModal } from "@posthog/ui/features/agent-applications/components/DeepLinkApprovalModal";
 import { useApprovalDeepLink } from "@posthog/ui/features/agent-applications/hooks/useApprovalDeepLink";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -207,7 +208,14 @@ function RootLayout() {
       (t) =>
         t.latest_run?.environment === "cloud" &&
         !workspaces[t.id] &&
-        !reconcilingTaskIds.current.has(t.id),
+        !reconcilingTaskIds.current.has(t.id) &&
+        // Skip prewarm placeholders. The prewarm-sandbox feature creates an
+        // empty cloud task while the user is still typing; adopting it here
+        // would give it a local workspace and surface a nameless, perpetually
+        // "loading agent" task in the sidebar that the user never created
+        // (GROW-52). Real tasks always carry the submitted prompt as their
+        // description.
+        !isContentlessTask(t),
     );
     if (missing.length === 0) return;
     const missingIds = missing.map((t) => t.id);

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -209,12 +209,6 @@ function RootLayout() {
         t.latest_run?.environment === "cloud" &&
         !workspaces[t.id] &&
         !reconcilingTaskIds.current.has(t.id) &&
-        // Skip prewarm placeholders. The prewarm-sandbox feature creates an
-        // empty cloud task while the user is still typing; adopting it here
-        // would give it a local workspace and surface a nameless, perpetually
-        // "loading agent" task in the sidebar that the user never created
-        // (GROW-52). Real tasks always carry the submitted prompt as their
-        // description.
         !isContentlessTask(t),
     );
     if (missing.length === 0) return;


### PR DESCRIPTION
## Problem

[GROW-52](https://linear.app/posthog-team-growth/issue/GROW-52) — while a user is typing a prompt in the cloud task input, an empty, nameless task appears in the sidebar and stays there even after the real task is submitted. Opening it only shows the sandbox provisioning ("loading agent").

## Root cause

Typing in a cloud task input (with a repo selected) fires `useWarmTask`, which calls the prewarm-sandbox endpoint. The backend creates a real but **empty** (no description/title) cloud Task + TaskRun to warm a sandbox, and the returned `{ task_id, run_id }` is discarded client-side.

Within 30s, `useTasks()` polls that placeholder back, and the `reconcileCloudWorkspaces` effect in `__root.tsx` adopts any cloud task lacking a local workspace — including this placeholder — creating a workspace row that makes it pass `filterVisibleTasks` and show up in the sidebar with an empty name. Opening it triggers `watchCloudTask`, which renders the sandbox provisioning steps.

## Fix

Skip content-less placeholder tasks during cloud-workspace reconcile. A genuinely created task always carries the submitted prompt as its `description`, so the new `isContentlessTask` predicate (no title **and** no description) only ever matches prewarm placeholders — never a real task, including one whose backend-generated title hasn't landed yet.

- Add `isContentlessTask` to `@posthog/shared/domain-types` (+ unit tests).
- Exclude content-less tasks from `reconcileCloudWorkspaces` in `__root.tsx`.

## Notes / scope

- `reconcileCloudWorkspaces` (gated by `SYNC_CLOUD_TASKS_FLAG`) is the only path by which a prewarm placeholder reaches the **default** sidebar.
- The "show all users" power-view lists the full task set directly and is out of scope here. The placeholder Task still exists server-side; a cleaner longer-term fix is for the warm flow to reuse the warmed task/run on submit (the returned id is currently discarded) instead of orphaning it.

## Testing

- `pnpm --filter @posthog/shared test` — 350 passed (incl. 8 new for `isContentlessTask`).
- `pnpm --filter @posthog/shared typecheck` + `pnpm --filter @posthog/ui typecheck` — clean.
- `biome lint` on changed files — clean.