### PR TITLE
fix(agent): resolve stuck "Starting agent" step on agent-proxy leg

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1234,6 +1234,38 @@ describe("AgentServer HTTP Mode", () => {
         { timeout: 15000, interval: 100 },
       );
     }, 30000);
+
+    it("emits a completed _posthog/progress for the agent step after session initialization", async () => {
+      await createServer().start();
+
+      // Resolves the setup card's "agent" step on the agent-proxy read leg,
+      // where the orchestrator's Django-only progress event never arrives.
+      await vi.waitFor(
+        () => {
+          const allEntries = appendLogCalls.flat() as Array<{
+            notification?: {
+              method?: string;
+              params?: Record<string, unknown>;
+            };
+          }>;
+          const agentProgress = allEntries.find(
+            (e) =>
+              e?.notification?.method === "_posthog/progress" &&
+              e?.notification?.params?.step === "agent",
+          );
+          expect(agentProgress).toBeDefined();
+          expect(agentProgress?.notification?.params).toMatchObject({
+            group: "setup:test-run-id",
+            step: "agent",
+            status: "completed",
+          });
+          expect(typeof agentProgress?.notification?.params?.label).toBe(
+            "string",
+          );
+        },
+        { timeout: 15000, interval: 100 },
+      );
+    }, 30000);
   });
 
   describe("getInitialPromptOverride", () => {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1336,6 +1336,28 @@ export class AgentServer {
       JSON.stringify(runStartedNotification),
     );
 
+    // Mirror the "agent" setup step onto the ingest leg the client is reading;
+    // the orchestrator's completed progress only lands in Django.
+    const agentStartedProgress = {
+      jsonrpc: "2.0" as const,
+      method: POSTHOG_NOTIFICATIONS.PROGRESS,
+      params: {
+        group: `setup:${payload.run_id}`,
+        step: "agent",
+        status: "completed",
+        label: "Started agent",
+      },
+    };
+    this.broadcastEvent({
+      type: "notification",
+      timestamp: new Date().toISOString(),
+      notification: agentStartedProgress,
+    });
+    this.session.logWriter.appendRawLine(
+      payload.run_id,
+      JSON.stringify(agentStartedProgress),
+    );
+
     // Signal in_progress so the UI can start polling for updates
     this.posthogAPI
       .updateTaskRun(payload.task_id, payload.run_id, {


### PR DESCRIPTION
## Problem

With durable streaming (agent-proxy) on and the write-leg feature flag enabled, the setup checklist's "Starting agent" step spins forever even though the agent responds normally.

The setup progress steps (sandbox, clone, checkout, agent) are emitted by the orchestrator into Django. The agent's own events (`_posthog/run_started`, message chunks) go through the agent-proxy ingest. A client reading the live proxy stream only receives agent-ingested events, so it never sees the orchestrator's `_posthog/progress {step:"agent", status:"completed"}`. The three earlier steps render as done only because they were already Django-persisted when the client fetched its single bootstrap snapshot; the durable read leg never re-reads Django mid-run, so the later "agent" completion is invisible. `run_started` does arrive over the proxy (which is why responses stream and the gate at `buildConversationItems.ts` `syncProgressCard` is released), but there is no completed status to reveal, so the row stays on its present-tense in-progress label "Starting agent".

## Changes

`agent-server.ts` now emits its own `_posthog/progress {group:"setup:<runId>", step:"agent", status:"completed", label:"Started agent"}` right after `_posthog/run_started`, mirroring that notification's dual write (broadcast over the ingest path plus `logWriter.appendRawLine` for snapshot/resume replay). It rides the same leg as `run_started` (proxy or Django), so the proxy read leg finally receives the completion and the step resolves. On the Django leg it is an idempotent, last-write-wins duplicate of the orchestrator's event.

Note: the label is fixed to "Started agent" to match the existing convention. If the orchestrator uses a different completed label there may be a cosmetic last-writer-wins on the label text, but the step resolves either way. The full fix is to have the orchestrator ingest its lifecycle events into the proxy so the proxy stream mirrors the whole run stream; this PR is the in-repo unblock.

## How did you test this?

- Added a unit test in `agent-server.test.ts` asserting the agent emits the completed `_posthog/progress` for the "agent" step after session initialization.
- `pnpm --filter @posthog/agent test` -- 827 passing (77 in `agent-server.test.ts`).
- `pnpm --filter @posthog/agent typecheck` -- clean.
- `biome lint` on both touched files -- clean (one pre-existing unrelated warning at line 1304).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
