### PR TITLE
feat(agent-applications): send supported_client_tools at /run

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -4964,14 +4964,21 @@ export class PostHogAPIClient {
     ingressBaseUrl: string,
     message: string,
     previewToken?: string | null,
+    supportedClientTools?: readonly string[],
   ): Promise<{ session_id: string; resumed?: boolean }> {
     const url = new URL(`${ingressBaseUrl.replace(/\/$/, "")}/run`);
+    // `supported_client_tools`: the kind:'client' tool ids this client can
+    // execute this session, so the runner exposes only those to the model.
+    const body: Record<string, unknown> = { message };
+    if (supportedClientTools && supportedClientTools.length > 0) {
+      body.supported_client_tools = supportedClientTools;
+    }
     const response = await this.api.fetcher.fetch({
       method: "post",
       url,
       path: url.pathname,
       parameters: previewTokenHeader(previewToken),
-      overrides: { body: JSON.stringify({ message }) },
+      overrides: { body: JSON.stringify(body) },
     });
     return (await response.json()) as { session_id: string; resumed?: boolean };
   }

--- a/packages/core/src/agent-chat/agentChatService.ts
+++ b/packages/core/src/agent-chat/agentChatService.ts
@@ -431,6 +431,7 @@ export class AgentChatService {
             session.ingressBaseUrl,
             session.buildWireText(text),
             token,
+            session.supportedClientTools,
           ),
       );
       agentChatStore.getState().setSessionId(session.chatId, session_id);

--- a/packages/core/src/agent-chat/identifiers.ts
+++ b/packages/core/src/agent-chat/identifiers.ts
@@ -49,6 +49,8 @@ export interface AgentChatSession {
   ingressBaseUrl: string;
   /** Non-null targets a specific draft revision (preview token attached per call). */
   revisionId: string | null;
+  /** `kind:'client'` tool ids this client can fulfil; sent to the runner at /run. */
+  supportedClientTools?: readonly string[];
   createMapper(): AgentChatMapper;
   /** Resolve a client-tool call; `defer`/null ⇒ the service won't post a result. */
   resolveClientTool(

--- a/packages/ui/src/features/agent-applications/agent-builder/AgentBuilderDock.tsx
+++ b/packages/ui/src/features/agent-applications/agent-builder/AgentBuilderDock.tsx
@@ -25,7 +25,10 @@ import {
   useAgentBuilderStore,
 } from "./agentBuilderStore";
 import { suggestionsForPage } from "./agentBuilderSuggestions";
-import { useAgentBuilderClientTools } from "./useAgentBuilderClientTools";
+import {
+  AGENT_BUILDER_CLIENT_TOOLS,
+  useAgentBuilderClientTools,
+} from "./useAgentBuilderClientTools";
 
 const CHAT_ID = AGENT_BUILDER_CHAT_ID;
 
@@ -118,6 +121,7 @@ export function AgentBuilderDock() {
         orgId: currentOrgId,
       }),
     clientTools,
+    supportedClientTools: AGENT_BUILDER_CLIENT_TOOLS,
   });
   const pendingApproval = useAgentChatPendingApproval(CHAT_ID);
 

--- a/packages/ui/src/features/agent-applications/agent-builder/useAgentBuilderClientTools.ts
+++ b/packages/ui/src/features/agent-applications/agent-builder/useAgentBuilderClientTools.ts
@@ -4,6 +4,22 @@ import type { ClientToolHandler } from "../hooks/useAgentChat";
 import { useAgentBuilderStore } from "./agentBuilderStore";
 
 /**
+ * The `kind:'client'` tool ids the agent-builder dock can fulfil — sent to the
+ * runner as `supported_client_tools` at /run so it exposes only these to the
+ * model. Keep in sync with the handler below plus the built-in toast/get_context.
+ */
+export const AGENT_BUILDER_CLIENT_TOOLS = [
+  "set_secret",
+  "focus_tab",
+  "focus_file",
+  "focus_spec_section",
+  "focus_revision",
+  "focus_session",
+  "toast",
+  "get_context",
+] as const;
+
+/**
  * The agent builder's UI-driving client tools. The agent calls these to steer the
  * user's screen (`focus_*`, which navigate code's agent routes and report back
  * `{ focused }`) and to set secrets (`set_secret`, an interactive punch-out:

--- a/packages/ui/src/features/agent-applications/hooks/useAgentChat.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentChat.ts
@@ -50,6 +50,8 @@ export interface UseAgentChatOptions {
   contextProvider?: () => unknown;
   /** AgentBuilder UI-driving tools (focus_*, set_secret); null → built-in handling. */
   clientTools?: ClientToolHandler;
+  /** `kind:'client'` tool ids this client can fulfil; sent to the runner at /run. */
+  supportedClientTools?: readonly string[];
 }
 
 /**
@@ -68,6 +70,7 @@ export function useAgentChat({
   recordHistory = false,
   contextProvider,
   clientTools,
+  supportedClientTools,
 }: UseAgentChatOptions) {
   const client = useAuthenticatedClient();
   const service = useService<AgentChatService>(AGENT_CHAT_SERVICE);
@@ -88,6 +91,7 @@ export function useAgentChat({
       agentSlug,
       ingressBaseUrl: ingressBaseUrl ?? "",
       revisionId,
+      supportedClientTools,
       createMapper: createAgentChatMapper,
       resolveClientTool: (data) =>
         resolveClientTool(
@@ -113,7 +117,15 @@ export function useAgentChat({
             })
         : undefined,
     }),
-    [chatId, agentSlug, ingressBaseUrl, revisionId, recordHistory, recordChat],
+    [
+      chatId,
+      agentSlug,
+      ingressBaseUrl,
+      revisionId,
+      supportedClientTools,
+      recordHistory,
+      recordChat,
+    ],
   );
 
   const send = useCallback(


### PR DESCRIPTION
## What & why

Producer counterpart to the agent-platform server change **PostHog/posthog#66161**, which makes the runner expose `kind:'client'` tools to the model **only if the caller declared them** at `/run` (`supported_client_tools`). Without this, once the server change lands, code clients would send nothing and **lose all client tools** (focus_*, set_secret, toast, get_context).

This wires the agent-builder dock to declare and send that list.

## Changes

- **`runAgentSession`** (`api-client`): optional `supportedClientTools`, added to the `/run` body as `supported_client_tools` when non-empty.
- **`AgentChatSession`** (`core`): carries `supportedClientTools`; `agentChatService` forwards it to `runAgentSession`.
- **`useAgentChat`** (`ui`): new `supportedClientTools` option threaded into the session config (+ memo deps).
- **`AGENT_BUILDER_CLIENT_TOOLS`**: declares the dock's fulfillable ids and is passed from `AgentBuilderDock`.

## Tool-list cross-check

`AGENT_BUILDER_CLIENT_TOOLS` was verified against the agent-builder agent's `spec.json` `kind:'client'` declarations — they match **exactly** (8 ids, all `required: false`):

`focus_tab, focus_file, focus_revision, focus_session, focus_spec_section, toast, get_context, set_secret`

So every declared client tool is in the supported list (nothing dropped by the server's spec ∩ supported intersection), and none are `required` (no session-open-fail risk). `connect_mcp` is intentionally **not** included — it doesn't exist on `main` (it's part of the separate MCP-connections work).

## Compatibility

Order-independent with the server PR: an old server ignores the extra body field (Zod strips unknowns); an old client that omits the field just gets no client tools exposed.

## Verification

`turbo typecheck` green for `@posthog/api-client`, `@posthog/core`, `@posthog/ui`; biome clean; pre-commit (biome + full typecheck) passed.

## Agent context

Authored from a Claude Code session, in an isolated worktree off `main`. Scoped to the producer plumbing only (not the broader MCP feature on the `agent-mcp-connections` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)