### PR TITLE
fix(cloud-task): bundle a local skill tagged on the first message

### DIFF
--- a/packages/core/src/task-detail/taskCreationHost.ts
+++ b/packages/core/src/task-detail/taskCreationHost.ts
@@ -104,6 +104,14 @@ export interface ITaskCreationHost {
     prompt: string | ContentBlock[],
     filePaths?: string[],
   ): CloudPromptTransport;
+  /**
+   * Rewrite a leading local-skill slash command (e.g. `/my-skill args`) into a
+   * `<skill .../>` tag so its bundle is uploaded on the first cloud message.
+   * Returns the prompt unchanged when it isn't a local-skill invocation. The
+   * follow-up message path already does this; the initial-creation path must
+   * too, or a typed `/my-skill` reaches the sandbox with no bundle attached.
+   */
+  resolveLocalSkillCommandPrompt(prompt: string): Promise<string>;
   uploadRunAttachments(
     client: TaskCreationApiClient,
     taskId: string,

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -20,6 +20,7 @@ const mockHost = vi.hoisted(() => ({
   getEnvironment: vi.fn(),
   detectRepo: vi.fn(),
   getCloudPromptTransport: vi.fn(),
+  resolveLocalSkillCommandPrompt: vi.fn(async (prompt: string) => prompt),
   uploadRunAttachments: vi.fn(),
   setProvisioningActive: vi.fn(),
   clearProvisioning: vi.fn(),
@@ -413,6 +414,106 @@ describe("TaskCreationSaga", () => {
       onTaskReady.mock.invocationCallOrder[0],
     );
   });
+
+  it("resolves a typed local-skill slash command before building the cloud transport", async () => {
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+
+    const skillTag =
+      '<skill name="my-skill" source="user" path="/skills/my-skill" /> do it';
+    mockHost.resolveLocalSkillCommandPrompt.mockResolvedValue(skillTag);
+    mockHost.getCloudPromptTransport.mockReturnValue({
+      filePaths: [],
+      skillBundles: [
+        { name: "my-skill", source: "user", path: "/skills/my-skill" },
+      ],
+      messageText: "/my-skill do it",
+      promptText: "/my-skill do it",
+    });
+    mockHost.uploadRunAttachments.mockResolvedValue(["skill-artifact-1"]);
+
+    const saga = makeSaga({
+      createTask: createTaskMock,
+      createTaskRun: createTaskRunMock,
+      startTaskRun: startTaskRunMock,
+    });
+
+    const result = await saga.run({
+      content: "/my-skill do it",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockHost.resolveLocalSkillCommandPrompt).toHaveBeenCalledWith(
+      "/my-skill do it",
+    );
+    // The resolved tag (not the raw slash command) must reach the transport so
+    // the bundle is collected and uploaded on the first message.
+    expect(mockHost.getCloudPromptTransport).toHaveBeenCalledWith(
+      skillTag,
+      undefined,
+    );
+    expect(startTaskRunMock).toHaveBeenCalledWith("task-123", "run-123", {
+      pendingUserMessage: "/my-skill do it",
+      pendingUserArtifactIds: ["skill-artifact-1"],
+    });
+  });
+
+  it.each([
+    ["a plain-text prompt that isn't a slash command", "just do the thing"],
+    ["a slash command that isn't a local skill", "/good keep going"],
+  ])(
+    "passes %s through to the transport unchanged",
+    async (_label, content) => {
+      const createdTask = createTask();
+      const startedTask = createTask({ latest_run: createRun() });
+      const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+      const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+
+      // The host resolver is a no-op for non-local-skill prompts — it returns the
+      // original string unchanged (mirrors `resolveLocalSkillPrompt` yielding null
+      // and the host falling back to the prompt).
+      mockHost.resolveLocalSkillCommandPrompt.mockImplementation(
+        async (prompt: string) => prompt,
+      );
+      mockHost.getCloudPromptTransport.mockReturnValue({
+        filePaths: [],
+        skillBundles: [],
+        messageText: content,
+        promptText: content,
+      });
+      mockHost.uploadRunAttachments.mockResolvedValue([]);
+
+      const saga = makeSaga({
+        createTask: vi.fn().mockResolvedValue(createdTask),
+        createTaskRun: createTaskRunMock,
+        startTaskRun: startTaskRunMock,
+      });
+
+      const result = await saga.run({
+        content,
+        repository: "posthog/posthog",
+        workspaceMode: "cloud",
+        branch: "main",
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockHost.resolveLocalSkillCommandPrompt).toHaveBeenCalledWith(
+        content,
+      );
+      // Resolution is a no-op, so the original content (not a rewritten skill tag)
+      // reaches the transport and no bundle is collected.
+      expect(mockHost.getCloudPromptTransport).toHaveBeenCalledWith(
+        content,
+        undefined,
+      );
+    },
+  );
 
   it("uses the selected user GitHub integration for cloud task creation", async () => {
     const createdTask = createTask({

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -281,11 +281,21 @@ export class TaskCreationSaga extends Saga<
         execute: async () => {
           const prAuthorshipMode = input.cloudPrAuthorshipMode ?? "user";
 
+          // Resolve a typed local-skill slash command (`/my-skill …`) into a
+          // `<skill .../>` tag before building the transport, so the skill
+          // bundle is collected and uploaded with the very first cloud message.
+          // Without this a first-message `/my-skill` reaches the sandbox with no
+          // bundle and is rejected as an unknown command (only a follow-up,
+          // which already resolves, would work).
+          const resolvedContent = input.content
+            ? await this.deps.host.resolveLocalSkillCommandPrompt(input.content)
+            : input.content;
+
           const transport =
             (input.content || input.filePaths?.length) &&
             workspaceMode === "cloud"
               ? this.deps.host.getCloudPromptTransport(
-                  input.content ?? "",
+                  resolvedContent ?? "",
                   input.filePaths,
                 )
               : null;

--- a/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
+++ b/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
@@ -29,6 +29,7 @@ import { injectable } from "inversify";
 import { track } from "../../shell/analytics";
 import { getAuthenticatedClient } from "../auth/authClientImperative";
 import { assertCloudUsageAvailable } from "../billing/preflightCloudUsage";
+import { resolveLocalSkillPrompt } from "../message-editor/commands";
 import { DEFAULT_PANEL_IDS } from "../panels/panelConstants";
 import { usePanelLayoutStore } from "../panels/panelLayoutStore";
 import { useProvisioningStore } from "../provisioning/store";
@@ -144,6 +145,14 @@ export class TrpcTaskCreationHost implements ITaskCreationHost {
     filePaths?: string[],
   ): CloudPromptTransport {
     return getCloudPromptTransport(prompt, filePaths);
+  }
+
+  async resolveLocalSkillCommandPrompt(prompt: string): Promise<string> {
+    return (
+      (await resolveLocalSkillPrompt(prompt, () =>
+        hostClient().skills.list.query(),
+      )) ?? prompt
+    );
   }
 
   uploadRunAttachments(


### PR DESCRIPTION
## Problem

starting a cloud task whose first message is a local-skill slash command failed, the skill's bundle was never uploaded, so the sandbox had no such skill.
The initial task-creation path did not resolved a typed local-skill command into the skill tag

## Changes

resolve a leading local-skill slash command into a `<skill …/>` tag in the initial task-creation path, mirroring what the follow-up path already does