### PR TITLE
feat(settings): warn that keep-awake cannot survive a closed laptop lid

### DIFF
--- a/apps/code/src/main/platform-adapters/electron-power-manager.ts
+++ b/apps/code/src/main/platform-adapters/electron-power-manager.ts
@@ -9,8 +9,6 @@ const execFileAsync = promisify(execFile);
 
 @injectable()
 export class ElectronPowerManager implements IPowerManager {
-  private hasBuiltInBatteryResult: Promise<boolean> | null = null;
-
   public onResume(handler: () => void): () => void {
     powerMonitor.on("resume", handler);
     return () => powerMonitor.off("resume", handler);
@@ -26,12 +24,12 @@ export class ElectronPowerManager implements IPowerManager {
   }
 
   public hasBuiltInBattery(): Promise<boolean> {
-    if (!this.hasBuiltInBatteryResult) {
-      this.hasBuiltInBatteryResult = detectBuiltInBattery().catch(() => false);
-    }
-    return this.hasBuiltInBatteryResult;
+    memoizedBuiltInBattery ??= detectBuiltInBattery().catch(() => false);
+    return memoizedBuiltInBattery;
   }
 }
+
+let memoizedBuiltInBattery: Promise<boolean> | null = null;
 
 async function detectBuiltInBattery(): Promise<boolean> {
   switch (process.platform) {

--- a/apps/code/src/main/platform-adapters/electron-power-manager.ts
+++ b/apps/code/src/main/platform-adapters/electron-power-manager.ts
@@ -1,9 +1,16 @@
+import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import { promisify } from "node:util";
 import type { IPowerManager } from "@posthog/platform/power-manager";
 import { powerMonitor, powerSaveBlocker } from "electron";
 import { injectable } from "inversify";
 
+const execFileAsync = promisify(execFile);
+
 @injectable()
 export class ElectronPowerManager implements IPowerManager {
+  private hasBuiltInBatteryResult: Promise<boolean> | null = null;
+
   public onResume(handler: () => void): () => void {
     powerMonitor.on("resume", handler);
     return () => powerMonitor.off("resume", handler);
@@ -16,5 +23,39 @@ export class ElectronPowerManager implements IPowerManager {
         powerSaveBlocker.stop(id);
       }
     };
+  }
+
+  public hasBuiltInBattery(): Promise<boolean> {
+    if (!this.hasBuiltInBatteryResult) {
+      this.hasBuiltInBatteryResult = detectBuiltInBattery().catch(() => false);
+    }
+    return this.hasBuiltInBatteryResult;
+  }
+}
+
+async function detectBuiltInBattery(): Promise<boolean> {
+  switch (process.platform) {
+    case "darwin": {
+      const { stdout } = await execFileAsync("ioreg", [
+        "-rc",
+        "AppleSmartBattery",
+      ]);
+      return stdout.includes("AppleSmartBattery");
+    }
+    case "win32": {
+      const { stdout } = await execFileAsync("powershell", [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "[bool](Get-CimInstance -ClassName Win32_Battery)",
+      ]);
+      return stdout.trim().toLowerCase() === "true";
+    }
+    case "linux": {
+      const supplies = await readdir("/sys/class/power_supply");
+      return supplies.some((name) => name.startsWith("BAT"));
+    }
+    default:
+      return false;
   }
 }

--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -27,6 +27,7 @@ vi.mock("@posthog/shared", async (importOriginal) => {
 const mockPowerManager = vi.hoisted(() => ({
   onResume: vi.fn(() => () => {}),
   preventSleep: vi.fn(() => () => {}),
+  hasBuiltInBattery: vi.fn(async () => false),
 }));
 
 function createSessionPort(): IAuthSessionStore {

--- a/packages/core/src/sleep/sleep.test.ts
+++ b/packages/core/src/sleep/sleep.test.ts
@@ -18,6 +18,7 @@ function createDeps(preventSleepInitially = true) {
   const powerManager: IPowerManager = {
     onResume: vi.fn(() => () => {}),
     preventSleep: vi.fn(() => release),
+    hasBuiltInBattery: vi.fn(async () => false),
   };
 
   let stored = preventSleepInitially;

--- a/packages/core/src/sleep/sleep.ts
+++ b/packages/core/src/sleep/sleep.ts
@@ -43,6 +43,10 @@ export class SleepService {
     return this.enabled;
   }
 
+  hasBuiltInBattery(): Promise<boolean> {
+    return this.powerManager.hasBuiltInBattery();
+  }
+
   acquire(activityId: string): void {
     this.activeActivities.add(activityId);
     this.updateBlocker();

--- a/packages/host-router/src/routers/sleep.router.ts
+++ b/packages/host-router/src/routers/sleep.router.ts
@@ -15,4 +15,10 @@ export const sleepRouter = router({
     .mutation(({ ctx, input }) => {
       ctx.container.get<SleepService>(SLEEP_SERVICE).setEnabled(input.enabled);
     }),
+
+  hasBuiltInBattery: publicProcedure
+    .output(z.boolean())
+    .query(({ ctx }) =>
+      ctx.container.get<SleepService>(SLEEP_SERVICE).hasBuiltInBattery(),
+    ),
 });

--- a/packages/platform/src/power-manager.ts
+++ b/packages/platform/src/power-manager.ts
@@ -1,6 +1,7 @@
 export interface IPowerManager {
   onResume(handler: () => void): () => void;
   preventSleep(reason: string): () => void;
+  hasBuiltInBattery(): Promise<boolean>;
 }
 
 export const POWER_MANAGER_SERVICE = Symbol.for(

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -40,6 +40,9 @@ export function GeneralSettings() {
   const { data: serverPreventSleep } = useQuery(
     hostTRPC.sleep.getEnabled.queryOptions(),
   );
+  const { data: hasBuiltInBattery } = useQuery(
+    hostTRPC.sleep.hasBuiltInBattery.queryOptions(),
+  );
   const preventSleepMutation = useMutation(
     hostTRPC.sleep.setEnabled.mutationOptions(),
   );
@@ -434,7 +437,11 @@ export function GeneralSettings() {
 
       <SettingRow
         label="Keep awake while agents work"
-        description="Prevent your computer from sleeping while the agent is running a task"
+        description={
+          hasBuiltInBattery
+            ? "Prevent your computer from going to sleep on its own while the agent is running a task. Closing the lid will still put it to sleep."
+            : "Prevent your computer from going to sleep on its own while the agent is running a task"
+        }
         noBorder
       >
         <Switch

--- a/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/packages/workspace-server/src/services/agent/agent.test.ts
@@ -157,6 +157,7 @@ function createMockDependencies() {
     powerManager: {
       onResume: vi.fn(() => () => {}),
       preventSleep: vi.fn(() => () => {}),
+      hasBuiltInBattery: vi.fn(async () => false),
     },
     bundledResources: {
       resolve: vi.fn((rel: string) => `/mock/appPath/${rel}`),


### PR DESCRIPTION
## Problem

The "Keep awake while agents work" setting uses Electron's `powerSaveBlocker("prevent-app-suspension")`, which only prevents **idle** system sleep. Closing a laptop lid forces sleep on macOS (and by default on Windows) — no user-space API can block that. Users reasonably expect the toggle to keep an agent running with the lid closed, and it can't.

## Change

- Add `hasBuiltInBattery()` to the `IPowerManager` platform interface, implemented in the Electron adapter:
  - macOS: `ioreg -rc AppleSmartBattery`
  - Windows: `Get-CimInstance Win32_Battery` (covers Windows laptops, which also sleep on lid close by default)
  - Linux: `/sys/class/power_supply/BAT*`
  - Result is cached; detection failure falls back to `false` (no caveat shown).
- Expose it via `SleepService` and a new `sleep.hasBuiltInBattery` host-router query.
- On devices with a built-in battery, the setting description now reads: *"Prevent your computer from going to sleep on its own while the agent is running a task. Closing the lid will still put it to sleep."*

## Testing

- `pnpm --filter` typecheck green for platform, core, host-router, ui, workspace-server, code.
- Core unit tests pass; `IPowerManager` test fakes updated.
- Verified `ioreg -rc AppleSmartBattery` detection on a MacBook.

Related: recovery of turns interrupted by sleep is addressed separately.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*