### PR TITLE
feat(window): persist UI zoom level across restarts

### DIFF
--- a/apps/code/src/main/menu.ts
+++ b/apps/code/src/main/menu.ts
@@ -20,7 +20,7 @@ import { container } from "./di/container";
 import { AUTH_SERVICE, UPDATES_SERVICE } from "./di/tokens";
 import { isDevBuild } from "./utils/env";
 import { getLogFilePath } from "./utils/logger";
-import { saveZoomLevel } from "./window";
+import { saveZoomLevel } from "./utils/store";
 
 // Zoom is measured in Electron "levels" (factor = 1.2 ** level; 0 = 100%).
 // ZOOM_STEP is one Zoom In/Out notch; the bounds clamp the level so a runaway

--- a/apps/code/src/main/menu.ts
+++ b/apps/code/src/main/menu.ts
@@ -22,13 +22,21 @@ import { isDevBuild } from "./utils/env";
 import { getLogFilePath } from "./utils/logger";
 import { saveZoomLevel } from "./window";
 
+// Zoom is measured in Electron "levels" (factor = 1.2 ** level; 0 = 100%).
+// ZOOM_STEP is one Zoom In/Out notch; the bounds clamp the level so a runaway
+// accelerator can't persist an unusable zoom across restarts.
+const ZOOM_STEP = 0.5;
+const ZOOM_MIN = -3;
+const ZOOM_MAX = 3;
+
 // Apply a zoom change to the focused window and persist the new level so it
 // survives restarts. `delta` adjusts relative to the current level; "reset"
 // returns to 100%.
 function applyZoom(delta: number | "reset"): void {
   const webContents = BrowserWindow.getFocusedWindow()?.webContents;
   if (!webContents) return;
-  const level = delta === "reset" ? 0 : webContents.getZoomLevel() + delta;
+  const next = delta === "reset" ? 0 : webContents.getZoomLevel() + delta;
+  const level = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, next));
   webContents.setZoomLevel(level);
   saveZoomLevel(level);
 }
@@ -328,7 +336,7 @@ function buildViewMenu(): MenuItemConstructorOptions {
       {
         label: "Zoom In",
         accelerator: "CmdOrCtrl+Plus",
-        click: () => applyZoom(0.5),
+        click: () => applyZoom(ZOOM_STEP),
       },
       // Hidden duplicate so Cmd+= (i.e. Cmd++ without Shift) also zooms in,
       // matching the built-in zoomIn role's dual accelerator.
@@ -336,12 +344,12 @@ function buildViewMenu(): MenuItemConstructorOptions {
         label: "Zoom In",
         accelerator: "CmdOrCtrl+=",
         visible: false,
-        click: () => applyZoom(0.5),
+        click: () => applyZoom(ZOOM_STEP),
       },
       {
         label: "Zoom Out",
         accelerator: "CmdOrCtrl+-",
-        click: () => applyZoom(-0.5),
+        click: () => applyZoom(-ZOOM_STEP),
       },
       { type: "separator" },
       { role: "togglefullscreen" },

--- a/apps/code/src/main/menu.ts
+++ b/apps/code/src/main/menu.ts
@@ -20,6 +20,18 @@ import { container } from "./di/container";
 import { AUTH_SERVICE, UPDATES_SERVICE } from "./di/tokens";
 import { isDevBuild } from "./utils/env";
 import { getLogFilePath } from "./utils/logger";
+import { saveZoomLevel } from "./window";
+
+// Apply a zoom change to the focused window and persist the new level so it
+// survives restarts. `delta` adjusts relative to the current level; "reset"
+// returns to 100%.
+function applyZoom(delta: number | "reset"): void {
+  const webContents = BrowserWindow.getFocusedWindow()?.webContents;
+  if (!webContents) return;
+  const level = delta === "reset" ? 0 : webContents.getZoomLevel() + delta;
+  webContents.setZoomLevel(level);
+  saveZoomLevel(level);
+}
 
 function findLatestCrashDump(): string | null {
   const pendingDir = path.join(app.getPath("crashDumps"), "pending");
@@ -308,9 +320,29 @@ function buildViewMenu(): MenuItemConstructorOptions {
       },
       { role: "toggleDevTools" },
       { type: "separator" },
-      { role: "resetZoom" },
-      { role: "zoomIn" },
-      { role: "zoomOut" },
+      {
+        label: "Actual Size",
+        accelerator: "CmdOrCtrl+0",
+        click: () => applyZoom("reset"),
+      },
+      {
+        label: "Zoom In",
+        accelerator: "CmdOrCtrl+Plus",
+        click: () => applyZoom(0.5),
+      },
+      // Hidden duplicate so Cmd+= (i.e. Cmd++ without Shift) also zooms in,
+      // matching the built-in zoomIn role's dual accelerator.
+      {
+        label: "Zoom In",
+        accelerator: "CmdOrCtrl+=",
+        visible: false,
+        click: () => applyZoom(0.5),
+      },
+      {
+        label: "Zoom Out",
+        accelerator: "CmdOrCtrl+-",
+        click: () => applyZoom(-0.5),
+      },
       { type: "separator" },
       { role: "togglefullscreen" },
       { type: "separator" },

--- a/apps/code/src/main/utils/store.ts
+++ b/apps/code/src/main/utils/store.ts
@@ -24,6 +24,7 @@ export interface WindowStateSchema {
   width: number;
   height: number;
   isMaximized: boolean;
+  zoomLevel: number;
 }
 
 const userDataDir = getUserDataDir();
@@ -50,5 +51,6 @@ export const windowStateStore = new Store<WindowStateSchema>({
     width: 1200,
     height: 600,
     isMaximized: true,
+    zoomLevel: 0,
   },
 });

--- a/apps/code/src/main/utils/store.ts
+++ b/apps/code/src/main/utils/store.ts
@@ -54,3 +54,7 @@ export const windowStateStore = new Store<WindowStateSchema>({
     zoomLevel: 0,
   },
 });
+
+export function saveZoomLevel(level: number): void {
+  windowStateStore.set("zoomLevel", level);
+}

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -44,6 +44,7 @@ function getSavedWindowState(): WindowStateSchema {
     width: windowStateStore.get("width", 1200),
     height: windowStateStore.get("height", 600),
     isMaximized: windowStateStore.get("isMaximized", true),
+    zoomLevel: windowStateStore.get("zoomLevel", 0),
   };
 
   // Validate position is still on a connected display
@@ -70,6 +71,10 @@ export function saveWindowState(window: BrowserWindow): void {
     windowStateStore.set("width", bounds.width);
     windowStateStore.set("height", bounds.height);
   }
+}
+
+export function saveZoomLevel(level: number): void {
+  windowStateStore.set("zoomLevel", level);
 }
 
 let mainWindow: BrowserWindow | null = null;
@@ -232,6 +237,21 @@ export function createWindow(): void {
 
   mainWindow.once("ready-to-show", showWindow);
   const showFallback = setTimeout(showWindow, 3000);
+
+  // Restore the saved zoom level once the renderer has loaded. Using
+  // did-finish-load (rather than ready-to-show) also re-applies it after
+  // in-app reloads, which reset Chromium's per-webContents zoom.
+  mainWindow.webContents.on("did-finish-load", () => {
+    mainWindow?.webContents.setZoomLevel(savedState.zoomLevel);
+  });
+
+  // Persist mouse-wheel/pinch zoom. Menu-driven zoom is persisted by the
+  // menu items themselves (see buildViewMenu in menu.ts).
+  mainWindow.webContents.on("zoom-changed", () => {
+    if (mainWindow) {
+      saveZoomLevel(mainWindow.webContents.getZoomLevel());
+    }
+  });
 
   // Persist window state on changes
   mainWindow.on(

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -19,7 +19,11 @@ import { trpcRouter } from "./trpc/router";
 import { collectMemorySnapshot } from "./utils/crash-diagnostics";
 import { isDevBuild } from "./utils/env";
 import { logger, readChromiumLogTail } from "./utils/logger";
-import { type WindowStateSchema, windowStateStore } from "./utils/store";
+import {
+  saveZoomLevel,
+  type WindowStateSchema,
+  windowStateStore,
+} from "./utils/store";
 
 const log = logger.scope("window");
 
@@ -71,10 +75,6 @@ export function saveWindowState(window: BrowserWindow): void {
     windowStateStore.set("width", bounds.width);
     windowStateStore.set("height", bounds.height);
   }
-}
-
-export function saveZoomLevel(level: number): void {
-  windowStateStore.set("zoomLevel", level);
 }
 
 let mainWindow: BrowserWindow | null = null;

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -238,11 +238,12 @@ export function createWindow(): void {
   mainWindow.once("ready-to-show", showWindow);
   const showFallback = setTimeout(showWindow, 3000);
 
-  // Restore the saved zoom level once the renderer has loaded. Using
-  // did-finish-load (rather than ready-to-show) also re-applies it after
-  // in-app reloads, which reset Chromium's per-webContents zoom.
+  // Restore the zoom level once the renderer has loaded. Read the latest
+  // persisted value from the store (not the create-time snapshot) so zooming
+  // done during the session survives in-app reloads, which otherwise reset
+  // Chromium's per-webContents zoom.
   mainWindow.webContents.on("did-finish-load", () => {
-    mainWindow?.webContents.setZoomLevel(savedState.zoomLevel);
+    mainWindow?.webContents.setZoomLevel(windowStateStore.get("zoomLevel", 0));
   });
 
   // Persist mouse-wheel/pinch zoom. Menu-driven zoom is persisted by the


### PR DESCRIPTION
## Problem

Zooming the UI with `CMD`+`+` / `CMD`+`-` / `CMD`+`0` worked during a session, but the zoom reset to 100% on every relaunch.

The View-menu zoom items used Electron's built-in `zoomIn`/`zoomOut`/`resetZoom` roles, which only adjust Chromium's in-memory per-`webContents` zoom and expose no `click` hook to persist it. Nothing saved the level.

## Change

Give zoom the same treatment as the existing window-state persistence (bounds/maximized), all in `apps/code/src/main/`:

- **`utils/store.ts`** — add `zoomLevel` to `WindowStateSchema` and the `windowStateStore` defaults (`0` = 100%).
- **`window.ts`** — read the saved level in `getSavedWindowState()`; add `saveZoomLevel()`; re-apply the level on `did-finish-load` (covers fresh launches *and* in-app reloads, which reset Chromium's zoom); persist wheel/pinch zoom via `zoom-changed`.
- **`menu.ts`** — replace the built-in zoom roles with custom items backed by a shared `applyZoom()` helper that sets and persists the level. Keeps `CMD`+`+`, `CMD`+`=` (hidden duplicate, matching the built-in role's dual accelerator), `CMD`+`-`, and `CMD`+`0`.

## Verification

- `pnpm --filter code typecheck` passes.
- Biome lint clean on the three files.
- Manual: zoom in, quit fully, relaunch → level restored; `zoomLevel` is written to `<userData>/window-state.json`; survives `CMD+Shift+R` reload.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*