### PR TITLE
fix(agent): require local commit ownership before attributing a PR to a run

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -207,6 +207,14 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => ({
   query: mockedClaudeSdk.query,
 }));
 
+const mockedGitQueries = vi.hoisted(() => ({
+  commitExistsLocally: vi.fn(async () => true),
+}));
+vi.mock("@posthog/git/queries", async (importOriginal) => ({
+  ...(await importOriginal()),
+  commitExistsLocally: mockedGitQueries.commitExistsLocally,
+}));
+
 interface TestableServer {
   getInitialPromptOverride(run: TaskRun): string | null;
   getClearedPendingUserState(run: TaskRun | null): string[] | null;
@@ -1557,74 +1565,125 @@ describe("AgentServer HTTP Mode", () => {
       _meta: { terminal_output: `Creating draft pull request...\n${url}\n` },
     });
 
+    type PrAttributionMetadata = {
+      createdAt: string | null;
+      headRef: string | null;
+      headSha: string | null;
+      authorLogin: string | null;
+    };
+
     type PrTestServer = {
       maybeAttachCreatedPr(
         p: JwtPayload,
         u: Record<string, unknown> | undefined,
       ): void;
-      fetchPrCreatedAt(url: string): Promise<string | null>;
+      fetchPrAttributionMetadata(
+        url: string,
+      ): Promise<PrAttributionMetadata | null>;
       detectedPrUrl: string | null;
       posthogAPI: { updateTaskRun: ReturnType<typeof vi.fn> };
     };
 
     const justNow = () => new Date().toISOString();
     const longAgo = "2020-01-01T00:00:00Z";
+    const SHA = "abc1234def5678";
+    const HEAD_REF = "posthog-code/my-feature";
 
-    const setup = (prCreatedAt: string | null): PrTestServer => {
+    const metadata = (
+      overrides: Partial<PrAttributionMetadata> = {},
+    ): PrAttributionMetadata => ({
+      createdAt: justNow(),
+      headRef: HEAD_REF,
+      headSha: SHA,
+      authorLogin: "posthog[bot]",
+      ...overrides,
+    });
+
+    const setup = (pr: PrAttributionMetadata | null): PrTestServer => {
       const s = createServer() as unknown as PrTestServer;
-      s.fetchPrCreatedAt = vi.fn(async () => prCreatedAt);
+      s.fetchPrAttributionMetadata = vi.fn(async () => pr);
       s.posthogAPI = { updateTaskRun: vi.fn(async () => ({})) };
+      mockedGitQueries.commitExistsLocally.mockReset();
+      mockedGitQueries.commitExistsLocally.mockResolvedValue(true);
       return s;
     };
 
     const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-    it("attributes a PR created just now from terminal output alone", async () => {
-      const s = setup(justNow());
+    it("attributes a recent PR whose head SHA is in the local repo", async () => {
+      const s = setup(metadata());
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledWith("t", "r", {
-        output: { pr_url: PR_URL },
+        output: { pr_url: PR_URL, head_branch: HEAD_REF },
       });
       expect(s.detectedPrUrl).toBe(PR_URL);
     });
 
     it("does not attribute an older PR the run only viewed (e.g. on a long run)", async () => {
-      const s = setup(longAgo);
+      const s = setup(metadata({ createdAt: longAgo }));
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+      expect(mockedGitQueries.commitExistsLocally).not.toHaveBeenCalled();
+      expect(s.detectedPrUrl).toBeNull();
+    });
+
+    it("does not attribute when the PR's head SHA is not in the local repo", async () => {
+      // The case Cleo's incident exhibited: agent merely reads a PR URL from an
+      // MCP/tool response for a PR opened by a sibling run; the recency window
+      // passes, but the SHA was never produced by this sandbox.
+      const s = setup(metadata());
+      mockedGitQueries.commitExistsLocally.mockResolvedValue(false);
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
       expect(s.detectedPrUrl).toBeNull();
     });
 
+    it("does not attribute when the PR has no head SHA", async () => {
+      // Defensive: a malformed `gh pr view` response shouldn't fall through to
+      // the ownership-skipped path and stamp anyway.
+      const s = setup(metadata({ headSha: null }));
+      s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
+      await flush();
+      expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+      expect(mockedGitQueries.commitExistsLocally).not.toHaveBeenCalled();
+      expect(s.detectedPrUrl).toBeNull();
+    });
+
     it("ignores updates with no PR URL", async () => {
-      const s = setup(justNow());
+      const s = setup(metadata());
       s.maybeAttachCreatedPr(payload, { sessionUpdate: "agent_thought_chunk" });
       await flush();
-      expect(s.fetchPrCreatedAt).not.toHaveBeenCalled();
+      expect(s.fetchPrAttributionMetadata).not.toHaveBeenCalled();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
     });
 
     it("attributes once and looks up GitHub once across repeated updates", async () => {
-      const s = setup(justNow());
+      const s = setup(metadata());
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
-      expect(s.fetchPrCreatedAt).toHaveBeenCalledTimes(1);
+      expect(s.fetchPrAttributionMetadata).toHaveBeenCalledTimes(1);
       expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(1);
     });
 
     it("attributes the most recent PR when a run opens several, in detection order", async () => {
       // output.pr_url holds one value; the latest PR the run created is the useful one.
-      const s = setup(justNow());
+      const s = setup(metadata());
       const second = "https://github.com/PostHog/posthog.com/pull/17765";
+      const secondSha = "f00dcafef00dcafe";
+      s.fetchPrAttributionMetadata = vi.fn(async (url: string) =>
+        url === PR_URL ? metadata() : metadata({ headSha: secondSha }),
+      );
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       s.maybeAttachCreatedPr(payload, terminalUpdate(second));
       await flush();
       expect(s.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(2);
       expect(s.posthogAPI.updateTaskRun).toHaveBeenLastCalledWith("t", "r", {
-        output: { pr_url: second },
+        output: { pr_url: second, head_branch: HEAD_REF },
       });
       expect(s.detectedPrUrl).toBe(second);
     });
@@ -1632,9 +1691,9 @@ describe("AgentServer HTTP Mode", () => {
     it("does not let an older PR the run only viewed overwrite the one it created", async () => {
       const viewed = "https://github.com/PostHog/posthog.com/pull/1";
       // The created PR reads as recent; the later, merely-viewed PR reads as old.
-      const s = setup(justNow());
-      s.fetchPrCreatedAt = vi.fn(async (url: string) =>
-        url === PR_URL ? justNow() : longAgo,
+      const s = setup(metadata());
+      s.fetchPrAttributionMetadata = vi.fn(async (url: string) =>
+        url === PR_URL ? metadata() : metadata({ createdAt: longAgo }),
       );
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       s.maybeAttachCreatedPr(payload, terminalUpdate(viewed));

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -208,11 +208,11 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => ({
 }));
 
 const mockedGitQueries = vi.hoisted(() => ({
-  commitExistsLocally: vi.fn(async () => true),
+  commitReachableFromHead: vi.fn(async () => true),
 }));
 vi.mock("@posthog/git/queries", async (importOriginal) => ({
   ...(await importOriginal()),
-  commitExistsLocally: mockedGitQueries.commitExistsLocally,
+  commitReachableFromHead: mockedGitQueries.commitReachableFromHead,
 }));
 
 interface TestableServer {
@@ -1603,14 +1603,14 @@ describe("AgentServer HTTP Mode", () => {
       const s = createServer() as unknown as PrTestServer;
       s.fetchPrAttributionMetadata = vi.fn(async () => pr);
       s.posthogAPI = { updateTaskRun: vi.fn(async () => ({})) };
-      mockedGitQueries.commitExistsLocally.mockReset();
-      mockedGitQueries.commitExistsLocally.mockResolvedValue(true);
+      mockedGitQueries.commitReachableFromHead.mockReset();
+      mockedGitQueries.commitReachableFromHead.mockResolvedValue(true);
       return s;
     };
 
     const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-    it("attributes a recent PR whose head SHA is in the local repo", async () => {
+    it("attributes a recent PR whose head SHA is reachable from local HEAD", async () => {
       const s = setup(metadata());
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
@@ -1625,16 +1625,18 @@ describe("AgentServer HTTP Mode", () => {
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
-      expect(mockedGitQueries.commitExistsLocally).not.toHaveBeenCalled();
+      expect(mockedGitQueries.commitReachableFromHead).not.toHaveBeenCalled();
       expect(s.detectedPrUrl).toBeNull();
     });
 
-    it("does not attribute when the PR's head SHA is not in the local repo", async () => {
-      // The case Cleo's incident exhibited: agent merely reads a PR URL from an
-      // MCP/tool response for a PR opened by a sibling run; the recency window
-      // passes, but the SHA was never produced by this sandbox.
+    it("does not attribute when the PR's head SHA is not reachable from local HEAD", async () => {
+      // The case the incident exhibited: agent merely reads a PR URL from an
+      // MCP/tool response for a PR opened by a sibling run. The recency window
+      // passes, but the SHA isn't reachable from this clone's HEAD — either
+      // because the object isn't in the DB at all (shallow clone) or because
+      // it sits on a sibling branch the agent never touched (full clone).
       const s = setup(metadata());
-      mockedGitQueries.commitExistsLocally.mockResolvedValue(false);
+      mockedGitQueries.commitReachableFromHead.mockResolvedValue(false);
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
@@ -1648,7 +1650,7 @@ describe("AgentServer HTTP Mode", () => {
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
-      expect(mockedGitQueries.commitExistsLocally).not.toHaveBeenCalled();
+      expect(mockedGitQueries.commitReachableFromHead).not.toHaveBeenCalled();
       expect(s.detectedPrUrl).toBeNull();
     });
 

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -15,7 +15,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import { type ServerType, serve } from "@hono/node-server";
 import { execGh } from "@posthog/git/gh";
-import { getCurrentBranch } from "@posthog/git/queries";
+import { commitExistsLocally, getCurrentBranch } from "@posthog/git/queries";
 import { unzipSync } from "fflate";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -253,6 +253,13 @@ interface BuiltPrompt {
 interface LocalSkillPromptContext {
   skillName: string;
   context: string;
+}
+
+interface PrAttributionMetadata {
+  createdAt: string | null;
+  headRef: string | null;
+  headSha: string | null;
+  authorLogin: string | null;
 }
 
 function getTaskRunStateString(
@@ -3095,9 +3102,9 @@ ${signedCommitInstructions}
     // Already the attributed PR (e.g. seeded from a Slack notification, or re-detected).
     if (prUrl === this.detectedPrUrl) return;
 
-    let createdAt: string | null;
+    let pr: PrAttributionMetadata | null;
     try {
-      createdAt = await this.fetchPrCreatedAt(prUrl);
+      pr = await this.fetchPrAttributionMetadata(prUrl);
     } catch (err) {
       this.logger.debug("PR attribution lookup failed", {
         runId: payload.run_id,
@@ -3106,20 +3113,52 @@ ${signedCommitInstructions}
       });
       return;
     }
+    if (!pr) return;
 
-    // Only attribute PRs created during this run, not ones the agent merely viewed.
-    if (!wasCreatedRecently(createdAt, Date.now())) return;
+    // Cheap pre-filter: a PR created long before this update couldn't have
+    // been opened by the agent's current activity. Stops most false positives
+    // before we touch the local git database.
+    if (!wasCreatedRecently(pr.createdAt, Date.now())) return;
+
+    // Ownership: the PR's head commit must exist in this sandbox's local git
+    // object database. A run that didn't produce (or fetch) that commit cannot
+    // have created the PR. Unlike a regex match on tool output, a SHA can't be
+    // spoofed by the agent merely seeing the URL in some response — e.g. an
+    // inbox listing that references a sibling task's PR.
+    if (!this.config.repositoryPath || !pr.headSha) {
+      this.logger.debug("PR attribution rejected: no repo path or head SHA", {
+        runId: payload.run_id,
+        prUrl,
+        hasRepoPath: !!this.config.repositoryPath,
+        hasHeadSha: !!pr.headSha,
+      });
+      return;
+    }
+    const ownsCommit = await commitExistsLocally(
+      this.config.repositoryPath,
+      pr.headSha,
+    );
+    if (!ownsCommit) {
+      this.logger.debug("PR attribution rejected: head SHA not in local repo", {
+        runId: payload.run_id,
+        prUrl,
+        headSha: pr.headSha,
+      });
+      return;
+    }
 
     this.detectedPrUrl = prUrl;
 
     try {
       await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
-        output: { pr_url: prUrl },
+        output: { pr_url: prUrl, head_branch: pr.headRef },
       });
       this.logger.debug("Attributed created PR to task run", {
         taskId: payload.task_id,
         runId: payload.run_id,
         prUrl,
+        headRef: pr.headRef,
+        headSha: pr.headSha,
       });
     } catch (err) {
       this.logger.error("Failed to attach PR URL to task run", {
@@ -3131,16 +3170,36 @@ ${signedCommitInstructions}
     }
   }
 
-  private async fetchPrCreatedAt(prUrl: string): Promise<string | null> {
-    const res = await execGh(["pr", "view", prUrl, "--json", "createdAt"], {
-      cwd: this.config.repositoryPath,
-      timeoutMs: 10_000,
-    });
+  private async fetchPrAttributionMetadata(
+    prUrl: string,
+  ): Promise<PrAttributionMetadata | null> {
+    const res = await execGh(
+      [
+        "pr",
+        "view",
+        prUrl,
+        "--json",
+        "createdAt,headRefName,headRefOid,author",
+      ],
+      {
+        cwd: this.config.repositoryPath,
+        timeoutMs: 10_000,
+      },
+    );
     if (res.exitCode !== 0) return null;
     try {
-      return (
-        (JSON.parse(res.stdout) as { createdAt?: string }).createdAt ?? null
-      );
+      const data = JSON.parse(res.stdout) as {
+        createdAt?: string;
+        headRefName?: string;
+        headRefOid?: string;
+        author?: { login?: string };
+      };
+      return {
+        createdAt: data.createdAt ?? null,
+        headRef: data.headRefName ?? null,
+        headSha: data.headRefOid ?? null,
+        authorLogin: data.author?.login ?? null,
+      };
     } catch {
       return null;
     }

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -15,7 +15,10 @@ import {
 } from "@agentclientprotocol/sdk";
 import { type ServerType, serve } from "@hono/node-server";
 import { execGh } from "@posthog/git/gh";
-import { commitExistsLocally, getCurrentBranch } from "@posthog/git/queries";
+import {
+  commitReachableFromHead,
+  getCurrentBranch,
+} from "@posthog/git/queries";
 import { unzipSync } from "fflate";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -3120,11 +3123,13 @@ ${signedCommitInstructions}
     // before we touch the local git database.
     if (!wasCreatedRecently(pr.createdAt, Date.now())) return;
 
-    // Ownership: the PR's head commit must exist in this sandbox's local git
-    // object database. A run that didn't produce (or fetch) that commit cannot
-    // have created the PR. Unlike a regex match on tool output, a SHA can't be
-    // spoofed by the agent merely seeing the URL in some response — e.g. an
-    // inbox listing that references a sibling task's PR.
+    // Ownership: the PR's head commit must be reachable from this sandbox's
+    // HEAD. Mere object-DB existence isn't enough — a full clone (default for
+    // signal_report runs) has `refs/remotes/origin/*` populated for every
+    // branch, so every open PR's head commit sits in the object database
+    // whether this run pushed it or not. Ancestor-of-HEAD restricts that to
+    // commits this clone produced (or rebased on top of) and rejects sibling
+    // PRs whose branches the agent never touched.
     if (!this.config.repositoryPath || !pr.headSha) {
       this.logger.debug("PR attribution rejected: no repo path or head SHA", {
         runId: payload.run_id,
@@ -3134,16 +3139,19 @@ ${signedCommitInstructions}
       });
       return;
     }
-    const ownsCommit = await commitExistsLocally(
+    const ownsCommit = await commitReachableFromHead(
       this.config.repositoryPath,
       pr.headSha,
     );
     if (!ownsCommit) {
-      this.logger.debug("PR attribution rejected: head SHA not in local repo", {
-        runId: payload.run_id,
-        prUrl,
-        headSha: pr.headSha,
-      });
+      this.logger.debug(
+        "PR attribution rejected: head SHA not reachable from local HEAD",
+        {
+          runId: payload.run_id,
+          prUrl,
+          headSha: pr.headSha,
+        },
+      );
       return;
     }
 

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -107,18 +107,24 @@ export async function getCurrentBranch(
 }
 
 /**
- * Whether `sha` resolves to a commit object in the local git database.
+ * Whether `sha` is reachable from this clone's current HEAD — i.e. HEAD
+ * descends from (or equals) the commit.
  *
- * Backed by `git cat-file -e <sha>^{commit}`: exit 0 if the object exists and
- * is a commit, non-zero otherwise. Used as a cheap ownership signal — a commit
- * that was never produced (or fetched) by this clone cannot be one this run
- * pushed, regardless of what URLs the agent has seen in tool output.
+ * Backed by `git merge-base --is-ancestor <sha> HEAD`: exit 0 if reachable,
+ * exit 1 if not, non-zero otherwise. A stronger ownership signal than mere
+ * object-DB existence: a clone with `refs/remotes/origin/*` populated for
+ * every branch (full clone) will have *every* open PR's head commit sitting
+ * in its object database, but only the commits this clone actually produced
+ * (or rebased on top of) will be ancestors of HEAD.
  *
- * Fails closed: any error (missing repo, invalid SHA, git unavailable) returns
- * `false`, so callers that use this to gate destructive or attributive writes
- * default to "no, don't proceed" on uncertainty.
+ * Fails closed: any error (missing repo, invalid SHA, git unavailable,
+ * detached HEAD with no commit history) returns `false`, so callers that use
+ * this to gate attributive writes default to "no, don't claim it" on
+ * uncertainty. The cost of dropping a real attribution is much lower than
+ * the cost of taking a wrong one — a wrong one keeps the babysitting loop
+ * firing into the wrong run for hours.
  */
-export async function commitExistsLocally(
+export async function commitReachableFromHead(
   baseDir: string,
   sha: string,
   options?: CreateGitClientOptions,
@@ -132,7 +138,7 @@ export async function commitExistsLocally(
       baseDir,
       async (git) => {
         try {
-          await git.raw(["cat-file", "-e", `${sha}^{commit}`]);
+          await git.raw(["merge-base", "--is-ancestor", sha, "HEAD"]);
           return true;
         } catch {
           return false;

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -106,6 +106,45 @@ export async function getCurrentBranch(
   );
 }
 
+/**
+ * Whether `sha` resolves to a commit object in the local git database.
+ *
+ * Backed by `git cat-file -e <sha>^{commit}`: exit 0 if the object exists and
+ * is a commit, non-zero otherwise. Used as a cheap ownership signal — a commit
+ * that was never produced (or fetched) by this clone cannot be one this run
+ * pushed, regardless of what URLs the agent has seen in tool output.
+ *
+ * Fails closed: any error (missing repo, invalid SHA, git unavailable) returns
+ * `false`, so callers that use this to gate destructive or attributive writes
+ * default to "no, don't proceed" on uncertainty.
+ */
+export async function commitExistsLocally(
+  baseDir: string,
+  sha: string,
+  options?: CreateGitClientOptions,
+): Promise<boolean> {
+  if (!sha || !/^[0-9a-f]{4,64}$/i.test(sha)) {
+    return false;
+  }
+  const manager = getGitOperationManager();
+  try {
+    return await manager.executeRead(
+      baseDir,
+      async (git) => {
+        try {
+          await git.raw(["cat-file", "-e", `${sha}^{commit}`]);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { signal: options?.abortSignal },
+    );
+  } catch {
+    return false;
+  }
+}
+
 export async function getDefaultBranch(
   baseDir: string,
   options?: CreateGitClientOptions,


### PR DESCRIPTION
## Problem

The PR-attribution path in the agent server stamps `output.pr_url` onto the current TaskRun whenever a recently-created PR URL appears in any `session/update` text — regardless of whether *this* run actually opened the PR. Any sandbox that reads a PR URL from a tool response (e.g. a `signals/reports` listing whose `implementation_pr_url` field references a sibling run's PR, or a GitHub query that surfaces another bot's recent PR) gets attributed to that PR.

The downstream effects are nontrivial. `output.pr_url` is the field that:

- drives the Temporal babysitting orchestrator's CI follow-up loop (the agent gets re-entered every ~15 min with *"address CI feedback on the pull request you opened"*), and
- triggers a `_post_slack_update_for_pr` call that posts a "Pull request opened" card into whatever Slack thread is mapped to the run.

So a single misattribution can both surface a stranger's PR into the wrong Slack thread *and* keep the wrong agent session alive for hours debugging a PR it had no part in opening.

## Root cause

`maybeAttachCreatedPr` / `attachPrIfCreatedThisRun`:

```ts
const prUrl = findPrUrl(JSON.stringify(update));     // any URL in any text
…
if (!wasCreatedRecently(createdAt, Date.now())) return;   // 15-min window — the only gate
await posthogAPI.updateTaskRun(taskId, runId, { output: { pr_url: prUrl } });
```

Pre-#2765 the detector required the URL to come from a `Bash` tool's `gh pr create` stdout — a real "this run produced the PR" signal. #2765 traded that for a 15-minute time window, which fires whenever any sibling run's PR happens to be recent. That latent bug became frequent once babysitting was enabled for all `signal_report`-origin runs (lots of bot-authored PRs concurrently in the window), and started showing up as cross-thread "Pull request opened" surprises.

## What this changes

Reintroduce an ownership check that can't be spoofed by reading text in a tool response.

- `fetchPrCreatedAt` → `fetchPrAttributionMetadata`: also returns the PR's `headRefName`, `headRefOid`, and `author.login`.
- Before stamping `output.pr_url`, require the PR's head SHA to resolve to a commit object in this sandbox's local git database via a new `commitExistsLocally` helper (`git cat-file -e <sha>^{commit}`). A run that didn't produce (or fetch) that commit cannot have created the PR — SHAs can't be regex-matched into existence.
- Keep the 15-minute recency window as a cheap pre-filter so the git check only runs for plausible candidates.
- Also persist `output.head_branch` alongside `output.pr_url` so the row's shape matches what the GitHub webhook attribution backstop already writes.

`commitExistsLocally` fails closed on every error path (missing repo path, malformed SHA, git unavailable, abort signal). The cost of dropping a real attribution on the floor is much lower than the cost of taking a wrong one — that's how this bug compounded into multi-hour babysitting loops.

## Test plan

- [x] `pnpm vitest run packages/agent/src/server/agent-server.test.ts` — 78/78 pass, including the new ownership cases:
  - rejects when `commitExistsLocally` returns false (the failure mode in production)
  - rejects when the PR returns no head SHA (defensive)
  - existing cases adapted to the new metadata shape and `head_branch` write
- [x] `pnpm vitest run packages/git/src/queries.test.ts` — 30/30 pass
- [x] `pnpm biome check --write` on the three changed files
- [x] `pnpm typecheck` clean on the changed packages (ran via lint-staged on commit)

## Notes for reviewers

- The new test mocks `commitExistsLocally` via `vi.mock("@posthog/git/queries", …)` with a `vi.hoisted` factory — necessary because the existing pattern of overriding instance methods doesn't reach a module-level imported function.
- I considered also gating on `author.login === gitAuthorLogin` (cheap, no git call) but it's redundant once the SHA check is in place and gives a false sense of security when multiple runs share `posthog[bot]`. SHA membership is the single load-bearing check.
- Defense-in-depth I'm intentionally *not* including here, in scope for a follow-up: server-side rejection in the PostHog API for `output.pr_url` writes whose `head_branch` doesn't match `task_run.branch`. That belongs in `posthog/posthog`'s facade, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)