### PR TITLE
feat(agent): expose post-barrier sessionInitMs on /health

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -436,6 +436,7 @@ describe("AgentServer HTTP Mode", () => {
         status: "ok",
         hasSession: true,
         bootMs: expect.any(Number),
+        sessionInitMs: expect.any(Number),
       });
     }, 30000);
   });

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1300,10 +1300,7 @@ export class AgentServer {
     });
 
     this.sessionReadyBootMs = Math.round(process.uptime() * 1000);
-    this.sessionInitMs =
-      this.barrierReleasedAtMs !== undefined
-        ? Math.max(0, Date.now() - this.barrierReleasedAtMs)
-        : this.sessionReadyBootMs;
+    this.sessionInitMs = Math.max(0, Date.now() - this.barrierReleasedAtMs!);
     this.logger.debug("Session initialized successfully", {
       bootMs: this.sessionReadyBootMs,
       sessionInitMs: this.sessionInitMs,

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -272,6 +272,8 @@ function getTaskRunStateString(
 export class AgentServer {
   private config: AgentServerConfig;
   private sessionReadyBootMs?: number;
+  private sessionInitMs?: number;
+  private barrierReleasedAtMs?: number;
   private logger: Logger;
   private server: ServerType | null = null;
   private session: ActiveSession | null = null;
@@ -394,6 +396,7 @@ export class AgentServer {
         status: "ok",
         hasSession: !!this.session,
         bootMs: this.sessionReadyBootMs,
+        sessionInitMs: this.sessionInitMs,
       });
     });
 
@@ -1297,8 +1300,13 @@ export class AgentServer {
     });
 
     this.sessionReadyBootMs = Math.round(process.uptime() * 1000);
+    this.sessionInitMs =
+      this.barrierReleasedAtMs !== undefined
+        ? Math.max(0, Date.now() - this.barrierReleasedAtMs)
+        : this.sessionReadyBootMs;
     this.logger.debug("Session initialized successfully", {
       bootMs: this.sessionReadyBootMs,
+      sessionInitMs: this.sessionInitMs,
     });
     this.logger.debug(
       `Agent version: ${this.config.version ?? packageJson.version}`,
@@ -2222,7 +2230,10 @@ export class AgentServer {
 
   private async waitForRepoReady(): Promise<void> {
     const readyFile = this.config.repoReadyFile;
-    if (!readyFile) return;
+    if (!readyFile) {
+      this.barrierReleasedAtMs = Date.now();
+      return;
+    }
 
     const REPO_READY_TIMEOUT_MS = 5 * 60_000;
     const POLL_MS = 100;
@@ -2232,6 +2243,7 @@ export class AgentServer {
     for (;;) {
       try {
         await access(readyFile);
+        this.barrierReleasedAtMs = Date.now();
         this.logger.debug("Repo-ready barrier released", {
           readyFile,
           waitedMs: Date.now() - startedAt,
@@ -2249,6 +2261,7 @@ export class AgentServer {
         }
       }
       if (Date.now() - startedAt > REPO_READY_TIMEOUT_MS) {
+        this.barrierReleasedAtMs = Date.now();
         this.logger.warn("Repo-ready barrier timed out; proceeding", {
           readyFile,
           waitedMs: Date.now() - startedAt,


### PR DESCRIPTION
## Problem

The agent-server's `/health` reports `bootMs` — `process.uptime()` at session-ready. When clone/boot overlap is on, session creation blocks on the repo-ready barrier first, so `bootMs` includes the time spent idling for the concurrent clone and swings with the clone duration. The cloud backend reads this for its `agent_server_boot` metric, which then double-counts the clone and looks worse with overlap on (even though boot didn't change).

## Changes

Add `sessionInitMs` to `/health`: the time from when the repo-ready barrier releases to when the session is ready — the agent-server's genuine post-barrier work, independent of how long it idled waiting for the clone. Captured via a new `barrierReleasedAtMs` set at every `waitForRepoReady` exit (including the no-barrier fast path), so it's well-defined whether or not overlap is on. `bootMs` is unchanged.

The cloud backend records `sessionInitMs` as a new `agent_server_session_init` step. Companion PR: PostHog/posthog#67004.

## How did you test this?

I'm an agent (Claude Code). `pnpm exec tsc --noEmit` clean. Verified end-to-end against local Modal sandboxes: `/health` returned `sessionInitMs` 724–834ms across overlap-on, overlap-off, and agentsh (network-restricted) runs, while `bootMs` swung 1838–5450ms — confirming `sessionInitMs` excludes the barrier/clone wait and is mode-invariant.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
