### PR TITLE
fix(command): stop highlight jumping to top on section-title hover

### DIFF
--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -445,6 +445,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
           items={sections}
           value={query}
           autoHighlight="always"
+          keepHighlight
           onValueChange={(val, eventDetails) => {
             if (eventDetails.reason !== "input-change") return;
             if (typeof val === "string") {

--- a/packages/ui/src/features/command/FilePicker.tsx
+++ b/packages/ui/src/features/command/FilePicker.tsx
@@ -83,6 +83,7 @@ export function FilePicker({
           filter={null}
           value={searchQuery}
           autoHighlight="always"
+          keepHighlight
           onValueChange={(val, eventDetails) => {
             if (eventDetails.reason !== "input-change") return;
             if (typeof val === "string") setSearchQuery(val);


### PR DESCRIPTION
## Problem

In the command palette and file picker, sliding the cursor over a **section title** yanks the highlight to the topmost item. Jarring, since a section header isn't selectable and shouldn't move the selection.

## Changes


Before

https://github.com/user-attachments/assets/5b049afd-2a09-4e0c-af5f-dcf9060c8a8a



After:

https://github.com/user-attachments/assets/49caa3e3-66fe-4df1-8443-b4df86e81880



Root cause: both palettes use `autoHighlight="always"` with base-ui's default `keepHighlight={false}`. Crossing a section label fires `onPointerLeave` with a non-item `relatedTarget`, which resets the active index to null, and `autoHighlight="always"` then snaps it back to item 0.

- Added `keepHighlight` to the `Autocomplete` in `CommandMenu.tsx` and `FilePicker.tsx`, so pointer-leave preserves the current highlight instead of resetting + snapping to the top.

## How did you test this?

- `pnpm typecheck` (via precommit) passed.
- Not yet manually verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*