### PR TITLE
Add per-OS download tables to release notes

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -223,6 +223,21 @@ jobs:
             apps/code/out/*-mac.zip \
             apps/code/out/*.blockmap
 
+      # Hash the same files uploaded above; finalize-release turns these into
+      # the download tables in the release notes.
+      - name: Compute artifact checksums
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+        working-directory: apps/code/out
+        run: shasum -a 256 *.dmg *-mac.zip *.blockmap > "checksums-macos-$MATRIX_ARCH.txt"
+
+      - name: Upload checksums artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: checksums-macos-${{ matrix.arch }}
+          path: apps/code/out/checksums-macos-${{ matrix.arch }}.txt
+          retention-days: 1
+
       - name: Upload mac manifest artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -331,6 +346,20 @@ jobs:
           $items += Get-ChildItem $out -File -Filter "*.blockmap"
           $files = $items | Select-Object -ExpandProperty FullName
           gh release upload "v$env:APP_VERSION" --repo PostHog/code --clobber @files
+
+      # Hash the same files uploaded above (minus latest.yml); finalize-release
+      # turns these into the download tables in the release notes.
+      - name: Compute artifact checksums
+        shell: bash
+        working-directory: apps/code/out
+        run: sha256sum *.exe *.blockmap > checksums-windows-x64.txt
+
+      - name: Upload checksums artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: checksums-windows-x64
+          path: apps/code/out/checksums-windows-x64.txt
+          retention-days: 1
 
   publish-linux:
     needs: [prepare-release]
@@ -444,6 +473,21 @@ jobs:
             apps/code/out/*.deb \
             apps/code/out/*.rpm
 
+      # Hash the same files uploaded above; finalize-release turns these into
+      # the download tables in the release notes.
+      - name: Compute artifact checksums
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+        working-directory: apps/code/out
+        run: sha256sum *.AppImage *.deb *.rpm > "checksums-linux-$MATRIX_ARCH.txt"
+
+      - name: Upload checksums artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: checksums-linux-${{ matrix.arch }}
+          path: apps/code/out/checksums-linux-${{ matrix.arch }}.txt
+          retention-days: 1
+
   finalize-release:
     needs: [publish-macos, publish-windows, publish-linux]
     # Publish only when every platform built successfully. Without an `if:` override
@@ -471,6 +515,7 @@ jobs:
         with:
           sparse-checkout: |
             apps/code/scripts/merge-mac-manifests.mjs
+            apps/code/scripts/generate-release-download-tables.mjs
           sparse-checkout-cone-mode: false
 
       - name: Setup Node.js
@@ -508,10 +553,19 @@ jobs:
         run: |
           gh release upload "v$APP_VERSION" --repo PostHog/code --clobber /tmp/latest-mac.yml
 
+      - name: Download checksum artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: checksums-*
+          merge-multiple: true
+          path: /tmp/checksums
+
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_VERSION: ${{ steps.version.outputs.version }}
         run: |
           gh api repos/PostHog/code/releases/generate-notes -f tag_name="v$APP_VERSION" --jq '.body' > /tmp/release-notes.md
+          printf '\n' >> /tmp/release-notes.md
+          node apps/code/scripts/generate-release-download-tables.mjs "$APP_VERSION" /tmp/checksums >> /tmp/release-notes.md
           gh release edit "v$APP_VERSION" --repo PostHog/code --draft=false --notes-file /tmp/release-notes.md

--- a/apps/code/scripts/generate-release-download-tables.mjs
+++ b/apps/code/scripts/generate-release-download-tables.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Renders the "Downloads" section appended to GitHub release notes: one
+// markdown table per OS with a direct download link, blockmap link, and
+// SHA-256 per installer. Input is a directory of sha256sum/shasum output
+// files collected from the publish jobs in code-release.yml — the asset
+// patterns below must cover every file those jobs checksum.
+import { readdirSync, readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DOWNLOAD_BASE = "https://github.com/PostHog/code/releases/download";
+
+const ASSET_KINDS = [
+  { pattern: /-mac\.dmg$/, os: "macos", pkg: "DMG", pkgOrder: 0 },
+  { pattern: /-mac\.zip$/, os: "macos", pkg: "ZIP", pkgOrder: 1 },
+  {
+    pattern: /-win\.exe$/,
+    os: "windows",
+    pkg: "Installer (.exe)",
+    pkgOrder: 0,
+  },
+  { pattern: /\.AppImage$/, os: "linux", pkg: "AppImage", pkgOrder: 0 },
+  { pattern: /\.deb$/, os: "linux", pkg: "Debian (.deb)", pkgOrder: 1 },
+  { pattern: /\.rpm$/, os: "linux", pkg: "RPM (.rpm)", pkgOrder: 2 },
+];
+
+const OS_SECTIONS = [
+  // macOS sorts by arch first: users pick their chip, then a format.
+  // Linux sorts by package first: the distro dictates deb/rpm/AppImage.
+  {
+    os: "macos",
+    heading: "macOS",
+    archOrder: ["arm64", "x64"],
+    archFirst: true,
+  },
+  {
+    os: "windows",
+    heading: "Windows",
+    archOrder: ["x64", "arm64"],
+    archFirst: false,
+  },
+  {
+    os: "linux",
+    heading: "Linux",
+    archOrder: ["x64", "arm64"],
+    archFirst: false,
+  },
+];
+
+const ARCH_LABELS = {
+  macos: { arm64: "Apple Silicon (arm64)", x64: "Intel (x64)" },
+  windows: { arm64: "arm64", x64: "x64" },
+  linux: { arm64: "arm64", x64: "x64" },
+};
+
+// Parses `sha256sum`/`shasum -a 256` output into a filename -> sha map.
+export function parseChecksums(text) {
+  const checksums = new Map();
+  for (const line of text.split("\n")) {
+    const match = line.trim().match(/^([0-9a-f]{64})[ *]+(.+)$/);
+    if (match) checksums.set(match[2], match[1]);
+  }
+  return checksums;
+}
+
+function detectArch(name) {
+  if (/aarch64|arm64/.test(name)) return "arm64";
+  if (/x86_64|amd64|x64/.test(name)) return "x64";
+  return "unknown";
+}
+
+export function buildDownloadTables(version, checksums) {
+  const base = `${DOWNLOAD_BASE}/v${version.replace(/^v/, "")}`;
+  const rows = { macos: [], windows: [], linux: [] };
+
+  for (const [name, sha] of checksums) {
+    if (name.endsWith(".blockmap")) continue;
+    const kind = ASSET_KINDS.find((k) => k.pattern.test(name));
+    if (!kind) continue;
+    const arch = detectArch(name);
+    const blockmapName = `${name}.blockmap`;
+    const blockmap = checksums.has(blockmapName)
+      ? `[blockmap](${base}/${blockmapName})`
+      : "—";
+    rows[kind.os].push({
+      name,
+      arch,
+      pkgOrder: kind.pkgOrder,
+      cells: [
+        kind.pkg,
+        ARCH_LABELS[kind.os][arch] ?? arch,
+        `[${name}](${base}/${name})`,
+        blockmap,
+        // Abbreviated sha; the link title shows the full hash on hover.
+        `[\`${sha.slice(0, 6)}\`](${base}/${name} "${sha}")`,
+      ],
+    });
+  }
+
+  const sections = [];
+  for (const { os, heading, archOrder, archFirst } of OS_SECTIONS) {
+    if (rows[os].length === 0) continue;
+    const archRank = (row) => {
+      const rank = archOrder.indexOf(row.arch);
+      return rank === -1 ? archOrder.length : rank;
+    };
+    rows[os].sort((a, b) => {
+      const aKey = archFirst
+        ? [archRank(a), a.pkgOrder]
+        : [a.pkgOrder, archRank(a)];
+      const bKey = archFirst
+        ? [archRank(b), b.pkgOrder]
+        : [b.pkgOrder, archRank(b)];
+      return (
+        aKey[0] - bKey[0] || aKey[1] - bKey[1] || a.name.localeCompare(b.name)
+      );
+    });
+    sections.push(
+      [
+        `### ${heading}`,
+        "",
+        "| Package | Architecture | Download | Blockmap | SHA-256 |",
+        "| --- | --- | --- | --- | --- |",
+        ...rows[os].map((row) => `| ${row.cells.join(" | ")} |`),
+      ].join("\n"),
+    );
+  }
+
+  if (sections.length === 0) return "";
+  return `## Downloads\n\n${sections.join("\n\n")}\n`;
+}
+
+function main() {
+  const [, , version, checksumsDir] = process.argv;
+
+  if (!version || !checksumsDir) {
+    console.error(
+      "Usage: generate-release-download-tables.mjs <version> <checksums-dir>",
+    );
+    process.exit(1);
+  }
+
+  const files = readdirSync(checksumsDir)
+    .filter((name) => name.endsWith(".txt"))
+    .sort();
+  const text = files
+    .map((name) => readFileSync(join(checksumsDir, name), "utf8"))
+    .join("\n");
+  const checksums = parseChecksums(text);
+
+  for (const name of checksums.keys()) {
+    if (
+      !name.endsWith(".blockmap") &&
+      !ASSET_KINDS.some((kind) => kind.pattern.test(name))
+    ) {
+      console.error(`Skipping unrecognized artifact: ${name}`);
+    }
+  }
+
+  const markdown = buildDownloadTables(version, checksums);
+  if (!markdown) {
+    console.error(`No release artifacts found in ${checksumsDir}`);
+    process.exit(1);
+  }
+  process.stdout.write(markdown);
+}
+
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/apps/code/scripts/generate-release-download-tables.test.mjs
+++ b/apps/code/scripts/generate-release-download-tables.test.mjs
@@ -44,19 +44,26 @@ const downloadCells = (markdown) =>
   tableRows(markdown).map((line) => line.split(" | ")[2]);
 
 describe("parseChecksums", () => {
-  it("parses sha256sum and shasum output, ignoring other lines", () => {
-    const text = [
+  it.each([
+    [
+      "sha256sum text mode (two spaces)",
       `${sha("a")}  PostHog-Code-1.2.3-arm64-mac.dmg`,
+      "PostHog-Code-1.2.3-arm64-mac.dmg",
+      sha("a"),
+    ],
+    [
+      "shasum binary mode (space + asterisk)",
       `${sha("b")} *PostHog-Code-1.2.3-x64-win.exe`,
-      "not a checksum line",
-      "",
-    ].join("\n");
+      "PostHog-Code-1.2.3-x64-win.exe",
+      sha("b"),
+    ],
+  ])("parses %s output, ignoring other lines", (_label, line, name, hash) => {
+    const text = [line, "not a checksum line", ""].join("\n");
 
     const checksums = parseChecksums(text);
 
-    expect(checksums.get("PostHog-Code-1.2.3-arm64-mac.dmg")).toBe(sha("a"));
-    expect(checksums.get("PostHog-Code-1.2.3-x64-win.exe")).toBe(sha("b"));
-    expect(checksums.size).toBe(2);
+    expect(checksums.get(name)).toBe(hash);
+    expect(checksums.size).toBe(1);
   });
 });
 
@@ -93,17 +100,18 @@ describe("buildDownloadTables", () => {
     ]);
   });
 
-  it("links the blockmap when present and shows a dash when absent", () => {
-    const markdown = buildDownloadTables("0.56.90", releaseChecksums());
-    const rows = tableRows(markdown);
-
-    const dmgRow = rows.find((row) => row.includes("arm64-mac.dmg]("));
-    expect(dmgRow).toContain(
+  it.each([
+    [
+      "links the blockmap when present",
+      "arm64-mac.dmg](",
       "[blockmap](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-mac.dmg.blockmap)",
-    );
+    ],
+    ["shows a dash when the blockmap is absent", "amd64-linux.deb](", "| — |"],
+  ])("%s", (_label, rowFragment, expected) => {
+    const rows = tableRows(buildDownloadTables("0.56.90", releaseChecksums()));
 
-    const debRow = rows.find((row) => row.includes("amd64-linux.deb]("));
-    expect(debRow).toContain("| — |");
+    const row = rows.find((line) => line.includes(rowFragment));
+    expect(row).toContain(expected);
   });
 
   it("abbreviates the sha to 6 digits with the full hash as hover tooltip", () => {

--- a/apps/code/scripts/generate-release-download-tables.test.mjs
+++ b/apps/code/scripts/generate-release-download-tables.test.mjs
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDownloadTables,
+  parseChecksums,
+} from "./generate-release-download-tables.mjs";
+
+const sha = (seed) => seed.repeat(64).slice(0, 64);
+
+// Asset names as produced by a real release (v0.56.90).
+const releaseChecksums = () =>
+  new Map(
+    [
+      "PostHog-Code-0.56.90-arm64-mac.dmg",
+      "PostHog-Code-0.56.90-arm64-mac.dmg.blockmap",
+      "PostHog-Code-0.56.90-arm64-mac.zip",
+      "PostHog-Code-0.56.90-arm64-mac.zip.blockmap",
+      "PostHog-Code-0.56.90-x64-mac.dmg",
+      "PostHog-Code-0.56.90-x64-mac.dmg.blockmap",
+      "PostHog-Code-0.56.90-x64-mac.zip",
+      "PostHog-Code-0.56.90-x64-mac.zip.blockmap",
+      "PostHog-Code-0.56.90-x64-win.exe",
+      "PostHog-Code-0.56.90-x64-win.exe.blockmap",
+      "PostHog-Code-0.56.90-x86_64-linux.AppImage",
+      "PostHog-Code-0.56.90-arm64-linux.AppImage",
+      "PostHog-Code-0.56.90-amd64-linux.deb",
+      "PostHog-Code-0.56.90-arm64-linux.deb",
+      "PostHog-Code-0.56.90-x86_64-linux.rpm",
+      "PostHog-Code-0.56.90-aarch64-linux.rpm",
+    ].map((name, index) => [name, sha(`${index % 10}`)]),
+  );
+
+const tableRows = (markdown) =>
+  markdown
+    .split("\n")
+    .filter(
+      (line) =>
+        line.startsWith("| ") &&
+        !line.startsWith("| Package") &&
+        !line.startsWith("| ---"),
+    );
+
+// Cell 2 of `| Package | Architecture | Download | ... |` split on " | ".
+const downloadCells = (markdown) =>
+  tableRows(markdown).map((line) => line.split(" | ")[2]);
+
+describe("parseChecksums", () => {
+  it("parses sha256sum and shasum output, ignoring other lines", () => {
+    const text = [
+      `${sha("a")}  PostHog-Code-1.2.3-arm64-mac.dmg`,
+      `${sha("b")} *PostHog-Code-1.2.3-x64-win.exe`,
+      "not a checksum line",
+      "",
+    ].join("\n");
+
+    const checksums = parseChecksums(text);
+
+    expect(checksums.get("PostHog-Code-1.2.3-arm64-mac.dmg")).toBe(sha("a"));
+    expect(checksums.get("PostHog-Code-1.2.3-x64-win.exe")).toBe(sha("b"));
+    expect(checksums.size).toBe(2);
+  });
+});
+
+describe("buildDownloadTables", () => {
+  it("renders one section per OS, in macOS/Windows/Linux order", () => {
+    const markdown = buildDownloadTables("0.56.90", releaseChecksums());
+
+    const headings = markdown
+      .split("\n")
+      .filter((line) => line.startsWith("#"));
+    expect(headings).toEqual([
+      "## Downloads",
+      "### macOS",
+      "### Windows",
+      "### Linux",
+    ]);
+  });
+
+  it("orders macOS by arch (Apple Silicon first) and Linux by package", () => {
+    const markdown = buildDownloadTables("0.56.90", releaseChecksums());
+
+    expect(downloadCells(markdown)).toEqual([
+      "[PostHog-Code-0.56.90-arm64-mac.dmg](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-mac.dmg)",
+      "[PostHog-Code-0.56.90-arm64-mac.zip](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-mac.zip)",
+      "[PostHog-Code-0.56.90-x64-mac.dmg](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-x64-mac.dmg)",
+      "[PostHog-Code-0.56.90-x64-mac.zip](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-x64-mac.zip)",
+      "[PostHog-Code-0.56.90-x64-win.exe](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-x64-win.exe)",
+      "[PostHog-Code-0.56.90-x86_64-linux.AppImage](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-x86_64-linux.AppImage)",
+      "[PostHog-Code-0.56.90-arm64-linux.AppImage](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-linux.AppImage)",
+      "[PostHog-Code-0.56.90-amd64-linux.deb](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-amd64-linux.deb)",
+      "[PostHog-Code-0.56.90-arm64-linux.deb](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-linux.deb)",
+      "[PostHog-Code-0.56.90-x86_64-linux.rpm](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-x86_64-linux.rpm)",
+      "[PostHog-Code-0.56.90-aarch64-linux.rpm](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-aarch64-linux.rpm)",
+    ]);
+  });
+
+  it("links the blockmap when present and shows a dash when absent", () => {
+    const markdown = buildDownloadTables("0.56.90", releaseChecksums());
+    const rows = tableRows(markdown);
+
+    const dmgRow = rows.find((row) => row.includes("arm64-mac.dmg]("));
+    expect(dmgRow).toContain(
+      "[blockmap](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-mac.dmg.blockmap)",
+    );
+
+    const debRow = rows.find((row) => row.includes("amd64-linux.deb]("));
+    expect(debRow).toContain("| — |");
+  });
+
+  it("abbreviates the sha to 6 digits with the full hash as hover tooltip", () => {
+    const checksums = releaseChecksums();
+    const markdown = buildDownloadTables("0.56.90", checksums);
+    const exeRow = markdown
+      .split("\n")
+      .find((line) => line.includes("x64-win.exe]("));
+    const fullSha = checksums.get("PostHog-Code-0.56.90-x64-win.exe");
+
+    expect(exeRow).toContain(
+      `[\`${fullSha.slice(0, 6)}\`](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-x64-win.exe "${fullSha}")`,
+    );
+    expect(exeRow).not.toContain(`\`${fullSha}\``);
+  });
+
+  it("does not render blockmaps or unrecognized files as rows", () => {
+    const checksums = releaseChecksums();
+    checksums.set("latest-mac.yml", sha("c"));
+    const markdown = buildDownloadTables("0.56.90", checksums);
+
+    expect(markdown).not.toContain("latest-mac.yml");
+    expect(markdown).not.toContain(
+      "[PostHog-Code-0.56.90-arm64-mac.dmg.blockmap](",
+    );
+  });
+
+  it("accepts a version with a leading v without doubling it in URLs", () => {
+    const markdown = buildDownloadTables("v0.56.90", releaseChecksums());
+
+    expect(markdown).toContain("/releases/download/v0.56.90/");
+    expect(markdown).not.toContain("vv0.56.90");
+  });
+
+  it("labels macOS architectures and skips empty sections", () => {
+    const macOnly = new Map([
+      ["PostHog-Code-1.2.3-arm64-mac.dmg", sha("a")],
+      ["PostHog-Code-1.2.3-x64-mac.dmg", sha("b")],
+    ]);
+
+    const markdown = buildDownloadTables("1.2.3", macOnly);
+
+    expect(markdown).toContain("Apple Silicon (arm64)");
+    expect(markdown).toContain("Intel (x64)");
+    expect(markdown).not.toContain("### Windows");
+    expect(markdown).not.toContain("### Linux");
+  });
+
+  it("returns an empty string when there are no recognized artifacts", () => {
+    expect(buildDownloadTables("1.2.3", new Map())).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

Every release has ~18 assets in a flat list, and it's hard to find the right file for your system: https://github.com/PostHog/code/releases/tag/v0.56.90

## Changes

Release notes now end with a `## Downloads` section containing three tables (macOS, Windows, Linux), one row per package + architecture combo:

| Package | Architecture | Download | Blockmap | SHA-256 |
| --- | --- | --- | --- | --- |
| DMG | Apple Silicon (arm64) | [PostHog-Code-0.56.90-arm64-mac.dmg](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-mac.dmg) | [blockmap](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-mac.dmg.blockmap) | [`c0a308`](https://github.com/PostHog/code/releases/download/v0.56.90/PostHog-Code-0.56.90-arm64-mac.dmg "c0a3087381195aea92d86f18804b8eab533231ed567c9c131ba12ce56841518a") |

- Every cell links to the direct download; the SHA cell shows the first 6 digits and reveals the full hash as a hover tooltip (markdown link title).
- macOS rows sort by chip first (Apple Silicon, then Intel); Linux rows sort by package format first (AppImage, deb, rpm) since the distro dictates the format.
- Linux artifacts have no blockmaps in the release, so those cells show a dash.

## How

- Each publish job (`publish-macos` x2, `publish-windows`, `publish-linux` x2) runs `shasum -a 256`/`sha256sum` over the exact globs it uploads to the release, and stores the output as a 1-day `checksums-<os>-<arch>` workflow artifact (same pattern as the mac manifest artifacts).
- `finalize-release` downloads the checksum artifacts and the new `apps/code/scripts/generate-release-download-tables.mjs` (added to its sparse checkout) appends the tables to the GitHub-generated notes before `gh release edit` flips the release out of draft.
- If no checksums are found, the script exits non-zero and the release stays a draft instead of publishing without tables; unrecognized artifact names only log a warning.

## Testing

- 9 vitest tests colocated with the script, using the real v0.56.90 asset names as fixture (section order, sorting, blockmap link/dash, tooltip sha cell, empty-section handling).
- Rendered end-to-end locally from sha256sum-format fixture files to verify the exact markdown above.
- Workflow YAML parse-checked; Biome clean.
