### PR TITLE
feat(code-review): file action icons (revert, stage, open) in diff headers

### DIFF
--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -12,9 +12,11 @@ import {
   usePrChangedFiles,
 } from "../../git-interaction/useGitQueries";
 import { usePrDetails } from "../../git-interaction/usePrDetails";
+import { makeFileKey } from "../../git-interaction/utils/fileKey";
 import { usePanelLayoutStore } from "../../panels/panelLayoutStore";
 import { useCwd } from "../../sidebar/useCwd";
 import { useDiscardFile } from "../../task-detail/hooks/useDiscardFile";
+import { useStageToggle } from "../../task-detail/hooks/useStageToggle";
 import { REVIEW_FILE_CACHE_TIME_MS, REVIEW_MAX_FILE_LINES } from "../constants";
 import { useEffectiveDiffSource } from "../hooks/useEffectiveDiffSource";
 import { useReviewDiffs } from "../hooks/useReviewDiffs";
@@ -265,10 +267,18 @@ function LocalReviewContent({
   usePrefetchUntrackedFileContents(repoPath, untrackedFiles, true);
 
   const discardFile = useDiscardFile(repoPath);
+  const stageToggle = useStageToggle(repoPath);
   const filesByPath = useMemo(() => {
     const map = new Map<string, ChangedFile>();
     for (const file of changedFiles) {
       if (!map.has(file.path)) map.set(file.path, file);
+    }
+    return map;
+  }, [changedFiles]);
+  const filesByKey = useMemo(() => {
+    const map = new Map<string, ChangedFile>();
+    for (const file of changedFiles) {
+      map.set(makeFileKey(file.staged, file.path), file);
     }
     return map;
   }, [changedFiles]);
@@ -280,6 +290,14 @@ function LocalReviewContent({
       void discardFile(file, fileName);
     },
     [filesByPath, discardFile],
+  );
+  const onStageFile = useCallback(
+    (key: string) => {
+      const file = filesByKey.get(key);
+      if (!file) return;
+      void stageToggle(file);
+    },
+    [filesByKey, stageToggle],
   );
 
   const items = useMemo<ReviewListItem[]>(() => {
@@ -301,6 +319,7 @@ function LocalReviewContent({
           toggleFile,
           openFile,
           onDiscardFile,
+          onStageFile,
           prUrl,
           commentThreads,
         }),
@@ -328,6 +347,7 @@ function LocalReviewContent({
         toggleFile,
         openFile,
         onDiscardFile,
+        onStageFile,
         prUrl,
         commentThreads,
       }),
@@ -341,6 +361,7 @@ function LocalReviewContent({
         collapsedFiles,
         toggleFile,
         onDiscardFile,
+        onStageFile,
       }),
     );
 
@@ -351,6 +372,7 @@ function LocalReviewContent({
     diffOptions,
     hasStagedFiles,
     onDiscardFile,
+    onStageFile,
     openFile,
     prUrl,
     repoPath,

--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -5,7 +5,7 @@ import { useHostTRPC } from "@posthog/host-router/react";
 import type { ChangedFile, Task } from "@posthog/shared/domain-types";
 import { Flex, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useDiffViewerStore } from "../../code-editor/diffViewerStore";
 import {
   useLocalBranchChangedFiles,
@@ -14,6 +14,7 @@ import {
 import { usePrDetails } from "../../git-interaction/usePrDetails";
 import { usePanelLayoutStore } from "../../panels/panelLayoutStore";
 import { useCwd } from "../../sidebar/useCwd";
+import { useDiscardFile } from "../../task-detail/hooks/useDiscardFile";
 import { REVIEW_FILE_CACHE_TIME_MS, REVIEW_MAX_FILE_LINES } from "../constants";
 import { useEffectiveDiffSource } from "../hooks/useEffectiveDiffSource";
 import { useReviewDiffs } from "../hooks/useReviewDiffs";
@@ -174,6 +175,7 @@ export function ReviewPage({ task }: ReviewPageProps) {
       repoPath={repoPath}
       taskId={taskId}
       openFile={openFile}
+      changedFiles={changedFiles}
       prUrl={prUrl}
       totalFileCount={totalFileCount}
       linesAdded={linesAdded}
@@ -206,6 +208,7 @@ function LocalReviewContent({
   repoPath,
   taskId,
   openFile,
+  changedFiles,
   prUrl,
   totalFileCount,
   linesAdded,
@@ -234,6 +237,7 @@ function LocalReviewContent({
   repoPath: string;
   taskId: string;
   openFile: (taskId: string, path: string, preview: boolean) => void;
+  changedFiles: ChangedFile[];
   prUrl: string | null;
   totalFileCount: number;
   linesAdded: number;
@@ -260,6 +264,24 @@ function LocalReviewContent({
 }) {
   usePrefetchUntrackedFileContents(repoPath, untrackedFiles, true);
 
+  const discardFile = useDiscardFile(repoPath);
+  const filesByPath = useMemo(() => {
+    const map = new Map<string, ChangedFile>();
+    for (const file of changedFiles) {
+      if (!map.has(file.path)) map.set(file.path, file);
+    }
+    return map;
+  }, [changedFiles]);
+  const onDiscardFile = useCallback(
+    (filePath: string) => {
+      const file = filesByPath.get(filePath);
+      if (!file) return;
+      const fileName = filePath.split("/").pop() ?? filePath;
+      void discardFile(file, fileName);
+    },
+    [filesByPath, discardFile],
+  );
+
   const items = useMemo<ReviewListItem[]>(() => {
     const reviewItems: ReviewListItem[] = [];
 
@@ -278,6 +300,7 @@ function LocalReviewContent({
           collapsedFiles,
           toggleFile,
           openFile,
+          onDiscardFile,
           prUrl,
           commentThreads,
         }),
@@ -304,6 +327,7 @@ function LocalReviewContent({
         collapsedFiles,
         toggleFile,
         openFile,
+        onDiscardFile,
         prUrl,
         commentThreads,
       }),
@@ -316,6 +340,7 @@ function LocalReviewContent({
         diffOptions,
         collapsedFiles,
         toggleFile,
+        onDiscardFile,
       }),
     );
 
@@ -325,6 +350,7 @@ function LocalReviewContent({
     commentThreads,
     diffOptions,
     hasStagedFiles,
+    onDiscardFile,
     openFile,
     prUrl,
     repoPath,

--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -268,13 +268,6 @@ function LocalReviewContent({
 
   const discardFile = useDiscardFile(repoPath);
   const stageToggle = useStageToggle(repoPath);
-  const filesByPath = useMemo(() => {
-    const map = new Map<string, ChangedFile>();
-    for (const file of changedFiles) {
-      if (!map.has(file.path)) map.set(file.path, file);
-    }
-    return map;
-  }, [changedFiles]);
   const filesByKey = useMemo(() => {
     const map = new Map<string, ChangedFile>();
     for (const file of changedFiles) {
@@ -283,13 +276,13 @@ function LocalReviewContent({
     return map;
   }, [changedFiles]);
   const onDiscardFile = useCallback(
-    (filePath: string) => {
-      const file = filesByPath.get(filePath);
+    (key: string) => {
+      const file = filesByKey.get(key);
       if (!file) return;
-      const fileName = filePath.split("/").pop() ?? filePath;
+      const fileName = file.path.split("/").pop() ?? file.path;
       void discardFile(file, fileName);
     },
-    [filesByPath, discardFile],
+    [filesByKey, discardFile],
   );
   const onStageFile = useCallback(
     (key: string) => {

--- a/packages/ui/src/features/code-review/components/ReviewRows.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewRows.tsx
@@ -27,7 +27,7 @@ interface PatchRowProps {
   skipExpansion: boolean;
   toggleFile: (key: string) => void;
   openFile: (taskId: string, path: string, preview: boolean) => void;
-  onDiscardFile?: (filePath: string) => void;
+  onDiscardFile?: (key: string) => void;
   onStageFile?: (key: string) => void;
   staged?: boolean;
   prUrl: string | null;
@@ -60,8 +60,8 @@ export const PatchRow = memo(function PatchRow({
     [openFile, taskId, repoPath, filePath],
   );
   const onDiscard = useMemo(
-    () => (onDiscardFile ? () => onDiscardFile(filePath) : undefined),
-    [onDiscardFile, filePath],
+    () => (onDiscardFile ? () => onDiscardFile(itemKey) : undefined),
+    [onDiscardFile, itemKey],
   );
   const onStage = useMemo(
     () => (onStageFile ? () => onStageFile(itemKey) : undefined),
@@ -107,7 +107,7 @@ interface UntrackedRowProps {
   diffOptions: DiffOptions;
   collapsed: boolean;
   toggleFile: (key: string) => void;
-  onDiscardFile?: (filePath: string) => void;
+  onDiscardFile?: (key: string) => void;
   onStageFile?: (key: string) => void;
 }
 
@@ -127,8 +127,8 @@ export const UntrackedRow = memo(function UntrackedRow({
     [toggleFile, itemKey],
   );
   const onDiscard = useMemo(
-    () => (onDiscardFile ? () => onDiscardFile(file.path) : undefined),
-    [onDiscardFile, file.path],
+    () => (onDiscardFile ? () => onDiscardFile(itemKey) : undefined),
+    [onDiscardFile, itemKey],
   );
   const onStage = useMemo(
     () => (onStageFile ? () => onStageFile(itemKey) : undefined),

--- a/packages/ui/src/features/code-review/components/ReviewRows.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewRows.tsx
@@ -27,6 +27,7 @@ interface PatchRowProps {
   skipExpansion: boolean;
   toggleFile: (key: string) => void;
   openFile: (taskId: string, path: string, preview: boolean) => void;
+  onDiscardFile?: (filePath: string) => void;
   prUrl: string | null;
   commentThreads?: Map<number, PrCommentThread>;
 }
@@ -42,6 +43,7 @@ export const PatchRow = memo(function PatchRow({
   skipExpansion,
   toggleFile,
   openFile,
+  onDiscardFile,
   prUrl,
   commentThreads,
 }: PatchRowProps) {
@@ -52,6 +54,10 @@ export const PatchRow = memo(function PatchRow({
   const onOpenFile = useCallback(
     () => openFile(taskId, `${repoPath}/${filePath}`, false),
     [openFile, taskId, repoPath, filePath],
+  );
+  const onDiscard = useMemo(
+    () => (onDiscardFile ? () => onDiscardFile(filePath) : undefined),
+    [onDiscardFile, filePath],
   );
   const options = useMemo(
     () => ({ ...diffOptions, collapsed }),
@@ -64,9 +70,10 @@ export const PatchRow = memo(function PatchRow({
         collapsed={collapsed}
         onToggle={onToggle}
         onOpenFile={onOpenFile}
+        onDiscard={onDiscard}
       />
     ),
-    [collapsed, onToggle, onOpenFile],
+    [collapsed, onToggle, onOpenFile, onDiscard],
   );
   return (
     <InteractiveFileDiff
@@ -90,6 +97,7 @@ interface UntrackedRowProps {
   diffOptions: DiffOptions;
   collapsed: boolean;
   toggleFile: (key: string) => void;
+  onDiscardFile?: (filePath: string) => void;
 }
 
 export const UntrackedRow = memo(function UntrackedRow({
@@ -100,10 +108,15 @@ export const UntrackedRow = memo(function UntrackedRow({
   diffOptions,
   collapsed,
   toggleFile,
+  onDiscardFile,
 }: UntrackedRowProps) {
   const onToggle = useCallback(
     () => toggleFile(itemKey),
     [toggleFile, itemKey],
+  );
+  const onDiscard = useMemo(
+    () => (onDiscardFile ? () => onDiscardFile(file.path) : undefined),
+    [onDiscardFile, file.path],
   );
   return (
     <UntrackedFileDiff
@@ -112,6 +125,7 @@ export const UntrackedRow = memo(function UntrackedRow({
       options={diffOptions}
       collapsed={collapsed}
       onToggle={onToggle}
+      onDiscard={onDiscard}
       taskId={taskId}
     />
   );
@@ -163,6 +177,7 @@ function UntrackedFileDiff({
   options,
   collapsed,
   onToggle,
+  onDiscard,
 }: {
   file: ChangedFile;
   repoPath: string;
@@ -170,6 +185,7 @@ function UntrackedFileDiff({
   options: DiffOptions;
   collapsed: boolean;
   onToggle: () => void;
+  onDiscard?: () => void;
 }) {
   const [containerRef, inView] = useInView<HTMLDivElement>({
     rootMargin: REVIEW_PREFETCH_ROOT_MARGIN,
@@ -231,6 +247,7 @@ function UntrackedFileDiff({
               fileDiff={fd}
               collapsed={collapsed}
               onToggle={onToggle}
+              onDiscard={onDiscard}
             />
           )}
         />

--- a/packages/ui/src/features/code-review/components/ReviewRows.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewRows.tsx
@@ -28,6 +28,8 @@ interface PatchRowProps {
   toggleFile: (key: string) => void;
   openFile: (taskId: string, path: string, preview: boolean) => void;
   onDiscardFile?: (filePath: string) => void;
+  onStageFile?: (key: string) => void;
+  staged?: boolean;
   prUrl: string | null;
   commentThreads?: Map<number, PrCommentThread>;
 }
@@ -44,6 +46,8 @@ export const PatchRow = memo(function PatchRow({
   toggleFile,
   openFile,
   onDiscardFile,
+  onStageFile,
+  staged,
   prUrl,
   commentThreads,
 }: PatchRowProps) {
@@ -59,6 +63,10 @@ export const PatchRow = memo(function PatchRow({
     () => (onDiscardFile ? () => onDiscardFile(filePath) : undefined),
     [onDiscardFile, filePath],
   );
+  const onStage = useMemo(
+    () => (onStageFile ? () => onStageFile(itemKey) : undefined),
+    [onStageFile, itemKey],
+  );
   const options = useMemo(
     () => ({ ...diffOptions, collapsed }),
     [diffOptions, collapsed],
@@ -71,9 +79,11 @@ export const PatchRow = memo(function PatchRow({
         onToggle={onToggle}
         onOpenFile={onOpenFile}
         onDiscard={onDiscard}
+        onStage={onStage}
+        staged={staged}
       />
     ),
-    [collapsed, onToggle, onOpenFile, onDiscard],
+    [collapsed, onToggle, onOpenFile, onDiscard, onStage, staged],
   );
   return (
     <InteractiveFileDiff
@@ -98,6 +108,7 @@ interface UntrackedRowProps {
   collapsed: boolean;
   toggleFile: (key: string) => void;
   onDiscardFile?: (filePath: string) => void;
+  onStageFile?: (key: string) => void;
 }
 
 export const UntrackedRow = memo(function UntrackedRow({
@@ -109,6 +120,7 @@ export const UntrackedRow = memo(function UntrackedRow({
   collapsed,
   toggleFile,
   onDiscardFile,
+  onStageFile,
 }: UntrackedRowProps) {
   const onToggle = useCallback(
     () => toggleFile(itemKey),
@@ -118,6 +130,10 @@ export const UntrackedRow = memo(function UntrackedRow({
     () => (onDiscardFile ? () => onDiscardFile(file.path) : undefined),
     [onDiscardFile, file.path],
   );
+  const onStage = useMemo(
+    () => (onStageFile ? () => onStageFile(itemKey) : undefined),
+    [onStageFile, itemKey],
+  );
   return (
     <UntrackedFileDiff
       file={file}
@@ -126,6 +142,7 @@ export const UntrackedRow = memo(function UntrackedRow({
       collapsed={collapsed}
       onToggle={onToggle}
       onDiscard={onDiscard}
+      onStage={onStage}
       taskId={taskId}
     />
   );
@@ -178,6 +195,7 @@ function UntrackedFileDiff({
   collapsed,
   onToggle,
   onDiscard,
+  onStage,
 }: {
   file: ChangedFile;
   repoPath: string;
@@ -186,6 +204,7 @@ function UntrackedFileDiff({
   collapsed: boolean;
   onToggle: () => void;
   onDiscard?: () => void;
+  onStage?: () => void;
 }) {
   const [containerRef, inView] = useInView<HTMLDivElement>({
     rootMargin: REVIEW_PREFETCH_ROOT_MARGIN,
@@ -248,6 +267,8 @@ function UntrackedFileDiff({
               collapsed={collapsed}
               onToggle={onToggle}
               onDiscard={onDiscard}
+              onStage={onStage}
+              staged={false}
             />
           )}
         />

--- a/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
+++ b/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
@@ -20,6 +20,7 @@ interface BuildPatchReviewItemsArgs {
   collapsedFiles: Set<string>;
   toggleFile: (key: string) => void;
   openFile: (taskId: string, path: string, preview: boolean) => void;
+  onDiscardFile?: (filePath: string) => void;
   prUrl: string | null;
   commentThreads?: Map<number, PrCommentThread>;
 }
@@ -34,6 +35,7 @@ export function buildPatchReviewItems({
   collapsedFiles,
   toggleFile,
   openFile,
+  onDiscardFile,
   prUrl,
   commentThreads,
 }: BuildPatchReviewItemsArgs): ReviewListItem[] {
@@ -62,6 +64,7 @@ export function buildPatchReviewItems({
           skipExpansion={skipExpansion}
           toggleFile={toggleFile}
           openFile={openFile}
+          onDiscardFile={onDiscardFile}
           prUrl={prUrl}
           commentThreads={commentThreads}
         />
@@ -77,6 +80,7 @@ interface BuildUntrackedReviewItemsArgs {
   diffOptions: DiffOptions;
   collapsedFiles: Set<string>;
   toggleFile: (key: string) => void;
+  onDiscardFile?: (filePath: string) => void;
 }
 
 export function buildUntrackedReviewItems({
@@ -86,6 +90,7 @@ export function buildUntrackedReviewItems({
   diffOptions,
   collapsedFiles,
   toggleFile,
+  onDiscardFile,
 }: BuildUntrackedReviewItemsArgs): ReviewListItem[] {
   return files.map((file) => {
     const key = makeFileKey(file.staged, file.path);
@@ -103,6 +108,7 @@ export function buildUntrackedReviewItems({
           diffOptions={diffOptions}
           collapsed={isCollapsed}
           toggleFile={toggleFile}
+          onDiscardFile={onDiscardFile}
         />
       ),
     };

--- a/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
+++ b/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
@@ -21,6 +21,7 @@ interface BuildPatchReviewItemsArgs {
   toggleFile: (key: string) => void;
   openFile: (taskId: string, path: string, preview: boolean) => void;
   onDiscardFile?: (filePath: string) => void;
+  onStageFile?: (key: string) => void;
   prUrl: string | null;
   commentThreads?: Map<number, PrCommentThread>;
 }
@@ -36,6 +37,7 @@ export function buildPatchReviewItems({
   toggleFile,
   openFile,
   onDiscardFile,
+  onStageFile,
   prUrl,
   commentThreads,
 }: BuildPatchReviewItemsArgs): ReviewListItem[] {
@@ -65,6 +67,8 @@ export function buildPatchReviewItems({
           toggleFile={toggleFile}
           openFile={openFile}
           onDiscardFile={onDiscardFile}
+          onStageFile={onStageFile}
+          staged={staged}
           prUrl={prUrl}
           commentThreads={commentThreads}
         />
@@ -81,6 +85,7 @@ interface BuildUntrackedReviewItemsArgs {
   collapsedFiles: Set<string>;
   toggleFile: (key: string) => void;
   onDiscardFile?: (filePath: string) => void;
+  onStageFile?: (key: string) => void;
 }
 
 export function buildUntrackedReviewItems({
@@ -91,6 +96,7 @@ export function buildUntrackedReviewItems({
   collapsedFiles,
   toggleFile,
   onDiscardFile,
+  onStageFile,
 }: BuildUntrackedReviewItemsArgs): ReviewListItem[] {
   return files.map((file) => {
     const key = makeFileKey(file.staged, file.path);
@@ -109,6 +115,7 @@ export function buildUntrackedReviewItems({
           collapsed={isCollapsed}
           toggleFile={toggleFile}
           onDiscardFile={onDiscardFile}
+          onStageFile={onStageFile}
         />
       ),
     };

--- a/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
+++ b/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
@@ -20,7 +20,7 @@ interface BuildPatchReviewItemsArgs {
   collapsedFiles: Set<string>;
   toggleFile: (key: string) => void;
   openFile: (taskId: string, path: string, preview: boolean) => void;
-  onDiscardFile?: (filePath: string) => void;
+  onDiscardFile?: (key: string) => void;
   onStageFile?: (key: string) => void;
   prUrl: string | null;
   commentThreads?: Map<number, PrCommentThread>;
@@ -84,7 +84,7 @@ interface BuildUntrackedReviewItemsArgs {
   diffOptions: DiffOptions;
   collapsedFiles: Set<string>;
   toggleFile: (key: string) => void;
-  onDiscardFile?: (filePath: string) => void;
+  onDiscardFile?: (key: string) => void;
   onStageFile?: (key: string) => void;
 }
 

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -14,6 +14,7 @@ import {
 import type { ChangedFile, Task } from "@posthog/shared/domain-types";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { FileIcon } from "../../primitives/FileIcon";
+import { Tooltip } from "../../primitives/Tooltip";
 import { useThemeStore } from "../../shell/themeStore";
 import { useDiffViewerStore } from "../code-editor/diffViewerStore";
 import { computeDiffStats } from "../git-interaction/utils/diffStats";
@@ -215,29 +216,32 @@ export function DiffFileHeader({
         (onDiscard || onOpenFile) && (
           <span className="ml-auto inline-flex items-center gap-[2px]">
             {onDiscard && (
-              <button
-                type="button"
-                title="Discard changes"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDiscard();
-                }}
-                className="inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
-              >
-                <ArrowCounterClockwise size={14} />
-              </button>
+              <Tooltip content="Discard changes">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDiscard();
+                  }}
+                  className="inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
+                >
+                  <ArrowCounterClockwise size={14} />
+                </button>
+              </Tooltip>
             )}
             {onOpenFile && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpenFile();
-                }}
-                className="inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
-              >
-                <ArrowSquareOut size={14} />
-              </button>
+              <Tooltip content="Open file">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOpenFile();
+                  }}
+                  className="inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
+                >
+                  <ArrowSquareOut size={14} />
+                </button>
+              </Tooltip>
             )}
           </span>
         )

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -1,4 +1,8 @@
-import { ArrowSquareOut, CaretDown } from "@phosphor-icons/react";
+import {
+  ArrowCounterClockwise,
+  ArrowSquareOut,
+  CaretDown,
+} from "@phosphor-icons/react";
 import type { FileDiffMetadata } from "@pierre/diffs/react";
 import type { ResolvedDiffSource } from "@posthog/core/code-review/resolveDiffSource";
 import {
@@ -184,11 +188,13 @@ export function DiffFileHeader({
   collapsed,
   onToggle,
   onOpenFile,
+  onDiscard,
 }: {
   fileDiff: FileDiffMetadata;
   collapsed: boolean;
   onToggle: () => void;
   onOpenFile?: () => void;
+  onDiscard?: () => void;
 }) {
   const fullPath =
     fileDiff.prevName && fileDiff.prevName !== fileDiff.name
@@ -206,17 +212,34 @@ export function DiffFileHeader({
       collapsed={collapsed}
       onToggle={onToggle}
       trailing={
-        onOpenFile && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpenFile();
-            }}
-            className="ml-auto inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
-          >
-            <ArrowSquareOut size={14} />
-          </button>
+        (onDiscard || onOpenFile) && (
+          <span className="ml-auto inline-flex items-center gap-[2px]">
+            {onDiscard && (
+              <button
+                type="button"
+                title="Discard changes"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDiscard();
+                }}
+                className="inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
+              >
+                <ArrowCounterClockwise size={14} />
+              </button>
+            )}
+            {onOpenFile && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenFile();
+                }}
+                className="inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
+              >
+                <ArrowSquareOut size={14} />
+              </button>
+            )}
+          </span>
         )
       }
     />

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -2,6 +2,8 @@ import {
   ArrowCounterClockwise,
   ArrowSquareOut,
   CaretDown,
+  Minus,
+  Plus,
 } from "@phosphor-icons/react";
 import type { FileDiffMetadata } from "@pierre/diffs/react";
 import type { ResolvedDiffSource } from "@posthog/core/code-review/resolveDiffSource";
@@ -190,12 +192,16 @@ export function DiffFileHeader({
   onToggle,
   onOpenFile,
   onDiscard,
+  onStage,
+  staged,
 }: {
   fileDiff: FileDiffMetadata;
   collapsed: boolean;
   onToggle: () => void;
   onOpenFile?: () => void;
   onDiscard?: () => void;
+  onStage?: () => void;
+  staged?: boolean;
 }) {
   const fullPath =
     fileDiff.prevName && fileDiff.prevName !== fileDiff.name
@@ -213,8 +219,22 @@ export function DiffFileHeader({
       collapsed={collapsed}
       onToggle={onToggle}
       trailing={
-        (onDiscard || onOpenFile) && (
+        (onStage || onDiscard || onOpenFile) && (
           <span className="ml-auto inline-flex items-center gap-[2px]">
+            {onStage && (
+              <Tooltip content={staged ? "Unstage" : "Stage"}>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onStage();
+                  }}
+                  className="inline-flex cursor-pointer rounded-[3px] border-0 bg-transparent p-[2px] text-(--gray-9) hover:bg-gray-4"
+                >
+                  {staged ? <Minus size={14} /> : <Plus size={14} />}
+                </button>
+              </Tooltip>
+            )}
             {onDiscard && (
               <Tooltip content="Discard changes">
                 <button


### PR DESCRIPTION
## Summary

Adds inline action icons to each **local** file-change accordion header in the review/diff view, so you can act on a file without leaving the diff:

- **Stage / Unstage** — plus icon ("Stage") for unstaged & untracked files, minus icon ("Unstage") for staged files
- **Discard changes** — revert icon (`git checkout` / restore, with the existing confirm dialog)
- **Open file** — open-in-editor icon

All three have tooltips via the shared `@posthog/ui` `Tooltip` primitive. Remote/PR rows are unaffected (their changes can't be staged or discarded).

Before:
<img width="1678" height="458" alt="CleanShot 2026-06-29 at 18 02 10@2x" src="https://github.com/user-attachments/assets/5c209119-e680-4788-b548-995e2cb3e31c" />


After:
<img width="1854" height="486" alt="CleanShot 2026-06-29 at 17 59 55@2x" src="https://github.com/user-attachments/assets/74571056-c69d-4600-9e6f-f9447bf42027" />


## Implementation

- `DiffFileHeader` (`reviewShellParts.tsx`) gained optional `onStage` / `onDiscard` / `staged` props and renders the icon buttons in the header's trailing slot.
- The callbacks are threaded `PatchRow` / `UntrackedRow` → `reviewItemBuilders` → `LocalReviewContent`, which wires them to the existing `useDiscardFile` and `useStageToggle` hooks.
- Stage lookups are keyed by the staged-aware file key (`makeFileKey(staged, path)`) so a partially-staged file's staged and unstaged sections each toggle the correct entry.

No backend changes — reuses the existing `git.discardFileChanges`, `git.stageFiles`, and `git.unstageFiles` mutations (the same paths the sidebar file list uses).

## Verification

- `pnpm --filter @posthog/ui typecheck` passes
- Biome clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)