### PR TITLE
fix(tasks): recover tasks interrupted mid-creation

### DIFF
--- a/apps/code/src/main/services/app-lifecycle/service.test.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.test.ts
@@ -1,6 +1,7 @@
+import { INSTALL_SHUTDOWN_TIMEOUT_MS } from "@posthog/core/updates/updates";
 import type { IAppLifecycle } from "@posthog/platform/app-lifecycle";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AppLifecycleService } from "./service";
+import { AppLifecycleService, PENDING_CREATION_WAIT_MS } from "./service";
 
 const {
   mockAppLifecycle,
@@ -301,6 +302,14 @@ describe("AppLifecycleService", () => {
 
       expect(beforeExit).toHaveBeenCalledTimes(1);
       expect(callOrder).toEqual(["dbClose", "beforeExit", "exit"]);
+    });
+  });
+
+  describe("shutdown budgets", () => {
+    it("gives the install timeout headroom over the pending-creation wait", () => {
+      expect(INSTALL_SHUTDOWN_TIMEOUT_MS).toBeGreaterThanOrEqual(
+        PENDING_CREATION_WAIT_MS + 3000,
+      );
     });
   });
 });

--- a/apps/code/src/main/services/app-lifecycle/service.test.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.test.ts
@@ -8,6 +8,7 @@ const {
   mockSuspensionService,
   mockWatcherRegistry,
   mockProcessTracking,
+  mockWorkspaceService,
   mockTrackAppEvent,
   mockShutdownPostHog,
   mockShutdownOtelTransport,
@@ -22,6 +23,10 @@ const {
     },
     mockWatcherRegistry: {
       shutdownAll: vi.fn(() => Promise.resolve()),
+    },
+    mockWorkspaceService: {
+      pendingCreationCount: 0,
+      waitForPendingCreations: vi.fn(() => Promise.resolve()),
     },
     mockProcessTracking: {
       getSnapshot: vi.fn(() =>
@@ -83,12 +88,14 @@ describe("AppLifecycleService", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     process.exit = mockProcessExit;
+    mockWorkspaceService.pendingCreationCount = 0;
     service = new AppLifecycleService(
       mockAppLifecycle as unknown as IAppLifecycle,
       mockDatabaseService as never,
       mockSuspensionService as never,
       mockWatcherRegistry as never,
       mockProcessTracking as never,
+      mockWorkspaceService as never,
     );
   });
 
@@ -202,6 +209,50 @@ describe("AppLifecycleService", () => {
       await promise;
 
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("shutdownWithoutContainer", () => {
+    it("skips the wait when no creations are pending", async () => {
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(
+        mockWorkspaceService.waitForPendingCreations,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("waits for in-flight workspace creations before teardown", async () => {
+      mockWorkspaceService.pendingCreationCount = 1;
+      const callOrder: string[] = [];
+      mockWorkspaceService.waitForPendingCreations.mockImplementation(
+        async () => {
+          callOrder.push("waitForCreations");
+        },
+      );
+      mockWatcherRegistry.shutdownAll.mockImplementation(async () => {
+        callOrder.push("teardown");
+      });
+
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(callOrder).toEqual(["waitForCreations", "teardown"]);
+    });
+
+    it("proceeds with teardown when creations do not settle in time", async () => {
+      mockWorkspaceService.pendingCreationCount = 1;
+      mockWorkspaceService.waitForPendingCreations.mockReturnValue(
+        new Promise(() => {}),
+      );
+
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockProcessTracking.getSnapshot).toHaveBeenCalled();
     });
   });
 

--- a/apps/code/src/main/services/app-lifecycle/service.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.ts
@@ -20,10 +20,11 @@ import { shutdownOtelTransport } from "../../utils/otel-log-transport";
 
 const log = logger.scope("app-lifecycle");
 
+export const PENDING_CREATION_WAIT_MS = 10_000;
+
 @injectable()
 export class AppLifecycleService {
   private static readonly SHUTDOWN_TIMEOUT_MS = 3000;
-  private static readonly PENDING_CREATION_WAIT_MS = 10_000;
 
   private _isQuittingForUpdate = false;
   private _isShuttingDown = false;
@@ -167,11 +168,11 @@ export class AppLifecycleService {
 
     log.warn(
       `Waiting for ${pending} in-flight workspace creations before teardown`,
-      { timeoutMs: AppLifecycleService.PENDING_CREATION_WAIT_MS },
+      { timeoutMs: PENDING_CREATION_WAIT_MS },
     );
     const result = await withTimeout(
       this.workspaceService.waitForPendingCreations(),
-      AppLifecycleService.PENDING_CREATION_WAIT_MS,
+      PENDING_CREATION_WAIT_MS,
     );
     if (result.result === "timeout") {
       log.warn(

--- a/apps/code/src/main/services/app-lifecycle/service.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.ts
@@ -10,8 +10,9 @@ import type { ProcessTrackingService } from "@posthog/workspace-server/services/
 import { SUSPENSION_SERVICE } from "@posthog/workspace-server/services/suspension/identifiers";
 import type { SuspensionService } from "@posthog/workspace-server/services/suspension/suspension";
 import type { WatcherRegistryService } from "@posthog/workspace-server/services/watcher-registry/watcher-registry";
+import type { WorkspaceService } from "@posthog/workspace-server/services/workspace/workspace";
 import { inject, injectable } from "inversify";
-import { WATCHER_REGISTRY_SERVICE } from "../../di/tokens";
+import { WATCHER_REGISTRY_SERVICE, WORKSPACE_SERVICE } from "../../di/tokens";
 import { posthogNodeAnalytics } from "../../platform-adapters/posthog-analytics";
 import { withTimeout } from "../../utils/async";
 import { logger } from "../../utils/logger";
@@ -22,6 +23,7 @@ const log = logger.scope("app-lifecycle");
 @injectable()
 export class AppLifecycleService {
   private static readonly SHUTDOWN_TIMEOUT_MS = 3000;
+  private static readonly PENDING_CREATION_WAIT_MS = 10_000;
 
   private _isQuittingForUpdate = false;
   private _isShuttingDown = false;
@@ -37,6 +39,8 @@ export class AppLifecycleService {
     private readonly watcherRegistry: WatcherRegistryService,
     @inject(PROCESS_TRACKING_SERVICE)
     private readonly processTracking: ProcessTrackingService,
+    @inject(WORKSPACE_SERVICE)
+    private readonly workspaceService: WorkspaceService,
   ) {}
 
   get isQuittingForUpdate(): boolean {
@@ -93,6 +97,7 @@ export class AppLifecycleService {
    */
   async shutdownWithoutContainer(): Promise<void> {
     log.info("Partial shutdown started (keeping container)");
+    await this.waitForPendingWorkspaceCreations();
     await this.teardownNativeResources();
     try {
       this.db.close();
@@ -149,6 +154,32 @@ export class AppLifecycleService {
     }
 
     log.info("Shutdown complete");
+  }
+
+  /**
+   * An update install that lands while a task's workspace is still being
+   * created leaves the task permanently half-provisioned. Give in-flight
+   * creations a bounded window to settle before tearing processes down.
+   */
+  private async waitForPendingWorkspaceCreations(): Promise<void> {
+    const pending = this.workspaceService.pendingCreationCount;
+    if (pending === 0) return;
+
+    log.warn(
+      `Waiting for ${pending} in-flight workspace creations before teardown`,
+      { timeoutMs: AppLifecycleService.PENDING_CREATION_WAIT_MS },
+    );
+    const result = await withTimeout(
+      this.workspaceService.waitForPendingCreations(),
+      AppLifecycleService.PENDING_CREATION_WAIT_MS,
+    );
+    if (result.result === "timeout") {
+      log.warn(
+        "Workspace creations still pending after wait, proceeding with teardown",
+      );
+    } else {
+      log.info("In-flight workspace creations settled before teardown");
+    }
   }
 
   /**

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -505,12 +505,13 @@ function classifyTurnEventKind(
   return "other";
 }
 
+export const TASK_CREATION_IN_FLIGHT_TTL_MS = 10 * 60 * 1000;
+
 export class SessionService {
   private connectingTasks = new Map<string, Promise<void>>();
   private reconcilingTasks = new Set<string>();
   private reconcileSkipLogged = new Set<string>();
   private taskCreationMarks = new Map<string, number>();
-  private static readonly TASK_CREATION_IN_FLIGHT_TTL_MS = 10 * 60 * 1000;
   private activityHeartbeats = new Map<
     string,
     ReturnType<typeof setInterval>
@@ -4400,8 +4401,7 @@ export class SessionService {
   private isTaskCreationInFlight(taskId: string): boolean {
     const markedAt = this.taskCreationMarks.get(taskId);
     if (markedAt === undefined) return false;
-    const expired =
-      Date.now() - markedAt > SessionService.TASK_CREATION_IN_FLIGHT_TTL_MS;
+    const expired = Date.now() - markedAt > TASK_CREATION_IN_FLIGHT_TTL_MS;
     if (expired) {
       this.taskCreationMarks.delete(taskId);
       return false;

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1660,6 +1660,8 @@ export class SessionService {
     this.connectingTasks.clear();
     this.localRepoPaths.clear();
     this.localRecoveryAttempts.clear();
+    this.reconcileSkipLogged.clear();
+    this.taskCreationMarks.clear();
     this.sessionLastUsedAt.clear();
     this.cloudPermissionRequestIds.clear();
     this.liveTurnContent.clear();
@@ -4494,10 +4496,13 @@ export class SessionService {
       return () => {};
     }
 
+    const connectParams: ConnectParams = { task, repoPath };
+
     // A local task with no run means creation was interrupted before its
     // first run started (e.g. the app quit for an update mid-setup). Connect
     // fresh and deliver the prompt persisted as the task description, unless
-    // a creation saga is actively working on this task right now.
+    // a creation saga is actively working on this task right now. Recovery
+    // replays the description as literal text; original attachments are gone.
     if (!task.latest_run?.id) {
       if (this.isTaskCreationInFlight(taskId)) {
         this.logReconcileSkipOnce(taskId, "creation-in-flight");
@@ -4507,23 +4512,15 @@ export class SessionService {
         taskId,
         hasDescription: !!task.description,
       });
-      const connectParams: ConnectParams = { task, repoPath };
       if (task.description) {
         connectParams.initialPrompt = [
           { type: "text", text: task.description },
         ];
       }
-      this.reconcilingTasks.add(taskId);
-      this.connectToTask(connectParams).finally(() => {
-        this.reconcilingTasks.delete(taskId);
-      });
-      return () => {
-        this.reconcilingTasks.delete(taskId);
-      };
     }
 
     this.reconcilingTasks.add(taskId);
-    this.connectToTask({ task, repoPath }).finally(() => {
+    this.connectToTask(connectParams).finally(() => {
       this.reconcilingTasks.delete(taskId);
     });
 

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -508,6 +508,9 @@ function classifyTurnEventKind(
 export class SessionService {
   private connectingTasks = new Map<string, Promise<void>>();
   private reconcilingTasks = new Set<string>();
+  private reconcileSkipLogged = new Set<string>();
+  private taskCreationMarks = new Map<string, number>();
+  private static readonly TASK_CREATION_IN_FLIGHT_TTL_MS = 10 * 60 * 1000;
   private activityHeartbeats = new Map<
     string,
     ReturnType<typeof setInterval>
@@ -612,6 +615,7 @@ export class SessionService {
   async connectToTask(params: ConnectParams): Promise<void> {
     const { task } = params;
     const taskId = task.id;
+    this.taskCreationMarks.delete(taskId);
     this.localRepoPaths.set(taskId, params.repoPath);
     this.sessionLastUsedAt.set(taskId, Date.now());
     void this.evictIdleSessions(taskId);
@@ -4365,8 +4369,42 @@ export class SessionService {
       });
     }
 
+    this.logReconcileSkipOnce(task.id, "no-workspace-path", {
+      hasRun: !!task.latest_run?.id,
+    });
     this.loadLogsOnlyIfDisconnected(task, session);
     return () => {};
+  }
+
+  private logReconcileSkipOnce(
+    taskId: string,
+    reason: string,
+    context: Record<string, unknown> = {},
+  ): void {
+    const key = `${taskId}:${reason}`;
+    if (this.reconcileSkipLogged.has(key)) return;
+    this.reconcileSkipLogged.add(key);
+    this.d.log.info("Skipping local session reconcile", {
+      taskId,
+      reason,
+      ...context,
+    });
+  }
+
+  public markTaskCreationInFlight(taskId: string): void {
+    this.taskCreationMarks.set(taskId, Date.now());
+  }
+
+  private isTaskCreationInFlight(taskId: string): boolean {
+    const markedAt = this.taskCreationMarks.get(taskId);
+    if (markedAt === undefined) return false;
+    const expired =
+      Date.now() - markedAt > SessionService.TASK_CREATION_IN_FLIGHT_TTL_MS;
+    if (expired) {
+      this.taskCreationMarks.delete(taskId);
+      return false;
+    }
+    return true;
   }
 
   private reconcileCloudConnection(
@@ -4456,7 +4494,33 @@ export class SessionService {
       return () => {};
     }
 
-    if (!task.latest_run?.id) return () => {};
+    // A local task with no run means creation was interrupted before its
+    // first run started (e.g. the app quit for an update mid-setup). Connect
+    // fresh and deliver the prompt persisted as the task description, unless
+    // a creation saga is actively working on this task right now.
+    if (!task.latest_run?.id) {
+      if (this.isTaskCreationInFlight(taskId)) {
+        this.logReconcileSkipOnce(taskId, "creation-in-flight");
+        return () => {};
+      }
+      this.d.log.info("Recovering local task with no run", {
+        taskId,
+        hasDescription: !!task.description,
+      });
+      const connectParams: ConnectParams = { task, repoPath };
+      if (task.description) {
+        connectParams.initialPrompt = [
+          { type: "text", text: task.description },
+        ];
+      }
+      this.reconcilingTasks.add(taskId);
+      this.connectToTask(connectParams).finally(() => {
+        this.reconcilingTasks.delete(taskId);
+      });
+      return () => {
+        this.reconcilingTasks.delete(taskId);
+      };
+    }
 
     this.reconcilingTasks.add(taskId);
     this.connectToTask({ task, repoPath }).finally(() => {

--- a/packages/core/src/sessions/sessionServiceEviction.test.ts
+++ b/packages/core/src/sessions/sessionServiceEviction.test.ts
@@ -5,31 +5,18 @@ import { MAX_CONNECTED_SESSIONS } from "./sessionEviction";
 import {
   type ReconcileTaskConnectionParams,
   SessionService,
-  type SessionServiceDeps,
 } from "./sessionService";
+import {
+  makeAgentSession,
+  makeSessionServiceDeps,
+} from "./sessionServiceTestKit";
 
 function makeSession(
   taskId: string,
   startedAt: number,
   overrides: Partial<AgentSession> = {},
 ): AgentSession {
-  return {
-    taskRunId: `run-${taskId}`,
-    taskId,
-    taskTitle: taskId,
-    channel: "",
-    events: [],
-    startedAt,
-    status: "connected",
-    isPromptPending: false,
-    isCompacting: false,
-    promptStartedAt: null,
-    pendingPermissions: new Map(),
-    pausedDurationMs: 0,
-    messageQueue: [],
-    optimisticItems: [],
-    ...overrides,
-  } as AgentSession;
+  return makeAgentSession(taskId, { startedAt, ...overrides });
 }
 
 function createHarness(seedSessions: AgentSession[]) {
@@ -37,48 +24,14 @@ function createHarness(seedSessions: AgentSession[]) {
   for (const session of seedSessions) {
     sessions[session.taskRunId] = session;
   }
-  const removeSession = vi.fn((taskRunId: string) => {
-    delete sessions[taskRunId];
-  });
-  const cancelMutate = vi.fn().mockResolvedValue(undefined);
-  const removePersistedConfigOptions = vi.fn();
-  const removeAdapter = vi.fn();
-
-  const store = {
-    getSessions: () => sessions,
-    getSessionByTaskId: (taskId: string) =>
-      Object.values(sessions).find((s) => s.taskId === taskId),
-    removeSession,
-    updateSession: vi.fn(),
-  };
-
-  const log = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  };
-
-  const deps = {
-    store,
+  const {
+    deps,
     log,
-    getPersistedConfigOptions: () => undefined,
-    setPersistedConfigOptions: vi.fn(),
+    removeSession,
+    cancelMutate,
     removePersistedConfigOptions,
-    adapterStore: {
-      getAdapter: () => undefined,
-      setAdapter: vi.fn(),
-      removeAdapter,
-    },
-    trpc: {
-      agent: {
-        cancel: { mutate: cancelMutate },
-        onSessionIdleKilled: {
-          subscribe: () => ({ unsubscribe: vi.fn() }),
-        },
-      },
-    },
-  } as unknown as SessionServiceDeps;
+    removeAdapter,
+  } = makeSessionServiceDeps(sessions);
 
   const service = new SessionService(deps);
   return {

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -92,26 +92,28 @@ describe("SessionService run-less local task recovery", () => {
     vi.useRealTimers();
   });
 
-  it("starts a first run and sends the description as the prompt", () => {
-    const { service, connectToTask } = createHarness();
-    const task = makeTask();
-
-    reconcile(service, task);
-
-    expect(connectToTask).toHaveBeenCalledWith({
-      task,
-      repoPath: "/repo",
+  it.each([
+    {
+      case: "sends the description as the initial prompt",
+      description: "Ship the fix",
       initialPrompt: [{ type: "text", text: "Ship the fix" }],
-    });
-  });
-
-  it("connects without a prompt when the task has no description", () => {
+    },
+    {
+      case: "connects without a prompt when the description is empty",
+      description: "",
+      initialPrompt: undefined,
+    },
+  ])("starts a first run and $case", ({ description, initialPrompt }) => {
     const { service, connectToTask } = createHarness();
-    const task = makeTask({ description: "" });
+    const task = makeTask({ description });
 
     reconcile(service, task);
 
-    expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+    const expected: Record<string, unknown> = { task, repoPath: "/repo" };
+    if (initialPrompt) {
+      expected.initialPrompt = initialPrompt;
+    }
+    expect(connectToTask).toHaveBeenCalledWith(expected);
   });
 
   it("defers to an in-flight creation and recovers once the mark expires", () => {

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -5,9 +5,8 @@ import {
   type ReconcileTaskConnectionParams,
   SessionService,
   type SessionServiceDeps,
+  TASK_CREATION_IN_FLIGHT_TTL_MS,
 } from "./sessionService";
-
-const IN_FLIGHT_TTL_MS = 10 * 60 * 1000;
 
 function makeSession(taskId: string): AgentSession {
   return {
@@ -157,7 +156,7 @@ describe("SessionService run-less local task recovery", () => {
     reconcile(service, task);
     expect(connectToTask).not.toHaveBeenCalled();
 
-    vi.setSystemTime(IN_FLIGHT_TTL_MS + 1);
+    vi.setSystemTime(TASK_CREATION_IN_FLIGHT_TTL_MS + 1);
     reconcile(service, task);
     expect(connectToTask).toHaveBeenCalledTimes(1);
   });
@@ -186,5 +185,48 @@ describe("SessionService run-less local task recovery", () => {
     reconcile(service, task);
 
     expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+  });
+
+  function skipLogs(log: { info: ReturnType<typeof vi.fn> }, reason: string) {
+    return log.info.mock.calls.filter(
+      ([message, context]) =>
+        message === "Skipping local session reconcile" &&
+        (context as { reason?: string }).reason === reason,
+    );
+  }
+
+  it("logs the creation-in-flight skip once across repeated reconciles", () => {
+    const { service, log } = createHarness();
+    const task = makeTask();
+    service.markTaskCreationInFlight(task.id);
+
+    reconcile(service, task);
+    reconcile(service, task);
+
+    const skips = skipLogs(log, "creation-in-flight");
+    expect(skips).toHaveLength(1);
+    expect(skips[0][1]).toMatchObject({ taskId: task.id });
+  });
+
+  it("logs the missing-workspace-path skip once across repeated reconciles", () => {
+    const { service, log } = createHarness();
+    const task = makeTask();
+
+    const reconcileWithoutPath = () =>
+      service.reconcileTaskConnection({
+        task,
+        session: undefined,
+        repoPath: "",
+        isCloud: false,
+        isOnline: true,
+        cloudAuth: { status: "loading" },
+      } as ReconcileTaskConnectionParams);
+
+    reconcileWithoutPath();
+    reconcileWithoutPath();
+
+    const skips = skipLogs(log, "no-workspace-path");
+    expect(skips).toHaveLength(1);
+    expect(skips[0][1]).toMatchObject({ taskId: task.id, hasRun: false });
   });
 });

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -76,10 +76,14 @@ function createHarness({ spyConnect = true } = {}) {
   return { service, sessions, connectToTask, log };
 }
 
-function reconcile(service: SessionService, task: Task): () => void {
+function reconcile(
+  service: SessionService,
+  task: Task,
+  session?: AgentSession,
+): () => void {
   return service.reconcileTaskConnection({
     task,
-    session: undefined,
+    session,
     repoPath: "/repo",
     isCloud: false,
     isOnline: true,
@@ -114,6 +118,33 @@ describe("SessionService run-less local task recovery", () => {
       expected.initialPrompt = initialPrompt;
     }
     expect(connectToTask).toHaveBeenCalledWith(expected);
+  });
+
+  it("recovers a run-less task whose session is disconnected", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+    const session = {
+      ...makeSession(task.id),
+      status: "disconnected" as const,
+    };
+
+    reconcile(service, task, session);
+
+    expect(connectToTask).toHaveBeenCalledWith({
+      task,
+      repoPath: "/repo",
+      initialPrompt: [{ type: "text", text: "Ship the fix" }],
+    });
+  });
+
+  it("does not recover while a session is connecting", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+    const session = { ...makeSession(task.id), status: "connecting" as const };
+
+    reconcile(service, task, session);
+
+    expect(connectToTask).not.toHaveBeenCalled();
   });
 
   it("defers to an in-flight creation and recovers once the mark expires", () => {

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -4,28 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type ReconcileTaskConnectionParams,
   SessionService,
-  type SessionServiceDeps,
   TASK_CREATION_IN_FLIGHT_TTL_MS,
 } from "./sessionService";
+import {
+  makeAgentSession,
+  makeSessionServiceDeps,
+} from "./sessionServiceTestKit";
 
-function makeSession(taskId: string): AgentSession {
-  return {
-    taskRunId: `run-${taskId}`,
-    taskId,
-    taskTitle: taskId,
-    channel: "",
-    events: [],
-    startedAt: 1,
-    status: "connected",
-    isPromptPending: false,
-    isCompacting: false,
-    promptStartedAt: null,
-    pendingPermissions: new Map(),
-    pausedDurationMs: 0,
-    messageQueue: [],
-    optimisticItems: [],
-  } as AgentSession;
-}
+const makeSession = makeAgentSession;
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -38,35 +24,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
 }
 
 function createHarness({ spyConnect = true } = {}) {
-  const sessions: Record<string, AgentSession> = {};
-  const store = {
-    getSessions: () => sessions,
-    getSessionByTaskId: (taskId: string) =>
-      Object.values(sessions).find((s) => s.taskId === taskId),
-    removeSession: vi.fn(),
-    updateSession: vi.fn(),
-  };
-  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
-  const deps = {
-    store,
-    log,
-    getPersistedConfigOptions: () => undefined,
-    setPersistedConfigOptions: vi.fn(),
-    removePersistedConfigOptions: vi.fn(),
-    adapterStore: {
-      getAdapter: () => undefined,
-      setAdapter: vi.fn(),
-      removeAdapter: vi.fn(),
-    },
-    trpc: {
-      agent: {
-        cancel: { mutate: vi.fn().mockResolvedValue(undefined) },
-        onSessionIdleKilled: {
-          subscribe: () => ({ unsubscribe: vi.fn() }),
-        },
-      },
-    },
-  } as unknown as SessionServiceDeps;
+  const { deps, sessions, log } = makeSessionServiceDeps();
 
   const service = new SessionService(deps);
   const connectToTask = spyConnect

--- a/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -1,0 +1,157 @@
+import type { AgentSession } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ReconcileTaskConnectionParams,
+  SessionService,
+  type SessionServiceDeps,
+} from "./sessionService";
+
+const IN_FLIGHT_TTL_MS = 10 * 60 * 1000;
+
+function makeSession(taskId: string): AgentSession {
+  return {
+    taskRunId: `run-${taskId}`,
+    taskId,
+    taskTitle: taskId,
+    channel: "",
+    events: [],
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+  } as AgentSession;
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Test task",
+    description: "Ship the fix",
+    latest_run: null,
+    ...overrides,
+  } as Task;
+}
+
+function createHarness({ spyConnect = true } = {}) {
+  const sessions: Record<string, AgentSession> = {};
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    removeSession: vi.fn(),
+    updateSession: vi.fn(),
+  };
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const deps = {
+    store,
+    log,
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    removePersistedConfigOptions: vi.fn(),
+    adapterStore: {
+      getAdapter: () => undefined,
+      setAdapter: vi.fn(),
+      removeAdapter: vi.fn(),
+    },
+    trpc: {
+      agent: {
+        cancel: { mutate: vi.fn().mockResolvedValue(undefined) },
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  const connectToTask = spyConnect
+    ? vi.spyOn(service, "connectToTask").mockResolvedValue(undefined)
+    : undefined;
+  return { service, sessions, connectToTask, log };
+}
+
+function reconcile(service: SessionService, task: Task): () => void {
+  return service.reconcileTaskConnection({
+    task,
+    session: undefined,
+    repoPath: "/repo",
+    isCloud: false,
+    isOnline: true,
+    cloudAuth: { status: "loading" },
+  } as ReconcileTaskConnectionParams);
+}
+
+describe("SessionService run-less local task recovery", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts a first run and sends the description as the prompt", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+
+    reconcile(service, task);
+
+    expect(connectToTask).toHaveBeenCalledWith({
+      task,
+      repoPath: "/repo",
+      initialPrompt: [{ type: "text", text: "Ship the fix" }],
+    });
+  });
+
+  it("connects without a prompt when the task has no description", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask({ description: "" });
+
+    reconcile(service, task);
+
+    expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+  });
+
+  it("defers to an in-flight creation and recovers once the mark expires", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { service, connectToTask } = createHarness();
+    const task = makeTask();
+
+    service.markTaskCreationInFlight(task.id);
+    reconcile(service, task);
+    expect(connectToTask).not.toHaveBeenCalled();
+
+    vi.setSystemTime(IN_FLIGHT_TTL_MS + 1);
+    reconcile(service, task);
+    expect(connectToTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the in-flight mark when a connect starts", async () => {
+    const { service, sessions } = createHarness({ spyConnect: false });
+    const task = makeTask();
+    sessions[`run-${task.id}`] = makeSession(task.id);
+    service.markTaskCreationInFlight(task.id);
+
+    await service.connectToTask({ task, repoPath: "/repo" });
+
+    const connectToTask = vi
+      .spyOn(service, "connectToTask")
+      .mockResolvedValue(undefined);
+    reconcile(service, task);
+    expect(connectToTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes an existing run without injecting a prompt", () => {
+    const { service, connectToTask } = createHarness();
+    const task = makeTask({
+      latest_run: { id: "run-9" } as Task["latest_run"],
+    });
+
+    reconcile(service, task);
+
+    expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+  });
+});

--- a/packages/core/src/sessions/sessionServiceTestKit.ts
+++ b/packages/core/src/sessions/sessionServiceTestKit.ts
@@ -1,0 +1,75 @@
+import type { AgentSession } from "@posthog/shared";
+import { vi } from "vitest";
+import type { SessionServiceDeps } from "./sessionService";
+
+export function makeAgentSession(
+  taskId: string,
+  overrides: Partial<AgentSession> = {},
+): AgentSession {
+  return {
+    taskRunId: `run-${taskId}`,
+    taskId,
+    taskTitle: taskId,
+    channel: "",
+    events: [],
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    ...overrides,
+  } as AgentSession;
+}
+
+export function makeSessionServiceDeps(
+  sessions: Record<string, AgentSession> = {},
+) {
+  const removeSession = vi.fn((taskRunId: string) => {
+    delete sessions[taskRunId];
+  });
+  const cancelMutate = vi.fn().mockResolvedValue(undefined);
+  const removePersistedConfigOptions = vi.fn();
+  const removeAdapter = vi.fn();
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+  const deps = {
+    store: {
+      getSessions: () => sessions,
+      getSessionByTaskId: (taskId: string) =>
+        Object.values(sessions).find((s) => s.taskId === taskId),
+      removeSession,
+      updateSession: vi.fn(),
+    },
+    log,
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    removePersistedConfigOptions,
+    adapterStore: {
+      getAdapter: () => undefined,
+      setAdapter: vi.fn(),
+      removeAdapter,
+    },
+    trpc: {
+      agent: {
+        cancel: { mutate: cancelMutate },
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  return {
+    deps,
+    sessions,
+    log,
+    removeSession,
+    cancelMutate,
+    removePersistedConfigOptions,
+    removeAdapter,
+  };
+}

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -40,6 +40,7 @@ const sessionService = {
   connectToTask: vi.fn(),
   disconnectFromTask: vi.fn(),
   rememberInitialCloudPrompt: vi.fn(),
+  markTaskCreationInFlight: vi.fn(),
 } as unknown as SessionService;
 
 const createTask = (overrides: Partial<Task> = {}): Task => ({

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -751,6 +751,31 @@ describe("TaskCreationSaga", () => {
     );
   });
 
+  it("marks task creation in flight before connecting the session", async () => {
+    const createTaskMock = vi.fn().mockResolvedValue(createTask());
+    mockHost.addFolder.mockResolvedValue({ id: "folder-1", path: "/repo" });
+    mockHost.detectRepo.mockResolvedValue(null);
+
+    const saga = makeSaga({ createTask: createTaskMock });
+
+    const result = await saga.run({
+      content: "Ship the fix",
+      repoPath: "/repo",
+      workspaceMode: "local",
+    });
+
+    expect(result.success).toBe(true);
+    expect(sessionService.markTaskCreationInFlight).toHaveBeenCalledWith(
+      "task-123",
+    );
+    expect(
+      vi.mocked(sessionService.markTaskCreationInFlight).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(sessionService.connectToTask).mock.invocationCallOrder[0],
+    );
+  });
+
   it("rolls back the import snapshot and tracking row when a later step fails", async () => {
     const createdTask = createTask();
     const createTaskMock = vi.fn().mockResolvedValue(createdTask);

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -776,6 +776,29 @@ describe("TaskCreationSaga", () => {
     );
   });
 
+  it("does not mark creation in flight for a cloud create", async () => {
+    const createTaskMock = vi.fn().mockResolvedValue(createTask());
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi
+      .fn()
+      .mockResolvedValue(createTask({ latest_run: createRun() }));
+
+    const saga = makeSaga({
+      createTask: createTaskMock,
+      createTaskRun: createTaskRunMock,
+      startTaskRun: startTaskRunMock,
+    });
+
+    const result = await saga.run({
+      content: "Ship the fix",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+    });
+
+    expect(result.success).toBe(true);
+    expect(sessionService.markTaskCreationInFlight).not.toHaveBeenCalled();
+  });
+
   it("rolls back the import snapshot and tracking row when a later step fails", async () => {
     const createdTask = createTask();
     const createTaskMock = vi.fn().mockResolvedValue(createdTask);

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -161,6 +161,8 @@ export class TaskCreationSaga extends Saga<
           error,
         });
         this.deps.host.clearProvisioning(task.id);
+        // The in-flight mark is left to TTL-expire on purpose: this state has
+        // its own retry-prompt UX, and auto-recovery would race the retry.
         return { task, workspace: null, provisioningError };
       }
     } else if (workspaceMode === "cloud") {

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -62,9 +62,16 @@ export class TaskCreationSaga extends Saga<
         )
       : await this.createTask(input);
 
+    const workspaceMode =
+      input.workspaceMode ??
+      (task.latest_run?.environment === "cloud" ? "cloud" : "local");
+
     // Session reconcile auto-recovers run-less local tasks; mark this one as
     // mid-creation so the recovery doesn't race the agent_session step below.
-    this.deps.sessionService.markTaskCreationInFlight(task.id);
+    // Cloud creates never connect locally, so nothing would clear their mark.
+    if (workspaceMode !== "cloud") {
+      this.deps.sessionService.markTaskCreationInFlight(task.id);
+    }
 
     if (importedClaude && input.repoPath) {
       await this.recordClaudeImport(input, importedClaude, task.id);
@@ -76,10 +83,6 @@ export class TaskCreationSaga extends Saga<
       (await this.readOnlyStep("resolve_repo_path", () =>
         this.deps.host.getTaskDirectory(task.id, repoKey ?? undefined),
       ));
-
-    const workspaceMode =
-      input.workspaceMode ??
-      (task.latest_run?.environment === "cloud" ? "cloud" : "local");
 
     let workspace: Workspace | null = null;
     const branch = input.branch ?? task.latest_run?.branch ?? null;

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -62,6 +62,10 @@ export class TaskCreationSaga extends Saga<
         )
       : await this.createTask(input);
 
+    // Session reconcile auto-recovers run-less local tasks; mark this one as
+    // mid-creation so the recovery doesn't race the agent_session step below.
+    this.deps.sessionService.markTaskCreationInFlight(task.id);
+
     if (importedClaude && input.repoPath) {
       await this.recordClaudeImport(input, importedClaude, task.id);
     }

--- a/packages/core/src/updates/updates.test.ts
+++ b/packages/core/src/updates/updates.test.ts
@@ -389,14 +389,14 @@ describe("UpdatesService", () => {
       );
 
       const resultPromise = service.installUpdate();
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(15_000);
 
       await expect(resultPromise).resolves.toEqual({ installed: true });
       expect(mockUpdater.quitAndInstall).toHaveBeenCalled();
       expect(mockLog.warn).toHaveBeenCalledWith(
         "Partial shutdown timed out before update install",
         expect.objectContaining({
-          timeoutMs: 3000,
+          timeoutMs: 15_000,
           downloadedVersion: "v2.0.0",
         }),
       );

--- a/packages/core/src/updates/updates.ts
+++ b/packages/core/src/updates/updates.ts
@@ -50,7 +50,10 @@ type TransitionContext = {
 export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
   private static readonly CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
   private static readonly CHECK_TIMEOUT_MS = 60 * 1000; // 1 minute timeout for checks
-  private static readonly INSTALL_SHUTDOWN_TIMEOUT_MS = 3000;
+  // Must exceed AppLifecycleService.PENDING_CREATION_WAIT_MS (10s) plus
+  // teardown headroom, or the pending-creation wait inside partial shutdown
+  // gets cut off and quitAndInstall proceeds without any teardown at all.
+  private static readonly INSTALL_SHUTDOWN_TIMEOUT_MS = 15_000;
 
   @inject(UPDATE_LIFECYCLE_SERVICE)
   private lifecycle!: IUpdateLifecycle;

--- a/packages/core/src/updates/updates.ts
+++ b/packages/core/src/updates/updates.ts
@@ -46,14 +46,15 @@ type TransitionContext = {
   error?: string;
 };
 
+// Must exceed the app lifecycle's PENDING_CREATION_WAIT_MS (10s) plus
+// teardown headroom, or the pending-creation wait inside partial shutdown
+// gets cut off and quitAndInstall proceeds without any teardown at all.
+export const INSTALL_SHUTDOWN_TIMEOUT_MS = 15_000;
+
 @injectable()
 export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
   private static readonly CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
   private static readonly CHECK_TIMEOUT_MS = 60 * 1000; // 1 minute timeout for checks
-  // Must exceed AppLifecycleService.PENDING_CREATION_WAIT_MS (10s) plus
-  // teardown headroom, or the pending-creation wait inside partial shutdown
-  // gets cut off and quitAndInstall proceeds without any teardown at all.
-  private static readonly INSTALL_SHUTDOWN_TIMEOUT_MS = 15_000;
 
   @inject(UPDATE_LIFECYCLE_SERVICE)
   private lifecycle!: IUpdateLifecycle;
@@ -255,11 +256,11 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       this.lifecycle.setQuittingForUpdate();
       const cleanupResult = await withTimeout(
         this.lifecycle.shutdownWithoutContainer(),
-        UpdatesService.INSTALL_SHUTDOWN_TIMEOUT_MS,
+        INSTALL_SHUTDOWN_TIMEOUT_MS,
       );
       if (cleanupResult.result === "timeout") {
         this.log.warn("Partial shutdown timed out before update install", {
-          timeoutMs: UpdatesService.INSTALL_SHUTDOWN_TIMEOUT_MS,
+          timeoutMs: INSTALL_SHUTDOWN_TIMEOUT_MS,
           downloadedVersion: this.downloadedVersion,
         });
       }

--- a/packages/ui/src/features/navigation/taskBinderImpl.test.ts
+++ b/packages/ui/src/features/navigation/taskBinderImpl.test.ts
@@ -1,0 +1,179 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const services = vi.hoisted(() => new Map<symbol, unknown>());
+
+vi.mock("@posthog/di/container", () => ({
+  resolveService: (token: symbol) => services.get(token),
+}));
+
+vi.mock("@posthog/ui/shell/logger", () => ({
+  logger: {
+    scope: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+import { HOST_TRPC_CLIENT } from "@posthog/host-router/client";
+import { WORKSPACE_QUERY_KEY } from "@posthog/ui/features/workspace/identifiers";
+import { IMPERATIVE_QUERY_CLIENT } from "@posthog/ui/shell/queryClient";
+import { navigationTaskBinder } from "./taskBinderImpl";
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Test task",
+    description: "Ship the fix",
+    repository: "posthog/code",
+    latest_run: null,
+    ...overrides,
+  } as Task;
+}
+
+function setup({
+  workspaces = {},
+  folders = [] as Array<{ id: string; path: string; exists: boolean }>,
+  repositoryPath = null as string | null,
+} = {}) {
+  const workspaceGetAll = vi.fn().mockResolvedValue(workspaces);
+  const workspaceCreate = vi.fn().mockResolvedValue(undefined);
+  const foldersGetFolders = vi.fn().mockResolvedValue(folders);
+  const addFolder = vi.fn().mockResolvedValue(undefined);
+  const getRepositoryByRemoteUrl = vi
+    .fn()
+    .mockResolvedValue(repositoryPath ? { path: repositoryPath } : null);
+  const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+
+  services.set(HOST_TRPC_CLIENT, {
+    workspace: {
+      getAll: { query: workspaceGetAll },
+      create: { mutate: workspaceCreate },
+    },
+    folders: {
+      getFolders: { query: foldersGetFolders },
+      addFolder: { mutate: addFolder },
+      getRepositoryByRemoteUrl: { query: getRepositoryByRemoteUrl },
+    },
+  });
+  services.set(IMPERATIVE_QUERY_CLIENT, { invalidateQueries });
+
+  return {
+    workspaceCreate,
+    addFolder,
+    getRepositoryByRemoteUrl,
+    invalidateQueries,
+  };
+}
+
+beforeEach(() => {
+  services.clear();
+});
+
+describe("navigationTaskBinder.ensureWorkspaceForTask", () => {
+  it("defers workspace creation for a task with no run", async () => {
+    const { workspaceCreate, addFolder, getRepositoryByRemoteUrl } = setup({
+      repositoryPath: "/repo",
+    });
+    const task = makeTask();
+
+    const result = await navigationTaskBinder.ensureWorkspaceForTask(task);
+
+    expect(result).toBeUndefined();
+    expect(getRepositoryByRemoteUrl).not.toHaveBeenCalled();
+    expect(addFolder).not.toHaveBeenCalled();
+    expect(workspaceCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { environment: "local", mode: "local" },
+    { environment: "cloud", mode: "cloud" },
+  ])(
+    "binds a $environment run with a resolved directory as mode $mode",
+    async ({ environment, mode }) => {
+      const { workspaceCreate, addFolder, invalidateQueries } = setup({
+        repositoryPath: "/repo",
+      });
+      const task = makeTask({
+        latest_run: { id: "run-1", environment } as Task["latest_run"],
+      });
+
+      await navigationTaskBinder.ensureWorkspaceForTask(task);
+
+      expect(addFolder).toHaveBeenCalledWith({ folderPath: "/repo" });
+      expect(workspaceCreate).toHaveBeenCalledWith({
+        taskId: task.id,
+        mainRepoPath: "/repo",
+        folderId: "",
+        folderPath: "/repo",
+        mode,
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: WORKSPACE_QUERY_KEY,
+      });
+    },
+  );
+
+  it("creates a cloud workspace when a cloud run resolves no directory", async () => {
+    const { workspaceCreate, invalidateQueries } = setup();
+    const task = makeTask({
+      latest_run: { id: "run-1", environment: "cloud" } as Task["latest_run"],
+    });
+
+    await navigationTaskBinder.ensureWorkspaceForTask(task);
+
+    expect(workspaceCreate).toHaveBeenCalledWith({
+      taskId: task.id,
+      mainRepoPath: "",
+      folderId: "",
+      folderPath: "",
+      mode: "cloud",
+    });
+    expect(invalidateQueries).toHaveBeenCalled();
+  });
+
+  it("does nothing when a local run resolves no directory", async () => {
+    const { workspaceCreate, invalidateQueries } = setup();
+    const task = makeTask({
+      latest_run: { id: "run-1", environment: "local" } as Task["latest_run"],
+    });
+
+    await navigationTaskBinder.ensureWorkspaceForTask(task);
+
+    expect(workspaceCreate).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing workspace whose folder is still live", async () => {
+    const { workspaceCreate, invalidateQueries } = setup({
+      workspaces: { "task-1": { folderId: "f1" } },
+      folders: [{ id: "f1", path: "/repo", exists: true }],
+    });
+    const task = makeTask({
+      latest_run: { id: "run-1", environment: "local" } as Task["latest_run"],
+    });
+
+    const result = await navigationTaskBinder.ensureWorkspaceForTask(task);
+
+    expect(result).toBeUndefined();
+    expect(workspaceCreate).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate the workspace cache when creation fails", async () => {
+    const { workspaceCreate, invalidateQueries } = setup({
+      repositoryPath: "/repo",
+    });
+    workspaceCreate.mockRejectedValueOnce(new Error("db locked"));
+    const task = makeTask({
+      latest_run: { id: "run-1", environment: "local" } as Task["latest_run"],
+    });
+
+    await navigationTaskBinder.ensureWorkspaceForTask(task);
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/features/navigation/taskBinderImpl.ts
+++ b/packages/ui/src/features/navigation/taskBinderImpl.ts
@@ -10,12 +10,23 @@ import type {
   NavigationTaskBinder,
 } from "@posthog/ui/features/navigation/taskBinder";
 import { useProvisioningStore } from "@posthog/ui/features/provisioning/store";
+import { WORKSPACE_QUERY_KEY } from "@posthog/ui/features/workspace/identifiers";
 import { logger } from "@posthog/ui/shell/logger";
+import {
+  IMPERATIVE_QUERY_CLIENT,
+  type ImperativeQueryClient,
+} from "@posthog/ui/shell/queryClient";
 
 const log = logger.scope("navigation-store");
 
 function hostClient(): HostTrpcClient {
   return resolveService<HostTrpcClient>(HOST_TRPC_CLIENT);
+}
+
+function invalidateWorkspaces(): void {
+  void resolveService<ImperativeQueryClient>(
+    IMPERATIVE_QUERY_CLIENT,
+  ).invalidateQueries({ queryKey: WORKSPACE_QUERY_KEY });
 }
 
 async function getTaskDirectory(
@@ -84,11 +95,17 @@ export const navigationTaskBinder: NavigationTaskBinder = {
     const directory = await getTaskDirectory(task.id, repoKey ?? undefined);
 
     if (directory) {
+      const workspaceMode =
+        task.latest_run?.environment === "cloud" ? "cloud" : "local";
+      log.info("Ensuring workspace binding on task open", {
+        taskId: task.id,
+        directory,
+        mode: workspaceMode,
+        hadWorkspaceRecord: !!existingWorkspace,
+        hasRun: !!task.latest_run?.id,
+      });
       try {
         await hostClient().folders.addFolder.mutate({ folderPath: directory });
-
-        const workspaceMode =
-          task.latest_run?.environment === "cloud" ? "cloud" : "local";
 
         await hostClient().workspace.create.mutate({
           taskId: task.id,
@@ -97,6 +114,7 @@ export const navigationTaskBinder: NavigationTaskBinder = {
           folderPath: directory,
           mode: workspaceMode,
         });
+        invalidateWorkspaces();
       } catch (error) {
         log.error("Failed to auto-register folder on task open:", error);
       }
@@ -107,6 +125,13 @@ export const navigationTaskBinder: NavigationTaskBinder = {
         folderId: "",
         folderPath: "",
         mode: "cloud",
+      });
+      invalidateWorkspaces();
+    } else {
+      log.warn("No directory resolved on task open, workspace not created", {
+        taskId: task.id,
+        repoKey: repoKey ?? null,
+        hasRun: !!task.latest_run?.id,
       });
     }
 

--- a/packages/ui/src/features/navigation/taskBinderImpl.ts
+++ b/packages/ui/src/features/navigation/taskBinderImpl.ts
@@ -92,17 +92,30 @@ export const navigationTaskBinder: NavigationTaskBinder = {
       }
     }
 
-    const directory = await getTaskDirectory(task.id, repoKey ?? undefined);
+    const hasRun = !!task.latest_run?.id;
+    const isCloudRun = task.latest_run?.environment === "cloud";
+
+    // A run-less task is mid-creation or had its creation interrupted; its
+    // intended mode isn't knowable from here, and defaulting to "local" would
+    // hand a cloud-intended task's recovery a local checkout. Leave the
+    // workspace row to the creation saga (or its retry) instead.
+    if (!hasRun) {
+      log.info("Task has no run yet, deferring workspace creation", {
+        taskId: task.id,
+        repoKey: repoKey ?? null,
+      });
+      return undefined;
+    }
+
+    const directory = await getTaskDirectory(task.id, repoKey);
 
     if (directory) {
-      const workspaceMode =
-        task.latest_run?.environment === "cloud" ? "cloud" : "local";
+      const workspaceMode = isCloudRun ? "cloud" : "local";
       log.info("Ensuring workspace binding on task open", {
         taskId: task.id,
         directory,
         mode: workspaceMode,
         hadWorkspaceRecord: !!existingWorkspace,
-        hasRun: !!task.latest_run?.id,
       });
       try {
         await hostClient().folders.addFolder.mutate({ folderPath: directory });
@@ -118,7 +131,7 @@ export const navigationTaskBinder: NavigationTaskBinder = {
       } catch (error) {
         log.error("Failed to auto-register folder on task open:", error);
       }
-    } else if (task.latest_run?.environment === "cloud") {
+    } else if (isCloudRun) {
       await hostClient().workspace.create.mutate({
         taskId: task.id,
         mainRepoPath: "",
@@ -131,7 +144,6 @@ export const navigationTaskBinder: NavigationTaskBinder = {
       log.warn("No directory resolved on task open, workspace not created", {
         taskId: task.id,
         repoKey: repoKey ?? null,
-        hasRun: !!task.latest_run?.id,
       });
     }
 

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -578,6 +578,64 @@ describe("WorkspaceService", () => {
     });
   });
 
+  describe("pending creations", () => {
+    afterEach(() => {
+      vi.mocked(getCurrentBranch).mockReset();
+    });
+
+    function localInput(taskId: string): CreateWorkspaceInput {
+      return {
+        taskId,
+        mainRepoPath: "/repo",
+        folderId: "folder-1",
+        folderPath: "/repo",
+        mode: "local",
+        branch: "feature/x",
+      };
+    }
+
+    it("tracks in-flight creations and clears them when creation settles", async () => {
+      let rejectBranch: (error: Error) => void = () => {};
+      vi.mocked(getCurrentBranch).mockReturnValue(
+        new Promise((_, reject) => {
+          rejectBranch = reject;
+        }),
+      );
+
+      const pending = service.createWorkspace(localInput("task-1"));
+      expect(service.pendingCreationCount).toBe(1);
+
+      rejectBranch(new Error("boom"));
+      await expect(pending).rejects.toThrow("boom");
+      expect(service.pendingCreationCount).toBe(0);
+    });
+
+    it("waitForPendingCreations resolves even when creations reject", async () => {
+      const rejectors: Array<(error: Error) => void> = [];
+      const deferredBranch = () =>
+        new Promise<string | null>((_, reject) => {
+          rejectors.push(reject);
+        });
+      vi.mocked(getCurrentBranch)
+        .mockReturnValueOnce(deferredBranch())
+        .mockReturnValueOnce(deferredBranch());
+
+      const first = service.createWorkspace(localInput("task-1"));
+      const second = service.createWorkspace(localInput("task-2"));
+      expect(service.pendingCreationCount).toBe(2);
+
+      const wait = service.waitForPendingCreations();
+      for (const reject of rejectors) {
+        reject(new Error("boom"));
+      }
+
+      await expect(wait).resolves.toBeUndefined();
+      await expect(first).rejects.toThrow("boom");
+      await expect(second).rejects.toThrow("boom");
+      expect(service.pendingCreationCount).toBe(0);
+    });
+  });
+
   describe("worktree path resolved from the stored row", () => {
     const tempDirs: string[] = [];
 

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -531,6 +531,14 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     };
   }
 
+  get pendingCreationCount(): number {
+    return this.creatingWorkspaces.size;
+  }
+
+  async waitForPendingCreations(): Promise<void> {
+    await Promise.allSettled([...this.creatingWorkspaces.values()]);
+  }
+
   async createWorkspace(options: CreateWorkspaceInput): Promise<WorkspaceInfo> {
     // Prevent concurrent workspace creation for the same task
     const existingPromise = this.creatingWorkspaces.get(options.taskId);
@@ -541,11 +549,22 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       return existingPromise;
     }
 
+    const startedAt = Date.now();
     const promise = this.doCreateWorkspace(options);
     this.creatingWorkspaces.set(options.taskId, promise);
 
     try {
-      return await promise;
+      const workspaceInfo = await promise;
+      this.log.info(
+        `Workspace ready for task ${options.taskId} after ${Date.now() - startedAt}ms (mode: ${workspaceInfo.mode})`,
+      );
+      return workspaceInfo;
+    } catch (error) {
+      this.log.error(
+        `Workspace creation failed for task ${options.taskId} after ${Date.now() - startedAt}ms`,
+        error,
+      );
+      throw error;
     } finally {
       this.creatingWorkspaces.delete(options.taskId);
     }
@@ -629,6 +648,9 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         repositoryId,
         mode: "local",
       });
+      this.log.info(
+        `Workspace record persisted for task ${taskId} (mode: local)`,
+      );
 
       const localBranch = await getBranchFromPath(folderPath);
       return {


### PR DESCRIPTION
## Problem

An update install (or any quit) landing while a task's creation saga is still running leaves the task permanently half-provisioned: the task row exists on the server but no workspace or first run was ever created, and reopening the task did nothing. Update installs also tore down processes while workspace creation writes were mid-flight.

## Changes

Recovery flow:

- `WorkspaceService` tracks in-flight creations (`pendingCreationCount`, `waitForPendingCreations`), and partial shutdown before `quitAndInstall` now waits up to 10s for them to settle before tearing down processes and closing the DB.
- Session reconcile recovers a local task that has no run: it connects fresh and replays the persisted task description as the initial prompt. A creation-in-flight mark (10 min TTL) stops recovery from racing an active creation saga, and is cleared as soon as the saga's own connect starts.
- `taskBinderImpl` invalidates the workspace query cache after binding so the task view picks the new workspace up immediately.

Hardening on top of that (from branch review):

- Raised the install shutdown timeout from 3s to 15s: the old outer 3s `withTimeout` cut off the new inner 10s wait every time, and a guard test now pins the install budget to keep headroom over the creation wait so the nesting can't silently regress.
- Run-less tasks no longer get a workspace row fabricated on open. Guessing the mode there defaulted a cloud-intended task to "local" when creation was interrupted before its workspace row persisted, which would have let recovery silently start a local agent with the task's prompt. Recovery now only engages when the saga-persisted workspace (with its true mode) exists.
- Cloud creates no longer set the creation-in-flight mark (nothing on the cloud path ever cleared it, leaking an entry per created task).
- `reset()` clears the new per-task state; reconcile skip logs are deduped per task and reason; the TTL constant is exported and imported by tests instead of hand-copied.

## How did you test this?

- New unit coverage: run-less recovery branch (prompt replay, empty description, in-flight deferral, TTL expiry, mark cleared on connect, session-status guard precedence, skip-log dedup), workspace pending-creation tracking (count lifecycle, settled-on-failure, concurrency), saga mark ordering plus cloud no-mark, taskBinder binding matrix (defer without run, local/cloud modes, cloud fallback, no-invalidate on failure, live-folder reuse) and the shutdown budget relationship.
- Full suites green: packages/core 1936 tests, packages/ui 1215, apps/code 183. Typecheck passes in core, ui and both apps/code tsconfigs. Biome clean on all touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
