### PR TITLE
feat(permissions): add copy-to-clipboard button for plan content

### DIFF
--- a/packages/ui/src/features/permissions/PlanContent.tsx
+++ b/packages/ui/src/features/permissions/PlanContent.tsx
@@ -1,4 +1,12 @@
-import { ArrowsIn, ArrowsOut, ListChecks, X } from "@phosphor-icons/react";
+import {
+  ArrowsIn,
+  ArrowsOut,
+  Check,
+  Copy,
+  ListChecks,
+  X,
+} from "@phosphor-icons/react";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -15,6 +23,13 @@ interface PlanContentProps {
 export function PlanContent({ id, plan }: PlanContentProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(plan);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -79,15 +94,31 @@ export function PlanContent({ id, plan }: PlanContentProps) {
                   <ListChecks size={14} className="text-blue-11" />
                   <Text className="text-blue-11 text-sm">Plan</Text>
                 </Flex>
-                <IconButton
-                  size="1"
-                  variant="ghost"
-                  color="gray"
-                  onClick={() => setIsFullscreen(false)}
-                  title="Exit fullscreen (Escape)"
-                >
-                  <X size={14} />
-                </IconButton>
+                <Flex align="center" gap="2">
+                  <Tooltip
+                    content={copied ? "Copied!" : "Copy plan to clipboard"}
+                    side="bottom"
+                  >
+                    <IconButton
+                      size="1"
+                      variant="ghost"
+                      color="gray"
+                      onClick={handleCopy}
+                    >
+                      {copied ? <Check size={12} /> : <Copy size={12} />}
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip content="Exit fullscreen (Escape)" side="bottom">
+                    <IconButton
+                      size="1"
+                      variant="ghost"
+                      color="gray"
+                      onClick={() => setIsFullscreen(false)}
+                    >
+                      <X size={14} />
+                    </IconButton>
+                  </Tooltip>
+                </Flex>
               </Flex>
 
               <Box
@@ -109,16 +140,31 @@ export function PlanContent({ id, plan }: PlanContentProps) {
       ref={scrollRef}
       className="relative max-h-[50vh] max-w-[750px] overflow-y-auto rounded-lg border-2 border-blue-6 bg-blue-2 p-4"
     >
-      <IconButton
-        size="1"
-        variant="ghost"
-        color="gray"
-        className="sticky top-0 z-10 float-right"
-        onClick={() => setIsFullscreen(true)}
-        title="Expand to fullscreen"
-      >
-        <ArrowsOut size={12} />
-      </IconButton>
+      <Flex gap="2" className="sticky top-0 z-10 float-right">
+        <Tooltip
+          content={copied ? "Copied!" : "Copy plan to clipboard"}
+          side="bottom"
+        >
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={handleCopy}
+          >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip content="Expand to fullscreen" side="bottom">
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={() => setIsFullscreen(true)}
+          >
+            <ArrowsOut size={12} />
+          </IconButton>
+        </Tooltip>
+      </Flex>
 
       <Box className="plan-markdown text-blue-12">{markdown}</Box>
     </Box>


### PR DESCRIPTION
## TL;DR
Added a copy-to-clipboard button to the plan content display that allows users to easily copy the full plan text. The button shows a confirmation state ("Copied!") after clicking and appears in both normal and fullscreen views.

## Problem
Users viewing plan content had limited options for interacting with it. Adding a copy-to-clipboard button makes it easier to share or work with plan text without manual selection and copying.

## Changes
- Added `Copy` and `Check` icons from `@phosphor-icons/react` for the copy button and confirmation state
- Imported `Tooltip` component for better UX on icon buttons
- Added `copied` state to track clipboard action confirmation
- Implemented `handleCopy()` function that copies plan text to clipboard and temporarily shows "Copied!" confirmation (1.5 second duration)
- Added copy button with tooltip ("Copy plan to clipboard") in the fullscreen modal header
- Added matching copy button with tooltip in the normal plan view (sticky top-right position)
- Wrapped both header buttons in a `Flex` container for consistent spacing and alignment
- Added tooltips to existing buttons ("Exit fullscreen" and "Expand to fullscreen") for consistency

## How did you test this?
- Visual verification of button placement in both normal and fullscreen views
- Tested copy functionality and confirmation state display
- Verified tooltip content displays correctly

## Automatic notifications
- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*