### PR TITLE
fix(agent): show skill name in permission prompt

### DIFF
--- a/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
+++ b/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
@@ -404,6 +404,17 @@ export function toolInfoFromToolUse(
         content: [],
       };
 
+    case "Skill": {
+      const skill = typeof input?.skill === "string" ? input.skill : undefined;
+      const skillArgs =
+        typeof input?.args === "string" ? input.args : undefined;
+      return {
+        title: skill ? `Skill: ${skill}` : "Skill",
+        kind: "other",
+        content: skillArgs ? toolContent().text(skillArgs).build() : [],
+      };
+    }
+
     case "ExitPlanMode":
       return {
         title: "Ready to code?",


### PR DESCRIPTION
## Problem

Invoking a skill produced a permission prompt that read just **"Skill / Do you want to proceed?"** — with no indication of *which* skill was being run.

The raw Claude SDK tool name `Skill` had no case in `toolInfoFromToolUse` (`packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts`), so it fell through to the `default` branch → `title: "Skill"`, `kind: "other"`. In the UI, `kind: "other"` routes to `DefaultPermission`, which renders the bare title. (Notably, `ToolCallView` already has a `Skill` display entry for the in-conversation view — only the permission path was missing it.)

## Fix

Add a `Skill` case that surfaces the skill name from `input.skill`, so the prompt now reads **"Skill: deep-research / Do you want to proceed?"**, and passes any `args` through as tool-call content.

Kept `kind: "other"` so it continues routing to `DefaultPermission` — no new component needed. A dedicated `SkillPermission` renderer (icon + styling) could follow later.

## Verification
- `pnpm --filter @posthog/agent typecheck` → clean
- `biome lint` on the changed file → no issues