### PR TITLE
feat(agent): overlap repo clone with boot via repo-ready barrier

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -38,7 +38,7 @@ import {
   SIGNED_REWRITE_QUALIFIED_TOOL_NAME,
 } from "../adapters/signed-commit-shared";
 import type { PermissionMode } from "../execution-mode";
-import { DEFAULT_CODEX_MODEL } from "../gateway-models";
+import { DEFAULT_CODEX_MODEL, fetchGatewayModels } from "../gateway-models";
 import { HandoffCheckpointTracker } from "../handoff-checkpoint";
 import { PostHogAPIClient } from "../posthog-api";
 import { findPrUrl, wasCreatedRecently } from "../pr-url-detector";
@@ -1054,6 +1054,12 @@ export class AgentServer {
       taskTitle: preTask?.title,
     });
 
+    if (this.config.repoReadyFile && gatewayEnv.anthropicBaseUrl) {
+      void fetchGatewayModels({
+        gatewayUrl: gatewayEnv.anthropicBaseUrl,
+      }).catch(() => {});
+    }
+
     const prUrl = getTaskRunStateString(preTaskRun, "slack_notified_pr_url");
 
     // Unconditional so a re-init on the same instance drops a stale PR URL.
@@ -1186,6 +1192,8 @@ export class AgentServer {
       ...(this.config.baseBranch && { baseBranch: this.config.baseBranch }),
       ...this.buildClaudeCodeSessionMeta(runtimeAdapter),
     };
+
+    await this.waitForRepoReady();
 
     const nativeResume = await this.prepareNativeResume(
       payload,
@@ -1844,6 +1852,34 @@ export class AgentServer {
     const baseName = basename(name).trim();
     const normalizedName = baseName.replace(/[^\w.-]/g, "_");
     return normalizedName.length > 0 ? normalizedName : "attachment";
+  }
+
+  private async waitForRepoReady(): Promise<void> {
+    const readyFile = this.config.repoReadyFile;
+    if (!readyFile) return;
+
+    const REPO_READY_TIMEOUT_MS = 5 * 60_000;
+    const POLL_MS = 100;
+    const startedAt = Date.now();
+
+    for (;;) {
+      try {
+        await access(readyFile);
+        this.logger.debug("Repo-ready barrier released", {
+          readyFile,
+          waitedMs: Date.now() - startedAt,
+        });
+        return;
+      } catch {}
+      if (Date.now() - startedAt > REPO_READY_TIMEOUT_MS) {
+        this.logger.warn("Repo-ready barrier timed out; proceeding", {
+          readyFile,
+          waitedMs: Date.now() - startedAt,
+        });
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+    }
   }
 
   private async autoInitializeSession(): Promise<void> {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1861,6 +1861,7 @@ export class AgentServer {
     const REPO_READY_TIMEOUT_MS = 5 * 60_000;
     const POLL_MS = 100;
     const startedAt = Date.now();
+    let loggedUnexpectedError = false;
 
     for (;;) {
       try {
@@ -1870,7 +1871,17 @@ export class AgentServer {
           waitedMs: Date.now() - startedAt,
         });
         return;
-      } catch {}
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        if (code !== "ENOENT" && !loggedUnexpectedError) {
+          loggedUnexpectedError = true;
+          this.logger.debug("Repo-ready barrier access error; still polling", {
+            readyFile,
+            code,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
       if (Date.now() - startedAt > REPO_READY_TIMEOUT_MS) {
         this.logger.warn("Repo-ready barrier timed out; proceeding", {
           readyFile,

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -89,6 +89,10 @@ program
     "interactive",
   )
   .option("--repositoryPath <path>", "Path to the repository")
+  .option(
+    "--repoReadyFile <path>",
+    "Sentinel file; session creation blocks until it exists (set while cloning concurrently)",
+  )
   .requiredOption("--taskId <id>", "Task ID")
   .requiredOption("--runId <id>", "Task run ID")
   .option(
@@ -161,6 +165,7 @@ program
       eventIngestStreamWindowMs:
         env.POSTHOG_TASK_RUN_EVENT_INGEST_STREAM_WINDOW_MS,
       repositoryPath: options.repositoryPath,
+      repoReadyFile: options.repoReadyFile,
       apiUrl: env.POSTHOG_API_URL,
       apiKey: env.POSTHOG_PERSONAL_API_KEY,
       projectId: env.POSTHOG_PROJECT_ID,

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -11,6 +11,7 @@ export interface ClaudeCodeConfig {
 export interface AgentServerConfig {
   port: number;
   repositoryPath?: string;
+  repoReadyFile?: string;
   apiUrl: string;
   apiKey: string;
   projectId: number;


### PR DESCRIPTION
## What

The agent-server boot and the repo clone run sequentially today: the backend clones the repo into the sandbox, then starts the agent-server, then the agent-server creates the adapter session. This adds a `--repoReadyFile` sentinel so the agent-server can boot concurrently with the clone
## Changes

- `--repoReadyFile <path>` flag + `repoReadyFile` config. When set, `createSession` blocks in `waitForRepoReady()` 
- while waiting, prefetch the gateway model list (`fetchGatewayModels`) so that round-trip overlaps the clone instead of landing on the session-init critical path