### PR TITLE
fix(code-review): refresh diffs on git state changes

### DIFF
--- a/packages/ui/src/features/git-interaction/gitCacheKeys.ts
+++ b/packages/ui/src/features/git-interaction/gitCacheKeys.ts
@@ -23,6 +23,10 @@ export function invalidateGitWorkingTreeQueries(repoPath: string) {
 }
 
 export function invalidateGitBranchQueries(repoPath: string) {
+  // A branch/index change (stage, commit, checkout) also changes the working
+  // tree, so the diff and changed-file queries must refresh too.
+  invalidateGitWorkingTreeQueries(repoPath);
+
   const queryClient = resolveService<ImperativeQueryClient>(
     IMPERATIVE_QUERY_CLIENT,
   );
@@ -40,10 +44,6 @@ export function invalidateGitBranchQueries(repoPath: string) {
   queryClient.invalidateQueries(
     provider.gitQueryFilter("getGitSyncStatus", input),
   );
-  queryClient.invalidateQueries(
-    provider.gitQueryFilter("getChangedFilesHead", input),
-  );
-  queryClient.invalidateQueries(provider.gitQueryFilter("getDiffStats", input));
   queryClient.invalidateQueries(
     provider.gitQueryFilter("getLatestCommit", input),
   );


### PR DESCRIPTION
## Problem

Stale code changes show in the reviewer side panel. When the agent (or user) stages, commits, or checks out via the terminal, only the `.git` index/refs change. The watcher emits `git-state-changed` (not `working-tree-changed`), which runs `invalidateGitBranchQueries`.

That function refreshed the changed-files list but **not** the diff patch queries (`getDiffCached` / `getDiffUnstaged`), so the panel kept rendering already-committed/staged diffs while the file list moved on. The two fell out of sync.

## Changes

- `invalidateGitBranchQueries` now composes over `invalidateGitWorkingTreeQueries`, since a branch/index change implies the working tree may have changed too.
- This refreshes `getDiffCached` / `getDiffUnstaged` / `getChangedFilesHead` / `getDiffStats` on git-state changes, and removes the duplicated invalidation lines between the two functions.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` (pre-commit hook also ran full typecheck)
- `biome check` on the changed file
- Not yet manually verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*