### PR TITLE
feat(agent): add keep-proxy-stream-open ingest flag

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -366,6 +366,7 @@ export class AgentServer {
       this.eventStreamSender = new TaskRunEventStreamSender({
         apiUrl: config.apiUrl,
         eventIngestBaseUrl: config.eventIngestBaseUrl,
+        keepProxyStreamOpen: config.eventIngestKeepStreamOpen,
         projectId: config.projectId,
         taskId: config.taskId,
         runId: config.runId,

--- a/packages/agent/src/server/bin.ts
+++ b/packages/agent/src/server/bin.ts
@@ -43,6 +43,10 @@ const envSchema = z.object({
     )
     .transform((value) => parseInt(value, 10))
     .optional(),
+  POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN: z
+    .enum(["true", "false"])
+    .transform((value) => value === "true")
+    .optional(),
 });
 
 const program = new Command();
@@ -167,6 +171,8 @@ program
       eventIngestBaseUrl: env.POSTHOG_TASK_RUN_EVENT_INGEST_URL,
       eventIngestStreamWindowMs:
         env.POSTHOG_TASK_RUN_EVENT_INGEST_STREAM_WINDOW_MS,
+      eventIngestKeepStreamOpen:
+        env.POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN,
       repositoryPath: options.repositoryPath,
       repoReadyFile: options.repoReadyFile,
       apiUrl: env.POSTHOG_API_URL,

--- a/packages/agent/src/server/event-stream-sender.test.ts
+++ b/packages/agent/src/server/event-stream-sender.test.ts
@@ -124,19 +124,6 @@ function createSender(
   });
 }
 
-async function waitFor(
-  predicate: () => boolean,
-  timeoutMs = 100,
-): Promise<void> {
-  const deadlineAtMs = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() >= deadlineAtMs) {
-      throw new Error("Timed out waiting for condition");
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1));
-  }
-}
-
 describe("TaskRunEventStreamSender", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -208,7 +195,7 @@ describe("TaskRunEventStreamSender", () => {
     expect(lastCall[0]).not.toContain("/api/projects/");
   });
 
-  it("closes the active ingest upload after each drained batch on the proxy path", async () => {
+  it("closes the ingest upload per drained batch on the proxy path by default", async () => {
     const requestBodies: string[] = [];
     let contentUploads = 0;
     const fetchMock = vi.fn(
@@ -231,25 +218,63 @@ describe("TaskRunEventStreamSender", () => {
       eventIngestBaseUrl: "http://agent-proxy:8003/",
     });
 
-    // A buffering ingress only forwards the request body when the upload
-    // closes, so each drained batch must ride its own promptly-closed upload
-    // rather than one long-lived request held open until stop.
     sender.enqueue({ type: "notification", notification: { method: "first" } });
-    await waitFor(() => contentUploads === 1);
-    expect(eventSequences(requestBodies[0])).toEqual([1]);
-    expect(completionSequences(requestBodies[0])).toEqual([]);
+    await vi.waitFor(() => expect(contentUploads).toBe(1));
 
     sender.enqueue({
       type: "notification",
       notification: { method: "second" },
     });
-    await waitFor(() => contentUploads === 2);
-    expect(eventSequences(requestBodies[1])).toEqual([2]);
-    expect(completionSequences(requestBodies[1])).toEqual([]);
+    await vi.waitFor(() => expect(contentUploads).toBe(2));
 
     await sender.stop();
 
+    expect(eventSequences(requestBodies[0] ?? "")).toEqual([1]);
+    expect(eventSequences(requestBodies[1] ?? "")).toEqual([2]);
+  });
+
+  it("holds one long-lived upload across batches when keepProxyStreamOpen is set", async () => {
+    const requestBodies: string[] = [];
+    let streamingRequests = 0;
+    let contentUploads = 0;
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        if (!init?.body || typeof init.body === "string") {
+          return responseForBody(await readRequestBody(init));
+        }
+
+        // Counted on open; resolves only once the sender closes the upload body.
+        streamingRequests += 1;
+        const body = await readRequestBody(init);
+        contentUploads += 1;
+        requestBodies.push(body);
+        return responseForBody(body);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sender = createSender({
+      flushDelayMs: 0,
+      eventIngestBaseUrl: "http://agent-proxy:8003/",
+      keepProxyStreamOpen: true,
+    });
+
+    sender.enqueue({ type: "notification", notification: { method: "first" } });
+    // First batch opens the upload and holds it open: nothing is delivered yet.
+    await vi.waitFor(() => expect(streamingRequests).toBe(1));
+    expect(contentUploads).toBe(0);
+
+    // A second batch reuses the held-open upload instead of opening another.
+    sender.enqueue({
+      type: "notification",
+      notification: { method: "second" },
+    });
+    await sender.stop();
+
+    expect(streamingRequests).toBe(1);
+    expect(contentUploads).toBe(1);
     const finalBody = requestBodies.at(-1) ?? "";
+    expect(eventSequences(finalBody)).toEqual([1, 2]);
     expect(completionSequences(finalBody)).toEqual([2]);
   });
 

--- a/packages/agent/src/server/event-stream-sender.ts
+++ b/packages/agent/src/server/event-stream-sender.ts
@@ -10,6 +10,7 @@ interface TaskRunEventStreamSenderConfig {
   apiUrl: string;
   // Base URL for the event-ingest POST only; falls back to apiUrl (Django path) when unset.
   eventIngestBaseUrl?: string;
+  keepProxyStreamOpen?: boolean;
   projectId: number;
   taskId: string;
   runId: string;
@@ -70,6 +71,7 @@ export class TaskRunEventStreamSender {
   private readonly stopTimeoutMs: number;
   private readonly streamWindowMs: number;
   private readonly usingProxy: boolean;
+  private readonly keepProxyStreamOpen: boolean;
   private readonly createStreamingUpload: StreamingUploadFactory;
   private readonly encoder = new TextEncoder();
   private sequence = 0;
@@ -114,6 +116,7 @@ export class TaskRunEventStreamSender {
     this.stopTimeoutMs = config.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
     this.streamWindowMs = config.streamWindowMs ?? DEFAULT_STREAM_WINDOW_MS;
     this.usingProxy = usingProxy;
+    this.keepProxyStreamOpen = config.keepProxyStreamOpen ?? false;
     this.createStreamingUpload =
       config.createStreamingUpload ?? createNodeStreamingUpload;
   }
@@ -210,14 +213,9 @@ export class TaskRunEventStreamSender {
 
     try {
       await flushPromise;
-      // On the proxy path, deliver the drained batch now instead of holding one
-      // long-lived upload. The ingress in front of the proxy buffers the ingest
-      // request body and only forwards it once the request closes, so a
-      // long-lived upload strands events; closing per batch forwards each within
-      // a round-trip. Gated to the proxy write leg so the Django path keeps its
-      // existing long-lived upload. The stop path leaves closing to drainForStop
-      // so the completion line rides the final upload.
-      if (!this.stopped && this.usingProxy) {
+      // The ingress ahead of the agent-proxy only forwards the request body once the
+      // upload closes, so close per drained batch to avoid stranding buffered events.
+      if (!this.stopped && this.usingProxy && !this.keepProxyStreamOpen) {
         await this.closeActiveStream();
       }
       return this.bufferedEvents.length < previousBufferLength;

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -20,6 +20,7 @@ export interface AgentServerConfig {
   // Base URL for the event-ingest POST only; falls back to apiUrl when unset.
   eventIngestBaseUrl?: string;
   eventIngestStreamWindowMs?: number;
+  eventIngestKeepStreamOpen?: boolean;
   mode: AgentMode;
   taskId: string;
   runId: string;


### PR DESCRIPTION
## Problem

On the event-ingest proxy path, `flush()` closes the active NDJSON upload after every drained batch. The ingress in front of the agent-proxy buffers the request body and only forwards it once the upload closes, so closing per batch forwards each batch within a round-trip instead of stranding events in a long-lived upload.

We want to switch the proxy path back to a single long-lived buffered upload (matching the Django path) to investigate the ingestion buffering behavior, without changing the default for every run. This puts that behavior behind the `tasks-agent-proxy-keep-stream-open` feature flag, off by default.

## Changes

- Add a `keepProxyStreamOpen` option to `TaskRunEventStreamSender`, sourced from `POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN` via `AgentServerConfig.eventIngestKeepStreamOpen`.
- Gate the per-batch `closeActiveStream()` on the proxy write leg in `flush()` behind the flag. Off (default) keeps today's behavior: close per drained batch. On holds one long-lived buffered upload and delivers on the normal roll triggers and at stop.
- The env var is set by the control plane when the `tasks-agent-proxy-keep-stream-open` flag is enabled (companion PR PostHog/posthog#67492).
- Cover both branches in the sender test: default closes per batch, flag on holds one upload.

## How did you test this?

- `pnpm --filter @posthog/agent test event-stream-sender` -> 18/18 pass.
- `pnpm --filter @posthog/agent typecheck` -> clean.
- Pre-commit hook ran repo-wide Biome + `pnpm typecheck`; CI green on the pushed commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
