### PR TITLE
fix(archive): stop "Archive running task?" dialog firing on idle tasks

### DIFF
--- a/packages/core/src/sidebar/taskRunning.test.ts
+++ b/packages/core/src/sidebar/taskRunning.test.ts
@@ -1,0 +1,132 @@
+import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import type { TaskData } from "./sidebarData.types";
+import { isTaskActivelyRunning } from "./taskRunning";
+
+const task = (overrides: Partial<TaskData>): TaskData => ({
+  id: "t",
+  title: "t",
+  createdAt: 0,
+  lastActivityAt: 0,
+  isGenerating: false,
+  isUnread: false,
+  isPinned: false,
+  needsPermission: false,
+  repository: null,
+  isSuspended: false,
+  folderPath: null,
+  cloudPrUrl: null,
+  branchName: null,
+  linkedBranch: null,
+  ...overrides,
+});
+
+describe("isTaskActivelyRunning", () => {
+  it.each<{
+    name: string;
+    environment: "local" | "cloud" | undefined;
+    status: TaskRunStatus | undefined;
+    isGenerating: boolean;
+    expected: boolean;
+  }>([
+    // The regression: local runs stay "in_progress" forever, so this must NOT
+    // count as running or the warning fires on every local task ever run.
+    {
+      name: "stale local in_progress with no live prompt",
+      environment: "local",
+      status: "in_progress",
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "local run with a prompt in flight",
+      environment: "local",
+      status: "in_progress",
+      isGenerating: true,
+      expected: true,
+    },
+    {
+      name: "finished local run",
+      environment: "local",
+      status: "completed",
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "idle local task that never ran",
+      environment: "local",
+      status: undefined,
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "cloud run in progress",
+      environment: "cloud",
+      status: "in_progress",
+      isGenerating: false,
+      expected: true,
+    },
+    {
+      name: "queued cloud run (not yet running)",
+      environment: "cloud",
+      status: "queued",
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "completed cloud run",
+      environment: "cloud",
+      status: "completed",
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "failed cloud run",
+      environment: "cloud",
+      status: "failed",
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "cancelled cloud run",
+      environment: "cloud",
+      status: "cancelled",
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "cloud run generating",
+      environment: "cloud",
+      status: "in_progress",
+      isGenerating: true,
+      expected: true,
+    },
+    {
+      name: "unknown environment with stale in_progress status",
+      environment: undefined,
+      status: "in_progress",
+      isGenerating: false,
+      expected: false,
+    },
+    {
+      name: "generating before any run environment is recorded",
+      environment: undefined,
+      status: undefined,
+      isGenerating: true,
+      expected: true,
+    },
+  ])(
+    "$name -> $expected",
+    ({ environment, status, isGenerating, expected }) => {
+      expect(
+        isTaskActivelyRunning(
+          task({
+            taskRunEnvironment: environment,
+            taskRunStatus: status,
+            isGenerating,
+          }),
+        ),
+      ).toBe(expected);
+    },
+  );
+});

--- a/packages/core/src/sidebar/taskRunning.ts
+++ b/packages/core/src/sidebar/taskRunning.ts
@@ -1,0 +1,12 @@
+import type { TaskData } from "./sidebarData.types";
+
+// Drives the "Archive running task?" confirmation. Persisted run status is only
+// trustworthy for cloud runs; local runs stay "in_progress" forever (nothing
+// writes a terminal status when the agent goes idle), so a local run counts as
+// running only while a prompt is in flight (isGenerating).
+export function isTaskActivelyRunning(task: TaskData): boolean {
+  if (task.isGenerating) return true;
+  return (
+    task.taskRunEnvironment === "cloud" && task.taskRunStatus === "in_progress"
+  );
+}

--- a/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -1,3 +1,4 @@
+import { isTaskActivelyRunning } from "@posthog/core/sidebar/taskRunning";
 import { useHostTRPCClient } from "@posthog/host-router/react";
 import { Separator } from "@posthog/quill";
 import type { Task } from "@posthog/shared/types";
@@ -11,10 +12,7 @@ import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTa
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTaskSelectionStore } from "@posthog/ui/features/sidebar/taskSelectionStore";
 import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
-import {
-  type TaskData,
-  useSidebarData,
-} from "@posthog/ui/features/sidebar/useSidebarData";
+import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { useTaskContextMenu } from "@posthog/ui/features/tasks/useTaskContextMenu";
 import { useRenameTask } from "@posthog/ui/features/tasks/useTaskMutations";
@@ -39,10 +37,6 @@ import { TaskListView } from "./TaskListView";
 import { TasksHeader } from "./TasksHeader";
 
 const log = logger.scope("sidebar-menu");
-
-function isTaskActivelyRunning(task: TaskData): boolean {
-  return task.taskRunStatus === "in_progress" || task.isGenerating;
-}
 
 function SidebarMenuComponent() {
   const hostClient = useHostTRPCClient();


### PR DESCRIPTION
## Problem

The **"Archive running task?"** confirmation was popping up on nearly every archive, even for tasks that weren't running.

The guard in `SidebarMenu.tsx` was:

```ts
task.taskRunStatus === "in_progress" || task.isGenerating
```

where `taskRunStatus` falls back to `task.latest_run.status`. That persisted status is only kept current by the backend for **cloud** runs (it flips to `completed`/`failed`/`cancelled` when the sandbox finishes or crashes).

**Local runs never get a terminal status written back** — nothing PATCHes the run when the local agent goes idle or the app closes — so `latest_run.status` stays `"in_progress"` forever. Once there's no live session, the guard read that stale status and treated the task as running.

## Fix

Moved the predicate into core as a pure, tested helper (`packages/core/src/sidebar/taskRunning.ts`, mirroring `runEnvironment.ts`) and corrected the logic:

```ts
export function isTaskActivelyRunning(task: TaskData): boolean {
  if (task.isGenerating) return true;
  return task.taskRunEnvironment === "cloud" && task.taskRunStatus === "in_progress";
}
```

- **Local** tasks count as running only while a prompt is actually in flight (`isGenerating`); the stale persisted status is ignored.
- **Cloud** tasks keep the reliable, backend-tracked `in_progress` signal — behaviour unchanged.

This matches the existing session-based "running" logic in `canvasGenerationStatus.ts` and how `TaskIcon` already gates run-status semantics to cloud tasks.

## Testing

- New parameterised test `taskRunning.test.ts` (12 cases), including the exact regression: stale local `in_progress` with no live prompt → **not running**.
- `pnpm --filter @posthog/core test` → 185 files / 1859 tests pass.
- `typecheck` (core + ui) and `biome lint` clean.

## Note (out of scope)

The mobile guard (`apps/mobile/.../archiveGuard.ts`) uses raw `!isTerminalStatus(latest_run.status)`, which has the same latent flaw for local tasks — only sound today because mobile is cloud-only. Left untouched here.