### PR TITLE
feat(scouts): scout scratchpad browse surface

### DIFF
--- a/packages/core/src/scouts/scoutScratchpad.test.ts
+++ b/packages/core/src/scouts/scoutScratchpad.test.ts
@@ -1,0 +1,120 @@
+import type { ScoutScratchpadEntry } from "@posthog/api-client/posthog-client";
+import { describe, expect, it } from "vitest";
+import {
+  filterScratchpadEntries,
+  groupScratchpadEntries,
+  humanizeNamespace,
+  scoutDisplayName,
+  scratchpadNamespaceOf,
+  splitScratchpadKey,
+} from "./scoutScratchpad";
+
+function entry(
+  key: string,
+  content: string,
+  updatedAt: string,
+): ScoutScratchpadEntry {
+  return {
+    key,
+    content,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    created_by_run_id: null,
+  };
+}
+
+describe("scratchpadNamespaceOf", () => {
+  it.each([
+    ["tags:errors:taxonomy", "tags"],
+    ["dedupe:abc", "dedupe"],
+    ["no-namespace", "general"],
+    [":leading-colon", "general"],
+  ])("%s → %s", (key, expected) => {
+    expect(scratchpadNamespaceOf(key)).toBe(expected);
+  });
+});
+
+describe("humanizeNamespace", () => {
+  it.each([
+    ["general", "General"],
+    ["tags", "Tags"],
+    ["watch-list", "Watch List"],
+    ["error_tracking", "Error Tracking"],
+  ])("%s → %s", (namespace, expected) => {
+    expect(humanizeNamespace(namespace)).toBe(expected);
+  });
+});
+
+describe("splitScratchpadKey", () => {
+  it("splits on the first colon", () => {
+    expect(splitScratchpadKey("tags:errors:taxonomy")).toEqual({
+      kind: "tags",
+      body: "errors:taxonomy",
+    });
+  });
+
+  it("returns a null kind for keys without a prefix", () => {
+    expect(splitScratchpadKey("standalone")).toEqual({
+      kind: null,
+      body: "standalone",
+    });
+  });
+});
+
+describe("scoutDisplayName", () => {
+  it("strips the fleet prefix", () => {
+    expect(scoutDisplayName("signals-scout-apm")).toBe("apm");
+  });
+
+  it("leaves non-fleet names untouched", () => {
+    expect(scoutDisplayName("custom-scout")).toBe("custom-scout");
+  });
+});
+
+describe("groupScratchpadEntries", () => {
+  it("clusters by namespace and orders clusters by most recent entry", () => {
+    const entries = [
+      entry("watch:b", "newest overall", "2026-06-03T00:00:00Z"),
+      entry("tags:a", "older", "2026-06-01T00:00:00Z"),
+      entry("watch:a", "middle", "2026-06-02T00:00:00Z"),
+    ];
+
+    const groups = groupScratchpadEntries(entries);
+
+    // `watch` floats above `tags` because its newest entry is more recent.
+    expect(groups.map((group) => group.namespace)).toEqual(["watch", "tags"]);
+    // Input order is preserved within a cluster.
+    expect(groups[0]?.entries.map((e) => e.key)).toEqual([
+      "watch:b",
+      "watch:a",
+    ]);
+    expect(groups[0]?.label).toBe("Watch");
+  });
+
+  it("returns an empty list for no entries", () => {
+    expect(groupScratchpadEntries([])).toEqual([]);
+  });
+});
+
+describe("filterScratchpadEntries", () => {
+  const entries = [
+    entry("tags:errors", "taxonomy for error tracking", "2026-06-01T00:00:00Z"),
+    entry("dedupe:replay", "fingerprint logic", "2026-06-02T00:00:00Z"),
+  ];
+
+  it("returns all entries for an empty query", () => {
+    expect(filterScratchpadEntries(entries, "  ")).toHaveLength(2);
+  });
+
+  it("matches on key", () => {
+    expect(filterScratchpadEntries(entries, "DEDUPE")).toEqual([entries[1]]);
+  });
+
+  it("matches on content", () => {
+    expect(filterScratchpadEntries(entries, "taxonomy")).toEqual([entries[0]]);
+  });
+
+  it("returns nothing when no entry matches", () => {
+    expect(filterScratchpadEntries(entries, "nomatch")).toEqual([]);
+  });
+});

--- a/packages/core/src/scouts/scoutScratchpad.ts
+++ b/packages/core/src/scouts/scoutScratchpad.ts
@@ -1,0 +1,108 @@
+import type { ScoutScratchpadEntry } from "@posthog/api-client/posthog-client";
+
+/**
+ * Read-only view helpers over the scout fleet's durable memory
+ * (`SignalScratchpad` on the Cloud backend). The harness writes these notes on
+ * internal scope while scanning a project; humans only inspect them. These pure
+ * functions mirror the Cloud `scratchpadLogic` selectors so the desktop surface
+ * groups, labels, and searches the fleet's memory the same way.
+ */
+
+/** The list shows two ways to read the memory: newest-first (the API's native
+ * order) or clustered by the key namespace scouts choose (`tags:*`, `dedupe:*`). */
+export type ScratchpadGrouping = "recent" | "topic";
+
+/** One namespace cluster in the "By topic" view: the raw prefix, a friendly
+ * label, and the entries that share it. */
+export interface ScratchpadNamespaceGroup {
+  namespace: string;
+  label: string;
+  entries: ScoutScratchpadEntry[];
+}
+
+/** Scouts namespace keys with a leading `prefix:` (e.g. `tags:errors:taxonomy`).
+ * Everything before the first colon is the topic; keys without one fall into a
+ * shared "general" bucket. */
+export function scratchpadNamespaceOf(key: string): string {
+  const idx = key.indexOf(":");
+  return idx > 0 ? key.slice(0, idx) : "general";
+}
+
+export function humanizeNamespace(namespace: string): string {
+  if (namespace === "general") {
+    return "General";
+  }
+  return namespace
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+/** Split a key into its `kind` prefix (what the scout was doing when it wrote
+ * the note) and the human-readable body after the first colon. */
+export function splitScratchpadKey(key: string): {
+  kind: string | null;
+  body: string;
+} {
+  const idx = key.indexOf(":");
+  return idx > 0
+    ? { kind: key.slice(0, idx), body: key.slice(idx + 1) }
+    : { kind: null, body: key };
+}
+
+/** `signals-scout-apm` → `apm`. The fleet prefix is noise once you're inside
+ * the scouts surface. */
+export function scoutDisplayName(skill: string): string {
+  return skill.replace(/^signals-scout-/, "");
+}
+
+/**
+ * Group entries by their key namespace. Entries arrive newest-first; that order
+ * is preserved within each cluster, and the clusters are ordered by their most
+ * recently touched entry so the liveliest topic floats to the top.
+ */
+export function groupScratchpadEntries(
+  entries: ScoutScratchpadEntry[],
+): ScratchpadNamespaceGroup[] {
+  const byNamespace = new Map<string, ScoutScratchpadEntry[]>();
+  for (const entry of entries) {
+    const namespace = scratchpadNamespaceOf(entry.key);
+    const bucket = byNamespace.get(namespace);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      byNamespace.set(namespace, [entry]);
+    }
+  }
+  return [...byNamespace.entries()]
+    .map(([namespace, namespaceEntries]) => ({
+      namespace,
+      label: humanizeNamespace(namespace),
+      entries: namespaceEntries,
+    }))
+    .sort((a, b) =>
+      (b.entries[0]?.updated_at ?? "").localeCompare(
+        a.entries[0]?.updated_at ?? "",
+      ),
+    );
+}
+
+/**
+ * Case-insensitive client-side search over key + content. The Cloud endpoint
+ * exposes a server-side `?text=` ILIKE, but the desktop surface pulls the whole
+ * newest-first window once and filters here so typing is instant and doesn't
+ * fire a request per keystroke.
+ */
+export function filterScratchpadEntries(
+  entries: ScoutScratchpadEntry[],
+  search: string,
+): ScoutScratchpadEntry[] {
+  const query = search.trim().toLowerCase();
+  if (!query) {
+    return entries;
+  }
+  return entries.filter(
+    (entry) =>
+      entry.key.toLowerCase().includes(query) ||
+      entry.content.toLowerCase().includes(query),
+  );
+}

--- a/packages/ui/src/features/scouts/components/FleetMemoryCallout.tsx
+++ b/packages/ui/src/features/scouts/components/FleetMemoryCallout.tsx
@@ -1,0 +1,54 @@
+import { ArrowRightIcon, NotebookIcon } from "@phosphor-icons/react";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { Flex, Text } from "@radix-ui/themes";
+import { Link } from "@tanstack/react-router";
+import { useScoutScratchpad } from "../hooks/useScoutScratchpad";
+
+/**
+ * Scratchpad stat card for the scout fleet section. Surfaces that the scouts
+ * have jotted down context about this project — count + recency hint at what
+ * they're picking up — and links into the full scratchpad browse/search surface.
+ * Renders nothing until there is at least one note, so a fresh project isn't
+ * nudged toward an empty page.
+ */
+export function FleetMemoryCallout() {
+  const { data: entries } = useScoutScratchpad();
+
+  // Hold until the first load settles, then only show when there's something to
+  // read. Entries arrive newest-first, so the head drives the "updated" hint.
+  if (!entries || entries.length === 0) {
+    return null;
+  }
+
+  const totalCount = entries.length;
+  const lastUpdatedAt = entries[0]?.updated_at ?? null;
+
+  return (
+    <Link
+      to="/code/agents/scouts/scratchpad"
+      className="flex w-full items-center gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-4 py-3.5 text-left no-underline transition-colors duration-150 hover:border-(--gray-6) hover:bg-(--gray-2)"
+    >
+      <NotebookIcon size={20} className="shrink-0 text-(--iris-9)" />
+      <Flex direction="column" className="min-w-0">
+        <Text className="font-medium text-[13px] text-gray-12">
+          Scout scratchpad
+        </Text>
+        <Text className="truncate text-[12px] text-gray-11 leading-snug">
+          {totalCount} note{totalCount === 1 ? "" : "s"} your scouts have jotted
+          down about this project
+          {lastUpdatedAt ? (
+            <>
+              {" · updated "}
+              <RelativeTimestamp
+                timestamp={lastUpdatedAt}
+                className="inline text-[12px] text-gray-11"
+              />
+            </>
+          ) : null}
+        </Text>
+      </Flex>
+      <span className="flex-1" />
+      <ArrowRightIcon size={14} className="shrink-0 text-gray-10" />
+    </Link>
+  );
+}

--- a/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
@@ -31,6 +31,7 @@ import { useScoutChatTask } from "../hooks/useScoutChatTask";
 import { useScoutConfigMutations } from "../hooks/useScoutConfigMutations";
 import { useScoutConfigs } from "../hooks/useScoutConfigs";
 import { useScoutRuns } from "../hooks/useScoutRuns";
+import { FleetMemoryCallout } from "./FleetMemoryCallout";
 import { ScoutAlphaBanner } from "./ScoutAlphaBanner";
 import { ScoutHelperSkillLinks } from "./ScoutHelperSkillLinks";
 import { ScoutRowCard } from "./ScoutRowCard";
@@ -226,6 +227,9 @@ function ScoutsFleetList({ configs }: { configs: ScoutConfig[] }) {
           icon={PlusIcon}
         />
       </Flex>
+
+      {/* Fleet memory: renders only once scouts have written scratchpad notes. */}
+      <FleetMemoryCallout />
 
       {/* Bounded to roughly 10 rows; larger fleets scroll within the section. */}
       <div className="max-h-[710px] overflow-y-auto">

--- a/packages/ui/src/features/scouts/components/ScratchpadEntryCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScratchpadEntryCard.tsx
@@ -1,0 +1,100 @@
+import { CaretRightIcon, ClockIcon } from "@phosphor-icons/react";
+import type { ScoutScratchpadEntry } from "@posthog/api-client/posthog-client";
+import { splitScratchpadKey } from "@posthog/core/scouts/scoutScratchpad";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { Badge, type BadgeProps, Box, Flex, Text } from "@radix-ui/themes";
+import { useState } from "react";
+
+// The key prefix (everything before the first colon) encodes the note's *kind* —
+// what the scout was doing when it wrote it. Surface it as a colored tag so the
+// list scans at a glance.
+const KIND_TAG_COLOR: Record<string, BadgeProps["color"]> = {
+  pattern: "iris",
+  dedupe: "gray",
+  noise: "gray",
+  baseline: "green",
+  watch: "amber",
+  watchlist: "amber",
+  coverage: "blue",
+  emerging: "purple",
+  explore: "cyan",
+  tags: "cyan",
+  recheck: "orange",
+};
+
+/**
+ * One scratchpad note the scout fleet has written about this project. Shares the
+ * collapse/expand grammar of the scout emission cards: a header (chevron · kind ·
+ * key · updated time) that stays visible, a 2-line markdown preview when
+ * collapsed, the full body plus an attribution footer when open.
+ */
+export function ScratchpadEntryCard({
+  entry,
+}: {
+  entry: ScoutScratchpadEntry;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const { kind, body } = splitScratchpadKey(entry.key);
+
+  return (
+    <Box className="min-w-0 overflow-hidden rounded-(--radius-2) border border-(--gray-6) bg-gray-1">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        className="flex w-full select-none items-center gap-2 px-3 py-2 text-left"
+      >
+        <CaretRightIcon
+          size={11}
+          className={`shrink-0 text-gray-9 transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
+        />
+        {kind ? (
+          <Badge
+            variant="soft"
+            color={KIND_TAG_COLOR[kind] ?? "gray"}
+            size="1"
+            className="shrink-0 text-[11px]"
+          >
+            {kind}
+          </Badge>
+        ) : null}
+        <Text className="truncate font-mono text-[12px] text-gray-12">
+          {body}
+        </Text>
+        <span className="flex-1" />
+        {entry.updated_at ? (
+          <Flex align="center" gap="1" className="shrink-0 text-gray-10">
+            <ClockIcon size={11} className="text-gray-9" />
+            <RelativeTimestamp timestamp={entry.updated_at} />
+          </Flex>
+        ) : null}
+      </button>
+
+      <Box className="px-3 pb-2 pl-9">
+        <Box
+          className={`text-pretty break-words text-[13px] text-gray-11 leading-relaxed [&_code]:text-[11px] [&_p:last-child]:mb-0 [&_p]:mb-1 [&_pre]:text-[11px] ${
+            expanded ? "" : "line-clamp-2"
+          }`}
+        >
+          <MarkdownRenderer content={entry.content || "_No content._"} />
+        </Box>
+
+        {expanded && entry.created_at ? (
+          <Flex
+            align="center"
+            gap="2"
+            mt="2"
+            pt="2"
+            wrap="wrap"
+            className="border-t border-t-(--gray-5) text-[11px] text-gray-10"
+          >
+            <Text className="text-[11px] text-gray-10">Created</Text>
+            <RelativeTimestamp timestamp={entry.created_at} />
+          </Flex>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/ui/src/features/scouts/components/ScratchpadView.tsx
+++ b/packages/ui/src/features/scouts/components/ScratchpadView.tsx
@@ -1,0 +1,293 @@
+import {
+  ArrowLeftIcon,
+  CaretDownIcon,
+  ClockIcon,
+  MagnifyingGlassIcon,
+  NotebookIcon,
+  StackIcon,
+} from "@phosphor-icons/react";
+import {
+  filterScratchpadEntries,
+  groupScratchpadEntries,
+  type ScratchpadGrouping,
+} from "@posthog/core/scouts/scoutScratchpad";
+import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { Box, Flex, SegmentedControl, Text, TextField } from "@radix-ui/themes";
+import { Link } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { useScoutScratchpad } from "../hooks/useScoutScratchpad";
+import { ScratchpadEntryCard } from "./ScratchpadEntryCard";
+
+/**
+ * Browse + search surface for the scout fleet's scratchpad (`SignalScratchpad`).
+ * Frames what the scratchpad is up top, then lets the user read it newest-first
+ * or clustered by topic, and search it. Read-only: the harness writes the notes
+ * on internal scope; humans inspect them here.
+ *
+ * Mirrors the PostHog Cloud `ScratchpadPanel`, kept structurally aligned so the
+ * two surfaces stay in parity as the backend evolves.
+ */
+export function ScratchpadView() {
+  const { data: entries, isLoading, isError, refetch } = useScoutScratchpad();
+  const [searchText, setSearchText] = useState("");
+  const [grouping, setGrouping] = useState<ScratchpadGrouping>("recent");
+
+  const headerContent = useMemo(
+    () => (
+      <Flex align="center" gap="2" className="w-full min-w-0">
+        <NotebookIcon size={12} className="shrink-0 text-gray-10" />
+        <Text
+          className="truncate whitespace-nowrap font-medium text-[13px]"
+          title="Scout scratchpad"
+        >
+          Scout scratchpad
+        </Text>
+      </Flex>
+    ),
+    [],
+  );
+  useSetHeaderContent(headerContent);
+
+  const isSearching = searchText.trim().length > 0;
+  const allEntries = entries ?? [];
+  const visibleEntries = useMemo(
+    () => filterScratchpadEntries(allEntries, searchText),
+    [allEntries, searchText],
+  );
+  const groups = useMemo(
+    () => groupScratchpadEntries(visibleEntries),
+    [visibleEntries],
+  );
+
+  const totalCount = entries?.length ?? null;
+  const lastUpdatedAt = entries?.[0]?.updated_at ?? null;
+
+  return (
+    <Flex direction="column" className="h-full min-h-0">
+      <Flex
+        direction="column"
+        gap="2"
+        className="border-(--gray-5) border-b px-6 pt-5 pb-5"
+      >
+        <Link
+          to="/code/agents/scouts"
+          className="flex w-fit items-center gap-1 text-[12px] text-gray-10 no-underline hover:text-gray-12"
+        >
+          <ArrowLeftIcon size={12} />
+          Scouts
+        </Link>
+        <Flex align="center" gap="2">
+          <NotebookIcon size={20} className="shrink-0 text-(--iris-9)" />
+          <Text className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">
+            Scout scratchpad
+          </Text>
+        </Flex>
+        <Text className="max-w-2xl text-pretty text-[12.5px] text-gray-11 leading-relaxed">
+          Where your scouts jot down useful context as they scan your project —
+          things they&apos;ve classified, ruled out, or the vocabulary
+          they&apos;ve settled on. Browse it to see what they&apos;re picking up
+          about your setup.
+        </Text>
+        {totalCount !== null && totalCount > 0 ? (
+          <Flex align="center" gap="1" className="text-[12px] text-gray-10">
+            <Text className="text-[12px] text-gray-10">
+              {totalCount} note{totalCount === 1 ? "" : "s"}
+            </Text>
+            {lastUpdatedAt ? (
+              <>
+                <Text className="text-[12px] text-gray-9">· last updated</Text>
+                <RelativeTimestamp
+                  timestamp={lastUpdatedAt}
+                  className="text-[12px] text-gray-10"
+                />
+              </>
+            ) : null}
+          </Flex>
+        ) : null}
+      </Flex>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="mx-auto max-w-4xl px-6 py-6">
+          <Flex direction="column" gap="4">
+            <Flex align="center" gap="2" wrap="wrap">
+              <TextField.Root
+                type="search"
+                placeholder="Search the scratchpad…"
+                value={searchText}
+                onChange={(event) => setSearchText(event.target.value)}
+                size="2"
+                className="min-w-[14rem] flex-1"
+              >
+                <TextField.Slot>
+                  <MagnifyingGlassIcon size={14} className="text-gray-10" />
+                </TextField.Slot>
+              </TextField.Root>
+              <SegmentedControl.Root
+                value={grouping}
+                size="1"
+                onValueChange={(value) =>
+                  setGrouping(value as ScratchpadGrouping)
+                }
+                aria-label="Scratchpad grouping"
+              >
+                <SegmentedControl.Item value="recent">
+                  <span className="inline-flex items-center gap-1.5">
+                    <ClockIcon size={12} />
+                    Recent
+                  </span>
+                </SegmentedControl.Item>
+                <SegmentedControl.Item value="topic">
+                  <span className="inline-flex items-center gap-1.5">
+                    <StackIcon size={12} />
+                    By topic
+                  </span>
+                </SegmentedControl.Item>
+              </SegmentedControl.Root>
+            </Flex>
+
+            <ScratchpadBody
+              isLoading={isLoading}
+              isError={isError}
+              onRetry={() => refetch()}
+              entries={visibleEntries}
+              groups={groups}
+              grouping={grouping}
+              isSearching={isSearching}
+            />
+          </Flex>
+        </div>
+      </div>
+    </Flex>
+  );
+}
+
+function ScratchpadBody({
+  isLoading,
+  isError,
+  onRetry,
+  entries,
+  groups,
+  grouping,
+  isSearching,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  entries: ReturnType<typeof filterScratchpadEntries>;
+  groups: ReturnType<typeof groupScratchpadEntries>;
+  grouping: ScratchpadGrouping;
+  isSearching: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <Flex direction="column" gap="2">
+        {[0, 1, 2].map((key) => (
+          <Box
+            key={key}
+            className="h-12 w-full animate-pulse rounded-(--radius-2) bg-(--gray-3)"
+          />
+        ))}
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Flex
+        direction="column"
+        align="center"
+        gap="2"
+        className="rounded-(--radius-2) border border-(--gray-6) border-dashed bg-gray-1 px-4 py-8 text-center text-[12.5px] text-gray-11"
+      >
+        <Text className="text-[12.5px] text-gray-11">
+          Couldn&apos;t load the scratchpad. The scout API may be unavailable or
+          this project may not be enrolled yet.
+        </Text>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-(--radius-2) border border-(--gray-7) px-2.5 py-1 text-[12px] text-gray-11 transition-colors hover:bg-(--gray-3)"
+        >
+          Retry
+        </button>
+      </Flex>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <Box className="rounded-(--radius-2) border border-(--gray-6) border-dashed bg-gray-1 px-4 py-8 text-center text-[12.5px] text-gray-11">
+        {isSearching
+          ? "No notes match your search."
+          : "Your scouts haven't jotted anything down yet. As they scan your project, their notes show up here."}
+      </Box>
+    );
+  }
+
+  if (grouping === "topic") {
+    return (
+      <Flex direction="column" gap="3">
+        {groups.map((group) => (
+          <ScratchpadTopicGroup
+            key={group.namespace}
+            label={group.label}
+            entries={group.entries}
+            // A search forces every matching topic open so results stay visible
+            // without a click.
+            forceOpen={isSearching}
+          />
+        ))}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="2">
+      {entries.map((entry) => (
+        <ScratchpadEntryCard key={entry.key} entry={entry} />
+      ))}
+    </Flex>
+  );
+}
+
+function ScratchpadTopicGroup({
+  label,
+  entries,
+  forceOpen,
+}: {
+  label: string;
+  entries: ReturnType<typeof filterScratchpadEntries>;
+  forceOpen: boolean;
+}) {
+  // Collapsed by default for a high-level scan; a search forces it open.
+  const [expanded, setExpanded] = useState(false);
+  const isExpanded = forceOpen || expanded;
+
+  return (
+    <Flex direction="column" gap="2">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={isExpanded}
+        className="flex items-center gap-2 text-left"
+      >
+        <CaretDownIcon
+          size={14}
+          className={`shrink-0 text-gray-9 transition-transform ${isExpanded ? "" : "-rotate-90"}`}
+        />
+        <Text className="font-medium text-[12px] text-gray-11 uppercase tracking-wide">
+          {label}
+        </Text>
+        <Text className="text-[11px] text-gray-10">
+          {entries.length} note{entries.length === 1 ? "" : "s"}
+        </Text>
+      </button>
+      {isExpanded
+        ? entries.map((entry) => (
+            <ScratchpadEntryCard key={entry.key} entry={entry} />
+          ))
+        : null}
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/scouts/hooks/scoutQueryKeys.ts
+++ b/packages/ui/src/features/scouts/hooks/scoutQueryKeys.ts
@@ -4,6 +4,8 @@ export const scoutQueryKeys = {
   metadata: (projectId: number | null) =>
     ["scouts", "metadata", projectId] as const,
   runs: (projectId: number | null) => ["scouts", "runs", projectId] as const,
+  scratchpad: (projectId: number | null) =>
+    ["scouts", "scratchpad", projectId] as const,
   emissions: (projectId: number | null, runId: string) =>
     ["scouts", "emissions", projectId, runId] as const,
   emissionReports: (projectId: number | null, runId: string) =>

--- a/packages/ui/src/features/scouts/hooks/useScoutScratchpad.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutScratchpad.ts
@@ -1,0 +1,35 @@
+import type { ScoutScratchpadEntry } from "@posthog/api-client/posthog-client";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+import { scoutQueryKeys } from "./scoutQueryKeys";
+
+/**
+ * The scratchpad `list` endpoint caps at 500 newest-first entries with no
+ * pagination wrapper, so pull the whole window in one read and group/search it
+ * client-side. A team that routinely exceeds 500 notes would want the endpoint's
+ * `date_to` cursor wired into a "load more" here.
+ */
+const SCRATCHPAD_FETCH_LIMIT = 500;
+
+/**
+ * The scout fleet's durable memory (`SignalScratchpad`) for the current project,
+ * newest-first. Read-only: the harness writes these notes on internal scope; this
+ * surface only inspects them. Backed by the same `/signals/scout/` endpoints as
+ * the rest of the scouts UI.
+ */
+export function useScoutScratchpad() {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<ScoutScratchpadEntry[]>(
+    scoutQueryKeys.scratchpad(projectId),
+    (client) =>
+      projectId
+        ? client.searchScoutScratchpad(projectId, {
+            limit: SCRATCHPAD_FETCH_LIMIT,
+          })
+        : Promise.resolve([]),
+    {
+      enabled: !!projectId,
+      staleTime: 30_000,
+    },
+  );
+}

--- a/packages/ui/src/router/routeTree.gen.ts
+++ b/packages/ui/src/router/routeTree.gen.ts
@@ -54,6 +54,7 @@ import { Route as CodeInboxRunsReportIdRouteImport } from './routes/code/inbox/r
 import { Route as CodeInboxReportsReportIdRouteImport } from './routes/code/inbox/reports.$reportId'
 import { Route as CodeInboxPullsReportIdRouteImport } from './routes/code/inbox/pulls.$reportId'
 import { Route as CodeInboxDismissedReportIdRouteImport } from './routes/code/inbox/dismissed.$reportId'
+import { Route as CodeAgentsScoutsScratchpadRouteImport } from './routes/code/agents/scouts.scratchpad'
 import { Route as CodeAgentsScoutsSkillNameRouteImport } from './routes/code/agents/scouts.$skillName'
 import { Route as CodeAgentsApplicationsApprovalsRouteImport } from './routes/code/agents/applications/approvals'
 import { Route as CodeAgentsApplicationsIdOrSlugRouteImport } from './routes/code/agents/applications/$idOrSlug'
@@ -298,6 +299,12 @@ const CodeInboxDismissedReportIdRoute =
     path: '/$reportId',
     getParentRoute: () => CodeInboxDismissedRoute,
   } as any)
+const CodeAgentsScoutsScratchpadRoute =
+  CodeAgentsScoutsScratchpadRouteImport.update({
+    id: '/scratchpad',
+    path: '/scratchpad',
+    getParentRoute: () => CodeAgentsScoutsRoute,
+  } as any)
 const CodeAgentsScoutsSkillNameRoute =
   CodeAgentsScoutsSkillNameRouteImport.update({
     id: '/$skillName',
@@ -413,6 +420,7 @@ export interface FileRoutesByFullPath {
   '/code/agents/applications/$idOrSlug': typeof CodeAgentsApplicationsIdOrSlugRouteWithChildren
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
+  '/code/agents/scouts/scratchpad': typeof CodeAgentsScoutsScratchpadRoute
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
@@ -462,6 +470,7 @@ export interface FileRoutesByTo {
   '/code/inbox': typeof CodeInboxIndexRoute
   '/website/$channelId': typeof WebsiteChannelIdIndexRoute
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
+  '/code/agents/scouts/scratchpad': typeof CodeAgentsScoutsScratchpadRoute
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
@@ -523,6 +532,7 @@ export interface FileRoutesById {
   '/code/agents/applications/$idOrSlug': typeof CodeAgentsApplicationsIdOrSlugRouteWithChildren
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
+  '/code/agents/scouts/scratchpad': typeof CodeAgentsScoutsScratchpadRoute
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
   '/code/inbox/reports/$reportId': typeof CodeInboxReportsReportIdRoute
@@ -585,6 +595,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/$idOrSlug'
     | '/code/agents/applications/approvals'
     | '/code/agents/scouts/$skillName'
+    | '/code/agents/scouts/scratchpad'
     | '/code/inbox/dismissed/$reportId'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
@@ -634,6 +645,7 @@ export interface FileRouteTypes {
     | '/code/inbox'
     | '/website/$channelId'
     | '/code/agents/applications/approvals'
+    | '/code/agents/scouts/scratchpad'
     | '/code/inbox/dismissed/$reportId'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
@@ -694,6 +706,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/$idOrSlug'
     | '/code/agents/applications/approvals'
     | '/code/agents/scouts/$skillName'
+    | '/code/agents/scouts/scratchpad'
     | '/code/inbox/dismissed/$reportId'
     | '/code/inbox/pulls/$reportId'
     | '/code/inbox/reports/$reportId'
@@ -1054,6 +1067,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CodeInboxDismissedReportIdRouteImport
       parentRoute: typeof CodeInboxDismissedRoute
     }
+    '/code/agents/scouts/scratchpad': {
+      id: '/code/agents/scouts/scratchpad'
+      path: '/scratchpad'
+      fullPath: '/code/agents/scouts/scratchpad'
+      preLoaderRoute: typeof CodeAgentsScoutsScratchpadRouteImport
+      parentRoute: typeof CodeAgentsScoutsRoute
+    }
     '/code/agents/scouts/$skillName': {
       id: '/code/agents/scouts/$skillName'
       path: '/$skillName'
@@ -1254,11 +1274,13 @@ const CodeAgentsScoutsSkillNameRouteWithChildren =
 
 interface CodeAgentsScoutsRouteChildren {
   CodeAgentsScoutsSkillNameRoute: typeof CodeAgentsScoutsSkillNameRouteWithChildren
+  CodeAgentsScoutsScratchpadRoute: typeof CodeAgentsScoutsScratchpadRoute
   CodeAgentsScoutsIndexRoute: typeof CodeAgentsScoutsIndexRoute
 }
 
 const CodeAgentsScoutsRouteChildren: CodeAgentsScoutsRouteChildren = {
   CodeAgentsScoutsSkillNameRoute: CodeAgentsScoutsSkillNameRouteWithChildren,
+  CodeAgentsScoutsScratchpadRoute: CodeAgentsScoutsScratchpadRoute,
   CodeAgentsScoutsIndexRoute: CodeAgentsScoutsIndexRoute,
 }
 

--- a/packages/ui/src/router/routes/code/agents/scouts.scratchpad.tsx
+++ b/packages/ui/src/router/routes/code/agents/scouts.scratchpad.tsx
@@ -1,0 +1,6 @@
+import { ScratchpadView } from "@posthog/ui/features/scouts/components/ScratchpadView";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/agents/scouts/scratchpad")({
+  component: ScratchpadView,
+});


### PR DESCRIPTION
this is bringing code scouts ui in line with posthog cloud ui

## Problem

The PostHog Cloud inbox surfaces the scout fleet's durable memory (the `SignalScratchpad`) as a browsable "scratchpad" page. The Code desktop app already mirrors Cloud's scouts/inbox surfaces but had no equivalent, so the fleet's accumulated context wasn't visible here. We want to keep the two in parity over time.

## Changes

<img width="1970" height="972" alt="image" src="https://github.com/user-attachments/assets/93591860-7276-4a93-854c-b1764fc22c09" />


Adds a read-only scout scratchpad surface, kept structurally aligned with Cloud's `ScratchpadPanel` so the two stay in parity as the backend evolves.

- **Callout**: a "Scout scratchpad" card in the scout fleet section (`ScoutsFleetSection`) that links into the page. Renders only once scouts have written notes, so a fresh project isn't nudged toward an empty page.
- **Page** at `/code/agents/scouts/scratchpad` (`ScratchpadView`): frames what the scratchpad is, then lets you read notes newest-first or grouped by topic, with client-side search over key + content. Handles loading / error / empty states.
- **Entry card** (`ScratchpadEntryCard`): collapsible note matching the existing `ScoutEmissionCard` grammar — kind tag, mono key, markdown body, timestamps.
- **Data**: `useScoutScratchpad` hook fetches the newest-first window via the existing `/signals/scout/scratchpad/` endpoint on the api-client (`searchScoutScratchpad`, already present). Pure grouping/namespace/search helpers live in `@posthog/core/scouts/scoutScratchpad` with unit tests.

Notes on parity gaps vs Cloud: the desktop `ScoutScratchpadEntry` type only carries `created_by_run_id` (no `created_by_skill` / `created_by_run_url`), so the "by X scout" attribution link and "carried forward N days" line are omitted until those fields are added to the api-client type + serializer. Search is client-side over the 500-entry window rather than Cloud's server-side `?text=` ILIKE — equivalent under the cap, and instant.

## How did you test this?

- `pnpm --filter @posthog/core test scoutScratchpad` — 18 unit tests pass (namespace grouping, ordering, key splitting, search).
- Biome clean on all new/changed files, incl. `@posthog/core` import boundaries.
- No typecheck errors in any new/changed file; pre-commit `pnpm typecheck` passed.
- Not yet eyeballed in the running app — author is doing that locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?