### PR TITLE
fix(code): keep diff stats, PR button, and diff panel refreshing in sync

### DIFF
--- a/packages/ui/src/features/code-review/hooks/useEffectiveDiffSource.ts
+++ b/packages/ui/src/features/code-review/hooks/useEffectiveDiffSource.ts
@@ -2,6 +2,7 @@ import {
   type ResolvedDiffSource,
   resolveDiffSource,
 } from "@posthog/core/code-review/resolveDiffSource";
+import { EMPTY_DIFF_STATS } from "@posthog/core/code-review/selectTaskDiffStats";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useQuery } from "@tanstack/react-query";
 import { useDiffViewerStore } from "../../code-editor/diffViewerStore";
@@ -31,11 +32,6 @@ export function useEffectiveDiffSource(taskId: string): EffectiveDiffSource {
   const configured = useDiffViewerStore((s) => s.diffSource[taskId] ?? null);
 
   const enabled = !!repoPath;
-  const emptyDiffStats: DiffStats = {
-    filesChanged: 0,
-    linesAdded: 0,
-    linesRemoved: 0,
-  };
 
   const { data: syncStatus } = useQuery(
     trpc.git.getGitSyncStatus.queryOptions(
@@ -51,7 +47,7 @@ export function useEffectiveDiffSource(taskId: string): EffectiveDiffSource {
     ),
   );
 
-  const { data: diffStats = emptyDiffStats } = useDiffStats(repoPath ?? null);
+  const { data: diffStats = EMPTY_DIFF_STATS } = useDiffStats(repoPath ?? null);
 
   const aheadOfDefault = syncStatus?.aheadOfDefault ?? 0;
   const defaultBranch = repoInfo?.defaultBranch ?? null;

--- a/packages/ui/src/features/diff-stats/useDiffStats.ts
+++ b/packages/ui/src/features/diff-stats/useDiffStats.ts
@@ -1,24 +1,34 @@
-import { useWorkspaceTRPC } from "@posthog/workspace-client/trpc";
+import { useHostTRPC } from "@posthog/host-router/react";
 import { useQuery } from "@tanstack/react-query";
 
-const DEFAULT_REFETCH_INTERVAL_MS = 30_000;
+const EMPTY_DIFF_STATS = { filesChanged: 0, linesAdded: 0, linesRemoved: 0 };
 
 export interface UseDiffStatsOptions {
   enabled?: boolean;
-  refetchInterval?: number;
 }
 
+/**
+ * Working-tree diff stats for the header badge / session chip.
+ *
+ * Deliberately reads the same `git.getDiffStats` query that `useGitQueries`
+ * (the changes panel + PR button) and the diff panel rely on, so the numbers
+ * share one cache entry and one fetch, and refresh off the same file-watcher
+ * invalidation (`invalidateGitWorkingTreeQueries`). A separate transport with
+ * its own poll interval used to back this and drifted out of sync with the
+ * panel; keep it unified.
+ */
 export function useDiffStats(
   directoryPath: string | null,
   options: UseDiffStatsOptions = {},
 ) {
-  const trpc = useWorkspaceTRPC();
+  const trpc = useHostTRPC();
   return useQuery(
-    trpc.diffStats.getDiffStats.queryOptions(
+    trpc.git.getDiffStats.queryOptions(
       { directoryPath: directoryPath ?? "" },
       {
         enabled: (options.enabled ?? true) && !!directoryPath,
-        refetchInterval: options.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS,
+        staleTime: 30_000,
+        placeholderData: (prev) => prev ?? EMPTY_DIFF_STATS,
       },
     ),
   );

--- a/packages/ui/src/features/diff-stats/useDiffStats.ts
+++ b/packages/ui/src/features/diff-stats/useDiffStats.ts
@@ -1,7 +1,6 @@
+import { EMPTY_DIFF_STATS } from "@posthog/core/code-review/selectTaskDiffStats";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useQuery } from "@tanstack/react-query";
-
-const EMPTY_DIFF_STATS = { filesChanged: 0, linesAdded: 0, linesRemoved: 0 };
 
 export interface UseDiffStatsOptions {
   enabled?: boolean;
@@ -28,7 +27,12 @@ export function useDiffStats(
       {
         enabled: (options.enabled ?? true) && !!directoryPath,
         staleTime: 30_000,
-        placeholderData: (prev) => prev ?? EMPTY_DIFF_STATS,
+        // Plain value, not the `(prev) => prev` carry-over idiom: the header
+        // badge's observer survives task switches without remounting, so
+        // carrying data across query keys would show the previous repo's
+        // numbers — indefinitely when the next task has no cwd and the query
+        // stays disabled.
+        placeholderData: EMPTY_DIFF_STATS,
       },
     ),
   );

--- a/packages/ui/src/features/git-interaction/useGitQueries.ts
+++ b/packages/ui/src/features/git-interaction/useGitQueries.ts
@@ -1,7 +1,7 @@
+import { EMPTY_DIFF_STATS } from "@posthog/core/code-review/selectTaskDiffStats";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useQuery } from "@tanstack/react-query";
 
-const EMPTY_DIFF_STATS = { filesChanged: 0, linesAdded: 0, linesRemoved: 0 };
 const EMPTY_CHANGED_FILES: never[] = [];
 
 const GIT_QUERY_DEFAULTS = {

--- a/packages/workspace-server/src/services/watcher/service.test.ts
+++ b/packages/workspace-server/src/services/watcher/service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FileWatcherEvent, WatcherEvent } from "./schemas";
-import { WatcherService } from "./service";
+import { DEBOUNCE_MS, MAX_WAIT_MS, WatcherService } from "./service";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -81,10 +81,6 @@ describe("WatcherService.watchRepo ignore patterns", () => {
     expect(gitDirCalls[0]?.ignore).toEqual(["**/worktrees/**"]);
   });
 });
-
-// Mirrors DEBOUNCE_MS / MAX_WAIT_MS in service.ts.
-const DEBOUNCE_MS = 500;
-const MAX_WAIT_MS = 1000;
 
 interface ManualGen {
   gen: AsyncGenerator<WatcherEvent[]>;
@@ -192,19 +188,23 @@ describe("WatcherService.watchRepo debounce", () => {
     const { events, done } = drainEvents(startWatch(wt));
     await vi.advanceTimersByTimeAsync(0);
 
-    // Push faster than the trailing debounce (every 300ms < 500ms) so the
-    // quiet-period timer keeps resetting and would not fire on its own until
-    // 1400ms (300*3 + 500).
-    for (let i = 0; i < 3; i++) {
-      wt.push([{ type: "update", path: `/repo/f${i}.ts` }]);
-      await vi.advanceTimersByTimeAsync(300);
+    // Push faster than the trailing debounce so its quiet-period timer keeps
+    // resetting and can never fire on its own; only the max-wait can flush.
+    const step = DEBOUNCE_MS - 100;
+    let elapsed = 0;
+    while (elapsed + step < MAX_WAIT_MS) {
+      wt.push([{ type: "update", path: `/repo/f${elapsed}.ts` }]);
+      await vi.advanceTimersByTimeAsync(step);
+      elapsed += step;
     }
+    // Continuously active for longer than the debounce window but not yet the
+    // max-wait: the trailing debounce alone would not have emitted anything.
+    expect(elapsed).toBeGreaterThan(DEBOUNCE_MS);
     expect(events).toHaveLength(0);
 
-    // The first event landed at ~0ms, so the max-wait forces a flush at
-    // MAX_WAIT_MS even though the trailing debounce is still pending.
-    wt.push([{ type: "update", path: "/repo/f3.ts" }]);
-    await vi.advanceTimersByTimeAsync(MAX_WAIT_MS - 900 + 1);
+    // Crossing MAX_WAIT_MS forces a flush despite the ongoing activity.
+    wt.push([{ type: "update", path: "/repo/final.ts" }]);
+    await vi.advanceTimersByTimeAsync(MAX_WAIT_MS - elapsed + 1);
     expect(workingTreeChanges(events)).toEqual([
       { kind: "working-tree-changed", repoPath: "/repo" },
     ]);

--- a/packages/workspace-server/src/services/watcher/service.test.ts
+++ b/packages/workspace-server/src/services/watcher/service.test.ts
@@ -132,12 +132,8 @@ function startWatch(wt: ManualGen): AsyncGenerator<FileWatcherEvent> {
     gitDir: null,
     commonDir: null,
   });
-  vi.spyOn(service, "watch").mockImplementation(
-    (_dir: string, options: { ignore?: string[] }) => {
-      if (options.ignore?.includes("**/node_modules/**")) return wt.gen;
-      return (async function* (): AsyncGenerator<WatcherEvent[]> {})();
-    },
-  );
+  // With no git dirs resolved, the only watch() call is the working-tree one.
+  vi.spyOn(service, "watch").mockReturnValue(wt.gen);
   return service.watchRepo("/repo", new AbortController().signal);
 }
 

--- a/packages/workspace-server/src/services/watcher/service.test.ts
+++ b/packages/workspace-server/src/services/watcher/service.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
-import type { WatcherEvent } from "./schemas";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FileWatcherEvent, WatcherEvent } from "./schemas";
 import { WatcherService } from "./service";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 /**
  * Records every `watch()` call so we can assert what each watched directory is
@@ -75,5 +79,137 @@ describe("WatcherService.watchRepo ignore patterns", () => {
     const gitDirCalls = calls.filter((c) => c.dir === "/main/.git");
     expect(gitDirCalls).toHaveLength(1);
     expect(gitDirCalls[0]?.ignore).toEqual(["**/worktrees/**"]);
+  });
+});
+
+// Mirrors DEBOUNCE_MS / MAX_WAIT_MS in service.ts.
+const DEBOUNCE_MS = 500;
+const MAX_WAIT_MS = 1000;
+
+interface ManualGen {
+  gen: AsyncGenerator<WatcherEvent[]>;
+  push: (batch: WatcherEvent[]) => void;
+  end: () => void;
+}
+
+/** A watch generator whose batches the test emits on demand. */
+function manualGen(): ManualGen {
+  const queue: WatcherEvent[][] = [];
+  let notify: (() => void) | null = null;
+  let ended = false;
+
+  const wake = () => {
+    if (notify) {
+      const n = notify;
+      notify = null;
+      n();
+    }
+  };
+
+  async function* generate(): AsyncGenerator<WatcherEvent[]> {
+    while (true) {
+      while (queue.length > 0) yield queue.shift() as WatcherEvent[];
+      if (ended) return;
+      await new Promise<void>((resolve) => {
+        notify = resolve;
+      });
+    }
+  }
+
+  return {
+    gen: generate(),
+    push(batch) {
+      queue.push(batch);
+      wake();
+    },
+    end() {
+      ended = true;
+      wake();
+    },
+  };
+}
+
+/** Drives watchRepo with a controllable working-tree watch and no git dirs. */
+function startWatch(wt: ManualGen): AsyncGenerator<FileWatcherEvent> {
+  const service = new WatcherService();
+  vi.spyOn(service, "resolveGitDirs").mockResolvedValue({
+    gitDir: null,
+    commonDir: null,
+  });
+  vi.spyOn(service, "watch").mockImplementation(
+    (_dir: string, options: { ignore?: string[] }) => {
+      if (options.ignore?.includes("**/node_modules/**")) return wt.gen;
+      return (async function* (): AsyncGenerator<WatcherEvent[]> {})();
+    },
+  );
+  return service.watchRepo("/repo", new AbortController().signal);
+}
+
+/**
+ * A working-tree change also emits per-file/dir events (below BULK_THRESHOLD);
+ * the coalesced `working-tree-changed` is the one that drives invalidation, so
+ * the debounce tests assert on just those.
+ */
+const workingTreeChanges = (events: FileWatcherEvent[]): FileWatcherEvent[] =>
+  events.filter((e) => e.kind === "working-tree-changed");
+
+/** Consumes watchRepo in the background, collecting every emitted event. */
+function drainEvents(out: AsyncGenerator<FileWatcherEvent>): {
+  events: FileWatcherEvent[];
+  done: Promise<void>;
+} {
+  const events: FileWatcherEvent[] = [];
+  const done = (async () => {
+    for await (const ev of out) events.push(ev);
+  })();
+  return { events, done };
+}
+
+describe("WatcherService.watchRepo debounce", () => {
+  it("coalesces a burst and emits once it goes quiet", async () => {
+    vi.useFakeTimers();
+    const wt = manualGen();
+    const { events, done } = drainEvents(startWatch(wt));
+    // Let watchRepo settle past resolveGitDirs and start its file loop.
+    await vi.advanceTimersByTimeAsync(0);
+
+    wt.push([{ type: "update", path: "/repo/a.ts" }]);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS - 1);
+    expect(events).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(workingTreeChanges(events)).toEqual([
+      { kind: "working-tree-changed", repoPath: "/repo" },
+    ]);
+
+    wt.end();
+    await done;
+  });
+
+  it("flushes during sustained activity via the max-wait", async () => {
+    vi.useFakeTimers();
+    const wt = manualGen();
+    const { events, done } = drainEvents(startWatch(wt));
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Push faster than the trailing debounce (every 300ms < 500ms) so the
+    // quiet-period timer keeps resetting and would not fire on its own until
+    // 1400ms (300*3 + 500).
+    for (let i = 0; i < 3; i++) {
+      wt.push([{ type: "update", path: `/repo/f${i}.ts` }]);
+      await vi.advanceTimersByTimeAsync(300);
+    }
+    expect(events).toHaveLength(0);
+
+    // The first event landed at ~0ms, so the max-wait forces a flush at
+    // MAX_WAIT_MS even though the trailing debounce is still pending.
+    wt.push([{ type: "update", path: "/repo/f3.ts" }]);
+    await vi.advanceTimersByTimeAsync(MAX_WAIT_MS - 900 + 1);
+    expect(workingTreeChanges(events)).toEqual([
+      { kind: "working-tree-changed", repoPath: "/repo" },
+    ]);
+
+    wt.end();
+    await done;
   });
 });

--- a/packages/workspace-server/src/services/watcher/service.ts
+++ b/packages/workspace-server/src/services/watcher/service.ts
@@ -23,13 +23,13 @@ const IGNORE_PATTERNS = ["**/node_modules/**", "**/.git/**", "**/.jj/**"];
 // noise; shared refs (`refs/heads`, `packed-refs`) live outside `worktrees/`
 // and are still observed.
 const GIT_IGNORE_PATTERNS = ["**/worktrees/**"];
-const DEBOUNCE_MS = 500;
+export const DEBOUNCE_MS = 500;
 // Upper bound on how long working-tree events may be coalesced. The trailing
 // debounce resets on every event, so an agent writing continuously would other-
 // wise never trip it until it paused, freezing the diff panel/stats mid-run.
 // The max-wait forces a flush at least this often during sustained activity so
 // the UI keeps advancing while the agent works.
-const MAX_WAIT_MS = 1000;
+export const MAX_WAIT_MS = 1000;
 const BULK_THRESHOLD = 100;
 
 const dirname = (p: string): string => {

--- a/packages/workspace-server/src/services/watcher/service.ts
+++ b/packages/workspace-server/src/services/watcher/service.ts
@@ -24,6 +24,12 @@ const IGNORE_PATTERNS = ["**/node_modules/**", "**/.git/**", "**/.jj/**"];
 // and are still observed.
 const GIT_IGNORE_PATTERNS = ["**/worktrees/**"];
 const DEBOUNCE_MS = 500;
+// Upper bound on how long working-tree events may be coalesced. The trailing
+// debounce resets on every event, so an agent writing continuously would other-
+// wise never trip it until it paused, freezing the diff panel/stats mid-run.
+// The max-wait forces a flush at least this often during sustained activity so
+// the UI keeps advancing while the agent works.
+const MAX_WAIT_MS = 1000;
 const BULK_THRESHOLD = 100;
 
 const dirname = (p: string): string => {
@@ -167,6 +173,7 @@ export class WatcherService {
 
     const pending = createPending();
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let maxWaitTimer: ReturnType<typeof setTimeout> | null = null;
     const outQueue: FileWatcherEvent[] = [];
     let outResolve: ((next: FileWatcherEvent[] | null) => void) | null = null;
     let outClosed = false;
@@ -191,18 +198,32 @@ export class WatcherService {
       }
     };
 
+    const flushPending = () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      if (maxWaitTimer) {
+        clearTimeout(maxWaitTimer);
+        maxWaitTimer = null;
+      }
+      pushOut(drainPending(repoPath, pending));
+    };
+
     const fileLoop = (async () => {
       try {
         for await (const batch of fileEvents) {
           accumulateFsEvents(pending, batch);
+          // Trailing debounce: coalesce a burst and emit once it goes quiet.
           if (debounceTimer) clearTimeout(debounceTimer);
-          debounceTimer = setTimeout(() => {
-            debounceTimer = null;
-            pushOut(drainPending(repoPath, pending));
-          }, DEBOUNCE_MS);
+          debounceTimer = setTimeout(flushPending, DEBOUNCE_MS);
+          // Max-wait: bound the coalescing so sustained activity still flushes.
+          if (!maxWaitTimer)
+            maxWaitTimer = setTimeout(flushPending, MAX_WAIT_MS);
         }
       } finally {
         if (debounceTimer) clearTimeout(debounceTimer);
+        if (maxWaitTimer) clearTimeout(maxWaitTimer);
         closeOut();
       }
     })();

--- a/packages/workspace-server/src/trpc.ts
+++ b/packages/workspace-server/src/trpc.ts
@@ -750,12 +750,6 @@ export function createAppRouter({
         }
       }),
     }),
-    diffStats: t.router({
-      getDiffStats: t.procedure
-        .input(diffStatsInput)
-        .output(diffStatsSchema)
-        .query(({ input }) => gitService().getDiffStats(input.directoryPath)),
-    }),
     fs: t.router({
       listDirectory: t.procedure
         .input(listDirectoryInput)


### PR DESCRIPTION
## Problem

The diff numbers in the top bar (and the PR `+/-` badge) updated on a different cadence than the diff panel and PR button — they'd sit stale for up to 30s after the agent edited files.

**Root cause:** the header badge / session chip read `diffStats.getDiffStats` over the *workspace-client* transport, while the panel, PR button, and changes panel read `git.getDiffStats` over the *host-router* transport. The file-watcher invalidation (`invalidateGitWorkingTreeQueries`) is keyed on the host `git.*` namespace, so it never named the workspace-client query — that path only refreshed on a 30s poll. The two procedures were byte-identical, and both were mounted at once, so the split also ran `git diff --numstat` twice.

## Changes

- **Unify the stats onto the watcher-invalidated query.** `useDiffStats` now reads the host-router `git.getDiffStats` — the same query `useGitQueries` (changes panel + PR button) and the diff panel already use. The header badge and session chip share one watcher-invalidated cache entry: no duplicate fetch, no separate 30s poll, and all diff surfaces refresh together.
- **Remove the orphaned `diffStats` router** from workspace-server (it duplicated `git.getDiffStats`).
- **Add a max-wait to the file watcher.** The working-tree watcher used a pure trailing 500ms debounce that reset on every FS event, so a continuously-writing agent never tripped it until it paused (the "panel lags behind the agent" feeling). A 1000ms max-wait keeps coalescing bursts but guarantees a flush at least once a second during sustained activity, so the panel/stats advance mid-run.

The PR button was already on the correct (watcher-invalidated) path and is unchanged; only the `+/-` number beside it was stale, which the unification fixes.

## Tests

- New fake-timer tests for the watcher: trailing debounce coalesces a burst and emits once quiet; the max-wait forces a flush during sustained activity (fails on the old trailing-only behavior).
- `@posthog/ui` and `@posthog/workspace-server` typecheck clean; `biome check` clean; watcher suite 4/4, full workspace-server unit suite 547 pass. (The only failing suites are pre-existing git/archive *integration* tests that shell out to `git commit`, unrelated to this change.)