### PR TITLE
fix(sessions): fire cloud completion notification once per turn

### DIFF
--- a/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/packages/core/src/cloud-task/cloud-task.test.ts
@@ -348,6 +348,79 @@ describe("CloudTaskService", () => {
     expect(messages).toEqual(["first", "second"]);
   });
 
+  it("delivers an id-colliding entry after a retry resets the watcher", async () => {
+    const updates: unknown[] = [];
+    service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));
+
+    // Route by URL: the initial watch and the retry-triggered rebuild each
+    // fetch run detail and history, plus post-bootstrap status verification.
+    mockNetFetch.mockImplementation((input: string | Request) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.includes("/session_logs/")) {
+        return Promise.resolve(
+          createJsonResponse([], 200, { "X-Has-More": "false" }),
+        );
+      }
+      return Promise.resolve(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          error_message: null,
+          branch: "main",
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      );
+    });
+
+    const consoleEntry = (message: string) =>
+      `data: {"type":"notification","timestamp":"2026-01-01T00:00:01Z","notification":{"jsonrpc":"2.0","method":"_posthog/console","params":{"sessionId":"run-1","level":"info","message":"${message}"}}}`;
+
+    // The rebuilt connection re-resolves the read leg, so its id space is
+    // unrelated to the first connection's: id 1 here is a different entry.
+    mockStreamFetch
+      .mockResolvedValueOnce(
+        createOpenSseResponse(`id: 1\n${consoleEntry("before retry")}\n\n`),
+      )
+      .mockResolvedValueOnce(
+        createOpenSseResponse(`id: 1\n${consoleEntry("after retry")}\n\n`),
+      );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    const messages = () =>
+      updates
+        .filter((u) => (u as { kind?: string }).kind === "logs")
+        .flatMap(
+          (u) =>
+            (
+              u as {
+                newEntries: Array<{ notification?: { params?: unknown } }>;
+              }
+            ).newEntries,
+        )
+        .map(
+          (entry) =>
+            (entry.notification?.params as { message?: string } | undefined)
+              ?.message,
+        );
+
+    await waitFor(() => messages().includes("before retry"));
+
+    await service.retry("task-1", "run-1");
+
+    // An id retained across the reset would false-match the new connection's
+    // id 1 and silently drop this entry before it is counted or emitted.
+    await waitFor(() => messages().includes("after retry"));
+    expect(messages()).toEqual(["before retry", "after retry"]);
+  });
+
   it("reconnects with Last-Event-ID after a stream error", async () => {
     vi.useFakeTimers();
 

--- a/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/packages/core/src/cloud-task/cloud-task.test.ts
@@ -283,6 +283,71 @@ describe("CloudTaskService", () => {
     );
   });
 
+  it("drops a re-delivered log entry with a duplicate stream id", async () => {
+    const updates: unknown[] = [];
+    service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));
+
+    mockNetFetch
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          error_message: null,
+          branch: "main",
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      );
+
+    const consoleEntry = (message: string) =>
+      `data: {"type":"notification","timestamp":"2026-01-01T00:00:01Z","notification":{"jsonrpc":"2.0","method":"_posthog/console","params":{"sessionId":"run-1","level":"info","message":"${message}"}}}`;
+
+    // The durable stream re-sends the tail by id on reconnect/replay. Here id 1
+    // arrives twice; the second copy must be dropped so the entry is delivered
+    // — and counted — exactly once (the fix for duplicate transcript entries and
+    // back-to-back completion notifications).
+    mockStreamFetch.mockResolvedValueOnce(
+      createOpenSseResponse(
+        `id: 1\n${consoleEntry("first")}\n\nid: 1\n${consoleEntry("first")}\n\nid: 2\n${consoleEntry("second")}\n\n`,
+      ),
+    );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() =>
+      updates.some(
+        (u) =>
+          (u as { kind?: string; totalEntryCount?: number }).kind === "logs" &&
+          ((u as { totalEntryCount?: number }).totalEntryCount ?? 0) >= 2,
+      ),
+    );
+
+    const messages = updates
+      .filter((u) => (u as { kind?: string }).kind === "logs")
+      .flatMap(
+        (u) =>
+          (u as { newEntries: Array<{ notification?: { params?: unknown } }> })
+            .newEntries,
+      )
+      .map(
+        (entry) =>
+          (entry.notification?.params as { message?: string } | undefined)
+            ?.message,
+      );
+
+    // id 1 delivered once (not twice), id 2 delivered once, order preserved.
+    expect(messages).toEqual(["first", "second"]);
+  });
+
   it("reconnects with Last-Event-ID after a stream error", async () => {
     vi.useFakeTimers();
 

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -426,6 +426,11 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     watcher.lastEventId = null;
     watcher.lastEventIdLeg = null;
     watcher.streamLeg = null;
+    // The rebuild re-resolves the read leg, so a retained id could false-match a
+    // different entry on the next connection — and the leg-switch clear in
+    // connectSse can't catch it, since lastEventId was just nulled. The re-fetched
+    // snapshot re-delivers history, so no dedup state is lost.
+    watcher.seenEventIds.clear();
     watcher.totalEntryCount = 0;
     watcher.isBootstrapping = false;
     watcher.streamTargetResolved = false;

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -119,6 +119,11 @@ interface WatcherState {
   // Leg that issued lastEventId, and the leg of the connection currently being read.
   lastEventIdLeg: StreamLeg | null;
   streamLeg: StreamLeg | null;
+  // Ids of log entries already ingested on the current leg. The durable stream
+  // re-sends the tail by id on reconnect/replay, so dropping a seen id here is
+  // what stops a re-delivered entry (e.g. a `turn_complete`) from being counted
+  // and emitted twice. Cleared on a leg switch, where the id space changes.
+  seenEventIds: Set<string>;
   lastStatus: TaskRunStatus | null;
   lastStage: string | null;
   lastOutput: Record<string, unknown> | null;
@@ -538,6 +543,7 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       lastEventId: null,
       lastEventIdLeg: null,
       streamLeg: null,
+      seenEventIds: new Set(),
       lastStatus: null,
       lastStage: null,
       lastOutput: null,
@@ -790,6 +796,9 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       });
       watcher.lastEventId = null;
       watcher.lastEventIdLeg = null;
+      // Proxy and Django ids are unrelated, so a retained id could false-match a
+      // different entry on the new leg. Drop them; the snapshot covers the gap.
+      watcher.seenEventIds.clear();
     }
     watcher.streamLeg = leg;
 
@@ -1134,6 +1143,20 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
         options: event.data.options,
       });
       return null;
+    }
+
+    // Drop a re-delivered log entry by its stream id. The durable stream
+    // re-sends the tail on reconnect/replay, and each resend would otherwise be
+    // counted as a new entry (advancing totalEntryCount past the renderer's
+    // processedLineCount guard) and emitted again — the root cause of duplicate
+    // transcript entries and back-to-back completion notifications. Entries
+    // without an id (legacy servers) fall through and are handled downstream.
+    const eventId = event.id;
+    if (eventId !== undefined) {
+      if (watcher.seenEventIds.has(eventId)) {
+        return null;
+      }
+      watcher.seenEventIds.add(eventId);
     }
 
     watcher.pendingLogEntries.push(event.data as StoredLogEntry);

--- a/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -195,24 +195,15 @@ describe("cloud task update notifications", () => {
     expect(harness.markActivity).not.toHaveBeenCalled();
   });
 
-  // The completion notification must fire exactly once per turn regardless of
-  // how the turn's entries are delivered. Each case is a sequence of updates
-  // applied to a fresh harness; `expected` is the resulting notify count.
+  // Each case applies a sequence of updates to a fresh harness; `expected` is
+  // the resulting notify count. Snapshots never ring; each live turn_complete
+  // rings once. Re-delivered stream entries are dropped upstream in
+  // CloudTaskService by their event id (see cloud-task.test.ts), so a replay
+  // never reaches this layer.
   it.each([
     {
       label: "a live turn that starts and completes",
       updates: [logsUpdate([sessionPrompt(1), turnComplete()], 2)],
-      expected: 1,
-    },
-    {
-      // A reconnect/durable re-emit replays the tail: the same turn_complete
-      // arrives again with a fresh totalEntryCount, slipping past the
-      // processedLineCount guard. It must not ring a second time.
-      label: "a re-delivered live turn_complete",
-      updates: [
-        logsUpdate([sessionPrompt(1), turnComplete()], 2),
-        logsUpdate([turnComplete()], 3),
-      ],
       expected: 1,
     },
     {

--- a/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -47,6 +47,32 @@ function permissionRequest(
   };
 }
 
+function logsUpdate(
+  newEntries: StoredLogEntry[],
+  totalEntryCount: number,
+): CloudTaskUpdatePayload {
+  return {
+    taskId: TASK_ID,
+    runId: RUN_ID,
+    kind: "logs",
+    newEntries,
+    totalEntryCount,
+  };
+}
+
+function snapshotUpdate(
+  newEntries: StoredLogEntry[],
+  totalEntryCount: number,
+): CloudTaskUpdatePayload {
+  return {
+    taskId: TASK_ID,
+    runId: RUN_ID,
+    kind: "snapshot",
+    newEntries,
+    totalEntryCount,
+  };
+}
+
 function createHarness() {
   const sessions: Record<string, AgentSession> = {};
   const store = {
@@ -169,17 +195,57 @@ describe("cloud task update notifications", () => {
     expect(harness.markActivity).not.toHaveBeenCalled();
   });
 
-  it("notifies once for a live turn that starts and completes", () => {
-    const harness = createHarness();
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      kind: "logs",
-      newEntries: [sessionPrompt(1), turnComplete()],
-      totalEntryCount: 2,
-    });
+  // The completion notification must fire exactly once per turn regardless of
+  // how the turn's entries are delivered. Each case is a sequence of updates
+  // applied to a fresh harness; `expected` is the resulting notify count.
+  it.each([
+    {
+      label: "a live turn that starts and completes",
+      updates: [logsUpdate([sessionPrompt(1), turnComplete()], 2)],
+      expected: 1,
+    },
+    {
+      // A reconnect/durable re-emit replays the tail: the same turn_complete
+      // arrives again with a fresh totalEntryCount, slipping past the
+      // processedLineCount guard. It must not ring a second time.
+      label: "a re-delivered live turn_complete",
+      updates: [
+        logsUpdate([sessionPrompt(1), turnComplete()], 2),
+        logsUpdate([turnComplete()], 3),
+      ],
+      expected: 1,
+    },
+    {
+      label: "several turns each completing",
+      updates: [
+        logsUpdate([sessionPrompt(1), turnComplete()], 2),
+        logsUpdate([sessionPrompt(2), turnComplete()], 4),
+      ],
+      expected: 2,
+    },
+    {
+      // Opening a task mid-turn: its session/prompt is already in history and
+      // only the turn_complete arrives live. The completion must still ring.
+      label: "a prompt seen only in the snapshot, completing live",
+      updates: [
+        snapshotUpdate([sessionPrompt(1)], 1),
+        logsUpdate([turnComplete()], 2),
+      ],
+      expected: 1,
+    },
+  ])(
+    "fires the completion notification once per turn: $label",
+    ({ updates, expected }) => {
+      const harness = createHarness();
+      for (const update of updates) harness.sendUpdate(update);
+      expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(expected);
+    },
+  );
 
-    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
+  it("notifies with the task title and stop reason, and marks activity", () => {
+    const harness = createHarness();
+    harness.sendUpdate(logsUpdate([sessionPrompt(1), turnComplete()], 2));
+
     expect(harness.notifyPromptComplete).toHaveBeenCalledWith(
       "Cloud Task",
       "end_turn",
@@ -187,75 +253,6 @@ describe("cloud task update notifications", () => {
       undefined,
     );
     expect(harness.markActivity).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not notify again when a live turn_complete is re-delivered", () => {
-    const harness = createHarness();
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      kind: "logs",
-      newEntries: [sessionPrompt(1), turnComplete()],
-      totalEntryCount: 2,
-    });
-    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
-
-    // The stream replays the tail (reconnect/durable re-emit): the same
-    // turn_complete arrives again with a fresh totalEntryCount, slipping past
-    // the processedLineCount guard. It must not ring a second time.
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      kind: "logs",
-      newEntries: [turnComplete()],
-      totalEntryCount: 3,
-    });
-
-    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
-  });
-
-  it("notifies once per turn across multiple turns", () => {
-    const harness = createHarness();
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      kind: "logs",
-      newEntries: [sessionPrompt(1), turnComplete()],
-      totalEntryCount: 2,
-    });
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      kind: "logs",
-      newEntries: [sessionPrompt(2), turnComplete()],
-      totalEntryCount: 4,
-    });
-
-    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(2);
-  });
-
-  it("notifies when the in-flight prompt was only seen in the snapshot", () => {
-    const harness = createHarness();
-    // Opening a task mid-turn: its session/prompt is already in history, and
-    // only the turn_complete arrives live. The completion must still ring.
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      kind: "snapshot",
-      newEntries: [sessionPrompt(1)],
-      totalEntryCount: 1,
-    });
-    expect(harness.notifyPromptComplete).not.toHaveBeenCalled();
-
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
-      kind: "logs",
-      newEntries: [turnComplete()],
-      totalEntryCount: 2,
-    });
-
-    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
   });
 
   it("notifies a pending permission once across repeated snapshots", () => {

--- a/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -16,6 +16,20 @@ function turnComplete(): StoredLogEntry {
   };
 }
 
+// The `session/prompt` request that opens a turn. Its arrival is what arms the
+// turn's single completion notification, so realistic sequences pair it with a
+// later `turn_complete`.
+function sessionPrompt(id: number): StoredLogEntry {
+  return {
+    type: "notification",
+    notification: {
+      id,
+      method: "session/prompt",
+      params: { sessionId: RUN_ID, prompt: [] },
+    },
+  };
+}
+
 function permissionRequest(
   requestId: string,
   toolCallId: string,
@@ -155,22 +169,14 @@ describe("cloud task update notifications", () => {
     expect(harness.markActivity).not.toHaveBeenCalled();
   });
 
-  it("notifies once for a live turn_complete delta after the snapshot", () => {
+  it("notifies once for a live turn that starts and completes", () => {
     const harness = createHarness();
     harness.sendUpdate({
       taskId: TASK_ID,
       runId: RUN_ID,
-      kind: "snapshot",
-      newEntries: [turnComplete(), turnComplete()],
-      totalEntryCount: 2,
-    });
-
-    harness.sendUpdate({
-      taskId: TASK_ID,
-      runId: RUN_ID,
       kind: "logs",
-      newEntries: [turnComplete()],
-      totalEntryCount: 3,
+      newEntries: [sessionPrompt(1), turnComplete()],
+      totalEntryCount: 2,
     });
 
     expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
@@ -181,6 +187,75 @@ describe("cloud task update notifications", () => {
       undefined,
     );
     expect(harness.markActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify again when a live turn_complete is re-delivered", () => {
+    const harness = createHarness();
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "logs",
+      newEntries: [sessionPrompt(1), turnComplete()],
+      totalEntryCount: 2,
+    });
+    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
+
+    // The stream replays the tail (reconnect/durable re-emit): the same
+    // turn_complete arrives again with a fresh totalEntryCount, slipping past
+    // the processedLineCount guard. It must not ring a second time.
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "logs",
+      newEntries: [turnComplete()],
+      totalEntryCount: 3,
+    });
+
+    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies once per turn across multiple turns", () => {
+    const harness = createHarness();
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "logs",
+      newEntries: [sessionPrompt(1), turnComplete()],
+      totalEntryCount: 2,
+    });
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "logs",
+      newEntries: [sessionPrompt(2), turnComplete()],
+      totalEntryCount: 4,
+    });
+
+    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(2);
+  });
+
+  it("notifies when the in-flight prompt was only seen in the snapshot", () => {
+    const harness = createHarness();
+    // Opening a task mid-turn: its session/prompt is already in history, and
+    // only the turn_complete arrives live. The completion must still ring.
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "snapshot",
+      newEntries: [sessionPrompt(1)],
+      totalEntryCount: 1,
+    });
+    expect(harness.notifyPromptComplete).not.toHaveBeenCalled();
+
+    harness.sendUpdate({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "logs",
+      newEntries: [turnComplete()],
+      totalEntryCount: 2,
+    });
+
+    expect(harness.notifyPromptComplete).toHaveBeenCalledTimes(1);
   });
 
   it("notifies a pending permission once across repeated snapshots", () => {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -549,6 +549,14 @@ export class SessionService {
     string,
     { startedAtTs: number; agentTextChunks: number; agentOutputEvents: number }
   >();
+  // Cloud runs whose in-flight turn still owes exactly one completion
+  // notification. Armed when the turn's `session/prompt` is processed and
+  // consumed when its `turn_complete` fires the notification. Cloud streams can
+  // re-deliver the `turn_complete` tail (durable-stream re-emit or a reconnect
+  // replay), each delivery slipping past the processedLineCount guard with a
+  // fresh totalEntryCount; without this a replay rang a second "meep"/toast for
+  // the same turn.
+  private cloudTurnAwaitingCompletionNotify = new Set<string>();
   private idleKilledSubscription: { unsubscribe: () => void } | null = null;
   /**
    * Cached preview-config-options responses keyed by `${apiHost}::${adapter}`.
@@ -1057,6 +1065,7 @@ export class SessionService {
     this.evictedRunIds.delete(taskRunId);
     this.d.store.removeSession(taskRunId);
     this.cloudRunIdleTracker.delete(taskRunId);
+    this.cloudTurnAwaitingCompletionNotify.delete(taskRunId);
     this.cloudLogGapReconciler.forgetDeficiency(taskRunId);
     if (session) {
       this.localRepoPaths.delete(session.taskId);
@@ -1659,6 +1668,7 @@ export class SessionService {
     this.sessionLastUsedAt.clear();
     this.cloudPermissionRequestIds.clear();
     this.liveTurnContent.clear();
+    this.cloudTurnAwaitingCompletionNotify.clear();
     this.cloudLogGapReconciler.clear();
     this.dispatchingCloudQueues.clear();
     this.scheduledCloudQueueFlushes.clear();
@@ -1744,6 +1754,10 @@ export class SessionService {
         }
         const promptSession = this.d.store.getSessions()[taskRunId];
         if (promptSession?.isCloud) {
+          // A fresh turn started — arm its single completion notification.
+          // Processed for snapshot and live alike so that opening a task whose
+          // in-flight prompt is only in history still notifies when it finishes.
+          this.cloudTurnAwaitingCompletionNotify.add(taskRunId);
           this.cloudRunIdleTracker.markBusy(promptSession);
           if (promptSession.agentIdleForRunId) {
             this.d.store.updateSession(taskRunId, {
@@ -1781,6 +1795,13 @@ export class SessionService {
         // above. Cloud sessions never see that response.
         const session = this.getSessionByRunId(taskRunId);
         if (session?.isCloud) {
+          // Consume the turn's armed completion notification. Done for snapshot
+          // and live alike so a completed turn replayed in history doesn't leave
+          // the run armed for a later spurious notify. `delete` returns whether
+          // it was still armed — a re-delivered `turn_complete` finds it already
+          // consumed and rings nothing, which is what stops the duplicate.
+          const awaitingNotify =
+            this.cloudTurnAwaitingCompletionNotify.delete(taskRunId);
           this.d.store.updateSession(taskRunId, {
             isPromptPending: false,
             promptStartedAt: null,
@@ -1788,7 +1809,7 @@ export class SessionService {
           });
           if (isLive) {
             // Queued messages will start a new turn — suppress the "done" notification in that case.
-            if (session.messageQueue.length === 0) {
+            if (awaitingNotify && session.messageQueue.length === 0) {
               this.d.notifyPromptComplete(
                 session.taskTitle,
                 "end_turn",

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -549,14 +549,6 @@ export class SessionService {
     string,
     { startedAtTs: number; agentTextChunks: number; agentOutputEvents: number }
   >();
-  // Cloud runs whose in-flight turn still owes exactly one completion
-  // notification. Armed when the turn's `session/prompt` is processed and
-  // consumed when its `turn_complete` fires the notification. Cloud streams can
-  // re-deliver the `turn_complete` tail (durable-stream re-emit or a reconnect
-  // replay), each delivery slipping past the processedLineCount guard with a
-  // fresh totalEntryCount; without this a replay rang a second "meep"/toast for
-  // the same turn.
-  private cloudTurnAwaitingCompletionNotify = new Set<string>();
   private idleKilledSubscription: { unsubscribe: () => void } | null = null;
   /**
    * Cached preview-config-options responses keyed by `${apiHost}::${adapter}`.
@@ -1065,7 +1057,6 @@ export class SessionService {
     this.evictedRunIds.delete(taskRunId);
     this.d.store.removeSession(taskRunId);
     this.cloudRunIdleTracker.delete(taskRunId);
-    this.cloudTurnAwaitingCompletionNotify.delete(taskRunId);
     this.cloudLogGapReconciler.forgetDeficiency(taskRunId);
     if (session) {
       this.localRepoPaths.delete(session.taskId);
@@ -1668,7 +1659,6 @@ export class SessionService {
     this.sessionLastUsedAt.clear();
     this.cloudPermissionRequestIds.clear();
     this.liveTurnContent.clear();
-    this.cloudTurnAwaitingCompletionNotify.clear();
     this.cloudLogGapReconciler.clear();
     this.dispatchingCloudQueues.clear();
     this.scheduledCloudQueueFlushes.clear();
@@ -1754,10 +1744,6 @@ export class SessionService {
         }
         const promptSession = this.d.store.getSessions()[taskRunId];
         if (promptSession?.isCloud) {
-          // A fresh turn started — arm its single completion notification.
-          // Processed for snapshot and live alike so that opening a task whose
-          // in-flight prompt is only in history still notifies when it finishes.
-          this.cloudTurnAwaitingCompletionNotify.add(taskRunId);
           this.cloudRunIdleTracker.markBusy(promptSession);
           if (promptSession.agentIdleForRunId) {
             this.d.store.updateSession(taskRunId, {
@@ -1795,13 +1781,6 @@ export class SessionService {
         // above. Cloud sessions never see that response.
         const session = this.getSessionByRunId(taskRunId);
         if (session?.isCloud) {
-          // Consume the turn's armed completion notification. Done for snapshot
-          // and live alike so a completed turn replayed in history doesn't leave
-          // the run armed for a later spurious notify. `delete` returns whether
-          // it was still armed — a re-delivered `turn_complete` finds it already
-          // consumed and rings nothing, which is what stops the duplicate.
-          const awaitingNotify =
-            this.cloudTurnAwaitingCompletionNotify.delete(taskRunId);
           this.d.store.updateSession(taskRunId, {
             isPromptPending: false,
             promptStartedAt: null,
@@ -1809,7 +1788,7 @@ export class SessionService {
           });
           if (isLive) {
             // Queued messages will start a new turn — suppress the "done" notification in that case.
-            if (awaitingNotify && session.messageQueue.length === 0) {
+            if (session.messageQueue.length === 0) {
               this.d.notifyPromptComplete(
                 session.taskTitle,
                 "end_turn",


### PR DESCRIPTION
## What

Cloud tasks fired **duplicate completion notifications** — two rapid back-to-back "meep" sounds and two stacked in-app toasts every time a turn finished. The same re-delivery could also duplicate **transcript entries**. This dedups the stream at the source so each entry is delivered exactly once.

## Root cause

The durable cloud SSE stream re-sends the tail by id on reconnect/replay. A re-delivered log entry (e.g. a `_posthog/turn_complete`) was counted as **new** — advancing `totalEntryCount` past the renderer's `processedLineCount` guard — and emitted again, so `notifyPromptComplete` fired a second time (and the entry could reappear in the transcript). The count/offset guard can't catch this because the replay legitimately advances the count.

The notification-bus refactor (#2934) didn't cause the double; it unmasked it — the old focused-elsewhere tier was a native OS notification (which the OS coalesces), the new one stacks toasts and replays a JS sound per call.

## How

Deduplicate re-delivered entries by their **SSE `event.id`** at ingestion, in `CloudTaskService.handleSseEvent`, before anything is counted or emitted:

- Each watcher tracks the ids it has ingested on the current leg (`seenEventIds`). A log entry whose id was already seen is dropped.
- Ids are **leg-scoped**: the set is cleared on a proxy↔django leg switch, and on a watcher re-bootstrap reset (`retry()` / stream self-heal), which re-resolves the leg. In both cases the old id space is unrelated to the new one, so a retained id would false-match — and silently drop — a legitimate new entry; the re-fetched snapshot's existing content-dedup covers the gap instead.
- Entries without an id (legacy servers) fall through unchanged.

Because the stream layer no longer produces re-deliveries, the notification path stays simple — the completion notification just fires on each live turn completion, with no special de-dup bookkeeping.

> Evolution: an earlier revision added a per-turn notification guard (`cloudTurnAwaitingCompletionNotify`) in `SessionService`. Per review (thanks @jonathanmieloo), that treated the symptom; this replaces it with id-based dedup at the source, which also fixes duplicate transcript entries. `SessionService` is back to its original notify logic. A follow-up review pass then caught that the re-bootstrap reset path retained the id set (the inverse hazard: silent drops after a retry), fixed by clearing it in `resetWatcherForRebootstrap`.

## Testing

- New `CloudTaskService` test: a stream that re-sends `id: 1` delivers the entry exactly once (`["first","second"]`, not `["first","first","second"]`) — **verified failing without the dedup**.
- New `CloudTaskService` test: after `retry()` rebuilds the watcher, an entry on the new connection that reuses a previously-seen id is still delivered — **verified failing without the reset-path clear**.
- Renderer notification tests remain (parameterised, snapshot-suppression, payload, permission dedup); the re-delivery case moved upstream to the CloudTaskService suite.
- Full `@posthog/core` suite green (1921 tests), core typecheck clean, biome clean (zero `noRestrictedImports`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
