### PR TITLE
chore(ui): replace ArrowUUpLeft with PencilSimple icon in queued message

### DIFF
--- a/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/QueuedMessageView.tsx
@@ -1,6 +1,6 @@
 import {
   ArrowBendDownLeft,
-  ArrowUUpLeft,
+  PencilSimple,
   Stack,
   Trash,
 } from "@phosphor-icons/react";
@@ -64,7 +64,7 @@ export function QueuedMessageView({
                 aria-label="Return to editor"
                 onClick={onReturnToEditor}
               >
-                <ArrowUUpLeft size={12} />
+                <PencilSimple size={12} />
               </IconButton>
             </Tooltip>
           )}


### PR DESCRIPTION
## Problem

The queued message view was using a non intuitive icon (ArrowUUpLeft) for the "return to editor" action. A pencil icon better represents the editing action.

## Changes

Before
<img width="1798" height="282" alt="CleanShot 2026-07-02 at 12 28 07@2x" src="https://github.com/user-attachments/assets/3b043721-15a9-42a6-a582-2b432c1107c8" />


After:
<img width="1544" height="180" alt="CleanShot 2026-07-02 at 12 28 20@2x" src="https://github.com/user-attachments/assets/a884ae5c-749a-45a5-b36d-e640d7e94886" />


- Replaced `ArrowUUpLeft` icon import with `PencilSimple` from `@phosphor-icons/react`
- Updated the icon rendered in the queued message editor button from `<ArrowUUpLeft size={12} />` to `<PencilSimple size={12} />`
- The button's tooltip and functionality remain unchanged ("Return to editor")

## How did you test this?

Visual inspection of the icon change in the queued message component.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*