### PR TITLE
fix(sessions): preserve model on session retry

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1299,6 +1299,12 @@ export class SessionService {
     session.channel = result.channel;
     session.status = "connected";
     session.adapter = adapter;
+    // Capture the run configuration so retry/reset flows (clearSessionError)
+    // can recreate the session with the user's original choices instead of
+    // falling back to DEFAULT_GATEWAY_MODEL and losing e.g. a Fable selection.
+    session.model = model;
+    session.executionMode = executionMode;
+    session.reasoningLevel = reasoningLevel;
 
     // An imported CLI session had its history replayed during agent.start;
     // the replay is already in the local run log, so load it for the UI.
@@ -3389,7 +3395,14 @@ export class SessionService {
     this.localRepoPaths.set(taskId, repoPath);
     const session = this.d.store.getSessionByTaskId(taskId);
     if (session?.initialPrompt?.length) {
-      const { taskTitle, initialPrompt } = session;
+      const {
+        taskTitle,
+        initialPrompt,
+        executionMode,
+        adapter,
+        model,
+        reasoningLevel,
+      } = session;
       await this.teardownSession(session.taskRunId);
       const authStatus = await this.getAuthCredentialsStatus();
       if (authStatus.kind === "restoring") {
@@ -3400,12 +3413,18 @@ export class SessionService {
           "Unable to reach server. Please check your connection.",
         );
       }
+      // Preserve the original run configuration so the retried session keeps
+      // the user's model/adapter/mode instead of reverting to defaults.
       await this.createNewLocalSession(
         taskId,
         taskTitle,
         repoPath,
         authStatus.auth,
         initialPrompt,
+        executionMode,
+        adapter,
+        model,
+        reasoningLevel,
       );
       return;
     }

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1299,9 +1299,6 @@ export class SessionService {
     session.channel = result.channel;
     session.status = "connected";
     session.adapter = adapter;
-    // Capture the run configuration so retry/reset flows (clearSessionError)
-    // can recreate the session with the user's original choices instead of
-    // falling back to DEFAULT_GATEWAY_MODEL and losing e.g. a Fable selection.
     session.model = model;
     session.executionMode = executionMode;
     session.reasoningLevel = reasoningLevel;
@@ -3413,8 +3410,6 @@ export class SessionService {
           "Unable to reach server. Please check your connection.",
         );
       }
-      // Preserve the original run configuration so the retried session keeps
-      // the user's model/adapter/mode instead of reverting to defaults.
       await this.createNewLocalSession(
         taskId,
         taskTitle,

--- a/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -1,0 +1,88 @@
+import type { AgentSession } from "@posthog/shared";
+import { describe, expect, it, vi } from "vitest";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+function makeSession(overrides: Partial<AgentSession> = {}): AgentSession {
+  return {
+    taskRunId: "run-1",
+    taskId: "task-1",
+    taskTitle: "Test task",
+    channel: "",
+    events: [],
+    startedAt: 1,
+    status: "error",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    initialPrompt: [{ type: "text", text: "Ship the fix" }],
+    ...overrides,
+  } as AgentSession;
+}
+
+function createHarness(session: AgentSession) {
+  const sessions: Record<string, AgentSession> = {
+    [session.taskRunId]: session,
+  };
+  const deps = {
+    store: {
+      getSessionByTaskId: (taskId: string) =>
+        Object.values(sessions).find((s) => s.taskId === taskId),
+    },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    trpc: {
+      agent: {
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  vi.spyOn(
+    service as unknown as { teardownSession: () => Promise<void> },
+    "teardownSession",
+  ).mockResolvedValue(undefined);
+  vi.spyOn(
+    service as unknown as {
+      getAuthCredentialsStatus: () => Promise<unknown>;
+    },
+    "getAuthCredentialsStatus",
+  ).mockResolvedValue({ kind: "ready", auth: { client: {} } });
+  const createNewLocalSession = vi
+    .spyOn(
+      service as unknown as {
+        createNewLocalSession: (...args: unknown[]) => Promise<void>;
+      },
+      "createNewLocalSession",
+    )
+    .mockResolvedValue(undefined);
+
+  return { service, createNewLocalSession };
+}
+
+describe("SessionService.clearSessionError retry config", () => {
+  it("recreates the session with the original run configuration", async () => {
+    const session = makeSession({
+      model: "claude-fable-5",
+      adapter: "claude",
+      executionMode: "auto",
+      reasoningLevel: "high",
+    });
+    const { service, createNewLocalSession } = createHarness(session);
+
+    await service.clearSessionError("task-1", "/repo");
+
+    // args: taskId, taskTitle, repoPath, auth, initialPrompt,
+    //       executionMode, adapter, model, reasoningLevel
+    const call = createNewLocalSession.mock.calls[0];
+    expect(call[5]).toBe("auto"); // executionMode
+    expect(call[6]).toBe("claude"); // adapter
+    expect(call[7]).toBe("claude-fable-5"); // model
+    expect(call[8]).toBe("high"); // reasoningLevel
+  });
+});

--- a/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -77,12 +77,16 @@ describe("SessionService.clearSessionError retry config", () => {
 
     await service.clearSessionError("task-1", "/repo");
 
-    // args: taskId, taskTitle, repoPath, auth, initialPrompt,
-    //       executionMode, adapter, model, reasoningLevel
-    const call = createNewLocalSession.mock.calls[0];
-    expect(call[5]).toBe("auto"); // executionMode
-    expect(call[6]).toBe("claude"); // adapter
-    expect(call[7]).toBe("claude-fable-5"); // model
-    expect(call[8]).toBe("high"); // reasoningLevel
+    expect(createNewLocalSession).toHaveBeenCalledWith(
+      "task-1",
+      "Test task",
+      "/repo",
+      { client: {} },
+      session.initialPrompt,
+      "auto", // executionMode
+      "claude", // adapter
+      "claude-fable-5", // model
+      "high", // reasoningLevel
+    );
   });
 });

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -64,6 +64,14 @@ export interface AgentSession {
   processedLineCount?: number;
   framework?: "claude";
   adapter?: Adapter;
+  /**
+   * Run configuration captured at session creation so retry/reset flows can
+   * recreate the session with the user's original choices instead of silently
+   * falling back to defaults (e.g. reverting a Fable run to the default model).
+   */
+  model?: string;
+  executionMode?: ExecutionMode;
+  reasoningLevel?: string;
   configOptions?: SessionConfigOption[];
   pendingPermissions: Map<string, PermissionRequest>;
   pausedDurationMs: number;

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -64,11 +64,6 @@ export interface AgentSession {
   processedLineCount?: number;
   framework?: "claude";
   adapter?: Adapter;
-  /**
-   * Run configuration captured at session creation so retry/reset flows can
-   * recreate the session with the user's original choices instead of silently
-   * falling back to defaults (e.g. reverting a Fable run to the default model).
-   */
   model?: string;
   executionMode?: ExecutionMode;
   reasoningLevel?: string;


### PR DESCRIPTION
## Problem

See my bug report here: https://posthog.slack.com/archives/C09G8Q32R6F/p1783085269646269?thread_ts=1783085269.646269&cid=C09G8Q32R6F

Claude Code continues:

Users who selected a non-default model (e.g. Fable) for a task saw the task silently run on the default model (Opus 4.8) instead. This happened whenever the first session-create attempt failed: the connection auto-retry (and the manual retry button) recreated the local session without the user's chosen model, so it fell back to `DEFAULT_GATEWAY_MODEL`. The original failure was even logged with the correct model, making the drop hard to spot.

## Changes

`clearSessionError` recreated the session passing only the prompt, omitting model, adapter, execution mode, and reasoning level — so `createNewLocalSession` fell back to `DEFAULT_GATEWAY_MODEL`. The `AgentSession` object also never persisted the model, so there was nothing to recover it from.

- Capture `model`, `executionMode`, and `reasoningLevel` on the session at creation (adapter was already stored).
- On retry, read them back and pass them through to `createNewLocalSession` so the retried session keeps the user's original choices.
- Add a regression test asserting the retry forwards the persisted config.

## How did you test this?

- Added `sessionServiceRetryConfig.test.ts` verifying `clearSessionError` recreates the session with the original model/adapter/mode/effort; it passes.
- `pnpm --filter @posthog/core test` (full core suite) and `pnpm --filter @posthog/core typecheck` pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783085269646269?thread_ts=1783085269.646269&cid=C09G8Q32R6F)*