### PR TITLE
feat(command-center): add support for standalone terminal cells

### DIFF
--- a/packages/core/src/command-center/cells.test.ts
+++ b/packages/core/src/command-center/cells.test.ts
@@ -1,7 +1,7 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
 import { buildCommandCenterCells } from "./cells";
-import { BRAINROT_CELL } from "./grid";
+import { BRAINROT_CELL, makeTerminalCellValue } from "./grid";
 
 const EMPTY_INPUT = {
   taskById: new Map<string, Task>(),
@@ -23,9 +23,21 @@ describe("buildCommandCenterCells", () => {
       },
     },
     {
+      name: "terminal cell exposes its terminal id and no task",
+      input: makeTerminalCellValue("term-1"),
+      expected: {
+        cellIndex: 0,
+        terminalId: "term-1",
+        isBrainrot: false,
+        taskId: null,
+        task: undefined,
+        status: "idle",
+      },
+    },
+    {
       name: "empty cell is a non-brainrot empty slot",
       input: null,
-      expected: { isBrainrot: false, taskId: null },
+      expected: { isBrainrot: false, taskId: null, terminalId: null },
     },
     {
       name: "unknown task id is a non-brainrot cell",

--- a/packages/core/src/command-center/cells.ts
+++ b/packages/core/src/command-center/cells.ts
@@ -1,6 +1,6 @@
 import type { AgentSession, WorkspaceMode } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
-import { isBrainrotCell } from "./grid";
+import { getTerminalCellId, isBrainrotCell, isTerminalCell } from "./grid";
 import { type CellStatus, deriveStatus, getRepoName } from "./status";
 
 export interface CommandCenterCellData {
@@ -13,6 +13,8 @@ export interface CommandCenterCellData {
   workspaceMode: WorkspaceMode | null;
   // Brainrot: a looping video slot rather than a task.
   isBrainrot: boolean;
+  // Standalone terminal slot, independent of any agent run.
+  terminalId: string | null;
 }
 
 export interface BuildCellsInput {
@@ -21,6 +23,17 @@ export interface BuildCellsInput {
   workspaces: Record<string, { mode: WorkspaceMode } | undefined> | undefined;
 }
 
+const EMPTY_CELL_DATA = {
+  taskId: null,
+  task: undefined,
+  session: undefined,
+  status: "idle" as const,
+  repoName: null,
+  workspaceMode: null,
+  isBrainrot: false,
+  terminalId: null,
+};
+
 export function buildCommandCenterCells(
   storeCells: (string | null)[],
   input: BuildCellsInput,
@@ -28,15 +41,14 @@ export function buildCommandCenterCells(
   const { taskById, sessionByTaskId, workspaces } = input;
   return storeCells.map((cellValue, cellIndex) => {
     if (isBrainrotCell(cellValue)) {
+      return { ...EMPTY_CELL_DATA, cellIndex, isBrainrot: true };
+    }
+
+    if (isTerminalCell(cellValue)) {
       return {
+        ...EMPTY_CELL_DATA,
         cellIndex,
-        taskId: null,
-        task: undefined,
-        session: undefined,
-        status: "idle" as const,
-        repoName: null,
-        workspaceMode: null,
-        isBrainrot: true,
+        terminalId: getTerminalCellId(cellValue),
       };
     }
 
@@ -48,6 +60,7 @@ export function buildCommandCenterCells(
     const workspaceMode = (taskId ? workspaces?.[taskId]?.mode : null) ?? null;
 
     return {
+      ...EMPTY_CELL_DATA,
       cellIndex,
       taskId,
       task,
@@ -55,7 +68,6 @@ export function buildCommandCenterCells(
       status,
       repoName,
       workspaceMode,
-      isBrainrot: false,
     };
   });
 }

--- a/packages/core/src/command-center/grid.test.ts
+++ b/packages/core/src/command-center/grid.test.ts
@@ -5,7 +5,10 @@ import {
   getCellCount,
   getCellSessionId,
   getGridDimensions,
+  getTerminalCellId,
   isBrainrotCell,
+  isTerminalCell,
+  makeTerminalCellValue,
   resizeCells,
 } from "./grid";
 
@@ -60,6 +63,23 @@ describe("isBrainrotCell", () => {
     { value: null, expected: false },
   ])("$value -> $expected", ({ value, expected }) => {
     expect(isBrainrotCell(value)).toBe(expected);
+  });
+});
+
+describe("terminal cells", () => {
+  it("round-trips a terminal id through the cell value", () => {
+    const value = makeTerminalCellValue("abc123");
+    expect(isTerminalCell(value)).toBe(true);
+    expect(getTerminalCellId(value)).toBe("abc123");
+  });
+
+  it.each([
+    { value: "some-task-uuid", expected: false },
+    { value: BRAINROT_CELL, expected: false },
+    { value: null, expected: false },
+  ])("isTerminalCell($value) -> $expected", ({ value, expected }) => {
+    expect(isTerminalCell(value)).toBe(expected);
+    expect(getTerminalCellId(value)).toBeNull();
   });
 });
 

--- a/packages/core/src/command-center/grid.ts
+++ b/packages/core/src/command-center/grid.ts
@@ -17,6 +17,24 @@ export function isBrainrotCell(value: string | null): boolean {
   return value === BRAINROT_CELL;
 }
 
+// Reserved prefix for standalone terminal cells. Never collides with a task id
+// (uuids) or with BRAINROT_CELL ("__brainrot__").
+export const TERMINAL_CELL_PREFIX = "__terminal__:";
+
+export function isTerminalCell(value: string | null): value is string {
+  return value?.startsWith(TERMINAL_CELL_PREFIX) ?? false;
+}
+
+export function makeTerminalCellValue(terminalId: string): string {
+  return `${TERMINAL_CELL_PREFIX}${terminalId}`;
+}
+
+export function getTerminalCellId(value: string | null): string | null {
+  return isTerminalCell(value)
+    ? value.slice(TERMINAL_CELL_PREFIX.length)
+    : null;
+}
+
 export function getGridDimensions(preset: LayoutPreset): GridDimensions {
   const [cols, rows] = preset.split("x").map(Number);
   return { cols, rows };

--- a/packages/ui/src/features/command-center/commandCenterStore.test.ts
+++ b/packages/ui/src/features/command-center/commandCenterStore.test.ts
@@ -1,4 +1,7 @@
-import { BRAINROT_CELL } from "@posthog/core/command-center/grid";
+import {
+  BRAINROT_CELL,
+  makeTerminalCellValue,
+} from "@posthog/core/command-center/grid";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@posthog/ui/shell/rendererStorage", () => ({
@@ -123,6 +126,39 @@ describe("commandCenterStore", () => {
 
     it("ignores out-of-range indices", () => {
       useCommandCenterStore.getState().setBrainrotCell(9);
+      expect(useCommandCenterStore.getState().cells).toEqual([
+        null,
+        null,
+        null,
+        null,
+      ]);
+    });
+  });
+
+  describe("setTerminalCell", () => {
+    it("stores the terminal cell value without disturbing others", () => {
+      useCommandCenterStore.setState({ cells: ["t1", null, null, null] });
+      useCommandCenterStore.getState().setTerminalCell(2, "term-1");
+      expect(useCommandCenterStore.getState().cells).toEqual([
+        "t1",
+        null,
+        makeTerminalCellValue("term-1"),
+        null,
+      ]);
+    });
+
+    it("focuses the cell, clears its creating state, and marks the grid curated", () => {
+      useCommandCenterStore.setState({ creatingCells: [3] });
+      useCommandCenterStore.getState().setTerminalCell(3, "term-1");
+      const state = useCommandCenterStore.getState();
+      expect(state.activeCellIndex).toBe(3);
+      expect(state.activeTaskId).toBeNull();
+      expect(state.creatingCells).toEqual([]);
+      expect(state.hasAutofilled).toBe(true);
+    });
+
+    it("ignores out-of-range indices", () => {
+      useCommandCenterStore.getState().setTerminalCell(9, "term-1");
       expect(useCommandCenterStore.getState().cells).toEqual([
         null,
         null,

--- a/packages/ui/src/features/command-center/commandCenterStore.ts
+++ b/packages/ui/src/features/command-center/commandCenterStore.ts
@@ -3,6 +3,7 @@ import {
   clampZoom,
   getCellCount,
   type LayoutPreset,
+  makeTerminalCellValue,
   resizeCells,
   ZOOM_STEP,
 } from "@posthog/core/command-center/grid";
@@ -33,8 +34,9 @@ interface CommandCenterStoreActions {
   setActiveCell: (cellIndex: number | null) => void;
   assignTask: (cellIndex: number, taskId: string) => void;
   setBrainrotCell: (cellIndex: number) => void;
+  setTerminalCell: (cellIndex: number, terminalId: string) => void;
   autofillCells: (taskIds: string[]) => void;
-  removeTask: (cellIndex: number) => void;
+  clearCell: (cellIndex: number) => void;
   removeTaskById: (taskId: string) => void;
   clearAll: () => void;
   setZoom: (zoom: number) => void;
@@ -116,6 +118,20 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
           };
         }),
 
+      setTerminalCell: (cellIndex, terminalId) =>
+        set((state) => {
+          if (cellIndex < 0 || cellIndex >= state.cells.length) return state;
+          const cells = [...state.cells];
+          cells[cellIndex] = makeTerminalCellValue(terminalId);
+          return {
+            cells,
+            activeTaskId: null,
+            activeCellIndex: cellIndex,
+            creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
+            hasAutofilled: true,
+          };
+        }),
+
       autofillCells: (taskIds) =>
         set((state) => {
           // Grid already full: nothing to place, but the bootstrap is done.
@@ -133,7 +149,7 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
           return { cells, hasAutofilled: true };
         }),
 
-      removeTask: (cellIndex) =>
+      clearCell: (cellIndex) =>
         set((state) => {
           const cells = [...state.cells];
           const removedTaskId = cells[cellIndex];

--- a/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
+++ b/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
@@ -1,3 +1,4 @@
+import { destroyShellTerminal } from "@posthog/ui/features/terminal/destroyShellTerminal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FOCUSABLE_SELECTOR } from "../../../utils/overlay";
 import {
@@ -6,6 +7,7 @@ import {
   useCommandCenterStore,
 } from "../commandCenterStore";
 import type { CommandCenterCellData } from "../hooks/useCommandCenterData";
+import { getTerminalCellStateKey } from "../terminalCells";
 import { CommandCenterPanel } from "./CommandCenterPanel";
 
 interface CommandCenterGridProps {
@@ -105,10 +107,13 @@ function GridCell({
       setIsDragOver(false);
       const taskId = e.dataTransfer.getData("text/x-task-id");
       if (taskId) {
+        if (cell.terminalId) {
+          destroyShellTerminal(getTerminalCellStateKey(cell.terminalId));
+        }
         useCommandCenterStore.getState().assignTask(cell.cellIndex, taskId);
       }
     },
-    [cell.cellIndex],
+    [cell.cellIndex, cell.terminalId],
   );
 
   return (

--- a/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -6,16 +6,21 @@ import {
   GitFork,
   Lightning,
   Plus,
+  Terminal,
   X,
 } from "@phosphor-icons/react";
 import { isBrainrotCell } from "@posthog/core/command-center/grid";
 import { ANALYTICS_EVENTS, type WorkspaceMode } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { destroyShellTerminal } from "@posthog/ui/features/terminal/destroyShellTerminal";
+import { ShellTerminal } from "@posthog/ui/features/terminal/ShellTerminal";
 import { openTask } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
+import { secureRandomString } from "@posthog/ui/utils/random";
 import { Flex, Spinner, Text } from "@radix-ui/themes";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useFolders } from "../../folders/useFolders";
 import { useCloudPrUrl } from "../../git-interaction/useCloudPrUrl";
 import { useDraftStore } from "../../message-editor/draftStore";
 import { EmbeddedSessionView } from "../../sessions/components/EmbeddedSessionView";
@@ -28,6 +33,7 @@ import type {
   CommandCenterCellData,
 } from "../hooks/useCommandCenterData";
 import { useElementOrientation } from "../hooks/useElementOrientation";
+import { getTerminalCellStateKey } from "../terminalCells";
 import { CommandCenterPRButton } from "./CommandCenterPRButton";
 import { TaskSelector } from "./TaskSelector";
 
@@ -109,6 +115,7 @@ function EmptyCell({ cellIndex }: { cellIndex: number }) {
   );
   const assignTask = useCommandCenterStore((s) => s.assignTask);
   const setBrainrotCell = useCommandCenterStore((s) => s.setBrainrotCell);
+  const setTerminalCell = useCommandCenterStore((s) => s.setTerminalCell);
   const startCreating = useCommandCenterStore((s) => s.startCreating);
   const stopCreating = useCommandCenterStore((s) => s.stopCreating);
   const layout = useCommandCenterStore((s) => s.layout);
@@ -125,6 +132,10 @@ function EmptyCell({ cellIndex }: { cellIndex: number }) {
     });
     setBrainrotCell(cellIndex);
   }, [layout, cells, setBrainrotCell, cellIndex]);
+
+  const handleNewTerminal = useCallback(() => {
+    setTerminalCell(cellIndex, secureRandomString(8));
+  }, [setTerminalCell, cellIndex]);
 
   const handleTaskCreated = useCallback(
     (task: Task) => {
@@ -184,6 +195,7 @@ function EmptyCell({ cellIndex }: { cellIndex: number }) {
           open={selectorOpen}
           onOpenChange={setSelectorOpen}
           onNewTask={() => startCreating(cellIndex)}
+          onNewTerminal={handleNewTerminal}
           onBrainrot={brainrotMode ? handleBrainrot : undefined}
         >
           <button
@@ -209,7 +221,7 @@ const BRAINROT_PORTRAIT_URL =
   "https://res.cloudinary.com/dmukukwp6/video/upload/brainrot_portrait_0f14096e6a.mp4";
 
 function BrainrotCell({ cellIndex }: { cellIndex: number }) {
-  const removeTask = useCommandCenterStore((s) => s.removeTask);
+  const clearCell = useCommandCenterStore((s) => s.clearCell);
   const stageRef = useRef<HTMLDivElement>(null);
   const orientation = useElementOrientation(stageRef);
   const src =
@@ -231,7 +243,7 @@ function BrainrotCell({ cellIndex }: { cellIndex: number }) {
         </Text>
         <button
           type="button"
-          onClick={() => removeTask(cellIndex)}
+          onClick={() => clearCell(cellIndex)}
           className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-gray-10 transition-colors hover:bg-gray-4 hover:text-gray-12"
           title="Remove from grid"
         >
@@ -264,6 +276,59 @@ function BrainrotCell({ cellIndex }: { cellIndex: number }) {
   );
 }
 
+function TerminalCell({
+  cellIndex,
+  terminalId,
+}: {
+  cellIndex: number;
+  terminalId: string;
+}) {
+  const clearCell = useCommandCenterStore((s) => s.clearCell);
+  const { getRecentFolders, getFolderDisplayName } = useFolders();
+  const cwd = getRecentFolders(1)[0]?.path;
+  const folderName = cwd ? getFolderDisplayName(cwd) : null;
+  const stateKey = getTerminalCellStateKey(terminalId);
+
+  const handleRemove = useCallback(() => {
+    destroyShellTerminal(stateKey);
+    clearCell(cellIndex);
+  }, [stateKey, clearCell, cellIndex]);
+
+  return (
+    <Flex direction="column" height="100%">
+      <Flex
+        align="center"
+        gap="2"
+        px="2"
+        py="1"
+        className="shrink-0 border-gray-6 border-b"
+      >
+        <Terminal size={12} className="shrink-0 text-gray-10" />
+        <Text className="min-w-0 flex-1 truncate font-medium text-[12px]">
+          Terminal
+        </Text>
+        {folderName && (
+          <span className="inline-flex items-center gap-0.5 rounded bg-gray-3 px-1 py-0.5 text-[10px] text-gray-10">
+            <Folder size={10} />
+            {folderName}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={handleRemove}
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-gray-10 transition-colors hover:bg-gray-4 hover:text-gray-12"
+          title="Remove from grid"
+        >
+          <X size={12} />
+        </button>
+      </Flex>
+      <Flex direction="column" className="min-h-0 flex-1">
+        <ShellTerminal cwd={cwd} stateKey={stateKey} />
+      </Flex>
+    </Flex>
+  );
+}
+
 function PopulatedCell({
   cell,
   isActiveSession,
@@ -271,15 +336,15 @@ function PopulatedCell({
   cell: CommandCenterCellData & { task: Task };
   isActiveSession: boolean;
 }) {
-  const removeTask = useCommandCenterStore((s) => s.removeTask);
+  const clearCell = useCommandCenterStore((s) => s.clearCell);
 
   const handleExpand = useCallback(() => {
     void openTask(cell.task);
   }, [cell.task]);
 
   const handleRemove = useCallback(() => {
-    removeTask(cell.cellIndex);
-  }, [removeTask, cell.cellIndex]);
+    clearCell(cell.cellIndex);
+  }, [clearCell, cell.cellIndex]);
 
   return (
     <Flex direction="column" height="100%">
@@ -344,6 +409,12 @@ export function CommandCenterPanel({
 }: CommandCenterPanelProps) {
   if (cell.isBrainrot) {
     return <BrainrotCell cellIndex={cell.cellIndex} />;
+  }
+
+  if (cell.terminalId) {
+    return (
+      <TerminalCell cellIndex={cell.cellIndex} terminalId={cell.terminalId} />
+    );
   }
 
   if (!cell.taskId || !cell.task) {

--- a/packages/ui/src/features/command-center/components/CommandCenterToolbar.tsx
+++ b/packages/ui/src/features/command-center/components/CommandCenterToolbar.tsx
@@ -3,12 +3,15 @@ import {
   MagnifyingGlassPlus,
   Trash,
 } from "@phosphor-icons/react";
+import { getCellCount } from "@posthog/core/command-center/grid";
 import { Flex, Select, Text } from "@radix-ui/themes";
+import { useCallback } from "react";
 import {
   type LayoutPreset,
   useCommandCenterStore,
 } from "../commandCenterStore";
 import type { StatusSummary } from "../hooks/useCommandCenterData";
+import { destroyTerminalCells } from "../terminalCells";
 
 function LayoutIcon({ cols, rows }: { cols: number; rows: number }) {
   const size = 14;
@@ -83,6 +86,21 @@ export function CommandCenterToolbar({ summary }: CommandCenterToolbarProps) {
   const layout = useCommandCenterStore((s) => s.layout);
   const setLayout = useCommandCenterStore((s) => s.setLayout);
   const clearAll = useCommandCenterStore((s) => s.clearAll);
+
+  const handleSetLayout = useCallback(
+    (preset: LayoutPreset) => {
+      const cells = useCommandCenterStore.getState().cells;
+      destroyTerminalCells(cells.slice(getCellCount(preset)));
+      setLayout(preset);
+    },
+    [setLayout],
+  );
+
+  const handleClearAll = useCallback(() => {
+    destroyTerminalCells(useCommandCenterStore.getState().cells);
+    clearAll();
+  }, [clearAll]);
+
   const zoom = useCommandCenterStore((s) => s.zoom);
   const zoomIn = useCommandCenterStore((s) => s.zoomIn);
   const zoomOut = useCommandCenterStore((s) => s.zoomOut);
@@ -97,7 +115,7 @@ export function CommandCenterToolbar({ summary }: CommandCenterToolbarProps) {
     >
       <Select.Root
         value={layout}
-        onValueChange={(v) => setLayout(v as LayoutPreset)}
+        onValueChange={(v) => handleSetLayout(v as LayoutPreset)}
       >
         <Select.Trigger variant="ghost" className="text-[12px]" />
         <Select.Content position="popper">
@@ -142,7 +160,7 @@ export function CommandCenterToolbar({ summary }: CommandCenterToolbarProps) {
 
       <button
         type="button"
-        onClick={clearAll}
+        onClick={handleClearAll}
         className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[12px] text-gray-10 transition-colors hover:bg-gray-4 hover:text-gray-12"
         title="Clear all cells"
       >

--- a/packages/ui/src/features/command-center/components/TaskSelector.tsx
+++ b/packages/ui/src/features/command-center/components/TaskSelector.tsx
@@ -1,4 +1,4 @@
-import { Lightning, Plus } from "@phosphor-icons/react";
+import { Lightning, Plus, Terminal } from "@phosphor-icons/react";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { Popover } from "@radix-ui/themes";
 import { type ReactNode, useCallback } from "react";
@@ -11,6 +11,7 @@ interface TaskSelectorProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onNewTask?: () => void;
+  onNewTerminal?: () => void;
   onBrainrot?: () => void;
   children: ReactNode;
 }
@@ -20,6 +21,7 @@ export function TaskSelector({
   open,
   onOpenChange,
   onNewTask,
+  onNewTerminal,
   onBrainrot,
   children,
 }: TaskSelectorProps) {
@@ -42,6 +44,11 @@ export function TaskSelector({
       openTaskInput();
     }
   }, [onOpenChange, onNewTask]);
+
+  const handleNewTerminal = useCallback(() => {
+    onOpenChange(false);
+    onNewTerminal?.();
+  }, [onOpenChange, onNewTerminal]);
 
   const handleBrainrot = useCallback(() => {
     onOpenChange(false);
@@ -93,6 +100,16 @@ export function TaskSelector({
                 <Plus size={11} weight="bold" />
                 New task
               </button>
+              {onNewTerminal && (
+                <button
+                  type="button"
+                  className="combobox-footer-button"
+                  onClick={handleNewTerminal}
+                >
+                  <Terminal size={11} weight="bold" />
+                  Terminal
+                </button>
+              )}
               {onBrainrot && (
                 <button
                   type="button"

--- a/packages/ui/src/features/command-center/terminalCells.ts
+++ b/packages/ui/src/features/command-center/terminalCells.ts
@@ -1,0 +1,15 @@
+import { getTerminalCellId } from "@posthog/core/command-center/grid";
+import { destroyShellTerminal } from "../terminal/destroyShellTerminal";
+
+export function getTerminalCellStateKey(terminalId: string): string {
+  return `cc-terminal-${terminalId}`;
+}
+
+export function destroyTerminalCells(cellValues: (string | null)[]): void {
+  for (const value of cellValues) {
+    const terminalId = getTerminalCellId(value);
+    if (terminalId) {
+      destroyShellTerminal(getTerminalCellStateKey(terminalId));
+    }
+  }
+}

--- a/packages/ui/src/features/terminal/destroyShellTerminal.ts
+++ b/packages/ui/src/features/terminal/destroyShellTerminal.ts
@@ -1,0 +1,26 @@
+import { resolveService } from "@posthog/di/container";
+import {
+  SHELL_CLIENT,
+  type ShellClient,
+} from "@posthog/ui/features/terminal/shellClient";
+import { logger } from "@posthog/ui/shell/logger";
+import { terminalManager } from "./TerminalManager";
+import { useTerminalStore } from "./terminalStore";
+
+const log = logger.scope("destroy-shell-terminal");
+
+// Standalone terminals have no task/workspace teardown to kill their pty, so
+// removal must destroy the server-side session explicitly.
+export function destroyShellTerminal(stateKey: string): void {
+  const sessionId =
+    useTerminalStore.getState().terminalStates[stateKey]?.sessionId;
+  if (sessionId) {
+    terminalManager.destroy(sessionId);
+    resolveService<ShellClient>(SHELL_CLIENT)
+      .destroy({ sessionId })
+      .catch((error: Error) => {
+        log.error("Failed to destroy shell session:", sessionId, error);
+      });
+  }
+  useTerminalStore.getState().clearTerminalState(stateKey);
+}


### PR DESCRIPTION
## Problem

Command center only supported adding tasks. No way to open a terminal independent of an agent run.

## Changes

https://github.com/user-attachments/assets/930a47c0-7740-41aa-82bc-3910b27650cb


- Adds a **Terminal** option to the cell selector (alongside New task / Brainrot)
- New `__terminal__:<id>` cell sentinel in `grid.ts`, mirroring the brainrot pattern
- `TerminalCell` component — opens a shell in the most recently accessed folder (`$HOME` fallback)
- Renamed `removeTask` store action → `clearCell` (it clears any cell type, not just tasks)
- Cleanup on remove, drag-overwrite, layout shrink, and clear-all so ptys don't leak
- New `destroyShellTerminal` helper: kills xterm instance + server-side pty + persisted state

## How did you test this?

- `pnpm --filter @posthog/core typecheck` and `pnpm --filter @posthog/ui typecheck` — clean
- Unit tests: `packages/core` command-center suite (46 tests) and `packages/ui` store suite (1211 tests) — all pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*