### PR TITLE
fix(agent): stream autonomous /loop turns live instead of on next prompt

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.idle-drain.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.idle-drain.test.ts
@@ -232,4 +232,21 @@ describe("ClaudeAcpAgent — between-turns idle drain (autonomous /loop turns)",
     // follow-up prompt drained the backlog).
     expect(texts.filter((t) => t === "autonomous update")).toHaveLength(1);
   });
+
+  it("cancel while idle-draining stops the drainer and returns cleanly", async () => {
+    const { agent } = makeAgent();
+    const sessionId = "s-idle-3";
+    const { query, input } = installFakeSession(agent, sessionId);
+
+    await runTurn(agent, query, input, sessionId, "loop", "answer", "r1");
+    // Drainer starts and blocks on query.next().
+    await tick();
+    const drainSlot = () =>
+      (agent as unknown as { idleDrain: unknown }).idleDrain;
+    expect(drainSlot()).not.toBeNull();
+
+    // Cancelling must await the drainer's exit (not return with it still live).
+    await agent.cancel({ sessionId });
+    expect(drainSlot()).toBeNull();
+  });
 });

--- a/packages/agent/src/adapters/claude/claude-agent.idle-drain.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.idle-drain.test.ts
@@ -1,11 +1,19 @@
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
-import type {
-  SDKMessage,
-  SDKUserMessage,
-} from "@anthropic-ai/claude-agent-sdk";
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockQuery, type MockQuery } from "../../test/mocks/claude-sdk";
-import { Pushable } from "../../utils/streams";
+import {
+  assistantMessage,
+  type ClientMocks,
+  echoUserMessage,
+  installFakeSession,
+  makeClientMocks,
+  messageChunkTexts,
+  resultSuccess,
+  send,
+  tick,
+} from "../../test/helpers/claude-agent";
+import type { MockQuery } from "../../test/mocks/claude-sdk";
+import type { Pushable } from "../../utils/streams";
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: vi.fn(),
@@ -25,124 +33,10 @@ vi.mock("./mcp/tool-metadata", () => ({
 const { ClaudeAcpAgent } = await import("./claude-agent");
 type Agent = InstanceType<typeof ClaudeAcpAgent>;
 
-interface ClientMocks {
-  sessionUpdate: ReturnType<typeof vi.fn>;
-  extNotification: ReturnType<typeof vi.fn>;
-}
-
 function makeAgent(): { agent: Agent; client: ClientMocks } {
-  const client: ClientMocks = {
-    sessionUpdate: vi.fn().mockResolvedValue(undefined),
-    extNotification: vi.fn().mockResolvedValue(undefined),
-  };
+  const client = makeClientMocks();
   const agent = new ClaudeAcpAgent(client as unknown as AgentSideConnection);
   return { agent, client };
-}
-
-function installFakeSession(
-  agent: Agent,
-  sessionId: string,
-): { query: MockQuery; input: Pushable<SDKUserMessage> } {
-  const query = createMockQuery();
-  const input = new Pushable<SDKUserMessage>();
-  const abortController = new AbortController();
-
-  const session = {
-    query,
-    queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
-    buildInProcessMcpServers: () => ({}),
-    localToolsServerNames: [] as string[],
-    input,
-    cancelled: false,
-    interruptReason: undefined,
-    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
-    permissionMode: "default" as const,
-    abortController,
-    accumulatedUsage: {
-      inputTokens: 0,
-      outputTokens: 0,
-      cachedReadTokens: 0,
-      cachedWriteTokens: 0,
-    },
-    sessionResources: new Set(),
-    configOptions: [],
-    promptRunning: false,
-    pendingMessages: new Map(),
-    nextPendingOrder: 0,
-    cwd: "/tmp/repo",
-    notificationHistory: [] as unknown[],
-    taskRunId: "run-1",
-    lastContextWindowSize: 200_000,
-    modelId: "claude-sonnet-4-6",
-    taskState: new Map(),
-  };
-
-  (agent as unknown as { session: typeof session }).session = session;
-  (agent as unknown as { sessionId: string }).sessionId = sessionId;
-
-  return { query, input };
-}
-
-function tick(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
-}
-
-async function send(query: MockQuery, message: unknown): Promise<void> {
-  query._mockHelpers.sendMessage(message as SDKMessage);
-  await tick();
-}
-
-// Replays the prompt's own user message back through the query so
-// `promptReplayed` flips and the terminal `result` is not skipped.
-async function echoUserMessage(
-  query: MockQuery,
-  input: Pushable<SDKUserMessage>,
-): Promise<void> {
-  const { value: pushed } = await input[Symbol.asyncIterator]().next();
-  await send(query, pushed);
-}
-
-function assistantMessage(sessionId: string, apiId: string, text: string) {
-  return {
-    type: "assistant",
-    parent_tool_use_id: null,
-    session_id: sessionId,
-    uuid: `assistant-${apiId}`,
-    message: {
-      id: apiId,
-      role: "assistant",
-      content: [{ type: "text", text }],
-    },
-  };
-}
-
-function resultSuccess(sessionId: string, uuid = "result-1") {
-  return {
-    type: "result",
-    subtype: "success",
-    session_id: sessionId,
-    uuid,
-    result: "",
-    is_error: false,
-    usage: {},
-    modelUsage: {},
-  };
-}
-
-function messageChunkTexts(
-  calls: ClientMocks["sessionUpdate"]["mock"]["calls"],
-): string[] {
-  return calls
-    .map(
-      ([call]) =>
-        (
-          call as {
-            update?: { sessionUpdate?: string; content?: { text?: string } };
-          }
-        ).update,
-    )
-    .filter((update) => update?.sessionUpdate === "agent_message_chunk")
-    .map((update) => update?.content?.text ?? "");
 }
 
 // Runs one complete turn: prompt -> echo -> assistant text -> result.

--- a/packages/agent/src/adapters/claude/claude-agent.idle-drain.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.idle-drain.test.ts
@@ -1,0 +1,235 @@
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import type {
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockQuery, type MockQuery } from "../../test/mocks/claude-sdk";
+import { Pushable } from "../../utils/streams";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("./mcp/tool-metadata", () => ({
+  fetchMcpToolMetadata: vi.fn().mockResolvedValue(undefined),
+  getConnectedMcpServerNames: vi.fn().mockReturnValue([]),
+  getCachedMcpTools: vi.fn().mockReturnValue([]),
+  clearMcpToolMetadataCache: vi.fn(),
+  setMcpToolApprovalStates: vi.fn(),
+  isMcpToolReadOnly: vi.fn().mockReturnValue(false),
+  getMcpToolMetadata: vi.fn().mockReturnValue(undefined),
+  getMcpToolApprovalState: vi.fn().mockReturnValue(undefined),
+}));
+
+const { ClaudeAcpAgent } = await import("./claude-agent");
+type Agent = InstanceType<typeof ClaudeAcpAgent>;
+
+interface ClientMocks {
+  sessionUpdate: ReturnType<typeof vi.fn>;
+  extNotification: ReturnType<typeof vi.fn>;
+}
+
+function makeAgent(): { agent: Agent; client: ClientMocks } {
+  const client: ClientMocks = {
+    sessionUpdate: vi.fn().mockResolvedValue(undefined),
+    extNotification: vi.fn().mockResolvedValue(undefined),
+  };
+  const agent = new ClaudeAcpAgent(client as unknown as AgentSideConnection);
+  return { agent, client };
+}
+
+function installFakeSession(
+  agent: Agent,
+  sessionId: string,
+): { query: MockQuery; input: Pushable<SDKUserMessage> } {
+  const query = createMockQuery();
+  const input = new Pushable<SDKUserMessage>();
+  const abortController = new AbortController();
+
+  const session = {
+    query,
+    queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
+    buildInProcessMcpServers: () => ({}),
+    localToolsServerNames: [] as string[],
+    input,
+    cancelled: false,
+    interruptReason: undefined,
+    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
+    permissionMode: "default" as const,
+    abortController,
+    accumulatedUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    },
+    sessionResources: new Set(),
+    configOptions: [],
+    promptRunning: false,
+    pendingMessages: new Map(),
+    nextPendingOrder: 0,
+    cwd: "/tmp/repo",
+    notificationHistory: [] as unknown[],
+    taskRunId: "run-1",
+    lastContextWindowSize: 200_000,
+    modelId: "claude-sonnet-4-6",
+    taskState: new Map(),
+  };
+
+  (agent as unknown as { session: typeof session }).session = session;
+  (agent as unknown as { sessionId: string }).sessionId = sessionId;
+
+  return { query, input };
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function send(query: MockQuery, message: unknown): Promise<void> {
+  query._mockHelpers.sendMessage(message as SDKMessage);
+  await tick();
+}
+
+// Replays the prompt's own user message back through the query so
+// `promptReplayed` flips and the terminal `result` is not skipped.
+async function echoUserMessage(
+  query: MockQuery,
+  input: Pushable<SDKUserMessage>,
+): Promise<void> {
+  const { value: pushed } = await input[Symbol.asyncIterator]().next();
+  await send(query, pushed);
+}
+
+function assistantMessage(sessionId: string, apiId: string, text: string) {
+  return {
+    type: "assistant",
+    parent_tool_use_id: null,
+    session_id: sessionId,
+    uuid: `assistant-${apiId}`,
+    message: {
+      id: apiId,
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+function resultSuccess(sessionId: string, uuid = "result-1") {
+  return {
+    type: "result",
+    subtype: "success",
+    session_id: sessionId,
+    uuid,
+    result: "",
+    is_error: false,
+    usage: {},
+    modelUsage: {},
+  };
+}
+
+function messageChunkTexts(
+  calls: ClientMocks["sessionUpdate"]["mock"]["calls"],
+): string[] {
+  return calls
+    .map(
+      ([call]) =>
+        (
+          call as {
+            update?: { sessionUpdate?: string; content?: { text?: string } };
+          }
+        ).update,
+    )
+    .filter((update) => update?.sessionUpdate === "agent_message_chunk")
+    .map((update) => update?.content?.text ?? "");
+}
+
+// Runs one complete turn: prompt -> echo -> assistant text -> result.
+async function runTurn(
+  agent: Agent,
+  query: MockQuery,
+  input: Pushable<SDKUserMessage>,
+  sessionId: string,
+  promptText: string,
+  answerText: string,
+  resultUuid: string,
+): Promise<void> {
+  const promptPromise = agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: promptText }],
+  });
+  await tick();
+  await echoUserMessage(query, input);
+  await send(query, assistantMessage(sessionId, resultUuid, answerText));
+  await send(query, resultSuccess(sessionId, resultUuid));
+  const result = await promptPromise;
+  expect(result.stopReason).toBe("end_turn");
+}
+
+describe("ClaudeAcpAgent — between-turns idle drain (autonomous /loop turns)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("streams an autonomous turn to the client with no second user prompt", async () => {
+    const { agent, client } = makeAgent();
+    const sessionId = "s-idle-1";
+    const { query, input } = installFakeSession(agent, sessionId);
+
+    await runTurn(
+      agent,
+      query,
+      input,
+      sessionId,
+      "loop until CI passes",
+      "checking CI now",
+      "r1",
+    );
+
+    // Let the deferred startIdleDrain() run and block on query.next().
+    await tick();
+
+    // A fired ScheduleWakeup/loop turn appears with NO new prompt() call.
+    await send(
+      query,
+      assistantMessage(sessionId, "r2", "still running, retrying"),
+    );
+
+    expect(messageChunkTexts(client.sessionUpdate.mock.calls)).toContain(
+      "still running, retrying",
+    );
+  });
+
+  it("hands the query back to a follow-up prompt without losing its echo", async () => {
+    const { agent, client } = makeAgent();
+    const sessionId = "s-idle-2";
+    const { query, input } = installFakeSession(agent, sessionId);
+
+    await runTurn(agent, query, input, sessionId, "loop", "first answer", "r1");
+    await tick();
+
+    // Autonomous turn streams in while idle.
+    await send(query, assistantMessage(sessionId, "r2", "autonomous update"));
+    await send(query, resultSuccess(sessionId, "r2"));
+
+    // The user sends a follow-up. The drainer must release the query and hand
+    // its echo to prompt() so the turn completes normally.
+    await runTurn(
+      agent,
+      query,
+      input,
+      sessionId,
+      "keep going",
+      "second answer",
+      "r3",
+    );
+
+    const texts = messageChunkTexts(client.sessionUpdate.mock.calls);
+    expect(texts).toContain("autonomous update");
+    expect(texts).toContain("second answer");
+    // The autonomous message must appear exactly once (not re-emitted when the
+    // follow-up prompt drained the backlog).
+    expect(texts.filter((t) => t === "autonomous update")).toHaveLength(1);
+  });
+});

--- a/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
@@ -1,8 +1,11 @@
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockQuery, type MockQuery } from "../../test/mocks/claude-sdk";
-import { Pushable } from "../../utils/streams";
+import {
+  type ClientMocks,
+  installFakeSession,
+  makeClientMocks,
+} from "../../test/helpers/claude-agent";
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: vi.fn(),
@@ -20,63 +23,10 @@ vi.mock("./mcp/tool-metadata", () => ({
 const { ClaudeAcpAgent } = await import("./claude-agent");
 type Agent = InstanceType<typeof ClaudeAcpAgent>;
 
-interface ClientMocks {
-  sessionUpdate: ReturnType<typeof vi.fn>;
-  extNotification: ReturnType<typeof vi.fn>;
-}
-
 function makeAgent(): { agent: Agent; client: ClientMocks } {
-  const client: ClientMocks = {
-    sessionUpdate: vi.fn().mockResolvedValue(undefined),
-    extNotification: vi.fn().mockResolvedValue(undefined),
-  };
+  const client = makeClientMocks();
   const agent = new ClaudeAcpAgent(client as unknown as AgentSideConnection);
   return { agent, client };
-}
-
-function installFakeSession(
-  agent: Agent,
-  sessionId: string,
-  knownSlashCommands?: Set<string>,
-): MockQuery {
-  const query = createMockQuery();
-  const input = new Pushable();
-  const abortController = new AbortController();
-
-  const session = {
-    query,
-    queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
-    buildInProcessMcpServers: () => ({}),
-    localToolsServerNames: [] as string[],
-    input,
-    cancelled: false,
-    interruptReason: undefined,
-    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
-    permissionMode: "default" as const,
-    abortController,
-    accumulatedUsage: {
-      inputTokens: 0,
-      outputTokens: 0,
-      cachedReadTokens: 0,
-      cachedWriteTokens: 0,
-    },
-    sessionResources: new Set(),
-    configOptions: [],
-    promptRunning: false,
-    pendingMessages: new Map(),
-    nextPendingOrder: 0,
-    cwd: "/tmp/repo",
-    notificationHistory: [] as unknown[],
-    taskRunId: "run-1",
-    lastContextWindowSize: 200_000,
-    modelId: "claude-sonnet-4-6",
-    knownSlashCommands,
-  };
-
-  (agent as unknown as { session: typeof session }).session = session;
-  (agent as unknown as { sessionId: string }).sessionId = sessionId;
-
-  return query;
 }
 
 function findUnsupportedChunkText(
@@ -148,7 +98,7 @@ describe("ClaudeAcpAgent.prompt — early idle handling", () => {
 
   it.each(cases)("$label", async (tc) => {
     const { agent, client } = makeAgent();
-    const query = installFakeSession(
+    const { query } = installFakeSession(
       agent,
       tc.sessionId,
       tc.knownCommands as Set<string> | undefined,
@@ -208,7 +158,7 @@ describe("ClaudeAcpAgent.prompt — force-cancel backstop", () => {
   it("returns 'cancelled' when the SDK never yields after interrupt (issue #680)", async () => {
     const { agent } = makeAgent();
     const sessionId = "s-wedged";
-    const query = installFakeSession(agent, sessionId);
+    const { query } = installFakeSession(agent, sessionId);
     query.interrupt.mockImplementation(async () => {});
     (agent as unknown as { forceCancelGraceMs: number }).forceCancelGraceMs = 5;
 

--- a/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
@@ -1,11 +1,16 @@
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
-import type {
-  SDKMessage,
-  SDKUserMessage,
-} from "@anthropic-ai/claude-agent-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockQuery, type MockQuery } from "../../test/mocks/claude-sdk";
-import { Pushable } from "../../utils/streams";
+import {
+  assistantMessage,
+  type ClientMocks,
+  echoUserMessage,
+  installFakeSession,
+  makeClientMocks,
+  messageChunkTexts,
+  resultSuccess,
+  send,
+  tick,
+} from "../../test/helpers/claude-agent";
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: vi.fn(),
@@ -25,62 +30,10 @@ vi.mock("./mcp/tool-metadata", () => ({
 const { ClaudeAcpAgent } = await import("./claude-agent");
 type Agent = InstanceType<typeof ClaudeAcpAgent>;
 
-interface ClientMocks {
-  sessionUpdate: ReturnType<typeof vi.fn>;
-  extNotification: ReturnType<typeof vi.fn>;
-}
-
 function makeAgent(): { agent: Agent; client: ClientMocks } {
-  const client: ClientMocks = {
-    sessionUpdate: vi.fn().mockResolvedValue(undefined),
-    extNotification: vi.fn().mockResolvedValue(undefined),
-  };
+  const client = makeClientMocks();
   const agent = new ClaudeAcpAgent(client as unknown as AgentSideConnection);
   return { agent, client };
-}
-
-function installFakeSession(
-  agent: Agent,
-  sessionId: string,
-): { query: MockQuery; input: Pushable<SDKUserMessage> } {
-  const query = createMockQuery();
-  const input = new Pushable<SDKUserMessage>();
-  const abortController = new AbortController();
-
-  const session = {
-    query,
-    queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
-    buildInProcessMcpServers: () => ({}),
-    localToolsServerNames: [] as string[],
-    input,
-    cancelled: false,
-    interruptReason: undefined,
-    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
-    permissionMode: "default" as const,
-    abortController,
-    accumulatedUsage: {
-      inputTokens: 0,
-      outputTokens: 0,
-      cachedReadTokens: 0,
-      cachedWriteTokens: 0,
-    },
-    sessionResources: new Set(),
-    configOptions: [],
-    promptRunning: false,
-    pendingMessages: new Map(),
-    nextPendingOrder: 0,
-    cwd: "/tmp/repo",
-    notificationHistory: [] as unknown[],
-    taskRunId: "run-1",
-    lastContextWindowSize: 200_000,
-    modelId: "claude-sonnet-4-6",
-    taskState: new Map(),
-  };
-
-  (agent as unknown as { session: typeof session }).session = session;
-  (agent as unknown as { sessionId: string }).sessionId = sessionId;
-
-  return { query, input };
 }
 
 // Mark the session as having an enabled (but currently disconnected) in-process
@@ -102,26 +55,6 @@ function enableSignedCommitServer(agent: Agent): void {
       instance: {},
     },
   });
-}
-
-function tick(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
-}
-
-async function send(query: MockQuery, message: unknown): Promise<void> {
-  query._mockHelpers.sendMessage(message as SDKMessage);
-  await tick();
-}
-
-// Replays the prompt's own user message back through the query so
-// `promptReplayed` flips and the terminal `result` message is not skipped as a
-// background-task result.
-async function echoUserMessage(
-  query: MockQuery,
-  input: Pushable<SDKUserMessage>,
-): Promise<void> {
-  const { value: pushed } = await input[Symbol.asyncIterator]().next();
-  await send(query, pushed);
 }
 
 function messageStart(sessionId: string, apiId: string) {
@@ -146,49 +79,6 @@ function textDelta(sessionId: string, text: string) {
       delta: { type: "text_delta", text },
     },
   };
-}
-
-function assistantMessage(sessionId: string, apiId: string, text: string) {
-  return {
-    type: "assistant",
-    parent_tool_use_id: null,
-    session_id: sessionId,
-    uuid: `assistant-${apiId}`,
-    message: {
-      id: apiId,
-      role: "assistant",
-      content: [{ type: "text", text }],
-    },
-  };
-}
-
-function resultSuccess(sessionId: string) {
-  return {
-    type: "result",
-    subtype: "success",
-    session_id: sessionId,
-    uuid: "result-1",
-    result: "",
-    is_error: false,
-    usage: {},
-    modelUsage: {},
-  };
-}
-
-function messageChunkTexts(
-  calls: ClientMocks["sessionUpdate"]["mock"]["calls"],
-): string[] {
-  return calls
-    .map(
-      ([call]) =>
-        (
-          call as {
-            update?: { sessionUpdate?: string; content?: { text?: string } };
-          }
-        ).update,
-    )
-    .filter((update) => update?.sessionUpdate === "agent_message_chunk")
-    .map((update) => update?.content?.text ?? "");
 }
 
 describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -572,34 +572,17 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     }
     let lastContextWindowSize = this.session.lastContextWindowSize;
 
-    const supportsTerminalOutput =
-      (
-        this.clientCapabilities?._meta as
-          | ClientCapabilities["_meta"]
-          | undefined
-      )?.terminal_output === true;
-
-    const context = {
-      session: this.session,
-      sessionId: params.sessionId,
-      client: this.client,
-      toolUseCache: this.toolUseCache,
-      toolUseStreamCache: this.toolUseStreamCache,
-      fileContentCache: this.fileContentCache,
-      enrichedReadCache: this.enrichedReadCache,
-      logger: this.logger,
-      supportsTerminalOutput,
-      streamedAssistantBlocks: {
-        textIds: new Set<string>(),
-        thinkingIds: new Set<string>(),
-      },
-    };
+    const context = this.buildMessageContext(params.sessionId);
 
     // Wait for the idle drainer to release the query. Our user message was
     // already pushed above, so its echo is what unblocks the drainer's pending
     // `query.next()`; the drainer hands that message back to us here rather than
-    // consuming it, so `promptReplayed` still flips below.
-    let carriedMessage = await this.settleIdleDrainStop();
+    // consuming it, so `promptReplayed` still flips below. Skip the await on the
+    // common path where no drainer is running so a plain prompt pays no
+    // microtask hop.
+    let carriedMessage = this.idleDrain
+      ? await this.settleIdleDrainStop()
+      : undefined;
 
     try {
       while (true) {
@@ -1106,22 +1089,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           }
 
           case "tool_progress": {
-            await this.client.sessionUpdate({
-              sessionId: params.sessionId,
-              update: {
-                sessionUpdate: "tool_call_update",
-                toolCallId: message.tool_use_id,
-                status: "in_progress",
-                _meta: {
-                  claudeCode: {
-                    toolName: message.tool_name,
-                    toolResponse: {
-                      elapsedTimeSeconds: message.elapsed_time_seconds,
-                    },
-                  },
-                } satisfies ToolUpdateMeta,
-              },
-            });
+            await this.emitToolProgress(params.sessionId, message);
             break;
           }
           case "rate_limit_event": {
@@ -1316,6 +1284,61 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   }
 
   /**
+   * Build the per-turn message-handler context shared by the prompt turn loop
+   * and the idle drainer. Fresh `streamedAssistantBlocks` Sets per call so each
+   * turn dedupes its own streamed blocks independently.
+   */
+  private buildMessageContext(sessionId: string): MessageHandlerContext {
+    const supportsTerminalOutput =
+      (
+        this.clientCapabilities?._meta as
+          | ClientCapabilities["_meta"]
+          | undefined
+      )?.terminal_output === true;
+    return {
+      session: this.session,
+      sessionId,
+      client: this.client,
+      toolUseCache: this.toolUseCache,
+      toolUseStreamCache: this.toolUseStreamCache,
+      fileContentCache: this.fileContentCache,
+      enrichedReadCache: this.enrichedReadCache,
+      logger: this.logger,
+      supportsTerminalOutput,
+      streamedAssistantBlocks: {
+        textIds: new Set<string>(),
+        thinkingIds: new Set<string>(),
+      },
+    };
+  }
+
+  /**
+   * Forward a `tool_progress` SDK message to the client as an in-progress
+   * `tool_call_update`. Shared by the prompt turn loop and the idle drainer.
+   */
+  private async emitToolProgress(
+    sessionId: string,
+    message: Extract<SDKMessage, { type: "tool_progress" }>,
+  ): Promise<void> {
+    await this.client.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: message.tool_use_id,
+        status: "in_progress",
+        _meta: {
+          claudeCode: {
+            toolName: message.tool_name,
+            toolResponse: {
+              elapsedTimeSeconds: message.elapsed_time_seconds,
+            },
+          },
+        } satisfies ToolUpdateMeta,
+      },
+    });
+  }
+
+  /**
    * Pump the SDK query stream between turns.
    *
    * The turn loop in `prompt()` only reads `query.next()` while a prompt is in
@@ -1340,27 +1363,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // `this.session` out from under us; binding here keeps this loop scoped to
     // the query it started on, which will end (iterator done) on that refresh.
     const query = this.session.query;
-    const supportsTerminalOutput =
-      (
-        this.clientCapabilities?._meta as
-          | ClientCapabilities["_meta"]
-          | undefined
-      )?.terminal_output === true;
-    const context: MessageHandlerContext = {
-      session: this.session,
-      sessionId,
-      client: this.client,
-      toolUseCache: this.toolUseCache,
-      toolUseStreamCache: this.toolUseStreamCache,
-      fileContentCache: this.fileContentCache,
-      enrichedReadCache: this.enrichedReadCache,
-      logger: this.logger,
-      supportsTerminalOutput,
-      streamedAssistantBlocks: {
-        textIds: new Set<string>(),
-        thinkingIds: new Set<string>(),
-      },
-    };
+    const context = this.buildMessageContext(sessionId);
 
     const state: IdleDrainState = { stop: false, done: Promise.resolve() };
     this.idleDrain = state;
@@ -1465,22 +1468,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         resetStreamDedupe();
         return;
       case "tool_progress":
-        await this.client.sessionUpdate({
-          sessionId: context.sessionId,
-          update: {
-            sessionUpdate: "tool_call_update",
-            toolCallId: message.tool_use_id,
-            status: "in_progress",
-            _meta: {
-              claudeCode: {
-                toolName: message.tool_name,
-                toolResponse: {
-                  elapsedTimeSeconds: message.elapsed_time_seconds,
-                },
-              },
-            } satisfies ToolUpdateMeta,
-          },
-        });
+        await this.emitToolProgress(context.sessionId, message);
         return;
       default:
         // auth_status, rate_limit_event, prompt_suggestion, tool_use_summary,

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -39,6 +39,7 @@ import {
   type Options,
   type Query,
   query,
+  type SDKMessage,
   type SDKUserMessage,
   type SlashCommand,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -88,6 +89,7 @@ import {
   handleStreamEvent,
   handleSystemMessage,
   handleUserAssistantMessage,
+  type MessageHandlerContext,
 } from "./conversion/sdk-to-acp";
 import {
   rehydrateTaskState,
@@ -242,6 +244,26 @@ export interface ClaudeAcpAgentOptions {
   gatewayEnv?: GatewayEnv;
 }
 
+/**
+ * Tracks the background "idle drain" loop that pumps the SDK query stream
+ * between turns (see {@link ClaudeAcpAgent.startIdleDrain}). Without it, output
+ * the SDK produces on its own — e.g. a fired `ScheduleWakeup` / `/loop`
+ * continuation — sits unread in the query iterator until the next `prompt()`
+ * call, so autonomous turns appear frozen until the user sends another message.
+ */
+interface IdleDrainState {
+  /** Set by a starting `prompt()` (or teardown) to hand the query back. */
+  stop: boolean;
+  /**
+   * A message the drainer pulled after `stop` was requested. It is handed to
+   * the incoming `prompt()` so its turn loop processes it (and, when it is the
+   * user-message echo, still sees `promptReplayed`). Never dropped.
+   */
+  handoff?: SDKMessage;
+  /** Resolves when the drain loop has fully exited. */
+  done: Promise<void>;
+}
+
 export class ClaudeAcpAgent extends BaseAcpAgent {
   readonly adapterName = "claude";
   declare session: Session;
@@ -253,6 +275,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   private options?: ClaudeAcpAgentOptions;
   private enrichment?: Enrichment;
   private enrichedReadCache: EnrichedReadCache = new Map();
+  /** Non-null while the between-turns idle drainer is running. */
+  private idleDrain: IdleDrainState | null = null;
 
   constructor(client: AgentSideConnection, options?: ClaudeAcpAgentOptions) {
     super(client);
@@ -435,6 +459,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
+    // Reclaim the query stream from the between-turns idle drainer (if running)
+    // before we touch it. This only flags it; `settleIdleDrainStop()` below waits
+    // for it to actually release ownership once our user message is pushed.
+    this.requestIdleDrainStop();
+
     const userMessage = promptToClaude(params);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
@@ -566,25 +595,40 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       },
     };
 
+    // Wait for the idle drainer to release the query. Our user message was
+    // already pushed above, so its echo is what unblocks the drainer's pending
+    // `query.next()`; the drainer hands that message back to us here rather than
+    // consuming it, so `promptReplayed` still flips below.
+    let carriedMessage = await this.settleIdleDrainStop();
+
     try {
       while (true) {
-        const nextMessage = this.session.query.next();
-        const next = await withAbort(nextMessage, cancelController.signal);
-        if (next.result === "aborted" || cancelController.signal.aborted) {
-          void nextMessage.catch((err) =>
-            this.logger.warn("in-flight query.next() rejected after cancel", {
-              sessionId: params.sessionId,
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-          return {
-            stopReason: "cancelled",
-            _meta: this.session.interruptReason
-              ? { interruptReason: this.session.interruptReason }
-              : undefined,
-          };
+        let message: SDKMessage | undefined;
+        let done: boolean | undefined;
+        if (carriedMessage) {
+          message = carriedMessage;
+          carriedMessage = undefined;
+          done = false;
+        } else {
+          const nextMessage = this.session.query.next();
+          const next = await withAbort(nextMessage, cancelController.signal);
+          if (next.result === "aborted" || cancelController.signal.aborted) {
+            void nextMessage.catch((err) =>
+              this.logger.warn("in-flight query.next() rejected after cancel", {
+                sessionId: params.sessionId,
+                error: err instanceof Error ? err.message : String(err),
+              }),
+            );
+            return {
+              stopReason: "cancelled",
+              _meta: this.session.interruptReason
+                ? { interruptReason: this.session.interruptReason }
+                : undefined,
+            };
+          }
+          message = next.value.value ?? undefined;
+          done = next.value.done;
         }
-        const { value: message, done } = next.value;
 
         if (done || !message) {
           if (this.session.cancelled) {
@@ -1172,6 +1216,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       // entries behind; without this they'd carry over into the next turn
       // and collide with new content-block indices.
       this.toolUseStreamCache.clear();
+      let handedOffQueued = false;
       if (!handedOff) {
         this.session.promptRunning = false;
         if (errored) {
@@ -1192,14 +1237,34 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           if (next) {
             next[1].resolve(false);
             this.session.pendingMessages.delete(next[0]);
+            handedOffQueued = true;
           }
         }
+      }
+
+      // Clean, idle end of turn: start pumping the query stream in the
+      // background so an autonomous continuation (a fired `ScheduleWakeup` /
+      // `/loop` turn) streams to the client immediately instead of buffering
+      // until the user sends the next message. Skip when another turn already
+      // owns the loop (handoff), when the turn errored/cancelled, or when the
+      // session is tearing down. Deferred so this prompt() returns first.
+      if (
+        !errored &&
+        !handedOff &&
+        !handedOffQueued &&
+        !this.session.cancelled
+      ) {
+        const sessionId = params.sessionId;
+        queueMicrotask(() => this.startIdleDrain(sessionId));
       }
     }
   }
 
   // Called by BaseAcpAgent#cancel() to interrupt the session
   protected async interrupt(): Promise<void> {
+    // A cancel/close may land while the between-turns idle drainer owns the
+    // query; stop it so `query.interrupt()` below isn't racing a live reader.
+    this.requestIdleDrainStop();
     this.session.cancelled = true;
     for (const [, pending] of this.session.pendingMessages) {
       pending.resolve(true);
@@ -1222,6 +1287,206 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     }
 
     await this.session.query.interrupt();
+  }
+
+  /**
+   * Flag the idle drainer (if any) to release the query at its next boundary.
+   * Cheap and synchronous; `settleIdleDrainStop()` performs the actual wait.
+   */
+  private requestIdleDrainStop(): void {
+    if (this.idleDrain) {
+      this.idleDrain.stop = true;
+    }
+  }
+
+  /**
+   * Wait for a stop-requested idle drainer to release the query and return the
+   * message it pulled last (if any) so the caller's turn loop can process it.
+   * Returns undefined when no drainer was running.
+   */
+  private async settleIdleDrainStop(): Promise<SDKMessage | undefined> {
+    const state = this.idleDrain;
+    if (!state) return undefined;
+    state.stop = true;
+    await state.done;
+    if (this.idleDrain === state) {
+      this.idleDrain = null;
+    }
+    return state.handoff;
+  }
+
+  /**
+   * Pump the SDK query stream between turns.
+   *
+   * The turn loop in `prompt()` only reads `query.next()` while a prompt is in
+   * flight, so anything the SDK emits on its own after a turn ends — a fired
+   * `ScheduleWakeup` / `/loop` continuation — is never read and stays buffered
+   * in the iterator until the next `prompt()`, which is why autonomous turns
+   * look frozen until the user sends another message. This background loop reads
+   * those messages and forwards them to the client as they arrive.
+   *
+   * Ownership is single-reader: a starting `prompt()` (or `interrupt()`) calls
+   * `requestIdleDrainStop()` + `settleIdleDrainStop()`, and this loop releases
+   * the query — handing back the one message it had pulled — before `prompt()`
+   * reads it. Every step is guarded so a drainer fault only stops draining
+   * (reverting to prior behavior), never breaks the session.
+   */
+  private startIdleDrain(sessionId: string): void {
+    if (this.idleDrain) return;
+    if (this.session.promptRunning) return;
+    if (this.session.abortController.signal.aborted) return;
+
+    // Capture the query and a context up front. A `refreshSession()` may swap
+    // `this.session` out from under us; binding here keeps this loop scoped to
+    // the query it started on, which will end (iterator done) on that refresh.
+    const query = this.session.query;
+    const supportsTerminalOutput =
+      (
+        this.clientCapabilities?._meta as
+          | ClientCapabilities["_meta"]
+          | undefined
+      )?.terminal_output === true;
+    const context: MessageHandlerContext = {
+      session: this.session,
+      sessionId,
+      client: this.client,
+      toolUseCache: this.toolUseCache,
+      toolUseStreamCache: this.toolUseStreamCache,
+      fileContentCache: this.fileContentCache,
+      enrichedReadCache: this.enrichedReadCache,
+      logger: this.logger,
+      supportsTerminalOutput,
+      streamedAssistantBlocks: {
+        textIds: new Set<string>(),
+        thinkingIds: new Set<string>(),
+      },
+    };
+
+    const state: IdleDrainState = { stop: false, done: Promise.resolve() };
+    this.idleDrain = state;
+
+    state.done = (async () => {
+      try {
+        while (!state.stop) {
+          let result: IteratorResult<SDKMessage, void>;
+          try {
+            result = await query.next();
+          } catch (err) {
+            this.logger.debug("Idle drain query ended", {
+              sessionId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            break;
+          }
+          if (state.stop) {
+            // A prompt() is taking the query back. Hand it the message we just
+            // pulled instead of processing it, so it isn't lost and so a user
+            // echo still flips promptReplayed there.
+            if (!result.done && result.value) {
+              state.handoff = result.value;
+            }
+            break;
+          }
+          if (result.done || !result.value) break;
+          try {
+            await this.forwardAutonomousMessage(result.value, context);
+          } catch (err) {
+            this.logger.warn("Idle drain failed to forward message", {
+              sessionId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      } finally {
+        // Clear the slot unless we're holding a handoff message for an incoming
+        // prompt() — that case is cleared by settleIdleDrainStop() once it has
+        // read the message. Clearing whenever there's nothing to hand back means
+        // a stop from interrupt()/refreshSession (which never call settle) can't
+        // leak a stale drainer slot.
+        if (state.handoff === undefined && this.idleDrain === state) {
+          this.idleDrain = null;
+        }
+      }
+    })();
+  }
+
+  /**
+   * Forward a single SDK message produced by an autonomous (non-prompt) turn to
+   * the client, reusing the same handlers as the main turn loop so displayed
+   * content is identical. Turn-control concerns (usage accounting, refusal
+   * capture, pending-prompt handoff) are intentionally omitted — an autonomous
+   * turn has no awaiting `prompt()` and no queued prompts — and result/idle
+   * markers only reset per-turn streaming dedupe state.
+   */
+  private async forwardAutonomousMessage(
+    message: SDKMessage,
+    context: MessageHandlerContext,
+  ): Promise<void> {
+    const resetStreamDedupe = () => {
+      context.streamedAssistantBlocks?.textIds.clear();
+      context.streamedAssistantBlocks?.thinkingIds.clear();
+    };
+
+    switch (message.type) {
+      case "assistant":
+      case "user": {
+        if (
+          message.type === "user" &&
+          "isReplay" in message &&
+          (message as Record<string, unknown>).isReplay
+        ) {
+          return;
+        }
+        const result = await handleUserAssistantMessage(message, context);
+        if (result.error) {
+          this.logger.warn("Idle drain: user/assistant handler error", {
+            sessionId: context.sessionId,
+            error: result.error.message,
+          });
+        }
+        return;
+      }
+      case "stream_event":
+        await handleStreamEvent(message, context);
+        return;
+      case "system": {
+        if (
+          message.subtype === "session_state_changed" &&
+          (message as Record<string, unknown>).state === "idle"
+        ) {
+          resetStreamDedupe();
+          return;
+        }
+        await handleSystemMessage(message, context);
+        return;
+      }
+      case "result":
+        // Autonomous turn boundary; its content was already forwarded above.
+        resetStreamDedupe();
+        return;
+      case "tool_progress":
+        await this.client.sessionUpdate({
+          sessionId: context.sessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: message.tool_use_id,
+            status: "in_progress",
+            _meta: {
+              claudeCode: {
+                toolName: message.tool_name,
+                toolResponse: {
+                  elapsedTimeSeconds: message.elapsed_time_seconds,
+                },
+              },
+            } satisfies ToolUpdateMeta,
+          },
+        });
+        return;
+      default:
+        // auth_status, rate_limit_event, prompt_suggestion, tool_use_summary,
+        // raw SDK passthroughs — nothing to surface for an autonomous turn.
+        return;
+    }
   }
 
   /**
@@ -1297,6 +1562,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       serverCount: Object.keys(mcpServers).length,
       sessionId: this.sessionId,
     });
+
+    // Stop the idle drainer before tearing the query down; the interrupt below
+    // ends its blocked `query.next()`, after which it self-clears.
+    this.requestIdleDrainStop();
 
     // Abort FIRST so any stuck in-flight HTTP request unblocks — otherwise
     // interrupt() can deadlock waiting on an API call that never returns.

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1223,7 +1223,16 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         !this.session.cancelled
       ) {
         const sessionId = params.sessionId;
-        queueMicrotask(() => this.startIdleDrain(sessionId));
+        const session = this.session;
+        queueMicrotask(() => {
+          // Bail if the session was swapped (e.g. by refreshSession) between
+          // scheduling and running: startIdleDrain reads this.session at
+          // execution time, so without this it could drain the new query while
+          // tagging events with the old session id.
+          if (this.session === session) {
+            this.startIdleDrain(sessionId);
+          }
+        });
       }
     }
   }
@@ -1231,7 +1240,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   // Called by BaseAcpAgent#cancel() to interrupt the session
   protected async interrupt(): Promise<void> {
     // A cancel/close may land while the between-turns idle drainer owns the
-    // query; stop it so `query.interrupt()` below isn't racing a live reader.
+    // query; flag it now so it stops at its next boundary, and fence its exit
+    // after `query.interrupt()` below (see end of method).
     this.requestIdleDrainStop();
     this.session.cancelled = true;
     for (const [, pending] of this.session.pendingMessages) {
@@ -1255,6 +1265,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     }
 
     await this.session.query.interrupt();
+
+    // Fence the drainer's exit. `query.interrupt()` unblocks a drainer suspended
+    // in `query.next()`, but one mid-forward only exits after its in-flight
+    // `client.sessionUpdate()` settles. Awaiting here keeps interrupt() from
+    // returning while the drainer can still emit an event for a cancelled
+    // session. No-op when no drainer is running.
+    await this.settleIdleDrainStop();
   }
 
   /**
@@ -1355,6 +1372,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
    * (reverting to prior behavior), never breaks the session.
    */
   private startIdleDrain(sessionId: string): void {
+    // At most one drainer at a time. Combined with "drainers are only scheduled
+    // after a completed turn", this is what keeps the slot unambiguous: while a
+    // drainer holds a handoff for an in-flight prompt(), `this.idleDrain` stays
+    // non-null (its finally skips clearing), so no second drainer can be
+    // assigned before settleIdleDrainStop() clears it.
     if (this.idleDrain) return;
     if (this.session.promptRunning) return;
     if (this.session.abortController.signal.aborted) return;

--- a/packages/agent/src/test/helpers/claude-agent.ts
+++ b/packages/agent/src/test/helpers/claude-agent.ts
@@ -1,0 +1,144 @@
+import type {
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { vi } from "vitest";
+import { Pushable } from "../../utils/streams";
+import { createMockQuery, type MockQuery } from "../mocks/claude-sdk";
+
+/**
+ * Shared test harness for `ClaudeAcpAgent` unit tests. `makeAgent` stays in each
+ * test file because it news up the dynamically-imported (post-`vi.mock`) agent
+ * class; everything here is class-independent so it carries no mock-timing risk.
+ */
+
+export interface ClientMocks {
+  sessionUpdate: ReturnType<typeof vi.fn>;
+  extNotification: ReturnType<typeof vi.fn>;
+}
+
+export function makeClientMocks(): ClientMocks {
+  return {
+    sessionUpdate: vi.fn().mockResolvedValue(undefined),
+    extNotification: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * Install a fake in-memory session on an agent and return its query + input
+ * stream. Pass `knownSlashCommands` for slash-command tests; other fields are
+ * inert for tests that don't use them.
+ */
+export function installFakeSession(
+  agent: object,
+  sessionId: string,
+  knownSlashCommands?: Set<string>,
+): { query: MockQuery; input: Pushable<SDKUserMessage> } {
+  const query = createMockQuery();
+  const input = new Pushable<SDKUserMessage>();
+  const abortController = new AbortController();
+
+  const session = {
+    query,
+    queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
+    buildInProcessMcpServers: () => ({}),
+    localToolsServerNames: [] as string[],
+    input,
+    cancelled: false,
+    interruptReason: undefined,
+    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
+    permissionMode: "default" as const,
+    abortController,
+    accumulatedUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    },
+    sessionResources: new Set(),
+    configOptions: [],
+    promptRunning: false,
+    pendingMessages: new Map(),
+    nextPendingOrder: 0,
+    cwd: "/tmp/repo",
+    notificationHistory: [] as unknown[],
+    taskRunId: "run-1",
+    lastContextWindowSize: 200_000,
+    modelId: "claude-sonnet-4-6",
+    taskState: new Map(),
+    knownSlashCommands,
+  };
+
+  (agent as unknown as { session: typeof session }).session = session;
+  (agent as unknown as { sessionId: string }).sessionId = sessionId;
+
+  return { query, input };
+}
+
+export function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+export async function send(query: MockQuery, message: unknown): Promise<void> {
+  query._mockHelpers.sendMessage(message as SDKMessage);
+  await tick();
+}
+
+/**
+ * Replay the prompt's own user message back through the query so
+ * `promptReplayed` flips and the terminal `result` is not skipped.
+ */
+export async function echoUserMessage(
+  query: MockQuery,
+  input: Pushable<SDKUserMessage>,
+): Promise<void> {
+  const { value: pushed } = await input[Symbol.asyncIterator]().next();
+  await send(query, pushed);
+}
+
+export function assistantMessage(
+  sessionId: string,
+  apiId: string,
+  text: string,
+) {
+  return {
+    type: "assistant",
+    parent_tool_use_id: null,
+    session_id: sessionId,
+    uuid: `assistant-${apiId}`,
+    message: {
+      id: apiId,
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+export function resultSuccess(sessionId: string, uuid = "result-1") {
+  return {
+    type: "result",
+    subtype: "success",
+    session_id: sessionId,
+    uuid,
+    result: "",
+    is_error: false,
+    usage: {},
+    modelUsage: {},
+  };
+}
+
+export function messageChunkTexts(
+  calls: ClientMocks["sessionUpdate"]["mock"]["calls"],
+): string[] {
+  return calls
+    .map(
+      ([call]) =>
+        (
+          call as {
+            update?: { sessionUpdate?: string; content?: { text?: string } };
+          }
+        ).update,
+    )
+    .filter((update) => update?.sessionUpdate === "agent_message_chunk")
+    .map((update) => update?.content?.text ?? "");
+}


### PR DESCRIPTION
This ensures we properly consumed loops/crons triggered by the Claude SDK :) 