### PR TITLE
fix(sessions): preserve permission mode and effort on cloud resume

### DIFF
--- a/packages/core/src/sessions/cloudRunOptions.test.ts
+++ b/packages/core/src/sessions/cloudRunOptions.test.ts
@@ -87,25 +87,31 @@ describe("getCloudRuntimeOptions", () => {
     expect(result.initialPermissionMode).toBeUndefined();
   });
 
-  it("prefers the session mode config option for permission mode", () => {
-    const result = getCloudRuntimeOptions(
-      session({
-        configOptions: [
-          { category: "mode", currentValue: "acceptEdits" },
-          // biome-ignore lint/suspicious/noExplicitAny: minimal config option shape
-        ] as any,
-      }),
-      {
+  it.each([
+    {
+      label: "prefers the session mode config option for permission mode",
+      configOptions: [
+        { category: "mode", currentValue: "acceptEdits" },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal config option shape
+      ] as any,
+      previousRun: {
         state: { initial_permission_mode: "plan" },
       } as unknown as TaskRun,
+      expected: "acceptEdits",
+    },
+    {
+      label: "falls back to the previous run state for permission mode",
+      configOptions: [],
+      previousRun: {
+        state: { initial_permission_mode: "acceptEdits" },
+      } as unknown as TaskRun,
+      expected: "acceptEdits",
+    },
+  ])("$label", ({ configOptions, previousRun, expected }) => {
+    const result = getCloudRuntimeOptions(
+      session({ configOptions }),
+      previousRun,
     );
-    expect(result.initialPermissionMode).toBe("acceptEdits");
-  });
-
-  it("falls back to the previous run state for permission mode", () => {
-    const result = getCloudRuntimeOptions(session({ configOptions: [] }), {
-      state: { initial_permission_mode: "acceptEdits" },
-    } as unknown as TaskRun);
-    expect(result.initialPermissionMode).toBe("acceptEdits");
+    expect(result.initialPermissionMode).toBe(expected);
   });
 });

--- a/packages/core/src/sessions/cloudRunOptions.test.ts
+++ b/packages/core/src/sessions/cloudRunOptions.test.ts
@@ -84,5 +84,28 @@ describe("getCloudRuntimeOptions", () => {
     expect(result.model).toBeUndefined();
     expect(result.reasoningLevel).toBeUndefined();
     expect(result.adapter).toBeUndefined();
+    expect(result.initialPermissionMode).toBeUndefined();
+  });
+
+  it("prefers the session mode config option for permission mode", () => {
+    const result = getCloudRuntimeOptions(
+      session({
+        configOptions: [
+          { category: "mode", currentValue: "acceptEdits" },
+          // biome-ignore lint/suspicious/noExplicitAny: minimal config option shape
+        ] as any,
+      }),
+      {
+        state: { initial_permission_mode: "plan" },
+      } as unknown as TaskRun,
+    );
+    expect(result.initialPermissionMode).toBe("acceptEdits");
+  });
+
+  it("falls back to the previous run state for permission mode", () => {
+    const result = getCloudRuntimeOptions(session({ configOptions: [] }), {
+      state: { initial_permission_mode: "acceptEdits" },
+    } as unknown as TaskRun);
+    expect(result.initialPermissionMode).toBe("acceptEdits");
   });
 });

--- a/packages/core/src/sessions/cloudRunOptions.ts
+++ b/packages/core/src/sessions/cloudRunOptions.ts
@@ -60,10 +60,6 @@ export function getCloudRuntimeOptions(
       typeof thoughtLevelOption?.currentValue === "string"
         ? thoughtLevelOption.currentValue
         : (previousRun?.reasoning_effort ?? undefined),
-    // Preserve the prior run's approval preset on resume. The session's `mode`
-    // config option reflects the user's current selection (seeded from the
-    // previous run); fall back to the run state. Without this the resume
-    // request omits the mode and the backend reverts to its default ("plan").
     initialPermissionMode:
       typeof modeOption?.currentValue === "string"
         ? (modeOption.currentValue as ExecutionMode)

--- a/packages/core/src/sessions/cloudRunOptions.ts
+++ b/packages/core/src/sessions/cloudRunOptions.ts
@@ -2,6 +2,7 @@ import {
   type Adapter,
   type AgentSession,
   type CloudRunSource,
+  type ExecutionMode,
   getConfigOptionByCategory,
   type PrAuthorshipMode,
 } from "@posthog/shared";
@@ -34,6 +35,7 @@ export interface CloudRuntimeOptions {
   adapter?: Adapter;
   model?: string;
   reasoningLevel?: string;
+  initialPermissionMode?: ExecutionMode;
 }
 
 export function getCloudRuntimeOptions(
@@ -45,6 +47,8 @@ export function getCloudRuntimeOptions(
     session.configOptions,
     "thought_level",
   );
+  const modeOption = getConfigOptionByCategory(session.configOptions, "mode");
+  const previousMode = previousRun?.state?.initial_permission_mode;
 
   return {
     adapter: session.adapter ?? previousRun?.runtime_adapter ?? undefined,
@@ -56,5 +60,15 @@ export function getCloudRuntimeOptions(
       typeof thoughtLevelOption?.currentValue === "string"
         ? thoughtLevelOption.currentValue
         : (previousRun?.reasoning_effort ?? undefined),
+    // Preserve the prior run's approval preset on resume. The session's `mode`
+    // config option reflects the user's current selection (seeded from the
+    // previous run); fall back to the run state. Without this the resume
+    // request omits the mode and the backend reverts to its default ("plan").
+    initialPermissionMode:
+      typeof modeOption?.currentValue === "string"
+        ? (modeOption.currentValue as ExecutionMode)
+        : typeof previousMode === "string"
+          ? (previousMode as ExecutionMode)
+          : undefined,
   };
 }

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -3271,9 +3271,6 @@ export class SessionService {
             return { ...opt, currentValue: initialModel };
           }
         }
-        // Seed the effort option from the prior run so resume preserves it.
-        // The preview defaults effort to "high"; without this seeding the
-        // resume request reuses that default instead of the run's real value.
         if (
           opt.category === "thought_level" &&
           opt.type === "select" &&

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -48,6 +48,7 @@ import { classifyCloudLogAppend } from "./cloudLogGap";
 import { CloudLogGapReconciler } from "./cloudLogGapReconciler";
 import { CloudRunIdleTracker } from "./cloudRunIdleTracker";
 import {
+  type CloudRuntimeOptions,
   getCloudPrAuthorshipMode,
   getCloudRunSource,
   getCloudRuntimeOptions,
@@ -2589,6 +2590,7 @@ export class SessionService {
     };
 
     let updatedTask: Task;
+    let runtimeOptions: CloudRuntimeOptions;
     try {
       const artifactIds = await this.d.h.uploadTaskStagedAttachments(
         authCredentials.client,
@@ -2625,7 +2627,7 @@ export class SessionService {
         previousStatus: session.cloudStatus,
       });
 
-      const runtimeOptions = getCloudRuntimeOptions(session, previousRun);
+      runtimeOptions = getCloudRuntimeOptions(session, previousRun);
 
       // Backend derives the snapshot from resumeFromRunId and restores the sandbox.
       updatedTask = await authCredentials.client.runTaskInCloud(
@@ -2694,13 +2696,8 @@ export class SessionService {
     )?.currentValue;
     const initialModel =
       newRun.model ?? (typeof priorModel === "string" ? priorModel : undefined);
-    const priorEffort = getConfigOptionByCategory(
-      session.configOptions,
-      "thought_level",
-    )?.currentValue;
     const initialReasoningEffort =
-      newRun.reasoning_effort ??
-      (typeof priorEffort === "string" ? priorEffort : undefined);
+      newRun.reasoning_effort ?? runtimeOptions.reasoningLevel;
     this.watchCloudTask(
       session.taskId,
       newRun.id,
@@ -4128,7 +4125,8 @@ export class SessionService {
     const adapter =
       task.latest_run?.runtime_adapter === "codex" ? "codex" : "claude";
     const initialModel = task.latest_run?.model ?? undefined;
-    const initialReasoningEffort = task.latest_run?.reasoning_effort ?? undefined;
+    const initialReasoningEffort =
+      task.latest_run?.reasoning_effort ?? undefined;
 
     return this.watchCloudTask(
       task.id,

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2635,6 +2635,7 @@ export class SessionService {
           adapter: runtimeOptions.adapter,
           model: runtimeOptions.model,
           reasoningLevel: runtimeOptions.reasoningLevel,
+          initialPermissionMode: runtimeOptions.initialPermissionMode,
           resumeFromRunId: session.taskRunId,
           pendingUserMessage: transport.messageText,
           pendingUserArtifactIds:
@@ -2693,6 +2694,13 @@ export class SessionService {
     )?.currentValue;
     const initialModel =
       newRun.model ?? (typeof priorModel === "string" ? priorModel : undefined);
+    const priorEffort = getConfigOptionByCategory(
+      session.configOptions,
+      "thought_level",
+    )?.currentValue;
+    const initialReasoningEffort =
+      newRun.reasoning_effort ??
+      (typeof priorEffort === "string" ? priorEffort : undefined);
     this.watchCloudTask(
       session.taskId,
       newRun.id,
@@ -2705,6 +2713,8 @@ export class SessionService {
       initialModel,
       undefined,
       resumeFromEntryCount,
+      undefined,
+      initialReasoningEffort,
     );
 
     this.d.queryClient.invalidateQueries({ queryKey: ["tasks"] });
@@ -3217,6 +3227,7 @@ export class SessionService {
     apiHost: string,
     adapter: Adapter,
     initialModel?: string,
+    initialReasoningEffort?: string,
   ): Promise<void> {
     const cacheKey = `${apiHost}::${adapter}`;
     let entry = this.previewConfigOptionsCache.get(cacheKey);
@@ -3260,6 +3271,19 @@ export class SessionService {
             return { ...opt, currentValue: initialModel };
           }
         }
+        // Seed the effort option from the prior run so resume preserves it.
+        // The preview defaults effort to "high"; without this seeding the
+        // resume request reuses that default instead of the run's real value.
+        if (
+          opt.category === "thought_level" &&
+          opt.type === "select" &&
+          typeof initialReasoningEffort === "string"
+        ) {
+          const flat = flattenSelectOptions(opt.options);
+          if (flat.some((o) => o.value === initialReasoningEffort)) {
+            return { ...opt, currentValue: initialReasoningEffort };
+          }
+        }
         return opt;
       });
 
@@ -3298,6 +3322,7 @@ export class SessionService {
     taskDescription?: string,
     resumeFromEntryCount?: number,
     runStatus?: TaskRunStatus,
+    initialReasoningEffort?: string,
   ): () => void {
     const taskRunId = runId;
 
@@ -3337,6 +3362,7 @@ export class SessionService {
           apiHost,
           adapter,
           initialModel,
+          initialReasoningEffort,
         );
       }
       return () => {};
@@ -3428,6 +3454,7 @@ export class SessionService {
       apiHost,
       adapter,
       initialModel,
+      initialReasoningEffort,
     );
 
     if (shouldHydrateSession) {
@@ -4104,6 +4131,7 @@ export class SessionService {
     const adapter =
       task.latest_run?.runtime_adapter === "codex" ? "codex" : "claude";
     const initialModel = task.latest_run?.model ?? undefined;
+    const initialReasoningEffort = task.latest_run?.reasoning_effort ?? undefined;
 
     return this.watchCloudTask(
       task.id,
@@ -4118,6 +4146,7 @@ export class SessionService {
       task.description ?? undefined,
       undefined,
       task.latest_run?.status,
+      initialReasoningEffort,
     );
   }
 


### PR DESCRIPTION
## Problem

Cloud runs kept resuming in **plan mode** with **effort high**, even when the task was started — or last messaged — with different settings. Reported from a Slack thread.

Two independent client-side misses (the backend honors whatever the resume request sends; the client just didn't send the right values):

1. **Permission mode** — `resumeCloudRun` built its options via `getCloudRuntimeOptions`, which never included the approval preset, so the `runTaskInCloud` call omitted `initialPermissionMode` and the backend reverted to its default (`plan`).
2. **Effort** — the `thought_level` config option's `currentValue` came from the preview defaults (hardcoded `high`) and was never seeded from the prior run, so resume reused `high` instead of the run's real effort.

## Changes

- `getCloudRuntimeOptions` now derives `initialPermissionMode` from the session's `mode` config option, falling back to the previous run's `initial_permission_mode`; `resumeCloudRun` forwards it to `runTaskInCloud`.
- `fetchAndApplyCloudPreviewOptions` now seeds the effort option's `currentValue` from the prior run's `reasoning_effort` (mirroring how the model option is seeded), threaded through `watchCloudTask` from `reconcileCloudConnection` and the resume path.

## How did you test this?

- Added unit tests in `cloudRunOptions.test.ts` for permission-mode derivation (session option preferred, run-state fallback, undefined when neither present).
- `pnpm --filter @posthog/core typecheck` — clean.
- `biome lint` on the changed files — clean.
- Ran the full `packages/core/src/sessions` suite — 183 tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1782751185874479?thread_ts=1782751185.874479&cid=C09G8Q32R6F)*