### PR TITLE
fix(model-picker): keep picker open when switching harness

### DIFF
--- a/packages/ui/src/features/message-editor/components/ModeSelector.tsx
+++ b/packages/ui/src/features/message-editor/components/ModeSelector.tsx
@@ -19,6 +19,7 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { flattenSelectOptions } from "@posthog/ui/features/sessions/sessionStore";
+import { useRetainedConfigOption } from "@posthog/ui/features/sessions/useRetainedConfigOption";
 import { useRef, useState } from "react";
 
 interface ModeStyle {
@@ -81,10 +82,17 @@ export function ModeSelector({
 }: ModeSelectorProps) {
   const [open, setOpen] = useState(false);
   const pendingValueRef = useRef<string | null>(null);
+  const displayOption = useRetainedConfigOption(modeOption);
 
-  if (!modeOption || modeOption.type !== "select") return null;
+  if (!displayOption || displayOption.type !== "select") return null;
 
-  const allOptions = flattenSelectOptions(modeOption.options);
+  // `modeOption` blanks out while the preview config reloads (e.g. a harness
+  // switch). Keep showing the last mode, disabled, so the toolbar stays put
+  // instead of collapsing and snapping the open model menu sideways.
+  const isReloading = !modeOption;
+  const isDisabled = disabled || isReloading;
+
+  const allOptions = flattenSelectOptions(displayOption.options);
   const options = allowBypassPermissions
     ? allOptions
     : allOptions.filter(
@@ -93,7 +101,7 @@ export function ModeSelector({
       );
   if (options.length === 0) return null;
 
-  const currentValue = modeOption.currentValue;
+  const currentValue = displayOption.currentValue;
   const currentStyle = getStyle(currentValue);
   const currentLabel =
     allOptions.find((opt) => opt.value === currentValue)?.name ?? currentValue;
@@ -115,7 +123,7 @@ export function ModeSelector({
             type="button"
             variant="default"
             size="sm"
-            disabled={disabled}
+            disabled={isDisabled}
             aria-label="Mode"
           >
             <span className={currentStyle.className}>{currentStyle.icon}</span>

--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -374,7 +374,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
                     onInsertChip={insertChip}
                     onRemoveChip={removeChipById}
                   />
-                  {modeOption && onModeChange && (
+                  {onModeChange && (
                     <ModeSelector
                       modeOption={modeOption}
                       onChange={onModeChange}

--- a/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -11,12 +11,14 @@ import {
 } from "@posthog/quill";
 import { useRef, useState } from "react";
 import { flattenSelectOptions } from "../sessionStore";
+import { useRetainedConfigOption } from "../useRetainedConfigOption";
 
 interface ReasoningLevelSelectorProps {
   thoughtOption?: SessionConfigOption;
   adapter?: "claude" | "codex";
   onChange?: (value: string) => void;
   disabled?: boolean;
+  isLoading?: boolean;
 }
 
 export function ReasoningLevelSelector({
@@ -24,17 +26,26 @@ export function ReasoningLevelSelector({
   adapter,
   onChange,
   disabled,
+  isLoading,
 }: ReasoningLevelSelectorProps) {
   const [open, setOpen] = useState(false);
   const pendingValueRef = useRef<string | null>(null);
+  const displayOption = useRetainedConfigOption(thoughtOption);
 
-  if (!thoughtOption || thoughtOption.type !== "select") {
+  // Genuinely no reasoning levels for this harness/model: hide. While the
+  // preview config reloads (a harness switch) keep showing the last value,
+  // disabled, so the toolbar doesn't collapse mid-switch.
+  if (!thoughtOption && !isLoading) return null;
+  if (!displayOption || displayOption.type !== "select") {
     return null;
   }
 
-  const options = flattenSelectOptions(thoughtOption.options);
+  const isReloading = !thoughtOption;
+  const isDisabled = disabled || isReloading;
+
+  const options = flattenSelectOptions(displayOption.options);
   if (options.length === 0) return null;
-  const activeLevel = thoughtOption.currentValue;
+  const activeLevel = displayOption.currentValue;
   const activeLabel =
     options.find((opt) => opt.value === activeLevel)?.name ?? activeLevel;
   const prefix = adapter === "codex" ? "Reasoning" : "Effort";
@@ -56,7 +67,7 @@ export function ReasoningLevelSelector({
             type="button"
             variant="default"
             size="sm"
-            disabled={disabled}
+            disabled={isDisabled}
             aria-label={`${prefix}: ${activeLabel}`}
           >
             <Brain size={14} className="text-muted-foreground" />

--- a/packages/ui/src/features/sessions/components/UnifiedModelSelector.tsx
+++ b/packages/ui/src/features/sessions/components/UnifiedModelSelector.tsx
@@ -21,6 +21,7 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { flattenSelectOptions } from "@posthog/ui/features/sessions/sessionStore";
+import { useRetainedConfigOption } from "@posthog/ui/features/sessions/useRetainedConfigOption";
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
 import { Fragment, useMemo, useRef, useState } from "react";
 
@@ -57,7 +58,13 @@ export function UnifiedModelSelector({
 }: UnifiedModelSelectorProps) {
   const [open, setOpen] = useState(false);
   const pendingValueRef = useRef<string | null>(null);
-  const selectOption = modelOption?.type === "select" ? modelOption : undefined;
+  // Keep the last model on the trigger while the new harness's config loads, so
+  // the trigger doesn't shrink to the "Model" fallback and jostle the toolbar
+  // mid-switch. The radio group below still renders from the live option once
+  // loading finishes.
+  const displayOption = useRetainedConfigOption(modelOption);
+  const selectOption =
+    displayOption?.type === "select" ? displayOption : undefined;
   const options = selectOption
     ? flattenSelectOptions(selectOption.options)
     : [];

--- a/packages/ui/src/features/sessions/components/UnifiedModelSelector.tsx
+++ b/packages/ui/src/features/sessions/components/UnifiedModelSelector.tsx
@@ -75,7 +75,12 @@ export function UnifiedModelSelector({
 
   const otherAdapter = getOtherAdapter(adapter);
 
-  if (isConnecting) {
+  // Collapse to a bare loading button only while the menu is closed (initial
+  // load). When the menu is open we keep it mounted and surface the loading
+  // state inside the content instead — switching harness refetches the new
+  // adapter's config, and unmounting here would dismiss the picker mid-switch
+  // and force the user to reopen it just to choose a model.
+  if (isConnecting && !open) {
     return (
       <Button type="button" variant="default" size="sm" disabled>
         <Spinner size={12} className="animate-spin" />
@@ -123,38 +128,48 @@ export function UnifiedModelSelector({
         className="min-w-[220px]"
       >
         <MenuLabel>{ADAPTER_LABELS[adapter]}</MenuLabel>
-        <DropdownMenuRadioGroup
-          value={currentValue ?? ""}
-          onValueChange={(value) => {
-            pendingValueRef.current = value;
-            setOpen(false);
-          }}
-        >
-          {groupedOptions.length > 0
-            ? groupedOptions.map((group, index) => (
-                <Fragment key={group.group}>
-                  {index > 0 && <DropdownMenuSeparator />}
-                  <MenuLabel>{group.name}</MenuLabel>
-                  {group.options.map((model) => (
-                    <DropdownMenuRadioItem
-                      key={model.value}
-                      value={model.value}
-                    >
-                      <span className="whitespace-nowrap">{model.name}</span>
-                    </DropdownMenuRadioItem>
-                  ))}
-                </Fragment>
-              ))
-            : options.map((model) => (
-                <DropdownMenuRadioItem key={model.value} value={model.value}>
-                  <span className="whitespace-nowrap">{model.name}</span>
-                </DropdownMenuRadioItem>
-              ))}
-        </DropdownMenuRadioGroup>
+        {isConnecting ? (
+          <div className="flex items-center gap-2 px-2 py-1.5 text-muted-foreground">
+            <Spinner size={12} className="animate-spin" />
+            Loading...
+          </div>
+        ) : (
+          <DropdownMenuRadioGroup
+            value={currentValue ?? ""}
+            onValueChange={(value) => {
+              pendingValueRef.current = value;
+              setOpen(false);
+            }}
+          >
+            {groupedOptions.length > 0
+              ? groupedOptions.map((group, index) => (
+                  <Fragment key={group.group}>
+                    {index > 0 && <DropdownMenuSeparator />}
+                    <MenuLabel>{group.name}</MenuLabel>
+                    {group.options.map((model) => (
+                      <DropdownMenuRadioItem
+                        key={model.value}
+                        value={model.value}
+                      >
+                        <span className="whitespace-nowrap">{model.name}</span>
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </Fragment>
+                ))
+              : options.map((model) => (
+                  <DropdownMenuRadioItem key={model.value} value={model.value}>
+                    <span className="whitespace-nowrap">{model.name}</span>
+                  </DropdownMenuRadioItem>
+                ))}
+          </DropdownMenuRadioGroup>
+        )}
 
         <DropdownMenuSeparator />
 
-        <DropdownMenuItem onClick={() => onAdapterChange(otherAdapter)}>
+        <DropdownMenuItem
+          closeOnClick={false}
+          onClick={() => onAdapterChange(otherAdapter)}
+        >
           <ArrowsClockwise size={12} weight="bold" />
           Switch to {ADAPTER_LABELS[otherAdapter]}
         </DropdownMenuItem>

--- a/packages/ui/src/features/sessions/useRetainedConfigOption.test.ts
+++ b/packages/ui/src/features/sessions/useRetainedConfigOption.test.ts
@@ -1,0 +1,63 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useRetainedConfigOption } from "./useRetainedConfigOption";
+
+function option(currentValue: string): SessionConfigOption {
+  return {
+    id: "model",
+    name: "Model",
+    type: "select",
+    category: "model",
+    currentValue,
+    options: [{ value: currentValue, name: currentValue }],
+  } as SessionConfigOption;
+}
+
+describe("useRetainedConfigOption", () => {
+  it("returns undefined until an option is seen", () => {
+    const { result } = renderHook(({ opt }) => useRetainedConfigOption(opt), {
+      initialProps: { opt: undefined as SessionConfigOption | undefined },
+    });
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns the live option when present", () => {
+    const claude = option("claude-sonnet");
+    const { result } = renderHook(({ opt }) => useRetainedConfigOption(opt), {
+      initialProps: { opt: claude as SessionConfigOption | undefined },
+    });
+    expect(result.current).toBe(claude);
+  });
+
+  it("retains the last option while it is transiently absent", () => {
+    const claude = option("claude-sonnet");
+    const { result, rerender } = renderHook(
+      ({ opt }) => useRetainedConfigOption(opt),
+      { initialProps: { opt: claude as SessionConfigOption | undefined } },
+    );
+    expect(result.current).toBe(claude);
+
+    // Preview config cleared mid-switch: keep showing the previous option.
+    rerender({ opt: undefined });
+    expect(result.current).toBe(claude);
+  });
+
+  it("swaps to the new option once it loads, without sticking on the stale one", () => {
+    const claude = option("claude-sonnet");
+    const codex = option("gpt-5-codex");
+    const { result, rerender } = renderHook(
+      ({ opt }) => useRetainedConfigOption(opt),
+      { initialProps: { opt: claude as SessionConfigOption | undefined } },
+    );
+
+    rerender({ opt: undefined }); // reload window during the switch
+    expect(result.current).toBe(claude);
+
+    rerender({ opt: codex }); // new harness config arrives
+    expect(result.current).toBe(codex);
+
+    rerender({ opt: undefined }); // a later reload retains codex, not claude
+    expect(result.current).toBe(codex);
+  });
+});

--- a/packages/ui/src/features/sessions/useRetainedConfigOption.ts
+++ b/packages/ui/src/features/sessions/useRetainedConfigOption.ts
@@ -1,0 +1,23 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { useRef } from "react";
+
+/**
+ * Returns the latest config option, falling back to the last non-empty value
+ * while the option is transiently absent.
+ *
+ * The preview config is cleared and refetched whenever the harness changes, so
+ * `modeOption`/`modelOption`/`thoughtOption` momentarily read as `undefined`
+ * mid-switch. Selectors that key their visibility on those values would unmount
+ * and remount, collapsing the toolbar and yanking any open menu sideways.
+ * Retaining the previous option lets a selector stay mounted (rendered disabled)
+ * until the new harness's config lands, so the switch reads as a smooth update
+ * rather than a flicker. The retained value is for display only — submission
+ * keeps reading the live (cleared) option, so a stale id is never sent.
+ */
+export function useRetainedConfigOption(
+  option: SessionConfigOption | undefined,
+): SessionConfigOption | undefined {
+  const lastSeen = useRef(option);
+  if (option) lastSeen.current = option;
+  return option ?? lastSeen.current;
+}

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -928,14 +928,13 @@ export function TaskInput({
                 />
               }
               reasoningSelector={
-                !isPreviewLoading && (
-                  <ReasoningLevelSelector
-                    thoughtOption={thoughtOption}
-                    adapter={adapter}
-                    onChange={handleThoughtChange}
-                    disabled={isCreatingTask}
-                  />
-                )
+                <ReasoningLevelSelector
+                  thoughtOption={thoughtOption}
+                  adapter={adapter}
+                  onChange={handleThoughtChange}
+                  disabled={isCreatingTask}
+                  isLoading={isPreviewLoading}
+                />
               }
               getPromptHistory={getPromptHistory}
               onEmptyChange={handleEditorEmptyChange}


### PR DESCRIPTION
## Problem

In the unified model picker, clicking **"Switch to Claude/Codex"** dismissed the whole dropdown — so to pick a model for the newly selected harness, the user had to reopen the picker.

Two independent things were closing it:

1. **The menu item closed itself.** quill's `DropdownMenuItem` wraps Base UI's `Menu.Item`, whose `closeOnClick` defaults to `true`.
2. **The component unmounted itself.** Switching harness flips `lastUsedAdapter`, which makes `usePreviewConfig` refetch the new adapter's models, setting `isConnecting` → `true`. The old `if (isConnecting)` early-return replaced the entire `<DropdownMenu>` with a bare "Loading…" button, tearing the open menu out of the tree (and `open` reset to `false` on remount).

Fixing only one wouldn't keep the picker open.

## Fix

All in `packages/ui/src/features/sessions/components/UnifiedModelSelector.tsx`:

- `closeOnClick={false}` on the "Switch to…" item.
- Guard the loading early-return with `&& !open` — it still collapses to a "Loading…" button on *initial* load (closed), but while the menu is **open** it stays mounted.
- Show an in-menu "Loading…" row while the new adapter's models fetch, so the open menu doesn't flash an empty model list before the new models land.

Selecting an actual **model** still closes the picker as before. This also improves the same component as used in the workflow Action editor.

## Verification

- `pnpm --filter @posthog/ui typecheck` — clean
- Biome — clean
- `pnpm build` — succeeds
- Full UI test suite — 1022 passed, no regressions