### PR TITLE
fix(git): time out hung worktree-creation git processes

### DIFF
--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -347,7 +347,7 @@ describe("armProcessTimeout", () => {
     expect(timeout.timedOut()).toBe(true);
     expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
 
-    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(KILL_GRACE_MS);
     expect(proc.kill).toHaveBeenCalledWith("SIGKILL");
   });
 

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createGitClient } from "./client";
-import { armProcessTimeout, WorktreeManager } from "./worktree";
+import { armProcessTimeout, KILL_GRACE_MS, WorktreeManager } from "./worktree";
 
 async function initBareRemote(): Promise<string> {
   const dir = await mkdtemp(path.join(tmpdir(), "posthog-code-remote-"));

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -1,9 +1,9 @@
 import { mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createGitClient } from "./client";
-import { WorktreeManager } from "./worktree";
+import { armProcessTimeout, WorktreeManager } from "./worktree";
 
 async function initBareRemote(): Promise<string> {
   const dir = await mkdtemp(path.join(tmpdir(), "posthog-code-remote-"));
@@ -302,5 +302,66 @@ describe("WorktreeManager.createWorktreeForRemoteBranch", () => {
     await expect(
       manager.createWorktreeForRemoteBranch("contributor/pr"),
     ).rejects.toThrow(/Failed to fetch branch 'contributor\/pr'/);
+  });
+});
+
+describe("armProcessTimeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function fakeProc(): { kill: ReturnType<typeof vi.fn> } {
+    return { kill: vi.fn() };
+  }
+
+  it("does not kill the process before the timeout elapses", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const timeout = armProcessTimeout(proc as never, 1000);
+
+    vi.advanceTimersByTime(999);
+
+    expect(proc.kill).not.toHaveBeenCalled();
+    expect(timeout.timedOut()).toBe(false);
+    timeout.clear();
+  });
+
+  it("clear() before the timeout prevents any kill", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const timeout = armProcessTimeout(proc as never, 1000);
+
+    timeout.clear();
+    vi.advanceTimersByTime(10_000);
+
+    expect(proc.kill).not.toHaveBeenCalled();
+    expect(timeout.timedOut()).toBe(false);
+  });
+
+  it("SIGTERMs on timeout then escalates to SIGKILL after the grace period", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const timeout = armProcessTimeout(proc as never, 1000);
+
+    vi.advanceTimersByTime(1000);
+    expect(timeout.timedOut()).toBe(true);
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+
+    vi.advanceTimersByTime(5000);
+    expect(proc.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("clear() after the timeout cancels the pending SIGKILL", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const timeout = armProcessTimeout(proc as never, 1000);
+
+    vi.advanceTimersByTime(1000);
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+
+    timeout.clear();
+    vi.advanceTimersByTime(10_000);
+
+    expect(proc.kill).not.toHaveBeenCalledWith("SIGKILL");
   });
 });

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn } from "node:child_process";
+import { type ChildProcess, execFile, spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getCleanEnv, getGitOperationManager } from "./operation-manager";
@@ -29,6 +29,34 @@ export interface WorktreeConfig {
 }
 
 const WORKTREE_FOLDER_NAME = ".posthog-code";
+
+const WORKTREE_ADD_TIMEOUT_MS = 120_000;
+const POST_CHECKOUT_HOOK_TIMEOUT_MS = 300_000;
+const KILL_GRACE_MS = 5_000;
+
+export function armProcessTimeout(
+  proc: ChildProcess,
+  timeoutMs: number,
+): { timedOut: () => boolean; clear: () => void } {
+  let timedOut = false;
+  let hardKillTimer: NodeJS.Timeout | undefined;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill("SIGTERM");
+    hardKillTimer = setTimeout(() => proc.kill("SIGKILL"), KILL_GRACE_MS);
+    hardKillTimer.unref();
+  }, timeoutMs);
+  timer.unref();
+  return {
+    timedOut: () => timedOut,
+    clear: () => {
+      clearTimeout(timer);
+      if (hardKillTimer) {
+        clearTimeout(hardKillTimer);
+      }
+    },
+  };
+}
 
 export class WorktreeManager {
   private mainRepoPath: string;
@@ -435,8 +463,22 @@ export class WorktreeManager {
       proc.stdout.on("data", handleData);
       proc.stderr.on("data", handleData);
 
-      proc.on("error", (err) => reject(err));
+      const timeout = armProcessTimeout(proc, WORKTREE_ADD_TIMEOUT_MS);
+
+      proc.on("error", (err) => {
+        timeout.clear();
+        reject(err);
+      });
       proc.on("close", (code) => {
+        timeout.clear();
+        if (timeout.timedOut()) {
+          reject(
+            new Error(
+              `git worktree add timed out after ${WORKTREE_ADD_TIMEOUT_MS}ms`,
+            ),
+          );
+          return;
+        }
         if (code !== 0) {
           reject(
             new Error(
@@ -775,8 +817,22 @@ export async function runPostCheckoutHook(
 
     proc.stdout.on("data", handleData);
     proc.stderr.on("data", handleData);
-    proc.on("error", (err) => resolve({ path: hookPath, error: err.message }));
+
+    const timeout = armProcessTimeout(proc, POST_CHECKOUT_HOOK_TIMEOUT_MS);
+
+    proc.on("error", (err) => {
+      timeout.clear();
+      resolve({ path: hookPath, error: err.message });
+    });
     proc.on("close", (code) => {
+      timeout.clear();
+      if (timeout.timedOut()) {
+        resolve({
+          path: hookPath,
+          error: `post-checkout hook timed out after ${POST_CHECKOUT_HOOK_TIMEOUT_MS}ms`,
+        });
+        return;
+      }
       if (code !== 0) {
         resolve({
           path: hookPath,

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -32,7 +32,7 @@ const WORKTREE_FOLDER_NAME = ".posthog-code";
 
 const WORKTREE_ADD_TIMEOUT_MS = 120_000;
 const POST_CHECKOUT_HOOK_TIMEOUT_MS = 300_000;
-const KILL_GRACE_MS = 5_000;
+export const KILL_GRACE_MS = 5_000;
 
 export function armProcessTimeout(
   proc: ChildProcess,


### PR DESCRIPTION
Adds a 2 min timeout to `git worktree add` and 5 min timeout to the post-checkout hook.

On failure, the prompt is recovered with the changes made in #3053 

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*