### PR TITLE
refactor(agents): drop 'preview' as mocking shorthand in chat-with-draft

### DIFF
--- a/packages/core/src/agent-chat/agentChatService.ts
+++ b/packages/core/src/agent-chat/agentChatService.ts
@@ -104,7 +104,7 @@ interface ChatRuntime {
  * Drives live chats against deployed agents' ingress: starts/sends/cancels via
  * the api-client, streams SSE through the host's mapper, and pumps the resulting
  * ACP messages into the core `agentChatStore` keyed by `chatId` (so the agent
- * builder dock and per-agent previews coexist). One `ChatRuntime` per chat holds
+ * builder dock and per-agent chats coexist). One `ChatRuntime` per chat holds
  * the reconnect loop, epoch supersede, and preview-token cache.
  *
  * The renderer hook supplies the authenticated client per call and the UI seams

--- a/packages/core/src/agent-chat/agentChatStore.ts
+++ b/packages/core/src/agent-chat/agentChatStore.ts
@@ -5,7 +5,7 @@ import { createStore } from "zustand/vanilla";
 /**
  * Domain state for deployed-agent live chats. Keyed by an opaque `chatId` so
  * several chats can be live at once — e.g. the always-on agent builder dock
- * (`"agent-builder"`) and a per-agent preview (`"preview:<slug>"`) side by side.
+ * (`"agent-builder"`) and a per-agent chat (`"preview:<slug>"`) side by side.
  * The UI hook (`useAgentChat`) owns the transport (run/send/cancel + the SSE
  * loop, via the api-client) and pumps mapped `AcpMessage`s in here; components
  * read one chat by id and render it through `ConversationView`.

--- a/packages/core/src/agent-chat/identifiers.ts
+++ b/packages/core/src/agent-chat/identifiers.ts
@@ -47,7 +47,7 @@ export interface AgentChatSession {
   /** Agent slug the chat targets. */
   agentSlug: string;
   ingressBaseUrl: string;
-  /** Non-null targets a specific draft revision (preview token attached per call). */
+  /** Non-null routes this chat to a non-live revision (ingress JWT attached per call). */
   revisionId: string | null;
   createMapper(): AgentChatMapper;
   /** Resolve a client-tool call; `defer`/null ⇒ the service won't post a result. */

--- a/packages/ui/src/features/agent-applications/chat/chatHistoryStore.ts
+++ b/packages/ui/src/features/agent-applications/chat/chatHistoryStore.ts
@@ -3,34 +3,35 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 /**
- * Locally-persisted index of preview chats the user started against an agent
+ * Locally-persisted index of recent chats the user started against an agent
  * *from this app*. These are the only sessions surfaced in the chat pane's
  * rail — deliberately NOT the agent's full server session list, which can
  * include real customer conversations. Keyed by agent slug; each entry is just
  * enough to re-attach (`/listen` replays the transcript) and label the rail.
  */
-export interface PreviewChatEntry {
+export interface RecentChatEntry {
   sessionId: string;
   /** First user message of the chat, for the rail label. */
   title: string;
   /** Epoch ms when the chat was started here. */
   startedAt: number;
   /**
-   * Revision the chat targets, when the user opened it as a draft preview.
-   * Undefined for sessions that ran against `live_revision`. Lets the rail
-   * label drafts and route resumes back to the right preview surface.
+   * Revision the chat targets, when the user opened it as a chat against a
+   * non-live revision. Undefined for sessions that ran against `live_revision`.
+   * Lets the rail label draft chats and route resumes back to the right
+   * revision surface.
    */
   revisionId?: string;
 }
 
 interface ChatHistoryState {
-  byAgent: Record<string, PreviewChatEntry[]>;
-  /** Record (or move-to-top) a preview chat the user started here. */
-  record: (agentKey: string, entry: PreviewChatEntry) => void;
+  byAgent: Record<string, RecentChatEntry[]>;
+  /** Record (or move-to-top) a recent chat the user started here. */
+  record: (agentKey: string, entry: RecentChatEntry) => void;
   remove: (agentKey: string, sessionId: string) => void;
 }
 
-/** Per-agent cap; preview chats are throwaway, so an old tail is fine to drop. */
+/** Per-agent cap; entries are throwaway, so an old tail is fine to drop. */
 const MAX_PER_AGENT = 50;
 
 export const useChatHistoryStore = create<ChatHistoryState>()(

--- a/packages/ui/src/features/agent-applications/chat/chatHistoryStore.ts
+++ b/packages/ui/src/features/agent-applications/chat/chatHistoryStore.ts
@@ -3,13 +3,13 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 /**
- * Locally-persisted index of recent chats the user started against an agent
+ * Locally-persisted index of chats the user started against an agent
  * *from this app*. These are the only sessions surfaced in the chat pane's
  * rail — deliberately NOT the agent's full server session list, which can
  * include real customer conversations. Keyed by agent slug; each entry is just
  * enough to re-attach (`/listen` replays the transcript) and label the rail.
  */
-export interface RecentChatEntry {
+export interface ChatHistoryEntry {
   sessionId: string;
   /** First user message of the chat, for the rail label. */
   title: string;
@@ -25,9 +25,9 @@ export interface RecentChatEntry {
 }
 
 interface ChatHistoryState {
-  byAgent: Record<string, RecentChatEntry[]>;
-  /** Record (or move-to-top) a recent chat the user started here. */
-  record: (agentKey: string, entry: RecentChatEntry) => void;
+  byAgent: Record<string, ChatHistoryEntry[]>;
+  /** Record (or move-to-top) a chat the user started here. */
+  record: (agentKey: string, entry: ChatHistoryEntry) => void;
   remove: (agentKey: string, sessionId: string) => void;
 }
 

--- a/packages/ui/src/features/agent-applications/components/AgentApprovalDecisionForm.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentApprovalDecisionForm.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
  * editor (when allowed), reason note, error surface, and the two action
  * buttons. Owns its own UI state but takes the decision callback from the
  * caller, so both the full `AgentApprovalDetail` (Approvals tab + Fleet route)
- * and the inline `AgentChatPendingApprovalCard` (live chat preview) can wrap
+ * and the inline `AgentChatPendingApprovalCard` (chat pane) can wrap
  * it with their own `useDecideAgentApproval` glue.
  */
 export function AgentApprovalDecisionForm({

--- a/packages/ui/src/features/agent-applications/components/AgentChatPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentChatPane.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuthStateValue } from "../../auth/store";
 import {
-  type PreviewChatEntry,
+  type RecentChatEntry,
   useChatHistoryStore,
 } from "../chat/chatHistoryStore";
 import { useAgentApplication } from "../hooks/useAgentApplication";
@@ -23,7 +23,7 @@ import { AgentChatPendingApprovalCard } from "./AgentChatPendingApprovalCard";
 import { AgentChatSurface } from "./AgentChatSurface";
 import { AgentDetailEmptyState, AgentDetailLayout } from "./AgentDetailLayout";
 
-const EMPTY_CHATS: PreviewChatEntry[] = [];
+const EMPTY_CHATS: RecentChatEntry[] = [];
 
 function rec(v: unknown): Record<string, unknown> {
   return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
@@ -42,18 +42,19 @@ function relativeTime(ms: number): string {
 }
 
 /**
- * Live chat against a deployed agent (the console's "preview/test"). Streams the
- * agent-ingress SSE through the native `ConversationView`. Only meaningful for
- * agents that expose a chat trigger and have a public ingress URL.
+ * In-app chat against a deployed agent. Streams the agent-ingress SSE through
+ * the native `ConversationView`. Only meaningful for agents that expose a chat
+ * trigger and have a public ingress URL.
  *
- * A left rail lists the preview chats the user started *here* (persisted
- * locally — never the agent's full server session list, which can include real
- * customer chats), and a banner makes clear this talks to the deployed revision.
+ * A left rail lists the chats the user started *here* (persisted locally —
+ * never the agent's full server session list, which can include real customer
+ * chats), and a banner makes clear which revision this targets.
  *
  * When `revisionId` targets a non-live revision (the "Test draft" affordance
- * from the revision bar), the hook mints a short-lived preview token and
- * scopes the ingress to that draft; chatId/banner switch accordingly so a
- * draft session can't be confused with a live one.
+ * from the revision bar), the hook mints a short-lived ingress JWT and routes
+ * the run to that draft; chatId/banner switch accordingly so a draft session
+ * can't be confused with a live one. Side effects (Slack, approvals, tools)
+ * still run for real — only the revision serving the request differs.
  */
 export function AgentChatPane({
   idOrSlug,
@@ -73,12 +74,12 @@ export function AgentChatPane({
   const navigate = useNavigate();
   const { data: application } = useAgentApplication(idOrSlug);
   // null/equal-to-live → fall back to the live revision; explicit non-live
-  // revision id → draft preview mode.
+  // revision id → route this chat to the draft.
   const targetRevisionId =
     revisionId && revisionId !== application?.live_revision
       ? revisionId
       : (application?.live_revision ?? null);
-  const isDraftPreview =
+  const isDraftRevisionChat =
     !!revisionId && revisionId !== application?.live_revision;
   const { data: revision } = useAgentRevision(idOrSlug, targetRevisionId);
   const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
@@ -89,16 +90,16 @@ export function AgentChatPane({
   const hasChatTrigger = (revision?.spec?.triggers ?? []).some(
     (t) => rec(t).type === "chat",
   );
-  // Keyed by revision so a draft preview and the live chat coexist in the store
+  // Keyed by revision so a draft chat and the live chat coexist in the store
   // without trampling each other.
-  const chatId = isDraftPreview
+  const chatId = isDraftRevisionChat
     ? `preview:${idOrSlug}:${revisionId}`
     : `preview:${idOrSlug}`;
   const chat = useAgentChat({
     chatId,
     agentSlug: idOrSlug,
     ingressBaseUrl,
-    revisionId: isDraftPreview ? revisionId : null,
+    revisionId: isDraftRevisionChat ? revisionId : null,
     recordHistory: true,
   });
   const pendingApproval = useAgentChatPendingApproval(chatId);
@@ -106,12 +107,12 @@ export function AgentChatPane({
   const removeChat = useChatHistoryStore((s) => s.remove);
 
   // Partition the rail into "matches the current target" vs everything else
-  // so a live view doesn't drown in old draft previews (and vice-versa). The
+  // so a live view doesn't drown in old draft chats (and vice-versa). The
   // expander reveals the rest on demand.
-  const currentRev = isDraftPreview ? (revisionId ?? null) : null;
+  const currentRev = isDraftRevisionChat ? (revisionId ?? null) : null;
   const { matchingChats, otherChats } = useMemo(() => {
-    const matching: PreviewChatEntry[] = [];
-    const other: PreviewChatEntry[] = [];
+    const matching: RecentChatEntry[] = [];
+    const other: RecentChatEntry[] = [];
     for (const c of chats) {
       if ((c.revisionId ?? null) === currentRev) matching.push(c);
       else other.push(c);
@@ -147,7 +148,7 @@ export function AgentChatPane({
 
   // The rail mixes chats from every revision; decide per click whether to
   // resume inline (same target) or navigate to a different revision's surface.
-  const handleRailSelect = (entry: PreviewChatEntry) => {
+  const handleRailSelect = (entry: RecentChatEntry) => {
     if ((entry.revisionId ?? null) === currentRev) {
       chat.resume(entry.sessionId);
       return;
@@ -175,7 +176,7 @@ export function AgentChatPane({
           <AgentDetailEmptyState
             title="No chat trigger"
             description={
-              isDraftPreview
+              isDraftRevisionChat
                 ? "This draft revision doesn't expose a chat trigger, so there's nothing to chat with. Add a chat trigger via the agent builder to test it here."
                 : "This agent's live revision doesn't expose a chat trigger, so there's nothing to chat with. Add a chat trigger via the agent builder to test it here."
             }
@@ -194,9 +195,9 @@ export function AgentChatPane({
             onDelete={(sessionId) => removeChat(idOrSlug, sessionId)}
           />
           <Flex direction="column" className="min-w-0 flex-1">
-            <PreviewBanner
+            <RevisionChatBanner
               revisionId={targetRevisionId}
-              isDraft={isDraftPreview}
+              isDraft={isDraftRevisionChat}
               model={revision?.spec?.model}
               region={cloudRegion}
             />
@@ -229,7 +230,7 @@ export function AgentChatPane({
   );
 }
 
-function PreviewBanner({
+function RevisionChatBanner({
   revisionId,
   isDraft,
   model,
@@ -251,8 +252,8 @@ function PreviewBanner({
       <InfoIcon size={14} className="shrink-0 text-gray-10" />
       <Text className="text-[12px] text-gray-11 leading-snug">
         {isDraft
-          ? "Draft preview — messages run against an unpublished revision. Promote it to make this the live one."
-          : "Live preview — messages run against the currently deployed revision. Only chats you start here appear in the list."}
+          ? "Chatting with a draft revision — Slack posts, approvals, and tools all run for real. Promote the revision to make this the live one."
+          : "Chatting with the live revision — messages run against the currently deployed revision. Only chats you start here appear in the list."}
       </Text>
       <Flex align="center" gap="2" className="ml-auto shrink-0">
         {model ? (
@@ -284,15 +285,15 @@ function ChatHistoryRail({
   onSelect,
   onDelete,
 }: {
-  chats: PreviewChatEntry[];
+  chats: RecentChatEntry[];
   /** Chats from other revisions — hidden behind an expander to keep this surface focused. */
-  otherChats: PreviewChatEntry[];
+  otherChats: RecentChatEntry[];
   showOthers: boolean;
   onToggleShowOthers: () => void;
   activeSessionId: string | null;
   onNewChat: () => void;
   /** Receives the full entry so the parent can route by revision, not just resume. */
-  onSelect: (entry: PreviewChatEntry) => void;
+  onSelect: (entry: RecentChatEntry) => void;
   onDelete: (sessionId: string) => void;
 }) {
   return (
@@ -365,9 +366,9 @@ function RailEntry({
   onSelect,
   onDelete,
 }: {
-  entry: PreviewChatEntry;
+  entry: RecentChatEntry;
   active: boolean;
-  onSelect: (entry: PreviewChatEntry) => void;
+  onSelect: (entry: RecentChatEntry) => void;
   onDelete: (sessionId: string) => void;
 }) {
   return (
@@ -391,7 +392,7 @@ function RailEntry({
                 <span aria-hidden>·</span>
                 <span
                   className="rounded-(--radius-1) bg-(--amber-3) px-1 font-mono text-(--amber-11) text-[10px]"
-                  title={`Draft preview against revision ${entry.revisionId}`}
+                  title={`Chat against draft revision ${entry.revisionId}`}
                 >
                   rev {entry.revisionId.slice(0, 8)}
                 </span>

--- a/packages/ui/src/features/agent-applications/components/AgentChatPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentChatPane.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuthStateValue } from "../../auth/store";
 import {
-  type RecentChatEntry,
+  type ChatHistoryEntry,
   useChatHistoryStore,
 } from "../chat/chatHistoryStore";
 import { useAgentApplication } from "../hooks/useAgentApplication";
@@ -23,7 +23,7 @@ import { AgentChatPendingApprovalCard } from "./AgentChatPendingApprovalCard";
 import { AgentChatSurface } from "./AgentChatSurface";
 import { AgentDetailEmptyState, AgentDetailLayout } from "./AgentDetailLayout";
 
-const EMPTY_CHATS: RecentChatEntry[] = [];
+const EMPTY_CHATS: ChatHistoryEntry[] = [];
 
 function rec(v: unknown): Record<string, unknown> {
   return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
@@ -111,8 +111,8 @@ export function AgentChatPane({
   // expander reveals the rest on demand.
   const currentRev = isDraftRevisionChat ? (revisionId ?? null) : null;
   const { matchingChats, otherChats } = useMemo(() => {
-    const matching: RecentChatEntry[] = [];
-    const other: RecentChatEntry[] = [];
+    const matching: ChatHistoryEntry[] = [];
+    const other: ChatHistoryEntry[] = [];
     for (const c of chats) {
       if ((c.revisionId ?? null) === currentRev) matching.push(c);
       else other.push(c);
@@ -148,7 +148,7 @@ export function AgentChatPane({
 
   // The rail mixes chats from every revision; decide per click whether to
   // resume inline (same target) or navigate to a different revision's surface.
-  const handleRailSelect = (entry: RecentChatEntry) => {
+  const handleRailSelect = (entry: ChatHistoryEntry) => {
     if ((entry.revisionId ?? null) === currentRev) {
       chat.resume(entry.sessionId);
       return;
@@ -285,15 +285,15 @@ function ChatHistoryRail({
   onSelect,
   onDelete,
 }: {
-  chats: RecentChatEntry[];
+  chats: ChatHistoryEntry[];
   /** Chats from other revisions — hidden behind an expander to keep this surface focused. */
-  otherChats: RecentChatEntry[];
+  otherChats: ChatHistoryEntry[];
   showOthers: boolean;
   onToggleShowOthers: () => void;
   activeSessionId: string | null;
   onNewChat: () => void;
   /** Receives the full entry so the parent can route by revision, not just resume. */
-  onSelect: (entry: RecentChatEntry) => void;
+  onSelect: (entry: ChatHistoryEntry) => void;
   onDelete: (sessionId: string) => void;
 }) {
   return (
@@ -366,9 +366,9 @@ function RailEntry({
   onSelect,
   onDelete,
 }: {
-  entry: RecentChatEntry;
+  entry: ChatHistoryEntry;
   active: boolean;
-  onSelect: (entry: RecentChatEntry) => void;
+  onSelect: (entry: ChatHistoryEntry) => void;
   onDelete: (sessionId: string) => void;
 }) {
   return (

--- a/packages/ui/src/features/agent-applications/components/AgentChatPendingApprovalCard.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentChatPendingApprovalCard.tsx
@@ -16,8 +16,8 @@ import { AgentApprovalDecisionForm } from "./AgentApprovalDecisionForm";
 import { ArgsSection } from "./AgentApprovalDetail";
 
 /**
- * Inline pending-approval card surfaced in the live chat preview / agent
- * builder dock. Renders between the conversation and the composer when the
+ * Inline pending-approval card surfaced in the chat pane / agent builder
+ * dock. Renders between the conversation and the composer when the
  * agent has paused on an approval-gated tool call.
  *
  * Decision routing follows the approval `type`:

--- a/packages/ui/src/features/agent-applications/components/AgentChatSurface.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentChatSurface.tsx
@@ -12,7 +12,7 @@ import { type KeyboardEvent, type ReactNode, useState } from "react";
 
 /**
  * The conversation + composer half of a deployed-agent chat, shared by the
- * per-agent preview pane and the agent builder dock. Renders the live ACP messages
+ * per-agent chat pane and the agent builder dock. Renders the live ACP messages
  * through the native `ConversationView` (collapse disabled so the agent's prose
  * shows inline) and an auto-growing composer with Enter-to-send / Cancel that
  * mirrors the main task chat's input shell.

--- a/packages/ui/src/features/agent-applications/components/AgentRevisionBar.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentRevisionBar.tsx
@@ -247,10 +247,11 @@ export function AgentRevisionBar({
 
       <Flex gap="2">
         {/*
-         * Test — runs this not-yet-promoted revision through the live ingress
-         * with a preview token (the chat tab mints + attaches it via
-         * useAgentChat). Live uses the default Chat tab; archived can't be
-         * exercised.
+         * Test — routes this not-yet-promoted revision through the ingress
+         * with a short-lived JWT (the chat tab mints + attaches it via
+         * useAgentChat). Side effects run for real; the revision serving the
+         * request is the only difference from a live chat. Live uses the
+         * default Chat tab; archived can't be exercised.
          */}
         {selected.state !== "live" &&
         selected.state !== "archived" &&

--- a/packages/ui/src/features/agent-applications/hooks/useAgentChat.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentChat.ts
@@ -41,7 +41,7 @@ export interface UseAgentChatOptions {
    * agent's currently live revision.
    */
   revisionId?: string | null;
-  /** Index started sessions in the local recent-chats rail. */
+  /** Index started sessions in the local chat-history rail. */
   recordHistory?: boolean;
   /**
    * Supplies the "what am I looking at" object. When set, it's prepended as a

--- a/packages/ui/src/features/agent-applications/hooks/useAgentChat.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentChat.ts
@@ -35,12 +35,13 @@ export interface UseAgentChatOptions {
   agentSlug: string;
   ingressBaseUrl: string | null;
   /**
-   * When set, this chat targets a specific non-live revision. The service mints
-   * a short-lived preview token and attaches it on every ingress call. Leave
-   * null/unset to use the agent's currently live revision.
+   * When set, this chat routes to a specific non-live revision. The service
+   * mints a short-lived ingress JWT scoped to that revision and attaches it on
+   * every call; side effects still run for real. Leave null/unset to use the
+   * agent's currently live revision.
    */
   revisionId?: string | null;
-  /** Index started sessions in the local recent-chats rail (preview only). */
+  /** Index started sessions in the local recent-chats rail. */
   recordHistory?: boolean;
   /**
    * Supplies the "what am I looking at" object. When set, it's prepended as a

--- a/packages/ui/src/features/agent-applications/hooks/useAgentChatPendingApproval.ts
+++ b/packages/ui/src/features/agent-applications/hooks/useAgentChatPendingApproval.ts
@@ -4,7 +4,7 @@ import { useStore } from "zustand";
 
 /**
  * The approval-gated tool call this chat is currently paused on, or null —
- * what drives the inline approval card in the live preview / agent builder dock.
+ * what drives the inline approval card in the chat pane / agent builder dock.
  *
  * The chat service maintains it from the stream: a `queued` approval marker
  * triggers a one-shot fetch of the full request from the ingress, and a

--- a/packages/ui/src/router/routes/code/agents/applications/$idOrSlug/chat.tsx
+++ b/packages/ui/src/router/routes/code/agents/applications/$idOrSlug/chat.tsx
@@ -4,10 +4,12 @@ import { createFileRoute } from "@tanstack/react-router";
 export const Route = createFileRoute(
   "/code/agents/applications/$idOrSlug/chat",
 )({
-  // `revision` opts into draft preview (the pane mints a preview token and
-  // scopes the ingress to that revision). `session` re-attaches a specific
-  // session on mount — set by rail clicks that cross revisions so the new
-  // mount resumes the right conversation instead of starting empty.
+  // `revision` routes this chat to a non-live revision (the pane mints a
+  // short-lived ingress JWT scoped to that revision; side effects still run
+  // for real, only the revision serving the request changes). `session`
+  // re-attaches a specific session on mount — set by rail clicks that cross
+  // revisions so the new mount resumes the right conversation instead of
+  // starting empty.
   validateSearch: (
     search: Record<string, unknown>,
   ): { revision?: string; session?: string } => ({


### PR DESCRIPTION
## Summary

PostHog/posthog#65978 kept the entire preview-token flow (`preview_proxy*`, `preview_token*`, `INGRESS_PREVIEW` JWT audience, `preview_token_required` SSE, resolver routing to non-live revisions) and ripped out **only** the side-effect mocking it drove. A draft-revision chat now executes real Slack posts, real HTTP calls, real memory/table writes, real approvals, real failure notifications — differing from a live chat only in *which revision* serves the request.

That makes "preview" misleading on the client where it still suggested "mocked test sandbox". This PR is a cosmetic naming + copy pass. **No behavior change.**

### What changed

| Old name | New name |
| --- | --- |
| `isDraftPreview` (AgentChatPane local flag) | `isDraftRevisionChat` |
| `PreviewChatEntry` (chatHistoryStore type) | `ChatHistoryEntry` |
| `PreviewBanner` (AgentChatPane local component) | `RevisionChatBanner` |

`ChatHistoryEntry` is the symmetric pair to the existing `useChatHistoryStore` / `ChatHistoryState` already in that file — describes what the entries are, not when they surface.

Banner copy is rewritten:
- Draft path: "Chatting with a draft revision — Slack posts, approvals, and tools all run for real. Promote the revision to make this the live one."
- Live path: "Chatting with the live revision — messages run against the currently deployed revision. Only chats you start here appear in the list."

Cross-package doc comments stop calling the chat surface a "preview".

### What deliberately stays

The wire-aligned `preview` vocabulary is left intact because it maps directly to the server contract: `AgentPreviewToken`, `AgentPreviewTokenRequiredEvent`, `AgentPreviewEndpoints`, `X-Agent-Preview-Token`, `mintAgentPreviewToken`, `withPreviewToken`/`getPreviewToken`, the `preview_token_required` event kind, the `endpoints.preview_proxy` field, the `agent-preview-chats` zustand persistence key, the local `preview:` chatId prefix, and the unrelated `session.preview` message-content summary.

### Context

This is the follow-up to #2918 (closed) — that PR's premise (preview chats don't pay rent) was invalidated by the server-side keep-the-flow-drop-the-mocking move.

## Test plan

- [x] `pnpm --filter @posthog/core typecheck` — no new errors (pre-existing `task-detail/customInstructions` + `AgentPreviewToken` export-resolution errors are unchanged from `main`)
- [x] `pnpm --filter @posthog/ui typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Smoke: open an agent's Chat tab — banner reads "Chatting with the live revision"
- [ ] Smoke: open the Revisions tab on a draft → Test draft → banner reads "Chatting with a draft revision — Slack posts, approvals, and tools all run for real"
- [ ] Smoke: rail still partitions matching vs other revisions, "Show N from other revision(s)" expander still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)