### PR TITLE
feat(home): add auto-run toggle to quick actions

### DIFF
--- a/packages/core/src/workflow/schemas.ts
+++ b/packages/core/src/workflow/schemas.ts
@@ -61,6 +61,10 @@ export const workflowAction = z
     prompt: z.string().min(1).max(8_000),
     adapter: z.enum(["claude", "codex"]).optional(),
     model: z.string().min(1).optional(),
+    // When true, the server-side classifier auto-runs this action as a cloud
+    // task whenever a workstream's primary situation matches the binding (gated
+    // so it never piles onto a workstream that already has a running task).
+    auto: z.boolean().optional(),
   })
   .strict();
 export type WorkflowAction = z.infer<typeof workflowAction>;

--- a/packages/core/src/workflow/schemas.ts
+++ b/packages/core/src/workflow/schemas.ts
@@ -94,6 +94,8 @@ export const validationDiagnostic = z
       "duplicate_action_id",
       "action_empty_prompt",
       "action_empty_label",
+      // Emitted only by server-side save validation (not the client validator);
+      // listed here so server-returned diagnostics still parse via saveResult.
       "action_auto_not_bool",
     ]),
     message: z.string(),

--- a/packages/core/src/workflow/schemas.ts
+++ b/packages/core/src/workflow/schemas.ts
@@ -94,6 +94,7 @@ export const validationDiagnostic = z
       "duplicate_action_id",
       "action_empty_prompt",
       "action_empty_label",
+      "action_auto_not_bool",
     ]),
     message: z.string(),
     situationId: situationId.optional(),

--- a/packages/core/src/workflow/schemas.ts
+++ b/packages/core/src/workflow/schemas.ts
@@ -61,9 +61,6 @@ export const workflowAction = z
     prompt: z.string().min(1).max(8_000),
     adapter: z.enum(["claude", "codex"]).optional(),
     model: z.string().min(1).optional(),
-    // When true, the server-side classifier auto-runs this action as a cloud
-    // task whenever a workstream's primary situation matches the binding (gated
-    // so it never piles onto a workstream that already has a running task).
     auto: z.boolean().optional(),
   })
   .strict();
@@ -94,8 +91,6 @@ export const validationDiagnostic = z
       "duplicate_action_id",
       "action_empty_prompt",
       "action_empty_label",
-      // Emitted only by server-side save validation (not the client validator);
-      // listed here so server-returned diagnostics still parse via saveResult.
       "action_auto_not_bool",
     ]),
     message: z.string(),

--- a/packages/ui/src/features/home/config/ActionEditorPanel.tsx
+++ b/packages/ui/src/features/home/config/ActionEditorPanel.tsx
@@ -12,7 +12,14 @@ import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { usePreviewConfig } from "@posthog/ui/features/task-detail/hooks/usePreviewConfig";
 import { Combobox } from "@posthog/ui/primitives/combobox/Combobox";
 import type { ComboboxSearchKeys } from "@posthog/ui/primitives/combobox/useComboboxFilter";
-import { Card, Flex, Switch, Text, TextArea, TextField } from "@radix-ui/themes";
+import {
+  Card,
+  Flex,
+  Switch,
+  Text,
+  TextArea,
+  TextField,
+} from "@radix-ui/themes";
 import { useMemo } from "react";
 import { SITUATION_TONE } from "./workflowMapLayout";
 
@@ -191,23 +198,18 @@ export function ActionEditorPanel({
           </Field>
 
           <Field label="Auto-run">
-            <Flex align="center" gap="2">
-              <Switch
-                size="1"
-                checked={action.auto ?? false}
-                onCheckedChange={(checked) => patch({ auto: checked })}
-                aria-label="Auto-run this action"
-              />
-              <Text className="text-[11px] text-gray-11">
-                Run automatically when a workstream enters this state
-              </Text>
-            </Flex>
-            {action.auto ? (
-              <Text className="mt-1 text-[10px] text-gray-10">
-                A cloud task starts on its own — skipped while the workstream
-                already has a running task.
-              </Text>
-            ) : null}
+            <Switch
+              className="self-start"
+              size="1"
+              checked={action.auto ?? false}
+              onCheckedChange={(checked) => patch({ auto: checked })}
+              aria-label="Auto-run this action"
+            />
+            <Text className="mt-1 text-[10px] text-gray-10">
+              {action.auto
+                ? "A cloud task starts on its own — skipped while the workstream already has a running task."
+                : "Run automatically when a workstream enters this state."}
+            </Text>
           </Field>
         </Card>
 

--- a/packages/ui/src/features/home/config/ActionEditorPanel.tsx
+++ b/packages/ui/src/features/home/config/ActionEditorPanel.tsx
@@ -202,7 +202,9 @@ export function ActionEditorPanel({
               className="self-start"
               size="1"
               checked={action.auto ?? false}
-              onCheckedChange={(checked) => patch({ auto: checked })}
+              onCheckedChange={(checked) =>
+                patch({ auto: checked || undefined })
+              }
               aria-label="Auto-run this action"
             />
             <Text className="mt-1 text-[10px] text-gray-10">

--- a/packages/ui/src/features/home/config/ActionEditorPanel.tsx
+++ b/packages/ui/src/features/home/config/ActionEditorPanel.tsx
@@ -12,7 +12,7 @@ import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { usePreviewConfig } from "@posthog/ui/features/task-detail/hooks/usePreviewConfig";
 import { Combobox } from "@posthog/ui/primitives/combobox/Combobox";
 import type { ComboboxSearchKeys } from "@posthog/ui/primitives/combobox/useComboboxFilter";
-import { Card, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
+import { Card, Flex, Switch, Text, TextArea, TextField } from "@radix-ui/themes";
 import { useMemo } from "react";
 import { SITUATION_TONE } from "./workflowMapLayout";
 
@@ -188,6 +188,26 @@ export function ActionEditorPanel({
                 Runs on your default model unless you pick one.
               </Text>
             )}
+          </Field>
+
+          <Field label="Auto-run">
+            <Flex align="center" gap="2">
+              <Switch
+                size="1"
+                checked={action.auto ?? false}
+                onCheckedChange={(checked) => patch({ auto: checked })}
+                aria-label="Auto-run this action"
+              />
+              <Text className="text-[11px] text-gray-11">
+                Run automatically when a workstream enters this state
+              </Text>
+            </Flex>
+            {action.auto ? (
+              <Text className="mt-1 text-[10px] text-gray-10">
+                A cloud task starts on its own — skipped while the workstream
+                already has a running task.
+              </Text>
+            ) : null}
           </Field>
         </Card>
 

--- a/packages/ui/src/features/home/config/SituationStation.tsx
+++ b/packages/ui/src/features/home/config/SituationStation.tsx
@@ -1,4 +1,4 @@
-import { Plus, Sparkle } from "@phosphor-icons/react";
+import { Lightning, Plus, Sparkle } from "@phosphor-icons/react";
 import {
   SITUATIONS,
   type SituationId,
@@ -111,7 +111,11 @@ export function SituationStation({ id, bindings }: Props) {
                   : action.label
               }
             >
-              <Sparkle size={9} />
+              {action.auto ? (
+                <Lightning size={9} weight="fill" className="text-(--amber-9)" />
+              ) : (
+                <Sparkle size={9} />
+              )}
               <span className="truncate">{action.label || "(no label)"}</span>
             </button>
           );

--- a/packages/ui/src/features/home/config/SituationStation.tsx
+++ b/packages/ui/src/features/home/config/SituationStation.tsx
@@ -112,7 +112,11 @@ export function SituationStation({ id, bindings }: Props) {
               }
             >
               {action.auto ? (
-                <Lightning size={9} weight="fill" className="text-(--amber-9)" />
+                <Lightning
+                  size={9}
+                  weight="fill"
+                  className="text-(--amber-9)"
+                />
               ) : (
                 <Sparkle size={9} />
               )}

--- a/packages/ui/src/features/home/stores/workflowEditorStore.test.ts
+++ b/packages/ui/src/features/home/stores/workflowEditorStore.test.ts
@@ -117,6 +117,15 @@ describe("workflowEditorStore", () => {
       expect(store().draft?.bindings.working[0].label).toBe("Review");
       expect(store().dirty).toBe(false);
     });
+
+    it("toggles the auto flag and marks dirty", () => {
+      store().beginEdit(makeConfig({ ci_failing: [makeAction({ id: "a" })] }));
+      store().updateAction("ci_failing", "a", { auto: true });
+      expect(store().draft?.bindings.ci_failing[0].auto).toBe(true);
+      expect(store().dirty).toBe(true);
+      store().updateAction("ci_failing", "a", { auto: false });
+      expect(store().draft?.bindings.ci_failing[0].auto).toBe(false);
+    });
   });
 
   describe("removeAction", () => {

--- a/packages/ui/src/features/home/stores/workflowEditorStore.test.ts
+++ b/packages/ui/src/features/home/stores/workflowEditorStore.test.ts
@@ -126,6 +126,19 @@ describe("workflowEditorStore", () => {
       store().updateAction("ci_failing", "a", { auto: false });
       expect(store().draft?.bindings.ci_failing[0].auto).toBe(false);
     });
+
+    it("clears dirty when auto is toggled on then back off", () => {
+      // The editor sends `checked || undefined`, so disabling clears the key
+      // rather than writing `auto: false`. That restores the exact baseline
+      // serialization (no `auto` key), so the dirty flag must return to false —
+      // otherwise an enable→disable round-trip falsely prompts an unsaved-changes save.
+      store().beginEdit(makeConfig({ ci_failing: [makeAction({ id: "a" })] }));
+      store().updateAction("ci_failing", "a", { auto: true });
+      expect(store().dirty).toBe(true);
+      store().updateAction("ci_failing", "a", { auto: undefined });
+      expect(store().draft?.bindings.ci_failing[0].auto).toBeUndefined();
+      expect(store().dirty).toBe(false);
+    });
   });
 
   describe("removeAction", () => {


### PR DESCRIPTION
## What

Adds an **auto-run** toggle to Home-tab quick actions. When a quick action has auto-run enabled, the server-side classifier will launch it as a cloud task whenever a workstream lands in that action's situation (deduped against already-running tasks).

This PR is the **config + UI half** in `posthog/code`. It's harmless on its own — the flag is just stored in the workflow config until the backend honors it. The backend auto-run (the `evaluate-code-workstreams` worker + dedup) ships in a companion `posthog/posthog` PR.

## Changes

- **`packages/core/src/workflow/schemas.ts`** — add `auto?: boolean` to `workflowAction` (the schema is `.strict()`, so the field is required for it to round-trip on save). Type propagates to all consumers.
- **`ActionEditorPanel.tsx`** — add an "Auto-run" `Switch` to the quick-action editor.
- **`SituationStation.tsx`** — auto-enabled actions show a filled lightning glyph (instead of the sparkle) on the config map so they're visible at a glance.
- **Tests** — `workflowEditorStore` round-trips the `auto` flag and marks the draft dirty.

## How it works (full picture)

`auto` rides along inside the `CodeWorkflowConfig.bindings` JSON. The server worker reads the per-user bindings, and for a workstream's **primary situation** fires any bound action with `auto: true` — once per workstream+action, and only when no task is already running on that workstream.

## Test plan

- [x] `pnpm --filter @posthog/core typecheck`
- [x] `pnpm --filter @posthog/ui typecheck`
- [x] `pnpm --filter @posthog/ui test` (973 passing, incl. new auto-flag test)
- [x] `biome lint` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)