### PR TITLE
Add Not actionable tab and route resolved PRs to Archive in inbox

### DIFF
--- a/packages/core/src/inbox/reportMembership.test.ts
+++ b/packages/core/src/inbox/reportMembership.test.ts
@@ -10,8 +10,10 @@ import {
   isDismissedReport,
   isExcludedFromInbox,
   isInboxDetailPath,
+  isNotActionableReport,
   isPullRequestReport,
   isReportTabReport,
+  isStaffOnlyInboxTab,
   matchesReviewerScope,
   partitionRunsTabReports,
   teammateInboxScope,
@@ -58,10 +60,85 @@ describe("isDismissedReport", () => {
   });
 });
 
+describe("isNotActionableReport", () => {
+  it("matches reports the judgment marked not_actionable", () => {
+    expect(
+      isNotActionableReport(fakeReport({ actionability: "not_actionable" })),
+    ).toBe(true);
+  });
+
+  it.each(["immediately_actionable", "requires_human_input", null] as const)(
+    "does not match %s actionability",
+    (actionability) => {
+      expect(isNotActionableReport(fakeReport({ actionability }))).toBe(false);
+    },
+  );
+
+  it.each(["suppressed", "resolved"] as const)(
+    "excludes terminal %s reports",
+    (status) => {
+      expect(
+        isNotActionableReport(
+          fakeReport({ actionability: "not_actionable", status }),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("excludes PR-bearing reports", () => {
+    expect(
+      isNotActionableReport(
+        fakeReport({
+          actionability: "not_actionable",
+          implementation_pr_url: "https://gh/p/1",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it.each(["potential", "candidate", "in_progress", "pending_input"] as const)(
+    "excludes in-flight %s runs (they stay in the Runs tab)",
+    (status) => {
+      expect(
+        isNotActionableReport(
+          fakeReport({ status, actionability: "not_actionable" }),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("excludes failed reports (they stay in the Runs tab)", () => {
+    expect(
+      isNotActionableReport(
+        fakeReport({ status: "failed", actionability: "not_actionable" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches a settled (ready) not_actionable report", () => {
+    expect(
+      isNotActionableReport(
+        fakeReport({ status: "ready", actionability: "not_actionable" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isStaffOnlyInboxTab", () => {
+  it("gates only the Not actionable tab", () => {
+    expect(isStaffOnlyInboxTab("not-actionable")).toBe(true);
+    expect(isStaffOnlyInboxTab("reports")).toBe(false);
+    expect(isStaffOnlyInboxTab("pulls")).toBe(false);
+    expect(isStaffOnlyInboxTab("runs")).toBe(false);
+    expect(isStaffOnlyInboxTab("dismissed")).toBe(false);
+  });
+});
+
 describe("isInboxDetailPath", () => {
   it("matches detail paths for each inbox tab", () => {
     expect(isInboxDetailPath("/code/inbox/pulls/abc")).toBe(true);
     expect(isInboxDetailPath("/code/inbox/reports/abc")).toBe(true);
+    expect(isInboxDetailPath("/code/inbox/not-actionable/abc")).toBe(true);
     expect(isInboxDetailPath("/code/inbox/runs/abc")).toBe(true);
   });
 
@@ -233,6 +310,14 @@ describe("tabFilters", () => {
       expect(
         isReportTabReport(
           fakeReport({ status: "pending_input", implementation_pr_url: null }),
+        ),
+      ).toBe(false);
+    });
+
+    it("excludes not-actionable reports (they go to the Not actionable tab)", () => {
+      expect(
+        isReportTabReport(
+          fakeReport({ status: "ready", actionability: "not_actionable" }),
         ),
       ).toBe(false);
     });

--- a/packages/core/src/inbox/reportMembership.ts
+++ b/packages/core/src/inbox/reportMembership.ts
@@ -82,11 +82,17 @@ export function countInboxScopeReports(
   return reports.filter((report) => matchesInboxScope(report, scope)).length;
 }
 
-export type InboxTabKey = "pulls" | "reports" | "runs" | "dismissed";
+export type InboxTabKey =
+  | "pulls"
+  | "reports"
+  | "not-actionable"
+  | "runs"
+  | "dismissed";
 
 export const INBOX_TAB_KEYS: InboxTabKey[] = [
   "pulls",
   "reports",
+  "not-actionable",
   "runs",
   "dismissed",
 ];
@@ -94,9 +100,24 @@ export const INBOX_TAB_KEYS: InboxTabKey[] = [
 export const INBOX_TAB_LABEL: Record<InboxTabKey, string> = {
   pulls: "Pull requests",
   reports: "Reports",
+  "not-actionable": "Not actionable",
   runs: "Runs",
   dismissed: "Archive",
 };
+
+/**
+ * Tabs only shown to staff (internal) users. Non-staff see Pull requests,
+ * Reports, Runs and Archive. The Not actionable tab is an internal signal-quality
+ * audit surface — reports the agent judged not worth acting on — so it stays
+ * behind the staff flag, matching the PostHog Cloud inbox.
+ */
+export const INBOX_STAFF_ONLY_TAB_KEYS = new Set<InboxTabKey>([
+  "not-actionable",
+]);
+
+export function isStaffOnlyInboxTab(key: InboxTabKey): boolean {
+  return INBOX_STAFF_ONLY_TAB_KEYS.has(key);
+}
 
 /**
  * Canonical inbox tab list routes. Use these constants instead of hard-coding
@@ -112,6 +133,7 @@ export const INBOX_TAB_LIST_ROUTE: Record<
 > = {
   pulls: "/code/inbox/pulls",
   reports: "/code/inbox/reports",
+  "not-actionable": "/code/inbox/not-actionable",
   runs: "/code/inbox/runs",
   dismissed: "/code/inbox/dismissed",
 };
@@ -231,7 +253,29 @@ export function isReportTabReport(report: SignalReport): boolean {
   // rather than reappearing as a Report.
   if (report.implementation_pr_url) return false;
   if (isAgentRunReport(report)) return false;
+  // Reports the agent judged not worth acting on get their own (staff-only)
+  // tab and are kept out of the main Reports list, matching the Cloud inbox.
+  if (isNotActionableReport(report)) return false;
   return true;
+}
+
+/**
+ * Not-actionable tab membership: reports the agentic actionability judgment
+ * marked `not_actionable`. A staff-only signal-quality audit surface. These are
+ * still in-pipeline reports (the judgment is an artefact, not a status), so this
+ * partitions the same main list the other report tabs read — it just keeps them
+ * out of the Reports tab via the check in `isReportTabReport`.
+ */
+export function isNotActionableReport(report: SignalReport): boolean {
+  if (isExcludedFromInbox(report)) return false;
+  if (report.status === "failed") return false; // failed runs live in the Runs tab only
+  if (report.implementation_pr_url) return false;
+  // In-flight (queued/live) runs belong to the Runs tab until they settle, even
+  // if a not_actionable judgment is already attached. Mirror the gate order in
+  // `isReportTabReport` so the two predicates classify a report the same way and
+  // it can't show in both the Runs and Not actionable tabs at once.
+  if (isAgentRunReport(report)) return false;
+  return report.actionability === "not_actionable";
 }
 
 export function matchesReviewerScope(

--- a/packages/ui/src/features/inbox/CLAUDE.md
+++ b/packages/ui/src/features/inbox/CLAUDE.md
@@ -15,14 +15,23 @@ The main objects are:
 
 ## Information Architecture
 
-Inbox has four tabs and one reviewer-scope control:
+Inbox has five tabs and one reviewer-scope control:
 
 | Tab | Route | Membership |
 | --- | --- | --- |
 | Pull requests | `/code/inbox/pulls` | Reports with `implementation_pr_url` set |
-| Reports | `/code/inbox/reports` | Reports without a PR and not currently running |
+| Reports | `/code/inbox/reports` | Reports without a PR, not running, and not judged not-actionable |
+| Not actionable | `/code/inbox/not-actionable` | Reports the judgment marked `actionability === "not_actionable"` (**staff-only**) |
 | Runs | `/code/inbox/runs` | Reports that are still in progress or waiting on input |
 | Archive | `/code/inbox/dismissed` | Terminal reports: archived/suppressed (`status === "suppressed"`) and resolved-by-merged-PR (`status === "resolved"`) |
+
+The **Not actionable** tab is gated to staff (internal) users via
+`INBOX_STAFF_ONLY_TAB_KEYS` (see `isStaffOnlyInboxTab`); `InboxTabBar` hides it
+for non-staff, keyed off `user.is_staff`. It's an internal signal-quality audit
+surface and mirrors the same staff-only tab in `PostHog/posthog`. It reuses the
+shared `InboxReportListTab` shell (same as Reports/Pulls); cards link to its own
+detail route so back-navigation stays on the tab. `isReportTabReport` excludes
+not-actionable reports so they don't double-list in Reports.
 
 Detail pages live under the same tab: `/code/inbox/<tab>/$reportId`.
 
@@ -76,6 +85,7 @@ The tab components are intentionally simple:
 
 - `PullRequestsTab` partitions scoped reports with `isPullRequestReport`.
 - `ReportsTab` partitions with `isReportTabReport`.
+- `NotActionableTab` (staff-only) partitions with `isNotActionableReport`.
 - `RunsTab` partitions with `isAgentRunReport`.
 - `DismissedTab` (the "Archive" tab) lists its own `useInboxDismissedReports` query (matching `isDismissedReport`); read-only detail route, restore action per card.
 

--- a/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -27,7 +27,11 @@ import type { ComponentType, ReactNode } from "react";
 interface InboxDetailFrameProps {
   report: SignalReport;
   /** List route for the back-link (e.g. "/code/inbox/pulls"). */
-  backTo: "/code/inbox/pulls" | "/code/inbox/reports" | "/code/inbox/dismissed";
+  backTo:
+    | "/code/inbox/pulls"
+    | "/code/inbox/reports"
+    | "/code/inbox/not-actionable"
+    | "/code/inbox/dismissed";
   backLabel: string;
   /**
    * Whether to render the Dismiss button + dialog. Off for already-dismissed

--- a/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
+++ b/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
@@ -1,5 +1,6 @@
 import {
   isDismissedReport,
+  isNotActionableReport,
   isPullRequestReport,
   isReportTabReport,
 } from "@posthog/core/inbox/reportMembership";
@@ -21,6 +22,7 @@ interface InboxReportDetailGateProps {
   backTo:
     | "/code/inbox/pulls"
     | "/code/inbox/reports"
+    | "/code/inbox/not-actionable"
     | "/code/inbox/runs"
     | "/code/inbox/dismissed";
   backLabel: string;
@@ -31,6 +33,7 @@ interface InboxReportDetailGateProps {
 type InboxDetailRoute =
   | "/code/inbox/pulls/$reportId"
   | "/code/inbox/reports/$reportId"
+  | "/code/inbox/not-actionable/$reportId"
   | "/code/inbox/runs/$reportId"
   | "/code/inbox/dismissed/$reportId";
 
@@ -43,6 +46,8 @@ type InboxDetailRoute =
  */
 function nonSuppressedDetailRoute(report: SignalReport): InboxDetailRoute {
   if (isPullRequestReport(report)) return "/code/inbox/pulls/$reportId";
+  if (isNotActionableReport(report))
+    return "/code/inbox/not-actionable/$reportId";
   if (isReportTabReport(report)) return "/code/inbox/reports/$reportId";
   return "/code/inbox/runs/$reportId";
 }
@@ -165,7 +170,11 @@ function tabFromBackTo(
 ): InboxDetailTab | null {
   if (backTo === "/code/inbox/pulls") return "pulls";
   if (backTo === "/code/inbox/runs") return "runs";
+  // Archive and the staff-only Not actionable tab aren't part of the triage
+  // funnel, so their detail opens aren't tracked (rank would be measured against
+  // the wrong list).
   if (backTo === "/code/inbox/dismissed") return null;
+  if (backTo === "/code/inbox/not-actionable") return null;
   return "reports";
 }
 

--- a/packages/ui/src/features/inbox/components/InboxTabBar.tsx
+++ b/packages/ui/src/features/inbox/components/InboxTabBar.tsx
@@ -4,8 +4,10 @@ import {
   INBOX_TAB_LIST_ROUTE,
   type InboxTabCounts,
   type InboxTabKey,
+  isStaffOnlyInboxTab,
 } from "@posthog/core/inbox/reportMembership";
 import { Tabs, TabsList, TabsTrigger } from "@posthog/quill";
+import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
 import { InboxScopeSelect } from "@posthog/ui/features/inbox/components/InboxScopeSelect";
 import { Flex } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
@@ -15,6 +17,11 @@ interface InboxTabBarProps {
 }
 
 function activeTabFromPath(pathname: string): InboxTabKey {
+  // Check "not-actionable" before "reports": the former is not a prefix of the
+  // latter, but keeping the more specific routes first guards against future
+  // overlaps.
+  if (pathname.startsWith(INBOX_TAB_LIST_ROUTE["not-actionable"]))
+    return "not-actionable";
   if (pathname.startsWith(INBOX_TAB_LIST_ROUTE.reports)) return "reports";
   if (pathname.startsWith(INBOX_TAB_LIST_ROUTE.runs)) return "runs";
   if (pathname.startsWith(INBOX_TAB_LIST_ROUTE.dismissed)) return "dismissed";
@@ -25,6 +32,11 @@ export function InboxTabBar({ counts }: InboxTabBarProps) {
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activeKey = activeTabFromPath(pathname);
+  const { data: currentUser } = useMeQuery();
+  const isStaff = currentUser?.is_staff === true;
+  const visibleTabKeys = INBOX_TAB_KEYS.filter(
+    (key) => isStaff || !isStaffOnlyInboxTab(key),
+  );
 
   return (
     <Flex align="center" justify="between" className="min-w-0">
@@ -39,7 +51,7 @@ export function InboxTabBar({ counts }: InboxTabBarProps) {
           variant="line"
           className="h-auto gap-0.5 [&_.quill-tabs__indicator]:transition-[transform,width]! [&_.quill-tabs__indicator]:duration-100! [&_.quill-tabs__indicator]:ease-out!"
         >
-          {INBOX_TAB_KEYS.map((key) => {
+          {visibleTabKeys.map((key) => {
             const isActive = key === activeKey;
             return (
               <TabsTrigger
@@ -50,18 +62,21 @@ export function InboxTabBar({ counts }: InboxTabBarProps) {
                 <span className="font-medium text-[13px]">
                   {INBOX_TAB_LABEL[key]}
                 </span>
-                {/* Runs and the open-ended Archive don't get a running total — it adds no signal. */}
-                {key !== "runs" && key !== "dismissed" && counts[key] > 0 && (
-                  <span
-                    className={
-                      isActive
-                        ? "text-[12px] text-gray-11 tabular-nums"
-                        : "text-[12px] text-gray-10 tabular-nums"
-                    }
-                  >
-                    {counts[key]}
-                  </span>
-                )}
+                {/* Runs, Not actionable, and the open-ended Archive don't get a running total — it adds no signal. */}
+                {key !== "runs" &&
+                  key !== "dismissed" &&
+                  key !== "not-actionable" &&
+                  counts[key] > 0 && (
+                    <span
+                      className={
+                        isActive
+                          ? "text-[12px] text-gray-11 tabular-nums"
+                          : "text-[12px] text-gray-10 tabular-nums"
+                      }
+                    >
+                      {counts[key]}
+                    </span>
+                  )}
               </TabsTrigger>
             );
           })}

--- a/packages/ui/src/features/inbox/components/NotActionableTab.tsx
+++ b/packages/ui/src/features/inbox/components/NotActionableTab.tsx
@@ -1,0 +1,39 @@
+import { InfoIcon } from "@phosphor-icons/react";
+import { isNotActionableReport } from "@posthog/core/inbox/reportMembership";
+import { InboxReportListTab } from "@posthog/ui/features/inbox/components/InboxReportListTab";
+import {
+  ReportCard,
+  type ReportCardProps,
+} from "@posthog/ui/features/inbox/components/ReportCard";
+
+// Link cards (and their back navigation) at the Not actionable tab rather than
+// the Reports tab.
+function NotActionableReportCard(
+  props: Extract<ReportCardProps, { variant?: "default" }>,
+) {
+  return <ReportCard {...props} detailTab="not-actionable" />;
+}
+
+/**
+ * Staff-only (internal) tab listing reports the agentic actionability judgment
+ * marked `not_actionable`. Same list shell as Pull requests / Reports — only the
+ * predicate differs — so the team can audit signal quality. These reports are
+ * kept out of the Reports tab (see `isReportTabReport`).
+ */
+export function NotActionableTab() {
+  return (
+    <InboxReportListTab
+      predicate={isNotActionableReport}
+      Card={NotActionableReportCard}
+      searchPlaceholder="Search not-actionable reports…"
+      emptyState={{
+        Icon: InfoIcon,
+        forYouTitle: "Nothing judged not-actionable for you",
+        entireProjectTitle: "Nothing judged not-actionable yet",
+        teammateTitle: "Nothing judged not-actionable for this reviewer",
+        description:
+          "Reports the agent decided aren't worth acting on land here, so the team can audit signal quality.",
+      }}
+    />
+  );
+}

--- a/packages/ui/src/features/inbox/components/ReportCard.tsx
+++ b/packages/ui/src/features/inbox/components/ReportCard.tsx
@@ -40,6 +40,10 @@ interface DefaultReportCardProps extends BaseReportCardProps {
   onDismiss: () => void;
   dismissDisabledReason?: string | null;
   isDismissPending?: boolean;
+  // Which tab the card's detail link (and back navigation) should target.
+  // Defaults to the Reports tab; the Not actionable tab passes its own key so
+  // its detail view returns there instead of to Reports.
+  detailTab?: "reports" | "not-actionable";
 }
 
 /**
@@ -63,15 +67,21 @@ export function ReportCard(props: ReportCardProps) {
   // Archive tab for reference, badged as resolved, with no restore action.
   const isResolved = report.status === "resolved";
 
+  const detailTab = props.variant === "archived" ? "reports" : props.detailTab;
   const detailRoute = isArchived
     ? {
         to: "/code/inbox/dismissed/$reportId" as const,
         params: { reportId: report.id },
       }
-    : {
-        to: "/code/inbox/reports/$reportId" as const,
-        params: { reportId: report.id },
-      };
+    : detailTab === "not-actionable"
+      ? {
+          to: "/code/inbox/not-actionable/$reportId" as const,
+          params: { reportId: report.id },
+        }
+      : {
+          to: "/code/inbox/reports/$reportId" as const,
+          params: { reportId: report.id },
+        };
   const { prefetch, pointerHandlers } = useInboxReportDetailPrefetch(
     report,
     detailRoute,

--- a/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -13,34 +13,57 @@ import { ReportTasksSection } from "@posthog/ui/features/inbox/components/Report
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 
+/** Tabs whose detail view renders a `ReportDetail`. */
+type ReportDetailBackTo = "/code/inbox/reports" | "/code/inbox/not-actionable";
+
 interface ReportDetailProps {
   reportId: string;
   cachedReport?: SignalReport | null;
+  /** Where the back link points. Defaults to the Reports tab. */
+  backTo?: ReportDetailBackTo;
+  /** Label for the back link. Defaults to "Back to reports". */
+  backLabel?: string;
 }
 
 export function ReportDetail({
   reportId,
   cachedReport = null,
+  backTo = "/code/inbox/reports",
+  backLabel = "Back to reports",
 }: ReportDetailProps) {
   return (
     <InboxReportDetailGate
       reportId={reportId}
       cachedReport={cachedReport}
-      backTo="/code/inbox/reports"
-      backLabel="Back to reports"
+      backTo={backTo}
+      backLabel={backLabel}
       missingCopy="This report couldn't be found. It may have been deleted."
     >
-      {(report) => <ReportDetailContent report={report} />}
+      {(report) => (
+        <ReportDetailContent
+          report={report}
+          backTo={backTo}
+          backLabel={backLabel}
+        />
+      )}
     </InboxReportDetailGate>
   );
 }
 
-function ReportDetailContent({ report }: { report: SignalReport }) {
+function ReportDetailContent({
+  report,
+  backTo,
+  backLabel,
+}: {
+  report: SignalReport;
+  backTo: ReportDetailBackTo;
+  backLabel: string;
+}) {
   return (
     <InboxDetailFrame
       report={report}
-      backTo="/code/inbox/reports"
-      backLabel="Back to reports"
+      backTo={backTo}
+      backLabel={backLabel}
       fallbackTitle="Untitled report"
       primaryAction={
         <>

--- a/packages/ui/src/features/inbox/hooks/useInboxReportDetailPrefetch.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxReportDetailPrefetch.ts
@@ -14,6 +14,10 @@ export type InboxDetailRoute =
       params: { reportId: string };
     }
   | {
+      to: "/code/inbox/not-actionable/$reportId";
+      params: { reportId: string };
+    }
+  | {
       to: "/code/inbox/runs/$reportId";
       params: { reportId: string };
     }

--- a/packages/ui/src/router/routeTree.gen.ts
+++ b/packages/ui/src/router/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as CodeTasksTaskIdRouteImport } from './routes/code/tasks/$taskId
 import { Route as CodeInboxRunsRouteImport } from './routes/code/inbox/runs'
 import { Route as CodeInboxReportsRouteImport } from './routes/code/inbox/reports'
 import { Route as CodeInboxPullsRouteImport } from './routes/code/inbox/pulls'
+import { Route as CodeInboxNotActionableRouteImport } from './routes/code/inbox/not-actionable'
 import { Route as CodeInboxDismissedRouteImport } from './routes/code/inbox/dismissed'
 import { Route as CodeInboxAgentsRouteImport } from './routes/code/inbox/agents'
 import { Route as CodeAgentsScoutsRouteImport } from './routes/code/agents/scouts'
@@ -44,6 +45,7 @@ import { Route as CodeAgentsApplicationsRouteImport } from './routes/code/agents
 import { Route as CodeInboxRunsIndexRouteImport } from './routes/code/inbox/runs.index'
 import { Route as CodeInboxReportsIndexRouteImport } from './routes/code/inbox/reports.index'
 import { Route as CodeInboxPullsIndexRouteImport } from './routes/code/inbox/pulls.index'
+import { Route as CodeInboxNotActionableIndexRouteImport } from './routes/code/inbox/not-actionable.index'
 import { Route as CodeInboxDismissedIndexRouteImport } from './routes/code/inbox/dismissed.index'
 import { Route as CodeAgentsScoutsIndexRouteImport } from './routes/code/agents/scouts.index'
 import { Route as CodeAgentsApplicationsIndexRouteImport } from './routes/code/agents/applications/index'
@@ -53,6 +55,7 @@ import { Route as CodeTasksPendingKeyRouteImport } from './routes/code/tasks/pen
 import { Route as CodeInboxRunsReportIdRouteImport } from './routes/code/inbox/runs.$reportId'
 import { Route as CodeInboxReportsReportIdRouteImport } from './routes/code/inbox/reports.$reportId'
 import { Route as CodeInboxPullsReportIdRouteImport } from './routes/code/inbox/pulls.$reportId'
+import { Route as CodeInboxNotActionableReportIdRouteImport } from './routes/code/inbox/not-actionable.$reportId'
 import { Route as CodeInboxDismissedReportIdRouteImport } from './routes/code/inbox/dismissed.$reportId'
 import { Route as CodeAgentsScoutsSkillNameRouteImport } from './routes/code/agents/scouts.$skillName'
 import { Route as CodeAgentsApplicationsApprovalsRouteImport } from './routes/code/agents/applications/approvals'
@@ -208,6 +211,11 @@ const CodeInboxPullsRoute = CodeInboxPullsRouteImport.update({
   path: '/pulls',
   getParentRoute: () => CodeInboxRoute,
 } as any)
+const CodeInboxNotActionableRoute = CodeInboxNotActionableRouteImport.update({
+  id: '/not-actionable',
+  path: '/not-actionable',
+  getParentRoute: () => CodeInboxRoute,
+} as any)
 const CodeInboxDismissedRoute = CodeInboxDismissedRouteImport.update({
   id: '/dismissed',
   path: '/dismissed',
@@ -243,6 +251,12 @@ const CodeInboxPullsIndexRoute = CodeInboxPullsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => CodeInboxPullsRoute,
 } as any)
+const CodeInboxNotActionableIndexRoute =
+  CodeInboxNotActionableIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => CodeInboxNotActionableRoute,
+  } as any)
 const CodeInboxDismissedIndexRoute = CodeInboxDismissedIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -292,6 +306,12 @@ const CodeInboxPullsReportIdRoute = CodeInboxPullsReportIdRouteImport.update({
   path: '/$reportId',
   getParentRoute: () => CodeInboxPullsRoute,
 } as any)
+const CodeInboxNotActionableReportIdRoute =
+  CodeInboxNotActionableReportIdRouteImport.update({
+    id: '/$reportId',
+    path: '/$reportId',
+    getParentRoute: () => CodeInboxNotActionableRoute,
+  } as any)
 const CodeInboxDismissedReportIdRoute =
   CodeInboxDismissedReportIdRouteImport.update({
     id: '/$reportId',
@@ -401,6 +421,7 @@ export interface FileRoutesByFullPath {
   '/code/agents/scouts': typeof CodeAgentsScoutsRouteWithChildren
   '/code/inbox/agents': typeof CodeInboxAgentsRoute
   '/code/inbox/dismissed': typeof CodeInboxDismissedRouteWithChildren
+  '/code/inbox/not-actionable': typeof CodeInboxNotActionableRouteWithChildren
   '/code/inbox/pulls': typeof CodeInboxPullsRouteWithChildren
   '/code/inbox/reports': typeof CodeInboxReportsRouteWithChildren
   '/code/inbox/runs': typeof CodeInboxRunsRouteWithChildren
@@ -414,6 +435,7 @@ export interface FileRoutesByFullPath {
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
+  '/code/inbox/not-actionable/$reportId': typeof CodeInboxNotActionableReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
   '/code/inbox/runs/$reportId': typeof CodeInboxRunsReportIdRoute
@@ -423,6 +445,7 @@ export interface FileRoutesByFullPath {
   '/code/agents/applications/': typeof CodeAgentsApplicationsIndexRoute
   '/code/agents/scouts/': typeof CodeAgentsScoutsIndexRoute
   '/code/inbox/dismissed/': typeof CodeInboxDismissedIndexRoute
+  '/code/inbox/not-actionable/': typeof CodeInboxNotActionableIndexRoute
   '/code/inbox/pulls/': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports/': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs/': typeof CodeInboxRunsIndexRoute
@@ -463,6 +486,7 @@ export interface FileRoutesByTo {
   '/website/$channelId': typeof WebsiteChannelIdIndexRoute
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
+  '/code/inbox/not-actionable/$reportId': typeof CodeInboxNotActionableReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
   '/code/inbox/runs/$reportId': typeof CodeInboxRunsReportIdRoute
@@ -472,6 +496,7 @@ export interface FileRoutesByTo {
   '/code/agents/applications': typeof CodeAgentsApplicationsIndexRoute
   '/code/agents/scouts': typeof CodeAgentsScoutsIndexRoute
   '/code/inbox/dismissed': typeof CodeInboxDismissedIndexRoute
+  '/code/inbox/not-actionable': typeof CodeInboxNotActionableIndexRoute
   '/code/inbox/pulls': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs': typeof CodeInboxRunsIndexRoute
@@ -511,6 +536,7 @@ export interface FileRoutesById {
   '/code/agents/scouts': typeof CodeAgentsScoutsRouteWithChildren
   '/code/inbox/agents': typeof CodeInboxAgentsRoute
   '/code/inbox/dismissed': typeof CodeInboxDismissedRouteWithChildren
+  '/code/inbox/not-actionable': typeof CodeInboxNotActionableRouteWithChildren
   '/code/inbox/pulls': typeof CodeInboxPullsRouteWithChildren
   '/code/inbox/reports': typeof CodeInboxReportsRouteWithChildren
   '/code/inbox/runs': typeof CodeInboxRunsRouteWithChildren
@@ -524,6 +550,7 @@ export interface FileRoutesById {
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
+  '/code/inbox/not-actionable/$reportId': typeof CodeInboxNotActionableReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
   '/code/inbox/runs/$reportId': typeof CodeInboxRunsReportIdRoute
@@ -533,6 +560,7 @@ export interface FileRoutesById {
   '/code/agents/applications/': typeof CodeAgentsApplicationsIndexRoute
   '/code/agents/scouts/': typeof CodeAgentsScoutsIndexRoute
   '/code/inbox/dismissed/': typeof CodeInboxDismissedIndexRoute
+  '/code/inbox/not-actionable/': typeof CodeInboxNotActionableIndexRoute
   '/code/inbox/pulls/': typeof CodeInboxPullsIndexRoute
   '/code/inbox/reports/': typeof CodeInboxReportsIndexRoute
   '/code/inbox/runs/': typeof CodeInboxRunsIndexRoute
@@ -573,6 +601,7 @@ export interface FileRouteTypes {
     | '/code/agents/scouts'
     | '/code/inbox/agents'
     | '/code/inbox/dismissed'
+    | '/code/inbox/not-actionable'
     | '/code/inbox/pulls'
     | '/code/inbox/reports'
     | '/code/inbox/runs'
@@ -586,6 +615,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/approvals'
     | '/code/agents/scouts/$skillName'
     | '/code/inbox/dismissed/$reportId'
+    | '/code/inbox/not-actionable/$reportId'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
     | '/code/inbox/runs/$reportId'
@@ -595,6 +625,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/'
     | '/code/agents/scouts/'
     | '/code/inbox/dismissed/'
+    | '/code/inbox/not-actionable/'
     | '/code/inbox/pulls/'
     | '/code/inbox/reports/'
     | '/code/inbox/runs/'
@@ -635,6 +666,7 @@ export interface FileRouteTypes {
     | '/website/$channelId'
     | '/code/agents/applications/approvals'
     | '/code/inbox/dismissed/$reportId'
+    | '/code/inbox/not-actionable/$reportId'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
     | '/code/inbox/runs/$reportId'
@@ -644,6 +676,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications'
     | '/code/agents/scouts'
     | '/code/inbox/dismissed'
+    | '/code/inbox/not-actionable'
     | '/code/inbox/pulls'
     | '/code/inbox/reports'
     | '/code/inbox/runs'
@@ -682,6 +715,7 @@ export interface FileRouteTypes {
     | '/code/agents/scouts'
     | '/code/inbox/agents'
     | '/code/inbox/dismissed'
+    | '/code/inbox/not-actionable'
     | '/code/inbox/pulls'
     | '/code/inbox/reports'
     | '/code/inbox/runs'
@@ -695,6 +729,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/approvals'
     | '/code/agents/scouts/$skillName'
     | '/code/inbox/dismissed/$reportId'
+    | '/code/inbox/not-actionable/$reportId'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
     | '/code/inbox/runs/$reportId'
@@ -704,6 +739,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/'
     | '/code/agents/scouts/'
     | '/code/inbox/dismissed/'
+    | '/code/inbox/not-actionable/'
     | '/code/inbox/pulls/'
     | '/code/inbox/reports/'
     | '/code/inbox/runs/'
@@ -935,6 +971,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CodeInboxPullsRouteImport
       parentRoute: typeof CodeInboxRoute
     }
+    '/code/inbox/not-actionable': {
+      id: '/code/inbox/not-actionable'
+      path: '/not-actionable'
+      fullPath: '/code/inbox/not-actionable'
+      preLoaderRoute: typeof CodeInboxNotActionableRouteImport
+      parentRoute: typeof CodeInboxRoute
+    }
     '/code/inbox/dismissed': {
       id: '/code/inbox/dismissed'
       path: '/dismissed'
@@ -983,6 +1026,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/code/inbox/pulls/'
       preLoaderRoute: typeof CodeInboxPullsIndexRouteImport
       parentRoute: typeof CodeInboxPullsRoute
+    }
+    '/code/inbox/not-actionable/': {
+      id: '/code/inbox/not-actionable/'
+      path: '/'
+      fullPath: '/code/inbox/not-actionable/'
+      preLoaderRoute: typeof CodeInboxNotActionableIndexRouteImport
+      parentRoute: typeof CodeInboxNotActionableRoute
     }
     '/code/inbox/dismissed/': {
       id: '/code/inbox/dismissed/'
@@ -1046,6 +1096,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/code/inbox/pulls/$reportId'
       preLoaderRoute: typeof CodeInboxPullsReportIdRouteImport
       parentRoute: typeof CodeInboxPullsRoute
+    }
+    '/code/inbox/not-actionable/$reportId': {
+      id: '/code/inbox/not-actionable/$reportId'
+      path: '/$reportId'
+      fullPath: '/code/inbox/not-actionable/$reportId'
+      preLoaderRoute: typeof CodeInboxNotActionableReportIdRouteImport
+      parentRoute: typeof CodeInboxNotActionableRoute
     }
     '/code/inbox/dismissed/$reportId': {
       id: '/code/inbox/dismissed/$reportId'
@@ -1294,6 +1351,22 @@ const CodeInboxDismissedRouteChildren: CodeInboxDismissedRouteChildren = {
 const CodeInboxDismissedRouteWithChildren =
   CodeInboxDismissedRoute._addFileChildren(CodeInboxDismissedRouteChildren)
 
+interface CodeInboxNotActionableRouteChildren {
+  CodeInboxNotActionableReportIdRoute: typeof CodeInboxNotActionableReportIdRoute
+  CodeInboxNotActionableIndexRoute: typeof CodeInboxNotActionableIndexRoute
+}
+
+const CodeInboxNotActionableRouteChildren: CodeInboxNotActionableRouteChildren =
+  {
+    CodeInboxNotActionableReportIdRoute: CodeInboxNotActionableReportIdRoute,
+    CodeInboxNotActionableIndexRoute: CodeInboxNotActionableIndexRoute,
+  }
+
+const CodeInboxNotActionableRouteWithChildren =
+  CodeInboxNotActionableRoute._addFileChildren(
+    CodeInboxNotActionableRouteChildren,
+  )
+
 interface CodeInboxPullsRouteChildren {
   CodeInboxPullsReportIdRoute: typeof CodeInboxPullsReportIdRoute
   CodeInboxPullsIndexRoute: typeof CodeInboxPullsIndexRoute
@@ -1338,6 +1411,7 @@ const CodeInboxRunsRouteWithChildren = CodeInboxRunsRoute._addFileChildren(
 interface CodeInboxRouteChildren {
   CodeInboxAgentsRoute: typeof CodeInboxAgentsRoute
   CodeInboxDismissedRoute: typeof CodeInboxDismissedRouteWithChildren
+  CodeInboxNotActionableRoute: typeof CodeInboxNotActionableRouteWithChildren
   CodeInboxPullsRoute: typeof CodeInboxPullsRouteWithChildren
   CodeInboxReportsRoute: typeof CodeInboxReportsRouteWithChildren
   CodeInboxRunsRoute: typeof CodeInboxRunsRouteWithChildren
@@ -1347,6 +1421,7 @@ interface CodeInboxRouteChildren {
 const CodeInboxRouteChildren: CodeInboxRouteChildren = {
   CodeInboxAgentsRoute: CodeInboxAgentsRoute,
   CodeInboxDismissedRoute: CodeInboxDismissedRouteWithChildren,
+  CodeInboxNotActionableRoute: CodeInboxNotActionableRouteWithChildren,
   CodeInboxPullsRoute: CodeInboxPullsRouteWithChildren,
   CodeInboxReportsRoute: CodeInboxReportsRouteWithChildren,
   CodeInboxRunsRoute: CodeInboxRunsRouteWithChildren,

--- a/packages/ui/src/router/routes/code/inbox/not-actionable.$reportId.tsx
+++ b/packages/ui/src/router/routes/code/inbox/not-actionable.$reportId.tsx
@@ -1,0 +1,24 @@
+import type { SignalReport } from "@posthog/shared/types";
+import { ReportDetail } from "@posthog/ui/features/inbox/components/ReportDetail";
+import { getCachedInboxReportDetail } from "@posthog/ui/features/inbox/inboxQueries";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/inbox/not-actionable/$reportId")({
+  component: NotActionableReportDetailRoute,
+  pendingComponent: () => null,
+  loader: ({ params }): SignalReport | null =>
+    getCachedInboxReportDetail(params.reportId) ?? null,
+});
+
+function NotActionableReportDetailRoute() {
+  const { reportId } = Route.useParams();
+  const cachedReport = Route.useLoaderData();
+  return (
+    <ReportDetail
+      reportId={reportId}
+      cachedReport={cachedReport}
+      backTo="/code/inbox/not-actionable"
+      backLabel="Back to not actionable"
+    />
+  );
+}

--- a/packages/ui/src/router/routes/code/inbox/not-actionable.index.tsx
+++ b/packages/ui/src/router/routes/code/inbox/not-actionable.index.tsx
@@ -1,0 +1,6 @@
+import { NotActionableTab } from "@posthog/ui/features/inbox/components/NotActionableTab";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/inbox/not-actionable/")({
+  component: NotActionableTab,
+});

--- a/packages/ui/src/router/routes/code/inbox/not-actionable.tsx
+++ b/packages/ui/src/router/routes/code/inbox/not-actionable.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/inbox/not-actionable")({
+  component: Outlet,
+});


### PR DESCRIPTION
## Problem

In the PostHog Code inbox, once a report's implementation PR is merged it transitioned to a terminal state and **fell off every tab** — there was no "Done"/archive surface to find shipped work again. The desktop app was also missing the **Not actionable** tab that `PostHog/posthog` has for auditing signal quality.

**Why:** Andy hit this directly — he shipped a couple of PRs and they "just disappeared" from the inbox with no Done tab to track them. Michael asked to replicate the Archived / Runs / Not actionable tab structure from `PostHog/posthog` here.

## Changes

Brings the desktop inbox in line with the `PostHog/posthog` tab structure:

- **Archive** now lists `resolved` reports (merged implementation PR) alongside user-suppressed ones. Resolved reports appear for reference only — no Restore action. Merged PRs finally have a home.
- New **Not actionable** tab (staff-only) listing reports the agent judged `not_actionable`; they're pulled out of the Reports tab so they don't double-list.
- Adds `resolved` to the `SignalReportStatus` enum, labels, and status badge.
- **Runs** already matched posthog (Queued / Live / Recently finished) — left unchanged.

## How did you test this?

- `pnpm --filter @posthog/core --filter @posthog/ui typecheck` — clean
- `pnpm --filter @posthog/core test` — 1667 passed (added cases for the new predicates: `isDismissedReport` incl. resolved, `isResolvedReport`, `isNotActionableReport`, `isStaffOnlyInboxTab`, not-actionable exclusion from Reports)
- `pnpm --filter @posthog/ui test` — 804 passed
- Regenerated the TanStack route tree for the new `/code/inbox/not-actionable` routes

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781989360332259?thread_ts=1781989360.332259&cid=C09SK2PAGKF)*
