### PR TITLE
feat(settings): add toggle to disable in-app toast notifications

### DIFF
--- a/packages/ui/src/features/connectivity/connectivityToast.ts
+++ b/packages/ui/src/features/connectivity/connectivityToast.ts
@@ -5,7 +5,7 @@ const OFFLINE_DEBOUNCE_MS = 5_000;
 
 // The live offline toast's id, tracked so re-entry never stacks a second one and
 // reconnect dismisses exactly this toast.
-let offlineToastId: string | null = null;
+let offlineToastId: string | undefined;
 
 export function showOfflineToast() {
   if (offlineToastId) return;
@@ -19,7 +19,7 @@ export function showOfflineToast() {
 function dismissOfflineToast() {
   if (!offlineToastId) return;
   toast.dismiss(offlineToastId);
-  offlineToastId = null;
+  offlineToastId = undefined;
 }
 
 // Debounces flaky transitions: only surfaces a toast when continuously offline

--- a/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -39,6 +39,7 @@ export function NotificationsSettings() {
     desktopNotifications,
     dockBadgeNotifications,
     dockBounceNotifications,
+    toastNotifications,
     completionSound,
     completionVolume,
     scaleSoundWithTaskLength,
@@ -46,6 +47,7 @@ export function NotificationsSettings() {
     setDesktopNotifications,
     setDockBadgeNotifications,
     setDockBounceNotifications,
+    setToastNotifications,
     setCompletionSound,
     setCompletionVolume,
     setScaleSoundWithTaskLength,
@@ -104,6 +106,18 @@ export function NotificationsSettings() {
     [desktopNotifications, setDesktopNotifications],
   );
 
+  const handleToastNotificationsChange = useCallback(
+    (checked: boolean) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "toast_notifications",
+        new_value: checked,
+        old_value: toastNotifications,
+      });
+      setToastNotifications(checked);
+    },
+    [toastNotifications, setToastNotifications],
+  );
+
   const handleCompletionSoundChange = useCallback(
     (value: CompletionSound) => {
       // Don't leak generated custom-sound ids into analytics.
@@ -136,6 +150,7 @@ export function NotificationsSettings() {
     setDesktopNotifications(NOTIFICATION_DEFAULTS.desktopNotifications);
     setDockBadgeNotifications(NOTIFICATION_DEFAULTS.dockBadgeNotifications);
     setDockBounceNotifications(NOTIFICATION_DEFAULTS.dockBounceNotifications);
+    setToastNotifications(NOTIFICATION_DEFAULTS.toastNotifications);
     setCompletionSound(NOTIFICATION_DEFAULTS.completionSound);
     setCompletionVolume(NOTIFICATION_DEFAULTS.completionVolume);
     setScaleSoundWithTaskLength(NOTIFICATION_DEFAULTS.scaleSoundWithTaskLength);
@@ -144,6 +159,7 @@ export function NotificationsSettings() {
     setDesktopNotifications,
     setDockBadgeNotifications,
     setDockBounceNotifications,
+    setToastNotifications,
     setCompletionSound,
     setCompletionVolume,
     setScaleSoundWithTaskLength,
@@ -195,6 +211,17 @@ export function NotificationsSettings() {
         <Switch
           checked={dockBounceNotifications}
           onCheckedChange={setDockBounceNotifications}
+          size="1"
+        />
+      </SettingRow>
+
+      <SettingRow
+        label="In-app toasts"
+        description="Show an in-app toast when the agent finishes a task or needs your input, and for other in-app confirmations. Error messages always show."
+      >
+        <Switch
+          checked={toastNotifications}
+          onCheckedChange={handleToastNotificationsChange}
           size="1"
         />
       </SettingRow>

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -111,6 +111,7 @@ interface SettingsStore {
   desktopNotifications: boolean;
   dockBadgeNotifications: boolean;
   dockBounceNotifications: boolean;
+  toastNotifications: boolean;
   completionSound: CompletionSound;
   completionVolume: number;
   scaleSoundWithTaskLength: boolean;
@@ -118,6 +119,7 @@ interface SettingsStore {
   setDesktopNotifications: (enabled: boolean) => void;
   setDockBadgeNotifications: (enabled: boolean) => void;
   setDockBounceNotifications: (enabled: boolean) => void;
+  setToastNotifications: (enabled: boolean) => void;
   setCompletionSound: (sound: CompletionSound) => void;
   setCompletionVolume: (volume: number) => void;
   setScaleSoundWithTaskLength: (enabled: boolean) => void;
@@ -193,6 +195,7 @@ export const NOTIFICATION_DEFAULTS = {
   desktopNotifications: true,
   dockBadgeNotifications: true,
   dockBounceNotifications: false,
+  toastNotifications: true,
   completionSound: "none" as CompletionSound,
   completionVolume: 80,
   scaleSoundWithTaskLength: false,
@@ -260,6 +263,7 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ dockBadgeNotifications: enabled }),
       setDockBounceNotifications: (enabled) =>
         set({ dockBounceNotifications: enabled }),
+      setToastNotifications: (enabled) => set({ toastNotifications: enabled }),
       setCompletionSound: (sound) => set({ completionSound: sound }),
       setCompletionVolume: (volume) => set({ completionVolume: volume }),
       setScaleSoundWithTaskLength: (enabled) =>
@@ -394,6 +398,7 @@ export const useSettingsStore = create<SettingsStore>()(
         desktopNotifications: state.desktopNotifications,
         dockBadgeNotifications: state.dockBadgeNotifications,
         dockBounceNotifications: state.dockBounceNotifications,
+        toastNotifications: state.toastNotifications,
         completionSound: state.completionSound,
         completionVolume: state.completionVolume,
         scaleSoundWithTaskLength: state.scaleSoundWithTaskLength,

--- a/packages/ui/src/primitives/toast.test.ts
+++ b/packages/ui/src/primitives/toast.test.ts
@@ -109,6 +109,17 @@ describe("toast wrapper", () => {
     expect(quill.error).toHaveBeenCalled();
   });
 
+  it.each([
+    [undefined, undefined],
+    ["stable-id", "stable-id"],
+  ])(
+    "returns %s (not a fabricated id) when suppressed with detail id %s",
+    (id, expected) => {
+      settings.toastNotifications = false;
+      expect(toast.success("Title", id ? { id } : undefined)).toBe(expected);
+    },
+  );
+
   it("after a toast closes, its id frees up to create again", () => {
     toast.success("First", { id: "dup" });
     quill.success.mock.calls[0]?.[0]?.onClose?.(); // simulate the toast closing

--- a/packages/ui/src/primitives/toast.test.ts
+++ b/packages/ui/src/primitives/toast.test.ts
@@ -22,11 +22,18 @@ const quill = vi.hoisted(() => {
 
 vi.mock("@posthog/quill", () => ({ toast: quill }));
 
+const settings = vi.hoisted(() => ({ toastNotifications: true }));
+
+vi.mock("@posthog/ui/features/settings/settingsStore", () => ({
+  useSettingsStore: { getState: () => settings },
+}));
+
 import { toast } from "./toast";
 
 beforeEach(() => {
   vi.clearAllMocks();
   quill._reset();
+  settings.toastNotifications = true;
   // clearAllMocks resets the level fns to undefined returns; restore ids.
   let n = 0;
   for (const key of [
@@ -85,6 +92,21 @@ describe("toast wrapper", () => {
     expect(quill.error).toHaveBeenCalledWith(
       expect.objectContaining({ timeout: 0 }),
     );
+  });
+
+  it.each(["success", "info", "warning", "loading"] as const)(
+    "suppresses %s when toast notifications are disabled",
+    (level) => {
+      settings.toastNotifications = false;
+      toast[level]("Title");
+      expect(quill[level]).not.toHaveBeenCalled();
+    },
+  );
+
+  it("always shows error toasts, even when toast notifications are disabled", () => {
+    settings.toastNotifications = false;
+    toast.error("Offline");
+    expect(quill.error).toHaveBeenCalled();
   });
 
   it("after a toast closes, its id frees up to create again", () => {

--- a/packages/ui/src/primitives/toast.tsx
+++ b/packages/ui/src/primitives/toast.tsx
@@ -1,4 +1,5 @@
 import { toast as quillToast } from "@posthog/quill";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 
 // Thin wrapper over quill's toast so the whole app shares one import and a
 // stable `(title, options)` signature. Quill (base-ui under the hood) owns
@@ -45,6 +46,11 @@ function emit(
   defaultTimeout?: number,
 ): string {
   const o = normalize(detail);
+  // Toasts can be disabled in settings; errors always show since they carry
+  // information the user needs regardless of that preference.
+  if (level !== "error" && !useSettingsStore.getState().toastNotifications) {
+    return o.id ?? "";
+  }
   // base-ui auto-dismisses any non-loading toast with `timeout > 0`; it has no
   // Infinity special-case (Infinity would fire immediately), so a request to
   // never auto-dismiss maps to `0`.

--- a/packages/ui/src/primitives/toast.tsx
+++ b/packages/ui/src/primitives/toast.tsx
@@ -44,12 +44,12 @@ function emit(
   title: string,
   detail: Detail | undefined,
   defaultTimeout?: number,
-): string {
+): string | undefined {
   const o = normalize(detail);
   // Toasts can be disabled in settings; errors always show since they carry
   // information the user needs regardless of that preference.
   if (level !== "error" && !useSettingsStore.getState().toastNotifications) {
-    return o.id ?? "";
+    return o.id;
   }
   // base-ui auto-dismisses any non-loading toast with `timeout > 0`; it has no
   // Infinity special-case (Infinity would fire immediately), so a request to


### PR DESCRIPTION
## Summary
- Adds a `toastNotifications` setting (default on) alongside the existing push/dock notification toggles
- Gates all non-error toasts on it in the shared toast wrapper's `emit()` — a single choke point every `toast.*` call in the app goes through, so no per-feature changes were needed
- Error toasts are exempt and always show
- Adds an "In-app toasts" toggle to the Notifications settings page, wired into "Reset to defaults"

## Test plan
- [x] `pnpm --filter @posthog/ui typecheck`
- [x] `pnpm --filter @posthog/ui test` (28/28 passing, including new parameterized suppression cases)
- [x] `biome check` on changed files

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*