### PR TITLE
fix(cloud-task): lower session-log history page request size

### DIFF
--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -31,7 +31,7 @@ const SSE_RECONNECT_MAX_DELAY_MS = 30_000;
 const SSE_HEALTHY_CONNECTION_MS = 60_000;
 const EVENT_BATCH_FLUSH_MS = 16;
 const EVENT_BATCH_MAX_SIZE = 50;
-const SESSION_LOG_PAGE_LIMIT = 5_000;
+const SESSION_LOG_PAGE_LIMIT = 1_000;
 
 interface SessionLogsPage {
   entries: StoredLogEntry[];


### PR DESCRIPTION
## Problem

On bootstrap the cloud-task watcher loads run history by paging `session_logs`. With the page size at 5,000 entries, the first page of a long run can be many MB and fail to transfer within the watcher's per-request fetch timeout, so it retries indefinitely and the run is stuck "Connecting to your cloud runner" even though it is healthy.

## Changes

Lower `SESSION_LOG_PAGE_LIMIT` from 5,000 to 1,000 so the first (and every) history page request stays small
