### PR TITLE
fix(command-center): stop focus from scrolling the cell on click

### DIFF
--- a/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
+++ b/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
@@ -80,7 +80,9 @@ function GridCell({
       }
       const selection = window.getSelection();
       if (selection && !selection.isCollapsed) return;
-      cellRef.current?.querySelector<HTMLElement>("[tabindex='0']")?.focus();
+      cellRef.current
+        ?.querySelector<HTMLElement>("[tabindex='0']")
+        ?.focus({ preventScroll: true });
     },
     [markActive],
   );

--- a/packages/ui/src/features/message-editor/tiptap/useDraftSync.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useDraftSync.ts
@@ -169,7 +169,7 @@ export function useDraftSync(
     if (!editor || !pendingContent) return;
 
     editor.commands.setContent(editorContentToTiptapJson(pendingContent));
-    editor.commands.focus("end");
+    editor.commands.focus("end", { scrollIntoView: false });
     draftActions.clearPendingContent(sessionId);
   }, [editor, pendingContent, sessionId, draftActions]);
 

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -615,7 +615,9 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
 
   const focus = useCallback(() => {
     if (editor?.view) {
-      editor.commands.focus("end");
+      // scrollIntoView:false keeps a focus request from yanking the viewport
+      // when the composer is off-screen (e.g. embedded in a command-center cell).
+      editor.commands.focus("end", { scrollIntoView: false });
     }
   }, [editor]);
   const blur = useCallback(() => editor?.commands.blur(), [editor]);
@@ -630,7 +632,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
     (text: string) => {
       if (!editor) return;
       editor.commands.setContent(text);
-      editor.commands.focus("end");
+      editor.commands.focus("end", { scrollIntoView: false });
       draft.saveDraft(editor, attachments);
     },
     [editor, draft, attachments],


### PR DESCRIPTION
## Problem

Clicking inside a Command Center cell scrolled the cell's content upward. The click moved focus to the composer (and to the cell's `tabindex=0` element), and the browser's default scroll-into-view on focus yanked the clipped cell content out of view.

It only happened in the Command Center, never in the individual task view: there the composer is docked at the bottom of a full-height pane and is always on-screen, so scroll-into-view is a no-op. In a Command Center cell the same composer sits inside a small, `overflow-hidden` cell stacked under the conversation scroller, so revealing the caret actually scrolls the cell.

## Changes

Suppress scroll on every programmatic focus of the composer so focus moves without dragging the viewport:

- `useTiptapEditor.ts` — the shared `focus()` now uses `focus("end", { scrollIntoView: false })`, covering the pane-click, draft-store focus request, auto-focus-on-typing, and mount-time `requestFocus` paths. Same applied to the `setContent` focus.
- `useDraftSync.ts` — pending-content restore focuses with `scrollIntoView: false`.
- `CommandCenterGrid.tsx` — the cell's focus redirect uses `focus({ preventScroll: true })`.

These are the right defaults for a bottom-docked composer regardless of host, so behavior in the full task view is unchanged (the editor is already visible there).

## How did you test this?

Manually in the running app: confirmed clicking anywhere in a Command Center cell, including the composer, no longer scrolls the cell content up, and that the individual task view is unaffected. `pnpm typecheck` passes (also enforced by the pre-commit hook).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*