### PR TITLE
fix(code-review): live diff line highlight + clean comment box background

### DIFF
--- a/packages/core/src/code-review/diffAnnotations.test.ts
+++ b/packages/core/src/code-review/diffAnnotations.test.ts
@@ -87,18 +87,21 @@ describe("buildCommentMergedOptions", () => {
     { hasOpenComment: false, expectedEnabled: true },
     { hasOpenComment: true, expectedEnabled: false },
   ])(
-    "with hasOpenComment=$hasOpenComment sets selection/gutter enabled=$expectedEnabled and routes both callbacks to the handler",
+    "with hasOpenComment=$hasOpenComment sets selection/gutter enabled=$expectedEnabled and routes callbacks to the handlers",
     ({ hasOpenComment, expectedEnabled }) => {
-      const handler = () => {};
+      const onChange = () => {};
+      const onEnd = () => {};
       const merged = buildCommentMergedOptions(
         undefined,
         hasOpenComment,
-        handler,
+        onChange,
+        onEnd,
       );
       expect(merged.enableLineSelection).toBe(expectedEnabled);
       expect(merged.enableGutterUtility).toBe(expectedEnabled);
-      expect(merged.onLineSelectionEnd).toBe(handler);
-      expect(merged.onGutterUtilityClick).toBe(handler);
+      expect(merged.onLineSelectionChange).toBe(onChange);
+      expect(merged.onLineSelectionEnd).toBe(onEnd);
+      expect(merged.onGutterUtilityClick).toBe(onEnd);
     },
   );
 });

--- a/packages/core/src/code-review/diffAnnotations.ts
+++ b/packages/core/src/code-review/diffAnnotations.ts
@@ -54,12 +54,14 @@ export function buildDraftAnnotations(
 export function buildCommentMergedOptions(
   options: DiffOptions | undefined,
   hasOpenComment: boolean,
+  handleLineSelectionChange: (range: SelectedLineRange | null) => void,
   handleLineSelectionEnd: (range: SelectedLineRange | null) => void,
 ): DiffOptions {
   return {
     ...options,
     enableLineSelection: !hasOpenComment,
     enableGutterUtility: !hasOpenComment,
+    onLineSelectionChange: handleLineSelectionChange,
     onLineSelectionEnd: handleLineSelectionEnd,
     onGutterUtilityClick: handleLineSelectionEnd,
   };

--- a/packages/ui/src/features/code-review/components/CommentAnnotation.tsx
+++ b/packages/ui/src/features/code-review/components/CommentAnnotation.tsx
@@ -127,7 +127,10 @@ export function CommentAnnotation({
         : "Send to agent";
 
   return (
-    <div data-comment-annotation="" className="px-3 py-1.5 font-sans">
+    <div
+      data-comment-annotation=""
+      className="bg-(--diffs-bg) px-3 py-1.5 font-sans"
+    >
       <InputGroup>
         <InputGroupTextarea
           ref={setTextareaRef}

--- a/packages/ui/src/features/code-review/components/InteractiveFileDiff.tsx
+++ b/packages/ui/src/features/code-review/components/InteractiveFileDiff.tsx
@@ -193,6 +193,7 @@ function PatchDiffView({
     hasOpenComment,
     editSeed,
     reset,
+    handleLineSelectionChange,
     handleLineSelectionEnd,
     openCommentForEdit,
   } = useCommentState();
@@ -302,9 +303,15 @@ function PatchDiffView({
       buildCommentMergedOptions(
         options,
         hasOpenComment,
+        handleLineSelectionChange,
         handleLineSelectionEnd,
       ),
-    [options, hasOpenComment, handleLineSelectionEnd],
+    [
+      options,
+      hasOpenComment,
+      handleLineSelectionChange,
+      handleLineSelectionEnd,
+    ],
   );
 
   return (
@@ -350,6 +357,7 @@ function FilesDiffView({
     hasOpenComment,
     editSeed,
     reset,
+    handleLineSelectionChange,
     handleLineSelectionEnd,
     openCommentForEdit,
   } = useCommentState();
@@ -394,9 +402,15 @@ function FilesDiffView({
       buildCommentMergedOptions(
         options,
         hasOpenComment,
+        handleLineSelectionChange,
         handleLineSelectionEnd,
       ),
-    [options, hasOpenComment, handleLineSelectionEnd],
+    [
+      options,
+      hasOpenComment,
+      handleLineSelectionChange,
+      handleLineSelectionEnd,
+    ],
   );
 
   return (

--- a/packages/ui/src/features/code-review/hooks/useCommentState.ts
+++ b/packages/ui/src/features/code-review/hooks/useCommentState.ts
@@ -31,6 +31,13 @@ export function useCommentState() {
     setEditSeed(null);
   }, []);
 
+  const handleLineSelectionChange = useCallback(
+    (range: SelectedLineRange | null) => {
+      setSelectedRange(range);
+    },
+    [],
+  );
+
   const handleLineSelectionEnd = useCallback(
     (range: SelectedLineRange | null) => {
       setSelectedRange(range);
@@ -80,6 +87,7 @@ export function useCommentState() {
     hasOpenComment,
     editSeed,
     reset,
+    handleLineSelectionChange,
     handleLineSelectionEnd,
     openCommentForEdit,
   };


### PR DESCRIPTION
## Problem

When dragging to select lines in a PR diff, two things were off:
- The selected lines didn't highlight until **after** releasing the mouse.
- The inline comment box rendered with a **blue** background (the selection highlight bleeding into it).

## Changes

Before:

https://github.com/user-attachments/assets/25cc2881-27d1-49fb-af83-5ed713d349f1


After

https://github.com/user-attachments/assets/7af57e8e-75ec-4d84-a528-37d4a4dfed53



- The diff was always in `@pierre/diffs` "controlled selection" mode (we passed `selectedLines={null}`, never `undefined`), so the highlight only painted when the prop changed — on selection *end*. Wired `onLineSelectionChange` to update the range live during the drag.
- Gave the comment box container an opaque `bg-(--diffs-bg)` so the selection highlight stops at the lines instead of tinting the box.

## How did you test this?

- Manually reloaded the app: lines now highlight live while dragging, and the comment box renders on a clean background.
- `pnpm --filter @posthog/core test diffAnnotations` (5 passing, updated for the new signature).
- Typecheck clean on all touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*