### PR TITLE
feat(mobile): warm sandbox on the selected model and runtime (port #2936)

### DIFF
--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -383,6 +383,9 @@ export default function NewTaskScreen() {
     repository: selection.repository,
     githubIntegrationId: selection.integrationId,
     composerIsEmpty: !hasContent,
+    runtimeAdapter: "claude",
+    model,
+    reasoningEffort: showReasoningPill ? reasoning : null,
   });
 
   if (isLoading && hasGithubIntegration === null) {

--- a/apps/mobile/src/features/tasks/api.ts
+++ b/apps/mobile/src/features/tasks/api.ts
@@ -306,6 +306,9 @@ export async function warmTask(options: {
   repository: string;
   github_integration: number;
   branch?: string | null;
+  runtime_adapter?: string | null;
+  model?: string | null;
+  reasoning_effort?: string | null;
 }): Promise<{ task_id: string; run_id: string } | null> {
   const baseUrl = getBaseUrl();
   const projectId = getProjectId();
@@ -318,6 +321,9 @@ export async function warmTask(options: {
         repository: options.repository,
         github_integration: options.github_integration,
         branch: options.branch ?? null,
+        runtime_adapter: options.runtime_adapter ?? null,
+        model: options.model ?? null,
+        reasoning_effort: options.reasoning_effort ?? null,
       }),
     },
   );

--- a/apps/mobile/src/features/tasks/api.warm.test.ts
+++ b/apps/mobile/src/features/tasks/api.warm.test.ts
@@ -51,6 +51,40 @@ describe("warmTask", () => {
           repository: "posthog/posthog",
           github_integration: 7,
           branch: "main",
+          runtime_adapter: null,
+          model: null,
+          reasoning_effort: null,
+        }),
+      }),
+    );
+  });
+
+  it("forwards the selected runtime, model, and reasoning effort", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task_id: "task-1", run_id: "run-1" }), {
+        status: 200,
+      }),
+    );
+
+    await warmTask({
+      repository: "posthog/posthog",
+      github_integration: 7,
+      branch: "main",
+      runtime_adapter: "claude",
+      model: "claude-opus-4-8",
+      reasoning_effort: "high",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://app.posthog.test/api/projects/42/tasks/warm/",
+      expect.objectContaining({
+        body: JSON.stringify({
+          repository: "posthog/posthog",
+          github_integration: 7,
+          branch: "main",
+          runtime_adapter: "claude",
+          model: "claude-opus-4-8",
+          reasoning_effort: "high",
         }),
       }),
     );
@@ -72,6 +106,9 @@ describe("warmTask", () => {
           repository: "posthog/posthog",
           github_integration: 7,
           branch: null,
+          runtime_adapter: null,
+          model: null,
+          reasoning_effort: null,
         }),
       }),
     );

--- a/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
+++ b/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
@@ -141,76 +141,62 @@ describe("useWarmTask", () => {
 
   it.each<{
     name: string;
+    initial?: Partial<Props>;
     change: Partial<Props>;
-    expectedRepository: string;
-    expectedBranch: string;
+    expected: Record<string, unknown>;
   }>([
     {
       name: "repository",
       change: { repository: "acme/other" },
-      expectedRepository: "acme/other",
-      expectedBranch: "main",
+      expected: {
+        repository: "acme/other",
+        github_integration: 42,
+        branch: "main",
+        ...NULL_RUNTIME,
+      },
     },
     {
       name: "branch",
       change: { branch: "feature/x" },
-      expectedRepository: "acme/repo",
-      expectedBranch: "feature/x",
+      expected: {
+        repository: "acme/repo",
+        github_integration: 42,
+        branch: "feature/x",
+        ...NULL_RUNTIME,
+      },
+    },
+    {
+      name: "model",
+      initial: {
+        runtimeAdapter: "claude",
+        model: "claude-opus-4-8",
+        reasoningEffort: "high",
+      },
+      change: { model: "claude-sonnet-4-6" },
+      expected: {
+        repository: "acme/repo",
+        github_integration: 42,
+        branch: "main",
+        runtime_adapter: "claude",
+        model: "claude-sonnet-4-6",
+        reasoning_effort: "high",
+      },
     },
   ])(
     "warms the new selection when the $name changes",
-    async ({ change, expectedRepository, expectedBranch }) => {
-      const { rerender } = render(composing);
+    async ({ initial, change, expected }) => {
+      const base = { ...composing, ...initial };
+      const { rerender } = render(base);
       await flushDebounce();
       expect(mockWarmTask).toHaveBeenCalledOnce();
 
-      rerender({ ...composing, ...change });
+      rerender({ ...base, ...change });
       await flushDebounce();
 
-      expect(mockWarmTask).toHaveBeenLastCalledWith({
-        repository: expectedRepository,
-        github_integration: 42,
-        branch: expectedBranch,
-        ...NULL_RUNTIME,
-      });
+      expect(mockWarmTask).toHaveBeenLastCalledWith(expected);
       expect(mockWarmTask).toHaveBeenCalledTimes(2);
     },
   );
-
-  it("forwards the selected runtime and re-warms when the model changes", async () => {
-    const { rerender } = render({
-      ...composing,
-      runtimeAdapter: "claude",
-      model: "claude-opus-4-8",
-      reasoningEffort: "high",
-    });
-    await flushDebounce();
-    expect(mockWarmTask).toHaveBeenLastCalledWith({
-      repository: "acme/repo",
-      github_integration: 42,
-      branch: "main",
-      runtime_adapter: "claude",
-      model: "claude-opus-4-8",
-      reasoning_effort: "high",
-    });
-
-    rerender({
-      ...composing,
-      runtimeAdapter: "claude",
-      model: "claude-sonnet-4-6",
-      reasoningEffort: "high",
-    });
-    await flushDebounce();
-    expect(mockWarmTask).toHaveBeenLastCalledWith({
-      repository: "acme/repo",
-      github_integration: 42,
-      branch: "main",
-      runtime_adapter: "claude",
-      model: "claude-sonnet-4-6",
-      reasoning_effort: "high",
-    });
-    expect(mockWarmTask).toHaveBeenCalledTimes(2);
-  });
 
   it("warms again for a new selection after a failed warm", async () => {
     mockWarmTask.mockRejectedValueOnce(new Error("boom"));

--- a/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
+++ b/apps/mobile/src/features/tasks/hooks/useWarmTask.test.tsx
@@ -29,6 +29,9 @@ interface Props {
   githubIntegrationId?: number | null;
   branch?: string | null;
   composerIsEmpty: boolean;
+  runtimeAdapter?: string | null;
+  model?: string | null;
+  reasoningEffort?: string | null;
 }
 
 const composing: Props = {
@@ -36,6 +39,12 @@ const composing: Props = {
   githubIntegrationId: 42,
   branch: "main",
   composerIsEmpty: false,
+};
+
+const NULL_RUNTIME = {
+  runtime_adapter: null,
+  model: null,
+  reasoning_effort: null,
 };
 
 function render(initial: Props) {
@@ -87,6 +96,7 @@ describe("useWarmTask", () => {
       repository: "acme/repo",
       github_integration: 42,
       branch: "main",
+      ...NULL_RUNTIME,
     });
   });
 
@@ -161,10 +171,46 @@ describe("useWarmTask", () => {
         repository: expectedRepository,
         github_integration: 42,
         branch: expectedBranch,
+        ...NULL_RUNTIME,
       });
       expect(mockWarmTask).toHaveBeenCalledTimes(2);
     },
   );
+
+  it("forwards the selected runtime and re-warms when the model changes", async () => {
+    const { rerender } = render({
+      ...composing,
+      runtimeAdapter: "claude",
+      model: "claude-opus-4-8",
+      reasoningEffort: "high",
+    });
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenLastCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "main",
+      runtime_adapter: "claude",
+      model: "claude-opus-4-8",
+      reasoning_effort: "high",
+    });
+
+    rerender({
+      ...composing,
+      runtimeAdapter: "claude",
+      model: "claude-sonnet-4-6",
+      reasoningEffort: "high",
+    });
+    await flushDebounce();
+    expect(mockWarmTask).toHaveBeenLastCalledWith({
+      repository: "acme/repo",
+      github_integration: 42,
+      branch: "main",
+      runtime_adapter: "claude",
+      model: "claude-sonnet-4-6",
+      reasoning_effort: "high",
+    });
+    expect(mockWarmTask).toHaveBeenCalledTimes(2);
+  });
 
   it("warms again for a new selection after a failed warm", async () => {
     mockWarmTask.mockRejectedValueOnce(new Error("boom"));

--- a/apps/mobile/src/features/tasks/hooks/useWarmTask.ts
+++ b/apps/mobile/src/features/tasks/hooks/useWarmTask.ts
@@ -13,6 +13,9 @@ interface UseWarmTaskOptions {
   githubIntegrationId?: number | null;
   branch?: string | null;
   composerIsEmpty: boolean;
+  runtimeAdapter?: string | null;
+  model?: string | null;
+  reasoningEffort?: string | null;
 }
 
 export function useWarmTask({
@@ -20,6 +23,9 @@ export function useWarmTask({
   githubIntegrationId,
   branch,
   composerIsEmpty,
+  runtimeAdapter,
+  model,
+  reasoningEffort,
 }: UseWarmTaskOptions): void {
   const enabled = useFeatureFlag(TASKS_PREWARM_SANDBOX_FLAG);
 
@@ -27,6 +33,9 @@ export function useWarmTask({
   const lastWarmedKeyRef = useRef<string | null>(null);
 
   const normalizedBranch = branch ?? null;
+  const normalizedRuntimeAdapter = runtimeAdapter ?? null;
+  const normalizedModel = model ?? null;
+  const normalizedReasoningEffort = reasoningEffort ?? null;
   const eligible =
     !!enabled &&
     !!repository &&
@@ -34,7 +43,7 @@ export function useWarmTask({
     !composerIsEmpty;
   const key =
     repository && githubIntegrationId != null
-      ? `${githubIntegrationId}:${repository}:${normalizedBranch ?? ""}`
+      ? `${githubIntegrationId}:${repository}:${normalizedBranch ?? ""}:${normalizedRuntimeAdapter ?? ""}:${normalizedModel ?? ""}:${normalizedReasoningEffort ?? ""}`
       : null;
 
   useEffect(() => {
@@ -56,6 +65,9 @@ export function useWarmTask({
     const repo = repository;
     const githubIntegration = githubIntegrationId;
     const warmBranch = normalizedBranch;
+    const warmRuntimeAdapter = normalizedRuntimeAdapter;
+    const warmModel = normalizedModel;
+    const warmReasoningEffort = normalizedReasoningEffort;
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
       lastWarmedKeyRef.current = key;
@@ -63,6 +75,9 @@ export function useWarmTask({
         repository: repo,
         github_integration: githubIntegration,
         branch: warmBranch,
+        runtime_adapter: warmRuntimeAdapter,
+        model: warmModel,
+        reasoning_effort: warmReasoningEffort,
       }).catch((error) => {
         lastWarmedKeyRef.current = null;
         log.warn("Failed to warm task", error);
@@ -70,5 +85,14 @@ export function useWarmTask({
     }, WARM_DEBOUNCE_MS);
 
     return clearDebounce;
-  }, [eligible, key, repository, githubIntegrationId, normalizedBranch]);
+  }, [
+    eligible,
+    key,
+    repository,
+    githubIntegrationId,
+    normalizedBranch,
+    normalizedRuntimeAdapter,
+    normalizedModel,
+    normalizedReasoningEffort,
+  ]);
 }


### PR DESCRIPTION
## Problem

When composing a new cloud task, mobile pre-warms a sandbox in the background. The warm request only carried `repository`, `github_integration`, and `branch`, so the backend could provision the sandbox on a default runtime/model rather than the one the user actually selected. On submit the task reused that mismatched sandbox, wasting the warm.

## Change

Ports desktop PR #2936 ("feat(cloud-tasks): warm sandbox on the selected runtime and model") to `apps/mobile`:

- `warmTask` (api.ts) accepts optional `runtime_adapter`, `model`, `reasoning_effort` and includes them in the POST body, sending `null` when absent — matching the desktop wire shape.
- `useWarmTask` accepts `runtimeAdapter`, `model`, `reasoningEffort` and forwards them, folding them into the dedup key so changing the model (or reasoning effort) re-warms.
- The composer passes the currently-selected `model`, runtime adapter (`"claude"`), and reasoning effort.

Mobile's runtime is Claude-only, so `runtime_adapter` is effectively always `"claude"`; the meaningful part is the selected `model` and `reasoning_effort`.

## Tests

Extended `api.warm.test.ts` and `useWarmTask.test.tsx` to cover the new fields (forwarded when set, `null` when absent, and re-warm on model change). Mobile warm tests pass; lint clean on the changed scope.