### PR TITLE
feat(bluebird): Slack-style channel feed with task cards and threads

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -71,8 +71,10 @@ import type {
   SuggestedReviewersArtefact,
   SuggestedReviewerWriteEntry,
   Task,
+  TaskChannel,
   TaskRun,
   TaskRunArtefact,
+  TaskThreadMessage,
   UserBasic,
 } from "@posthog/shared/domain-types";
 import {
@@ -2120,6 +2122,7 @@ export class PostHogAPIClient {
     createdBy?: number;
     originProduct?: string;
     internal?: boolean;
+    channel?: string;
   }) {
     const teamId = await this.getTeamId();
     const params: Record<string, string | number | boolean> = {
@@ -2140,6 +2143,10 @@ export class PostHogAPIClient {
 
     if (options?.internal) {
       params.internal = true;
+    }
+
+    if (options?.channel) {
+      params.channel = options.channel;
     }
 
     const data = await this.api.get(`/api/projects/{project_id}/tasks/`, {
@@ -2210,6 +2217,7 @@ export class PostHogAPIClient {
         runtime_adapter?: string | null;
         model?: string | null;
         reasoning_effort?: string | null;
+        channel?: string | null;
       },
   ) {
     const teamId = await this.getTeamId();
@@ -2257,6 +2265,121 @@ export class PostHogAPIClient {
       github_integration: task.github_integration,
       github_user_integration: task.github_user_integration,
     });
+  }
+
+  // Task channels + threads. Not in the generated OpenAPI client yet, so these
+  // go through the raw fetcher like the desktop file-system endpoints above.
+
+  // List backend task channels: all public channels plus the requester's
+  // personal "#me" channel (provisioned lazily server-side on first list).
+  async getTaskChannels(): Promise<TaskChannel[]> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/task_channels/`;
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch task channels: ${response.statusText}`);
+    }
+    return (await response.json()) as TaskChannel[];
+  }
+
+  // Resolve-or-create a public channel by name (idempotent server-side).
+  async resolveTaskChannel(name: string): Promise<TaskChannel> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/task_channels/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+      overrides: { body: JSON.stringify({ name }) },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to resolve task channel: ${response.statusText}`);
+    }
+    return (await response.json()) as TaskChannel;
+  }
+
+  async getTaskThreadMessages(taskId: string): Promise<TaskThreadMessage[]> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/thread_messages/`;
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch thread messages: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as TaskThreadMessage[];
+  }
+
+  async createTaskThreadMessage(
+    taskId: string,
+    content: string,
+  ): Promise<TaskThreadMessage> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/thread_messages/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+      overrides: { body: JSON.stringify({ content }) },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to post thread message: ${response.statusText}`);
+    }
+    return (await response.json()) as TaskThreadMessage;
+  }
+
+  async deleteTaskThreadMessage(
+    taskId: string,
+    messageId: string,
+  ): Promise<void> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/thread_messages/${encodeURIComponent(messageId)}/`;
+    const response = await this.api.fetcher.fetch({
+      method: "delete",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+    });
+    if (!response.ok && response.status !== 404) {
+      throw new Error(
+        `Failed to delete thread message: ${response.statusText}`,
+      );
+    }
+  }
+
+  // Forward a thread message into the task's live run. Task author only; the
+  // backend rejects with 400/403 otherwise (surfaced via the error body detail).
+  async sendTaskThreadMessageToAgent(
+    taskId: string,
+    messageId: string,
+  ): Promise<TaskThreadMessage> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/thread_messages/${encodeURIComponent(messageId)}/send_to_agent/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+      overrides: { body: JSON.stringify({}) },
+    });
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      let message = `Failed to send message to agent: ${response.statusText}`;
+      try {
+        const parsed = JSON.parse(errorText) as { detail?: string };
+        if (parsed.detail) message = parsed.detail;
+      } catch {
+        if (errorText) message = errorText;
+      }
+      throw new Error(message);
+    }
+    return (await response.json()) as TaskThreadMessage;
   }
 
   async sendRunCommand(

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -645,6 +645,7 @@ export class TaskCreationSaga extends Saga<
               ? (input.reasoningLevel ?? null)
               : undefined,
           signal_report: input.signalReportId ?? undefined,
+          channel: input.channelId ?? undefined,
         });
         return result as unknown as Task;
       },

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -21,6 +21,7 @@ export interface PrepareTaskInputOptions {
   additionalDirectories?: string[];
   channelContext?: string;
   channelName?: string;
+  channelId?: string;
   customInstructions?: string;
   allowNoRepo?: boolean;
 }
@@ -59,6 +60,7 @@ export function prepareTaskInput(
     additionalDirectories: isCloud ? undefined : options.additionalDirectories,
     channelContext: options.channelContext,
     channelName: options.channelName,
+    channelId: options.channelId,
     customInstructions: isCloud ? options.customInstructions : undefined,
     allowNoRepo: options.allowNoRepo,
   };

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -53,7 +53,37 @@ export interface Task {
   json_schema?: Record<string, unknown> | null;
   signal_report?: string | null;
   internal?: boolean;
+  /** Backend channel (tasks product Channel UUID) this task is owned by. */
+  channel?: string | null;
   latest_run?: TaskRun;
+}
+
+/**
+ * A backend task channel — the shared feed a task is kicked off in. Distinct
+ * from the desktop file-system "channel" folders: those carry CONTEXT.md and
+ * artifacts, while this owns the task feed and threads. `personal` is the
+ * user's private "#me" channel.
+ */
+export interface TaskChannel {
+  id: string;
+  name: string;
+  channel_type: "public" | "personal";
+  created_at: string;
+  created_by?: UserBasic | null;
+}
+
+/**
+ * One human message in a task's thread. Thread messages never reach the agent
+ * unless the task author forwards one, which stamps the forwarded_* fields.
+ */
+export interface TaskThreadMessage {
+  id: string;
+  task: string;
+  content: string;
+  created_at: string;
+  author?: UserBasic | null;
+  forwarded_to_agent_at?: string | null;
+  forwarded_by?: UserBasic | null;
 }
 
 export type TaskRunStatus =

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -46,6 +46,8 @@ export interface TaskCreationInput {
   channelContext?: string;
   /** Display name of that channel, embedded in the context block for the UI. */
   channelName?: string;
+  /** Backend channel UUID the created task is owned by (its feed home). */
+  channelId?: string;
   /**
    * The user's saved personalization (Settings → Personalization custom
    * instructions). Cloud-only: local tasks already receive these through the

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -2,12 +2,22 @@ import {
   ArrowSquareOutIcon,
   ChatCircleIcon,
   GitBranchIcon,
+  RobotIcon,
+  UserIcon,
 } from "@phosphor-icons/react";
 import {
+  Avatar,
+  AvatarFallback,
+  AvatarGroup,
   Badge,
   Button,
+  ButtonGroup,
   Card,
   CardContent,
+  ChatMessage,
+  ChatMessageAvatar,
+  ChatMessageContent,
+  ChatMessageHeader,
   ChatMessageScroller,
   ChatMessageScrollerButton,
   ChatMessageScrollerContent,
@@ -15,17 +25,26 @@ import {
   ChatMessageScrollerProvider,
   ChatMessageScrollerViewport,
   Spinner,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
+import { useTaskThread } from "@posthog/ui/features/canvas/hooks/useTaskThread";
 import {
   userDisplayName,
   userInitials,
-} from "@posthog/ui/features/canvas/components/ThreadPanel";
+} from "@posthog/ui/features/canvas/utils/userDisplay";
 import { xmlToPlainText } from "@posthog/ui/features/message-editor/content";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
-import { Avatar, Text } from "@radix-ui/themes";
+import { Text } from "@radix-ui/themes";
 import { useMemo } from "react";
+
+// Feed rows poll their reply counts slower than the open thread panel — the
+// shared query key means an open panel naturally speeds the row up too.
+const FEED_REPLIES_POLL_INTERVAL_MS = 15_000;
 
 const STATUS_LABELS: Record<TaskRunStatus, string> = {
   not_started: "Not started",
@@ -34,6 +53,16 @@ const STATUS_LABELS: Record<TaskRunStatus, string> = {
   completed: "Completed",
   failed: "Failed",
   cancelled: "Cancelled",
+};
+
+const ORIGIN_LABELS: Record<string, string> = {
+  error_tracking: "Error tracking",
+  signal_report: "Signal report",
+  signals_scout: "Signals scout",
+  automation: "Automation",
+  slack: "Slack",
+  onboarding: "Onboarding",
+  session_summaries: "Session summaries",
 };
 
 function statusBadge(status: TaskRunStatus | undefined) {
@@ -66,6 +95,121 @@ function promptText(task: Task): string {
   }
 }
 
+// The card's context line, mirroring the storybook feed: who/what kicked the
+// task off ("Requested by @Ann" for humans, the origin product otherwise).
+function TaskCardOrigin({ task }: { task: Task }) {
+  const isUserCreated = task.origin_product === "user_created";
+  const label = isUserCreated
+    ? `Requested by @${userDisplayName(task.created_by)}`
+    : (ORIGIN_LABELS[task.origin_product] ?? task.origin_product);
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5 text-muted-foreground text-xs">
+      {isUserCreated ? <UserIcon size={12} /> : <RobotIcon size={12} />}
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+// The task the message kicked off, as a card everyone in the channel sees:
+// origin + status up top, bold title, then run metadata.
+function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
+  const prUrl =
+    typeof task.latest_run?.output?.pr_url === "string"
+      ? task.latest_run.output.pr_url
+      : undefined;
+  const meta = [
+    task.slug || null,
+    task.repository,
+    task.latest_run?.stage ?? null,
+    task.latest_run?.environment === "cloud" ? "Cloud" : null,
+  ].filter(Boolean) as string[];
+
+  return (
+    <Card
+      size="sm"
+      className="mt-1.5 max-w-xl cursor-pointer transition-colors hover:border-border-primary"
+      onClick={onOpen}
+    >
+      <CardContent className="flex flex-col gap-1 py-2.5">
+        <div className="flex items-center justify-between gap-2">
+          <TaskCardOrigin task={task} />
+          {statusBadge(task.latest_run?.status)}
+        </div>
+        <Text size="2" weight="medium" className="line-clamp-2">
+          {task.title || "Untitled task"}
+        </Text>
+        {(meta.length > 0 || prUrl) && (
+          <div className="flex min-w-0 items-center gap-3">
+            {task.repository && (
+              <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
+                <GitBranchIcon size={12} />
+                {task.repository}
+              </span>
+            )}
+            <Text size="1" className="truncate text-muted-foreground">
+              {meta.filter((m) => m !== task.repository).join(" · ")}
+            </Text>
+            {prUrl && (
+              <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs">
+                <ArrowSquareOutIcon size={12} />
+                PR
+              </span>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// Slack-style thread teaser under the card: reply-author facepile, count, and
+// last-reply time. Only renders once the thread has messages; starting a
+// thread lives in the row's hover toolbar.
+function RepliesRow({
+  taskId,
+  onOpenThread,
+}: {
+  taskId: string;
+  onOpenThread: () => void;
+}) {
+  const { messages } = useTaskThread(taskId, {
+    pollIntervalMs: FEED_REPLIES_POLL_INTERVAL_MS,
+  });
+  const authors = useMemo(() => {
+    const seen = new Map<string, (typeof messages)[number]["author"]>();
+    for (const message of messages) {
+      const key = message.author?.uuid ?? "unknown";
+      if (!seen.has(key)) seen.set(key, message.author);
+    }
+    return [...seen.values()].slice(0, 4);
+  }, [messages]);
+
+  if (messages.length === 0) return null;
+  const last = messages[messages.length - 1];
+
+  return (
+    <button
+      type="button"
+      onClick={onOpenThread}
+      className="mt-1 flex w-fit items-center gap-2 rounded-md px-1.5 py-1 hover:bg-fill-secondary"
+    >
+      <AvatarGroup size="xs" stacked>
+        {authors.map((author, index) => (
+          <Avatar key={author?.uuid ?? index} size="xs">
+            <AvatarFallback>{userInitials(author)}</AvatarFallback>
+          </Avatar>
+        ))}
+      </AvatarGroup>
+      <Text size="1" weight="medium" className="text-accent-11">
+        {messages.length} {messages.length === 1 ? "reply" : "replies"}
+      </Text>
+      <Text size="1" className="text-muted-foreground">
+        Last reply {formatRelativeTimeShort(last.created_at)}
+      </Text>
+    </button>
+  );
+}
+
 function FeedItem({
   task,
   onOpenTask,
@@ -76,84 +220,78 @@ function FeedItem({
   onOpenThread: (task: Task) => void;
 }) {
   const prompt = useMemo(() => promptText(task), [task]);
-  const prUrl =
-    typeof task.latest_run?.output?.pr_url === "string"
-      ? task.latest_run.output.pr_url
-      : undefined;
+  const isAgent = !task.created_by || task.origin_product !== "user_created";
 
   return (
-    <div className="group relative flex gap-2.5 px-4 py-2.5 hover:bg-fill-secondary/50">
-      <Avatar
-        size="2"
-        radius="full"
-        fallback={userInitials(task.created_by)}
-        className="mt-0.5 shrink-0"
-      />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
-          <Text size="2" weight="medium" className="truncate">
-            {userDisplayName(task.created_by)}
+    <ChatMessage className="group relative rounded-md px-3 py-2 hover:bg-fill-secondary/50">
+      <ChatMessageAvatar>
+        <Avatar>
+          <AvatarFallback>
+            {isAgent && !task.created_by ? (
+              <RobotIcon size={16} />
+            ) : (
+              userInitials(task.created_by)
+            )}
+          </AvatarFallback>
+        </Avatar>
+      </ChatMessageAvatar>
+      <ChatMessageContent className="min-w-0 gap-0.5">
+        <ChatMessageHeader className="items-baseline gap-2">
+          <Text size="2" weight="bold" className="truncate">
+            {task.created_by ? userDisplayName(task.created_by) : "Agent"}
           </Text>
+          {isAgent && <Badge variant="info">Agent</Badge>}
           <Text size="1" className="shrink-0 text-muted-foreground">
             {formatRelativeTimeShort(task.created_at)}
           </Text>
-        </div>
+        </ChatMessageHeader>
 
-        <Text
-          size="2"
-          className="mt-0.5 line-clamp-4 block whitespace-pre-wrap break-words"
-        >
+        <Text size="2" className="line-clamp-4 whitespace-pre-wrap break-words">
           {prompt}
         </Text>
 
-        {/* The task the message kicked off, as a card everyone in the channel sees. */}
-        <Card
-          size="sm"
-          className="mt-2 max-w-xl cursor-pointer transition-colors hover:border-border-primary"
-          onClick={() => onOpenTask(task)}
-        >
-          <CardContent className="flex flex-col gap-1.5 py-2.5">
-            <div className="flex items-center gap-2">
-              {statusBadge(task.latest_run?.status)}
-              {task.latest_run?.stage && (
-                <Text size="1" className="text-muted-foreground">
-                  {task.latest_run.stage}
-                </Text>
-              )}
-            </div>
-            <Text size="2" weight="medium" className="line-clamp-2">
-              {task.title || "Untitled task"}
-            </Text>
-            <div className="flex items-center gap-3">
-              {task.repository && (
-                <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
-                  <GitBranchIcon size={12} />
-                  {task.repository}
-                </span>
-              )}
-              {prUrl && (
-                <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
-                  <ArrowSquareOutIcon size={12} />
-                  PR
-                </span>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+        <TaskCard task={task} onOpen={() => onOpenTask(task)} />
+        <RepliesRow taskId={task.id} onOpenThread={() => onOpenThread(task)} />
+      </ChatMessageContent>
 
-        <div className="mt-1">
-          <Button
-            variant="default"
-            size="xs"
-            onClick={() => onOpenThread(task)}
-            className="opacity-0 transition-opacity group-hover:opacity-100"
-          >
-            <ChatCircleIcon size={13} />
-            Reply in thread
-          </Button>
-        </div>
+      {/* Hover toolbar, storybook-style: floats top-right of the row. */}
+      <div className="absolute top-1 right-2 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+        <TooltipProvider delay={400}>
+          <ButtonGroup className="rounded-md border border-border bg-surface shadow-sm">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="default"
+                    size="icon-sm"
+                    aria-label="Reply in thread"
+                    onClick={() => onOpenThread(task)}
+                  >
+                    <ChatCircleIcon size={15} />
+                  </Button>
+                }
+              />
+              <TooltipContent side="top">Reply in thread</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="default"
+                    size="icon-sm"
+                    aria-label="Open task"
+                    onClick={() => onOpenTask(task)}
+                  >
+                    <ArrowSquareOutIcon size={15} />
+                  </Button>
+                }
+              />
+              <TooltipContent side="top">Open task</TooltipContent>
+            </Tooltip>
+          </ButtonGroup>
+        </TooltipProvider>
       </div>
-    </div>
+    </ChatMessage>
   );
 }
 
@@ -189,7 +327,7 @@ export function ChannelFeedView({
     <ChatMessageScrollerProvider defaultScrollPosition="end">
       <ChatMessageScroller className="min-h-0 flex-1">
         <ChatMessageScrollerViewport>
-          <ChatMessageScrollerContent className="mx-auto w-full max-w-[820px] py-3">
+          <ChatMessageScrollerContent className="mx-auto w-full max-w-[820px] px-1 py-3">
             {tasks.map((task) => (
               <ChatMessageScrollerItem key={task.id} messageId={task.id}>
                 <FeedItem

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -1,0 +1,208 @@
+import {
+  ArrowSquareOutIcon,
+  ChatCircleIcon,
+  GitBranchIcon,
+} from "@phosphor-icons/react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  ChatMessageScroller,
+  ChatMessageScrollerButton,
+  ChatMessageScrollerContent,
+  ChatMessageScrollerItem,
+  ChatMessageScrollerProvider,
+  ChatMessageScrollerViewport,
+  Spinner,
+} from "@posthog/quill";
+import { formatRelativeTimeShort } from "@posthog/shared";
+import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
+import {
+  userDisplayName,
+  userInitials,
+} from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { xmlToPlainText } from "@posthog/ui/features/message-editor/content";
+import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
+import { Avatar, Text } from "@radix-ui/themes";
+import { useMemo } from "react";
+
+const STATUS_LABELS: Record<TaskRunStatus, string> = {
+  not_started: "Not started",
+  queued: "Queued",
+  in_progress: "In progress",
+  completed: "Completed",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+function statusBadge(status: TaskRunStatus | undefined) {
+  if (!status) return <Badge>Draft</Badge>;
+  const variant =
+    status === "completed"
+      ? "success"
+      : status === "failed"
+        ? "destructive"
+        : status === "in_progress"
+          ? "info"
+          : "default";
+  return (
+    <Badge variant={variant}>
+      {status === "in_progress" && <Spinner className="size-2.5" />}
+      {STATUS_LABELS[status]}
+    </Badge>
+  );
+}
+
+// The prompt as the user typed it: drop the channel CONTEXT.md block the saga
+// prepended and flatten the editor XML back to plain text.
+function promptText(task: Task): string {
+  const raw =
+    extractChannelContext(task.description)?.stripped ?? task.description;
+  try {
+    return xmlToPlainText(raw).trim() || task.title;
+  } catch {
+    return raw.trim() || task.title;
+  }
+}
+
+function FeedItem({
+  task,
+  onOpenTask,
+  onOpenThread,
+}: {
+  task: Task;
+  onOpenTask: (task: Task) => void;
+  onOpenThread: (task: Task) => void;
+}) {
+  const prompt = useMemo(() => promptText(task), [task]);
+  const prUrl =
+    typeof task.latest_run?.output?.pr_url === "string"
+      ? task.latest_run.output.pr_url
+      : undefined;
+
+  return (
+    <div className="group relative flex gap-2.5 px-4 py-2.5 hover:bg-fill-secondary/50">
+      <Avatar
+        size="2"
+        radius="full"
+        fallback={userInitials(task.created_by)}
+        className="mt-0.5 shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <Text size="2" weight="medium" className="truncate">
+            {userDisplayName(task.created_by)}
+          </Text>
+          <Text size="1" className="shrink-0 text-muted-foreground">
+            {formatRelativeTimeShort(task.created_at)}
+          </Text>
+        </div>
+
+        <Text
+          size="2"
+          className="mt-0.5 line-clamp-4 block whitespace-pre-wrap break-words"
+        >
+          {prompt}
+        </Text>
+
+        {/* The task the message kicked off, as a card everyone in the channel sees. */}
+        <Card
+          size="sm"
+          className="mt-2 max-w-xl cursor-pointer transition-colors hover:border-border-primary"
+          onClick={() => onOpenTask(task)}
+        >
+          <CardContent className="flex flex-col gap-1.5 py-2.5">
+            <div className="flex items-center gap-2">
+              {statusBadge(task.latest_run?.status)}
+              {task.latest_run?.stage && (
+                <Text size="1" className="text-muted-foreground">
+                  {task.latest_run.stage}
+                </Text>
+              )}
+            </div>
+            <Text size="2" weight="medium" className="line-clamp-2">
+              {task.title || "Untitled task"}
+            </Text>
+            <div className="flex items-center gap-3">
+              {task.repository && (
+                <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
+                  <GitBranchIcon size={12} />
+                  {task.repository}
+                </span>
+              )}
+              {prUrl && (
+                <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
+                  <ArrowSquareOutIcon size={12} />
+                  PR
+                </span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="mt-1">
+          <Button
+            variant="default"
+            size="xs"
+            onClick={() => onOpenThread(task)}
+            className="opacity-0 transition-opacity group-hover:opacity-100"
+          >
+            <ChatCircleIcon size={13} />
+            Reply in thread
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// The Slack-style channel feed: every task kicked off in the channel, oldest
+// first, rendered as a kickoff message + task card. Multiplayer — the list is
+// team-visible and polls for teammates' cards and status flips.
+export function ChannelFeedView({
+  tasks,
+  isLoading,
+  emptyState,
+  onOpenTask,
+  onOpenThread,
+}: {
+  tasks: Task[];
+  isLoading: boolean;
+  emptyState?: React.ReactNode;
+  onOpenTask: (task: Task) => void;
+  onOpenThread: (task: Task) => void;
+}) {
+  if (isLoading && tasks.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return <div className="flex-1 overflow-y-auto">{emptyState}</div>;
+  }
+
+  return (
+    <ChatMessageScrollerProvider defaultScrollPosition="end">
+      <ChatMessageScroller className="min-h-0 flex-1">
+        <ChatMessageScrollerViewport>
+          <ChatMessageScrollerContent className="mx-auto w-full max-w-[820px] py-3">
+            {tasks.map((task) => (
+              <ChatMessageScrollerItem key={task.id} messageId={task.id}>
+                <FeedItem
+                  task={task}
+                  onOpenTask={onOpenTask}
+                  onOpenThread={onOpenThread}
+                />
+              </ChatMessageScrollerItem>
+            ))}
+          </ChatMessageScrollerContent>
+        </ChatMessageScrollerViewport>
+        <ChatMessageScrollerButton />
+      </ChatMessageScroller>
+    </ChatMessageScrollerProvider>
+  );
+}

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -33,15 +33,14 @@ import {
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { getUserInitials } from "@posthog/ui/features/auth/userInitials";
 import { TaskTabIcon } from "@posthog/ui/features/browser-tabs/TaskTabIcon";
 import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannelTaskData";
 import { useTaskThread } from "@posthog/ui/features/canvas/hooks/useTaskThread";
-import {
-  userDisplayName,
-  userInitials,
-} from "@posthog/ui/features/canvas/utils/userDisplay";
+import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { xmlToPlainText } from "@posthog/ui/features/message-editor/content";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
+import { getOriginProductMeta } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
 import { Text } from "@radix-ui/themes";
 import { useMemo } from "react";
 
@@ -56,16 +55,6 @@ const STATUS_LABELS: Record<TaskRunStatus, string> = {
   completed: "Completed",
   failed: "Failed",
   cancelled: "Cancelled",
-};
-
-const ORIGIN_LABELS: Record<string, string> = {
-  error_tracking: "Error tracking",
-  signal_report: "Signal report",
-  signals_scout: "Signals scout",
-  automation: "Automation",
-  slack: "Slack",
-  onboarding: "Onboarding",
-  session_summaries: "Session summaries",
 };
 
 function statusBadge(status: TaskRunStatus) {
@@ -129,7 +118,7 @@ function TaskCardOrigin({ task }: { task: Task }) {
   const isUserCreated = task.origin_product === "user_created";
   const label = isUserCreated
     ? `Requested by @${userDisplayName(task.created_by)}`
-    : (ORIGIN_LABELS[task.origin_product] ?? task.origin_product);
+    : (getOriginProductMeta(task.origin_product)?.label ?? task.origin_product);
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5 text-muted-foreground text-xs">
       {isUserCreated ? <UserIcon size={12} /> : <RobotIcon size={12} />}
@@ -145,9 +134,10 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
     typeof task.latest_run?.output?.pr_url === "string"
       ? task.latest_run.output.pr_url
       : undefined;
+  // The repository renders separately with its icon; `meta` is the plain-text
+  // remainder of the row.
   const meta = [
     task.slug || null,
-    task.repository,
     task.latest_run?.stage ?? null,
     task.latest_run?.environment === "cloud" ? "Cloud" : null,
   ].filter(Boolean) as string[];
@@ -172,7 +162,7 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
             {task.title || "Untitled task"}
           </Text>
         </div>
-        {(meta.length > 0 || prUrl) && (
+        {(meta.length > 0 || task.repository || prUrl) && (
           <div className="flex min-w-0 items-center gap-3">
             {task.repository && (
               <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
@@ -180,9 +170,11 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
                 {task.repository}
               </span>
             )}
-            <Text size="1" className="truncate text-muted-foreground">
-              {meta.filter((m) => m !== task.repository).join(" · ")}
-            </Text>
+            {meta.length > 0 && (
+              <Text size="1" className="truncate text-muted-foreground">
+                {meta.join(" · ")}
+              </Text>
+            )}
             {prUrl && (
               <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs">
                 <ArrowSquareOutIcon size={12} />
@@ -230,7 +222,7 @@ function RepliesRow({
       <AvatarGroup size="xs" stacked>
         {authors.map((author, index) => (
           <Avatar key={author?.uuid ?? index} size="xs">
-            <AvatarFallback>{userInitials(author)}</AvatarFallback>
+            <AvatarFallback>{getUserInitials(author)}</AvatarFallback>
           </Avatar>
         ))}
       </AvatarGroup>
@@ -267,7 +259,7 @@ function FeedItem({
             {isAgent && !task.created_by ? (
               <RobotIcon size={16} />
             ) : (
-              userInitials(task.created_by)
+              getUserInitials(task.created_by)
             )}
           </AvatarFallback>
         </Avatar>

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -32,6 +32,9 @@ import {
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
+import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { TaskTabIcon } from "@posthog/ui/features/browser-tabs/TaskTabIcon";
+import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannelTaskData";
 import { useTaskThread } from "@posthog/ui/features/canvas/hooks/useTaskThread";
 import {
   userDisplayName,
@@ -65,8 +68,7 @@ const ORIGIN_LABELS: Record<string, string> = {
   session_summaries: "Session summaries",
 };
 
-function statusBadge(status: TaskRunStatus | undefined) {
-  if (!status) return <Badge>Draft</Badge>;
+function statusBadge(status: TaskRunStatus) {
   const variant =
     status === "completed"
       ? "success"
@@ -81,6 +83,32 @@ function statusBadge(status: TaskRunStatus | undefined) {
       {STATUS_LABELS[status]}
     </Badge>
   );
+}
+
+// Live status for the card, derived the same way the sidebar's TaskIcon does
+// (via useChannelTaskData: local session + workspace + cloud run). The raw
+// `latest_run.status` alone is wrong for local runs — the backend row often
+// stays "queued" while the agent runs on the creator's machine — so it is
+// only trusted for cloud runs and terminal states (which imply a sync).
+function TaskStatusBadge({ task }: { task: Task }) {
+  const data = useChannelTaskData(task);
+  if (data?.needsPermission)
+    return <Badge variant="warning">Needs input</Badge>;
+  if (data?.isGenerating) {
+    return (
+      <Badge variant="info">
+        <Spinner className="size-2.5" />
+        In progress
+      </Badge>
+    );
+  }
+  const status = data?.taskRunStatus ?? task.latest_run?.status;
+  const environment = data?.taskRunEnvironment ?? task.latest_run?.environment;
+  if (!status) return <Badge>Draft</Badge>;
+  if (environment === "cloud" || isTerminalStatus(status)) {
+    return statusBadge(status);
+  }
+  return <Badge>Local</Badge>;
 }
 
 // The prompt as the user typed it: drop the channel CONTEXT.md block the saga
@@ -127,17 +155,23 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
   return (
     <Card
       size="sm"
-      className="mt-1.5 max-w-xl cursor-pointer transition-colors hover:border-border-primary"
+      className="mt-1.5 w-full cursor-pointer transition-colors hover:border-border-primary"
       onClick={onOpen}
     >
       <CardContent className="flex flex-col gap-1 py-2.5">
         <div className="flex items-center justify-between gap-2">
           <TaskCardOrigin task={task} />
-          {statusBadge(task.latest_run?.status)}
+          <TaskStatusBadge task={task} />
         </div>
-        <Text size="2" weight="medium" className="line-clamp-2">
-          {task.title || "Untitled task"}
-        </Text>
+        <div className="flex min-w-0 items-center gap-1.5">
+          {/* Same live status icon as the code side nav, so the card and the
+              nav never disagree (generating spinner, needs-permission, cloud
+              status colors, PR state). */}
+          <TaskTabIcon task={task} size={14} />
+          <Text size="2" weight="medium" className="line-clamp-2">
+            {task.title || "Untitled task"}
+          </Text>
+        </div>
         {(meta.length > 0 || prUrl) && (
           <div className="flex min-w-0 items-center gap-3">
             {task.repository && (
@@ -224,7 +258,10 @@ function FeedItem({
 
   return (
     <ChatMessage className="group relative rounded-md px-3 py-2 hover:bg-fill-secondary/50">
-      <ChatMessageAvatar>
+      {/* Quill's avatar slot bottom-aligns for bubble chats; a Slack feed
+          anchors it beside the name row. The slot draws its own circle, so
+          drop its background and let the inner Avatar render. */}
+      <ChatMessageAvatar className="self-start bg-transparent">
         <Avatar>
           <AvatarFallback>
             {isAgent && !task.created_by ? (
@@ -236,7 +273,7 @@ function FeedItem({
         </Avatar>
       </ChatMessageAvatar>
       <ChatMessageContent className="min-w-0 gap-0.5">
-        <ChatMessageHeader className="items-baseline gap-2">
+        <ChatMessageHeader className="items-baseline gap-2 px-0">
           <Text size="2" weight="bold" className="truncate">
             {task.created_by ? userDisplayName(task.created_by) : "Agent"}
           </Text>

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -35,6 +35,8 @@ interface ChannelHomeComposerProps {
   channelName?: string;
   /** Channel CONTEXT.md, attached to the created task as background. */
   channelContext?: string;
+  /** Backend channel UUID that will own the created task (its feed home). */
+  backendChannelId?: string;
   onTaskCreated: (task: Task) => void;
 }
 
@@ -48,7 +50,7 @@ export const ChannelHomeComposer = forwardRef<
   ChannelHomeComposerHandle,
   ChannelHomeComposerProps
 >(function ChannelHomeComposer(
-  { channelId, channelName, channelContext, onTaskCreated },
+  { channelId, channelName, channelContext, backendChannelId, onTaskCreated },
   ref,
 ) {
   const sessionId = `channel-home:${channelId}`;
@@ -127,6 +129,7 @@ export const ChannelHomeComposer = forwardRef<
     allowNoRepo: true,
     channelContext,
     channelName,
+    channelId: backendChannelId,
     onTaskCreated,
   });
 

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -3,6 +3,7 @@ import {
   DotsThreeIcon,
   FileTextIcon,
   HashIcon,
+  LockSimpleIcon,
   PencilSimpleIcon,
   PlusIcon,
   StarIcon,
@@ -50,6 +51,10 @@ import {
   useChannels,
 } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import {
+  PERSONAL_CHANNEL_NAME,
+  useTaskChannels,
+} from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex, Text } from "@radix-ui/themes";
@@ -467,14 +472,68 @@ function ChannelSection({ channel }: { channel: Channel }) {
   );
 }
 
-// The channel list — the Channels space sidebar body. Starred channels surface
-// in their own section at the top so the ones you use most stay in reach; the
-// rest sit under a "Channels" label with the "New" channel button.
+// The user's private "#me" channel, pinned above the shared channel list.
+// The feed and task ownership live on the per-user backend personal channel;
+// the "me" folder is the bridge that keeps the folder-keyed surfaces
+// (CONTEXT.md, artifacts) routable, created lazily on first open.
+function PersonalChannelRow() {
+  const navigate = useNavigate();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const { channels } = useChannels();
+  const { createChannel, isCreating } = useChannelMutations();
+  // Listing backend channels lazily provisions the personal channel server-side.
+  useTaskChannels();
+
+  const meFolder = channels.find((c) => c.name === PERSONAL_CHANNEL_NAME);
+  const isActive =
+    !!meFolder &&
+    (pathname === `/website/${meFolder.id}` ||
+      pathname.startsWith(`/website/${meFolder.id}/`));
+
+  const open = async () => {
+    try {
+      const folder = meFolder ?? (await createChannel(PERSONAL_CHANNEL_NAME));
+      void navigate({
+        to: "/website/$channelId",
+        params: { channelId: folder.id },
+      });
+    } catch (error) {
+      toast.error("Couldn't open #me", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  return (
+    <Button
+      variant="default"
+      size="default"
+      left
+      data-selected={isActive || undefined}
+      disabled={isCreating}
+      onClick={() => void open()}
+      className="w-full min-w-0 justify-start gap-2 data-selected:bg-fill-selected data-selected:text-gray-12"
+    >
+      <HashIcon size={14} className="shrink-0 text-gray-9" />
+      <span className="truncate font-medium text-[13px] text-gray-12">
+        {PERSONAL_CHANNEL_NAME}
+      </span>
+      <LockSimpleIcon size={12} className="ml-auto shrink-0 text-gray-9" />
+    </Button>
+  );
+}
+
+// The channel list — the Channels space sidebar body. The private "#me"
+// channel is pinned at the top; starred channels surface in their own section
+// so the ones you use most stay in reach; the rest sit under a "Channels"
+// label with the "New" channel button.
 export function ChannelsList() {
-  const { channels, isLoading } = useChannels();
+  const { channels: allChannels, isLoading } = useChannels();
   const { starredRefToShortcutId } = useChannelStars();
   const [modalOpen, setModalOpen] = useState(false);
 
+  // The "me" folder renders as the pinned personal row, not a shared channel.
+  const channels = allChannels.filter((c) => c.name !== PERSONAL_CHANNEL_NAME);
   const starred = channels.filter((c) => starredRefToShortcutId.has(c.path));
   const others = channels.filter((c) => !starredRefToShortcutId.has(c.path));
 
@@ -499,6 +558,8 @@ export function ChannelsList() {
         <Box className="py-1.5">
           <Separator className="bg-border" />
         </Box>
+
+        <PersonalChannelRow />
 
         {starred.length > 0 && (
           <>

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -1,0 +1,305 @@
+import {
+  CaretRightIcon,
+  DotsThreeIcon,
+  PaperPlaneRightIcon,
+  RobotIcon,
+  TrashIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import {
+  Badge,
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Spinner,
+} from "@posthog/quill";
+import { formatRelativeTimeShort } from "@posthog/shared";
+import type {
+  Task,
+  TaskThreadMessage,
+  UserBasic,
+} from "@posthog/shared/domain-types";
+import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import {
+  useTaskThread,
+  useTaskThreadMutations,
+} from "@posthog/ui/features/canvas/hooks/useTaskThread";
+import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { toast } from "@posthog/ui/primitives/toast";
+import { Avatar, Text } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+
+export function userDisplayName(user: UserBasic | null | undefined): string {
+  if (!user) return "Unknown";
+  const name = [user.first_name, user.last_name].filter(Boolean).join(" ");
+  return name || user.email;
+}
+
+export function userInitials(user: UserBasic | null | undefined): string {
+  return userDisplayName(user).slice(0, 1).toUpperCase();
+}
+
+function ThreadMessageRow({
+  message,
+  isTaskAuthor,
+  isOwnMessage,
+  canForward,
+  onSendToAgent,
+  onDelete,
+}: {
+  message: TaskThreadMessage;
+  /** Whether the current user authored the task (may forward to the agent). */
+  isTaskAuthor: boolean;
+  isOwnMessage: boolean;
+  canForward: boolean;
+  onSendToAgent: () => void;
+  onDelete: () => void;
+}) {
+  const forwarded = !!message.forwarded_to_agent_at;
+  const showMenu = (isTaskAuthor && !forwarded) || isOwnMessage;
+
+  return (
+    <div className="group flex gap-2 rounded-md px-2 py-1.5 hover:bg-fill-secondary">
+      <Avatar
+        size="1"
+        radius="full"
+        fallback={userInitials(message.author)}
+        className="mt-0.5 shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <Text size="1" weight="medium" className="truncate">
+            {userDisplayName(message.author)}
+          </Text>
+          <Text size="1" className="shrink-0 text-muted-foreground">
+            {formatRelativeTimeShort(message.created_at)}
+          </Text>
+        </div>
+        <Text size="1" className="block whitespace-pre-wrap break-words">
+          {message.content}
+        </Text>
+        {forwarded && (
+          <Badge variant="info" className="mt-1">
+            <RobotIcon size={10} />
+            Sent to agent
+          </Badge>
+        )}
+      </div>
+      {showMenu && (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                variant="default"
+                size="icon-xs"
+                aria-label="Message actions"
+                className="opacity-0 transition-opacity group-hover:opacity-100 data-popup-open:opacity-100"
+              >
+                <DotsThreeIcon size={14} />
+              </Button>
+            }
+          />
+          <DropdownMenuContent align="end">
+            {isTaskAuthor && !forwarded && (
+              <DropdownMenuItem disabled={!canForward} onClick={onSendToAgent}>
+                <PaperPlaneRightIcon size={14} />
+                Send to agent
+              </DropdownMenuItem>
+            )}
+            {isOwnMessage && (
+              <DropdownMenuItem variant="destructive" onClick={onDelete}>
+                <TrashIcon size={14} />
+                Delete message
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}
+
+// The right-hand thread dock: the human-only conversation around a task.
+// Nothing here reaches the agent unless the task author explicitly forwards a
+// message ("Send to agent" in the row's hover menu).
+export function ThreadPanel({
+  taskId,
+  task: taskProp,
+  onClose,
+  collapsed,
+  onToggleCollapsed,
+}: {
+  taskId: string;
+  /** The thread's task when the caller already has it; fetched otherwise. */
+  task?: Task;
+  onClose?: () => void;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
+}) {
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
+  const { data: fetchedTask } = useQuery({
+    ...taskDetailQuery(taskId),
+    enabled: !taskProp,
+  });
+  const task = taskProp ?? fetchedTask;
+
+  const { messages, isLoading } = useTaskThread(collapsed ? undefined : taskId);
+  const { postMessage, deleteMessage, sendToAgent, isPosting } =
+    useTaskThreadMutations(taskId);
+
+  const [draft, setDraft] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Keep the newest message in view, Slack-style.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new messages
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages.length]);
+
+  const isTaskAuthor =
+    !!currentUser?.uuid && currentUser.uuid === task?.created_by?.uuid;
+  // Forwarding needs a run the workflow can still signal.
+  const canForward =
+    !!task?.latest_run && !isTerminalStatus(task.latest_run.status);
+
+  const submit = () => {
+    const content = draft.trim();
+    if (!content || isPosting) return;
+    setDraft("");
+    postMessage(content).catch((error: unknown) => {
+      setDraft(content);
+      toast.error("Couldn't post message", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    });
+  };
+
+  const handleSendToAgent = (messageId: string) => {
+    sendToAgent(messageId).catch((error: unknown) => {
+      toast.error("Couldn't send message to agent", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    });
+  };
+
+  if (collapsed) {
+    return (
+      <div className="flex h-full w-9 flex-col items-center border-border border-l bg-gray-1 py-2">
+        <Button
+          variant="default"
+          size="icon-sm"
+          aria-label="Expand thread"
+          onClick={onToggleCollapsed}
+        >
+          <CaretRightIcon size={14} className="rotate-180" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-w-0 flex-col bg-gray-1">
+      <div className="flex items-center gap-1 border-border border-b px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <Text size="2" weight="medium" className="block">
+            Thread
+          </Text>
+          {task && (
+            <Text size="1" className="block truncate text-muted-foreground">
+              {task.title || "Untitled task"}
+            </Text>
+          )}
+        </div>
+        {onToggleCollapsed && (
+          <Button
+            variant="default"
+            size="icon-sm"
+            aria-label="Collapse thread"
+            onClick={onToggleCollapsed}
+          >
+            <CaretRightIcon size={14} />
+          </Button>
+        )}
+        {onClose && (
+          <Button
+            variant="default"
+            size="icon-sm"
+            aria-label="Close thread"
+            onClick={onClose}
+          >
+            <XIcon size={14} />
+          </Button>
+        )}
+      </div>
+
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-2">
+        {isLoading && messages.length === 0 ? (
+          <div className="flex justify-center py-6">
+            <Spinner />
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="px-2 py-6 text-center">
+            <Text size="1" className="text-muted-foreground">
+              Discuss this task with your team. Messages stay between humans
+              unless the task author sends one to the agent.
+            </Text>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {messages.map((message) => (
+              <ThreadMessageRow
+                key={message.id}
+                message={message}
+                isTaskAuthor={isTaskAuthor}
+                isOwnMessage={
+                  !!currentUser?.uuid &&
+                  currentUser.uuid === message.author?.uuid
+                }
+                canForward={canForward}
+                onSendToAgent={() => handleSendToAgent(message.id)}
+                onDelete={() => void deleteMessage(message.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="border-border border-t p-2">
+        <div className="flex items-end gap-1 rounded-md border border-border bg-surface p-1">
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            placeholder="Reply in thread…"
+            rows={2}
+            className={cn(
+              "max-h-40 min-h-9 flex-1 resize-none bg-transparent px-2 py-1.5",
+              "text-[13px] outline-none placeholder:text-muted-foreground",
+            )}
+          />
+          <Button
+            variant="primary"
+            size="icon-sm"
+            aria-label="Send"
+            disabled={!draft.trim() || isPosting}
+            onClick={submit}
+          >
+            <PaperPlaneRightIcon size={14} />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -26,14 +26,12 @@ import type { Task, TaskThreadMessage } from "@posthog/shared/domain-types";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { getUserInitials } from "@posthog/ui/features/auth/userInitials";
 import {
   useTaskThread,
   useTaskThreadMutations,
 } from "@posthog/ui/features/canvas/hooks/useTaskThread";
-import {
-  userDisplayName,
-  userInitials,
-} from "@posthog/ui/features/canvas/utils/userDisplay";
+import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { toast } from "@posthog/ui/primitives/toast";
 import { Text } from "@radix-ui/themes";
@@ -62,7 +60,7 @@ function ThreadMessageRow({
   return (
     <div className="group flex gap-2 rounded-md px-2 py-1.5 hover:bg-fill-secondary">
       <Avatar size="xs" className="mt-0.5 shrink-0">
-        <AvatarFallback>{userInitials(message.author)}</AvatarFallback>
+        <AvatarFallback>{getUserInitials(message.author)}</AvatarFallback>
       </Avatar>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
@@ -143,8 +141,13 @@ export function ThreadPanel({
   const task = taskProp ?? fetchedTask;
 
   const { messages, isLoading } = useTaskThread(collapsed ? undefined : taskId);
-  const { postMessage, deleteMessage, sendToAgent, isPosting } =
-    useTaskThreadMutations(taskId);
+  const {
+    postMessage,
+    deleteMessage,
+    sendToAgent,
+    isPosting,
+    isSendingToAgent,
+  } = useTaskThreadMutations(taskId);
 
   const [draft, setDraft] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -157,9 +160,11 @@ export function ThreadPanel({
 
   const isTaskAuthor =
     !!currentUser?.uuid && currentUser.uuid === task?.created_by?.uuid;
-  // Forwarding needs a run the workflow can still signal.
+  // Forwarding needs a run the workflow can still signal, one send at a time.
   const canForward =
-    !!task?.latest_run && !isTerminalStatus(task.latest_run.status);
+    !!task?.latest_run &&
+    !isTerminalStatus(task.latest_run.status) &&
+    !isSendingToAgent;
 
   const submit = () => {
     const content = draft.trim();

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -9,11 +9,14 @@ import {
 import {
   Badge,
   Button,
-  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupTextarea,
   Spinner,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
@@ -272,8 +275,8 @@ export function ThreadPanel({
       </div>
 
       <div className="border-border border-t p-2">
-        <div className="flex items-end gap-1 rounded-md border border-border bg-surface p-1">
-          <textarea
+        <InputGroup className="h-auto cursor-text bg-card">
+          <InputGroupTextarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={(e) => {
@@ -284,21 +287,22 @@ export function ThreadPanel({
             }}
             placeholder="Reply in thread…"
             rows={2}
-            className={cn(
-              "max-h-40 min-h-9 flex-1 resize-none bg-transparent px-2 py-1.5",
-              "text-[13px] outline-none placeholder:text-muted-foreground",
-            )}
+            className="max-h-40 text-[13px]"
           />
-          <Button
-            variant="primary"
-            size="icon-sm"
-            aria-label="Send"
-            disabled={!draft.trim() || isPosting}
-            onClick={submit}
-          >
-            <PaperPlaneRightIcon size={14} />
-          </Button>
-        </div>
+          <InputGroupAddon align="block-end" className="p-1">
+            <span className="ml-auto flex items-center gap-1">
+              <InputGroupButton
+                variant="primary"
+                size="icon-sm"
+                aria-label="Send"
+                disabled={!draft.trim() || isPosting}
+                onClick={submit}
+              >
+                <PaperPlaneRightIcon size={14} />
+              </InputGroupButton>
+            </span>
+          </InputGroupAddon>
+        </InputGroup>
       </div>
     </div>
   );

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -7,6 +7,8 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import {
+  Avatar,
+  AvatarFallback,
   Badge,
   Button,
   DropdownMenu,
@@ -20,11 +22,7 @@ import {
   Spinner,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
-import type {
-  Task,
-  TaskThreadMessage,
-  UserBasic,
-} from "@posthog/shared/domain-types";
+import type { Task, TaskThreadMessage } from "@posthog/shared/domain-types";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
@@ -32,21 +30,15 @@ import {
   useTaskThread,
   useTaskThreadMutations,
 } from "@posthog/ui/features/canvas/hooks/useTaskThread";
+import {
+  userDisplayName,
+  userInitials,
+} from "@posthog/ui/features/canvas/utils/userDisplay";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { toast } from "@posthog/ui/primitives/toast";
-import { Avatar, Text } from "@radix-ui/themes";
+import { Text } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-
-export function userDisplayName(user: UserBasic | null | undefined): string {
-  if (!user) return "Unknown";
-  const name = [user.first_name, user.last_name].filter(Boolean).join(" ");
-  return name || user.email;
-}
-
-export function userInitials(user: UserBasic | null | undefined): string {
-  return userDisplayName(user).slice(0, 1).toUpperCase();
-}
 
 function ThreadMessageRow({
   message,
@@ -69,12 +61,9 @@ function ThreadMessageRow({
 
   return (
     <div className="group flex gap-2 rounded-md px-2 py-1.5 hover:bg-fill-secondary">
-      <Avatar
-        size="1"
-        radius="full"
-        fallback={userInitials(message.author)}
-        className="mt-0.5 shrink-0"
-      />
+      <Avatar size="xs" className="mt-0.5 shrink-0">
+        <AvatarFallback>{userInitials(message.author)}</AvatarFallback>
+      </Avatar>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
           <Text size="1" weight="medium" className="truncate">
@@ -192,6 +181,14 @@ export function ThreadPanel({
     });
   };
 
+  const handleDelete = (messageId: string) => {
+    deleteMessage(messageId).catch((error: unknown) => {
+      toast.error("Couldn't delete message", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    });
+  };
+
   if (collapsed) {
     return (
       <div className="flex h-full w-9 flex-col items-center border-border border-l bg-gray-1 py-2">
@@ -267,7 +264,7 @@ export function ThreadPanel({
                 }
                 canForward={canForward}
                 onSendToAgent={() => handleSendToAgent(message.id)}
-                onDelete={() => void deleteMessage(message.id)}
+                onDelete={() => handleDelete(message.id)}
               />
             ))}
           </div>

--- a/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
@@ -1,0 +1,55 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { ThreadPanel } from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
+import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
+import { useState } from "react";
+
+// The right-hand dock hosting a task's ThreadPanel: a thin rail when
+// collapsed, a resizable sidebar otherwise. Shared by the channel feed and the
+// task detail route; owns the panel-store size/collapse reads so parents don't
+// re-render on every resize tick.
+export function ThreadSidebar({
+  taskId,
+  task,
+  onClose,
+}: {
+  taskId: string;
+  /** The thread's task when the caller already has it; fetched otherwise. */
+  task?: Task;
+  onClose?: () => void;
+}) {
+  const collapsed = useThreadPanelStore((s) => s.collapsed);
+  const width = useThreadPanelStore((s) => s.width);
+  const setWidth = useThreadPanelStore((s) => s.setWidth);
+  const setCollapsed = useThreadPanelStore((s) => s.setCollapsed);
+  const [isResizing, setIsResizing] = useState(false);
+
+  if (collapsed) {
+    return (
+      <ThreadPanel
+        taskId={taskId}
+        task={task}
+        collapsed
+        onToggleCollapsed={() => setCollapsed(false)}
+      />
+    );
+  }
+
+  return (
+    <ResizableSidebar
+      open
+      width={width}
+      setWidth={setWidth}
+      isResizing={isResizing}
+      setIsResizing={setIsResizing}
+      side="right"
+    >
+      <ThreadPanel
+        taskId={taskId}
+        task={task}
+        onClose={onClose}
+        onToggleCollapsed={() => setCollapsed(true)}
+      />
+    </ResizableSidebar>
+  );
+}

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -1,26 +1,37 @@
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
+import { ChannelFeedView } from "@posthog/ui/features/canvas/components/ChannelFeedView";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import {
   ChannelHomeComposer,
   type ChannelHomeComposerHandle,
 } from "@posthog/ui/features/canvas/components/ChannelHomeComposer";
+import { ThreadPanel } from "@posthog/ui/features/canvas/components/ThreadPanel";
+import {
+  channelFeedQueryKey,
+  useChannelFeed,
+} from "@posthog/ui/features/canvas/hooks/useChannelFeed";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
+import { useBackendChannel } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { SuggestedPromptCard } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-// A channel's homepage: a heading and a composer that files new tasks into the
-// channel. The channel's tasks + canvases live behind the "History" tab.
+// A channel: a Slack-style multiplayer feed. Each member message kicks off a
+// task rendered as a card everyone in the channel sees; the composer stays
+// pinned at the bottom and threads open in a right-hand panel. The channel's
+// artifacts/history/context views stay in the tabs above (ChannelHeader).
 export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -31,11 +42,31 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const { data: instructions } = useFolderInstructions(channelId);
   const channelContext = instructions?.content;
 
+  // The folder channel maps onto a backend channel (by name; "me" → the
+  // personal channel), which owns the task feed and threads.
+  const { channel: backendChannel } = useBackendChannel(channelName);
+  const { tasks, isLoading } = useChannelFeed(backendChannel?.id);
+
   useSetHeaderContent(
     useMemo(() => <ChannelHeader channelId={channelId} />, [channelId]),
   );
 
   const composerRef = useRef<ChannelHomeComposerHandle>(null);
+
+  const threadTaskId = useThreadPanelStore((s) => s.taskId);
+  const threadCollapsed = useThreadPanelStore((s) => s.collapsed);
+  const threadWidth = useThreadPanelStore((s) => s.width);
+  const setThreadWidth = useThreadPanelStore((s) => s.setWidth);
+  const openThread = useThreadPanelStore((s) => s.openThread);
+  const closeThread = useThreadPanelStore((s) => s.closeThread);
+  const setThreadCollapsed = useThreadPanelStore((s) => s.setCollapsed);
+  const [isResizingThread, setIsResizingThread] = useState(false);
+
+  // A thread from another channel shouldn't linger when switching feeds.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-close per channel
+  useEffect(() => {
+    closeThread();
+  }, [closeThread, channelId]);
 
   const handleSuggestionSelect = useCallback(
     (prompt: string, mode?: string) => {
@@ -44,9 +75,19 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
     [],
   );
 
+  const invalidateFeed = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: channelFeedQueryKey(backendChannel?.id),
+    });
+  }, [queryClient, backendChannel?.id]);
+
+  // Slack behavior: submitting keeps you in the channel; the new card appears
+  // in the feed and updates live. Filing into the folder keeps the Artifacts /
+  // Recents tabs working.
   const onTaskCreated = useCallback(
     (task: Task) => {
       queryClient.setQueryData(taskDetailQuery(task.id).queryKey, task);
+      invalidateFeed();
       void fileTask(channelId, task.id, task.title)
         .then(() =>
           track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
@@ -69,52 +110,106 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
             description: error instanceof Error ? error.message : String(error),
           });
         });
+    },
+    [channelId, fileTask, invalidateFeed, queryClient],
+  );
+
+  const handleOpenTask = useCallback(
+    (task: Task) => {
+      openThread(task.id);
       void navigate({
         to: "/website/$channelId/tasks/$taskId",
         params: { channelId, taskId: task.id },
       });
     },
-    [channelId, fileTask, navigate, queryClient],
+    [channelId, navigate, openThread],
+  );
+
+  const handleOpenThread = useCallback(
+    (task: Task) => openThread(task.id),
+    [openThread],
+  );
+
+  const threadTask = threadTaskId
+    ? tasks.find((t) => t.id === threadTaskId)
+    : undefined;
+
+  const emptyState = (
+    <div className="mx-auto flex min-h-full w-full max-w-[680px] flex-col justify-center gap-6 px-4 py-10">
+      <div className="text-center">
+        <h1 className="font-semibold text-2xl text-gray-12 tracking-tight">
+          {channelName ? `Welcome to #${channelName}` : "Welcome"}
+        </h1>
+        <Text className="mt-2 block text-[13px] text-gray-10">
+          Every message kicks off a task the whole channel can follow.
+        </Text>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Text size="1" weight="medium" className="px-1 text-(--gray-11)">
+          Suggestions
+        </Text>
+        <div className="grid grid-cols-2 gap-2">
+          {CHANNEL_TASK_SUGGESTIONS.map((suggestion) => (
+            <SuggestedPromptCard
+              key={suggestion.label}
+              suggestion={suggestion}
+              onSelect={() =>
+                handleSuggestionSelect(suggestion.prompt, suggestion.mode)
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </div>
   );
 
   return (
-    <div className="h-full overflow-y-auto bg-gray-1">
-      <div className="mx-auto flex min-h-full w-full max-w-[680px] flex-col justify-center gap-6 px-4 py-10">
-        <div className="text-center">
-          <h1 className="font-semibold text-2xl text-gray-12 tracking-tight">
-            What can I do for you today?
-          </h1>
-          <Text className="mt-2 block text-[13px] text-gray-10">
-            Ask anything, kick off a task, or pick up where you left off.
-          </Text>
-        </div>
-
-        {/* Starter prompts, always shown directly above the box. */}
-        <div className="flex flex-col gap-2">
-          <Text size="1" weight="medium" className="px-1 text-(--gray-11)">
-            Suggestions
-          </Text>
-          <div className="grid grid-cols-2 gap-2">
-            {CHANNEL_TASK_SUGGESTIONS.map((suggestion) => (
-              <SuggestedPromptCard
-                key={suggestion.label}
-                suggestion={suggestion}
-                onSelect={() =>
-                  handleSuggestionSelect(suggestion.prompt, suggestion.mode)
-                }
-              />
-            ))}
-          </div>
-        </div>
-
-        <ChannelHomeComposer
-          ref={composerRef}
-          channelId={channelId}
-          channelName={channelName}
-          channelContext={channelContext}
-          onTaskCreated={onTaskCreated}
+    <div className="flex h-full min-w-0 bg-gray-1">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <ChannelFeedView
+          tasks={tasks}
+          isLoading={isLoading}
+          emptyState={emptyState}
+          onOpenTask={handleOpenTask}
+          onOpenThread={handleOpenThread}
         />
+        <div className="mx-auto w-full max-w-[820px] px-4 pb-4">
+          <ChannelHomeComposer
+            ref={composerRef}
+            channelId={channelId}
+            channelName={channelName}
+            channelContext={channelContext}
+            backendChannelId={backendChannel?.id}
+            onTaskCreated={onTaskCreated}
+          />
+        </div>
       </div>
+
+      {threadTaskId &&
+        (threadCollapsed ? (
+          <ThreadPanel
+            taskId={threadTaskId}
+            task={threadTask}
+            collapsed
+            onToggleCollapsed={() => setThreadCollapsed(false)}
+          />
+        ) : (
+          <ResizableSidebar
+            open
+            width={threadWidth}
+            setWidth={setThreadWidth}
+            isResizing={isResizingThread}
+            setIsResizing={setIsResizingThread}
+            side="right"
+          >
+            <ThreadPanel
+              taskId={threadTaskId}
+              task={threadTask}
+              onClose={closeThread}
+              onToggleCollapsed={() => setThreadCollapsed(true)}
+            />
+          </ResizableSidebar>
+        ))}
     </div>
   );
 }

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -7,7 +7,7 @@ import {
   ChannelHomeComposer,
   type ChannelHomeComposerHandle,
 } from "@posthog/ui/features/canvas/components/ChannelHomeComposer";
-import { ThreadPanel } from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { ThreadSidebar } from "@posthog/ui/features/canvas/components/ThreadSidebar";
 import {
   channelFeedQueryKey,
   useChannelFeed,
@@ -20,13 +20,12 @@ import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPa
 import { SuggestedPromptCard } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
-import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 // A channel: a Slack-style multiplayer feed. Each member message kicks off a
 // task rendered as a card everyone in the channel sees; the composer stays
@@ -54,13 +53,8 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const composerRef = useRef<ChannelHomeComposerHandle>(null);
 
   const threadTaskId = useThreadPanelStore((s) => s.taskId);
-  const threadCollapsed = useThreadPanelStore((s) => s.collapsed);
-  const threadWidth = useThreadPanelStore((s) => s.width);
-  const setThreadWidth = useThreadPanelStore((s) => s.setWidth);
   const openThread = useThreadPanelStore((s) => s.openThread);
   const closeThread = useThreadPanelStore((s) => s.closeThread);
-  const setThreadCollapsed = useThreadPanelStore((s) => s.setCollapsed);
-  const [isResizingThread, setIsResizingThread] = useState(false);
 
   // A thread from another channel shouldn't linger when switching feeds.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-close per channel
@@ -185,31 +179,13 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
         </div>
       </div>
 
-      {threadTaskId &&
-        (threadCollapsed ? (
-          <ThreadPanel
-            taskId={threadTaskId}
-            task={threadTask}
-            collapsed
-            onToggleCollapsed={() => setThreadCollapsed(false)}
-          />
-        ) : (
-          <ResizableSidebar
-            open
-            width={threadWidth}
-            setWidth={setThreadWidth}
-            isResizing={isResizingThread}
-            setIsResizing={setIsResizingThread}
-            side="right"
-          >
-            <ThreadPanel
-              taskId={threadTaskId}
-              task={threadTask}
-              onClose={closeThread}
-              onToggleCollapsed={() => setThreadCollapsed(true)}
-            />
-          </ResizableSidebar>
-        ))}
+      {threadTaskId && (
+        <ThreadSidebar
+          taskId={threadTaskId}
+          task={threadTask}
+          onClose={closeThread}
+        />
+      )}
     </div>
   );
 }

--- a/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
@@ -1,0 +1,38 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useMemo } from "react";
+
+// Feeds are multiplayer: poll fast enough that a teammate's new task card and
+// run-status flips feel live without a dedicated push channel.
+const CHANNEL_FEED_POLL_INTERVAL_MS = 5_000;
+
+export function channelFeedQueryKey(channelId: string | undefined) {
+  return ["channel-feed", channelId ?? "none"] as const;
+}
+
+/**
+ * A channel's task feed, oldest first (Slack ordering — the composer sits at
+ * the bottom and new cards land above it).
+ */
+export function useChannelFeed(channelId: string | undefined): {
+  tasks: Task[];
+  isLoading: boolean;
+} {
+  const query = useAuthenticatedQuery<Task[]>(
+    channelFeedQueryKey(channelId),
+    (client) =>
+      client.getTasks({ channel: channelId }) as unknown as Promise<Task[]>,
+    {
+      enabled: !!channelId,
+      refetchInterval: CHANNEL_FEED_POLL_INTERVAL_MS,
+    },
+  );
+  const tasks = useMemo(
+    () =>
+      [...(query.data ?? [])].sort((a, b) =>
+        a.created_at.localeCompare(b.created_at),
+      ),
+    [query.data],
+  );
+  return { tasks, isLoading: query.isLoading };
+}

--- a/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
@@ -1,6 +1,8 @@
 import type { TaskChannel } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
-import { useMemo } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
 
 const TASK_CHANNELS_POLL_INTERVAL_MS = 30_000;
 export const TASK_CHANNELS_QUERY_KEY = ["task-channels"] as const;
@@ -18,7 +20,7 @@ export function normalizeChannelName(name: string): string {
  * folder "channels" stay on the desktop file system for CONTEXT.md and
  * artifacts). Listing also lazily provisions the requester's #me channel.
  */
-export function useTaskChannels(options?: { enabled?: boolean }): {
+export function useTaskChannels(): {
   channels: TaskChannel[];
   personalChannel: TaskChannel | undefined;
   isLoading: boolean;
@@ -26,10 +28,7 @@ export function useTaskChannels(options?: { enabled?: boolean }): {
   const query = useAuthenticatedQuery<TaskChannel[]>(
     TASK_CHANNELS_QUERY_KEY,
     (client) => client.getTaskChannels(),
-    {
-      enabled: options?.enabled ?? true,
-      refetchInterval: TASK_CHANNELS_POLL_INTERVAL_MS,
-    },
+    { refetchInterval: TASK_CHANNELS_POLL_INTERVAL_MS },
   );
   const channels = useMemo(() => query.data ?? [], [query.data]);
   const personalChannel = useMemo(
@@ -52,6 +51,8 @@ export function useBackendChannel(channelName: string | undefined): {
   const normalized = channelName ? normalizeChannelName(channelName) : "";
   const isPersonal = normalized === PERSONAL_CHANNEL_NAME;
   const { channels, personalChannel, isLoading } = useTaskChannels();
+  const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
 
   const existing = isPersonal
     ? personalChannel
@@ -59,16 +60,33 @@ export function useBackendChannel(channelName: string | undefined): {
         (c) => c.channel_type === "public" && c.name === normalized,
       );
 
-  // resolve is idempotent server-side (get_or_create), so running it as a
-  // query keyed on the name is safe and self-deduplicating.
-  const resolveQuery = useAuthenticatedQuery<TaskChannel>(
-    ["task-channel-resolve", normalized],
-    (client) => client.resolveTaskChannel(normalized),
-    { enabled: !!normalized && !isPersonal && !isLoading && !existing },
-  );
+  // Resolve-or-create is a POST, so it runs as a mutation fired once per
+  // missing name — not a query TanStack would refire on focus/remount. The
+  // result is merged into the channels-list cache, which stops the effect.
+  const resolveMutation = useMutation({
+    mutationFn: async (name: string) => {
+      if (!client) throw new Error("Not authenticated");
+      return client.resolveTaskChannel(name);
+    },
+    onSuccess: (channel) => {
+      queryClient.setQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+        (prev) =>
+          prev?.some((c) => c.id === channel.id)
+            ? prev
+            : [...(prev ?? []), channel],
+      );
+    },
+  });
+  const { mutate: resolve, isPending: isResolving } = resolveMutation;
+  useEffect(() => {
+    if (normalized && !isPersonal && !isLoading && !existing && !isResolving) {
+      resolve(normalized);
+    }
+  }, [normalized, isPersonal, isLoading, existing, isResolving, resolve]);
 
   return {
-    channel: existing ?? resolveQuery.data ?? undefined,
-    isLoading: isLoading || (!existing && resolveQuery.isLoading),
+    channel: existing,
+    isLoading: isLoading || (!existing && isResolving),
   };
 }

--- a/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
@@ -1,0 +1,74 @@
+import type { TaskChannel } from "@posthog/shared/domain-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useMemo } from "react";
+
+const TASK_CHANNELS_POLL_INTERVAL_MS = 30_000;
+export const TASK_CHANNELS_QUERY_KEY = ["task-channels"] as const;
+
+/** Name reserved for the personal channel; mirrors the backend constant. */
+export const PERSONAL_CHANNEL_NAME = "me";
+
+/** Client-side mirror of the backend's channel-name normalization. */
+export function normalizeChannelName(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, "-").slice(0, 128);
+}
+
+/**
+ * Backend task channels — the feed/ownership side of a channel (the sidebar's
+ * folder "channels" stay on the desktop file system for CONTEXT.md and
+ * artifacts). Listing also lazily provisions the requester's #me channel.
+ */
+export function useTaskChannels(options?: { enabled?: boolean }): {
+  channels: TaskChannel[];
+  personalChannel: TaskChannel | undefined;
+  isLoading: boolean;
+} {
+  const query = useAuthenticatedQuery<TaskChannel[]>(
+    TASK_CHANNELS_QUERY_KEY,
+    (client) => client.getTaskChannels(),
+    {
+      enabled: options?.enabled ?? true,
+      refetchInterval: TASK_CHANNELS_POLL_INTERVAL_MS,
+    },
+  );
+  const channels = useMemo(() => query.data ?? [], [query.data]);
+  const personalChannel = useMemo(
+    () => channels.find((c) => c.channel_type === "personal"),
+    [channels],
+  );
+  return { channels, personalChannel, isLoading: query.isLoading };
+}
+
+/**
+ * Map a folder channel (by display name) onto its backend channel. The "me"
+ * folder is the bridge for the personal channel; any other name resolves (or
+ * creates) the matching public channel, so feeds keep working for channels
+ * created before backend channels existed.
+ */
+export function useBackendChannel(channelName: string | undefined): {
+  channel: TaskChannel | undefined;
+  isLoading: boolean;
+} {
+  const normalized = channelName ? normalizeChannelName(channelName) : "";
+  const isPersonal = normalized === PERSONAL_CHANNEL_NAME;
+  const { channels, personalChannel, isLoading } = useTaskChannels();
+
+  const existing = isPersonal
+    ? personalChannel
+    : channels.find(
+        (c) => c.channel_type === "public" && c.name === normalized,
+      );
+
+  // resolve is idempotent server-side (get_or_create), so running it as a
+  // query keyed on the name is safe and self-deduplicating.
+  const resolveQuery = useAuthenticatedQuery<TaskChannel>(
+    ["task-channel-resolve", normalized],
+    (client) => client.resolveTaskChannel(normalized),
+    { enabled: !!normalized && !isPersonal && !isLoading && !existing },
+  );
+
+  return {
+    channel: existing ?? resolveQuery.data ?? undefined,
+    isLoading: isLoading || (!existing && resolveQuery.isLoading),
+  };
+}

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -1,0 +1,68 @@
+import type { TaskThreadMessage } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+const THREAD_POLL_INTERVAL_MS = 5_000;
+
+export function taskThreadQueryKey(taskId: string | undefined) {
+  return ["task-thread", taskId ?? "none"] as const;
+}
+
+/** A task's thread — the human side conversation — in chronological order. */
+export function useTaskThread(taskId: string | undefined): {
+  messages: TaskThreadMessage[];
+  isLoading: boolean;
+} {
+  const query = useAuthenticatedQuery<TaskThreadMessage[]>(
+    taskThreadQueryKey(taskId),
+    (client) => client.getTaskThreadMessages(taskId as string),
+    { enabled: !!taskId, refetchInterval: THREAD_POLL_INTERVAL_MS },
+  );
+  return { messages: query.data ?? [], isLoading: query.isLoading };
+}
+
+export function useTaskThreadMutations(taskId: string | undefined) {
+  const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: taskThreadQueryKey(taskId),
+    });
+  }, [queryClient, taskId]);
+
+  const postMutation = useMutation({
+    mutationFn: async (content: string) => {
+      if (!client || !taskId) throw new Error("Not authenticated");
+      return client.createTaskThreadMessage(taskId, content);
+    },
+    onSuccess: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (messageId: string) => {
+      if (!client || !taskId) throw new Error("Not authenticated");
+      return client.deleteTaskThreadMessage(taskId, messageId);
+    },
+    onSuccess: invalidate,
+  });
+
+  const sendToAgentMutation = useMutation({
+    mutationFn: async (messageId: string) => {
+      if (!client || !taskId) throw new Error("Not authenticated");
+      return client.sendTaskThreadMessageToAgent(taskId, messageId);
+    },
+    onSuccess: invalidate,
+  });
+
+  return {
+    postMessage: (content: string) => postMutation.mutateAsync(content),
+    deleteMessage: (messageId: string) => deleteMutation.mutateAsync(messageId),
+    sendToAgent: (messageId: string) =>
+      sendToAgentMutation.mutateAsync(messageId),
+    isPosting: postMutation.isPending,
+    isSendingToAgent: sendToAgentMutation.isPending,
+  };
+}

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -21,12 +21,16 @@ export function useTaskThread(
   messages: TaskThreadMessage[];
   isLoading: boolean;
 } {
+  const pollIntervalMs = options?.pollIntervalMs ?? THREAD_POLL_INTERVAL_MS;
   const query = useAuthenticatedQuery<TaskThreadMessage[]>(
     taskThreadQueryKey(taskId),
     (client) => client.getTaskThreadMessages(taskId as string),
     {
       enabled: !!taskId,
-      refetchInterval: options?.pollIntervalMs ?? THREAD_POLL_INTERVAL_MS,
+      refetchInterval: pollIntervalMs,
+      // Fresh-within-the-poll-window so focus/remount doesn't refire every
+      // feed row's thread query on top of the interval.
+      staleTime: pollIntervalMs,
     },
   );
   return { messages: query.data ?? [], isLoading: query.isLoading };

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -11,14 +11,23 @@ export function taskThreadQueryKey(taskId: string | undefined) {
 }
 
 /** A task's thread — the human side conversation — in chronological order. */
-export function useTaskThread(taskId: string | undefined): {
+export function useTaskThread(
+  taskId: string | undefined,
+  options?: {
+    /** Poll cadence override; feed rows poll slower than the open panel. */
+    pollIntervalMs?: number;
+  },
+): {
   messages: TaskThreadMessage[];
   isLoading: boolean;
 } {
   const query = useAuthenticatedQuery<TaskThreadMessage[]>(
     taskThreadQueryKey(taskId),
     (client) => client.getTaskThreadMessages(taskId as string),
-    { enabled: !!taskId, refetchInterval: THREAD_POLL_INTERVAL_MS },
+    {
+      enabled: !!taskId,
+      refetchInterval: options?.pollIntervalMs ?? THREAD_POLL_INTERVAL_MS,
+    },
   );
   return { messages: query.data ?? [], isLoading: query.isLoading };
 }

--- a/packages/ui/src/features/canvas/stores/threadPanelStore.ts
+++ b/packages/ui/src/features/canvas/stores/threadPanelStore.ts
@@ -1,0 +1,42 @@
+import { electronStorage } from "@posthog/ui/shell/rendererStorage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+// View state for the thread side panel — the right-hand human conversation
+// dock next to a channel feed or task detail. Which thread is open is
+// per-navigation state; collapse and width are persisted user preferences so
+// the panel keeps its shape across tasks and channels.
+const DEFAULT_PANEL_WIDTH = 360;
+
+interface ThreadPanelState {
+  /** Task whose thread is open, or null when the panel is closed. */
+  taskId: string | null;
+  collapsed: boolean;
+  width: number;
+  openThread: (taskId: string) => void;
+  closeThread: () => void;
+  setCollapsed: (collapsed: boolean) => void;
+  setWidth: (width: number) => void;
+}
+
+export const useThreadPanelStore = create<ThreadPanelState>()(
+  persist(
+    (set) => ({
+      taskId: null,
+      collapsed: false,
+      width: DEFAULT_PANEL_WIDTH,
+      openThread: (taskId) => set({ taskId, collapsed: false }),
+      closeThread: () => set({ taskId: null }),
+      setCollapsed: (collapsed) => set({ collapsed }),
+      setWidth: (width) => set({ width }),
+    }),
+    {
+      name: "thread-panel-storage",
+      storage: electronStorage,
+      partialize: (state) => ({
+        collapsed: state.collapsed,
+        width: state.width,
+      }),
+    },
+  ),
+);

--- a/packages/ui/src/features/canvas/utils/userDisplay.ts
+++ b/packages/ui/src/features/canvas/utils/userDisplay.ts
@@ -1,0 +1,16 @@
+import type { UserBasic } from "@posthog/shared/domain-types";
+
+/**
+ * Display helpers for a task/thread author's `UserBasic`. Shared by the
+ * channel feed and the thread panel so kickoff messages and thread replies
+ * render names and avatar initials identically.
+ */
+export function userDisplayName(user: UserBasic | null | undefined): string {
+  if (!user) return "Unknown";
+  const name = [user.first_name, user.last_name].filter(Boolean).join(" ");
+  return name || user.email;
+}
+
+export function userInitials(user: UserBasic | null | undefined): string {
+  return userDisplayName(user).slice(0, 1).toUpperCase();
+}

--- a/packages/ui/src/features/canvas/utils/userDisplay.ts
+++ b/packages/ui/src/features/canvas/utils/userDisplay.ts
@@ -1,16 +1,12 @@
 import type { UserBasic } from "@posthog/shared/domain-types";
 
 /**
- * Display helpers for a task/thread author's `UserBasic`. Shared by the
- * channel feed and the thread panel so kickoff messages and thread replies
- * render names and avatar initials identically.
+ * Display name for a task/thread author's `UserBasic`, shared by the channel
+ * feed and the thread panel. Avatar initials come from the app-wide
+ * `getUserInitials` (`@posthog/ui/features/auth/userInitials`).
  */
 export function userDisplayName(user: UserBasic | null | undefined): string {
   if (!user) return "Unknown";
   const name = [user.first_name, user.last_name].filter(Boolean).join(" ");
   return name || user.email;
-}
-
-export function userInitials(user: UserBasic | null | undefined): string {
-  return userDisplayName(user).slice(0, 1).toUpperCase();
 }

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -52,7 +52,7 @@ const ORIGIN_PRODUCT_META: Record<string, OriginProductMeta> = {
   automation: { Icon: Robot, label: "Automation" },
 };
 
-function getOriginProductMeta(
+export function getOriginProductMeta(
   originProduct?: string,
 ): OriginProductMeta | undefined {
   return originProduct ? ORIGIN_PRODUCT_META[originProduct] : undefined;

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -70,6 +70,8 @@ interface UseTaskCreationOptions {
   signalReportId?: string;
   channelContext?: string;
   channelName?: string;
+  /** Backend channel UUID the created task is owned by (its feed home). */
+  channelId?: string;
   /**
    * Channels "generic chat box" mode: drop the repo/branch requirement so a
    * task can be submitted without picking a repo. The agent decides at runtime
@@ -156,6 +158,7 @@ export function useTaskCreation({
   signalReportId,
   channelContext,
   channelName,
+  channelId,
   allowNoRepo,
   onTaskCreated,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
@@ -310,6 +313,7 @@ export function useTaskCreation({
           additionalDirectories,
           channelContext,
           channelName,
+          channelId,
           customInstructions: useSettingsStore.getState().customInstructions,
           allowNoRepo,
         });
@@ -468,6 +472,7 @@ export function useTaskCreation({
       additionalDirectories,
       channelContext,
       channelName,
+      channelId,
       allowNoRepo,
       clearTaskInputReportAssociation,
       invalidateTasks,

--- a/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
+++ b/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
@@ -1,5 +1,7 @@
 import type { Task } from "@posthog/shared/domain-types";
+import { ThreadPanel } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { TaskDetail } from "@posthog/ui/features/task-detail/components/TaskDetail";
 import {
@@ -8,10 +10,11 @@ import {
   taskDetailQuery,
 } from "@posthog/ui/features/tasks/queries";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
+import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { RoutePending } from "@posthog/ui/router/RoutePending";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export const Route = createFileRoute("/website/$channelId/tasks/$taskId")({
   component: ChannelTaskDetailRoute,
@@ -38,6 +41,18 @@ function ChannelTaskDetailRoute() {
     markAsViewed(taskId);
   }, [taskId, markAsViewed]);
 
+  // Opening a task shows its thread docked on the right (collapsible). The
+  // panel follows the task being viewed.
+  const openThread = useThreadPanelStore((s) => s.openThread);
+  const threadCollapsed = useThreadPanelStore((s) => s.collapsed);
+  const threadWidth = useThreadPanelStore((s) => s.width);
+  const setThreadWidth = useThreadPanelStore((s) => s.setWidth);
+  const setThreadCollapsed = useThreadPanelStore((s) => s.setCollapsed);
+  const [isResizingThread, setIsResizingThread] = useState(false);
+  useEffect(() => {
+    openThread(taskId);
+  }, [openThread, taskId]);
+
   const { data: fetched } = useQuery({
     ...taskDetailQuery(taskId),
     enabled: !fromList && !loaderTask,
@@ -50,11 +65,38 @@ function ChannelTaskDetailRoute() {
   }
 
   return (
-    <TaskDetail
-      key={task.id}
-      task={task}
-      channelName={channelName ?? "Channel"}
-      channelId={channelId}
-    />
+    <div className="flex h-full min-w-0">
+      <div className="min-w-0 flex-1">
+        <TaskDetail
+          key={task.id}
+          task={task}
+          channelName={channelName ?? "Channel"}
+          channelId={channelId}
+        />
+      </div>
+      {threadCollapsed ? (
+        <ThreadPanel
+          taskId={taskId}
+          task={task}
+          collapsed
+          onToggleCollapsed={() => setThreadCollapsed(false)}
+        />
+      ) : (
+        <ResizableSidebar
+          open
+          width={threadWidth}
+          setWidth={setThreadWidth}
+          isResizing={isResizingThread}
+          setIsResizing={setIsResizingThread}
+          side="right"
+        >
+          <ThreadPanel
+            taskId={taskId}
+            task={task}
+            onToggleCollapsed={() => setThreadCollapsed(true)}
+          />
+        </ResizableSidebar>
+      )}
+    </div>
   );
 }

--- a/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
+++ b/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
@@ -1,5 +1,5 @@
 import type { Task } from "@posthog/shared/domain-types";
-import { ThreadPanel } from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { ThreadSidebar } from "@posthog/ui/features/canvas/components/ThreadSidebar";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
@@ -10,11 +10,10 @@ import {
   taskDetailQuery,
 } from "@posthog/ui/features/tasks/queries";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
-import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { RoutePending } from "@posthog/ui/router/RoutePending";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 export const Route = createFileRoute("/website/$channelId/tasks/$taskId")({
   component: ChannelTaskDetailRoute,
@@ -44,11 +43,6 @@ function ChannelTaskDetailRoute() {
   // Opening a task shows its thread docked on the right (collapsible). The
   // panel follows the task being viewed.
   const openThread = useThreadPanelStore((s) => s.openThread);
-  const threadCollapsed = useThreadPanelStore((s) => s.collapsed);
-  const threadWidth = useThreadPanelStore((s) => s.width);
-  const setThreadWidth = useThreadPanelStore((s) => s.setWidth);
-  const setThreadCollapsed = useThreadPanelStore((s) => s.setCollapsed);
-  const [isResizingThread, setIsResizingThread] = useState(false);
   useEffect(() => {
     openThread(taskId);
   }, [openThread, taskId]);
@@ -74,29 +68,7 @@ function ChannelTaskDetailRoute() {
           channelId={channelId}
         />
       </div>
-      {threadCollapsed ? (
-        <ThreadPanel
-          taskId={taskId}
-          task={task}
-          collapsed
-          onToggleCollapsed={() => setThreadCollapsed(false)}
-        />
-      ) : (
-        <ResizableSidebar
-          open
-          width={threadWidth}
-          setWidth={setThreadWidth}
-          isResizing={isResizingThread}
-          setIsResizing={setIsResizingThread}
-          side="right"
-        >
-          <ThreadPanel
-            taskId={taskId}
-            task={task}
-            onToggleCollapsed={() => setThreadCollapsed(true)}
-          />
-        </ResizableSidebar>
-      )}
+      <ThreadSidebar taskId={taskId} task={task} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Revamps the bluebird channel view into a Slack-style multiplayer feed. Backend counterpart (models + API): PostHog/posthog#68254 (spec in `products/tasks/docs/CHANNELS.md` there).

### Channel feed

- A channel now opens as a feed of the tasks kicked off in it, oldest first, built on quill's `ChatMessageScroller` primitives: each item shows the kickoff message (author avatar + name + prompt, with the `<channel_context>` block stripped) and a live task card (status badge, stage, repository, PR indicator) that everyone in the channel sees.
- The composer stays pinned at the bottom; submitting keeps you in the channel and the new card lands in the feed (5s poll keeps teammates' cards and status flips fresh).
- The existing tabs above the channel (Inbox / Artifacts / Recents / CONTEXT.md) are unchanged.

### Threads

- New `ThreadPanel`: a resizable, collapsible right-hand dock for the human-only conversation around a task. Messages never reach the agent unless the task author forwards one via the row's hover menu ("Send to agent", disabled once the run is terminal); forwarded messages show a "Sent to agent" badge. Deleting is own-messages-only.
- "Reply in thread" on a feed card opens the panel beside the feed; opening a task auto-opens the same panel (collapsible) beside the task detail.

### Task ownership + #me

- Tasks created in a channel are owned by a backend channel: `channelId` threads through `prepareTaskInput` → `TaskCreationSaga` → `createTask`.
- Sidebar channels remain desktop-file-system folders (CONTEXT.md, canvases, artifacts stay keyed to the folder); each maps onto a backend channel by normalized name via an idempotent resolve endpoint. The private **#me** personal channel is pinned at the top of the sidebar (the `me` folder bridges its folder-keyed tabs).
- Degrades gracefully when the backend branch isn't deployed: tasks still create (unowned), the feed just stays empty.

### New pieces

`ChannelFeedView`, `ThreadPanel`, `useTaskChannels` / `useBackendChannel`, `useChannelFeed`, `useTaskThread`, `threadPanelStore`; api-client methods for `task_channels` + `thread_messages`; `TaskChannel` / `TaskThreadMessage` domain types and `Task.channel`.

## Test plan

- `shared` / `api-client` / `core` / `ui` typecheck clean; Biome clean.
- Full unit suites pass: 1,953 core + 1,216 ui + shared/api-client.
- Manual run against the backend branch still needed for the end-to-end flow (feed, thread forwarding, #me provisioning).

Known v1 gaps (in the spec): no reply counts on feed cards, polling rather than push for feed/thread updates, no channel membership beyond public/personal, and #me's CONTEXT.md tab rides a shared `me` folder even though the feed itself is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)