### PR TITLE
fix(folder-picker): import toast from ui primitive, not sonner

### DIFF
--- a/packages/ui/src/features/folder-picker/FolderPicker.tsx
+++ b/packages/ui/src/features/folder-picker/FolderPicker.tsx
@@ -26,10 +26,10 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
+import { toast } from "@posthog/ui/primitives/toast";
 import { FIELD_TRIGGER_CLASS } from "@posthog/ui/styles/fieldTrigger";
 import { Flex, Text } from "@radix-ui/themes";
 import { type RefObject, useState } from "react";
-import { toast } from "sonner";
 
 interface FolderPickerProps {
   value: string;


### PR DESCRIPTION
## Problem

`packages/ui/src/features/folder-picker/FolderPicker.tsx` imports `toast` from
`sonner`, but `sonner` was removed as a dependency in #2958 ("remove stale sonner
references") and is not declared in any `package.json` nor present in the
lockfile. #2859 then re-introduced the `sonner` import, so current `main` fails
`build`, `typecheck`, `unit-test`, and `integration-test` for everyone.

**Why:** unblock CI / local builds on `main`.

## Changes

Import `toast` from the canonical `@posthog/ui/primitives/toast` (the same
`toast.error(title, { description })` API used by the other 66 call sites in the
codebase). One-line change; no behavior change.

## How did you test this?

- Confirmed `sonner` is undeclared in every `package.json` and absent from the
  lockfile, and that `FolderPicker.tsx` is the only remaining `sonner` importer.
- Verified the `@posthog/ui/primitives/toast` `toast.error(title, { description })`
  signature matches the existing call.
- `biome check` clean on the changed file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
