### PR TITLE
fix(cloud-task): recover queued messages after sandbox stops

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1372,6 +1372,109 @@ describe("AgentServer HTTP Mode", () => {
     });
   });
 
+  describe("resume prompt display", () => {
+    it("hides synthetic resume context while keeping the pending user message visible", async () => {
+      const s = createServer() as unknown as {
+        resumeState: ResumeState | null;
+        session: {
+          payload: JwtPayload;
+          acpSessionId: string;
+          clientConnection: {
+            prompt: ReturnType<typeof vi.fn>;
+          };
+          logWriter: {
+            resetTurnMessages: ReturnType<typeof vi.fn>;
+            appendRawLine: ReturnType<typeof vi.fn>;
+            flushAll: ReturnType<typeof vi.fn>;
+          };
+          sseController: null;
+          deviceInfo: { type: "cloud"; name: string };
+          permissionMode: PermissionMode;
+          hasDesktopConnected: boolean;
+        };
+        sendResumeMessage(
+          payload: JwtPayload,
+          taskRun: TaskRun | null,
+        ): Promise<void>;
+      };
+      const payload: JwtPayload = {
+        run_id: "test-run-id",
+        task_id: "test-task-id",
+        team_id: 1,
+        user_id: 1,
+        distinct_id: "test-distinct-id",
+        mode: "interactive",
+      };
+      const prompt = vi.fn(async () => ({ stopReason: "cancelled" }));
+      s.session = {
+        payload,
+        acpSessionId: "acp-session",
+        clientConnection: { prompt },
+        logWriter: {
+          resetTurnMessages: vi.fn(),
+          appendRawLine: vi.fn(),
+          flushAll: vi.fn(),
+        },
+        sseController: null,
+        deviceInfo: { type: "cloud", name: "test-sandbox" },
+        permissionMode: "bypassPermissions",
+        hasDesktopConnected: false,
+      };
+      s.resumeState = {
+        conversation: [
+          { role: "user", content: [{ type: "text", text: "old request" }] },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "old answer" }],
+          },
+        ],
+        latestGitCheckpoint: null,
+        interrupted: false,
+        logEntryCount: 2,
+        sessionId: "prior-session",
+      };
+
+      await s.sendResumeMessage(
+        payload,
+        createTaskRun({
+          id: "test-run-id",
+          task: "test-task-id",
+          state: {
+            pending_user_message: "visible follow-up",
+            pending_user_message_ts: "123.456",
+          },
+        }),
+      );
+
+      const [{ prompt: promptBlocks }] = prompt.mock.calls[0] as unknown as [
+        { prompt: ContentBlock[] },
+      ];
+      const visibleText = promptBlocks
+        .filter(
+          (block) =>
+            block.type === "text" &&
+            !(
+              (block as { _meta?: { ui?: { hidden?: boolean } } })._meta?.ui
+                ?.hidden === true
+            ),
+        )
+        .map((block) => (block as { text: string }).text);
+
+      expect(promptBlocks[0]).toMatchObject({
+        type: "text",
+        _meta: { ui: { hidden: true } },
+      });
+      expect((promptBlocks[0] as { text: string }).text).toContain(
+        "You are resuming a previous conversation",
+      );
+      expect(visibleText).toEqual(["visible follow-up"]);
+      expect(promptBlocks.at(-1)).toMatchObject({
+        type: "text",
+        _meta: { ui: { hidden: true } },
+      });
+    });
+  });
+
   describe("runtime adapter selection", () => {
     it("defaults to claude when no runtime adapter is configured", () => {
       const s = createServer();

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -250,6 +250,14 @@ interface BuiltPrompt {
   meta?: Record<string, unknown>;
 }
 
+function hiddenTextBlock(text: string): ContentBlock {
+  return {
+    type: "text",
+    text,
+    _meta: { ui: { hidden: true } },
+  } as ContentBlock;
+}
+
 interface LocalSkillPromptContext {
   skillName: string;
   context: string;
@@ -1571,39 +1579,34 @@ export class AgentServer {
 
       const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
 
-      const sandboxContext = checkpointApplied
+      const checkpointContext = checkpointApplied
         ? `The workspace environment (all files, packages, and code changes) has been fully restored from the latest checkpoint.`
-        : `The workspace from the previous session was not restored from a checkpoint, so you are starting with a fresh environment. Your conversation history is fully preserved below.`;
+        : `No additional git checkpoint was applied before resuming. Use the current workspace contents together with the preserved conversation history below.`;
 
       let resumePromptBlocks: ContentBlock[];
       let resumePromptMeta: Record<string, unknown> | undefined;
       if (pendingUserPrompt?.prompt.length) {
         resumePromptMeta = pendingUserPrompt.meta;
         resumePromptBlocks = [
-          {
-            type: "text",
-            text:
-              `You are resuming a previous conversation. ${sandboxContext}\n\n` +
+          hiddenTextBlock(
+            `You are resuming a previous conversation. ${checkpointContext}\n\n` +
               `Here is the conversation history from the previous session:\n\n` +
               `${conversationSummary}\n\n` +
               `The user has sent a new message:\n\n`,
-          },
+          ),
           ...pendingUserPrompt.prompt,
-          {
-            type: "text",
-            text: "\n\nRespond to the user's new message above. You have full context from the previous session.",
-          },
+          hiddenTextBlock(
+            "\n\nRespond to the user's new message above. You have full context from the previous session.",
+          ),
         ];
       } else {
         resumePromptBlocks = [
-          {
-            type: "text",
-            text:
-              `You are resuming a previous conversation. ${sandboxContext}\n\n` +
+          hiddenTextBlock(
+            `You are resuming a previous conversation. ${checkpointContext}\n\n` +
               `Here is the conversation history from the previous session:\n\n` +
               `${conversationSummary}\n\n` +
               `Continue from where you left off. The user is waiting for your response.`,
-          },
+          ),
         ];
       }
 

--- a/packages/core/src/cloud-task/cloud-task-types.ts
+++ b/packages/core/src/cloud-task/cloud-task-types.ts
@@ -18,6 +18,7 @@ export interface CloudTaskStatusUpdate extends CloudTaskUpdateBase {
   output?: Record<string, unknown> | null;
   errorMessage?: string | null;
   branch?: string | null;
+  sandboxAlive?: boolean | null;
 }
 
 export interface CloudTaskSnapshotUpdate extends CloudTaskUpdateBase {
@@ -29,6 +30,7 @@ export interface CloudTaskSnapshotUpdate extends CloudTaskUpdateBase {
   output?: Record<string, unknown> | null;
   errorMessage?: string | null;
   branch?: string | null;
+  sandboxAlive?: boolean | null;
 }
 
 export interface CloudTaskErrorUpdate extends CloudTaskUpdateBase {

--- a/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/packages/core/src/cloud-task/cloud-task.test.ts
@@ -340,6 +340,75 @@ describe("CloudTaskService", () => {
     );
   });
 
+  it("emits sandbox liveness from run detail when retrying a live watcher", async () => {
+    const updates: unknown[] = [];
+    service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));
+
+    mockNetFetch
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          state: { sandbox_alive: true },
+          error_message: null,
+          branch: "main",
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          state: { sandbox_alive: false },
+          error_message: null,
+          branch: "main",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      );
+
+    mockStreamFetch
+      .mockResolvedValueOnce(createOpenSseResponse(""))
+      .mockResolvedValueOnce(createOpenSseResponse(""));
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() =>
+      updates.some(
+        (update) =>
+          typeof update === "object" &&
+          update !== null &&
+          (update as { kind?: string; sandboxAlive?: boolean }).kind ===
+            "snapshot" &&
+          (update as { sandboxAlive?: boolean }).sandboxAlive === true,
+      ),
+    );
+
+    await service.retry("task-1", "run-1");
+
+    await waitFor(() =>
+      updates.some(
+        (update) =>
+          typeof update === "object" &&
+          update !== null &&
+          (update as { kind?: string; sandboxAlive?: boolean }).kind ===
+            "status" &&
+          (update as { sandboxAlive?: boolean }).sandboxAlive === false,
+      ),
+    );
+  });
+
   it("replays a current snapshot when a subscriber attaches to an existing watcher", async () => {
     const updates: unknown[] = [];
     service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -75,6 +75,7 @@ interface TaskRunResponse {
   status: TaskRunStatus;
   stage?: string | null;
   output?: Record<string, unknown> | null;
+  state?: Record<string, unknown> | null;
   error_message?: string | null;
   branch?: string | null;
   updated_at?: string;
@@ -86,6 +87,7 @@ interface TaskRunStateEvent {
   status?: TaskRunStatus;
   stage?: string | null;
   output?: Record<string, unknown> | null;
+  state?: Record<string, unknown> | null;
   error_message?: string | null;
   branch?: string | null;
   updated_at?: string | null;
@@ -122,6 +124,7 @@ interface WatcherState {
   lastOutput: Record<string, unknown> | null;
   lastErrorMessage: string | null;
   lastBranch: string | null;
+  lastSandboxAlive: boolean | null;
   lastStatusUpdatedAt: string | null;
   connStartedAt: number;
   connSentLastEventId: string | null;
@@ -303,6 +306,25 @@ function filterEntriesNotInFrequencyMap(
   });
 }
 
+function extractSandboxAlive(
+  state: Record<string, unknown> | null | undefined,
+): boolean | null | undefined {
+  if (!state || !Object.hasOwn(state, "sandbox_alive")) {
+    return undefined;
+  }
+
+  const sandboxAlive = state.sandbox_alive;
+  return typeof sandboxAlive === "boolean" ? sandboxAlive : null;
+}
+
+function sandboxAlivePayload(watcher: { lastSandboxAlive: boolean | null }): {
+  sandboxAlive?: boolean | null;
+} {
+  return watcher.lastSandboxAlive === null
+    ? {}
+    : { sandboxAlive: watcher.lastSandboxAlive };
+}
+
 @injectable()
 export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
   private watchers = new Map<string, WatcherState>();
@@ -355,7 +377,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     }
   }
 
-  retry(taskId: string, runId: string): void {
+  async retry(taskId: string, runId: string): Promise<void> {
     const key = watcherKey(taskId, runId);
     const watcher = this.watchers.get(key);
     if (!watcher) return;
@@ -521,6 +543,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       lastOutput: null,
       lastErrorMessage: null,
       lastBranch: null,
+      lastSandboxAlive: null,
       lastStatusUpdatedAt: null,
       connStartedAt: 0,
       connSentLastEventId: null,
@@ -629,6 +652,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
         output: watcher.lastOutput,
         errorMessage: watcher.lastErrorMessage,
         branch: watcher.lastBranch,
+        ...sandboxAlivePayload(watcher),
       });
       this.stopWatcher(key);
       return;
@@ -669,6 +693,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       output: watcher.lastOutput,
       errorMessage: watcher.lastErrorMessage,
       branch: watcher.lastBranch,
+      ...sandboxAlivePayload(watcher),
     });
 
     watcher.isBootstrapping = false;
@@ -718,6 +743,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       output: watcher.lastOutput,
       errorMessage: watcher.lastErrorMessage,
       branch: watcher.lastBranch,
+      ...sandboxAlivePayload(watcher),
     });
   }
 
@@ -1091,6 +1117,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
             output: watcher.lastOutput,
             errorMessage: watcher.lastErrorMessage,
             branch: watcher.lastBranch,
+            ...sandboxAlivePayload(watcher),
           });
         }
       }
@@ -1256,6 +1283,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       output: watcher.lastOutput,
       errorMessage: watcher.lastErrorMessage,
       branch: watcher.lastBranch,
+      ...sandboxAlivePayload(watcher),
     });
   }
 
@@ -1497,6 +1525,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
           | "status"
           | "stage"
           | "output"
+          | "state"
           | "error_message"
           | "branch"
           | "updated_at"
@@ -1517,19 +1546,24 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     const nextOutput = run.output ?? null;
     const nextErrorMessage = run.error_message ?? null;
     const nextBranch = run.branch ?? null;
+    const sandboxAlive = extractSandboxAlive(run.state);
+    const nextSandboxAlive =
+      sandboxAlive === undefined ? watcher.lastSandboxAlive : sandboxAlive;
 
     const changed =
       nextStatus !== watcher.lastStatus ||
       nextStage !== watcher.lastStage ||
       JSON.stringify(nextOutput) !== JSON.stringify(watcher.lastOutput) ||
       nextErrorMessage !== watcher.lastErrorMessage ||
-      nextBranch !== watcher.lastBranch;
+      nextBranch !== watcher.lastBranch ||
+      nextSandboxAlive !== watcher.lastSandboxAlive;
 
     watcher.lastStatus = nextStatus ?? null;
     watcher.lastStage = nextStage;
     watcher.lastOutput = nextOutput;
     watcher.lastErrorMessage = nextErrorMessage;
     watcher.lastBranch = nextBranch;
+    watcher.lastSandboxAlive = nextSandboxAlive;
     if (updatedAt) {
       watcher.lastStatusUpdatedAt = updatedAt;
     }

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2721,6 +2721,7 @@ export class SessionService {
       resumeFromEntryCount,
       undefined,
       initialReasoningEffort,
+      newRun.state,
     );
 
     this.d.queryClient.invalidateQueries({ queryKey: ["tasks"] });
@@ -3326,6 +3327,7 @@ export class SessionService {
     resumeFromEntryCount?: number,
     runStatus?: TaskRunStatus,
     initialReasoningEffort?: string,
+    runState?: Record<string, unknown>,
   ): () => void {
     const taskRunId = runId;
 
@@ -3467,6 +3469,7 @@ export class SessionService {
         logUrl,
         taskDescription,
         runStatus,
+        runState,
       );
     }
 
@@ -3552,14 +3555,17 @@ export class SessionService {
     logUrl?: string,
     taskDescription?: string,
     runStatus?: TaskRunStatus,
+    runState?: Record<string, unknown>,
   ): void {
     void (async () => {
       let rawEntries: StoredLogEntry[];
       let totalLineCount: number;
-      if (isTerminalStatus(runStatus)) {
-        // Terminal runs: fetch the full resume chain (matches the snapshot) so a
-        // resumed run isn't under-counted. In-progress runs use the single-run
-        // log so hydrate can't race the live stream and double the active turn.
+      const isResumeRun = Boolean(runState?.resume_from_run_id);
+      if (isTerminalStatus(runStatus) || isResumeRun) {
+        // Resume chains need the full history even while the leaf run is still
+        // active; otherwise a renderer restart hydrates only the final run.
+        // Non-resume in-progress runs keep using the single-run log so hydrate
+        // cannot race the live stream and double the active turn.
         const authStatus = await this.getAuthCredentialsStatus();
         if (authStatus.kind !== "ready") {
           return;
@@ -3614,6 +3620,7 @@ export class SessionService {
       if (hasUserPrompt) {
         // The real prompt has landed; the stash is no longer needed.
         this.initialCloudOptimisticPrompt.delete(taskId);
+        this.d.store.clearTailOptimisticItems(taskRunId);
       }
 
       if (rawEntries.length === 0) {
@@ -4151,6 +4158,7 @@ export class SessionService {
       undefined,
       task.latest_run?.status,
       initialReasoningEffort,
+      task.latest_run?.state,
     );
   }
 

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2494,7 +2494,10 @@ export class SessionService {
    * Skipping early lets the next trigger retry instead of re-queueing the
    * already-dequeued prompt back into the same queue.
    */
-  private async sendQueuedCloudMessages(taskId: string): Promise<void> {
+  private async sendQueuedCloudMessages(
+    taskId: string,
+    options?: { force?: boolean },
+  ): Promise<void> {
     if (this.dispatchingCloudQueues.has(taskId)) return;
 
     this.dispatchingCloudQueues.add(taskId);
@@ -2509,7 +2512,7 @@ export class SessionService {
       const canSendNow =
         isTerminal ||
         (session.cloudStatus === "in_progress" &&
-          session.status === "connected");
+          (session.status === "connected" || options?.force === true));
       if (!canSendNow || session.isPromptPending) return;
 
       // Draining while auth is still restoring would route through the restoring
@@ -4302,7 +4305,11 @@ export class SessionService {
    * state; `sendQueuedCloudMessages` is reentrancy-guarded so stacked
    * schedules from multiple triggers collapse to one.
    */
-  private scheduleCloudQueueFlush(taskId: string, reason: string): void {
+  private scheduleCloudQueueFlush(
+    taskId: string,
+    reason: string,
+    options?: { force?: boolean },
+  ): void {
     if (
       this.scheduledCloudQueueFlushes.has(taskId) ||
       this.dispatchingCloudQueues.has(taskId)
@@ -4313,7 +4320,7 @@ export class SessionService {
     this.scheduledCloudQueueFlushes.add(taskId);
     setTimeout(() => {
       this.scheduledCloudQueueFlushes.delete(taskId);
-      this.sendQueuedCloudMessages(taskId).catch((err) =>
+      this.sendQueuedCloudMessages(taskId, options).catch((err) =>
         this.d.log.error("cloud queue flush failed", {
           taskId,
           reason,
@@ -4339,7 +4346,10 @@ export class SessionService {
    * alive (`cloudStatus === "in_progress"`) and the agent provably idle
    * for THIS run (`isAgentIdleForRun`), recover readiness and drain.
    */
-  private tryRecoverIdleCloudQueue(taskRunId: string): void {
+  private tryRecoverIdleCloudQueue(
+    taskRunId: string,
+    options?: { serverSandboxAlive?: boolean | null },
+  ): void {
     const session = this.d.store.getSessions()[taskRunId];
     if (!session?.isCloud || session.messageQueue.length === 0) {
       return;
@@ -4357,6 +4367,8 @@ export class SessionService {
     const recoverableAfterTransportDrop =
       (session.status === "disconnected" || session.status === "error") &&
       !session.isPromptPending;
+    const serverReportsSandboxStopped =
+      options?.serverSandboxAlive === false && recoverableAfterTransportDrop;
 
     if (session.status !== "connected" && !recoverableAfterTransportDrop) {
       return;
@@ -4365,6 +4377,17 @@ export class SessionService {
     // A local prompt in flight means a queued follow-up would double-send.
     // The idle scan below is still the real safety check after reconnect.
     if (session.isPromptPending) {
+      return;
+    }
+
+    if (serverReportsSandboxStopped) {
+      this.d.log.info("Recovering cloud queue after sandbox stopped", {
+        taskId: session.taskId,
+        previousStatus: session.status,
+      });
+      this.scheduleCloudQueueFlush(session.taskId, "sandbox-stopped-recovery", {
+        force: true,
+      });
       return;
     }
 
@@ -4501,7 +4524,9 @@ export class SessionService {
       });
 
       if (update.status === "in_progress") {
-        this.tryRecoverIdleCloudQueue(taskRunId);
+        this.tryRecoverIdleCloudQueue(taskRunId, {
+          serverSandboxAlive: update.sandboxAlive,
+        });
       }
 
       if (isTerminalStatus(update.status)) {

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -148,6 +148,7 @@ export interface CloudTaskStatusUpdate extends CloudTaskUpdateBase {
   output?: Record<string, unknown> | null;
   errorMessage?: string | null;
   branch?: string | null;
+  sandboxAlive?: boolean | null;
 }
 
 export interface CloudTaskSnapshotUpdate extends CloudTaskUpdateBase {
@@ -159,6 +160,7 @@ export interface CloudTaskSnapshotUpdate extends CloudTaskUpdateBase {
   output?: Record<string, unknown> | null;
   errorMessage?: string | null;
   branch?: string | null;
+  sandboxAlive?: boolean | null;
 }
 
 export interface CloudTaskErrorUpdate extends CloudTaskUpdateBase {

--- a/packages/ui/src/features/sessions/sessionServiceHost.recovery.integration.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.recovery.integration.test.ts
@@ -513,6 +513,50 @@ describe("SessionService cloud queue recovery (real store, e2e)", () => {
     expect(drained?.messageQueue).toHaveLength(0);
   });
 
+  it("drains a stranded queue when the server reports the sandbox stopped", async () => {
+    const service = getSessionService();
+    service.watchCloudTask(
+      TASK_ID,
+      RUN_ID,
+      "https://api.anthropic.com",
+      123,
+      undefined,
+      "https://logs.example.com/run",
+    );
+    const onData = latestOnData();
+
+    const rawPrompt: ContentBlock = { type: "text", text: "lol" };
+    sessionStoreSetters.setSession(
+      makeBaseSession({
+        status: "disconnected",
+        messageQueue: [
+          { id: "q-1", content: "lol", rawPrompt: [rawPrompt], queuedAt: 1 },
+        ],
+      }),
+    );
+
+    onData({
+      kind: "status",
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      status: "in_progress",
+      sandboxAlive: false,
+    });
+
+    await vi.waitFor(() => {
+      expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: TASK_ID,
+          runId: RUN_ID,
+          method: "user_message",
+          params: expect.objectContaining({ content: "lol" }),
+        }),
+      );
+    });
+    const drained = useSessionStore.getState().sessions[RUN_ID];
+    expect(drained?.messageQueue).toHaveLength(0);
+  });
+
   it("does not drain while the agent is still booting (boot race protected)", async () => {
     const service = getSessionService();
     service.watchCloudTask(

--- a/packages/ui/src/features/sessions/sessionServiceHost.recovery.integration.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.recovery.integration.test.ts
@@ -513,49 +513,52 @@ describe("SessionService cloud queue recovery (real store, e2e)", () => {
     expect(drained?.messageQueue).toHaveLength(0);
   });
 
-  it("drains a stranded queue when the server reports the sandbox stopped", async () => {
-    const service = getSessionService();
-    service.watchCloudTask(
-      TASK_ID,
-      RUN_ID,
-      "https://api.anthropic.com",
-      123,
-      undefined,
-      "https://logs.example.com/run",
-    );
-    const onData = latestOnData();
+  it.each<AgentSession["status"]>(["disconnected", "error"])(
+    "drains a stranded queue when the server reports the sandbox stopped and the session is %s",
+    async (status) => {
+      const service = getSessionService();
+      service.watchCloudTask(
+        TASK_ID,
+        RUN_ID,
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run",
+      );
+      const onData = latestOnData();
 
-    const rawPrompt: ContentBlock = { type: "text", text: "lol" };
-    sessionStoreSetters.setSession(
-      makeBaseSession({
-        status: "disconnected",
-        messageQueue: [
-          { id: "q-1", content: "lol", rawPrompt: [rawPrompt], queuedAt: 1 },
-        ],
-      }),
-    );
-
-    onData({
-      kind: "status",
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      status: "in_progress",
-      sandboxAlive: false,
-    });
-
-    await vi.waitFor(() => {
-      expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          taskId: TASK_ID,
-          runId: RUN_ID,
-          method: "user_message",
-          params: expect.objectContaining({ content: "lol" }),
+      const rawPrompt: ContentBlock = { type: "text", text: "lol" };
+      sessionStoreSetters.setSession(
+        makeBaseSession({
+          status,
+          messageQueue: [
+            { id: "q-1", content: "lol", rawPrompt: [rawPrompt], queuedAt: 1 },
+          ],
         }),
       );
-    });
-    const drained = useSessionStore.getState().sessions[RUN_ID];
-    expect(drained?.messageQueue).toHaveLength(0);
-  });
+
+      onData({
+        kind: "status",
+        taskId: TASK_ID,
+        runId: RUN_ID,
+        status: "in_progress",
+        sandboxAlive: false,
+      });
+
+      await vi.waitFor(() => {
+        expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            taskId: TASK_ID,
+            runId: RUN_ID,
+            method: "user_message",
+            params: expect.objectContaining({ content: "lol" }),
+          }),
+        );
+      });
+      const drained = useSessionStore.getState().sessions[RUN_ID];
+      expect(drained?.messageQueue).toHaveLength(0);
+    },
+  );
 
   it("does not drain while the agent is still booting (boot race protected)", async () => {
     const service = getSessionService();

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -3167,6 +3167,110 @@ describe("SessionService", () => {
         mockSessionStoreSetters.appendOptimisticItem,
       ).not.toHaveBeenCalled();
     });
+
+    it("hydrates an in-progress resumed run from the full session-log chain", async () => {
+      const service = getSessionService();
+      const resumedSession = createMockSession({
+        taskRunId: "run-456",
+        taskId: "task-123",
+        status: "disconnected",
+        isCloud: true,
+        events: [],
+        optimisticItems: [
+          {
+            id: "optimistic-follow-up",
+            type: "user_message",
+            content: "continue",
+            timestamp: 1700000001,
+            pinToTop: false,
+          },
+        ],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        resumedSession,
+      );
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-456": resumedSession,
+      });
+      const chainedEntries = [
+        { timestamp: "2024-01-01T00:00:00Z", notification: {} },
+        { timestamp: "2024-01-01T00:01:00Z", notification: {} },
+      ];
+      mockAuthenticatedClient.getTaskRunSessionLogs.mockResolvedValue(
+        chainedEntries,
+      );
+      mockTrpcLogs.readLocalLogs.query.mockResolvedValue(
+        "leaf log should not be used",
+      );
+      mockTrpcLogs.fetchS3Logs.query.mockResolvedValue(
+        "leaf s3 log should not be used",
+      );
+
+      const priorPrompt = {
+        type: "acp_message" as const,
+        ts: 1700000000,
+        message: {
+          jsonrpc: "2.0" as const,
+          id: 1,
+          method: "session/prompt",
+          params: { prompt: [{ type: "text", text: "first request" }] },
+        },
+      };
+      const resumePrompt = {
+        type: "acp_message" as const,
+        ts: 1700000060,
+        message: {
+          jsonrpc: "2.0" as const,
+          id: 2,
+          method: "session/prompt",
+          params: { prompt: [{ type: "text", text: "continue" }] },
+        },
+      };
+      mockConvertStoredEntriesToEvents.mockReturnValueOnce([
+        priorPrompt,
+        resumePrompt,
+      ]);
+
+      service.watchCloudTask(
+        "task-123",
+        "run-456",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://logs.example.com/run-456",
+        undefined,
+        "claude",
+        undefined,
+        "first request",
+        undefined,
+        "in_progress",
+        undefined,
+        { resume_from_run_id: "run-123" },
+      );
+
+      await vi.waitFor(() => {
+        expect(
+          mockAuthenticatedClient.getTaskRunSessionLogs,
+        ).toHaveBeenCalledWith("task-123", "run-456", { limit: 100000 });
+      });
+      expect(mockConvertStoredEntriesToEvents).toHaveBeenCalledWith(
+        chainedEntries,
+      );
+      expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+        "run-456",
+        expect.objectContaining({
+          events: [priorPrompt, resumePrompt],
+          processedLineCount: chainedEntries.length,
+        }),
+      );
+      expect(
+        mockSessionStoreSetters.clearTailOptimisticItems,
+      ).toHaveBeenCalledWith("run-456");
+      expect(
+        mockSessionStoreSetters.appendOptimisticItem,
+      ).not.toHaveBeenCalled();
+    });
+
     it("ignores stale async starts when the same watcher is replaced", async () => {
       const service = getSessionService();
       let resolveFirstWatchStart!: () => void;


### PR DESCRIPTION
## Problem

Cloud task runs can remain `in_progress` after the backing sandbox has stopped. When the renderer is disconnected in that state, a follow-up message is queued behind the agent-ready guard, but no fresh `run_started` or `turn_complete` event arrives to drain it.

## Changes

- propagate task-run `state.sandbox_alive` through cloud task watcher status and snapshot updates
- refetch run detail during retry for already-hydrated watchers so reconnects surface the current sandbox liveness
- force-drain a stranded queued cloud message when the server reports the sandbox is stopped and the local session is disconnected or errored