### PR TITLE
perf(sessions): coalesce each flush batch into one store append per notification run

### DIFF
--- a/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -34,9 +34,9 @@ function chunkText(event: AcpMessage): string {
 
 /** The renderer-side echo of a user prompt — a JSON-RPC request (carries an
  * id), so it must not be coalesced with plain notifications. */
-function promptEcho(id: number, text: string): AcpMessage {
+function promptEcho(id: number, text: string, ts = 1): AcpMessage {
   return {
-    ts: 1,
+    ts,
     message: {
       jsonrpc: "2.0",
       id,
@@ -50,9 +50,9 @@ function promptEcho(id: number, text: string): AcpMessage {
 }
 
 /** The agent's terminal response for a prompt — completes the turn. */
-function stopResponse(id: number): AcpMessage {
+function stopResponse(id: number, ts = 2): AcpMessage {
   return {
-    ts: 2,
+    ts,
     message: {
       jsonrpc: "2.0",
       id,
@@ -161,29 +161,6 @@ function createHarness() {
   };
 }
 
-function promptEcho(id: number, ts: number): AcpMessage {
-  return {
-    ts,
-    message: {
-      jsonrpc: "2.0",
-      id,
-      method: "session/prompt",
-      params: { sessionId: RUN_ID, prompt: [] },
-    },
-  } as unknown as AcpMessage;
-}
-
-function promptResponse(id: number, ts: number): AcpMessage {
-  return {
-    ts,
-    message: {
-      jsonrpc: "2.0",
-      id,
-      result: { stopReason: "end_turn" },
-    },
-  } as unknown as AcpMessage;
-}
-
 describe("streamed event batching", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -208,39 +185,60 @@ describe("streamed event batching", () => {
     expect(h.events().map(chunkText)).toEqual(["a", "b", "c"]);
   });
 
-  it("coalesces a run of plain notifications into one appendEvents call", () => {
+  // Coalescing table: chunks are plain notifications (coalesce into one
+  // appendEvents call per run — each store write costs O(transcript), so this
+  // is the batching that keeps big transcripts smooth during streaming);
+  // { echoId } items are id-carrying prompt echoes handled individually.
+  it.each<{
+    name: string;
+    emitted: (string | { echoId: number })[];
+    expectedGroups: string[][];
+  }>([
+    {
+      name: "coalesces a run of plain notifications into one appendEvents call",
+      emitted: ["a", "b", "c"],
+      expectedGroups: [["a", "b", "c"]],
+    },
+    {
+      name: "an id-carrying event splits the run but preserves global order",
+      emitted: ["a", "b", { echoId: 7 }, "c"],
+      expectedGroups: [["a", "b"], ["c"]],
+    },
+    {
+      name: "consecutive id-carrying events do not produce empty appends",
+      emitted: ["a", { echoId: 7 }, { echoId: 8 }, "b"],
+      expectedGroups: [["a"], ["b"]],
+    },
+    {
+      name: "a single-notification batch appends once",
+      emitted: ["a"],
+      expectedGroups: [["a"]],
+    },
+    {
+      name: "a batch of only id-carrying events never calls appendEvents",
+      emitted: [{ echoId: 7 }],
+      expectedGroups: [],
+    },
+  ])("$name", ({ emitted, expectedGroups }) => {
     const h = createHarness();
 
-    h.emit(chunk("a"));
-    h.emit(chunk("b"));
-    h.emit(chunk("c"));
+    for (const item of emitted) {
+      h.emit(
+        typeof item === "string"
+          ? chunk(item)
+          : promptEcho(item.echoId, "user prompt"),
+      );
+    }
     vi.advanceTimersByTime(FLUSH_MS);
 
-    // One store write for the whole run — not one per event. Each write costs
-    // O(transcript) (map copy + subscriber fan-out), so this is the batching
-    // that keeps big transcripts smooth during streaming.
-    expect(h.appendEvents).toHaveBeenCalledTimes(1);
-    expect(h.appendEvents.mock.calls[0][1].map(chunkText)).toEqual([
-      "a",
-      "b",
-      "c",
-    ]);
-  });
-
-  it("an id-carrying event splits the run but preserves global order", () => {
-    const h = createHarness();
-
-    h.emit(chunk("a"));
-    h.emit(chunk("b"));
-    h.emit(promptEcho(7, "user steer-less prompt"));
-    h.emit(chunk("c"));
-    vi.advanceTimersByTime(FLUSH_MS);
-
-    // Two coalesced appends around the individually-handled echo.
-    expect(h.appendEvents).toHaveBeenCalledTimes(2);
-    expect(h.appendEvents.mock.calls[0][1].map(chunkText)).toEqual(["a", "b"]);
-    expect(h.appendEvents.mock.calls[1][1].map(chunkText)).toEqual(["c"]);
-    expect(h.events().map(chunkText)).toEqual(["a", "b", "c"]);
+    expect(
+      h.appendEvents.mock.calls.map((call) => call[1].map(chunkText)),
+    ).toEqual(expectedGroups);
+    // Arrival order is preserved in the transcript (echoes go through
+    // replaceOptimisticWithEvent, so only chunks land in `events`).
+    expect(h.events().map(chunkText)).toEqual(
+      emitted.filter((item) => typeof item === "string"),
+    );
   });
 
   it("a stop-reason response batched with chunks still completes the turn", () => {
@@ -281,10 +279,10 @@ describe("streamed event batching", () => {
   it("keeps the turn duration when the prompt mutation clears state before the response flushes", () => {
     const h = createHarness();
 
-    h.emit(promptEcho(1, 1_000));
+    h.emit(promptEcho(1, "user prompt", 1_000));
     vi.advanceTimersByTime(FLUSH_MS);
 
-    h.emit(promptResponse(1, 6_000));
+    h.emit(stopResponse(1, 6_000));
     h.updateSession(RUN_ID, { isPromptPending: false, promptStartedAt: null });
     vi.advanceTimersByTime(FLUSH_MS);
 

--- a/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -32,6 +32,35 @@ function chunkText(event: AcpMessage): string {
   return params.update.content.text;
 }
 
+/** The renderer-side echo of a user prompt — a JSON-RPC request (carries an
+ * id), so it must not be coalesced with plain notifications. */
+function promptEcho(id: number, text: string): AcpMessage {
+  return {
+    ts: 1,
+    message: {
+      jsonrpc: "2.0",
+      id,
+      method: "session/prompt",
+      params: {
+        sessionId: RUN_ID,
+        prompt: [{ type: "text", text }],
+      },
+    },
+  } as unknown as AcpMessage;
+}
+
+/** The agent's terminal response for a prompt — completes the turn. */
+function stopResponse(id: number): AcpMessage {
+  return {
+    ts: 2,
+    message: {
+      jsonrpc: "2.0",
+      id,
+      result: { stopReason: "end_turn" },
+    },
+  } as unknown as AcpMessage;
+}
+
 function createHarness() {
   const sessions: Record<string, AgentSession> = {
     [RUN_ID]: {
@@ -62,6 +91,9 @@ function createHarness() {
       sessions[session.taskRunId] = session;
     },
     updateSession: (taskRunId: string, updates: Partial<AgentSession>) => {
+      // Like the real store: produce a NEW session object per update, so a
+      // reference captured before the update keeps its pre-update values
+      // (handleSessionEvent's stop-reason check depends on that).
       const session = sessions[taskRunId];
       if (session) sessions[taskRunId] = { ...session, ...updates };
     },
@@ -174,6 +206,60 @@ describe("streamed event batching", () => {
     // A single flush tick drains the whole burst, in arrival order.
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events().map(chunkText)).toEqual(["a", "b", "c"]);
+  });
+
+  it("coalesces a run of plain notifications into one appendEvents call", () => {
+    const h = createHarness();
+
+    h.emit(chunk("a"));
+    h.emit(chunk("b"));
+    h.emit(chunk("c"));
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    // One store write for the whole run — not one per event. Each write costs
+    // O(transcript) (map copy + subscriber fan-out), so this is the batching
+    // that keeps big transcripts smooth during streaming.
+    expect(h.appendEvents).toHaveBeenCalledTimes(1);
+    expect(h.appendEvents.mock.calls[0][1].map(chunkText)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("an id-carrying event splits the run but preserves global order", () => {
+    const h = createHarness();
+
+    h.emit(chunk("a"));
+    h.emit(chunk("b"));
+    h.emit(promptEcho(7, "user steer-less prompt"));
+    h.emit(chunk("c"));
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    // Two coalesced appends around the individually-handled echo.
+    expect(h.appendEvents).toHaveBeenCalledTimes(2);
+    expect(h.appendEvents.mock.calls[0][1].map(chunkText)).toEqual(["a", "b"]);
+    expect(h.appendEvents.mock.calls[1][1].map(chunkText)).toEqual(["c"]);
+    expect(h.events().map(chunkText)).toEqual(["a", "b", "c"]);
+  });
+
+  it("a stop-reason response batched with chunks still completes the turn", () => {
+    const h = createHarness();
+
+    // Turn starts: the echo claims currentPromptId…
+    h.emit(promptEcho(9, "do the thing"));
+    // …streams some content…
+    h.emit(chunk("a"));
+    h.emit(chunk("b"));
+    // …and finishes, all within one flush window.
+    h.emit(stopResponse(9));
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    // Transcript keeps everything appendable: the two chunks plus the
+    // response itself (the echo goes through replaceOptimisticWithEvent).
+    expect(h.events()).toHaveLength(3);
+    expect(h.events().slice(0, 2).map(chunkText)).toEqual(["a", "b"]);
+    expect(h.notifyPromptComplete).toHaveBeenCalledTimes(1);
   });
 
   it("flushes buffered events synchronously on teardown", () => {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1540,9 +1540,7 @@ export class SessionService {
     const batches = this.pendingSessionEvents;
     this.pendingSessionEvents = new Map();
     for (const [taskRunId, events] of batches) {
-      for (const acpMsg of events) {
-        this.handleSessionEvent(taskRunId, acpMsg);
-      }
+      this.handleSessionEvents(taskRunId, events);
     }
   }
 
@@ -1552,9 +1550,7 @@ export class SessionService {
     const events = this.pendingSessionEvents.get(taskRunId);
     if (!events) return;
     this.pendingSessionEvents.delete(taskRunId);
-    for (const acpMsg of events) {
-      this.handleSessionEvent(taskRunId, acpMsg);
-    }
+    this.handleSessionEvents(taskRunId, events);
   }
 
   // --- Transcript residency (memory eviction) ---
@@ -1965,6 +1961,50 @@ export class SessionService {
     }
   }
 
+  /** Apply one flush batch for a task. Runs of plain notifications (message
+   * chunks, tool-call updates — the bulk of a streamed turn) are appended to
+   * the store in a single `appendEvents` call: every store write costs
+   * O(transcript) (session-map copy plus subscriber notification fan-out), so
+   * writing per event made a 15-event flush walk the whole transcript 15
+   * times. Events carrying a JSON-RPC `id` (user-prompt echoes, stop-reason
+   * responses) keep going through `handleSessionEvent` one at a time, so
+   * turn-lifecycle semantics are untouched. Global event order is preserved:
+   * a run is flushed before any id-carrying event is handled. */
+  private handleSessionEvents(taskRunId: string, acpMsgs: AcpMessage[]): void {
+    let run: AcpMessage[] = [];
+
+    const flushRun = () => {
+      if (run.length === 0) return;
+      const batch = run;
+      run = [];
+      const session = this.d.store.getSessions()[taskRunId];
+      if (!session) return;
+      // Once the agent starts responding, clear initialPrompt so that retry
+      // reconnects to this session instead of creating a new one.
+      if (session.initialPrompt?.length) {
+        this.d.store.updateSession(taskRunId, { initialPrompt: undefined });
+      }
+      this.d.store.appendEvents(taskRunId, batch);
+      this.updatePromptStateFromEvents(taskRunId, batch, { isLive: true });
+      for (const acpMsg of batch) {
+        this.applyNotificationEffects(taskRunId, acpMsg, session);
+      }
+    };
+
+    for (const acpMsg of acpMsgs) {
+      // Notifications carry no JSON-RPC id; requests and responses do. Only
+      // id-less events are safe to coalesce: they are pure appends plus
+      // field-level side effects, with no turn-lifecycle branching.
+      if ("id" in acpMsg.message) {
+        flushRun();
+        this.handleSessionEvent(taskRunId, acpMsg);
+      } else {
+        run.push(acpMsg);
+      }
+    }
+    flushRun();
+  }
+
   private handleSessionEvent(taskRunId: string, acpMsg: AcpMessage): void {
     const session = this.d.store.getSessions()[taskRunId];
     if (!session) return;
@@ -2026,6 +2066,20 @@ export class SessionService {
 
       this.d.taskViewedApi.markActivity(session.taskId);
     }
+
+    this.applyNotificationEffects(taskRunId, acpMsg, session);
+  }
+
+  /** Side effects carried by session notifications (config, usage, adapter,
+   * compaction status). Split out of `handleSessionEvent` so a coalesced run
+   * of notifications (see `handleSessionEvents`) shares it; no-op for
+   * requests/responses, which carry no `method`. */
+  private applyNotificationEffects(
+    taskRunId: string,
+    acpMsg: AcpMessage,
+    session: AgentSession,
+  ): void {
+    const msg = acpMsg.message;
 
     if ("method" in msg && msg.method === "session/update" && "params" in msg) {
       const params = msg.params as {

--- a/scripts/measure-append-hotpath.ts
+++ b/scripts/measure-append-hotpath.ts
@@ -1,0 +1,88 @@
+// Mide el hot path real de appendEvents (módulo real, sin réplicas):
+// 1 segundo de streaming pesado = 60 flushes x 15 eventos sobre un transcript
+// de N eventos. Correr en main y en la rama para comparar.
+//   bun scripts/measure-append-hotpath.ts
+import type { AcpMessage, AgentSession } from "@posthog/shared";
+import { sessionStoreSetters } from "../packages/core/src/sessions/sessionStore";
+
+const RUN_ID = "run-bench";
+let seq = 0;
+function makeEvent(): AcpMessage {
+  seq++;
+  const message =
+    seq % 12 === 0
+      ? {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: RUN_ID,
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: `tool-${seq % 40}`,
+              status: "in_progress",
+              rawInput: { file_path: "/src/app.ts", content: "x".repeat(2048) },
+            },
+          },
+        }
+      : {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: RUN_ID,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "palabra ".repeat(10) },
+            },
+          },
+        };
+  return { ts: 1700000000000 + seq, message } as unknown as AcpMessage;
+}
+
+function seedSession(n: number): void {
+  const events: AcpMessage[] = [];
+  for (let i = 0; i < n; i++) events.push(Object.freeze(makeEvent()));
+  sessionStoreSetters.setSession({
+    taskRunId: RUN_ID,
+    taskId: "task-bench",
+    events,
+    messageQueue: [],
+    pendingPermissions: new Map(),
+    status: "connected",
+  } as unknown as AgentSession);
+}
+
+const FRAMES = 60;
+const PER_FRAME = 15;
+
+function run(perEvent: boolean): number {
+  const batches: AcpMessage[][] = [];
+  for (let f = 0; f < FRAMES; f++) {
+    const b: AcpMessage[] = [];
+    for (let e = 0; e < PER_FRAME; e++) b.push(makeEvent());
+    batches.push(b);
+  }
+  const t0 = performance.now();
+  for (const batch of batches) {
+    if (perEvent) {
+      for (const ev of batch) sessionStoreSetters.appendEvents(RUN_ID, [ev]);
+    } else {
+      sessionStoreSetters.appendEvents(RUN_ID, batch);
+    }
+  }
+  return performance.now() - t0;
+}
+
+for (const n of [10_000, 30_000]) {
+  for (const perEvent of [true, false]) {
+    const label = perEvent ? "per-evento x15" : "batcheado x1  ";
+    const times: number[] = [];
+    for (let rep = 0; rep < 7; rep++) {
+      seedSession(n);
+      times.push(run(perEvent));
+    }
+    times.sort((a, b) => a - b);
+    console.log(
+      `transcript ${n.toLocaleString()} | ${label} | mediana ${times[3].toFixed(1)} ms/seg-streaming (min ${times[0].toFixed(1)}, max ${times[6].toFixed(1)})`,
+    );
+  }
+}

--- a/scripts/measure-append-hotpath.ts
+++ b/scripts/measure-append-hotpath.ts
@@ -1,7 +1,8 @@
-// Mide el hot path real de appendEvents (módulo real, sin réplicas):
-// 1 segundo de streaming pesado = 60 flushes x 15 eventos sobre un transcript
-// de N eventos. Correr en main y en la rama para comparar.
-//   bun scripts/measure-append-hotpath.ts
+// Measures the real appendEvents hot path (the actual store module, no
+// replicas): 1 second of heavy streaming = 60 flushes x 15 events over a
+// transcript seeded with N events. Run on main and on a branch to compare.
+//   node node_modules/.bin/tsx scripts/measure-append-hotpath.ts
+// (use tsx/Node so numbers come from V8, the engine Electron ships)
 import type { AcpMessage, AgentSession } from "@posthog/shared";
 import { sessionStoreSetters } from "../packages/core/src/sessions/sessionStore";
 
@@ -31,7 +32,7 @@ function makeEvent(): AcpMessage {
             sessionId: RUN_ID,
             update: {
               sessionUpdate: "agent_message_chunk",
-              content: { type: "text", text: "palabra ".repeat(10) },
+              content: { type: "text", text: "word ".repeat(16) },
             },
           },
         };
@@ -74,7 +75,7 @@ function run(perEvent: boolean): number {
 
 for (const n of [10_000, 30_000]) {
   for (const perEvent of [true, false]) {
-    const label = perEvent ? "per-evento x15" : "batcheado x1  ";
+    const label = perEvent ? "per-event x15" : "coalesced x1 ";
     const times: number[] = [];
     for (let rep = 0; rep < 7; rep++) {
       seedSession(n);
@@ -82,7 +83,7 @@ for (const n of [10_000, 30_000]) {
     }
     times.sort((a, b) => a - b);
     console.log(
-      `transcript ${n.toLocaleString()} | ${label} | mediana ${times[3].toFixed(1)} ms/seg-streaming (min ${times[0].toFixed(1)}, max ${times[6].toFixed(1)})`,
+      `transcript ${n.toLocaleString("en-US")} | ${label} | median ${times[3].toFixed(1)} ms per streamed second (min ${times[0].toFixed(1)}, max ${times[6].toFixed(1)})`,
     );
   }
 }


### PR DESCRIPTION
## Problem

The 16ms flush introduced in #3063 batches *processing*, but not *store writes*: `flushSessionEvents` still hands its buffered events to `handleSessionEvent` one at a time, so a 15-event burst does 15 `setState` calls through the session store. Each write is O(transcript) — immer produces a new session map and every store subscriber gets notified — so during heavy streaming the store write path alone costs, measured on a real 30k-event transcript, **~248ms of main-thread time per streamed second** (V8, see below). It scales linearly with transcript length, which is why long-running tasks get progressively more janky while streaming: components subscribed to the session (`useSessionForTask` callers) get re-render-notified ~900 times/second.

## Changes

`handleSessionEvents` (new) applies one flush batch per task: runs of plain notifications — agent message chunks and tool-call updates, the bulk of a turn — are coalesced into a **single `appendEvents` call**, followed by one `updatePromptStateFromEvents` for the run (it already takes arrays).

- Events carrying a JSON-RPC `id` (user-prompt echoes, stop-reason responses) still go through `handleSessionEvent` **individually, unchanged**, so turn-lifecycle semantics (optimistic replacement, `currentPromptId` matching, queue draining, prompt-complete notifications) are untouched.
- Global order is preserved: the pending run is flushed before each id-carrying event is handled.
- The notification side effects (config/usage/adapter/compaction updates) split out into `applyNotificationEffects`, shared verbatim by both paths.

Complements #3132 (which adds `useSessionSelector` to narrow the *read* side); this PR narrows the *write* side. No overlap in files.

## How did you test this?

- New unit tests in `sessionEventBatching.test.ts`: a 3-chunk burst produces exactly **one** `appendEvents` call in order; an id-carrying echo splits the run but preserves global transcript order; a stop-reason response batched together with chunks still fires `notifyPromptComplete`. (The harness `updateSession` mock now replaces the session object like the real store, instead of mutating in place — the stop-reason check depends on pre-update snapshots.)
- Full suites: `@posthog/core` 1,972 passed, `@posthog/ui` sessions 317 passed; core typecheck and Biome clean.
- Measured with the included `scripts/measure-append-hotpath.ts` (imports the real store module; run with `tsx` on V8): 60 flushes × 15 events over a seeded transcript, median of 7 runs:

| Transcript | per-event (main) | coalesced (this PR) | |
| --- | --- | --- | --- |
| 10,000 events | 20.9 ms/s | 2.9 ms/s | ~7x |
| 30,000 events | 248.1 ms/s | 25.9 ms/s | **~10x** |

Store subscriber notifications during streaming drop from ~900/s to ~60/s.

Honest caveats: numbers are store-write CPU measured in isolation (Node/V8), not end-to-end frame timings in the app; and a handwritten (immer-free) `appendEvents` was also tried and measured **within noise** of the immer version on the real module, so it was deliberately left out to keep the diff minimal.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*