### PR TITLE
fix(tasks): keep worktree task and prompt when provisioning fails

### DIFF
--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -680,6 +680,9 @@ describe("TaskCreationSaga", () => {
     });
 
     expect(result.success).toBe(false);
+    // Local (non-worktree) mode is not the kept-on-failure path, so the task
+    // is rolled back as before.
+    expect(deleteTaskMock).toHaveBeenCalledWith("task-123");
     // Record step rollback drops the tracking row...
     expect(mockHost.deleteClaudeCliImportRecord).toHaveBeenCalledWith({
       importedSessionId: "imported-session-id",
@@ -689,6 +692,71 @@ describe("TaskCreationSaga", () => {
       repoPath: "/repo",
       importedSessionId: "imported-session-id",
     });
+  });
+
+  it("keeps the worktree task (and its prompt) when provisioning fails", async () => {
+    const createdTask = createTask();
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const deleteTaskMock = vi.fn().mockResolvedValue(undefined);
+    const onTaskReady = vi.fn();
+    mockHost.addFolder.mockResolvedValue({ id: "folder-1", path: "/repo" });
+    mockHost.detectRepo.mockResolvedValue(null);
+    mockHost.createWorkspace.mockRejectedValue(new Error("worktree boom"));
+
+    const saga = makeSaga(
+      { createTask: createTaskMock, deleteTask: deleteTaskMock },
+      { onTaskReady },
+    );
+
+    const result = await saga.run({
+      content: "Fix the login flow",
+      repoPath: "/repo",
+      workspaceMode: "worktree",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected worktree provisioning failure to be kept");
+    }
+    expect(result.data.task.id).toBe("task-123");
+    expect(result.data.workspace).toBeNull();
+    expect(result.data.provisioningError).toContain("worktree boom");
+    // The task (and its persisted prompt) survives for retry.
+    expect(deleteTaskMock).not.toHaveBeenCalled();
+    // Spinner is dismissed and no agent session starts without a worktree.
+    expect(mockHost.clearProvisioning).toHaveBeenCalledWith("task-123");
+    expect(sessionService.connectToTask).not.toHaveBeenCalled();
+    // The early onTaskReady already navigated onto the task.
+    expect(onTaskReady).toHaveBeenCalledTimes(1);
+    expect(onTaskReady.mock.calls[0][0].workspace).toBeNull();
+  });
+
+  it("still rolls back a worktree task when a later (non-provisioning) step fails", async () => {
+    const createdTask = createTask();
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const deleteTaskMock = vi.fn().mockResolvedValue(undefined);
+    mockHost.addFolder.mockResolvedValue({ id: "folder-1", path: "/repo" });
+    mockHost.detectRepo.mockResolvedValue(null);
+    mockHost.createWorkspace.mockResolvedValue({});
+    vi.mocked(sessionService.connectToTask).mockImplementationOnce(() => {
+      throw new Error("agent boom");
+    });
+
+    const saga = makeSaga({
+      createTask: createTaskMock,
+      deleteTask: deleteTaskMock,
+    });
+
+    const result = await saga.run({
+      content: "Fix the login flow",
+      repoPath: "/repo",
+      workspaceMode: "worktree",
+    });
+
+    expect(result.success).toBe(false);
+    // Only workspace_creation is protected; an agent_session failure rolls back.
+    expect(deleteTaskMock).toHaveBeenCalledWith("task-123");
+    expect(mockHost.deleteWorkspace).toHaveBeenCalled();
   });
 
   it("does not import a Claude CLI session for non-local workspace modes", async () => {

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -96,51 +96,68 @@ export class TaskCreationSaga extends Saga<
             this.resolveFolder(repoPath),
           );
 
-      const workspaceInfo = await this.step({
-        name: "workspace_creation",
-        execute: async () => {
-          return this.deps.host.createWorkspace({
-            taskId: task.id,
-            mainRepoPath: repoPath,
-            folderId: folder.id,
-            folderPath: repoPath,
-            mode: workspaceMode,
-            branch: branch ?? undefined,
-            allowRemoteBranchCheckout: input.allowRemoteBranchCheckout,
-            reuseExistingWorktree: input.reuseExistingWorktree,
-          });
-        },
-        rollback: async () => {
-          this.log.info("Rolling back: deleting workspace", {
-            taskId: task.id,
-          });
-          await this.deps.host.deleteWorkspace({
-            taskId: task.id,
-            mainRepoPath: repoPath,
-          });
-        },
-      });
+      try {
+        const workspaceInfo = await this.step({
+          name: "workspace_creation",
+          execute: async () => {
+            return this.deps.host.createWorkspace({
+              taskId: task.id,
+              mainRepoPath: repoPath,
+              folderId: folder.id,
+              folderPath: repoPath,
+              mode: workspaceMode,
+              branch: branch ?? undefined,
+              allowRemoteBranchCheckout: input.allowRemoteBranchCheckout,
+              reuseExistingWorktree: input.reuseExistingWorktree,
+            });
+          },
+          rollback: async () => {
+            this.log.info("Rolling back: deleting workspace", {
+              taskId: task.id,
+            });
+            await this.deps.host.deleteWorkspace({
+              taskId: task.id,
+              mainRepoPath: repoPath,
+            });
+          },
+        });
 
-      workspace = {
-        taskId: task.id,
-        folderId: folder.id,
-        folderPath: repoPath,
-        mode: workspaceMode,
-        worktreePath: workspaceInfo.worktree?.worktreePath ?? null,
-        worktreeName: workspaceInfo.worktree?.worktreeName ?? null,
-        branchName: workspaceInfo.worktree?.branchName ?? null,
-        baseBranch: workspaceInfo.worktree?.baseBranch ?? null,
-        linkedBranch: workspaceInfo.linkedBranch ?? null,
-        createdAt:
-          workspaceInfo.worktree?.createdAt ?? new Date().toISOString(),
-      };
+        workspace = {
+          taskId: task.id,
+          folderId: folder.id,
+          folderPath: repoPath,
+          mode: workspaceMode,
+          worktreePath: workspaceInfo.worktree?.worktreePath ?? null,
+          worktreeName: workspaceInfo.worktree?.worktreeName ?? null,
+          branchName: workspaceInfo.worktree?.branchName ?? null,
+          baseBranch: workspaceInfo.worktree?.baseBranch ?? null,
+          linkedBranch: workspaceInfo.linkedBranch ?? null,
+          createdAt:
+            workspaceInfo.worktree?.createdAt ?? new Date().toISOString(),
+        };
 
-      // Link after the workspace row exists, so the branch-mismatch prompt can
-      // compare the session's branch against the live checkout.
-      if (importedClaude) {
-        this.linkImportedSessionBranch(input, task.id);
-        workspace.linkedBranch =
-          input.importedClaudeSession?.branch ?? workspace.linkedBranch;
+        // Link after the workspace row exists, so the branch-mismatch prompt can
+        // compare the session's branch against the live checkout.
+        if (importedClaude) {
+          this.linkImportedSessionBranch(input, task.id);
+          workspace.linkedBranch =
+            input.importedClaudeSession?.branch ?? workspace.linkedBranch;
+        }
+      } catch (error) {
+        // For a fresh worktree task the prompt is already persisted as the task
+        // description and the UI has navigated onto the task. Rolling the saga
+        // back here would run task_creation's deleteTask and destroy that task,
+        // losing the prompt. Instead keep the task with no workspace (the shape
+        // openTask re-provisions from) so the user can retry setup on it.
+        if (!hasProvisioning) throw error;
+        const provisioningError =
+          error instanceof Error ? error.message : String(error);
+        this.log.error("Worktree provisioning failed; keeping task for retry", {
+          taskId: task.id,
+          error,
+        });
+        this.deps.host.clearProvisioning(task.id);
+        return { task, workspace: null, provisioningError };
       }
     } else if (workspaceMode === "cloud") {
       await this.step({

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -74,4 +74,11 @@ export interface TaskCreationInput {
 export interface TaskCreationOutput {
   task: Task;
   workspace: Workspace | null;
+  /**
+   * Set when worktree provisioning failed but the task was kept (not rolled
+   * back) so the user can retry setup on the existing task. The saga returns a
+   * partial success in this case; consumers surface the error and keep the user
+   * on the task rather than reopening the composer.
+   */
+  provisioningError?: string;
 }

--- a/packages/ui/src/features/navigation/taskBinderImpl.ts
+++ b/packages/ui/src/features/navigation/taskBinderImpl.ts
@@ -9,6 +9,7 @@ import type {
   EnsureWorkspaceResult,
   NavigationTaskBinder,
 } from "@posthog/ui/features/navigation/taskBinder";
+import { useProvisioningStore } from "@posthog/ui/features/provisioning/store";
 import { logger } from "@posthog/ui/shell/logger";
 
 const log = logger.scope("navigation-store");
@@ -44,6 +45,14 @@ export const navigationTaskBinder: NavigationTaskBinder = {
     task: Task,
   ): Promise<EnsureWorkspaceResult | undefined> {
     const repoKey = getTaskRepository(task) ?? undefined;
+
+    // A worktree task whose provisioning failed is kept with no workspace so
+    // the user can retry. Don't auto-create a workspace here — that path only
+    // makes a plain "local" checkout (below), silently downgrading the worktree.
+    // The task view's retry prompt re-runs setup in worktree mode instead.
+    if (useProvisioningStore.getState().errors[task.id]) {
+      return undefined;
+    }
 
     const workspaces = await hostClient().workspace.getAll.query();
     const existingWorkspace = workspaces?.[task.id] ?? null;

--- a/packages/ui/src/features/provisioning/store.test.ts
+++ b/packages/ui/src/features/provisioning/store.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useProvisioningStore } from "./store";
+
+describe("useProvisioningStore", () => {
+  beforeEach(() => {
+    useProvisioningStore.setState({
+      activeTasks: new Set(),
+      output: {},
+      errors: {},
+    });
+  });
+
+  it("records a provisioning failure and stops treating the task as active", () => {
+    const { setActive, setFailed } = useProvisioningStore.getState();
+    setActive("task-1");
+    setFailed("task-1", "worktree boom");
+
+    const state = useProvisioningStore.getState();
+    expect(state.errors["task-1"]).toBe("worktree boom");
+    expect(state.activeTasks.has("task-1")).toBe(false);
+  });
+
+  it("clears a stale error when the task provisions again", () => {
+    const { setFailed, setActive } = useProvisioningStore.getState();
+    setFailed("task-1", "worktree boom");
+    setActive("task-1");
+
+    expect(useProvisioningStore.getState().errors["task-1"]).toBeUndefined();
+  });
+
+  it("clear removes the error alongside active state and output", () => {
+    const { setFailed, appendChunk, clear } = useProvisioningStore.getState();
+    setFailed("task-1", "worktree boom");
+    appendChunk("task-1", "line");
+    clear("task-1");
+
+    const state = useProvisioningStore.getState();
+    expect(state.errors["task-1"]).toBeUndefined();
+    expect(state.output["task-1"]).toBeUndefined();
+  });
+});

--- a/packages/ui/src/features/provisioning/store.ts
+++ b/packages/ui/src/features/provisioning/store.ts
@@ -4,10 +4,12 @@ import { create } from "zustand";
 interface ProvisioningStoreState {
   activeTasks: Set<string>;
   output: Record<string, string[]>;
+  errors: Record<string, string>;
 }
 
 interface ProvisioningStoreActions {
   setActive: (taskId: string) => void;
+  setFailed: (taskId: string, message: string) => void;
   clear: (taskId: string) => void;
   isActive: (taskId: string) => boolean;
   appendChunk: (taskId: string, chunk: string) => void;
@@ -18,12 +20,24 @@ type ProvisioningStore = ProvisioningStoreState & ProvisioningStoreActions;
 export const useProvisioningStore = create<ProvisioningStore>()((set, get) => ({
   activeTasks: new Set(),
   output: {},
+  errors: {},
 
   setActive: (taskId) =>
     set((state) => {
       const next = new Set(state.activeTasks);
       next.add(taskId);
-      return { activeTasks: next };
+      const { [taskId]: _clearedError, ...errors } = state.errors;
+      return { activeTasks: next, errors };
+    }),
+
+  setFailed: (taskId, message) =>
+    set((state) => {
+      const next = new Set(state.activeTasks);
+      next.delete(taskId);
+      return {
+        activeTasks: next,
+        errors: { ...state.errors, [taskId]: message },
+      };
     }),
 
   clear: (taskId) =>
@@ -31,7 +45,8 @@ export const useProvisioningStore = create<ProvisioningStore>()((set, get) => ({
       const next = new Set(state.activeTasks);
       next.delete(taskId);
       const { [taskId]: _removed, ...output } = state.output;
-      return { activeTasks: next, output };
+      const { [taskId]: _clearedError, ...errors } = state.errors;
+      return { activeTasks: next, output, errors };
     }),
 
   isActive: (taskId) => get().activeTasks.has(taskId),

--- a/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
@@ -41,6 +41,8 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
   const { restoreTask, isRestoring } = useRestoreTask();
 
   const isProvisioning = useProvisioningStore((s) => s.activeTasks.has(taskId));
+  const provisioningError = useProvisioningStore((s) => s.errors[taskId]);
+  const clearProvisioning = useProvisioningStore((s) => s.clear);
 
   const { requestFocus } = useDraftStore((s) => s.actions);
 
@@ -93,12 +95,41 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
     requestFocus(taskId);
   }, [taskId, requestFocus]);
 
+  // Once a retry provisions a workspace, drop the stale provisioning error so
+  // the guard in ensureWorkspaceForTask stops firing and the retry prompt hides.
+  useEffect(() => {
+    if (repoPath && provisioningError) {
+      clearProvisioning(taskId);
+    }
+  }, [repoPath, provisioningError, taskId, clearProvisioning]);
+
   const handleRestoreWorktree = useCallback(async () => {
     await restoreTask(taskId);
   }, [taskId, restoreTask]);
 
   if (isProvisioning) {
     return <ProvisioningView taskId={taskId} />;
+  }
+
+  // Worktree provisioning failed but the task was kept. Offer to retry setup
+  // (worktree mode) on the existing task. Takes priority over the folder-picker
+  // branch below, whose !hasDirectoryMapping gate wouldn't fire here since the
+  // task's repo folder is already registered.
+  if (
+    provisioningError &&
+    !repoPath &&
+    !isCloud &&
+    !isSuspended &&
+    isWorkspaceLoaded &&
+    !isCreatingWorkspace
+  ) {
+    return (
+      <BackgroundWrapper>
+        <Box height="100%" width="100%">
+          <WorkspaceSetupPrompt taskId={taskId} task={task} />
+        </Box>
+      </BackgroundWrapper>
+    );
   }
 
   if (

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -39,6 +39,7 @@ import {
 import { useDraftStore } from "../../message-editor/draftStore";
 import { useTaskInputHistoryStore } from "../../message-editor/taskInputHistoryStore";
 import type { EditorHandle } from "../../message-editor/types";
+import { useProvisioningStore } from "../../provisioning/store";
 import { useSettingsStore } from "../../settings/settingsStore";
 import { useCreateTask } from "../../tasks/useTaskCrudMutations";
 import { useTasks } from "../../tasks/useTasks";
@@ -360,6 +361,19 @@ export function useTaskCreation({
           },
           { skipCloudUsagePreflight: true },
         );
+
+        if (result.success && result.data.provisioningError) {
+          // Worktree provisioning failed but the task (and its prompt) was kept
+          // so the user can retry setup on it. Stay on the task the onTaskReady
+          // callback already navigated to — don't reopen the composer — and
+          // flag the failure so the task view shows a retry prompt.
+          useProvisioningStore
+            .getState()
+            .setFailed(result.data.task.id, result.data.provisioningError);
+          toast.error(getErrorTitle("workspace_creation"), {
+            description: result.data.provisioningError,
+          });
+        }
 
         if (result.success) {
           setAdditionalDirectoriesOverride(null);


### PR DESCRIPTION
## Problem

When creating a new **worktree** task, the prompt is persisted (as the task `description`) *before* the worktree is set up — but `task_creation` and `workspace_creation` are both compensatable saga steps. A worktree-setup failure triggered the saga's reverse-order rollback, which ran `task_creation`'s `deleteTask` and **destroyed the task the user had already been navigated onto** (the UI navigates optimistically via the early `onTaskReady`). The prompt was lost and the user was dumped back to the composer.

## Fix

Catch the worktree `workspace_creation` failure locally and return a partial success `{ task, workspace: null, provisioningError }` instead of throwing. This keeps the task (and its persisted prompt), leaves `Saga` rollback semantics intact for every other path, and reuses the existing "task with no workspace is retryable" shape that `TaskService.openTask` already understands.

The UI then keeps the user on the persisted task and offers a **worktree** retry, guarding against the existing auto-downgrade in `ensureWorkspaceForTask` that would otherwise silently create a plain *local* checkout.

Scope is worktree-specific: cloud, plain-local, and reopen paths keep today's rollback behavior. A later non-provisioning failure on a worktree task (e.g. `agent_session`) still rolls back.

## Changes

- `packages/shared` — add `provisioningError?: string` to `TaskCreationOutput`.
- `packages/core/.../taskCreationSaga.ts` — wrap the worktree `workspace_creation` step in a try/catch gated on `hasProvisioning`; on failure clear the spinner and return partial success.
- `packages/ui/.../provisioning/store.ts` — add an `errors` map (`setFailed`; cleared by `clear`/`setActive`).
- `packages/ui/.../useTaskCreation.ts` — on success-with-`provisioningError`, flag the failure, toast it, and stay on the task (no composer reopen); draft still cleared so the prompt isn't duplicated.
- `packages/ui/.../taskBinderImpl.ts` — skip auto workspace creation when a provisioning error is pending (avoids the local-mode downgrade).
- `packages/ui/.../TaskLogsPanel.tsx` — add a retry branch rendering `WorkspaceSetupPrompt` (worktree mode) for a failed worktree task; clear the error once a workspace appears.

## Testing

- `packages/core` saga tests: 16 passed, incl. new "keeps the worktree task when provisioning fails" and "still rolls back on a later non-provisioning failure".
- New provisioning store test: 3 passed.
- `typecheck` clean for `@posthog/shared`, `@posthog/core`, `@posthog/ui`; Biome lint clean; zero `noRestrictedImports` in `packages/core`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*