### PR TITLE
fix(agent): coalesce cumulative rawInput streaming snapshots in session logs

### DIFF
--- a/packages/agent/src/session-log-writer.test.ts
+++ b/packages/agent/src/session-log-writer.test.ts
@@ -417,6 +417,176 @@ describe("SessionLogWriter", () => {
     });
   });
 
+  describe("API-path rawInput snapshot coalescing", () => {
+    function rawInputSnapshot(toolCallId: string, rawInput: unknown): string {
+      return makeSessionUpdate("tool_call_update", { toolCallId, rawInput });
+    }
+
+    it("persists only the last cumulative snapshot, before the completing update", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("tool_call", {
+          toolCallId: "tc1",
+          status: "pending",
+        }),
+      );
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", {}));
+      logWriter.appendRawLine(
+        sessionId,
+        rawInputSnapshot("tc1", { command: "ls" }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        rawInputSnapshot("tc1", { command: "ls -la" }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("tool_call_update", {
+          toolCallId: "tc1",
+          status: "completed",
+          rawOutput: { content: [] },
+        }),
+      );
+
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries).toHaveLength(3);
+      expect(entries[1].notification.params?.update).toEqual({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc1",
+        rawInput: { command: "ls -la" },
+      });
+      expect(
+        (entries[2].notification.params?.update as { status?: string }).status,
+      ).toBe("completed");
+    });
+
+    it("drops the buffered snapshot when a richer update carries rawInput itself", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", { a: 1 }));
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("tool_call_update", {
+          toolCallId: "tc1",
+          title: "Execute command",
+          kind: "execute",
+          rawInput: { a: 1, b: 2 },
+        }),
+      );
+
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries).toHaveLength(1);
+      expect(entries[0].notification.params?.update).toEqual({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc1",
+        title: "Execute command",
+        kind: "execute",
+        rawInput: { a: 1, b: 2 },
+      });
+    });
+
+    it("buffers interleaved tool calls independently", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", { n: 1 }));
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc2", { m: 1 }));
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", { n: 2 }));
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc2", { m: 2 }));
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("tool_call_update", {
+          toolCallId: "tc1",
+          status: "completed",
+          rawOutput: {},
+        }),
+      );
+
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries).toHaveLength(2);
+      expect(entries[0].notification.params?.update).toEqual({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc1",
+        rawInput: { n: 2 },
+      });
+    });
+
+    it("does not emit buffered snapshots on a timed flush mid-stream", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", { a: 1 }));
+
+      await logWriter.flush(sessionId);
+
+      expect(mockAppendLog).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        drainVia: "flushAll",
+        drain: (writer: SessionLogWriter) => writer.flushAll(),
+      },
+      {
+        drainVia: "flush with coalesce",
+        drain: (writer: SessionLogWriter) =>
+          writer.flush("s1", { coalesce: true }),
+      },
+    ])(
+      "drains buffered snapshots on $drainVia, keeping only the latest",
+      async ({ drain }) => {
+        const sessionId = "s1";
+        logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+        logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", { a: 1 }));
+        logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", { a: 2 }));
+
+        await drain(logWriter);
+
+        expect(mockAppendLog).toHaveBeenCalledTimes(1);
+        const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+        expect(entries).toHaveLength(1);
+        expect(entries[0].notification.params?.update).toEqual({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tc1",
+          rawInput: { a: 2 },
+        });
+      },
+    );
+
+    it("keeps snapshots buffered while other events flow to the API", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(sessionId, rawInputSnapshot("tc1", { a: 1 }));
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_message", {
+          content: { type: "text", text: "still working" },
+        }),
+      );
+
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries).toHaveLength(1);
+      expect(
+        (entries[0].notification.params?.update as { sessionUpdate?: string })
+          .sessionUpdate,
+      ).toBe("agent_message");
+    });
+  });
+
   describe("register", () => {
     it("does not re-register existing sessions", () => {
       const sessionId = "s1";
@@ -605,7 +775,7 @@ describe("SessionLogWriter — local-cache tool_call_update coalescing", () => {
     });
   });
 
-  it("keeps every uncoalesced update on the API path, unmutated by the merge", async () => {
+  it("keeps the final snapshot and terminal update on the API path, unmutated by the merge", async () => {
     const appendLog = vi.fn().mockResolvedValue(undefined);
     const apiWriter = new SessionLogWriter({
       localCachePath: tmp,

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -44,6 +44,7 @@ interface SessionState {
   lastAgentMessage?: string;
   currentTurnMessages: string[];
   toolUpdateCache: Map<string, BufferedToolUpdate>;
+  pendingRawInputSnapshots: Map<string, StoredNotification>;
 }
 
 export class SessionLogWriter {
@@ -51,9 +52,10 @@ export class SessionLogWriter {
    * When consecutive in-progress tool updates for one call span more than this
    * window, the buffered union is written and a new window starts, so the
    * local cache keeps periodic snapshots during active streaming instead of only
-   * the final one. Not a durability bound: the API log receives every update
-   * uncoalesced and the local file is a load cache. A buffered union is
-   * otherwise written on a terminal update, any non-tool event, or flushAll.
+   * the final one. Not a durability bound: the local file is a load cache, and
+   * the API log keeps every update except intermediate rawInput-only streaming
+   * snapshots (see queueForApiLog). A buffered union is otherwise written on a
+   * terminal update, any non-tool event, or flushAll.
    */
   private static readonly TOOL_UPDATE_MAX_HOLD_MS = 2000;
   private static readonly FLUSH_DEBOUNCE_MS = 500;
@@ -89,6 +91,7 @@ export class SessionLogWriter {
     for (const [sessionId, session] of this.sessions) {
       this.emitCoalescedMessage(sessionId, session);
       this.flushToolUpdateCache(sessionId, session);
+      this.drainRawInputSnapshots(sessionId, session);
       flushPromises.push(this.flush(sessionId));
     }
     await Promise.all(flushPromises);
@@ -103,6 +106,7 @@ export class SessionLogWriter {
       context,
       currentTurnMessages: [],
       toolUpdateCache: new Map(),
+      pendingRawInputSnapshots: new Map(),
     });
 
     this.lastFlushAttemptTime.set(sessionId, Date.now());
@@ -180,8 +184,7 @@ export class SessionLogWriter {
       // snapshots (they re-send the full growing output) and write one merged
       // update per toolCallId. Written on a terminal update, any non-tool
       // event, or — during a long run of updates — once the hold window is
-      // exceeded. The API path is untouched, so the durable log keeps every
-      // update.
+      // exceeded. The API path coalesces separately in queueForApiLog.
       const tcu = this.toolCallUpdateInfo(message);
       if (tcu && !tcu.terminal) {
         const cache = session.toolUpdateCache;
@@ -232,10 +235,7 @@ export class SessionLogWriter {
       }
 
       if (this.posthogAPI) {
-        const pending = this.pendingEntries.get(sessionId) ?? [];
-        pending.push(entry);
-        this.pendingEntries.set(sessionId, pending);
-        this.scheduleFlush(sessionId);
+        this.queueForApiLog(sessionId, session, entry, tcu);
       }
     } catch {
       this.logger.warn("Failed to parse raw line for persistence", {
@@ -254,6 +254,7 @@ export class SessionLogWriter {
       const session = this.sessions.get(sessionId);
       if (session) {
         this.emitCoalescedMessage(sessionId, session);
+        this.drainRawInputSnapshots(sessionId, session);
       }
     }
 
@@ -386,6 +387,54 @@ export class SessionLogWriter {
     session.toolUpdateCache.clear();
   }
 
+  private queueForApiLog(
+    sessionId: string,
+    session: SessionState,
+    entry: StoredNotification,
+    tcu: { toolCallId: string; update: Record<string, unknown> } | null,
+  ): void {
+    if (tcu && this.isRawInputOnlyUpdate(tcu.update)) {
+      session.pendingRawInputSnapshots.set(tcu.toolCallId, entry);
+      return;
+    }
+    if (tcu) {
+      const buffered = session.pendingRawInputSnapshots.get(tcu.toolCallId);
+      if (buffered) {
+        session.pendingRawInputSnapshots.delete(tcu.toolCallId);
+        if (tcu.update.rawInput === undefined) {
+          this.pushPendingEntry(sessionId, buffered);
+        }
+      }
+    }
+    this.pushPendingEntry(sessionId, entry);
+  }
+
+  private isRawInputOnlyUpdate(update: Record<string, unknown>): boolean {
+    if (update.rawInput === undefined) return false;
+    return Object.keys(update).every(
+      (key) =>
+        key === "sessionUpdate" || key === "toolCallId" || key === "rawInput",
+    );
+  }
+
+  private pushPendingEntry(sessionId: string, entry: StoredNotification): void {
+    const pending = this.pendingEntries.get(sessionId) ?? [];
+    pending.push(entry);
+    this.pendingEntries.set(sessionId, pending);
+    this.scheduleFlush(sessionId);
+  }
+
+  private drainRawInputSnapshots(
+    sessionId: string,
+    session: SessionState,
+  ): void {
+    if (session.pendingRawInputSnapshots.size === 0) return;
+    for (const entry of session.pendingRawInputSnapshots.values()) {
+      this.pushPendingEntry(sessionId, entry);
+    }
+    session.pendingRawInputSnapshots.clear();
+  }
+
   private isAgentMessageChunk(message: Record<string, unknown>): boolean {
     return this.getSessionUpdateType(message) === "agent_message_chunk";
   }
@@ -428,10 +477,7 @@ export class SessionLogWriter {
     this.writeToLocalCache(sessionId, entry);
 
     if (this.posthogAPI) {
-      const pending = this.pendingEntries.get(sessionId) ?? [];
-      pending.push(entry);
-      this.pendingEntries.set(sessionId, pending);
-      this.scheduleFlush(sessionId);
+      this.pushPendingEntry(sessionId, entry);
     }
   }
 


### PR DESCRIPTION
## Problem

Every `tool_call_update` carrying the model's streamed input is persisted to the durable S3 log as a full cumulative `rawInput` snapshot — one 15KB `Write` produced 2,004 log entries (~15MB), making run logs O(n²) in input size. A real 3-run resume chain reached ~242MB, which the tasks UIs cannot load reasonably (96% of its `tool_call_update` entries were bare rawInput snapshots).

#3079 coalesces these snapshots for the **local cache** only — the API path was left untouched by design, so the durable log still bloats. This PR adds the equivalent coalescing to the **API path** (`pendingEntries` → `append_log` → S3), layered on top of #3079's structure.

## Changes

- `queueForApiLog`: rawInput-only `tool_call_update`s replace the previously buffered one per `toolCallId`; the survivor is queued right before the call's next richer update, or dropped when that update carries `rawInput` itself
- Buffers drain on `flushAll` and coalescing flushes, so shutdown loses nothing; the local-cache coalescing from #3079 is unchanged
- Replaying these rules over the affected production logs shrinks them from 242MB → 28MB
- Tests: last-snapshot persistence, supersede-by-richer-update, interleaved tool calls, timed-flush no-op, parameterised drain paths