### PR TITLE
chore(agent): log agent-server boot timing (bootMs)

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -423,7 +423,11 @@ describe("AgentServer HTTP Mode", () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toEqual({ status: "ok", hasSession: true });
+      expect(body).toEqual({
+        status: "ok",
+        hasSession: true,
+        bootMs: expect.any(Number),
+      });
     }, 30000);
   });
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -249,6 +249,7 @@ function getTaskRunStateString(
 
 export class AgentServer {
   private config: AgentServerConfig;
+  private sessionReadyBootMs?: number;
   private logger: Logger;
   private server: ServerType | null = null;
   private session: ActiveSession | null = null;
@@ -364,7 +365,11 @@ export class AgentServer {
     const app = new Hono();
 
     app.get("/health", (c) => {
-      return c.json({ status: "ok", hasSession: !!this.session });
+      return c.json({
+        status: "ok",
+        hasSession: !!this.session,
+        bootMs: this.sessionReadyBootMs,
+      });
     });
 
     app.get("/events", async (c) => {
@@ -1226,8 +1231,9 @@ export class AgentServer {
       },
     });
 
+    this.sessionReadyBootMs = Math.round(process.uptime() * 1000);
     this.logger.debug("Session initialized successfully", {
-      bootMs: Math.round(process.uptime() * 1000),
+      bootMs: this.sessionReadyBootMs,
     });
     this.logger.debug(
       `Agent version: ${this.config.version ?? packageJson.version}`,

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -558,6 +558,7 @@ export class AgentServer {
         () => {
           this.logger.debug(
             `HTTP server listening on port ${this.config.port}`,
+            { bootMs: Math.round(process.uptime() * 1000) },
           );
           resolve();
         },
@@ -1225,7 +1226,9 @@ export class AgentServer {
       },
     });
 
-    this.logger.debug("Session initialized successfully");
+    this.logger.debug("Session initialized successfully", {
+      bootMs: Math.round(process.uptime() * 1000),
+    });
     this.logger.debug(
       `Agent version: ${this.config.version ?? packageJson.version}`,
     );


### PR DESCRIPTION
## Problem

Cloud-task agent-server spawn time, from node process start to a usable session (`hasSession=true`, what the backend health poll waits on) is currently unmeasured, so we're optimizing it blind. We want to land lightweight timing first and verify where boot time actually goes in production before shipping any speedups.

## Changes

Add `bootMs` (wall-clock since process start, via `process.uptime()`) to two existing agent-server log lines:

- **"HTTP server listening"** — process start → HTTP accepting (node boot + bundle/SDK parse)
- **"Session initialized successfully"** — process start → `hasSession=true` (the full spawn)
