### PR TITLE
fix(sessions): disable steer for cloud tasks to stop spurious interruptions

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1900,13 +1900,22 @@ export class SessionService {
     }
 
     // Steer: the user sent a message mid-turn and asked to fold it into the
-    // running turn rather than queue it. Native (Claude) injects at the next
-    // tool boundary; everything else interrupts the turn and resends below as a
-    // fresh prompt. Compaction always falls through to the queue.
-    if (options?.steer && session.isPromptPending && !session.isCompacting) {
-      const supportsNativeSteer =
-        !session.isCloud && session.adapter === "claude";
-      if (supportsNativeSteer) {
+    // running turn rather than queue it. Native (Claude, local) injects at the
+    // next tool boundary; local Codex interrupts the turn and resends below as
+    // a fresh prompt.
+    //
+    // Cloud has no real mid-turn steer: the backend only delivers user messages
+    // between turns, so a cloud "steer" would cancel the running turn for no
+    // gain (the message lands next turn either way) while surfacing a jarring
+    // interruption. Until the backend supports true steering, cloud steer falls
+    // through to the queue like a normal message. Compaction also falls through.
+    if (
+      options?.steer &&
+      !session.isCloud &&
+      session.isPromptPending &&
+      !session.isCompacting
+    ) {
+      if (session.adapter === "claude") {
         return this.sendSteerPrompt(session, prompt);
       }
       await this.cancelPrompt(taskId);

--- a/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
+++ b/packages/ui/src/features/sessions/components/QueuedMessagesDock.tsx
@@ -28,8 +28,12 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
   const sessionService = useService<SessionService>(SESSION_SERVICE);
   const supportsNativeSteer = useSupportsNativeSteer(taskId);
   const returnToEditor = useReturnQueuedMessageToEditor(taskId);
+  const session = useSessionForTask(taskId);
   // Steer can't inject mid-compaction, so it would be a silent no-op; hide it.
-  const isCompacting = useSessionForTask(taskId)?.isCompacting ?? false;
+  // Cloud has no real mid-turn steer either (it would just interrupt the turn),
+  // so hide it there too — the message stays queued and lands next turn.
+  const canSteer =
+    !(session?.isCompacting ?? false) && !(session?.isCloud ?? false);
 
   if (queued.length === 0) return null;
 
@@ -41,9 +45,8 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
           message={message}
           supportsNativeSteer={supportsNativeSteer}
           onSteer={
-            isCompacting
-              ? undefined
-              : () => {
+            canSteer
+              ? () => {
                   void sessionService
                     .steerQueuedMessage(taskId, message.id)
                     .catch(() => {
@@ -52,6 +55,7 @@ export function QueuedMessagesDock({ taskId }: QueuedMessagesDockProps) {
                       );
                     });
                 }
+              : undefined
           }
           onReturnToEditor={() => returnToEditor(message)}
           onRemove={() =>

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -650,11 +650,13 @@ export function SessionView({
                             ) : null
                           }
                           messagingModeToggle={
-                            taskId ? (
+                            taskId && !isCloudRun ? (
                               <SteerQueueToggle taskId={taskId} />
                             ) : undefined
                           }
-                          onToggleMessagingMode={toggleMessagingMode}
+                          onToggleMessagingMode={
+                            isCloudRun ? undefined : toggleMessagingMode
+                          }
                           onBeforeSubmit={handleBeforeSubmit}
                           onSubmit={handleSubmit}
                           onBashCommand={onBashCommand}

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -3632,6 +3632,35 @@ describe("SessionService", () => {
       expect(mockTrpcCloudTask.sendCommand.mutate).not.toHaveBeenCalled();
     });
 
+    it("queues a cloud steer instead of interrupting the running turn", async () => {
+      // Regression: cloud has no native mid-turn steer, so steering used to
+      // fall back to cancel-then-resend — which surfaced as a jarring user
+      // interruption. Cloud steer must now queue like a normal message and
+      // never cancel the running turn.
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({
+          isCloud: true,
+          cloudStatus: "in_progress",
+          status: "connected",
+          isPromptPending: true,
+        }),
+      );
+
+      const prompt: ContentBlock[] = [{ type: "text", text: "steer me" }];
+      const result = await service.sendPrompt("task-123", prompt, {
+        steer: true,
+      });
+
+      expect(result.stopReason).toBe("queued");
+      expect(mockSessionStoreSetters.enqueueMessage).toHaveBeenCalledWith(
+        "task-123",
+        "steer me",
+        prompt,
+      );
+      expect(mockTrpcCloudTask.sendCommand.mutate).not.toHaveBeenCalled();
+    });
+
     it("kicks an SSE retry when queueing on a disconnected cloud session", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(


### PR DESCRIPTION
## Problem

"Steer" appears broken for **cloud tasks** — instead of folding the message into the running turn, it triggers what looks like a user interruption.

This is a real, by-design symptom of the current fallback. Cloud runs have **no native mid-turn steer**: the backend `command` endpoint only delivers a `user_message` *between* turns (via a Temporal signal that waits for the agent to go idle), and the only way to act on a running turn is `cancel`, which is proxied straight to the sandbox. So `SessionService.sendPrompt` fell back to **cancel-then-resend** for cloud:

1. `cancelPrompt` → `cancelCloudPrompt` sends `method: "cancel"` → the sandbox interrupts the live turn → **this is the "user interruption"**.
2. The text is then resent as a normal `user_message`, delivered as the next turn.

The kicker: for cloud, this gains nothing over plain **Queue** mode (the message lands next turn either way) but adds a jarring interrupt — and a post-cancel race can leave you with *just* the interruption while the resend gets re-queued.

## Fix (stopgap)

Disable steer for cloud until the backend supports real mid-turn steering:

- **Core** (`sessionService.ts`): gate cloud out of the steer branch in `sendPrompt`, so a cloud steer falls through to the normal queue path and **never cancels the running turn**. Local Claude (native injection) and local Codex (interrupt-and-resend) are unchanged.
- **UI**: hide the steer affordances on cloud runs so the controls match behavior —
  - the `Steer/Queue` toggle + its `mod+s` switch hotkey (`SessionView.tsx`)
  - the per-queued-message "Steer" button (`QueuedMessagesDock.tsx`)
- **Test**: regression test asserting a cloud steer returns `queued` and does not call `cancel`/`sendCommand`.

## Not in scope

The proper fix — true mid-turn steering for cloud — needs backend support (the sandbox agent-server accepting a `user_message` while a prompt is in flight, plus a `steer` path through the command endpoint + Temporal flow). Tracked separately; happy to discuss the design.

## Test plan

- [x] `pnpm --filter @posthog/ui exec vitest run src/features/sessions/sessionServiceHost.test.ts` — 120 passed (incl. new test)
- [x] `pnpm --filter @posthog/core typecheck` / `pnpm --filter @posthog/ui typecheck` — clean
- [x] `biome check` / `biome lint packages/core` — clean

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*