### PR TITLE
Tidy custom notification sound settings layout

### DIFF
--- a/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -261,7 +261,11 @@ export function NotificationsSettings() {
 
       <SettingRow
         label="Custom sounds"
-        description="Sounds you recorded or imported. Rename or remove them here."
+        description={
+          customSounds.length > 0
+            ? "Sounds you recorded or imported. Rename or remove them here."
+            : "Record or import your own sound to play when an agent finishes a task or needs your input."
+        }
       >
         <Flex direction="column" gap="2" className="w-full max-w-[260px]">
           {customSounds.map((sound) => (

--- a/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -241,9 +241,10 @@ export function NotificationsSettings() {
             </Select.Content>
           </Select.Root>
           {completionSound !== "none" && (
-            <Button
+            <IconButton
               variant="soft"
               size="1"
+              aria-label="Test sound"
               onClick={() =>
                 playCompletionSound(
                   completionSound,
@@ -252,33 +253,36 @@ export function NotificationsSettings() {
                 )
               }
             >
-              Test
-            </Button>
+              <Play weight="fill" />
+            </IconButton>
           )}
-          <Button variant="soft" size="1" onClick={() => setAddSoundOpen(true)}>
+        </Flex>
+      </SettingRow>
+
+      <SettingRow
+        label="Custom sounds"
+        description="Sounds you recorded or imported. Rename or remove them here."
+      >
+        <Flex direction="column" gap="2" className="w-full max-w-[260px]">
+          {customSounds.map((sound) => (
+            <CustomSoundRow
+              key={sound.id}
+              sound={sound}
+              volume={completionVolume}
+              onRename={renameCustomSound}
+              onRemove={removeCustomSound}
+            />
+          ))}
+          <Button
+            variant="soft"
+            size="1"
+            className="self-start"
+            onClick={() => setAddSoundOpen(true)}
+          >
             <Plus /> Add
           </Button>
         </Flex>
       </SettingRow>
-
-      {customSounds.length > 0 && (
-        <SettingRow
-          label="Custom sounds"
-          description="Sounds you recorded or imported. Rename or remove them here."
-        >
-          <Flex direction="column" gap="2" className="w-full max-w-[260px]">
-            {customSounds.map((sound) => (
-              <CustomSoundRow
-                key={sound.id}
-                sound={sound}
-                volume={completionVolume}
-                onRename={renameCustomSound}
-                onRemove={removeCustomSound}
-              />
-            ))}
-          </Flex>
-        </SettingRow>
-      )}
 
       <AddCustomSoundDialog
         open={addSoundOpen}
@@ -355,16 +359,6 @@ function CustomSoundRow({
 
   return (
     <Flex align="center" gap="2">
-      <IconButton
-        variant="soft"
-        size="1"
-        aria-label={`Play ${sound.name}`}
-        onClick={() =>
-          playCompletionSound(`custom:${sound.id}`, volume, [sound])
-        }
-      >
-        <Play weight="fill" />
-      </IconButton>
       <TextField.Root
         key={sound.name}
         className="flex-1"
@@ -379,6 +373,16 @@ function CustomSoundRow({
       <Text color="gray" className="text-[12px] tabular-nums">
         {formatDurationSeconds(sound.durationMs)}
       </Text>
+      <IconButton
+        variant="soft"
+        size="1"
+        aria-label={`Play ${sound.name}`}
+        onClick={() =>
+          playCompletionSound(`custom:${sound.id}`, volume, [sound])
+        }
+      >
+        <Play weight="fill" />
+      </IconButton>
       <IconButton
         variant="ghost"
         color="gray"

--- a/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -17,6 +17,7 @@ import {
   useSettingsStore,
 } from "@posthog/ui/features/settings/settingsStore";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { formatDurationSeconds } from "@posthog/ui/utils/customSound";
@@ -241,20 +242,22 @@ export function NotificationsSettings() {
             </Select.Content>
           </Select.Root>
           {completionSound !== "none" && (
-            <IconButton
-              variant="soft"
-              size="1"
-              aria-label="Test sound"
-              onClick={() =>
-                playCompletionSound(
-                  completionSound,
-                  completionVolume,
-                  customSounds,
-                )
-              }
-            >
-              <Play weight="fill" />
-            </IconButton>
+            <Tooltip content="Test sound">
+              <IconButton
+                variant="soft"
+                size="1"
+                aria-label="Test sound"
+                onClick={() =>
+                  playCompletionSound(
+                    completionSound,
+                    completionVolume,
+                    customSounds,
+                  )
+                }
+              >
+                <Play weight="fill" />
+              </IconButton>
+            </Tooltip>
           )}
         </Flex>
       </SettingRow>
@@ -377,16 +380,18 @@ function CustomSoundRow({
       <Text color="gray" className="text-[12px] tabular-nums">
         {formatDurationSeconds(sound.durationMs)}
       </Text>
-      <IconButton
-        variant="soft"
-        size="1"
-        aria-label={`Play ${sound.name}`}
-        onClick={() =>
-          playCompletionSound(`custom:${sound.id}`, volume, [sound])
-        }
-      >
-        <Play weight="fill" />
-      </IconButton>
+      <Tooltip content={`Play ${sound.name}`}>
+        <IconButton
+          variant="soft"
+          size="1"
+          aria-label={`Play ${sound.name}`}
+          onClick={() =>
+            playCompletionSound(`custom:${sound.id}`, volume, [sound])
+          }
+        >
+          <Play weight="fill" />
+        </IconButton>
+      </Tooltip>
       <IconButton
         variant="ghost"
         color="gray"


### PR DESCRIPTION
## Problem

UI feedback on the new custom notification sounds section: the Add button sat next to the sound picker rather than with the custom sounds, the picker's "Test" control and the per-sound "Play" control looked different, and the Play button was to the left of each sound's name.

## Changes

- Move the **Add** button into the Custom sounds section as a new row below the list. The section now always renders, so adding a sound simply appends a row.
- Replace the **Test** text button next to the sound picker with a **Play** icon button, matching the custom sound rows.
- In each custom sound row, move the **Play** button to the right of the sound name.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck`
- `biome lint` on the changed file

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AP5NXF8D7/p1782896717789609?thread_ts=1782896717.789609&cid=C0AP5NXF8D7)*