### PR TITLE
feat(inbox): stamp inbox_client=code on inbox analytics events

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -1286,3 +1286,25 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.CANVAS_PROMPT_SENT]: CanvasPromptSentProperties;
   [ANALYTICS_EVENTS.CONTEXT_ACTION]: ContextActionProperties;
 };
+
+/**
+ * The inbox event family. Every host stamps an `inbox_client` property (e.g.
+ * "code" on desktop, "mobile" on the mobile app, "cloud" on the PostHog web
+ * frontend) on exactly these events so the shared PostHog project can be sliced
+ * by surface. Mirrors posthog's `frontend/src/scenes/inbox/inboxAnalytics.ts`.
+ *
+ * Keep this in sync with the inbox entries in `EventPropertyMap` above.
+ */
+export const INBOX_ANALYTICS_EVENT_NAMES: ReadonlySet<string> = new Set([
+  ANALYTICS_EVENTS.INBOX_VIEWED,
+  ANALYTICS_EVENTS.INBOX_REPORT_OPENED,
+  ANALYTICS_EVENTS.INBOX_REPORT_CLOSED,
+  ANALYTICS_EVENTS.INBOX_REPORT_ACTION,
+  ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED,
+  ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED,
+]);
+
+/** True when `eventName` is an inbox event that should carry `inbox_client`. */
+export function isInboxAnalyticsEvent(eventName: string): boolean {
+  return INBOX_ANALYTICS_EVENT_NAMES.has(eventName);
+}

--- a/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
@@ -1,3 +1,4 @@
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockPosthog = {
@@ -124,6 +125,48 @@ describe("registerAppVersion", () => {
       team: "posthog-code",
       app_version: "1.2.3",
     });
+  });
+});
+
+describe("track", () => {
+  it("stamps inbox_client on inbox events", async () => {
+    const { initializePostHog, track } = await loadAnalytics();
+    initializePostHog();
+
+    track(ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED, {
+      source_product: "github",
+      is_first_connection: true,
+      via_setup_wizard: false,
+    });
+
+    expect(mockPosthog.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED,
+      expect.objectContaining({ inbox_client: "code" }),
+    );
+  });
+
+  it("does not stamp inbox_client on non-inbox events", async () => {
+    const { initializePostHog, track } = await loadAnalytics();
+    initializePostHog();
+
+    track(ANALYTICS_EVENTS.PROMPT_HISTORY_OPENED, { entry_count: 3 });
+
+    expect(mockPosthog.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.PROMPT_HISTORY_OPENED,
+      expect.not.objectContaining({ inbox_client: expect.anything() }),
+    );
+  });
+
+  it("does nothing before init", async () => {
+    const { track } = await loadAnalytics();
+
+    track(ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED, {
+      source_product: "github",
+      is_first_connection: true,
+      via_setup_wizard: false,
+    });
+
+    expect(mockPosthog.capture).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -3,9 +3,10 @@ import posthog from "posthog-js/dist/module.full.no-external";
 // The module.full.no-external bundle includes rrweb but not the initSessionRecording function
 // posthog-recorder (vs lazy-recorder) ensures recording is ready immediately
 import "posthog-js/dist/posthog-recorder";
-import type {
-  EventPropertyMap,
-  UserIdentifyProperties,
+import {
+  type EventPropertyMap,
+  isInboxAnalyticsEvent,
+  type UserIdentifyProperties,
 } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import type { FeatureFlags } from "@posthog/ui/features/feature-flags/identifiers";
@@ -17,6 +18,12 @@ import type {
 import { logger } from "@posthog/ui/shell/logger";
 
 const log = logger.scope("analytics");
+
+// Client discriminator stamped on every inbox analytics event so the shared
+// PostHog project can be sliced by surface (this desktop host = "code";
+// mobile sends "mobile"; the PostHog web frontend sends "cloud"). Mirrors
+// posthog's frontend/src/scenes/inbox/inboxAnalytics.ts.
+const INBOX_CLIENT = "code" as const;
 
 let isInitialized = false;
 
@@ -230,7 +237,13 @@ export function track<K extends keyof EventPropertyMap>(
     return;
   }
 
-  posthog.capture(eventName, args[0]);
+  // Stamp inbox events with the client discriminator. Spread first so a caller
+  // could override it, matching posthog's inboxAnalytics.ts (none do today).
+  const properties = isInboxAnalyticsEvent(eventName)
+    ? { inbox_client: INBOX_CLIENT, ...args[0] }
+    : args[0];
+
+  posthog.capture(eventName, properties);
 }
 
 /**


### PR DESCRIPTION
## Summary

We want every custom inbox analytics event from the desktop Code app to carry an `inbox_client=code` property, so the shared PostHog project (which also receives inbox events from the web frontend and mobile) can be sliced by surface.

This mirrors how `posthog` does it in `frontend/src/scenes/inbox/inboxAnalytics.ts`, which stamps an `inbox_client` discriminator (`'cloud'` there) on every inbox event via a **central helper** rather than per call site.

## What changed

- **`@posthog/shared`** — added `INBOX_ANALYTICS_EVENT_NAMES` (the inbox event family: *Inbox viewed / report opened / closed / action / scrolled* + *Signal source connected*) and an `isInboxAnalyticsEvent()` helper, kept next to `EventPropertyMap`.
- **`posthogAnalyticsImpl.ts`** — added `const INBOX_CLIENT = "code"` and stamp it at the single `track()` → `posthog.capture()` choke point for inbox events. Central injection means no call site can miss it and future inbox events are covered automatically. Spread order matches posthog's helper.
- **Tests** — cover that inbox events get `inbox_client: "code"`, non-inbox events don't, and nothing fires before init.

## Notes / follow-ups

- **Value `code` vs `desktop`:** posthog's `inboxAnalytics.ts` doc comment refers to the Code app's discriminator as `'desktop'`. This PR uses `code` per request. Each client sets its own string, so this only matters for how breakdowns read — happy to switch to `desktop` (and/or update the posthog comment) if we want the two repos to agree.
- **Mobile:** `apps/mobile` sends the same inbox event names through its own tracker and currently emits no `inbox_client`. Out of scope here; it would send `inbox_client="mobile"` via the same pattern if we want to slice it out too.

## Test plan

- [x] `pnpm --filter @posthog/shared typecheck` + `build`
- [x] `pnpm --filter @posthog/ui test` (1113 passing, incl. new cases)
- [x] Biome clean on changed files
- [x] Pre-commit `pnpm typecheck` passed