### PR TITLE
fix(analytics): stop session replay canvas capture eating CPU

### DIFF
--- a/packages/ui/src/features/terminal/TerminalManager.test.ts
+++ b/packages/ui/src/features/terminal/TerminalManager.test.ts
@@ -258,6 +258,7 @@ describe("TerminalManager.destroyForTask", () => {
     terminalManager.detach("sess-parked");
 
     const parking = document.getElementById("terminal-parking");
+    expect(parking?.classList.contains("ph-no-capture")).toBe(true);
     expect(parking?.childElementCount).toBe(1);
 
     terminalManager.destroy("sess-parked");

--- a/packages/ui/src/features/terminal/TerminalManager.ts
+++ b/packages/ui/src/features/terminal/TerminalManager.ts
@@ -21,6 +21,9 @@ function getParkingContainer(): HTMLElement {
   if (!parkingContainer) {
     parkingContainer = document.createElement("div");
     parkingContainer.id = "terminal-parking";
+    // Parked terminals keep live WebGL canvases; ph-no-capture stops PostHog
+    // session replay snapshotting every one of them at canvasFps forever.
+    parkingContainer.className = "ph-no-capture";
     parkingContainer.style.position = "absolute";
     parkingContainer.style.visibility = "hidden";
     parkingContainer.style.pointerEvents = "none";

--- a/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
@@ -192,6 +192,19 @@ describe("initializePostHog", () => {
     expect(mockPosthog.onFeatureFlags).not.toHaveBeenCalled();
   });
 
+  it("disables replay canvas capture regardless of remote config", async () => {
+    const { initializePostHog } = await loadAnalytics();
+
+    initializePostHog();
+
+    expect(mockPosthog.init).toHaveBeenCalledWith(
+      "test-key",
+      expect.objectContaining({
+        session_recording: { captureCanvas: { recordCanvas: false } },
+      }),
+    );
+  });
+
   it("bootstraps posthog with the main-owned session id", async () => {
     const { initializePostHog } = await loadAnalytics();
 

--- a/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -72,6 +72,13 @@ export function initializePostHog(sessionId?: string) {
     // and rely on explicit instrumentation instead.
     capture_pageview: false,
     disable_session_recording: false,
+    // Never let the project's remote canvasRecording config apply here: our
+    // canvases are xterm terminals (secrets show up as pixels, bypassing text
+    // masking) and decorative WebGL (hedgehog, confetti). Capturing them costs
+    // an image encode per canvas at canvasFps for the whole app lifetime.
+    session_recording: {
+      captureCanvas: { recordCanvas: false },
+    },
     session_idle_timeout_seconds: SESSION_IDLE_TIMEOUT_SECONDS,
     ...(sessionId ? { bootstrap: { sessionID: sessionId } } : {}),
     capture_exceptions: import.meta.env.DEV


### PR DESCRIPTION
## Problem

The desktop app self-records into PostHog with session replay, and the project's remote replay config has canvas recording enabled (`recordCanvas: true, canvasFps: 3`). That config is meant for our web surfaces, but the SDK applies it here too, and this app is full of WebGL canvases:

- every terminal is an xterm.js WebGL canvas, and `TerminalManager.detach()` parks terminals (canvas and live WebGL addon included) in a hidden `#terminal-parking` container — they accumulate for the whole app lifetime
- hedgehog mode is a permanently-animating pixi.js canvas
- confetti renders to a transient full-screen canvas

rrweb's canvas capture snapshots every non-blocked canvas in the document (hidden ones included) at 3fps: a `querySelectorAll("*")` DOM sweep plus `createImageBitmap` GPU readback on the main thread per tick, then a webp encode per canvas per frame in a worker — the encode runs even when the canvas hasn't changed. On a machine with a day's worth of parked terminals this pegged the renderer at ~90% of a core; an Activity Monitor sample showed the replay canvas worker on-CPU for 74% of samples, and the process had burned ~4h CPU in 7h of uptime.

## Changes

- `posthog.init` now sets `session_recording.captureCanvas.recordCanvas: false`, so the remote project config can keep canvas recording on for web surfaces while this app never captures canvases. Nothing in this app's canvas inventory (terminals, hedgehog, confetti, a 14px attachment thumbnail) is worth replaying as 3fps images, and terminals actively must not be.
- The `#terminal-parking` container is `ph-no-capture`, as defence in depth for the accumulating parked-terminal canvases if canvas capture is ever re-enabled.

## How did you test this?

- Extended `posthogAnalyticsImpl.test.ts` to assert the init config disables canvas capture, and the existing parked-terminal test to assert the parking container carries `ph-no-capture` — both would catch either line being dropped.
- Ran `vitest` on both touched test files (19 tests pass), `tsc --noEmit` on `@posthog/ui`, and biome on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
