### PR TITLE
fix(git-interaction): reset isSubmitting flag on PR creation cancel

### DIFF
--- a/packages/ui/src/features/git-interaction/state/gitInteractionStore.ts
+++ b/packages/ui/src/features/git-interaction/state/gitInteractionStore.ts
@@ -194,6 +194,7 @@ export const useGitInteractionStore = create<GitInteractionStore>()(
             prBody: existingDraft?.prBody ?? "",
             isGeneratingCommitMessage: false,
             isGeneratingPr: false,
+            isSubmitting: false,
             activeCreatePrDraftKey: draftKey,
           });
         },
@@ -201,7 +202,7 @@ export const useGitInteractionStore = create<GitInteractionStore>()(
           const state = get();
           const key = state.activeCreatePrDraftKey;
           if (key === null) {
-            set({ createPrOpen: false });
+            set({ createPrOpen: false, isSubmitting: false });
             return;
           }
           const snapshot: CreatePrDraftValues = {
@@ -220,6 +221,7 @@ export const useGitInteractionStore = create<GitInteractionStore>()(
             createPrOpen: false,
             createPrDrafts: nextDrafts,
             activeCreatePrDraftKey: null,
+            isSubmitting: false,
           });
         },
         setCreatePrStep: (step) => set({ createPrStep: step }),


### PR DESCRIPTION
## Problem

When users click the "create draft PR" button and then cancel the action, the button remains in a permanent loading state instead of returning to its normal state. This happens because the `isSubmitting` flag is not being reset when the PR creation flow is cancelled.

## Changes

- Reset `isSubmitting` flag to `false` when opening the PR creation dialog (to ensure clean initial state)
- Reset `isSubmitting` flag to `false` when closing the PR creation dialog without a draft key
- Reset `isSubmitting` flag to `false` after successfully saving and closing the PR creation dialog

These changes ensure that the loading state is properly cleared in all cancellation and completion scenarios for the PR creation workflow.

## How did you test this?

Manual testing of the PR creation flow:
1. Click the "create draft PR" button to open the dialog
2. Cancel/close the dialog
3. Verify the button returns to normal state (not loading)
4. Repeat the process to ensure consistent behavior

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*