### PR TITLE
fix(github): link org installs to the app page instead of a 404

### DIFF
--- a/packages/core/src/integrations/githubApp.ts
+++ b/packages/core/src/integrations/githubApp.ts
@@ -1,0 +1,4 @@
+// GitHub's per-installation settings page for an org install is owner-only and
+// 404s for members, so org installs point at the app page, which loads for
+// anyone (owners get Configure, members get request access).
+export const POSTHOG_GITHUB_APP_URL = "https://github.com/apps/posthog";

--- a/packages/core/src/onboarding/githubConnectPanel.test.ts
+++ b/packages/core/src/onboarding/githubConnectPanel.test.ts
@@ -76,13 +76,13 @@ describe("isAnyIntegrationStale", () => {
 });
 
 describe("buildInstallationSettingsUrl", () => {
-  it("builds an org settings url", () => {
+  it("links an org install to the app page (org settings are owner-only)", () => {
     expect(
       buildInstallationSettingsUrl(
         { type: "Organization", name: "acme" },
         "42",
       ),
-    ).toBe("https://github.com/organizations/acme/settings/installations/42");
+    ).toBe("https://github.com/apps/posthog");
   });
 
   it("builds a personal settings url otherwise", () => {

--- a/packages/core/src/onboarding/githubConnectPanel.test.ts
+++ b/packages/core/src/onboarding/githubConnectPanel.test.ts
@@ -85,6 +85,15 @@ describe("buildInstallationSettingsUrl", () => {
     ).toBe("https://github.com/apps/posthog");
   });
 
+  it("matches the organization account type case-insensitively", () => {
+    expect(
+      buildInstallationSettingsUrl(
+        { type: "organization", name: "acme" },
+        "42",
+      ),
+    ).toBe("https://github.com/apps/posthog");
+  });
+
   it("builds a personal settings url otherwise", () => {
     expect(buildInstallationSettingsUrl({ type: "User" }, "42")).toBe(
       "https://github.com/settings/installations/42",

--- a/packages/core/src/onboarding/githubConnectPanel.ts
+++ b/packages/core/src/onboarding/githubConnectPanel.ts
@@ -1,3 +1,5 @@
+import { POSTHOG_GITHUB_APP_URL } from "../integrations/githubApp";
+
 export interface GithubPanelMessageOptions {
   hasConnectError: boolean;
   connectErrorMessage: string;
@@ -53,16 +55,11 @@ export function isAnyIntegrationStale(
   );
 }
 
-// GitHub's per-installation settings page for an org install is owner-only and
-// 404s for members, so org installs point at the app page, which loads for
-// anyone (owners get Configure, members get request access).
-const POSTHOG_GITHUB_APP_URL = "https://github.com/apps/posthog";
-
 export function buildInstallationSettingsUrl(
   account: GithubInstallationAccount | null | undefined,
   installationId: string,
 ): string {
-  if (account?.type === "Organization") {
+  if (account?.type?.toLowerCase() === "organization") {
     return POSTHOG_GITHUB_APP_URL;
   }
   return `https://github.com/settings/installations/${installationId}`;

--- a/packages/core/src/onboarding/githubConnectPanel.ts
+++ b/packages/core/src/onboarding/githubConnectPanel.ts
@@ -53,12 +53,17 @@ export function isAnyIntegrationStale(
   );
 }
 
+// GitHub's per-installation settings page for an org install is owner-only and
+// 404s for members, so org installs point at the app page, which loads for
+// anyone (owners get Configure, members get request access).
+const POSTHOG_GITHUB_APP_URL = "https://github.com/apps/posthog";
+
 export function buildInstallationSettingsUrl(
   account: GithubInstallationAccount | null | undefined,
   installationId: string,
 ): string {
-  if (account?.type === "Organization" && account.name) {
-    return `https://github.com/organizations/${account.name}/settings/installations/${installationId}`;
+  if (account?.type === "Organization") {
+    return POSTHOG_GITHUB_APP_URL;
   }
   return `https://github.com/settings/installations/${installationId}`;
 }

--- a/packages/core/src/settings/githubRepoSummary.test.ts
+++ b/packages/core/src/settings/githubRepoSummary.test.ts
@@ -27,16 +27,25 @@ describe("summarizeReposByOwner", () => {
 });
 
 describe("githubInstallationSettingsUrl", () => {
-  it("builds an org URL for organization accounts", () => {
+  it("links organization installs to the app page (org settings are owner-only)", () => {
     expect(
       githubInstallationSettingsUrl({
         installation_id: 42,
         account: { type: "Organization", name: "acme" },
       }),
-    ).toBe("https://github.com/organizations/acme/settings/installations/42");
+    ).toBe("https://github.com/apps/posthog");
   });
 
-  it("builds a user URL otherwise", () => {
+  it("matches the organization account type case-insensitively", () => {
+    expect(
+      githubInstallationSettingsUrl({
+        installation_id: 42,
+        account: { type: "organization", name: "acme" },
+      }),
+    ).toBe("https://github.com/apps/posthog");
+  });
+
+  it("builds a user installation URL otherwise", () => {
     expect(
       githubInstallationSettingsUrl({
         installation_id: 7,

--- a/packages/core/src/settings/githubRepoSummary.ts
+++ b/packages/core/src/settings/githubRepoSummary.ts
@@ -1,3 +1,5 @@
+import { POSTHOG_GITHUB_APP_URL } from "../integrations/githubApp";
+
 export function summarizeReposByOwner(
   repositories: readonly string[],
 ): { owner: string; count: number }[] {
@@ -20,11 +22,6 @@ export interface GithubInstallationLike {
   installation_id: string | number;
   account?: GithubInstallationAccount | null;
 }
-
-// GitHub's per-installation settings page for an org install is owner-only and
-// 404s for members, so org installs point at the app page, which loads for
-// anyone (owners get Configure, members get request access).
-const POSTHOG_GITHUB_APP_URL = "https://github.com/apps/posthog";
 
 export function githubInstallationSettingsUrl(
   integration: GithubInstallationLike,

--- a/packages/core/src/settings/githubRepoSummary.ts
+++ b/packages/core/src/settings/githubRepoSummary.ts
@@ -21,18 +21,20 @@ export interface GithubInstallationLike {
   account?: GithubInstallationAccount | null;
 }
 
+// GitHub's per-installation settings page for an org install is owner-only and
+// 404s for members, so org installs point at the app page, which loads for
+// anyone (owners get Configure, members get request access).
+const POSTHOG_GITHUB_APP_URL = "https://github.com/apps/posthog";
+
 export function githubInstallationSettingsUrl(
   integration: GithubInstallationLike,
 ): string {
   const accountType = integration.account?.type;
-  const accountName = integration.account?.name;
   if (
     typeof accountType === "string" &&
-    accountType.toLowerCase() === "organization" &&
-    typeof accountName === "string" &&
-    accountName
+    accountType.toLowerCase() === "organization"
   ) {
-    return `https://github.com/organizations/${accountName}/settings/installations/${integration.installation_id}`;
+    return POSTHOG_GITHUB_APP_URL;
   }
   return `https://github.com/settings/installations/${integration.installation_id}`;
 }


### PR DESCRIPTION
## Problem

The "Manage on GitHub" gear in **Settings → GitHub** (and the **Settings** button in the onboarding GitHub panel) links to GitHub's per-installation settings page for an org install: `https://github.com/organizations/<org>/settings/installations/<id>`.

That page is **org-owner-only**, so it 404s for any org member who isn't an owner. Cory hit this on the PostHog org's shared `posthog` app installation.

I confirmed against the live GitHub API that this is not a stale/wrong ID or a bad URL format:

- Installation `99844466` is an **Organization** install of the `posthog` GitHub App.
- Its canonical `html_url` is **exactly** the URL the app builds (and the one that 404s).
- Org GitHub App settings pages require org-owner access, so members get a 404. There is no per-installation GitHub URL a non-owner can open.

## Changes

- For **Organization** installs, both URL builders now return the GitHub App page `https://github.com/apps/posthog`, which loads for everyone (owners land on Configure, members get request/install).
  - `githubInstallationSettingsUrl` in `packages/core/src/settings/githubRepoSummary.ts` (the reported Settings gear).
  - `buildInstallationSettingsUrl` in `packages/core/src/onboarding/githubConnectPanel.ts` (the onboarding panel, same latent bug).
- **Personal (User)** installs keep their existing `https://github.com/settings/installations/<id>` link, which that user can access.

No visual UI change: this only changes where the existing gear/button navigates.

## How did you test this?

- Updated and ran the unit tests for both helpers.
- `pnpm --filter @posthog/core test`: 1851 passed.
- `pnpm --filter @posthog/core typecheck` and `pnpm --filter @posthog/ui typecheck`: clean. Pre-commit `pnpm typecheck` (full workspace) also passed.
- `biome lint` on the changed files: clean.
- Verified the destination `https://github.com/apps/posthog` loads as a valid public app page.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
