### PR TITLE
fix(cloud-task): don't show file_unchanged read sentinel as sidebar content

### DIFF
--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -22,6 +22,7 @@ function toolCall(overrides: Partial<ParsedToolCall>): ParsedToolCall {
     status: overrides.status ?? "completed",
     locations: overrides.locations,
     content: overrides.content,
+    rawOutput: overrides.rawOutput,
   };
 }
 
@@ -189,6 +190,41 @@ describe("extractCloudFileContent", () => {
     );
     const result = extractCloudFileContent(calls, "src/app.ts");
     expect(result).toEqual({ content: "edited content", touched: true });
+  });
+
+  it("ignores a file_unchanged read so its dedup sentinel is not shown as content", () => {
+    const calls = makeToolCalls(
+      toolCall({
+        kind: "read",
+        locations: [{ path: "src/app.ts" }],
+        rawOutput: { type: "file_unchanged" },
+        content: textContent(
+          "```\nWasted call — file unchanged since your last Read. Refer to that earlier tool_result instead.\n```",
+        ),
+      }),
+    );
+    const result = extractCloudFileContent(calls, "src/app.ts");
+    expect(result).toEqual({ content: null, touched: false });
+  });
+
+  it("keeps real content when a later read of the same file is file_unchanged", () => {
+    const calls = makeToolCalls(
+      toolCall({
+        toolCallId: "tc-read",
+        kind: "read",
+        locations: [{ path: "src/app.ts" }],
+        content: textContent("real content"),
+      }),
+      toolCall({
+        toolCallId: "tc-reread",
+        kind: "read",
+        locations: [{ path: "src/app.ts" }],
+        rawOutput: { type: "file_unchanged" },
+        content: textContent("Wasted call — file unchanged since your last Read."),
+      }),
+    );
+    const result = extractCloudFileContent(calls, "src/app.ts");
+    expect(result).toEqual({ content: "real content", touched: true });
   });
 
   it("marks deleted files as touched with null content", () => {

--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -192,39 +192,57 @@ describe("extractCloudFileContent", () => {
     expect(result).toEqual({ content: "edited content", touched: true });
   });
 
-  it("ignores a file_unchanged read so its dedup sentinel is not shown as content", () => {
-    const calls = makeToolCalls(
-      toolCall({
-        kind: "read",
-        locations: [{ path: "src/app.ts" }],
-        rawOutput: { type: "file_unchanged" },
-        content: textContent(
-          "```\nWasted call — file unchanged since your last Read. Refer to that earlier tool_result instead.\n```",
-        ),
-      }),
-    );
-    const result = extractCloudFileContent(calls, "src/app.ts");
-    expect(result).toEqual({ content: null, touched: false });
-  });
+  // A file_unchanged read carries Claude Code's "Wasted call ..." dedup
+  // sentinel instead of the file body, so it must never be treated as content.
+  const fileUnchangedRead = (id: string): ParsedToolCall =>
+    toolCall({
+      toolCallId: id,
+      kind: "read",
+      locations: [{ path: "src/app.ts" }],
+      rawOutput: { type: "file_unchanged" },
+      content: textContent(
+        "```\nWasted call — file unchanged since your last Read. Refer to that earlier tool_result instead.\n```",
+      ),
+    });
 
-  it("keeps real content when a later read of the same file is file_unchanged", () => {
-    const calls = makeToolCalls(
-      toolCall({
-        toolCallId: "tc-read",
-        kind: "read",
-        locations: [{ path: "src/app.ts" }],
-        content: textContent("real content"),
-      }),
-      toolCall({
-        toolCallId: "tc-reread",
-        kind: "read",
-        locations: [{ path: "src/app.ts" }],
-        rawOutput: { type: "file_unchanged" },
-        content: textContent("Wasted call — file unchanged since your last Read."),
-      }),
+  it.each([
+    {
+      name: "read alone yields no content (dedup sentinel not shown)",
+      calls: [fileUnchangedRead("tc-unchanged")],
+      expected: { content: null, touched: false },
+    },
+    {
+      name: "read after a real read keeps the real content",
+      calls: [
+        toolCall({
+          toolCallId: "tc-read",
+          kind: "read",
+          locations: [{ path: "src/app.ts" }],
+          content: textContent("real content"),
+        }),
+        fileUnchangedRead("tc-unchanged"),
+      ],
+      expected: { content: "real content", touched: true },
+    },
+    {
+      name: "read after a write keeps the written content",
+      calls: [
+        toolCall({
+          toolCallId: "tc-write",
+          kind: "write",
+          locations: [{ path: "src/app.ts" }],
+          content: diffContent("src/app.ts", "written content"),
+        }),
+        fileUnchangedRead("tc-unchanged"),
+      ],
+      expected: { content: "written content", touched: true },
+    },
+  ])("file_unchanged $name", ({ calls, expected }) => {
+    const result = extractCloudFileContent(
+      makeToolCalls(...calls),
+      "src/app.ts",
     );
-    const result = extractCloudFileContent(calls, "src/app.ts");
-    expect(result).toEqual({ content: "real content", touched: true });
+    expect(result).toEqual(expected);
   });
 
   it("marks deleted files as touched with null content", () => {

--- a/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.ts
@@ -46,6 +46,23 @@ export interface ParsedToolCall {
   status?: string | null;
   locations?: ToolCallLocation[];
   content?: ToolCallContent[];
+  rawOutput?: unknown;
+}
+
+/**
+ * A Read whose file is unchanged since the agent's last read returns a
+ * `file_unchanged` result (Claude Code's "Wasted call — ... Refer to that
+ * earlier tool_result instead." sentinel) instead of the file body. Its
+ * `content` is that sentinel message, not the file, so it must not be treated
+ * as file content.
+ */
+function isFileUnchangedRead(toolCall: ParsedToolCall): boolean {
+  const raw = toolCall.rawOutput;
+  return (
+    typeof raw === "object" &&
+    raw !== null &&
+    (raw as { type?: unknown }).type === "file_unchanged"
+  );
 }
 
 // Match file paths that may differ in format (absolute vs relative)
@@ -87,6 +104,7 @@ function mergeToolCall(
       patch.content && patch.content.length > 0
         ? patch.content
         : existing?.content,
+    rawOutput: patch.rawOutput ?? existing?.rawOutput,
   };
 }
 
@@ -204,6 +222,7 @@ export function buildCloudEventSummary(
         content: Array.isArray(update.content)
           ? (update.content as ToolCallContent[])
           : undefined,
+        rawOutput: update.rawOutput,
       };
 
       const merged = mergeToolCall(toolCalls.get(toolCallId), patch);
@@ -329,6 +348,8 @@ export function extractCloudFileContent(
     const locationPath = toolCall.locations?.[0]?.path;
 
     if (kind === "read" && pathsMatch(locationPath, filePath)) {
+      // A `file_unchanged` read carries the dedup sentinel, not the file body.
+      if (isFileUnchangedRead(toolCall)) continue;
       const text = getReadToolContent(toolCall.content);
       if (text != null) {
         latestContent = text;


### PR DESCRIPTION
## Problem

In cloud tasks, opening a file the agent had created and read showed the wrong thing in the file sidebar, root cause: when the agent Reads a file that hasn't changed since its last read, claude returns a `file_unchanged` result whose `content` block is that "Wasted call…" sentinel, not the file body. The cloud file-panel reconstruction (`extractCloudFileContent`) treated any `read` tool call's content as the file body, so the sentinel became the displayed content and falsely flipped `touched` to true.

## Changes

`packages/core/src/task-detail/cloudToolChanges.ts`:
- capture each tool call's `rawOutput` in `ParsedToolCall` / `buildCloudEventSummary` / `mergeToolCall`
- in `extractCloudFileContent`, skip reads whose `rawOutput.type === "file_unchanged"` so the dedup sentinel is never treated as content or `touched`. A real prior read/edit's content is preserved
