### PR TITLE
fix(thread): stop ChatThread snapping to top on prompt submit

### DIFF
--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -512,27 +512,6 @@ const ThreadRow = memo(function ThreadRow({
   );
 });
 
-function AnchorNewPrompt({ items }: { items: ConversationItem[] }) {
-  const { scrollToMessage } = useChatMessageScroller();
-  const lastItem = items.at(-1);
-  const userMessageCount = useMemo(
-    () =>
-      items.reduce((n, item) => (item.type === "user_message" ? n + 1 : n), 0),
-    [items],
-  );
-  const prevCountRef = useRef(userMessageCount);
-
-  useLayoutEffect(() => {
-    const previous = prevCountRef.current;
-    prevCountRef.current = userMessageCount;
-    if (previous === 0 || userMessageCount <= previous) return;
-    if (lastItem?.type !== "user_message") return;
-    scrollToMessage(lastItem.id, { align: "start" });
-  }, [userMessageCount, lastItem, scrollToMessage]);
-
-  return null;
-}
-
 /** The scroll body, under the Provider so the overlay + scroll-button hooks can read engine state. */
 function ThreadScrollBody({
   items,
@@ -559,7 +538,6 @@ function ThreadScrollBody({
   return (
     <ChatMessageScroller className="group/thread">
       <StickyHeaderOverlay items={items} />
-      <AnchorNewPrompt items={items} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent className="py-4 pb-8" density="default">
           {keyedRows.map(({ item, key }) => (

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -134,7 +134,7 @@ function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
   const flush = () => {
     if (toolCount >= 2) {
       const tools = buffer.filter(isToolCallItem);
-      out.push({ type: "tool_group", id: `tool-group-${tools[0].id}`, tools });
+      out.push({ type: "tool_group", id: tools[0].id, tools });
     } else {
       out.push(...buffer);
     }
@@ -512,6 +512,27 @@ const ThreadRow = memo(function ThreadRow({
   );
 });
 
+function AnchorNewPrompt({ items }: { items: ConversationItem[] }) {
+  const { scrollToMessage } = useChatMessageScroller();
+  const lastItem = items.at(-1);
+  const userMessageCount = useMemo(
+    () =>
+      items.reduce((n, item) => (item.type === "user_message" ? n + 1 : n), 0),
+    [items],
+  );
+  const prevCountRef = useRef(userMessageCount);
+
+  useLayoutEffect(() => {
+    const previous = prevCountRef.current;
+    prevCountRef.current = userMessageCount;
+    if (previous === 0 || userMessageCount <= previous) return;
+    if (lastItem?.type !== "user_message") return;
+    scrollToMessage(lastItem.id, { align: "start" });
+  }, [userMessageCount, lastItem, scrollToMessage]);
+
+  return null;
+}
+
 /** The scroll body, under the Provider so the overlay + scroll-button hooks can read engine state. */
 function ThreadScrollBody({
   items,
@@ -525,15 +546,24 @@ function ThreadScrollBody({
   /** Status row (duration / context usage) pinned as the last item in the thread. */
   footer?: ReactNode;
 }) {
+  const keyedRows = useMemo(() => {
+    let userTurn = 0;
+    return rows.map((item) => ({
+      item,
+      key: item.type === "user_message" ? `user-turn-${userTurn++}` : item.id,
+    }));
+  }, [rows]);
+
   // `group/thread` so the footer's hover-reveal (opacity-50 → 100 on group-hover) tracks the thread,
   // mirroring the legacy ConversationView container.
   return (
     <ChatMessageScroller className="group/thread">
       <StickyHeaderOverlay items={items} />
+      <AnchorNewPrompt items={items} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent className="py-4 pb-8" density="default">
-          {rows.map((item) => (
-            <ThreadRow key={item.id} item={item} renderItem={renderItem} />
+          {keyedRows.map(({ item, key }) => (
+            <ThreadRow key={key} item={item} renderItem={renderItem} />
           ))}
           {footer && (
             <div

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -19,6 +19,7 @@ import {
   ChatMessageScrollerViewport,
   cn,
   useChatMessageScroller,
+  useChatMessageScrollerScrollable,
   useChatMessageScrollerVisibility,
 } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
@@ -513,14 +514,23 @@ const ThreadRow = memo(function ThreadRow({
 });
 
 /**
- * Scrolls to the end when the user sends a prompt, regardless of current position. The engine only
- * auto-follows in `following-bottom` mode, which it re-enters solely within 8px of the exact bottom
- * — with the thread's bottom padding you're rarely that close, so without this a submit can leave
- * the new prompt (and the streaming response) below the fold. `scrollToEnd` also puts the engine
- * back into `following-bottom`, so the response streams with the view following.
+ * Keeps the view pinned to the bottom from prompt submit until the user scrolls away.
+ *
+ * The engine's own follow mode isn't enough on its own:
+ * - It only re-engages within `scrollEdgeThreshold` of the exact bottom, so a submit from anywhere
+ *   higher would leave the new prompt (and the reply) below the fold. Scrolling to the end on
+ *   submit also flips the engine back into `following-bottom`.
+ * - Each engine autoscroll is guarded by a 180ms grace window; a large streamed block (heavy
+ *   markdown render) can jank past it, making the engine observe "content below the fold while not
+ *   autoscrolling" and silently demote itself to `free-scrolling` mid-reply. While armed, any
+ *   commit that leaves content below the fold re-issues `scrollToEnd` to recapture follow.
+ *
+ * User scroll intent (wheel, touch, pointer, keys — same signals the engine listens to) disarms
+ * the pin; the next submit or the scroll-to-bottom button re-engages following.
  */
-function ScrollToEndOnSubmit({ items }: { items: ConversationItem[] }) {
+function ThreadAutoFollow({ items }: { items: ConversationItem[] }) {
   const { scrollToEnd } = useChatMessageScroller();
+  const { end } = useChatMessageScrollerScrollable();
   const lastItem = items.at(-1);
   const userMessageCount = useMemo(
     () =>
@@ -528,16 +538,45 @@ function ScrollToEndOnSubmit({ items }: { items: ConversationItem[] }) {
     [items],
   );
   const prevCountRef = useRef(userMessageCount);
+  const armedRef = useRef(false);
+  const probeRef = useRef<HTMLSpanElement>(null);
 
   useLayoutEffect(() => {
     const previous = prevCountRef.current;
     prevCountRef.current = userMessageCount;
     if (previous === 0 || userMessageCount <= previous) return;
     if (lastItem?.type !== "user_message") return;
+    armedRef.current = true;
     scrollToEnd({ behavior: "auto" });
   }, [userMessageCount, lastItem, scrollToEnd]);
 
-  return null;
+  useEffect(() => {
+    const viewport = probeRef.current
+      ?.closest('[data-slot="chat-message-scroller"]')
+      ?.querySelector('[data-slot="chat-message-scroller-viewport"]');
+    if (!viewport) return;
+    const disarm = () => {
+      armedRef.current = false;
+    };
+    const events = ["wheel", "touchmove", "pointerdown", "keydown"] as const;
+    for (const event of events) {
+      viewport.addEventListener(event, disarm, { passive: true });
+    }
+    return () => {
+      for (const event of events) {
+        viewport.removeEventListener(event, disarm);
+      }
+    };
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-check on every streamed change — `end` alone doesn't re-notify while it stays true across commits.
+  useEffect(() => {
+    if (armedRef.current && end) {
+      scrollToEnd({ behavior: "auto" });
+    }
+  }, [items, end, scrollToEnd]);
+
+  return <span ref={probeRef} className="hidden" aria-hidden="true" />;
 }
 
 /** The scroll body, under the Provider so the overlay + scroll-button hooks can read engine state. */
@@ -566,7 +605,7 @@ function ThreadScrollBody({
   return (
     <ChatMessageScroller className="group/thread">
       <StickyHeaderOverlay items={items} />
-      <ScrollToEndOnSubmit items={items} />
+      <ThreadAutoFollow items={items} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent className="py-4 pb-8" density="default">
           {keyedRows.map(({ item, key }) => (

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -512,6 +512,34 @@ const ThreadRow = memo(function ThreadRow({
   );
 });
 
+/**
+ * Scrolls to the end when the user sends a prompt, regardless of current position. The engine only
+ * auto-follows in `following-bottom` mode, which it re-enters solely within 8px of the exact bottom
+ * — with the thread's bottom padding you're rarely that close, so without this a submit can leave
+ * the new prompt (and the streaming response) below the fold. `scrollToEnd` also puts the engine
+ * back into `following-bottom`, so the response streams with the view following.
+ */
+function ScrollToEndOnSubmit({ items }: { items: ConversationItem[] }) {
+  const { scrollToEnd } = useChatMessageScroller();
+  const lastItem = items.at(-1);
+  const userMessageCount = useMemo(
+    () =>
+      items.reduce((n, item) => (item.type === "user_message" ? n + 1 : n), 0),
+    [items],
+  );
+  const prevCountRef = useRef(userMessageCount);
+
+  useLayoutEffect(() => {
+    const previous = prevCountRef.current;
+    prevCountRef.current = userMessageCount;
+    if (previous === 0 || userMessageCount <= previous) return;
+    if (lastItem?.type !== "user_message") return;
+    scrollToEnd({ behavior: "auto" });
+  }, [userMessageCount, lastItem, scrollToEnd]);
+
+  return null;
+}
+
 /** The scroll body, under the Provider so the overlay + scroll-button hooks can read engine state. */
 function ThreadScrollBody({
   items,
@@ -538,6 +566,7 @@ function ThreadScrollBody({
   return (
     <ChatMessageScroller className="group/thread">
       <StickyHeaderOverlay items={items} />
+      <ScrollToEndOnSubmit items={items} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent className="py-4 pb-8" density="default">
           {keyedRows.map(({ item, key }) => (
@@ -700,6 +729,11 @@ export function ChatThread({
           <ChatMessageScrollerProvider
             autoScroll
             defaultScrollPosition="end"
+            // Default is 8px: with the thread's bottom padding you're rarely that close, so
+            // auto-follow ("following-bottom") would disengage on any stray trackpad wheel and
+            // never re-engage. Within this band the engine recaptures follow on the next content
+            // change; deliberate upward flicks travel past it and stay free-scrolling.
+            scrollEdgeThreshold={100}
             scrollPreviousItemPeek={64}
           >
             <ThreadScrollBody


### PR DESCRIPTION
## Problem

In the new ChatThread view (behind `useNewChatThread`):

1. Submitting a prompt in a conversation with history snapped the scroll position back to the top of the conversation on every prompt.
2. Stick-to-bottom was unreliable: submits and streaming replies often didn't scroll the view, and fast streams (large blocks) dropped out of follow mid-reply.

## Root causes

**The snap.** quill's message scroller reacts to childList mutations on the scroller content by comparing direct-child counts. When a prompt is sent, the optimistic user bubble (`optimistic-…` id) is swapped for the echoed real prompt (`turn-…-user` id) in a single React commit — a mutation where the child count doesn't change. In that case the engine falls into a re-anchor branch that scans all rows from the top for the first `data-scroll-anchor` element it hasn't scrolled to before. Historical user messages never qualify as handled, so it scrolls to the first user message in the conversation. A second trigger of the same branch: a lone tool marker collapsing into a `tool_group` row (1 row → 1 row, key change) mid-response.

**Unreliable following.** The engine only auto-follows in `following-bottom` mode, which it re-enters solely within `scrollEdgeThreshold` (default 8px) of the exact bottom — with the thread's bottom padding the view is rarely that close, and any stray trackpad wheel exits follow mode. Additionally, each engine autoscroll is guarded by a 180ms grace window; a large streamed block (heavy markdown render) can jank past it, making the engine observe "content below the fold while not autoscrolling" and demote itself to `free-scrolling` mid-reply.

## Fix

All in `ChatThread.tsx`:

- Key user-message rows by occurrence index (`user-turn-N`) instead of `item.id`, so the optimistic→real swap reuses the same DOM element and the buggy re-anchor branch never fires.
- Reuse the first tool's item id as the `tool_group` id, so a lone marker growing into a group keeps its key/element.
- `ThreadAutoFollow`: pin the view to the bottom from prompt submit until the user scrolls away — scroll to end on submit (which also re-engages the engine's `following-bottom`), and while armed re-issue `scrollToEnd` whenever content slips below the fold, recapturing follow after stream bursts. User scroll intent (wheel/touch/pointer/keys) disarms.
- Widen `scrollEdgeThreshold` to 100px so near-bottom counts as at-bottom for the engine's own follow-mode recapture.

Follow-up: the underlying count-neutral re-anchor bug should also be fixed upstream in `@posthog/quill`'s message scroller.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*