### PR TITLE
fix(tasks): restore context menu for pinned tasks

### DIFF
--- a/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -237,10 +237,10 @@ function SidebarMenuComponent() {
       clearSelection();
     }
 
-    const task = taskMap.get(taskId);
+    const taskData = allSidebarTasks.find((t) => t.id === taskId);
+    const task = taskMap.get(taskId) ?? taskData;
     if (task) {
       const workspace = workspaces[taskId];
-      const taskData = allSidebarTasks.find((t) => t.id === taskId);
       const isInCommandCenter = commandCenterCells.some(
         (id) => id === taskId && taskMap.has(id),
       );

--- a/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -38,7 +38,7 @@ export function useTaskContextMenu() {
 
   const showContextMenu = useCallback(
     async (
-      task: Task,
+      task: Pick<Task, "id" | "title">,
       event: React.MouseEvent,
       options?: {
         worktreePath?: string;


### PR DESCRIPTION
## Problem

Right-clicking on pinned tasks in the sidebar no longer opens the context menu, preventing users from accessing task options after pinning.

## Changes

- **SidebarMenu.tsx**: Refactored task lookup logic to fall back to `allSidebarTasks` when `taskMap` doesn't contain the task. Pinned tasks may not be in `taskMap`, so we now check `allSidebarTasks` as a fallback to ensure `taskData` is always available when needed.
- **useTaskContextMenu.ts**: Relaxed the `task` parameter type from `Task` to `Pick<Task, "id" | "title">` to accommodate partial task objects, allowing the context menu to work with pinned tasks that may only have basic properties available.

## How did you test this?

Manual testing of right-click context menu on pinned tasks in the sidebar.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*