### PR TITLE
feat(analytics): instrument Claude Code session import

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -914,6 +914,36 @@ export interface SubscriptionCancelledProperties {
   plan_key: string;
 }
 
+// Claude Code session import events
+/** Where in the new-task suggestions the import was launched from. */
+export type ClaudeSessionImportSource = "inline_card" | "picker_dialog";
+/**
+ * Import status of a listed CLI session. "imported" sessions are hidden from
+ * the suggestions, so an import is only ever started from a "new" or "updated"
+ * one; the wider union mirrors the domain status field.
+ */
+type ClaudeSessionImportStatus = "new" | "imported" | "updated";
+
+export interface ClaudeSessionsShownProperties {
+  /** Resumable Claude Code CLI sessions surfaced for the repo. */
+  sessions_count: number;
+}
+
+export interface ClaudeSessionImportedProperties {
+  source: ClaudeSessionImportSource;
+  session_status: ClaudeSessionImportStatus;
+  has_git_branch: boolean;
+  /** Resumable sessions available when this one was imported. */
+  sessions_available_count: number;
+}
+
+export interface ClaudeSessionImportFailedProperties {
+  source: ClaudeSessionImportSource;
+  session_status: ClaudeSessionImportStatus;
+  /** Saga step that failed, e.g. "import_claude_session" or "task_creation". */
+  failed_step?: string;
+}
+
 // Event names as constants
 export const ANALYTICS_EVENTS = {
   // App lifecycle
@@ -933,6 +963,11 @@ export const ANALYTICS_EVENTS = {
   TASK_RUN_COMPLETED: "Task run completed",
   TASK_RUN_CANCELLED: "Task run cancelled",
   PROMPT_SENT: "Prompt sent",
+
+  // Claude Code session import
+  CLAUDE_SESSIONS_SHOWN: "Claude Code sessions shown",
+  CLAUDE_SESSION_IMPORTED: "Claude Code session imported",
+  CLAUDE_SESSION_IMPORT_FAILED: "Claude Code session import failed",
 
   // Repository
   REPOSITORY_SELECTED: "Repository selected",
@@ -1079,6 +1114,11 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.TASK_RUN_COMPLETED]: TaskRunCompletedProperties;
   [ANALYTICS_EVENTS.TASK_RUN_CANCELLED]: TaskRunCancelledProperties;
   [ANALYTICS_EVENTS.PROMPT_SENT]: PromptSentProperties;
+
+  // Claude Code session import
+  [ANALYTICS_EVENTS.CLAUDE_SESSIONS_SHOWN]: ClaudeSessionsShownProperties;
+  [ANALYTICS_EVENTS.CLAUDE_SESSION_IMPORTED]: ClaudeSessionImportedProperties;
+  [ANALYTICS_EVENTS.CLAUDE_SESSION_IMPORT_FAILED]: ClaudeSessionImportFailedProperties;
 
   // Git operations
   [ANALYTICS_EVENTS.GIT_ACTION_EXECUTED]: GitActionExecutedProperties;

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -922,7 +922,7 @@ export type ClaudeSessionImportSource = "inline_card" | "picker_dialog";
  * the suggestions, so an import is only ever started from a "new" or "updated"
  * one; the wider union mirrors the domain status field.
  */
-type ClaudeSessionImportStatus = "new" | "imported" | "updated";
+export type ClaudeSessionImportStatus = "new" | "imported" | "updated";
 
 export interface ClaudeSessionsShownProperties {
   /** Resumable Claude Code CLI sessions surfaced for the repo. */

--- a/packages/ui/src/features/task-detail/components/ContinueCliSessions.tsx
+++ b/packages/ui/src/features/task-detail/components/ContinueCliSessions.tsx
@@ -4,8 +4,14 @@ import {
   type TaskService,
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
-import { formatRelativeTimeShort, type WorkspaceMode } from "@posthog/shared";
+import {
+  ANALYTICS_EVENTS,
+  type ClaudeSessionImportSource,
+  formatRelativeTimeShort,
+  type WorkspaceMode,
+} from "@posthog/shared";
 import { openTask } from "@posthog/ui/router/useOpenTask";
+import { track } from "@posthog/ui/shell/analytics";
 import {
   Dialog,
   Flex,
@@ -14,7 +20,7 @@ import {
   Text,
   TextField,
 } from "@radix-ui/themes";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import claudeMark from "../../../assets/services/claude.svg";
 import { toast } from "../../../primitives/toast";
 import { useCreateTask } from "../../tasks/useTaskCrudMutations";
@@ -196,7 +202,7 @@ interface ContinueCliSessionsInlineProps {
   sessions: CliSession[];
   runningId: string | null;
   disabled?: boolean;
-  onContinue: (session: CliSession) => void;
+  onContinue: (session: CliSession, source: ClaudeSessionImportSource) => void;
 }
 
 /**
@@ -226,7 +232,7 @@ export function ContinueCliSessionsInline({
             running={runningId === latest.sourceSessionId}
             disabled={disabled || !!runningId}
             showHelpText
-            onClick={() => onContinue(latest)}
+            onClick={() => onContinue(latest, "inline_card")}
           />
         </div>
         {sessions.length > 1 && (
@@ -247,7 +253,7 @@ export function ContinueCliSessionsInline({
         disabled={disabled}
         onContinue={(session) => {
           setPickerOpen(false);
-          onContinue(session);
+          onContinue(session, "picker_dialog");
         }}
       />
     </>
@@ -278,6 +284,7 @@ export function NewTaskSuggestions({
   const taskService = useService<TaskService>(TASK_SERVICE);
   const { invalidateTasks } = useCreateTask();
   const [runningId, setRunningId] = useState<string | null>(null);
+  const shownForRepoRef = useRef<string | null>(null);
 
   // Hide sessions already imported and unchanged — they're a task now. One
   // reappears only when its CLI transcript changes again (status "updated").
@@ -288,7 +295,22 @@ export function NewTaskSuggestions({
         )
       : [];
 
-  const handleContinue = async (session: CliSession) => {
+  // The top of the import funnel: fire once per repo when resumable sessions
+  // first surface, so we can measure how many of these lead-ins convert.
+  useEffect(() => {
+    if (sessions.length === 0 || shownForRepoRef.current === repoPath) {
+      return;
+    }
+    shownForRepoRef.current = repoPath;
+    track(ANALYTICS_EVENTS.CLAUDE_SESSIONS_SHOWN, {
+      sessions_count: sessions.length,
+    });
+  }, [repoPath, sessions.length]);
+
+  const handleContinue = async (
+    session: CliSession,
+    source: ClaudeSessionImportSource,
+  ) => {
     if (runningId || !repoPath) return;
     setRunningId(session.sourceSessionId);
     try {
@@ -307,7 +329,19 @@ export function NewTaskSuggestions({
           void openTask(output.task);
         },
       );
-      if (!result.success) {
+      if (result.success) {
+        track(ANALYTICS_EVENTS.CLAUDE_SESSION_IMPORTED, {
+          source,
+          session_status: session.status,
+          has_git_branch: !!session.gitBranch,
+          sessions_available_count: sessions.length,
+        });
+      } else {
+        track(ANALYTICS_EVENTS.CLAUDE_SESSION_IMPORT_FAILED, {
+          source,
+          session_status: session.status,
+          failed_step: result.failedStep,
+        });
         toast.error("Couldn't continue Claude Code session", {
           description: result.error,
         });

--- a/packages/ui/src/features/task-detail/components/ContinueCliSessions.tsx
+++ b/packages/ui/src/features/task-detail/components/ContinueCliSessions.tsx
@@ -20,7 +20,7 @@ import {
   Text,
   TextField,
 } from "@radix-ui/themes";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import claudeMark from "../../../assets/services/claude.svg";
 import { toast } from "../../../primitives/toast";
 import { useCreateTask } from "../../tasks/useTaskCrudMutations";
@@ -267,6 +267,14 @@ interface NewTaskSuggestionsProps {
 }
 
 /**
+ * Repos whose "Claude Code sessions shown" event has already fired this app
+ * session. Module-level so it outlives NewTaskSuggestions remounts (navigating
+ * away and back), keeping the funnel top at one impression per repo per session
+ * rather than one per mount.
+ */
+const shownRepos = new Set<string>();
+
+/**
  * The new-task suggestions panel with the Claude Code resume card injected as
  * the first item, so CLI sessions live inside the single "Suggestions" list
  * rather than as a separate section. Clicking the card imports its transcript
@@ -284,7 +292,6 @@ export function NewTaskSuggestions({
   const taskService = useService<TaskService>(TASK_SERVICE);
   const { invalidateTasks } = useCreateTask();
   const [runningId, setRunningId] = useState<string | null>(null);
-  const shownForRepoRef = useRef<string | null>(null);
 
   // Hide sessions already imported and unchanged — they're a task now. One
   // reappears only when its CLI transcript changes again (status "updated").
@@ -298,10 +305,10 @@ export function NewTaskSuggestions({
   // The top of the import funnel: fire once per repo when resumable sessions
   // first surface, so we can measure how many of these lead-ins convert.
   useEffect(() => {
-    if (sessions.length === 0 || shownForRepoRef.current === repoPath) {
+    if (!repoPath || sessions.length === 0 || shownRepos.has(repoPath)) {
       return;
     }
-    shownForRepoRef.current = repoPath;
+    shownRepos.add(repoPath);
     track(ANALYTICS_EVENTS.CLAUDE_SESSIONS_SHOWN, {
       sessions_count: sessions.length,
     });


### PR DESCRIPTION
## Summary

The **Claude Code session import** flow (the "Continue a Claude Code session" cards in the new-task suggestions) had **zero product analytics**. This adds type-safe instrumentation covering the full conversion funnel, following the app's existing conventions (`docs/conventions.md`) and the `Task created` / `Task creation failed` precedent.

## Events added

| Event | When | Properties |
|---|---|---|
| `Claude Code sessions shown` | Funnel top — resumable CLI sessions first surface for a repo (fired once per repo) | `sessions_count` |
| `Claude Code session imported` | Import + task creation succeeds | `source`, `session_status`, `has_git_branch`, `sessions_available_count` |
| `Claude Code session import failed` | Import fails | `source`, `session_status`, `failed_step` |

- **`source`** — `inline_card` vs `picker_dialog`, so we can tell whether the lead-in card or the "see all" archive dialog drives imports.
- **`failed_step`** — the saga step that broke (`import_claude_session`, `task_creation`, `workspace_creation`, …), the real diagnostic for a new feature's reliability.
- **`session_status`** — `new` vs `updated`, i.e. fresh import vs re-import of a changed transcript.

## Implementation

- **`packages/shared/src/analytics-events.ts`** — three property interfaces, the event-name constants, and their `EventPropertyMap` entries (so `track()` calls are compile-time-checked).
- **`packages/ui/src/features/task-detail/components/ContinueCliSessions.tsx`** — fires the events via the renderer `track()` helper: a ref-guarded `useEffect` for "shown" (once per repo), and success/failure branches in `handleContinue`. The `source` discriminator is threaded through the inline-card vs picker-dialog click paths.

## Conventions followed

- Event names: `Object verbed`, Title Case first word, past-tense, abbreviations spelled out.
- Properties: `snake_case`; `has_` boolean, `_count` counts, enum unions for `source` / `session_status`.
- **No PII** — deliberately excluded the raw error message (can contain file paths), branch name, session title, and prompt text; only booleans / enums / counts are sent.
- Renderer path (`track` from `@posthog/ui/shell/analytics`), since this is UI code.

## Verification

- `@posthog/shared` typecheck: clean
- `@posthog/ui` typecheck: clean
- `biome check` (lint + format + import sort) on both files: clean

## Note

These are **dedicated import events** rather than also firing the generic `Task created` (the import path doesn't currently fire it). If unified task-creation reporting is preferred, imports could instead carry a `created_from: "claude_code_import"` discriminator on `Task created` — happy to switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
