### PR TITLE
fix(onboarding): stop resetting users to the start when a step disappears

### DIFF
--- a/apps/code/src/main/trpc/router.ts
+++ b/apps/code/src/main/trpc/router.ts
@@ -1,3 +1,4 @@
+import type { HostRouter } from "@posthog/host-router/router";
 import { additionalDirectoriesRouter } from "@posthog/host-router/routers/additional-directories.router";
 import { agentRouter } from "@posthog/host-router/routers/agent.router";
 import { analyticsRouter } from "@posthog/host-router/routers/analytics.router";
@@ -31,6 +32,7 @@ import { mcpAppsRouter } from "@posthog/host-router/routers/mcp-apps.router";
 import { mcpCallbackRouter } from "@posthog/host-router/routers/mcp-callback.router";
 import { notificationRouter } from "@posthog/host-router/routers/notification.router";
 import { oauthRouter } from "@posthog/host-router/routers/oauth.router";
+import { onboardingImportRouter } from "@posthog/host-router/routers/onboarding-import.router";
 import { osRouter } from "@posthog/host-router/routers/os.router";
 import { processTrackingRouter } from "@posthog/host-router/routers/process-tracking.router";
 import { provisioningRouter } from "@posthog/host-router/routers/provisioning.router";
@@ -85,6 +87,7 @@ export const trpcRouter = router({
   mcpCallback: mcpCallbackRouter,
   notification: notificationRouter,
   oauth: oauthRouter,
+  onboardingImport: onboardingImportRouter,
   logs: logsRouter,
   os: osRouter,
   processTracking: processTrackingRouter,
@@ -104,3 +107,15 @@ export const trpcRouter = router({
 });
 
 export type TrpcRouter = typeof trpcRouter;
+
+/**
+ * The renderer and @posthog/ui are typed against HostRouter, so every route it
+ * declares must actually be served by this assembly — a route present in the
+ * type but missing here fails only at runtime with NOT_FOUND (#2442 dropped
+ * onboardingImport this way, silently breaking the onboarding import step).
+ * When this assignment errors, its expected type names the missing routes.
+ */
+type MissingHostRoutes = Exclude<keyof HostRouter, keyof TrpcRouter>;
+export const servesEveryHostRoute: [MissingHostRoutes] extends [never]
+  ? true
+  : MissingHostRoutes = true;

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -30,6 +30,7 @@ import {
 } from "./utils/store";
 
 const log = logger.scope("window");
+const trpcLog = logger.scope("host-trpc");
 
 const MAIN_WINDOW_VITE_DEV_SERVER_URL = process.env.ELECTRON_RENDERER_URL;
 const MAIN_WINDOW_VITE_NAME = "main_window";
@@ -280,6 +281,13 @@ export function createWindow(): void {
     router: trpcRouter,
     windows: [mainWindow],
     createContext: async () => ({ container }),
+    // Input is deliberately not logged — it can carry tokens or file contents.
+    onError: ({ error, path, type }) => {
+      trpcLog.error(`${type} '${path ?? "<unknown>"}' failed (${error.code})`, {
+        message: error.message,
+        cause: error.cause instanceof Error ? error.cause.stack : error.cause,
+      });
+    },
   });
 
   setupExternalLinkHandlers(mainWindow);

--- a/packages/core/src/onboarding/steps.test.ts
+++ b/packages/core/src/onboarding/steps.test.ts
@@ -54,6 +54,10 @@ describe("nearestActiveStep", () => {
       "project-select",
     );
   });
+
+  it("returns the step itself when no steps are active", () => {
+    expect(nearestActiveStep([], "import-config")).toBe("import-config");
+  });
 });
 
 describe("step navigation", () => {

--- a/packages/core/src/onboarding/steps.test.ts
+++ b/packages/core/src/onboarding/steps.test.ts
@@ -3,8 +3,10 @@ import {
   computeActiveSteps,
   isFirstStep,
   isLastStep,
+  nearestActiveStep,
   nextStep,
   ONBOARDING_STEPS,
+  type OnboardingStep,
   previousStep,
   stepDirection,
 } from "./steps";
@@ -22,6 +24,35 @@ describe("computeActiveSteps", () => {
 
   it("drops import-config when there is no importable config", () => {
     expect(computeActiveSteps(false, false)).not.toContain("import-config");
+  });
+});
+
+describe("nearestActiveStep", () => {
+  const withoutConditionals = computeActiveSteps(true, false);
+
+  it("returns the step itself while it is still active", () => {
+    expect(nearestActiveStep(ONBOARDING_STEPS, "import-config")).toBe(
+      "import-config",
+    );
+  });
+
+  it.each<{ removed: OnboardingStep; expected: OnboardingStep }>([
+    // import-config vanished under the user: continue forward to select-repo,
+    // not back to welcome (the regression that reset onboarding mid-flow).
+    { removed: "import-config", expected: "select-repo" },
+    { removed: "invite-code", expected: "connect-github" },
+  ])(
+    "moves forward to $expected when $removed drops out",
+    ({ removed, expected }) => {
+      expect(nearestActiveStep(withoutConditionals, removed)).toBe(expected);
+    },
+  );
+
+  it("falls back to the closest earlier step when nothing follows", () => {
+    const onlyEarlySteps: OnboardingStep[] = ["welcome", "project-select"];
+    expect(nearestActiveStep(onlyEarlySteps, "import-config")).toBe(
+      "project-select",
+    );
   });
 });
 

--- a/packages/core/src/onboarding/steps.ts
+++ b/packages/core/src/onboarding/steps.ts
@@ -43,6 +43,30 @@ export function stepIndexOf(
   return activeSteps.indexOf(step);
 }
 
+/**
+ * Where to send the user when the step they are standing on drops out of
+ * `activeSteps` (the conditional steps appear and disappear as their async
+ * gates resolve). Prefers the next remaining step in canonical order — the
+ * user was moving forward — and falls back to the closest earlier one, so a
+ * vanishing step never resets progress to the start of the flow.
+ */
+export function nearestActiveStep(
+  activeSteps: OnboardingStep[],
+  step: OnboardingStep,
+): OnboardingStep {
+  if (activeSteps.includes(step)) return step;
+  const canonicalIndex = ONBOARDING_STEPS.indexOf(step);
+  for (let i = canonicalIndex + 1; i < ONBOARDING_STEPS.length; i++) {
+    const candidate = ONBOARDING_STEPS[i];
+    if (activeSteps.includes(candidate)) return candidate;
+  }
+  for (let i = canonicalIndex - 1; i >= 0; i--) {
+    const candidate = ONBOARDING_STEPS[i];
+    if (activeSteps.includes(candidate)) return candidate;
+  }
+  return activeSteps[0];
+}
+
 export function isFirstStep(currentIndex: number): boolean {
   return currentIndex === 0;
 }

--- a/packages/core/src/onboarding/steps.ts
+++ b/packages/core/src/onboarding/steps.ts
@@ -48,7 +48,9 @@ export function stepIndexOf(
  * `activeSteps` (the conditional steps appear and disappear as their async
  * gates resolve). Prefers the next remaining step in canonical order — the
  * user was moving forward — and falls back to the closest earlier one, so a
- * vanishing step never resets progress to the start of the flow.
+ * vanishing step never resets progress to the start of the flow. Returns
+ * `step` unchanged when it is still active, or when `activeSteps` is empty
+ * (degenerate input: the flow always keeps at least the welcome step).
  */
 export function nearestActiveStep(
   activeSteps: OnboardingStep[],
@@ -64,7 +66,7 @@ export function nearestActiveStep(
     const candidate = ONBOARDING_STEPS[i];
     if (activeSteps.includes(candidate)) return candidate;
   }
-  return activeSteps[0];
+  return step;
 }
 
 export function isFirstStep(currentIndex: number): boolean {

--- a/packages/electron-trpc/src/main/__tests__/handleIPCMessage.test.ts
+++ b/packages/electron-trpc/src/main/__tests__/handleIPCMessage.test.ts
@@ -149,6 +149,62 @@ describe("api", () => {
     });
   });
 
+  test("reports subscription stream failures through onError", async () => {
+    const failingSubRouter = t.router({
+      failingSubscription: t.procedure.subscription(() =>
+        observable((emit) => {
+          emit.error(new Error("stream exploded"));
+          return () => {};
+        }),
+      ),
+    });
+    const onError = vi.fn();
+    const event = makeEvent({
+      reply: vi.fn(),
+      sender: {
+        isDestroyed: () => false,
+        on: () => {},
+      },
+    });
+
+    await handleIPCMessage({
+      createContext: async () => ({}),
+      event,
+      internalId: "1-1:1",
+      message: {
+        method: "request",
+        operation: {
+          context: {},
+          id: 1,
+          input: undefined,
+          path: "failingSubscription",
+          type: "subscription",
+          signal: undefined,
+        },
+      },
+      router: failingSubRouter,
+      operations: new Map(),
+      onError,
+    });
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledOnce();
+    });
+    expect(onError.mock.lastCall?.[0]).toMatchObject({
+      path: "failingSubscription",
+      type: "subscription",
+    });
+    // The stream error is serialized to the renderer before the final
+    // "stopped" message, so it is not necessarily the last reply.
+    await vi.waitFor(() => {
+      expect(
+        event.reply.mock.calls.some(
+          ([, payload]) => (payload as { error?: unknown }).error !== undefined,
+        ),
+      ).toBe(true);
+    });
+  });
+
   test("handles subscriptions using observables", async () => {
     const operations = new Map();
     const ee = new EventEmitter();

--- a/packages/electron-trpc/src/main/__tests__/handleIPCMessage.test.ts
+++ b/packages/electron-trpc/src/main/__tests__/handleIPCMessage.test.ts
@@ -102,6 +102,53 @@ describe("api", () => {
     expect(event.reply).not.toHaveBeenCalled();
   });
 
+  test("reports procedure failures through onError and still responds", async () => {
+    const failingRouter = t.router({
+      failingQuery: t.procedure.query(() => {
+        throw new Error("db exploded");
+      }),
+    });
+    const onError = vi.fn();
+    const event = makeEvent({
+      reply: vi.fn(),
+      sender: {
+        isDestroyed: () => false,
+        on: () => {},
+      },
+    });
+
+    await handleIPCMessage({
+      createContext: async () => ({}),
+      event,
+      internalId: "1-1:1",
+      message: {
+        method: "request",
+        operation: {
+          context: {},
+          id: 1,
+          input: undefined,
+          path: "failingQuery",
+          type: "query",
+          signal: undefined,
+        },
+      },
+      router: failingRouter,
+      operations: new Map(),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.lastCall?.[0]).toMatchObject({
+      path: "failingQuery",
+      type: "query",
+    });
+    expect(onError.mock.lastCall?.[0].error.cause?.message).toBe("db exploded");
+    expect(event.reply.mock.lastCall?.[1]).toMatchObject({
+      id: 1,
+      error: expect.anything(),
+    });
+  });
+
   test("handles subscriptions using observables", async () => {
     const operations = new Map();
     const ee = new EventEmitter();

--- a/packages/electron-trpc/src/main/createIPCHandler.ts
+++ b/packages/electron-trpc/src/main/createIPCHandler.ts
@@ -5,7 +5,7 @@ import { ipcMain } from "electron";
 import { ELECTRON_TRPC_CHANNEL } from "../constants";
 import type { ETRPCRequest } from "../types";
 import { handleIPCMessage } from "./handleIPCMessage";
-import type { CreateContextOptions } from "./types";
+import type { CreateContextOptions, OnProcedureError } from "./types";
 
 type MaybePromise<TType> = Promise<TType> | TType;
 
@@ -24,12 +24,14 @@ class IPCHandler<TRouter extends AnyTRPCRouter> {
     createContext,
     router,
     windows = [],
+    onError,
   }: {
     createContext?: (
       opts: CreateContextOptions,
     ) => MaybePromise<inferRouterContext<TRouter>>;
     router: TRouter;
     windows?: BrowserWindow[];
+    onError?: OnProcedureError;
   }) {
     for (const win of windows) {
       this.attachWindow(win);
@@ -43,6 +45,7 @@ class IPCHandler<TRouter extends AnyTRPCRouter> {
         event,
         message: request,
         operations: this.#operations,
+        onError,
       });
     };
     ipcMain.on(ELECTRON_TRPC_CHANNEL, this.#listener);
@@ -116,16 +119,18 @@ export const createIPCHandler = <TRouter extends AnyTRPCRouter>({
   createContext,
   router,
   windows = [],
+  onError,
 }: {
   createContext?: (
     opts: CreateContextOptions,
   ) => Promise<inferRouterContext<TRouter>>;
   router: TRouter;
   windows?: Electron.BrowserWindow[];
+  onError?: OnProcedureError;
 }) => {
   if (currentHandler) {
     currentHandler.destroy();
   }
-  currentHandler = new IPCHandler({ createContext, router, windows });
+  currentHandler = new IPCHandler({ createContext, router, windows, onError });
   return currentHandler;
 };

--- a/packages/electron-trpc/src/main/handleIPCMessage.ts
+++ b/packages/electron-trpc/src/main/handleIPCMessage.ts
@@ -16,7 +16,7 @@ import type { IpcMainEvent } from "electron";
 import { ELECTRON_TRPC_CHANNEL } from "../constants";
 import type { ETRPCRequest } from "../types";
 import { Unpromise } from "../vendor/unpromise";
-import type { CreateContextOptions } from "./types";
+import type { CreateContextOptions, OnProcedureError } from "./types";
 import { isAsyncIterable, iteratorResource, run } from "./utils";
 
 export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
@@ -26,6 +26,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
   message,
   event,
   operations,
+  onError,
 }: {
   router: TRouter;
   createContext?: (
@@ -35,6 +36,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
   message: ETRPCRequest;
   event: IpcMainEvent;
   operations: Map<string, AbortController>;
+  onError?: OnProcedureError;
 }) {
   if (
     message.method === "subscription.stop" ||
@@ -155,6 +157,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
         }
         if (next instanceof Error) {
           const error = getTRPCErrorFromUnknown(next);
+          onError?.({ error, path, type, input });
           respond({
             id,
             error: getErrorShape({
@@ -205,6 +208,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
       operations.delete(internalId);
     }).catch((cause) => {
       const error = getTRPCErrorFromUnknown(cause);
+      onError?.({ error, path, type, input });
       respond({
         id,
         error: getErrorShape({
@@ -229,6 +233,7 @@ export async function handleIPCMessage<TRouter extends AnyTRPCRouter>({
   } catch (cause) {
     operations.delete(internalId);
     const error: TRPCError = getTRPCErrorFromUnknown(cause);
+    onError?.({ error, path, type, input });
 
     return respond({
       id,

--- a/packages/electron-trpc/src/main/types.ts
+++ b/packages/electron-trpc/src/main/types.ts
@@ -1,5 +1,19 @@
+import type { TRPCError } from "@trpc/server";
 import type { IpcMainInvokeEvent } from "electron";
 
 export interface CreateContextOptions {
   event: IpcMainInvokeEvent;
 }
+
+export interface ProcedureErrorPayload {
+  error: TRPCError;
+  path: string | undefined;
+  type: "query" | "mutation" | "subscription";
+  input: unknown;
+}
+
+/**
+ * Called whenever procedure resolution fails. Errors are otherwise only
+ * serialized back to the renderer, leaving no trace in main process logs.
+ */
+export type OnProcedureError = (payload: ProcedureErrorPayload) => void;

--- a/packages/ui/src/features/onboarding/hooks/useHasImportableConfig.ts
+++ b/packages/ui/src/features/onboarding/hooks/useHasImportableConfig.ts
@@ -3,11 +3,14 @@ import { useQuery } from "@tanstack/react-query";
 
 export function useHasImportableConfig(): boolean {
   const trpc = useHostTRPC();
-  const { data, isError } = useQuery(
+  const { data } = useQuery(
     trpc.onboardingImport.getSummary.queryOptions(undefined, {
       staleTime: 60_000,
     }),
   );
-  if (isError) return false;
-  return data?.total !== 0;
+  // Loading and error states must NOT include the import-config step: this
+  // gates a step in a flow the user is standing in, and a step that appears
+  // while the query is pending and disappears when it settles ejects whoever
+  // is on it. Only proven importable config earns the step a place.
+  return data !== undefined && data.total > 0;
 }

--- a/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -9,6 +9,7 @@ import {
   nextStep as computeNextStep,
   previousStep as computePreviousStep,
   type DetectedRepo,
+  nearestActiveStep,
   type OnboardingStep,
   stepDirection,
 } from "@posthog/core/onboarding/steps";
@@ -87,7 +88,7 @@ export function useOnboardingFlow() {
 
   useEffect(() => {
     if (!activeSteps.includes(currentStep)) {
-      setCurrentStep(activeSteps[0]);
+      setCurrentStep(nearestActiveStep(activeSteps, currentStep));
     }
   }, [activeSteps, currentStep, setCurrentStep]);
 


### PR DESCRIPTION
## The bug

Onboarding kept kicking users back to the beginning ([Paul's report](https://posthog.slack.com/archives/C0BDT87GH28)). Reconstructed from his logs + our own analytics (`Onboarding step viewed/completed` events, project 2):

1. `useHasImportableConfig` returned `data?.total !== 0`, which is **`true` while the `onboardingImport.getSummary` query has no data yet** (`undefined !== 0`). The import-config step ("Your Claude Code environment is ready") therefore flickers **into** `activeSteps` during every pending/retry window and **out** when the query settles at 0 or errors. With `refetchOnWindowFocus: true` and a query that keeps rejecting, every alt-tab back into the app re-arms the trap (TanStack v5 resets a no-data query to `pending`/`error: null` when a refetch starts).
2. Anyone who clicked Continue on install-cli during an "in" window landed on the phantom step; seconds later it vanished and `useOnboardingFlow` did `setCurrentStep(activeSteps[0])` → welcome. Paul hit this twice in one session (10:22:20 and 10:22:54 his time), matching his screenshots to the second.
3. Since June 10: **65 users landed on import-config, zero ever completed it**, still occurring on current builds (~1 in 6 onboardings pass through the trap window). The same reset also fires for the invite-code step when `hasCodeAccess` resolves late.

## Root cause of the failing query

**The app never serves `onboardingImport`.** The renderer and `@posthog/ui` are typed against `HostRouter` (the merged router in `packages/host-router`, which has the route), but the Electron main process serves the hand-assembled `trpcRouter` in `apps/code/src/main/trpc/router.ts`. Before the #2442 package split (June 10) that file registered `onboardingImport` and the feature worked; the split moved the router file into `packages/host-router`, added it to the merged `hostRouter` (used only for its type), and **dropped it from the served assembly**. Every `getSummary` call since has died instantly with `NOT_FOUND` — silently, because IPC procedure errors were never logged. The analytics corroborate: `import-config` step views begin June 9, the zero-completion pattern begins exactly June 10.

## The fixes

- **`apps/code` router**: register `onboardingImport` again, and add a compile-time guard (`Exclude<keyof HostRouter, keyof TrpcRouter>` must be `never`) so dropping any HostRouter route from the app assembly now fails typecheck with an error that names the missing route.
- **`useOnboardingFlow`**: when the current step drops out of `activeSteps`, move to the nearest surviving step (forward in canonical order, then backward) via a new pure `nearestActiveStep` helper in `@posthog/core` — never back to the start.
- **`useHasImportableConfig`**: only include the step once the summary has **resolved with `total > 0`**. Loading and error states no longer conjure a step the user can be dropped into.
- **`electron-trpc`**: `createIPCHandler` now accepts an `onError` hook, wired in `apps/code` main to a `host-trpc` scoped logger, so host procedure failures show up in main.log instead of vanishing (this is why Paul's logs were empty through the whole loop).

## Tests

- `nearestActiveStep` unit tests (forward, backward, still-active cases) in `packages/core`
- `onError` transport test in `packages/electron-trpc`
- Compile-time guard verified both ways: with the route removed, `tsc` fails with `Type 'true' is not assignable to type '"onboardingImport"'`; with it registered, clean
- `pnpm --filter @posthog/core|@posthog/ui|@posthog/electron-trpc test` and typechecks for core/ui/electron-trpc/apps-code all pass; biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)