### PR TITLE
fix(ci): fix failing nightly release tag workflow

### DIFF
--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -26,6 +26,7 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'Create release'))
     permissions:
       contents: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Get app token
@@ -45,7 +46,7 @@ jobs:
         id: quiet
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.quiet_retries != '0')
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           QUIET_RETRIES: ${{ github.event.inputs.quiet_retries || 0 }}
         run: |
           RETRIES="${QUIET_RETRIES}"


### PR DESCRIPTION
## Problem

The scheduled "Tag PostHog Code Release" workflow fails whenever a commit lands on main within 15 minutes of the run ([28609351804](https://github.com/PostHog/code/actions/runs/28609351804), [28463734760](https://github.com/PostHog/code/actions/runs/28463734760)). The quiet period step sleeps out the remainder of the window, then tries to re-dispatch the workflow with `gh workflow run` and dies:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
```

The step authenticates with the Array Releaser app token, which has contents access for pushing tags but no `actions: write`, so it cannot create workflow_dispatch events. The 17:00 UTC schedule lands during active work hours, so a fresh commit is usually present and the run hits this broken retry path.

## Changes

- Run the quiet period step with the workflow's own `GITHUB_TOKEN` and grant the job `actions: write`. Dispatch events created with `GITHUB_TOKEN` still trigger runs (`workflow_dispatch` and `repository_dispatch` are the documented exceptions to the recursive-run guard).
- The app token is untouched for checkout and the tag push, where it is needed so the pushed tag triggers the release build.

## How did you test this?

- Confirmed the July 2 and June 30 scheduled failures both show the same 403 from `gh workflow run` under the app token, and that scheduled runs without a recent commit succeed.
- Parsed the workflow YAML. The retry path itself only runs on a schedule after a fresh commit, so it can only be observed after merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
