### PR TITLE
feat(sessions): add compact option to stale conversation cost warning

### DIFF
--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -643,6 +643,12 @@ export function SessionView({
                           lastActivityAt={staleGate.lastActivityAt}
                           costUsd={staleGate.costUsd}
                           onContinue={staleGate.onContinue}
+                          onCompact={() => {
+                            // Acknowledge so the gate clears and the dialog
+                            // closes, then trigger the agent's manual compaction.
+                            staleGate.onContinue();
+                            onSendPrompt("/compact");
+                          }}
                           onOpenChange={staleGate.onDialogOpenChange}
                         />
                         <PromptInput

--- a/packages/ui/src/features/sessions/components/StaleConversationCostDialog.tsx
+++ b/packages/ui/src/features/sessions/components/StaleConversationCostDialog.tsx
@@ -10,6 +10,8 @@ interface StaleConversationCostDialogProps {
   /** Cumulative session cost so far, when the gateway reports it. */
   costUsd: number | null;
   onContinue: () => void;
+  /** Compact the history in place (runs `/compact`) instead of reloading it whole. */
+  onCompact: () => void;
   onOpenChange: (open: boolean) => void;
 }
 
@@ -19,6 +21,7 @@ export function StaleConversationCostDialog({
   lastActivityAt,
   costUsd,
   onContinue,
+  onCompact,
   onOpenChange,
 }: StaleConversationCostDialogProps) {
   const activity =
@@ -40,8 +43,9 @@ export function StaleConversationCostDialog({
           message re-processes the whole conversation at full input price
           instead of the ~10% cached rate
           {costUsd !== null ? ` (≈$${costUsd.toFixed(2)} spent so far)` : ""}.
-          Starting a new conversation avoids the cost — continue only if you
-          need this thread's context.
+          Compacting summarizes the history so you keep this thread's context at
+          a fraction of the size, or start a new conversation to avoid the cost
+          entirely.
         </AlertDialog.Description>
 
         <Flex justify="end" gap="2" mt="4">
@@ -51,8 +55,13 @@ export function StaleConversationCostDialog({
             </Button>
           </AlertDialog.Cancel>
           <AlertDialog.Action>
-            <Button variant="solid" size="1" onClick={onContinue}>
+            <Button variant="soft" color="gray" size="1" onClick={onContinue}>
               Continue anyway
+            </Button>
+          </AlertDialog.Action>
+          <AlertDialog.Action>
+            <Button variant="solid" size="1" onClick={onCompact}>
+              Compact instead
             </Button>
           </AlertDialog.Action>
         </Flex>


### PR DESCRIPTION
## Problem

When a large, idle conversation's prompt cache has expired, staff get a warning that continuing will re-process the whole thread at full input price (the "≈\$33" notice). The dialog only offered two ways out: **Continue anyway** (pay the full reload) or **Not now** (pause). There was no way to keep the thread's context *without* the expensive reload, so the useful middle option — compacting — was missing.

## Changes

Add a **Compact instead** action to `StaleConversationCostDialog`. It runs the agent's existing manual-compaction command (`/compact`), summarizing the history so the thread's context shrinks to a fraction of its size instead of being reloaded whole or thrown away.

- `StaleConversationCostDialog` gains an `onCompact` prop and a third button; the copy now names compaction as the cheap middle path.
- `SessionView` wires `onCompact` to acknowledge the gate (closing the dialog and unlocking the composer) and send `/compact`, which surfaces the usual "Compacting conversation history…" progress.

Screenshots: n/a (copy + one button in an existing dialog).

## How did you test this?

- `biome check` on both changed files (clean).
- Manual reasoning through the gate flow: `/compact` is the same command the context-error tip already directs users to type, sent through the normal prompt path, so it queues/spawns like any message and drives the existing compaction UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783284133907719?thread_ts=1783284133.907719&cid=C09G8Q32R6F)*