### PR TITLE
feat(ui): show workspace mode badge in task header

### DIFF
--- a/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -128,6 +128,11 @@ export function TaskDetail({
       channelName ? (
         <ChannelBreadcrumb
           channelName={channelName}
+          leafIcon={
+            workspaceMode ? (
+              <WorkspaceModeBadge mode={workspaceMode} />
+            ) : undefined
+          }
           leafLabel={task.title}
           onRename={handleTitleEditSubmit}
           trailing={trailing}

--- a/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -23,6 +23,7 @@ import { useWorkspaceEvents } from "../../workspace/useWorkspaceEvents";
 import { HeaderTitleEditor } from "../HeaderTitleEditor";
 import { useTaskData } from "../hooks/useTaskData";
 import { ExternalAppsOpener } from "./ExternalAppsOpener";
+import { WorkspaceModeBadge } from "./WorkspaceModeBadge";
 
 const MIN_REVIEW_WIDTH = 300;
 const log = logger.scope("task-detail");
@@ -117,6 +118,8 @@ export function TaskDetail({
   const trailing = openTargetPath ? (
     <ExternalAppsOpener targetPath={openTargetPath} />
   ) : null;
+  const workspace = useWorkspace(taskId);
+  const workspaceMode = workspace?.mode;
   const headerContent = useMemo(
     () =>
       // Inside a channel, prefix the editable title with the channel
@@ -138,15 +141,18 @@ export function TaskDetail({
               onCancel={handleTitleEditCancel}
             />
           ) : (
-            <Tooltip content={task.title} side="bottom" delayDuration={300}>
-              <Text
-                truncate
-                className="no-drag min-w-0 font-medium text-[13px]"
-                onDoubleClick={() => setIsEditingTitle(true)}
-              >
-                {task.title}
-              </Text>
-            </Tooltip>
+            <Flex align="center" gap="2" minWidth="0">
+              <WorkspaceModeBadge mode={workspaceMode} />
+              <Tooltip content={task.title} side="bottom" delayDuration={300}>
+                <Text
+                  truncate
+                  className="no-drag min-w-0 font-medium text-[13px]"
+                  onDoubleClick={() => setIsEditingTitle(true)}
+                >
+                  {task.title}
+                </Text>
+              </Tooltip>
+            </Flex>
           )}
           {trailing}
         </Flex>
@@ -156,6 +162,7 @@ export function TaskDetail({
       task.title,
       trailing,
       isEditingTitle,
+      workspaceMode,
       handleTitleEditSubmit,
       handleTitleEditCancel,
     ],
@@ -166,7 +173,6 @@ export function TaskDetail({
   const reviewMode = useReviewNavigationStore(
     (s) => s.reviewModes[taskId] ?? "closed",
   );
-  const workspace = useWorkspace(taskId);
   const isCloud =
     workspace?.mode === "cloud" || task.latest_run?.environment === "cloud";
 

--- a/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
+++ b/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
@@ -26,7 +26,7 @@ const MODE_META: Record<
   },
   cloud: {
     Icon: Cloud,
-    label: "Cloud — runs in the cloud",
+    label: "Cloud — runs on a remote machine",
     color: "var(--accent-11)",
   },
 };

--- a/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
+++ b/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
@@ -2,14 +2,6 @@ import { Cloud, GitFork, HardDrives } from "@phosphor-icons/react";
 import type { WorkspaceMode } from "@posthog/shared";
 import { Tooltip } from "../../../primitives/Tooltip";
 
-// Visual identity for each workspace mode, so a task's location (running on the
-// local checkout, in an isolated git worktree, or in the cloud) is legible at a
-// glance from the header without opening anything.
-//
-// Cloud mirrors the sidebar TaskIcon (Cloud glyph, accent). Worktree uses
-// GitFork rather than GitBranch on purpose: the sidebar already uses an amber
-// GitBranch to mean "has uncommitted changes", so reusing it here would be
-// ambiguous. Worktree gets teal — a hue none of the sidebar status icons use.
 const MODE_META: Record<
   WorkspaceMode,
   { Icon: typeof Cloud; label: string; color: string }
@@ -31,11 +23,6 @@ const MODE_META: Record<
   },
 };
 
-/**
- * Small icon shown before the task title that distinguishes where a task runs:
- * local working copy, isolated git worktree, or cloud. Renders nothing until
- * the workspace mode is known so it never flickers a wrong indicator.
- */
 export function WorkspaceModeBadge({ mode }: { mode?: WorkspaceMode }) {
   if (!mode) return null;
   const { Icon, label, color } = MODE_META[mode];

--- a/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
+++ b/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
@@ -36,19 +36,13 @@ const MODE_META: Record<
  * local working copy, isolated git worktree, or cloud. Renders nothing until
  * the workspace mode is known so it never flickers a wrong indicator.
  */
-export function WorkspaceModeBadge({
-  mode,
-  size = 13,
-}: {
-  mode?: WorkspaceMode;
-  size?: number;
-}) {
+export function WorkspaceModeBadge({ mode }: { mode?: WorkspaceMode }) {
   if (!mode) return null;
   const { Icon, label, color } = MODE_META[mode];
   return (
     <Tooltip content={label} side="bottom" delayDuration={300}>
       <span className="no-drag flex shrink-0 items-center justify-center">
-        <Icon size={size} weight="fill" color={color} />
+        <Icon size={13} weight="fill" color={color} />
       </span>
     </Tooltip>
   );

--- a/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
+++ b/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
@@ -1,0 +1,55 @@
+import { Cloud, GitFork, HardDrives } from "@phosphor-icons/react";
+import type { WorkspaceMode } from "@posthog/shared";
+import { Tooltip } from "../../../primitives/Tooltip";
+
+// Visual identity for each workspace mode, so a task's location (running on the
+// local checkout, in an isolated git worktree, or in the cloud) is legible at a
+// glance from the header without opening anything.
+//
+// Cloud mirrors the sidebar TaskIcon (Cloud glyph, accent). Worktree uses
+// GitFork rather than GitBranch on purpose: the sidebar already uses an amber
+// GitBranch to mean "has uncommitted changes", so reusing it here would be
+// ambiguous. Worktree gets teal — a hue none of the sidebar status icons use.
+const MODE_META: Record<
+  WorkspaceMode,
+  { Icon: typeof Cloud; label: string; color: string }
+> = {
+  local: {
+    Icon: HardDrives,
+    label: "Local — runs on your working copy",
+    color: "var(--gray-10)",
+  },
+  worktree: {
+    Icon: GitFork,
+    label: "Worktree — runs in an isolated git worktree",
+    color: "var(--teal-11)",
+  },
+  cloud: {
+    Icon: Cloud,
+    label: "Cloud — runs in the cloud",
+    color: "var(--accent-11)",
+  },
+};
+
+/**
+ * Small icon shown before the task title that distinguishes where a task runs:
+ * local working copy, isolated git worktree, or cloud. Renders nothing until
+ * the workspace mode is known so it never flickers a wrong indicator.
+ */
+export function WorkspaceModeBadge({
+  mode,
+  size = 13,
+}: {
+  mode?: WorkspaceMode;
+  size?: number;
+}) {
+  if (!mode) return null;
+  const { Icon, label, color } = MODE_META[mode];
+  return (
+    <Tooltip content={label} side="bottom" delayDuration={300}>
+      <span className="no-drag flex shrink-0 items-center justify-center">
+        <Icon size={size} weight="fill" color={color} />
+      </span>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Problem:
When running different tasks, some on local, on cloud, worktrees, its hard to tell which one is running where.

## Solution

Adds a small icon before the task title showing where a task runs: local, worktree, or cloud. The mode was already 

known (`useWorkspace().mode`) but nothing showed it.

<img width="1316" height="242" alt="CleanShot 2026-06-26 at 14 25 25@2x" src="https://github.com/user-attachments/assets/b9fdcc42-8b0f-4fea-b1c1-ba93908b1da7" />
<img width="1466" height="364" alt="CleanShot 2026-06-26 at 14 25 36@2x" src="https://github.com/user-attachments/assets/14bb92f7-5d81-4ef4-ad3f-ef7b90e17dc3" />
<img width="752" height="156" alt="CleanShot 2026-06-26 at 14 25 45@2x" src="https://github.com/user-attachments/assets/dbfb6101-65f6-4eff-ac9b-725fb7cac262" />


| Mode | Icon |
|------|------|
| Local | `HardDrives` (gray) |
| Worktree | `GitFork` (teal) |
| Cloud | `Cloud` (accent) |

Hover for a tooltip. Shows in both the plain and channel (`# channel / title`) headers.