### PR TITLE
fix(ui): stop archived and deleted tasks from showing in global search

### DIFF
--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -42,6 +42,7 @@ import {
 import { useFileSearchContext } from "@posthog/ui/features/command/useFileSearchContext";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
+import { useProvisioningStore } from "@posthog/ui/features/provisioning/store";
 import {
   closeSettings,
   openSettings,
@@ -157,6 +158,9 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
   const { data: tasks = [] } = useTasks();
   const archivedTaskIds = useArchivedTaskIds();
   const { data: workspaces, isFetched: workspacesFetched } = useWorkspaces();
+  const provisioningTaskIds = useProvisioningStore(
+    (state) => state.activeTasks,
+  );
   const [query, setQuery] = useState("");
   const { repoPath } = useFileSearchContext();
   const canSearchFiles = !!repoPath;
@@ -456,9 +460,11 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     const visibleTasks = tasks.filter(
       (task) =>
         !archivedTaskIds.has(task.id) &&
-        (!workspacesFetched || workspaceIds.has(task.id)),
+        (!workspacesFetched ||
+          workspaceIds.has(task.id) ||
+          provisioningTaskIds.has(task.id)),
     );
-    if (!visibleTasks.length) return [];
+    if (visibleTasks.length === 0) return [];
     return [
       {
         label: "Tasks",
@@ -493,6 +499,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     archivedTaskIds,
     workspaces,
     workspacesFetched,
+    provisioningTaskIds,
     taskChannelMap,
     bluebirdEnabled,
     closeSettingsDialog,

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -28,6 +28,7 @@ import {
   type CommandMenuAction,
 } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useTaskChannelMap } from "@posthog/ui/features/canvas/hooks/useTaskChannelMap";
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
@@ -48,6 +49,7 @@ import { TaskIcon } from "@posthog/ui/features/sidebar/components/items/TaskIcon
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
+import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import {
   goBackInHistory,
   goForwardInHistory,
@@ -152,6 +154,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     (state) => state.getReviewMode,
   );
   const { data: tasks = [] } = useTasks();
+  const archivedTaskIds = useArchivedTaskIds();
+  const { data: workspaces } = useWorkspaces();
   const [query, setQuery] = useState("");
   const { repoPath } = useFileSearchContext();
   const canSearchFiles = !!repoPath;
@@ -447,11 +451,14 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
   ]);
 
   const taskSections = useMemo<CommandSection[]>(() => {
-    if (tasks.length === 0) return [];
+    const visibleTasks = tasks.filter(
+      (task) => !archivedTaskIds.has(task.id) && Boolean(workspaces?.[task.id]),
+    );
+    if (!visibleTasks.length) return [];
     return [
       {
         label: "Tasks",
-        items: tasks.map((task) => {
+        items: visibleTasks.map((task) => {
           const channel = taskChannelMap.get(task.id);
           return {
             id: `task-${task.id}`,
@@ -477,7 +484,14 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         }),
       },
     ];
-  }, [tasks, taskChannelMap, bluebirdEnabled, closeSettingsDialog]);
+  }, [
+    tasks,
+    archivedTaskIds,
+    workspaces,
+    taskChannelMap,
+    bluebirdEnabled,
+    closeSettingsDialog,
+  ]);
 
   const channelSections = useMemo<CommandSection[]>(() => {
     if (channels.length === 0) return [];

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -4,6 +4,7 @@ import {
   ChartLine,
   EnvelopeSimple,
 } from "@phosphor-icons/react";
+import { workspaceIdSet } from "@posthog/core/command-center/eligibility";
 import { resolveService } from "@posthog/di/container";
 import {
   HOST_TRPC_CLIENT,
@@ -155,7 +156,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
   );
   const { data: tasks = [] } = useTasks();
   const archivedTaskIds = useArchivedTaskIds();
-  const { data: workspaces } = useWorkspaces();
+  const { data: workspaces, isFetched: workspacesFetched } = useWorkspaces();
   const [query, setQuery] = useState("");
   const { repoPath } = useFileSearchContext();
   const canSearchFiles = !!repoPath;
@@ -451,8 +452,11 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
   ]);
 
   const taskSections = useMemo<CommandSection[]>(() => {
+    const workspaceIds = workspaceIdSet(workspaces);
     const visibleTasks = tasks.filter(
-      (task) => !archivedTaskIds.has(task.id) && Boolean(workspaces?.[task.id]),
+      (task) =>
+        !archivedTaskIds.has(task.id) &&
+        (!workspacesFetched || workspaceIds.has(task.id)),
     );
     if (!visibleTasks.length) return [];
     return [
@@ -488,6 +492,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     tasks,
     archivedTaskIds,
     workspaces,
+    workspacesFetched,
     taskChannelMap,
     bluebirdEnabled,
     closeSettingsDialog,


### PR DESCRIPTION
## Summary

- Filter the command menu (global search) task list to exclude archived tasks and archived-then-deleted tasks.
- Search now mirrors the sidebar and command center: a task appears only when it is not archived and still has a workspace.

Fixes #3161 

## Problem

The command menu built its "Tasks" section directly from `useTasks()` with no visibility filtering:

- It never checked `archivedTaskIds`, so archived tasks appeared in search.
- It never checked workspace presence, so archived-then-deleted tasks appeared too.


## Solution

In `CommandMenu.tsx`, filter tasks to `!archivedTaskIds.has(task.id) && Boolean(workspaces?.[task.id])` before building the search results. Because the workspaces query shares `WORKSPACE_QUERY_KEY` (already invalidated on archived-task delete), deleted tasks drop out of search immediately.

## Video
https://github.com/user-attachments/assets/310ad1e1-a7f5-4043-ab54-01e1be83ada4
## Notes

- This narrows global search to tasks with a local workspace, matching the sidebar and command center. Tasks without a workspace row no longer appear in search.
- Follow-up (separate): make archived-task delete also delete the cloud task record so "delete" is permanent everywhere without per-surface filtering.

