### PR TITLE
fix(agent): shorten PR attribution window to 5 minutes

### DIFF
--- a/packages/agent/src/pr-url-detector.ts
+++ b/packages/agent/src/pr-url-detector.ts
@@ -2,7 +2,7 @@ const PR_URL_REGEX = /https:\/\/github\.com\/[^/\s"]+\/[^/\s"]+\/pull\/\d+/;
 
 // A fixed window (not "since run start") so a PR the agent merely views on a
 // long run is too old to be mistaken for one it just created.
-export const PR_CREATION_RECENCY_MS = 15 * 60 * 1000;
+export const PR_CREATION_RECENCY_MS = 5 * 60 * 1000;
 
 export function findPrUrl(text: string): string | null {
   return text.match(PR_URL_REGEX)?.[0] ?? null;


### PR DESCRIPTION
## Problem

When a PR URL appears anywhere in agent/tool output, we attribute it to the current run if the PR was created within a recency window. That window was 15 minutes, wide enough that an agent which merely surfaces a recently-created PR URL (e.g. a sibling task's bot PR returned by an inbox query) can wrongly PATCH it onto its own run.

## Changes

Narrow `PR_CREATION_RECENCY_MS` from 15 to 5 minutes to shrink that collision window. This is a mitigation, not a root-cause fix (which is attributing only PRs this run actually created).

## How did you test this?

No new tests run — `wasCreatedRecently` is called with an explicit `maxAge` in its unit tests, and the existing cases (created 2 min ago, created 3 h ago) still hold under a 5-minute window.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782813370710309?thread_ts=1782813370.710309&cid=C09SK2PAGKF)*
