### PR TITLE
fix(code): fix busted kdb shortcut icon

### DIFF
--- a/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -38,7 +38,6 @@ import {
   ItemContent,
   ItemDescription,
   ItemTitle,
-  Kbd,
 } from "@posthog/quill";
 import { EXTERNAL_LINKS } from "@posthog/shared";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
@@ -339,7 +338,7 @@ export function ProjectSwitcher({
                   <Keyboard size={14} className="text-gray-11" />
                   Keyboard Shortcuts
                   <DropdownMenuShortcut>
-                    <Kbd>{isMac ? "⌘/" : "Ctrl+/"}</Kbd>
+                    {isMac ? "⌘/" : "Ctrl+/"}
                   </DropdownMenuShortcut>
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
@@ -349,7 +348,7 @@ export function ProjectSwitcher({
               <Gear size={14} className="text-gray-11" />
               Settings
               <DropdownMenuShortcut>
-                <Kbd>{isMac ? "⌘," : "Ctrl+,"}</Kbd>
+                {isMac ? "⌘," : "Ctrl+,"}
               </DropdownMenuShortcut>
             </DropdownMenuItem>
 

--- a/packages/ui/src/features/task-detail/components/ExternalAppsOpener.tsx
+++ b/packages/ui/src/features/task-detail/components/ExternalAppsOpener.tsx
@@ -8,7 +8,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuTrigger,
-  Kbd,
 } from "@posthog/quill";
 import { ChevronDown } from "lucide-react";
 import { useCallback } from "react";
@@ -136,9 +135,7 @@ export function ExternalAppsOpener({ targetPath }: ExternalAppsOpenerProps) {
               )}
               {app.name}
               {app.id === defaultApp?.id && (
-                <DropdownMenuShortcut>
-                  <Kbd>⌘O</Kbd>
-                </DropdownMenuShortcut>
+                <DropdownMenuShortcut>⌘O</DropdownMenuShortcut>
               )}
             </DropdownMenuItem>
           ))}
@@ -146,9 +143,7 @@ export function ExternalAppsOpener({ targetPath }: ExternalAppsOpenerProps) {
           <DropdownMenuItem onClick={handleCopyPath}>
             <CopyIcon size={THUMBNAIL_ICON_SIZE} weight="regular" />
             Copy Path
-            <DropdownMenuShortcut>
-              <Kbd>⌘⇧C</Kbd>
-            </DropdownMenuShortcut>
+            <DropdownMenuShortcut>⌘⇧C</DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
## Problem

kbd shortcut icon is double-wrapped

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

fixed

| before | after |
| --- | --- |
| ![Screenshot 2026-06-30 at 9.17.43 AM.png](https://app.graphite.com/user-attachments/assets/fa94a63f-0815-439b-ae6e-6a4ff9d64638.png)<br> | ![Screenshot 2026-06-30 at 9.18.39 AM.png](https://app.graphite.com/user-attachments/assets/a00da804-7c25-45e3-aeb0-c548503f307b.png)<br> |

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?