### PR TITLE
fix(canvas): send runtime_adapter + model on cloud canvas runs

### DIFF
--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -312,11 +312,15 @@ export class TaskCreationSaga extends Saga<
               pendingUserMessage,
             );
           }
+          // A cloud run always needs an explicit runtime adapter — the API rejects
+          // `initial_permission_mode` unless `runtime_adapter` is set. Callers that don't pick one
+          // (e.g. canvas generation) default to claude, matching the local-connect default below.
+          const cloudAdapter = input.adapter ?? "claude";
           const taskRun = await this.deps.posthogClient.createTaskRun(task.id, {
             environment: "cloud",
             mode: "interactive",
             branch,
-            adapter: input.adapter,
+            adapter: cloudAdapter,
             model: input.model,
             reasoningLevel: input.reasoningLevel,
             sandboxEnvironmentId: input.sandboxEnvironmentId,
@@ -324,10 +328,9 @@ export class TaskCreationSaga extends Saga<
             runSource: input.cloudRunSource ?? "manual",
             signalReportId: input.signalReportId,
             homeQuickAction: input.homeQuickActionLabel,
-            initialPermissionMode: input.adapter
-              ? (input.executionMode ??
-                (input.adapter === "codex" ? "auto" : "plan"))
-              : input.executionMode,
+            initialPermissionMode:
+              input.executionMode ??
+              (cloudAdapter === "codex" ? "auto" : "plan"),
           });
           if (!taskRun?.id) {
             throw new Error("Failed to create cloud run");

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -1,3 +1,7 @@
+import {
+  REPORT_MODEL_RESOLVER,
+  type ReportModelResolver,
+} from "@posthog/core/inbox/identifiers";
 import { TITLE_GENERATOR_SERVICE } from "@posthog/core/sessions/titleGeneratorIdentifiers";
 import type { TitleGeneratorService } from "@posthog/core/sessions/titleGeneratorService";
 import {
@@ -6,7 +10,8 @@ import {
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
-import type { WorkspaceMode } from "@posthog/shared";
+import { getCloudUrlFromRegion, type WorkspaceMode } from "@posthog/shared";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { buildFreeformGenerationPrompt } from "@posthog/ui/features/canvas/freeformPrompt";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import {
@@ -37,6 +42,8 @@ export function useGenerateFreeformCanvas(args: {
 }) {
   const { dashboardId, channelId, name, channelName, templateId } = args;
   const taskService = useService<TaskService>(TASK_SERVICE);
+  const modelResolver = useService<ReportModelResolver>(REPORT_MODEL_RESOLVER);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const titleGenerator = useService<TitleGeneratorService>(
     TITLE_GENERATOR_SERVICE,
   );
@@ -64,6 +71,33 @@ export function useGenerateFreeformCanvas(args: {
     }): Promise<string | null> => {
       setIsStarting(true);
       try {
+        // Defaults to a cloud run — canvas generation should never tie up (or
+        // depend on) the local machine, and it's never the sticky last-used
+        // workspace mode. The dev-only picker can override to "local" to test a
+        // local build of these features before merging.
+        const workspaceMode = opts.workspaceMode ?? "cloud";
+
+        // A cloud run requires an explicit adapter + model (the API rejects a
+        // cloud runtime without a model). Canvas has no model picker, so resolve
+        // the adapter's server default the same way the inbox one-click flows do
+        // — the resolver validates against the gateway, so a stale id can't slip
+        // through and 403 the run.
+        let model: string | undefined;
+        if (workspaceMode === "cloud") {
+          model = cloudRegion
+            ? await modelResolver.resolveDefaultModel(
+                getCloudUrlFromRegion(cloudRegion),
+                "claude",
+              )
+            : undefined;
+          if (!model) {
+            toast.error("Couldn't start canvas generation", {
+              description: "No model is configured for cloud runs.",
+            });
+            return null;
+          }
+        }
+
         const result = await taskService.createTask(
           {
             content: buildFreeformGenerationPrompt({
@@ -78,11 +112,9 @@ export function useGenerateFreeformCanvas(args: {
             taskDescription: `Generate canvas "${name}"`,
             // Unattended generation: run in auto mode so it doesn't stall on edit-approval prompts.
             executionMode: "auto" as const,
-            // Defaults to a cloud run — canvas generation should never tie up
-            // (or depend on) the local machine, and it's never the sticky
-            // last-used workspace mode. The dev-only picker can override to
-            // "local" to test a local build of these features before merging.
-            workspaceMode: opts.workspaceMode ?? "cloud",
+            workspaceMode,
+            adapter: "claude",
+            model,
             allowNoRepo: true,
             channelContext,
             channelName,
@@ -138,6 +170,8 @@ export function useGenerateFreeformCanvas(args: {
     },
     [
       taskService,
+      modelResolver,
+      cloudRegion,
       titleGenerator,
       trpc,
       queryClient,


### PR DESCRIPTION
## Problem

Creating a canvas failed with two sequential `400 validation_error`s from the cloud create-run endpoint:

1. `This field requires runtime_adapter to be set.` (attr: `initial_permission_mode`)
2. `This field is required when selecting a cloud runtime.` (attr: `model`)

Canvas generation kicks off a **cloud run** but never picks an adapter or model (there's no picker — it's unattended generation), so the request body carried `initial_permission_mode` with no `runtime_adapter`, and once that was fixed, no `model`.

## Fix

- **`taskCreationSaga.ts`** — the cloud-run path only set `runtime_adapter` when an adapter was explicitly chosen, but always sent `initial_permission_mode`. Default the cloud adapter to `claude` (matching the existing local-connect default) so `runtime_adapter` is always present, and simplify the permission-mode default now that the adapter is always known.
- **`useGenerateFreeformCanvas.ts`** — resolve the adapter's server-default `model` via the shared `REPORT_MODEL_RESOLVER` (the same pattern the inbox one-click flows use; the resolver validates against the gateway so a stale id can't 403 the run) and pass `adapter` + `model` into the cloud run. Only resolves for cloud runs; surfaces a toast if no model is configured.

## Testing

- `@posthog/core` typecheck + `taskCreationSaga` tests (14) pass.
- `@posthog/ui` typecheck + Biome lint clean on the changed files.
- Verified manually: canvas creation now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)