### PR TITLE
fix(release): drop Squirrel installer on Windows

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -324,18 +324,11 @@ jobs:
           APP_VERSION: ${{ steps.version.outputs.version }}
         run: |
           $out = "apps/code/out"
-          $sq = Join-Path $out "squirrel-windows"
           $items = @()
           # NSIS installer + electron-updater metadata live in the output root.
           $items += Get-ChildItem $out -File -Filter "*.exe"
           $items += Get-ChildItem $out -File -Filter "latest.yml"
           $items += Get-ChildItem $out -File -Filter "*.blockmap"
-          # Squirrel.Windows artifacts (nupkg + RELEASES + Setup) land in out/squirrel-windows.
-          if (Test-Path $sq) {
-            $items += Get-ChildItem $sq -File -Filter "*.nupkg"
-            $items += Get-ChildItem $sq -File -Filter "RELEASES"
-            $items += Get-ChildItem $sq -File -Filter "*.exe"
-          }
           $files = $items | Select-Object -ExpandProperty FullName
           gh release upload "v$env:APP_VERSION" --repo PostHog/code --clobber @files
 

--- a/apps/code/electron-builder.ts
+++ b/apps/code/electron-builder.ts
@@ -94,7 +94,7 @@ const config: Configuration = {
   },
 
   win: {
-    target: ["nsis", "squirrel"],
+    target: ["nsis"],
     // biome-ignore lint/suspicious/noTemplateCurlyInString: electron-builder interpolation tokens, not JS template literals
     artifactName: "PostHog-Code-${version}-${arch}-win.${ext}",
     // electron-builder generates the multi-size .ico from this 1024px PNG; a real
@@ -105,13 +105,6 @@ const config: Configuration = {
   nsis: {
     oneClick: false,
     deleteAppDataOnUninstall: false,
-  },
-
-  squirrelWindows: {
-    name: "PostHogCode",
-    // Squirrel.Windows requires a URL for the install/shortcut icon.
-    iconUrl:
-      "https://raw.githubusercontent.com/PostHog/code/main/apps/code/build/app-icon.ico",
   },
 
   linux: {

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -19,7 +19,7 @@ electron-builder generates and uploads a `latest-mac.yml` (macOS) or `latest.yml
 
 **macOS**: DMG + zip artifacts are uploaded; the merged `latest-mac.yml` covers both arm64 and x64 so the correct build is selected per architecture.
 
-**Windows**: Both NSIS and Squirrel.Windows installers are shipped during the transition period. Existing Squirrel users continue receiving updates via the legacy feed; once they reinstall via the NSIS installer they move to the electron-updater flow permanently.
+**Windows**: A single NSIS installer is shipped and updated through electron-updater via `latest.yml`. The legacy Squirrel.Windows installer is no longer built; anyone still on an old Squirrel install must reinstall once via the NSIS installer to keep receiving updates.
 
 **Linux**: No auto-update. AppImage, deb and rpm packages are manual downloads from the GitHub Release.
 


### PR DESCRIPTION
## Problem

The `Release PostHog Code` workflow fails on Windows at the "Upload release artifacts" step:

> HTTP 404: Not Found (https://uploads.github.com/repos/PostHog/code/releases/&lt;id&gt;/assets?...name=PostHog-Code-&lt;version&gt;-x64-win.exe)

The Windows build emits two installers that electron-builder names identically, because the `nsis` and `squirrel` targets share `win.artifactName`: the NSIS installer and the Squirrel `Setup.exe` both come out as `PostHog-Code-<version>-<arch>-win.exe`. A GitHub release can't hold two assets with the same name, so the second upload 404s and the job fails.

## Changes

- Drop the `squirrel` target from the Windows build in `apps/code/electron-builder.ts`, so only the NSIS installer is produced, and remove the now-unused `squirrelWindows` config.
- Simplify the Windows "Upload release artifacts" step to upload only the NSIS installer plus its electron-updater metadata (`latest.yml`, `.blockmap`). There are no Squirrel artifacts left to handle.
- Update `docs/UPDATES.md`: Windows ships a single NSIS installer. Anyone still on an old Squirrel install must reinstall once via the NSIS installer to keep receiving updates.

Auto-update is unaffected: current Windows builds update through electron-updater (`latest.yml`), not Squirrel.

## How did you test this?

- The release workflow only runs on `push: tags: v*`, so PR CI does not exercise it, and I did not run a real release.
- This change touches `apps/code`, so this PR's CI runs build, typecheck, unit tests and Biome against it (a release-workflow-only change would skip them).
- Reviewed the upload step: only the NSIS `.exe`, `latest.yml` and `.blockmap` remain, so no two release assets share a name.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
