### PR TITLE
fix(diff): exclude binary files from diff line counts

### DIFF
--- a/packages/core/src/git-interaction/diffStats.test.ts
+++ b/packages/core/src/git-interaction/diffStats.test.ts
@@ -1,0 +1,41 @@
+import type { ChangedFile } from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+
+import { computeDiffStats } from "./diffStats";
+
+describe("computeDiffStats", () => {
+  it("sums line counts across text files", () => {
+    const files: ChangedFile[] = [
+      { path: "src/a.ts", status: "modified", linesAdded: 3, linesRemoved: 1 },
+      { path: "src/b.ts", status: "added", linesAdded: 10, linesRemoved: 0 },
+    ];
+    expect(computeDiffStats(files)).toEqual({
+      filesChanged: 2,
+      linesAdded: 13,
+      linesRemoved: 1,
+    });
+  });
+
+  it("counts image/video files but excludes their lines from the totals", () => {
+    const files: ChangedFile[] = [
+      { path: "src/a.ts", status: "modified", linesAdded: 3, linesRemoved: 1 },
+      {
+        path: "assets/logo.png",
+        status: "added",
+        linesAdded: 5000,
+        linesRemoved: 0,
+      },
+      {
+        path: "assets/demo.mp4",
+        status: "added",
+        linesAdded: 90000,
+        linesRemoved: 0,
+      },
+    ];
+    expect(computeDiffStats(files)).toEqual({
+      filesChanged: 3,
+      linesAdded: 3,
+      linesRemoved: 1,
+    });
+  });
+});

--- a/packages/core/src/git-interaction/diffStats.ts
+++ b/packages/core/src/git-interaction/diffStats.ts
@@ -1,3 +1,4 @@
+import { isBinaryFile } from "@posthog/shared";
 import type { ChangedFile } from "@posthog/shared/domain-types";
 
 export interface DiffStats {
@@ -11,9 +12,10 @@ export function computeDiffStats(files: ChangedFile[]): DiffStats {
   let linesRemoved = 0;
   const uniquePaths = new Set<string>();
   for (const file of files) {
+    uniquePaths.add(file.path);
+    if (isBinaryFile(file.path)) continue;
     linesAdded += file.linesAdded ?? 0;
     linesRemoved += file.linesRemoved ?? 0;
-    uniquePaths.add(file.path);
   }
   return { filesChanged: uniquePaths.size, linesAdded, linesRemoved };
 }

--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -110,6 +110,21 @@ describe("extractCloudToolChangedFiles", () => {
     expect(file.linesRemoved).toBe(removed);
   });
 
+  it("leaves line counts undefined for image/video files", () => {
+    const calls = makeToolCalls(
+      toolCall({
+        toolCallId: "tc-img",
+        kind: "write",
+        locations: [{ path: "assets/logo.png" }],
+        content: diffContent("assets/logo.png", "a\nb\nc\nd\ne"),
+      }),
+    );
+    const [file] = extractCloudToolChangedFiles(calls);
+    expect(file.path).toBe("assets/logo.png");
+    expect(file.linesAdded).toBeUndefined();
+    expect(file.linesRemoved).toBeUndefined();
+  });
+
   it("memoizes diff stats by diff-object identity", () => {
     const diff = diffObj("a\nB\nc", "a\nb\nc");
     const first = cachedDiffStats(diff);

--- a/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.ts
@@ -2,7 +2,11 @@ import type {
   ToolCallContent,
   ToolCallLocation,
 } from "@agentclientprotocol/sdk";
-import { type AcpMessage, isJsonRpcNotification } from "@posthog/shared";
+import {
+  type AcpMessage,
+  isBinaryFile,
+  isJsonRpcNotification,
+} from "@posthog/shared";
 import type { ChangedFile } from "@posthog/shared/domain-types";
 
 function getContentText(
@@ -282,7 +286,7 @@ export function extractCloudToolChangedFiles(
         status: "deleted",
       };
     } else {
-      const diffStats = cachedDiffStats(diff);
+      const diffStats = isBinaryFile(path) ? {} : cachedDiffStats(diff);
       file = {
         path,
         status: kind === "write" && !diff?.oldText ? "added" : "modified",


### PR DESCRIPTION
## What

Image, video, and other binary files were inflating the `+/-` line counts in the diff panel. The local git path already drops binary files to `undefined`, but the **cloud-session path** computed counts via a bag-of-lines diff over raw file content with no binary check — so writing an image blew the numbers up.

This reuses the existing `isBinaryFile` helper from `@posthog/shared` (images, video, audio, archives, fonts, PDFs; SVG stays text) at two layers:

- **`extractCloudToolChangedFiles`** — skips line-count computation for binary paths, leaving `linesAdded`/`linesRemoved` `undefined`, so per-file rows in `ChangesPanel` stay clean for cloud sessions.
- **`computeDiffStats`** — still counts the file in `filesChanged` but excludes its lines from the aggregate totals (diff-stats badge, review toolbar), regardless of source.

Files still appear in the list and in "N files changed" — they just no longer contribute nonsensical line counts.

## Tests

- New `diffStats.test.ts` covering the aggregate exclusion.
- New binary-exclusion case in `cloudToolChanges.test.ts`.
- All 22 tests pass; Biome clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)