### PR TITLE
feat(updates): add View changelog button to settings

### DIFF
--- a/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
+++ b/packages/ui/src/features/settings/sections/UpdatesSettings.tsx
@@ -7,6 +7,7 @@ import { useHostTRPC } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
 import { track } from "@posthog/ui/shell/analytics";
 import { logger } from "@posthog/ui/shell/logger";
 import { Badge, Button, Flex, Spinner, Switch, Text } from "@radix-ui/themes";
@@ -103,9 +104,18 @@ export function UpdatesSettings() {
   return (
     <Flex direction="column">
       <SettingRow label="Current version">
-        <Badge size="1" variant="soft" color="gray">
-          {appVersion || "Loading..."}
-        </Badge>
+        <Flex align="center" gap="2">
+          <Button
+            variant="ghost"
+            size="1"
+            onClick={() => useWhatsNewStore.getState().open()}
+          >
+            View changelog
+          </Button>
+          <Badge size="1" variant="soft" color="gray">
+            {appVersion || "Loading..."}
+          </Badge>
+        </Flex>
       </SettingRow>
 
       {updatesEnabled?.enabled ? (


### PR DESCRIPTION
## Problem

There was no way to view the release changelog from Settings. The "What's New" changelog (full release history) was only reachable from the project switcher menu, so a user looking at their current version in Settings → Updates had no path to see what changed.

## Changes

Added a **View changelog** button to the left of the current-version badge in Settings → Updates. It opens the existing `WhatsNewModal` (release history grouped by day/week, with "Latest" and "Current" badges marking the version you're on).

- Reuses the existing `useWhatsNewStore.getState().open()` pattern already used by `ProjectSwitcher`'s "View changelog" menu item, so behavior is consistent.
- The `WhatsNewModal` is already mounted on the settings route, so no extra wiring was needed.
- `Button` and `Flex` were already imported in `UpdatesSettings.tsx`; only the `useWhatsNewStore` import was added.

## How did you test this?

- `pnpm typecheck` (full monorepo, via the pre-commit hook) — passed
- `pnpm --filter @posthog/ui typecheck` — passed
- `biome check` on the changed file (via the pre-commit hook) — passed

No screenshot attached: this worktree can't launch the packaged Electron app, so I couldn't capture the running UI. The change is a small ghost-style **View changelog** button placed to the left of the existing current-version badge in Settings → Updates; clicking it opens the already-built What's New modal (release history grouped by day/week). No new modal or layout was introduced.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
