### PR TITLE
fix(os-service): use pathToFileURL for cross-platform log folder path

### DIFF
--- a/packages/workspace-server/src/services/os/os.test.ts
+++ b/packages/workspace-server/src/services/os/os.test.ts
@@ -159,6 +159,14 @@ describe("OsService simple delegations", () => {
     await service.openExternal("https://posthog.com");
     expect(urlLauncher.launch).toHaveBeenCalledWith("https://posthog.com");
   });
+
+  it("opens the log folder as a file URL via the url launcher", async () => {
+    const { service, urlLauncher } = createService();
+    await service.showLogFolder();
+    expect(urlLauncher.launch).toHaveBeenCalledWith(
+      expect.stringMatching(/^file:\/\//),
+    );
+  });
 });
 
 describe("OsService.getClaudePermissions", () => {

--- a/packages/workspace-server/src/services/os/os.ts
+++ b/packages/workspace-server/src/services/os/os.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { APP_META_SERVICE, type IAppMeta } from "@posthog/platform/app-meta";
 import {
   DIALOG_SERVICE,
@@ -169,7 +170,9 @@ export class OsService {
   }
 
   async showLogFolder(): Promise<void> {
-    await this.urlLauncher.launch(`file://${this.storagePaths.logFolderPath}`);
+    await this.urlLauncher.launch(
+      pathToFileURL(this.storagePaths.logFolderPath).href,
+    );
   }
 
   async searchDirectories(query: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

Follow-up to #3005. Fixes `showLogFolder` to produce a valid file URI on all platforms.

- `file://${path}` breaks on Windows (`C:\...` → `file://C:\...`, invalid)
- `pathToFileURL(path).href` (Node built-in) handles this correctly on all platforms
- Adds a test asserting the launcher is called with a `file://` URL

> **Danger level: 1/5**

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*