### PR TITLE
feat(command-menu): show keyboard shortcuts in command menu

### DIFF
--- a/apps/code/src/main/platform-adapters/electron-storage-paths.ts
+++ b/apps/code/src/main/platform-adapters/electron-storage-paths.ts
@@ -1,6 +1,8 @@
+import { dirname } from "node:path";
 import type { IStoragePaths } from "@posthog/platform/storage-paths";
 import { app } from "electron";
 import { injectable } from "inversify";
+import { getLogFilePath } from "../utils/logger";
 
 @injectable()
 export class ElectronStoragePaths implements IStoragePaths {
@@ -10,5 +12,9 @@ export class ElectronStoragePaths implements IStoragePaths {
 
   public get logsPath(): string {
     return app.getPath("logs");
+  }
+
+  public get logFolderPath(): string {
+    return dirname(getLogFilePath());
   }
 }

--- a/packages/host-router/src/routers/os.router.ts
+++ b/packages/host-router/src/routers/os.router.ts
@@ -59,6 +59,10 @@ export const osRouter = router({
       ctx.container.get<OsService>(OS_SERVICE).openExternal(input.url),
     ),
 
+  showLogFolder: publicProcedure.mutation(({ ctx }) =>
+    ctx.container.get<OsService>(OS_SERVICE).showLogFolder(),
+  ),
+
   searchDirectories: publicProcedure
     .input(searchDirectoriesInput)
     .query(({ ctx, input }) =>

--- a/packages/platform/src/storage-paths.ts
+++ b/packages/platform/src/storage-paths.ts
@@ -1,6 +1,7 @@
 export interface IStoragePaths {
   readonly appDataPath: string;
   readonly logsPath: string;
+  readonly logFolderPath: string;
 }
 
 export const STORAGE_PATHS_SERVICE = Symbol.for(

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -50,7 +50,9 @@ export type CommandMenuAction =
   | "go-back"
   | "go-forward"
   | "open-task"
-  | "open-channel";
+  | "open-channel"
+  | "reload-window"
+  | "show-log-folder";
 
 // Event property interfaces
 export interface TaskListViewProperties {

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -47,6 +47,8 @@ export type CommandMenuAction =
   | "toggle-theme"
   | "toggle-left-sidebar"
   | "open-review-panel"
+  | "go-back"
+  | "go-forward"
   | "open-task"
   | "open-channel";
 

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -439,7 +439,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       )}
                       {cmd.shortcut && (
                         <span className="ml-auto shrink-0 pl-2">
-                          <KbdGroup>
+                          <KbdGroup className="gap-1">
                             {formatHotkeyParts(cmd.shortcut).map((part) => (
                               <Kbd key={part}>{part}</Kbd>
                             ))}

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -44,6 +44,7 @@ import {
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
+import { showLogFolder } from "@posthog/ui/shell/openExternal";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
 import {
   DesktopIcon,
@@ -51,6 +52,7 @@ import {
   GearIcon,
   HomeIcon,
   MoonIcon,
+  ReloadIcon,
   SunIcon,
   ViewVerticalIcon,
 } from "@radix-ui/react-icons";
@@ -280,9 +282,30 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
       },
     ];
 
+    const developer: Command[] = [
+      {
+        id: "show-log-folder",
+        label: "Show log folder",
+        keywords: "logs debug files finder",
+        icon: <FileTextIcon className="h-3 w-3 text-gray-11" />,
+        action: "show-log-folder",
+        onRun: showLogFolder,
+      },
+      {
+        id: "reload-window",
+        label: "Reload window",
+        keywords: "refresh restart",
+        icon: <ReloadIcon className="h-3 w-3 text-gray-11" />,
+        action: "reload-window",
+        shortcut: SHORTCUTS.RELOAD_WINDOW,
+        onRun: () => window.location.reload(),
+      },
+    ];
+
     const out: CommandSection[] = [
       { label: "Actions", items: actions },
       { label: "Navigation", items: navigation },
+      { label: "Developer", items: developer },
     ];
 
     if (folders.length > 0) {

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -421,10 +421,12 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       value={cmd.id}
                       onClick={() => handleSelect(cmd.id)}
                       // Long task names wrap instead of truncating, so the
-                      // item must grow: min-height, not a fixed height. Full-
-                      // width flex so a trailing shortcut can `ml-auto` to the
-                      // end of the row.
-                      className="flex h-auto! min-h-7 w-full items-center gap-2 py-1.5 text-left"
+                      // item must grow: min-height, not a fixed height. Quill
+                      // wraps our children in an inner content span; force it to
+                      // fill the row (so a trailing shortcut can `ml-auto` to the
+                      // end) and let it overflow visibly so the shortcut Kbd
+                      // boxes aren't clipped by the wrapper's `truncate`.
+                      className="flex h-auto! min-h-7 w-full items-center gap-2 py-1.5 pr-2 text-left [&>span]:w-full [&>span]:overflow-visible"
                     >
                       {cmd.icon}
                       <span className="wrap-break-word min-w-0 whitespace-normal">
@@ -438,8 +440,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       {cmd.shortcut && (
                         <span className="ml-auto shrink-0 pl-2">
                           <KbdGroup>
-                            {formatHotkeyParts(cmd.shortcut).map((part, i) => (
-                              <Kbd key={i}>{part}</Kbd>
+                            {formatHotkeyParts(cmd.shortcut).map((part) => (
+                              <Kbd key={part}>{part}</Kbd>
                             ))}
                           </KbdGroup>
                         </span>

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -10,6 +10,8 @@ import {
   AutocompleteStatus,
   Dialog,
   DialogContent,
+  Kbd,
+  KbdGroup,
 } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import {
@@ -21,6 +23,10 @@ import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useTaskChannelMap } from "@posthog/ui/features/canvas/hooks/useTaskChannelMap";
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
 import { CommandKeyHints } from "@posthog/ui/features/command/CommandKeyHints";
+import {
+  formatHotkeyParts,
+  SHORTCUTS,
+} from "@posthog/ui/features/command/keyboard-shortcuts";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import {
@@ -62,6 +68,8 @@ type Command = {
   action: CommandMenuAction;
   /** Channel in scope for the bluebird open-channel / open-task actions. */
   channelId?: string;
+  /** Hotkey string (e.g. "mod+b") shown right-aligned when present. */
+  shortcut?: string;
   onRun: () => void;
 };
 
@@ -208,6 +216,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         label: "Settings",
         icon: <GearIcon className="h-3 w-3 text-gray-11" />,
         action: "settings",
+        shortcut: SHORTCUTS.SETTINGS,
         onRun: () => openSettingsDialog(),
       },
     ];
@@ -219,6 +228,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         label: "Toggle left sidebar",
         icon: <ViewVerticalIcon className="h-3 w-3 text-gray-11" />,
         action: "toggle-left-sidebar",
+        shortcut: SHORTCUTS.TOGGLE_LEFT_SIDEBAR,
         onRun: toggleLeftSidebar,
       },
       ...(reviewTaskId
@@ -230,6 +240,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                 <ViewVerticalIcon className="h-3 w-3 rotate-180 text-gray-11" />
               ),
               action: "open-review-panel" as CommandMenuAction,
+              shortcut: SHORTCUTS.TOGGLE_REVIEW_PANEL,
               onRun: openReviewPanel,
             },
           ]
@@ -240,6 +251,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         keywords: "create",
         icon: <FileTextIcon className="h-3 w-3 text-gray-11" />,
         action: "new-task",
+        shortcut: SHORTCUTS.NEW_TASK,
         onRun: () => {
           closeSettingsDialog();
           openTaskInput();
@@ -419,6 +431,15 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       {cmd.detail && (
                         <span className="shrink-0 text-gray-9">
                           · #{cmd.detail}
+                        </span>
+                      )}
+                      {cmd.shortcut && (
+                        <span className="ml-auto shrink-0 pl-2">
+                          <KbdGroup>
+                            {formatHotkeyParts(cmd.shortcut).map((part) => (
+                              <Kbd key={part}>{part}</Kbd>
+                            ))}
+                          </KbdGroup>
                         </span>
                       )}
                     </AutocompleteItem>

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -1,4 +1,8 @@
-import { HashIcon } from "@phosphor-icons/react";
+import {
+  CaretLeftIcon,
+  CaretRightIcon,
+  HashIcon,
+} from "@phosphor-icons/react";
 import {
   Autocomplete,
   AutocompleteCollection,
@@ -36,7 +40,11 @@ import { TaskIcon } from "@posthog/ui/features/sidebar/components/items/TaskIcon
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
-import { navigateToChannel } from "@posthog/ui/router/navigationBridge";
+import {
+  goBackInHistory,
+  goForwardInHistory,
+  navigateToChannel,
+} from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
@@ -209,6 +217,24 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
           closeSettingsDialog();
           openTaskInput();
         },
+      },
+      {
+        id: "go-back",
+        label: "Go back",
+        keywords: "navigate history previous",
+        icon: <CaretLeftIcon size={12} className="text-gray-11" />,
+        action: "go-back",
+        shortcut: SHORTCUTS.GO_BACK,
+        onRun: goBackInHistory,
+      },
+      {
+        id: "go-forward",
+        label: "Go forward",
+        keywords: "navigate history next",
+        icon: <CaretRightIcon size={12} className="text-gray-11" />,
+        action: "go-forward",
+        shortcut: SHORTCUTS.GO_FORWARD,
+        onRun: goForwardInHistory,
       },
       {
         id: "settings",

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -11,7 +11,6 @@ import {
   Dialog,
   DialogContent,
   Kbd,
-  KbdGroup,
 } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import {
@@ -438,12 +437,10 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                         </span>
                       )}
                       {cmd.shortcut && (
-                        <span className="ml-auto shrink-0 pl-2">
-                          <KbdGroup className="gap-1">
-                            {formatHotkeyParts(cmd.shortcut).map((part) => (
-                              <Kbd key={part}>{part}</Kbd>
-                            ))}
-                          </KbdGroup>
+                        <span className="ml-auto flex shrink-0 items-center gap-1 pl-2">
+                          {formatHotkeyParts(cmd.shortcut).map((part) => (
+                            <Kbd key={part}>{part}</Kbd>
+                          ))}
                         </span>
                       )}
                     </AutocompleteItem>

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -421,8 +421,10 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       value={cmd.id}
                       onClick={() => handleSelect(cmd.id)}
                       // Long task names wrap instead of truncating, so the
-                      // item must grow: min-height, not a fixed height.
-                      className="h-auto! min-h-7 py-1.5 text-left"
+                      // item must grow: min-height, not a fixed height. Full-
+                      // width flex so a trailing shortcut can `ml-auto` to the
+                      // end of the row.
+                      className="flex h-auto! min-h-7 w-full items-center gap-2 py-1.5 text-left"
                     >
                       {cmd.icon}
                       <span className="wrap-break-word min-w-0 whitespace-normal">

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -463,7 +463,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                         </span>
                       )}
                       {cmd.shortcut && (
-                        <span className="ml-auto flex shrink-0 items-center gap-1 pl-2">
+                        <span className="ml-auto flex shrink-0 items-center gap-2 pl-2">
                           {formatHotkeyParts(cmd.shortcut).map((part) => (
                             <Kbd key={part}>{part}</Kbd>
                           ))}

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -440,8 +440,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       {cmd.shortcut && (
                         <span className="ml-auto shrink-0 pl-2">
                           <KbdGroup>
-                            {formatHotkeyParts(cmd.shortcut).map((part, i) => (
-                              <Kbd key={i}>{part}</Kbd>
+                            {formatHotkeyParts(cmd.shortcut).map((part) => (
+                              <Kbd key={part}>{part}</Kbd>
                             ))}
                           </KbdGroup>
                         </span>

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -1,8 +1,4 @@
-import {
-  CaretLeftIcon,
-  CaretRightIcon,
-  HashIcon,
-} from "@phosphor-icons/react";
+import { CaretLeftIcon, CaretRightIcon, HashIcon } from "@phosphor-icons/react";
 import {
   Autocomplete,
   AutocompleteCollection,

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -438,8 +438,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       {cmd.shortcut && (
                         <span className="ml-auto shrink-0 pl-2">
                           <KbdGroup>
-                            {formatHotkeyParts(cmd.shortcut).map((part) => (
-                              <Kbd key={part}>{part}</Kbd>
+                            {formatHotkeyParts(cmd.shortcut).map((part, i) => (
+                              <Kbd key={i}>{part}</Kbd>
                             ))}
                           </KbdGroup>
                         </span>

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -281,8 +281,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     ];
 
     const out: CommandSection[] = [
-      { label: "Navigation", items: navigation },
       { label: "Actions", items: actions },
+      { label: "Navigation", items: navigation },
     ];
 
     if (folders.length > 0) {

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -215,6 +215,14 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         },
       },
       {
+        id: "settings",
+        label: "Settings",
+        icon: <GearIcon className="h-3 w-3 text-gray-11" />,
+        action: "settings",
+        shortcut: SHORTCUTS.SETTINGS,
+        onRun: () => openSettingsDialog(),
+      },
+      {
         id: "go-back",
         label: "Go back",
         keywords: "navigate history previous",
@@ -231,14 +239,6 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         action: "go-forward",
         shortcut: SHORTCUTS.GO_FORWARD,
         onRun: goForwardInHistory,
-      },
-      {
-        id: "settings",
-        label: "Settings",
-        icon: <GearIcon className="h-3 w-3 text-gray-11" />,
-        action: "settings",
-        shortcut: SHORTCUTS.SETTINGS,
-        onRun: () => openSettingsDialog(),
       },
     ];
 

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -440,8 +440,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                       {cmd.shortcut && (
                         <span className="ml-auto shrink-0 pl-2">
                           <KbdGroup>
-                            {formatHotkeyParts(cmd.shortcut).map((part) => (
-                              <Kbd key={part}>{part}</Kbd>
+                            {formatHotkeyParts(cmd.shortcut).map((part, i) => (
+                              <Kbd key={i}>{part}</Kbd>
                             ))}
                           </KbdGroup>
                         </span>

--- a/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -25,6 +25,7 @@ export const SHORTCUTS = {
   BLUR: "escape",
   SUBMIT_BLUR: "mod+enter",
   SWITCH_MESSAGING_MODE: "mod+s",
+  RELOAD_WINDOW: "mod+shift+r",
 } as const;
 
 export type ShortcutCategory = "general" | "navigation" | "panels" | "editor";

--- a/packages/ui/src/shell/GlobalEventHandlers.tsx
+++ b/packages/ui/src/shell/GlobalEventHandlers.tsx
@@ -167,6 +167,11 @@ export function GlobalEventHandlers({
     setReviewMode(currentTaskId, mode === "closed" ? "split" : "closed");
   }, [currentTaskId, getReviewMode, setReviewMode]);
 
+  useHotkeys(
+    SHORTCUTS.RELOAD_WINDOW,
+    () => window.location.reload(),
+    globalOptions,
+  );
   useHotkeys(SHORTCUTS.TOGGLE_LEFT_SIDEBAR, toggleLeftSidebar, globalOptions);
   useHotkeys(SHORTCUTS.TOGGLE_REVIEW_PANEL, handleToggleReview, globalOptions);
   useHotkeys(SHORTCUTS.SHORTCUTS_SHEET, onToggleShortcutsSheet, globalOptions);

--- a/packages/ui/src/shell/openExternal.ts
+++ b/packages/ui/src/shell/openExternal.ts
@@ -9,3 +9,9 @@ export function openExternalUrl(url: string): void {
     url,
   });
 }
+
+export function showLogFolder(): void {
+  void resolveService<HostTrpcClient>(
+    HOST_TRPC_CLIENT,
+  ).os.showLogFolder.mutate();
+}

--- a/packages/workspace-server/src/services/os/os.test.ts
+++ b/packages/workspace-server/src/services/os/os.test.ts
@@ -32,12 +32,19 @@ function createService() {
     getWorktreeLocation: vi.fn(() => "/tmp/worktrees"),
   };
 
+  const storagePaths = {
+    appDataPath: "/data",
+    logsPath: "/logs",
+    logFolderPath: "/logs",
+  };
+
   const service = new OsService(
     dialog as never,
     urlLauncher as never,
     appMeta as never,
     imageProcessor as never,
     workspaceSettings as never,
+    storagePaths as never,
   );
 
   return { service, dialog, urlLauncher, appMeta, workspaceSettings };
@@ -151,6 +158,14 @@ describe("OsService simple delegations", () => {
     const { service, urlLauncher } = createService();
     await service.openExternal("https://posthog.com");
     expect(urlLauncher.launch).toHaveBeenCalledWith("https://posthog.com");
+  });
+
+  it("opens the log folder as a file URL via the url launcher", async () => {
+    const { service, urlLauncher } = createService();
+    await service.showLogFolder();
+    expect(urlLauncher.launch).toHaveBeenCalledWith(
+      expect.stringMatching(/^file:\/\//),
+    );
   });
 });
 

--- a/packages/workspace-server/src/services/os/os.ts
+++ b/packages/workspace-server/src/services/os/os.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { APP_META_SERVICE, type IAppMeta } from "@posthog/platform/app-meta";
 import {
   DIALOG_SERVICE,
@@ -11,6 +12,10 @@ import {
   type IImageProcessor,
   IMAGE_PROCESSOR_SERVICE,
 } from "@posthog/platform/image-processor";
+import {
+  type IStoragePaths,
+  STORAGE_PATHS_SERVICE,
+} from "@posthog/platform/storage-paths";
 import {
   type IUrlLauncher,
   URL_LAUNCHER_SERVICE,
@@ -55,6 +60,8 @@ export class OsService {
     private readonly imageProcessor: IImageProcessor,
     @inject(WORKSPACE_SETTINGS_SERVICE)
     private readonly workspaceSettings: IWorkspaceSettings,
+    @inject(STORAGE_PATHS_SERVICE)
+    private readonly storagePaths: IStoragePaths,
   ) {}
 
   async getClaudePermissions(): Promise<ClaudePermissions> {
@@ -160,6 +167,12 @@ export class OsService {
 
   async openExternal(url: string): Promise<void> {
     await this.urlLauncher.launch(url);
+  }
+
+  async showLogFolder(): Promise<void> {
+    await this.urlLauncher.launch(
+      pathToFileURL(this.storagePaths.logFolderPath).href,
+    );
   }
 
   async searchDirectories(query: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Adds right-aligned keyboard shortcut hints to command menu items
- Adds **Go back** / **Go forward** navigation actions
- Reorders sections: Actions before Navigation

> **Danger level: 1/5**

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*