### PR TITLE
chore: remove stale sonner references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,6 @@ See [docs/conventions.md](./docs/conventions.md).
 - TanStack Query, TanStack Router
 - Zustand, InversifyJS (with `@inversifyjs/strongly-typed`), Zod
 - xterm.js, CodeMirror, Tiptap
-- Sonner
 
 ## Testing
 

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -41,7 +41,7 @@ import {
 } from "@posthog/ui/features/settings/settingsStore";
 import { useCreateTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
 import { Badge } from "@posthog/ui/primitives/Badge";
-import { toast as sonnerToast, toast } from "@posthog/ui/primitives/toast";
+import { toast } from "@posthog/ui/primitives/toast";
 import { openTask } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { logger } from "@posthog/ui/shell/logger";
@@ -314,7 +314,7 @@ function SetupTaskSection() {
       const model = resolvedModel ?? settings.lastUsedModel;
 
       if (!model) {
-        sonnerToast.dismiss(toastId);
+        toast.dismiss(toastId);
         trackSetupFailure();
         toast.error("Failed to start Self-driving setup", {
           description:
@@ -349,7 +349,7 @@ function SetupTaskSection() {
         void openTask(output.task);
       });
 
-      sonnerToast.dismiss(toastId);
+      toast.dismiss(toastId);
       track(ANALYTICS_EVENTS.AGENTS_ACTION, {
         action_type: "run_setup_agent",
         success: result.success,
@@ -375,7 +375,7 @@ function SetupTaskSection() {
         });
       }
     } catch (error) {
-      sonnerToast.dismiss(toastId);
+      toast.dismiss(toastId);
       track(ANALYTICS_EVENTS.AGENTS_ACTION, {
         action_type: "run_setup_agent",
         success: false,

--- a/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -15,7 +15,7 @@ import { resolveDefaultModel } from "@posthog/ui/features/inbox/hooks/resolveDef
 import { useUserRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useCreateTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
-import { toast as sonnerToast, toast } from "@posthog/ui/primitives/toast";
+import { toast } from "@posthog/ui/primitives/toast";
 import { openTask } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { logger } from "@posthog/ui/shell/logger";
@@ -150,7 +150,7 @@ export function useInboxCloudTaskRunner({
     const model = resolvedModel ?? settings.lastUsedModel;
 
     if (!model) {
-      sonnerToast.dismiss(toastId);
+      toast.dismiss(toastId);
       toast.error(copy.errorTitle, { description: copy.missingModel });
       setIsRunning(false);
       return;
@@ -186,7 +186,7 @@ export function useInboxCloudTaskRunner({
       });
 
       if (result.success) {
-        sonnerToast.dismiss(toastId);
+        toast.dismiss(toastId);
         if (!redirectOnSuccess) {
           const task = createdTask;
           toast.success(copy.successTitle ?? "Task started", {
@@ -217,7 +217,7 @@ export function useInboxCloudTaskRunner({
           ...analyticsExtras,
         });
       } else {
-        sonnerToast.dismiss(toastId);
+        toast.dismiss(toastId);
         // Usage-limit blocks already show the upgrade modal; don't double-toast.
         if (!isUsageLimitResult(result)) {
           toast.error(copy.errorTitle, { description: result.error });
@@ -230,7 +230,7 @@ export function useInboxCloudTaskRunner({
         }
       }
     } catch (error) {
-      sonnerToast.dismiss(toastId);
+      toast.dismiss(toastId);
       const description =
         error instanceof Error ? error.message : "Unknown error";
       toast.error(copy.errorTitle, { description });

--- a/packages/ui/src/primitives/toast.tsx
+++ b/packages/ui/src/primitives/toast.tsx
@@ -3,7 +3,7 @@ import { toast as quillToast } from "@posthog/quill";
 // Thin wrapper over quill's toast so the whole app shares one import and a
 // stable `(title, options)` signature. Quill (base-ui under the hood) owns
 // rendering, stacking, auto-dismiss, hover-to-pause, and the close button —
-// which is why this exists instead of a hand-rolled sonner custom toast.
+// which is why this exists instead of a hand-rolled custom toast.
 
 export interface ToastAction {
   label: string;
@@ -13,7 +13,7 @@ export interface ToastAction {
 export interface ToastOptions {
   description?: string;
   // A caller-chosen stable id: upserts (creates or replaces) the toast with
-  // that id so it never stacks — matching sonner's `{ id }`. quill itself can't
+  // that id so it never stacks. quill itself can't
   // pick an id at create time, so the wrapper maps it (see idRegistry).
   id?: string;
   action?: ToastAction;
@@ -22,8 +22,8 @@ export interface ToastOptions {
   duration?: number;
 }
 
-// The second argument may be a bare description string (sonner-style shorthand)
-// or the full options object.
+// The second argument may be a bare description string (shorthand) or the full
+// options object.
 type Detail = string | ToastOptions;
 
 type Level = "success" | "error" | "info" | "warning" | "loading";


### PR DESCRIPTION
Toasts now route through `@posthog/quill`, not sonner. This clears the leftover references:

- Drop the redundant `toast as sonnerToast` import aliases in `useInboxCloudTaskRunner.ts` and `ConfigureAgentsSection.tsx`; `sonnerToast.dismiss` → `toast.dismiss`.
- Reword the three sonner-mentioning comments in the `toast.tsx` quill wrapper.
- Remove `Sonner` from the Key Libraries list in `AGENTS.md` (CLAUDE.md symlinks to it).

No behavior change — pure cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)