### PR TITLE
feat(settings): add random notification sound options

### DIFF
--- a/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -242,6 +242,10 @@ export function NotificationsSettings() {
             <Select.Trigger className="min-w-[100px]" />
             <Select.Content>
               <Select.Item value="none">None</Select.Item>
+              <Select.Item value="random-all">Random (all)</Select.Item>
+              {customSounds.length > 0 && (
+                <Select.Item value="random-custom">Random (custom)</Select.Item>
+              )}
               <Select.Item value="guitar">Guitar solo</Select.Item>
               <Select.Item value="danilo">I'm ready</Select.Item>
               <Select.Item value="revi">Cute noise</Select.Item>

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -257,8 +257,6 @@ describe("feature settingsStore custom sounds", () => {
         JSON.stringify({ state: persistedState, version: 0 }),
       );
 
-      useSettingsStore.setState({ completionSound: "none", customSounds: [] });
-
       await useSettingsStore.persist.rehydrate();
 
       expect(useSettingsStore.getState().completionSound).toBe(

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -230,6 +230,42 @@ describe("feature settingsStore custom sounds", () => {
     const persisted = JSON.parse(lastCall[1]);
     expect(persisted.state.customSounds).toEqual([sound]);
   });
+
+  it.each([
+    {
+      label: "random-custom with empty customSounds array",
+      persistedState: { completionSound: "random-custom", customSounds: [] },
+      expectedCompletionSound: "none",
+    },
+    {
+      label: "random-custom with absent customSounds key",
+      persistedState: { completionSound: "random-custom" },
+      expectedCompletionSound: "none",
+    },
+    {
+      label: "random-custom with non-empty library",
+      persistedState: {
+        completionSound: "random-custom",
+        customSounds: [sound],
+      },
+      expectedCompletionSound: "random-custom",
+    },
+  ])(
+    "rehydrate merge normalizes $label",
+    async ({ persistedState, expectedCompletionSound }) => {
+      getItem.mockResolvedValue(
+        JSON.stringify({ state: persistedState, version: 0 }),
+      );
+
+      useSettingsStore.setState({ completionSound: "none", customSounds: [] });
+
+      await useSettingsStore.persist.rehydrate();
+
+      expect(useSettingsStore.getState().completionSound).toBe(
+        expectedCompletionSound,
+      );
+    },
+  );
 });
 
 describe("feature settingsStore terminal font", () => {

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -195,6 +195,11 @@ describe("feature settingsStore custom sounds", () => {
       activeSound: "meep" as CompletionSound,
       expectedSound: "meep" as CompletionSound,
     },
+    {
+      label: "last sound feeding random-custom",
+      activeSound: "random-custom" as CompletionSound,
+      expectedSound: "none" as CompletionSound,
+    },
   ])(
     "removing the $label leaves completionSound as $expectedSound",
     ({ activeSound, expectedSound }) => {
@@ -205,6 +210,14 @@ describe("feature settingsStore custom sounds", () => {
       expect(useSettingsStore.getState().completionSound).toBe(expectedSound);
     },
   );
+
+  it("keeps random-custom active while other custom sounds remain", () => {
+    useSettingsStore.getState().addCustomSound(sound);
+    useSettingsStore.getState().addCustomSound({ ...sound, id: "def" });
+    useSettingsStore.getState().setCompletionSound("random-custom");
+    useSettingsStore.getState().removeCustomSound("abc");
+    expect(useSettingsStore.getState().completionSound).toBe("random-custom");
+  });
 
   it("persists custom sounds", async () => {
     useSettingsStore.getState().addCustomSound(sound);

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -45,7 +45,11 @@ export type BuiltInCompletionSound =
   | "icq";
 
 // A user-installed sound is selected by referencing its id as `custom:<id>`.
-export type CompletionSound = BuiltInCompletionSound | `custom:${string}`;
+export type CompletionSound =
+  | BuiltInCompletionSound
+  | "random-all"
+  | "random-custom"
+  | `custom:${string}`;
 
 // A notification sound the user recorded or imported. The clip is stored inline
 // as a base64 data URL so it persists with the rest of the settings (no host
@@ -276,14 +280,21 @@ export const useSettingsStore = create<SettingsStore>()(
       addCustomSound: (sound) =>
         set((state) => ({ customSounds: [...state.customSounds, sound] })),
       removeCustomSound: (id) =>
-        set((state) => ({
-          customSounds: state.customSounds.filter((s) => s.id !== id),
-          // If the deleted sound was the active one, fall back to silence.
-          completionSound:
-            state.completionSound === `custom:${id}`
+        set((state) => {
+          const customSounds = state.customSounds.filter((s) => s.id !== id);
+          // If the deleted sound was the active one, or it was the last sound
+          // feeding "random-custom", fall back to silence.
+          const soundNowUnplayable =
+            state.completionSound === `custom:${id}` ||
+            (state.completionSound === "random-custom" &&
+              customSounds.length === 0);
+          return {
+            customSounds,
+            completionSound: soundNowUnplayable
               ? "none"
               : state.completionSound,
-        })),
+          };
+        }),
       renameCustomSound: (id, name) =>
         set((state) => ({
           customSounds: state.customSounds.map((s) =>

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -469,6 +469,12 @@ export const useSettingsStore = create<SettingsStore>()(
         if ((merged.autoConvertLongText as string) === "500") {
           (merged as Record<string, unknown>).autoConvertLongText = "1000";
         }
+        if (
+          merged.completionSound === "random-custom" &&
+          (!merged.customSounds || merged.customSounds.length === 0)
+        ) {
+          (merged as Record<string, unknown>).completionSound = "none";
+        }
         return merged;
       },
     },

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -282,8 +282,6 @@ export const useSettingsStore = create<SettingsStore>()(
       removeCustomSound: (id) =>
         set((state) => {
           const customSounds = state.customSounds.filter((s) => s.id !== id);
-          // If the deleted sound was the active one, or it was the last sound
-          // feeding "random-custom", fall back to silence.
           const soundNowUnplayable =
             state.completionSound === `custom:${id}` ||
             (state.completionSound === "random-custom" &&

--- a/packages/ui/src/utils/sounds.test.ts
+++ b/packages/ui/src/utils/sounds.test.ts
@@ -2,7 +2,7 @@ import type {
   CompletionSound,
   CustomSound,
 } from "@posthog/ui/features/settings/settingsStore";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { playbackRateForTaskDuration, resolveSoundUrl } from "./sounds";
 
 const customs: CustomSound[] = [
@@ -38,6 +38,41 @@ describe("resolveSoundUrl", () => {
   it("returns null when the custom id is no longer installed", () => {
     // e.g. the active sound was deleted from the library.
     expect(resolveSoundUrl("custom:gone", customs)).toBeNull();
+  });
+
+  describe("random modes", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("'random-all' with no custom sounds picks a built-in asset", () => {
+      const url = resolveSoundUrl("random-all", []);
+      expect(url).toBeTruthy();
+      expect(url).not.toMatch(/^data:/);
+    });
+
+    it("'random-custom' with a single custom sound picks it", () => {
+      expect(resolveSoundUrl("random-custom", customs)).toBe(
+        "data:audio/wav;base64,AAAA",
+      );
+    });
+
+    it("'random-custom' with no custom sounds returns null", () => {
+      expect(resolveSoundUrl("random-custom", [])).toBeNull();
+    });
+
+    it.each([
+      ["lowest roll picks a built-in", 0, false],
+      ["highest roll picks a custom sound", 0.999999, true],
+    ])(
+      "'random-all' spans built-ins and customs: %s",
+      (_label, roll, expectCustom) => {
+        vi.spyOn(Math, "random").mockReturnValue(roll);
+        const url = resolveSoundUrl("random-all", customs);
+        expect(url === "data:audio/wav;base64,AAAA").toBe(expectCustom);
+        expect(url).toBeTruthy();
+      },
+    );
   });
 });
 

--- a/packages/ui/src/utils/sounds.ts
+++ b/packages/ui/src/utils/sounds.ts
@@ -68,15 +68,27 @@ export function playbackRateForTaskDuration(durationMs: number): number {
 
 let currentAudio: HTMLAudioElement | null = null;
 
+function pickRandom(pool: string[]): string | null {
+  if (pool.length === 0) return null;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
 // Resolves the playable URL for a completion sound: a bundled asset URL for the
-// built-ins, or the inline data URL of a user-installed custom sound. Returns
-// null for `none`, an unknown built-in, or a `custom:` id no longer installed
-// (e.g. the active sound was deleted) — callers then play nothing.
+// built-ins, the inline data URL of a user-installed custom sound, or a fresh
+// random pick per call for the `random-*` modes. Returns null for `none`, an
+// unknown built-in, a `custom:` id no longer installed (e.g. the active sound
+// was deleted), or `random-custom` with no sounds installed — callers then
+// play nothing.
 export function resolveSoundUrl(
   sound: CompletionSound,
   customSounds: CustomSound[],
 ): string | null {
   if (sound === "none") return null;
+  const customUrls = customSounds.map((s) => s.dataUrl);
+  if (sound === "random-all") {
+    return pickRandom([...Object.values(SOUND_URLS), ...customUrls]);
+  }
+  if (sound === "random-custom") return pickRandom(customUrls);
   if (sound.startsWith(CUSTOM_SOUND_PREFIX)) {
     const id = sound.slice(CUSTOM_SOUND_PREFIX.length);
     return customSounds.find((s) => s.id === id)?.dataUrl ?? null;


### PR DESCRIPTION
## Summary

Adds two options to the notification "Sound effect" dropdown in Settings > Notifications:

- **Random (all)** — picks a fresh sound per notification from the built-in sounds plus any installed custom sounds
- **Random (custom)** — picks from the user's custom sounds only; the option is shown once at least one custom sound is installed (same condition as the existing Custom group)

## Details

- New `CompletionSound` values `random-all` / `random-custom` live alongside the `custom:<id>` sentinel rather than in `BuiltInCompletionSound`, which keys the `SOUND_URLS` asset record
- Resolution happens in `resolveSoundUrl`, which is called per notification (and per press of the "Test sound" button), so each firing draws a fresh random pick with no extra plumbing
- `random-custom` with an empty pool resolves to `null` and plays nothing, matching the existing deleted-custom-sound behaviour; removing the *last* custom sound while `random-custom` is active falls back to "None", extending the existing fallback in `removeCustomSound`

## Testing

- Extended `sounds.test.ts`: pool membership for both modes, `null` for `random-custom` with nothing installed, and a `Math.random` spy at both extremes proving custom sounds are reachable in the `random-all` pool
- Extended the parameterised `removeCustomSound` test in `settingsStore.test.ts` with the `random-custom` fallback, plus a case verifying it stays active while other custom sounds remain

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*