### PR TITLE
fix(tasks): recover tasks stuck after interrupted creation

### DIFF
--- a/apps/code/src/main/services/app-lifecycle/service.test.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.test.ts
@@ -8,6 +8,7 @@ const {
   mockSuspensionService,
   mockWatcherRegistry,
   mockProcessTracking,
+  mockWorkspaceService,
   mockTrackAppEvent,
   mockShutdownPostHog,
   mockShutdownOtelTransport,
@@ -22,6 +23,10 @@ const {
     },
     mockWatcherRegistry: {
       shutdownAll: vi.fn(() => Promise.resolve()),
+    },
+    mockWorkspaceService: {
+      pendingCreationCount: 0,
+      waitForPendingCreations: vi.fn(() => Promise.resolve()),
     },
     mockProcessTracking: {
       getSnapshot: vi.fn(() =>
@@ -83,12 +88,14 @@ describe("AppLifecycleService", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     process.exit = mockProcessExit;
+    mockWorkspaceService.pendingCreationCount = 0;
     service = new AppLifecycleService(
       mockAppLifecycle as unknown as IAppLifecycle,
       mockDatabaseService as never,
       mockSuspensionService as never,
       mockWatcherRegistry as never,
       mockProcessTracking as never,
+      mockWorkspaceService as never,
     );
   });
 
@@ -202,6 +209,50 @@ describe("AppLifecycleService", () => {
       await promise;
 
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("shutdownWithoutContainer", () => {
+    it("skips the wait when no creations are pending", async () => {
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(
+        mockWorkspaceService.waitForPendingCreations,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("waits for in-flight workspace creations before teardown", async () => {
+      mockWorkspaceService.pendingCreationCount = 1;
+      const callOrder: string[] = [];
+      mockWorkspaceService.waitForPendingCreations.mockImplementation(
+        async () => {
+          callOrder.push("waitForCreations");
+        },
+      );
+      mockWatcherRegistry.shutdownAll.mockImplementation(async () => {
+        callOrder.push("teardown");
+      });
+
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(callOrder).toEqual(["waitForCreations", "teardown"]);
+    });
+
+    it("proceeds with teardown when creations do not settle in time", async () => {
+      mockWorkspaceService.pendingCreationCount = 1;
+      mockWorkspaceService.waitForPendingCreations.mockReturnValue(
+        new Promise(() => {}),
+      );
+
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockProcessTracking.getSnapshot).toHaveBeenCalled();
     });
   });
 

--- a/apps/code/src/main/services/app-lifecycle/service.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.ts
@@ -10,8 +10,9 @@ import type { ProcessTrackingService } from "@posthog/workspace-server/services/
 import { SUSPENSION_SERVICE } from "@posthog/workspace-server/services/suspension/identifiers";
 import type { SuspensionService } from "@posthog/workspace-server/services/suspension/suspension";
 import type { WatcherRegistryService } from "@posthog/workspace-server/services/watcher-registry/watcher-registry";
+import type { WorkspaceService } from "@posthog/workspace-server/services/workspace/workspace";
 import { inject, injectable } from "inversify";
-import { WATCHER_REGISTRY_SERVICE } from "../../di/tokens";
+import { WATCHER_REGISTRY_SERVICE, WORKSPACE_SERVICE } from "../../di/tokens";
 import { posthogNodeAnalytics } from "../../platform-adapters/posthog-analytics";
 import { withTimeout } from "../../utils/async";
 import { logger } from "../../utils/logger";
@@ -22,6 +23,7 @@ const log = logger.scope("app-lifecycle");
 @injectable()
 export class AppLifecycleService {
   private static readonly SHUTDOWN_TIMEOUT_MS = 3000;
+  private static readonly PENDING_CREATION_WAIT_MS = 10_000;
 
   private _isQuittingForUpdate = false;
   private _isShuttingDown = false;
@@ -37,6 +39,8 @@ export class AppLifecycleService {
     private readonly watcherRegistry: WatcherRegistryService,
     @inject(PROCESS_TRACKING_SERVICE)
     private readonly processTracking: ProcessTrackingService,
+    @inject(WORKSPACE_SERVICE)
+    private readonly workspaceService: WorkspaceService,
   ) {}
 
   get isQuittingForUpdate(): boolean {
@@ -93,6 +97,7 @@ export class AppLifecycleService {
    */
   async shutdownWithoutContainer(): Promise<void> {
     log.info("Partial shutdown started (keeping container)");
+    await this.waitForPendingWorkspaceCreations();
     await this.teardownNativeResources();
     try {
       this.db.close();
@@ -149,6 +154,32 @@ export class AppLifecycleService {
     }
 
     log.info("Shutdown complete");
+  }
+
+  /**
+   * An update install that lands while a task's workspace is still being
+   * created leaves the task permanently half-provisioned. Give in-flight
+   * creations a bounded window to settle before tearing processes down.
+   */
+  private async waitForPendingWorkspaceCreations(): Promise<void> {
+    const pending = this.workspaceService.pendingCreationCount;
+    if (pending === 0) return;
+
+    log.warn(
+      `Waiting for ${pending} in-flight workspace creations before teardown`,
+      { timeoutMs: AppLifecycleService.PENDING_CREATION_WAIT_MS },
+    );
+    const result = await withTimeout(
+      this.workspaceService.waitForPendingCreations(),
+      AppLifecycleService.PENDING_CREATION_WAIT_MS,
+    );
+    if (result.result === "timeout") {
+      log.warn(
+        "Workspace creations still pending after wait, proceeding with teardown",
+      );
+    } else {
+      log.info("In-flight workspace creations settled before teardown");
+    }
   }
 
   /**

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1660,6 +1660,8 @@ export class SessionService {
     this.connectingTasks.clear();
     this.localRepoPaths.clear();
     this.localRecoveryAttempts.clear();
+    this.reconcileSkipLogged.clear();
+    this.taskCreationMarks.clear();
     this.sessionLastUsedAt.clear();
     this.cloudPermissionRequestIds.clear();
     this.liveTurnContent.clear();
@@ -4494,10 +4496,13 @@ export class SessionService {
       return () => {};
     }
 
+    const connectParams: ConnectParams = { task, repoPath };
+
     // A local task with no run means creation was interrupted before its
     // first run started (e.g. the app quit for an update mid-setup). Connect
     // fresh and deliver the prompt persisted as the task description, unless
-    // a creation saga is actively working on this task right now.
+    // a creation saga is actively working on this task right now. Recovery
+    // replays the description as literal text; original attachments are gone.
     if (!task.latest_run?.id) {
       if (this.isTaskCreationInFlight(taskId)) {
         this.logReconcileSkipOnce(taskId, "creation-in-flight");
@@ -4507,23 +4512,15 @@ export class SessionService {
         taskId,
         hasDescription: !!task.description,
       });
-      const connectParams: ConnectParams = { task, repoPath };
       if (task.description) {
         connectParams.initialPrompt = [
           { type: "text", text: task.description },
         ];
       }
-      this.reconcilingTasks.add(taskId);
-      this.connectToTask(connectParams).finally(() => {
-        this.reconcilingTasks.delete(taskId);
-      });
-      return () => {
-        this.reconcilingTasks.delete(taskId);
-      };
     }
 
     this.reconcilingTasks.add(taskId);
-    this.connectToTask({ task, repoPath }).finally(() => {
+    this.connectToTask(connectParams).finally(() => {
       this.reconcilingTasks.delete(taskId);
     });
 

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -508,6 +508,9 @@ function classifyTurnEventKind(
 export class SessionService {
   private connectingTasks = new Map<string, Promise<void>>();
   private reconcilingTasks = new Set<string>();
+  private reconcileSkipLogged = new Set<string>();
+  private taskCreationMarks = new Map<string, number>();
+  private static readonly TASK_CREATION_IN_FLIGHT_TTL_MS = 10 * 60 * 1000;
   private activityHeartbeats = new Map<
     string,
     ReturnType<typeof setInterval>
@@ -612,6 +615,7 @@ export class SessionService {
   async connectToTask(params: ConnectParams): Promise<void> {
     const { task } = params;
     const taskId = task.id;
+    this.taskCreationMarks.delete(taskId);
     this.localRepoPaths.set(taskId, params.repoPath);
     this.sessionLastUsedAt.set(taskId, Date.now());
     void this.evictIdleSessions(taskId);
@@ -4365,8 +4369,42 @@ export class SessionService {
       });
     }
 
+    this.logReconcileSkipOnce(task.id, "no-workspace-path", {
+      hasRun: !!task.latest_run?.id,
+    });
     this.loadLogsOnlyIfDisconnected(task, session);
     return () => {};
+  }
+
+  private logReconcileSkipOnce(
+    taskId: string,
+    reason: string,
+    context: Record<string, unknown> = {},
+  ): void {
+    const key = `${taskId}:${reason}`;
+    if (this.reconcileSkipLogged.has(key)) return;
+    this.reconcileSkipLogged.add(key);
+    this.d.log.info("Skipping local session reconcile", {
+      taskId,
+      reason,
+      ...context,
+    });
+  }
+
+  public markTaskCreationInFlight(taskId: string): void {
+    this.taskCreationMarks.set(taskId, Date.now());
+  }
+
+  private isTaskCreationInFlight(taskId: string): boolean {
+    const markedAt = this.taskCreationMarks.get(taskId);
+    if (markedAt === undefined) return false;
+    const expired =
+      Date.now() - markedAt > SessionService.TASK_CREATION_IN_FLIGHT_TTL_MS;
+    if (expired) {
+      this.taskCreationMarks.delete(taskId);
+      return false;
+    }
+    return true;
   }
 
   private reconcileCloudConnection(
@@ -4456,7 +4494,33 @@ export class SessionService {
       return () => {};
     }
 
-    if (!task.latest_run?.id) return () => {};
+    // A local task with no run means creation was interrupted before its
+    // first run started (e.g. the app quit for an update mid-setup). Connect
+    // fresh and deliver the prompt persisted as the task description, unless
+    // a creation saga is actively working on this task right now.
+    if (!task.latest_run?.id) {
+      if (this.isTaskCreationInFlight(taskId)) {
+        this.logReconcileSkipOnce(taskId, "creation-in-flight");
+        return () => {};
+      }
+      this.d.log.info("Recovering local task with no run", {
+        taskId,
+        hasDescription: !!task.description,
+      });
+      const connectParams: ConnectParams = { task, repoPath };
+      if (task.description) {
+        connectParams.initialPrompt = [
+          { type: "text", text: task.description },
+        ];
+      }
+      this.reconcilingTasks.add(taskId);
+      this.connectToTask(connectParams).finally(() => {
+        this.reconcilingTasks.delete(taskId);
+      });
+      return () => {
+        this.reconcilingTasks.delete(taskId);
+      };
+    }
 
     this.reconcilingTasks.add(taskId);
     this.connectToTask({ task, repoPath }).finally(() => {

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -92,26 +92,28 @@ describe("SessionService run-less local task recovery", () => {
     vi.useRealTimers();
   });
 
-  it("starts a first run and sends the description as the prompt", () => {
-    const { service, connectToTask } = createHarness();
-    const task = makeTask();
-
-    reconcile(service, task);
-
-    expect(connectToTask).toHaveBeenCalledWith({
-      task,
-      repoPath: "/repo",
+  it.each([
+    {
+      case: "sends the description as the initial prompt",
+      description: "Ship the fix",
       initialPrompt: [{ type: "text", text: "Ship the fix" }],
-    });
-  });
-
-  it("connects without a prompt when the task has no description", () => {
+    },
+    {
+      case: "connects without a prompt when the description is empty",
+      description: "",
+      initialPrompt: undefined,
+    },
+  ])("starts a first run and $case", ({ description, initialPrompt }) => {
     const { service, connectToTask } = createHarness();
-    const task = makeTask({ description: "" });
+    const task = makeTask({ description });
 
     reconcile(service, task);
 
-    expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+    const expected: Record<string, unknown> = { task, repoPath: "/repo" };
+    if (initialPrompt) {
+      expected.initialPrompt = initialPrompt;
+    }
+    expect(connectToTask).toHaveBeenCalledWith(expected);
   });
 
   it("defers to an in-flight creation and recovers once the mark expires", () => {

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -76,10 +76,14 @@ function createHarness({ spyConnect = true } = {}) {
   return { service, sessions, connectToTask, log };
 }
 
-function reconcile(service: SessionService, task: Task): () => void {
+function reconcile(
+  service: SessionService,
+  task: Task,
+  session?: AgentSession,
+): () => void {
   return service.reconcileTaskConnection({
     task,
-    session: undefined,
+    session,
     repoPath: "/repo",
     isCloud: false,
     isOnline: true,
@@ -114,6 +118,33 @@ describe("SessionService run-less local task recovery", () => {
       expected.initialPrompt = initialPrompt;
     }
     expect(connectToTask).toHaveBeenCalledWith(expected);
+  });
+
+  it("recovers a run-less task whose session is disconnected", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+    const session = {
+      ...makeSession(task.id),
+      status: "disconnected" as const,
+    };
+
+    reconcile(service, task, session);
+
+    expect(connectToTask).toHaveBeenCalledWith({
+      task,
+      repoPath: "/repo",
+      initialPrompt: [{ type: "text", text: "Ship the fix" }],
+    });
+  });
+
+  it("does not recover while a session is connecting", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+    const session = { ...makeSession(task.id), status: "connecting" as const };
+
+    reconcile(service, task, session);
+
+    expect(connectToTask).not.toHaveBeenCalled();
   });
 
   it("defers to an in-flight creation and recovers once the mark expires", () => {

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -1,0 +1,157 @@
+import type { AgentSession } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ReconcileTaskConnectionParams,
+  SessionService,
+  type SessionServiceDeps,
+} from "./sessionService";
+
+const IN_FLIGHT_TTL_MS = 10 * 60 * 1000;
+
+function makeSession(taskId: string): AgentSession {
+  return {
+    taskRunId: `run-${taskId}`,
+    taskId,
+    taskTitle: taskId,
+    channel: "",
+    events: [],
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+  } as AgentSession;
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Test task",
+    description: "Ship the fix",
+    latest_run: null,
+    ...overrides,
+  } as Task;
+}
+
+function createHarness({ spyConnect = true } = {}) {
+  const sessions: Record<string, AgentSession> = {};
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    removeSession: vi.fn(),
+    updateSession: vi.fn(),
+  };
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const deps = {
+    store,
+    log,
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    removePersistedConfigOptions: vi.fn(),
+    adapterStore: {
+      getAdapter: () => undefined,
+      setAdapter: vi.fn(),
+      removeAdapter: vi.fn(),
+    },
+    trpc: {
+      agent: {
+        cancel: { mutate: vi.fn().mockResolvedValue(undefined) },
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  const connectToTask = spyConnect
+    ? vi.spyOn(service, "connectToTask").mockResolvedValue(undefined)
+    : undefined;
+  return { service, sessions, connectToTask, log };
+}
+
+function reconcile(service: SessionService, task: Task): () => void {
+  return service.reconcileTaskConnection({
+    task,
+    session: undefined,
+    repoPath: "/repo",
+    isCloud: false,
+    isOnline: true,
+    cloudAuth: { status: "loading" },
+  } as ReconcileTaskConnectionParams);
+}
+
+describe("SessionService run-less local task recovery", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts a first run and sends the description as the prompt", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+
+    reconcile(service, task);
+
+    expect(connectToTask).toHaveBeenCalledWith({
+      task,
+      repoPath: "/repo",
+      initialPrompt: [{ type: "text", text: "Ship the fix" }],
+    });
+  });
+
+  it("connects without a prompt when the task has no description", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask({ description: "" });
+
+    reconcile(service, task);
+
+    expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+  });
+
+  it("defers to an in-flight creation and recovers once the mark expires", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+
+    service.markTaskCreationInFlight(task.id);
+    reconcile(service, task);
+    expect(connectToTask).not.toHaveBeenCalled();
+
+    vi.setSystemTime(IN_FLIGHT_TTL_MS + 1);
+    reconcile(service, task);
+    expect(connectToTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the in-flight mark when a connect starts", async () => {
+    const { service, sessions } = createHarness({ spyConnect: false });
+    const task = makeTask();
+    sessions[`run-${task.id}`] = makeSession(task.id);
+    service.markTaskCreationInFlight(task.id);
+
+    await service.connectToTask({ task, repoPath: "/repo" });
+
+    const connectToTask = vi
+      .spyOn(service, "connectToTask")
+      .mockResolvedValue(undefined);
+    reconcile(service, task);
+    expect(connectToTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes an existing run without injecting a prompt", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask({
+      latest_run: { id: "run-9" } as Task["latest_run"],
+    });
+
+    reconcile(service, task);
+
+    expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+  });
+});

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -40,6 +40,7 @@ const sessionService = {
   connectToTask: vi.fn(),
   disconnectFromTask: vi.fn(),
   rememberInitialCloudPrompt: vi.fn(),
+  markTaskCreationInFlight: vi.fn(),
 } as unknown as SessionService;
 
 const createTask = (overrides: Partial<Task> = {}): Task => ({

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -751,6 +751,31 @@ describe("TaskCreationSaga", () => {
     );
   });
 
+  it("marks task creation in flight before connecting the session", async () => {
+    const createTaskMock = vi.fn().mockResolvedValue(createTask());
+    mockHost.addFolder.mockResolvedValue({ id: "folder-1", path: "/repo" });
+    mockHost.detectRepo.mockResolvedValue(null);
+
+    const saga = makeSaga({ createTask: createTaskMock });
+
+    const result = await saga.run({
+      content: "Ship the fix",
+      repoPath: "/repo",
+      workspaceMode: "local",
+    });
+
+    expect(result.success).toBe(true);
+    expect(sessionService.markTaskCreationInFlight).toHaveBeenCalledWith(
+      "task-123",
+    );
+    expect(
+      vi.mocked(sessionService.markTaskCreationInFlight).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(sessionService.connectToTask).mock.invocationCallOrder[0],
+    );
+  });
+
   it("rolls back the import snapshot and tracking row when a later step fails", async () => {
     const createdTask = createTask();
     const createTaskMock = vi.fn().mockResolvedValue(createdTask);

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -161,6 +161,8 @@ export class TaskCreationSaga extends Saga<
           error,
         });
         this.deps.host.clearProvisioning(task.id);
+        // The in-flight mark is left to TTL-expire on purpose: this state has
+        // its own retry-prompt UX, and auto-recovery would race the retry.
         return { task, workspace: null, provisioningError };
       }
     } else if (workspaceMode === "cloud") {

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -62,6 +62,10 @@ export class TaskCreationSaga extends Saga<
         )
       : await this.createTask(input);
 
+    // Session reconcile auto-recovers run-less local tasks; mark this one as
+    // mid-creation so the recovery doesn't race the agent_session step below.
+    this.deps.sessionService.markTaskCreationInFlight(task.id);
+
     if (importedClaude && input.repoPath) {
       await this.recordClaudeImport(input, importedClaude, task.id);
     }

--- a/packages/core/src/updates/updates.test.ts
+++ b/packages/core/src/updates/updates.test.ts
@@ -389,14 +389,14 @@ describe("UpdatesService", () => {
       );
 
       const resultPromise = service.installUpdate();
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(15_000);
 
       await expect(resultPromise).resolves.toEqual({ installed: true });
       expect(mockUpdater.quitAndInstall).toHaveBeenCalled();
       expect(mockLog.warn).toHaveBeenCalledWith(
         "Partial shutdown timed out before update install",
         expect.objectContaining({
-          timeoutMs: 3000,
+          timeoutMs: 15_000,
           downloadedVersion: "v2.0.0",
         }),
       );

--- a/packages/core/src/updates/updates.ts
+++ b/packages/core/src/updates/updates.ts
@@ -50,7 +50,10 @@ type TransitionContext = {
 export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
   private static readonly CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
   private static readonly CHECK_TIMEOUT_MS = 60 * 1000; // 1 minute timeout for checks
-  private static readonly INSTALL_SHUTDOWN_TIMEOUT_MS = 3000;
+  // Must exceed AppLifecycleService.PENDING_CREATION_WAIT_MS (10s) plus
+  // teardown headroom, or the pending-creation wait inside partial shutdown
+  // gets cut off and quitAndInstall proceeds without any teardown at all.
+  private static readonly INSTALL_SHUTDOWN_TIMEOUT_MS = 15_000;
 
   @inject(UPDATE_LIFECYCLE_SERVICE)
   private lifecycle!: IUpdateLifecycle;

--- a/packages/ui/src/features/navigation/taskBinderImpl.ts
+++ b/packages/ui/src/features/navigation/taskBinderImpl.ts
@@ -10,12 +10,23 @@ import type {
   NavigationTaskBinder,
 } from "@posthog/ui/features/navigation/taskBinder";
 import { useProvisioningStore } from "@posthog/ui/features/provisioning/store";
+import { WORKSPACE_QUERY_KEY } from "@posthog/ui/features/workspace/identifiers";
 import { logger } from "@posthog/ui/shell/logger";
+import {
+  IMPERATIVE_QUERY_CLIENT,
+  type ImperativeQueryClient,
+} from "@posthog/ui/shell/queryClient";
 
 const log = logger.scope("navigation-store");
 
 function hostClient(): HostTrpcClient {
   return resolveService<HostTrpcClient>(HOST_TRPC_CLIENT);
+}
+
+function invalidateWorkspaces(): void {
+  void resolveService<ImperativeQueryClient>(
+    IMPERATIVE_QUERY_CLIENT,
+  ).invalidateQueries({ queryKey: WORKSPACE_QUERY_KEY });
 }
 
 async function getTaskDirectory(
@@ -84,11 +95,17 @@ export const navigationTaskBinder: NavigationTaskBinder = {
     const directory = await getTaskDirectory(task.id, repoKey ?? undefined);
 
     if (directory) {
+      const workspaceMode =
+        task.latest_run?.environment === "cloud" ? "cloud" : "local";
+      log.info("Ensuring workspace binding on task open", {
+        taskId: task.id,
+        directory,
+        mode: workspaceMode,
+        hadWorkspaceRecord: !!existingWorkspace,
+        hasRun: !!task.latest_run?.id,
+      });
       try {
         await hostClient().folders.addFolder.mutate({ folderPath: directory });
-
-        const workspaceMode =
-          task.latest_run?.environment === "cloud" ? "cloud" : "local";
 
         await hostClient().workspace.create.mutate({
           taskId: task.id,
@@ -97,6 +114,7 @@ export const navigationTaskBinder: NavigationTaskBinder = {
           folderPath: directory,
           mode: workspaceMode,
         });
+        invalidateWorkspaces();
       } catch (error) {
         log.error("Failed to auto-register folder on task open:", error);
       }
@@ -107,6 +125,13 @@ export const navigationTaskBinder: NavigationTaskBinder = {
         folderId: "",
         folderPath: "",
         mode: "cloud",
+      });
+      invalidateWorkspaces();
+    } else {
+      log.warn("No directory resolved on task open, workspace not created", {
+        taskId: task.id,
+        repoKey: repoKey ?? null,
+        hasRun: !!task.latest_run?.id,
       });
     }
 

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -578,6 +578,64 @@ describe("WorkspaceService", () => {
     });
   });
 
+  describe("pending creations", () => {
+    afterEach(() => {
+      vi.mocked(getCurrentBranch).mockReset();
+    });
+
+    function localInput(taskId: string): CreateWorkspaceInput {
+      return {
+        taskId,
+        mainRepoPath: "/repo",
+        folderId: "folder-1",
+        folderPath: "/repo",
+        mode: "local",
+        branch: "feature/x",
+      };
+    }
+
+    it("tracks in-flight creations and clears them when creation settles", async () => {
+      let rejectBranch: (error: Error) => void = () => {};
+      vi.mocked(getCurrentBranch).mockReturnValue(
+        new Promise((_, reject) => {
+          rejectBranch = reject;
+        }),
+      );
+
+      const pending = service.createWorkspace(localInput("task-1"));
+      expect(service.pendingCreationCount).toBe(1);
+
+      rejectBranch(new Error("boom"));
+      await expect(pending).rejects.toThrow("boom");
+      expect(service.pendingCreationCount).toBe(0);
+    });
+
+    it("waitForPendingCreations resolves even when creations reject", async () => {
+      const rejectors: Array<(error: Error) => void> = [];
+      const deferredBranch = () =>
+        new Promise<string | null>((_, reject) => {
+          rejectors.push(reject);
+        });
+      vi.mocked(getCurrentBranch)
+        .mockReturnValueOnce(deferredBranch())
+        .mockReturnValueOnce(deferredBranch());
+
+      const first = service.createWorkspace(localInput("task-1"));
+      const second = service.createWorkspace(localInput("task-2"));
+      expect(service.pendingCreationCount).toBe(2);
+
+      const wait = service.waitForPendingCreations();
+      for (const reject of rejectors) {
+        reject(new Error("boom"));
+      }
+
+      await expect(wait).resolves.toBeUndefined();
+      await expect(first).rejects.toThrow("boom");
+      await expect(second).rejects.toThrow("boom");
+      expect(service.pendingCreationCount).toBe(0);
+    });
+  });
+
   describe("worktree path resolved from the stored row", () => {
     const tempDirs: string[] = [];
 

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -531,6 +531,14 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     };
   }
 
+  get pendingCreationCount(): number {
+    return this.creatingWorkspaces.size;
+  }
+
+  async waitForPendingCreations(): Promise<void> {
+    await Promise.allSettled([...this.creatingWorkspaces.values()]);
+  }
+
   async createWorkspace(options: CreateWorkspaceInput): Promise<WorkspaceInfo> {
     // Prevent concurrent workspace creation for the same task
     const existingPromise = this.creatingWorkspaces.get(options.taskId);
@@ -541,11 +549,22 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       return existingPromise;
     }
 
+    const startedAt = Date.now();
     const promise = this.doCreateWorkspace(options);
     this.creatingWorkspaces.set(options.taskId, promise);
 
     try {
-      return await promise;
+      const workspaceInfo = await promise;
+      this.log.info(
+        `Workspace ready for task ${options.taskId} after ${Date.now() - startedAt}ms (mode: ${workspaceInfo.mode})`,
+      );
+      return workspaceInfo;
+    } catch (error) {
+      this.log.error(
+        `Workspace creation failed for task ${options.taskId} after ${Date.now() - startedAt}ms`,
+        error,
+      );
+      throw error;
     } finally {
       this.creatingWorkspaces.delete(options.taskId);
     }
@@ -629,6 +648,9 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         repositoryId,
         mode: "local",
       });
+      this.log.info(
+        `Workspace record persisted for task ${taskId} (mode: local)`,
+      );
 
       const localBranch = await getBranchFromPath(folderPath);
       return {


### PR DESCRIPTION
## Problem

Restarting the app while a task is still being set up leaves that task permanently stuck on a spinner, with the typed prompt never delivered. Abe hit this today: he created a task and clicked "restart to update" 14 seconds later, while the workspace was still being created. The update install killed the creation saga between the cloud task record and the first run, leaving a task with `latest_run: null`, no workspace row and no session.

Nothing in the app recovers that state:

- Boot reconciliation only repairs cloud tasks (`__root.tsx` filters on `latest_run?.environment === "cloud"`).
- Opening the task from the sidebar re-creates the workspace row but never starts a run or session.
- `reconcileLocalConnection` silently returned on `!task.latest_run?.id`, so it only ever resumed existing runs.
- `SessionView` shows a spinner until a session exists, so the task spins forever across restarts.

Every dead end was a silent return, so the incident log (`main.log`) showed nothing after the relaunch.

## Changes

**Recovery (the fix)**

- `reconcileLocalConnection` now treats a local task with no run as an interrupted creation: it starts the first run and sends the task description (the prompt persisted at creation time) as the initial prompt. Without the prompt send the view would keep spinning, since `isInitializing` holds until the first event arrives.
- To keep recovery from racing an active creation, `TaskCreationSaga` marks the task id as mid-creation as soon as it is known. The mark is cleared when `connectToTask` runs and expires after 10 minutes as a backstop, so a crashed saga can never permanently block recovery.
- `ensureWorkspaceForTask` invalidates the workspace query after re-creating a missing workspace row, so a mounted task view sees the new repo path and reconciliation runs immediately instead of after the 60s stale window.

**Prevention**

- The update install path (`shutdownWithoutContainer`) now waits up to 10s for in-flight workspace creations to settle before tearing down processes. Full quit is untouched, so this adds no delay to normal shutdown.

**Debug logging** (all lands in `main.log`)

- Workspace creation logs ready/failed with elapsed ms, and local mode logs when the row is persisted, bracketing which git call stalled if a creation is interrupted again.
- Session reconciliation logs its skip reasons once per task (`no-workspace-path`, `creation-in-flight`) and logs recovery attempts, so a stuck task now prints a smoking-gun line on every launch.
- Task open logs the workspace binding decision, including the previously silent "no directory resolved" dead end.

## How did you test this?

- `pnpm --filter @posthog/core test`: 1930 passed, including new `sessionServiceRecovery.test.ts` covering the description prompt send, prompt-less connect, in-flight deferral with TTL expiry, mark clearing on connect and existing-run resume.
- `apps/code` vitest on `app-lifecycle`: 18 passed, including new `shutdownWithoutContainer` tests for the wait, the skip and the timeout path.
- `pnpm --filter @posthog/ui test` (1208 passed) and `pnpm --filter @posthog/workspace-server test` (602 passed).
- Typecheck passes on core, ui and workspace-server. Biome is clean on all changed files. `node scripts/check-host-boundaries.mjs` reports no new violations.
- Not tested: a live reproduction of the interrupted-update scenario end to end.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
