### PR TITLE
feat(scouts): cross-fleet scout findings page

### DIFF
--- a/packages/core/src/scouts/scoutFindings.test.ts
+++ b/packages/core/src/scouts/scoutFindings.test.ts
@@ -1,0 +1,333 @@
+import type {
+  LinkedSignalReport,
+  ScoutEmission,
+  ScoutRun,
+} from "@posthog/api-client/posthog-client";
+import {
+  availableScouts,
+  buildFindingRows,
+  emittedRunsKey,
+  FINDINGS_SCOUT_FILTER_ALL,
+  FINDINGS_SEVERITY_FILTER_ALL,
+  filterAndSortFindings,
+  latestEmittedAt,
+  mostRecentEmittedRuns,
+  reportsBySourceId,
+  type ScoutFindingRow,
+} from "@posthog/core/scouts/scoutFindings";
+import { describe, expect, it } from "vitest";
+
+function run(partial: Partial<ScoutRun> & Pick<ScoutRun, "run_id">): ScoutRun {
+  return {
+    skill_name: "signals-scout-error-tracking",
+    skill_version: 1,
+    status: "completed",
+    started_at: "2026-06-29T10:00:00Z",
+    completed_at: "2026-06-29T10:05:00Z",
+    task_id: null,
+    task_run_id: null,
+    task_url: null,
+    summary: "",
+    emitted_count: 1,
+    emitted_finding_ids: [],
+    ...partial,
+  };
+}
+
+function emission(
+  partial: Partial<ScoutEmission> & Pick<ScoutEmission, "id" | "run_id">,
+): ScoutEmission {
+  return {
+    finding_id: `finding-${partial.id}`,
+    description: "Something happened",
+    weight: 1,
+    confidence: 0.5,
+    severity: "P2",
+    source_id: `run:${partial.run_id}:finding:${partial.id}`,
+    emitted_at: "2026-06-29T10:01:00Z",
+    ...partial,
+  };
+}
+
+const report: LinkedSignalReport = {
+  id: "report-1",
+  title: "An incident",
+  status: "ready",
+};
+
+describe("mostRecentEmittedRuns", () => {
+  it("keeps only runs that emitted, newest-first by started_at", () => {
+    const runs = [
+      run({
+        run_id: "a",
+        started_at: "2026-06-29T08:00:00Z",
+        emitted_count: 2,
+      }),
+      run({
+        run_id: "b",
+        started_at: "2026-06-29T09:00:00Z",
+        emitted_count: 0,
+      }),
+      run({
+        run_id: "c",
+        started_at: "2026-06-29T10:00:00Z",
+        emitted_count: 1,
+      }),
+    ];
+    expect(mostRecentEmittedRuns(runs).map((r) => r.run_id)).toEqual([
+      "c",
+      "a",
+    ]);
+  });
+
+  it("treats null emitted_count as quiet", () => {
+    const runs = [run({ run_id: "a", emitted_count: null })];
+    expect(mostRecentEmittedRuns(runs)).toEqual([]);
+  });
+
+  it("caps the run set", () => {
+    const runs = Array.from({ length: 5 }, (_, i) =>
+      run({ run_id: `r${i}`, started_at: `2026-06-29T1${i}:00:00Z` }),
+    );
+    expect(mostRecentEmittedRuns(runs, 2)).toHaveLength(2);
+  });
+});
+
+describe("emittedRunsKey", () => {
+  it("is order-independent and includes emitted_count", () => {
+    const a = [
+      run({ run_id: "x", emitted_count: 1 }),
+      run({ run_id: "y", emitted_count: 2 }),
+    ];
+    const b = [
+      run({ run_id: "y", emitted_count: 2 }),
+      run({ run_id: "x", emitted_count: 1 }),
+    ];
+    expect(emittedRunsKey(a)).toBe(emittedRunsKey(b));
+  });
+
+  it("changes when a run emits more", () => {
+    const before = emittedRunsKey([run({ run_id: "x", emitted_count: 1 })]);
+    const after = emittedRunsKey([run({ run_id: "x", emitted_count: 2 })]);
+    expect(before).not.toBe(after);
+  });
+});
+
+describe("buildFindingRows", () => {
+  it("joins emissions to their run and linked report", () => {
+    const runs = [run({ run_id: "a" })];
+    const emissions = [emission({ id: "1", run_id: "a", source_id: "src-1" })];
+    const reportBySourceId = reportsBySourceId([
+      { source_id: "src-1", report },
+    ]);
+    const rows = buildFindingRows(emissions, runs, reportBySourceId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.run.run_id).toBe("a");
+    expect(rows[0]?.report).toBe(report);
+  });
+
+  it("drops emissions whose run is absent", () => {
+    const emissions = [emission({ id: "1", run_id: "gone" })];
+    expect(
+      buildFindingRows(emissions, [run({ run_id: "a" })], new Map()),
+    ).toEqual([]);
+  });
+
+  it("leaves report null when unlinked", () => {
+    const runs = [run({ run_id: "a" })];
+    const emissions = [emission({ id: "1", run_id: "a", source_id: "src-1" })];
+    expect(buildFindingRows(emissions, runs, new Map())[0]?.report).toBeNull();
+  });
+});
+
+describe("reportsBySourceId", () => {
+  it("indexes only links with a report", () => {
+    const map = reportsBySourceId([
+      { source_id: "src-1", report },
+      { source_id: "src-2", report: null },
+    ]);
+    expect(map.get("src-1")).toBe(report);
+    expect(map.has("src-2")).toBe(false);
+  });
+});
+
+function rowsFrom(
+  specs: {
+    id: string;
+    skill: string;
+    severity: string | null;
+    confidence: number;
+    emittedAt: string;
+    description?: string;
+  }[],
+): ScoutFindingRow[] {
+  return specs.map((spec) => ({
+    emission: emission({
+      id: spec.id,
+      run_id: spec.id,
+      severity: spec.severity,
+      confidence: spec.confidence,
+      emitted_at: spec.emittedAt,
+      description: spec.description ?? "x",
+    }),
+    run: run({ run_id: spec.id, skill_name: spec.skill }),
+    report: null,
+  }));
+}
+
+describe("availableScouts", () => {
+  it("counts distinct scouts and labels them, sorted by label", () => {
+    const rows = rowsFrom([
+      {
+        id: "1",
+        skill: "signals-scout-web-analytics",
+        severity: "P1",
+        confidence: 0.5,
+        emittedAt: "2026-06-29T10:00:00Z",
+      },
+      {
+        id: "2",
+        skill: "signals-scout-error-tracking",
+        severity: "P1",
+        confidence: 0.5,
+        emittedAt: "2026-06-29T10:00:00Z",
+      },
+      {
+        id: "3",
+        skill: "signals-scout-error-tracking",
+        severity: "P1",
+        confidence: 0.5,
+        emittedAt: "2026-06-29T10:00:00Z",
+      },
+    ]);
+    const scouts = availableScouts(rows);
+    expect(scouts.map((s) => s.skillName)).toEqual([
+      "signals-scout-error-tracking",
+      "signals-scout-web-analytics",
+    ]);
+    expect(scouts[0]?.count).toBe(2);
+    expect(scouts[0]?.label).toBe("Error tracking");
+  });
+});
+
+describe("filterAndSortFindings", () => {
+  const base = {
+    searchText: "",
+    scoutFilter: FINDINGS_SCOUT_FILTER_ALL,
+    severityFilter: FINDINGS_SEVERITY_FILTER_ALL,
+    sortKey: "newest" as const,
+  };
+  const rows = rowsFrom([
+    {
+      id: "a",
+      skill: "signals-scout-error-tracking",
+      severity: "P0",
+      confidence: 0.3,
+      emittedAt: "2026-06-29T08:00:00Z",
+      description: "database outage",
+    },
+    {
+      id: "b",
+      skill: "signals-scout-web-analytics",
+      severity: "P3",
+      confidence: 0.9,
+      emittedAt: "2026-06-29T10:00:00Z",
+      description: "traffic dip",
+    },
+    {
+      id: "c",
+      skill: "signals-scout-error-tracking",
+      severity: "P2",
+      confidence: 0.6,
+      emittedAt: "2026-06-29T09:00:00Z",
+      description: "slow query",
+    },
+  ]);
+
+  it("sorts newest-first by default", () => {
+    expect(filterAndSortFindings(rows, base).map((r) => r.emission.id)).toEqual(
+      ["b", "c", "a"],
+    );
+  });
+
+  it("sorts oldest-first", () => {
+    expect(
+      filterAndSortFindings(rows, { ...base, sortKey: "oldest" }).map(
+        (r) => r.emission.id,
+      ),
+    ).toEqual(["a", "c", "b"]);
+  });
+
+  it("sorts by severity (most severe first)", () => {
+    expect(
+      filterAndSortFindings(rows, { ...base, sortKey: "severity" }).map(
+        (r) => r.emission.id,
+      ),
+    ).toEqual(["a", "c", "b"]);
+  });
+
+  it("sorts by confidence (highest first)", () => {
+    expect(
+      filterAndSortFindings(rows, { ...base, sortKey: "confidence" }).map(
+        (r) => r.emission.id,
+      ),
+    ).toEqual(["b", "c", "a"]);
+  });
+
+  it("filters by scout", () => {
+    expect(
+      filterAndSortFindings(rows, {
+        ...base,
+        scoutFilter: "signals-scout-web-analytics",
+      }).map((r) => r.emission.id),
+    ).toEqual(["b"]);
+  });
+
+  it("filters by severity", () => {
+    expect(
+      filterAndSortFindings(rows, { ...base, severityFilter: "P0" }).map(
+        (r) => r.emission.id,
+      ),
+    ).toEqual(["a"]);
+  });
+
+  it("searches over description and prettified scout name", () => {
+    expect(
+      filterAndSortFindings(rows, { ...base, searchText: "outage" }).map(
+        (r) => r.emission.id,
+      ),
+    ).toEqual(["a"]);
+    // "Error tracking" is the prettified skill name for two rows.
+    expect(
+      filterAndSortFindings(rows, { ...base, searchText: "error tracking" })
+        .map((r) => r.emission.id)
+        .sort(),
+    ).toEqual(["a", "c"]);
+  });
+});
+
+describe("latestEmittedAt", () => {
+  it("returns the max emitted_at", () => {
+    const rows = rowsFrom([
+      {
+        id: "a",
+        skill: "s",
+        severity: "P1",
+        confidence: 0.5,
+        emittedAt: "2026-06-29T08:00:00Z",
+      },
+      {
+        id: "b",
+        skill: "s",
+        severity: "P1",
+        confidence: 0.5,
+        emittedAt: "2026-06-29T10:00:00Z",
+      },
+    ]);
+    expect(latestEmittedAt(rows)).toBe("2026-06-29T10:00:00Z");
+  });
+
+  it("returns null for no rows", () => {
+    expect(latestEmittedAt([])).toBeNull();
+  });
+});

--- a/packages/core/src/scouts/scoutFindings.test.ts
+++ b/packages/core/src/scouts/scoutFindings.test.ts
@@ -9,6 +9,7 @@ import {
   emittedRunsKey,
   FINDINGS_SCOUT_FILTER_ALL,
   FINDINGS_SEVERITY_FILTER_ALL,
+  type FindingsSortKey,
   filterAndSortFindings,
   latestEmittedAt,
   mostRecentEmittedRuns,
@@ -244,51 +245,28 @@ describe("filterAndSortFindings", () => {
     },
   ]);
 
-  it("sorts newest-first by default", () => {
-    expect(filterAndSortFindings(rows, base).map((r) => r.emission.id)).toEqual(
-      ["b", "c", "a"],
-    );
-  });
-
-  it("sorts oldest-first", () => {
+  it.each<[FindingsSortKey, string[]]>([
+    ["newest", ["b", "c", "a"]],
+    ["oldest", ["a", "c", "b"]],
+    ["severity", ["a", "c", "b"]],
+    ["confidence", ["b", "c", "a"]],
+  ])("sorts by %s", (sortKey, expected) => {
     expect(
-      filterAndSortFindings(rows, { ...base, sortKey: "oldest" }).map(
+      filterAndSortFindings(rows, { ...base, sortKey }).map(
         (r) => r.emission.id,
       ),
-    ).toEqual(["a", "c", "b"]);
+    ).toEqual(expected);
   });
 
-  it("sorts by severity (most severe first)", () => {
+  it.each<[string, Partial<typeof base>, string[]]>([
+    ["scout", { scoutFilter: "signals-scout-web-analytics" }, ["b"]],
+    ["severity", { severityFilter: "P0" }, ["a"]],
+  ])("filters by %s", (_label, override, expected) => {
     expect(
-      filterAndSortFindings(rows, { ...base, sortKey: "severity" }).map(
+      filterAndSortFindings(rows, { ...base, ...override }).map(
         (r) => r.emission.id,
       ),
-    ).toEqual(["a", "c", "b"]);
-  });
-
-  it("sorts by confidence (highest first)", () => {
-    expect(
-      filterAndSortFindings(rows, { ...base, sortKey: "confidence" }).map(
-        (r) => r.emission.id,
-      ),
-    ).toEqual(["b", "c", "a"]);
-  });
-
-  it("filters by scout", () => {
-    expect(
-      filterAndSortFindings(rows, {
-        ...base,
-        scoutFilter: "signals-scout-web-analytics",
-      }).map((r) => r.emission.id),
-    ).toEqual(["b"]);
-  });
-
-  it("filters by severity", () => {
-    expect(
-      filterAndSortFindings(rows, { ...base, severityFilter: "P0" }).map(
-        (r) => r.emission.id,
-      ),
-    ).toEqual(["a"]);
+    ).toEqual(expected);
   });
 
   it("searches over description and prettified scout name", () => {

--- a/packages/core/src/scouts/scoutFindings.ts
+++ b/packages/core/src/scouts/scoutFindings.ts
@@ -1,0 +1,218 @@
+import type {
+  LinkedSignalReport,
+  ScoutEmission,
+  ScoutRun,
+} from "@posthog/api-client/posthog-client";
+import { prettifyScoutSkillName } from "@posthog/core/scouts/scoutPresentation";
+
+/**
+ * Cross-fleet findings model — the pure counterpart of the per-scout
+ * {@link ScoutSignalsSection} aggregation, shared by the findings page. Mirrors
+ * the PostHog Cloud `findingsLogic` selectors so the two surfaces stay in
+ * parity: flatten every recent emission into one row joined to its run (for the
+ * emitting scout + task-run link) and the inbox report it grouped into, then
+ * search / filter / sort over that flat list.
+ */
+
+/** A single finding paired with its run and the inbox report it fed into. */
+export interface ScoutFindingRow {
+  emission: ScoutEmission;
+  run: ScoutRun;
+  /** The inbox report this finding's signal grouped into, or null when unlinked. */
+  report: LinkedSignalReport | null;
+}
+
+export type FindingsSortKey = "newest" | "oldest" | "severity" | "confidence";
+
+export const FINDINGS_SCOUT_FILTER_ALL = "all";
+export const FINDINGS_SEVERITY_FILTER_ALL = "all";
+
+/** Severities the fleet emits, most severe first — drives the severity sort + filter options. */
+export const FINDINGS_SEVERITIES = ["P0", "P1", "P2", "P3", "P4"] as const;
+
+/**
+ * Cap on the emitted runs whose findings the page fans out to fetch. A scout is
+ * bounded to ~48 runs per 72h window by its 30-minute minimum cadence, but a
+ * larger fleet multiplies that, so capping the run set caps the per-run
+ * emissions-query fan-out the page mounts.
+ */
+export const FINDINGS_MAX_EMITTED_RUNS = 40;
+
+/** Lowest number = most severe, so the severity sort is a plain ascending compare. Unknown sinks last. */
+const SEVERITY_RANK: Record<string, number> = {
+  P0: 0,
+  P1: 1,
+  P2: 2,
+  P3: 3,
+  P4: 4,
+};
+function severityRank(severity: string | null): number {
+  return severity == null ? 99 : (SEVERITY_RANK[severity] ?? 98);
+}
+
+/** Newest-first by the run's start time; runs without one sink last. */
+function byRunStartedDesc(a: ScoutRun, b: ScoutRun): number {
+  return (b.started_at ?? "").localeCompare(a.started_at ?? "");
+}
+
+/**
+ * The emitted runs whose findings the page fetches: those that actually emitted,
+ * newest-first, capped fleet-wide. Mirrors the Cloud `mostRecentEmittedRuns`
+ * util so the page and any callout summary count the exact same run set.
+ */
+export function mostRecentEmittedRuns(
+  runs: ScoutRun[],
+  cap: number = FINDINGS_MAX_EMITTED_RUNS,
+): ScoutRun[] {
+  return runs
+    .filter((run) => (run.emitted_count ?? 0) > 0)
+    .slice()
+    .sort(byRunStartedDesc)
+    .slice(0, cap);
+}
+
+/**
+ * Stable key over the emitted-run set — lets the page refetch only when the set
+ * changes, not on every poll. Includes `emitted_count` so an in-progress run
+ * that emits more findings retriggers.
+ */
+export function emittedRunsKey(runs: ScoutRun[]): string {
+  return runs
+    .map((run) => `${run.run_id}:${run.emitted_count ?? 0}`)
+    .sort()
+    .join(",");
+}
+
+/**
+ * Join each emission back to its run and the report it grouped into. Emissions
+ * whose run is absent from the set (e.g. evicted past the cap) are dropped.
+ */
+export function buildFindingRows(
+  emissions: ScoutEmission[],
+  runs: ScoutRun[],
+  reportBySourceId: Map<string, LinkedSignalReport>,
+): ScoutFindingRow[] {
+  const runsById = new Map(runs.map((run) => [run.run_id, run]));
+  return emissions
+    .map((emission): ScoutFindingRow | null => {
+      const run = runsById.get(emission.run_id);
+      return run
+        ? {
+            emission,
+            run,
+            report: reportBySourceId.get(emission.source_id) ?? null,
+          }
+        : null;
+    })
+    .filter((row): row is ScoutFindingRow => row !== null);
+}
+
+/** A linked report indexed by its finding's `source_id`, for {@link buildFindingRows}. */
+export function reportsBySourceId(
+  links: { source_id: string; report: LinkedSignalReport | null }[],
+): Map<string, LinkedSignalReport> {
+  const map = new Map<string, LinkedSignalReport>();
+  for (const link of links) {
+    if (link.report) map.set(link.source_id, link.report);
+  }
+  return map;
+}
+
+export interface ScoutAvailableScout {
+  skillName: string;
+  label: string;
+  count: number;
+}
+
+/** Distinct scouts present in the rows, with a per-scout count, for the scout filter. */
+export function availableScouts(
+  rows: ScoutFindingRow[],
+): ScoutAvailableScout[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    counts.set(row.run.skill_name, (counts.get(row.run.skill_name) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([skillName, count]) => ({
+      skillName,
+      label: prettifyScoutSkillName(skillName),
+      count,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export interface FindingsFilter {
+  searchText: string;
+  /** A `skill_name`, or {@link FINDINGS_SCOUT_FILTER_ALL}. */
+  scoutFilter: string;
+  /** A severity, or {@link FINDINGS_SEVERITY_FILTER_ALL}. */
+  severityFilter: string;
+  sortKey: FindingsSortKey;
+}
+
+function byEmittedDesc(a: ScoutFindingRow, b: ScoutFindingRow): number {
+  return (b.emission.emitted_at ?? "").localeCompare(
+    a.emission.emitted_at ?? "",
+  );
+}
+
+/**
+ * Visible set: search (over finding text + prettified scout name) + scout +
+ * severity, then sort. Pure; the page wires it to its filter state.
+ */
+export function filterAndSortFindings(
+  rows: ScoutFindingRow[],
+  { searchText, scoutFilter, severityFilter, sortKey }: FindingsFilter,
+): ScoutFindingRow[] {
+  const needle = searchText.trim().toLowerCase();
+  const filtered = rows.filter((row) => {
+    if (
+      scoutFilter !== FINDINGS_SCOUT_FILTER_ALL &&
+      row.run.skill_name !== scoutFilter
+    ) {
+      return false;
+    }
+    if (
+      severityFilter !== FINDINGS_SEVERITY_FILTER_ALL &&
+      row.emission.severity !== severityFilter
+    ) {
+      return false;
+    }
+    if (needle) {
+      const haystack =
+        `${row.emission.description ?? ""} ${prettifyScoutSkillName(row.run.skill_name)}`.toLowerCase();
+      if (!haystack.includes(needle)) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return filtered.slice().sort((a, b) => {
+    if (sortKey === "oldest") {
+      return -byEmittedDesc(a, b);
+    }
+    if (sortKey === "severity") {
+      const diff =
+        severityRank(a.emission.severity) - severityRank(b.emission.severity);
+      return diff !== 0 ? diff : byEmittedDesc(a, b);
+    }
+    if (sortKey === "confidence") {
+      const diff = (b.emission.confidence ?? 0) - (a.emission.confidence ?? 0);
+      return diff !== 0 ? diff : byEmittedDesc(a, b);
+    }
+    return byEmittedDesc(a, b);
+  });
+}
+
+/** Most recent `emitted_at` across the rows, for the page's "latest" hint. */
+export function latestEmittedAt(rows: ScoutFindingRow[]): string | null {
+  let latest: string | null = null;
+  for (const row of rows) {
+    const at = row.emission.emitted_at;
+    if (at && (!latest || at > latest)) {
+      latest = at;
+    }
+  }
+  return latest;
+}

--- a/packages/core/src/scouts/scoutFindings.ts
+++ b/packages/core/src/scouts/scoutFindings.ts
@@ -66,7 +66,6 @@ export function mostRecentEmittedRuns(
 ): ScoutRun[] {
   return runs
     .filter((run) => (run.emitted_count ?? 0) > 0)
-    .slice()
     .sort(byRunStartedDesc)
     .slice(0, cap);
 }
@@ -188,7 +187,7 @@ export function filterAndSortFindings(
     return true;
   });
 
-  return filtered.slice().sort((a, b) => {
+  return filtered.sort((a, b) => {
     if (sortKey === "oldest") {
       return -byEmittedDesc(a, b);
     }

--- a/packages/ui/src/features/scouts/components/FleetFindingsCallout.tsx
+++ b/packages/ui/src/features/scouts/components/FleetFindingsCallout.tsx
@@ -1,5 +1,4 @@
 import { ArrowRightIcon, CompassIcon } from "@phosphor-icons/react";
-import { mostRecentEmittedRuns } from "@posthog/core/scouts/scoutFindings";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { Flex, Text } from "@radix-ui/themes";
 import { Link } from "@tanstack/react-router";
@@ -17,8 +16,12 @@ import { useScoutRuns } from "../hooks/useScoutRuns";
 export function FleetFindingsCallout() {
   const { data: runsWindow } = useScoutRuns();
 
+  // Every emitted run in the window — uncapped. The page caps its per-run
+  // emissions fan-out, but this card only sums the cheap `emitted_count`
+  // metadata, so it must count the whole fleet or larger fleets undercount.
   const emittedRuns = useMemo(
-    () => mostRecentEmittedRuns(runsWindow?.runs ?? []),
+    () =>
+      (runsWindow?.runs ?? []).filter((run) => (run.emitted_count ?? 0) > 0),
     [runsWindow],
   );
 
@@ -30,10 +33,11 @@ export function FleetFindingsCallout() {
     return null;
   }
 
-  // Emitted runs are newest-first, so the head dates the most recent finding.
-  const latestRun = emittedRuns[0];
-  const lastEmittedAt =
-    latestRun?.completed_at ?? latestRun?.started_at ?? null;
+  // The newest emitted run dates the most recent finding.
+  const lastEmittedAt = emittedRuns.reduce<string | null>((latest, run) => {
+    const at = run.completed_at ?? run.started_at;
+    return at && (!latest || at > latest) ? at : latest;
+  }, null);
 
   return (
     <Link

--- a/packages/ui/src/features/scouts/components/FleetFindingsCallout.tsx
+++ b/packages/ui/src/features/scouts/components/FleetFindingsCallout.tsx
@@ -1,0 +1,66 @@
+import { ArrowRightIcon, CompassIcon } from "@phosphor-icons/react";
+import { mostRecentEmittedRuns } from "@posthog/core/scouts/scoutFindings";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { Flex, Text } from "@radix-ui/themes";
+import { Link } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { useScoutRuns } from "../hooks/useScoutRuns";
+
+/**
+ * Findings stat card for the scout fleet section. Surfaces that the troop has
+ * emitted findings recently — count + recency — and links into the full
+ * cross-fleet findings browse/filter surface. Reads the cheap `emitted_count`
+ * sum off the already-polled runs window (no per-run emissions fan-out, that's
+ * the page's job). Renders nothing until there's at least one finding, so a
+ * fresh project isn't nudged toward an empty page.
+ */
+export function FleetFindingsCallout() {
+  const { data: runsWindow } = useScoutRuns();
+
+  const emittedRuns = useMemo(
+    () => mostRecentEmittedRuns(runsWindow?.runs ?? []),
+    [runsWindow],
+  );
+
+  const totalFindings = emittedRuns.reduce(
+    (sum, run) => sum + (run.emitted_count ?? 0),
+    0,
+  );
+  if (totalFindings === 0) {
+    return null;
+  }
+
+  // Emitted runs are newest-first, so the head dates the most recent finding.
+  const latestRun = emittedRuns[0];
+  const lastEmittedAt =
+    latestRun?.completed_at ?? latestRun?.started_at ?? null;
+
+  return (
+    <Link
+      to="/code/agents/scouts/findings"
+      className="flex w-full items-center gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-4 py-3.5 text-left no-underline transition-colors duration-150 hover:border-(--gray-6) hover:bg-(--gray-2)"
+    >
+      <CompassIcon size={20} className="shrink-0 text-(--iris-9)" />
+      <Flex direction="column" className="min-w-0">
+        <Text className="font-medium text-[13px] text-gray-12">
+          Scout findings
+        </Text>
+        <Text className="truncate text-[12px] text-gray-11 leading-snug">
+          {totalFindings} finding{totalFindings === 1 ? "" : "s"} your scouts
+          emitted recently, across the fleet
+          {lastEmittedAt ? (
+            <>
+              {" · latest "}
+              <RelativeTimestamp
+                timestamp={lastEmittedAt}
+                className="inline text-[12px] text-gray-11"
+              />
+            </>
+          ) : null}
+        </Text>
+      </Flex>
+      <span className="flex-1" />
+      <ArrowRightIcon size={14} className="shrink-0 text-gray-10" />
+    </Link>
+  );
+}

--- a/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
@@ -3,6 +3,7 @@ import type {
   LinkedSignalReport,
   ScoutEmission,
 } from "@posthog/api-client/posthog-client";
+import { prettifyScoutSkillName } from "@posthog/core/scouts/scoutPresentation";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
@@ -20,6 +21,7 @@ export function ScoutEmissionCard({
   linkedReport,
   defaultExpanded = false,
   highlighted = false,
+  showScout = false,
 }: {
   emission: ScoutEmission;
   /** The emitting scout, attached to analytics events when known. */
@@ -37,6 +39,11 @@ export function ScoutEmissionCard({
   defaultExpanded?: boolean;
   /** True when a shared finding link targets this card – scrolls it into view. */
   highlighted?: boolean;
+  /**
+   * Cross-fleet surfaces (the findings page) mix scouts, so the header titles
+   * the card with the emitting scout instead of the generic "Finding".
+   */
+  showScout?: boolean;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const cardRef = useRef<HTMLDivElement>(null);
@@ -76,7 +83,11 @@ export function ScoutEmissionCard({
           className={`shrink-0 text-gray-9 transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
         />
         <CompassIcon size={14} className="shrink-0 text-(--iris-9)" />
-        <Text className="font-medium text-[13px] text-gray-10">Finding</Text>
+        <Text className="truncate font-medium text-[13px] text-gray-10">
+          {showScout && skillName
+            ? prettifyScoutSkillName(skillName)
+            : "Finding"}
+        </Text>
         <SeverityBadge severity={emission.severity} />
         <Text className="text-[11px] text-gray-10">
           confidence {Math.round(emission.confidence * 100)}%

--- a/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
@@ -41,7 +41,7 @@ const SORT_OPTIONS: { value: FindingsSortKey; label: string }[] = [
  * so the two surfaces stay in parity as the backend evolves.
  */
 export function ScoutFindingsView() {
-  const { rows, isLoading, isError, partialFailedRuns, refetch } =
+  const { rows, isLoading, isError, incompleteRuns, windowTruncated, refetch } =
     useScoutFindings();
   const [searchText, setSearchText] = useState("");
   const [scoutFilter, setScoutFilter] = useState(FINDINGS_SCOUT_FILTER_ALL);
@@ -206,15 +206,16 @@ export function ScoutFindingsView() {
               </Select.Root>
             </Flex>
 
-            {partialFailedRuns > 0 ? (
+            {incompleteRuns > 0 || windowTruncated ? (
               <Flex
                 align="center"
                 gap="2"
                 className="rounded-(--radius-2) border border-(--amber-6) bg-(--amber-2) px-3 py-2 text-(--amber-11) text-[12px]"
               >
                 <Text className="flex-1 text-(--amber-11) text-[12px]">
-                  Some findings couldn&apos;t be loaded, so this list may be
-                  incomplete.
+                  {incompleteRuns > 0
+                    ? "Some findings couldn't be loaded, so this list may be incomplete."
+                    : "Showing the most recent runs only — older findings in this window may be missing."}
                 </Text>
                 <button
                   type="button"

--- a/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
@@ -1,0 +1,338 @@
+import {
+  ArrowLeftIcon,
+  CompassIcon,
+  MagnifyingGlassIcon,
+} from "@phosphor-icons/react";
+import {
+  availableScouts as deriveAvailableScouts,
+  latestEmittedAt as deriveLatestEmittedAt,
+  FINDINGS_SCOUT_FILTER_ALL,
+  FINDINGS_SEVERITIES,
+  FINDINGS_SEVERITY_FILTER_ALL,
+  type FindingsSortKey,
+  filterAndSortFindings,
+} from "@posthog/core/scouts/scoutFindings";
+import { SCOUT_RUNS_WINDOW_SPAN } from "@posthog/core/scouts/scoutRunsWindow";
+import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { getPostHogUrl } from "@posthog/ui/utils/urls";
+import { Box, Flex, Select, Text, TextField } from "@radix-ui/themes";
+import { Link } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { useScoutFindings } from "../hooks/useScoutFindings";
+import { ScoutEmissionCard } from "./ScoutEmissionCard";
+import { ScoutFindingDiscussButton } from "./ScoutFindingDiscussButton";
+import { ScoutFindingShareButton } from "./ScoutFindingShareButton";
+import { ScoutTaskRunLink } from "./ScoutTaskRunLink";
+
+const SORT_OPTIONS: { value: FindingsSortKey; label: string }[] = [
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "severity", label: "Severity" },
+  { value: "confidence", label: "Confidence" },
+];
+
+/**
+ * Cross-fleet findings browser — every finding the troop emitted in the recent
+ * runs window, in one place, newest first, searchable and filterable by scout /
+ * severity with a sort toggle. Reuses the per-scout {@link ScoutEmissionCard}
+ * with `showScout` on. Read-only; acting on a finding happens in its inbox
+ * report. Mirrors the PostHog Cloud `FindingsPanel`, kept structurally aligned
+ * so the two surfaces stay in parity as the backend evolves.
+ */
+export function ScoutFindingsView() {
+  const { rows, isLoading, isError, partialFailedRuns, refetch } =
+    useScoutFindings();
+  const [searchText, setSearchText] = useState("");
+  const [scoutFilter, setScoutFilter] = useState(FINDINGS_SCOUT_FILTER_ALL);
+  const [severityFilter, setSeverityFilter] = useState(
+    FINDINGS_SEVERITY_FILTER_ALL,
+  );
+  const [sortKey, setSortKey] = useState<FindingsSortKey>("newest");
+
+  const headerContent = useMemo(
+    () => (
+      <Flex align="center" gap="2" className="w-full min-w-0">
+        <CompassIcon size={12} className="shrink-0 text-gray-10" />
+        <Text
+          className="truncate whitespace-nowrap font-medium text-[13px]"
+          title="Scout findings"
+        >
+          Scout findings
+        </Text>
+      </Flex>
+    ),
+    [],
+  );
+  useSetHeaderContent(headerContent);
+
+  const availableScouts = useMemo(() => deriveAvailableScouts(rows), [rows]);
+  const filteredRows = useMemo(
+    () =>
+      filterAndSortFindings(rows, {
+        searchText,
+        scoutFilter,
+        severityFilter,
+        sortKey,
+      }),
+    [rows, searchText, scoutFilter, severityFilter, sortKey],
+  );
+
+  const totalCount = rows.length;
+  const scoutCount = availableScouts.length;
+  const latest = useMemo(() => deriveLatestEmittedAt(rows), [rows]);
+  const isFiltering =
+    searchText.trim().length > 0 ||
+    scoutFilter !== FINDINGS_SCOUT_FILTER_ALL ||
+    severityFilter !== FINDINGS_SEVERITY_FILTER_ALL;
+
+  return (
+    <Flex direction="column" className="h-full min-h-0">
+      <Flex
+        direction="column"
+        gap="2"
+        className="border-(--gray-5) border-b px-6 pt-5 pb-5"
+      >
+        <Link
+          to="/code/agents/scouts"
+          className="flex w-fit items-center gap-1 text-[12px] text-gray-10 no-underline hover:text-gray-12"
+        >
+          <ArrowLeftIcon size={12} />
+          Scouts
+        </Link>
+        <Flex align="center" gap="2">
+          <CompassIcon size={20} className="shrink-0 text-(--iris-9)" />
+          <Text className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">
+            Scout findings
+          </Text>
+        </Flex>
+        <Text className="max-w-2xl text-pretty text-[12.5px] text-gray-11 leading-relaxed">
+          Every signal your scouts have emitted recently, in one place — newest
+          first. See what&apos;s been surfaced across the whole troop, which
+          scout found it, and the inbox report it fed into.
+        </Text>
+        {totalCount > 0 ? (
+          <Flex align="center" gap="1" className="text-[12px] text-gray-10">
+            <Text className="text-[12px] text-gray-10">
+              {totalCount} finding{totalCount === 1 ? "" : "s"} · {scoutCount}{" "}
+              scout{scoutCount === 1 ? "" : "s"}
+            </Text>
+            {latest ? (
+              <>
+                <Text className="text-[12px] text-gray-9">· latest</Text>
+                <RelativeTimestamp
+                  timestamp={latest}
+                  className="text-[12px] text-gray-10"
+                />
+              </>
+            ) : null}
+          </Flex>
+        ) : null}
+        <Text className="text-[12px] text-gray-9">
+          Covers findings from the most recent {SCOUT_RUNS_WINDOW_SPAN} of troop
+          runs. Older findings live on in the inbox reports they produced.
+        </Text>
+      </Flex>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="mx-auto max-w-4xl px-6 py-6">
+          <Flex direction="column" gap="4">
+            <Flex align="center" gap="2" wrap="wrap">
+              <TextField.Root
+                type="search"
+                placeholder="Search findings…"
+                value={searchText}
+                onChange={(event) => setSearchText(event.target.value)}
+                size="2"
+                className="min-w-[14rem] flex-1"
+              >
+                <TextField.Slot>
+                  <MagnifyingGlassIcon size={14} className="text-gray-10" />
+                </TextField.Slot>
+              </TextField.Root>
+
+              <Select.Root
+                value={scoutFilter}
+                size="2"
+                onValueChange={setScoutFilter}
+              >
+                <Select.Trigger
+                  className="min-w-[10rem]"
+                  aria-label="Filter by scout"
+                />
+                <Select.Content>
+                  <Select.Item value={FINDINGS_SCOUT_FILTER_ALL}>
+                    All scouts
+                  </Select.Item>
+                  {availableScouts.map((scout) => (
+                    <Select.Item key={scout.skillName} value={scout.skillName}>
+                      {scout.label} ({scout.count})
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
+
+              <Select.Root
+                value={severityFilter}
+                size="2"
+                onValueChange={setSeverityFilter}
+              >
+                <Select.Trigger aria-label="Filter by severity" />
+                <Select.Content>
+                  <Select.Item value={FINDINGS_SEVERITY_FILTER_ALL}>
+                    All severities
+                  </Select.Item>
+                  {FINDINGS_SEVERITIES.map((severity) => (
+                    <Select.Item key={severity} value={severity}>
+                      {severity}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
+
+              <Select.Root
+                value={sortKey}
+                size="2"
+                onValueChange={(value) => setSortKey(value as FindingsSortKey)}
+              >
+                <Select.Trigger aria-label="Sort findings" />
+                <Select.Content>
+                  {SORT_OPTIONS.map((option) => (
+                    <Select.Item key={option.value} value={option.value}>
+                      Sort: {option.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
+            </Flex>
+
+            {partialFailedRuns > 0 ? (
+              <Flex
+                align="center"
+                gap="2"
+                className="rounded-(--radius-2) border border-(--amber-6) bg-(--amber-2) px-3 py-2 text-(--amber-11) text-[12px]"
+              >
+                <Text className="flex-1 text-(--amber-11) text-[12px]">
+                  Some findings couldn&apos;t be loaded, so this list may be
+                  incomplete.
+                </Text>
+                <button
+                  type="button"
+                  onClick={() => refetch()}
+                  className="rounded-(--radius-2) border border-(--amber-7) px-2.5 py-1 text-(--amber-11) text-[12px] transition-colors hover:bg-(--amber-3)"
+                >
+                  Retry
+                </button>
+              </Flex>
+            ) : null}
+
+            <FindingsBody
+              isLoading={isLoading}
+              isError={isError}
+              onRetry={() => refetch()}
+              rows={filteredRows}
+              isFiltering={isFiltering}
+            />
+          </Flex>
+        </div>
+      </div>
+    </Flex>
+  );
+}
+
+function FindingsBody({
+  isLoading,
+  isError,
+  onRetry,
+  rows,
+  isFiltering,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  rows: ReturnType<typeof filterAndSortFindings>;
+  isFiltering: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <Flex direction="column" gap="2">
+        {[0, 1, 2].map((key) => (
+          <Box
+            key={key}
+            className="h-20 w-full animate-pulse rounded-(--radius-2) bg-(--gray-3)"
+          />
+        ))}
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Flex
+        direction="column"
+        align="center"
+        gap="2"
+        className="rounded-(--radius-2) border border-(--gray-6) border-dashed bg-gray-1 px-4 py-8 text-center text-[12.5px] text-gray-11"
+      >
+        <Text className="text-[12.5px] text-gray-11">
+          Couldn&apos;t load findings. The scout API may be unavailable or this
+          project may not be enrolled yet.
+        </Text>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-(--radius-2) border border-(--gray-7) px-2.5 py-1 text-[12px] text-gray-11 transition-colors hover:bg-(--gray-3)"
+        >
+          Retry
+        </button>
+      </Flex>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <Box className="rounded-(--radius-2) border border-(--gray-6) border-dashed bg-gray-1 px-4 py-8 text-center text-[12.5px] text-gray-11">
+        {isFiltering
+          ? "No findings match your search and filters."
+          : "Your scouts haven't emitted any findings yet. As they scan your project, what they surface shows up here."}
+      </Box>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="2">
+      {rows.map((row) => {
+        const taskRunUrl = row.run.task_url
+          ? getPostHogUrl(row.run.task_url)
+          : null;
+        return (
+          <ScoutEmissionCard
+            // emission.id, not source_id — a run can re-emit a finding_id, sharing source_id.
+            key={row.emission.id}
+            emission={row.emission}
+            skillName={row.run.skill_name}
+            showScout
+            linkedReport={row.report}
+            actions={
+              <>
+                <ScoutFindingDiscussButton
+                  emission={row.emission}
+                  skillName={row.run.skill_name}
+                />
+                <ScoutFindingShareButton
+                  emission={row.emission}
+                  skillName={row.run.skill_name}
+                />
+              </>
+            }
+            footerEnd={
+              taskRunUrl ? (
+                <ScoutTaskRunLink run={row.run} taskRunUrl={taskRunUrl} />
+              ) : undefined
+            }
+          />
+        );
+      })}
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutsFleetSection.tsx
@@ -31,6 +31,7 @@ import { useScoutChatTask } from "../hooks/useScoutChatTask";
 import { useScoutConfigMutations } from "../hooks/useScoutConfigMutations";
 import { useScoutConfigs } from "../hooks/useScoutConfigs";
 import { useScoutRuns } from "../hooks/useScoutRuns";
+import { FleetFindingsCallout } from "./FleetFindingsCallout";
 import { FleetMemoryCallout } from "./FleetMemoryCallout";
 import { ScoutAlphaBanner } from "./ScoutAlphaBanner";
 import { ScoutHelperSkillLinks } from "./ScoutHelperSkillLinks";
@@ -227,6 +228,9 @@ function ScoutsFleetList({ configs }: { configs: ScoutConfig[] }) {
           icon={PlusIcon}
         />
       </Flex>
+
+      {/* Cross-fleet findings: renders only once the troop has emitted something. */}
+      <FleetFindingsCallout />
 
       {/* Fleet memory: renders only once scouts have written scratchpad notes. */}
       <FleetMemoryCallout />

--- a/packages/ui/src/features/scouts/hooks/useScoutFindings.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutFindings.ts
@@ -85,7 +85,13 @@ export function useScoutFindings(): ScoutFindings {
 
   const reportResults = useQueries({
     queries: emittedRuns.map((run) => ({
-      queryKey: scoutQueryKeys.emissionReports(projectId, run.run_id),
+      // emitted_count in the key alongside the emissions query, so a run that
+      // emits more refetches its report links too — otherwise the newly loaded
+      // findings would show without their inbox-report chip until focus/retry.
+      queryKey: [
+        ...scoutQueryKeys.emissionReports(projectId, run.run_id),
+        run.emitted_count ?? 0,
+      ],
       queryFn: async (): Promise<ScoutEmissionReportLink[]> => {
         if (!client) throw new Error("Not authenticated");
         if (!projectId) return [];
@@ -137,8 +143,10 @@ export function useScoutFindings(): ScoutFindings {
         const result = emissionsResults[index];
         if (!result) return count;
         if (result.isError) return count + 1;
-        const empty = (result.data?.length ?? 0) === 0;
-        if (result.isSuccess && empty && (run.emitted_count ?? 0) > 0) {
+        // Promised more findings than it returned — empty, or a partial
+        // response (eventual-consistency lag). Either undercounts the list.
+        const loaded = result.data?.length ?? 0;
+        if (result.isSuccess && loaded < (run.emitted_count ?? 0)) {
           return count + 1;
         }
         return count;

--- a/packages/ui/src/features/scouts/hooks/useScoutFindings.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutFindings.ts
@@ -22,10 +22,18 @@ export interface ScoutFindings {
   isLoading: boolean;
   /** True when the runs window failed, or every emitted run's emissions fetch failed. */
   isError: boolean;
-  /** Emitted runs whose emissions fetch failed while others succeeded — the list is incomplete. */
-  partialFailedRuns: number;
-  /** False when the runs-window pagination stopped early, so the run set may be incomplete. */
-  runsComplete: boolean;
+  /**
+   * Emitted runs whose promised findings are missing from the list — the
+   * emissions fetch either failed or resolved empty despite `emitted_count > 0`.
+   * Non-zero means the visible list is an undercount.
+   */
+  incompleteRuns: number;
+  /**
+   * True when the recent-runs set the page covers is itself clipped — pagination
+   * stopped early, or more emitted runs exist than the fan-out cap fetches. The
+   * window's own findings may therefore be missing, beyond {@link incompleteRuns}.
+   */
+  windowTruncated: boolean;
   refetch: () => void;
 }
 
@@ -43,6 +51,13 @@ export function useScoutFindings(): ScoutFindings {
   const projectId = useAuthStateValue((state) => state.currentProjectId);
   const runsQuery = useScoutRuns();
 
+  const allEmittedRuns = useMemo(
+    () =>
+      (runsQuery.data?.runs ?? []).filter(
+        (run) => (run.emitted_count ?? 0) > 0,
+      ),
+    [runsQuery.data],
+  );
   const emittedRuns = useMemo(
     () => mostRecentEmittedRuns(runsQuery.data?.runs ?? []),
     [runsQuery.data],
@@ -50,7 +65,13 @@ export function useScoutFindings(): ScoutFindings {
 
   const emissionsResults = useQueries({
     queries: emittedRuns.map((run) => ({
-      queryKey: scoutQueryKeys.emissions(projectId, run.run_id),
+      // emitted_count in the key so an in-progress run that emits more retriggers
+      // its fetch; completed runs hold a stable count and never refetch. The
+      // shared prefix stays intact for prefix-targeted invalidation.
+      queryKey: [
+        ...scoutQueryKeys.emissions(projectId, run.run_id),
+        run.emitted_count ?? 0,
+      ],
       queryFn: async (): Promise<ScoutEmission[]> => {
         if (!client) throw new Error("Not authenticated");
         if (!projectId) return [];
@@ -105,18 +126,36 @@ export function useScoutFindings(): ScoutFindings {
     emissionsResults.every((result) => result.isError);
   const isError = runsQuery.isError || allEmissionsFailed;
 
-  // Partial failure only matters when some runs did load — a total failure is
-  // reported as `isError` instead.
-  const partialFailedRuns = allEmissionsFailed
+  // Runs that promised findings (emitted_count > 0) but didn't deliver them:
+  // the fetch errored, or it resolved empty (eventual-consistency lag, or a
+  // backend quirk). Either way those findings are missing from the list, so
+  // the page can warn rather than imply completeness. Only meaningful when it
+  // isn't a total failure (that surfaces as `isError`).
+  const incompleteRuns = allEmissionsFailed
     ? 0
-    : emissionsResults.filter((result) => result.isError).length;
+    : emittedRuns.reduce((count, run, index) => {
+        const result = emissionsResults[index];
+        if (!result) return count;
+        if (result.isError) return count + 1;
+        const empty = (result.data?.length ?? 0) === 0;
+        if (result.isSuccess && empty && (run.emitted_count ?? 0) > 0) {
+          return count + 1;
+        }
+        return count;
+      }, 0);
+
+  // The run set itself is clipped when pagination stopped early, or when more
+  // emitted runs exist than the fan-out cap fetches.
+  const windowTruncated =
+    !(runsQuery.data?.complete ?? true) ||
+    allEmittedRuns.length > emittedRuns.length;
 
   return {
     rows,
     isLoading,
     isError,
-    partialFailedRuns,
-    runsComplete: runsQuery.data?.complete ?? true,
+    incompleteRuns,
+    windowTruncated,
     refetch: () => {
       void runsQuery.refetch();
       for (const result of emissionsResults) void result.refetch();

--- a/packages/ui/src/features/scouts/hooks/useScoutFindings.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutFindings.ts
@@ -1,0 +1,126 @@
+import type {
+  ScoutEmission,
+  ScoutEmissionReportLink,
+} from "@posthog/api-client/posthog-client";
+import {
+  buildFindingRows,
+  mostRecentEmittedRuns,
+  reportsBySourceId,
+  type ScoutFindingRow,
+} from "@posthog/core/scouts/scoutFindings";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useAuthStateValue } from "../../auth/store";
+import { scoutQueryKeys } from "./scoutQueryKeys";
+import { useScoutRuns } from "./useScoutRuns";
+
+export interface ScoutFindings {
+  rows: ScoutFindingRow[];
+  /** True until the runs window and its first emissions fan-out have resolved once. */
+  isLoading: boolean;
+  /** True when the runs window failed, or every emitted run's emissions fetch failed. */
+  isError: boolean;
+  /** Emitted runs whose emissions fetch failed while others succeeded — the list is incomplete. */
+  partialFailedRuns: number;
+  /** False when the runs-window pagination stopped early, so the run set may be incomplete. */
+  runsComplete: boolean;
+  refetch: () => void;
+}
+
+/**
+ * Cross-fleet findings — the data behind the findings page. Reads the polled
+ * runs window, narrows it to the recent emitted runs, then fans out one
+ * emissions query + one report-link query per run (emissions are only fetchable
+ * per run), and flattens the lot into one row list via the core
+ * {@link buildFindingRows}. The per-scout {@link ScoutSignalsSection} renders a
+ * child component per run instead; a single sortable list can't, so the fan-out
+ * lives here as `useQueries`.
+ */
+export function useScoutFindings(): ScoutFindings {
+  const client = useOptionalAuthenticatedClient();
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  const runsQuery = useScoutRuns();
+
+  const emittedRuns = useMemo(
+    () => mostRecentEmittedRuns(runsQuery.data?.runs ?? []),
+    [runsQuery.data],
+  );
+
+  const emissionsResults = useQueries({
+    queries: emittedRuns.map((run) => ({
+      queryKey: scoutQueryKeys.emissions(projectId, run.run_id),
+      queryFn: async (): Promise<ScoutEmission[]> => {
+        if (!client) throw new Error("Not authenticated");
+        if (!projectId) return [];
+        return client.listScoutRunEmissions(projectId, run.run_id);
+      },
+      enabled: !!client && !!projectId,
+      staleTime: 60_000,
+      meta: AUTH_SCOPED_QUERY_META,
+    })),
+  });
+
+  const reportResults = useQueries({
+    queries: emittedRuns.map((run) => ({
+      queryKey: scoutQueryKeys.emissionReports(projectId, run.run_id),
+      queryFn: async (): Promise<ScoutEmissionReportLink[]> => {
+        if (!client) throw new Error("Not authenticated");
+        if (!projectId) return [];
+        return client.listScoutEmissionReports(projectId, run.run_id);
+      },
+      enabled: !!client && !!projectId,
+      staleTime: 60_000,
+      meta: AUTH_SCOPED_QUERY_META,
+    })),
+  });
+
+  const emissions = useMemo(
+    () => emissionsResults.flatMap((result) => result.data ?? []),
+    [emissionsResults],
+  );
+  const reportLinks = useMemo(
+    () => reportResults.flatMap((result) => result.data ?? []),
+    [reportResults],
+  );
+
+  const rows = useMemo(
+    () =>
+      buildFindingRows(emissions, emittedRuns, reportsBySourceId(reportLinks)),
+    [emissions, emittedRuns, reportLinks],
+  );
+
+  // First load only — `isLoading` stays false across background polls so the
+  // list doesn't flash a skeleton each refetch.
+  const emissionsLoading = emissionsResults.some((result) => result.isLoading);
+  const isLoading =
+    runsQuery.isLoading ||
+    (emittedRuns.length > 0 && emissionsLoading && emissions.length === 0);
+
+  // Total failure: the window failed, or it loaded but every emitted run's
+  // emissions fetch rejected (so there is nothing to show).
+  const allEmissionsFailed =
+    emittedRuns.length > 0 &&
+    emissionsResults.every((result) => result.isError);
+  const isError = runsQuery.isError || allEmissionsFailed;
+
+  // Partial failure only matters when some runs did load — a total failure is
+  // reported as `isError` instead.
+  const partialFailedRuns = allEmissionsFailed
+    ? 0
+    : emissionsResults.filter((result) => result.isError).length;
+
+  return {
+    rows,
+    isLoading,
+    isError,
+    partialFailedRuns,
+    runsComplete: runsQuery.data?.complete ?? true,
+    refetch: () => {
+      void runsQuery.refetch();
+      for (const result of emissionsResults) void result.refetch();
+      for (const result of reportResults) void result.refetch();
+    },
+  };
+}

--- a/packages/ui/src/router/routeTree.gen.ts
+++ b/packages/ui/src/router/routeTree.gen.ts
@@ -55,6 +55,7 @@ import { Route as CodeInboxReportsReportIdRouteImport } from './routes/code/inbo
 import { Route as CodeInboxPullsReportIdRouteImport } from './routes/code/inbox/pulls.$reportId'
 import { Route as CodeInboxDismissedReportIdRouteImport } from './routes/code/inbox/dismissed.$reportId'
 import { Route as CodeAgentsScoutsScratchpadRouteImport } from './routes/code/agents/scouts.scratchpad'
+import { Route as CodeAgentsScoutsFindingsRouteImport } from './routes/code/agents/scouts.findings'
 import { Route as CodeAgentsScoutsSkillNameRouteImport } from './routes/code/agents/scouts.$skillName'
 import { Route as CodeAgentsApplicationsApprovalsRouteImport } from './routes/code/agents/applications/approvals'
 import { Route as CodeAgentsApplicationsIdOrSlugRouteImport } from './routes/code/agents/applications/$idOrSlug'
@@ -305,6 +306,12 @@ const CodeAgentsScoutsScratchpadRoute =
     path: '/scratchpad',
     getParentRoute: () => CodeAgentsScoutsRoute,
   } as any)
+const CodeAgentsScoutsFindingsRoute =
+  CodeAgentsScoutsFindingsRouteImport.update({
+    id: '/findings',
+    path: '/findings',
+    getParentRoute: () => CodeAgentsScoutsRoute,
+  } as any)
 const CodeAgentsScoutsSkillNameRoute =
   CodeAgentsScoutsSkillNameRouteImport.update({
     id: '/$skillName',
@@ -420,6 +427,7 @@ export interface FileRoutesByFullPath {
   '/code/agents/applications/$idOrSlug': typeof CodeAgentsApplicationsIdOrSlugRouteWithChildren
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
+  '/code/agents/scouts/findings': typeof CodeAgentsScoutsFindingsRoute
   '/code/agents/scouts/scratchpad': typeof CodeAgentsScoutsScratchpadRoute
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
@@ -470,6 +478,7 @@ export interface FileRoutesByTo {
   '/code/inbox': typeof CodeInboxIndexRoute
   '/website/$channelId': typeof WebsiteChannelIdIndexRoute
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
+  '/code/agents/scouts/findings': typeof CodeAgentsScoutsFindingsRoute
   '/code/agents/scouts/scratchpad': typeof CodeAgentsScoutsScratchpadRoute
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
@@ -532,6 +541,7 @@ export interface FileRoutesById {
   '/code/agents/applications/$idOrSlug': typeof CodeAgentsApplicationsIdOrSlugRouteWithChildren
   '/code/agents/applications/approvals': typeof CodeAgentsApplicationsApprovalsRoute
   '/code/agents/scouts/$skillName': typeof CodeAgentsScoutsSkillNameRouteWithChildren
+  '/code/agents/scouts/findings': typeof CodeAgentsScoutsFindingsRoute
   '/code/agents/scouts/scratchpad': typeof CodeAgentsScoutsScratchpadRoute
   '/code/inbox/dismissed/$reportId': typeof CodeInboxDismissedReportIdRoute
   '/code/inbox/pulls/$reportId': typeof CodeInboxPullsReportIdRoute
@@ -595,6 +605,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/$idOrSlug'
     | '/code/agents/applications/approvals'
     | '/code/agents/scouts/$skillName'
+    | '/code/agents/scouts/findings'
     | '/code/agents/scouts/scratchpad'
     | '/code/inbox/dismissed/$reportId'
     | '/code/inbox/pulls/$reportId'
@@ -645,6 +656,7 @@ export interface FileRouteTypes {
     | '/code/inbox'
     | '/website/$channelId'
     | '/code/agents/applications/approvals'
+    | '/code/agents/scouts/findings'
     | '/code/agents/scouts/scratchpad'
     | '/code/inbox/dismissed/$reportId'
     | '/code/inbox/pulls/$reportId'
@@ -706,6 +718,7 @@ export interface FileRouteTypes {
     | '/code/agents/applications/$idOrSlug'
     | '/code/agents/applications/approvals'
     | '/code/agents/scouts/$skillName'
+    | '/code/agents/scouts/findings'
     | '/code/agents/scouts/scratchpad'
     | '/code/inbox/dismissed/$reportId'
     | '/code/inbox/pulls/$reportId'
@@ -1074,6 +1087,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CodeAgentsScoutsScratchpadRouteImport
       parentRoute: typeof CodeAgentsScoutsRoute
     }
+    '/code/agents/scouts/findings': {
+      id: '/code/agents/scouts/findings'
+      path: '/findings'
+      fullPath: '/code/agents/scouts/findings'
+      preLoaderRoute: typeof CodeAgentsScoutsFindingsRouteImport
+      parentRoute: typeof CodeAgentsScoutsRoute
+    }
     '/code/agents/scouts/$skillName': {
       id: '/code/agents/scouts/$skillName'
       path: '/$skillName'
@@ -1274,12 +1294,14 @@ const CodeAgentsScoutsSkillNameRouteWithChildren =
 
 interface CodeAgentsScoutsRouteChildren {
   CodeAgentsScoutsSkillNameRoute: typeof CodeAgentsScoutsSkillNameRouteWithChildren
+  CodeAgentsScoutsFindingsRoute: typeof CodeAgentsScoutsFindingsRoute
   CodeAgentsScoutsScratchpadRoute: typeof CodeAgentsScoutsScratchpadRoute
   CodeAgentsScoutsIndexRoute: typeof CodeAgentsScoutsIndexRoute
 }
 
 const CodeAgentsScoutsRouteChildren: CodeAgentsScoutsRouteChildren = {
   CodeAgentsScoutsSkillNameRoute: CodeAgentsScoutsSkillNameRouteWithChildren,
+  CodeAgentsScoutsFindingsRoute: CodeAgentsScoutsFindingsRoute,
   CodeAgentsScoutsScratchpadRoute: CodeAgentsScoutsScratchpadRoute,
   CodeAgentsScoutsIndexRoute: CodeAgentsScoutsIndexRoute,
 }

--- a/packages/ui/src/router/routes/code/agents/scouts.findings.tsx
+++ b/packages/ui/src/router/routes/code/agents/scouts.findings.tsx
@@ -1,0 +1,6 @@
+import { ScoutFindingsView } from "@posthog/ui/features/scouts/components/ScoutFindingsView";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/agents/scouts/findings")({
+  component: ScoutFindingsView,
+});


### PR DESCRIPTION
this is bringing code app scouts pages in line with the could inbox scouts pages where you have a place to see all recent scout signals

## Problem

The Code app's scouts feature surfaces findings (emissions) only inline on a single scout's detail page and inside individual inbox reports. There's no way to see every finding the whole troop emitted recently in one place — which PostHog Cloud's inbox already offers via its `FindingsPanel` at `/inbox/scouts/findings`. This adds the equivalent cross-fleet findings surface to the Code app.

## Changes

<img width="1910" height="794" alt="image" src="https://github.com/user-attachments/assets/5f0cb371-99a1-4b3b-9d7e-ded4fab26f08" />


Adds a cross-fleet **Scout findings** page at `/code/agents/scouts/findings`, mirroring Cloud's `FindingsPanel` but built in the Code app's idioms (React Query hooks + TanStack file routes + Radix/Tailwind + pure `@posthog/core` helpers — not Kea).

- **`packages/core/src/scouts/scoutFindings.ts`** — host-agnostic aggregation logic (the pure counterpart of Cloud's `findingsLogic` selectors): narrow the runs window to recent emitted runs, join each emission to its run + linked inbox report, derive the scout filter list, and search/filter/sort the flat row list. Fully unit-tested.
- **`useScoutFindings.ts`** — fans out one emissions + one report-link query per emitted run via `useQueries` and flattens through the core helper. (The per-scout `ScoutSignalsSection` renders a child component per run, which can't produce one sortable list.) Distinguishes partial vs. total fetch failure so the page can warn when the list is incomplete.
- **`ScoutFindingsView.tsx`** — the page: header, search box, scout/severity/sort selectors, and a list of `ScoutEmissionCard`s with discuss/share/task-run actions and the linked-report chip.
- **`FleetFindingsCallout.tsx`** — entry-point stat card on the fleet section (beside the existing scratchpad callout), reading the cheap `emitted_count` sum; renders nothing until the troop has emitted something.
- **`ScoutEmissionCard.tsx`** — new optional `showScout` prop so cross-fleet cards title with the emitting scout instead of the generic "Finding".
- Route registered and `routeTree.gen.ts` regenerated.

Read-only surface; acting on a finding still happens in its inbox report. No backend, host, or DI changes.

## How did you test this?

- `pnpm --filter @posthog/core typecheck` and `pnpm --filter @posthog/ui typecheck` — clean
- `pnpm --filter @posthog/core test scoutFindings` — 19 unit tests pass (aggregation, filtering, sorting, edge cases)
- `biome check` clean on all touched files; `noRestrictedImports` clean on core
- Pre-commit hook re-ran Biome + full `pnpm typecheck` — passed
- Not yet exercised in the running app (handed to the author to dogfood locally)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?