### PR TITLE
feat(billing): add billions unit formatting for token display

### DIFF
--- a/packages/core/src/billing/spendAnalysisFormat.test.ts
+++ b/packages/core/src/billing/spendAnalysisFormat.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { formatTokens } from "./spendAnalysisFormat";
+
+describe("formatTokens", () => {
+  it.each([
+    [0, "0"],
+    [999, "999"],
+    [1_000, "1k"],
+    [108_400, "108k"],
+    [1_500_000, "1.5M"],
+    [999_949_999, "999.9M"],
+    [1_000_000_000, "1.0B"],
+    [2_449_300_000, "2.4B"],
+  ])("formats %d as %s", (input, expected) => {
+    expect(formatTokens(input)).toBe(expected);
+  });
+});

--- a/packages/core/src/billing/spendAnalysisFormat.ts
+++ b/packages/core/src/billing/spendAnalysisFormat.ts
@@ -6,6 +6,7 @@ export function formatUsd(amount: number): string {
 }
 
 export function formatTokens(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
   return n.toString();


### PR DESCRIPTION
## TL;DR
Add support for formatting token counts in billions (B) unit in the plan usage display, complementing the existing thousands (k) and millions (M) formatting.

## Problem
Plan usage metrics can reach billions of tokens, but the token formatting utility only supported up to millions. This change extends support to display values at the billions scale for better readability.

## Changes
- Extended `formatTokens()` function in `spendAnalysisFormat.ts` to handle values >= 1 billion, displaying them with one decimal place (e.g., "1.0B", "2.4B")
- Added comprehensive unit tests in new `spendAnalysisFormat.test.ts` covering the full range of formatting scenarios:
  - Small numbers (0, 999) display as-is
  - Thousands (1k, 108k)
  - Millions (1.5M, 999.9M)
  - Billions (1.0B, 2.4B)

## How did you test this?
Added unit tests with parameterized test cases covering boundary conditions and all supported unit levels (base, thousands, millions, billions).

## Automatic notifications
- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*