### PR TITLE
fix(sessions): dedupe cloud prompt echo when attachments add a summary

### DIFF
--- a/packages/core/src/editor/cloud-prompt.test.ts
+++ b/packages/core/src/editor/cloud-prompt.test.ts
@@ -4,6 +4,7 @@ import {
   buildCloudTaskDescription,
   serializeCloudPrompt,
   stripAbsoluteFileTags,
+  stripTrailingAttachmentSummary,
 } from "@posthog/core/editor/cloud-prompt";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -61,6 +62,17 @@ describe("cloud-prompt", () => {
     expect(description).toBe(
       'review <file path="src/index.ts" /> and\n\nAttached files: test.txt',
     );
+  });
+
+  it("strips the trailing attachment summary from a task description", () => {
+    expect(
+      stripTrailingAttachmentSummary("do this\n\nAttached files: a.png, b.txt"),
+    ).toBe("do this");
+    expect(stripTrailingAttachmentSummary("Attached files: a.png")).toBe("");
+    expect(stripTrailingAttachmentSummary("do this")).toBe("do this");
+    expect(
+      stripTrailingAttachmentSummary("Attached files: a.png\n\nthen do this"),
+    ).toBe("Attached files: a.png\n\nthen do this");
   });
 
   it("uses resource_link path references for text attachments", async () => {

--- a/packages/core/src/editor/cloud-prompt.test.ts
+++ b/packages/core/src/editor/cloud-prompt.test.ts
@@ -64,15 +64,21 @@ describe("cloud-prompt", () => {
     );
   });
 
-  it("strips the trailing attachment summary from a task description", () => {
-    expect(
-      stripTrailingAttachmentSummary("do this\n\nAttached files: a.png, b.txt"),
-    ).toBe("do this");
-    expect(stripTrailingAttachmentSummary("Attached files: a.png")).toBe("");
-    expect(stripTrailingAttachmentSummary("do this")).toBe("do this");
-    expect(
-      stripTrailingAttachmentSummary("Attached files: a.png\n\nthen do this"),
-    ).toBe("Attached files: a.png\n\nthen do this");
+  it.each([
+    [
+      "text + trailing summary",
+      "do this\n\nAttached files: a.png, b.txt",
+      "do this",
+    ],
+    ["summary only", "Attached files: a.png", ""],
+    ["no summary", "do this", "do this"],
+    [
+      "summary not at end",
+      "Attached files: a.png\n\nthen do this",
+      "Attached files: a.png\n\nthen do this",
+    ],
+  ])("stripTrailingAttachmentSummary: %s", (_label, input, expected) => {
+    expect(stripTrailingAttachmentSummary(input)).toBe(expected);
   });
 
   it("uses resource_link path references for text attachments", async () => {

--- a/packages/core/src/editor/cloud-prompt.ts
+++ b/packages/core/src/editor/cloud-prompt.ts
@@ -147,6 +147,12 @@ export function getAbsoluteAttachmentPaths(
   );
 }
 
+const TRAILING_ATTACHMENT_SUMMARY_REGEX = /(?:^|\n)Attached files: [^\n]*$/;
+
+export function stripTrailingAttachmentSummary(text: string): string {
+  return text.replace(TRAILING_ATTACHMENT_SUMMARY_REGEX, "").trim();
+}
+
 export function buildCloudTaskDescription(
   prompt: string,
   filePaths: string[] = [],

--- a/packages/core/src/editor/cloud-prompt.ts
+++ b/packages/core/src/editor/cloud-prompt.ts
@@ -147,7 +147,10 @@ export function getAbsoluteAttachmentPaths(
   );
 }
 
-const TRAILING_ATTACHMENT_SUMMARY_REGEX = /(?:^|\n)Attached files: [^\n]*$/;
+export const ATTACHMENT_SUMMARY_PREFIX = "Attached files: ";
+const TRAILING_ATTACHMENT_SUMMARY_REGEX = new RegExp(
+  `(?:^|\\n)${ATTACHMENT_SUMMARY_PREFIX}[^\\n]*$`,
+);
 
 export function stripTrailingAttachmentSummary(text: string): string {
   return text.replace(TRAILING_ATTACHMENT_SUMMARY_REGEX, "").trim();
@@ -166,7 +169,7 @@ export function buildCloudTaskDescription(
     return strippedPrompt;
   }
 
-  const attachmentSummary = `Attached files: ${attachmentNames.join(", ")}`;
+  const attachmentSummary = `${ATTACHMENT_SUMMARY_PREFIX}${attachmentNames.join(", ")}`;
   return strippedPrompt
     ? `${strippedPrompt}\n\n${attachmentSummary}`
     : attachmentSummary;

--- a/packages/core/src/sessions/cloudPrompt.ts
+++ b/packages/core/src/sessions/cloudPrompt.ts
@@ -1,5 +1,6 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import {
+  ATTACHMENT_SUMMARY_PREFIX,
   buildCloudTaskDescription,
   getAbsoluteAttachmentPaths,
   stripAbsoluteFileTags,
@@ -87,7 +88,7 @@ function summarizePrompt(text: string, filePaths: string[]): string {
     return text.trim();
   }
 
-  const attachmentSummary = `Attached files: ${filePaths.map(getFileName).join(", ")}`;
+  const attachmentSummary = `${ATTACHMENT_SUMMARY_PREFIX}${filePaths.map(getFileName).join(", ")}`;
   return text.trim()
     ? `${text.trim()}\n\n${attachmentSummary}`
     : attachmentSummary;

--- a/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
@@ -72,6 +72,57 @@ describe("mergeConversationItems", () => {
     expect(pinned.content).toBe(echoedWithContext);
   });
 
+  it("cloud: dedupes the echo when the placeholder carries an 'Attached files:' summary the echo lacks", () => {
+    const echoed = {
+      ...userMessage("echo", "hello\n\nDo this"),
+      attachments: [
+        { id: "file:///tmp/clipboard.png", label: "clipboard.png" },
+      ],
+    };
+    const result = mergeConversationItems({
+      conversationItems: [echoed, userMessage("other", "different")],
+      optimisticItems: [
+        userMessage("opt", "hello\n\nDo this\n\nAttached files: clipboard.png"),
+      ],
+      isCloud: true,
+    });
+    expect(result.map((i) => i.id)).toEqual(["opt", "other"]);
+    const pinned = result.find((i) => i.id === "opt");
+    if (pinned?.type !== "user_message")
+      throw new Error("expected user_message");
+    expect(pinned.content).toBe("hello\n\nDo this");
+    expect(pinned.attachments).toEqual(echoed.attachments);
+  });
+
+  it("cloud: dedupes an attachment-only placeholder against its text-less echo", () => {
+    const echoed = {
+      ...userMessage("echo", ""),
+      attachments: [{ id: "file:///tmp/notes.txt", label: "notes.txt" }],
+    };
+    const result = mergeConversationItems({
+      conversationItems: [echoed],
+      optimisticItems: [userMessage("opt", "Attached files: notes.txt")],
+      isCloud: true,
+    });
+    expect(result.map((i) => i.id)).toEqual(["opt"]);
+    const pinned = result.find((i) => i.id === "opt");
+    if (pinned?.type !== "user_message")
+      throw new Error("expected user_message");
+    expect(pinned.attachments).toEqual(echoed.attachments);
+  });
+
+  it("cloud: a pinned placeholder consumes only one echo, later identical messages render", () => {
+    const result = mergeConversationItems({
+      conversationItems: [
+        userMessage("echo", "repeat"),
+        userMessage("again", "repeat"),
+      ],
+      optimisticItems: [userMessage("opt", "repeat")],
+      isCloud: true,
+    });
+    expect(result.map((i) => i.id)).toEqual(["opt", "again"]);
+  });
+
   it("cloud: dedupe is no-op when there are no optimistic items", () => {
     const conversationItems = [
       userMessage("a", "first"),

--- a/packages/ui/src/features/sessions/components/mergeConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/mergeConversationItems.ts
@@ -1,3 +1,4 @@
+import { stripTrailingAttachmentSummary } from "@posthog/core/editor/cloud-prompt";
 import type { ConversationItem } from "./buildConversationItems";
 import { extractChannelContext } from "./session-update/channelContext";
 import { extractCustomInstructions } from "./session-update/customInstructions";
@@ -8,15 +9,22 @@ interface MergeConversationItemsArgs {
   isCloud: boolean;
 }
 
+type UserMessageItem = Extract<ConversationItem, { type: "user_message" }>;
+
 // The pinned optimistic bubble is seeded from the bare task description, but the
 // echoed `session/prompt` that streams back from the sandbox may additionally
 // carry the channel's CONTEXT.md and/or the user's personalization, folded into
 // the prompt at task creation (see buildChannelContextText /
-// buildCustomInstructionsText in @posthog/core). Dedupe and upgrade compare on the
-// text with both blocks stripped so the echo still matches its placeholder.
+// buildCustomInstructionsText in @posthog/core). The description side instead
+// appends an `Attached files: <names>` summary line that the echo carries as
+// resource_link blocks, not text (see buildCloudTaskDescription). Dedupe and
+// upgrade compare on the text with all three stripped so the echo still matches
+// its placeholder.
 function strippedUserContent(content: string): string {
   const withoutChannel = extractChannelContext(content)?.stripped ?? content;
-  return extractCustomInstructions(withoutChannel)?.stripped ?? withoutChannel;
+  const withoutInstructions =
+    extractCustomInstructions(withoutChannel)?.stripped ?? withoutChannel;
+  return stripTrailingAttachmentSummary(withoutInstructions);
 }
 
 // Cloud's initial optimistic is pinned to the top so the user's prompt stays
@@ -44,43 +52,55 @@ export function mergeConversationItems({
   const tailOptimisticItems = optimisticItems.filter(
     (item) => item.type === "user_message" && item.pinToTop === false,
   );
-  const pinnedOptimisticUserContents = new Set(
-    pinnedOptimisticItems
-      .filter(
-        (item): item is Extract<typeof item, { type: "user_message" }> =>
-          item.type === "user_message",
-      )
-      .map((item) => strippedUserContent(item.content)),
-  );
+  const unconsumedPinnedKeyCounts = new Map<string, number>();
+  for (const item of pinnedOptimisticItems) {
+    if (item.type !== "user_message") continue;
+    const key = strippedUserContent(item.content);
+    unconsumedPinnedKeyCounts.set(
+      key,
+      (unconsumedPinnedKeyCounts.get(key) ?? 0) + 1,
+    );
+  }
 
   // When the echoed prompt matches a pinned optimistic placeholder, drop the
-  // echo but remember its content: it may carry the channel CONTEXT.md block the
-  // placeholder lacks, so we surface the richer copy on the pinned bubble below.
-  const echoedContentByKey = new Map<string, string>();
+  // echo but remember it: it may carry the channel CONTEXT.md block and the
+  // attachment chips the placeholder lacks, so we surface the richer copy on
+  // the pinned bubble below.
+  const echoedItemByKey = new Map<string, UserMessageItem>();
   const dedupedConversation =
-    pinnedOptimisticUserContents.size === 0
+    unconsumedPinnedKeyCounts.size === 0
       ? conversationItems
       : conversationItems.filter((item) => {
           if (item.type !== "user_message") return true;
           const key = strippedUserContent(item.content);
-          if (!pinnedOptimisticUserContents.has(key)) return true;
-          if (!echoedContentByKey.has(key)) {
-            echoedContentByKey.set(key, item.content);
+          const remaining = unconsumedPinnedKeyCounts.get(key) ?? 0;
+          if (remaining === 0) return true;
+          unconsumedPinnedKeyCounts.set(key, remaining - 1);
+          if (!echoedItemByKey.has(key)) {
+            echoedItemByKey.set(key, item);
           }
           return false;
         });
 
   const resolvedPinnedItems =
-    echoedContentByKey.size === 0
+    echoedItemByKey.size === 0
       ? pinnedOptimisticItems
       : pinnedOptimisticItems.map((item) => {
           if (item.type !== "user_message") return item;
-          const echoed = echoedContentByKey.get(
-            strippedUserContent(item.content),
-          );
-          return echoed !== undefined && echoed !== item.content
-            ? { ...item, content: echoed }
-            : item;
+          const echoed = echoedItemByKey.get(strippedUserContent(item.content));
+          if (
+            !echoed ||
+            (echoed.content === item.content && !echoed.attachments?.length)
+          ) {
+            return item;
+          }
+          return {
+            ...item,
+            content: echoed.content,
+            ...(echoed.attachments?.length
+              ? { attachments: echoed.attachments }
+              : {}),
+          };
         });
 
   return [


### PR DESCRIPTION
## Problem

Creating a cloud task with an attachment rendered the user's prompt twice. The pinned optimistic bubble is seeded from the task description, which appends an `Attached files: <names>` line, while the echoed `session/prompt` carries attachments as `resource_link` blocks with no such line — so the text-based dedupe in `mergeConversationItems` never matched and both bubbles rendered.

## Changes

- Add `stripTrailingAttachmentSummary` to `@posthog/core/editor/cloud-prompt` and fold it into the dedupe key in `mergeConversationItems`, so the description-seeded placeholder matches its echo.
- Carry the echoed prompt's attachments onto the pinned bubble when upgrading it, so the file chip replaces the literal summary line.
- Each pinned placeholder now consumes at most one matching echo, so a later follow-up repeating the same text still renders.
- Unit tests for the attachment, attachment-only, and repeated-text cases; verified end-to-end over CDP (fresh task with pasted image, real resume, cold reload).