### PR TITLE
fix(ui): stop deleted archived tasks from reappearing in sidebar

### DIFF
--- a/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
+++ b/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
@@ -3,11 +3,11 @@ import type {
   DeleteOutcome,
   RestoreOutcome,
 } from "@posthog/core/archive/archivedTasksController";
+import { WORKSPACE_QUERY_KEY } from "@posthog/ui/features/workspace/identifiers";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { WORKSPACE_QUERY_KEY } from "../workspace/identifiers";
 
 const ARCHIVE_FILTER = { queryKey: [["archive"]] };
 
@@ -46,12 +46,11 @@ describe("useUnarchiveTask", () => {
     });
   });
 
-  it("invalidates the workspace query when an archived task is deleted", async () => {
-    // Regression: the delete path once skipped WORKSPACE_QUERY_KEY, so the
-    // sidebar kept showing deleted archived tasks. Pin the invalidation here so
-    // the restore/delete sets can't silently drift apart again.
+  it("invalidates the workspace, archive and tasks caches together when an archived task is deleted", async () => {
+    // Regression: delete once skipped WORKSPACE_QUERY_KEY, leaving stale sidebar rows.
     controller.remove.mockResolvedValue({ kind: "deleted" } as DeleteOutcome);
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const refetchSpy = vi.spyOn(queryClient, "refetchQueries");
     const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
 
     await act(async () => {
@@ -61,54 +60,114 @@ describe("useUnarchiveTask", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: WORKSPACE_QUERY_KEY,
     });
+    expect(invalidateSpy).toHaveBeenCalledWith(ARCHIVE_FILTER);
+    expect(refetchSpy).toHaveBeenCalledWith({ queryKey: ["tasks"] });
   });
 
-  it("does not invalidate when deletion fails", async () => {
-    controller.remove.mockResolvedValue({
-      kind: "error",
-      message: "nope",
-    } as DeleteOutcome);
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+  it.each<[string, DeleteOutcome, boolean]>([
+    ["deleted", { kind: "deleted" }, true],
+    ["error", { kind: "error", message: "nope" }, false],
+  ])(
+    "remove() with outcome %s invalidates the workspace query: %s",
+    async (_name, outcome, shouldInvalidate) => {
+      controller.remove.mockResolvedValue(outcome);
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
 
-    await act(async () => {
-      await result.current.remove("t1");
-    });
+      await act(async () => {
+        await result.current.remove("t1");
+      });
 
-    expect(invalidateSpy).not.toHaveBeenCalled();
-  });
+      if (shouldInvalidate) {
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: WORKSPACE_QUERY_KEY,
+        });
+      } else {
+        expect(invalidateSpy).not.toHaveBeenCalled();
+      }
+    },
+  );
 
-  it("invalidates the workspace query when a task is restored", async () => {
-    controller.restore.mockResolvedValue({
-      kind: "restored",
-      navigateToTaskId: "t1",
-    } as RestoreOutcome);
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+  it.each<[string, RestoreOutcome, boolean]>([
+    ["restored", { kind: "restored", navigateToTaskId: "t1" }, true],
+    [
+      "branch-not-found",
+      { kind: "branch-not-found", taskId: "t1", branchName: "b" },
+      false,
+    ],
+    ["error", { kind: "error", message: "nope" }, false],
+  ])(
+    "restore() with outcome %s invalidates the workspace query: %s",
+    async (_name, outcome, shouldInvalidate) => {
+      controller.restore.mockResolvedValue(outcome);
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
 
-    await act(async () => {
-      await result.current.restore("t1", true);
-    });
+      await act(async () => {
+        await result.current.restore("t1", true);
+      });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: WORKSPACE_QUERY_KEY,
-    });
-  });
+      if (shouldInvalidate) {
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: WORKSPACE_QUERY_KEY,
+        });
+      } else {
+        expect(invalidateSpy).not.toHaveBeenCalled();
+      }
+    },
+  );
 
-  it("invalidates the workspace query when the context menu deletes a task", async () => {
-    controller.runContextMenuAction.mockResolvedValue({
-      kind: "delete",
-      outcome: { kind: "deleted" },
-    } as ContextMenuOutcome);
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+  it.each<[string, ContextMenuOutcome, boolean]>([
+    ["noop", { kind: "noop" }, false],
+    ["menu-error", { kind: "menu-error", message: "nope" }, false],
+    [
+      "restore -> restored",
+      {
+        kind: "restore",
+        outcome: { kind: "restored", navigateToTaskId: "t1" },
+      },
+      true,
+    ],
+    [
+      "restore -> branch-not-found",
+      {
+        kind: "restore",
+        outcome: {
+          kind: "branch-not-found",
+          taskId: "t1",
+          branchName: "b",
+        },
+      },
+      false,
+    ],
+    [
+      "delete -> deleted",
+      { kind: "delete", outcome: { kind: "deleted" } },
+      true,
+    ],
+    [
+      "delete -> error",
+      { kind: "delete", outcome: { kind: "error", message: "nope" } },
+      false,
+    ],
+  ])(
+    "runContextMenuAction() with outcome %s invalidates the workspace query: %s",
+    async (_name, outcome, shouldInvalidate) => {
+      controller.runContextMenuAction.mockResolvedValue(outcome);
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
 
-    await act(async () => {
-      await result.current.runContextMenuAction("t1", "Task 1", true);
-    });
+      await act(async () => {
+        await result.current.runContextMenuAction("t1", "Task 1", true);
+      });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: WORKSPACE_QUERY_KEY,
-    });
-  });
+      if (shouldInvalidate) {
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: WORKSPACE_QUERY_KEY,
+        });
+      } else {
+        expect(invalidateSpy).not.toHaveBeenCalled();
+      }
+    },
+  );
 });

--- a/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
+++ b/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
@@ -1,0 +1,114 @@
+import type {
+  ContextMenuOutcome,
+  DeleteOutcome,
+  RestoreOutcome,
+} from "@posthog/core/archive/archivedTasksController";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKSPACE_QUERY_KEY } from "../workspace/identifiers";
+
+const ARCHIVE_FILTER = { queryKey: [["archive"]] };
+
+const controller = vi.hoisted(() => ({
+  restore: vi.fn(),
+  remove: vi.fn(),
+  runContextMenuAction: vi.fn(),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useService: () => controller,
+}));
+
+vi.mock("@posthog/host-router/react", () => ({
+  useHostTRPC: () => ({
+    archive: {
+      pathFilter: () => ARCHIVE_FILTER,
+    },
+  }),
+}));
+
+import { useUnarchiveTask } from "./useUnarchiveTask";
+
+let queryClient: QueryClient;
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useUnarchiveTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  it("invalidates the workspace query when an archived task is deleted", async () => {
+    // Regression: the delete path once skipped WORKSPACE_QUERY_KEY, so the
+    // sidebar kept showing deleted archived tasks. Pin the invalidation here so
+    // the restore/delete sets can't silently drift apart again.
+    controller.remove.mockResolvedValue({ kind: "deleted" } as DeleteOutcome);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.remove("t1");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: WORKSPACE_QUERY_KEY,
+    });
+  });
+
+  it("does not invalidate when deletion fails", async () => {
+    controller.remove.mockResolvedValue({
+      kind: "error",
+      message: "nope",
+    } as DeleteOutcome);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.remove("t1");
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the workspace query when a task is restored", async () => {
+    controller.restore.mockResolvedValue({
+      kind: "restored",
+      navigateToTaskId: "t1",
+    } as RestoreOutcome);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.restore("t1", true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: WORKSPACE_QUERY_KEY,
+    });
+  });
+
+  it("invalidates the workspace query when the context menu deletes a task", async () => {
+    controller.runContextMenuAction.mockResolvedValue({
+      kind: "delete",
+      outcome: { kind: "deleted" },
+    } as ContextMenuOutcome);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.runContextMenuAction("t1", "Task 1", true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: WORKSPACE_QUERY_KEY,
+    });
+  });
+});

--- a/packages/ui/src/features/archive/useUnarchiveTask.ts
+++ b/packages/ui/src/features/archive/useUnarchiveTask.ts
@@ -34,15 +34,16 @@ export function useUnarchiveTask(): UseUnarchiveTask {
 
   const invalidateArchiveQueries = useCallback(async () => {
     await Promise.all([
+      queryClient.invalidateQueries({ queryKey: WORKSPACE_QUERY_KEY }),
       queryClient.invalidateQueries(trpc.archive.pathFilter()),
       queryClient.refetchQueries({ queryKey: ["tasks"] }),
     ]);
   }, [queryClient, trpc]);
 
-  const invalidateOnRestore = useCallback(async () => {
-    await queryClient.invalidateQueries({ queryKey: WORKSPACE_QUERY_KEY });
-    await invalidateArchiveQueries();
-  }, [queryClient, invalidateArchiveQueries]);
+  const invalidateOnRestore = useCallback(
+    async () => invalidateArchiveQueries(),
+    [invalidateArchiveQueries],
+  );
 
   const restore = useCallback(
     async (

--- a/packages/ui/src/features/archive/useUnarchiveTask.ts
+++ b/packages/ui/src/features/archive/useUnarchiveTask.ts
@@ -40,11 +40,6 @@ export function useUnarchiveTask(): UseUnarchiveTask {
     ]);
   }, [queryClient, trpc]);
 
-  const invalidateOnRestore = useCallback(
-    async () => invalidateArchiveQueries(),
-    [invalidateArchiveQueries],
-  );
-
   const restore = useCallback(
     async (
       taskId: string,
@@ -53,11 +48,11 @@ export function useUnarchiveTask(): UseUnarchiveTask {
     ) => {
       const outcome = await controller.restore(taskId, hasTask, options);
       if (outcome.kind === "restored") {
-        await invalidateOnRestore();
+        await invalidateArchiveQueries();
       }
       return outcome;
     },
-    [controller, invalidateOnRestore],
+    [controller, invalidateArchiveQueries],
   );
 
   const remove = useCallback(
@@ -79,7 +74,7 @@ export function useUnarchiveTask(): UseUnarchiveTask {
         hasTask,
       );
       if (outcome.kind === "restore" && outcome.outcome.kind === "restored") {
-        await invalidateOnRestore();
+        await invalidateArchiveQueries();
       } else if (
         outcome.kind === "delete" &&
         outcome.outcome.kind === "deleted"
@@ -88,7 +83,7 @@ export function useUnarchiveTask(): UseUnarchiveTask {
       }
       return outcome;
     },
-    [controller, invalidateOnRestore, invalidateArchiveQueries],
+    [controller, invalidateArchiveQueries],
   );
 
   return { restore, remove, runContextMenuAction };

--- a/packages/ui/src/features/archive/useUnarchiveTask.ts
+++ b/packages/ui/src/features/archive/useUnarchiveTask.ts
@@ -32,7 +32,7 @@ export function useUnarchiveTask(): UseUnarchiveTask {
   const trpc = useHostTRPC();
   const queryClient = useQueryClient();
 
-  const invalidateArchiveQueries = useCallback(async () => {
+  const invalidateTaskListCaches = useCallback(async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: WORKSPACE_QUERY_KEY }),
       queryClient.invalidateQueries(trpc.archive.pathFilter()),
@@ -48,22 +48,22 @@ export function useUnarchiveTask(): UseUnarchiveTask {
     ) => {
       const outcome = await controller.restore(taskId, hasTask, options);
       if (outcome.kind === "restored") {
-        await invalidateArchiveQueries();
+        await invalidateTaskListCaches();
       }
       return outcome;
     },
-    [controller, invalidateArchiveQueries],
+    [controller, invalidateTaskListCaches],
   );
 
   const remove = useCallback(
     async (taskId: string) => {
       const outcome = await controller.remove(taskId);
       if (outcome.kind === "deleted") {
-        await invalidateArchiveQueries();
+        await invalidateTaskListCaches();
       }
       return outcome;
     },
-    [controller, invalidateArchiveQueries],
+    [controller, invalidateTaskListCaches],
   );
 
   const runContextMenuAction = useCallback(
@@ -74,16 +74,16 @@ export function useUnarchiveTask(): UseUnarchiveTask {
         hasTask,
       );
       if (outcome.kind === "restore" && outcome.outcome.kind === "restored") {
-        await invalidateArchiveQueries();
+        await invalidateTaskListCaches();
       } else if (
         outcome.kind === "delete" &&
         outcome.outcome.kind === "deleted"
       ) {
-        await invalidateArchiveQueries();
+        await invalidateTaskListCaches();
       }
       return outcome;
     },
-    [controller, invalidateArchiveQueries],
+    [controller, invalidateTaskListCaches],
   );
 
   return { restore, remove, runContextMenuAction };


### PR DESCRIPTION
## Summary

- Invalidate the workspaces cache when an archived task is deleted, so the sidebar no longer shows the task after delete.
- Consolidate restore/delete post-action refresh into one helper that invalidates workspaces, archive, and tasks together.

Fixes #3143 

## Problem

Deleting a task from the Archived tasks view removes its local `archives` and `workspaces` rows, but the UI only refreshed archive and tasks caches. Sidebar visibility depends on both `archivedTaskIds` and `workspaces`, so after delete the app briefly had:

- not archived (refreshed)
- still has workspace (stale)

That made the task reappear in the sidebar until workspaces refetched for another reason.

Restore already invalidated workspaces via `invalidateOnRestore`; delete used a separate helper that did not.

## Solution

Include `WORKSPACE_QUERY_KEY` invalidation in `invalidateArchiveQueries`, which runs after archived-task delete (and is shared with restore).

## Video

https://github.com/user-attachments/assets/9a39b629-7280-4f24-8898-2b9f445dcdd9


