### PR TITLE
feat(command): add inbox and command center to command menu

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -51,6 +51,8 @@ export type CommandMenuAction =
   | "go-forward"
   | "open-task"
   | "open-channel"
+  | "open-command-center"
+  | "open-inbox"
   | "search-files"
   | "open-file"
   | "reload-window"

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -252,7 +252,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
       },
       {
         id: "command-center",
-        label: "Command Center",
+        label: "Command center",
         keywords: "lightning grid tasks parallel dashboard",
         icon: <LightningBoltIcon className="h-3 w-3 text-gray-11" />,
         action: "open-command-center",

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -1,4 +1,9 @@
-import { CaretLeftIcon, CaretRightIcon, HashIcon } from "@phosphor-icons/react";
+import {
+  CaretLeftIcon,
+  CaretRightIcon,
+  EnvelopeSimple,
+  HashIcon,
+} from "@phosphor-icons/react";
 import {
   Autocomplete,
   AutocompleteCollection,
@@ -42,6 +47,8 @@ import {
   goBackInHistory,
   goForwardInHistory,
   navigateToChannel,
+  navigateToCommandCenter,
+  navigateToInbox,
 } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
@@ -53,6 +60,7 @@ import {
   FileTextIcon,
   GearIcon,
   HomeIcon,
+  LightningBoltIcon,
   MagnifyingGlassIcon,
   MoonIcon,
   ReloadIcon,
@@ -229,6 +237,29 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         action: "settings",
         shortcut: SHORTCUTS.SETTINGS,
         onRun: () => openSettingsDialog(),
+      },
+      {
+        id: "inbox",
+        label: "Inbox",
+        keywords: "reports pull requests agents notifications",
+        icon: <EnvelopeSimple size={12} className="text-gray-11" />,
+        action: "open-inbox",
+        shortcut: SHORTCUTS.INBOX,
+        onRun: () => {
+          closeSettingsDialog();
+          navigateToInbox();
+        },
+      },
+      {
+        id: "command-center",
+        label: "Command Center",
+        keywords: "lightning grid tasks parallel dashboard",
+        icon: <LightningBoltIcon className="h-3 w-3 text-gray-11" />,
+        action: "open-command-center",
+        onRun: () => {
+          closeSettingsDialog();
+          navigateToCommandCenter();
+        },
       },
       {
         id: "go-back",


### PR DESCRIPTION
## TL;DR
Added two new commands to the command menu: "Inbox" and "Command Center". These allow users to quickly navigate to these features via the command palette with keyboard shortcuts.

## Problem
Users need quick access to the Inbox and Command Center features from the command menu, improving discoverability and navigation efficiency.

## Changes

<img width="1790" height="1036" alt="CleanShot 2026-07-03 at 17 02 39@2x" src="https://github.com/user-attachments/assets/27f5db32-7c6a-4bf8-945d-d3b9cb8bd3a1" />


- **Analytics events**: Added `"open-command-center"` and `"open-inbox"` to the `CommandMenuAction` type in `analytics-events.ts`
- **Command menu items**: Added two new command entries to the CommandMenu component:
  - **Inbox**: Uses EnvelopeSimple icon, includes keywords "reports pull requests agents notifications", triggers `navigateToInbox()`
  - **Command Center**: Uses LightningBolt icon, includes keywords "lightning grid tasks parallel dashboard", triggers `navigateToCommandCenter()`
- **Icons**: Imported `EnvelopeSimple` from Phosphor Icons and `LightningBoltIcon` from the custom icon set
- **Navigation**: Imported `navigateToCommandCenter` and `navigateToInbox` navigation functions
- Both commands close the settings dialog when executed to prevent UI conflicts

## How did you test this?
Manual verification that the new commands appear in the command palette and navigate to the correct destinations when invoked.

## Automatic notifications
- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*