### PR TITLE
fix(agent): rebuild resume transcripts from ACP top-level tool fields

### DIFF
--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -4,6 +4,7 @@ import {
   conversationTurnsToJsonlEntries,
   getSessionJsonlPath,
   rebuildConversation,
+  selectRecentTurns,
 } from "./jsonl-hydration";
 
 function entry(
@@ -284,6 +285,106 @@ describe("rebuildConversation", () => {
     expect(turns).toHaveLength(2);
     expect(turns[1].toolCalls).toHaveLength(1);
     expect(turns[1].toolCalls?.[0].result).toBeUndefined();
+  });
+
+  it("tracks tool calls from the ACP shape: top-level toolCallId/rawInput/rawOutput, toolName in _meta", () => {
+    // Mirrors the exact update sequence agent-server persists to S3. Before
+    // the top-level fields were read, every tool call was dropped and a
+    // 30-minute run resumed as a 4-line transcript.
+    const turns = rebuildConversation([
+      entry("user_message", { content: { type: "text", text: "fix it" } }),
+      entry("tool_call", {
+        toolCallId: "toolu_01",
+        _meta: { claudeCode: { toolName: "Bash" } },
+        rawInput: {},
+        status: "pending",
+        title: "Execute command",
+        kind: "execute",
+        content: [],
+      }),
+      entry("tool_call_update", {
+        toolCallId: "toolu_01",
+        rawInput: { command: "gh pr view 123" },
+      }),
+      entry("tool_call_update", {
+        toolCallId: "toolu_01",
+        _meta: { claudeCode: { toolName: "Bash" } },
+        status: "completed",
+        rawOutput: { stdout: "PR title" },
+      }),
+    ]);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[1].toolCalls).toEqual([
+      {
+        toolCallId: "toolu_01",
+        toolName: "Bash",
+        input: { command: "gh pr view 123" },
+        result: { stdout: "PR title" },
+      },
+    ]);
+  });
+
+  it("truncates oversized tool payloads", () => {
+    const bigOutput = "x".repeat(50_000);
+    const turns = rebuildConversation([
+      entry("user_message", { content: { type: "text", text: "go" } }),
+      entry("tool_call", {
+        toolCallId: "toolu_01",
+        _meta: { claudeCode: { toolName: "Bash" } },
+        rawInput: { command: "cat big-file" },
+      }),
+      entry("tool_call_update", {
+        toolCallId: "toolu_01",
+        rawOutput: bigOutput,
+      }),
+    ]);
+
+    const result = turns[1].toolCalls?.[0].result as string;
+    expect(result.length).toBeLessThan(11_000);
+    expect(result).toContain("[truncated");
+  });
+});
+
+describe("selectRecentTurns", () => {
+  it("keeps the user turn and sheds oldest tool calls when the final turn alone exceeds the budget", () => {
+    // A single-prompt run rebuilds into [user, one giant assistant turn].
+    // Before the fallback, that shape selected zero turns and hydration
+    // wrote an empty transcript.
+    const bigInput = { data: "y".repeat(8_000) };
+    const turns = rebuildConversation([
+      entry("user_message", { content: { type: "text", text: "the task" } }),
+      ...[1, 2, 3].map((i) =>
+        entry("tool_call", {
+          toolCallId: `toolu_0${i}`,
+          _meta: { claudeCode: { toolName: "Bash" } },
+          rawInput: bigInput,
+        }),
+      ),
+    ]);
+
+    // Budget fits the user turn plus roughly one big tool call.
+    const selected = selectRecentTurns(turns, 3_000);
+
+    expect(selected).toHaveLength(2);
+    expect(selected[0].role).toBe("user");
+    expect(selected[1].role).toBe("assistant");
+    const keptIds = selected[1].toolCalls?.map((tc) => tc.toolCallId);
+    expect(keptIds).toEqual(["toolu_03"]);
+  });
+
+  it("returns recent turns that fit the budget unchanged", () => {
+    const turns = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "a" }],
+      },
+      {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "b" }],
+      },
+    ];
+    expect(selectRecentTurns(turns, 1_000)).toEqual(turns);
   });
 });
 

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -325,14 +325,15 @@ describe("rebuildConversation", () => {
     ]);
   });
 
-  it("truncates oversized tool payloads", () => {
+  it("truncates oversized tool payloads, keeping object inputs as objects", () => {
     const bigOutput = "x".repeat(50_000);
+    const bigInput = { file_path: "/tmp/big.ts", content: "y".repeat(50_000) };
     const turns = rebuildConversation([
       entry("user_message", { content: { type: "text", text: "go" } }),
       entry("tool_call", {
         toolCallId: "toolu_01",
-        _meta: { claudeCode: { toolName: "Bash" } },
-        rawInput: { command: "cat big-file" },
+        _meta: { claudeCode: { toolName: "Write" } },
+        rawInput: bigInput,
       }),
       entry("tool_call_update", {
         toolCallId: "toolu_01",
@@ -340,9 +341,20 @@ describe("rebuildConversation", () => {
       }),
     ]);
 
+    // String outputs may truncate to a string; tool_use.input must stay an
+    // object per the Claude API schema.
     const result = turns[1].toolCalls?.[0].result as string;
     expect(result.length).toBeLessThan(11_000);
     expect(result).toContain("[truncated");
+
+    const input = turns[1].toolCalls?.[0].input as {
+      _truncated: boolean;
+      preview: string;
+      originalSize: number;
+    };
+    expect(input._truncated).toBe(true);
+    expect(input.preview.length).toBeLessThan(11_000);
+    expect(input.originalSize).toBeGreaterThan(50_000);
   });
 });
 

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -58,7 +58,12 @@ function capToolPayload(value: unknown): unknown {
   if (typeof text !== "string" || text.length <= MAX_TOOL_PAYLOAD_CHARS) {
     return value;
   }
-  return `${text.slice(0, MAX_TOOL_PAYLOAD_CHARS)}… [truncated ${text.length - MAX_TOOL_PAYLOAD_CHARS} chars]`;
+  const preview = `${text.slice(0, MAX_TOOL_PAYLOAD_CHARS)}… [truncated ${text.length - MAX_TOOL_PAYLOAD_CHARS} chars]`;
+  // tool_use.input must stay an object per the Claude API schema — wrap
+  // instead of replacing with a bare string.
+  return typeof value === "string"
+    ? preview
+    : { _truncated: true, preview, originalSize: text.length };
 }
 
 function isEmptyRecord(value: unknown): boolean {

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -42,6 +42,32 @@ interface SessionUpdate {
   sessionUpdate: string;
   content?: ContentBlock | ContentBlock[];
   _meta?: { claudeCode?: ClaudeCodeMeta };
+  // ACP puts these on the update itself; _meta.claudeCode only reliably
+  // carries toolName (and sometimes toolResponse).
+  toolCallId?: string;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+}
+
+// Individual tool payloads can be huge (whole-file Write inputs, full test
+// output). Cap each one so a single call can't dominate the resume budget.
+const MAX_TOOL_PAYLOAD_CHARS = 10_000;
+
+function capToolPayload(value: unknown): unknown {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (typeof text !== "string" || text.length <= MAX_TOOL_PAYLOAD_CHARS) {
+    return value;
+  }
+  return `${text.slice(0, MAX_TOOL_PAYLOAD_CHARS)}… [truncated ${text.length - MAX_TOOL_PAYLOAD_CHARS} chars]`;
+}
+
+function isEmptyRecord(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  );
 }
 
 const MAX_PROJECT_KEY_LENGTH = 200;
@@ -148,36 +174,47 @@ export function rebuildConversation(
         case "tool_call":
         case "tool_call_update": {
           const meta = update._meta?.claudeCode;
-          if (meta) {
-            const { toolCallId, toolName, toolInput, toolResponse } = meta;
+          const toolCallId = update.toolCallId ?? meta?.toolCallId;
+          if (!toolCallId) break;
 
-            if (toolCallId && toolName) {
-              let toolCall = currentToolCalls.find(
-                (tc) => tc.toolCallId === toolCallId,
-              );
-              if (!toolCall) {
-                toolCall = { toolCallId, toolName, input: toolInput };
-                currentToolCalls.push(toolCall);
-              }
-              if (toolResponse !== undefined) {
-                toolCall.result = toolResponse;
-              }
-            }
+          let toolCall = currentToolCalls.find(
+            (tc) => tc.toolCallId === toolCallId,
+          );
+          if (!toolCall) {
+            const toolName = meta?.toolName;
+            // Bare streaming updates carry no name; the opening tool_call
+            // always does, so the call exists by the time they arrive.
+            if (!toolName) break;
+            toolCall = { toolCallId, toolName, input: undefined };
+            currentToolCalls.push(toolCall);
+          }
+
+          const input = update.rawInput ?? meta?.toolInput;
+          // The opening tool_call ships rawInput: {} — don't clobber an
+          // already-streamed input with it.
+          if (
+            input !== undefined &&
+            !(isEmptyRecord(input) && toolCall.input !== undefined)
+          ) {
+            toolCall.input = capToolPayload(input);
+          }
+          const result = update.rawOutput ?? meta?.toolResponse;
+          if (result !== undefined) {
+            toolCall.result = capToolPayload(result);
           }
           break;
         }
 
         case "tool_result": {
           const meta = update._meta?.claudeCode;
-          if (meta) {
-            const { toolCallId, toolResponse } = meta;
-            if (toolCallId) {
-              const toolCall = currentToolCalls.find(
-                (tc) => tc.toolCallId === toolCallId,
-              );
-              if (toolCall && toolResponse !== undefined) {
-                toolCall.result = toolResponse;
-              }
+          const toolCallId = update.toolCallId ?? meta?.toolCallId;
+          if (toolCallId) {
+            const toolCall = currentToolCalls.find(
+              (tc) => tc.toolCallId === toolCallId,
+            );
+            const result = update.rawOutput ?? meta?.toolResponse;
+            if (toolCall && result !== undefined) {
+              toolCall.result = capToolPayload(result);
             }
           }
           break;
@@ -236,12 +273,60 @@ export function selectRecentTurns(
     startIndex = i;
   }
 
+  if (startIndex === turns.length && turns.length > 0) {
+    // Even the most recent turn alone exceeds the budget — typical for a
+    // single-prompt run, where everything after the prompt is one giant
+    // assistant turn. Resuming with nothing loses all context, so keep the
+    // nearest user turn (the task intent) and shed the assistant turn's
+    // oldest tool calls until it fits.
+    return selectOversizedTailFallback(turns, maxTokens);
+  }
+
   // Ensure we start on a user turn so the conversation is well-formed
   while (startIndex < turns.length && turns[startIndex].role !== "user") {
     startIndex++;
   }
 
   return turns.slice(startIndex);
+}
+
+function selectOversizedTailFallback(
+  turns: ConversationTurn[],
+  maxTokens: number,
+): ConversationTurn[] {
+  const last = turns[turns.length - 1];
+
+  let userIndex = turns.length - 1;
+  while (userIndex >= 0 && turns[userIndex].role !== "user") {
+    userIndex--;
+  }
+
+  const selected: ConversationTurn[] = [];
+  let budget = maxTokens;
+  if (userIndex >= 0) {
+    selected.push(turns[userIndex]);
+    budget -= estimateTurnTokens(turns[userIndex]);
+  }
+  if (userIndex !== turns.length - 1) {
+    selected.push(dropOldestToolCalls(last, Math.max(budget, 0)));
+  }
+  return selected;
+}
+
+function dropOldestToolCalls(
+  turn: ConversationTurn,
+  budget: number,
+): ConversationTurn {
+  if (!turn.toolCalls?.length) return turn;
+  const toolCalls = [...turn.toolCalls];
+  const trimmed: ConversationTurn = { ...turn, toolCalls };
+  while (toolCalls.length > 0 && estimateTurnTokens(trimmed) > budget) {
+    toolCalls.shift();
+  }
+  if (toolCalls.length === 0) {
+    trimmed.toolCalls = undefined;
+  }
+  return trimmed;
 }
 
 const BASE62 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";


### PR DESCRIPTION
## Problem

When a cloud run resumes into a successor run, the agent server rebuilds the prior Claude session JSONL from the run's S3 event log (`hydrateSessionJsonl`). The rebuild read `toolCallId`/`toolInput`/`toolResponse` from `_meta.claudeCode`, but in the logs agent-server actually persists, ACP puts `toolCallId`, `rawInput`, and `rawOutput` on the update object itself. `_meta.claudeCode` only reliably carries `toolName`.

Result: every tool call was silently dropped from the rebuilt transcript. A real 30-minute run with 7,522 log entries and 97 tool calls hydrated to a 4-line transcript (the prompt plus ~2KB of assistant prose), so the resumed agent greeted the user, found a clean tree, and re-implemented the whole task from scratch. 

## Changes

- `rebuildConversation` now reads `toolCallId` from the update (falling back to meta for older logs), takes input from `rawInput` (skipping the empty `{}` the opening `tool_call` ships so it can't clobber streamed input), and results from `rawOutput` or `meta.toolResponse`
- individual tool payloads are capped at 10k chars so one giant Write input or test dump can't dominate the resume budget
- `selectRecentTurns` gets a fallback for the shape every single-prompt run produces (one user turn plus one giant assistant turn): when the final turn alone exceeds the token budget it now sheds the oldest tool calls until it fits, instead of selecting zero turns and writing an empty transcript