### PR TITLE
feat(updates): add "Later" option to dismiss the update-ready banner

### DIFF
--- a/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -1,4 +1,5 @@
-import { ArrowsClockwise, Gift, Spinner } from "@phosphor-icons/react";
+import { ArrowsClockwise, Gift, Spinner, X } from "@phosphor-icons/react";
+import { useUpdateBannerStore } from "@posthog/ui/features/updates/updateBannerStore";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
   useInstallUpdate,
@@ -6,6 +7,7 @@ import {
 } from "@posthog/ui/features/updates/updateStore";
 import { Box } from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
+import { useEffect } from "react";
 
 interface UpdateBannerProps {
   variant?: "sidebar" | "compact";
@@ -16,9 +18,24 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
     useUpdateView();
   const installUpdate = useInstallUpdate();
   const openModal = useUpdateModalStore((state) => state.open);
+  const dismissedVersion = useUpdateBannerStore(
+    (state) => state.dismissedVersion,
+  );
+  const dismissBanner = useUpdateBannerStore((state) => state.dismiss);
+  const resetDismissal = useUpdateBannerStore((state) => state.reset);
+
+  useEffect(() => {
+    if (status === "available" || status === "downloading") {
+      resetDismissal();
+    }
+  }, [status, resetDismissal]);
+
+  const versionKey = version ?? "unknown";
+  const isDismissed = status === "ready" && dismissedVersion === versionKey;
 
   const isVisible =
     isEnabled &&
+    !isDismissed &&
     (status === "available" ||
       status === "downloading" ||
       status === "ready" ||
@@ -59,16 +76,27 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
             )}
 
             {status === "ready" && (
-              <button
-                type="button"
-                className="flex items-center gap-1.5 rounded-2 border border-(--green-a5) bg-(--green-a3) px-2.5 py-1 font-medium text-(--green-11) text-[13px] transition-colors hover:bg-(--green-a4)"
-                onClick={() => void installUpdate()}
-              >
-                <Gift size={14} weight="duotone" />
-                <span>
-                  {version ? `${version} ready` : "Update ready"} — Restart
-                </span>
-              </button>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 rounded-2 border border-(--green-a5) bg-(--green-a3) px-2.5 py-1 font-medium text-(--green-11) text-[13px] transition-colors hover:bg-(--green-a4)"
+                  onClick={() => void installUpdate()}
+                >
+                  <Gift size={14} weight="duotone" />
+                  <span>
+                    {version ? `${version} ready` : "Update ready"} — Restart
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  aria-label="Dismiss until next session"
+                  title="Dismiss until next session"
+                  className="rounded-2 p-1 text-(--green-a11) transition-colors hover:bg-(--green-a4) hover:text-(--green-11)"
+                  onClick={() => dismissBanner(versionKey)}
+                >
+                  <X size={12} weight="bold" />
+                </button>
+              </div>
             )}
 
             {status === "installing" && (
@@ -148,38 +176,49 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
 
             {status === "ready" && (
               <BannerCard key="ready">
-                <div className="flex w-full items-center gap-3 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
-                  <motion.div
-                    className="shrink-0"
-                    animate={{ rotate: [0, -12, 12, -8, 8, -4, 0] }}
-                    transition={{
-                      duration: 0.6,
-                      repeat: Infinity,
-                      repeatDelay: 4,
-                      ease: "easeInOut",
-                    }}
-                  >
-                    <Gift size={20} weight="duotone" />
-                  </motion.div>
-                  <button
-                    type="button"
-                    onClick={openModal}
-                    className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
-                  >
-                    <span className="font-medium">
-                      {version ? `${version} ready` : "Update ready"}
-                    </span>
-                    <span className="text-[11px] text-[var(--green-a11)]">
-                      Restart to apply
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
-                    onClick={() => void installUpdate()}
-                  >
-                    Restart
-                  </button>
+                <div className="flex w-full flex-col gap-2 rounded-md border border-[var(--green-a5)] bg-[var(--green-a3)] px-3 py-2.5 text-[13px] text-[var(--green-11)]">
+                  <div className="flex w-full items-center gap-3">
+                    <motion.div
+                      className="shrink-0"
+                      animate={{ rotate: [0, -12, 12, -8, 8, -4, 0] }}
+                      transition={{
+                        duration: 0.6,
+                        repeat: Infinity,
+                        repeatDelay: 4,
+                        ease: "easeInOut",
+                      }}
+                    >
+                      <Gift size={20} weight="duotone" />
+                    </motion.div>
+                    <button
+                      type="button"
+                      onClick={openModal}
+                      className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
+                    >
+                      <span className="truncate font-medium">
+                        {version ? `${version} ready` : "Update ready"}
+                      </span>
+                      <span className="truncate text-[11px] text-[var(--green-a11)]">
+                        Restart to apply
+                      </span>
+                    </button>
+                  </div>
+                  <div className="flex w-full items-center justify-end gap-1">
+                    <button
+                      type="button"
+                      className="shrink-0 rounded-2 px-2 py-1 font-medium text-[12px] text-[var(--green-a11)] transition-colors hover:bg-[var(--green-a4)] hover:text-[var(--green-11)]"
+                      onClick={() => dismissBanner(versionKey)}
+                    >
+                      Later
+                    </button>
+                    <button
+                      type="button"
+                      className="shrink-0 rounded-2 bg-[var(--green-a4)] px-2 py-1 font-medium text-[12px] text-[var(--green-11)] transition-colors hover:bg-[var(--green-a5)]"
+                      onClick={() => void installUpdate()}
+                    >
+                      Restart
+                    </button>
+                  </div>
                 </div>
               </BannerCard>
             )}

--- a/packages/ui/src/features/updates/updateBannerStore.ts
+++ b/packages/ui/src/features/updates/updateBannerStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface UpdateBannerStore {
+  dismissedVersion: string | null;
+  dismiss: (version: string) => void;
+  reset: () => void;
+}
+
+export const useUpdateBannerStore = create<UpdateBannerStore>((set) => ({
+  dismissedVersion: null,
+  dismiss: (version) => set({ dismissedVersion: version }),
+  reset: () => set({ dismissedVersion: null }),
+}));


### PR DESCRIPTION
## Problem

The update-ready notification only offers **Restart**, which forces an install decision mid-flow and breaks focus during active work. There is no way to dismiss it.

<img width="524" height="208" alt="update-banner-closeup" src="https://github.com/user-attachments/assets/a45aa6c6-c6cd-44ac-b060-43469a9896a0" />
<img width="1200" height="573" alt="update-banner-app" src="https://github.com/user-attachments/assets/731aca9d-e864-42df-9d6b-1289ada78e40" />


## Changes

- Added a "Later" button to the sidebar update-ready banner 
- dismissal lives in a new in-memory view store (`updateBannerStore`), so the banner resurfaces on the next session. A dismissed update still installs silently on the next quit (`autoInstallOnAppQuit`)