### PR TITLE
fix(steer): keep a quick follow-up message from vanishing

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1634,11 +1634,6 @@ export class SessionService {
       });
     }
 
-    // A steer rides on `session/prompt` but has no optimistic placeholder of its
-    // own (sendSteerPrompt skips applyOptimisticPrompt). Replacing here would
-    // wipe *other* in-flight messages' placeholders (e.g. a follow-up sent
-    // moments later), making them vanish until their own echo lands. Append it
-    // instead so it renders without disturbing pending placeholders.
     if (isUserPromptEcho && !this.isSteerMessage(acpMsg.message)) {
       this.d.store.replaceOptimisticWithEvent(taskRunId, acpMsg);
     } else {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1634,7 +1634,12 @@ export class SessionService {
       });
     }
 
-    if (isUserPromptEcho) {
+    // A steer rides on `session/prompt` but has no optimistic placeholder of its
+    // own (sendSteerPrompt skips applyOptimisticPrompt). Replacing here would
+    // wipe *other* in-flight messages' placeholders (e.g. a follow-up sent
+    // moments later), making them vanish until their own echo lands. Append it
+    // instead so it renders without disturbing pending placeholders.
+    if (isUserPromptEcho && !this.isSteerMessage(acpMsg.message)) {
       this.d.store.replaceOptimisticWithEvent(taskRunId, acpMsg);
     } else {
       this.d.store.appendEvents(taskRunId, [acpMsg]);

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -4635,12 +4635,21 @@ describe("SessionService", () => {
       return onData as (payload: unknown) => void;
     }
 
-    it("appends a steer echo without clearing pending optimistic placeholders", async () => {
+    it.each([
+      {
+        name: "appends a steer echo without clearing pending optimistic placeholders",
+        steer: true,
+      },
+      {
+        name: "replaces the optimistic placeholder for a normal prompt echo",
+        steer: false,
+      },
+    ])("$name", async ({ steer }) => {
       const onData = await connectAndCaptureOnData();
       mockSessionStoreSetters.appendEvents.mockClear();
       mockSessionStoreSetters.replaceOptimisticWithEvent.mockClear();
 
-      const steerEcho = {
+      const echo = {
         type: "acp_message",
         ts: 1700000001,
         message: {
@@ -4648,42 +4657,27 @@ describe("SessionService", () => {
           id: 101,
           method: "session/prompt",
           params: {
-            prompt: [{ type: "text", text: "steer me" }],
-            _meta: { steer: true },
+            prompt: [{ type: "text", text: "hello" }],
+            ...(steer ? { _meta: { steer: true } } : {}),
           },
         },
       };
-      onData(steerEcho);
+      onData(echo);
 
-      expect(mockSessionStoreSetters.appendEvents).toHaveBeenCalledWith(
-        "run-123",
-        [steerEcho],
-      );
-      expect(
-        mockSessionStoreSetters.replaceOptimisticWithEvent,
-      ).not.toHaveBeenCalled();
-    });
-
-    it("replaces the optimistic placeholder for a normal prompt echo", async () => {
-      const onData = await connectAndCaptureOnData();
-      mockSessionStoreSetters.appendEvents.mockClear();
-      mockSessionStoreSetters.replaceOptimisticWithEvent.mockClear();
-
-      const normalEcho = {
-        type: "acp_message",
-        ts: 1700000002,
-        message: {
-          jsonrpc: "2.0",
-          id: 102,
-          method: "session/prompt",
-          params: { prompt: [{ type: "text", text: "normal msg" }] },
-        },
-      };
-      onData(normalEcho);
-
-      expect(
-        mockSessionStoreSetters.replaceOptimisticWithEvent,
-      ).toHaveBeenCalledWith("run-123", normalEcho);
+      if (steer) {
+        expect(mockSessionStoreSetters.appendEvents).toHaveBeenCalledWith(
+          "run-123",
+          [echo],
+        );
+        expect(
+          mockSessionStoreSetters.replaceOptimisticWithEvent,
+        ).not.toHaveBeenCalled();
+      } else {
+        expect(
+          mockSessionStoreSetters.replaceOptimisticWithEvent,
+        ).toHaveBeenCalledWith("run-123", echo);
+        expect(mockSessionStoreSetters.appendEvents).not.toHaveBeenCalled();
+      }
     });
   });
 

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -4581,6 +4581,112 @@ describe("SessionService", () => {
     });
   });
 
+  describe("steer echo routing", () => {
+    async function connectAndCaptureOnData(): Promise<
+      (payload: unknown) => void
+    > {
+      const service = getSessionService();
+
+      let session: AgentSession | undefined;
+      mockSessionStoreSetters.getSessionByTaskId.mockImplementation(
+        () => session,
+      );
+      mockSessionStoreSetters.getSessions.mockImplementation(() =>
+        session ? { "run-123": session } : {},
+      );
+      mockSessionStoreSetters.updateSession.mockImplementation(
+        (_taskRunId, updates) => {
+          if (session) session = { ...session, ...updates };
+        },
+      );
+      mockSessionStoreSetters.setSession.mockImplementation((next) => {
+        session = next as AgentSession;
+      });
+
+      mockBuildAuthenticatedClient.mockReturnValue({
+        ...mockAuthenticatedClient,
+        createTaskRun: vi.fn().mockResolvedValue({ id: "run-123" }),
+        appendTaskRunLog: vi.fn(),
+      });
+      mockTrpcAgent.start.mutate.mockResolvedValue({
+        channel: "agent-event:run-123",
+        configOptions: [],
+      });
+
+      await service.connectToTask({
+        task: createMockTask(),
+        repoPath: "/repo",
+      });
+
+      session = createMockSession({
+        taskRunId: "run-123",
+        taskId: "task-123",
+        status: "connected",
+        isCloud: false,
+        adapter: "claude",
+        currentPromptId: 42,
+        isPromptPending: true,
+      });
+
+      const onData = mockTrpcAgent.onSessionEvent.subscribe.mock.calls.at(
+        -1,
+      )?.[1]?.onData as ((payload: unknown) => void) | undefined;
+      expect(onData).toBeDefined();
+      return onData as (payload: unknown) => void;
+    }
+
+    it("appends a steer echo without clearing pending optimistic placeholders", async () => {
+      const onData = await connectAndCaptureOnData();
+      mockSessionStoreSetters.appendEvents.mockClear();
+      mockSessionStoreSetters.replaceOptimisticWithEvent.mockClear();
+
+      const steerEcho = {
+        type: "acp_message",
+        ts: 1700000001,
+        message: {
+          jsonrpc: "2.0",
+          id: 101,
+          method: "session/prompt",
+          params: {
+            prompt: [{ type: "text", text: "steer me" }],
+            _meta: { steer: true },
+          },
+        },
+      };
+      onData(steerEcho);
+
+      expect(mockSessionStoreSetters.appendEvents).toHaveBeenCalledWith(
+        "run-123",
+        [steerEcho],
+      );
+      expect(
+        mockSessionStoreSetters.replaceOptimisticWithEvent,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("replaces the optimistic placeholder for a normal prompt echo", async () => {
+      const onData = await connectAndCaptureOnData();
+      mockSessionStoreSetters.appendEvents.mockClear();
+      mockSessionStoreSetters.replaceOptimisticWithEvent.mockClear();
+
+      const normalEcho = {
+        type: "acp_message",
+        ts: 1700000002,
+        message: {
+          jsonrpc: "2.0",
+          id: 102,
+          method: "session/prompt",
+          params: { prompt: [{ type: "text", text: "normal msg" }] },
+        },
+      };
+      onData(normalEcho);
+
+      expect(
+        mockSessionStoreSetters.replaceOptimisticWithEvent,
+      ).toHaveBeenCalledWith("run-123", normalEcho);
+    });
+  });
+
   describe("steerQueuedMessage", () => {
     const queuedMessage = {
       id: "q-1",


### PR DESCRIPTION
## Problem

Reported by a user using Steer. With a task in Queue mode, sending one message then switching to Steer steers that message correctly. But a second message sent in the brief window right after the switch is lost: it renders for a moment, then disappears from the chat once the first message is brought into context.

## Changes

Root cause: every `session/prompt` echo was routed through `replaceOptimisticWithEvent`, which clears all of a session's optimistic placeholders. A steer carries no optimistic placeholder of its own (`sendSteerPrompt` skips `applyOptimisticPrompt`), so when the first message's steer echo arrived it wiped the second message's still-pending placeholder, making it vanish until its own echo landed.

Now a steer echo is appended instead of replacing, so it renders without disturbing other in-flight placeholders. Normal prompt echoes still replace their placeholder as before.

## How did you test this?

- Added `steer echo routing` tests in `sessionServiceHost.test.ts`: a steer echo appends without clearing pending optimistic placeholders, and a normal prompt echo still replaces its own placeholder. Confirmed the new steer test fails against the pre-fix code.
- Ran locally, all green:
  - `@posthog/ui` unit suite (1039 tests)
  - `@posthog/core` unit suite (1788 tests)
  - `pnpm typecheck` (all packages)
  - Biome check on the changed files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
