### PR TITLE
fix(mobile): preserve permission mode and effort on cloud resume (port #2993)

### DIFF
--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.test.ts
@@ -23,9 +23,16 @@ vi.mock("../api", () => ({
   sendCloudCommand: vi.fn(),
 }));
 
-import type { CloudTaskUpdatePayload, StoredLogEntry } from "../types";
+import { getTask, runTaskInCloud } from "../api";
+import type {
+  CloudTaskUpdatePayload,
+  StoredLogEntry,
+  Task,
+  TaskRun,
+} from "../types";
 import { useMessageQueueStore } from "./messageQueueStore";
 import { type TaskSession, useTaskSessionStore } from "./taskSessionStore";
+import { useTaskStore } from "./taskStore";
 
 function seedSession(overrides: Partial<TaskSession> = {}): void {
   const session: TaskSession = {
@@ -130,6 +137,75 @@ describe("steerQueuedMessage", () => {
 
     expect(sendInterrupting).not.toHaveBeenCalled();
     expect(useMessageQueueStore.getState().getQueue("t1")).toHaveLength(1);
+  });
+});
+
+describe("_resumeCloudRun", () => {
+  const mockGetTask = vi.mocked(getTask);
+  const mockRunTaskInCloud = vi.mocked(runTaskInCloud);
+
+  function previousTask(latestRun: Partial<TaskRun>): Task {
+    return {
+      id: "t1",
+      latest_run: { id: "prev-run", ...latestRun } as TaskRun,
+    } as Task;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useTaskStore.setState({ composerConfigByTaskId: {} });
+    useTaskSessionStore.setState({ sessions: {} });
+    mockRunTaskInCloud.mockResolvedValue({
+      id: "t1",
+      latest_run: { id: "new-run" },
+    } as Task);
+  });
+
+  it("forwards the previous run's effort and permission mode", async () => {
+    mockGetTask.mockResolvedValue(
+      previousTask({
+        branch: "feature",
+        reasoning_effort: "low",
+        state: { initial_permission_mode: "acceptEdits" },
+      }),
+    );
+
+    await useTaskSessionStore
+      .getState()
+      ._resumeCloudRun("t1", "prev-run", "hi");
+
+    expect(mockRunTaskInCloud).toHaveBeenCalledWith("t1", {
+      branch: "feature",
+      resumeFromRunId: "prev-run",
+      pendingUserMessage: "hi",
+      reasoningEffort: "low",
+      initialPermissionMode: "acceptEdits",
+    });
+  });
+
+  it("prefers the composer's current selection over the previous run", async () => {
+    useTaskStore.setState({
+      composerConfigByTaskId: { t1: { mode: "plan", reasoning: "max" } },
+    });
+    mockGetTask.mockResolvedValue(
+      previousTask({
+        branch: null,
+        reasoning_effort: "low",
+        state: { initial_permission_mode: "acceptEdits" },
+      }),
+    );
+
+    await useTaskSessionStore
+      .getState()
+      ._resumeCloudRun("t1", "prev-run", "hi");
+
+    expect(mockRunTaskInCloud).toHaveBeenCalledWith(
+      "t1",
+      expect.objectContaining({
+        reasoningEffort: "max",
+        initialPermissionMode: "plan",
+      }),
+    );
   });
 });
 

--- a/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
+++ b/apps/mobile/src/features/tasks/stores/taskSessionStore.ts
@@ -34,6 +34,7 @@ import {
   combineQueuedMessages,
   useMessageQueueStore,
 } from "./messageQueueStore";
+import { useTaskStore } from "./taskStore";
 
 const log = logger.scope("task-session-store");
 
@@ -1118,12 +1119,26 @@ export const useTaskSessionStore = create<TaskSessionStore>((set, get) => ({
     prompt: string,
   ) => {
     const freshTask = await getTask(taskId);
-    const previousBranch = freshTask.latest_run?.branch ?? null;
+    const previousRun = freshTask.latest_run;
+    const previousBranch = previousRun?.branch ?? null;
+
+    const composerConfig =
+      useTaskStore.getState().composerConfigByTaskId[taskId];
+    const previousPermissionMode = previousRun?.state?.initial_permission_mode;
+    const reasoningEffort =
+      composerConfig?.reasoning ?? previousRun?.reasoning_effort ?? undefined;
+    const initialPermissionMode =
+      composerConfig?.mode ??
+      (typeof previousPermissionMode === "string"
+        ? previousPermissionMode
+        : undefined);
 
     const updatedTask = await runTaskInCloud(taskId, {
       branch: previousBranch,
       resumeFromRunId: previousRunId,
       pendingUserMessage: prompt,
+      reasoningEffort,
+      initialPermissionMode,
     });
 
     const newRun = updatedTask.latest_run;

--- a/apps/mobile/src/features/tasks/types.ts
+++ b/apps/mobile/src/features/tasks/types.ts
@@ -65,6 +65,7 @@ export interface TaskRun {
   status: TaskRunStatus;
   log_url: string;
   error_message: string | null;
+  reasoning_effort?: string | null;
   output: Record<string, unknown> | null;
   state: Record<string, unknown>;
   created_at: string;


### PR DESCRIPTION
## Problem

When a cloud task is **resumed** on mobile — which happens automatically when the sandbox has gone inactive and the user sends a follow-up — the resume run silently dropped the run's **reasoning effort** and **permission mode**, so the backend reverted to its defaults. The original run's settings were lost.

This is the mobile port of desktop PR #2993 (`fix(sessions): preserve permission mode and effort on cloud resume`). The desktop fix lives in shared `packages/core` (`getCloudRuntimeOptions` / `SessionService`), but the mobile app has its own resume implementation in `taskSessionStore`, so it had to be ported by hand.

## Changes

- `_resumeCloudRun` now resolves `reasoningEffort` and `initialPermissionMode` and forwards them to `runTaskInCloud` (which already supported both options). Precedence matches desktop: the per-task composer selection (`useTaskStore.composerConfigByTaskId`) wins; otherwise it falls back to the previous run's `reasoning_effort` (top-level) and `state.initial_permission_mode`.
- Added `reasoning_effort` to the mobile `TaskRun` type (the backend already returns it — it's shared with desktop). `initial_permission_mode` is read defensively from the existing `state` map.
- Added unit tests for the resume path covering the fallback to the previous run and the current-selection-overrides case.

## How did you test this?

- `pnpm --filter @posthog/mobile test src/features/tasks/stores/taskSessionStore.test.ts` — 8 passed.
- `biome check` on the changed files — clean.
- Mobile `tsc --noEmit` — no new errors in the changed files.