### PR TITLE
fix(agent): stop phantom desktop app boots from agent subprocesses

### DIFF
--- a/apps/code/src/main/bootstrap.ts
+++ b/apps/code/src/main/bootstrap.ts
@@ -22,6 +22,19 @@ import path from "node:path";
 import { app, crashReporter, protocol } from "electron";
 import { fixPath } from "./utils/fixPath";
 
+// The workspace-server tree runs with a `node -> app binary` PATH shim that
+// relies on ELECTRON_RUN_AS_NODE. If a descendant strips that var and runs
+// `node` (or process.execPath), this binary boots as a full app: it races the
+// single-instance lock and, whenever the lock is free, opens phantom windows.
+// POSTHOG_CODE_INTERNAL_CHILD marks that tree so we can refuse to boot here.
+if (app.isPackaged && process.env.POSTHOG_CODE_INTERNAL_CHILD) {
+  process.stderr.write(
+    "[posthog-code] Refusing to start the desktop app from inside its own " +
+      "child process tree (expected ELECTRON_RUN_AS_NODE=1).\n",
+  );
+  process.exit(1);
+}
+
 const isDev = !app.isPackaged;
 
 // Set app name for single-instance lock, crashReporter, etc

--- a/apps/code/src/main/services/workspace-server/service.ts
+++ b/apps/code/src/main/services/workspace-server/service.ts
@@ -191,6 +191,7 @@ export class WorkspaceServerService extends TypedEventEmitter<WorkspaceServerEve
       env: {
         ...process.env,
         ELECTRON_RUN_AS_NODE: "1",
+        POSTHOG_CODE_INTERNAL_CHILD: "1",
         WORKSPACE_SERVER_SECRET: secret,
         WORKSPACE_SERVER_PORT: String(port),
         WORKSPACE_SERVER_PARENT_PID: String(process.pid),

--- a/packages/agent/src/adapters/codex/codex-agent.test.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.test.ts
@@ -607,6 +607,14 @@ describe("CodexAcpAgent", () => {
       );
       expect(decoded).toEqual(schema);
 
+      // process.execPath is the Electron app binary when running inside the
+      // desktop app; this var keeps the spawned script in node mode instead
+      // of booting another app instance.
+      const runAsNode = (
+        forwarded.mcpServers[1].env as Array<{ name: string; value: string }>
+      ).find((e) => e.name === "ELECTRON_RUN_AS_NODE");
+      expect(runAsNode?.value).toBe("1");
+
       // Existing systemPrompt is preserved with the structured-output
       // instruction appended (not overwritten).
       expect(forwarded._meta.systemPrompt.startsWith("be terse.")).toBe(true);

--- a/packages/agent/src/adapters/codex/codex-agent.test.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.test.ts
@@ -63,6 +63,14 @@ vi.mock("node:fs", async (importActual) => {
   return { ...actual, existsSync: vi.fn(actual.existsSync) };
 });
 
+// Default to no enabled tools, which matches how these tests run for real
+// (no cloud-run meta, no GH token gates passing). Individual tests opt in.
+vi.mock("../local-tools", async (importActual) => {
+  const actual = await importActual<typeof import("../local-tools")>();
+  return { ...actual, enabledLocalTools: vi.fn(() => []) };
+});
+
+import { enabledLocalTools, LOCAL_TOOLS_MCP_NAME } from "../local-tools";
 import { CodexAcpAgent } from "./codex-agent";
 
 describe("CodexAcpAgent", () => {
@@ -619,6 +627,44 @@ describe("CodexAcpAgent", () => {
       // instruction appended (not overwritten).
       expect(forwarded._meta.systemPrompt.startsWith("be terse.")).toBe(true);
       expect(forwarded._meta.systemPrompt).toContain("create_output");
+    });
+
+    it("injects ELECTRON_RUN_AS_NODE on the local-tools MCP server env", async () => {
+      vi.mocked(enabledLocalTools).mockReturnValueOnce([
+        { name: "create_pull_request" },
+      ] as never);
+      const { agent } = createAgent();
+      mockCodexConnection.newSession.mockResolvedValue({
+        sessionId: "session-1",
+        modes: { currentModeId: "auto", availableModes: [] },
+        configOptions: [],
+      } satisfies Partial<NewSessionResponse>);
+
+      await agent.newSession({
+        cwd: process.cwd(),
+        mcpServers: [],
+      } as never);
+
+      const forwarded = mockCodexConnection.newSession.mock.calls[0][0] as {
+        mcpServers: Array<{
+          name: string;
+          command: string;
+          env: Array<{ name: string; value: string }>;
+        }>;
+      };
+
+      const localToolsServer = forwarded.mcpServers.find(
+        (s) => s.name === LOCAL_TOOLS_MCP_NAME,
+      );
+      expect(localToolsServer).toBeDefined();
+      expect(localToolsServer?.command).toBe(process.execPath);
+
+      // Same invariant as the structured-output server: the script must run
+      // as node even when process.execPath is the Electron app binary.
+      const runAsNode = localToolsServer?.env.find(
+        (e) => e.name === "ELECTRON_RUN_AS_NODE",
+      );
+      expect(runAsNode?.value).toBe("1");
     });
 
     it("is a no-op when jsonSchema is absent", async () => {

--- a/packages/agent/src/adapters/codex/codex-agent.ts
+++ b/packages/agent/src/adapters/codex/codex-agent.ts
@@ -320,6 +320,11 @@ function resolveBundledMcpScript(rel: string): string {
   );
 }
 
+// These MCP servers run `process.execPath`, which inside the desktop app's
+// workspace-server is the Electron app binary; without this var codex would
+// boot a whole new app instance instead of a node script. Inert under real node.
+const RUN_AS_NODE_ENV = { name: "ELECTRON_RUN_AS_NODE", value: "1" };
+
 function buildStructuredOutputMcpServer(
   jsonSchema: Record<string, unknown>,
 ): McpServerStdio {
@@ -333,7 +338,10 @@ function buildStructuredOutputMcpServer(
     name: STRUCTURED_OUTPUT_MCP_NAME,
     command: process.execPath,
     args: [scriptPath],
-    env: [{ name: "POSTHOG_OUTPUT_SCHEMA", value: schemaBase64 }],
+    env: [
+      { name: "POSTHOG_OUTPUT_SCHEMA", value: schemaBase64 },
+      RUN_AS_NODE_ENV,
+    ],
   };
 }
 
@@ -353,6 +361,7 @@ function buildLocalToolsMcpServer(
   const env = [
     { name: "POSTHOG_LOCAL_TOOLS_CTX", value: ctxBase64 },
     { name: "POSTHOG_LOCAL_TOOLS_ENABLED", value: enabledNames.join(",") },
+    RUN_AS_NODE_ENV,
   ];
   if (ctx.token) {
     // Token also on the child env so its own git remote ops (fetch/ls-remote)

--- a/packages/agent/src/adapters/codex/spawn.test.ts
+++ b/packages/agent/src/adapters/codex/spawn.test.ts
@@ -100,3 +100,18 @@ describe("spawnCodexProcess codex home", () => {
     expect(env.CODEX_HOME).toBe(process.env.CODEX_HOME);
   });
 });
+
+describe("spawnCodexProcess electron env", () => {
+  it("keeps ELECTRON_RUN_AS_NODE=1 so PATH node shims stay in node mode", () => {
+    spawnMock.mockClear();
+    spawnMock.mockReturnValue(makeFakeChild());
+
+    spawnCodexProcess({ logger: new Logger({ debug: false }) });
+
+    // The desktop app's workspace-server puts a `node -> app binary` symlink
+    // on PATH. Dropping this var would make every `node` spawned under codex
+    // boot a full desktop app instance instead of running as node.
+    const env = spawnMock.mock.calls[0][2].env;
+    expect(env.ELECTRON_RUN_AS_NODE).toBe("1");
+  });
+});

--- a/packages/agent/src/adapters/codex/spawn.ts
+++ b/packages/agent/src/adapters/codex/spawn.ts
@@ -116,7 +116,9 @@ export function spawnCodexProcess(options: CodexProcessOptions): CodexProcess {
 
   const env: NodeJS.ProcessEnv = { ...process.env };
 
-  delete env.ELECTRON_RUN_AS_NODE;
+  // The agent host puts a `node -> Electron app binary` shim on PATH; without
+  // this flag, every `node` this process tree spawns boots the full desktop app.
+  env.ELECTRON_RUN_AS_NODE = "1";
   delete env.ELECTRON_NO_ASAR;
 
   if (options.apiKey) {

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -1,4 +1,4 @@
-import fs, { mkdirSync, symlinkSync } from "node:fs";
+import fs from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
@@ -87,6 +87,7 @@ import {
   AGENT_REPO_FILES,
   AGENT_SLEEP_COORDINATOR,
 } from "./identifiers";
+import { ensureNodeShim } from "./node-shim";
 import type {
   AgentLogger,
   AgentMcpApps,
@@ -1560,19 +1561,7 @@ For git operations while detached:
     const mockNodeDir = getMockNodeDir();
     if (!this.mockNodeReady) {
       try {
-        mkdirSync(mockNodeDir, { recursive: true });
-        const nodeSymlinkPath = join(mockNodeDir, "node");
-        try {
-          symlinkSync(process.execPath, nodeSymlinkPath);
-        } catch (err) {
-          if (
-            !(err instanceof Error) ||
-            !("code" in err) ||
-            err.code !== "EEXIST"
-          ) {
-            throw err;
-          }
-        }
+        ensureNodeShim(mockNodeDir, process.execPath);
         this.mockNodeReady = true;
       } catch (err) {
         this.log.warn("Failed to setup mock node environment", err);

--- a/packages/workspace-server/src/services/agent/node-shim.test.ts
+++ b/packages/workspace-server/src/services/agent/node-shim.test.ts
@@ -1,0 +1,109 @@
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildNodeShimScript, ensureNodeShim } from "./node-shim";
+
+const EXEC_PATH = "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code";
+
+describe("ensureNodeShim", () => {
+  const dirs: string[] = [];
+
+  function makeDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "node-shim-test-"));
+    dirs.push(dir);
+    return join(dir, "shim");
+  }
+
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes an executable wrapper that sets ELECTRON_RUN_AS_NODE itself", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+
+    const shim = join(dir, "node");
+    const content = readFileSync(shim, "utf-8");
+    expect(content).toContain("#!/bin/sh");
+    expect(content).toContain("export ELECTRON_RUN_AS_NODE=1");
+    expect(content).toContain(`exec "${EXEC_PATH}" "$@"`);
+    expect(statSync(shim).mode & 0o111).not.toBe(0);
+  });
+
+  it("escapes shell-special characters in the binary path", () => {
+    expect(buildNodeShimScript('/odd/pa"th/$app`bin\\x')).toContain(
+      'exec "/odd/pa\\"th/\\$app\\`bin\\\\x" "$@"',
+    );
+  });
+
+  it("replaces a legacy symlink shim with the wrapper script", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    const shim = join(dir, "node");
+    rmSync(shim);
+    symlinkSync(EXEC_PATH, shim);
+
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+
+    expect(lstatSync(shim).isSymbolicLink()).toBe(false);
+    expect(readFileSync(shim, "utf-8")).toBe(buildNodeShimScript(EXEC_PATH));
+  });
+
+  it("rewrites the wrapper when the binary path changes", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, "/old/location/App", "darwin");
+
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+
+    expect(readFileSync(join(dir, "node"), "utf-8")).toBe(
+      buildNodeShimScript(EXEC_PATH),
+    );
+  });
+
+  it("leaves an up-to-date wrapper untouched", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    const shim = join(dir, "node");
+    const past = new Date("2020-01-01T00:00:00Z");
+    utimesSync(shim, past, past);
+
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+
+    expect(statSync(shim).mtimeMs).toBe(past.getTime());
+  });
+
+  it("replaces a corrupt shim that is not the expected script", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    const shim = join(dir, "node");
+    writeFileSync(shim, "not a shim");
+
+    ensureNodeShim(dir, EXEC_PATH, "darwin");
+
+    expect(readFileSync(shim, "utf-8")).toBe(buildNodeShimScript(EXEC_PATH));
+  });
+
+  it("keeps the symlink behavior on windows and tolerates an existing link", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, EXEC_PATH, "win32");
+    ensureNodeShim(dir, EXEC_PATH, "win32");
+
+    const shim = join(dir, "node");
+    expect(lstatSync(shim).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(shim)).toBe(EXEC_PATH);
+  });
+});

--- a/packages/workspace-server/src/services/agent/node-shim.ts
+++ b/packages/workspace-server/src/services/agent/node-shim.ts
@@ -1,0 +1,71 @@
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
+function escapeForDoubleQuotes(path: string): string {
+  return path.replace(/([$`"\\])/g, "\\$1");
+}
+
+export function buildNodeShimScript(execPath: string): string {
+  return [
+    "#!/bin/sh",
+    "export ELECTRON_RUN_AS_NODE=1",
+    `exec "${escapeForDoubleQuotes(execPath)}" "$@"`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Writes the `node` shim agents resolve via PATH. On POSIX this is a wrapper
+ * script that sets ELECTRON_RUN_AS_NODE itself before exec'ing the app binary,
+ * so the shim stays a node runtime even when a layer in between (user dotfiles,
+ * direnv/flox, shell snapshots, MCP clients with cleaned envs) strips the var.
+ * A bare symlink relied on every descendant preserving the env and booted the
+ * full desktop app whenever one didn't. Replaces a stale legacy symlink or a
+ * wrapper pointing at a moved binary; no-op when already current.
+ */
+export function ensureNodeShim(
+  mockNodeDir: string,
+  execPath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  mkdirSync(mockNodeDir, { recursive: true });
+  const shimPath = join(mockNodeDir, "node");
+
+  if (platform === "win32") {
+    try {
+      symlinkSync(execPath, shimPath);
+    } catch (err) {
+      if (!isErrnoException(err) || err.code !== "EEXIST") throw err;
+    }
+    return;
+  }
+
+  const script = buildNodeShimScript(execPath);
+  if (currentShimContent(shimPath) === script) return;
+
+  const tmpPath = `${shimPath}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, script);
+  chmodSync(tmpPath, 0o755);
+  renameSync(tmpPath, shimPath);
+}
+
+function currentShimContent(shimPath: string): string | null {
+  try {
+    if (lstatSync(shimPath).isSymbolicLink()) return null;
+    return readFileSync(shimPath, "utf-8");
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

Users on recent builds see dozens of empty dark windows cascade onto the screen, with dozens of hung "node" processes in Activity Monitor. The affected user was on the claude harness, so this is not codex-specific.

The agent host symlinks `node` to the desktop app binary (`$TMPDIR/agent-node-prod/node -> .../MacOS/PostHog Code`) and prepends that dir to the workspace-server's PATH. The shim only behaves as node while `ELECTRON_RUN_AS_NODE=1` is present, and that var has to survive arbitrary layers between us and whoever runs `node`:

- The codex adapter deleted it outright (`spawn.ts`), and its two stdio MCP servers run `command: process.execPath` (the app binary) without setting it.
- Claude Code's Bash tool replays commands under a login-shell snapshot env (`export PATH='...'` captured from the user's dotfiles), so whether the var survives depends on the user's shell setup: direnv, flox, mise or a stray `unset` kills it. The claude binary itself neither strips nor protects it (its embedded JS has zero references to the var).

Any `node` invocation that loses the var boots a full desktop app instance. While the real app is running, phantoms lose the single-instance lock and exit invisibly. When the lock is free (quit, crash, update restart) while detached agent processes survive, each spawn boots a real app instance: an empty `#0a0a0a` window shown by the 3s ready-to-show fallback. The lock does not even serialize a simultaneous herd: launching 15 Electron 42.4.0 instances at once against one userData produced 3 lock winners that all created windows.

Reproduced live: running the shim without the var exits 0 in 0.25s without executing the script, and the running app logs `second-instance event received` with the shim path as the commandLine. `packages/git/src/operation-manager.ts` already documents this exact failure mode for git hooks.

## Changes

- The `node` shim is now a wrapper script that exports `ELECTRON_RUN_AS_NODE=1` itself before exec'ing the app binary (POSIX; Windows keeps the prior symlink behavior). This removes the env-propagation dependency for every consumer, claude and codex alike, and also heals stale shims pointing at a moved binary, which the old EEXIST-skip symlink never did.
- `spawnCodexProcess` now sets `ELECTRON_RUN_AS_NODE=1` instead of deleting it, matching the claude adapter (`options.ts`).
- Both codex stdio MCP server configs (structured output and local tools) explicitly carry `ELECTRON_RUN_AS_NODE=1`, since they run `process.execPath` directly and bypass the PATH shim. Inert when `process.execPath` is real node (cloud runs).
- Defense in depth: the workspace-server child env carries a `POSTHOG_CODE_INTERNAL_CHILD=1` marker, and `bootstrap.ts` refuses to boot the packaged app when the marker is present without `ELECTRON_RUN_AS_NODE`, failing fast with a clear stderr message instead of racing the single-instance lock. The guard sits above `fixPath()`, so a phantom also never triggers the shell PATH resolution machinery from #1435.

The bootstrap guard applies to packaged builds only, so launching the dev app from an integrated terminal keeps working.

Follow-up (stacked): #3113 vendors a real Node runtime and points the shim at it, removing Electron-as-node from packaged builds entirely. The wrapper here remains as the dev fallback.

## How did you test this?

- New `node-shim.test.ts` covering the wrapper content, executable bit, shell escaping, legacy-symlink replacement, moved-binary rewrite, no-op when current and the Windows symlink branch (7 tests).
- New unit test in `spawn.test.ts` asserting the codex child env keeps `ELECTRON_RUN_AS_NODE=1`, plus assertions in `codex-agent.test.ts` that both injected MCP server envs carry it.
- `pnpm --filter @posthog/agent test` (845 passed), `pnpm --filter @posthog/workspace-server test` (609 passed), `pnpm --filter code test` (179 passed).
- Typecheck on `@posthog/agent`, `@posthog/workspace-server` and `@posthog/code`; biome check on all changed files.
- Live verification on a machine with the shim on disk: without the var the old symlink boots the app (second-instance logged by the running instance, script never executes); a wrapper-script shim runs the script as node 24.16.0 even with the var stripped from the caller env.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
