### PR TITLE
fix(cloud-tasks): seamless resume without flicker or duplicate prompts

### DIFF
--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -96,6 +96,10 @@ interface WatcherState {
   batchFlushTimeoutId: ReturnType<typeof setTimeout> | null;
   pendingLogEntries: StoredLogEntry[];
   totalEntryCount: number;
+  /** On resume the renderer already holds the prior conversation; start live-
+   *  only (no bootstrap fetch/snapshot) seeded at this count so the in-flight
+   *  turn can't collide with a re-fetched snapshot. Null on non-resume watches. */
+  resumeFromEntryCount: number | null;
   reconnectAttempts: number;
   streamErrorAttempts: number;
   cumulativeReconnectAttempts: number;
@@ -435,6 +439,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       batchFlushTimeoutId: null,
       pendingLogEntries: [],
       totalEntryCount: 0,
+      resumeFromEntryCount: input.resumeFromEntryCount ?? null,
       reconnectAttempts: 0,
       streamErrorAttempts: 0,
       cumulativeReconnectAttempts: 0,
@@ -506,6 +511,17 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     }
 
     this.applyTaskRunState(watcher, run);
+
+    if (
+      !isTerminalStatus(run.status) &&
+      watcher.resumeFromEntryCount !== null
+    ) {
+      watcher.totalEntryCount = watcher.resumeFromEntryCount;
+      watcher.hasEmittedSnapshot = true;
+      watcher.isBootstrapping = false;
+      void this.connectSse(key, { startLatest: true });
+      return;
+    }
 
     if (isTerminalStatus(run.status)) {
       const historicalEntries = await this.fetchAllSessionLogs(watcher);

--- a/packages/core/src/cloud-task/schemas.ts
+++ b/packages/core/src/cloud-task/schemas.ts
@@ -33,6 +33,7 @@ export const watchInput = z.object({
   runId: z.string(),
   apiHost: z.string(),
   teamId: z.number(),
+  resumeFromEntryCount: z.number().optional(),
 });
 
 export type WatchInput = z.infer<typeof watchInput>;

--- a/packages/core/src/sessions/sessionLogs.test.ts
+++ b/packages/core/src/sessions/sessionLogs.test.ts
@@ -1,13 +1,5 @@
-import type { AcpMessage } from "@posthog/shared";
 import { describe, expect, it, vi } from "vitest";
-import { parseSessionLogContent, planSkippedPromptFilter } from "./sessionLogs";
-
-function promptEvent(id: number): AcpMessage {
-  return { message: { id, method: "session/prompt" } } as AcpMessage;
-}
-function notifyEvent(method: string): AcpMessage {
-  return { message: { method } } as AcpMessage;
-}
+import { parseSessionLogContent } from "./sessionLogs";
 
 describe("parseSessionLogContent", () => {
   it("parses one stored entry per line", () => {
@@ -64,28 +56,5 @@ describe("parseSessionLogContent", () => {
     expect(result.rawEntries).toHaveLength(1);
     expect(onParseError).toHaveBeenCalledTimes(1);
     expect(onParseError).toHaveBeenCalledWith("not json");
-  });
-});
-
-describe("planSkippedPromptFilter", () => {
-  it("returns null when there is nothing to skip", () => {
-    expect(planSkippedPromptFilter(0, [promptEvent(1)])).toBeNull();
-    expect(planSkippedPromptFilter(undefined, [promptEvent(1)])).toBeNull();
-  });
-
-  it("returns null when no session/prompt event is present", () => {
-    expect(
-      planSkippedPromptFilter(2, [notifyEvent("a"), notifyEvent("b")]),
-    ).toBeNull();
-  });
-
-  it("drops the first session/prompt event and decrements the skip count", () => {
-    const events = [notifyEvent("a"), promptEvent(1), notifyEvent("b")];
-    const plan = planSkippedPromptFilter(2, events);
-
-    expect(plan).not.toBeNull();
-    expect(plan?.remainingSkipCount).toBe(1);
-    expect(plan?.events).toEqual([notifyEvent("a"), notifyEvent("b")]);
-    expect(events).toHaveLength(3);
   });
 });

--- a/packages/core/src/sessions/sessionLogs.ts
+++ b/packages/core/src/sessions/sessionLogs.ts
@@ -1,5 +1,4 @@
-import type { AcpMessage, Adapter, StoredLogEntry } from "@posthog/shared";
-import { isJsonRpcRequest } from "@posthog/shared";
+import type { Adapter, StoredLogEntry } from "@posthog/shared";
 
 export interface ParsedSessionLogs {
   rawEntries: StoredLogEntry[];
@@ -50,24 +49,4 @@ export function parseSessionLogContent(
     sessionId,
     adapter,
   };
-}
-
-export function planSkippedPromptFilter(
-  skipPolledPromptCount: number | undefined,
-  events: AcpMessage[],
-): { events: AcpMessage[]; remainingSkipCount: number } | null {
-  if (!skipPolledPromptCount || skipPolledPromptCount <= 0) {
-    return null;
-  }
-
-  const promptIdx = events.findIndex(
-    (e) => isJsonRpcRequest(e.message) && e.message.method === "session/prompt",
-  );
-  if (promptIdx === -1) {
-    return null;
-  }
-
-  const filtered = [...events];
-  filtered.splice(promptIdx, 1);
-  return { events: filtered, remainingSkipCount: skipPolledPromptCount - 1 };
 }

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -67,7 +67,6 @@ import {
 } from "./permissionResponse";
 import {
   convertStoredEntriesToEvents,
-  createUserPromptEvent,
   createUserShellExecuteEvent,
   extractPromptText,
   getUserShellExecutesSinceLastPrompt,
@@ -78,11 +77,7 @@ import {
   shellExecutesToContextBlocks,
 } from "./sessionEvents";
 import { createBaseSession } from "./sessionFactory";
-import {
-  type ParsedSessionLogs,
-  parseSessionLogContent,
-  planSkippedPromptFilter,
-} from "./sessionLogs";
+import { type ParsedSessionLogs, parseSessionLogContent } from "./sessionLogs";
 
 const LOCAL_SESSION_RECONNECT_ATTEMPTS = 3;
 const LOCAL_SESSION_RECONNECT_BACKOFF = {
@@ -97,6 +92,7 @@ const GITHUB_AUTHORIZATION_REQUIRED_CODE = "github_authorization_required";
 const AUTO_RETRY_MAX_ATTEMPTS = 2;
 const AUTO_RETRY_DELAY_MS = 10_000;
 const AUTH_RESTORE_MAX_RETRY_WAITS = 6;
+const MAX_SUPERSEDED_RUN_IDS = 100;
 
 class GitHubAuthorizationRequiredForCloudHandoffError extends Error {
   constructor(
@@ -205,7 +201,6 @@ export interface ISessionStore {
 
 export interface SessionServiceHelpers {
   extractSkillButtonId: (...args: any[]) => any;
-  cloudPromptToBlocks: (...args: any[]) => any;
   combineQueuedCloudPrompts: (...args: any[]) => any;
   getCloudPromptTransport: (...args: any[]) => any;
   resolveLocalSkillCommandPrompt?: (prompt: string) => Promise<string | null>;
@@ -492,6 +487,7 @@ export class SessionService {
   private scheduledCloudQueueFlushes = new Set<string>();
   private cloudRunIdleTracker: CloudRunIdleTracker;
   private nextCloudTaskWatchToken = 0;
+  private supersededRunIds = new Set<string>();
   private subscriptions = new Map<
     string,
     {
@@ -2563,74 +2559,103 @@ export class SessionService {
     ) {
       return { stopReason: "empty" };
     }
-    const artifactIds = await this.d.h.uploadTaskStagedAttachments(
-      authCredentials.client,
-      session.taskId,
-      transport.filePaths,
-      transport.skillBundles,
-    );
-
-    const previousRun = await authCredentials.client.getTaskRun(
-      session.taskId,
-      session.taskRunId,
-    );
-    const previousState = previousRun.state as Record<string, unknown>;
-    const previousOutput = (previousRun.output ?? {}) as Record<
-      string,
-      unknown
-    >;
-    // Prefer the actual working branch the agent last pushed to (synced by
-    // agent-server after each turn), then the run-level branch field, then
-    // the original base branch from state. This preserves unmerged work when
-    // the snapshot has expired and the sandbox is rebuilt from scratch.
-    const previousBaseBranch =
-      (typeof previousOutput.head_branch === "string"
-        ? previousOutput.head_branch
-        : null) ??
-      previousRun.branch ??
-      (typeof previousState.pr_base_branch === "string"
-        ? previousState.pr_base_branch
-        : null) ??
-      session.cloudBranch;
-    const prAuthorshipMode = getCloudPrAuthorshipMode(previousState);
-
-    this.d.log.info("Creating resume run for terminal cloud task", {
-      taskId: session.taskId,
-      previousRunId: session.taskRunId,
-      previousStatus: session.cloudStatus,
+    this.d.store.updateSession(session.taskRunId, {
+      isPromptPending: true,
+      promptStartedAt: Date.now(),
+      pausedDurationMs: 0,
+    });
+    this.d.store.appendOptimisticItem(session.taskRunId, {
+      type: "user_message",
+      content: transport.promptText,
+      timestamp: Date.now(),
+      pinToTop: false,
     });
 
-    const runtimeOptions = getCloudRuntimeOptions(session, previousRun);
+    const rollbackOptimisticPrompt = () => {
+      this.d.store.updateSession(session.taskRunId, {
+        isPromptPending: false,
+        promptStartedAt: null,
+      });
+      this.d.store.clearTailOptimisticItems(session.taskRunId);
+    };
 
-    // Create a new run WITH resume context — backend validates the previous run,
-    // derives snapshot_external_id server-side, and passes everything as extra_state.
-    // The agent will load conversation history and restore the sandbox snapshot.
-    const updatedTask = await authCredentials.client.runTaskInCloud(
-      session.taskId,
-      previousBaseBranch,
-      {
-        adapter: runtimeOptions.adapter,
-        model: runtimeOptions.model,
-        reasoningLevel: runtimeOptions.reasoningLevel,
-        resumeFromRunId: session.taskRunId,
-        pendingUserMessage: transport.messageText,
-        pendingUserArtifactIds:
-          artifactIds.length > 0 ? artifactIds : undefined,
-        prAuthorshipMode,
-        runSource: getCloudRunSource(previousState),
-        signalReportId:
-          typeof previousState.signal_report_id === "string"
-            ? previousState.signal_report_id
-            : undefined,
-      },
-    );
+    let updatedTask: Task;
+    try {
+      const artifactIds = await this.d.h.uploadTaskStagedAttachments(
+        authCredentials.client,
+        session.taskId,
+        transport.filePaths,
+        transport.skillBundles,
+      );
+
+      const previousRun = await authCredentials.client.getTaskRun(
+        session.taskId,
+        session.taskRunId,
+      );
+      const previousState = previousRun.state as Record<string, unknown>;
+      const previousOutput = (previousRun.output ?? {}) as Record<
+        string,
+        unknown
+      >;
+      // Prefer the branch the agent last pushed to, then the run branch, then
+      // the base branch — preserves unmerged work if the sandbox is rebuilt.
+      const previousBaseBranch =
+        (typeof previousOutput.head_branch === "string"
+          ? previousOutput.head_branch
+          : null) ??
+        previousRun.branch ??
+        (typeof previousState.pr_base_branch === "string"
+          ? previousState.pr_base_branch
+          : null) ??
+        session.cloudBranch;
+      const prAuthorshipMode = getCloudPrAuthorshipMode(previousState);
+
+      this.d.log.info("Creating resume run for terminal cloud task", {
+        taskId: session.taskId,
+        previousRunId: session.taskRunId,
+        previousStatus: session.cloudStatus,
+      });
+
+      const runtimeOptions = getCloudRuntimeOptions(session, previousRun);
+
+      // Backend derives the snapshot from resumeFromRunId and restores the sandbox.
+      updatedTask = await authCredentials.client.runTaskInCloud(
+        session.taskId,
+        previousBaseBranch,
+        {
+          adapter: runtimeOptions.adapter,
+          model: runtimeOptions.model,
+          reasoningLevel: runtimeOptions.reasoningLevel,
+          resumeFromRunId: session.taskRunId,
+          pendingUserMessage: transport.messageText,
+          pendingUserArtifactIds:
+            artifactIds.length > 0 ? artifactIds : undefined,
+          prAuthorshipMode,
+          runSource: getCloudRunSource(previousState),
+          signalReportId:
+            typeof previousState.signal_report_id === "string"
+              ? previousState.signal_report_id
+              : undefined,
+        },
+      );
+    } catch (error) {
+      rollbackOptimisticPrompt();
+      throw error;
+    }
     const newRun = updatedTask.latest_run;
     if (!newRun?.id) {
+      rollbackOptimisticPrompt();
       throw new Error("Failed to create resume run");
     }
 
-    // Replace session with one for the new run, preserving conversation history.
-    // setSession handles old session cleanup via taskIdIndex.
+    this.supersededRunIds.add(session.taskRunId);
+    while (this.supersededRunIds.size > MAX_SUPERSEDED_RUN_IDS) {
+      const oldest = this.supersededRunIds.values().next().value;
+      if (oldest === undefined) break;
+      this.supersededRunIds.delete(oldest);
+    }
+
+    // New-run session carrying the prior conversation; setSession drops the old one.
     const newSession = createBaseSession(
       newRun.id,
       session.taskId,
@@ -2638,25 +2663,15 @@ export class SessionService {
     );
     newSession.status = "disconnected";
     newSession.isCloud = true;
-    // Carry over existing events and add optimistic user bubble for the follow-up.
-    // Reset processedLineCount to 0 because the new run's log stream starts fresh.
-    newSession.events = [
-      ...session.events,
-      createUserPromptEvent(
-        transport.filePaths.length > 0
-          ? this.d.h.cloudPromptToBlocks(prompt)
-          : [{ type: "text", text: transport.promptText }],
-        Date.now(),
-      ),
-    ];
-    newSession.processedLineCount = 0;
-    // Skip the first session/prompt from polled logs — we already have the
-    // optimistic user event, so showing the polled one would duplicate it.
-    newSession.skipPolledPromptCount = 1;
+    newSession.isPromptPending = true;
+    newSession.promptStartedAt = Date.now();
+    newSession.events = [...session.events];
+    newSession.optimisticItems = (
+      this.getSessionByRunId(session.taskRunId)?.optimisticItems ?? []
+    ).filter((item) => item.type === "user_message" && item.pinToTop === false);
+    const resumeFromEntryCount = session.processedLineCount ?? 0;
+    newSession.processedLineCount = resumeFromEntryCount;
     this.d.store.setSession(newSession);
-
-    // No enqueueMessage / isPromptPending needed — the follow-up is passed
-    // in run state (pending_user_message), NOT via user_message command.
 
     // Start the watcher immediately so we don't miss status updates.
     const initialMode =
@@ -2679,9 +2694,10 @@ export class SessionService {
       initialMode,
       newRun.runtime_adapter ?? session.adapter ?? "claude",
       initialModel,
+      undefined,
+      resumeFromEntryCount,
     );
 
-    // Invalidate task queries so the UI picks up the new run metadata
     this.d.queryClient.invalidateQueries({ queryKey: ["tasks"] });
 
     this.d.track(ANALYTICS_EVENTS.PROMPT_SENT, {
@@ -3271,8 +3287,13 @@ export class SessionService {
     adapter: Adapter = "claude",
     initialModel?: string,
     taskDescription?: string,
+    resumeFromEntryCount?: number,
+    runStatus?: TaskRunStatus,
   ): () => void {
     const taskRunId = runId;
+
+    if (this.supersededRunIds.has(runId)) return () => {};
+
     const existingWatcher = this.cloudTaskWatchers.get(taskId);
 
     // Resuming same run — reuse the existing watcher.
@@ -3406,6 +3427,7 @@ export class SessionService {
         taskRunId,
         logUrl,
         taskDescription,
+        runStatus,
       );
     }
 
@@ -3452,6 +3474,7 @@ export class SessionService {
           runId,
           apiHost,
           teamId,
+          resumeFromEntryCount,
         });
 
         // If the local watcher was torn down while the watch request was in
@@ -3489,12 +3512,39 @@ export class SessionService {
     taskRunId: string,
     logUrl?: string,
     taskDescription?: string,
+    runStatus?: TaskRunStatus,
   ): void {
     void (async () => {
-      const { rawEntries, totalLineCount } = await this.fetchSessionLogs(
-        logUrl,
-        taskRunId,
-      );
+      let rawEntries: StoredLogEntry[];
+      let totalLineCount: number;
+      if (isTerminalStatus(runStatus)) {
+        // Terminal runs: fetch the full resume chain (matches the snapshot) so a
+        // resumed run isn't under-counted. In-progress runs use the single-run
+        // log so hydrate can't race the live stream and double the active turn.
+        const authStatus = await this.getAuthCredentialsStatus();
+        if (authStatus.kind !== "ready") {
+          return;
+        }
+        try {
+          rawEntries = await authStatus.auth.client.getTaskRunSessionLogs(
+            taskId,
+            taskRunId,
+            { limit: 100000 },
+          );
+        } catch (err) {
+          this.d.log.warn("Failed to fetch session-log chain for hydrate", {
+            taskId,
+            taskRunId,
+            err,
+          });
+          return;
+        }
+        totalLineCount = rawEntries.length;
+      } else {
+        const parsed = await this.fetchSessionLogs(logUrl, taskRunId);
+        rawEntries = parsed.rawEntries;
+        totalLineCount = parsed.totalLineCount;
+      }
 
       const session = this.d.store.getSessionByTaskId(taskId);
       if (!session || session.taskRunId !== taskRunId) {
@@ -4057,6 +4107,8 @@ export class SessionService {
       adapter,
       initialModel,
       task.description ?? undefined,
+      undefined,
+      task.latest_run?.status,
     );
   }
 
@@ -4367,12 +4419,7 @@ export class SessionService {
         // Already caught up — skip duplicate entries
       } else if (plan.kind === "append-tail") {
         const entriesToAppend = update.newEntries.slice(-plan.tailCount);
-        let newEvents = convertStoredEntriesToEvents(entriesToAppend);
-        newEvents = this.filterSkippedPromptEvents(
-          taskRunId,
-          session,
-          newEvents,
-        );
+        const newEvents = convertStoredEntriesToEvents(entriesToAppend);
         if (hasSessionPromptEvent(newEvents)) {
           this.d.store.clearTailOptimisticItems(taskRunId);
         }
@@ -4433,33 +4480,6 @@ export class SessionService {
         this.stopCloudTaskWatch(update.taskId);
       }
     }
-  }
-
-  /**
-   * Filter out session/prompt events that should be skipped during resume.
-   * When resuming a cloud run, the initial session/prompt from the new run's
-   * logs would duplicate the optimistic user bubble we already added.
-   */
-  // Note: `session` is a snapshot from the start of handleCloudTaskUpdate.
-  // The updateSession call below makes it stale, but this is safe because
-  // skipPolledPromptCount is only ever 1, so this method runs at most once.
-  private filterSkippedPromptEvents(
-    taskRunId: string,
-    session: AgentSession | undefined,
-    events: AcpMessage[],
-  ): AcpMessage[] {
-    const plan = planSkippedPromptFilter(
-      session?.skipPolledPromptCount,
-      events,
-    );
-    if (!plan) {
-      return events;
-    }
-
-    this.d.store.updateSession(taskRunId, {
-      skipPolledPromptCount: plan.remainingSkipCount,
-    });
-    return plan.events;
   }
 
   // --- Helper Methods ---

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -76,7 +76,6 @@ export interface AgentSession {
   initialPrompt?: ContentBlock[];
   cloudBranch?: string | null;
   handoffInProgress?: boolean;
-  skipPolledPromptCount?: number;
   optimisticItems: OptimisticItem[];
   contextUsed?: number;
   contextSize?: number;

--- a/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -289,6 +289,52 @@ describe("buildConversationItems", () => {
       expect(group.isActive).toBe(false);
     });
 
+    it("keeps the agent step in_progress until its run emits run_started", () => {
+      const runStarted = (ts: number, runId: string): AcpMessage => ({
+        type: "acp_message",
+        ts,
+        message: {
+          jsonrpc: "2.0",
+          method: "_posthog/run_started",
+          params: { runId },
+        },
+      });
+      const base: AcpMessage[] = [
+        progressMsg(
+          1,
+          "sandbox",
+          "completed",
+          "Restored sandbox",
+          undefined,
+          "setup:run-9",
+        ),
+        progressMsg(
+          2,
+          "agent",
+          "completed",
+          "Started agent",
+          undefined,
+          "setup:run-9",
+        ),
+      ];
+
+      const gated = findProgressGroups(
+        buildConversationItems(base, null).items,
+      )[0];
+      expect(gated.steps.find((s) => s.key === "agent")?.status).toBe(
+        "in_progress",
+      );
+      expect(gated.isActive).toBe(true);
+
+      const ready = findProgressGroups(
+        buildConversationItems([...base, runStarted(3, "run-9")], null).items,
+      )[0];
+      expect(ready.steps.find((s) => s.key === "agent")?.status).toBe(
+        "completed",
+      );
+      expect(ready.isActive).toBe(false);
+    });
+
     it("opens a separate progress_group per group id — distinct groups coexist inline", () => {
       const events: AcpMessage[] = [
         // Pre-prompt setup group.

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -91,6 +91,8 @@ interface ProgressCardState {
   };
   /** Index in `items` where this card sits. */
   itemIndex: number;
+  /** Run id parsed from the `group` (`setup:<runId>`); empty if absent. */
+  runId: string;
 }
 
 interface TurnState {
@@ -132,6 +134,9 @@ export interface ItemBuilder {
    *  Drives the generating indicator's status word so it advances on real work
    *  finishing rather than on a timer. */
   completedToolCallCount: number;
+  /** Runs that emitted `_posthog/run_started`; until then the setup card's
+   *  "agent" step stays in_progress rather than completing at HTTP-boot time. */
+  runStartedRunIds: Set<string>;
 }
 
 export function createItemBuilder(): ItemBuilder {
@@ -147,6 +152,7 @@ export function createItemBuilder(): ItemBuilder {
     progressCards: new Map(),
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
+    runStartedRunIds: new Set(),
   };
 }
 
@@ -206,7 +212,14 @@ export function buildConversationItems(
 ): BuildResult {
   const b = createItemBuilder();
 
-  for (const event of events) {
+  let ordered = events;
+  for (let i = 1; i < events.length; i++) {
+    if (events[i].ts < events[i - 1].ts) {
+      ordered = [...events].sort((a, b) => a.ts - b.ts);
+      break;
+    }
+  }
+  for (const event of ordered) {
     processEvent(b, event, options);
   }
 
@@ -484,6 +497,21 @@ function handleNotification(
     return;
   }
 
+  if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.RUN_STARTED)) {
+    const runId = (msg.params as { runId?: string } | undefined)?.runId;
+    if (runId) {
+      b.runStartedRunIds.add(runId);
+      const card = b.progressCards.get(`setup:${runId}`);
+      if (card) {
+        if (card.itemIndex < b.lowestTouchedProgressIndex) {
+          b.lowestTouchedProgressIndex = card.itemIndex;
+        }
+        syncProgressCard(card, b);
+      }
+    }
+    return;
+  }
+
   if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.COMPACT_BOUNDARY)) {
     if (!b.currentTurn) ensureImplicitTurn(b, ts);
     const params = msg.params as {
@@ -532,18 +560,26 @@ function ensureProgressCardForGroup(
     steps: [] as Step[],
     isActive: true,
   };
+  const colon = group.indexOf(":");
   const card: ProgressCardState = {
     steps: new Map(),
     renderItem,
     itemIndex: b.items.length,
+    runId: colon >= 0 ? group.slice(colon + 1) : "",
   };
   b.progressCards.set(group, card);
   pushItem(b, renderItem);
   return card;
 }
 
-function syncProgressCard(card: ProgressCardState) {
-  const ordered: Step[] = Array.from(card.steps.values());
+function syncProgressCard(card: ProgressCardState, b: ItemBuilder) {
+  const gateAgentStep =
+    card.runId !== "" && !b.runStartedRunIds.has(card.runId);
+  const ordered: Step[] = Array.from(card.steps.values()).map((step) =>
+    step.key === "agent" && step.status === "completed" && gateAgentStep
+      ? { ...step, status: "in_progress" as StepStatus }
+      : step,
+  );
   card.renderItem.steps = ordered;
   card.renderItem.isActive = ordered.some((s) => s.status === "in_progress");
 }
@@ -572,7 +608,7 @@ function handleProgress(b: ItemBuilder, rawParams: unknown, ts: number) {
     label: params.label,
     detail: params.detail,
   });
-  syncProgressCard(card);
+  syncProgressCard(card, b);
 }
 
 function normalizeStepStatus(raw: string | undefined): StepStatus {

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -126,6 +126,7 @@ const mockAuthenticatedClient = vi.hoisted(() => ({
   prepareTaskStagedArtifactUploads: vi.fn(),
   finalizeTaskStagedArtifactUploads: vi.fn(),
   startGithubUserIntegrationConnect: vi.fn(),
+  getTaskRunSessionLogs: vi.fn(),
 }));
 
 type MockAuthenticatedClient = typeof mockAuthenticatedClient;
@@ -394,6 +395,7 @@ describe("SessionService", () => {
     mockGetIsOnline.mockReturnValue(true);
     mockGetConfigOptionByCategory.mockReturnValue(undefined);
     mockBuildAuthenticatedClient.mockReturnValue(mockAuthenticatedClient);
+    mockAuthenticatedClient.getTaskRunSessionLogs.mockResolvedValue([]);
     mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(undefined);
     mockSessionStoreSetters.getSessions.mockReturnValue({});
     mockAuth.fetchAuthState.mockResolvedValue({
@@ -4201,7 +4203,7 @@ describe("SessionService", () => {
       );
     });
 
-    it("preserves attachment blocks in the optimistic resume event", async () => {
+    it("shows an optimistic user bubble when resuming a terminal cloud run", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
         createMockSession({
@@ -4302,19 +4304,18 @@ describe("SessionService", () => {
       const result = await service.sendPrompt("task-123", prompt);
 
       expect(result.stopReason).toBe("queued");
+      expect(mockSessionStoreSetters.appendOptimisticItem).toHaveBeenCalledWith(
+        "run-123",
+        expect.objectContaining({
+          type: "user_message",
+          content: "what is this about?\n\nAttached files: test.txt",
+          pinToTop: false,
+        }),
+      );
       expect(mockSessionStoreSetters.setSession).toHaveBeenCalledWith(
         expect.objectContaining({
-          events: expect.arrayContaining([
-            expect.objectContaining({
-              message: expect.objectContaining({
-                method: "session/prompt",
-                params: {
-                  prompt,
-                },
-              }),
-            }),
-          ]),
-          skipPolledPromptCount: 1,
+          taskRunId: "run-456",
+          isPromptPending: true,
         }),
       );
     });

--- a/packages/ui/src/features/sessions/sessionServiceHost.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.ts
@@ -2,7 +2,6 @@ import { DEFAULT_GATEWAY_MODEL } from "@posthog/agent/gateway-models";
 import { getIsOnline } from "@posthog/core/connectivity/connectivityStore";
 import { CloudArtifactService } from "@posthog/core/sessions/cloudArtifactService";
 import {
-  cloudPromptToBlocks,
   combineQueuedCloudPrompts,
   getCloudPromptTransport,
 } from "@posthog/core/sessions/cloudPrompt";
@@ -125,7 +124,6 @@ function buildSessionServiceDeps(): SessionServiceDeps {
     WORKSPACE_QUERY_KEY,
     h: {
       extractSkillButtonId,
-      cloudPromptToBlocks,
       combineQueuedCloudPrompts,
       getCloudPromptTransport,
       resolveLocalSkillCommandPrompt: (prompt) =>


### PR DESCRIPTION
## Problem

Resuming a cloud task (after its sandbox was snapshotted and the run concluded) was visibly broken in several ways:
- prior conversation history was lost or rendered out of chronological order
- on text submit, the view flickered
- replicated input field

https://github.com/user-attachments/assets/8db90aa6-d3a3-4d49-af2c-c95d802d5c66

## Changes

- route resumed runs through the standard bootstrap flow instead of a live-only initialization path, ensuring state can always recover from a consistent snapshot
- prevent dropped stream events by removing live-only seeding that could incorrectly mark new events as already processed
- avoid blank conversation flickers by skipping watches for superseded runs, preventing stale reconciles from replacing the active session
