### PR TITLE
feat(mobile): stamp inbox_client=mobile on inbox analytics events (port #3059)

### DIFF
--- a/apps/mobile/src/lib/analytics.test.ts
+++ b/apps/mobile/src/lib/analytics.test.ts
@@ -2,8 +2,10 @@ import { createElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ANALYTICS_EVENTS,
   computeReportAgeHours,
   useActiveTaskAnalyticsContext,
+  useAnalytics,
 } from "./analytics";
 
 const mockPosthog = {
@@ -92,5 +94,61 @@ describe("useActiveTaskAnalyticsContext", () => {
     expect(mockPosthog.register).not.toHaveBeenCalled();
     expect(mockPosthog.unregister).not.toHaveBeenCalled();
     hook.unmount();
+  });
+});
+
+function renderTrack() {
+  let track!: ReturnType<typeof useAnalytics>["track"];
+  function Wrapper() {
+    track = useAnalytics().track;
+    return null;
+  }
+  act(() => {
+    create(createElement(Wrapper));
+  });
+  return track;
+}
+
+describe("useAnalytics track", () => {
+  beforeEach(() => {
+    mockPosthog.capture.mockClear();
+  });
+
+  const INBOX_EVENTS = [
+    ANALYTICS_EVENTS.INBOX_VIEWED,
+    ANALYTICS_EVENTS.INBOX_REPORT_OPENED,
+    ANALYTICS_EVENTS.INBOX_REPORT_CLOSED,
+    ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED,
+    ANALYTICS_EVENTS.INBOX_REPORT_ACTION,
+  ] as const;
+
+  it.each(INBOX_EVENTS)("stamps inbox_client=mobile on %s", (eventName) => {
+    const track = renderTrack();
+    track(eventName as never, { foo: "bar" } as never);
+    expect(mockPosthog.capture).toHaveBeenCalledWith(
+      eventName,
+      expect.objectContaining({ inbox_client: "mobile", foo: "bar" }),
+    );
+  });
+
+  it("does not stamp inbox_client on non-inbox events", () => {
+    const track = renderTrack();
+    track(ANALYTICS_EVENTS.PROMPT_SENT as never, { foo: "bar" } as never);
+    const [, properties] = mockPosthog.capture.mock.calls[0];
+    expect(properties).not.toHaveProperty("inbox_client");
+  });
+
+  it("lets a caller-provided inbox_client win over the default", () => {
+    const track = renderTrack();
+    track(
+      ANALYTICS_EVENTS.INBOX_VIEWED as never,
+      {
+        inbox_client: "cloud",
+      } as never,
+    );
+    expect(mockPosthog.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.INBOX_VIEWED,
+      expect.objectContaining({ inbox_client: "cloud" }),
+    );
   });
 });

--- a/apps/mobile/src/lib/analytics.test.ts
+++ b/apps/mobile/src/lib/analytics.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ANALYTICS_EVENTS,
   computeReportAgeHours,
+  INBOX_ANALYTICS_EVENT_NAMES,
   useActiveTaskAnalyticsContext,
   useAnalytics,
 } from "./analytics";
@@ -114,22 +115,17 @@ describe("useAnalytics track", () => {
     mockPosthog.capture.mockClear();
   });
 
-  const INBOX_EVENTS = [
-    ANALYTICS_EVENTS.INBOX_VIEWED,
-    ANALYTICS_EVENTS.INBOX_REPORT_OPENED,
-    ANALYTICS_EVENTS.INBOX_REPORT_CLOSED,
-    ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED,
-    ANALYTICS_EVENTS.INBOX_REPORT_ACTION,
-  ] as const;
-
-  it.each(INBOX_EVENTS)("stamps inbox_client=mobile on %s", (eventName) => {
-    const track = renderTrack();
-    track(eventName as never, { foo: "bar" } as never);
-    expect(mockPosthog.capture).toHaveBeenCalledWith(
-      eventName,
-      expect.objectContaining({ inbox_client: "mobile", foo: "bar" }),
-    );
-  });
+  it.each([...INBOX_ANALYTICS_EVENT_NAMES])(
+    "stamps inbox_client=mobile on %s",
+    (eventName) => {
+      const track = renderTrack();
+      track(eventName as never, { foo: "bar" } as never);
+      expect(mockPosthog.capture).toHaveBeenCalledWith(
+        eventName,
+        expect.objectContaining({ inbox_client: "mobile", foo: "bar" }),
+      );
+    },
+  );
 
   it("does not stamp inbox_client on non-inbox events", () => {
     const track = renderTrack();

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -191,17 +191,34 @@ export interface Analytics {
   ): void;
 }
 
+// Client discriminator stamped on inbox events so the shared PostHog project
+// can be sliced by surface (desktop sends "code", the web frontend sends
+// "cloud"). Mirrors packages/ui/src/shell/posthogAnalyticsImpl.ts.
+const INBOX_CLIENT = "mobile" as const;
+
+const INBOX_ANALYTICS_EVENT_NAMES: ReadonlySet<string> = new Set([
+  ANALYTICS_EVENTS.INBOX_VIEWED,
+  ANALYTICS_EVENTS.INBOX_REPORT_OPENED,
+  ANALYTICS_EVENTS.INBOX_REPORT_CLOSED,
+  ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED,
+  ANALYTICS_EVENTS.INBOX_REPORT_ACTION,
+]);
+
 export function useAnalytics(): Analytics {
   const posthog = usePostHog();
   return useMemo<Analytics>(
     () => ({
       track: (eventName, properties) => {
+        // Spread first so a caller could override the client, matching desktop.
+        const enriched = INBOX_ANALYTICS_EVENT_NAMES.has(eventName)
+          ? { inbox_client: INBOX_CLIENT, ...properties }
+          : properties;
         // Our typed property interfaces don't carry an index signature; cast
         // to the wider PostHog event-properties shape without losing the
         // narrower call-site type-check.
         posthog?.capture(
           eventName,
-          properties as unknown as PostHogEventProperties,
+          enriched as unknown as PostHogEventProperties,
         );
       },
     }),

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -196,7 +196,7 @@ export interface Analytics {
 // "cloud"). Mirrors packages/ui/src/shell/posthogAnalyticsImpl.ts.
 const INBOX_CLIENT = "mobile" as const;
 
-const INBOX_ANALYTICS_EVENT_NAMES: ReadonlySet<string> = new Set([
+export const INBOX_ANALYTICS_EVENT_NAMES: ReadonlySet<string> = new Set([
   ANALYTICS_EVENTS.INBOX_VIEWED,
   ANALYTICS_EVENTS.INBOX_REPORT_OPENED,
   ANALYTICS_EVENTS.INBOX_REPORT_CLOSED,


### PR DESCRIPTION
## What

Ports desktop PR #3059 (`feat(inbox): stamp inbox_client=code on inbox analytics events`) to the mobile app.

Desktop added a client discriminator property, `inbox_client`, to every inbox-family analytics event so the shared PostHog project can be sliced by surface. The plan is: desktop stamps `"code"`, mobile stamps `"mobile"`, and the PostHog web frontend stamps `"cloud"`. This PR implements the mobile side.

## Changes

- `apps/mobile/src/lib/analytics.ts`: the `useAnalytics().track` wrapper now stamps `{ inbox_client: "mobile", ...properties }` on the mobile inbox-family events (`Inbox viewed`, `Inbox report opened`, `Inbox report closed`, `Inbox report scrolled`, `Inbox report action`). The client value is spread first so an explicit caller override wins, matching the desktop shape. Non-inbox events are untouched.
- Membership is determined via a small module-local `INBOX_ANALYTICS_EVENT_NAMES` set built from mobile's own `ANALYTICS_EVENTS` values — mobile already owns its own event map, so it keeps a mobile-local set rather than importing the shared helper. Mobile has no `SIGNAL_SOURCE_CONNECTED` event, so only the inbox events that exist in mobile are included.
- `apps/mobile/src/lib/analytics.test.ts`: added tests covering that inbox events get `inbox_client="mobile"` (parameterized across all inbox event names), that non-inbox events do not, and that a caller-provided `inbox_client` wins over the default.

## Testing

- `pnpm --filter mobile test src/lib/analytics.test.ts` — 12 passing
- Biome check clean on the changed files