### PR TITLE
fix(updates): keep ready status when reopening update settings

### DIFF
--- a/packages/core/src/settings/updateStatus.test.ts
+++ b/packages/core/src/settings/updateStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveUpdateStatus } from "./updateStatus";
+import { deriveUpdateStatus, resolveCheckResultAction } from "./updateStatus";
 
 describe("deriveUpdateStatus", () => {
   it("reports downloading", () => {
@@ -48,5 +48,42 @@ describe("deriveUpdateStatus", () => {
 
   it("returns empty while still checking", () => {
     expect(deriveUpdateStatus({ checking: true })).toEqual({});
+  });
+});
+
+describe("resolveCheckResultAction", () => {
+  it("returns null on success so the subscription owns the status", () => {
+    expect(resolveCheckResultAction({ success: true })).toBeNull();
+  });
+
+  it("returns null while a check is already in progress", () => {
+    expect(
+      resolveCheckResultAction({
+        success: false,
+        errorCode: "already_checking",
+      }),
+    ).toBeNull();
+  });
+
+  it("flags updates disabled and surfaces the reason", () => {
+    expect(
+      resolveCheckResultAction({
+        success: false,
+        errorCode: "disabled",
+        errorMessage: "Updates only available in packaged builds",
+      }),
+    ).toEqual({
+      updatesDisabled: true,
+      message: "Updates only available in packaged builds",
+      type: "error",
+    });
+  });
+
+  it("surfaces a generic failure when no message is provided", () => {
+    expect(resolveCheckResultAction({ success: false })).toEqual({
+      updatesDisabled: false,
+      message: "Failed to check for updates",
+      type: "error",
+    });
   });
 });

--- a/packages/core/src/settings/updateStatus.test.ts
+++ b/packages/core/src/settings/updateStatus.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { deriveUpdateStatus, resolveCheckResultAction } from "./updateStatus";
+import {
+  type CheckForUpdatesResult,
+  type CheckResultAction,
+  deriveUpdateStatus,
+  resolveCheckResultAction,
+} from "./updateStatus";
 
 describe("deriveUpdateStatus", () => {
   it("reports downloading", () => {
@@ -52,38 +57,45 @@ describe("deriveUpdateStatus", () => {
 });
 
 describe("resolveCheckResultAction", () => {
-  it("returns null on success so the subscription owns the status", () => {
-    expect(resolveCheckResultAction({ success: true })).toBeNull();
-  });
-
-  it("returns null while a check is already in progress", () => {
-    expect(
-      resolveCheckResultAction({
-        success: false,
-        errorCode: "already_checking",
-      }),
-    ).toBeNull();
-  });
-
-  it("flags updates disabled and surfaces the reason", () => {
-    expect(
-      resolveCheckResultAction({
+  it.each<[string, CheckForUpdatesResult, CheckResultAction | null]>([
+    ["success lets the subscription own the status", { success: true }, null],
+    [
+      "a check already in progress",
+      { success: false, errorCode: "already_checking" },
+      null,
+    ],
+    [
+      "disabled with a reason",
+      {
         success: false,
         errorCode: "disabled",
         errorMessage: "Updates only available in packaged builds",
-      }),
-    ).toEqual({
-      updatesDisabled: true,
-      message: "Updates only available in packaged builds",
-      type: "error",
-    });
-  });
-
-  it("surfaces a generic failure when no message is provided", () => {
-    expect(resolveCheckResultAction({ success: false })).toEqual({
-      updatesDisabled: false,
-      message: "Failed to check for updates",
-      type: "error",
-    });
+      },
+      {
+        updatesDisabled: true,
+        message: "Updates only available in packaged builds",
+        type: "error",
+      },
+    ],
+    [
+      "disabled without a reason falls back",
+      { success: false, errorCode: "disabled" },
+      {
+        updatesDisabled: true,
+        message: "Failed to check for updates",
+        type: "error",
+      },
+    ],
+    [
+      "a generic failure without a message",
+      { success: false },
+      {
+        updatesDisabled: false,
+        message: "Failed to check for updates",
+        type: "error",
+      },
+    ],
+  ])("resolves %s", (_label, result, expected) => {
+    expect(resolveCheckResultAction(result)).toEqual(expected);
   });
 });

--- a/packages/core/src/settings/updateStatus.ts
+++ b/packages/core/src/settings/updateStatus.ts
@@ -39,3 +39,28 @@ export function deriveUpdateStatus(
   }
   return {};
 }
+
+export interface CheckForUpdatesResult {
+  success: boolean;
+  errorCode?: "already_checking" | "disabled";
+  errorMessage?: string;
+}
+
+export interface CheckResultAction {
+  updatesDisabled: boolean;
+  message: string;
+  type: "error";
+}
+
+export function resolveCheckResultAction(
+  result: CheckForUpdatesResult,
+): CheckResultAction | null {
+  if (result.success || result.errorCode === "already_checking") {
+    return null;
+  }
+  return {
+    updatesDisabled: result.errorCode === "disabled",
+    message: result.errorMessage || "Failed to check for updates",
+    type: "error",
+  };
+}

--- a/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
+++ b/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
@@ -1,5 +1,8 @@
 import { CheckCircle, XCircle } from "@phosphor-icons/react";
-import { deriveUpdateStatus } from "@posthog/core/settings/updateStatus";
+import {
+  deriveUpdateStatus,
+  resolveCheckResultAction,
+} from "@posthog/core/settings/updateStatus";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
@@ -44,24 +47,21 @@ export function UpdatesSettings() {
     try {
       const result = await checkUpdatesMutation.mutateAsync();
 
-      if (result.success) {
-        setUpdateStatus({
-          message: "Checking for updates...",
-          type: "info",
-        });
-      } else if (result.errorCode === "already_checking") {
-        // A check is already in progress (e.g. boot check) — show spinner and wait
-        setUpdateStatus({ message: "Checking for updates...", type: "info" });
-      } else {
-        if (result.errorCode === "disabled") {
-          setUpdatesDisabled(true);
-        }
-        setUpdateStatus({
-          message: result.errorMessage || "Failed to check for updates",
-          type: "error",
-        });
-        setCheckingForUpdates(false);
+      // success and already_checking are non-terminal: the real outcome (up to
+      // date, available, downloading, ready, error) arrives over the onStatus
+      // subscription, which owns the message. Re-asserting "Checking..." here
+      // would clobber a terminal status the subscription already delivered,
+      // e.g. an update that is already staged and ready to install.
+      const action = resolveCheckResultAction(result);
+      if (!action) {
+        return;
       }
+
+      if (action.updatesDisabled) {
+        setUpdatesDisabled(true);
+      }
+      setUpdateStatus({ message: action.message, type: action.type });
+      setCheckingForUpdates(false);
     } catch (error) {
       log.error("Failed to check for updates:", error);
       setUpdateStatus({

--- a/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
+++ b/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
@@ -47,11 +47,6 @@ export function UpdatesSettings() {
     try {
       const result = await checkUpdatesMutation.mutateAsync();
 
-      // success and already_checking are non-terminal: the real outcome (up to
-      // date, available, downloading, ready, error) arrives over the onStatus
-      // subscription, which owns the message. Re-asserting "Checking..." here
-      // would clobber a terminal status the subscription already delivered,
-      // e.g. an update that is already staged and ready to install.
       const action = resolveCheckResultAction(result);
       if (!action) {
         return;


### PR DESCRIPTION
## Problem

The Updates settings panel gets stuck showing "Checking for updates..." even when an update is already downloaded and ready to apply. The sidebar banner correctly shows e.g. "0.56.7 ready, Restart to apply", but the settings row keeps the "Checking for updates..." text (with no spinner and an active "Check now" button), so it looks broken.

## Changes

Root cause: when the Updates settings panel opens it auto-triggers a check. If an update is already staged, `UpdatesService.checkForUpdates()` synchronously emits the staged status over the `onStatus` subscription and returns `{ success: true }`. The subscription delivers `"Update 0.56.7 ready to install"` and clears the spinner, but the awaited mutation's `result.success` branch then unconditionally re-set the message back to `"Checking for updates..."`, clobbering the terminal status the subscription had already delivered. The result was the exact stuck state: `"Checking for updates..."` text with `checkingForUpdates` already false (no spinner, enabled button).

- `UpdatesSettings.tsx`: the `onStatus` subscription is the source of truth for the post-check status. `success` and `already_checking` are non-terminal, so the handler now leaves the optimistic "Checking..." message in place and lets the subscription drive the terminal status (up to date / available / downloading / ready / error). Only synchronous failures (`disabled` / other) set an error message and clear the spinner.
- Extracted the synchronous-result decision into a pure `resolveCheckResultAction()` in `@posthog/core/settings/updateStatus`, mirroring the existing `resolveMenuCheckResult()` for the menu-check path, so the invariant is unit-tested instead of buried in component glue.

## How did you test this?

- Added 4 unit tests for `resolveCheckResultAction` (success and already_checking return null so the subscription owns the status; disabled and generic failures surface an error). `pnpm --filter @posthog/core test src/settings/updateStatus.test.ts`, 1787 passed.
- `pnpm --filter @posthog/core typecheck` and `pnpm --filter @posthog/ui typecheck`, both clean.
- `biome lint` on the three changed files, clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
