### PR TITLE
feat(channels): add recents + pinned to channel home

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -827,6 +827,8 @@ export interface ChannelActionProperties {
   channel_id?: string;
   /** For file/unfile/archive/open task actions. */
   task_id?: string;
+  /** For open_artifact when the artifact is a canvas. */
+  dashboard_id?: string;
   /** For file_task: destination channel when different from `channel_id`. */
   target_channel_id?: string;
   /** For nav_click: which destination ("home"|"inbox"|"canvas"|"agents"|"files"|"settings"). */

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -809,6 +809,7 @@ export type ChannelActionType =
   | "unstar"
   | "edit_context_open"
   | "new_task_open"
+  | "select_suggestion_category"
   | "new_task_suggestion"
   | "view_context"
   | "view_history"
@@ -833,6 +834,9 @@ export interface ChannelActionProperties {
   target_channel_id?: string;
   /** For nav_click: which destination ("home"|"inbox"|"canvas"|"agents"|"files"|"settings"). */
   nav_target?: string;
+  /** For select_suggestion_category / new_task_suggestion: the suggestion
+   * category id (e.g. "code", "analysis", "debug", "canvas"). */
+  category?: string;
   /** For new_task_suggestion: the starter-prompt card label. */
   suggestion_label?: string;
   /** Whether the underlying mutation resolved successfully. */

--- a/packages/ui/src/features/canvas/channelTaskSuggestions.ts
+++ b/packages/ui/src/features/canvas/channelTaskSuggestions.ts
@@ -2,92 +2,182 @@ import {
   Bug,
   ChartBar,
   ChartLine,
+  ChartPieSlice,
   ChatCircleText,
+  Code,
   Cube,
   CurrencyDollar,
   Flask,
+  type Icon,
+  SquaresFour,
+  TrendDown,
+  WarningOctagon,
   Wrench,
 } from "@phosphor-icons/react";
 import type { SuggestedPrompt } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
 
-// Starter prompts shown as cards on the channels (project-bluebird) new-task
-// screen. Clicking a card drops its `prompt` into the composer, ready to
-// edit/send. Each prompt ends with a "User input:" block of fill-in lines the
-// user completes before sending. Channels-only — the /code new-task screen
-// keeps its discovery suggestions. Card styling mirrors SuggestedTaskCard
-// (icon badge + title + description); the icon/color follow the same
-// `var(--<color>-N)` token scheme.
-export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
+// Starter prompts for the channels (project-bluebird) new-task surfaces. Picking
+// one drops its `prompt` into the composer, ready to edit/send. Each prompt ends
+// with a "User input:" block of fill-in lines the user completes before sending.
+// Channels-only — the /code new-task screen keeps its discovery suggestions.
+//
+// On the channel home these are grouped behind the category chips below; the
+// flat CHANNEL_TASK_SUGGESTIONS list (derived at the bottom) still feeds the
+// new-task screen's card grid.
+export interface SuggestionCategory {
+  id: string;
+  /** Chip label shown on the channel home. */
+  label: string;
+  icon: Icon;
+  /** Radix color token base (`var(--<color>-N)`) for the chip + row icons. */
+  color: string;
+  suggestions: SuggestedPrompt[];
+}
+
+export const CHANNEL_SUGGESTION_CATEGORIES: SuggestionCategory[] = [
   {
-    label: "Debug a user issue",
-    description: "Trace a specific user's events, replays, and errors",
-    icon: Bug,
-    color: "red",
-    mode: "auto",
-    prompt:
-      "Help me debug an issue a specific user is hitting. Pull their recent events, session replays, and errors, then figure out what went wrong.\n\n\nUser input:\n- Describe the user issue:\n- User identifier (distinct ID, email address, etc):",
+    id: "code",
+    label: "Code",
+    icon: Code,
+    color: "orange",
+    suggestions: [
+      {
+        label: "Fix a bug",
+        description: "Track down and fix a problem in the code",
+        icon: Wrench,
+        color: "orange",
+        mode: "plan",
+        prompt:
+          "Help me fix a bug — track down the root cause in the code and implement a fix. Open a PR if appropriate.\n\n\nUser input:\n- Describe the bug / what's going wrong:\n- Steps to reproduce (optional):\n- Where it happens (file, page, area — optional):",
+      },
+      {
+        label: "Build a new feature",
+        description: "Design and implement something new",
+        icon: Cube,
+        color: "teal",
+        mode: "plan",
+        prompt:
+          "Help me build a new feature — propose an approach, then implement it. Open a PR if appropriate.\n\n\nUser input:\n- Describe the feature you want:\n- Any constraints or requirements (optional):",
+      },
+    ],
   },
   {
-    label: "Run a feature analysis",
-    description: "Adoption, engagement, and retention of a feature",
+    id: "analysis",
+    label: "Analysis",
     icon: ChartLine,
     color: "blue",
-    mode: "auto",
-    prompt:
-      "Analyze how a feature is performing — adoption, engagement, and retention of users who use it vs. those who don't.\n\n\nUser input:\n- Feature to analyze:\n- Time period (optional):",
+    suggestions: [
+      {
+        label: "Run a feature analysis",
+        description: "Adoption, engagement, and retention of a feature",
+        icon: ChartLine,
+        color: "blue",
+        mode: "auto",
+        prompt:
+          "Analyze how a feature is performing — adoption, engagement, and retention of users who use it vs. those who don't.\n\n\nUser input:\n- Feature to analyze:\n- Time period (optional):",
+      },
+      {
+        label: "Understand revenue patterns",
+        description: "Trends over time, by plan, and by cohort",
+        icon: CurrencyDollar,
+        color: "green",
+        mode: "auto",
+        prompt:
+          "Analyze our revenue trends — break it down over time, by plan, and by cohort, and call out notable changes and likely drivers.\n\n\nUser input:\n- What revenue question are you trying to answer:\n- Time period (optional):",
+      },
+      {
+        label: "Summarize product usage",
+        description: "Top events, active users, and key funnels",
+        icon: ChartBar,
+        color: "violet",
+        mode: "auto",
+        prompt:
+          "Summarize how our product is being used — top events, active users, key funnels, and notable trends.\n\n\nUser input:\n- Product area or feature to focus on (optional):\n- Time period (optional):",
+      },
+      {
+        label: "Interpret experiment results",
+        description: "Significance and what to do next",
+        icon: Flask,
+        color: "purple",
+        mode: "auto",
+        prompt:
+          "Interpret the results of an experiment — explain what the metrics show, whether it's significant, and what to do next.\n\n\nUser input:\n- Experiment name or key:\n- What decision are you trying to make (optional):",
+      },
+      {
+        label: "Summarize user & agent feedback",
+        description: "Common themes across recent feedback",
+        icon: ChatCircleText,
+        color: "amber",
+        mode: "auto",
+        prompt:
+          "Summarize recent user and support/agent feedback — surface the common themes, complaints, and requests.\n\n\nUser input:\n- Feedback source or topic to focus on:\n- Time period (optional):",
+      },
+    ],
   },
   {
-    label: "Understand revenue patterns",
-    description: "Trends over time, by plan, and by cohort",
-    icon: CurrencyDollar,
-    color: "green",
-    mode: "auto",
-    prompt:
-      "Analyze our revenue trends — break it down over time, by plan, and by cohort, and call out notable changes and likely drivers.\n\n\nUser input:\n- What revenue question are you trying to answer:\n- Time period (optional):",
+    id: "debug",
+    label: "Debug",
+    icon: Bug,
+    color: "red",
+    suggestions: [
+      {
+        label: "Debug a user issue",
+        description: "Trace a specific user's events, replays, and errors",
+        icon: Bug,
+        color: "red",
+        mode: "auto",
+        prompt:
+          "Help me debug an issue a specific user is hitting. Pull their recent events, session replays, and errors, then figure out what went wrong.\n\n\nUser input:\n- Describe the user issue:\n- User identifier (distinct ID, email address, etc):",
+      },
+      {
+        label: "Investigate an error",
+        description: "Root cause, frequency, and who it affects",
+        icon: WarningOctagon,
+        color: "red",
+        mode: "auto",
+        prompt:
+          "Investigate an error or exception — find the root cause, how often it happens, and which users it affects.\n\n\nUser input:\n- Error message or issue:\n- Where you're seeing it (optional):",
+      },
+      {
+        label: "Diagnose a metric change",
+        description: "Why a metric dropped or spiked",
+        icon: TrendDown,
+        color: "amber",
+        mode: "auto",
+        prompt:
+          "Figure out why a metric dropped or spiked — break it down by segment and surface the likely causes.\n\n\nUser input:\n- Which metric changed:\n- When you noticed it (optional):",
+      },
+    ],
   },
   {
-    label: "Summarize product usage",
-    description: "Top events, active users, and key funnels",
-    icon: ChartBar,
+    id: "canvas",
+    label: "Canvas",
+    icon: SquaresFour,
     color: "violet",
-    mode: "auto",
-    prompt:
-      "Summarize how our product is being used — top events, active users, key funnels, and notable trends.\n\n\nUser input:\n- Product area or feature to focus on (optional):\n- Time period (optional):",
-  },
-  {
-    label: "Summarize user & agent feedback",
-    description: "Common themes across recent feedback",
-    icon: ChatCircleText,
-    color: "amber",
-    mode: "auto",
-    prompt:
-      "Summarize recent user and support/agent feedback — surface the common themes, complaints, and requests.\n\n\nUser input:\n- Feedback source or topic to focus on:\n- Time period (optional):",
-  },
-  {
-    label: "Interpret experiment results",
-    description: "Significance and what to do next",
-    icon: Flask,
-    color: "purple",
-    mode: "auto",
-    prompt:
-      "Interpret the results of an experiment — explain what the metrics show, whether it's significant, and what to do next.\n\n\nUser input:\n- Experiment name or key:\n- What decision are you trying to make (optional):",
-  },
-  {
-    label: "Fix a bug",
-    description: "Track down and fix a problem in the code",
-    icon: Wrench,
-    color: "orange",
-    mode: "plan",
-    prompt:
-      "Help me fix a bug — track down the root cause in the code and implement a fix. Open a PR if appropriate.\n\n\nUser input:\n- Describe the bug / what's going wrong:\n- Steps to reproduce (optional):\n- Where it happens (file, page, area — optional):",
-  },
-  {
-    label: "Build a new feature",
-    description: "Design and implement something new",
-    icon: Cube,
-    color: "teal",
-    mode: "plan",
-    prompt:
-      "Help me build a new feature — propose an approach, then implement it. Open a PR if appropriate.\n\n\nUser input:\n- Describe the feature you want:\n- Any constraints or requirements (optional):",
+    suggestions: [
+      {
+        label: "Build a dashboard",
+        description: "Lay out the key metrics on a canvas",
+        icon: SquaresFour,
+        color: "violet",
+        mode: "auto",
+        prompt:
+          "Build a dashboard canvas that brings together the metrics that matter for this work.\n\n\nUser input:\n- What should the dashboard cover:\n- Key metrics or breakdowns to include (optional):",
+      },
+      {
+        label: "Visualize a metric",
+        description: "Chart a single metric with the right breakdowns",
+        icon: ChartPieSlice,
+        color: "purple",
+        mode: "auto",
+        prompt:
+          "Create a canvas that visualizes a single metric over time, with the breakdowns that make it useful.\n\n\nUser input:\n- Metric to visualize:\n- Breakdowns or filters (optional):",
+      },
+    ],
   },
 ];
+
+// Flat list for the new-task screen's card grid (WebsiteNewTask), which shows
+// every starter prompt at once rather than grouping them behind chips.
+export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] =
+  CHANNEL_SUGGESTION_CATEGORIES.flatMap((category) => category.suggestions);

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -35,6 +35,9 @@ interface ChannelHomeComposerProps {
   channelName?: string;
   /** Channel CONTEXT.md, attached to the created task as background. */
   channelContext?: string;
+  /** Fires as the editor goes empty ⇄ non-empty, so the home page can fade out
+   * its suggestions / lists while the user is typing. */
+  onEmptyChange?: (isEmpty: boolean) => void;
   onTaskCreated: (task: Task) => void;
 }
 
@@ -48,13 +51,21 @@ export const ChannelHomeComposer = forwardRef<
   ChannelHomeComposerHandle,
   ChannelHomeComposerProps
 >(function ChannelHomeComposer(
-  { channelId, channelName, channelContext, onTaskCreated },
+  { channelId, channelName, channelContext, onEmptyChange, onTaskCreated },
   ref,
 ) {
   const sessionId = `channel-home:${channelId}`;
   const editorRef = useRef<EditorHandle>(null);
   const [editorIsEmpty, setEditorIsEmpty] = useState(true);
   const { isOnline } = useConnectivity();
+
+  const handleEmptyChange = useCallback(
+    (isEmpty: boolean) => {
+      setEditorIsEmpty(isEmpty);
+      onEmptyChange?.(isEmpty);
+    },
+    [onEmptyChange],
+  );
 
   const {
     lastUsedAdapter,
@@ -225,7 +236,7 @@ export const ChannelHomeComposer = forwardRef<
             />
           )
         }
-        onEmptyChange={setEditorIsEmpty}
+        onEmptyChange={handleEmptyChange}
         onSubmitClick={handleSubmit}
         onSubmit={() => {
           if (canSubmit) handleSubmit();

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -1,8 +1,11 @@
+import { FileText, X } from "@phosphor-icons/react";
 import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
 import type { Task } from "@posthog/shared/domain-types";
+import { Tooltip } from "@radix-ui/themes";
 import {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -58,6 +61,20 @@ export const ChannelHomeComposer = forwardRef<
   const editorRef = useRef<EditorHandle>(null);
   const [editorIsEmpty, setEditorIsEmpty] = useState(true);
   const { isOnline } = useConnectivity();
+
+  // The channel CONTEXT.md is attached to new tasks by default; the chip below
+  // the prompt surfaces that it's included and lets the user drop it from this
+  // task. Re-include whenever the source context changes (e.g. the doc loads or
+  // the channel switches) so a dismissal doesn't stick. Mirrors TaskInput.
+  const [channelContextDismissed, setChannelContextDismissed] = useState(false);
+  const lastChannelContextRef = useRef(channelContext);
+  useEffect(() => {
+    if (lastChannelContextRef.current !== channelContext) {
+      lastChannelContextRef.current = channelContext;
+      setChannelContextDismissed(false);
+    }
+  }, [channelContext]);
+  const includeChannelContext = !!channelContext && !channelContextDismissed;
 
   const handleEmptyChange = useCallback(
     (isEmpty: boolean) => {
@@ -136,7 +153,7 @@ export const ChannelHomeComposer = forwardRef<
     model: currentModel,
     reasoningLevel: currentReasoningLevel,
     allowNoRepo: true,
-    channelContext,
+    channelContext: includeChannelContext ? channelContext : undefined,
     channelName,
     onTaskCreated,
   });
@@ -242,6 +259,28 @@ export const ChannelHomeComposer = forwardRef<
           if (canSubmit) handleSubmit();
         }}
       />
+
+      {includeChannelContext && (
+        <div className="mt-2 flex select-none flex-wrap items-center gap-1.5 self-start rounded-md border border-gray-6 bg-gray-2 px-2 py-1 text-[12px] text-gray-11">
+          <span className="shrink-0 text-gray-10">Using:</span>
+          <span className="inline-flex items-center gap-1 rounded-[var(--radius-1)] bg-[var(--gray-a3)] px-1.5 py-px font-medium text-[var(--gray-11)]">
+            <FileText size={12} />
+            <span className="truncate">
+              {channelName ? `#${channelName} ` : ""}CONTEXT.md
+            </span>
+            <Tooltip content="Don't include this context">
+              <button
+                type="button"
+                onClick={() => setChannelContextDismissed(true)}
+                aria-label="Remove channel context from prompt"
+                className="ml-0.5 inline-flex size-3.5 items-center justify-center rounded text-gray-10 hover:bg-gray-5 hover:text-gray-12"
+              >
+                <X size={12} />
+              </button>
+            </Tooltip>
+          </span>
+        </div>
+      )}
     </div>
   );
 });

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -261,7 +261,7 @@ export const ChannelHomeComposer = forwardRef<
       />
 
       {includeChannelContext && (
-        <div className="mt-2 flex select-none flex-wrap items-center gap-1.5 self-start rounded-md border border-gray-6 bg-gray-2 px-2 py-1 text-[12px] text-gray-11">
+        <div className="-mt-px mx-2 flex select-none flex-wrap items-center gap-1.5 rounded-b-md border border-gray-6 border-t-0 bg-gray-2 px-2 py-1 text-[12px] text-gray-11">
           <span className="shrink-0 text-gray-10">Using:</span>
           <span className="inline-flex items-center gap-1 rounded-[var(--radius-1)] bg-[var(--gray-a3)] px-1.5 py-px font-medium text-[var(--gray-11)]">
             <FileText size={12} />

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -1,10 +1,13 @@
-import {
-  ArrowLeftIcon,
-  ArrowRightIcon,
-  CaretRightIcon,
-} from "@phosphor-icons/react";
+import { ArrowRightIcon, CaretRightIcon } from "@phosphor-icons/react";
 import type { DashboardSummary } from "@posthog/core/canvas/dashboardSchemas";
-import { cn } from "@posthog/quill";
+import {
+  cn,
+  Menubar,
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarTrigger,
+} from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
@@ -36,7 +39,7 @@ import { track } from "@posthog/ui/shell/analytics";
 import { Flex, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 const RECENT_TASK_LIMIT = 5;
 const PINNED_ARTIFACT_LIMIT = 5;
@@ -64,34 +67,27 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   // the prompt box.
   const [composerEmpty, setComposerEmpty] = useState(true);
 
-  // Which category chip is expanded into its action list. `displayedCategoryId`
-  // lags `activeCategoryId` so the detail box keeps its contents through the
-  // fade-out when collapsing back to the chips.
-  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
-  const [displayedCategoryId, setDisplayedCategoryId] = useState<string | null>(
-    null,
-  );
-  useEffect(() => {
-    if (activeCategoryId) {
-      setDisplayedCategoryId(activeCategoryId);
-      return;
-    }
-    const id = setTimeout(() => setDisplayedCategoryId(null), 200);
-    return () => clearTimeout(id);
-  }, [activeCategoryId]);
-  const displayedCategory = CHANNEL_SUGGESTION_CATEGORIES.find(
-    (c) => c.id === displayedCategoryId,
-  );
+  // Anchor for the category menus: pointing each popup at the whole menu bar
+  // (rather than its own trigger) makes Base UI's --anchor-width the bar width,
+  // so the popup fills the bar.
+  const menuBarRef = useRef<HTMLDivElement>(null);
 
-  const selectCategory = useCallback(
-    (category: SuggestionCategory) => {
-      setActiveCategoryId(category.id);
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-        action_type: "select_suggestion_category",
-        surface: "channel_home",
-        channel_id: channelId,
-        category: category.id,
-      });
+  // Which category menu is open, if any. The menu bar stays put while a menu is
+  // open, but the recents below fade out so the options have the floor.
+  const [openCategoryId, setOpenCategoryId] = useState<string | null>(null);
+  const handleCategoryOpenChange = useCallback(
+    (category: SuggestionCategory, open: boolean) => {
+      setOpenCategoryId((prev) =>
+        open ? category.id : prev === category.id ? null : prev,
+      );
+      if (open) {
+        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          action_type: "select_suggestion_category",
+          surface: "channel_home",
+          channel_id: channelId,
+          category: category.id,
+        });
+      }
     },
     [channelId],
   );
@@ -164,8 +160,8 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
           onTaskCreated={onTaskCreated}
         />
 
-        {/* Suggestions + recent/pinned glance. All fade out together while the
-            user is typing so the prompt box has the floor. */}
+        {/* Category menu bar + recent/pinned glance. Everything fades out while
+            the user is typing so the prompt box has the floor. */}
         <div
           className={cn(
             "transition-opacity duration-200",
@@ -174,54 +170,37 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
           aria-hidden={!composerEmpty}
           inert={!composerEmpty || undefined}
         >
-          {/* The chips + recents and the expanded category box share this
-              space and crossfade: the chips view stays in flow (holding the
-              height) while the detail box overlays it. */}
-          <div className="relative">
-            <div
-              className={cn(
-                "flex flex-col gap-6 transition-opacity duration-200",
-                activeCategoryId && "pointer-events-none opacity-0",
-              )}
-              aria-hidden={!!activeCategoryId}
-              inert={!!activeCategoryId || undefined}
-            >
-              <div className="flex flex-wrap items-center justify-center gap-2">
-                {CHANNEL_SUGGESTION_CATEGORIES.map((category) => (
-                  <CategoryChip
-                    key={category.id}
-                    category={category}
-                    onClick={() => selectCategory(category)}
-                  />
-                ))}
-              </div>
-
-              <div className="grid grid-cols-2 gap-6">
-                <RecentTasksColumn channelId={channelId} />
-                <PinnedArtifactsColumn channelId={channelId} />
-              </div>
-            </div>
-
-            <div
-              className={cn(
-                "absolute inset-0 transition-opacity duration-200",
-                activeCategoryId
-                  ? "opacity-100"
-                  : "pointer-events-none opacity-0",
-              )}
-              aria-hidden={!activeCategoryId}
-              inert={!activeCategoryId || undefined}
-            >
-              {displayedCategory ? (
-                <CategorySuggestions
-                  category={displayedCategory}
-                  onBack={() => setActiveCategoryId(null)}
+          {/* The bar is the anchor for every category popup: anchoring to it
+              (not the trigger) makes each popup fill the bar's width. */}
+          <div ref={menuBarRef} className="mx-auto my-4 w-fit">
+            <Menubar className="h-auto flex-wrap justify-center gap-2 border-0 bg-transparent p-0 shadow-none">
+              {CHANNEL_SUGGESTION_CATEGORIES.map((category) => (
+                <CategoryMenu
+                  key={category.id}
+                  category={category}
+                  anchor={menuBarRef}
+                  onOpenChange={(open) =>
+                    handleCategoryOpenChange(category, open)
+                  }
                   onSelect={(suggestion) =>
-                    applySuggestion(suggestion, displayedCategory.id)
+                    applySuggestion(suggestion, category.id)
                   }
                 />
-              ) : null}
-            </div>
+              ))}
+            </Menubar>
+          </div>
+
+          {/* Recents fade out while a category menu is open. */}
+          <div
+            className={cn(
+              "grid grid-cols-2 gap-6 transition-opacity duration-200",
+              openCategoryId && "pointer-events-none opacity-0",
+            )}
+            aria-hidden={!!openCategoryId}
+            inert={!!openCategoryId || undefined}
+          >
+            <RecentTasksColumn channelId={channelId} />
+            <PinnedArtifactsColumn channelId={channelId} />
           </div>
         </div>
       </div>
@@ -229,70 +208,55 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   );
 }
 
-// A category pill below the prompt box. Clicking it expands the category's
-// action list in place of the chips + recents.
-function CategoryChip({
+// One category in the menu bar: a chip-styled trigger, and a popup listing the
+// category's suggested actions. The popup is anchored to the whole bar so it
+// fills the bar's width (via Base UI's --anchor-width).
+function CategoryMenu({
   category,
-  onClick,
-}: {
-  category: SuggestionCategory;
-  onClick: () => void;
-}) {
-  const Icon = category.icon;
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group inline-flex items-center gap-1.5 rounded-full border border-(--gray-a4) bg-(--color-panel-solid) px-3 py-1.5 font-medium text-[13px] text-gray-11 shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,color] hover:border-(--chip-hover) hover:text-gray-12"
-      style={
-        { "--chip-hover": `var(--${category.color}-7)` } as React.CSSProperties
-      }
-    >
-      <Icon size={14} weight="duotone" color={`var(--${category.color}-9)`} />
-      {category.label}
-    </button>
-  );
-}
-
-// The expanded list for a category: a back button to collapse to the chips,
-// then one row per suggested action.
-function CategorySuggestions({
-  category,
-  onBack,
+  anchor,
+  onOpenChange,
   onSelect,
 }: {
   category: SuggestionCategory;
-  onBack: () => void;
+  anchor: React.RefObject<HTMLElement | null>;
+  onOpenChange: (open: boolean) => void;
   onSelect: (suggestion: SuggestedPrompt) => void;
 }) {
+  const Icon = category.icon;
   return (
-    <div className="flex flex-col gap-0.5 rounded-xl border border-(--gray-a3) bg-(--color-panel-solid) p-2 shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]">
-      <div className="mb-1 flex items-center gap-1.5 px-1">
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="Back to categories"
-          className="flex size-6 shrink-0 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
-        >
-          <ArrowLeftIcon size={14} />
-        </button>
-        <Text size="1" weight="medium" className="text-(--gray-11)">
-          {category.label}
-        </Text>
-      </div>
-      {category.suggestions.map((suggestion) => (
-        <SuggestionRow
-          key={suggestion.label}
-          suggestion={suggestion}
-          onSelect={() => onSelect(suggestion)}
-        />
-      ))}
-    </div>
+    <MenubarMenu onOpenChange={onOpenChange}>
+      <MenubarTrigger
+        className="inline-flex items-center gap-1.5 rounded-full border border-(--gray-a4) bg-(--color-panel-solid) px-3 py-1.5 font-medium text-[13px] text-gray-11 shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,color] hover:border-(--chip-hover) hover:bg-(--color-panel-solid) hover:text-gray-12 aria-expanded:border-(--chip-hover) aria-expanded:bg-(--color-panel-solid) aria-expanded:text-gray-12"
+        style={
+          {
+            "--chip-hover": `var(--${category.color}-7)`,
+          } as React.CSSProperties
+        }
+      >
+        <Icon size={14} weight="duotone" color={`var(--${category.color}-9)`} />
+        {category.label}
+      </MenubarTrigger>
+      <MenubarContent
+        anchor={anchor}
+        align="start"
+        alignOffset={0}
+        sideOffset={8}
+        className="flex flex-col gap-0.5 p-2"
+      >
+        {category.suggestions.map((suggestion) => (
+          <SuggestionRow
+            key={suggestion.label}
+            suggestion={suggestion}
+            onSelect={() => onSelect(suggestion)}
+          />
+        ))}
+      </MenubarContent>
+    </MenubarMenu>
   );
 }
 
-// A single suggested action: icon badge, title, then the description as muted
-// text alongside it.
+// A single suggested action row: icon badge, title, then the description as
+// muted text alongside it. Selecting it drops the prompt into the composer.
 function SuggestionRow({
   suggestion,
   onSelect,
@@ -302,10 +266,9 @@ function SuggestionRow({
 }) {
   const Icon = suggestion.icon;
   return (
-    <button
-      type="button"
+    <MenubarItem
       onClick={onSelect}
-      className="group flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-gray-3"
+      className="min-h-0 items-center gap-2.5 rounded-lg px-2 py-1.5"
     >
       <Flex
         align="center"
@@ -327,7 +290,7 @@ function SuggestionRow({
           {suggestion.description}
         </span>
       </span>
-    </button>
+    </MenubarItem>
   );
 }
 

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -1,4 +1,8 @@
-import { ArrowRightIcon, CaretRightIcon } from "@phosphor-icons/react";
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  CaretRightIcon,
+} from "@phosphor-icons/react";
 import type { DashboardSummary } from "@posthog/core/canvas/dashboardSchemas";
 import { cn } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
@@ -6,7 +10,10 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { TaskTabIcon } from "@posthog/ui/features/browser-tabs/TaskTabIcon";
-import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
+import {
+  CHANNEL_SUGGESTION_CATEGORIES,
+  type SuggestionCategory,
+} from "@posthog/ui/features/canvas/channelTaskSuggestions";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import {
   ChannelHomeComposer,
@@ -20,16 +27,16 @@ import {
 } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useDashboards } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
-import { SuggestedPromptCard } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
+import type { SuggestedPrompt } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
-import { Text } from "@radix-ui/themes";
+import { Flex, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const RECENT_TASK_LIMIT = 5;
 const PINNED_ARTIFACT_LIMIT = 5;
@@ -57,11 +64,50 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   // the prompt box.
   const [composerEmpty, setComposerEmpty] = useState(true);
 
-  const handleSuggestionSelect = useCallback(
-    (prompt: string, mode?: string) => {
-      composerRef.current?.applySuggestion(prompt, mode);
+  // Which category chip is expanded into its action list. `displayedCategoryId`
+  // lags `activeCategoryId` so the detail box keeps its contents through the
+  // fade-out when collapsing back to the chips.
+  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const [displayedCategoryId, setDisplayedCategoryId] = useState<string | null>(
+    null,
+  );
+  useEffect(() => {
+    if (activeCategoryId) {
+      setDisplayedCategoryId(activeCategoryId);
+      return;
+    }
+    const id = setTimeout(() => setDisplayedCategoryId(null), 200);
+    return () => clearTimeout(id);
+  }, [activeCategoryId]);
+  const displayedCategory = CHANNEL_SUGGESTION_CATEGORIES.find(
+    (c) => c.id === displayedCategoryId,
+  );
+
+  const selectCategory = useCallback(
+    (category: SuggestionCategory) => {
+      setActiveCategoryId(category.id);
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "select_suggestion_category",
+        surface: "channel_home",
+        channel_id: channelId,
+        category: category.id,
+      });
     },
-    [],
+    [channelId],
+  );
+
+  const applySuggestion = useCallback(
+    (suggestion: SuggestedPrompt, categoryId: string) => {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "new_task_suggestion",
+        surface: "channel_home",
+        channel_id: channelId,
+        category: categoryId,
+        suggestion_label: suggestion.label,
+      });
+      composerRef.current?.applySuggestion(suggestion.prompt, suggestion.mode);
+    },
+    [channelId],
   );
 
   const onTaskCreated = useCallback(
@@ -122,36 +168,166 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
             user is typing so the prompt box has the floor. */}
         <div
           className={cn(
-            "flex flex-col gap-6 transition-opacity duration-200",
+            "transition-opacity duration-200",
             !composerEmpty && "pointer-events-none opacity-0",
           )}
           aria-hidden={!composerEmpty}
           inert={!composerEmpty || undefined}
         >
-          <div className="flex flex-col gap-2">
-            <Text size="1" weight="medium" className="px-1 text-(--gray-11)">
-              Suggestions
-            </Text>
-            <div className="grid grid-cols-2 gap-2">
-              {CHANNEL_TASK_SUGGESTIONS.map((suggestion) => (
-                <SuggestedPromptCard
-                  key={suggestion.label}
-                  suggestion={suggestion}
-                  onSelect={() =>
-                    handleSuggestionSelect(suggestion.prompt, suggestion.mode)
+          {/* The chips + recents and the expanded category box share this
+              space and crossfade: the chips view stays in flow (holding the
+              height) while the detail box overlays it. */}
+          <div className="relative">
+            <div
+              className={cn(
+                "flex flex-col gap-6 transition-opacity duration-200",
+                activeCategoryId && "pointer-events-none opacity-0",
+              )}
+              aria-hidden={!!activeCategoryId}
+              inert={!!activeCategoryId || undefined}
+            >
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                {CHANNEL_SUGGESTION_CATEGORIES.map((category) => (
+                  <CategoryChip
+                    key={category.id}
+                    category={category}
+                    onClick={() => selectCategory(category)}
+                  />
+                ))}
+              </div>
+
+              <div className="grid grid-cols-2 gap-6">
+                <RecentTasksColumn channelId={channelId} />
+                <PinnedArtifactsColumn channelId={channelId} />
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                "absolute inset-0 transition-opacity duration-200",
+                activeCategoryId
+                  ? "opacity-100"
+                  : "pointer-events-none opacity-0",
+              )}
+              aria-hidden={!activeCategoryId}
+              inert={!activeCategoryId || undefined}
+            >
+              {displayedCategory ? (
+                <CategorySuggestions
+                  category={displayedCategory}
+                  onBack={() => setActiveCategoryId(null)}
+                  onSelect={(suggestion) =>
+                    applySuggestion(suggestion, displayedCategory.id)
                   }
                 />
-              ))}
+              ) : null}
             </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-6">
-            <RecentTasksColumn channelId={channelId} />
-            <PinnedArtifactsColumn channelId={channelId} />
           </div>
         </div>
       </div>
     </div>
+  );
+}
+
+// A category pill below the prompt box. Clicking it expands the category's
+// action list in place of the chips + recents.
+function CategoryChip({
+  category,
+  onClick,
+}: {
+  category: SuggestionCategory;
+  onClick: () => void;
+}) {
+  const Icon = category.icon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group inline-flex items-center gap-1.5 rounded-full border border-(--gray-a4) bg-(--color-panel-solid) px-3 py-1.5 font-medium text-[13px] text-gray-11 shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,color] hover:border-(--chip-hover) hover:text-gray-12"
+      style={
+        { "--chip-hover": `var(--${category.color}-7)` } as React.CSSProperties
+      }
+    >
+      <Icon size={14} weight="duotone" color={`var(--${category.color}-9)`} />
+      {category.label}
+    </button>
+  );
+}
+
+// The expanded list for a category: a back button to collapse to the chips,
+// then one row per suggested action.
+function CategorySuggestions({
+  category,
+  onBack,
+  onSelect,
+}: {
+  category: SuggestionCategory;
+  onBack: () => void;
+  onSelect: (suggestion: SuggestedPrompt) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 rounded-xl border border-(--gray-a3) bg-(--color-panel-solid) p-2 shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)]">
+      <div className="mb-1 flex items-center gap-1.5 px-1">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back to categories"
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+        >
+          <ArrowLeftIcon size={14} />
+        </button>
+        <Text size="1" weight="medium" className="text-(--gray-11)">
+          {category.label}
+        </Text>
+      </div>
+      {category.suggestions.map((suggestion) => (
+        <SuggestionRow
+          key={suggestion.label}
+          suggestion={suggestion}
+          onSelect={() => onSelect(suggestion)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// A single suggested action: icon badge, title, then the description as muted
+// text alongside it.
+function SuggestionRow({
+  suggestion,
+  onSelect,
+}: {
+  suggestion: SuggestedPrompt;
+  onSelect: () => void;
+}) {
+  const Icon = suggestion.icon;
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="group flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-gray-3"
+    >
+      <Flex
+        align="center"
+        justify="center"
+        className="size-6 shrink-0 rounded-md"
+        style={{ backgroundColor: `var(--${suggestion.color}-3)` }}
+      >
+        <Icon
+          size={14}
+          weight="duotone"
+          color={`var(--${suggestion.color}-9)`}
+        />
+      </Flex>
+      <span className="flex min-w-0 flex-1 items-baseline gap-2">
+        <span className="shrink-0 font-medium text-[13px] text-gray-12">
+          {suggestion.label}
+        </span>
+        <span className="truncate text-[12px] text-gray-10">
+          {suggestion.description}
+        </span>
+      </span>
+    </button>
   );
 }
 

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -1,26 +1,43 @@
+import { ArrowRightIcon, CaretRightIcon } from "@phosphor-icons/react";
+import type { DashboardSummary } from "@posthog/core/canvas/dashboardSchemas";
+import { cn } from "@posthog/quill";
+import { formatRelativeTimeShort } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { TaskTabIcon } from "@posthog/ui/features/browser-tabs/TaskTabIcon";
 import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import {
   ChannelHomeComposer,
   type ChannelHomeComposerHandle,
 } from "@posthog/ui/features/canvas/components/ChannelHomeComposer";
+import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
-import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
+import {
+  useChannelTaskMutations,
+  useChannelTasks,
+} from "@posthog/ui/features/canvas/hooks/useChannelTasks";
+import { useDashboards } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
 import { SuggestedPromptCard } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useMemo, useRef } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { useCallback, useMemo, useRef, useState } from "react";
 
-// A channel's homepage: a heading and a composer that files new tasks into the
-// channel. The channel's tasks + canvases live behind the "History" tab.
+const RECENT_TASK_LIMIT = 5;
+const PINNED_ARTIFACT_LIMIT = 5;
+
+// A channel's homepage: a heading, the composer that files new tasks into the
+// channel, the starter-prompt suggestions, and a two-column glance at the
+// channel's recent tasks and pinned artifacts. The full lists live behind the
+// "Recents" and "Artifacts" tabs.
 export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -36,6 +53,9 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   );
 
   const composerRef = useRef<ChannelHomeComposerHandle>(null);
+  // While the user is typing, dim the suggestions + lists so the focus stays on
+  // the prompt box.
+  const [composerEmpty, setComposerEmpty] = useState(true);
 
   const handleSuggestionSelect = useCallback(
     (prompt: string, mode?: string) => {
@@ -79,7 +99,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
 
   return (
     <div className="h-full overflow-y-auto bg-gray-1">
-      <div className="mx-auto flex min-h-full w-full max-w-[680px] flex-col justify-center gap-6 px-4 py-10">
+      <div className="mx-auto flex min-h-full w-full max-w-[760px] flex-col justify-center gap-6 px-4 py-10">
         <div className="text-center">
           <h1 className="font-semibold text-2xl text-gray-12 tracking-tight">
             What can I do for you today?
@@ -89,32 +109,226 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
           </Text>
         </div>
 
-        {/* Starter prompts, always shown directly above the box. */}
-        <div className="flex flex-col gap-2">
-          <Text size="1" weight="medium" className="px-1 text-(--gray-11)">
-            Suggestions
-          </Text>
-          <div className="grid grid-cols-2 gap-2">
-            {CHANNEL_TASK_SUGGESTIONS.map((suggestion) => (
-              <SuggestedPromptCard
-                key={suggestion.label}
-                suggestion={suggestion}
-                onSelect={() =>
-                  handleSuggestionSelect(suggestion.prompt, suggestion.mode)
-                }
-              />
-            ))}
-          </div>
-        </div>
-
         <ChannelHomeComposer
           ref={composerRef}
           channelId={channelId}
           channelName={channelName}
           channelContext={channelContext}
+          onEmptyChange={setComposerEmpty}
           onTaskCreated={onTaskCreated}
         />
+
+        {/* Suggestions + recent/pinned glance. All fade out together while the
+            user is typing so the prompt box has the floor. */}
+        <div
+          className={cn(
+            "flex flex-col gap-6 transition-opacity duration-200",
+            !composerEmpty && "pointer-events-none opacity-0",
+          )}
+          aria-hidden={!composerEmpty}
+        >
+          <div className="flex flex-col gap-2">
+            <Text size="1" weight="medium" className="px-1 text-(--gray-11)">
+              Suggestions
+            </Text>
+            <div className="grid grid-cols-2 gap-2">
+              {CHANNEL_TASK_SUGGESTIONS.map((suggestion) => (
+                <SuggestedPromptCard
+                  key={suggestion.label}
+                  suggestion={suggestion}
+                  onSelect={() =>
+                    handleSuggestionSelect(suggestion.prompt, suggestion.mode)
+                  }
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-6">
+            <RecentTasksColumn channelId={channelId} />
+            <PinnedArtifactsColumn channelId={channelId} />
+          </div>
+        </div>
       </div>
     </div>
+  );
+}
+
+// Left column: the channel's most recently active tasks, with the shared task
+// status icons. "All tasks" jumps to the Recents tab.
+function RecentTasksColumn({ channelId }: { channelId: string }) {
+  const navigate = useNavigate();
+  const { tasks: filedTasks } = useChannelTasks(channelId);
+  const { data: tasks } = useTasks();
+  const archivedTaskIds = useArchivedTaskIds();
+
+  const recentTasks = useMemo(() => {
+    const taskById = new Map(tasks?.map((t) => [t.id, t]) ?? []);
+    return filedTasks
+      .flatMap((f) => {
+        const task = taskById.get(f.taskId);
+        if (!task || archivedTaskIds.has(f.taskId)) return [];
+        return [{ task, ts: Date.parse(task.updated_at) || 0 }];
+      })
+      .sort((a, b) => b.ts - a.ts)
+      .slice(0, RECENT_TASK_LIMIT);
+  }, [filedTasks, tasks, archivedTaskIds]);
+
+  const openTask = useCallback(
+    (taskId: string) => {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "open_task",
+        surface: "channel_home",
+        channel_id: channelId,
+        task_id: taskId,
+      });
+      void navigate({
+        to: "/website/$channelId/tasks/$taskId",
+        params: { channelId, taskId },
+      });
+    },
+    [channelId, navigate],
+  );
+
+  return (
+    <ColumnShell
+      title="Recent tasks"
+      action={
+        <Link
+          to="/website/$channelId/history"
+          params={{ channelId }}
+          className="flex items-center gap-1 text-[12px] text-gray-10 transition-colors hover:text-gray-12"
+        >
+          All tasks
+          <ArrowRightIcon size={12} />
+        </Link>
+      }
+      empty={recentTasks.length === 0 ? "No tasks yet" : undefined}
+    >
+      {recentTasks.map(({ task, ts }) => (
+        <ListRow
+          key={task.id}
+          icon={<TaskTabIcon task={task} size={15} />}
+          title={task.title || "Untitled task"}
+          subtitle={formatRelativeTimeShort(ts)}
+          onClick={() => openTask(task.id)}
+        />
+      ))}
+    </ColumnShell>
+  );
+}
+
+// Right column: the channel's pinned canvases, most recently pinned first. No
+// dedicated page yet, so this is the only surface for them.
+function PinnedArtifactsColumn({ channelId }: { channelId: string }) {
+  const navigate = useNavigate();
+  const { dashboards } = useDashboards(channelId);
+
+  const pinned = useMemo(
+    () =>
+      dashboards
+        .filter((d: DashboardSummary) => d.pinnedAt != null)
+        .sort((a, b) => (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0))
+        .slice(0, PINNED_ARTIFACT_LIMIT),
+    [dashboards],
+  );
+
+  const openCanvas = useCallback(
+    (dashboardId: string) => {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "open_artifact",
+        surface: "channel_home",
+        channel_id: channelId,
+      });
+      void navigate({
+        to: "/website/$channelId/dashboards/$dashboardId",
+        params: { channelId, dashboardId },
+      });
+    },
+    [channelId, navigate],
+  );
+
+  return (
+    <ColumnShell
+      title="Pinned"
+      empty={pinned.length === 0 ? "No pinned artifacts yet" : undefined}
+    >
+      {pinned.map((d) => (
+        <ListRow
+          key={d.id}
+          icon={iconForTemplate(d.templateId, {
+            size: 15,
+            className: "text-violet-9",
+          })}
+          title={d.name}
+          subtitle={`Canvas · ${formatRelativeTimeShort(d.updatedAt)}`}
+          onClick={() => openCanvas(d.id)}
+        />
+      ))}
+    </ColumnShell>
+  );
+}
+
+function ColumnShell({
+  title,
+  action,
+  empty,
+  children,
+}: {
+  title: string;
+  action?: React.ReactNode;
+  empty?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between px-1">
+        <Text size="1" weight="medium" className="text-(--gray-11)">
+          {title}
+        </Text>
+        {action}
+      </div>
+      {empty ? (
+        <Text className="px-1 py-2 text-[12px] text-gray-9">{empty}</Text>
+      ) : (
+        <div className="flex flex-col gap-0.5">{children}</div>
+      )}
+    </div>
+  );
+}
+
+function ListRow({
+  icon,
+  title,
+  subtitle,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-gray-3"
+    >
+      <span className="flex size-5 shrink-0 items-center justify-center">
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate font-medium text-[13px] text-gray-12 leading-tight">
+          {title}
+        </span>
+        <span className="truncate text-[11px] text-gray-10 leading-tight">
+          {subtitle}
+        </span>
+      </span>
+      <CaretRightIcon
+        size={13}
+        className="shrink-0 text-gray-8 opacity-0 transition-opacity group-hover:opacity-100"
+      />
+    </button>
   );
 }

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -126,6 +126,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
             !composerEmpty && "pointer-events-none opacity-0",
           )}
           aria-hidden={!composerEmpty}
+          inert={!composerEmpty || undefined}
         >
           <div className="flex flex-col gap-2">
             <Text size="1" weight="medium" className="px-1 text-(--gray-11)">
@@ -158,8 +159,9 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
 // status icons. "All tasks" jumps to the Recents tab.
 function RecentTasksColumn({ channelId }: { channelId: string }) {
   const navigate = useNavigate();
-  const { tasks: filedTasks } = useChannelTasks(channelId);
-  const { data: tasks } = useTasks();
+  const { tasks: filedTasks, isLoading: filedLoading } =
+    useChannelTasks(channelId);
+  const { data: tasks, isLoading: tasksLoading } = useTasks();
   const archivedTaskIds = useArchivedTaskIds();
 
   const recentTasks = useMemo(() => {
@@ -203,7 +205,11 @@ function RecentTasksColumn({ channelId }: { channelId: string }) {
           <ArrowRightIcon size={12} />
         </Link>
       }
-      empty={recentTasks.length === 0 ? "No tasks yet" : undefined}
+      empty={
+        !filedLoading && !tasksLoading && recentTasks.length === 0
+          ? "No tasks yet"
+          : undefined
+      }
     >
       {recentTasks.map(({ task, ts }) => (
         <ListRow
@@ -222,7 +228,7 @@ function RecentTasksColumn({ channelId }: { channelId: string }) {
 // dedicated page yet, so this is the only surface for them.
 function PinnedArtifactsColumn({ channelId }: { channelId: string }) {
   const navigate = useNavigate();
-  const { dashboards } = useDashboards(channelId);
+  const { dashboards, isLoading } = useDashboards(channelId);
 
   const pinned = useMemo(
     () =>
@@ -239,6 +245,7 @@ function PinnedArtifactsColumn({ channelId }: { channelId: string }) {
         action_type: "open_artifact",
         surface: "channel_home",
         channel_id: channelId,
+        dashboard_id: dashboardId,
       });
       void navigate({
         to: "/website/$channelId/dashboards/$dashboardId",
@@ -251,7 +258,11 @@ function PinnedArtifactsColumn({ channelId }: { channelId: string }) {
   return (
     <ColumnShell
       title="Pinned"
-      empty={pinned.length === 0 ? "No pinned artifacts yet" : undefined}
+      empty={
+        !isLoading && pinned.length === 0
+          ? "No pinned artifacts yet"
+          : undefined
+      }
     >
       {pinned.map((d) => (
         <ListRow


### PR DESCRIPTION
## Problem

The channel home page only showed the starter suggestions above the prompt box, with no at-a-glance view of what's happening in the channel.

**Why:** Raquel wanted the channel home to surface recent activity and pinned artifacts directly, with the prompt box leading the page.

## Changes

- Move the prompt box **above** the starter suggestions.
- Add a two-column section below the suggestions:
  - **Left — Recent tasks:** the 5 most recently active tasks, sorted by activity, using the shared task status icons. An "All tasks →" link jumps to the Recents tab.
  - **Right — Pinned:** the 5 most recently pinned canvases (no dedicated page yet).
- Typing into the prompt box fades out the suggestions and both lists so the composer has the floor.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` passes.
- Biome check clean on the changed files.
- Did not run the app manually — please pull down and test locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*