### PR TITLE
feat(mobile): persist and recover pending task prompts on failure (port #3053)

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -17,6 +17,7 @@ import {
 import { useAuthStore } from "@/features/auth";
 import { setupNotificationResponseListener } from "@/features/notifications/lib/notifications";
 import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
+import { PendingPromptRecovery } from "@/features/tasks/components/PendingPromptRecovery";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import {
   POSTHOG_API_KEY,
@@ -197,6 +198,7 @@ export default function RootLayout() {
             <View style={themeVars} className="flex-1">
               <RootLayoutNav isConnected={isConnected} />
               <OfflineBanner isConnected={isConnected} />
+              <PendingPromptRecovery />
             </View>
             <StatusBar style={colorScheme === "dark" ? "light" : "dark"} />
           </QueryClientProvider>

--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -63,6 +63,7 @@ import { RepositoryPickerInline } from "@/features/tasks/composer/RepositoryPick
 import { SelectSheet } from "@/features/tasks/composer/SelectSheet";
 import { useUserIntegrations } from "@/features/tasks/hooks/useUserIntegrations";
 import { useWarmTask } from "@/features/tasks/hooks/useWarmTask";
+import { pendingPromptRecoveryStoreApi } from "@/features/tasks/stores/pendingPromptRecoveryStore";
 import {
   generatePendingTaskKey,
   pendingTaskPromptStoreApi,
@@ -286,6 +287,13 @@ export default function NewTaskScreen() {
       setAt: Date.now(),
     });
 
+    // Durably record the prompt so it survives the app being killed before
+    // creation completes; cleared once the task exists (or on failure, when
+    // the text is still live in the composer).
+    if (trimmedPrompt) {
+      pendingPromptRecoveryStoreApi.set(pendingKey, trimmedPrompt);
+    }
+
     // Tracks where the optimistic echo currently lives so the catch block
     // can clear the correct key regardless of how far the flow got.
     let currentPendingKey = pendingKey;
@@ -320,6 +328,7 @@ export default function NewTaskScreen() {
 
       pendingTaskPromptStoreApi.move(pendingKey, task.id);
       currentPendingKey = task.id;
+      pendingPromptRecoveryStoreApi.clear(pendingKey);
 
       // Seed the per-task composer config with the mode/model/reasoning the
       // user picked here, so the task detail screen reflects them and every
@@ -354,6 +363,7 @@ export default function NewTaskScreen() {
     } catch (creationError) {
       log.error("Failed to create task", creationError);
       pendingTaskPromptStoreApi.clear(currentPendingKey);
+      pendingPromptRecoveryStoreApi.clear(pendingKey);
     } finally {
       setCreating(false);
     }

--- a/apps/mobile/src/features/tasks/components/PendingPromptRecovery.test.tsx
+++ b/apps/mobile/src/features/tasks/components/PendingPromptRecovery.test.tsx
@@ -1,0 +1,95 @@
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPush, whenHydrated, getAllNewestFirst, clear, authState } =
+  vi.hoisted(() => ({
+    mockPush: vi.fn(),
+    whenHydrated: vi.fn(() => Promise.resolve()),
+    getAllNewestFirst: vi.fn(
+      () => [] as Array<{ key: string; prompt: { promptText: string } }>,
+    ),
+    clear: vi.fn(),
+    authState: { isAuthenticated: true },
+  }));
+
+vi.mock("expo-router", () => ({ router: { push: mockPush } }));
+
+vi.mock("@/features/auth", () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) =>
+    selector(authState),
+}));
+
+vi.mock("../stores/pendingPromptRecoveryStore", () => ({
+  pendingPromptRecoveryStoreApi: { whenHydrated, getAllNewestFirst, clear },
+}));
+
+async function mountRecovery() {
+  vi.resetModules();
+  const { PendingPromptRecovery } = await import("./PendingPromptRecovery");
+  await act(async () => {
+    create(createElement(PendingPromptRecovery));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return PendingPromptRecovery;
+}
+
+describe("PendingPromptRecovery", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    clear.mockReset();
+    whenHydrated.mockReset().mockResolvedValue(undefined);
+    getAllNewestFirst.mockReset().mockReturnValue([]);
+    authState.isAuthenticated = true;
+  });
+
+  it("recovers the newest orphaned prompt into the composer", async () => {
+    getAllNewestFirst.mockReturnValue([
+      { key: "newest", prompt: { promptText: "Newest prompt" } },
+      { key: "older", prompt: { promptText: "Older prompt" } },
+    ]);
+
+    await mountRecovery();
+
+    expect(clear).toHaveBeenCalledWith("newest");
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/task",
+      params: { prompt: "Newest prompt" },
+    });
+  });
+
+  it("runs only once even when re-mounted", async () => {
+    getAllNewestFirst.mockReturnValue([
+      { key: "newest", prompt: { promptText: "Newest prompt" } },
+    ]);
+
+    const PendingPromptRecovery = await mountRecovery();
+    await act(async () => {
+      create(createElement(PendingPromptRecovery));
+      await Promise.resolve();
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when there is no orphaned prompt", async () => {
+    getAllNewestFirst.mockReturnValue([]);
+
+    await mountRecovery();
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("does not recover until the user is authenticated", async () => {
+    authState.isAuthenticated = false;
+    getAllNewestFirst.mockReturnValue([
+      { key: "newest", prompt: { promptText: "Newest prompt" } },
+    ]);
+
+    await mountRecovery();
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/tasks/components/PendingPromptRecovery.test.tsx
+++ b/apps/mobile/src/features/tasks/components/PendingPromptRecovery.test.tsx
@@ -73,8 +73,19 @@ describe("PendingPromptRecovery", () => {
     expect(mockPush).toHaveBeenCalledTimes(1);
   });
 
-  it("does nothing when there is no orphaned prompt", async () => {
-    getAllNewestFirst.mockReturnValue([]);
+  it.each([
+    { name: "there is no orphaned prompt", setup: () => {} },
+    {
+      name: "the user is not authenticated",
+      setup: () => {
+        authState.isAuthenticated = false;
+        getAllNewestFirst.mockReturnValue([
+          { key: "newest", prompt: { promptText: "Newest prompt" } },
+        ]);
+      },
+    },
+  ])("does nothing when $name", async ({ setup }) => {
+    setup();
 
     await mountRecovery();
 
@@ -82,14 +93,33 @@ describe("PendingPromptRecovery", () => {
     expect(clear).not.toHaveBeenCalled();
   });
 
-  it("does not recover until the user is authenticated", async () => {
-    authState.isAuthenticated = false;
+  it("re-arms after logout so a new session recovers again", async () => {
     getAllNewestFirst.mockReturnValue([
       { key: "newest", prompt: { promptText: "Newest prompt" } },
     ]);
 
-    await mountRecovery();
+    vi.resetModules();
+    const { PendingPromptRecovery } = await import("./PendingPromptRecovery");
+    let renderer!: ReturnType<typeof create>;
+    await act(async () => {
+      renderer = create(createElement(PendingPromptRecovery));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockPush).toHaveBeenCalledTimes(1);
 
-    expect(mockPush).not.toHaveBeenCalled();
+    authState.isAuthenticated = false;
+    await act(async () => {
+      renderer.update(createElement(PendingPromptRecovery));
+      await Promise.resolve();
+    });
+
+    authState.isAuthenticated = true;
+    await act(async () => {
+      renderer.update(createElement(PendingPromptRecovery));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockPush).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/mobile/src/features/tasks/components/PendingPromptRecovery.tsx
+++ b/apps/mobile/src/features/tasks/components/PendingPromptRecovery.tsx
@@ -1,0 +1,34 @@
+import { router } from "expo-router";
+import { useEffect } from "react";
+import { useAuthStore } from "@/features/auth";
+import { logger } from "@/lib/logger";
+import { pendingPromptRecoveryStoreApi } from "../stores/pendingPromptRecoveryStore";
+
+const log = logger.scope("pending-prompt-recovery");
+
+let recoveryStarted = false;
+
+export function PendingPromptRecovery(): null {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  useEffect(() => {
+    if (!isAuthenticated || recoveryStarted) return;
+    recoveryStarted = true;
+    void recoverNewestPrompt();
+  }, [isAuthenticated]);
+
+  return null;
+}
+
+async function recoverNewestPrompt(): Promise<void> {
+  await pendingPromptRecoveryStoreApi.whenHydrated();
+  const [newest] = pendingPromptRecoveryStoreApi.getAllNewestFirst();
+  if (!newest) return;
+
+  log.info("Recovering a prompt whose task never finished creating");
+  pendingPromptRecoveryStoreApi.clear(newest.key);
+  router.push({
+    pathname: "/task",
+    params: { prompt: newest.prompt.promptText },
+  });
+}

--- a/apps/mobile/src/features/tasks/components/PendingPromptRecovery.tsx
+++ b/apps/mobile/src/features/tasks/components/PendingPromptRecovery.tsx
@@ -12,7 +12,13 @@ export function PendingPromptRecovery(): null {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
   useEffect(() => {
-    if (!isAuthenticated || recoveryStarted) return;
+    // Re-arm on logout so a fresh session recovers again without a full app
+    // restart (an orphaned prompt outlives logout in storage).
+    if (!isAuthenticated) {
+      recoveryStarted = false;
+      return;
+    }
+    if (recoveryStarted) return;
     recoveryStarted = true;
     void recoverNewestPrompt();
   }, [isAuthenticated]);

--- a/apps/mobile/src/features/tasks/stores/pendingPromptRecoveryStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/pendingPromptRecoveryStore.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  pendingPromptRecoveryStoreApi,
+  usePendingPromptRecoveryStore,
+} from "./pendingPromptRecoveryStore";
+
+describe("pendingPromptRecoveryStore", () => {
+  beforeEach(() => {
+    usePendingPromptRecoveryStore.setState({ byKey: {}, hasHydrated: true });
+  });
+
+  it("persists a prompt on submit and clears it on success", () => {
+    pendingPromptRecoveryStoreApi.set("pending-1", "Fix the login bug");
+    expect(pendingPromptRecoveryStoreApi.getAllNewestFirst()).toEqual([
+      {
+        key: "pending-1",
+        prompt: expect.objectContaining({ promptText: "Fix the login bug" }),
+      },
+    ]);
+
+    pendingPromptRecoveryStoreApi.clear("pending-1");
+    expect(pendingPromptRecoveryStoreApi.getAllNewestFirst()).toEqual([]);
+  });
+
+  it("caps the persisted set to the newest 20 entries", () => {
+    let now = 1000;
+    const spy = vi.spyOn(Date, "now").mockImplementation(() => now++);
+    for (let i = 0; i < 25; i++) {
+      pendingPromptRecoveryStoreApi.set(`k-${i}`, `prompt ${i}`);
+    }
+    spy.mockRestore();
+
+    const entries = pendingPromptRecoveryStoreApi.getAllNewestFirst();
+    const keys = entries.map((e) => e.key);
+    expect(entries).toHaveLength(20);
+    expect(keys[0]).toBe("k-24");
+    expect(keys).not.toContain("k-0");
+    expect(keys).not.toContain("k-4");
+  });
+
+  it("orders recoverable prompts newest-first", () => {
+    usePendingPromptRecoveryStore.setState({
+      byKey: {
+        old: { promptText: "old", createdAt: 1 },
+        newest: { promptText: "newest", createdAt: 3 },
+        mid: { promptText: "mid", createdAt: 2 },
+      },
+    });
+
+    expect(
+      pendingPromptRecoveryStoreApi.getAllNewestFirst().map((e) => e.key),
+    ).toEqual(["newest", "mid", "old"]);
+  });
+
+  it("whenHydrated resolves once the rehydration flag flips", async () => {
+    usePendingPromptRecoveryStore.setState({ hasHydrated: false });
+    let resolved = false;
+    const pending = pendingPromptRecoveryStoreApi.whenHydrated().then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+    usePendingPromptRecoveryStore.getState().setHasHydrated(true);
+    await pending;
+    expect(resolved).toBe(true);
+  });
+});

--- a/apps/mobile/src/features/tasks/stores/pendingPromptRecoveryStore.ts
+++ b/apps/mobile/src/features/tasks/stores/pendingPromptRecoveryStore.ts
@@ -1,0 +1,95 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+// Persisted (unlike the transient in-memory echo store, whose entries vanish
+// the instant the live SSE copy lands) so a prompt survives the app being
+// killed mid-create and can be recovered on the next launch.
+const MAX_RECOVERABLE_PROMPTS = 20;
+
+export interface RecoverablePrompt {
+  promptText: string;
+  createdAt: number;
+}
+
+interface PendingPromptRecoveryState {
+  byKey: Record<string, RecoverablePrompt>;
+  hasHydrated: boolean;
+  set: (key: string, promptText: string) => void;
+  clear: (key: string) => void;
+  setHasHydrated: (hydrated: boolean) => void;
+}
+
+function capToNewest(
+  byKey: Record<string, RecoverablePrompt>,
+): Record<string, RecoverablePrompt> {
+  const keys = Object.keys(byKey);
+  if (keys.length <= MAX_RECOVERABLE_PROMPTS) return byKey;
+  const kept = keys
+    .sort((a, b) => byKey[b].createdAt - byKey[a].createdAt)
+    .slice(0, MAX_RECOVERABLE_PROMPTS);
+  const trimmed: Record<string, RecoverablePrompt> = {};
+  for (const key of kept) trimmed[key] = byKey[key];
+  return trimmed;
+}
+
+export const usePendingPromptRecoveryStore =
+  create<PendingPromptRecoveryState>()(
+    persist(
+      (set) => ({
+        byKey: {},
+        hasHydrated: false,
+        set: (key, promptText) =>
+          set((state) => ({
+            byKey: capToNewest({
+              ...state.byKey,
+              [key]: { promptText, createdAt: Date.now() },
+            }),
+          })),
+        clear: (key) =>
+          set((state) => {
+            if (!(key in state.byKey)) return state;
+            const { [key]: _removed, ...rest } = state.byKey;
+            return { byKey: rest };
+          }),
+        setHasHydrated: (hydrated) => set({ hasHydrated: hydrated }),
+      }),
+      {
+        name: "pending-task-prompt-recovery",
+        storage: createJSONStorage(() => AsyncStorage),
+        partialize: (state) => ({ byKey: state.byKey }),
+        onRehydrateStorage: () => (state) => {
+          (state ?? usePendingPromptRecoveryStore.getState()).setHasHydrated(
+            true,
+          );
+        },
+      },
+    ),
+  );
+
+export const pendingPromptRecoveryStoreApi = {
+  set(key: string, promptText: string): void {
+    usePendingPromptRecoveryStore.getState().set(key, promptText);
+  },
+  clear(key: string): void {
+    usePendingPromptRecoveryStore.getState().clear(key);
+  },
+  getAllNewestFirst(): { key: string; prompt: RecoverablePrompt }[] {
+    return Object.entries(usePendingPromptRecoveryStore.getState().byKey)
+      .map(([key, prompt]) => ({ key, prompt }))
+      .sort((a, b) => b.prompt.createdAt - a.prompt.createdAt);
+  },
+  whenHydrated(): Promise<void> {
+    if (usePendingPromptRecoveryStore.getState().hasHydrated) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      const unsubscribe = usePendingPromptRecoveryStore.subscribe((state) => {
+        if (state.hasHydrated) {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+  },
+};


### PR DESCRIPTION
## Summary

Ports desktop **#3053** (*persist pending task prompts and recover them on failure*) to the mobile app, so a user's typed new-task prompt survives a failed or interrupted task creation instead of being silently lost.

On mobile the prompt is now durably recorded the moment a create begins, and recovered into the composer on the next launch if the task never finished creating.

## What changed

- **New `pendingPromptRecoveryStore`** (`apps/mobile/src/features/tasks/stores/pendingPromptRecoveryStore.ts`) — a small **AsyncStorage-backed** persisted store, kept deliberately separate from the existing transient in-memory echo store (`pendingTaskPromptStore`). The echo store must stay ephemeral (its entries disappear the instant the live SSE `user_message_chunk` echoes back), so persisting it would replay stale echoes on launch. The recovery store instead records `{ promptText, createdAt }`, caps itself to the newest ~20 entries, and tracks a `hasHydrated` flag exposed via `whenHydrated()`.
- **New `PendingPromptRecovery` component** (`apps/mobile/src/features/tasks/components/PendingPromptRecovery.tsx`) — mounted once at the app root; after hydration it takes the newest orphaned prompt exactly once per launch, clears it, and routes to the new-task composer (`/task`) pre-filled via the existing `prompt` route param. Guarded by a module-level flag so it runs once.
- **Create flow wiring** (`apps/mobile/src/app/task/index.tsx`) — records the prompt when submission begins, clears it once the task is confirmed created, and clears it on failure (the text stays live in the composer, so nothing is lost).

## Design notes

- Recovery restores **prompt text only**, matching desktop (mobile attachment URIs are ephemeral and don't survive an app kill).
- The separate-store approach was chosen over extending the echo store to keep the transient echo and durable recovery concerns cleanly isolated.

## Tests

Vitest coverage for the store (persist-on-submit, clear-on-success, cap-to-newest eviction, newest-first ordering, hydration gating) and the recovery component (recovers newest orphan once, no-op when empty, auth-gated). All green.

Ref: desktop PR #3053.