### PR TITLE
fix(sessions): persist run config on start-failure error session

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -652,6 +652,16 @@ export class SessionService {
     return connectPromise;
   }
 
+  private stampRunConfig(session: AgentSession, params: ConnectParams): void {
+    session.adapter = params.adapter;
+    session.model = params.model;
+    session.executionMode = params.executionMode;
+    session.reasoningLevel = params.reasoningLevel;
+    if (params.initialPrompt?.length) {
+      session.initialPrompt = params.initialPrompt;
+    }
+  }
+
   private async doConnect(params: ConnectParams): Promise<void> {
     const {
       task,
@@ -693,9 +703,7 @@ export class SessionService {
         session.status = "error";
         session.errorMessage =
           "Authentication required. Please sign in to continue.";
-        if (initialPrompt?.length) {
-          session.initialPrompt = initialPrompt;
-        }
+        this.stampRunConfig(session, params);
         this.d.store.setSession(session);
         return;
       }
@@ -784,9 +792,7 @@ export class SessionService {
 
       const taskRunId = latestRun?.id ?? `error-${taskId}`;
       const session = createBaseSession(taskRunId, taskId, taskTitle);
-      if (initialPrompt?.length) {
-        session.initialPrompt = initialPrompt;
-      }
+      this.stampRunConfig(session, params);
       if (latestRun?.log_url) {
         try {
           const { rawEntries } = await this.fetchSessionLogs(

--- a/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -165,3 +165,60 @@ describe("SessionService.connectToTask start failure", () => {
     ]);
   });
 });
+
+describe("SessionService.connectToTask missing auth", () => {
+  it("persists the run configuration on the auth-required error session", async () => {
+    const setSession = vi.fn();
+    const deps = {
+      store: {
+        getSessionByTaskId: () => undefined,
+        getSessions: () => ({}),
+        setSession,
+      },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      getIsOnline: () => true,
+      trpc: {
+        agent: {
+          onSessionIdleKilled: {
+            subscribe: () => ({ unsubscribe: vi.fn() }),
+          },
+        },
+      },
+    } as unknown as SessionServiceDeps;
+
+    const service = new SessionService(deps);
+    // No credentials → the no-auth branch stores an error session and returns
+    // before ever starting a run.
+    vi.spyOn(
+      service as unknown as {
+        getAuthCredentialsStatus: () => Promise<unknown>;
+      },
+      "getAuthCredentialsStatus",
+    ).mockResolvedValue({ kind: "missing" });
+
+    await service.connectToTask({
+      task: {
+        id: "task-1",
+        title: "Test task",
+        description: "Ship the fix",
+        latest_run: null,
+      } as unknown as Task,
+      repoPath: "/repo",
+      initialPrompt: [{ type: "text", text: "Ship the fix" }],
+      executionMode: "auto",
+      adapter: "claude",
+      model: "claude-fable-5",
+      reasoningLevel: "high",
+    });
+
+    const stored = setSession.mock.calls.at(-1)?.[0] as AgentSession;
+    expect(stored.status).toBe("error");
+    expect(stored.model).toBe("claude-fable-5");
+    expect(stored.adapter).toBe("claude");
+    expect(stored.executionMode).toBe("auto");
+    expect(stored.reasoningLevel).toBe("high");
+    expect(stored.initialPrompt).toEqual([
+      { type: "text", text: "Ship the fix" },
+    ]);
+  });
+});

--- a/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -1,4 +1,5 @@
 import type { AgentSession } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it, vi } from "vitest";
 import { SessionService, type SessionServiceDeps } from "./sessionService";
 
@@ -88,5 +89,79 @@ describe("SessionService.clearSessionError retry config", () => {
       "claude-fable-5", // model
       "high", // reasoningLevel
     );
+  });
+});
+
+describe("SessionService.connectToTask start failure", () => {
+  it("persists the run configuration on the error session so retry keeps the model", async () => {
+    const setSession = vi.fn();
+    const deps = {
+      store: {
+        getSessionByTaskId: () => undefined,
+        getSessions: () => ({}),
+        setSession,
+      },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      settings: { customInstructions: "" },
+      DEFAULT_GATEWAY_MODEL: "claude-opus-4-8",
+      // Online for the create-branch check, offline in the catch so the
+      // auto-retry loop is skipped and the stored error session is asserted.
+      getIsOnline: vi
+        .fn<() => boolean>()
+        .mockReturnValueOnce(true)
+        .mockReturnValue(false),
+      trpc: {
+        agent: {
+          start: {
+            mutate: vi
+              .fn()
+              .mockRejectedValue(new Error("session start timeout")),
+          },
+          onSessionIdleKilled: {
+            subscribe: () => ({ unsubscribe: vi.fn() }),
+          },
+        },
+      },
+    } as unknown as SessionServiceDeps;
+
+    const service = new SessionService(deps);
+    vi.spyOn(
+      service as unknown as {
+        getAuthCredentialsStatus: () => Promise<unknown>;
+      },
+      "getAuthCredentialsStatus",
+    ).mockResolvedValue({
+      kind: "ready",
+      auth: {
+        client: { createTaskRun: vi.fn().mockResolvedValue({ id: "run-1" }) },
+        apiHost: "https://app",
+        projectId: 1,
+      },
+    });
+
+    await service.connectToTask({
+      task: {
+        id: "task-1",
+        title: "Test task",
+        description: "Ship the fix",
+        latest_run: null,
+      } as unknown as Task,
+      repoPath: "/repo",
+      initialPrompt: [{ type: "text", text: "Ship the fix" }],
+      executionMode: "auto",
+      adapter: "claude",
+      model: "claude-fable-5",
+      reasoningLevel: "high",
+    });
+
+    const stored = setSession.mock.calls.at(-1)?.[0] as AgentSession;
+    expect(stored.status).toBe("error");
+    expect(stored.model).toBe("claude-fable-5");
+    expect(stored.adapter).toBe("claude");
+    expect(stored.executionMode).toBe("auto");
+    expect(stored.reasoningLevel).toBe("high");
+    expect(stored.initialPrompt).toEqual([
+      { type: "text", text: "Ship the fix" },
+    ]);
   });
 });

--- a/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -92,6 +92,33 @@ describe("SessionService.clearSessionError retry config", () => {
   });
 });
 
+const CONNECT_PARAMS = {
+  task: {
+    id: "task-1",
+    title: "Test task",
+    description: "Ship the fix",
+    latest_run: null,
+  } as unknown as Task,
+  repoPath: "/repo",
+  initialPrompt: [{ type: "text", text: "Ship the fix" }],
+  executionMode: "auto",
+  adapter: "claude",
+  model: "claude-fable-5",
+  reasoningLevel: "high",
+} as const;
+
+function assertRunConfigPersisted(setSession: ReturnType<typeof vi.fn>): void {
+  const stored = setSession.mock.calls.at(-1)?.[0] as AgentSession;
+  expect(stored.status).toBe("error");
+  expect(stored.model).toBe("claude-fable-5");
+  expect(stored.adapter).toBe("claude");
+  expect(stored.executionMode).toBe("auto");
+  expect(stored.reasoningLevel).toBe("high");
+  expect(stored.initialPrompt).toEqual([
+    { type: "text", text: "Ship the fix" },
+  ]);
+}
+
 describe("SessionService.connectToTask start failure", () => {
   it("persists the run configuration on the error session so retry keeps the model", async () => {
     const setSession = vi.fn();
@@ -139,30 +166,9 @@ describe("SessionService.connectToTask start failure", () => {
       },
     });
 
-    await service.connectToTask({
-      task: {
-        id: "task-1",
-        title: "Test task",
-        description: "Ship the fix",
-        latest_run: null,
-      } as unknown as Task,
-      repoPath: "/repo",
-      initialPrompt: [{ type: "text", text: "Ship the fix" }],
-      executionMode: "auto",
-      adapter: "claude",
-      model: "claude-fable-5",
-      reasoningLevel: "high",
-    });
+    await service.connectToTask(CONNECT_PARAMS);
 
-    const stored = setSession.mock.calls.at(-1)?.[0] as AgentSession;
-    expect(stored.status).toBe("error");
-    expect(stored.model).toBe("claude-fable-5");
-    expect(stored.adapter).toBe("claude");
-    expect(stored.executionMode).toBe("auto");
-    expect(stored.reasoningLevel).toBe("high");
-    expect(stored.initialPrompt).toEqual([
-      { type: "text", text: "Ship the fix" },
-    ]);
+    assertRunConfigPersisted(setSession);
   });
 });
 
@@ -196,29 +202,8 @@ describe("SessionService.connectToTask missing auth", () => {
       "getAuthCredentialsStatus",
     ).mockResolvedValue({ kind: "missing" });
 
-    await service.connectToTask({
-      task: {
-        id: "task-1",
-        title: "Test task",
-        description: "Ship the fix",
-        latest_run: null,
-      } as unknown as Task,
-      repoPath: "/repo",
-      initialPrompt: [{ type: "text", text: "Ship the fix" }],
-      executionMode: "auto",
-      adapter: "claude",
-      model: "claude-fable-5",
-      reasoningLevel: "high",
-    });
+    await service.connectToTask(CONNECT_PARAMS);
 
-    const stored = setSession.mock.calls.at(-1)?.[0] as AgentSession;
-    expect(stored.status).toBe("error");
-    expect(stored.model).toBe("claude-fable-5");
-    expect(stored.adapter).toBe("claude");
-    expect(stored.executionMode).toBe("auto");
-    expect(stored.reasoningLevel).toBe("high");
-    expect(stored.initialPrompt).toEqual([
-      { type: "text", text: "Ship the fix" },
-    ]);
+    assertRunConfigPersisted(setSession);
   });
 });

--- a/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -108,6 +108,10 @@ const CONNECT_PARAMS = {
 } as const;
 
 function assertRunConfigPersisted(setSession: ReturnType<typeof vi.fn>): void {
+  // Exactly one error session should be stored — pinning this stops a future
+  // setup change (e.g. one that lets the auto-retry loop run) from slipping an
+  // intermediate session past the last-call assertions below.
+  expect(setSession.mock.calls.length).toBe(1);
   const stored = setSession.mock.calls.at(-1)?.[0] as AgentSession;
   expect(stored.status).toBe("error");
   expect(stored.model).toBe("claude-fable-5");

--- a/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -1,7 +1,11 @@
 import type { AgentSession } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it, vi } from "vitest";
-import { SessionService, type SessionServiceDeps } from "./sessionService";
+import {
+  type ConnectParams,
+  SessionService,
+  type SessionServiceDeps,
+} from "./sessionService";
 
 function makeSession(overrides: Partial<AgentSession> = {}): AgentSession {
   return {
@@ -92,7 +96,7 @@ describe("SessionService.clearSessionError retry config", () => {
   });
 });
 
-const CONNECT_PARAMS = {
+const CONNECT_PARAMS: ConnectParams = {
   task: {
     id: "task-1",
     title: "Test task",
@@ -105,7 +109,7 @@ const CONNECT_PARAMS = {
   adapter: "claude",
   model: "claude-fable-5",
   reasoningLevel: "high",
-} as const;
+};
 
 function assertRunConfigPersisted(setSession: ReturnType<typeof vi.fn>): void {
   // Exactly one error session should be stored — pinning this stops a future


### PR DESCRIPTION
## Problem

Follow-up to #3127. That PR preserved the user's selected model across retries when a fully-created session later errored — but not when the initial session *start* times out. In that case the error session built in the connect catch-path carried only the initial prompt, so the auto-retry recreated the session without the model/adapter/mode/effort and fell back to the default model. This is the exact "Failed to create session" timeout users were hitting, so the selected model (e.g. Fable) still silently reverted to the default.

## Changes

- Add a `stampRunConfig` helper that persists the prompt, model, adapter, execution mode, and reasoning level onto a session in one place.
- Apply it at both error-path sites (start-failure catch + no-auth), so a retry after a start timeout keeps the user's original choices.

## How did you test this?

- Added a test driving a session-start failure and asserting the stored error session carries the full run config; it passes.
- `pnpm --filter @posthog/core typecheck` and the `packages/core/src/sessions` vitest suite pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783085269646269?thread_ts=1783085269.646269&cid=C09G8Q32R6F)*