### PR TITLE
feat(agent): add refusal handling and model fallback

### DIFF
--- a/packages/agent/src/adapters/claude/UPSTREAM.md
+++ b/packages/agent/src/adapters/claude/UPSTREAM.md
@@ -38,6 +38,12 @@ Fork of `@anthropic-ai/claude-agent-acp`. Upstream repo: https://github.com/anth
 - `SYSTEM_REMINDER` stripping from Read tool results
 - WebFetch `resourceLink` content enrichment
 - `customTitle` in listSessions (PostHog Code is ahead of upstream here)
+- Refusal support: `Options.fallbackModel` defaults to `FALLBACK_MODEL` in
+  `session/options.ts`; `model_refusal_fallback` system messages emit a
+  `_posthog/status` notification (`refusal_fallback`) in `sdk-to-acp.ts`; a
+  terminal `stop_reason: "refusal"` emits `_posthog/status` (`refusal`) instead
+  of upstream's raw-explanation `agent_message_chunk` (supersedes the v0.42.0
+  "Refusal handling" port and the v0.44.0 `model_refusal_fallback` skip)
 - SettingsManager `PreToolUse` hook for permission rules
 - `ensureLocalSettings` / `clearStatsigCache`
 - `ELECTRON_RUN_AS_NODE` / `ENABLE_TOOL_SEARCH` env vars

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -517,6 +517,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     let errored = false;
     let lastAssistantTotalUsage: number | null = null;
     let lastRefusalExplanation: string | null = null;
+    let lastRefusalCategory: string | null = null;
     let lastStreamUsage = {
       input_tokens: 0,
       output_tokens: 0,
@@ -870,15 +871,17 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
             if (
               (message as { stop_reason?: string }).stop_reason === "refusal"
             ) {
-              if (lastRefusalExplanation) {
-                await this.client.sessionUpdate({
-                  sessionId: params.sessionId,
-                  update: {
-                    sessionUpdate: "agent_message_chunk",
-                    content: { type: "text", text: lastRefusalExplanation },
-                  },
-                });
-              }
+              // The API's stop_details.explanation is integrator-facing prose,
+              // so surface the refusal as a structured status row rather than
+              // assistant text.
+              await this.client.extNotification(POSTHOG_NOTIFICATIONS.STATUS, {
+                sessionId: params.sessionId,
+                status: "refusal",
+                ...(lastRefusalExplanation && {
+                  explanation: lastRefusalExplanation,
+                }),
+                ...(lastRefusalCategory && { category: lastRefusalCategory }),
+              });
               return { stopReason: "refusal", usage };
             }
 
@@ -1002,11 +1005,15 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
             if (message.type === "assistant") {
               const inner = message.message as unknown as {
                 stop_reason?: string | null;
-                stop_details?: { explanation?: string | null } | null;
+                stop_details?: {
+                  category?: string | null;
+                  explanation?: string | null;
+                } | null;
               };
               if (inner.stop_reason === "refusal") {
                 lastRefusalExplanation =
                   inner.stop_details?.explanation ?? null;
+                lastRefusalCategory = inner.stop_details?.category ?? null;
               }
             }
 

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
@@ -390,44 +390,49 @@ describe("handleSystemMessage model_refusal_fallback", () => {
     };
   }
 
-  it("emits a refusal_fallback status notification with the model swap", async () => {
+  it.each<
+    [string, Partial<SDKModelRefusalFallbackMessage>, Record<string, unknown>]
+  >([
+    [
+      "emits a refusal_fallback status notification with the model swap",
+      {},
+      {
+        sessionId: "test-session",
+        status: "refusal_fallback",
+        fromModel: "claude-fable-5",
+        toModel: "claude-opus-4-8",
+        explanation: "This request was declined.",
+      },
+    ],
+    [
+      "omits the explanation when the refused response carried none",
+      { api_refusal_explanation: null },
+      {
+        sessionId: "test-session",
+        status: "refusal_fallback",
+        fromModel: "claude-fable-5",
+        toModel: "claude-opus-4-8",
+      },
+    ],
+  ])("%s", async (_name, overrides, expectedParams) => {
     const { context, updates, notifications } = createHandlerContext();
 
-    await handleSystemMessage(refusalFallbackMessage(), context);
+    await handleSystemMessage(refusalFallbackMessage(overrides), context);
 
     expect(updates).toEqual([]);
     expect(notifications).toEqual([
-      {
-        method: "_posthog/status",
-        params: {
-          sessionId: "test-session",
-          status: "refusal_fallback",
-          fromModel: "claude-fable-5",
-          toModel: "claude-opus-4-8",
-          explanation: "This request was declined.",
-        },
-      },
+      { method: "_posthog/status", params: expectedParams },
     ]);
   });
 
-  it("omits the explanation when the refused response carried none", async () => {
-    const { context, notifications } = createHandlerContext();
+  it.each(["revert", "sticky"] as const)(
+    "skips the notification for the legacy %s direction",
+    async (direction) => {
+      const { context, notifications } = createHandlerContext();
 
-    await handleSystemMessage(
-      refusalFallbackMessage({ api_refusal_explanation: null }),
-      context,
-    );
+      await handleSystemMessage(refusalFallbackMessage({ direction }), context);
 
-    expect(notifications).toEqual([
-      {
-        method: "_posthog/status",
-        params: {
-          sessionId: "test-session",
-          status: "refusal_fallback",
-          fromModel: "claude-fable-5",
-          toModel: "claude-opus-4-8",
-        },
-      },
-    ]);
-  });
+      expect(notifications).toEqual([]);
+    },
+  );
 });

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
@@ -4,6 +4,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import type {
   SDKAssistantMessage,
+  SDKModelRefusalFallbackMessage,
   SDKPartialAssistantMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -12,6 +13,7 @@ import { Logger } from "../../../utils/logger";
 import type { Session } from "../types";
 import {
   handleStreamEvent,
+  handleSystemMessage,
   handleUserAssistantMessage,
   type MessageHandlerContext,
   stripMarkerTags,
@@ -64,9 +66,13 @@ describe("stripMarkerTags", () => {
 
 function createHandlerContext() {
   const updates: SessionNotification[] = [];
+  const notifications: Array<{ method: string; params: unknown }> = [];
   const client = {
     sessionUpdate: async (notification: SessionNotification) => {
       updates.push(notification);
+    },
+    extNotification: async (method: string, params: unknown) => {
+      notifications.push({ method, params });
     },
   } as unknown as AgentSideConnection;
   const context: MessageHandlerContext = {
@@ -86,7 +92,7 @@ function createHandlerContext() {
       thinkingIds: new Set(),
     },
   };
-  return { context, updates };
+  return { context, updates, notifications };
 }
 
 function streamEvent(
@@ -359,5 +365,69 @@ describe("import replay (no client-side history)", () => {
       context,
     );
     expect(chunkTexts(updates, "agent_message_chunk")).toEqual([]);
+  });
+});
+
+describe("handleSystemMessage model_refusal_fallback", () => {
+  function refusalFallbackMessage(
+    overrides: Partial<SDKModelRefusalFallbackMessage> = {},
+  ): SDKModelRefusalFallbackMessage {
+    return {
+      type: "system",
+      subtype: "model_refusal_fallback",
+      trigger: "refusal",
+      direction: "retry",
+      original_model: "claude-fable-5",
+      fallback_model: "claude-opus-4-8",
+      request_id: "req_1",
+      api_refusal_category: "cyber",
+      api_refusal_explanation: "This request was declined.",
+      retracted_message_uuids: [],
+      content: "Retried on fallback model",
+      uuid: "00000000-0000-0000-0000-000000000009",
+      session_id: "test-session",
+      ...overrides,
+    };
+  }
+
+  it("emits a refusal_fallback status notification with the model swap", async () => {
+    const { context, updates, notifications } = createHandlerContext();
+
+    await handleSystemMessage(refusalFallbackMessage(), context);
+
+    expect(updates).toEqual([]);
+    expect(notifications).toEqual([
+      {
+        method: "_posthog/status",
+        params: {
+          sessionId: "test-session",
+          status: "refusal_fallback",
+          fromModel: "claude-fable-5",
+          toModel: "claude-opus-4-8",
+          explanation: "This request was declined.",
+        },
+      },
+    ]);
+  });
+
+  it("omits the explanation when the refused response carried none", async () => {
+    const { context, notifications } = createHandlerContext();
+
+    await handleSystemMessage(
+      refusalFallbackMessage({ api_refusal_explanation: null }),
+      context,
+    );
+
+    expect(notifications).toEqual([
+      {
+        method: "_posthog/status",
+        params: {
+          sessionId: "test-session",
+          status: "refusal_fallback",
+          fromModel: "claude-fable-5",
+          toModel: "claude-opus-4-8",
+        },
+      },
+    ]);
   });
 });

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -796,6 +796,26 @@ export async function handleSystemMessage(
         `Session ${sessionId}: failed to persist history: ${message.error}`,
       );
       break;
+    case "model_refusal_fallback": {
+      logger.info("Refusal retried on fallback model", {
+        sessionId,
+        direction: message.direction,
+        originalModel: message.original_model,
+        fallbackModel: message.fallback_model,
+        category: message.api_refusal_category ?? undefined,
+        requestId: message.request_id ?? undefined,
+      });
+      await client.extNotification(POSTHOG_NOTIFICATIONS.STATUS, {
+        sessionId,
+        status: "refusal_fallback",
+        fromModel: message.original_model,
+        toModel: message.fallback_model,
+        ...(message.api_refusal_explanation && {
+          explanation: message.api_refusal_explanation,
+        }),
+      });
+      break;
+    }
     case "permission_denied": {
       const reason = message.decision_reason ?? message.message;
       await client.sessionUpdate({

--- a/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -805,6 +805,9 @@ export async function handleSystemMessage(
         category: message.api_refusal_category ?? undefined,
         requestId: message.request_id ?? undefined,
       });
+      // Only "retry" is emitted live; "revert" and "sticky" are legacy enum
+      // values whose semantics don't match the "retried with" notice.
+      if (message.direction !== "retry") break;
       await client.extNotification(POSTHOG_NOTIFICATIONS.STATUS, {
         sessionId,
         status: "refusal_fallback",

--- a/packages/agent/src/adapters/claude/session/models.ts
+++ b/packages/agent/src/adapters/claude/session/models.ts
@@ -2,6 +2,10 @@ import type { EffortLevel } from "../types";
 
 export const DEFAULT_MODEL = "opus";
 
+// Refusal/overload rescue target. The SDK rejects fallbackModel === Options.model
+// at spawn, so this must stay distinct from the alias form used for DEFAULT_MODEL.
+export const FALLBACK_MODEL = "claude-opus-4-8";
+
 // Default thinking level when the user hasn't picked one. Adaptive-only models
 // like claude-fable-5 reject the SDK's no-effort `thinking: { type: "disabled" }`
 // shape, so effort-capable models default to high to keep thinking enabled.

--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -92,19 +92,19 @@ describe("buildSessionOptions", () => {
     expect(options.agents?.["ph-explore"]).toEqual(override);
   });
 
-  it("defaults fallbackModel so refusals and overloads retry on another model", () => {
-    const options = buildSessionOptions(makeParams());
+  it.each([
+    ["a new session", () => makeParams()],
+    ["a resumed session", () => ({ ...makeParams(), isResume: true })],
+  ])(
+    "defaults fallbackModel on %s so refusals and overloads retry on another model",
+    (_label, params) => {
+      const options = buildSessionOptions(params());
 
-    expect(options.fallbackModel).toBe("claude-opus-4-8");
-    // The SDK throws at spawn when fallbackModel equals Options.model.
-    expect(options.fallbackModel).not.toBe(options.model);
-  });
-
-  it("defaults fallbackModel on resumed sessions", () => {
-    const options = buildSessionOptions({ ...makeParams(), isResume: true });
-
-    expect(options.fallbackModel).toBe("claude-opus-4-8");
-  });
+      expect(options.fallbackModel).toBe("claude-opus-4-8");
+      // The SDK throws at spawn when fallbackModel equals Options.model.
+      expect(options.fallbackModel).not.toBe(options.model);
+    },
+  );
 
   it("preserves a caller-provided fallbackModel", () => {
     const options = buildSessionOptions({

--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -92,6 +92,29 @@ describe("buildSessionOptions", () => {
     expect(options.agents?.["ph-explore"]).toEqual(override);
   });
 
+  it("defaults fallbackModel so refusals and overloads retry on another model", () => {
+    const options = buildSessionOptions(makeParams());
+
+    expect(options.fallbackModel).toBe("claude-opus-4-8");
+    // The SDK throws at spawn when fallbackModel equals Options.model.
+    expect(options.fallbackModel).not.toBe(options.model);
+  });
+
+  it("defaults fallbackModel on resumed sessions", () => {
+    const options = buildSessionOptions({ ...makeParams(), isResume: true });
+
+    expect(options.fallbackModel).toBe("claude-opus-4-8");
+  });
+
+  it("preserves a caller-provided fallbackModel", () => {
+    const options = buildSessionOptions({
+      ...makeParams(),
+      userProvidedOptions: { fallbackModel: "claude-sonnet-5" },
+    });
+
+    expect(options.fallbackModel).toBe("claude-sonnet-5");
+  });
+
   it("threads onEnsureLocalToolsConnected into the signed-commit guard (cloud)", async () => {
     const healSpy = vi.fn().mockResolvedValue(true);
     await runPreToolUseHooks(

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -28,7 +28,7 @@ import type { CodeExecutionMode } from "../tools";
 import type { EffortLevel } from "../types";
 import { APPENDED_INSTRUCTIONS } from "./instructions";
 import { loadUserClaudeJsonMcpServers } from "./mcp-config";
-import { DEFAULT_MODEL } from "./models";
+import { DEFAULT_MODEL, FALLBACK_MODEL } from "./models";
 import type { SettingsManager } from "./settings";
 
 export interface ProcessSpawnedInfo {
@@ -485,6 +485,10 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
   } else {
     options.sessionId = params.sessionId;
     options.model = DEFAULT_MODEL;
+  }
+
+  if (!options.fallbackModel && options.model !== FALLBACK_MODEL) {
+    options.fallbackModel = FALLBACK_MODEL;
   }
 
   if (params.additionalDirectories) {

--- a/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -123,6 +123,22 @@ function statusMsg(
   };
 }
 
+function refusalStatusMsg(
+  ts: number,
+  status: "refusal" | "refusal_fallback",
+  fields: { explanation?: string; fromModel?: string; toModel?: string } = {},
+): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "_posthog/status",
+      params: { sessionId: "session-1", status, ...fields },
+    },
+  };
+}
+
 describe("buildConversationItems", () => {
   it("extracts cloud prompt attachments into user messages", () => {
     const uri = makeAttachmentUri("/tmp/hello world.txt");
@@ -220,6 +236,56 @@ describe("buildConversationItems", () => {
       },
     ]);
     expect(result.isCompacting).toBe(false);
+  });
+
+  it("renders a terminal refusal as a status row carrying the explanation", () => {
+    const result = buildConversationItems(
+      [
+        userPromptMsg(1, 1, "hi"),
+        refusalStatusMsg(2, "refusal", {
+          explanation: "This request was declined.",
+        }),
+      ],
+      null,
+    );
+
+    const statusItems = result.items.filter(
+      (i): i is Extract<ConversationItem, { type: "session_update" }> =>
+        i.type === "session_update" && i.update.sessionUpdate === "status",
+    );
+    expect(statusItems.map((i) => i.update)).toEqual([
+      {
+        sessionUpdate: "status",
+        status: "refusal",
+        explanation: "This request was declined.",
+      },
+    ]);
+  });
+
+  it("renders a refusal fallback status row carrying the model swap", () => {
+    const result = buildConversationItems(
+      [
+        userPromptMsg(1, 1, "hi"),
+        refusalStatusMsg(2, "refusal_fallback", {
+          fromModel: "claude-fable-5",
+          toModel: "claude-opus-4-8",
+        }),
+      ],
+      null,
+    );
+
+    const statusItems = result.items.filter(
+      (i): i is Extract<ConversationItem, { type: "session_update" }> =>
+        i.type === "session_update" && i.update.sessionUpdate === "status",
+    );
+    expect(statusItems.map((i) => i.update)).toEqual([
+      {
+        sessionUpdate: "status",
+        status: "refusal_fallback",
+        fromModel: "claude-fable-5",
+        toModel: "claude-opus-4-8",
+      },
+    ]);
   });
 
   it("marks cloud turns complete from structured turn completion notifications", () => {

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -535,7 +535,20 @@ function handleNotification(
       status: string;
       isComplete?: boolean;
       error?: string;
+      explanation?: string;
+      fromModel?: string;
+      toModel?: string;
     };
+    if (params.status === "refusal" || params.status === "refusal_fallback") {
+      pushItem(b, {
+        sessionUpdate: "status",
+        status: params.status,
+        explanation: params.explanation,
+        fromModel: params.fromModel,
+        toModel: params.toModel,
+      });
+      return;
+    }
     if (params.status === "compacting") {
       if (params.isComplete) {
         // Successful compaction — flip the existing "Compacting…" status to

--- a/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
@@ -35,6 +35,12 @@ export type RenderItem =
       isComplete?: boolean;
       /** Set when a status ends in failure (e.g. a failed compaction) so the row renders the error. */
       error?: string;
+      /** Refusal statuses: display-only stop_details.explanation from the API. */
+      explanation?: string;
+      /** Refusal fallback: the model that declined the request. */
+      fromModel?: string;
+      /** Refusal fallback: the model that retried the request. */
+      toModel?: string;
     }
   | {
       sessionUpdate: "error";
@@ -125,6 +131,9 @@ export const SessionUpdateView = memo(function SessionUpdateView({
           status={item.status}
           isComplete={item.isComplete}
           error={item.error}
+          explanation={item.explanation}
+          fromModel={item.fromModel}
+          toModel={item.toModel}
         />
       );
     case "error":

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -1,6 +1,11 @@
-import { Spinner, XCircle } from "@phosphor-icons/react";
+import {
+  ArrowsClockwise,
+  ShieldWarning,
+  Spinner,
+  XCircle,
+} from "@phosphor-icons/react";
 import { ChatMarker, ChatMarkerContent } from "@posthog/quill";
-import { Box, Flex, Text } from "@radix-ui/themes";
+import { Box, Callout, Flex, Text } from "@radix-ui/themes";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 
 interface StatusNotificationViewProps {
@@ -8,16 +13,74 @@ interface StatusNotificationViewProps {
   isComplete?: boolean;
   /** Failure reason, set on a `compacting_failed` status. */
   error?: string;
+  /** Refusal statuses: display-only stop_details.explanation from the API. */
+  explanation?: string;
+  /** Refusal fallback: the model that declined the request. */
+  fromModel?: string;
+  /** Refusal fallback: the model that retried the request. */
+  toModel?: string;
 }
 
 export function StatusNotificationView({
   status,
   isComplete,
   error,
+  explanation,
+  fromModel,
+  toModel,
 }: StatusNotificationViewProps) {
   // New thread renders status notes as centered separator markers; the legacy thread keeps its
   // bordered rows so ConversationView is unchanged when the chat thread is off.
   const chatChrome = useChatThreadChrome();
+
+  // Terminal refusal: the safety classifier declined the request and no
+  // fallback model rescued it. Rendered as a callout in both chromes.
+  if (status === "refusal") {
+    return (
+      <Box className="my-2">
+        <Callout.Root color="orange" size="1">
+          <Callout.Icon>
+            <ShieldWarning weight="fill" />
+          </Callout.Icon>
+          <Callout.Text>
+            <Flex direction="column" gap="1">
+              <Text className="font-medium text-sm">
+                Claude declined to continue with this request.
+              </Text>
+              {explanation && (
+                <Text className="text-[13px] text-gray-11">{explanation}</Text>
+              )}
+              <Text className="text-[13px] text-gray-11">
+                Try rephrasing your request, or switch models and retry.
+              </Text>
+            </Flex>
+          </Callout.Text>
+        </Callout.Root>
+      </Box>
+    );
+  }
+
+  if (status === "refusal_fallback") {
+    const message =
+      fromModel && toModel
+        ? `${fromModel} declined this request, retried with ${toModel}`
+        : "Request declined, retried with the fallback model";
+    if (chatChrome) {
+      return (
+        <ChatMarker variant="separator">
+          <ChatMarkerContent>{message}</ChatMarkerContent>
+        </ChatMarker>
+      );
+    }
+    return (
+      <Box className="my-1 border-orange-6 border-l-2 py-1 pl-3 dark:border-orange-8">
+        <Flex align="center" gap="2">
+          <ArrowsClockwise size={14} className="text-orange-9" />
+          <Text className="text-[13px] text-gray-11">{message}</Text>
+        </Flex>
+      </Box>
+    );
+  }
 
   // A failed compaction (e.g. "Not enough messages to compact"). The matching `compacting` spinner
   // is cleared separately; this row reports the outcome.


### PR DESCRIPTION
## Problem

End users on Claude Fable 5 can hit safety-classifier refusals: the API returns HTTP 200 with `stop_reason: "refusal"` and expects integrators to configure a fallback model (https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback). We configured none, and the adapter streamed the refusal's raw `stop_details.explanation` into the chat as assistant prose. A user saw their truncated answer followed by "API integrators: you can reduce refusals for your users by configuring a fallback model", which is platform text meant for us, not them.

## Changes

- `packages/agent`: sessions now spawn with `Options.fallbackModel: "claude-opus-4-8"`, so the SDK retries a refused (or overloaded) turn on Opus 4.8 and keeps the swap for the session. Caller-provided values win, and a guard avoids the SDK's spawn error when the fallback equals `Options.model`.
- `packages/agent`: the `model_refusal_fallback` system message (previously a silent no-op) now emits a `_posthog/status` notification carrying the model swap and the display-only explanation.
- `packages/agent`: a terminal refusal emits a structured `_posthog/status` refusal notification instead of an `agent_message_chunk` with the raw explanation text. The turn still returns ACP stop reason `refusal`.
- `packages/ui`: renders the two new statuses. A terminal refusal shows an orange callout with the explanation and a retry hint; a fallback retry shows a marker row ("claude-fable-5 declined this request, retried with claude-opus-4-8").
- `UPSTREAM.md`: documents the divergence so upstream syncs don't revert it.

Known limitation: on a mid-stream refusal the already-streamed partial text stays in the transcript. The SDK sends retraction uuids but the chunk-based transcript cannot evict them, so the sequence reads partial answer, fallback marker, then the fresh answer.

No screenshots: both states require a live safety-classifier refusal, which cannot be triggered on demand.

## How did you test this?

- New unit tests: `fallbackModel` default, resume and override behavior in `options.test.ts`; `model_refusal_fallback` notification shape in `sdk-to-acp.test.ts`; refusal and refusal_fallback item passthrough in `buildConversationItems.test.ts`.
- Full suites pass: claude adapter (20 files, 311 tests) and ui sessions (24 files, 306 tests).
- `pnpm --filter @posthog/agent typecheck`, `pnpm --filter @posthog/ui typecheck` and Biome on the changed files.
- Not verified against a live refusal; the flow is covered by the unit tests above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?