### PR TITLE
Use stored worktree path when creating task terminals

### DIFF
--- a/packages/workspace-server/src/services/shell/shell.test.ts
+++ b/packages/workspace-server/src/services/shell/shell.test.ts
@@ -1,7 +1,10 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockRepositoryRepository } from "../../db/repositories/repository-repository.mock";
+import { createMockWorkspaceRepository } from "../../db/repositories/workspace-repository.mock";
+import { createMockWorktreeRepository } from "../../db/repositories/worktree-repository.mock";
 import { ShellEvent } from "./schemas";
 
 const mockPty = vi.hoisted(() => ({
@@ -85,67 +88,52 @@ describe("ShellService.destroy", () => {
 
 describe("ShellService.createSession workspace env", () => {
   function createWorktreeTaskService(worktreePath: string) {
-    return createService({
-      workspaceRepo: {
-        findByTaskId: vi.fn(() => ({
-          id: "ws-1",
-          mode: "worktree",
-          repositoryId: "repo-1",
-        })),
-      },
-      repositoryRepo: {
-        findById: vi.fn(() => ({ id: "repo-1", path: "/repos/code" })),
-      },
-      worktreeRepo: {
-        findByWorkspaceId: vi.fn(() => ({
-          id: "wt-1",
-          workspaceId: "ws-1",
-          name: "spawn-tasks",
-          path: worktreePath,
-        })),
-      },
+    const repositoryRepo = createMockRepositoryRepository();
+    const workspaceRepo = createMockWorkspaceRepository();
+    const worktreeRepo = createMockWorktreeRepository();
+    const repo = repositoryRepo.create({ path: "/repos/code" });
+    const workspace = workspaceRepo.create({
+      taskId: "task-1",
+      repositoryId: repo.id,
+      mode: "worktree",
     });
+    worktreeRepo.create({
+      workspaceId: workspace.id,
+      name: "spawn-tasks",
+      path: worktreePath,
+    });
+    return createService({ repositoryRepo, workspaceRepo, worktreeRepo });
   }
 
   function spawnedEnv(): Record<string, string> {
     return mockPty.spawn.mock.calls[0][2].env;
   }
 
-  let tempDir: string;
-
   beforeEach(() => {
     mockPty.spawn.mockReset();
     mockPty.spawn.mockReturnValue(createMockPtyProcess());
     mockGitQueries.getCurrentBranch.mockResolvedValue("feature-branch");
     mockGitQueries.getDefaultBranch.mockResolvedValue("main");
-    tempDir = mkdtempSync(path.join(tmpdir(), "shell-test-"));
-  });
-
-  afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
   });
 
   it("uses the stored worktree path when it exists on disk", async () => {
-    const { service } = createWorktreeTaskService(tempDir);
+    const tempDir = mkdtempSync(path.join(tmpdir(), "shell-test-"));
+    try {
+      const { service } = createWorktreeTaskService(tempDir);
 
-    await service.createSession({
-      sessionId: "session-1",
-      cwd: tempDir,
-      taskId: "task-1",
-    });
+      await service.createSession({ sessionId: "session-1", taskId: "task-1" });
 
-    expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBe(tempDir);
-    expect(mockGitQueries.getCurrentBranch).toHaveBeenCalledWith(tempDir);
+      expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBe(tempDir);
+      expect(mockGitQueries.getCurrentBranch).toHaveBeenCalledWith(tempDir);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("falls back to the derived path when the stored path is missing", async () => {
     const { service } = createWorktreeTaskService("/does/not/exist");
 
-    await service.createSession({
-      sessionId: "session-1",
-      cwd: tempDir,
-      taskId: "task-1",
-    });
+    await service.createSession({ sessionId: "session-1", taskId: "task-1" });
 
     expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBe(
       path.join("/tmp/worktrees", "spawn-tasks", "code"),
@@ -156,14 +144,10 @@ describe("ShellService.createSession workspace env", () => {
     mockGitQueries.getDefaultBranch.mockRejectedValue(
       new Error("Cannot use simple-git on a directory that does not exist"),
     );
-    const { service } = createWorktreeTaskService(tempDir);
+    const { service } = createWorktreeTaskService("/does/not/exist");
 
     await expect(
-      service.createSession({
-        sessionId: "session-1",
-        cwd: tempDir,
-        taskId: "task-1",
-      }),
+      service.createSession({ sessionId: "session-1", taskId: "task-1" }),
     ).resolves.toBeDefined();
 
     expect(mockPty.spawn).toHaveBeenCalledTimes(1);

--- a/packages/workspace-server/src/services/shell/shell.test.ts
+++ b/packages/workspace-server/src/services/shell/shell.test.ts
@@ -105,7 +105,7 @@ describe("ShellService.createSession workspace env", () => {
     return createService({ repositoryRepo, workspaceRepo, worktreeRepo });
   }
 
-  function spawnedEnv(): Record<string, string> {
+  function spawnedEnv(): Record<string, string | undefined> {
     return mockPty.spawn.mock.calls[0][2].env;
   }
 
@@ -135,9 +135,9 @@ describe("ShellService.createSession workspace env", () => {
 
     await service.createSession({ sessionId: "session-1", taskId: "task-1" });
 
-    expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBe(
-      path.join("/tmp/worktrees", "spawn-tasks", "code"),
-    );
+    const derivedPath = path.join("/tmp/worktrees", "spawn-tasks", "code");
+    expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBe(derivedPath);
+    expect(mockGitQueries.getCurrentBranch).toHaveBeenCalledWith(derivedPath);
   });
 
   it("still creates the shell when env construction fails", async () => {

--- a/packages/workspace-server/src/services/shell/shell.test.ts
+++ b/packages/workspace-server/src/services/shell/shell.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ShellEvent } from "./schemas";
 
 const mockPty = vi.hoisted(() => ({
@@ -6,6 +9,13 @@ const mockPty = vi.hoisted(() => ({
 }));
 
 vi.mock("node-pty", () => mockPty);
+
+const mockGitQueries = vi.hoisted(() => ({
+  getCurrentBranch: vi.fn(async () => "feature-branch"),
+  getDefaultBranch: vi.fn(async () => "main"),
+}));
+
+vi.mock("@posthog/git/queries", () => mockGitQueries);
 
 import { ShellService } from "./shell";
 
@@ -21,7 +31,11 @@ function createMockPtyProcess() {
   };
 }
 
-function createService() {
+function createService(overrides?: {
+  repositoryRepo?: unknown;
+  workspaceRepo?: unknown;
+  worktreeRepo?: unknown;
+}) {
   const processTracking = {
     register: vi.fn(),
     unregister: vi.fn(),
@@ -37,9 +51,9 @@ function createService() {
   };
   const service = new ShellService(
     processTracking as never,
-    {} as never,
-    {} as never,
-    {} as never,
+    (overrides?.repositoryRepo ?? {}) as never,
+    (overrides?.workspaceRepo ?? {}) as never,
+    (overrides?.worktreeRepo ?? {}) as never,
     { getWorktreeLocation: vi.fn(() => "/tmp/worktrees") } as never,
     logger as never,
   );
@@ -66,5 +80,93 @@ describe("ShellService.destroy", () => {
   it("does nothing for non-existent session", () => {
     const { service } = createService();
     expect(() => service.destroy("nonexistent")).not.toThrow();
+  });
+});
+
+describe("ShellService.createSession workspace env", () => {
+  function createWorktreeTaskService(worktreePath: string) {
+    return createService({
+      workspaceRepo: {
+        findByTaskId: vi.fn(() => ({
+          id: "ws-1",
+          mode: "worktree",
+          repositoryId: "repo-1",
+        })),
+      },
+      repositoryRepo: {
+        findById: vi.fn(() => ({ id: "repo-1", path: "/repos/code" })),
+      },
+      worktreeRepo: {
+        findByWorkspaceId: vi.fn(() => ({
+          id: "wt-1",
+          workspaceId: "ws-1",
+          name: "spawn-tasks",
+          path: worktreePath,
+        })),
+      },
+    });
+  }
+
+  function spawnedEnv(): Record<string, string> {
+    return mockPty.spawn.mock.calls[0][2].env;
+  }
+
+  let tempDir: string;
+
+  beforeEach(() => {
+    mockPty.spawn.mockReset();
+    mockPty.spawn.mockReturnValue(createMockPtyProcess());
+    mockGitQueries.getCurrentBranch.mockResolvedValue("feature-branch");
+    mockGitQueries.getDefaultBranch.mockResolvedValue("main");
+    tempDir = mkdtempSync(path.join(tmpdir(), "shell-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses the stored worktree path when it exists on disk", async () => {
+    const { service } = createWorktreeTaskService(tempDir);
+
+    await service.createSession({
+      sessionId: "session-1",
+      cwd: tempDir,
+      taskId: "task-1",
+    });
+
+    expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBe(tempDir);
+    expect(mockGitQueries.getCurrentBranch).toHaveBeenCalledWith(tempDir);
+  });
+
+  it("falls back to the derived path when the stored path is missing", async () => {
+    const { service } = createWorktreeTaskService("/does/not/exist");
+
+    await service.createSession({
+      sessionId: "session-1",
+      cwd: tempDir,
+      taskId: "task-1",
+    });
+
+    expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBe(
+      path.join("/tmp/worktrees", "spawn-tasks", "code"),
+    );
+  });
+
+  it("still creates the shell when env construction fails", async () => {
+    mockGitQueries.getDefaultBranch.mockRejectedValue(
+      new Error("Cannot use simple-git on a directory that does not exist"),
+    );
+    const { service } = createWorktreeTaskService(tempDir);
+
+    await expect(
+      service.createSession({
+        sessionId: "session-1",
+        cwd: tempDir,
+        taskId: "task-1",
+      }),
+    ).resolves.toBeDefined();
+
+    expect(mockPty.spawn).toHaveBeenCalledTimes(1);
+    expect(spawnedEnv().POSTHOG_CODE_WORKSPACE_PATH).toBeUndefined();
   });
 });

--- a/packages/workspace-server/src/services/shell/shell.ts
+++ b/packages/workspace-server/src/services/shell/shell.ts
@@ -409,31 +409,31 @@ export class ShellService extends TypedEventEmitter<ShellEvents> {
   ): Promise<Record<string, string> | undefined> {
     if (!taskId) return undefined;
 
+    const workspace = this.workspaceRepo.findByTaskId(taskId);
+    if (!workspace || workspace.mode === "cloud" || !workspace.repositoryId) {
+      return undefined;
+    }
+
+    const repo = this.repositoryRepo.findById(workspace.repositoryId);
+    if (!repo) return undefined;
+
+    let worktreePath: string | null = null;
+    let worktreeName: string | null = null;
+
+    if (workspace.mode === "worktree") {
+      const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
+      if (worktree) {
+        worktreeName = worktree.name;
+        // The stored path is authoritative — reused worktrees can live
+        // outside the managed worktree directory. Only derive when the
+        // stored path is gone (e.g. stale row after a location move).
+        worktreePath = existsSync(worktree.path)
+          ? worktree.path
+          : this.deriveWorktreePath(repo.path, worktreeName);
+      }
+    }
+
     try {
-      const workspace = this.workspaceRepo.findByTaskId(taskId);
-      if (!workspace || workspace.mode === "cloud" || !workspace.repositoryId) {
-        return undefined;
-      }
-
-      const repo = this.repositoryRepo.findById(workspace.repositoryId);
-      if (!repo) return undefined;
-
-      let worktreePath: string | null = null;
-      let worktreeName: string | null = null;
-
-      if (workspace.mode === "worktree") {
-        const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
-        if (worktree) {
-          worktreeName = worktree.name;
-          // The stored path is authoritative — reused worktrees can live
-          // outside the managed worktree directory. Only derive when the
-          // stored path is gone (e.g. stale row after a location move).
-          worktreePath = existsSync(worktree.path)
-            ? worktree.path
-            : this.deriveWorktreePath(repo.path, worktreeName);
-        }
-      }
-
       return await buildWorkspaceEnv({
         taskId,
         folderPath: repo.path,

--- a/packages/workspace-server/src/services/shell/shell.ts
+++ b/packages/workspace-server/src/services/shell/shell.ts
@@ -409,31 +409,44 @@ export class ShellService extends TypedEventEmitter<ShellEvents> {
   ): Promise<Record<string, string> | undefined> {
     if (!taskId) return undefined;
 
-    const workspace = this.workspaceRepo.findByTaskId(taskId);
-    if (!workspace || workspace.mode === "cloud" || !workspace.repositoryId) {
+    try {
+      const workspace = this.workspaceRepo.findByTaskId(taskId);
+      if (!workspace || workspace.mode === "cloud" || !workspace.repositoryId) {
+        return undefined;
+      }
+
+      const repo = this.repositoryRepo.findById(workspace.repositoryId);
+      if (!repo) return undefined;
+
+      let worktreePath: string | null = null;
+      let worktreeName: string | null = null;
+
+      if (workspace.mode === "worktree") {
+        const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
+        if (worktree) {
+          worktreeName = worktree.name;
+          // The stored path is authoritative — reused worktrees can live
+          // outside the managed worktree directory. Only derive when the
+          // stored path is gone (e.g. stale row after a location move).
+          worktreePath = existsSync(worktree.path)
+            ? worktree.path
+            : this.deriveWorktreePath(repo.path, worktreeName);
+        }
+      }
+
+      return await buildWorkspaceEnv({
+        taskId,
+        folderPath: repo.path,
+        worktreePath,
+        worktreeName,
+        mode: workspace.mode,
+      });
+    } catch (error) {
+      this.log.warn(
+        `Failed to build workspace env for task ${taskId}, starting shell without it`,
+        error,
+      );
       return undefined;
     }
-
-    const repo = this.repositoryRepo.findById(workspace.repositoryId);
-    if (!repo) return undefined;
-
-    let worktreePath: string | null = null;
-    let worktreeName: string | null = null;
-
-    if (workspace.mode === "worktree") {
-      const worktree = this.worktreeRepo.findByWorkspaceId(workspace.id);
-      if (worktree) {
-        worktreeName = worktree.name;
-        worktreePath = await this.deriveWorktreePath(repo.path, worktreeName);
-      }
-    }
-
-    return buildWorkspaceEnv({
-      taskId,
-      folderPath: repo.path,
-      worktreePath,
-      worktreeName,
-      mode: workspace.mode,
-    });
   }
 }


### PR DESCRIPTION
## Problem

Task terminals fail to open when a task reuses an existing worktree that lives outside the managed worktree directory. `ShellService.getTaskEnv` always recomputed the worktree path from the managed layout, and that derived path doesn't exist on disk for reused worktrees, so `simple-git` throws and the terminal never opens.

## Changes

- `getTaskEnv` now uses the worktree's stored path when it exists on disk, and only falls back to deriving the path from the managed layout for stale rows.
- Workspace env construction failures are caught, so the shell still opens (without the `POSTHOG_CODE_*` vars) instead of failing terminal creation entirely.
- Added test coverage for the stored path, the fallback path, and graceful degradation on env construction failure. Replaced the test file's hand-rolled repository stubs with the shared mock factories.

## How did you test this?

Manually tested opening a task terminal for a task with an external worktree. Also ran the updated unit test suite (`vitest run shell.test.ts`, 5/5 passing), `tsc --noEmit`, and `biome check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?