### PR TITLE
feat(slack): send agent turn parts alongside joined text on /relay_message

### DIFF
--- a/packages/agent/src/posthog-api.ts
+++ b/packages/agent/src/posthog-api.ts
@@ -209,13 +209,21 @@ export class PostHogAPIClient {
     taskId: string,
     runId: string,
     text: string,
+    textParts?: string[],
   ): Promise<void> {
     const teamId = this.getTeamId();
+    // Send `text_parts` alongside the joined `text` so backends that understand
+    // the new schema can pick just the post-last-tool-use answer, while older
+    // backends still get the flat `text` field they already handle.
+    const body: { text: string; text_parts?: string[] } = { text };
+    if (textParts && textParts.length > 0) {
+      body.text_parts = textParts;
+    }
     await this.apiRequest<{ status: string }>(
       `/api/projects/${teamId}/tasks/${taskId}/runs/${runId}/relay_message/`,
       {
         method: "POST",
-        body: JSON.stringify({ text }),
+        body: JSON.stringify(body),
       },
     );
   }

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -3023,11 +3023,20 @@ ${signedCommitInstructions}
       return;
     }
 
+    // Ordered assistant text blocks (one per message between tool calls).
+    // The backend picks the last entry — the post-last-tool-use answer — so
+    // Slack no longer sees the "Let me check…" narration. `message` stays as
+    // the joined fallback for backends that don't understand `text_parts`.
+    const messageParts = this.session.logWriter.getAgentResponseParts(
+      payload.run_id,
+    );
+
     try {
       await this.posthogAPI.relayMessage(
         payload.task_id,
         payload.run_id,
         message,
+        messageParts,
       );
     } catch (error) {
       this.logger.debug("Failed to relay initial agent response to Slack", {

--- a/packages/agent/src/server/question-relay.test.ts
+++ b/packages/agent/src/server/question-relay.test.ts
@@ -471,6 +471,9 @@ describe("Question relay", () => {
         logWriter: {
           flush: vi.fn().mockResolvedValue(undefined),
           getFullAgentResponse: vi.fn().mockReturnValue("agent response"),
+          getAgentResponseParts: vi
+            .fn()
+            .mockReturnValue(["first part", "agent response"]),
           isRegistered: vi.fn().mockReturnValue(true),
         },
       };
@@ -482,6 +485,7 @@ describe("Question relay", () => {
         "test-task-id",
         "test-run-id",
         "agent response",
+        ["first part", "agent response"],
       );
     });
 

--- a/packages/agent/src/session-log-writer.test.ts
+++ b/packages/agent/src/session-log-writer.test.ts
@@ -343,6 +343,48 @@ describe("SessionLogWriter", () => {
       expect(response).toBe("first message\n\nsecond message");
     });
 
+    it("getAgentResponseParts returns each turn message as a separate entry", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_message_chunk", {
+          content: { type: "text", text: "I'll pull DAU." },
+        }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("tool_call", { toolCallId: "tc1" }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_message", {
+          content: { type: "text", text: "Here's your answer." },
+        }),
+      );
+
+      // getFullAgentResponse still joins for backends without text_parts support.
+      expect(logWriter.getFullAgentResponse(sessionId)).toBe(
+        "I'll pull DAU.\n\nHere's your answer.",
+      );
+      // getAgentResponseParts keeps the split — the Slack relay picks the last.
+      expect(logWriter.getAgentResponseParts(sessionId)).toEqual([
+        "I'll pull DAU.",
+        "Here's your answer.",
+      ]);
+    });
+
+    it("getAgentResponseParts returns undefined for an empty/unregistered turn", () => {
+      expect(
+        logWriter.getAgentResponseParts("never-registered"),
+      ).toBeUndefined();
+
+      const sessionId = "empty";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+      expect(logWriter.getAgentResponseParts(sessionId)).toBeUndefined();
+    });
+
     it("persisted log does not contain stale entries when chunks are superseded", async () => {
       const sessionId = "s1";
       logWriter.register(sessionId, { taskId: "t1", runId: sessionId });

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -328,6 +328,31 @@ export class SessionLogWriter {
     return session.currentTurnMessages.join("\n\n");
   }
 
+  /**
+   * Returns the ordered assistant text blocks for the current turn — one entry
+   * per message between tool calls. The last entry is the text after the final
+   * tool_use (the actual answer to the user).
+   *
+   * The Slack relay uses this so the backend can post only the last block
+   * instead of every interim "Let me check…" narration.
+   */
+  getAgentResponseParts(sessionId: string): string[] | undefined {
+    const session = this.sessions.get(sessionId);
+    if (!session || session.currentTurnMessages.length === 0) return undefined;
+
+    if (session.chunkBuffer) {
+      this.logger.warn(
+        "getAgentResponseParts called with non-empty chunk buffer",
+        {
+          sessionId,
+          bufferedLength: session.chunkBuffer.text.length,
+        },
+      );
+    }
+
+    return [...session.currentTurnMessages];
+  }
+
   resetTurnMessages(sessionId: string): void {
     const session = this.sessions.get(sessionId);
     if (session) {


### PR DESCRIPTION
## Problem

The Slack agent's initial reply posted the whole assistant turn including the "Let me pull DAU…" narration before each tool call. Slack should see only the final answer.

## Changes

`SessionLogWriter` already collects each assistant text block into `currentTurnMessages` before joining them at read time. Expose that raw list via `getAgentResponseParts()` and pipe it to the backend as `text_parts` alongside the existing joined `text` field.

The backend (PostHog/posthog#67297) posts the last non-empty `text_parts` entry when present, so only the post-last-tool-use text reaches Slack. `text` stays as the fallback for backends that don't understand `text_parts` both sides ship in either order.

Only the initial-reply site (`agent-server.ts`) sends `text_parts`; the Slack-question relay path is untouched (single formatted question, no interim narration to trim).

## How did you test this?

Automated only (agent, no manual testing claimed):

- `getAgentResponseParts` unit tests: returns each turn message as a separate entry; returns `undefined` for empty/unregistered sessions.
- Existing session-log-writer and posthog-api tests still pass.
- Tested locally

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Claude Opus 4.7 (1M context).