### PR TITLE
fix(message-editor): paste code copied from editors as verbatim plain text

### DIFF
--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -29,7 +29,7 @@ import { getGithubIssue, getGithubPullRequest } from "../hostApi";
 import { usePromptHistoryStore } from "../promptHistoryStore";
 import { getEditorExtensions } from "../tiptap/extensions";
 import { type DraftContext, useDraftSync } from "../tiptap/useDraftSync";
-import { htmlToMarkdown } from "../utils/htmlToMarkdown";
+import { htmlToMarkdown, isCodeEditorHtml } from "../utils/htmlToMarkdown";
 import {
   persistImageFile,
   persistTextContent,
@@ -440,8 +440,14 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
           }
 
           // Editor is plain-text, so preserve pasted formatting as Markdown.
+          // Code copied from editors (VS Code & co) is the exception: its
+          // highlighting HTML has no formatting worth keeping, so it pastes
+          // as the plain text verbatim below.
           const html = event.clipboardData?.getData("text/html");
-          const markdown = html ? htmlToMarkdown(html, clipboardText) : null;
+          const isCodePaste =
+            !!html && !!trimmedClipboardText && isCodeEditorHtml(html);
+          const markdown =
+            html && !isCodePaste ? htmlToMarkdown(html, clipboardText) : null;
           const effectiveText = markdown ?? clipboardText;
 
           // Auto-convert long pasted text into a file attachment
@@ -465,6 +471,21 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               }
             })();
 
+            return true;
+          }
+
+          // Bypass the native paste for code: ProseMirror would parse the
+          // highlighting HTML into one paragraph per line, which the composer
+          // serializes back with a blank line between every code line.
+          if (isCodePaste && clipboardText) {
+            event.preventDefault();
+            view.dispatch(
+              view.state.tr.insertText(
+                clipboardText.replace(/\r\n?/g, "\n"),
+                from,
+                to,
+              ),
+            );
             return true;
           }
 

--- a/packages/ui/src/features/message-editor/utils/htmlToMarkdown.test.ts
+++ b/packages/ui/src/features/message-editor/utils/htmlToMarkdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { htmlToMarkdown } from "./htmlToMarkdown";
+import { htmlToMarkdown, isCodeEditorHtml } from "./htmlToMarkdown";
 
 describe("htmlToMarkdown", () => {
   it.each([
@@ -73,5 +73,65 @@ describe("htmlToMarkdown", () => {
     expect(htmlToMarkdown(html, "See item_1. in arr[0]")).toBe(
       "See **item_1.** in arr[0]",
     );
+  });
+});
+
+describe("isCodeEditorHtml", () => {
+  // Shape of the text/html VS Code puts on the clipboard
+  // (editor.copyWithSyntaxHighlighting): a white-space:pre wrapper with one
+  // <div> per line of colored <span>s, <div><br/></div> for empty lines.
+  const vsCode = (lines: string) =>
+    `<meta charset='utf-8'><div style="color: #cccccc;background-color: #1f1f1f;font-family: Menlo, Monaco, 'Courier New', monospace;font-weight: normal;font-size: 12px;line-height: 18px;white-space: pre;">${lines}</div>`;
+
+  it.each([
+    [
+      "a single-token VS Code copy",
+      vsCode(
+        '<div><span style="color: #4fc1ff;">SKILL_BUNDLE_MAX_FILES</span></div>',
+      ),
+    ],
+    [
+      "a multi-line VS Code copy with an empty line",
+      vsCode(
+        '<div><span style="color: #c586c0;">const</span><span style="color: #4fc1ff;"> A</span><span> = </span><span style="color: #b5cea8;">1</span></div><div><br/></div><div><span style="color: #c586c0;">const</span><span style="color: #4fc1ff;"> B</span><span> = </span><span style="color: #b5cea8;">2</span></div>',
+      ),
+    ],
+    [
+      "a bare <pre> copy (JetBrains-style)",
+      '<pre style="background-color:#2b2b2b;color:#a9b7c6;"><span style="color:#cc7832;">const </span>SKILL_BUNDLE_MAX_FILES = <span style="color:#6897bb;">64</span></pre>',
+    ],
+  ])("matches %s", (_, html) => {
+    expect(isCodeEditorHtml(html)).toBe(true);
+  });
+
+  it.each([
+    [
+      "a web code block, which converts to fenced Markdown",
+      "<pre><code>const x = 1;</code></pre>",
+    ],
+    ["rich text", "<p>hello <strong>world</strong></p>"],
+    [
+      "preformatted text that still carries real formatting",
+      '<div style="white-space: pre-wrap;">see <a href="https://posthog.com">docs</a></div>',
+    ],
+    [
+      "multiple top-level blocks",
+      '<div style="white-space: pre;">a</div><p>b</p>',
+    ],
+  ])("rejects %s", (_, html) => {
+    expect(isCodeEditorHtml(html)).toBe(false);
+  });
+
+  it("exists because both paste conversions mangle the VS Code shape", () => {
+    // Turndown turns the per-line <div>s into paragraphs, so the Markdown
+    // gains a blank line between every code line and no longer matches the
+    // clipboard's plain text ("const A = 1\nconst B = 2").
+    const html = vsCode(
+      "<div><span>const A = 1</span></div><div><span>const B = 2</span></div>",
+    );
+    expect(htmlToMarkdown(html, "const A = 1\nconst B = 2")).toBe(
+      "const A = 1\n\nconst B = 2",
+    );
+    expect(isCodeEditorHtml(html)).toBe(true);
   });
 });

--- a/packages/ui/src/features/message-editor/utils/htmlToMarkdown.ts
+++ b/packages/ui/src/features/message-editor/utils/htmlToMarkdown.ts
@@ -46,3 +46,36 @@ export function htmlToMarkdown(
 
   return markdown;
 }
+
+const NON_CONTENT_TAGS = new Set(["META", "STYLE", "SCRIPT", "TITLE", "LINK"]);
+const CODE_STRUCTURE_TAGS = new Set(["DIV", "SPAN", "BR"]);
+
+/**
+ * True for the clipboard HTML shape code editors produce (VS Code/Monaco,
+ * JetBrains): a single `white-space: pre` block — or a bare `<pre>` — whose
+ * only structure is per-line <div>s of colored <span>s. That shape carries no
+ * formatting the composer keeps, and neither conversion handles it faithfully:
+ * Turndown emits a paragraph per line <div> (a blank line between every code
+ * line), and ProseMirror's native HTML paste splits the lines into separate
+ * paragraphs, which serialize back with blank lines too. Callers should paste
+ * the clipboard's plain text verbatim instead. Web code blocks (<pre><code>)
+ * are excluded; Turndown converts those to fenced Markdown correctly.
+ */
+export function isCodeEditorHtml(html: string): boolean {
+  const body = new DOMParser().parseFromString(html, "text/html").body;
+  const roots = Array.from(body.children).filter(
+    (el) => !NON_CONTENT_TAGS.has(el.tagName),
+  );
+  if (roots.length !== 1) return false;
+
+  const root = roots[0];
+  const isPre = root.tagName === "PRE";
+  const whiteSpace = root instanceof HTMLElement ? root.style.whiteSpace : "";
+  if (!isPre && !whiteSpace.startsWith("pre")) return false;
+  if (isPre && root.firstElementChild?.tagName === "CODE") return false;
+
+  for (const el of root.querySelectorAll("*")) {
+    if (!CODE_STRUCTURE_TAGS.has(el.tagName)) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Problem

Follow-up to #3089. Pasting a **multi-line** code selection from VS Code (or JetBrains IDEs) into the composer still gets mangled: a blank line appears between every pasted line, and survives into the sent message.

Repro on v0.56.90: copy 2+ lines of code in VS Code (with default `editor.copyWithSyntaxHighlighting`), Cmd+V into the composer.

## Cause

VS Code's clipboard `text/html` is a `white-space: pre` wrapper with one `<div>` per line of colored `<span>`s. Neither paste path handles that shape faithfully:

- Turndown converts the per-line `<div>`s into paragraphs, so the converted Markdown gains `\n\n` between every code line. That output no longer matches the plain-text fallback, so `htmlToMarkdown` doesn't defer and the doubled-spaced text is inserted literally.
- Deferring wouldn't help either: ProseMirror's native HTML paste splits the line `<div>`s into one paragraph each, which the composer serializes back with blank lines on send.

(#3089 fixed the other half of this — Turndown's backslash-escaping turning `SKILL_BUNDLE_MAX_FILES` into `SKILL\_BUNDLE\_MAX\_FILES` — but the multi-line spacing mangle remained.)

## Fix

New `isCodeEditorHtml()` detector for the code-editor clipboard shape: a single `white-space: pre` block — or a bare `<pre>` (JetBrains-style) — whose only structure is `div`/`span`/`br`. When a paste matches, insert the clipboard's **plain text verbatim** (line endings normalized) instead of Markdown-converting or native-HTML-parsing it.

Deliberately conservative:
- `<pre><code>` web code blocks keep the existing fenced-Markdown conversion.
- Any other element inside the block (links, bold, …) means real formatting, so the Markdown path still applies.
- Long pastes still auto-convert to a file attachment.

## Testing

- Unit tests for the detector with realistic VS Code / JetBrains clipboard fixtures, plus a regression test documenting why the detector exists (Turndown output vs plain text).
- `pnpm --filter @posthog/ui typecheck`, Biome clean, all 40 message-editor tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)