### PR TITLE
Persist in-progress question answers per question

### DIFF
--- a/packages/ui/src/features/permissions/PermissionSelector.tsx
+++ b/packages/ui/src/features/permissions/PermissionSelector.tsx
@@ -60,7 +60,9 @@ export function PermissionSelector({
     case "switch_mode":
       return <SwitchModePermission {...props} />;
     case "question":
-      return <QuestionPermission {...props} />;
+      // Key per question so answer state resets (and its draft is read) when a
+      // new question replaces the current one without unmounting.
+      return <QuestionPermission key={toolCall.toolCallId} {...props} />;
     default:
       return <DefaultPermission {...props} />;
   }

--- a/packages/ui/src/features/permissions/QuestionPermission.test.tsx
+++ b/packages/ui/src/features/permissions/QuestionPermission.test.tsx
@@ -21,7 +21,7 @@ function questionToolCall(toolCallId: string): PermissionToolCall {
         },
       ],
     },
-  } as unknown as PermissionToolCall;
+  } satisfies PermissionToolCall;
 }
 
 const options: PermissionOption[] = [];
@@ -103,6 +103,13 @@ describe("QuestionPermission draft persistence", () => {
     await user.keyboard("{Enter}");
 
     expect(onSelect).toHaveBeenCalled();
+    expect(useQuestionDraftStore.getState().actions.getDraft("q-1")).toBeNull();
+  });
+
+  it("does not persist a draft for an untouched question", async () => {
+    const { view } = renderQuestion(questionToolCall("q-1"));
+    // Mounting alone must not leave an empty draft behind on unmount.
+    view.unmount();
     expect(useQuestionDraftStore.getState().actions.getDraft("q-1")).toBeNull();
   });
 });

--- a/packages/ui/src/features/permissions/QuestionPermission.test.tsx
+++ b/packages/ui/src/features/permissions/QuestionPermission.test.tsx
@@ -1,0 +1,108 @@
+import type { PermissionOption } from "@agentclientprotocol/sdk";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QuestionPermission } from "./QuestionPermission";
+import { useQuestionDraftStore } from "./questionDraftStore";
+import type { PermissionToolCall } from "./types";
+
+function questionToolCall(toolCallId: string): PermissionToolCall {
+  return {
+    toolCallId,
+    title: "Question",
+    _meta: {
+      codeToolKind: "question",
+      questions: [
+        {
+          question: "What should the button say?",
+          header: "Button label",
+          options: [{ label: "Submit" }, { label: "Continue" }],
+        },
+      ],
+    },
+  } as unknown as PermissionToolCall;
+}
+
+const options: PermissionOption[] = [];
+
+function renderQuestion(toolCall: PermissionToolCall) {
+  const onSelect = vi.fn();
+  const onCancel = vi.fn();
+  const view = render(
+    <Theme>
+      <QuestionPermission
+        key={toolCall.toolCallId}
+        toolCall={toolCall}
+        options={options}
+        onSelect={onSelect}
+        onCancel={onCancel}
+      />
+    </Theme>,
+  );
+  return { onSelect, onCancel, view };
+}
+
+describe("QuestionPermission draft persistence", () => {
+  beforeEach(() => {
+    useQuestionDraftStore.setState({ drafts: {} });
+  });
+
+  // Options are Submit (1), Continue (2), and the free-text "Other" row (3).
+  const OTHER_KEY = "3";
+
+  it("restores a half-typed answer after unmount and remount", async () => {
+    const user = userEvent.setup();
+    const toolCall = questionToolCall("q-1");
+
+    const { view } = renderQuestion(toolCall);
+
+    // Focus the free-text option and type an in-progress answer.
+    await user.keyboard(OTHER_KEY);
+    const input = await screen.findByPlaceholderText("Type your answer...");
+    await user.type(input, "Buy now");
+
+    // Simulate switching to another session (component unmounts).
+    view.unmount();
+
+    // Return to the session: a fresh mount for the same question id.
+    renderQuestion(toolCall);
+
+    const restored = await screen.findByPlaceholderText<HTMLInputElement>(
+      "Type your answer...",
+    );
+    expect(restored.value).toBe("Buy now");
+  });
+
+  it("does not leak a draft to a different question id", async () => {
+    const user = userEvent.setup();
+
+    const { view } = renderQuestion(questionToolCall("q-1"));
+    await user.keyboard(OTHER_KEY);
+    await user.type(
+      await screen.findByPlaceholderText("Type your answer..."),
+      "for q-1",
+    );
+    view.unmount();
+
+    renderQuestion(questionToolCall("q-2"));
+    const input = await screen.findByPlaceholderText<HTMLInputElement>(
+      "Type your answer...",
+    );
+    expect(input.value).toBe("");
+  });
+
+  it("clears the draft once the question is answered", async () => {
+    const user = userEvent.setup();
+    const toolCall = questionToolCall("q-1");
+
+    const { onSelect } = renderQuestion(toolCall);
+    await user.keyboard(OTHER_KEY);
+    const input = await screen.findByPlaceholderText("Type your answer...");
+    await user.type(input, "Done");
+    await user.keyboard("{Enter}");
+
+    expect(onSelect).toHaveBeenCalled();
+    expect(useQuestionDraftStore.getState().actions.getDraft("q-1")).toBeNull();
+  });
+});

--- a/packages/ui/src/features/permissions/QuestionPermission.tsx
+++ b/packages/ui/src/features/permissions/QuestionPermission.tsx
@@ -123,13 +123,23 @@ export function QuestionPermission({
     },
   );
 
-  // Persist the draft on every change; cleared when the question is resolved.
+  // Persist the draft on every change, but only while it holds real content, so
+  // questions the user never answers (or that the agent later removes without a
+  // submit/cancel) don't leave empty entries accumulating in storage.
   useEffect(() => {
-    setDraft(questionId, {
-      activeStep,
-      stepAnswers: Object.fromEntries(stepAnswers),
-    });
-  }, [questionId, activeStep, stepAnswers, setDraft]);
+    const hasContent = Array.from(stepAnswers.values()).some(
+      (answer) =>
+        answer.selectedIds.length > 0 || answer.customInput.trim() !== "",
+    );
+    if (hasContent) {
+      setDraft(questionId, {
+        activeStep,
+        stepAnswers: Object.fromEntries(stepAnswers),
+      });
+    } else {
+      clearDraft(questionId);
+    }
+  }, [questionId, activeStep, stepAnswers, setDraft, clearDraft]);
 
   // Snapshot of persisted answers used to seed the selector's per-step state on
   // mount, so restored values are shown when navigating between steps.

--- a/packages/ui/src/features/permissions/QuestionPermission.tsx
+++ b/packages/ui/src/features/permissions/QuestionPermission.tsx
@@ -14,7 +14,8 @@ import {
   SUBMIT_OPTION_ID,
 } from "@posthog/ui/primitives/ActionSelector";
 import { Box, Flex, Text } from "@radix-ui/themes";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuestionDraftStore } from "./questionDraftStore";
 import { type BasePermissionProps, toSelectorOptions } from "./types";
 
 function parseQuestionMeta(raw: unknown): QuestionMeta | undefined {
@@ -98,10 +99,41 @@ export function QuestionPermission({
   const allQuestions = meta?.questions ?? [];
   const totalQuestions = allQuestions.length;
 
-  const [activeStep, setActiveStep] = useState(0);
-  const [stepAnswers, setStepAnswers] = useState<Map<number, StepAnswer>>(
-    () => new Map(),
+  // Drafts are keyed per question (the tool-call id), so a half-typed answer
+  // survives switching to another session and back.
+  const questionId = toolCall.toolCallId;
+  const { getDraft, setDraft, clearDraft } = useQuestionDraftStore(
+    (s) => s.actions,
   );
+
+  const [activeStep, setActiveStep] = useState(
+    () => getDraft(questionId)?.activeStep ?? 0,
+  );
+  const [stepAnswers, setStepAnswers] = useState<Map<number, StepAnswer>>(
+    () => {
+      const saved = getDraft(questionId)?.stepAnswers;
+      return saved
+        ? new Map(
+            Object.entries(saved).map(([step, answer]) => [
+              Number(step),
+              answer,
+            ]),
+          )
+        : new Map();
+    },
+  );
+
+  // Persist the draft on every change; cleared when the question is resolved.
+  useEffect(() => {
+    setDraft(questionId, {
+      activeStep,
+      stepAnswers: Object.fromEntries(stepAnswers),
+    });
+  }, [questionId, activeStep, stepAnswers, setDraft]);
+
+  // Snapshot of persisted answers used to seed the selector's per-step state on
+  // mount, so restored values are shown when navigating between steps.
+  const [initialStepAnswers] = useState(() => Object.fromEntries(stepAnswers));
 
   const isOnSubmitStep = activeStep >= totalQuestions;
 
@@ -136,6 +168,23 @@ export function QuestionPermission({
     [activeStep, totalQuestions],
   );
 
+  const resolveSelect = useCallback(
+    (
+      optionId: string,
+      customInput?: string,
+      answers?: Record<string, string>,
+    ) => {
+      clearDraft(questionId);
+      onSelect(optionId, customInput, answers);
+    },
+    [clearDraft, questionId, onSelect],
+  );
+
+  const handleCancel = useCallback(() => {
+    clearDraft(questionId);
+    onCancel();
+  }, [clearDraft, questionId, onCancel]);
+
   const handleMultiSelect = useCallback(
     (optionIds: string[], customInput?: string) => {
       if (totalQuestions === 1) {
@@ -144,23 +193,23 @@ export function QuestionPermission({
           [0, { selectedIds: optionIds, customInput: customInput ?? "" }],
         ]);
         const answers = buildAnswersRecord(singleAnswer, allQuestions);
-        onSelect(filteredIds[0] ?? "other", customInput, answers);
+        resolveSelect(filteredIds[0] ?? "other", customInput, answers);
         return;
       }
       advanceStep(optionIds, customInput);
     },
-    [totalQuestions, onSelect, advanceStep, allQuestions],
+    [totalQuestions, resolveSelect, advanceStep, allQuestions],
   );
 
   const handleSelect = useCallback(
     (optionId: string, customInput?: string) => {
       if (isOnSubmitStep) {
         if (optionId === CANCEL_OPTION_ID) {
-          onCancel();
+          handleCancel();
           return;
         }
         const answers = buildAnswersRecord(stepAnswers, allQuestions);
-        onSelect(SUBMIT_OPTION_ID, undefined, answers);
+        resolveSelect(SUBMIT_OPTION_ID, undefined, answers);
         return;
       }
 
@@ -169,7 +218,7 @@ export function QuestionPermission({
           [0, { selectedIds: [optionId], customInput: customInput ?? "" }],
         ]);
         const answers = buildAnswersRecord(singleAnswer, allQuestions);
-        onSelect(optionId, customInput, answers);
+        resolveSelect(optionId, customInput, answers);
         return;
       }
 
@@ -180,8 +229,8 @@ export function QuestionPermission({
       stepAnswers,
       allQuestions,
       totalQuestions,
-      onSelect,
-      onCancel,
+      resolveSelect,
+      handleCancel,
       advanceStep,
     ],
   );
@@ -194,6 +243,19 @@ export function QuestionPermission({
           selectedIds: optionIds,
           customInput: customInput ?? "",
         });
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Persist in-progress edits to the current step before it is committed via a
+  // step change or submit, so half-typed text is not lost on a session switch.
+  const handleDraftChange = useCallback(
+    (stepIndex: number, optionIds: string[], customInput: string) => {
+      setStepAnswers((prev) => {
+        const next = new Map(prev);
+        next.set(stepIndex, { selectedIds: optionIds, customInput });
         return next;
       });
     },
@@ -272,11 +334,14 @@ export function QuestionPermission({
       currentStep={activeStep}
       steps={steps}
       initialSelections={currentStepAnswer?.selectedIds}
+      initialCustomInput={currentStepAnswer?.customInput}
+      initialStepAnswers={initialStepAnswers}
       onSelect={handleSelect}
       onMultiSelect={handleMultiSelect}
-      onCancel={onCancel}
+      onCancel={handleCancel}
       onStepChange={handleStepChange}
       onStepAnswer={handleStepAnswer}
+      onDraftChange={handleDraftChange}
     />
   );
 }

--- a/packages/ui/src/features/permissions/questionDraftStore.test.ts
+++ b/packages/ui/src/features/permissions/questionDraftStore.test.ts
@@ -1,0 +1,85 @@
+import { registerRendererStateStorage } from "@posthog/ui/shell/rendererStorage";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQuestionDraftStore } from "./questionDraftStore";
+
+const getItem = vi.fn();
+const setItem = vi.fn();
+const removeItem = vi.fn();
+
+registerRendererStateStorage({ getItem, setItem, removeItem });
+
+describe("feature questionDraftStore", () => {
+  beforeEach(() => {
+    getItem.mockReset();
+    setItem.mockReset();
+    removeItem.mockReset();
+    getItem.mockResolvedValue(null);
+    setItem.mockResolvedValue(undefined);
+    removeItem.mockResolvedValue(undefined);
+
+    useQuestionDraftStore.setState({ drafts: {} });
+  });
+
+  it("keeps drafts separate per question id", () => {
+    const { setDraft, getDraft } = useQuestionDraftStore.getState().actions;
+
+    setDraft("tool-call-a", {
+      activeStep: 0,
+      stepAnswers: { 0: { selectedIds: [], customInput: "answer for a" } },
+    });
+    setDraft("tool-call-b", {
+      activeStep: 1,
+      stepAnswers: { 0: { selectedIds: ["option_1"], customInput: "" } },
+    });
+
+    expect(getDraft("tool-call-a")?.stepAnswers[0]?.customInput).toBe(
+      "answer for a",
+    );
+    expect(getDraft("tool-call-b")?.activeStep).toBe(1);
+    expect(getDraft("tool-call-b")?.stepAnswers[0]?.selectedIds).toEqual([
+      "option_1",
+    ]);
+  });
+
+  it("returns null for an unknown question id", () => {
+    expect(
+      useQuestionDraftStore.getState().actions.getDraft("nope"),
+    ).toBeNull();
+  });
+
+  it("clears a resolved question's draft without touching others", () => {
+    const { setDraft, clearDraft, getDraft } =
+      useQuestionDraftStore.getState().actions;
+
+    setDraft("tool-call-a", {
+      activeStep: 0,
+      stepAnswers: { 0: { selectedIds: [], customInput: "keep" } },
+    });
+    setDraft("tool-call-b", {
+      activeStep: 0,
+      stepAnswers: { 0: { selectedIds: [], customInput: "remove" } },
+    });
+
+    clearDraft("tool-call-b");
+
+    expect(getDraft("tool-call-b")).toBeNull();
+    expect(getDraft("tool-call-a")?.stepAnswers[0]?.customInput).toBe("keep");
+  });
+
+  it("persists drafts to the storage backend", async () => {
+    useQuestionDraftStore.getState().actions.setDraft("tool-call-a", {
+      activeStep: 0,
+      stepAnswers: { 0: { selectedIds: [], customInput: "persist me" } },
+    });
+
+    await vi.waitFor(() => {
+      expect(setItem).toHaveBeenCalled();
+    });
+
+    const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
+    const persisted = JSON.parse(lastCall[1]);
+    expect(
+      persisted.state.drafts["tool-call-a"].stepAnswers[0].customInput,
+    ).toBe("persist me");
+  });
+});

--- a/packages/ui/src/features/permissions/questionDraftStore.ts
+++ b/packages/ui/src/features/permissions/questionDraftStore.ts
@@ -1,0 +1,57 @@
+import type { StepAnswer } from "@posthog/ui/primitives/ActionSelector";
+import { electronStorage } from "@posthog/ui/shell/rendererStorage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
+
+// Keyed by the question's tool-call id so an in-progress answer survives
+// switching to another session and back. Deliberately per-question, not
+// per-session: two sessions each asking a question keep independent drafts.
+type QuestionId = string;
+
+export interface QuestionDraft {
+  activeStep: number;
+  // Record (not Map) so it serializes to the persisted storage backend.
+  stepAnswers: Record<number, StepAnswer>;
+}
+
+interface QuestionDraftState {
+  drafts: Record<QuestionId, QuestionDraft>;
+}
+
+export interface QuestionDraftActions {
+  getDraft: (questionId: QuestionId) => QuestionDraft | null;
+  setDraft: (questionId: QuestionId, draft: QuestionDraft) => void;
+  clearDraft: (questionId: QuestionId) => void;
+}
+
+type QuestionDraftStore = QuestionDraftState & {
+  actions: QuestionDraftActions;
+};
+
+export const useQuestionDraftStore = create<QuestionDraftStore>()(
+  persist(
+    immer((set, get) => ({
+      drafts: {},
+
+      actions: {
+        getDraft: (questionId) => get().drafts[questionId] ?? null,
+
+        setDraft: (questionId, draft) =>
+          set((state) => {
+            state.drafts[questionId] = draft;
+          }),
+
+        clearDraft: (questionId) =>
+          set((state) => {
+            delete state.drafts[questionId];
+          }),
+      },
+    })),
+    {
+      name: "question-answer-drafts",
+      storage: electronStorage,
+      partialize: (state) => ({ drafts: state.drafts }),
+    },
+  ),
+);

--- a/packages/ui/src/primitives/action-selector/ActionSelector.tsx
+++ b/packages/ui/src/primitives/action-selector/ActionSelector.tsx
@@ -18,12 +18,15 @@ export function ActionSelector({
   currentStep = 0,
   steps,
   initialSelections,
+  initialCustomInput,
+  initialStepAnswers,
   hideSubmitButton = false,
   onSelect,
   onMultiSelect,
   onCancel,
   onStepChange,
   onStepAnswer,
+  onDraftChange,
 }: ActionSelectorProps) {
   const state = useActionSelectorState({
     options,
@@ -33,10 +36,13 @@ export function ActionSelector({
     currentStep,
     steps,
     initialSelections,
+    initialCustomInput,
+    initialStepAnswers,
     onSelect,
     onMultiSelect,
     onStepChange,
     onStepAnswer,
+    onDraftChange,
   });
 
   const {

--- a/packages/ui/src/primitives/action-selector/types.ts
+++ b/packages/ui/src/primitives/action-selector/types.ts
@@ -28,6 +28,11 @@ export interface ActionSelectorProps {
   currentStep?: number;
   steps?: StepInfo[];
   initialSelections?: string[];
+  // Restores an in-progress free-text answer (e.g. after remounting).
+  initialCustomInput?: string;
+  // Seeds per-step answers so navigating between steps after a remount shows
+  // previously entered values. Only read on mount.
+  initialStepAnswers?: Record<number, StepAnswer>;
   hideSubmitButton?: boolean;
   onSelect: (optionId: string, customInput?: string) => void;
   onMultiSelect?: (optionIds: string[], customInput?: string) => void;
@@ -37,5 +42,12 @@ export interface ActionSelectorProps {
     stepIndex: number,
     optionIds: string[],
     customInput?: string,
+  ) => void;
+  // Fires on every edit to the current step's selection or free-text input, so
+  // a caller can persist a draft that is not yet committed via onStepAnswer.
+  onDraftChange?: (
+    stepIndex: number,
+    optionIds: string[],
+    customInput: string,
   ) => void;
 }

--- a/packages/ui/src/primitives/action-selector/useActionSelectorState.ts
+++ b/packages/ui/src/primitives/action-selector/useActionSelectorState.ts
@@ -44,10 +44,13 @@ interface UseActionSelectorStateProps {
   currentStep: number;
   steps: ActionSelectorProps["steps"];
   initialSelections?: string[];
+  initialCustomInput?: string;
+  initialStepAnswers?: ActionSelectorProps["initialStepAnswers"];
   onSelect: ActionSelectorProps["onSelect"];
   onMultiSelect: ActionSelectorProps["onMultiSelect"];
   onStepChange: ActionSelectorProps["onStepChange"];
   onStepAnswer: ActionSelectorProps["onStepAnswer"];
+  onDraftChange?: ActionSelectorProps["onDraftChange"];
 }
 
 export function useActionSelectorState({
@@ -58,21 +61,31 @@ export function useActionSelectorState({
   currentStep,
   steps,
   initialSelections,
+  initialCustomInput,
+  initialStepAnswers,
   onSelect,
   onMultiSelect,
   onStepChange,
   onStepAnswer,
+  onDraftChange,
 }: UseActionSelectorStateProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [checkedOptions, setCheckedOptions] = useState<Set<string>>(() =>
     initialSelections?.length ? new Set(initialSelections) : new Set(),
   );
-  const [customInput, setCustomInput] = useState("");
+  const [customInput, setCustomInput] = useState(initialCustomInput ?? "");
   const [isEditing, setIsEditing] = useState(false);
   const [internalStep, setInternalStep] = useState(currentStep);
-  const [stepAnswers, setStepAnswers] = useState<Map<number, StepAnswer>>(
-    () => new Map(),
+  const [stepAnswers, setStepAnswers] = useState<Map<number, StepAnswer>>(() =>
+    initialStepAnswers
+      ? new Map(
+          Object.entries(initialStepAnswers).map(([step, answer]) => [
+            Number(step),
+            answer,
+          ]),
+        )
+      : new Map(),
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const prevActiveStepRef = useRef(currentStep);
@@ -178,6 +191,38 @@ export function useActionSelectorState({
       });
     }
   }, [selectedOption, showSubmitButton, multiSelect]);
+
+  // On mount, if a free-text answer was restored, focus its custom-input option
+  // so the recovered text is visible rather than hidden behind an unselected row.
+  const restoredCustomInputRef = useRef(false);
+  useEffect(() => {
+    if (restoredCustomInputRef.current) return;
+    restoredCustomInputRef.current = true;
+    if (!(initialCustomInput ?? "").trim()) return;
+    const idx = allOptions.findIndex((opt) => needsCustomInput(opt));
+    if (idx >= 0) {
+      setSelectedIndex(idx);
+      setIsEditing(true);
+    }
+  }, [initialCustomInput, allOptions]);
+
+  // Report every edit to the current step's draft so callers can persist it.
+  // A ref skips the initial mount, so restoring a draft does not immediately
+  // echo it back.
+  const onDraftChangeRef = useRef(onDraftChange);
+  onDraftChangeRef.current = onDraftChange;
+  const draftReportMountedRef = useRef(false);
+  useEffect(() => {
+    if (!draftReportMountedRef.current) {
+      draftReportMountedRef.current = true;
+      return;
+    }
+    onDraftChangeRef.current?.(
+      internalStep,
+      Array.from(checkedOptions),
+      customInput,
+    );
+  }, [checkedOptions, customInput, internalStep]);
 
   const moveUp = useCallback(() => {
     setHoveredIndex(null);

--- a/packages/ui/src/primitives/action-selector/useActionSelectorState.ts
+++ b/packages/ui/src/primitives/action-selector/useActionSelectorState.ts
@@ -97,6 +97,23 @@ export function useActionSelectorState({
   const numSteps = steps?.length ?? 0;
   const showSubmitButton = !hideSubmitButton && (multiSelect || hasSteps);
 
+  // Refs let the edit handlers report the current draft imperatively without
+  // re-subscribing on every keystroke.
+  const activeStepRef = useRef(activeStep);
+  activeStepRef.current = activeStep;
+  const checkedOptionsRef = useRef(checkedOptions);
+  checkedOptionsRef.current = checkedOptions;
+  const onDraftChangeRef = useRef(onDraftChange);
+  onDraftChangeRef.current = onDraftChange;
+
+  const reportDraft = useCallback((checked: Set<string>, input: string) => {
+    onDraftChangeRef.current?.(
+      activeStepRef.current,
+      Array.from(checked),
+      input,
+    );
+  }, []);
+
   const allOptions = useMemo(() => {
     const opts = allowCustomInput
       ? [...options, { id: OTHER_OPTION_ID, label: "Other", description: "" }]
@@ -206,24 +223,6 @@ export function useActionSelectorState({
     }
   }, [initialCustomInput, allOptions]);
 
-  // Report every edit to the current step's draft so callers can persist it.
-  // A ref skips the initial mount, so restoring a draft does not immediately
-  // echo it back.
-  const onDraftChangeRef = useRef(onDraftChange);
-  onDraftChangeRef.current = onDraftChange;
-  const draftReportMountedRef = useRef(false);
-  useEffect(() => {
-    if (!draftReportMountedRef.current) {
-      draftReportMountedRef.current = true;
-      return;
-    }
-    onDraftChangeRef.current?.(
-      internalStep,
-      Array.from(checkedOptions),
-      customInput,
-    );
-  }, [checkedOptions, customInput, internalStep]);
-
   const moveUp = useCallback(() => {
     setHoveredIndex(null);
     setSelectedIndex((prev) => (prev > 0 ? prev - 1 : numOptions - 1));
@@ -250,26 +249,25 @@ export function useActionSelectorState({
 
   const toggleCheck = useCallback(
     (optionId: string) => {
-      setCheckedOptions((prev) => {
-        const next = new Set(prev);
-        if (multiSelect) {
-          if (next.has(optionId)) {
-            next.delete(optionId);
-          } else {
-            next.add(optionId);
-          }
+      const next = new Set(checkedOptionsRef.current);
+      if (multiSelect) {
+        if (next.has(optionId)) {
+          next.delete(optionId);
         } else {
-          if (next.has(optionId)) {
-            next.clear();
-          } else {
-            next.clear();
-            next.add(optionId);
-          }
+          next.add(optionId);
         }
-        return next;
-      });
+      } else {
+        if (next.has(optionId)) {
+          next.clear();
+        } else {
+          next.clear();
+          next.add(optionId);
+        }
+      }
+      setCheckedOptions(next);
+      reportDraft(next, customInputRef.current);
     },
-    [multiSelect],
+    [multiSelect, reportDraft],
   );
 
   const handleSubmitMulti = useCallback(() => {
@@ -475,28 +473,29 @@ export function useActionSelectorState({
   const handleCustomInputChange = useCallback(
     (value: string) => {
       setCustomInput(value);
+      let nextChecked = checkedOptionsRef.current;
       if (
         showSubmitButton &&
         selectedOption &&
         needsCustomInput(selectedOption)
       ) {
-        setCheckedOptions((prev) => {
-          const next = new Set(prev);
-          if (value.trim()) {
-            if (!prev.has(selectedOption.id)) {
-              if (!multiSelect) {
-                next.clear();
-              }
-              next.add(selectedOption.id);
+        const next = new Set(checkedOptionsRef.current);
+        if (value.trim()) {
+          if (!next.has(selectedOption.id)) {
+            if (!multiSelect) {
+              next.clear();
             }
-          } else {
-            next.delete(selectedOption.id);
+            next.add(selectedOption.id);
           }
-          return next;
-        });
+        } else {
+          next.delete(selectedOption.id);
+        }
+        nextChecked = next;
+        setCheckedOptions(next);
       }
+      reportDraft(nextChecked, value);
     },
-    [showSubmitButton, selectedOption, multiSelect],
+    [showSubmitButton, selectedOption, multiSelect, reportDraft],
   );
 
   const ensureChecked = useCallback((optionId: string) => {


### PR DESCRIPTION
## Problem

If you start typing an answer to a question the agent asked and then switch to another session (e.g. to copy something), the typed text is erased. The answer box kept its state only in local React state, so unmounting the view lost it.

## Changes

- Add a per-question draft store keyed by the question's tool-call id (not per session): active step, selected options, and free-text input are saved on every edit and restored on remount.
- The draft is cleared when the question is submitted or cancelled.
- The question selector is now keyed per question, so a new question no longer inherits the previous one's state.

## How did you test this?

- Added `questionDraftStore.test.ts` (store isolation, clearing, persistence) and `QuestionPermission.test.tsx` (type → unmount → remount restores the text; no leak across question ids; draft cleared on answer).
- `pnpm --filter @posthog/ui test` for the permissions + action-selector suites, `pnpm --filter @posthog/ui typecheck`, and Biome lint/format — all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783086167182099?thread_ts=1783086167.182099&cid=C09G8Q32R6F)*