### PR TITLE
feat(home): searchable skill picker in quick-action editor

### DIFF
--- a/packages/ui/src/features/home/config/ActionEditorPanel.tsx
+++ b/packages/ui/src/features/home/config/ActionEditorPanel.tsx
@@ -22,6 +22,10 @@ interface Props {
   indexInSituation: number;
 }
 
+// Search across both the skill name and its description.
+const skillSearchValue = (s: { name: string; description: string }) =>
+  `${s.name} ${s.description}`;
+
 export function ActionEditorPanel({
   situationId,
   action,
@@ -113,7 +117,7 @@ export function ActionEditorPanel({
               </Combobox.Trigger>
               <Combobox.Content
                 items={skills}
-                getValue={(s) => `${s.name} ${s.description}`}
+                getValue={skillSearchValue}
                 className="w-(--radix-popover-trigger-width)"
               >
                 {({ filtered, hasMore, moreCount }) => (

--- a/packages/ui/src/features/home/config/ActionEditorPanel.tsx
+++ b/packages/ui/src/features/home/config/ActionEditorPanel.tsx
@@ -10,6 +10,7 @@ import { useWorkflowEditorStore } from "@posthog/ui/features/home/stores/workflo
 import { UnifiedModelSelector } from "@posthog/ui/features/sessions/components/UnifiedModelSelector";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { usePreviewConfig } from "@posthog/ui/features/task-detail/hooks/usePreviewConfig";
+import { Combobox } from "@posthog/ui/primitives/combobox/Combobox";
 import { Card, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
 import { useMemo } from "react";
 import { SITUATION_TONE } from "./workflowMapLayout";
@@ -99,20 +100,45 @@ export function ActionEditorPanel({
           </Field>
 
           <Field label="Skill">
-            <select
+            <Combobox.Root
               value={action.skillId}
-              onChange={(e) => patch({ skillId: e.target.value })}
-              className="rounded-md border border-(--gray-6) bg-(--gray-1) px-2 py-1.5 text-[12px] text-gray-12"
+              onValueChange={(v) => patch({ skillId: v })}
+              size="2"
             >
-              <option value="">
-                {isLoading ? "Loading…" : "Pick a skill"}
-              </option>
-              {skills.map((s) => (
-                <option key={s.name} value={s.name}>
-                  {s.name}
-                </option>
-              ))}
-            </select>
+              <Combobox.Trigger
+                className="w-full"
+                placeholder={isLoading ? "Loading…" : "Pick a skill"}
+              >
+                {selectedSkill?.name}
+              </Combobox.Trigger>
+              <Combobox.Content
+                items={skills}
+                getValue={(s) => `${s.name} ${s.description}`}
+                className="w-(--radix-popover-trigger-width)"
+              >
+                {({ filtered, hasMore, moreCount }) => (
+                  <>
+                    <Combobox.Input placeholder="Search skills..." />
+                    <Combobox.Empty>No matching skills</Combobox.Empty>
+                    {filtered.map((s) => (
+                      <Combobox.Item
+                        key={s.name}
+                        value={s.name}
+                        textValue={s.name}
+                        description={s.description}
+                      >
+                        {s.name}
+                      </Combobox.Item>
+                    ))}
+                    {hasMore && (
+                      <div className="combobox-label">
+                        {moreCount} more; type to filter
+                      </div>
+                    )}
+                  </>
+                )}
+              </Combobox.Content>
+            </Combobox.Root>
             {selectedSkill ? (
               <Text className="mt-1 text-[10px] text-gray-10">
                 {selectedSkill.description}

--- a/packages/ui/src/features/home/config/ActionEditorPanel.tsx
+++ b/packages/ui/src/features/home/config/ActionEditorPanel.tsx
@@ -11,6 +11,7 @@ import { UnifiedModelSelector } from "@posthog/ui/features/sessions/components/U
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { usePreviewConfig } from "@posthog/ui/features/task-detail/hooks/usePreviewConfig";
 import { Combobox } from "@posthog/ui/primitives/combobox/Combobox";
+import type { ComboboxSearchKeys } from "@posthog/ui/primitives/combobox/useComboboxFilter";
 import { Card, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
 import { useMemo } from "react";
 import { SITUATION_TONE } from "./workflowMapLayout";
@@ -22,9 +23,16 @@ interface Props {
   indexInSituation: number;
 }
 
-// Search across both the skill name and its description.
-const skillSearchValue = (s: { name: string; description: string }) =>
-  `${s.name} ${s.description}`;
+type SkillOption = ReturnType<typeof useSkillsForPicker>["skills"][number];
+
+// Name-first so a prefix match on the name wins the exact-match promotion.
+const skillSearchValue = (s: SkillOption) => `${s.name} ${s.description}`;
+
+// Weight the skill name above its description so a name hit ranks first.
+const SKILL_SEARCH_KEYS: ComboboxSearchKeys<SkillOption> = [
+  { name: "name", weight: 0.7 },
+  { name: "description", weight: 0.3 },
+];
 
 export function ActionEditorPanel({
   situationId,
@@ -118,6 +126,7 @@ export function ActionEditorPanel({
               <Combobox.Content
                 items={skills}
                 getValue={skillSearchValue}
+                searchKeys={SKILL_SEARCH_KEYS}
                 className="w-(--radix-popover-trigger-width)"
               >
                 {({ filtered, hasMore, moreCount }) => (

--- a/packages/ui/src/features/home/config/ActionEditorPanel.tsx
+++ b/packages/ui/src/features/home/config/ActionEditorPanel.tsx
@@ -119,7 +119,9 @@ export function ActionEditorPanel({
                 {({ filtered, hasMore, moreCount }) => (
                   <>
                     <Combobox.Input placeholder="Search skills..." />
-                    <Combobox.Empty>No matching skills</Combobox.Empty>
+                    <Combobox.Empty>
+                      {isLoading ? "Loading skills…" : "No matching skills"}
+                    </Combobox.Empty>
                     {filtered.map((s) => (
                       <Combobox.Item
                         key={s.name}
@@ -131,9 +133,9 @@ export function ActionEditorPanel({
                       </Combobox.Item>
                     ))}
                     {hasMore && (
-                      <div className="combobox-label">
+                      <Combobox.Label>
                         {moreCount} more; type to filter
-                      </div>
+                      </Combobox.Label>
                     )}
                   </>
                 )}

--- a/packages/ui/src/primitives/combobox/Combobox.css
+++ b/packages/ui/src/primitives/combobox/Combobox.css
@@ -196,6 +196,31 @@
   white-space: nowrap;
 }
 
+.combobox-item-text-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.combobox-item-description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.85em;
+  line-height: 1.3;
+  color: var(--gray-10);
+}
+
+/* Two-line items grow to fit the description and top-align their content. */
+.combobox-content [cmdk-item]:has(.combobox-item-description) {
+  height: auto;
+  align-items: flex-start;
+  padding-top: var(--combobox-content-padding);
+  padding-bottom: var(--combobox-content-padding);
+}
+
 .combobox-content.size-1 [cmdk-item] {
   font-size: 13px;
   line-height: 20px;
@@ -250,6 +275,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Keep the check aligned to the first line on two-line items. */
+.combobox-content [cmdk-item]:has(.combobox-item-description)
+  .combobox-item-indicator {
+  align-self: flex-start;
 }
 
 .combobox-content [cmdk-empty] {

--- a/packages/ui/src/primitives/combobox/Combobox.stories.tsx
+++ b/packages/ui/src/primitives/combobox/Combobox.stories.tsx
@@ -419,9 +419,9 @@ export const WithDescriptions: Story = {
                 </Combobox.Item>
               ))}
               {hasMore && (
-                <div className="combobox-label">
+                <Combobox.Label>
                   {moreCount} more; type to filter
-                </div>
+                </Combobox.Label>
               )}
             </>
           )}

--- a/packages/ui/src/primitives/combobox/Combobox.stories.tsx
+++ b/packages/ui/src/primitives/combobox/Combobox.stories.tsx
@@ -369,6 +369,68 @@ export const FilteredContent: Story = {
   },
 };
 
+const skills = [
+  {
+    value: "investigate-metric",
+    label: "investigate-metric",
+    description: "Diagnose why a metric moved and surface the drivers.",
+  },
+  {
+    value: "querying-posthog-data",
+    label: "querying-posthog-data",
+    description: "Write and run HogQL against the project's event data.",
+  },
+  {
+    value: "creating-experiments",
+    label: "creating-experiments",
+    description:
+      "Define a hypothesis, configure rollout, and set up analytics for an A/B test.",
+  },
+  {
+    value: "investigating-replay",
+    label: "investigating-replay",
+    description: "Find and watch session replays relevant to an issue.",
+  },
+];
+
+export const WithDescriptions: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+
+    return (
+      <Combobox.Root value={value} onValueChange={setValue} size="2">
+        <Combobox.Trigger placeholder="Pick a skill..." className="w-[280px]" />
+        <Combobox.Content
+          items={skills}
+          getValue={(s) => `${s.label} ${s.description}`}
+        >
+          {({ filtered, hasMore, moreCount }) => (
+            <>
+              <Combobox.Input placeholder="Search skills..." />
+              <Combobox.Empty>No matching skills</Combobox.Empty>
+              {filtered.map((skill) => (
+                <Combobox.Item
+                  key={skill.value}
+                  value={skill.value}
+                  textValue={skill.label}
+                  description={skill.description}
+                >
+                  {skill.label}
+                </Combobox.Item>
+              ))}
+              {hasMore && (
+                <div className="combobox-label">
+                  {moreCount} more; type to filter
+                </div>
+              )}
+            </>
+          )}
+        </Combobox.Content>
+      </Combobox.Root>
+    );
+  },
+};
+
 export const ControlledSearch: Story = {
   render: () => {
     const [value, setValue] = useState("");

--- a/packages/ui/src/primitives/combobox/Combobox.tsx
+++ b/packages/ui/src/primitives/combobox/Combobox.tsx
@@ -358,91 +358,103 @@ interface ComboboxItemProps {
   className?: string;
   textValue?: string;
   icon?: React.ReactNode;
+  /** Optional muted second line, truncated to one line. */
+  description?: React.ReactNode;
 }
 
 const ComboboxItem = React.forwardRef<
   React.ElementRef<typeof CmdkCommand.Item>,
   ComboboxItemProps
->(({ children, value, disabled, className, textValue, icon }, ref) => {
-  const {
-    value: selectedValue,
-    onValueChange,
-    onOpenChange,
-    registerItem,
-    unregisterItem,
-  } = useComboboxContext();
+>(
+  (
+    { children, value, disabled, className, textValue, icon, description },
+    ref,
+  ) => {
+    const {
+      value: selectedValue,
+      onValueChange,
+      onOpenChange,
+      registerItem,
+      unregisterItem,
+    } = useComboboxContext();
 
-  const textRef = useRef<HTMLSpanElement>(null);
-  const itemRef = useRef<HTMLDivElement>(null);
-  const [showTooltip, setShowTooltip] = useState(false);
+    const textRef = useRef<HTMLSpanElement>(null);
+    const itemRef = useRef<HTMLDivElement>(null);
+    const [showTooltip, setShowTooltip] = useState(false);
 
-  useEffect(() => {
-    const label =
+    useEffect(() => {
+      const label =
+        textValue || (typeof children === "string" ? children : value);
+      registerItem(value, label);
+      return () => unregisterItem(value);
+    }, [value, children, textValue, registerItem, unregisterItem]);
+
+    useEffect(() => {
+      if (!showTooltip) return;
+      const scrollParent = itemRef.current?.closest("[cmdk-list]");
+      if (!scrollParent) return;
+      const dismiss = () => setShowTooltip(false);
+      scrollParent.addEventListener("scroll", dismiss, { passive: true });
+      return () => scrollParent.removeEventListener("scroll", dismiss);
+    }, [showTooltip]);
+
+    const isSelected = selectedValue === value;
+
+    const handleSelect = useCallback(() => {
+      if (!disabled) {
+        onValueChange(value);
+        onOpenChange(false);
+      }
+    }, [disabled, value, onValueChange, onOpenChange]);
+
+    const handleMouseEnter = useCallback(() => {
+      const el = textRef.current;
+      if (el && el.scrollWidth > el.clientWidth) {
+        setShowTooltip(true);
+      }
+    }, []);
+
+    const handleMouseLeave = useCallback(() => {
+      setShowTooltip(false);
+    }, []);
+
+    const tooltipContent =
       textValue || (typeof children === "string" ? children : value);
-    registerItem(value, label);
-    return () => unregisterItem(value);
-  }, [value, children, textValue, registerItem, unregisterItem]);
 
-  useEffect(() => {
-    if (!showTooltip) return;
-    const scrollParent = itemRef.current?.closest("[cmdk-list]");
-    if (!scrollParent) return;
-    const dismiss = () => setShowTooltip(false);
-    scrollParent.addEventListener("scroll", dismiss, { passive: true });
-    return () => scrollParent.removeEventListener("scroll", dismiss);
-  }, [showTooltip]);
-
-  const isSelected = selectedValue === value;
-
-  const handleSelect = useCallback(() => {
-    if (!disabled) {
-      onValueChange(value);
-      onOpenChange(false);
-    }
-  }, [disabled, value, onValueChange, onOpenChange]);
-
-  const handleMouseEnter = useCallback(() => {
-    const el = textRef.current;
-    if (el && el.scrollWidth > el.clientWidth) {
-      setShowTooltip(true);
-    }
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    setShowTooltip(false);
-  }, []);
-
-  const tooltipContent =
-    textValue || (typeof children === "string" ? children : value);
-
-  return (
-    <Tooltip content={tooltipContent} open={showTooltip} side="top">
-      <CmdkCommand.Item
-        ref={(node) => {
-          itemRef.current = node;
-          if (typeof ref === "function") ref(node);
-          else if (ref) ref.current = node;
-        }}
-        value={value}
-        disabled={disabled}
-        onSelect={handleSelect}
-        className={className}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      >
-        <span className="combobox-item-content">
-          {icon && <span className="combobox-item-icon">{icon}</span>}
-          <span ref={textRef} className="combobox-item-text">
-            {children}
+    return (
+      <Tooltip content={tooltipContent} open={showTooltip} side="top">
+        <CmdkCommand.Item
+          ref={(node) => {
+            itemRef.current = node;
+            if (typeof ref === "function") ref(node);
+            else if (ref) ref.current = node;
+          }}
+          value={value}
+          disabled={disabled}
+          onSelect={handleSelect}
+          className={className}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <span className="combobox-item-content">
+            {icon && <span className="combobox-item-icon">{icon}</span>}
+            <span className="combobox-item-text-group">
+              <span ref={textRef} className="combobox-item-text">
+                {children}
+              </span>
+              {description != null && (
+                <span className="combobox-item-description">{description}</span>
+              )}
+            </span>
           </span>
-        </span>
-        <span className="combobox-item-indicator">
-          {isSelected && <Check weight="bold" size={14} />}
-        </span>
-      </CmdkCommand.Item>
-    </Tooltip>
-  );
-});
+          <span className="combobox-item-indicator">
+            {isSelected && <Check weight="bold" size={14} />}
+          </span>
+        </CmdkCommand.Item>
+      </Tooltip>
+    );
+  },
+);
 
 ComboboxItem.displayName = "ComboboxItem";
 

--- a/packages/ui/src/primitives/combobox/Combobox.tsx
+++ b/packages/ui/src/primitives/combobox/Combobox.tsx
@@ -14,7 +14,10 @@ import React, {
 } from "react";
 import { Tooltip } from "../Tooltip";
 import "./Combobox.css";
-import { useComboboxFilter } from "./useComboboxFilter";
+import {
+  type ComboboxSearchKeys,
+  useComboboxFilter,
+} from "./useComboboxFilter";
 
 type ComboboxSize = "1" | "2" | "3";
 type ComboboxContentVariant = "solid" | "soft";
@@ -212,6 +215,12 @@ interface ComboboxContentFilteredProps<T> extends ComboboxContentBaseProps {
   items: T[];
   /** Extract the searchable string from each item. Defaults to `String(item)`. */
   getValue?: (item: T) => string;
+  /**
+   * Opt-in weighted fuzzy search across multiple fields (fuse.js). Each key
+   * carries a weight (e.g. name above description) and prefix matches on
+   * `getValue` are promoted. Pass a stable reference (a module constant).
+   */
+  searchKeys?: ComboboxSearchKeys<T>;
   /** Maximum items to render. Defaults to 50. */
   limit?: number;
   /** Values pinned to the top regardless of score. */
@@ -238,6 +247,7 @@ function ComboboxContent<T>({
   const hasItems = "items" in rest && rest.items !== undefined;
   const filterItems = hasItems ? rest.items : ([] as T[]);
   const getValue = hasItems ? rest.getValue : undefined;
+  const searchKeys = hasItems ? rest.searchKeys : undefined;
   const limit = hasItems ? rest.limit : undefined;
   const pinned = hasItems ? rest.pinned : undefined;
   const shouldFilter = hasItems
@@ -248,7 +258,7 @@ function ComboboxContent<T>({
 
   const filter = useComboboxFilter(
     filterItems,
-    { limit, pinned, open },
+    { limit, pinned, open, keys: searchKeys },
     getValue,
   );
 

--- a/packages/ui/src/primitives/combobox/Combobox.tsx
+++ b/packages/ui/src/primitives/combobox/Combobox.tsx
@@ -438,14 +438,18 @@ const ComboboxItem = React.forwardRef<
         >
           <span className="combobox-item-content">
             {icon && <span className="combobox-item-icon">{icon}</span>}
-            <span className="combobox-item-text-group">
+            {description ? (
+              <span className="combobox-item-text-group">
+                <span ref={textRef} className="combobox-item-text">
+                  {children}
+                </span>
+                <span className="combobox-item-description">{description}</span>
+              </span>
+            ) : (
               <span ref={textRef} className="combobox-item-text">
                 {children}
               </span>
-              {description != null && (
-                <span className="combobox-item-description">{description}</span>
-              )}
-            </span>
+            )}
           </span>
           <span className="combobox-item-indicator">
             {isSelected && <Check weight="bold" size={14} />}

--- a/packages/ui/src/primitives/combobox/useComboboxFilter.test.ts
+++ b/packages/ui/src/primitives/combobox/useComboboxFilter.test.ts
@@ -72,4 +72,59 @@ describe("useComboboxFilter", () => {
     );
     expect(result.current.filtered[0]).toBe("gamma");
   });
+
+  describe("weighted multi-key search (keys option)", () => {
+    interface Skill {
+      name: string;
+      description: string;
+    }
+    const skills: Skill[] = [
+      { name: "deploy-app", description: "Ship code to production" },
+      { name: "run-tests", description: "Deploy a test runner and report" },
+      { name: "lint", description: "Check formatting" },
+    ];
+    const keys = [
+      { name: "name" as const, weight: 0.7 },
+      { name: "description" as const, weight: 0.3 },
+    ];
+    const getValue = (s: Skill) => `${s.name} ${s.description}`;
+
+    const runSearch = (query: string) => {
+      const { result } = renderHook(() =>
+        useComboboxFilter(skills, { open: true, keys }, getValue),
+      );
+      act(() => {
+        result.current.onSearchChange(query);
+      });
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+      return result.current.filtered;
+    };
+
+    it("ranks a name match above a description-only match", () => {
+      // "deploy" hits deploy-app's name (weight 0.7) and run-tests' description
+      // (weight 0.3); the name match must win.
+      const filtered = runSearch("deploy");
+      expect(filtered.map((s) => s.name)).toEqual(["deploy-app", "run-tests"]);
+    });
+
+    it("promotes prefix matches for exact-match priority", () => {
+      const prefixFirst: Skill[] = [
+        { name: "unit-test", description: "Runs the unit suite" },
+        { name: "test-runner", description: "Generic harness" },
+      ];
+      const { result } = renderHook(() =>
+        useComboboxFilter(prefixFirst, { open: true, keys }, getValue),
+      );
+      act(() => {
+        result.current.onSearchChange("test");
+      });
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+      // Both names contain "test", but only "test-runner" starts with it.
+      expect(result.current.filtered[0]?.name).toBe("test-runner");
+    });
+  });
 });

--- a/packages/ui/src/primitives/combobox/useComboboxFilter.ts
+++ b/packages/ui/src/primitives/combobox/useComboboxFilter.ts
@@ -1,18 +1,34 @@
 import { defaultFilter } from "cmdk";
+import Fuse, { type IFuseOptions } from "fuse.js";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDebounce } from "../hooks/useDebounce";
 
 const DEFAULT_LIMIT = 50;
 const MIN_FUZZY_SCORE = 0.1;
 const DEBOUNCE_MS = 150;
+// fuse.js scores run 0 (perfect) → 1 (worst); only keep reasonably close matches.
+const FUSE_THRESHOLD = 0.4;
 
-interface UseComboboxFilterOptions {
+/** Weighted fields for the opt-in fuse.js search path. */
+export type ComboboxSearchKeys<T> = NonNullable<IFuseOptions<T>["keys"]>;
+
+interface UseComboboxFilterOptions<T> {
   /** Maximum number of items to render. Defaults to 50. */
   limit?: number;
   /** Values pinned to the top regardless of score. */
   pinned?: string[];
   /** Popover open state. Search resets when this becomes false. */
   open?: boolean;
+  /**
+   * Opt-in weighted fuzzy search across multiple fields, via fuse.js. Each key
+   * carries a weight (e.g. name above description), and items whose `getValue`
+   * starts with the query are promoted for exact-match priority. When omitted,
+   * scoring falls back to cmdk single-string matching over `getValue`.
+   *
+   * Pass a stable reference (a module constant) — a fresh array every render
+   * rebuilds the fuse index each time.
+   */
+  keys?: ComboboxSearchKeys<T>;
 }
 
 interface UseComboboxFilterResult<T> {
@@ -31,12 +47,13 @@ interface UseComboboxFilterResult<T> {
  */
 export function useComboboxFilter<T>(
   items: T[],
-  options?: UseComboboxFilterOptions,
+  options?: UseComboboxFilterOptions<T>,
   getValue?: (item: T) => string,
 ): UseComboboxFilterResult<T> {
   const limit = options?.limit ?? DEFAULT_LIMIT;
   const pinned = options?.pinned;
   const open = options?.open;
+  const keys = options?.keys;
   const [inputValue, setInputValue] = useState("");
   // delay=0 while closed so the next open starts on fresh empty-query results,
   // not a flash of the previous filtered set.
@@ -51,15 +68,41 @@ export function useComboboxFilter<T>(
     [getValue],
   );
 
+  // Build the fuse index only on the opt-in weighted path. `keys` must be a
+  // stable reference or this rebuilds every render.
+  const fuse = useMemo(
+    () =>
+      keys
+        ? new Fuse(items, {
+            keys,
+            threshold: FUSE_THRESHOLD,
+            ignoreLocation: true,
+            includeScore: true,
+          })
+        : null,
+    [items, keys],
+  );
+
   const { filtered, totalMatches } = useMemo(() => {
     const query = search.trim();
 
-    // Score and filter items. cmdk's fuzzy matcher can produce very low scores
-    // for scattered single-character matches (e.g. "vojta" matching v-o-j-t-a
-    // across "chore-remoVe-cOhort-Join-aTtempt"), so we require a minimum score
-    // to avoid noisy results.
+    // Scores below are normalised so higher always means a better match,
+    // letting the sort logic below stay identical across both paths.
     let scored: Array<{ item: T; score: number }>;
-    if (query) {
+    if (query && fuse) {
+      // Weighted multi-key fuzzy search. fuse scores 0 (best) → 1 (worst), so
+      // invert to higher-is-better, and promote prefix matches (+1) so an
+      // exact-ish hit on the leading field always outranks a fuzzy one.
+      const lowerQuery = query.toLowerCase();
+      scored = fuse.search(query).map(({ item, score }) => {
+        const prefix = resolve(item).toLowerCase().startsWith(lowerQuery);
+        return { item, score: (prefix ? 1 : 0) + (1 - (score ?? 1)) };
+      });
+    } else if (query) {
+      // cmdk's fuzzy matcher can produce very low scores for scattered
+      // single-character matches (e.g. "vojta" matching v-o-j-t-a across
+      // "chore-remoVe-cOhort-Join-aTtempt"), so we require a minimum score to
+      // avoid noisy results.
       scored = [];
       for (const item of items) {
         const score = defaultFilter(resolve(item), query);
@@ -94,7 +137,7 @@ export function useComboboxFilter<T>(
       filtered: scored.slice(0, limit).map((s) => s.item),
       totalMatches: total,
     };
-  }, [items, search, limit, pinned, resolve]);
+  }, [items, search, limit, pinned, resolve, fuse]);
 
   return {
     filtered,


### PR DESCRIPTION
## Summary

Improves skill selection while building a quick action in the home **Config** tab. The skill field in `ActionEditorPanel` is no longer a bare `<select>` of names — it's now a searchable combobox that:

- **Searches across both title and description** — typing filters on `name` *and* `description` (fuzzy, via the existing `useComboboxFilter`).
- **Shows the title with a truncated description** for each option, so skills are distinguishable without memorizing names.
- Keeps the full description of the selected skill shown beneath the field.

## Changes

- **Extended the shared `Combobox.Item` primitive** (`Combobox.tsx` + `Combobox.css`): added an optional `description` prop that renders a muted, single-line ellipsis-truncated second line. CSS lets two-line items grow to fit and keeps the selected-check top-aligned. Items without a description are unchanged, so existing consumers (`TaskSelector`, stories) are unaffected.
- **Rebuilt the skill picker** (`ActionEditorPanel.tsx`): `Combobox.Root` → `Trigger` → `Content` with `items={skills}` and `getValue={(s) => \`${s.name} ${s.description}\`}`, a search input, empty state, and a "N more; type to filter" hint.
- **Added a `WithDescriptions` Storybook story** documenting the new two-line item variant.

## Verification

- `pnpm build` — all 8 packages succeed.
- `pnpm --filter @posthog/ui typecheck` — clean.
- `biome check` on all changed files — no issues.

Not yet eyeballed in the running Electron app; happy to drive it over CDP and screenshot the dropdown if useful.