### PR TITLE
feat(code): condense plan approval options

### DIFF
--- a/packages/ui/src/features/message-editor/components/ModeSelector.tsx
+++ b/packages/ui/src/features/message-editor/components/ModeSelector.tsx
@@ -1,14 +1,5 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
-import {
-  CaretDown,
-  Circle,
-  Eye,
-  LockOpen,
-  Pause,
-  Pencil,
-  Robot,
-  ShieldCheck,
-} from "@phosphor-icons/react";
+import { CaretDown } from "@phosphor-icons/react";
 import {
   Button,
   DropdownMenu,
@@ -18,54 +9,10 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
+import { getModeStyle } from "@posthog/ui/features/sessions/modeStyles";
 import { flattenSelectOptions } from "@posthog/ui/features/sessions/sessionStore";
 import { useRetainedConfigOption } from "@posthog/ui/features/sessions/useRetainedConfigOption";
 import { useRef, useState } from "react";
-
-interface ModeStyle {
-  icon: React.ReactNode;
-  className: string;
-}
-
-const MODE_STYLES: Record<string, ModeStyle> = {
-  plan: {
-    icon: <Pause size={12} weight="bold" />,
-    className: "text-amber-11",
-  },
-  default: {
-    icon: <Pencil size={12} />,
-    className: "text-gray-11",
-  },
-  acceptEdits: {
-    icon: <ShieldCheck size={12} weight="fill" />,
-    className: "text-green-11",
-  },
-  bypassPermissions: {
-    icon: <LockOpen size={12} weight="bold" />,
-    className: "text-red-11",
-  },
-  auto: {
-    icon: <Robot size={12} weight="fill" />,
-    className: "text-blue-11",
-  },
-  "read-only": {
-    icon: <Eye size={12} />,
-    className: "text-amber-11",
-  },
-  "full-access": {
-    icon: <LockOpen size={12} weight="bold" />,
-    className: "text-red-11",
-  },
-};
-
-const DEFAULT_STYLE: ModeStyle = {
-  icon: <Circle size={12} />,
-  className: "text-gray-11",
-};
-
-function getStyle(value: string): ModeStyle {
-  return MODE_STYLES[value] ?? DEFAULT_STYLE;
-}
 
 interface ModeSelectorProps {
   modeOption: SessionConfigOption | undefined;
@@ -102,7 +49,7 @@ export function ModeSelector({
   if (options.length === 0) return null;
 
   const currentValue = displayOption.currentValue;
-  const currentStyle = getStyle(currentValue);
+  const currentStyle = getModeStyle(currentValue);
   const currentLabel =
     allOptions.find((opt) => opt.value === currentValue)?.name ?? currentValue;
 
@@ -151,7 +98,7 @@ export function ModeSelector({
           }}
         >
           {options.map((option) => {
-            const style = getStyle(option.value);
+            const style = getModeStyle(option.value);
             return (
               <DropdownMenuRadioItem key={option.value} value={option.value}>
                 <span className={`${style.className}`}>{style.icon}</span>

--- a/packages/ui/src/features/permissions/PlanApprovalSelector.stories.tsx
+++ b/packages/ui/src/features/permissions/PlanApprovalSelector.stories.tsx
@@ -1,0 +1,60 @@
+import type { PermissionOption } from "@agentclientprotocol/sdk";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PlanApprovalSelector } from "./PlanApprovalSelector";
+import type { PermissionToolCall } from "./types";
+
+const toolCall = {
+  toolCallId: "plan-story",
+  title: "Approve this plan to proceed?",
+} as PermissionToolCall;
+
+const BYPASS: PermissionOption = {
+  kind: "allow_always",
+  name: "Yes, bypass all permissions",
+  optionId: "bypassPermissions",
+};
+const AUTO: PermissionOption = {
+  kind: "allow_always",
+  name: 'Yes, and use "auto" mode',
+  optionId: "auto",
+};
+const ACCEPT_EDITS: PermissionOption = {
+  kind: "allow_always",
+  name: "Yes, and auto-accept edits",
+  optionId: "acceptEdits",
+};
+const DEFAULT_MODE: PermissionOption = {
+  kind: "allow_once",
+  name: "Yes, and manually approve edits",
+  optionId: "default",
+};
+const REJECT: PermissionOption = {
+  kind: "reject_once",
+  name: "No, and tell the agent what to do differently",
+  optionId: "reject_with_feedback",
+  _meta: { customInput: true },
+};
+
+const meta: Meta<typeof PlanApprovalSelector> = {
+  title: "Components/Permissions/PlanApprovalSelector",
+  component: PlanApprovalSelector,
+  parameters: { layout: "padded" },
+  args: { toolCall },
+  argTypes: {
+    onSelect: { action: "selected" },
+    onCancel: { action: "cancelled" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlanApprovalSelector>;
+
+// Non-root / non-sandbox: bypass is not offered. Default is "manually approve".
+export const Default: Story = {
+  args: { options: [AUTO, ACCEPT_EDITS, DEFAULT_MODE, REJECT] },
+};
+
+// Sandbox / root: bypass is offered but still not the default.
+export const WithBypass: Story = {
+  args: { options: [BYPASS, AUTO, ACCEPT_EDITS, DEFAULT_MODE, REJECT] },
+};

--- a/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
+++ b/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
@@ -1,0 +1,133 @@
+import type { PermissionOption } from "@agentclientprotocol/sdk";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlanApprovalSelector } from "./PlanApprovalSelector";
+import type { PermissionToolCall } from "./types";
+
+const AUTO: PermissionOption = {
+  kind: "allow_always",
+  name: 'Yes, and use "auto" mode',
+  optionId: "auto",
+};
+const ACCEPT_EDITS: PermissionOption = {
+  kind: "allow_always",
+  name: "Yes, and auto-accept edits",
+  optionId: "acceptEdits",
+};
+const DEFAULT_MODE: PermissionOption = {
+  kind: "allow_once",
+  name: "Yes, and manually approve edits",
+  optionId: "default",
+};
+const REJECT: PermissionOption = {
+  kind: "reject_once",
+  name: "No, and tell the agent what to do differently",
+  optionId: "reject_with_feedback",
+  _meta: { customInput: true },
+};
+
+const toolCall = {
+  toolCallId: "plan-1",
+  title: "Approve this plan to proceed?",
+} as PermissionToolCall;
+
+function renderSelector(options: PermissionOption[]) {
+  const onSelect = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <Theme>
+      <PlanApprovalSelector
+        toolCall={toolCall}
+        options={options}
+        onSelect={onSelect}
+        onCancel={onCancel}
+      />
+    </Theme>,
+  );
+  return { onSelect, onCancel };
+}
+
+describe("PlanApprovalSelector", () => {
+  beforeEach(() => {
+    // Reset the remembered choice so tests don't leak through persistence.
+    useSettingsStore.setState({ lastPlanApprovalMode: null });
+  });
+
+  it.each([
+    {
+      label: "there is no prior or remembered mode",
+      lastMode: null,
+      options: [AUTO, ACCEPT_EDITS, DEFAULT_MODE, REJECT],
+      expected: "auto",
+    },
+    {
+      label: "a last choice is remembered",
+      lastMode: "acceptEdits",
+      options: [AUTO, ACCEPT_EDITS, DEFAULT_MODE],
+      expected: "acceptEdits",
+    },
+  ] as const)(
+    "defaults to $expected when $label",
+    async ({ lastMode, options, expected }) => {
+      const user = userEvent.setup();
+      useSettingsStore.setState({ lastPlanApprovalMode: lastMode });
+      const { onSelect } = renderSelector([...options]);
+
+      await user.click(screen.getByText("Approve and proceed"));
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onSelect).toHaveBeenCalledWith(expected);
+    },
+  );
+
+  it("remembers the chosen mode on approve", async () => {
+    const user = userEvent.setup();
+    renderSelector([AUTO, ACCEPT_EDITS, DEFAULT_MODE, REJECT]);
+
+    await user.click(screen.getByText("Approve and proceed"));
+
+    expect(useSettingsStore.getState().lastPlanApprovalMode).toBe("auto");
+  });
+
+  it("rejects with the typed feedback", async () => {
+    const user = userEvent.setup();
+    const { onSelect } = renderSelector([DEFAULT_MODE, REJECT]);
+
+    // Selecting the reject row activates its inline textarea (as before).
+    await user.click(screen.getByText("2."));
+    await user.type(
+      screen.getByPlaceholderText(/tell the agent what to do differently/i),
+      "please use hooks{Enter}",
+    );
+
+    expect(onSelect).toHaveBeenCalledWith(
+      "reject_with_feedback",
+      "please use hooks",
+    );
+  });
+
+  it("does not reject on empty feedback (Enter is a no-op, exactly as before)", async () => {
+    const user = userEvent.setup();
+    const { onSelect } = renderSelector([DEFAULT_MODE, REJECT]);
+
+    await user.click(screen.getByText("2."));
+    await user.type(
+      screen.getByPlaceholderText(/tell the agent what to do differently/i),
+      "{Enter}",
+    );
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("cancels on Escape", async () => {
+    const user = userEvent.setup();
+    const { onCancel } = renderSelector([DEFAULT_MODE, REJECT]);
+
+    await user.keyboard("{Escape}");
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
+++ b/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
@@ -1,0 +1,335 @@
+import type {
+  PermissionOption,
+  SessionConfigOption,
+} from "@agentclientprotocol/sdk";
+import type { ExecutionMode } from "@posthog/shared";
+import { ModeSelector } from "@posthog/ui/features/message-editor/components/ModeSelector";
+import { MODE_LABELS } from "@posthog/ui/features/sessions/modeStyles";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import {
+  ActionSelector,
+  InlineEditableText,
+} from "@posthog/ui/primitives/ActionSelector";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { type BasePermissionProps, toSelectorOptions } from "./types";
+
+const TITLE = "Implementation Plan";
+const QUESTION = "Approve this plan to proceed?";
+
+function isApprove(option: PermissionOption): boolean {
+  return option.kind === "allow_once" || option.kind === "allow_always";
+}
+
+function isReject(option: PermissionOption): boolean {
+  return option.kind === "reject_once" || option.kind === "reject_always";
+}
+
+function hasCustomInput(option: PermissionOption): boolean {
+  return (
+    (option._meta as { customInput?: boolean } | null | undefined)
+      ?.customInput === true
+  );
+}
+
+// Don't steal focus from an interactive element in a different grid cell
+// (multi-task view). Mirrors the guard in useActionSelectorState.
+function isInteractiveElementInDifferentCell(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+): boolean {
+  const el = document.activeElement;
+  if (!(el instanceof HTMLElement)) return false;
+  const isInteractive =
+    el.tagName === "INPUT" ||
+    el.tagName === "TEXTAREA" ||
+    el.tagName === "SELECT" ||
+    el.getAttribute("contenteditable") === "true";
+  if (!isInteractive) return false;
+  const activeCell = el.closest("[data-grid-cell]");
+  const ownCell = containerRef.current?.closest("[data-grid-cell]");
+  if (!activeCell || !ownCell) return true;
+  return activeCell !== ownCell;
+}
+
+/**
+ * Plan-approval selector: keeps the original stacked-list shape — an "Approve"
+ * line on top and the inline reject-with-feedback line below — but collapses
+ * the per-mode "Yes, and…" rows into the shared prompt-input `ModeSelector`
+ * dropdown beside the Approve line. Everything is derived from the permission
+ * `options` and reported through `onSelect`/`onCancel`, so there is no backend
+ * contract change: approve → `onSelect(<modeOptionId>)`, reject →
+ * `onSelect(<rejectOptionId>, feedback)`.
+ */
+export function PlanApprovalSelector({
+  options,
+  onSelect,
+  onCancel,
+}: BasePermissionProps) {
+  const approveOptions = useMemo(() => options.filter(isApprove), [options]);
+  const rejectOption = useMemo(
+    () =>
+      options.find((o) => isReject(o) && hasCustomInput(o)) ??
+      options.find(isReject),
+    [options],
+  );
+
+  const lastApprovalMode = useSettingsStore((s) => s.lastPlanApprovalMode);
+  const setLastApprovalMode = useSettingsStore(
+    (s) => s.setLastPlanApprovalMode,
+  );
+
+  // Resolution order: the mode last approved with (remembered preference),
+  // then "auto", then manual-approve, then any single-use mode, then the first.
+  const initialMode = useMemo(() => {
+    const has = (id: string) => approveOptions.some((o) => o.optionId === id);
+    return (
+      (lastApprovalMode && has(lastApprovalMode)
+        ? lastApprovalMode
+        : undefined) ??
+      (has("auto") ? "auto" : undefined) ??
+      approveOptions.find((o) => o.optionId === "default")?.optionId ??
+      approveOptions.find((o) => o.kind === "allow_once")?.optionId ??
+      approveOptions[0]?.optionId
+    );
+  }, [approveOptions, lastApprovalMode]);
+
+  const [selectedMode, setSelectedMode] = useState(initialMode);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const rejectIndex = rejectOption ? 1 : -1;
+  const rowCount = rejectOption ? 2 : 1;
+  // The reject row is the inline feedback textarea, so "on the reject row" and
+  // "editing feedback" are the same state — derive it, don't duplicate it.
+  const rejectSelected = selectedIndex === rejectIndex;
+
+  // A `SessionConfigOption` shaped for the shared `ModeSelector` — reusing that
+  // component (rather than a bespoke dropdown) keeps styling/theming identical
+  // to the prompt-input mode selector. The backend already gates which modes
+  // appear, so bypass filtering isn't reapplied here.
+  const modeConfigOption = useMemo<SessionConfigOption>(
+    () => ({
+      type: "select",
+      id: "plan-approval-mode",
+      name: "Mode",
+      category: "mode",
+      currentValue: selectedMode ?? "",
+      options: approveOptions.map((o) => ({
+        value: o.optionId,
+        name: MODE_LABELS[o.optionId] ?? o.name,
+      })),
+    }),
+    [selectedMode, approveOptions],
+  );
+
+  // Focus the action row on mount so keyboard nav works immediately, unless a
+  // different grid cell (multi-task view) already owns focus. Selection-driven
+  // focus is handled inline in `selectRow`, not via a state-syncing effect.
+  useEffect(() => {
+    if (!isInteractiveElementInDifferentCell(containerRef)) {
+      containerRef.current?.focus();
+    }
+  }, []);
+
+  // Move selection and manage focus together (no state-syncing effect): the
+  // approve row focuses the container for keyboard nav; the reject row's
+  // textarea focuses itself via its `active` prop.
+  const selectRow = (index: number) => {
+    setHoveredIndex(null);
+    setSelectedIndex(index);
+    if (index !== rejectIndex) containerRef.current?.focus();
+  };
+
+  const approve = () => {
+    if (!selectedMode) return;
+    // Remember this choice so the next plan approval pre-selects it.
+    setLastApprovalMode(selectedMode as ExecutionMode);
+    onSelect(selectedMode);
+  };
+
+  const submitReject = () => {
+    const text = feedback.trim();
+    // Exactly as before: reject requires feedback text; empty Enter is a no-op
+    // (use Esc to dismiss the request without feedback).
+    if (!rejectOption || !text) return;
+    onSelect(rejectOption.optionId, text);
+  };
+
+  const moveSelection = (delta: number) => {
+    selectRow((selectedIndex + delta + rowCount) % rowCount);
+  };
+
+  const handleContainerKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // The reject textarea owns the keyboard while it's the selected row.
+    if (rejectSelected) return;
+    switch (e.key) {
+      case "ArrowUp":
+        e.preventDefault();
+        moveSelection(-1);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        moveSelection(1);
+        break;
+      case "Enter":
+        e.preventDefault();
+        approve();
+        break;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel();
+        break;
+      default:
+        if (/^[1-9]$/.test(e.key) && !e.metaKey && !e.ctrlKey) {
+          const idx = Number.parseInt(e.key, 10) - 1;
+          if (idx < rowCount) {
+            e.preventDefault();
+            if (idx === 0) approve();
+            else selectRow(idx);
+          }
+        }
+    }
+  };
+
+  // Degenerate case (a plan always has approve options): fall back to the
+  // generic list so the request stays actionable.
+  if (!selectedMode) {
+    return (
+      <ActionSelector
+        title={TITLE}
+        question={QUESTION}
+        options={toSelectorOptions(options)}
+        onSelect={onSelect}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  const rowClass = (index: number) => {
+    const bg =
+      selectedIndex === index
+        ? "bg-primary/10"
+        : hoveredIndex === index
+          ? "bg-fill-hover"
+          : "bg-transparent";
+    return `-mx-3 cursor-pointer select-none rounded-(--radius-2) pt-[4px] pr-3 pb-[4px] pl-3 ${bg}`;
+  };
+
+  const caret = (index: number) => (
+    <Text
+      className={`w-[1ch] shrink-0 text-[13px] leading-4 ${selectedIndex === index ? "text-primary" : "text-gray-11"}`}
+    >
+      {selectedIndex === index ? "›" : ""}
+    </Text>
+  );
+
+  const number = (index: number) => (
+    <Text
+      className={`min-w-[16px] shrink-0 whitespace-nowrap text-right text-[13px] leading-4 ${
+        selectedIndex === index || hoveredIndex === index
+          ? "text-primary"
+          : "text-gray-11"
+      }`}
+    >
+      {index + 1}.
+    </Text>
+  );
+
+  const approveActive = selectedIndex === 0 || hoveredIndex === 0;
+
+  return (
+    <Box
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={handleContainerKeyDown}
+      onClick={(e) => {
+        if (e.target === containerRef.current) containerRef.current?.focus();
+      }}
+      p="3"
+      className="rounded-(--radius-3) border border-(--gray-6) bg-(--gray-1) outline-none"
+    >
+      <Flex direction="column" gap="2">
+        <Text className="font-medium text-[13px] text-primary">{TITLE}</Text>
+
+        <Box>
+          <Text mb="2" as="p" className="text-[13px]">
+            {QUESTION}
+          </Text>
+
+          <Flex direction="column" gap="1" px="2">
+            {/* Approve line — mode dropdown (shared ModeSelector) beside it. */}
+            <Box
+              onClick={approve}
+              onMouseEnter={() => setHoveredIndex(0)}
+              onMouseLeave={() => setHoveredIndex(null)}
+              py="1"
+              className={rowClass(0)}
+            >
+              <Flex align="center" gap="2" className="leading-4">
+                {caret(0)}
+                {number(0)}
+                <Flex
+                  align="center"
+                  justify="between"
+                  gap="2"
+                  className="min-w-0 flex-1 leading-4"
+                >
+                  <Text
+                    className={`whitespace-pre-wrap font-medium text-[13px] leading-4 ${approveActive ? "text-primary" : "text-gray-12"}`}
+                  >
+                    Approve and proceed
+                  </Text>
+                  <Box onClick={(e) => e.stopPropagation()}>
+                    <ModeSelector
+                      modeOption={modeConfigOption}
+                      onChange={(value) => setSelectedMode(value)}
+                      allowBypassPermissions
+                    />
+                  </Box>
+                </Flex>
+              </Flex>
+            </Box>
+
+            {/* Reject line — the inline feedback textarea, exactly as before. */}
+            {rejectOption && (
+              <Box
+                onClick={() => selectRow(1)}
+                onMouseEnter={() => setHoveredIndex(1)}
+                onMouseLeave={() => setHoveredIndex(null)}
+                py="1"
+                className={rowClass(1)}
+              >
+                <Flex align="center" gap="2" className="leading-4">
+                  {caret(1)}
+                  {number(1)}
+                  <Box className="min-w-0 flex-1 leading-4">
+                    <InlineEditableText
+                      value={feedback}
+                      placeholder="Type here to tell the agent what to do differently"
+                      active={rejectSelected}
+                      onChange={setFeedback}
+                      onNavigateUp={() => selectRow(0)}
+                      onNavigateDown={() => selectRow(0)}
+                      onEscape={() => {
+                        setFeedback("");
+                        selectRow(0);
+                      }}
+                      onSubmit={submitReject}
+                    />
+                  </Box>
+                </Flex>
+              </Box>
+            )}
+          </Flex>
+
+          <Text color="gray" mt="2" as="p" className="text-[13px]">
+            Enter to select · ↑↓ to navigate · Esc to cancel
+          </Text>
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/packages/ui/src/features/permissions/SwitchModePermission.tsx
+++ b/packages/ui/src/features/permissions/SwitchModePermission.tsx
@@ -1,18 +1,6 @@
-import { ActionSelector } from "@posthog/ui/primitives/ActionSelector";
-import { type BasePermissionProps, toSelectorOptions } from "./types";
+import { PlanApprovalSelector } from "./PlanApprovalSelector";
+import type { BasePermissionProps } from "./types";
 
-export function SwitchModePermission({
-  options,
-  onSelect,
-  onCancel,
-}: BasePermissionProps) {
-  return (
-    <ActionSelector
-      title="Implementation Plan"
-      question="Approve this plan to proceed?"
-      options={toSelectorOptions(options)}
-      onSelect={onSelect}
-      onCancel={onCancel}
-    />
-  );
+export function SwitchModePermission(props: BasePermissionProps) {
+  return <PlanApprovalSelector {...props} />;
 }

--- a/packages/ui/src/features/sessions/modeStyles.tsx
+++ b/packages/ui/src/features/sessions/modeStyles.tsx
@@ -1,0 +1,68 @@
+import {
+  Circle,
+  Eye,
+  LockOpen,
+  Pause,
+  Pencil,
+  Robot,
+  ShieldCheck,
+} from "@phosphor-icons/react";
+
+export interface ModeStyle {
+  icon: React.ReactNode;
+  className: string;
+}
+
+export const MODE_STYLES: Record<string, ModeStyle> = {
+  plan: {
+    icon: <Pause size={12} weight="bold" />,
+    className: "text-amber-11",
+  },
+  default: {
+    icon: <Pencil size={12} />,
+    className: "text-gray-11",
+  },
+  acceptEdits: {
+    icon: <ShieldCheck size={12} weight="fill" />,
+    className: "text-green-11",
+  },
+  bypassPermissions: {
+    icon: <LockOpen size={12} weight="bold" />,
+    className: "text-red-11",
+  },
+  auto: {
+    icon: <Robot size={12} weight="fill" />,
+    className: "text-blue-11",
+  },
+  "read-only": {
+    icon: <Eye size={12} />,
+    className: "text-amber-11",
+  },
+  "full-access": {
+    icon: <LockOpen size={12} weight="bold" />,
+    className: "text-red-11",
+  },
+};
+
+export const DEFAULT_MODE_STYLE: ModeStyle = {
+  icon: <Circle size={12} />,
+  className: "text-gray-11",
+};
+
+export function getModeStyle(value: string): ModeStyle {
+  return MODE_STYLES[value] ?? DEFAULT_MODE_STYLE;
+}
+
+// Short, human labels keyed by mode id. The raw permission-option names are long
+// "Yes, and ..." strings; these read cleanly on the Approve button and in the
+// "Approve and…" dropdown. Callers fall back to the raw option name when a mode
+// isn't listed here.
+export const MODE_LABELS: Record<string, string> = {
+  plan: "Plan",
+  default: "Manually approve edits",
+  acceptEdits: "Accept edits",
+  auto: "Auto",
+  bypassPermissions: "Bypass permissions",
+  "read-only": "Read-only",
+  "full-access": "Full access",
+};

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -84,6 +84,8 @@ interface SettingsStore {
   lastUsedEnvironments: Record<string, string>;
   defaultInitialTaskMode: DefaultInitialTaskMode;
   lastUsedInitialTaskMode: ExecutionMode;
+  // Mode last chosen when approving a plan; pre-selected on the next approval.
+  lastPlanApprovalMode: ExecutionMode | null;
   defaultReasoningEffort: DefaultReasoningEffort;
   defaultMessagingMode: DefaultMessagingMode;
   setDefaultMessagingMode: (mode: DefaultMessagingMode) => void;
@@ -105,6 +107,7 @@ interface SettingsStore {
   getLastUsedEnvironment: (repoPath: string) => string | null;
   setDefaultInitialTaskMode: (mode: DefaultInitialTaskMode) => void;
   setLastUsedInitialTaskMode: (mode: ExecutionMode) => void;
+  setLastPlanApprovalMode: (mode: ExecutionMode) => void;
   setDefaultReasoningEffort: (effort: DefaultReasoningEffort) => void;
 
   // Notifications
@@ -214,6 +217,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedEnvironments: {},
       defaultInitialTaskMode: "plan",
       lastUsedInitialTaskMode: "plan",
+      lastPlanApprovalMode: null,
       defaultReasoningEffort: "last_used",
       defaultMessagingMode: "queue",
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
@@ -245,6 +249,7 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ defaultInitialTaskMode: mode }),
       setLastUsedInitialTaskMode: (mode) =>
         set({ lastUsedInitialTaskMode: mode }),
+      setLastPlanApprovalMode: (mode) => set({ lastPlanApprovalMode: mode }),
       setDefaultReasoningEffort: (effort) =>
         set({ defaultReasoningEffort: effort }),
       setDefaultMessagingMode: (mode) => set({ defaultMessagingMode: mode }),
@@ -387,6 +392,7 @@ export const useSettingsStore = create<SettingsStore>()(
         lastUsedEnvironments: state.lastUsedEnvironments,
         defaultInitialTaskMode: state.defaultInitialTaskMode,
         lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,
+        lastPlanApprovalMode: state.lastPlanApprovalMode,
         defaultReasoningEffort: state.defaultReasoningEffort,
         defaultMessagingMode: state.defaultMessagingMode,
 

--- a/packages/ui/src/primitives/ActionSelector.tsx
+++ b/packages/ui/src/primitives/ActionSelector.tsx
@@ -12,6 +12,7 @@ export {
   parseOptionIndex,
   SUBMIT_OPTION_ID,
 } from "./action-selector/constants";
+export { InlineEditableText } from "./action-selector/InlineEditableText";
 export type {
   ActionSelectorProps,
   SelectorOption,


### PR DESCRIPTION
## Problem

plan approval options are getting :peanuts:

![Screenshot 2026-07-01 at 3.08.03 PM.png](https://app.graphite.com/user-attachments/assets/ab9d973b-c607-401b-97d1-356498c11d86.png)

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

made them nice and condensed - two buttons:

1. yes, with mode dropdown
2. no, with feedback line

## ![Screenshot 2026-07-01 at 3.09.50 PM.png](https://app.graphite.com/user-attachments/assets/eadd692d-5571-41e7-bfe5-303c90738d5c.png)

user's last plan approval mode is stored and used as the default, falling back to "auto"

## How did you test this?

manually, storybook

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?