### PR TITLE
chore(code): put glm in cc behind flag

### DIFF
--- a/packages/shared/src/flags.ts
+++ b/packages/shared/src/flags.ts
@@ -8,3 +8,4 @@ export const DISCOVERY_RUN_FLAG = "posthog-code-discovery-run";
 // routes, channels and dashboards.
 export const PROJECT_BLUEBIRD_FLAG = "project-bluebird";
 export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";
+export const GLM_MODEL_FLAG = "posthog-code-glm-model";

--- a/packages/ui/src/features/sessions/components/ModelSelector.tsx
+++ b/packages/ui/src/features/sessions/components/ModelSelector.tsx
@@ -13,6 +13,9 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
+import { GLM_MODEL_FLAG } from "@posthog/shared";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { stripGlmModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
 import {
   flattenSelectOptions,
   useModelConfigOptionForTask,
@@ -34,7 +37,12 @@ export function ModelSelector({
 }: ModelSelectorProps) {
   const sessionService = useService<SessionService>(SESSION_SERVICE);
   const session = useSessionForTask(taskId);
-  const modelOption = useModelConfigOptionForTask(taskId);
+  const rawModelOption = useModelConfigOptionForTask(taskId);
+  const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
+  const modelOption =
+    glmEnabled || !rawModelOption
+      ? rawModelOption
+      : stripGlmModelOption(rawModelOption);
 
   const selectOption = modelOption?.type === "select" ? modelOption : undefined;
   const options = selectOption

--- a/packages/ui/src/features/sessions/modelOptionFilters.ts
+++ b/packages/ui/src/features/sessions/modelOptionFilters.ts
@@ -1,0 +1,27 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { isSelectGroup } from "@posthog/shared";
+
+export function stripGlmModelOption(
+  option: SessionConfigOption,
+): SessionConfigOption {
+  if (option.type !== "select") return option;
+
+  if (isSelectGroup(option.options)) {
+    return {
+      ...option,
+      options: option.options.map((group) => ({
+        ...group,
+        options: group.options.filter(
+          (o) => !o.value.toLowerCase().includes("glm"),
+        ),
+      })),
+    };
+  }
+
+  return {
+    ...option,
+    options: option.options.filter(
+      (o) => !o.value.toLowerCase().includes("glm"),
+    ),
+  };
+}

--- a/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -6,10 +6,12 @@ import {
   deriveInitialConfig,
 } from "@posthog/core/task-detail/previewConfig";
 import { useHostTRPCClient } from "@posthog/host-router/react";
-import { getCloudUrlFromRegion } from "@posthog/shared";
+import { GLM_MODEL_FLAG, getCloudUrlFromRegion } from "@posthog/shared";
+import { stripGlmModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { logger } from "../../../shell/logger";
 import { useAuthStateValue } from "../../auth/store";
+import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
 import { useSettingsStore } from "../../settings/settingsStore";
 
 const log = logger.scope("preview-config");
@@ -42,6 +44,7 @@ export function usePreviewConfig(
   adapter: "claude" | "codex",
 ): PreviewConfigResult {
   const hostClient = useHostTRPCClient();
+  const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const apiHost = useMemo(
     () => (cloudRegion ? getCloudUrlFromRegion(cloudRegion) : null),
@@ -74,8 +77,12 @@ export function usePreviewConfig(
 
     hostClient.agent.getPreviewConfigOptions
       .query({ apiHost, adapter }, { signal: abort.signal })
-      .then((options) => {
+      .then((serverOptions) => {
         if (abort.signal.aborted) return;
+
+        const options = glmEnabled
+          ? serverOptions
+          : serverOptions.map(stripGlmModelOption);
 
         const {
           defaultInitialTaskMode,
@@ -134,7 +141,7 @@ export function usePreviewConfig(
     return () => {
       abort.abort();
     };
-  }, [adapter, apiHost, hostClient, hasHydrated]);
+  }, [adapter, apiHost, hostClient, hasHydrated, glmEnabled]);
 
   const setConfigOption = useCallback(
     (configId: string, value: string) => {


### PR DESCRIPTION
## Problem

i don't think GLM as an available model in cc harness was intentional:

- i merged https://github.com/PostHog/posthog/pull/66532 to allowlist the model in phc, with the intent to expose it via opencode
- https://github.com/posthog/code/pull/2978 was merged to allow cc harness to run glm model, but seemingly with the intent for scout usage

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

puts glm-5.2 behind a feature flag [`posthog-code-glm-model`](https://us.posthog.com/project/2/feature_flags/740790) rolled out to team 2 only

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?