### PR TITLE
ci(tests): upload Vitest and Playwright JUnit reports to Trunk Flaky Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,6 @@ jobs:
           junit-paths: "apps/*/junit.xml,packages/*/junit.xml"
           org-slug: posthog-inc
           token: ${{ secrets.TRUNK_API_TOKEN }}
-        env:
-          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
 
   integration-test:
     needs: changes
@@ -169,8 +167,6 @@ jobs:
           junit-paths: "apps/code/tests/e2e/junit.xml"
           org-slug: posthog-inc
           token: ${{ secrets.TRUNK_API_TOKEN }}
-        env:
-          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,6 +159,19 @@ jobs:
         env:
           CI: true
 
+      - name: Upload test results to Trunk
+        # Run even when E2E tests fail so flaky/failed results are still
+        # reported, but never let an upload problem fail the job.
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+        with:
+          junit-paths: "apps/code/tests/e2e/junit.xml"
+          org-slug: posthog-inc
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+        env:
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,22 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Upload test results to Trunk
+        # Run even when tests fail so flaky/failed results are still reported,
+        # but never let an upload problem fail the job.
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+        with:
+          # Scope to each package root. A bare **/junit.xml glob descends into
+          # node_modules, where pnpm symlinks workspace packages, and uploads
+          # every report many times over.
+          junit-paths: "apps/*/junit.xml,packages/*/junit.xml"
+          org-slug: posthog-inc
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+        env:
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+
   integration-test:
     needs: changes
     # Fail closed: if change detection itself failed, run instead of skipping.

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ test-results/
 *storybook.log
 .session-store.json
 .playwright-mcp
+# Trunk Flaky Tests JUnit reports (one per package, uploaded from CI)
+junit.xml
 
 # Downloaded binaries
 apps/code/resources/codex-acp/

--- a/apps/code/tests/e2e/playwright.config.ts
+++ b/apps/code/tests/e2e/playwright.config.ts
@@ -12,7 +12,11 @@ export default defineConfig({
   workers: 1,
   // junit.xml (resolved next to this config) is uploaded to Trunk in CI.
   reporter: isCI
-    ? [["junit", { outputFile: "junit.xml" }], ["github"], ["html", { open: "never" }]]
+    ? [
+        ["junit", { outputFile: "junit.xml" }],
+        ["github"],
+        ["html", { open: "never" }],
+      ]
     : [["junit", { outputFile: "junit.xml" }], ["list"]],
   outputDir: "../playwright-results",
   use: {

--- a/apps/code/tests/e2e/playwright.config.ts
+++ b/apps/code/tests/e2e/playwright.config.ts
@@ -6,10 +6,14 @@ export default defineConfig({
   testDir: "./tests",
   testMatch: "**/*.spec.ts",
   timeout: 60000,
-  retries: isCI ? 2 : 0,
+  // No retries: Trunk Flaky Tests needs raw pass/fail results to detect flakes.
+  retries: 0,
   // Must run serially - Electron app has single instance lock
   workers: 1,
-  reporter: isCI ? [["github"], ["html", { open: "never" }]] : [["list"]],
+  // junit.xml (resolved next to this config) is uploaded to Trunk in CI.
+  reporter: isCI
+    ? [["junit", { outputFile: "junit.xml" }], ["github"], ["html", { open: "never" }]]
+    : [["junit", { outputFile: "junit.xml" }], ["list"]],
   outputDir: "../playwright-results",
   use: {
     trace: "retain-on-failure",

--- a/apps/code/vitest.config.ts
+++ b/apps/code/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     environment: "jsdom",
     setupFiles: ["./src/shared/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/dist/**", "tests/e2e/**"],

--- a/apps/code/vitest.config.ts
+++ b/apps/code/vitest.config.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
 import { rendererAliases } from "./vite.shared.mjs";
 
 export default defineConfig({
@@ -10,12 +11,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     environment: "jsdom",
     setupFiles: ["./src/shared/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/dist/**", "tests/e2e/**"],

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,17 +1,13 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
 
 export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     environment: "node",
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     environment: "node",
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
 
 export default defineConfig({
   resolve: {
@@ -9,12 +10,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/packages/electron-trpc/vitest.config.ts
+++ b/packages/electron-trpc/vitest.config.ts
@@ -2,17 +2,13 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
+import { trunkTestOptions } from "../../vitest.config.base";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     coverage: {
       all: true,
       include: ["src/**/*"],

--- a/packages/electron-trpc/vitest.config.ts
+++ b/packages/electron-trpc/vitest.config.ts
@@ -7,6 +7,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     coverage: {
       all: true,
       include: ["src/**/*"],

--- a/packages/git/vitest.config.ts
+++ b/packages/git/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/.git/**"],

--- a/packages/git/vitest.config.ts
+++ b/packages/git/vitest.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
 
 export default defineConfig({
   test: {
     globals: true,
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/.git/**"],

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
 
 export default defineConfig({
   test: {
     globals: true,
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
 
 export default defineConfig({
   plugins: [react()],
@@ -20,12 +21,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],

--- a/packages/workspace-server/vitest.config.ts
+++ b/packages/workspace-server/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    // Disable retries so flaky-test detection sees raw pass/fail results.
+    retry: 0,
+    reporters: [
+      "default",
+      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+    ],
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/packages/workspace-server/vitest.config.ts
+++ b/packages/workspace-server/vitest.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
 
 export default defineConfig({
   test: {
     globals: true,
-    // Disable retries so flaky-test detection sees raw pass/fail results.
-    retry: 0,
-    reporters: [
-      "default",
-      ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
-    ],
+    ...trunkTestOptions,
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -1,0 +1,18 @@
+// Shared Vitest test options for Trunk Flaky Tests uploads. Imported and spread
+// into each package's `test` block so the junit reporter and retry policy stay
+// defined in one place. See the upload steps in .github/workflows/test.yml.
+//
+// `outputFile` is relative, so each config writes ./junit.xml next to itself;
+// CI globs apps/*/junit.xml and packages/*/junit.xml. The explicit type keeps
+// the reporter tuple assignable across the Vitest 2.x and 4.x versions in use.
+export const trunkTestOptions: {
+  retry: number;
+  reporters: (string | [string, Record<string, unknown>])[];
+} = {
+  // Disable retries so flaky-test detection sees raw pass/fail results.
+  retry: 0,
+  reporters: [
+    "default",
+    ["junit", { outputFile: "./junit.xml", addFileAttribute: true }],
+  ],
+};


### PR DESCRIPTION
## What

Sets up [Trunk Flaky Tests](https://docs.trunk.io/flaky-tests) test uploads for the `posthog-inc` org. CI provider is GitHub Actions; covers both test frameworks in the repo — **Vitest** (unit/integration) and **Playwright** (E2E).

## Vitest

### Config (all 8 configs)
`apps/code`, `apps/mobile`, `packages/{ui,agent,git,shared,workspace-server,electron-trpc}`:
- Add the `junit` reporter (`outputFile: ./junit.xml`, `addFileAttribute: true` — Trunk needs the file attribute to map results to source) **alongside** the existing `default` reporter, so console output is preserved.
- Add explicit `retry: 0` so flaky detection sees raw pass/fail results. (`0` is already Vitest's default; this makes it explicit.)

### CI (`unit-test` job in `.github/workflows/test.yml`)
New `Upload test results to Trunk` step after `pnpm test`:
- `junit-paths: "apps/*/junit.xml,packages/*/junit.xml"` — scoped to package roots. A bare `**/junit.xml` glob descends into `node_modules` (pnpm symlinks workspace packages) and uploads each report dozens of times; the scoped glob matches exactly the 8 reports.

## Playwright

### Config (`apps/code/tests/e2e/playwright.config.ts`)
- Add the `junit` reporter (`outputFile: junit.xml`, resolved next to the config → `apps/code/tests/e2e/junit.xml`) to both the CI and local reporter sets.
- `retries: 0` (was `isCI ? 2 : 0`) so flaky detection sees raw pass/fail results.

### CI (`integration-test` job)
New `Upload test results to Trunk` step after the E2E run:
- `junit-paths: "apps/code/tests/e2e/junit.xml"`.

## Shared CI details
Both upload steps:
- Use `trunk-io/analytics-uploader` pinned to `v2.1.2` (SHA), per the repo's action-pinning convention.
- `if: ${{ !cancelled() }}` so failed/flaky results are still reported; `continue-on-error: true` so an upload hiccup can't fail the job.
- `org-slug: posthog-inc`; `TRUNK_API_TOKEN` wired as both the `token` input and a step env var.

`.gitignore` ignores the generated `junit.xml` reports.

## Local validation (`trunk-analytics-cli validate`)

- **Vitest:** 8 valid files, **0 warnings, 0 errors** (validated against the scoped globs the CI step uses).
- **Playwright:** **0 errors**, 1 non-blocking warning — `"report has test cases with missing file or filepath"`. This is inherent to Playwright's built-in JUnit reporter (no option to emit a per-`testcase` `file` attribute, confirmed in `playwright@1.58.1` source) and matches Trunk's documented Playwright config. Clearing it would require a custom reporter; happy to add one if we want absolute 0 warnings (low value today — there's no `CODEOWNERS` file for Trunk to map against).

## Follow-ups (not in this PR)

- **Add the `TRUNK_API_TOKEN` secret** to the repo's GitHub Actions secrets (from Trunk org settings). Confirm `posthog-inc` is the exact Trunk org URL slug. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)