### PR TITLE
perf(worktree): stop worktree session creation blocking on large-repo scans and deletes

### DIFF
--- a/packages/git/src/exclude-patterns.test.ts
+++ b/packages/git/src/exclude-patterns.test.ts
@@ -32,7 +32,12 @@ describe("matchesExcludePatterns", () => {
     ],
     ["comment lines never match", "# .env", ".env", false],
     ["star glob within a segment", "*.local", ".env.local", true],
-    ["star glob does not cross directories", "*.local", "a/b.local", true],
+    [
+      "star glob matches a nested file via the non-anchored prefix",
+      "*.local",
+      "a/b.local",
+      true,
+    ],
     ["star does not span slashes", "a*b", "a/b", false],
     ["question mark matches one char", ".env?", ".envX", true],
     ["question mark does not match slash", ".env?", ".env/", false],
@@ -87,8 +92,33 @@ describe("matchesExcludePatterns", () => {
     ["escaped bang matches literal bang", "\\!important", "!important", true],
     ["escaped hash matches literal hash", "\\#file", "#file", true],
     ["trailing spaces are trimmed", ".env   ", ".env", true],
+    ["CRLF line endings do not defeat matching", ".env\r\n", ".env", true],
+    [
+      "consecutive double-star segments collapse",
+      "**/**/logs",
+      "a/b/logs",
+      true,
+    ],
   ])("%s", (_label, content, entry, expected) => {
     expect(matches(content, entry)).toBe(expected);
+  });
+
+  it("skips a malformed pattern line instead of dropping the whole file", () => {
+    // An unterminated char class on one line must not throw out the valid ones.
+    const patterns = parseExcludePatterns(".env\n[\n.envrc");
+    expect(matchesExcludePatterns(".env", patterns)).toBe(true);
+    expect(matchesExcludePatterns(".envrc", patterns)).toBe(true);
+  });
+
+  it("matches a pathological consecutive-double-star pattern in bounded time", () => {
+    // Regression for ReDoS: a run of `**/` used to compile to that many
+    // overlapping backtracking groups, blowing up exponentially with path depth.
+    const pattern = `${Array(30).fill("**").join("/")}/NOMATCH`;
+    const patterns = parseExcludePatterns(pattern);
+    const deepPath = `${Array.from({ length: 24 }, (_, i) => String.fromCharCode(97 + (i % 26))).join("/")}/`;
+    const start = performance.now();
+    expect(matchesExcludePatterns(deepPath, patterns)).toBe(false);
+    expect(performance.now() - start).toBeLessThan(1000);
   });
 
   it("never matches entries only reachable through unrelated names", () => {

--- a/packages/git/src/exclude-patterns.test.ts
+++ b/packages/git/src/exclude-patterns.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  matchesExcludePatterns,
+  parseExcludePatterns,
+} from "./exclude-patterns";
+
+function matches(content: string, entry: string): boolean {
+  return matchesExcludePatterns(entry, parseExcludePatterns(content));
+}
+
+describe("parseExcludePatterns", () => {
+  it.each([
+    ["empty content", ""],
+    ["only comments", "# a comment\n# another"],
+    ["only blank lines", "\n\n  \n"],
+    ["a lone negation marker", "!"],
+    ["a lone slash", "/"],
+  ])("produces no patterns from %s", (_label, content) => {
+    expect(parseExcludePatterns(content)).toEqual([]);
+  });
+});
+
+describe("matchesExcludePatterns", () => {
+  it.each([
+    ["basename pattern matches at root", ".env", ".env", true],
+    ["basename pattern matches nested", ".env", "config/sub/.env", true],
+    [
+      "basename pattern does not match other names",
+      ".env",
+      ".env.local",
+      false,
+    ],
+    ["comment lines never match", "# .env", ".env", false],
+    ["star glob within a segment", "*.local", ".env.local", true],
+    ["star glob does not cross directories", "*.local", "a/b.local", true],
+    ["star does not span slashes", "a*b", "a/b", false],
+    ["question mark matches one char", ".env?", ".envX", true],
+    ["question mark does not match slash", ".env?", ".env/", false],
+    ["anchored pattern matches from root only", "/build", "build", true],
+    ["anchored pattern rejects nested path", "/build", "sub/build", false],
+    [
+      "middle-slash pattern anchors to root",
+      "config/secrets",
+      "config/secrets",
+      true,
+    ],
+    [
+      "middle-slash pattern rejects nested",
+      "config/secrets",
+      "app/config/secrets",
+      false,
+    ],
+    ["dir-only pattern matches directory entry", ".flox/", ".flox/", true],
+    ["dir-only pattern rejects plain file", ".flox/", ".flox", false],
+    ["dir pattern matches files beneath it", ".flox", ".flox/cache/data", true],
+    [
+      "dir-only pattern matches files beneath it",
+      ".flox/",
+      ".flox/cache/data",
+      true,
+    ],
+    ["double star prefix matches any depth", "**/logs", "a/b/logs", true],
+    ["double star suffix matches contents", "logs/**", "logs/a/b.txt", true],
+    [
+      "double star suffix does not match the dir itself",
+      "logs/**",
+      "logs",
+      false,
+    ],
+    ["middle double star spans directories", "a/**/b", "a/x/y/b", true],
+    ["middle double star matches zero directories", "a/**/b", "a/b", true],
+    ["character class matches", ".env.[ab]", ".env.a", true],
+    ["negated character class rejects", ".env.[!ab]", ".env.a", false],
+    [
+      "negation un-matches an earlier pattern",
+      ".env*\n!.env.example",
+      ".env.example",
+      false,
+    ],
+    [
+      "negation only affects matching entries",
+      ".env*\n!.env.example",
+      ".env",
+      true,
+    ],
+    ["later pattern wins over earlier negation", "!.env\n.env", ".env", true],
+    ["escaped bang matches literal bang", "\\!important", "!important", true],
+    ["escaped hash matches literal hash", "\\#file", "#file", true],
+    ["trailing spaces are trimmed", ".env   ", ".env", true],
+  ])("%s", (_label, content, entry, expected) => {
+    expect(matches(content, entry)).toBe(expected);
+  });
+
+  it("never matches entries only reachable through unrelated names", () => {
+    expect(matches(".env", "node_modules/")).toBe(false);
+    expect(matches(".env", "dist/")).toBe(false);
+  });
+});

--- a/packages/git/src/exclude-patterns.ts
+++ b/packages/git/src/exclude-patterns.ts
@@ -38,7 +38,15 @@ export function parseExcludePatterns(content: string): ExcludePattern[] {
       pattern = pattern.slice(1);
     }
 
-    patterns.push({ negated, dirOnly, regex: globToRegExp(pattern, anchored) });
+    // A single malformed pattern must not drop the whole exclude file: skip the
+    // offending line rather than letting a RegExp throw propagate out.
+    let regex: RegExp;
+    try {
+      regex = globToRegExp(pattern, anchored);
+    } catch {
+      continue;
+    }
+    patterns.push({ negated, dirOnly, regex });
   }
 
   return patterns;
@@ -86,7 +94,9 @@ function patternMatches(
 }
 
 function trimUnescapedTrailingSpaces(line: string): string {
-  return line.replace(/(?<!\\) +$/, "");
+  // Drop a trailing CR first so CRLF-terminated exclude files don't bake a \r
+  // into every pattern (which would make the compiled regex match nothing).
+  return line.replace(/\r$/, "").replace(/(?<!\\) +$/, "");
 }
 
 function globToRegExp(pattern: string, anchored: boolean): RegExp {
@@ -98,8 +108,19 @@ function globToRegExp(pattern: string, anchored: boolean): RegExp {
     if (char === "*") {
       if (pattern[i + 1] === "*") {
         if (pattern[i + 2] === "/") {
+          // Collapse a run of consecutive `**/` into one `(?:.*/)?`. They are
+          // semantically equivalent, and emitting one group per segment would
+          // stack overlapping backtracking `.*` groups — catastrophic on a
+          // slash-heavy path that fails the final literal (ReDoS).
           source += "(?:.*/)?";
           i += 3;
+          while (
+            pattern[i] === "*" &&
+            pattern[i + 1] === "*" &&
+            pattern[i + 2] === "/"
+          ) {
+            i += 3;
+          }
         } else {
           source += ".*";
           i += 2;

--- a/packages/git/src/exclude-patterns.ts
+++ b/packages/git/src/exclude-patterns.ts
@@ -1,0 +1,141 @@
+export interface ExcludePattern {
+  negated: boolean;
+  dirOnly: boolean;
+  regex: RegExp;
+}
+
+/**
+ * Parses gitignore-style pattern lines (comments, negation, dir-only trailing
+ * slash, root anchoring, `*`/`?`/`**`/`[...]` globs). Used to re-apply an
+ * exclude file's patterns in-process against paths git has already listed, so
+ * callers can avoid asking git to walk huge ignored trees.
+ */
+export function parseExcludePatterns(content: string): ExcludePattern[] {
+  const patterns: ExcludePattern[] = [];
+
+  for (const rawLine of content.split("\n")) {
+    const line = trimUnescapedTrailingSpaces(rawLine);
+    if (!line || line.startsWith("#")) continue;
+
+    let pattern = line;
+    let negated = false;
+    if (pattern.startsWith("!")) {
+      negated = true;
+      pattern = pattern.slice(1);
+    } else if (pattern.startsWith("\\!") || pattern.startsWith("\\#")) {
+      pattern = pattern.slice(1);
+    }
+
+    let dirOnly = false;
+    if (pattern.endsWith("/")) {
+      dirOnly = true;
+      pattern = pattern.slice(0, -1);
+    }
+    if (!pattern) continue;
+
+    const anchored = pattern.includes("/");
+    if (pattern.startsWith("/")) {
+      pattern = pattern.slice(1);
+    }
+
+    patterns.push({ negated, dirOnly, regex: globToRegExp(pattern, anchored) });
+  }
+
+  return patterns;
+}
+
+/**
+ * Whether a path matches the pattern list, last match wins (gitignore
+ * semantics). `entry` may carry a trailing slash to mark a directory, as in
+ * `git ls-files --directory` output. A pattern matching a parent directory
+ * matches everything beneath it.
+ */
+export function matchesExcludePatterns(
+  entry: string,
+  patterns: ExcludePattern[],
+): boolean {
+  const isDir = entry.endsWith("/");
+  const entryPath = isDir ? entry.slice(0, -1) : entry;
+
+  let matched = false;
+  for (const pattern of patterns) {
+    if (patternMatches(pattern, entryPath, isDir)) {
+      matched = !pattern.negated;
+    }
+  }
+  return matched;
+}
+
+function patternMatches(
+  pattern: ExcludePattern,
+  entryPath: string,
+  isDir: boolean,
+): boolean {
+  if ((isDir || !pattern.dirOnly) && pattern.regex.test(entryPath)) {
+    return true;
+  }
+
+  let separatorIndex = entryPath.indexOf("/");
+  while (separatorIndex !== -1) {
+    if (pattern.regex.test(entryPath.slice(0, separatorIndex))) {
+      return true;
+    }
+    separatorIndex = entryPath.indexOf("/", separatorIndex + 1);
+  }
+  return false;
+}
+
+function trimUnescapedTrailingSpaces(line: string): string {
+  return line.replace(/(?<!\\) +$/, "");
+}
+
+function globToRegExp(pattern: string, anchored: boolean): RegExp {
+  let source = anchored ? "^" : "^(?:.*/)?";
+  let i = 0;
+
+  while (i < pattern.length) {
+    const char = pattern[i];
+    if (char === "*") {
+      if (pattern[i + 1] === "*") {
+        if (pattern[i + 2] === "/") {
+          source += "(?:.*/)?";
+          i += 3;
+        } else {
+          source += ".*";
+          i += 2;
+        }
+      } else {
+        source += "[^/]*";
+        i += 1;
+      }
+    } else if (char === "?") {
+      source += "[^/]";
+      i += 1;
+    } else if (char === "[") {
+      const classEnd = pattern.indexOf("]", i + 2);
+      if (classEnd === -1) {
+        source += "\\[";
+        i += 1;
+      } else {
+        let charClass = pattern.slice(i + 1, classEnd);
+        if (charClass.startsWith("!")) {
+          charClass = `^${charClass.slice(1)}`;
+        }
+        source += `[${charClass}]`;
+        i = classEnd + 1;
+      }
+    } else if (char === "\\" && i + 1 < pattern.length) {
+      source += escapeRegExp(pattern[i + 1]);
+      i += 2;
+    } else {
+      source += escapeRegExp(char);
+      i += 1;
+    }
+  }
+
+  return new RegExp(`${source}$`);
+}
+
+function escapeRegExp(char: string): string {
+  return /[.*+?^${}()|[\]\\/]/.test(char) ? `\\${char}` : char;
+}

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -1,4 +1,13 @@
-import { mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -219,6 +228,104 @@ describe("WorktreeManager lifecycle (add / exists / list / remove / prune)", () 
     expect(deleted).toContain(info.worktreePath);
     expect(await dirExists(info.worktreePath)).toBe(false);
     expect(await manager.listWorktrees()).toEqual([]);
+  });
+});
+
+describe("WorktreeManager worktree link/include processing", () => {
+  let remoteDir: string;
+  let localDir: string;
+  let worktreeBaseDir: string;
+
+  beforeEach(async () => {
+    remoteDir = await initBareRemote();
+
+    const seedDir = await mkdtemp(path.join(tmpdir(), "posthog-code-seed-"));
+    const seedGit = createGitClient(seedDir);
+    await seedGit.init(["--initial-branch", "main"]);
+    await seedGit.addConfig("user.name", "Test");
+    await seedGit.addConfig("user.email", "test@example.com");
+    await seedGit.addConfig("commit.gpgsign", "false");
+    await writeFile(
+      path.join(seedDir, ".gitignore"),
+      ".env\n.envrc\nnode_modules/\n",
+    );
+    await writeFile(path.join(seedDir, ".worktreelink"), "# secrets\n.envrc\n");
+    await writeFile(path.join(seedDir, ".worktreeinclude"), ".env\n");
+    await seedGit.add([".gitignore", ".worktreelink", ".worktreeinclude"]);
+    await seedGit.commit("add worktree config");
+    await seedGit.addRemote("origin", remoteDir);
+    await seedGit.push(["origin", "main"]);
+    await rm(seedDir, { recursive: true, force: true });
+
+    localDir = await realpath(await initLocalClone(remoteDir));
+    worktreeBaseDir = await realpath(
+      await mkdtemp(path.join(tmpdir(), "posthog-code-wts-")),
+    );
+
+    await writeFile(path.join(localDir, ".env"), "secret\n");
+    await writeFile(path.join(localDir, ".envrc"), "export FOO=1\n");
+    await mkdir(path.join(localDir, "node_modules", "dep"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(localDir, "node_modules", "dep", ".env"),
+      "dep\n",
+    );
+    await writeFile(
+      path.join(localDir, "node_modules", "dep", ".envrc"),
+      "dep\n",
+    );
+  });
+
+  afterEach(async () => {
+    for (const d of [remoteDir, localDir, worktreeBaseDir]) {
+      await rm(d, { recursive: true, force: true });
+    }
+  });
+
+  it("links and copies matching gitignored files but never reaches into standard-ignored trees", async () => {
+    const manager = new WorktreeManager({
+      mainRepoPath: localDir,
+      worktreeBasePath: worktreeBaseDir,
+    });
+
+    const info = await manager.createWorktree({ baseBranch: "main" });
+
+    const linked = await lstat(path.join(info.worktreePath, ".envrc"));
+    expect(linked.isSymbolicLink()).toBe(true);
+
+    const copied = await readFile(
+      path.join(info.worktreePath, ".env"),
+      "utf-8",
+    );
+    expect(copied).toBe("secret\n");
+
+    // Regression: matches buried in node_modules used to be copied, which both
+    // walked the whole ignored tree and pre-created node_modules/ in the fresh
+    // worktree (defeating repos' own post-checkout bootstrap checks).
+    expect(await dirExists(path.join(info.worktreePath, "node_modules"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("WorktreeManager.sweepTrash", () => {
+  it("removes trashed worktrees left behind by interrupted deletes", async () => {
+    const worktreeBaseDir = await mkdtemp(
+      path.join(tmpdir(), "posthog-code-wts-"),
+    );
+    const trashDir = path.join(worktreeBaseDir, ".trash");
+    await mkdir(path.join(trashDir, "stale-worktree"), { recursive: true });
+    await writeFile(path.join(trashDir, "stale-worktree", "file.txt"), "x\n");
+
+    const manager = new WorktreeManager({
+      mainRepoPath: "/nonexistent-main-repo",
+      worktreeBasePath: worktreeBaseDir,
+    });
+    await manager.sweepTrash();
+
+    expect(await dirExists(trashDir)).toBe(false);
+    await rm(worktreeBaseDir, { recursive: true, force: true });
   });
 });
 

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -1,6 +1,11 @@
 import { type ChildProcess, execFile, spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import {
+  type ExcludePattern,
+  matchesExcludePatterns,
+  parseExcludePatterns,
+} from "./exclude-patterns";
 import { getCleanEnv, getGitOperationManager } from "./operation-manager";
 import {
   addToLocalExclude,
@@ -552,6 +557,16 @@ export class WorktreeManager {
       }
     }
 
+    const trashedPath = await this.moveToTrash(resolvedWorktreePath);
+    if (trashedPath) {
+      await manager.executeWrite(this.mainRepoPath, (git) =>
+        git.raw(["worktree", "prune"]),
+      );
+      await fs.rmdir(path.dirname(resolvedWorktreePath)).catch(() => {});
+      void forceRemove(trashedPath).catch(() => {});
+      return;
+    }
+
     await manager.executeWrite(this.mainRepoPath, async (git) => {
       try {
         await git.raw(["worktree", "remove", worktreePath, "--force"]);
@@ -560,6 +575,37 @@ export class WorktreeManager {
         await git.raw(["worktree", "prune"]);
       }
     });
+  }
+
+  private getTrashFolderPath(): string {
+    return path.join(this.getWorktreeBaseFolderPath(), ".trash");
+  }
+
+  /**
+   * Renames a worktree into the trash folder so callers get an instant delete;
+   * the multi-gigabyte recursive removal then runs in the background (and
+   * `sweepTrash` mops up anything left behind by a crash). Returns null when
+   * the rename cannot work (path missing, or on a different volume), in which
+   * case the caller falls back to removing in place.
+   */
+  private async moveToTrash(worktreePath: string): Promise<string | null> {
+    const trashDir = this.getTrashFolderPath();
+    const trashedPath = path.join(
+      trashDir,
+      `${path.basename(path.dirname(worktreePath))}-${Date.now()}`,
+    );
+    try {
+      await fs.mkdir(trashDir, { recursive: true });
+      await fs.rename(worktreePath, trashedPath);
+      return trashedPath;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Removes trashed worktrees left behind by interrupted background deletes. */
+  async sweepTrash(): Promise<void> {
+    await forceRemove(this.getTrashFolderPath());
   }
 
   async getWorktreeInfo(worktreePath: string): Promise<WorktreeInfo | null> {
@@ -658,7 +704,37 @@ export class WorktreeManager {
 /**
  * get all gitignored paths matching patterns from an exclude file
  */
-function getIgnoredPathsFromExcludeFile(
+async function getIgnoredPathsFromExcludeFile(
+  mainRepoPath: string,
+  excludeFile: string,
+): Promise<string[]> {
+  let patterns: ExcludePattern[];
+  try {
+    const content = await fs.readFile(
+      path.join(mainRepoPath, excludeFile),
+      "utf-8",
+    );
+    patterns = parseExcludePatterns(content);
+  } catch {
+    return [];
+  }
+  if (patterns.length === 0) return [];
+
+  const candidates = await listExcludeCandidates(mainRepoPath, excludeFile);
+  return candidates
+    .filter((candidate) => matchesExcludePatterns(candidate, patterns))
+    .map((candidate) => candidate.replace(/\/$/, ""));
+}
+
+/**
+ * Candidate untracked paths for exclude-file matching. `--exclude-standard`
+ * lets git collapse gitignored trees (node_modules et al) into a single entry
+ * instead of recursing through them — on a large repo that turns a multi-second
+ * walk into a sub-second one. The exclude file's own patterns are then
+ * re-applied in-process, which also stops matches buried inside standard-
+ * ignored directories (e.g. a stray .env deep in node_modules) from surfacing.
+ */
+function listExcludeCandidates(
   mainRepoPath: string,
   excludeFile: string,
 ): Promise<string[]> {
@@ -670,6 +746,7 @@ function getIgnoredPathsFromExcludeFile(
         "--ignored",
         "--others",
         "--directory",
+        "--exclude-standard",
         `--exclude-from=${excludeFile}`,
       ],
       { cwd: mainRepoPath },
@@ -682,8 +759,7 @@ function getIgnoredPathsFromExcludeFile(
           stdout
             .trim()
             .split("\n")
-            .filter((line) => line.length > 0)
-            .map((line) => line.replace(/\/$/, "")),
+            .filter((line) => line.length > 0),
         );
       },
     );

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -574,22 +574,27 @@ export class WorktreeManager {
           throw pruneError;
         }
       })
-      .catch(() => "prune-failed" as const);
+      // A null (rename couldn't happen) or a throw (prune failed, rename rolled
+      // back) both fall through to the in-place remove below.
+      .catch(() => null);
 
-    if (trashedPath && trashedPath !== "prune-failed") {
-      await fs.rmdir(path.dirname(resolvedWorktreePath)).catch(() => {});
+    if (trashedPath) {
       void forceRemove(trashedPath).catch(() => {});
-      return;
+    } else {
+      await manager.executeWrite(this.mainRepoPath, async (git) => {
+        try {
+          await git.raw(["worktree", "remove", worktreePath, "--force"]);
+        } catch {
+          await forceRemove(worktreePath);
+          await git.raw(["worktree", "prune"]);
+        }
+      });
     }
 
-    await manager.executeWrite(this.mainRepoPath, async (git) => {
-      try {
-        await git.raw(["worktree", "remove", worktreePath, "--force"]);
-      } catch {
-        await forceRemove(worktreePath);
-        await git.raw(["worktree", "prune"]);
-      }
-    });
+    // Both branches leave the worktree's `<base>/<name>` parent empty; remove it
+    // so a deleted worktree never leaves a stray directory behind (best-effort:
+    // rmdir no-ops if it isn't empty).
+    await fs.rmdir(path.dirname(resolvedWorktreePath)).catch(() => {});
   }
 
   private getTrashFolderPath(): string {

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -2,7 +2,6 @@ import { type ChildProcess, execFile, spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
-  type ExcludePattern,
   matchesExcludePatterns,
   parseExcludePatterns,
 } from "./exclude-patterns";
@@ -720,27 +719,76 @@ export class WorktreeManager {
 
 /**
  * get all gitignored paths matching patterns from an exclude file
+ *
+ * Fast path: list candidates with `--exclude-standard` (so git collapses
+ * standard-ignored trees) and re-apply the exclude file's patterns in-process.
+ * If that in-process matching ever throws, fall back to letting git do the
+ * whole match itself (`--exclude-from` only) — slower and does not collapse
+ * ignored trees, but it is git's own battle-tested ignore logic, so a bug in
+ * the hand-rolled matcher degrades to correct-but-slower rather than failing
+ * worktree setup or silently linking nothing.
  */
 async function getIgnoredPathsFromExcludeFile(
   mainRepoPath: string,
   excludeFile: string,
 ): Promise<string[]> {
-  let patterns: ExcludePattern[];
+  let content: string;
   try {
-    const content = await fs.readFile(
-      path.join(mainRepoPath, excludeFile),
-      "utf-8",
-    );
-    patterns = parseExcludePatterns(content);
+    content = await fs.readFile(path.join(mainRepoPath, excludeFile), "utf-8");
   } catch {
+    // No exclude file (the common case) — genuinely nothing to link/copy.
     return [];
   }
-  if (patterns.length === 0) return [];
 
-  const candidates = await listExcludeCandidates(mainRepoPath, excludeFile);
-  return candidates
-    .filter((candidate) => matchesExcludePatterns(candidate, patterns))
-    .map((candidate) => candidate.replace(/\/$/, ""));
+  try {
+    const patterns = parseExcludePatterns(content);
+    if (patterns.length === 0) return [];
+
+    const candidates = await listExcludeCandidates(mainRepoPath, excludeFile);
+    return candidates
+      .filter((candidate) => matchesExcludePatterns(candidate, patterns))
+      .map((candidate) => candidate.replace(/\/$/, ""));
+  } catch {
+    return listIgnoredPathsViaGit(mainRepoPath, excludeFile);
+  }
+}
+
+/**
+ * Fallback matcher: git's own ignore matching over the exclude file, without
+ * `--exclude-standard`. This is the pre-fast-path behavior — correct but it
+ * walks standard-ignored trees instead of collapsing them. Used only when the
+ * in-process matcher throws.
+ */
+function listIgnoredPathsViaGit(
+  mainRepoPath: string,
+  excludeFile: string,
+): Promise<string[]> {
+  return new Promise((resolve) => {
+    execFile(
+      "git",
+      [
+        "ls-files",
+        "--ignored",
+        "--others",
+        "--directory",
+        `--exclude-from=${excludeFile}`,
+      ],
+      { cwd: mainRepoPath },
+      (error, stdout) => {
+        if (error || !stdout) {
+          resolve([]);
+          return;
+        }
+        resolve(
+          stdout
+            .trim()
+            .split("\n")
+            .filter((line) => line.length > 0)
+            .map((line) => line.replace(/\/$/, "")),
+        );
+      },
+    );
+  });
 }
 
 /**

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -557,11 +557,27 @@ export class WorktreeManager {
       }
     }
 
-    const trashedPath = await this.moveToTrash(resolvedWorktreePath);
-    if (trashedPath) {
-      await manager.executeWrite(this.mainRepoPath, (git) =>
-        git.raw(["worktree", "prune"]),
-      );
+    // Rename-to-trash and prune both run inside the write lock so the on-disk
+    // move and the git metadata update are atomic: if prune can't run (e.g. a
+    // persistent external index.lock) we roll the rename back rather than leave
+    // the worktree gone from disk but still registered (which would strand the
+    // branch). Only the slow recursive removal of the trashed copy happens
+    // outside the lock.
+    const trashedPath = await manager
+      .executeWrite(this.mainRepoPath, async (git) => {
+        const moved = await this.moveToTrash(resolvedWorktreePath);
+        if (!moved) return null;
+        try {
+          await git.raw(["worktree", "prune"]);
+          return moved;
+        } catch (pruneError) {
+          await fs.rename(moved, resolvedWorktreePath).catch(() => {});
+          throw pruneError;
+        }
+      })
+      .catch(() => "prune-failed" as const);
+
+    if (trashedPath && trashedPath !== "prune-failed") {
       await fs.rmdir(path.dirname(resolvedWorktreePath)).catch(() => {});
       void forceRemove(trashedPath).catch(() => {});
       return;
@@ -586,7 +602,8 @@ export class WorktreeManager {
    * the multi-gigabyte recursive removal then runs in the background (and
    * `sweepTrash` mops up anything left behind by a crash). Returns null when
    * the rename cannot work (path missing, or on a different volume), in which
-   * case the caller falls back to removing in place.
+   * case the caller falls back to removing in place. Call inside the repo write
+   * lock so the move stays ordered with the follow-up `git worktree prune`.
    */
   private async moveToTrash(worktreePath: string): Promise<string | null> {
     const trashDir = this.getTrashFolderPath();

--- a/packages/workspace-server/src/services/folders/folders.test.ts
+++ b/packages/workspace-server/src/services/folders/folders.test.ts
@@ -28,6 +28,7 @@ const mockWorktreeRepo = vi.hoisted(() => ({
 const mockWorktreeManager = vi.hoisted(() => ({
   deleteWorktree: vi.fn(),
   cleanupOrphanedWorktrees: vi.fn(),
+  sweepTrash: vi.fn(),
 }));
 const mockInitRepositorySaga = vi.hoisted(() => ({
   run: vi.fn(),
@@ -52,6 +53,7 @@ vi.mock("@posthog/git/worktree", () => ({
   WorktreeManager: class MockWorktreeManager {
     deleteWorktree = mockWorktreeManager.deleteWorktree;
     cleanupOrphanedWorktrees = mockWorktreeManager.cleanupOrphanedWorktrees;
+    sweepTrash = mockWorktreeManager.sweepTrash;
   },
 }));
 

--- a/packages/workspace-server/src/services/folders/folders.ts
+++ b/packages/workspace-server/src/services/folders/folders.ts
@@ -80,18 +80,26 @@ export class FoldersService {
 
     const existingFolders = folders.filter((f) => f.exists);
     const results = await Promise.allSettled(
-      existingFolders.map((folder) =>
-        this.cleanupOrphanedWorktrees(folder.path),
-      ),
+      existingFolders.map(async (folder) => {
+        await this.createWorktreeManager(folder.path).sweepTrash();
+        await this.cleanupOrphanedWorktrees(folder.path);
+      }),
     );
     for (const [i, result] of results.entries()) {
       if (result.status === "rejected") {
         this.log.error(
-          `Failed to cleanup orphaned worktrees for ${existingFolders[i].path}:`,
+          `Failed to clean up worktrees for ${existingFolders[i].path}:`,
           result.reason,
         );
       }
     }
+  }
+
+  private createWorktreeManager(mainRepoPath: string): WorktreeManager {
+    return new WorktreeManager({
+      mainRepoPath,
+      worktreeBasePath: this.workspaceSettings.getWorktreeLocation(),
+    });
   }
 
   private getDisplayName(
@@ -225,11 +233,9 @@ export class FoldersService {
             worktree.name,
           );
           try {
-            const manager = new WorktreeManager({
-              mainRepoPath: repo.path,
-              worktreeBasePath,
-            });
-            await manager.deleteWorktree(worktreePath);
+            await this.createWorktreeManager(repo.path).deleteWorktree(
+              worktreePath,
+            );
           } catch (error) {
             this.log.error(`Failed to delete worktree ${worktreePath}:`, error);
           }
@@ -246,13 +252,12 @@ export class FoldersService {
   }
 
   async cleanupOrphanedWorktrees(mainRepoPath: string): Promise<void> {
-    const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
-    const manager = new WorktreeManager({ mainRepoPath, worktreeBasePath });
-
     const allWorktrees = this.worktreeRepo.findAll();
     const associatedWorktreePaths = allWorktrees.map((wt) => wt.path);
 
-    await manager.cleanupOrphanedWorktrees(associatedWorktreePaths);
+    await this.createWorktreeManager(mainRepoPath).cleanupOrphanedWorktrees(
+      associatedWorktreePaths,
+    );
   }
 
   private async resolveRepoKey(

--- a/packages/workspace-server/src/services/suspension/suspension.test.ts
+++ b/packages/workspace-server/src/services/suspension/suspension.test.ts
@@ -229,6 +229,37 @@ describe("SuspensionService", () => {
       expect(mocks.suspensionRepo.findAll()).toHaveLength(0);
     });
 
+    it("does nothing when active count equals the limit", async () => {
+      mockGetMaxActiveWorktrees.mockReturnValue(2);
+      seedWorktreeWorkspace(mocks, { taskId: "task-a" });
+      seedWorktreeWorkspace(mocks, { taskId: "task-b" });
+      await service.suspendLeastRecentIfOverLimit();
+      expect(mocks.suspensionRepo.findAll()).toHaveLength(0);
+    });
+
+    it("suspends every workspace over the limit, oldest first", async () => {
+      mockGetMaxActiveWorktrees.mockReturnValue(1);
+      const oldest = seedWorktreeWorkspace(mocks, {
+        taskId: "task-oldest",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      });
+      const middle = seedWorktreeWorkspace(mocks, {
+        taskId: "task-middle",
+        createdAt: "2024-02-01T00:00:00.000Z",
+      });
+      seedWorktreeWorkspace(mocks, {
+        taskId: "task-newest",
+        createdAt: "2024-03-01T00:00:00.000Z",
+      });
+
+      await service.suspendLeastRecentIfOverLimit();
+
+      const suspended = mocks.suspensionRepo.findAll();
+      expect(suspended.map((s) => s.workspaceId).sort()).toEqual(
+        [oldest.id, middle.id].sort(),
+      );
+    });
+
     it.each([
       [
         "lastActivityAt",

--- a/packages/workspace-server/src/services/suspension/suspension.ts
+++ b/packages/workspace-server/src/services/suspension/suspension.ts
@@ -66,6 +66,7 @@ export interface SuspensionServiceEvents {
 @injectable()
 export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents> {
   private inactivityTimerId: ReturnType<typeof setInterval> | null = null;
+  private suspendSweep: Promise<void> = Promise.resolve();
   private readonly log: ScopedLogger;
 
   constructor(
@@ -153,8 +154,21 @@ export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents
    * Suspends the least-recently-active worktree tasks until the active count
    * is back at the cap. Runs after a workspace is created (not before), so the
    * expensive checkpoint-and-delete never blocks creating a new session.
+   *
+   * Sweeps are serialized: it is called fire-and-forget from every worktree
+   * creation, and two concurrent sweeps would each read the same `active` list
+   * and pick the same oldest task, double-deleting one worktree. Chaining makes
+   * each sweep re-read `active` after the previous one's suspensions commit. The
+   * `.catch` keeps a failed sweep from wedging the chain for later callers.
    */
-  async suspendLeastRecentIfOverLimit(): Promise<void> {
+  suspendLeastRecentIfOverLimit(): Promise<void> {
+    this.suspendSweep = this.suspendSweep
+      .catch(() => {})
+      .then(() => this.runSuspendSweep());
+    return this.suspendSweep;
+  }
+
+  private async runSuspendSweep(): Promise<void> {
     if (!this.workspaceSettings.getAutoSuspendEnabled()) return;
     const maxActive = this.workspaceSettings.getMaxActiveWorktrees();
     const active = this.getActiveWorktreeWorkspaces();
@@ -167,10 +181,10 @@ export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents
       return aTime.localeCompare(bTime);
     });
 
+    this.log.info(
+      `Auto-suspending ${excess} task(s) over the worktree cap (max: ${maxActive}, active: ${active.length})`,
+    );
     for (const workspace of oldestFirst.slice(0, excess)) {
-      this.log.info(
-        `Auto-suspending task ${workspace.taskId} (max: ${maxActive}, active: ${active.length})`,
-      );
       await this.autoSuspend(workspace.taskId, "max_worktrees");
     }
   }

--- a/packages/workspace-server/src/services/suspension/suspension.ts
+++ b/packages/workspace-server/src/services/suspension/suspension.ts
@@ -149,23 +149,30 @@ export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents
     return this.suspensionRepo.findByWorkspaceId(workspace.id) !== null;
   }
 
+  /**
+   * Suspends the least-recently-active worktree tasks until the active count
+   * is back at the cap. Runs after a workspace is created (not before), so the
+   * expensive checkpoint-and-delete never blocks creating a new session.
+   */
   async suspendLeastRecentIfOverLimit(): Promise<void> {
     if (!this.workspaceSettings.getAutoSuspendEnabled()) return;
     const maxActive = this.workspaceSettings.getMaxActiveWorktrees();
     const active = this.getActiveWorktreeWorkspaces();
-    if (active.length < maxActive) return;
+    const excess = active.length - maxActive;
+    if (excess <= 0) return;
 
-    const oldest = active.sort((a, b) => {
+    const oldestFirst = active.sort((a, b) => {
       const aTime = a.lastActivityAt ?? a.createdAt ?? "";
       const bTime = b.lastActivityAt ?? b.createdAt ?? "";
       return aTime.localeCompare(bTime);
-    })[0];
+    });
 
-    if (!oldest) return;
-    this.log.info(
-      `Auto-suspending task ${oldest.taskId} (max: ${maxActive}, active: ${active.length})`,
-    );
-    await this.autoSuspend(oldest.taskId, "max_worktrees");
+    for (const workspace of oldestFirst.slice(0, excess)) {
+      this.log.info(
+        `Auto-suspending task ${workspace.taskId} (max: ${maxActive}, active: ${active.length})`,
+      );
+      await this.autoSuspend(workspace.taskId, "max_worktrees");
+    }
   }
 
   async suspendInactiveWorktrees(): Promise<void> {

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -662,8 +662,6 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       };
     }
 
-    await this.suspensionService.suspendLeastRecentIfOverLimit();
-
     const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
     const worktreeManager = new WorktreeManager({
       mainRepoPath,
@@ -794,6 +792,13 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       workspaceId: createdWorkspace.id,
       name: worktree.worktreeName,
       path: worktree.worktreePath,
+    });
+
+    // Enforce the worktree cap after the new workspace exists rather than
+    // before: suspending the least-recent task checkpoints and deletes a
+    // potentially multi-gigabyte worktree, which must not block this creation.
+    this.suspensionService.suspendLeastRecentIfOverLimit().catch((error) => {
+      this.log.error("Failed to auto-suspend over-limit worktrees:", error);
     });
 
     return {


### PR DESCRIPTION
## Problem

Starting a new worktree session in a large repo (posthog/posthog) gets slower and slower over a week of use. Three compounding causes, all measured on a real posthog checkout:

1. **~20s of ls-files walks per create.** `processWorktreeLink`/`processWorktreeInclude` each run `git ls-files --ignored --others --directory --exclude-from=<file>`. Because `--exclude-from` replaces the standard excludes, git cannot collapse `node_modules/` and recurses the entire ignored tree looking for pattern matches (9.6s + 9.8s, warm cache, growing with ignored-file count). The walk also matched strays like `node_modules/.pnpm/psl@1.9.0/node_modules/psl/.env`, and copying that pre-created `node_modules/.pnpm/` in the fresh worktree — silently defeating posthog's own `.husky/post-checkout` bootstrap check (`[ ! -d node_modules/.pnpm ]`).
2. **Creation blocks on suspending the least-recent task once at the worktree cap.** `doCreateWorkspace` awaited `suspendLeastRecentIfOverLimit()` before creating: a full checkpoint capture plus deletion of a ~6GB, node_modules-laden worktree, inline, before `git worktree add` even starts. Under the cap (early in the week) this branch is skipped entirely, which is why creation "became" slow after days of use.
3. **Worktree deletes rm multi-gigabyte trees inside the repo write lock.** Every suspend, archive, and hourly inactivity sweep serialized with worktree creation on the per-repo write lock while unlinking ~1M files.

## Changes

- `getIgnoredPathsFromExcludeFile` now lists candidates with `--exclude-standard --exclude-from=<file>` (so git collapses standard-ignored trees instead of recursing them) and re-applies the exclude file's own patterns in-process via a new gitignore-subset matcher (`exclude-patterns.ts`: comments, negation, dir-only, anchoring, `*`/`?`/`**`/`[...]`). Matches buried inside standard-ignored trees no longer surface, fixing the node_modules bootstrap bug. Repos without `.worktreelink`/`.worktreeinclude` now skip the git calls entirely.
- The worktree cap is enforced *after* workspace creation as a fire-and-forget, instead of blocking creation. `suspendLeastRecentIfOverLimit` now suspends exactly the excess over the cap, oldest first (previously it fired when merely *at* the cap, pre-create). Net behavior change: the active count can briefly reach `maxActiveWorktrees + 1` while the background suspend runs.
- `deleteWorktree` renames the worktree into `<worktreeBase>/.trash/` (instant, same volume), runs `git worktree prune` under the write lock, and does the recursive removal in the background. Falls back to the old `git worktree remove --force` path when the rename cannot work (cross-volume, already gone). Boot sweeps `.trash/` for leftovers from interrupted deletes, alongside the existing orphan cleanup.

Measured on posthog/posthog: the `.worktreeinclude` scan went from ~10s to ~140ms with identical output minus the node_modules stray; worktree deletion no longer holds the write lock for the duration of a multi-gigabyte rm.

## How did you test this?

- 36 new parameterized matcher tests (`exclude-patterns.test.ts`).
- New real-git integration test: `.envrc` linked, `.env` copied, and `node_modules/` never created in a fresh worktree (regression for the bootstrap bug).
- New suspension tests: at-cap does nothing, multi-excess suspends oldest first.
- New `sweepTrash` test; existing worktree lifecycle (add/remove/prune) tests pass unchanged against the trash-based delete.
- Full suites green: `@posthog/git` 306 tests, `@posthog/workspace-server` 612 tests. Typecheck and Biome clean.
- Verified the new scan end-to-end against the real posthog repo via the built package: `.worktreelink -> []` (comments only), `.worktreeinclude -> [".env"]` in ~140ms.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
