### PR TITLE
fix(mobile): hide warm-sandbox placeholder tasks from the task list (port #2935)

### DIFF
--- a/apps/mobile/src/features/tasks/stores/taskStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/taskStore.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { Task } from "../types";
+import { filterAndSortTasks } from "./taskStore";
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: "task-1",
+    task_number: 1,
+    slug: "task-1",
+    title: "A real task",
+    description: "Do the thing",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    origin_product: "tasks",
+    ...overrides,
+  };
+}
+
+describe("filterAndSortTasks", () => {
+  it("hides warm-sandbox placeholder tasks (no title and no description)", () => {
+    const placeholder = makeTask({ id: "warm", title: "", description: "" });
+    const real = makeTask({ id: "real" });
+
+    const result = filterAndSortTasks(
+      [placeholder, real],
+      "updated",
+      false,
+      "",
+    );
+
+    expect(result.map((t) => t.id)).toEqual(["real"]);
+  });
+
+  it("keeps a real task that only has a description (title not landed yet)", () => {
+    const pending = makeTask({
+      id: "pending",
+      title: "",
+      description: "Fix login",
+    });
+
+    const result = filterAndSortTasks([pending], "updated", false, "");
+
+    expect(result.map((t) => t.id)).toEqual(["pending"]);
+  });
+
+  it("keeps a task that only has a title", () => {
+    const titled = makeTask({
+      id: "titled",
+      title: "Fix login",
+      description: "",
+    });
+
+    const result = filterAndSortTasks([titled], "updated", false, "");
+
+    expect(result.map((t) => t.id)).toEqual(["titled"]);
+  });
+});

--- a/apps/mobile/src/features/tasks/stores/taskStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/taskStore.test.ts
@@ -17,41 +17,38 @@ function makeTask(overrides: Partial<Task>): Task {
 }
 
 describe("filterAndSortTasks", () => {
-  it("hides warm-sandbox placeholder tasks (no title and no description)", () => {
-    const placeholder = makeTask({ id: "warm", title: "", description: "" });
-    const real = makeTask({ id: "real" });
+  it.each([
+    { name: "empty title and description", title: "", description: "" },
+    { name: "whitespace-only fields", title: "   ", description: "\n\t" },
+  ])(
+    "hides warm-sandbox placeholder tasks ($name)",
+    ({ title, description }) => {
+      const placeholder = makeTask({ id: "warm", title, description });
+      const real = makeTask({ id: "real" });
 
-    const result = filterAndSortTasks(
-      [placeholder, real],
-      "updated",
-      false,
-      "",
-    );
+      const result = filterAndSortTasks(
+        [placeholder, real],
+        "updated",
+        false,
+        "",
+      );
 
-    expect(result.map((t) => t.id)).toEqual(["real"]);
-  });
+      expect(result.map((t) => t.id)).toEqual(["real"]);
+    },
+  );
 
-  it("keeps a real task that only has a description (title not landed yet)", () => {
-    const pending = makeTask({
-      id: "pending",
+  it.each([
+    {
+      name: "description only (title not landed yet)",
       title: "",
       description: "Fix login",
-    });
+    },
+    { name: "title only", title: "Fix login", description: "" },
+  ])("keeps a real task with $name", ({ title, description }) => {
+    const task = makeTask({ id: "real", title, description });
 
-    const result = filterAndSortTasks([pending], "updated", false, "");
+    const result = filterAndSortTasks([task], "updated", false, "");
 
-    expect(result.map((t) => t.id)).toEqual(["pending"]);
-  });
-
-  it("keeps a task that only has a title", () => {
-    const titled = makeTask({
-      id: "titled",
-      title: "Fix login",
-      description: "",
-    });
-
-    const result = filterAndSortTasks([titled], "updated", false, "");
-
-    expect(result.map((t) => t.id)).toEqual(["titled"]);
+    expect(result.map((t) => t.id)).toEqual(["real"]);
   });
 });

--- a/apps/mobile/src/features/tasks/stores/taskStore.ts
+++ b/apps/mobile/src/features/tasks/stores/taskStore.ts
@@ -1,3 +1,4 @@
+import { isContentlessTask } from "@posthog/shared/domain-types";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -126,6 +127,9 @@ export function filterAndSortTasks(
   filter: string,
 ): Task[] {
   let filtered = tasks;
+
+  // Warm-sandbox prewarming creates empty placeholder tasks; never surface them.
+  filtered = filtered.filter((task) => !isContentlessTask(task));
 
   // Visibility filter — mirrors desktop radio: External hides internal, Internal shows only internal.
   filtered = filtered.filter((task) =>


### PR DESCRIPTION
## Problem

While a user types a cloud-task prompt (with a repo selected), the app pre-warms a sandbox via the `/tasks/warm/` endpoint (`useWarmTask` → `warmTask`, added to mobile in #2928). The backend creates a **real but empty** placeholder cloud Task + TaskRun (no title, no description) just to warm the sandbox, and the returned `{ task_id, run_id }` is discarded client-side.

Mobile polls the full task list and renders every task it gets back. `filterAndSortTasks` did not exclude these content-less placeholders, so the empty, nameless warm-placeholder task appeared in the mobile task list — opening it only showed sandbox provisioning. This mirrors the desktop bug.

## Fix

Exclude content-less tasks in `filterAndSortTasks` (`apps/mobile/src/features/tasks/stores/taskStore.ts`) using the shared `isContentlessTask` predicate from `@posthog/shared` (no title **and** no description, after trimming). A genuinely created task always carries the submitted prompt as its `description`, so this only ever matches prewarm placeholders — never a real task, including one whose backend-generated title hasn't landed yet.

This ports desktop PR #2935, which added `isContentlessTask` to `@posthog/shared` and applied the same guard in the desktop cloud-workspace reconcile path. Only `apps/mobile` is touched here.

## Testing

- New `taskStore.test.ts` covers that content-less placeholders are filtered out and that real tasks (description-only or title-only) are kept.
- `pnpm test src/features/tasks/stores/ src/features/tasks/hooks/useTasks.test.ts` — 28 passed.
- `biome check` on the changed files — clean.