### PR TITLE
fix(agent): clear pending resume prompt state

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1534,7 +1534,7 @@ export class AgentServer {
     if (!this.session || !this.resumeState) return;
     const resumeState = this.resumeState;
 
-    await this.runResumeTurn(payload, "Resume message", async () => {
+    await this.runResumeTurn(payload, taskRun, "Resume message", async () => {
       const conversationSummary = formatConversationForResume(
         resumeState.conversation,
       );
@@ -1603,7 +1603,7 @@ export class AgentServer {
   ): Promise<void> {
     if (!this.session) return;
 
-    await this.runResumeTurn(payload, "Resume continuation", async () => {
+    await this.runResumeTurn(payload, taskRun, "Resume continuation", async () => {
       const checkpointApplied = this.nativeResume?.warm
         ? false
         : await this.applyResumeGitCheckpoint(payload);
@@ -1637,6 +1637,7 @@ export class AgentServer {
 
   private async runResumeTurn(
     payload: JwtPayload,
+    taskRun: TaskRun | null,
     logLabel: string,
     buildPrompt: () => Promise<BuiltPrompt>,
   ): Promise<void> {
@@ -1656,6 +1657,8 @@ export class AgentServer {
       this.logger.debug(`${logLabel} completed`, {
         stopReason: result.stopReason,
       });
+
+      await this.clearPendingInitialPromptState(payload, taskRun);
 
       if (result.stopReason === "end_turn") {
         void this.syncCloudBranchMetadata(payload);

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1603,36 +1603,41 @@ export class AgentServer {
   ): Promise<void> {
     if (!this.session) return;
 
-    await this.runResumeTurn(payload, taskRun, "Resume continuation", async () => {
-      const checkpointApplied = this.nativeResume?.warm
-        ? false
-        : await this.applyResumeGitCheckpoint(payload);
+    await this.runResumeTurn(
+      payload,
+      taskRun,
+      "Resume continuation",
+      async () => {
+        const checkpointApplied = this.nativeResume?.warm
+          ? false
+          : await this.applyResumeGitCheckpoint(payload);
 
-      const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
-      const prompt: ContentBlock[] = pendingUserPrompt?.prompt.length
-        ? pendingUserPrompt.prompt
-        : [
-            {
-              type: "text",
-              text: "Continue from where you left off. The user is waiting for your response.",
-            },
-          ];
+        const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
+        const prompt: ContentBlock[] = pendingUserPrompt?.prompt.length
+          ? pendingUserPrompt.prompt
+          : [
+              {
+                type: "text",
+                text: "Continue from where you left off. The user is waiting for your response.",
+              },
+            ];
 
-      this.logger.debug("Sending resume continuation", {
-        taskId: payload.task_id,
-        sessionId: this.nativeResume?.sessionId,
-        warm: this.nativeResume?.warm,
-        checkpointApplied,
-        hasPendingUserMessage: !!pendingUserPrompt?.prompt.length,
-      });
+        this.logger.debug("Sending resume continuation", {
+          taskId: payload.task_id,
+          sessionId: this.nativeResume?.sessionId,
+          warm: this.nativeResume?.warm,
+          checkpointApplied,
+          hasPendingUserMessage: !!pendingUserPrompt?.prompt.length,
+        });
 
-      this.resumeState = null;
-      this.nativeResume = null;
-      return {
-        prompt,
-        ...(pendingUserPrompt?.meta ? { meta: pendingUserPrompt.meta } : {}),
-      };
-    });
+        this.resumeState = null;
+        this.nativeResume = null;
+        return {
+          prompt,
+          ...(pendingUserPrompt?.meta ? { meta: pendingUserPrompt.meta } : {}),
+        };
+      },
+    );
   }
 
   private async runResumeTurn(


### PR DESCRIPTION
## Problem

Interactive resume runs consume `pending_user_message` from task run state, but the resume path did not clear the field after successful prompt delivery. Completed resume runs could retain stale pending prompt state.