### PR TITLE
fix(scouts): run scout chats repo-less instead of gating on a GitHub repo

### DIFF
--- a/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
+++ b/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
@@ -71,7 +71,9 @@ export function useCreatePrReport({
         reportUrl,
         feedback: feedbackRef.current,
       });
-      const targetRepo = ctx.cloudRepository.toLowerCase();
+      // Create-PR never runs repo-less, so the repo is always present here; the
+      // coalesce only satisfies the now-nullable context type.
+      const targetRepo = (ctx.cloudRepository ?? "").toLowerCase();
       const baseBranch = baseBranchOverrides
         ? (Object.entries(baseBranchOverrides).find(
             ([repo]) => repo.toLowerCase() === targetRepo,
@@ -81,7 +83,7 @@ export function useCreatePrReport({
         content: prompt,
         taskDescription: prompt,
         repository: ctx.cloudRepository,
-        githubUserIntegrationId: ctx.githubUserIntegrationId,
+        githubUserIntegrationId: ctx.githubUserIntegrationId ?? undefined,
         workspaceMode: "cloud",
         executionMode: "auto",
         adapter: ctx.adapter,

--- a/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
+++ b/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
@@ -40,7 +40,7 @@ export function useDiscussReport({
         content: prompt,
         taskDescription: prompt,
         repository: ctx.cloudRepository,
-        githubUserIntegrationId: ctx.githubUserIntegrationId,
+        githubUserIntegrationId: ctx.githubUserIntegrationId ?? undefined,
         workspaceMode: "cloud",
         executionMode: "auto",
         adapter: ctx.adapter,

--- a/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -50,8 +50,14 @@ export interface InboxCloudTaskCopy {
 export interface InboxCloudTaskInputContext {
   reportId?: string;
   reportTitle?: string | null;
-  cloudRepository: string;
-  githubUserIntegrationId: string;
+  /**
+   * Resolved repository, or null when the runner ran repo-less (only possible
+   * when the caller sets `allowMissingRepository`). Variants that require a repo
+   * never observe null here, since the runner bails before `buildInput`.
+   */
+  cloudRepository: string | null;
+  /** Null alongside a null `cloudRepository` (repo-less run). */
+  githubUserIntegrationId: string | null;
   adapter: "claude" | "codex";
   model: string;
   reasoningLevel?: string;
@@ -62,6 +68,14 @@ export interface UseInboxCloudTaskRunnerOptions {
   reportId?: string;
   reportTitle?: string | null;
   cloudRepository: string | null;
+  /**
+   * When true, a missing repository is not an error: the task is created
+   * repo-less (no clone, no GitHub identity). The backend provisions a bare
+   * sandbox in that case. Use for flows that only need the cloud sandbox plus
+   * PostHog MCP — e.g. scout chats — never for flows that author a PR. Defaults
+   * to false, preserving the repo + integration gate for Create-PR / Discuss.
+   */
+  allowMissingRepository?: boolean;
   copy: InboxCloudTaskCopy;
   /** Logger scope used for failure traces. */
   loggerScope: string;
@@ -94,6 +108,7 @@ export function useInboxCloudTaskRunner({
   reportId,
   reportTitle,
   cloudRepository,
+  allowMissingRepository = false,
   copy,
   loggerScope,
   buildInput,
@@ -118,14 +133,17 @@ export function useInboxCloudTaskRunner({
       return;
     }
 
-    if (!cloudRepository) {
+    if (!cloudRepository && !allowMissingRepository) {
       toast.error(copy.errorTitle, { description: copy.missingRepository });
       return;
     }
 
-    const githubUserIntegrationId =
-      getUserIntegrationIdForRepo(cloudRepository);
-    if (!githubUserIntegrationId) {
+    // A repo-less run has no GitHub identity; only resolve/require the user
+    // integration when a repository is actually in play.
+    const githubUserIntegrationId = cloudRepository
+      ? getUserIntegrationIdForRepo(cloudRepository)
+      : null;
+    if (cloudRepository && !githubUserIntegrationId) {
       toast.error(copy.errorTitle, { description: copy.missingIntegration });
       return;
     }
@@ -177,7 +195,9 @@ export function useInboxCloudTaskRunner({
       reportId,
       reportTitle,
       cloudRepository,
-      githubUserIntegrationId: String(githubUserIntegrationId),
+      githubUserIntegrationId: githubUserIntegrationId
+        ? String(githubUserIntegrationId)
+        : null,
       adapter,
       model,
       reasoningLevel,
@@ -212,7 +232,7 @@ export function useInboxCloudTaskRunner({
         track(ANALYTICS_EVENTS.TASK_CREATED, {
           auto_run: true,
           created_from: "command-menu",
-          repository_provider: "github",
+          ...(cloudRepository ? { repository_provider: "github" } : {}),
           workspace_mode: "cloud",
           ...(reportId
             ? {
@@ -254,6 +274,7 @@ export function useInboxCloudTaskRunner({
     isOnline,
     loggerScope,
     cloudRepository,
+    allowMissingRepository,
     cloudRegion,
     reportId,
     reportTitle,

--- a/packages/ui/src/features/scouts/hooks/useScoutChatTask.test.tsx
+++ b/packages/ui/src/features/scouts/hooks/useScoutChatTask.test.tsx
@@ -1,0 +1,130 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createTask = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ success: true, task: { id: "task-1" } }),
+);
+const getUserIntegrationIdForRepo = vi.hoisted(() => vi.fn(() => "ghu_1"));
+const resolveDefaultCloudRepository = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@posthog/ui/features/auth/store", () => ({
+  useAuthStateValue: (sel: (s: { cloudRegion: string }) => unknown) =>
+    sel({ cloudRegion: "us" }),
+}));
+vi.mock("@posthog/ui/hooks/useConnectivity", () => ({
+  useConnectivity: () => ({ isOnline: true }),
+}));
+vi.mock("@posthog/ui/features/connectivity/connectivityToast", () => ({
+  showOfflineToast: vi.fn(),
+}));
+vi.mock("@posthog/ui/features/inbox/hooks/resolveDefaultModel", () => ({
+  resolveDefaultModel: vi.fn().mockResolvedValue("claude-sonnet"),
+}));
+vi.mock("@posthog/ui/features/integrations/useIntegrations", () => ({
+  useUserRepositoryIntegration: () => ({
+    repositories: [],
+    getUserIntegrationIdForRepo,
+  }),
+}));
+vi.mock("@posthog/ui/features/settings/settingsStore", () => ({
+  resolveDefaultCloudRepository,
+  useSettingsStore: Object.assign(
+    (sel: (s: { lastUsedCloudRepository: string | null }) => unknown) =>
+      sel({ lastUsedCloudRepository: null }),
+    {
+      getState: () => ({
+        lastUsedAdapter: "claude",
+        lastUsedModel: "claude-sonnet",
+        lastUsedReasoningEffort: undefined,
+      }),
+    },
+  ),
+}));
+vi.mock("@posthog/di/react", () => ({
+  useService: (token: symbol) =>
+    token.description === "posthog.core.inbox.reportModelResolver"
+      ? { resolveDefaultModel: vi.fn() }
+      : { createTask },
+}));
+vi.mock("@posthog/ui/features/tasks/useTaskCrudMutations", () => ({
+  useCreateTask: () => ({ invalidateTasks: vi.fn() }),
+}));
+vi.mock("@posthog/ui/router/useOpenTask", () => ({
+  openTask: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+vi.mock("@posthog/ui/shell/logger", () => ({
+  logger: { scope: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }) },
+}));
+vi.mock("@posthog/ui/primitives/toast", () => ({
+  toast: {
+    error: toastError,
+    loading: vi.fn(() => "toast-1"),
+    dismiss: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { useScoutChatTask } from "./useScoutChatTask";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRunTask() {
+  return renderHook(
+    () =>
+      useScoutChatTask({
+        prompt: "Make a scout",
+        taskLabel: "scout authoring",
+        loggerScope: "scout-author",
+        chatType: "author_scout",
+        surface: "fleet_list",
+      }),
+    { wrapper: createWrapper() },
+  );
+}
+
+describe("useScoutChatTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a repo-less cloud task when no personal repo is resolvable", async () => {
+    // The PR #2986 scenario: team integration only, no personal install, so no
+    // user-level repo resolves. Scout authoring is pure PostHog-MCP work, so it
+    // must still run rather than failing with a "connect GitHub" toast.
+    resolveDefaultCloudRepository.mockReturnValue(null);
+
+    const { result } = renderRunTask();
+    await result.current.runTask();
+
+    expect(toastError).not.toHaveBeenCalled();
+    expect(createTask).toHaveBeenCalledTimes(1);
+    const input = createTask.mock.calls[0][0];
+    expect(input.repository).toBeNull();
+    expect(input.githubUserIntegrationId).toBeUndefined();
+    expect(input.workspaceMode).toBe("cloud");
+    expect(getUserIntegrationIdForRepo).not.toHaveBeenCalled();
+  });
+
+  it("passes the resolved repo through when one is available", async () => {
+    resolveDefaultCloudRepository.mockReturnValue("owner/repo");
+
+    const { result } = renderRunTask();
+    await result.current.runTask();
+
+    expect(createTask).toHaveBeenCalledTimes(1);
+    const input = createTask.mock.calls[0][0];
+    expect(input.repository).toBe("owner/repo");
+    expect(input.githubUserIntegrationId).toBe("ghu_1");
+  });
+});

--- a/packages/ui/src/features/scouts/hooks/useScoutChatTask.ts
+++ b/packages/ui/src/features/scouts/hooks/useScoutChatTask.ts
@@ -63,8 +63,11 @@ export function useScoutChatTask({
     (ctx: InboxCloudTaskInputContext): TaskCreationInput => ({
       content: prompt,
       taskDescription: prompt,
+      // Scout chats only need the cloud sandbox + PostHog MCP, so they run
+      // repo-less when no personal GitHub repo is resolvable. When one is
+      // available it's passed through (harmless, enables PR authorship).
       repository: ctx.cloudRepository,
-      githubUserIntegrationId: ctx.githubUserIntegrationId,
+      githubUserIntegrationId: ctx.githubUserIntegrationId ?? undefined,
       workspaceMode: "cloud",
       executionMode: "auto",
       adapter: ctx.adapter,
@@ -89,6 +92,11 @@ export function useScoutChatTask({
 
   const { run, isRunning } = useInboxCloudTaskRunner({
     cloudRepository,
+    // Authoring or asking about scouts is pure PostHog-MCP work; a missing repo
+    // must not block it. Without this, a user with only a team-level GitHub
+    // integration (no personal install) hit a confusing "Connect a GitHub
+    // repository" failure even though scouts never touch repo code.
+    allowMissingRepository: true,
     loggerScope,
     copy,
     buildInput,


### PR DESCRIPTION
## Problem

"Make a scout" — and the read-only fleet question chips ("How is my scout fleet performing?", "What signals were emitted recently?") — create auto-mode **cloud tasks** through `useInboxCloudTaskRunner`, which **hard-required a personal GitHub repo + user-level integration**:

```ts
// useInboxCloudTaskRunner.ts
if (!cloudRepository) { toast.error(copy.errorTitle, { description: copy.missingRepository }); return; }
```

A user with only a **team-level** GitHub integration (no personal install) saw the button enabled, then hit a confusing **"Failed to start scout authoring / Connect a GitHub repository"** toast when the runner bailed on a `null` repository. This is the bug #2986 set out to address.

## Root cause

Scout chats are **pure PostHog-MCP work** — the `SCOUT_AUTHOR_PROMPT` scans the project over MCP and writes a `SKILL.md` into the skills-store. They **never touch repo code**. The repo requirement was purely a **client-side artifact** of the shared cloud-task runner.

The backend already supports repo-less cloud tasks (verified in `PostHog/posthog`):
- `Task.repository` is `null=True, blank=True`; `_build_task` gates GitHub-integration validation entirely behind `if repository:`.
- Sandbox provisioning explicitly handles the no-repo case: `get_sandbox_for_repository.py` → `elif not has_repo: emit_agent_log(... "Creating environment without repository")`, and `execute_sandbox/workflow.py` guards clone/checkout on `bool(prepared.repository ...)`. No repo → bare sandbox, no clone, no GitHub token. The agent still gets `POSTHOG_PERSONAL_API_KEY` + an OAuth token, which is all a scout-authoring task needs.

## Fix

Add an opt-in `allowMissingRepository` to `useInboxCloudTaskRunner`: when set, a missing repo is **not** an error and the task is created repo-less (no `repository`, no `githubUserIntegrationId`). Scout chats opt in; **Create-PR and Discuss keep the existing repo + integration gate**. When a personal repo *is* resolvable it's still passed through (harmless, keeps PR-authorship capability).

This fixes all three scout chips at once and removes the GitHub coupling entirely, rather than papering over it.

## Supersedes #2986

#2986 only addressed the symptom — it swapped the "Make a scout" chip for a "Connect a personal GitHub repository" notice (and left the two read-only chips still requiring GitHub). This PR removes the requirement at the source, so the connect-notice is no longer needed. **#2986 can be closed in favour of this.**

## Verification

- `pnpm --filter @posthog/ui typecheck` ✓ (also via pre-commit hook)
- Biome ✓
- New `useScoutChatTask.test.tsx`: covers the repo-less path (no personal repo → task still created with `repository: null`, no integration lookup) and the resolved-repo passthrough. Full `@posthog/ui` suite green (1024 tests).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*