### PR TITLE
fix(review-panel): hide "Open review panel" command when no task is open

### DIFF
--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -132,14 +132,18 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     return () => mq.removeEventListener("change", onChange);
   }, []);
 
+  // The review panel lives in the task-detail view, so the command only makes
+  // sense when a task is open. Elsewhere (e.g. the new-task screen) it would be
+  // a no-op, so we omit it below rather than show a dead entry.
+  const reviewTaskId = view.type === "task-detail" ? view.taskId : undefined;
+
   const openReviewPanel = useCallback(() => {
-    const taskId = view.type === "task-detail" ? view.taskId : undefined;
-    if (!taskId) return;
-    const mode = getReviewMode(taskId);
+    if (!reviewTaskId) return;
+    const mode = getReviewMode(reviewTaskId);
     if (mode === "closed") {
-      setReviewMode(taskId, "split");
+      setReviewMode(reviewTaskId, "split");
     }
-  }, [view, getReviewMode, setReviewMode]);
+  }, [reviewTaskId, getReviewMode, setReviewMode]);
 
   useEffect(() => {
     if (open) {
@@ -217,13 +221,19 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         action: "toggle-left-sidebar",
         onRun: toggleLeftSidebar,
       },
-      {
-        id: "open-review-panel",
-        label: "Open review panel",
-        icon: <ViewVerticalIcon className="h-3 w-3 rotate-180 text-gray-11" />,
-        action: "open-review-panel",
-        onRun: openReviewPanel,
-      },
+      ...(reviewTaskId
+        ? [
+            {
+              id: "open-review-panel",
+              label: "Open review panel",
+              icon: (
+                <ViewVerticalIcon className="h-3 w-3 rotate-180 text-gray-11" />
+              ),
+              action: "open-review-panel" as CommandMenuAction,
+              onRun: openReviewPanel,
+            },
+          ]
+        : []),
       {
         id: "new-task",
         label: "New task",
@@ -267,6 +277,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     closeSettingsDialog,
     toggleLeftSidebar,
     openReviewPanel,
+    reviewTaskId,
   ]);
 
   const taskSections = useMemo<CommandSection[]>(() => {


### PR DESCRIPTION
## Problem

The command palette's "Open review panel" action was listed everywhere, including the home / new-task screen where no task is open. There it did nothing — `openReviewPanel` returns early when the current view isn't a task detail — so it showed up as a dead, no-op entry.

## Changes

Before:
<img width="3182" height="2124" alt="CleanShot 2026-06-29 at 16 30 56@2x" src="https://github.com/user-attachments/assets/004d1492-c265-4fe7-b736-73021c7165a8" />

After:
<img width="2246" height="2134" alt="CleanShot 2026-06-29 at 16 31 11@2x" src="https://github.com/user-attachments/assets/b8bee46f-09a7-4f62-b5f2-63abc7805f9d" />
<img width="4242" height="1952" alt="CleanShot 2026-06-29 at 16 31 25@2x" src="https://github.com/user-attachments/assets/34eea6c0-303e-44f2-a9cd-9b4154e1282e" />



- Only surface "Open review panel" in the command palette when a task detail is actually open (`view.type === "task-detail"`). Elsewhere it's omitted rather than shown as a no-op.

## How did you test this?

- Not run locally (no `node_modules` in this workspace). Change mirrors the existing `as CommandMenuAction` conditional-spread pattern already used for the task/channel command entries in the same file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?