### PR TITLE
fix(cloud-task): attribute ai_generation task_user_id to task creator

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1090,7 +1090,7 @@ export class AgentServer {
       aiStage: getTaskRunStateString(preTaskRun, "ai_stage"),
       taskId: payload.task_id,
       taskRunId: payload.run_id,
-      taskUserId: payload.user_id,
+      taskUserId: payload.user_id || preTask?.created_by?.id || null,
       taskTitle: preTask?.title,
     });
 


### PR DESCRIPTION
## Problem

Cloud task runs mis-attribute their LLM analytics. Every `$ai_generation` event emitted during a cloud run is stamped with `task_user_id: 0` instead of the id of the user who created the task, so per-user attribution/cost for cloud runs is wrong