### PR TITLE
feat(settings): allow resizing personalization textarea

### DIFF
--- a/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
@@ -59,6 +59,7 @@ export function PersonalizationSettings() {
         placeholder="e.g. Always write tests for new code. Prefer functional patterns."
         rows={6}
         size="1"
+        resize="vertical"
         className="w-full"
       />
       <Text color="gray" align="right" className="text-[13px]">


### PR DESCRIPTION
## Problem

The personalization custom-instructions textarea was a fixed height, making it awkward to edit longer prompts.

## Changes

- Added `resize="vertical"` to the personalization `TextArea` so users can drag it taller for bigger prompts.
- Kept `rows={6}` as the default starting height; vertical-only resize preserves the `w-full` layout.

## How did you test this?

- Typecheck passed (via pre-commit hook).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*