### PR TITLE
fix(agent): let the Claude adapter run Cloudflare-served models

### DIFF
--- a/packages/agent/src/adapters/base-acp-agent.ts
+++ b/packages/agent/src/adapters/base-acp-agent.ts
@@ -24,6 +24,7 @@ import {
   getClaudeModelRecency,
   isAnthropicModel,
   isCloudflareModel,
+  isCloudflareModelId,
 } from "../gateway-models";
 import { Logger } from "../utils/logger";
 /**
@@ -165,7 +166,7 @@ export abstract class BaseAcpAgent implements Agent {
     const isClaudeAdapterModelId = (modelId: string): boolean =>
       modelId.startsWith("claude-") ||
       modelId.startsWith("anthropic/") ||
-      modelId.startsWith("@cf/");
+      isCloudflareModelId(modelId);
 
     let currentModelId = currentModelOverride ?? DEFAULT_GATEWAY_MODEL;
 

--- a/packages/agent/src/adapters/base-acp-agent.ts
+++ b/packages/agent/src/adapters/base-acp-agent.ts
@@ -23,6 +23,7 @@ import {
   type GatewayModel,
   getClaudeModelRecency,
   isAnthropicModel,
+  isCloudflareModel,
 } from "../gateway-models";
 import { Logger } from "../utils/logger";
 /**
@@ -143,7 +144,9 @@ export abstract class BaseAcpAgent implements Agent {
     );
 
     const options = this.gatewayModels
-      .filter((model) => isAnthropicModel(model))
+      // Cloudflare models are servable on the Claude adapter too — the gateway translates the
+      // `@cf/` path onto its Anthropic-Messages surface — so include them alongside Anthropic models.
+      .filter((model) => isAnthropicModel(model) || isCloudflareModel(model))
       .map((model) => ({
         value: model.id,
         name: formatGatewayModelName(model),
@@ -156,19 +159,23 @@ export abstract class BaseAcpAgent implements Agent {
           getClaudeModelRecency(a.value) - getClaudeModelRecency(b.value),
       );
 
-    const isAnthropicModelId = (modelId: string): boolean =>
-      modelId.startsWith("claude-") || modelId.startsWith("anthropic/");
+    // Models the Claude adapter can drive: Anthropic ids, plus Cloudflare `@cf/` ids the gateway
+    // serves over its Anthropic-Messages surface. Anything else (e.g. a Codex/GPT id) is a genuine
+    // adapter/model desync and falls back to the default.
+    const isClaudeAdapterModelId = (modelId: string): boolean =>
+      modelId.startsWith("claude-") ||
+      modelId.startsWith("anthropic/") ||
+      modelId.startsWith("@cf/");
 
     let currentModelId = currentModelOverride ?? DEFAULT_GATEWAY_MODEL;
 
     if (!options.some((opt) => opt.value === currentModelId)) {
-      if (!isAnthropicModelId(currentModelId)) {
-        // A non-Anthropic model id reached the Claude adapter, which means the
-        // adapter and model desynced upstream (e.g. a Codex model paired with
-        // the Claude adapter). Log it instead of silently masquerading as a
-        // deliberate Opus session.
+      if (!isClaudeAdapterModelId(currentModelId)) {
+        // A model the Claude adapter can't drive reached it, which means the adapter and model
+        // desynced upstream (e.g. a Codex model paired with the Claude adapter). Log it instead of
+        // silently masquerading as a deliberate Opus session.
         this.logger.warn(
-          "Non-Anthropic model requested on Claude adapter; falling back to default model",
+          "Incompatible model requested on Claude adapter; falling back to default model",
           {
             requestedModel: currentModelId,
             fallbackModel: DEFAULT_GATEWAY_MODEL,

--- a/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
@@ -187,7 +187,9 @@ describe("ClaudeAcpAgent session model on resume", () => {
     );
     if (expectsWarn) {
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Non-Anthropic model"),
+        expect.stringContaining(
+          "Incompatible model requested on Claude adapter",
+        ),
         expect.objectContaining({ requestedModel: model }),
       );
     } else {

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -160,6 +160,8 @@ describe("isCloudflareModel", () => {
     { id: "claude-opus-4-8", owned_by: "anthropic", expected: false },
     { id: "@cf/zai-org/glm-5.2", owned_by: "", expected: true },
     { id: "gpt-5.5", owned_by: "", expected: false },
+    // A Cloudflare-served model can report an upstream owner; the `@cf/` prefix still wins.
+    { id: "@cf/openai/gpt-oss", owned_by: "openai", expected: true },
   ])(
     "isCloudflareModel($id, owned_by=$owned_by) → $expected",
     ({ id, owned_by, expected }) => {

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -155,19 +155,17 @@ describe("gateway model fetch timeout", () => {
 });
 
 describe("isCloudflareModel", () => {
-  it("matches by owned_by when present", () => {
-    expect(isCloudflareModel(model("@cf/zai-org/glm-5.2", "cloudflare"))).toBe(
-      true,
-    );
-    expect(isCloudflareModel(model("claude-opus-4-8", "anthropic"))).toBe(
-      false,
-    );
-  });
-
-  it("falls back to the @cf/ id prefix when owned_by is absent", () => {
-    expect(isCloudflareModel(model("@cf/zai-org/glm-5.2"))).toBe(true);
-    expect(isCloudflareModel(model("gpt-5.5"))).toBe(false);
-  });
+  it.each([
+    { id: "@cf/zai-org/glm-5.2", owned_by: "cloudflare", expected: true },
+    { id: "claude-opus-4-8", owned_by: "anthropic", expected: false },
+    { id: "@cf/zai-org/glm-5.2", owned_by: "", expected: true },
+    { id: "gpt-5.5", owned_by: "", expected: false },
+  ])(
+    "isCloudflareModel($id, owned_by=$owned_by) → $expected",
+    ({ id, owned_by, expected }) => {
+      expect(isCloudflareModel(model(id, owned_by))).toBe(expected);
+    },
+  );
 
   it("does not classify Cloudflare models as Anthropic", () => {
     // The Claude adapter accepts both, but they must stay distinguishable.

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -3,9 +3,20 @@ import {
   fetchGatewayModels,
   fetchModelsList,
   formatGatewayModelName,
+  type GatewayModel,
   getClaudeModelRecency,
+  isAnthropicModel,
   isBlockedModelId,
+  isCloudflareModel,
 } from "./gateway-models";
+
+const model = (id: string, owned_by = ""): GatewayModel => ({
+  id,
+  owned_by,
+  context_window: 128000,
+  supports_streaming: true,
+  supports_vision: false,
+});
 
 describe("formatGatewayModelName", () => {
   it("keeps Claude models in friendly title case", () => {
@@ -141,4 +152,27 @@ describe("gateway model fetch timeout", () => {
       expect(init?.signal).toBeInstanceOf(AbortSignal);
     },
   );
+});
+
+describe("isCloudflareModel", () => {
+  it("matches by owned_by when present", () => {
+    expect(isCloudflareModel(model("@cf/zai-org/glm-5.2", "cloudflare"))).toBe(
+      true,
+    );
+    expect(isCloudflareModel(model("claude-opus-4-8", "anthropic"))).toBe(
+      false,
+    );
+  });
+
+  it("falls back to the @cf/ id prefix when owned_by is absent", () => {
+    expect(isCloudflareModel(model("@cf/zai-org/glm-5.2"))).toBe(true);
+    expect(isCloudflareModel(model("gpt-5.5"))).toBe(false);
+  });
+
+  it("does not classify Cloudflare models as Anthropic", () => {
+    // The Claude adapter accepts both, but they must stay distinguishable.
+    const glm = model("@cf/zai-org/glm-5.2", "cloudflare");
+    expect(isCloudflareModel(glm)).toBe(true);
+    expect(isAnthropicModel(glm)).toBe(false);
+  });
 });

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -117,6 +117,13 @@ export function isOpenAIModel(model: GatewayModel): boolean {
   return model.id.startsWith("gpt-") || model.id.startsWith("openai/");
 }
 
+// Cloudflare Workers AI model ids carry the `@cf/` path prefix (e.g. `@cf/zai-org/glm-5.2`). Kept as
+// a standalone id-only check so callers that only have a model id (not a full GatewayModel) — like the
+// Claude adapter's desync guard — share one source of truth with `isCloudflareModel`.
+export function isCloudflareModelId(modelId: string): boolean {
+  return modelId.startsWith("@cf/");
+}
+
 // Cloudflare Workers AI models (e.g. `@cf/zai-org/glm-5.2`). The gateway serves these over both its
 // OpenAI and Anthropic-Messages surfaces (it translates the `@cf/` path), so the Claude adapter can
 // drive them just like an Anthropic model.
@@ -124,7 +131,7 @@ export function isCloudflareModel(model: GatewayModel): boolean {
   if (model.owned_by) {
     return model.owned_by === "cloudflare";
   }
-  return model.id.startsWith("@cf/");
+  return isCloudflareModelId(model.id);
 }
 
 export interface ModelInfo {

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -126,12 +126,11 @@ export function isCloudflareModelId(modelId: string): boolean {
 
 // Cloudflare Workers AI models (e.g. `@cf/zai-org/glm-5.2`). The gateway serves these over both its
 // OpenAI and Anthropic-Messages surfaces (it translates the `@cf/` path), so the Claude adapter can
-// drive them just like an Anthropic model.
+// drive them just like an Anthropic model. The `@cf/` path prefix is the structural, always-present
+// signal, so honour it regardless of `owned_by` — a Cloudflare-served model can report an upstream
+// owner (e.g. `@cf/openai/...` with `owned_by: "openai"`) and must still classify as Cloudflare.
 export function isCloudflareModel(model: GatewayModel): boolean {
-  if (model.owned_by) {
-    return model.owned_by === "cloudflare";
-  }
-  return isCloudflareModelId(model.id);
+  return isCloudflareModelId(model.id) || model.owned_by === "cloudflare";
 }
 
 export interface ModelInfo {

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -117,6 +117,16 @@ export function isOpenAIModel(model: GatewayModel): boolean {
   return model.id.startsWith("gpt-") || model.id.startsWith("openai/");
 }
 
+// Cloudflare Workers AI models (e.g. `@cf/zai-org/glm-5.2`). The gateway serves these over both its
+// OpenAI and Anthropic-Messages surfaces (it translates the `@cf/` path), so the Claude adapter can
+// drive them just like an Anthropic model.
+export function isCloudflareModel(model: GatewayModel): boolean {
+  if (model.owned_by) {
+    return model.owned_by === "cloudflare";
+  }
+  return model.id.startsWith("@cf/");
+}
+
 export interface ModelInfo {
   id: string;
   owned_by?: string;

--- a/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -1,3 +1,4 @@
+import { isSupportedReasoningEffort } from "@posthog/agent/adapters/reasoning-effort";
 import {
   REPORT_MODEL_RESOLVER,
   type ReportModelResolver,
@@ -166,11 +167,20 @@ export function useInboxCloudTaskRunner({
 
     // The persisted effort belongs to `lastUsedModel`; if the resolver swapped in
     // a fallback default, that tier may be unsupported for the new model and the
-    // cloud runtime rejects the pair (see agent `bin.ts`). Only carry the effort
-    // when the model is unchanged; otherwise let the runtime pick its default.
+    // cloud runtime rejects the pair (see agent `bin.ts`). Carry the effort only
+    // when the model is unchanged AND the tier is actually supported for it —
+    // an effort-less model (e.g. a Cloudflare `@cf/*` model) carrying a stale
+    // tier would otherwise hard-fail the run at startup. Otherwise let the
+    // runtime pick its default.
     const reasoningLevel =
-      model === settings.lastUsedModel
-        ? (settings.lastUsedReasoningEffort ?? undefined)
+      model === settings.lastUsedModel &&
+      settings.lastUsedReasoningEffort &&
+      isSupportedReasoningEffort(
+        adapter,
+        model,
+        settings.lastUsedReasoningEffort,
+      )
+        ? settings.lastUsedReasoningEffort
         : undefined;
 
     const input = buildInput({

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -30,9 +30,11 @@ import {
   DEFAULT_GATEWAY_MODEL,
   fetchGatewayModels,
   formatGatewayModelName,
+  type GatewayModel,
   getClaudeModelRecency,
   getProviderName,
   isAnthropicModel,
+  isCloudflareModel,
   isOpenAIModel,
 } from "@posthog/agent/gateway-models";
 import { getLlmGatewayUrl } from "@posthog/agent/posthog-api";
@@ -2132,7 +2134,14 @@ For git operations while detached:
     const gatewayUrl = getLlmGatewayUrl(apiHost);
     const gatewayModels = await fetchGatewayModels({ gatewayUrl });
 
-    const modelFilter = adapter === "codex" ? isOpenAIModel : isAnthropicModel;
+    // The Claude adapter can also drive Cloudflare `@cf/` models the gateway serves over its
+    // Anthropic-Messages surface, so the preview/default-model path must offer them too — otherwise an
+    // advertised `@cf/*` model is dropped here and the pre-session run falls back to Opus.
+    const modelFilter =
+      adapter === "codex"
+        ? isOpenAIModel
+        : (model: GatewayModel) =>
+            isAnthropicModel(model) || isCloudflareModel(model);
 
     const modelOptions = gatewayModels
       .filter((model) => modelFilter(model))


### PR DESCRIPTION
## Problem

A scout (or any headless run) routed onto a Cloudflare-served model — e.g. `@cf/zai-org/glm-5.2` via `POSTHOG_CODE_MODEL` — silently runs on `claude-opus-4-8` instead. The Claude ACP adapter restricts itself to Anthropic model ids in two places in `BaseAcpAgent.getModelConfigOptions`:

1. the model-picker filter `this.gatewayModels.filter((m) => isAnthropicModel(m))` drops `@cf/` models, and
2. the override check `isAnthropicModelId` (only `claude-*` / `anthropic/*`) rejects an explicitly-requested `@cf/` id and falls back to `DEFAULT_GATEWAY_MODEL`.

So the requested model never reaches the SDK. Observed live in a local signals-scout run:

```
[ClaudeAcpAgent] [warn] Non-Anthropic model requested on Claude adapter; falling back to default model
  requestedModel: "@cf/zai-org/glm-5.2"  →  fallbackModel: "claude-opus-4-8"
```

This is the agent-side half of the GLM-on-the-claude-runtime dogfooding effort: the gateway serves `@cf/` models over its Anthropic-Messages surface (it translates the `@cf/` path, tool-calling included), so the Claude adapter *can* drive them — it was just gating them out.

## Changes

- `gateway-models.ts`: add an `isCloudflareModel(model)` predicate, mirroring `isAnthropicModel` / `isOpenAIModel` (`owned_by === "cloudflare"`, falling back to the `@cf/` id prefix).
- `base-acp-agent.ts` `getModelConfigOptions`:
  - include Cloudflare models in the picker filter alongside Anthropic models;
  - broaden the override gate (renamed `isAnthropicModelId` → `isClaudeAdapterModelId`) to accept `@cf/` ids, so an explicitly-requested Cloudflare model isn't reset to the default. A genuinely incompatible id (e.g. a Codex/GPT model that desynced onto the Claude adapter) still falls back and logs.

Scope is limited to the Claude adapter — `getModelConfigOptions` is only used by `ClaudeAcpAgent`; the Codex adapter has its own model path and is unaffected. Downstream is safe: `toSdkModelId` passes unknown ids through unchanged and `getContextWindowForModel` falls back gracefully, so `@cf/` models flow to the SDK correctly once the gates allow them.

## How did you test this?

- `pnpm --filter @posthog/agent typecheck` — clean.
- `pnpm exec biome check` on the changed files — clean (and the pre-commit hook re-ran biome + typecheck).
- `pnpm --filter @posthog/agent test gateway-models` — 18 pass, including 3 new `isCloudflareModel` cases (owned_by match, `@cf/` prefix fallback, and that CF models stay distinct from Anthropic).
- Root cause was captured from a real local signals-scout run (the warn line above); the paired gateway change (advertising `@cf/` models on `/v1/models`) is tracked separately. Full end-to-end re-verification — building the sandbox from this local agent source (`LOCAL_POSTHOG_CODE_MONOREPO_ROOT`) and confirming a scout produces `@cf/zai-org/glm-5.2` generations instead of Opus — is in progress.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
