### PR TITLE
feat(cloud-tasks): warm sandbox on the selected runtime and model

### DIFF
--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -260,6 +260,42 @@ describe("PostHogAPIClient", () => {
               repository: "PostHog/posthog",
               github_integration: 42,
               branch: "feature/warm",
+              runtime_adapter: null,
+              model: null,
+              reasoning_effort: null,
+            }),
+          },
+        }),
+      );
+    });
+
+    it("forwards the selected runtime so the warm Run starts on it", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () =>
+          JSON.stringify({ task_id: "task-1", run_id: "run-1" }),
+      });
+      const client = makeClient(fetch);
+
+      await client.warmTask({
+        repository: "PostHog/posthog",
+        github_integration: 42,
+        branch: "feature/warm",
+        runtime_adapter: "codex",
+        model: "gpt-5.5",
+        reasoning_effort: "high",
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrides: {
+            body: JSON.stringify({
+              repository: "PostHog/posthog",
+              github_integration: 42,
+              branch: "feature/warm",
+              runtime_adapter: "codex",
+              model: "gpt-5.5",
+              reasoning_effort: "high",
             }),
           },
         }),
@@ -286,6 +322,9 @@ describe("PostHogAPIClient", () => {
               repository: "PostHog/posthog",
               github_integration: 42,
               branch: null,
+              runtime_adapter: null,
+              model: null,
+              reasoning_effort: null,
             }),
           },
         }),

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2139,6 +2139,9 @@ export class PostHogAPIClient {
         github_integration?: number | null;
         github_user_integration?: string | null;
         branch?: string | null;
+        runtime_adapter?: string | null;
+        model?: string | null;
+        reasoning_effort?: string | null;
       },
   ) {
     const teamId = await this.getTeamId();
@@ -2278,6 +2281,9 @@ export class PostHogAPIClient {
     repository: string;
     github_integration: number;
     branch?: string | null;
+    runtime_adapter?: string | null;
+    model?: string | null;
+    reasoning_effort?: string | null;
   }): Promise<{ task_id: string; run_id: string } | null> {
     const teamId = await this.getTeamId();
     const urlPath = `/api/projects/${teamId}/tasks/warm/`;
@@ -2291,6 +2297,9 @@ export class PostHogAPIClient {
           repository: options.repository,
           github_integration: options.github_integration,
           branch: options.branch ?? null,
+          runtime_adapter: options.runtime_adapter ?? null,
+          model: options.model ?? null,
+          reasoning_effort: options.reasoning_effort ?? null,
         }),
       },
     });

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -498,6 +498,16 @@ export class TaskCreationSaga extends Saga<
             input.workspaceMode === "cloud"
               ? (input.branch ?? null)
               : undefined,
+          runtime_adapter:
+            input.workspaceMode === "cloud"
+              ? (input.adapter ?? null)
+              : undefined,
+          model:
+            input.workspaceMode === "cloud" ? (input.model ?? null) : undefined,
+          reasoning_effort:
+            input.workspaceMode === "cloud"
+              ? (input.reasoningLevel ?? null)
+              : undefined,
           signal_report: input.signalReportId ?? undefined,
         });
         return result as unknown as Task;

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -318,13 +318,6 @@ export function TaskInput({
   const { githubIntegrations: orgGithubIntegrations } =
     useIntegrationSelectors();
   const orgGithubIntegrationId = orgGithubIntegrations[0]?.id;
-  useWarmTask({
-    workspaceMode,
-    selectedRepository: selectedCloudRepository,
-    githubIntegrationId: orgGithubIntegrationId,
-    branch: workspaceMode === "cloud" ? selectedBranch : null,
-    editorIsEmpty,
-  });
 
   const {
     data: cloudBranchData,
@@ -584,6 +577,17 @@ export function TaskInput({
     modeFallback;
   const currentReasoningLevel =
     thoughtOption?.type === "select" ? thoughtOption.currentValue : undefined;
+
+  useWarmTask({
+    workspaceMode,
+    selectedRepository: selectedCloudRepository,
+    githubIntegrationId: orgGithubIntegrationId,
+    branch: workspaceMode === "cloud" ? selectedBranch : null,
+    editorIsEmpty,
+    runtimeAdapter: adapter ?? null,
+    model: currentModel,
+    reasoningEffort: currentReasoningLevel,
+  });
 
   const branchForTaskCreation =
     effectiveWorkspaceMode === "worktree" || effectiveWorkspaceMode === "cloud"

--- a/packages/ui/src/features/task-detail/hooks/useWarmTask.test.tsx
+++ b/packages/ui/src/features/task-detail/hooks/useWarmTask.test.tsx
@@ -25,6 +25,9 @@ interface Props {
   githubIntegrationId?: number;
   branch?: string | null;
   editorIsEmpty: boolean;
+  runtimeAdapter?: string | null;
+  model?: string | null;
+  reasoningEffort?: string | null;
 }
 
 const cloudTyping: Props = {
@@ -33,6 +36,12 @@ const cloudTyping: Props = {
   githubIntegrationId: 42,
   branch: "main",
   editorIsEmpty: false,
+};
+
+const NULL_RUNTIME = {
+  runtime_adapter: null,
+  model: null,
+  reasoning_effort: null,
 };
 
 describe("useWarmTask", () => {
@@ -70,6 +79,7 @@ describe("useWarmTask", () => {
       repository: "acme/repo",
       github_integration: 42,
       branch: "main",
+      ...NULL_RUNTIME,
     });
   });
 
@@ -131,6 +141,7 @@ describe("useWarmTask", () => {
       repository: "acme/other",
       github_integration: 42,
       branch: "main",
+      ...NULL_RUNTIME,
     });
     expect(mockClient.warmTask).toHaveBeenCalledTimes(2);
   });
@@ -148,6 +159,44 @@ describe("useWarmTask", () => {
       repository: "acme/repo",
       github_integration: 42,
       branch: "feature/x",
+      ...NULL_RUNTIME,
+    });
+    expect(mockClient.warmTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards the selected runtime and re-warms when it changes", async () => {
+    const { rerender } = renderHook((props: Props) => useWarmTask(props), {
+      initialProps: {
+        ...cloudTyping,
+        runtimeAdapter: "claude",
+        model: "claude-opus-4-8",
+        reasoningEffort: "high",
+      },
+    });
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenLastCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "main",
+      runtime_adapter: "claude",
+      model: "claude-opus-4-8",
+      reasoning_effort: "high",
+    });
+
+    rerender({
+      ...cloudTyping,
+      runtimeAdapter: "codex",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+    });
+    await flushDebounce();
+    expect(mockClient.warmTask).toHaveBeenLastCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "main",
+      runtime_adapter: "codex",
+      model: "gpt-5.5",
+      reasoning_effort: "high",
     });
     expect(mockClient.warmTask).toHaveBeenCalledTimes(2);
   });

--- a/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
+++ b/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
@@ -17,6 +17,9 @@ interface UseWarmTaskOptions {
   githubIntegrationId?: number;
   branch?: string | null;
   editorIsEmpty: boolean;
+  runtimeAdapter?: string | null;
+  model?: string | null;
+  reasoningEffort?: string | null;
 }
 
 export function useWarmTask({
@@ -25,6 +28,9 @@ export function useWarmTask({
   githubIntegrationId,
   branch,
   editorIsEmpty,
+  runtimeAdapter,
+  model,
+  reasoningEffort,
 }: UseWarmTaskOptions): void {
   const enabled = useFeatureFlag(TASKS_PREWARM_SANDBOX_FLAG);
   const client = useOptionalAuthenticatedClient();
@@ -34,6 +40,9 @@ export function useWarmTask({
 
   const isCloud = workspaceMode === "cloud";
   const normalizedBranch = branch ?? null;
+  const normalizedRuntimeAdapter = runtimeAdapter ?? null;
+  const normalizedModel = model ?? null;
+  const normalizedReasoningEffort = reasoningEffort ?? null;
   const eligible =
     enabled &&
     isCloud &&
@@ -43,7 +52,7 @@ export function useWarmTask({
     !editorIsEmpty;
   const key =
     selectedRepository && githubIntegrationId !== undefined
-      ? `${githubIntegrationId}:${selectedRepository}:${normalizedBranch ?? ""}`
+      ? `${githubIntegrationId}:${selectedRepository}:${normalizedBranch ?? ""}:${normalizedRuntimeAdapter ?? ""}:${normalizedModel ?? ""}:${normalizedReasoningEffort ?? ""}`
       : null;
 
   useEffect(() => {
@@ -65,6 +74,9 @@ export function useWarmTask({
     const repository = selectedRepository;
     const githubIntegration = githubIntegrationId as number;
     const warmBranch = normalizedBranch;
+    const warmRuntimeAdapter = normalizedRuntimeAdapter;
+    const warmModel = normalizedModel;
+    const warmReasoningEffort = normalizedReasoningEffort;
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
       lastWarmedKeyRef.current = key;
@@ -73,6 +85,9 @@ export function useWarmTask({
           repository,
           github_integration: githubIntegration,
           branch: warmBranch,
+          runtime_adapter: warmRuntimeAdapter,
+          model: warmModel,
+          reasoning_effort: warmReasoningEffort,
         })
         .catch((error) => {
           lastWarmedKeyRef.current = null;
@@ -88,5 +103,8 @@ export function useWarmTask({
     selectedRepository,
     githubIntegrationId,
     normalizedBranch,
+    normalizedRuntimeAdapter,
+    normalizedModel,
+    normalizedReasoningEffort,
   ]);
 }


### PR DESCRIPTION
## Problem

`useWarmTask` warmed the sandbox while composing but sent only `repository`/`github_integration`/`branch` not the selected runtime. The backend therefore started a default Claude warm session, and the submit reused it, dropping the user's selection.
