### PR TITLE
perf(sessions): make opening a big task feel fast

### DIFF
--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -711,8 +711,11 @@ container.bind(LOGS_SERVICE).toDynamicValue((ctx) => {
     },
     readLocalLogs: (taskRunId: string) =>
       ws.localLogs.read.query({ taskRunId }),
-    readLocalLogsTail: (taskRunId: string, maxBytes: number) =>
-      ws.localLogs.readTail.query({ taskRunId, maxBytes }),
+    readLocalLogsWindow: (
+      taskRunId: string,
+      endOffset: number | null,
+      maxBytes: number,
+    ) => ws.localLogs.readWindow.query({ taskRunId, endOffset, maxBytes }),
     writeLocalLogs: (taskRunId: string, content: string) =>
       ws.localLogs.write.mutate({ taskRunId, content }),
   };

--- a/apps/code/src/renderer/components/Providers.tsx
+++ b/apps/code/src/renderer/components/Providers.tsx
@@ -1,5 +1,6 @@
 import { HostTRPCProvider } from "@posthog/host-router/react";
 import { ThemeWrapper } from "@posthog/ui/primitives/ThemeWrapper";
+import { DiffWorkerPoolProvider } from "@posthog/ui/shell/DiffWorkerPoolProvider";
 import { WorkspaceClientProvider } from "@posthog/workspace-client/provider";
 import {
   hostTrpcClient,
@@ -114,7 +115,9 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({
             queryClient={queryClient}
           >
             <ConnectedWorkspaceProvider>
-              <ThemeWrapper>{children}</ThemeWrapper>
+              <ThemeWrapper>
+                <DiffWorkerPoolProvider>{children}</DiffWorkerPoolProvider>
+              </ThemeWrapper>
             </ConnectedWorkspaceProvider>
           </HostTRPCProvider>
         </TRPCProvider>

--- a/packages/core/src/sessions/sessionOpenTailFirst.test.ts
+++ b/packages/core/src/sessions/sessionOpenTailFirst.test.ts
@@ -5,7 +5,7 @@ import { sessionStore, sessionStoreSetters } from "./sessionStore";
 const RUN = "run-tf";
 const TASK = "task-tf";
 
-function line(text: string): string {
+function contentLine(text: string): string {
   return JSON.stringify({
     type: "notification",
     notification: {
@@ -20,13 +20,24 @@ function line(text: string): string {
   });
 }
 
-function makeService(readTail?: unknown) {
+function configLine(): string {
+  return JSON.stringify({
+    type: "notification",
+    notification: {
+      method: "session/update",
+      params: { update: { sessionUpdate: "config_option_update" } },
+    },
+  });
+}
+
+function makeService(readWindow?: unknown) {
   const logs: Record<string, unknown> = {
     readLocalLogs: { query: vi.fn().mockResolvedValue(null) },
     fetchS3Logs: { query: vi.fn().mockResolvedValue(null) },
     writeLocalLogs: { mutate: vi.fn() },
   };
-  if (readTail !== undefined) logs.readLocalLogsTail = { query: readTail };
+  if (readWindow !== undefined)
+    logs.readLocalLogsWindow = { query: readWindow };
 
   const deps = {
     store: sessionStoreSetters,
@@ -59,30 +70,66 @@ const events = () => sessionStore.getState().sessions[RUN]?.events ?? [];
 afterEach(() => sessionStoreSetters.removeSession(RUN));
 
 describe("paintTailFirst", () => {
-  it("paints a session from the tail content", async () => {
-    const readTail = vi.fn().mockResolvedValue({
-      content: `${line("a")}\n${line("b")}\n`,
-      truncated: true,
+  it("paints from the tail window when it already holds content", async () => {
+    const readWindow = vi.fn().mockResolvedValue({
+      content: `${contentLine("a")}\n${contentLine("b")}\n`,
+      startOffset: 4096,
+      endOffset: 8192,
+      headReached: false,
     });
-    await paint(makeService(readTail));
+    await paint(makeService(readWindow));
 
-    expect(readTail).toHaveBeenCalledWith({
+    expect(readWindow).toHaveBeenCalledWith({
       taskRunId: RUN,
+      endOffset: null,
       maxBytes: 1_500_000,
     });
+    expect(readWindow).toHaveBeenCalledTimes(1);
     expect(events().length).toBeGreaterThan(0);
     expect(sessionStore.getState().sessions[RUN]?.logUrl).toBe("log-url");
   });
 
-  it("is a no-op when the host doesn't expose the tail read", async () => {
+  it("pages back past config-noise tails until it finds real messages", async () => {
+    const readWindow = vi
+      .fn()
+      // First (newest) window: only config noise, more history remains.
+      .mockResolvedValueOnce({
+        content: `${configLine()}\n${configLine()}\n`,
+        startOffset: 4096,
+        endOffset: 8192,
+        headReached: false,
+      })
+      // Paged back: real content.
+      .mockResolvedValueOnce({
+        content: `${contentLine("older")}\n`,
+        startOffset: 0,
+        endOffset: 4096,
+        headReached: true,
+      });
+    await paint(makeService(readWindow));
+
+    expect(readWindow).toHaveBeenCalledTimes(2);
+    expect(readWindow).toHaveBeenLastCalledWith({
+      taskRunId: RUN,
+      endOffset: 4096,
+      maxBytes: 1_500_000,
+    });
+    // Both pages' events are painted, oldest first.
+    expect(events().length).toBe(3);
+  });
+
+  it("is a no-op when the host doesn't expose the windowed read", async () => {
     await paint(makeService(undefined));
     expect(sessionStore.getState().sessions[RUN]).toBeUndefined();
   });
 
   it("is a no-op when a session already exists", async () => {
-    const readTail = vi
-      .fn()
-      .mockResolvedValue({ content: line("x"), truncated: true });
+    const readWindow = vi.fn().mockResolvedValue({
+      content: contentLine("x"),
+      startOffset: 0,
+      endOffset: 16,
+      headReached: true,
+    });
     sessionStoreSetters.setSession({
       taskRunId: RUN,
       taskId: TASK,
@@ -91,15 +138,18 @@ describe("paintTailFirst", () => {
       pendingPermissions: new Map(),
       status: "connected",
     } as never);
-    await paint(makeService(readTail));
-    expect(readTail).not.toHaveBeenCalled();
+    await paint(makeService(readWindow));
+    expect(readWindow).not.toHaveBeenCalled();
   });
 
-  it("is a no-op on empty tail content", async () => {
-    const readTail = vi
-      .fn()
-      .mockResolvedValue({ content: "  ", truncated: true });
-    await paint(makeService(readTail));
+  it("is a no-op on empty window content", async () => {
+    const readWindow = vi.fn().mockResolvedValue({
+      content: "  ",
+      startOffset: 0,
+      endOffset: 2,
+      headReached: true,
+    });
+    await paint(makeService(readWindow));
     expect(sessionStore.getState().sessions[RUN]).toBeUndefined();
   });
 });

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -116,6 +116,13 @@ const SESSION_EVENT_EVICT_GRACE_MS = 20_000;
  * plenty for the initial (scrolled-to-bottom) view.
  */
 const OPEN_TAIL_BYTES = 1_500_000;
+/**
+ * Cap on how far back the fast paint pages while seeking renderable content. A
+ * resumed session appends large config/mode/resume blobs to the log tail, so
+ * the last window can be all non-content noise; keep paging back (up to this
+ * many bytes) until real messages are in view, then paint what we have.
+ */
+const OPEN_TAIL_MAX_BYTES = 8_000_000;
 
 class GitHubAuthorizationRequiredForCloudHandoffError extends Error {
   constructor(
@@ -170,7 +177,7 @@ export interface SessionTrpc {
     readLocalLogs: TrpcQuery;
     /** Optional: only the Electron host exposes the tail read. Core feature-
      * detects and falls back to a full read when it's absent. */
-    readLocalLogsTail?: TrpcQuery;
+    readLocalLogsWindow?: TrpcQuery;
     fetchS3Logs: TrpcQuery;
     writeLocalLogs: TrpcMutation;
   };
@@ -4812,9 +4819,12 @@ export class SessionService {
    * Paint the tail of a task's local log immediately so a big transcript shows
    * its latest turns in tens of ms, instead of blocking on the full-log read +
    * IPC transfer. This is a throwaway fast-paint: the authoritative full read +
-   * connect (`reconnectToLocalSession`) replaces this session shortly after with
-   * correct processed-line tracking. No-op when a session already exists, the
-   * host doesn't expose the tail read, or there's no local log.
+   * connect (`reconnectToLocalSession`) replaces this session shortly after.
+   *
+   * Pages back past the config/mode/resume blobs a resumed session appends to
+   * the log tail, so the paint shows real messages instead of an empty
+   * transcript. No-op when a session already exists, the host doesn't expose
+   * the windowed read, or there's no local log.
    */
   private async paintTailFirst(
     taskRunId: string,
@@ -4822,27 +4832,61 @@ export class SessionService {
     taskTitle: string,
     logUrl: string,
   ): Promise<void> {
-    const tailQuery = this.d.trpc.logs.readLocalLogsTail;
-    if (!tailQuery) return;
+    const windowQuery = this.d.trpc.logs.readLocalLogsWindow;
+    if (!windowQuery) return;
     if (this.d.store.getSessionByTaskId(taskId)) return;
     try {
-      const res = (await tailQuery.query({
-        taskRunId,
-        maxBytes: OPEN_TAIL_BYTES,
-      })) as { content: string; truncated: boolean } | null;
-      if (!res?.content?.trim()) return;
+      let events: AcpMessage[] = [];
+      let endOffset: number | null = null;
+      let headReached = false;
+      let bytesRead = 0;
+      do {
+        const res = (await windowQuery.query({
+          taskRunId,
+          endOffset,
+          maxBytes: OPEN_TAIL_BYTES,
+        })) as {
+          content: string;
+          startOffset: number;
+          endOffset: number;
+          headReached: boolean;
+        } | null;
+        if (!res) break;
+        const { rawEntries } = this.parseLogContent(res.content);
+        events = [...convertStoredEntriesToEvents(rawEntries), ...events];
+        endOffset = res.startOffset;
+        headReached = res.headReached;
+        bytesRead += res.endOffset - res.startOffset;
+      } while (
+        !headReached &&
+        bytesRead < OPEN_TAIL_MAX_BYTES &&
+        !this.tailHasRenderableContent(events)
+      );
+
+      if (events.length === 0) return;
       // The full read may have set the session while we awaited the tail.
       if (this.d.store.getSessionByTaskId(taskId)) return;
-      const { rawEntries } = this.parseLogContent(res.content);
-      if (rawEntries.length === 0) return;
       const session = createBaseSession(taskRunId, taskId, taskTitle);
-      session.events = convertStoredEntriesToEvents(rawEntries);
+      session.events = events;
       session.logUrl = logUrl;
       session.status = "connecting";
       this.d.store.setSession(session);
     } catch (error) {
       this.d.log.debug("Tail-first paint skipped", { taskId, error });
     }
+  }
+
+  /**
+   * Whether the loaded window contains anything the transcript renders — a user
+   * prompt or agent output — as opposed to only config/mode/resume events.
+   */
+  private tailHasRenderableContent(events: AcpMessage[]): boolean {
+    for (const acpMsg of events) {
+      const msg = acpMsg.message;
+      if (isJsonRpcRequest(msg) && msg.method === "session/prompt") return true;
+      if (classifyTurnEventKind(msg) !== "other") return true;
+    }
+    return false;
   }
 
   private async fetchSessionLogs(

--- a/packages/host-router/src/routers/logs.router.ts
+++ b/packages/host-router/src/routers/logs.router.ts
@@ -6,8 +6,8 @@ import {
   fetchS3LogsOutput,
   readLocalLogsInput,
   readLocalLogsOutput,
-  readLocalLogsTailInput,
-  readLocalLogsTailOutput,
+  readLocalLogsWindowInput,
+  readLocalLogsWindowOutput,
   writeLocalLogsInput,
 } from "@posthog/workspace-server/services/local-logs/schemas";
 
@@ -28,13 +28,13 @@ export const logsRouter = router({
         .readLocalLogs(input.taskRunId),
     ),
 
-  readLocalLogsTail: publicProcedure
-    .input(readLocalLogsTailInput)
-    .output(readLocalLogsTailOutput)
+  readLocalLogsWindow: publicProcedure
+    .input(readLocalLogsWindowInput)
+    .output(readLocalLogsWindowOutput)
     .query(({ ctx, input }) =>
       ctx.container
         .get<ILogsService>(LOGS_SERVICE)
-        .readLocalLogsTail(input.taskRunId, input.maxBytes),
+        .readLocalLogsWindow(input.taskRunId, input.endOffset, input.maxBytes),
     ),
 
   writeLocalLogs: publicProcedure

--- a/packages/ui/src/shell/DiffWorkerPoolProvider.tsx
+++ b/packages/ui/src/shell/DiffWorkerPoolProvider.tsx
@@ -1,0 +1,29 @@
+import { WorkerPoolContextProvider } from "@pierre/diffs/react";
+import { useService } from "@posthog/di/react";
+import { DIFFS_HIGHLIGHTER_OPTIONS } from "@posthog/ui/features/sessions/diffHighlighterOptions";
+import type { ReactNode } from "react";
+import { DIFF_WORKER_FACTORY, type DiffWorkerFactory } from "./diffWorkerHost";
+
+/**
+ * Keeps the diff highlighter worker pool alive for the app's lifetime. The pool
+ * is a singleton that the per-view providers (transcript, review) share, but it
+ * self-terminates when the last of them unmounts — so navigating away from all
+ * diff views and back re-pays the worker's one-time init (WASM regex engine +
+ * theme normalization, ~1.7s). Mounting one provider at the root holds the
+ * pool's mount count above zero, so that init happens once at startup and every
+ * subsequent diff render reuses the warm worker.
+ *
+ * Uses the transcript's themes; languages load on demand, so the review
+ * surface's eager lang preset is not needed for correctness.
+ */
+export function DiffWorkerPoolProvider({ children }: { children: ReactNode }) {
+  const workerFactory = useService<DiffWorkerFactory>(DIFF_WORKER_FACTORY);
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={{ workerFactory }}
+      highlighterOptions={DIFFS_HIGHLIGHTER_OPTIONS}
+    >
+      {children}
+    </WorkerPoolContextProvider>
+  );
+}

--- a/packages/workspace-server/src/services/local-logs/identifiers.ts
+++ b/packages/workspace-server/src/services/local-logs/identifiers.ts
@@ -4,13 +4,20 @@ export interface ILogsService {
   fetchS3Logs(logUrl: string): Promise<string | null>;
   readLocalLogs(taskRunId: string): Promise<string | null>;
   /**
-   * Read only the last `maxBytes` of the log for a fast initial paint. Returns
-   * `truncated: true` when older history was skipped (the partial first line is
-   * dropped). `null` if there's no local log.
+   * Read a window of the log ending at `endOffset` bytes (end of file when
+   * null), at most `maxBytes` long, returning whole ndjson lines plus the byte
+   * offset they start at. Page backwards by passing the previous `startOffset`
+   * as the next `endOffset`. `null` if there's no local log.
    */
-  readLocalLogsTail(
+  readLocalLogsWindow(
     taskRunId: string,
+    endOffset: number | null,
     maxBytes: number,
-  ): Promise<{ content: string; truncated: boolean } | null>;
+  ): Promise<{
+    content: string;
+    startOffset: number;
+    endOffset: number;
+    headReached: boolean;
+  } | null>;
   writeLocalLogs(taskRunId: string, content: string): Promise<void>;
 }

--- a/packages/workspace-server/src/services/local-logs/schemas.ts
+++ b/packages/workspace-server/src/services/local-logs/schemas.ts
@@ -6,12 +6,18 @@ export const fetchS3LogsOutput = z.string().nullable();
 export const readLocalLogsInput = z.object({ taskRunId: z.string().min(1) });
 export const readLocalLogsOutput = z.string().nullable();
 
-export const readLocalLogsTailInput = z.object({
+export const readLocalLogsWindowInput = z.object({
   taskRunId: z.string().min(1),
+  endOffset: z.number().int().nonnegative().nullable(),
   maxBytes: z.number().int().positive(),
 });
-export const readLocalLogsTailOutput = z
-  .object({ content: z.string(), truncated: z.boolean() })
+export const readLocalLogsWindowOutput = z
+  .object({
+    content: z.string(),
+    startOffset: z.number().int().nonnegative(),
+    endOffset: z.number().int().nonnegative(),
+    headReached: z.boolean(),
+  })
   .nullable();
 
 export const writeLocalLogsInput = z.object({

--- a/packages/workspace-server/src/services/local-logs/service.ts
+++ b/packages/workspace-server/src/services/local-logs/service.ts
@@ -52,35 +52,78 @@ export class LocalLogsService implements ILogsService {
     }
   }
 
-  async readLocalLogsTail(
+  /**
+   * Read a window of the log ending at `endOffset` bytes (end of file when
+   * `endOffset` is null), spanning at most `maxBytes`. Returns the whole ndjson
+   * lines in that window plus the byte offset they start at, so a caller can
+   * page backwards by passing the previous `startOffset` as the next
+   * `endOffset`. `headReached` is true once the window reaches byte 0.
+   *
+   * A window that doesn't begin at byte 0 starts mid-line, so its first
+   * (partial, possibly broken multi-byte) line is dropped; that line ends
+   * exactly at the returned `startOffset`, so paging back includes it whole.
+   */
+  async readLocalLogsWindow(
     taskRunId: string,
+    endOffset: number | null,
     maxBytes: number,
-  ): Promise<{ content: string; truncated: boolean } | null> {
+  ): Promise<{
+    content: string;
+    startOffset: number;
+    endOffset: number;
+    headReached: boolean;
+  } | null> {
     const logPath = this.getLocalLogPath(taskRunId);
     try {
       const stat = await fs.promises.stat(logPath);
-      if (stat.size <= maxBytes) {
-        return {
-          content: await fs.promises.readFile(logPath, "utf-8"),
-          truncated: false,
-        };
+      const end = endOffset ?? stat.size;
+      if (end <= 0) {
+        return { content: "", startOffset: 0, endOffset: 0, headReached: true };
       }
+      const rawStart = Math.max(0, end - maxBytes);
       const handle = await fs.promises.open(logPath, "r");
       try {
+        if (rawStart === 0) {
+          const buf = Buffer.alloc(end);
+          const { bytesRead } = await handle.read(buf, 0, end, 0);
+          return {
+            content: buf.toString("utf-8", 0, bytesRead),
+            startOffset: 0,
+            endOffset: end,
+            headReached: true,
+          };
+        }
         // Read one extra byte before the window: a newline there means the
-        // window already starts on a whole line. Otherwise the first line is
-        // a fragment (and may start with a broken multi-byte char) — drop
-        // everything up to the first newline so only whole ndjson lines
-        // remain.
-        const start = stat.size - maxBytes - 1;
-        const buf = Buffer.alloc(maxBytes + 1);
-        const { bytesRead } = await handle.read(buf, 0, maxBytes + 1, start);
+        // window already starts on a whole line, so keep it. Otherwise the
+        // first line is a fragment (and may start with a broken multi-byte
+        // char) — drop everything up to the first newline. Either way the
+        // returned startOffset is the byte the retained content begins at, so
+        // paging back from it includes any dropped line whole.
+        const length = end - rawStart;
+        const buf = Buffer.alloc(length + 1);
+        const { bytesRead } = await handle.read(
+          buf,
+          0,
+          length + 1,
+          rawStart - 1,
+        );
         const raw = buf.toString("utf-8", 1, bytesRead);
         if (buf[0] === 0x0a) {
-          return { content: raw, truncated: true };
+          return {
+            content: raw,
+            startOffset: rawStart,
+            endOffset: end,
+            headReached: false,
+          };
         }
         const nl = raw.indexOf("\n");
-        return { content: nl >= 0 ? raw.slice(nl + 1) : "", truncated: true };
+        const dropped = nl >= 0 ? nl + 1 : raw.length;
+        return {
+          content: raw.slice(dropped),
+          startOffset: rawStart + Buffer.byteLength(raw.slice(0, dropped)),
+          endOffset: end,
+          headReached: false,
+        };
       } finally {
         await handle.close();
       }

--- a/packages/workspace-server/src/services/local-logs/serviceTail.test.ts
+++ b/packages/workspace-server/src/services/local-logs/serviceTail.test.ts
@@ -6,7 +6,7 @@ import { LocalLogsService } from "./service";
 
 const RUN = "run-tail";
 
-describe("LocalLogsService.readLocalLogsTail", () => {
+describe("LocalLogsService.readLocalLogsWindow", () => {
   let tmpHome: string;
 
   beforeEach(() => {
@@ -25,13 +25,22 @@ describe("LocalLogsService.readLocalLogsTail", () => {
   const logPath = () =>
     path.join(tmpHome, ".posthog-code", "sessions", RUN, "logs.ndjson");
 
-  it("returns the whole file untruncated when it's under maxBytes", async () => {
+  it("returns the whole file, head reached, when it fits in maxBytes", async () => {
     const content = "line1\nline2\nline3\n";
     fs.writeFileSync(logPath(), content);
 
-    const res = await new LocalLogsService().readLocalLogsTail(RUN, 1_000_000);
+    const res = await new LocalLogsService().readLocalLogsWindow(
+      RUN,
+      null,
+      1_000_000,
+    );
 
-    expect(res).toEqual({ content, truncated: false });
+    expect(res).toEqual({
+      content,
+      startOffset: 0,
+      endOffset: content.length,
+      headReached: true,
+    });
   });
 
   it("returns only the tail, dropping the partial first line, when over maxBytes", async () => {
@@ -41,39 +50,76 @@ describe("LocalLogsService.readLocalLogsTail", () => {
     );
     fs.writeFileSync(logPath(), `${lines.join("\n")}\n`);
 
-    const res = await new LocalLogsService().readLocalLogsTail(RUN, 5000);
+    const res = await new LocalLogsService().readLocalLogsWindow(
+      RUN,
+      null,
+      5000,
+    );
 
-    expect(res?.truncated).toBe(true);
+    expect(res?.headReached).toBe(false);
+    expect(res?.startOffset).toBeGreaterThan(0);
     const tailLines = res?.content.trim().split("\n") ?? [];
-    // Every retained line is a whole, parseable ndjson entry (no fragment).
     for (const line of tailLines) {
       expect(() => JSON.parse(line)).not.toThrow();
     }
-    // It's the suffix of the file — ends with the last written line.
     expect(tailLines.at(-1)).toBe(lines.at(-1));
-    // It's a strict tail, not the whole file.
     expect(tailLines.length).toBeLessThan(lines.length);
+  });
+
+  it("pages backwards to reconstruct the whole file with no gap or duplicate", async () => {
+    const lines = Array.from(
+      { length: 500 },
+      (_, i) => `{"i":${i},"pad":"${"y".repeat(120)}"}`,
+    );
+    fs.writeFileSync(logPath(), `${lines.join("\n")}\n`);
+    const svc = new LocalLogsService();
+
+    const collected: string[] = [];
+    let endOffset: number | null = null;
+    let headReached = false;
+    while (!headReached) {
+      const page = await svc.readLocalLogsWindow(RUN, endOffset, 3000);
+      if (!page) break;
+      const pageLines = page.content.trim()
+        ? page.content.trim().split("\n")
+        : [];
+      collected.unshift(...pageLines);
+      endOffset = page.startOffset;
+      headReached = page.headReached;
+    }
+
+    expect(collected).toEqual(lines);
   });
 
   it("keeps the whole first line when the window starts on a line boundary", async () => {
     fs.writeFileSync(logPath(), "aaaa\nbbbb\ncccc\n");
 
-    const res = await new LocalLogsService().readLocalLogsTail(RUN, 10);
+    const res = await new LocalLogsService().readLocalLogsWindow(RUN, null, 10);
 
-    expect(res).toEqual({ content: "bbbb\ncccc\n", truncated: true });
+    expect(res).toEqual({
+      content: "bbbb\ncccc\n",
+      startOffset: 5,
+      endOffset: 15,
+      headReached: false,
+    });
   });
 
   it("returns empty content when a single line exceeds maxBytes", async () => {
     fs.writeFileSync(logPath(), `{"pad":"${"x".repeat(500)}"}\n`);
 
-    const res = await new LocalLogsService().readLocalLogsTail(RUN, 100);
+    const res = await new LocalLogsService().readLocalLogsWindow(
+      RUN,
+      null,
+      100,
+    );
 
-    expect(res).toEqual({ content: "", truncated: true });
+    expect(res?.content).toBe("");
+    expect(res?.headReached).toBe(false);
   });
 
   it("returns null when the log doesn't exist", async () => {
     expect(
-      await new LocalLogsService().readLocalLogsTail("missing", 1000),
+      await new LocalLogsService().readLocalLogsWindow("missing", null, 1000),
     ).toBeNull();
   });
 });

--- a/packages/workspace-server/src/trpc.ts
+++ b/packages/workspace-server/src/trpc.ts
@@ -132,8 +132,8 @@ import {
   deleteLocalLogCacheInput,
   readLocalLogsInput,
   readLocalLogsOutput,
-  readLocalLogsTailInput,
-  readLocalLogsTailOutput,
+  readLocalLogsWindowInput,
+  readLocalLogsWindowOutput,
   seedLocalLogsInput,
   writeLocalLogsInput,
 } from "./services/local-logs/schemas";
@@ -856,11 +856,15 @@ export function createAppRouter({
           localLogsService().readLocalLogs(input.taskRunId),
         ),
 
-      readTail: t.procedure
-        .input(readLocalLogsTailInput)
-        .output(readLocalLogsTailOutput)
+      readWindow: t.procedure
+        .input(readLocalLogsWindowInput)
+        .output(readLocalLogsWindowOutput)
         .query(({ input }) =>
-          localLogsService().readLocalLogsTail(input.taskRunId, input.maxBytes),
+          localLogsService().readLocalLogsWindow(
+            input.taskRunId,
+            input.endOffset,
+            input.maxBytes,
+          ),
         ),
 
       write: t.procedure


### PR DESCRIPTION
## Problem

Opening a task with a large transcript felt slow — up to ~3.4s before anything showed in the task log, and hover/input froze during it. Two independent causes, both scaling with transcript size:

1. The diff highlighter's worker pool self-terminates when the last diff view unmounts, so opening a diff-heavy task after navigating away re-pays Shiki's one-time init (WASM regex engine + theme normalization, ~1.5–2.2s, off-main but it delays diff content).
2. The fast "tail-first" paint only read the last 1.5MB of the log. A heavily-resumed task appends megabytes of `config_option_update` / `current_mode_update` / resume blobs to the end, so the paint landed on pure noise, showed an empty transcript, and the user waited for the full read + build + render.

## Changes

- **Keep the diff worker pool warm app-wide.** Mount one `WorkerPoolContextProvider` at the app root so the pool's mount count never hits zero. Shiki inits once at startup; every subsequent diff render reuses the warm worker.
- **Seek real content in the fast paint.** Replace the fixed-tail `readLocalLogsTail` with a byte-windowed `readLocalLogsWindow` and page back past the config-noise until real messages are in view, then paint them. The full read still loads the complete transcript behind the paint.

Both are contained; no behavior change for small tasks (their tail already holds messages). Does not touch the separate ~1s of synchronous main-thread work (parse/build/render) — that's a bigger, off-main-parsing change left for later.

## How did you test this?

- Unit tests: `readLocalLogsWindow` (whole-file, tail-with-partial-line-drop, line-boundary, single-line-over-max, backwards paging reconstructs the file, missing log); `paintTailFirst` (paints when the tail holds content, pages back past config-noise, no-ops for missing host read / existing session / empty content).
- Typecheck + existing session suites pass.
- Measured on a heavily-resumed 20MB / 9k-event task via CDP CPU profiling: time-to-first-content **3364ms → ~1066ms** (~3x). The ~2.2s of off-main Shiki init drops out of the open path entirely; the fast paint then shows recent messages in ~1s (config-noise paging) — a typical task paints in ~150ms.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?