### PR TITLE
perf: reduce memory footprint across real workflows (idle agent reclaim, poll churn, worker pools)

### DIFF
--- a/apps/code/src/main/bootstrap.ts
+++ b/apps/code/src/main/bootstrap.ts
@@ -58,11 +58,15 @@ app.commandLine.appendSwitch("enable-logging", "file");
 app.commandLine.appendSwitch("log-file", chromiumLogPath);
 app.commandLine.appendSwitch("log-level", "0");
 
-// In dev, expose the renderer over CDP (:9222) for the test-electron-app skill.
-// electron-vite launches Electron itself, so this is set in-process rather than
-// via a CLI flag.
+// In dev, expose the renderer over CDP (:9222 by default) for the
+// test-electron-app skill. electron-vite launches Electron itself, so this is
+// set in-process rather than via a CLI flag. POSTHOG_CODE_CDP_PORT matches the
+// port resolution in scripts/electron-cdp.mjs, for when :9222 is taken.
 if (isDev) {
-  app.commandLine.appendSwitch("remote-debugging-port", "9222");
+  app.commandLine.appendSwitch(
+    "remote-debugging-port",
+    process.env.POSTHOG_CODE_CDP_PORT ?? "9222",
+  );
 }
 
 crashReporter.start({ uploadToServer: false });

--- a/packages/core/src/agent-chat/agentChatStore.test.ts
+++ b/packages/core/src/agent-chat/agentChatStore.test.ts
@@ -1,0 +1,45 @@
+import type { AcpMessage } from "@posthog/shared";
+import { beforeEach, describe, expect, it } from "vitest";
+import { agentChatStore, MAX_CHAT_MESSAGES } from "./agentChatStore";
+
+const message = (i: number): AcpMessage =>
+  ({
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { i },
+    },
+  }) as unknown as AcpMessage;
+
+describe("agentChatStore", () => {
+  beforeEach(() => {
+    agentChatStore.setState({ chats: {} });
+  });
+
+  it("appends messages in order", () => {
+    const { begin, appendMessages } = agentChatStore.getState();
+    begin("chat", "agent");
+    appendMessages("chat", [message(1), message(2)]);
+    appendMessages("chat", [message(3)]);
+
+    expect(agentChatStore.getState().chats.chat?.messages).toHaveLength(3);
+  });
+
+  it("caps retained messages at MAX_CHAT_MESSAGES, dropping oldest", () => {
+    const { begin, appendMessages } = agentChatStore.getState();
+    begin("chat", "agent");
+
+    const batch = Array.from({ length: MAX_CHAT_MESSAGES }, (_, i) =>
+      message(i),
+    );
+    appendMessages("chat", batch);
+    appendMessages("chat", [message(MAX_CHAT_MESSAGES)]);
+
+    const messages = agentChatStore.getState().chats.chat?.messages ?? [];
+    expect(messages).toHaveLength(MAX_CHAT_MESSAGES);
+    const first = messages[0]?.message as { params?: { i?: number } };
+    const last = messages.at(-1)?.message as { params?: { i?: number } };
+    expect(first.params?.i).toBe(1);
+    expect(last.params?.i).toBe(MAX_CHAT_MESSAGES);
+  });
+});

--- a/packages/core/src/agent-chat/agentChatStore.ts
+++ b/packages/core/src/agent-chat/agentChatStore.ts
@@ -37,6 +37,13 @@ export interface AgentChatState {
   error: string | null;
 }
 
+/**
+ * Retention cap per chat. A live chat streams an AcpMessage per chunk, so an
+ * unbounded array grows without limit on long sessions; past this the oldest
+ * messages fall off (the transcript of record lives server-side).
+ */
+export const MAX_CHAT_MESSAGES = 2000;
+
 export const EMPTY_CHAT: AgentChatState = {
   agentKey: null,
   sessionId: null,
@@ -87,11 +94,18 @@ export const agentChatStore = createStore<AgentChatStore>((set) => {
       set((s) => {
         if (messages.length === 0) return s;
         const cur = s.chats[chatId] ?? EMPTY_CHAT;
+        const appended = [...cur.messages, ...messages];
         return {
           ...s,
           chats: {
             ...s.chats,
-            [chatId]: { ...cur, messages: [...cur.messages, ...messages] },
+            [chatId]: {
+              ...cur,
+              messages:
+                appended.length > MAX_CHAT_MESSAGES
+                  ? appended.slice(-MAX_CHAT_MESSAGES)
+                  : appended,
+            },
           },
         };
       }),

--- a/packages/ui/src/features/canvas/stores/freeformChatStore.ts
+++ b/packages/ui/src/features/canvas/stores/freeformChatStore.ts
@@ -5,6 +5,11 @@ import { hostClient } from "../hostClient";
 
 const log = logger.scope("freeform-edit-store");
 
+// Edit-history retention: each version keeps a full copy of the canvas source
+// plus context, so unbounded history grows by whole-document copies. Oldest
+// versions fall off past this cap.
+const MAX_VERSIONS = 50;
+
 // Working copy of a freeform canvas's source + edit history. Generation no
 // longer streams in-process — it runs as a dedicated task that publishes the
 // result into the canvas's saved record (see useGenerateFreeformCanvas). This
@@ -206,9 +211,11 @@ export const useFreeformChatStore = create<FreeformChatStore>()((set, get) => {
         // Drop any redo tail before appending (linear history, as with code edits).
         const base =
           headIdx === -1 ? t.versions : t.versions.slice(0, headIdx + 1);
+        const capped =
+          base.length >= MAX_VERSIONS ? base.slice(-(MAX_VERSIONS - 1)) : base;
         patch(threadId, (prev) => ({
           ...prev,
-          versions: [...base, version],
+          versions: [...capped, version],
           currentVersionId: version.id,
         }));
       }

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -195,7 +195,9 @@ export function ReviewShell({
 
   return (
     <WorkerPoolContextProvider
-      poolOptions={{ workerFactory }}
+      // poolSize: each highlighter worker is a full V8 isolate with shiki
+      // grammars loaded (~40MB RSS); the library default of 8 is oversized.
+      poolOptions={{ workerFactory, poolSize: 2 }}
       highlighterOptions={{
         theme: { dark: "github-dark", light: "github-light" },
         langs: [

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -101,6 +101,10 @@ export function ConversationView({
     () => ({
       workerFactory: () => diffWorkerFactory(),
       totalASTLRUCacheSize: 200,
+      // Each pooled highlighter worker is a full V8 isolate with shiki
+      // grammars loaded (~40MB RSS); the library default of 8 costs hundreds
+      // of MB for parallelism conversation diffs don't need.
+      poolSize: 2,
     }),
     [diffWorkerFactory],
   );

--- a/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
@@ -9,9 +9,12 @@ import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import type { AgentSession } from "@posthog/ui/features/sessions/sessionStore";
 import { useConnectivity } from "@posthog/ui/hooks/useConnectivity";
 import { useUserPresence } from "@posthog/ui/hooks/useUserPresence";
+import { logger } from "@posthog/ui/shell/logger";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
 import { useChatTitleGenerator } from "./useChatTitleGenerator";
+
+const log = logger.scope("session-connection");
 
 interface UseSessionConnectionOptions {
   taskId: string;
@@ -83,7 +86,10 @@ export function useSessionConnection({
 
   useEffect(() => {
     if (!taskRunId) return;
-    if (!userPresent) return;
+    if (!userPresent) {
+      log.info("User away — pausing activity heartbeat", { taskRunId });
+      return;
+    }
     return sessionService.startActivityHeartbeat(taskRunId);
   }, [taskRunId, sessionService, userPresent]);
 

--- a/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
@@ -8,6 +8,7 @@ import type { Task } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import type { AgentSession } from "@posthog/ui/features/sessions/sessionStore";
 import { useConnectivity } from "@posthog/ui/hooks/useConnectivity";
+import { useUserPresence } from "@posthog/ui/hooks/useUserPresence";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
 import { useChatTitleGenerator } from "./useChatTitleGenerator";
@@ -32,6 +33,11 @@ export function useSessionConnection({
   const { isOnline } = useConnectivity();
   const cloudAuthState = useAuthStateValue((state) => state);
   const sessionService = useService<SessionService>(SESSION_SERVICE);
+  // A mounted view used to heartbeat (and auto-reconnect) forever, pinning a
+  // ~300-400MB agent process per visible task even when the user walked away.
+  // Presence-gate both so the workspace-server idle timeout can reclaim the
+  // agent; the existing idle-kill reconcile path restores it on return.
+  const userPresent = useUserPresence();
 
   useChatTitleGenerator(task);
 
@@ -77,8 +83,9 @@ export function useSessionConnection({
 
   useEffect(() => {
     if (!taskRunId) return;
+    if (!userPresent) return;
     return sessionService.startActivityHeartbeat(taskRunId);
-  }, [taskRunId, sessionService]);
+  }, [taskRunId, sessionService, userPresent]);
 
   useEffect(() => {
     return sessionService.reconcileTaskConnection({
@@ -86,7 +93,10 @@ export function useSessionConnection({
       session: connectionSession,
       repoPath,
       isCloud,
-      isSuspended,
+      // While the user is away, freeze local reconciling too — otherwise the
+      // idle-kill auto-reconnect would respawn the agent process seconds
+      // after the server reclaimed it. Cloud reconcile ignores this flag.
+      isSuspended: isSuspended || !userPresent,
       isOnline,
       cloudAuth: {
         status: cloudAuthState.status,
@@ -104,6 +114,7 @@ export function useSessionConnection({
     repoPath,
     isCloud,
     isSuspended,
+    userPresent,
     isOnline,
     cloudAuthState.status,
     cloudAuthState.bootstrapComplete,

--- a/packages/ui/src/features/tasks/useTasks.ts
+++ b/packages/ui/src/features/tasks/useTasks.ts
@@ -5,7 +5,19 @@ import { useAuthenticatedQuery } from "../../hooks/useAuthenticatedQuery";
 import { useMeQuery } from "../auth/useMeQuery";
 import { taskKeys } from "./taskKeys";
 
-const TASK_LIST_POLL_INTERVAL_MS = 30_000;
+// Full-task polls are heavy (~630KB per response at 100 tasks — descriptions
+// and latest_run blobs included), and idle-poll churn was the app's largest
+// memory/CPU drain. The sidebar's primary freshness comes from the slim
+// summaries poll; full-task consumers are lookups where a minute of staleness
+// is invisible.
+const TASK_LIST_POLL_INTERVAL_MS = 60_000;
+// Summaries are slim and drive the sidebar's live status — keep them fresh.
+const TASK_SUMMARY_POLL_INTERVAL_MS = 30_000;
+// A task's slack origin and thread URL are set at creation and never change;
+// this poll only decorates rows with slack icons/links, so it mainly needs to
+// notice new tasks. Full payloads across all users made this the single
+// heaviest poll in the app (~2.2MB per response every 30s).
+const SLACK_TASK_POLL_INTERVAL_MS = 5 * 60_000;
 
 export function useTasks(
   filters?: {
@@ -43,7 +55,7 @@ export function useTaskSummaries(
     (client) => client.getTaskSummaries(ids),
     {
       enabled: (options?.enabled ?? true) && ids.length > 0,
-      refetchInterval: TASK_LIST_POLL_INTERVAL_MS,
+      refetchInterval: TASK_SUMMARY_POLL_INTERVAL_MS,
       placeholderData: keepPreviousData,
     },
   );
@@ -67,7 +79,7 @@ export function useSlackTasks(options?: {
       }) as unknown as Promise<Task[]>,
     {
       enabled: options?.enabled ?? true,
-      refetchInterval: TASK_LIST_POLL_INTERVAL_MS,
+      refetchInterval: SLACK_TASK_POLL_INTERVAL_MS,
     },
   );
 }

--- a/packages/ui/src/features/terminal/TerminalManager.ts
+++ b/packages/ui/src/features/terminal/TerminalManager.ts
@@ -484,6 +484,9 @@ class TerminalManagerImpl {
       this.loadWebglRenderer(instance);
     } else if (instance.terminalElement) {
       element.appendChild(instance.terminalElement);
+      // Detach dropped the WebGL renderer to free its GPU context; restore it
+      // now that the terminal is visible again.
+      this.loadWebglRenderer(instance);
       instance.term.refresh(0, instance.term.rows - 1);
     }
 
@@ -535,6 +538,14 @@ class TerminalManagerImpl {
 
     if (instance.terminalElement) {
       getParkingContainer().appendChild(instance.terminalElement);
+    }
+
+    // A parked terminal renders nothing, but a live WebglAddon still holds a
+    // GPU context (Chromium also drops the oldest context past 16). Release
+    // it; attach() reloads it when the terminal becomes visible again.
+    if (instance.webglAddon) {
+      instance.webglAddon.dispose();
+      instance.webglAddon = null;
     }
 
     instance.attachedElement = null;

--- a/packages/ui/src/hooks/useUserPresence.test.ts
+++ b/packages/ui/src/hooks/useUserPresence.test.ts
@@ -82,6 +82,21 @@ describe("useUserPresence", () => {
     expect(result.current).toBe(false);
   });
 
+  it("stays present under a sub-throttle idle threshold while interacting", () => {
+    // idleMs below the 15s activity throttle: the throttle must scale down or
+    // active input would be dropped and the user pinned "away".
+    const { result } = renderHook(() => useUserPresence(10_000));
+
+    act(() => {
+      for (let i = 0; i < 20; i++) {
+        vi.advanceTimersByTime(4_000);
+        window.dispatchEvent(new Event("keydown"));
+      }
+    });
+
+    expect(result.current).toBe(true);
+  });
+
   it("removes listeners on unmount", () => {
     const removeSpy = vi.spyOn(window, "removeEventListener");
     const { unmount } = renderHook(() => useUserPresence());
@@ -90,7 +105,13 @@ describe("useUserPresence", () => {
 
     const removed = removeSpy.mock.calls.map(([event]) => event);
     expect(removed).toEqual(
-      expect.arrayContaining(["pointerdown", "keydown", "wheel", "focus"]),
+      expect.arrayContaining([
+        "pointerdown",
+        "pointermove",
+        "keydown",
+        "wheel",
+        "focus",
+      ]),
     );
   });
 });

--- a/packages/ui/src/hooks/useUserPresence.test.ts
+++ b/packages/ui/src/hooks/useUserPresence.test.ts
@@ -7,6 +7,8 @@ const MINUTE = 60 * 1000;
 describe("useUserPresence", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // Input only counts while the window has focus; jsdom has no real focus.
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -54,6 +56,20 @@ describe("useUserPresence", () => {
     });
 
     expect(result.current).toBe(true);
+  });
+
+  it("ignores input while the window is unfocused", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    const { result } = renderHook(() => useUserPresence());
+
+    act(() => {
+      for (let i = 0; i < 11; i++) {
+        vi.advanceTimersByTime(MINUTE);
+        window.dispatchEvent(new Event("pointermove"));
+      }
+    });
+
+    expect(result.current).toBe(false);
   });
 
   it("respects a custom idle threshold", () => {

--- a/packages/ui/src/hooks/useUserPresence.test.ts
+++ b/packages/ui/src/hooks/useUserPresence.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { USER_PRESENCE_IDLE_MS, useUserPresence } from "./useUserPresence";
+
+const MINUTE = 60 * 1000;
+
+describe("useUserPresence", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts present", () => {
+    const { result } = renderHook(() => useUserPresence());
+    expect(result.current).toBe(true);
+  });
+
+  it("flips to away after the idle threshold with no input", () => {
+    const { result } = renderHook(() => useUserPresence());
+
+    act(() => {
+      vi.advanceTimersByTime(USER_PRESENCE_IDLE_MS + MINUTE);
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("stays present while the user keeps interacting", () => {
+    const { result } = renderHook(() => useUserPresence());
+
+    act(() => {
+      for (let i = 0; i < 15; i++) {
+        vi.advanceTimersByTime(MINUTE);
+        window.dispatchEvent(new Event("pointermove"));
+      }
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns to present on interaction after going away", () => {
+    const { result } = renderHook(() => useUserPresence());
+
+    act(() => {
+      vi.advanceTimersByTime(USER_PRESENCE_IDLE_MS + MINUTE);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event("keydown"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("respects a custom idle threshold", () => {
+    const { result } = renderHook(() => useUserPresence(2 * MINUTE));
+
+    act(() => {
+      vi.advanceTimersByTime(3 * MINUTE);
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("removes listeners on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useUserPresence());
+
+    unmount();
+
+    const removed = removeSpy.mock.calls.map(([event]) => event);
+    expect(removed).toEqual(
+      expect.arrayContaining(["pointerdown", "keydown", "wheel", "focus"]),
+    );
+  });
+});

--- a/packages/ui/src/hooks/useUserPresence.ts
+++ b/packages/ui/src/hooks/useUserPresence.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+/**
+ * How long without any window input before the user counts as away.
+ *
+ * Tuned against the workspace-server agent idle timeout (15 min): once the
+ * activity heartbeat stops, the server reclaims the idle agent process
+ * (~300-400MB RSS per session) after its own timeout, so an away user frees
+ * memory after presence-idle + server-idle. Reconnect on return is automatic
+ * and takes seconds.
+ */
+export const USER_PRESENCE_IDLE_MS = 10 * 60 * 1000;
+
+/** Presence bookkeeping is coarse; avoid work on every mousemove. */
+const ACTIVITY_THROTTLE_MS = 15 * 1000;
+const IDLE_CHECK_INTERVAL_MS = 60 * 1000;
+
+const PRESENCE_EVENTS = [
+  "pointerdown",
+  "pointermove",
+  "keydown",
+  "wheel",
+  "focus",
+] as const;
+
+/**
+ * True while the user is actively using the app window; flips to false after
+ * `idleMs` without any input, and back to true on the next interaction.
+ */
+export function useUserPresence(
+  idleMs: number = USER_PRESENCE_IDLE_MS,
+): boolean {
+  const [present, setPresent] = useState(true);
+
+  useEffect(() => {
+    let lastActivityAt = Date.now();
+    let lastRecordedAt = lastActivityAt;
+
+    const onActivity = () => {
+      const now = Date.now();
+      if (now - lastRecordedAt < ACTIVITY_THROTTLE_MS) return;
+      lastRecordedAt = now;
+      lastActivityAt = now;
+      setPresent(true);
+    };
+
+    for (const event of PRESENCE_EVENTS) {
+      window.addEventListener(event, onActivity, { passive: true });
+    }
+    const idleCheck = setInterval(() => {
+      if (Date.now() - lastActivityAt >= idleMs) {
+        setPresent(false);
+      }
+    }, IDLE_CHECK_INTERVAL_MS);
+
+    return () => {
+      for (const event of PRESENCE_EVENTS) {
+        window.removeEventListener(event, onActivity);
+      }
+      clearInterval(idleCheck);
+    };
+  }, [idleMs]);
+
+  return present;
+}

--- a/packages/ui/src/hooks/useUserPresence.ts
+++ b/packages/ui/src/hooks/useUserPresence.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 
+const envIdleMs = Number(
+  (import.meta as { env?: Record<string, string | undefined> }).env
+    ?.VITE_PRESENCE_IDLE_MS,
+);
+
 /**
  * How long without any window input before the user counts as away.
  *
@@ -8,12 +13,15 @@ import { useEffect, useState } from "react";
  * (~300-400MB RSS per session) after its own timeout, so an away user frees
  * memory after presence-idle + server-idle. Reconnect on return is automatic
  * and takes seconds.
+ *
+ * VITE_PRESENCE_IDLE_MS overrides it (dev/test only — e.g. the memory bench
+ * shrinks it to verify the suspend/reclaim/reconnect loop in minutes).
  */
-export const USER_PRESENCE_IDLE_MS = 10 * 60 * 1000;
+export const USER_PRESENCE_IDLE_MS =
+  Number.isFinite(envIdleMs) && envIdleMs > 0 ? envIdleMs : 10 * 60 * 1000;
 
 /** Presence bookkeeping is coarse; avoid work on every mousemove. */
 const ACTIVITY_THROTTLE_MS = 15 * 1000;
-const IDLE_CHECK_INTERVAL_MS = 60 * 1000;
 
 const PRESENCE_EVENTS = [
   "pointerdown",
@@ -26,6 +34,9 @@ const PRESENCE_EVENTS = [
 /**
  * True while the user is actively using the app window; flips to false after
  * `idleMs` without any input, and back to true on the next interaction.
+ *
+ * Input only counts while the window has focus — a stray mouse-over of an
+ * unfocused window is not use. The window gaining focus counts by itself.
  */
 export function useUserPresence(
   idleMs: number = USER_PRESENCE_IDLE_MS,
@@ -36,7 +47,8 @@ export function useUserPresence(
     let lastActivityAt = Date.now();
     let lastRecordedAt = lastActivityAt;
 
-    const onActivity = () => {
+    const onActivity = (event: Event) => {
+      if (event.type !== "focus" && !document.hasFocus()) return;
       const now = Date.now();
       if (now - lastRecordedAt < ACTIVITY_THROTTLE_MS) return;
       lastRecordedAt = now;
@@ -47,11 +59,12 @@ export function useUserPresence(
     for (const event of PRESENCE_EVENTS) {
       window.addEventListener(event, onActivity, { passive: true });
     }
+    const checkIntervalMs = Math.min(60 * 1000, Math.max(idleMs / 2, 1000));
     const idleCheck = setInterval(() => {
       if (Date.now() - lastActivityAt >= idleMs) {
         setPresent(false);
       }
-    }, IDLE_CHECK_INTERVAL_MS);
+    }, checkIntervalMs);
 
     return () => {
       for (const event of PRESENCE_EVENTS) {

--- a/packages/ui/src/hooks/useUserPresence.ts
+++ b/packages/ui/src/hooks/useUserPresence.ts
@@ -46,11 +46,15 @@ export function useUserPresence(
   useEffect(() => {
     let lastActivityAt = Date.now();
     let lastRecordedAt = lastActivityAt;
+    // Scale the throttle down for small idleMs (test knobs): a fixed 15s
+    // throttle with idleMs <= 15s would drop every input and pin the user
+    // "away" while they actively interact.
+    const throttleMs = Math.min(ACTIVITY_THROTTLE_MS, idleMs / 4);
 
     const onActivity = (event: Event) => {
       if (event.type !== "focus" && !document.hasFocus()) return;
       const now = Date.now();
-      if (now - lastRecordedAt < ACTIVITY_THROTTLE_MS) return;
+      if (now - lastRecordedAt < throttleMs) return;
       lastRecordedAt = now;
       lastActivityAt = now;
       setPresent(true);

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -340,7 +340,12 @@ interface PendingPermission {
 
 @injectable()
 export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
-  private static readonly IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+  // POSTHOG_CODE_AGENT_IDLE_TIMEOUT_MS overrides for dev/test only — the
+  // memory bench shrinks it to verify idle reclaim in minutes.
+  private static readonly IDLE_TIMEOUT_MS =
+    Number(process.env.POSTHOG_CODE_AGENT_IDLE_TIMEOUT_MS) > 0
+      ? Number(process.env.POSTHOG_CODE_AGENT_IDLE_TIMEOUT_MS)
+      : 15 * 60 * 1000;
 
   private sessions = new Map<string, ManagedSession>();
   private pendingPermissions = new Map<string, PendingPermission>();

--- a/scripts/bench-memory-run.mjs
+++ b/scripts/bench-memory-run.mjs
@@ -43,6 +43,12 @@ const messageCount = Number(arg("messages", 2));
 const label = arg("label", "run");
 const outFile = arg("out", null);
 const idleOnly = flag("idle-only");
+/**
+ * thread  — N cheap agent turns in the restored thread (default)
+ * switch  — visit up to N tasks in the sidebar, then return to the first
+ * longout — one turn with a large (~40KB) bash tool output
+ */
+const scenario = arg("scenario", "thread");
 
 const BOOT_SETTLE_MS = 20_000;
 const CDP_TIMEOUT_MS = 120_000;
@@ -86,7 +92,7 @@ function sample(sampleLabel, durationS) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-async function driveWorkflow() {
+async function withRendererPage(fn) {
   const { chromium } = await import(
     path.join(repoRoot, "node_modules/playwright-core/index.mjs")
   );
@@ -95,35 +101,117 @@ async function driveWorkflow() {
     const pages = browser.contexts().flatMap((c) => c.pages());
     const page = pages.find((p) => !p.url().startsWith("devtools://"));
     if (!page) throw new Error("no renderer page target found");
-
-    const composer = page.locator('[contenteditable="true"]').last();
-    await composer.waitFor({ state: "visible", timeout: 30_000 });
-
-    const turns = [];
-    for (let i = 0; i < messageCount; i++) {
-      const token = `pong-${label}-${i}`;
-      const started = Date.now();
-      await composer.click();
-      await composer.pressSequentially(
-        `Reply with exactly: ${token} (benchmark turn, nothing else)`,
-      );
-      await page.getByRole("button", { name: "Send message" }).click();
-      // The reply contains the token; the composed message shows it too, so
-      // wait for at least two occurrences in the page text.
-      await page.waitForFunction(
-        (t) => (document.body.innerText.split(t).length - 1) >= 2,
-        token,
-        { timeout: REPLY_TIMEOUT_MS, polling: 1000 },
-      );
-      turns.push({ token, ms: Date.now() - started });
-      log(`turn ${i + 1}/${messageCount} done in ${turns[i].ms}ms`);
-    }
-    return turns;
+    return await fn(page);
   } finally {
-    // Do not browser.close(): over CDP that can close the app's window.
-    // Disconnecting the CDP session is enough.
+    // Do not close the app's window; disconnecting the CDP session is enough.
     await browser.close().catch(() => {});
   }
+}
+
+async function sendTurn(page, prompt, doneMarker) {
+  const composer = page.locator('[contenteditable="true"]').last();
+  await composer.waitFor({ state: "visible", timeout: 30_000 });
+  const started = Date.now();
+  await composer.click();
+  await composer.pressSequentially(prompt);
+  await page.getByRole("button", { name: "Send message" }).click();
+  // The reply contains the marker; the composed message shows it too, so
+  // wait for at least two occurrences in the page text.
+  await page.waitForFunction(
+    (t) => document.body.innerText.split(t).length - 1 >= 2,
+    doneMarker,
+    { timeout: REPLY_TIMEOUT_MS, polling: 1000 },
+  );
+  return Date.now() - started;
+}
+
+/** N cheap agent turns in the restored thread. */
+async function driveThread(page) {
+  const turns = [];
+  for (let i = 0; i < messageCount; i++) {
+    const token = `pong-${label}-${i}`;
+    const ms = await sendTurn(
+      page,
+      `Reply with exactly: ${token} (benchmark turn, nothing else)`,
+      token,
+    );
+    turns.push({ token, ms });
+    log(`turn ${i + 1}/${messageCount} done in ${ms}ms`);
+  }
+  return { turns };
+}
+
+/**
+ * One turn whose tool output is large (~40KB streamed to the transcript),
+ * exercising event streaming + conversation rendering, then a settle.
+ */
+async function driveLongOutput(page) {
+  const token = `longout-${label}`;
+  const ms = await sendTurn(
+    page,
+    `Run this exact bash command: seq 1 5000 — then reply with exactly: ${token}`,
+    token,
+  );
+  log(`long-output turn done in ${ms}ms`);
+  return { turns: [{ token, ms }] };
+}
+
+/**
+ * Hop across up to `messageCount` tasks in the sidebar (the realest daily
+ * workflow): expand the repo group, visit each task with a dwell so its
+ * transcript loads and its session connects, then return to the first.
+ */
+async function driveSwitch(page) {
+  const group = page.getByRole("button", { name: "posthog", exact: true });
+  if ((await group.getAttribute("aria-expanded")) === "false") {
+    await group.click();
+    await page.waitForTimeout(1500);
+  }
+  // Task rows are the only buttons with long accessible names.
+  const names = (
+    await page
+      .getByRole("button")
+      .evaluateAll((els) =>
+        els.map(
+          (el) => el.getAttribute("aria-label") || el.textContent?.trim() || "",
+        ),
+      )
+  )
+    // Row names end with a live relative-time suffix ("… 5m") that goes stale
+    // between enumeration and click; match on a title prefix instead.
+    .map((n) => n.replace(/\s*\d+[smhd]$/, "").slice(0, 40))
+    .filter((n) => n.length >= 30);
+  const visits = [];
+  const targets = names.slice(0, Math.max(2, messageCount));
+  for (const name of targets) {
+    const started = Date.now();
+    await page.getByRole("button", { name }).first().click();
+    await page.waitForTimeout(8000);
+    visits.push({ task: name, ms: Date.now() - started });
+    log(`visited: ${name}`);
+  }
+  // Best-effort return to the first task; the list may have re-sorted or
+  // virtualized it away, and the post-visit state is the measurement anyway.
+  if (targets.length) {
+    try {
+      await page
+        .getByRole("button", { name: targets[0] })
+        .first()
+        .click({ timeout: 5000 });
+      await page.waitForTimeout(5000);
+    } catch {
+      log("return-to-first skipped (row no longer locatable)");
+    }
+  }
+  return { visits };
+}
+
+async function driveWorkflow() {
+  return withRendererPage(async (page) => {
+    if (scenario === "switch") return driveSwitch(page);
+    if (scenario === "longout") return driveLongOutput(page);
+    return driveThread(page);
+  });
 }
 
 if (await portListening()) {
@@ -167,10 +255,10 @@ log(`idle: ${idle.totalRssMb}MB`);
 let workflow = null;
 let post = null;
 if (!idleOnly) {
-  const turns = await driveWorkflow();
+  workflow = await driveWorkflow();
+  workflow.scenario = scenario;
   await sleep(POST_WORKFLOW_SETTLE_MS);
   post = sample(`${label}-post`, 30);
-  workflow = { turns };
   log(`post-workflow: ${post.totalRssMb}MB`);
 }
 

--- a/scripts/bench-memory-run.mjs
+++ b/scripts/bench-memory-run.mjs
@@ -125,8 +125,33 @@ async function sendTurn(page, prompt, doneMarker) {
   return Date.now() - started;
 }
 
-/** N cheap agent turns in the restored thread. */
+/**
+ * Navigate to the dedicated local bench task before sending anything — the
+ * restored-at-boot task can be a real work task, and benchmark turns must
+ * never land in one.
+ */
+async function openBenchTask(page) {
+  const taskId = arg("thread-task-id", "5feefee1-c818-4931-84c7-e4a68d37b4f0");
+  const title = arg("thread-title", "Casual greeting");
+  await page.evaluate((id) => {
+    window.location.hash = `#/code/tasks/${id}`;
+  }, taskId);
+  await page.waitForTimeout(6000);
+  const header = await page
+    .locator("span.rt-truncate")
+    .first()
+    .textContent()
+    .catch(() => "");
+  if (!header?.includes(title)) {
+    throw new Error(
+      `refusing to send benchmark turns: open task is "${header}", expected "${title}"`,
+    );
+  }
+}
+
+/** N cheap agent turns in the dedicated bench thread. */
 async function driveThread(page) {
+  await openBenchTask(page);
   const turns = [];
   for (let i = 0; i < messageCount; i++) {
     const token = `pong-${label}-${i}`;
@@ -146,6 +171,7 @@ async function driveThread(page) {
  * exercising event streaming + conversation rendering, then a settle.
  */
 async function driveLongOutput(page) {
+  await openBenchTask(page);
   const token = `longout-${label}`;
   const ms = await sendTurn(
     page,

--- a/scripts/bench-memory-run.mjs
+++ b/scripts/bench-memory-run.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+/**
+ * End-to-end memory benchmark run for the PostHog Code dev app.
+ *
+ * Owns the full lifecycle so every run is comparable:
+ *   1. launches a fresh dev app (POSTHOG_CODE_CDP_PORT, default :9223)
+ *   2. waits for CDP + boot settle
+ *   3. samples idle RSS (scripts/bench-memory.mjs)
+ *   4. drives the reported-hot user workflow over CDP with playwright-core:
+ *      sends N cheap agent turns in the restored thread and waits for replies
+ *   5. samples post-workflow RSS
+ *   6. tears the app down
+ *
+ * Usage:
+ *   node scripts/bench-memory-run.mjs [--port 9223] [--messages 2]
+ *     [--label <label>] [--out results.jsonl] [--idle-only]
+ *
+ * Prints a JSON report; final line is `TOTAL_RSS_MB=<post-workflow median>`
+ * (idle median with --idle-only) for predicate extraction via `tail -1`.
+ *
+ * NOTE: workflow turns hit the real agent backend with trivial prompts
+ * ("reply with exactly <token>") to keep token cost minimal while exercising
+ * the real agent-session memory path.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const args = process.argv.slice(2);
+function arg(name, fallback) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] !== undefined ? args[i + 1] : fallback;
+}
+const flag = (name) => args.includes(`--${name}`);
+
+const port = Number(arg("port", 9223));
+const messageCount = Number(arg("messages", 2));
+const label = arg("label", "run");
+const outFile = arg("out", null);
+const idleOnly = flag("idle-only");
+
+const BOOT_SETTLE_MS = 20_000;
+const CDP_TIMEOUT_MS = 120_000;
+const REPLY_TIMEOUT_MS = 120_000;
+const POST_WORKFLOW_SETTLE_MS = 10_000;
+
+function log(message) {
+  console.error(`[bench-run] ${message}`);
+}
+
+async function portListening() {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json/version`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function sample(sampleLabel, durationS) {
+  const out = execFileSync(
+    process.execPath,
+    [
+      path.join(repoRoot, "scripts/bench-memory.mjs"),
+      "--port",
+      String(port),
+      "--duration",
+      String(durationS),
+      "--interval",
+      "2",
+      "--label",
+      sampleLabel,
+    ],
+    { encoding: "utf8" },
+  );
+  const json = out.slice(0, out.lastIndexOf("TOTAL_RSS_MB="));
+  return JSON.parse(json);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function driveWorkflow() {
+  const { chromium } = await import(
+    path.join(repoRoot, "node_modules/playwright-core/index.mjs")
+  );
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  try {
+    const pages = browser.contexts().flatMap((c) => c.pages());
+    const page = pages.find((p) => !p.url().startsWith("devtools://"));
+    if (!page) throw new Error("no renderer page target found");
+
+    const composer = page.locator('[contenteditable="true"]').last();
+    await composer.waitFor({ state: "visible", timeout: 30_000 });
+
+    const turns = [];
+    for (let i = 0; i < messageCount; i++) {
+      const token = `pong-${label}-${i}`;
+      const started = Date.now();
+      await composer.click();
+      await composer.pressSequentially(
+        `Reply with exactly: ${token} (benchmark turn, nothing else)`,
+      );
+      await page.getByRole("button", { name: "Send message" }).click();
+      // The reply contains the token; the composed message shows it too, so
+      // wait for at least two occurrences in the page text.
+      await page.waitForFunction(
+        (t) => (document.body.innerText.split(t).length - 1) >= 2,
+        token,
+        { timeout: REPLY_TIMEOUT_MS, polling: 1000 },
+      );
+      turns.push({ token, ms: Date.now() - started });
+      log(`turn ${i + 1}/${messageCount} done in ${turns[i].ms}ms`);
+    }
+    return turns;
+  } finally {
+    // Do not browser.close(): over CDP that can close the app's window.
+    // Disconnecting the CDP session is enough.
+    await browser.close().catch(() => {});
+  }
+}
+
+if (await portListening()) {
+  console.error(
+    `bench-run: something already listens on :${port}. This harness owns the app lifecycle; stop the running instance first.`,
+  );
+  process.exit(1);
+}
+
+log("launching dev app...");
+const child = spawn("pnpm", ["dev:code"], {
+  cwd: repoRoot,
+  env: { ...process.env, POSTHOG_CODE_CDP_PORT: String(port) },
+  stdio: ["ignore", "ignore", "ignore"],
+  detached: true,
+});
+
+function teardown() {
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {}
+}
+process.on("exit", teardown);
+process.on("SIGINT", () => process.exit(130));
+process.on("SIGTERM", () => process.exit(143));
+
+const deadline = Date.now() + CDP_TIMEOUT_MS;
+while (!(await portListening())) {
+  if (Date.now() > deadline) {
+    console.error("bench-run: app never opened CDP port");
+    process.exit(1);
+  }
+  await sleep(1000);
+}
+log(`CDP up on :${port}, settling ${BOOT_SETTLE_MS / 1000}s...`);
+await sleep(BOOT_SETTLE_MS);
+
+const idle = sample(`${label}-idle`, 20);
+log(`idle: ${idle.totalRssMb}MB`);
+
+let workflow = null;
+let post = null;
+if (!idleOnly) {
+  const turns = await driveWorkflow();
+  await sleep(POST_WORKFLOW_SETTLE_MS);
+  post = sample(`${label}-post`, 30);
+  workflow = { turns };
+  log(`post-workflow: ${post.totalRssMb}MB`);
+}
+
+teardown();
+
+const report = {
+  label,
+  port,
+  messages: idleOnly ? 0 : messageCount,
+  idle,
+  workflow,
+  post,
+  metricMb: idleOnly ? idle.totalRssMb : post.totalRssMb,
+};
+console.log(JSON.stringify(report, null, 2));
+if (outFile) appendFileSync(outFile, `${JSON.stringify(report)}\n`);
+console.log(`TOTAL_RSS_MB=${report.metricMb}`);

--- a/scripts/bench-memory-run.mjs
+++ b/scripts/bench-memory-run.mjs
@@ -15,6 +15,8 @@
  * Usage:
  *   node scripts/bench-memory-run.mjs [--port 9223] [--messages 2]
  *     [--label <label>] [--out results.jsonl] [--idle-only]
+ *     [--scenario thread|switch|longout]
+ *     [--thread-task-id <id>] [--thread-title <title>]
  *
  * Prints a JSON report; final line is `TOTAL_RSS_MB=<post-workflow median>`
  * (idle median with --idle-only) for predicate extraction via `tail -1`.
@@ -22,6 +24,13 @@
  * NOTE: workflow turns hit the real agent backend with trivial prompts
  * ("reply with exactly <token>") to keep token cost minimal while exercising
  * the real agent-session memory path.
+ *
+ * IMPORTANT: the `thread` and `longout` scenarios send turns into a dedicated
+ * throwaway task so benchmark chatter never lands in real work. The default
+ * --thread-task-id/--thread-title point at the original author's local bench
+ * task — in any other environment, create a scratch task once and pass its id
+ * and title explicitly, or the run aborts with "refusing to send benchmark
+ * turns".
  */
 
 import { execFileSync, spawn } from "node:child_process";
@@ -29,7 +38,10 @@ import { appendFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
 
 const args = process.argv.slice(2);
 function arg(name, fallback) {
@@ -144,7 +156,8 @@ async function openBenchTask(page) {
     .catch(() => "");
   if (!header?.includes(title)) {
     throw new Error(
-      `refusing to send benchmark turns: open task is "${header}", expected "${title}"`,
+      `refusing to send benchmark turns: open task is "${header}", expected "${title}". ` +
+        `Create a throwaway task in your environment and pass --thread-task-id/--thread-title.`,
     );
   }
 }

--- a/scripts/bench-memory.mjs
+++ b/scripts/bench-memory.mjs
@@ -122,7 +122,9 @@ async function rendererHeapMb() {
       signal: AbortSignal.timeout(2000),
     });
     const targets = await res.json();
-    const page = targets.find((t) => t.type === "page" && t.webSocketDebuggerUrl);
+    const page = targets.find(
+      (t) => t.type === "page" && t.webSocketDebuggerUrl,
+    );
     if (!page) return null;
     const ws = new WebSocket(page.webSocketDebuggerUrl);
     const heap = await new Promise((resolve) => {
@@ -162,9 +164,7 @@ function median(values) {
   if (!values.length) return 0;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2
-    ? sorted[mid]
-    : (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 const rootPid = rootPidFromCdpPort();
@@ -198,7 +198,8 @@ const heapSamples = samples.map((s) => s.heapMb).filter((h) => h != null);
 const categories = {};
 for (const s of samples) {
   for (const [k, v] of Object.entries(s.byCategoryMb)) {
-    (categories[k] ??= []).push(v);
+    categories[k] ??= [];
+    categories[k].push(v);
   }
 }
 

--- a/scripts/bench-memory.mjs
+++ b/scripts/bench-memory.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * Memory benchmark for the PostHog Code dev app.
+ *
+ * Samples RSS across the app's entire process tree (main, renderers, GPU,
+ * utility, workspace-server, spawned agents) plus the renderer JS heap over
+ * CDP, and reports a steady-state total suitable for before/after comparison.
+ *
+ * Usage:
+ *   node scripts/bench-memory.mjs [--port 9223] [--duration 30] [--interval 2]
+ *                                 [--label idle] [--out results.json]
+ *
+ * The app must already be running in dev with CDP enabled
+ * (POSTHOG_CODE_CDP_PORT=<port> pnpm dev:code). The root process is located
+ * via the CDP listener, so no pid needs to be passed.
+ *
+ * Prints a JSON report and, as the final line, `TOTAL_RSS_MB=<median total>`
+ * so callers can extract the metric with `tail -1`.
+ */
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+function arg(name, fallback) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] !== undefined ? args[i + 1] : fallback;
+}
+
+const port = Number(arg("port", process.env.POSTHOG_CODE_CDP_PORT ?? 9223));
+const durationS = Number(arg("duration", 30));
+const intervalS = Number(arg("interval", 2));
+const label = arg("label", "unlabeled");
+const outFile = arg("out", null);
+
+function fail(message) {
+  console.error(`bench-memory: ${message}`);
+  process.exit(1);
+}
+
+function rootPidFromCdpPort() {
+  try {
+    const out = execFileSync(
+      "lsof",
+      ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"],
+      { encoding: "utf8" },
+    ).trim();
+    const pid = Number(out.split("\n")[0]);
+    if (!Number.isInteger(pid)) throw new Error("no pid");
+    return pid;
+  } catch {
+    fail(
+      `nothing listening on CDP :${port}. Launch the app first: POSTHOG_CODE_CDP_PORT=${port} pnpm dev:code`,
+    );
+  }
+}
+
+function processTable() {
+  const out = execFileSync("ps", ["-eo", "pid=,ppid=,rss=,command="], {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  const rows = [];
+  for (const line of out.split("\n")) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/);
+    if (m) {
+      rows.push({
+        pid: Number(m[1]),
+        ppid: Number(m[2]),
+        rssKb: Number(m[3]),
+        command: m[4],
+      });
+    }
+  }
+  return rows;
+}
+
+function descendants(rootPid, rows) {
+  const byParent = new Map();
+  for (const row of rows) {
+    if (!byParent.has(row.ppid)) byParent.set(row.ppid, []);
+    byParent.get(row.ppid).push(row);
+  }
+  const result = [];
+  const queue = [rootPid];
+  const seen = new Set(queue);
+  while (queue.length) {
+    const pid = queue.shift();
+    const row = rows.find((r) => r.pid === pid);
+    if (row) result.push(row);
+    for (const child of byParent.get(pid) ?? []) {
+      if (!seen.has(child.pid)) {
+        seen.add(child.pid);
+        queue.push(child.pid);
+      }
+    }
+  }
+  return result;
+}
+
+function classify(row, rootPid) {
+  const c = row.command;
+  if (row.pid === rootPid) return "main";
+  const type = c.match(/--type=([a-z-]+)/)?.[1];
+  if (type === "renderer") return "renderer";
+  if (type === "gpu-process") return "gpu";
+  if (type === "utility") {
+    const sub = c.match(/--utility-sub-type=([a-zA-Z.]+)/)?.[1];
+    return sub === "node.mojom.NodeService" ? "utility-node" : "utility";
+  }
+  if (type) return type;
+  if (c.includes("workspace-server")) return "workspace-server";
+  if (c.includes("crashpad")) return "crashpad";
+  if (/\bnode\b|\.mjs|\.js/.test(c)) return "node-child";
+  return "other";
+}
+
+async function rendererHeapMb() {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json/list`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    const targets = await res.json();
+    const page = targets.find((t) => t.type === "page" && t.webSocketDebuggerUrl);
+    if (!page) return null;
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    const heap = await new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(null), 3000);
+      ws.onopen = () => {
+        ws.send(
+          JSON.stringify({
+            id: 1,
+            method: "Runtime.evaluate",
+            params: {
+              expression: "performance.memory.usedJSHeapSize",
+              returnByValue: true,
+            },
+          }),
+        );
+      };
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data);
+        if (msg.id === 1) {
+          clearTimeout(timer);
+          resolve(msg.result?.result?.value ?? null);
+        }
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        resolve(null);
+      };
+    });
+    ws.close();
+    return heap == null ? null : heap / (1024 * 1024);
+  } catch {
+    return null;
+  }
+}
+
+function median(values) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+const rootPid = rootPidFromCdpPort();
+const samples = [];
+const sampleCount = Math.max(1, Math.floor(durationS / intervalS));
+
+for (let i = 0; i < sampleCount; i++) {
+  const rows = descendants(rootPid, processTable());
+  const byCategory = {};
+  let totalKb = 0;
+  for (const row of rows) {
+    const category = classify(row, rootPid);
+    byCategory[category] = (byCategory[category] ?? 0) + row.rssKb;
+    totalKb += row.rssKb;
+  }
+  samples.push({
+    totalMb: totalKb / 1024,
+    byCategoryMb: Object.fromEntries(
+      Object.entries(byCategory).map(([k, v]) => [k, +(v / 1024).toFixed(1)]),
+    ),
+    processCount: rows.length,
+    heapMb: await rendererHeapMb(),
+  });
+  if (i < sampleCount - 1) {
+    await new Promise((r) => setTimeout(r, intervalS * 1000));
+  }
+}
+
+const totalMedianMb = median(samples.map((s) => s.totalMb));
+const heapSamples = samples.map((s) => s.heapMb).filter((h) => h != null);
+const categories = {};
+for (const s of samples) {
+  for (const [k, v] of Object.entries(s.byCategoryMb)) {
+    (categories[k] ??= []).push(v);
+  }
+}
+
+const report = {
+  label,
+  port,
+  rootPid,
+  samples: samples.length,
+  durationS,
+  totalRssMb: +totalMedianMb.toFixed(1),
+  peakRssMb: +Math.max(...samples.map((s) => s.totalMb)).toFixed(1),
+  rendererHeapMb: heapSamples.length ? +median(heapSamples).toFixed(1) : null,
+  byCategoryMb: Object.fromEntries(
+    Object.entries(categories).map(([k, v]) => [k, +median(v).toFixed(1)]),
+  ),
+  processCount: Math.round(median(samples.map((s) => s.processCount))),
+};
+
+console.log(JSON.stringify(report, null, 2));
+if (outFile) appendFileSync(outFile, `${JSON.stringify(report)}\n`);
+console.log(`TOTAL_RSS_MB=${report.totalRssMb}`);


### PR DESCRIPTION
Reduces PostHog Code's memory footprint in real user workflows, driven by an autonomous measure → change → verify loop against the live dev app. Users report the app hogging memory and CPU; this PR attacks the verified causes rather than guesses.

## TL;DR results

| Finding | Fix | Verified effect |
|---|---|---|
| The visible task pins a ~340MB `claude-cli` + ~75MB MCP servers **forever** (activity heartbeat + auto-reconnect never let the existing 15-min idle kill fire) | Presence-gate the heartbeat and the reconcile (`useUserPresence`) | Agent reclaimed after user is away (test knobs: at t+177s; total RSS 1500 → 1168MB, agent children 0). Focus + click auto-reconnects with a fresh agent in ~15s |
| Idle poll churn: **~5.7MB/min of API traffic while untouched** (96% task-list fetches: full descriptions + `latest_run` blobs every 30s ×3 pollers), driving renderer RSS up ~19MB/min with flat JS heap — also a big slice of the reported CPU drain | Full task lists 30s→60s (lookup consumers only), slack-origin list 30s→5min (origin is immutable), slim summaries stay at 30s | Task-switch scenario delta **+158MB → −2MB**; idle churn 5.7 → 3.1MB/min (show-all-users profile), ~6× lower for default profiles |
| `@pierre/diffs` spawns **8 shiki highlighter workers** per pool by default (each a full V8 isolate with grammars loaded); two pools mount | `poolSize: 2` at both providers | **−67MB** total RSS benchmarked; 9 workers → 3 |
| Parked (hidden) terminals keep a live WebGL GPU context indefinitely (Chromium drops the oldest past 16) | Dispose on detach, reload on attach | One GPU context freed per hidden terminal |
| Unbounded in-memory accumulation: agent-chat feed (an `AcpMessage` per stream chunk), canvas edit history (full source copy per version) | Caps: 2000 messages / 50 versions | Bounds worst-case growth on long sessions |

## Research method

Everything was measured on the real dev app (live tRPC, workspace-server, real agent backend) — no synthetic fixtures.

**Instrumentation (included in this PR):**
- `scripts/bench-memory.mjs` — samples RSS across the app's entire process tree via the CDP listener pid, classifies each process (main / renderer / GPU / utility / workspace-server / agent children), and reads renderer JS heap over CDP. Emits median steady-state totals.
- `scripts/bench-memory-run.mjs` — owns the full benchmark lifecycle for comparability: fresh app launch per run (`POSTHOG_CODE_CDP_PORT`, added in `bootstrap.ts`, since Chrome typically owns :9222), drives a scenario over CDP with `playwright-core`, samples idle + post-workflow, tears down. Scenarios: `thread` (N cheap real agent turns — "reply with exactly <token>"), `switch` (visit 6 sidebar tasks with dwell — the realest daily workflow), `longout` (one turn with a ~40KB bash tool output). Thread scenarios navigate to a dedicated bench task by id and refuse to send turns into any other task.
- Test knobs for fast verification of the idle-reclaim loop: `VITE_PRESENCE_IDLE_MS` (renderer) and `POSTHOG_CODE_AGENT_IDLE_TIMEOUT_MS` (workspace-server) — the full suspend → reclaim → return → reconnect cycle is verifiable in ~4 minutes with the window defocused instead of ~25.

**Protocol:** pinned metric (post-workflow steady-state total RSS, median over 30s), one change per cycle, keep/discard by measurement plus guards (`pnpm typecheck`, scoped vitest suites, `biome lint packages/core`, host-boundary check). Measured noise floor: ±35–50MB run-to-run (each bench run also grows the bench thread's transcript, drifting the baseline upward — treated sub-noise deltas as neutral).

**Key diagnostics that found the issues:**
- Per-process RSS attribution showed a claude-cli child alive at *boot* with `--resume` and ~340MB — before any user action.
- Reading the heartbeat/reconcile code explained why the workspace-server's existing idle kill (which demonstrably works — log history) could never fire for a mounted task.
- A 35-min unattended idle profile failed to show reclaim — root-caused to the experiment itself: HMR from concurrent edits plus the dev window sitting on the user's active desktop, where stray mouse-overs counted as presence. That produced the focus-gate hardening (input only counts while the window has focus) and the fast-verify knobs.
- The task-switch scenario retained +158MB with flat JS heap and flat DOM; a decay watch showed renderer RSS climbing ~19MB/min at idle, and a playwright network tap attributed 96% of a steady ~5.7MB/min of idle traffic to two full-payload task-list polls (630KB `created_by` + 2.2MB slack-origin/all-users, each every 30s, `limit=500` — ~630KB of which is 205KB task descriptions + 320KB `latest_run` blobs per response).

**Structural floors (measured, not worth chasing client-side):** Electron main ~310MB RSS with only ~60MB JS heap; GPU ~130MB; network/utility ~78MB; renderer ~590MB dev / ~340–380MB prod with ~145MB JS heap.

## Verification

- Idle-reclaim loop verified end-to-end with short knobs and a defocused window: boot spawn → presence lapse → heartbeat paused → workspace-server "Killing idle session" → agent + MCP children gone (node-child 0MB) → focus + click → auto-reconnect ~15s.
- Task-switch scenario re-run post-fix: visit-6-tasks delta +158MB → −2MB.
- Regression gate: `@posthog/ui` full suite green (incl. 7 new presence tests), `@posthog/core` 1970/1971 (the 1 failure is a locale-dependent billing test that fails identically on `main`), workspace-server agent suite 63/63 (archive integration failures identical to `main`), `check-host-boundaries` clean.

## Follow-ups (found, not implemented — product calls)

1. **Server-side slim tasks endpoint** — the show-all-users sidebar still needs the 2.25MB full poll only because `/tasks/summaries/` lacks `origin_product`/creator fields; adding them cuts the heaviest remaining poll ~20×.
2. **Cold boot resume** — the app spawns `claude-cli --resume` at every launch before any user action (~340MB for up to 25 min; booting on a cloud task vs a local task swings idle RSS by ~450MB). Needs a "cold session" state that paints the transcript from logs and connects on first prompt.
3. **Quiet "suspended" UI state** — an idle-killed session currently shows the error-flavored "disconnected due to inactivity" while the user is away; a dedicated state would look intentional.
4. `sessionStore.events` grows unbounded for the *live viewed* session during long streaming runs (residency eviction only covers backgrounded sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cVSjw1BsiioCeA5Fhhavz
