### PR TITLE
fix(agent): Drop empty text blocks from session resume

### DIFF
--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -200,6 +200,20 @@ describe("rebuildConversation", () => {
     expect(turns[1].content[1]).toEqual({ type: "text", text: "answer" });
   });
 
+  it("drops empty text and thinking blocks from assistant content", () => {
+    const turns = rebuildConversation([
+      entry("user_message", { content: { type: "text", text: "hi" } }),
+      entry("agent_thought_chunk", { content: { type: "text", text: "" } }),
+      entry("agent_thought_chunk", {
+        content: { type: "thinking", thinking: "" },
+      }),
+      entry("agent_message_chunk", { content: { type: "text", text: "done" } }),
+    ]);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[1].content).toEqual([{ type: "text", text: "done" }]);
+  });
+
   it("produces alternating user/assistant turns for multi-round conversation", () => {
     const turns = rebuildConversation([
       entry("user_message", { content: { type: "text", text: "q1" } }),
@@ -595,6 +609,65 @@ describe("conversationTurnsToJsonlEntries", () => {
 
     const [parsed] = parseConversationEntries(lines);
     expect(parsed.message.content).toEqual([{ type: "text", text: " " }]);
+  });
+
+  it("drops empty text and thinking blocks from assistant lines", () => {
+    const lines = conversationTurnsToJsonlEntries(
+      [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "" },
+            { type: "thinking", thinking: "" } as unknown as {
+              type: "text";
+              text: string;
+            },
+            { type: "text", text: "answer" },
+          ],
+        },
+      ],
+      config,
+    );
+
+    const conv = parseConversationEntries(lines);
+    expect(conv).toHaveLength(2);
+    expect(conv[1].message.content).toEqual([{ type: "text", text: "answer" }]);
+    expect(conv[1].message.stop_reason).toBe("end_turn");
+  });
+
+  it("emits no assistant lines when all blocks are empty and there are no tool calls", () => {
+    const lines = conversationTurnsToJsonlEntries(
+      [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+        { role: "assistant", content: [{ type: "text", text: "" }] },
+      ],
+      config,
+    );
+
+    const conv = parseConversationEntries(lines);
+    expect(conv).toHaveLength(1);
+    expect(conv[0].type).toBe("user");
+  });
+
+  it("produces no empty content blocks from logs containing empty thought chunks", () => {
+    const turns = rebuildConversation([
+      entry("user_message", { content: { type: "text", text: "fix the bug" } }),
+      entry("agent_thought_chunk", { content: { type: "text", text: "" } }),
+      entry("agent_message_chunk", {
+        content: { type: "text", text: "on it" },
+      }),
+    ]);
+    const lines = conversationTurnsToJsonlEntries(turns, config);
+
+    const conv = parseConversationEntries(lines);
+    expect(conv.length).toBeGreaterThan(0);
+    for (const parsed of conv) {
+      for (const block of parsed.message.content) {
+        if (block.type === "text") expect(block.text).not.toBe("");
+        if (block.type === "thinking") expect(block.thinking).not.toBe("");
+      }
+    }
   });
 
   it("uses custom model and version from config", () => {

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -204,13 +204,13 @@ describe("rebuildConversation", () => {
     expect(turns[1].content[1]).toEqual({ type: "text", text: "answer" });
   });
 
-  it("drops empty text and thinking blocks from assistant content", () => {
+  it.each([
+    { kind: "text", block: { type: "text", text: "" } },
+    { kind: "thinking", block: { type: "thinking", thinking: "" } },
+  ])("drops empty $kind blocks from assistant content", ({ block }) => {
     const turns = rebuildConversation([
       entry("user_message", { content: { type: "text", text: "hi" } }),
-      entry("agent_thought_chunk", { content: { type: "text", text: "" } }),
-      entry("agent_thought_chunk", {
-        content: { type: "thinking", thinking: "" },
-      }),
+      entry("agent_thought_chunk", { content: block }),
       entry("agent_message_chunk", { content: { type: "text", text: "done" } }),
     ]);
 
@@ -615,18 +615,17 @@ describe("conversationTurnsToJsonlEntries", () => {
     expect(parsed.message.content).toEqual([{ type: "text", text: " " }]);
   });
 
-  it("drops empty text and thinking blocks from assistant lines", () => {
+  it.each([
+    { kind: "text", block: { type: "text", text: "" } },
+    { kind: "thinking", block: { type: "thinking", thinking: "" } },
+  ])("drops empty $kind blocks from assistant lines", ({ block }) => {
     const lines = conversationTurnsToJsonlEntries(
       [
         { role: "user", content: [{ type: "text", text: "hi" }] },
         {
           role: "assistant",
           content: [
-            { type: "text", text: "" },
-            { type: "thinking", thinking: "" } as unknown as {
-              type: "text";
-              text: string;
-            },
+            block as unknown as { type: "text"; text: string },
             { type: "text", text: "answer" },
           ],
         },

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -1,9 +1,13 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { StoredEntry } from "../../../types";
 import {
   conversationTurnsToJsonlEntries,
   getSessionJsonlPath,
   rebuildConversation,
+  sanitizeSessionJsonl,
   selectRecentTurns,
 } from "./jsonl-hydration";
 
@@ -1085,5 +1089,99 @@ describe("end-to-end: S3 log entries -> JSONL output", () => {
     const msg1 = conv[1].message as Record<string, unknown>;
     expect(msg1.id).toBe(msg2.id);
     expect(msg2.id).toBe(msg3.id);
+  });
+});
+
+describe("sanitizeSessionJsonl", () => {
+  async function writeJsonl(lines: unknown[]): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "jsonl-sanitize-"));
+    const file = path.join(dir, "sess.jsonl");
+    await fs.writeFile(
+      file,
+      `${lines.map((l) => JSON.stringify(l)).join("\n")}\n`,
+    );
+    return file;
+  }
+
+  async function readJsonl(file: string): Promise<Record<string, unknown>[]> {
+    const raw = await fs.readFile(file, "utf8");
+    return raw
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+  }
+
+  it("removes empty text and thinking blocks from existing files", async () => {
+    const file = await writeJsonl([
+      {
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      },
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: "u1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "" },
+            { type: "text", text: "hello" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await sanitizeSessionJsonl(file)).toBe(true);
+
+    const lines = await readJsonl(file);
+    expect(lines[0].message).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+    });
+    const assistant = lines[1].message as { content: unknown };
+    expect(assistant.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(lines[1].uuid).toBe("a1");
+    expect(lines[1].parentUuid).toBe("u1");
+  });
+
+  it("replaces all-empty content with a single space block", async () => {
+    const file = await writeJsonl([
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: null,
+        message: { role: "assistant", content: [{ type: "text", text: "" }] },
+      },
+    ]);
+
+    expect(await sanitizeSessionJsonl(file)).toBe(true);
+
+    const lines = await readJsonl(file);
+    const assistant = lines[0].message as { content: unknown };
+    expect(assistant.content).toEqual([{ type: "text", text: " " }]);
+  });
+
+  it("leaves clean files unchanged", async () => {
+    const file = await writeJsonl([
+      { type: "queue-operation", operation: "enqueue" },
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: null,
+        message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      },
+    ]);
+    const before = await fs.readFile(file, "utf8");
+
+    expect(await sanitizeSessionJsonl(file)).toBe(false);
+    expect(await fs.readFile(file, "utf8")).toBe(before);
+  });
+
+  it("returns false for missing files", async () => {
+    expect(await sanitizeSessionJsonl("/nonexistent/dir/sess.jsonl")).toBe(
+      false,
+    );
   });
 });

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -1,11 +1,13 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PostHogAPIClient } from "../../../posthog-api";
 import type { StoredEntry } from "../../../types";
 import {
   conversationTurnsToJsonlEntries,
   getSessionJsonlPath,
+  hydrateSessionJsonl,
   rebuildConversation,
   sanitizeSessionJsonl,
   selectRecentTurns,
@@ -216,6 +218,21 @@ describe("rebuildConversation", () => {
 
     expect(turns).toHaveLength(2);
     expect(turns[1].content).toEqual([{ type: "text", text: "done" }]);
+  });
+
+  it("produces no assistant turn when every chunk is empty", () => {
+    const turns = rebuildConversation([
+      entry("user_message", { content: { type: "text", text: "q1" } }),
+      entry("agent_thought_chunk", { content: { type: "text", text: "" } }),
+      entry("user_message", { content: { type: "text", text: "q2" } }),
+    ]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].role).toBe("user");
+    expect(turns[0].content).toEqual([
+      { type: "text", text: "q1" },
+      { type: "text", text: "q2" },
+    ]);
   });
 
   it("produces alternating user/assistant turns for multi-round conversation", () => {
@@ -637,6 +654,32 @@ describe("conversationTurnsToJsonlEntries", () => {
     expect(conv).toHaveLength(2);
     expect(conv[1].message.content).toEqual([{ type: "text", text: "answer" }]);
     expect(conv[1].message.stop_reason).toBe("end_turn");
+  });
+
+  it("emits only tool lines when all content blocks are empty", () => {
+    const lines = conversationTurnsToJsonlEntries(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "" }],
+          toolCalls: [
+            {
+              toolCallId: "tc-1",
+              toolName: "Bash",
+              input: { command: "ls" },
+              result: "out",
+            },
+          ],
+        },
+      ],
+      config,
+    );
+
+    const conv = parseConversationEntries(lines);
+    expect(conv).toHaveLength(2);
+    expect(conv[0].message.content[0].type).toBe("tool_use");
+    expect(conv[0].message.stop_reason).toBe("tool_use");
+    expect(conv[1].message.content[0].type).toBe("tool_result");
   });
 
   it("emits no assistant lines when all blocks are empty and there are no tool calls", () => {
@@ -1092,12 +1135,21 @@ describe("end-to-end: S3 log entries -> JSONL output", () => {
 });
 
 describe("sanitizeSessionJsonl", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "jsonl-sanitize-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
   async function writeJsonl(lines: unknown[]): Promise<string> {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "jsonl-sanitize-"));
     const file = path.join(dir, "sess.jsonl");
     await fs.writeFile(
       file,
-      `${lines.map((l) => JSON.stringify(l)).join("\n")}\n`,
+      `${lines.map((l) => (typeof l === "string" ? l : JSON.stringify(l))).join("\n")}\n`,
     );
     return file;
   }
@@ -1134,6 +1186,9 @@ describe("sanitizeSessionJsonl", () => {
 
     expect(await sanitizeSessionJsonl(file)).toBe(true);
 
+    const raw = await fs.readFile(file, "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+
     const lines = await readJsonl(file);
     expect(lines[0].message).toEqual({
       role: "user",
@@ -1162,6 +1217,90 @@ describe("sanitizeSessionJsonl", () => {
     expect(assistant.content).toEqual([{ type: "text", text: " " }]);
   });
 
+  it("keeps tool_use blocks while stripping empty siblings", async () => {
+    const file = await writeJsonl([
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: null,
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tc-1", name: "Bash", input: {} },
+            { type: "text", text: "" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await sanitizeSessionJsonl(file)).toBe(true);
+
+    const lines = await readJsonl(file);
+    const assistant = lines[0].message as { content: unknown };
+    expect(assistant.content).toEqual([
+      { type: "tool_use", id: "tc-1", name: "Bash", input: {} },
+    ]);
+  });
+
+  it("sanitizes empty blocks in user lines too", async () => {
+    const file = await writeJsonl([
+      {
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "" },
+            { type: "text", text: "prompt" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await sanitizeSessionJsonl(file)).toBe(true);
+
+    const lines = await readJsonl(file);
+    const user = lines[0].message as { content: unknown };
+    expect(user.content).toEqual([{ type: "text", text: "prompt" }]);
+  });
+
+  it("preserves unparseable lines while fixing valid ones", async () => {
+    const corruptLine = '{"type":"assistant","message":';
+    const file = await writeJsonl([
+      corruptLine,
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: null,
+        message: { role: "assistant", content: [{ type: "text", text: "" }] },
+      },
+    ]);
+
+    expect(await sanitizeSessionJsonl(file)).toBe(true);
+
+    const raw = await fs.readFile(file, "utf8");
+    const rawLines = raw.split("\n").filter((l) => l.trim());
+    expect(rawLines[0]).toBe(corruptLine);
+    const assistant = JSON.parse(rawLines[1]).message as { content: unknown };
+    expect(assistant.content).toEqual([{ type: "text", text: " " }]);
+  });
+
+  it("passes through string message content", async () => {
+    const file = await writeJsonl([
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: null,
+        message: { role: "assistant", content: "" },
+      },
+    ]);
+    const before = await fs.readFile(file, "utf8");
+
+    expect(await sanitizeSessionJsonl(file)).toBe(false);
+    expect(await fs.readFile(file, "utf8")).toBe(before);
+  });
+
   it("leaves clean files unchanged", async () => {
     const file = await writeJsonl([
       { type: "queue-operation", operation: "enqueue" },
@@ -1182,5 +1321,108 @@ describe("sanitizeSessionJsonl", () => {
     expect(await sanitizeSessionJsonl("/nonexistent/dir/sess.jsonl")).toBe(
       false,
     );
+  });
+});
+
+describe("hydrateSessionJsonl", () => {
+  let configDir: string;
+  let originalConfigDir: string | undefined;
+  const cwd = "/repo";
+  const sessionId = "sess-hydrate";
+
+  beforeEach(async () => {
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), "jsonl-hydrate-"));
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    await fs
+      .chmod(path.dirname(getSessionJsonlPath(sessionId, cwd)), 0o755)
+      .catch(() => {});
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  async function writeSessionFile(): Promise<string> {
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const file = getSessionJsonlPath(sessionId, cwd);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    const poisoned = {
+      type: "assistant",
+      uuid: "a1",
+      parentUuid: null,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "" },
+          { type: "text", text: "hello" },
+        ],
+      },
+    };
+    await fs.writeFile(file, `${JSON.stringify(poisoned)}\n`);
+    return file;
+  }
+
+  function makeDeps() {
+    return {
+      posthogAPI: { getTaskRun: vi.fn() } as unknown as PostHogAPIClient,
+      log: { info: vi.fn(), warn: vi.fn() },
+    };
+  }
+
+  it("sanitizes an existing file and skips S3 hydration", async () => {
+    const file = await writeSessionFile();
+    const { posthogAPI, log } = makeDeps();
+
+    const result = await hydrateSessionJsonl({
+      sessionId,
+      cwd,
+      taskId: "t1",
+      runId: "r1",
+      posthogAPI,
+      log,
+    });
+
+    expect(result).toBe(true);
+    expect(
+      (posthogAPI as unknown as { getTaskRun: ReturnType<typeof vi.fn> })
+        .getTaskRun,
+    ).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      "Removed empty content blocks from existing session JSONL",
+      expect.anything(),
+    );
+    expect(await fs.readFile(file, "utf8")).not.toContain('"text":""');
+  });
+
+  it("still resumes from the existing file when sanitize cannot write", async () => {
+    const file = await writeSessionFile();
+    const before = await fs.readFile(file, "utf8");
+    await fs.chmod(path.dirname(file), 0o555);
+    const { posthogAPI, log } = makeDeps();
+
+    const result = await hydrateSessionJsonl({
+      sessionId,
+      cwd,
+      taskId: "t1",
+      runId: "r1",
+      posthogAPI,
+      log,
+    });
+
+    expect(result).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(
+      "Failed to sanitize existing session JSONL",
+      expect.anything(),
+    );
+    expect(
+      (posthogAPI as unknown as { getTaskRun: ReturnType<typeof vi.fn> })
+        .getTaskRun,
+    ).not.toHaveBeenCalled();
+
+    await fs.chmod(path.dirname(file), 0o755);
+    expect(await fs.readFile(file, "utf8")).toBe(before);
   });
 });

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -6,6 +6,7 @@ import type { ContentBlock } from "@agentclientprotocol/sdk";
 import { DEFAULT_GATEWAY_MODEL } from "../../../gateway-models";
 import type { PostHogAPIClient } from "../../../posthog-api";
 import type { StoredEntry } from "../../../types";
+import { isEmptyContentBlock } from "../../../utils/acp-content";
 import { supports1MContext } from "./models";
 
 interface ConversationTurn {
@@ -73,15 +74,6 @@ function isEmptyRecord(value: unknown): boolean {
     !Array.isArray(value) &&
     Object.keys(value).length === 0
   );
-}
-
-// The API rejects replayed history containing empty content blocks with a 400
-// ("text content blocks must be non-empty").
-function isEmptyAssistantBlock(block: ContentBlock): boolean {
-  const candidate = block as { type: string; text?: string; thinking?: string };
-  if (candidate.type === "text") return !candidate.text;
-  if (candidate.type === "thinking") return !candidate.thinking;
-  return false;
 }
 
 const MAX_PROJECT_KEY_LENGTH = 200;
@@ -168,7 +160,7 @@ export function rebuildConversation(
           if (
             content &&
             !Array.isArray(content) &&
-            !isEmptyAssistantBlock(content)
+            !isEmptyContentBlock(content)
           ) {
             if (
               content.type === "text" &&
@@ -492,7 +484,7 @@ export function conversationTurnsToJsonlEntries(
         const blockType = (block as { type: string }).type;
         if (
           (blockType === "thinking" || blockType === "text") &&
-          !isEmptyAssistantBlock(block)
+          !isEmptyContentBlock(block)
         ) {
           allBlocks.push(block);
         }
@@ -608,7 +600,9 @@ export async function sanitizeSessionJsonl(
   jsonlPath: string,
 ): Promise<boolean> {
   let raw: string;
+  let statBefore: { mtimeMs: number; size: number };
   try {
+    statBefore = await fs.stat(jsonlPath);
     raw = await fs.readFile(jsonlPath, "utf8");
   } catch {
     return false;
@@ -625,9 +619,7 @@ export async function sanitizeSessionJsonl(
     }
     const message = parsed.message as { content?: unknown } | undefined;
     if (!message || !Array.isArray(message.content)) return line;
-    const kept = message.content.filter(
-      (block) => !isEmptyAssistantBlock(block as ContentBlock),
-    );
+    const kept = message.content.filter((block) => !isEmptyContentBlock(block));
     if (kept.length === message.content.length) return line;
     changed = true;
     message.content = kept.length > 0 ? kept : [{ type: "text", text: " " }];
@@ -637,9 +629,26 @@ export async function sanitizeSessionJsonl(
   if (!changed) return false;
 
   const tmpPath = `${jsonlPath}.tmp.${Date.now()}`;
-  await fs.writeFile(tmpPath, sanitized.join("\n"));
-  await fs.rename(tmpPath, jsonlPath);
-  return true;
+  let renamed = false;
+  try {
+    await fs.writeFile(tmpPath, sanitized.join("\n"));
+    // A concurrent writer may still own the file; abort rather than clobber
+    // lines appended since the read. The next resume retries.
+    const statNow = await fs.stat(jsonlPath);
+    if (
+      statNow.mtimeMs !== statBefore.mtimeMs ||
+      statNow.size !== statBefore.size
+    ) {
+      return false;
+    }
+    await fs.rename(tmpPath, jsonlPath);
+    renamed = true;
+    return true;
+  } finally {
+    if (!renamed) {
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  }
 }
 
 export async function hydrateSessionJsonl(params: {
@@ -666,6 +675,7 @@ export async function hydrateSessionJsonl(params: {
           });
         }
       } catch (err) {
+        // A sanitize failure must not block resuming from the existing file.
         log.warn("Failed to sanitize existing session JSONL", {
           jsonlPath,
           error: err instanceof Error ? err.message : String(err),

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -75,6 +75,15 @@ function isEmptyRecord(value: unknown): boolean {
   );
 }
 
+// The API rejects replayed history containing empty content blocks with a 400
+// ("text content blocks must be non-empty").
+function isEmptyAssistantBlock(block: ContentBlock): boolean {
+  const candidate = block as { type: string; text?: string; thinking?: string };
+  if (candidate.type === "text") return !candidate.text;
+  if (candidate.type === "thinking") return !candidate.thinking;
+  return false;
+}
+
 const MAX_PROJECT_KEY_LENGTH = 200;
 
 function hashString(s: string): string {
@@ -156,7 +165,11 @@ export function rebuildConversation(
         case "agent_message_chunk":
         case "agent_thought_chunk": {
           const content = update.content;
-          if (content && !Array.isArray(content)) {
+          if (
+            content &&
+            !Array.isArray(content) &&
+            !isEmptyAssistantBlock(content)
+          ) {
             if (
               content.type === "text" &&
               currentAssistantContent.length > 0 &&
@@ -477,7 +490,10 @@ export function conversationTurnsToJsonlEntries(
 
       for (const block of turn.content) {
         const blockType = (block as { type: string }).type;
-        if (blockType === "thinking" || blockType === "text") {
+        if (
+          (blockType === "thinking" || blockType === "text") &&
+          !isEmptyAssistantBlock(block)
+        ) {
           allBlocks.push(block);
         }
       }

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -602,6 +602,46 @@ interface HydrationLog {
   warn: (msg: string, data?: unknown) => void;
 }
 
+// Heals JSONL files written before the empty-block filters existed; without
+// this an already-poisoned transcript keeps 400ing on every resume.
+export async function sanitizeSessionJsonl(
+  jsonlPath: string,
+): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(jsonlPath, "utf8");
+  } catch {
+    return false;
+  }
+
+  let changed = false;
+  const sanitized = raw.split("\n").map((line) => {
+    if (!line.trim()) return line;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return line;
+    }
+    const message = parsed.message as { content?: unknown } | undefined;
+    if (!message || !Array.isArray(message.content)) return line;
+    const kept = message.content.filter(
+      (block) => !isEmptyAssistantBlock(block as ContentBlock),
+    );
+    if (kept.length === message.content.length) return line;
+    changed = true;
+    message.content = kept.length > 0 ? kept : [{ type: "text", text: " " }];
+    return JSON.stringify(parsed);
+  });
+
+  if (!changed) return false;
+
+  const tmpPath = `${jsonlPath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, sanitized.join("\n"));
+  await fs.rename(tmpPath, jsonlPath);
+  return true;
+}
+
 export async function hydrateSessionJsonl(params: {
   sessionId: string;
   cwd: string;
@@ -619,6 +659,18 @@ export async function hydrateSessionJsonl(params: {
     const jsonlPath = getSessionJsonlPath(params.sessionId, params.cwd);
     try {
       await fs.access(jsonlPath);
+      try {
+        if (await sanitizeSessionJsonl(jsonlPath)) {
+          log.info("Removed empty content blocks from existing session JSONL", {
+            jsonlPath,
+          });
+        }
+      } catch (err) {
+        log.warn("Failed to sanitize existing session JSONL", {
+          jsonlPath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       return true;
     } catch {
       // File doesn't exist, proceed with hydration

--- a/packages/agent/src/session-log-writer.test.ts
+++ b/packages/agent/src/session-log-writer.test.ts
@@ -160,20 +160,28 @@ describe("SessionLogWriter", () => {
   });
 
   describe("empty agent_thought_chunk filtering", () => {
-    it("does not persist empty thought chunks", async () => {
+    it.each([
+      {
+        kind: "empty text content",
+        extra: { content: { type: "text", text: "" } },
+      },
+      {
+        kind: "empty thinking content",
+        extra: { content: { type: "thinking", thinking: "" } },
+      },
+      { kind: "no content", extra: {} },
+    ])("does not persist thought chunks with $kind", async ({ extra }) => {
       const sessionId = "s1";
       logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
 
       logWriter.appendRawLine(
         sessionId,
-        makeSessionUpdate("agent_thought_chunk", {
-          content: { type: "text", text: "" },
-        }),
+        makeSessionUpdate("agent_thought_chunk", extra),
       );
       logWriter.appendRawLine(
         sessionId,
         makeSessionUpdate("agent_thought_chunk", {
-          content: { type: "text", text: "planning the fix" },
+          content: { type: "thinking", thinking: "planning the fix" },
         }),
       );
 
@@ -184,7 +192,7 @@ describe("SessionLogWriter", () => {
       expect(entries).toHaveLength(1);
       expect(entries[0].notification.params?.update).toEqual({
         sessionUpdate: "agent_thought_chunk",
-        content: { type: "text", text: "planning the fix" },
+        content: { type: "thinking", thinking: "planning the fix" },
       });
     });
 

--- a/packages/agent/src/session-log-writer.test.ts
+++ b/packages/agent/src/session-log-writer.test.ts
@@ -159,6 +159,73 @@ describe("SessionLogWriter", () => {
     });
   });
 
+  describe("empty agent_thought_chunk filtering", () => {
+    it("does not persist empty thought chunks", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_thought_chunk", {
+          content: { type: "text", text: "" },
+        }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_thought_chunk", {
+          content: { type: "text", text: "planning the fix" },
+        }),
+      );
+
+      await logWriter.flush(sessionId);
+
+      expect(mockAppendLog).toHaveBeenCalledTimes(1);
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries).toHaveLength(1);
+      expect(entries[0].notification.params?.update).toEqual({
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "planning the fix" },
+      });
+    });
+
+    it("keeps message chunks coalescing across an interleaved empty thought chunk", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_message_chunk", {
+          content: { type: "text", text: "Hello " },
+        }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_thought_chunk", {
+          content: { type: "text", text: "" },
+        }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("agent_message_chunk", {
+          content: { type: "text", text: "world" },
+        }),
+      );
+      logWriter.appendRawLine(
+        sessionId,
+        makeSessionUpdate("tool_call", { toolCallId: "tc1" }),
+      );
+
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(entries).toHaveLength(2);
+      expect(entries[0].notification.params?.update).toEqual({
+        sessionUpdate: "agent_message",
+        content: { type: "text", text: "Hello world" },
+      });
+    });
+  });
+
   describe("_doFlush does not prematurely coalesce", () => {
     it("does not coalesce buffered chunks during a timed flush", async () => {
       const sessionId = "s1";

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -5,6 +5,7 @@ import { serializeError } from "@posthog/shared";
 import type { SessionContext } from "./otel-log-writer";
 import type { PostHogAPIClient } from "./posthog-api";
 import type { StoredNotification } from "./types";
+import { isEmptyContentBlock } from "./utils/acp-content";
 import { Logger } from "./utils/logger";
 
 export interface SessionLogWriterOptions {
@@ -337,13 +338,18 @@ export class SessionLogWriter {
     }
   }
 
+  private getUpdate(
+    message: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
+    const params = message.params as Record<string, unknown> | undefined;
+    return params?.update as Record<string, unknown> | undefined;
+  }
+
   private getSessionUpdateType(
     message: Record<string, unknown>,
   ): string | undefined {
     if (message.method !== "session/update") return undefined;
-    const params = message.params as Record<string, unknown> | undefined;
-    const update = params?.update as Record<string, unknown> | undefined;
-    return update?.sessionUpdate as string | undefined;
+    return this.getUpdate(message)?.sessionUpdate as string | undefined;
   }
 
   private isDirectAgentMessage(message: Record<string, unknown>): boolean {
@@ -356,8 +362,7 @@ export class SessionLogWriter {
     update: Record<string, unknown>;
   } | null {
     if (this.getSessionUpdateType(message) !== "tool_call_update") return null;
-    const params = message.params as Record<string, unknown> | undefined;
-    const update = params?.update as Record<string, unknown> | undefined;
+    const update = this.getUpdate(message);
     const toolCallId = update?.toolCallId;
     if (!update || typeof toolCallId !== "string") return null;
     const status = update.status;
@@ -449,21 +454,13 @@ export class SessionLogWriter {
     if (this.getSessionUpdateType(message) !== "agent_thought_chunk") {
       return false;
     }
-    const params = message.params as Record<string, unknown> | undefined;
-    const update = params?.update as Record<string, unknown> | undefined;
-    const content = update?.content as
-      | { type?: string; text?: string; thinking?: string }
-      | undefined;
+    const content = this.getUpdate(message)?.content;
     if (!content) return true;
-    if (content.type === "text") return !content.text;
-    if (content.type === "thinking") return !content.thinking;
-    return false;
+    return isEmptyContentBlock(content);
   }
 
   private extractChunkText(message: Record<string, unknown>): string {
-    const params = message.params as Record<string, unknown> | undefined;
-    const update = params?.update as Record<string, unknown> | undefined;
-    const content = update?.content as
+    const content = this.getUpdate(message)?.content as
       | { type: string; text?: string }
       | undefined;
     if (content?.type === "text" && content.text) {
@@ -562,8 +559,7 @@ export class SessionLogWriter {
       return null;
     }
 
-    const params = message.params as Record<string, unknown> | undefined;
-    const update = params?.update as Record<string, unknown> | undefined;
+    const update = this.getUpdate(message);
     if (update?.sessionUpdate !== "agent_message") {
       return null;
     }

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -145,6 +145,12 @@ export class SessionLogWriter {
       const message = JSON.parse(line);
       const timestamp = new Date().toISOString();
 
+      // Persisted empty thought chunks poison session resume: they rebuild
+      // into empty text blocks the API rejects with a 400.
+      if (this.isEmptyThoughtChunk(message)) {
+        return;
+      }
+
       // Check if this is an agent_message_chunk event
       if (this.isAgentMessageChunk(message)) {
         const text = this.extractChunkText(message);
@@ -437,6 +443,21 @@ export class SessionLogWriter {
 
   private isAgentMessageChunk(message: Record<string, unknown>): boolean {
     return this.getSessionUpdateType(message) === "agent_message_chunk";
+  }
+
+  private isEmptyThoughtChunk(message: Record<string, unknown>): boolean {
+    if (this.getSessionUpdateType(message) !== "agent_thought_chunk") {
+      return false;
+    }
+    const params = message.params as Record<string, unknown> | undefined;
+    const update = params?.update as Record<string, unknown> | undefined;
+    const content = update?.content as
+      | { type?: string; text?: string; thinking?: string }
+      | undefined;
+    if (!content) return true;
+    if (content.type === "text") return !content.text;
+    if (content.type === "thinking") return !content.thinking;
+    return false;
   }
 
   private extractChunkText(message: Record<string, unknown>): string {

--- a/packages/agent/src/utils/acp-content.ts
+++ b/packages/agent/src/utils/acp-content.ts
@@ -12,6 +12,18 @@ export function image(
   return { type: "image", data, mimeType, uri };
 }
 
+// The API rejects replayed history containing empty content blocks with a 400
+// ("text content blocks must be non-empty").
+export function isEmptyContentBlock(block: unknown): boolean {
+  const candidate = block as
+    | { type?: string; text?: string; thinking?: string }
+    | null
+    | undefined;
+  if (candidate?.type === "text") return !candidate.text;
+  if (candidate?.type === "thinking") return !candidate.thinking;
+  return false;
+}
+
 export function resourceLink(
   uri: string,
   name: string,


### PR DESCRIPTION
## Problem

Resumed tasks fail every prompt with `API Error: 400 "text content blocks must be non-empty"`. The API streams `content_block_start` with empty text for thinking blocks; the empty `agent_thought_chunk` gets persisted to the session log, and on resume the JSONL rebuild replays it as an assistant message containing `{"type": "text", "text": ""}`, which the API rejects. Every prompt re-sends the poisoned history, so the task stays stuck. Tasks whose JSONL was already rebuilt by a broken build stay stuck even after updating, because hydration is skipped when the file exists.

## Changes

- `rebuildConversation` and `conversationTurnsToJsonlEntries` drop empty text and thinking blocks (shared `isEmptyContentBlock` in `utils/acp-content.ts`), so rebuilt JSONL is never poisoned.
- `sanitizeSessionJsonl` heals an existing JSONL on resume by rewriting it without empty blocks. It aborts if the file changed between read and rename and always cleans up its tmp file.
- `SessionLogWriter.appendRawLine` skips empty thought chunks so they are never persisted (empty message chunks were already filtered).

The emission-side guard in `handleThinkingChunk` lands separately with the v0.54.1 adapter sync.

## How did you test this?

- Unit tests for the rebuild filter, the JSONL filter, the on-disk sanitizer (corrupt lines, string content, read-only failure) and the log writer guard, plus first-time coverage for `hydrateSessionJsonl`.
- Full `@posthog/agent` suite (941 tests), typecheck and biome pass locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?