### PR TITLE
feat(canvas): shareable links for canvases

### DIFF
--- a/apps/code/src/main/di/bindings.ts
+++ b/apps/code/src/main/di/bindings.ts
@@ -45,8 +45,10 @@ import type {
 } from "@posthog/core/integrations/identifiers";
 import type { SlackIntegrationService } from "@posthog/core/integrations/slack";
 import type { ApprovalLinkService } from "@posthog/core/links/approval-link";
+import type { CanvasLinkService } from "@posthog/core/links/canvas-link";
 import type {
   APPROVAL_LINK_SERVICE,
+  CANVAS_LINK_SERVICE,
   INBOX_LINK_SERVICE,
   NEW_TASK_LINK_SERVICE,
   SCOUT_LINK_SERVICE,
@@ -240,6 +242,7 @@ import type {
   AUTH_PREFERENCE_REPOSITORY as MAIN_AUTH_PREFERENCE_REPOSITORY,
   AUTH_SERVICE as MAIN_AUTH_SERVICE,
   AUTH_SESSION_REPOSITORY as MAIN_AUTH_SESSION_REPOSITORY,
+  CANVAS_LINK_SERVICE as MAIN_CANVAS_LINK_SERVICE,
   CLOUD_TASK_SERVICE as MAIN_CLOUD_TASK_SERVICE,
   CONTEXT_MENU_SERVICE as MAIN_CONTEXT_MENU_SERVICE,
   DATABASE_SERVICE as MAIN_DATABASE_SERVICE,
@@ -405,11 +408,13 @@ export interface MainBindings {
   [MAIN_SCOUT_LINK_SERVICE]: ScoutLinkService;
   [MAIN_NEW_TASK_LINK_SERVICE]: NewTaskLinkService;
   [MAIN_APPROVAL_LINK_SERVICE]: ApprovalLinkService;
+  [MAIN_CANVAS_LINK_SERVICE]: CanvasLinkService;
   [TASK_LINK_SERVICE]: TaskLinkService;
   [INBOX_LINK_SERVICE]: InboxLinkService;
   [SCOUT_LINK_SERVICE]: ScoutLinkService;
   [NEW_TASK_LINK_SERVICE]: NewTaskLinkService;
   [APPROVAL_LINK_SERVICE]: ApprovalLinkService;
+  [CANVAS_LINK_SERVICE]: CanvasLinkService;
 
   // Watcher registry
   [MAIN_WATCHER_REGISTRY_SERVICE]: WatcherRegistryService;

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -47,8 +47,10 @@ import { handoffModule } from "@posthog/core/handoff/handoff.module";
 import { HANDOFF_HOST } from "@posthog/core/handoff/identifiers";
 import { integrationsModule } from "@posthog/core/integrations/integrations.module";
 import { ApprovalLinkService } from "@posthog/core/links/approval-link";
+import { CanvasLinkService } from "@posthog/core/links/canvas-link";
 import {
   APPROVAL_LINK_SERVICE,
+  CANVAS_LINK_SERVICE,
   INBOX_LINK_SERVICE,
   NEW_TASK_LINK_SERVICE,
   SCOUT_LINK_SERVICE,
@@ -252,6 +254,7 @@ import {
   AUTH_PREFERENCE_REPOSITORY as MAIN_AUTH_PREFERENCE_REPOSITORY,
   AUTH_SERVICE as MAIN_AUTH_SERVICE,
   AUTH_SESSION_REPOSITORY as MAIN_AUTH_SESSION_REPOSITORY,
+  CANVAS_LINK_SERVICE as MAIN_CANVAS_LINK_SERVICE,
   CLOUD_TASK_SERVICE as MAIN_CLOUD_TASK_SERVICE,
   CONTEXT_MENU_SERVICE as MAIN_CONTEXT_MENU_SERVICE,
   DATABASE_SERVICE as MAIN_DATABASE_SERVICE,
@@ -621,6 +624,8 @@ container.bind(MAIN_NEW_TASK_LINK_SERVICE).to(NewTaskLinkService);
 container.bind(NEW_TASK_LINK_SERVICE).toService(MAIN_NEW_TASK_LINK_SERVICE);
 container.bind(MAIN_APPROVAL_LINK_SERVICE).to(ApprovalLinkService);
 container.bind(APPROVAL_LINK_SERVICE).toService(MAIN_APPROVAL_LINK_SERVICE);
+container.bind(MAIN_CANVAS_LINK_SERVICE).to(CanvasLinkService);
+container.bind(CANVAS_LINK_SERVICE).toService(MAIN_CANVAS_LINK_SERVICE);
 container.load(watcherRegistryModule);
 container
   .bind(MAIN_WATCHER_REGISTRY_SERVICE)

--- a/apps/code/src/main/di/tokens.ts
+++ b/apps/code/src/main/di/tokens.ts
@@ -106,6 +106,9 @@ export const NEW_TASK_LINK_SERVICE = Symbol.for(
 export const APPROVAL_LINK_SERVICE = Symbol.for(
   "posthog.host.main.approval-link.service",
 );
+export const CANVAS_LINK_SERVICE = Symbol.for(
+  "posthog.host.main.canvas-link.service",
+);
 export const WATCHER_REGISTRY_SERVICE = Symbol.for(
   "posthog.host.main.watcher-registry.service",
 );

--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -23,6 +23,7 @@ import {
 } from "@posthog/core/integrations/identifiers";
 import type { SlackIntegrationService } from "@posthog/core/integrations/slack";
 import type { ApprovalLinkService } from "@posthog/core/links/approval-link";
+import type { CanvasLinkService } from "@posthog/core/links/canvas-link";
 import type { InboxLinkService } from "@posthog/core/links/inbox-link";
 import type { NewTaskLinkService } from "@posthog/core/links/new-task-link";
 import type { ScoutLinkService } from "@posthog/core/links/scout-link";
@@ -52,6 +53,7 @@ import {
   APP_LIFECYCLE_SERVICE,
   APPROVAL_LINK_SERVICE,
   AUTH_SERVICE,
+  CANVAS_LINK_SERVICE,
   DATABASE_SERVICE,
   DISCORD_PRESENCE_SERVICE,
   EXTERNAL_APPS_SERVICE,
@@ -247,6 +249,9 @@ async function initializeServices(): Promise<void> {
   container.get<ScoutLinkService>(SCOUT_LINK_SERVICE);
   container.get<NewTaskLinkService>(NEW_TASK_LINK_SERVICE);
   container.get<ApprovalLinkService>(APPROVAL_LINK_SERVICE);
+  // Eagerly resolved so its constructor registers the `canvas` deep-link
+  // handler at boot, before any link arrives.
+  container.get<CanvasLinkService>(CANVAS_LINK_SERVICE);
   container.get<GitHubIntegrationService>(GITHUB_INTEGRATION_SERVICE);
   container.get<SlackIntegrationService>(SLACK_INTEGRATION_SERVICE);
   container.get<ExternalAppsService>(EXTERNAL_APPS_SERVICE);

--- a/docs/DEEP-LINKS.md
+++ b/docs/DEEP-LINKS.md
@@ -10,7 +10,7 @@ PostHog Code registers custom URL schemes so the desktop app can be opened with 
 | Development | `posthog-code-dev://` |
 | Legacy (production only) | `twig://`, `array://` |
 
-All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `scout`, `approval`, `new`, `plan`, `issue`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
+All schemes route through the same dispatcher. The host portion of the URL selects the handler (`task`, `inbox`, `scout`, `approval`, `canvas`, `new`, `plan`, `issue`, `callback`, `integration`, `slack-integration`, `mcp-oauth-complete`).
 
 If the app is not running, the OS launches it and the link is queued until the renderer is ready. If the app is minimised, it is restored and focused before the link is handled.
 
@@ -130,6 +130,25 @@ Emitted by the agent-runner on a gated tool call so non-PostHog-Code clients
 posthog-code://approval/ar_abc123
 ```
 
+### `posthog-code://canvas/<channelId>/<dashboardId>`
+
+Open a canvas (a dashboard inside a Channels-space channel) straight in the
+desktop app. Gated on the `project-bluebird` flag. Unlike the links above,
+users don't share this scheme link directly — the "Copy link" affordance on a
+canvas copies an **https** link (`<instance>/code/canvas/<channelId>/<dashboardId>`)
+that resolves to a web interstitial in PostHog Cloud, which fires this scheme
+(or offers the desktop-app download). That way the link works for anyone,
+whether or not they have the app.
+
+| Segment | Required | Description |
+|---|---|---|
+| `<channelId>` | Yes | Channel (folder) row id the canvas lives under. |
+| `<dashboardId>` | Yes | Dashboard row id of the canvas. Both are stable, rename-proof desktop file-system row ids. |
+
+```
+posthog-code://canvas/019ebc38-d862-77f2-9e56-c5ec42965758/dash_abc123
+```
+
 ## OAuth callback links
 
 These are issued by external services and consumed by the app. You should not need to construct them yourself, but they are documented for completeness.
@@ -195,6 +214,7 @@ In development the same payload is delivered to `http://localhost:8238/mcp-oauth
 | `inbox` | [packages/core/src/links/inbox-link.ts](../packages/core/src/links/inbox-link.ts) |
 | `scout` | [packages/core/src/links/scout-link.ts](../packages/core/src/links/scout-link.ts) |
 | `approval` | [packages/core/src/links/approval-link.ts](../packages/core/src/links/approval-link.ts) |
+| `canvas` | [packages/core/src/links/canvas-link.ts](../packages/core/src/links/canvas-link.ts) |
 | `new`, `plan`, `issue` | [packages/core/src/links/new-task-link.ts](../packages/core/src/links/new-task-link.ts) |
 | `callback` | [packages/core/src/oauth/oauth.ts](../packages/core/src/oauth/oauth.ts) |
 | `integration` | [packages/core/src/integrations/github.ts](../packages/core/src/integrations/github.ts) |

--- a/packages/core/src/links/canvas-link.test.ts
+++ b/packages/core/src/links/canvas-link.test.ts
@@ -1,0 +1,130 @@
+import type {
+  DeepLinkHandler,
+  IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
+import type { IMainWindow } from "@posthog/platform/main-window";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CanvasLinkEvent, CanvasLinkService } from "./canvas-link";
+
+function makeLogger() {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    scope: vi.fn(() => logger),
+  };
+  return logger;
+}
+
+function makeDeepLinkService() {
+  const handlers = new Map<string, DeepLinkHandler>();
+  const service = {
+    registerHandler: vi.fn((key: string, handler: DeepLinkHandler) => {
+      handlers.set(key, handler);
+    }),
+    trigger: (key: string, path: string) => {
+      const handler = handlers.get(key);
+      if (!handler) throw new Error(`No handler for ${key}`);
+      return handler(path, new URLSearchParams());
+    },
+  };
+  return service as unknown as IDeepLinkRegistry & {
+    trigger: (key: string, path: string) => boolean;
+  };
+}
+
+function makeMainWindow() {
+  return {
+    focus: vi.fn(),
+    restore: vi.fn(),
+    isMinimized: vi.fn().mockReturnValue(false),
+  } as unknown as IMainWindow & {
+    focus: ReturnType<typeof vi.fn>;
+    restore: ReturnType<typeof vi.fn>;
+    isMinimized: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("CanvasLinkService", () => {
+  let deepLinkService: ReturnType<typeof makeDeepLinkService>;
+  let mainWindow: ReturnType<typeof makeMainWindow>;
+  let service: CanvasLinkService;
+
+  beforeEach(() => {
+    deepLinkService = makeDeepLinkService();
+    mainWindow = makeMainWindow();
+    service = new CanvasLinkService(deepLinkService, mainWindow, makeLogger());
+  });
+
+  it("registers a 'canvas' handler on the DeepLinkService", () => {
+    expect(deepLinkService.registerHandler).toHaveBeenCalledWith(
+      "canvas",
+      expect.any(Function),
+    );
+  });
+
+  it("emits OpenCanvas with the channel and dashboard ids", () => {
+    const listener = vi.fn();
+    service.on(CanvasLinkEvent.OpenCanvas, listener);
+
+    const result = deepLinkService.trigger("canvas", "chan-1/dash-2");
+
+    expect(result).toBe(true);
+    expect(listener).toHaveBeenCalledWith({
+      channelId: "chan-1",
+      dashboardId: "dash-2",
+    });
+  });
+
+  it("decodes URL-encoded id segments", () => {
+    const listener = vi.fn();
+    service.on(CanvasLinkEvent.OpenCanvas, listener);
+
+    deepLinkService.trigger("canvas", "chan%2Fa/dash%20b");
+
+    expect(listener).toHaveBeenCalledWith({
+      channelId: "chan/a",
+      dashboardId: "dash b",
+    });
+  });
+
+  it("queues a pending deep link when no listener is attached", () => {
+    deepLinkService.trigger("canvas", "chan-1/dash-2");
+
+    const pending = service.consumePendingDeepLink();
+    expect(pending).toEqual({ channelId: "chan-1", dashboardId: "dash-2" });
+
+    // Draining clears it
+    expect(service.consumePendingDeepLink()).toBeNull();
+  });
+
+  it.each([
+    ["empty path", ""],
+    ["channel only (no dashboard)", "chan-1"],
+  ])("returns false and does not emit for %s", (_label, path) => {
+    const listener = vi.fn();
+    service.on(CanvasLinkEvent.OpenCanvas, listener);
+
+    const result = deepLinkService.trigger("canvas", path);
+
+    expect(result).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("focuses the main window on link arrival", () => {
+    deepLinkService.trigger("canvas", "chan-1/dash-2");
+
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1);
+    expect(mainWindow.restore).not.toHaveBeenCalled();
+  });
+
+  it("restores the main window when it is minimized", () => {
+    mainWindow.isMinimized.mockReturnValue(true);
+
+    deepLinkService.trigger("canvas", "chan-1/dash-2");
+
+    expect(mainWindow.restore).toHaveBeenCalledTimes(1);
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/links/canvas-link.ts
+++ b/packages/core/src/links/canvas-link.ts
@@ -1,0 +1,114 @@
+import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
+import {
+  DEEP_LINK_SERVICE,
+  type IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
+import {
+  type IMainWindow,
+  MAIN_WINDOW_SERVICE,
+} from "@posthog/platform/main-window";
+import { TypedEventEmitter } from "@posthog/shared";
+import { inject, injectable } from "inversify";
+import type { LinkLogger } from "./identifiers";
+
+export const CanvasLinkEvent = {
+  OpenCanvas: "openCanvas",
+} as const;
+
+export interface CanvasLinkPayload {
+  /** Channel (folder) row id the canvas lives under. */
+  channelId: string;
+  /** Dashboard row id of the canvas. */
+  dashboardId: string;
+}
+
+export interface CanvasLinkEvents {
+  [CanvasLinkEvent.OpenCanvas]: CanvasLinkPayload;
+}
+
+/**
+ * Handles canvas deep links (`<scheme>://canvas/{channelId}/{dashboardId}`, e.g.
+ * `posthog-code://…` in production and `posthog-code-dev://…` in local dev).
+ * Shareable canvas links resolve to a web interstitial that fires this scheme,
+ * so a teammate can open a canvas straight in the desktop app. Both ids are
+ * stable, rename-proof desktop file-system row ids.
+ *
+ * Mirrors `InboxLinkService`: queues a link that arrived before the renderer was
+ * ready, and emits for links delivered while the app is already running.
+ */
+@injectable()
+export class CanvasLinkService extends TypedEventEmitter<CanvasLinkEvents> {
+  private pendingDeepLink: CanvasLinkPayload | null = null;
+  private readonly log: LinkLogger;
+
+  constructor(
+    @inject(DEEP_LINK_SERVICE)
+    private readonly deepLinkService: IDeepLinkRegistry,
+    @inject(MAIN_WINDOW_SERVICE)
+    private readonly mainWindow: IMainWindow,
+    @inject(ROOT_LOGGER)
+    rootLogger: RootLogger,
+  ) {
+    super();
+    this.log = rootLogger.scope("canvas-link-service");
+
+    this.deepLinkService.registerHandler("canvas", (path) =>
+      this.handleCanvasLink(path),
+    );
+  }
+
+  private handleCanvasLink(path: string): boolean {
+    const [channelId, dashboardId] = path
+      .split("/")
+      .map((segment) => decodeSegment(segment));
+
+    if (!channelId || !dashboardId) {
+      this.log.warn("Canvas link missing channel or dashboard id");
+      return false;
+    }
+
+    const payload: CanvasLinkPayload = { channelId, dashboardId };
+
+    const hasListeners = this.listenerCount(CanvasLinkEvent.OpenCanvas) > 0;
+
+    if (hasListeners) {
+      this.log.info(
+        `Emitting canvas link event: channelId=${channelId} dashboardId=${dashboardId}`,
+      );
+      this.emit(CanvasLinkEvent.OpenCanvas, payload);
+    } else {
+      this.log.info(
+        `Queueing canvas link (renderer not ready): channelId=${channelId} dashboardId=${dashboardId}`,
+      );
+      this.pendingDeepLink = payload;
+    }
+
+    this.log.info("Deep link focusing window", { channelId, dashboardId });
+    if (this.mainWindow.isMinimized()) {
+      this.mainWindow.restore();
+    }
+    this.mainWindow.focus();
+
+    return true;
+  }
+
+  public consumePendingDeepLink(): CanvasLinkPayload | null {
+    const pending = this.pendingDeepLink;
+    this.pendingDeepLink = null;
+    if (pending) {
+      this.log.info(
+        `Consumed pending canvas link: channelId=${pending.channelId} dashboardId=${pending.dashboardId}`,
+      );
+    }
+    return pending;
+  }
+}
+
+function decodeSegment(segment: string | undefined): string {
+  if (!segment) return "";
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/packages/core/src/links/identifiers.ts
+++ b/packages/core/src/links/identifiers.ts
@@ -14,3 +14,4 @@ export const NEW_TASK_LINK_SERVICE = Symbol.for(
 export const APPROVAL_LINK_SERVICE = Symbol.for(
   "posthog.core.approvalLinkService",
 );
+export const CANVAS_LINK_SERVICE = Symbol.for("posthog.core.canvasLinkService");

--- a/packages/host-router/src/routers/deep-link.router.ts
+++ b/packages/host-router/src/routers/deep-link.router.ts
@@ -4,7 +4,13 @@ import {
   type ApprovalLinkService,
 } from "@posthog/core/links/approval-link";
 import {
+  CanvasLinkEvent,
+  type CanvasLinkPayload,
+  type CanvasLinkService,
+} from "@posthog/core/links/canvas-link";
+import {
   APPROVAL_LINK_SERVICE,
+  CANVAS_LINK_SERVICE,
   INBOX_LINK_SERVICE,
   NEW_TASK_LINK_SERVICE,
   SCOUT_LINK_SERVICE,
@@ -125,6 +131,25 @@ export const deepLinkRouter = router({
     ({ ctx }): ApprovalLinkPayload | null => {
       return ctx.container
         .get<ApprovalLinkService>(APPROVAL_LINK_SERVICE)
+        .consumePendingDeepLink();
+    },
+  ),
+
+  onOpenCanvas: publicProcedure.subscription(async function* (opts) {
+    const service =
+      opts.ctx.container.get<CanvasLinkService>(CANVAS_LINK_SERVICE);
+    const iterable = service.toIterable(CanvasLinkEvent.OpenCanvas, {
+      signal: opts.signal,
+    });
+    for await (const data of iterable) {
+      yield data;
+    }
+  }),
+
+  getPendingCanvasLink: publicProcedure.query(
+    ({ ctx }): CanvasLinkPayload | null => {
+      return ctx.container
+        .get<CanvasLinkService>(CANVAS_LINK_SERVICE)
         .consumePendingDeepLink();
     },
   ),

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -332,6 +332,11 @@ export interface DeepLinkIssueFailedProperties {
   error_message?: string;
 }
 
+export interface DeepLinkCanvasProperties {
+  channel_id: string;
+  dashboard_id: string;
+}
+
 // Feedback events
 export interface TaskFeedbackProperties {
   task_id: string;
@@ -825,7 +830,8 @@ export type DashboardActionType =
   | "revert"
   | "refresh"
   | "poll_mode_change"
-  | "date_range_apply";
+  | "date_range_apply"
+  | "link_copied";
 
 export interface DashboardActionProperties {
   action_type: DashboardActionType;
@@ -1010,6 +1016,7 @@ export const ANALYTICS_EVENTS = {
   DEEP_LINK_PLAN: "Deep link plan",
   DEEP_LINK_ISSUE: "Deep link issue",
   DEEP_LINK_ISSUE_FAILED: "Deep link issue failed",
+  DEEP_LINK_CANVAS: "Deep link canvas",
 
   // Error events
   TASK_CREATION_FAILED: "Task creation failed",
@@ -1152,6 +1159,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.DEEP_LINK_PLAN]: DeepLinkPlanProperties;
   [ANALYTICS_EVENTS.DEEP_LINK_ISSUE]: DeepLinkIssueProperties;
   [ANALYTICS_EVENTS.DEEP_LINK_ISSUE_FAILED]: DeepLinkIssueFailedProperties;
+  [ANALYTICS_EVENTS.DEEP_LINK_CANVAS]: DeepLinkCanvasProperties;
 
   // Error events
   [ANALYTICS_EVENTS.TASK_CREATION_FAILED]: TaskCreationFailedProperties;

--- a/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteDashboardsIndex.tsx
@@ -1,4 +1,4 @@
-import { DotsThreeIcon, TrashIcon } from "@phosphor-icons/react";
+import { DotsThreeIcon, LinkIcon, TrashIcon } from "@phosphor-icons/react";
 import type { DashboardSummary } from "@posthog/core/canvas/dashboardSchemas";
 import {
   Badge,
@@ -22,6 +22,7 @@ import {
   useDashboardMutations,
   useDashboards,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { copyCanvasLink } from "@posthog/ui/features/canvas/utils/copyCanvasLink";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
@@ -269,6 +270,14 @@ function DashboardCardMenu({
           }
         />
         <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
+          <DropdownMenuItem
+            onClick={() =>
+              void copyCanvasLink(channelId, id, "dashboards_grid")
+            }
+          >
+            <LinkIcon size={14} />
+            Copy link
+          </DropdownMenuItem>
           <DropdownMenuItem
             variant="destructive"
             disabled={isDeleting}

--- a/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -1,4 +1,9 @@
-import { GitForkIcon, PencilSimpleIcon, XIcon } from "@phosphor-icons/react";
+import {
+  GitForkIcon,
+  LinkIcon,
+  PencilSimpleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { ChannelBreadcrumb } from "@posthog/ui/features/canvas/components/ChannelBreadcrumb";
@@ -18,6 +23,7 @@ import {
   useFreeformChatStore,
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
+import { copyCanvasLink } from "@posthog/ui/features/canvas/utils/copyCanvasLink";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
@@ -151,6 +157,14 @@ function FreeformEditControls({
           Save as fork
         </Button>
       )}
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => void copyCanvasLink(channelId, dashboardId, "canvas")}
+      >
+        <LinkIcon size={14} />
+        Copy link
+      </Button>
       <Button
         variant="outline"
         size="sm"

--- a/packages/ui/src/features/canvas/hooks/useCanvasDeepLink.ts
+++ b/packages/ui/src/features/canvas/hooks/useCanvasDeepLink.ts
@@ -1,0 +1,75 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
+import { track } from "@posthog/ui/shell/analytics";
+import { logger } from "@posthog/ui/shell/logger";
+import { useQuery } from "@tanstack/react-query";
+import { useSubscription } from "@trpc/tanstack-react-query";
+import { useCallback, useEffect } from "react";
+
+const log = logger.scope("canvas-deep-link");
+
+/**
+ * Handles canvas deep links (`<scheme>://canvas/{channelId}/{dashboardId}`, e.g.
+ * `posthog-code://…` in production and `posthog-code-dev://…` in local dev) and
+ * opens the canvas in the Channels space. These arrive from a shareable https
+ * link's web interstitial, so a teammate can open a canvas straight in the app.
+ *
+ * Mirrors `useScoutDeepLink`: drains any link that arrived before the renderer
+ * was ready (the main process clears its pending entry on read) and also
+ * subscribes for links delivered while the app is already running. Gated on
+ * project-bluebird — the Channels space (and canvases) only exist behind it.
+ */
+export function useCanvasDeepLink() {
+  const trpcReact = useHostTRPC();
+  const isAuthenticated = useAuthStateValue(
+    (s) => s.status === "authenticated",
+  );
+  const bluebirdEnabled = useFeatureFlag(
+    PROJECT_BLUEBIRD_FLAG,
+    import.meta.env.DEV,
+  );
+  const enabled = isAuthenticated && bluebirdEnabled;
+
+  const pendingDeepLink = useQuery(
+    trpcReact.deepLink.getPendingCanvasLink.queryOptions(undefined, {
+      enabled,
+      // Drain once per session – the main process clears its pending entry on read.
+      staleTime: Number.POSITIVE_INFINITY,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }),
+  );
+
+  const openCanvas = useCallback((channelId: string, dashboardId: string) => {
+    log.info(
+      `Opening canvas from deep link: channelId=${channelId} dashboardId=${dashboardId}`,
+    );
+    track(ANALYTICS_EVENTS.DEEP_LINK_CANVAS, {
+      channel_id: channelId,
+      dashboard_id: dashboardId,
+    });
+    navigateToChannelDashboard(channelId, dashboardId);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const pending = pendingDeepLink.data;
+    if (pending?.channelId && pending?.dashboardId) {
+      openCanvas(pending.channelId, pending.dashboardId);
+    }
+  }, [enabled, pendingDeepLink.data, openCanvas]);
+
+  useSubscription(
+    trpcReact.deepLink.onOpenCanvas.subscriptionOptions(undefined, {
+      onData: (data) => {
+        if (enabled && data?.channelId && data?.dashboardId) {
+          openCanvas(data.channelId, data.dashboardId);
+        }
+      },
+    }),
+  );
+}

--- a/packages/ui/src/features/canvas/hooks/useCanvasDeepLink.ts
+++ b/packages/ui/src/features/canvas/hooks/useCanvasDeepLink.ts
@@ -1,8 +1,6 @@
 import { useHostTRPC } from "@posthog/host-router/react";
-import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
 import { logger } from "@posthog/ui/shell/logger";
@@ -20,23 +18,22 @@ const log = logger.scope("canvas-deep-link");
  *
  * Mirrors `useScoutDeepLink`: drains any link that arrived before the renderer
  * was ready (the main process clears its pending entry on read) and also
- * subscribes for links delivered while the app is already running. Gated on
- * project-bluebird — the Channels space (and canvases) only exist behind it.
+ * subscribes for links delivered while the app is already running. The live
+ * subscription acts on every link unconditionally — gating it behind the
+ * project-bluebird flag would drop a link that arrives before the flag resolves
+ * (the main process emits rather than queues once a listener is attached, so a
+ * discarded payload is unrecoverable). Navigation is safe regardless: the
+ * Channels space is flag-gated at the route, which redirects out when off.
  */
 export function useCanvasDeepLink() {
   const trpcReact = useHostTRPC();
   const isAuthenticated = useAuthStateValue(
     (s) => s.status === "authenticated",
   );
-  const bluebirdEnabled = useFeatureFlag(
-    PROJECT_BLUEBIRD_FLAG,
-    import.meta.env.DEV,
-  );
-  const enabled = isAuthenticated && bluebirdEnabled;
 
   const pendingDeepLink = useQuery(
     trpcReact.deepLink.getPendingCanvasLink.queryOptions(undefined, {
-      enabled,
+      enabled: isAuthenticated,
       // Drain once per session – the main process clears its pending entry on read.
       staleTime: Number.POSITIVE_INFINITY,
       refetchOnWindowFocus: false,
@@ -56,17 +53,16 @@ export function useCanvasDeepLink() {
   }, []);
 
   useEffect(() => {
-    if (!enabled) return;
     const pending = pendingDeepLink.data;
     if (pending?.channelId && pending?.dashboardId) {
       openCanvas(pending.channelId, pending.dashboardId);
     }
-  }, [enabled, pendingDeepLink.data, openCanvas]);
+  }, [pendingDeepLink.data, openCanvas]);
 
   useSubscription(
     trpcReact.deepLink.onOpenCanvas.subscriptionOptions(undefined, {
       onData: (data) => {
-        if (enabled && data?.channelId && data?.dashboardId) {
+        if (data?.channelId && data?.dashboardId) {
           openCanvas(data.channelId, data.dashboardId);
         }
       },

--- a/packages/ui/src/features/canvas/utils/copyCanvasLink.ts
+++ b/packages/ui/src/features/canvas/utils/copyCanvasLink.ts
@@ -1,0 +1,53 @@
+import {
+  ANALYTICS_EVENTS,
+  type ChannelsSurface,
+} from "@posthog/shared/analytics-events";
+import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
+import { canvasShareUrl } from "@posthog/ui/utils/posthogLinks";
+
+/**
+ * Copy a canvas's shareable https link (`<instance>/code/canvas/<channelId>/
+ * <dashboardId>`) to the clipboard, toasting success or failure. Shared by every
+ * "Copy link" affordance (canvas toolbar, dashboards grid) so the link format
+ * and feedback stay in one place. Unlike the inbox/scout copy actions — which
+ * copy the raw `<scheme>://` deep link — this copies an https link that resolves
+ * to a web interstitial, so it opens for anyone whether or not they have the
+ * desktop app.
+ */
+export async function copyCanvasLink(
+  channelId: string,
+  dashboardId: string,
+  surface: ChannelsSurface,
+): Promise<void> {
+  const url = canvasShareUrl(channelId, dashboardId);
+  if (!url) {
+    toast.error("Couldn't build a shareable link");
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(url);
+    toast.success("Link copied", {
+      description: "Anyone with the link can open this canvas.",
+    });
+    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+      action_type: "link_copied",
+      surface,
+      channel_id: channelId,
+      dashboard_id: dashboardId,
+      success: true,
+    });
+  } catch (error) {
+    toast.error("Couldn't copy link", {
+      description: error instanceof Error ? error.message : String(error),
+    });
+    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+      action_type: "link_copied",
+      surface,
+      channel_id: channelId,
+      dashboard_id: dashboardId,
+      success: false,
+    });
+  }
+}

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -21,6 +21,7 @@ import {
   FeedbackModal,
   type FeedbackModalMode,
 } from "@posthog/ui/features/canvas/components/FeedbackModal";
+import { useCanvasDeepLink } from "@posthog/ui/features/canvas/hooks/useCanvasDeepLink";
 import { CommandMenu } from "@posthog/ui/features/command/CommandMenu";
 import { KeyboardShortcutsSheet } from "@posthog/ui/features/command/KeyboardShortcutsSheet";
 import { useNewTaskDeepLink } from "@posthog/ui/features/deep-links/useNewTaskDeepLink";
@@ -193,6 +194,7 @@ function RootLayout() {
   useTaskDeepLink();
   useInboxDeepLink();
   useScoutDeepLink();
+  useCanvasDeepLink();
   const approvalDeepLink = useApprovalDeepLink();
   useSetupDiscovery();
   useNewTaskDeepLink();

--- a/packages/ui/src/utils/posthogLinks.test.ts
+++ b/packages/ui/src/utils/posthogLinks.test.ts
@@ -1,9 +1,20 @@
-import { errorTrackingIssueUrl } from "@posthog/ui/utils/posthogLinks";
+import {
+  canvasShareUrl,
+  errorTrackingIssueUrl,
+} from "@posthog/ui/utils/posthogLinks";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@posthog/ui/utils/urls", () => ({
   getPostHogUrl: (path: string) => `https://us.posthog.com${path}`,
 }));
+
+describe("canvasShareUrl", () => {
+  it("builds an https /code/canvas link with encoded ids", () => {
+    expect(canvasShareUrl("chan/1", "dash 2", "us")).toBe(
+      "https://us.posthog.com/code/canvas/chan%2F1/dash%202",
+    );
+  });
+});
 
 describe("errorTrackingIssueUrl", () => {
   it("links to the issue when no fingerprint is provided", () => {

--- a/packages/ui/src/utils/posthogLinks.ts
+++ b/packages/ui/src/utils/posthogLinks.ts
@@ -80,6 +80,25 @@ export function skillUrl(
   );
 }
 
+/**
+ * The shareable https link for a canvas (a dashboard inside a channel):
+ * `<instance>/code/canvas/<channelId>/<dashboardId>`. Opening it in a browser
+ * hits a web interstitial that deep-links into the desktop app (or offers the
+ * download), so the link works for anyone — app installed or not. Not
+ * project-scoped: the ids are globally-unique desktop file-system row ids. The
+ * inbound desktop side lives in `CanvasLinkService` / `useCanvasDeepLink`.
+ */
+export function canvasShareUrl(
+  channelId: string,
+  dashboardId: string,
+  regionOverride?: CloudRegion | null,
+): string | null {
+  return getPostHogUrl(
+    `/code/canvas/${encodeURIComponent(channelId)}/${encodeURIComponent(dashboardId)}`,
+    regionOverride,
+  );
+}
+
 export function errorTrackingIssueUrl(
   issueId: string,
   overrides?: ErrorTrackingIssueLinkOverrides,


### PR DESCRIPTION
## Problem

Canvases only exist in the PostHog Code desktop app, so there was no way to hand someone a link to a specific canvas. We want each canvas to have a link that anyone can open — including people who don't have the desktop app yet.

**Why:** make canvases shareable. A link should open in a normal browser, deep-link into the desktop app for people who have it, and offer a download to everyone else.

## Changes

This is the **desktop-app half**. The companion web interstitial that makes the link work in a browser is in PostHog/posthog (PostHog/posthog#66153).

- **"Copy link"** on the canvas toolbar and on each card in the dashboards grid. It copies an **https** share link (`<instance>/code/canvas/<channelId>/<dashboardId>`) — not a raw `posthog-code://` link — so it works for anyone, app or no app. (This is the key difference from the existing inbox/scout copy actions, which copy the raw scheme link.)
- **Inbound deep link**: a new `canvas` scheme handler (`CanvasLinkService`) + tRPC bridge + `useCanvasDeepLink` renderer hook that navigates straight to the canvas. Gated on `project-bluebird`.
- Analytics (`link_copied` action, `DEEP_LINK_CANVAS` event) and docs (`DEEP-LINKS.md`).

## How did you test this?

I'm an agent. I ran, and these pass:
- `pnpm typecheck` for `@posthog/shared`, `@posthog/core`, `@posthog/host-router`, `@posthog/ui`, and `apps/code`.
- `biome check` on all changed files (clean).
- Unit tests: new `canvas-link.test.ts` (8 cases, core) and a `canvasShareUrl` case in `posthogLinks.test.ts` (ui).

I did **not** manually click through the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*