### PR TITLE
fix(notifications): restore completion sound speed scaling for local tasks

### DIFF
--- a/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -6,9 +6,10 @@ import { SessionService, type SessionServiceDeps } from "./sessionService";
 const TASK_ID = "task-1";
 const RUN_ID = "run-1";
 
-function turnComplete(): StoredLogEntry {
+function turnComplete(timestamp?: string): StoredLogEntry {
   return {
     type: "notification",
+    timestamp,
     notification: {
       method: "_posthog/turn_complete",
       params: { sessionId: RUN_ID, stopReason: "end_turn" },
@@ -19,9 +20,10 @@ function turnComplete(): StoredLogEntry {
 // The `session/prompt` request that opens a turn. Its arrival is what arms the
 // turn's single completion notification, so realistic sequences pair it with a
 // later `turn_complete`.
-function sessionPrompt(id: number): StoredLogEntry {
+function sessionPrompt(id: number, timestamp?: string): StoredLogEntry {
   return {
     type: "notification",
+    timestamp,
     notification: {
       id,
       method: "session/prompt",
@@ -233,15 +235,23 @@ describe("cloud task update notifications", () => {
     },
   );
 
-  it("notifies with the task title and stop reason, and marks activity", () => {
+  it("notifies with the task title, stop reason and turn duration, and marks activity", () => {
     const harness = createHarness();
-    harness.sendUpdate(logsUpdate([sessionPrompt(1), turnComplete()], 2));
+    harness.sendUpdate(
+      logsUpdate(
+        [
+          sessionPrompt(1, "2026-01-01T00:00:00Z"),
+          turnComplete("2026-01-01T00:00:45Z"),
+        ],
+        2,
+      ),
+    );
 
     expect(harness.notifyPromptComplete).toHaveBeenCalledWith(
       "Cloud Task",
       "end_turn",
       TASK_ID,
-      undefined,
+      45_000,
     );
     expect(harness.markActivity).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -37,6 +37,7 @@ function createHarness() {
     [RUN_ID]: {
       taskRunId: RUN_ID,
       taskId: TASK_ID,
+      taskTitle: "Local Task",
       events: [],
       messageQueue: [],
       pendingPermissions: new Map(),
@@ -62,7 +63,7 @@ function createHarness() {
     },
     updateSession: (taskRunId: string, updates: Partial<AgentSession>) => {
       const session = sessions[taskRunId];
-      if (session) Object.assign(session, updates);
+      if (session) sessions[taskRunId] = { ...session, ...updates };
     },
     appendEvents,
     replaceOptimisticWithEvent: vi.fn(),
@@ -80,10 +81,11 @@ function createHarness() {
     debug: vi.fn(),
   };
 
+  const notifyPromptComplete = vi.fn();
   const deps = {
     store,
     log: noopLog,
-    notifyPromptComplete: vi.fn(),
+    notifyPromptComplete,
     notifyPermissionRequest: vi.fn(),
     taskViewedApi: { markActivity: vi.fn() },
     getPersistedConfigOptions: () => undefined,
@@ -120,9 +122,34 @@ function createHarness() {
   return {
     service,
     appendEvents,
+    notifyPromptComplete,
+    updateSession: store.updateSession,
     emit: (event: AcpMessage) => onEvent?.(event),
     events: () => sessions[RUN_ID].events,
   };
+}
+
+function promptEcho(id: number, ts: number): AcpMessage {
+  return {
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      id,
+      method: "session/prompt",
+      params: { sessionId: RUN_ID, prompt: [] },
+    },
+  } as unknown as AcpMessage;
+}
+
+function promptResponse(id: number, ts: number): AcpMessage {
+  return {
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      id,
+      result: { stopReason: "end_turn" },
+    },
+  } as unknown as AcpMessage;
 }
 
 describe("streamed event batching", () => {
@@ -163,5 +190,23 @@ describe("streamed event batching", () => {
     // The flush timer was cleared, so advancing does not re-apply anything.
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events()).toHaveLength(2);
+  });
+
+  it("keeps the turn duration when the prompt mutation clears state before the response flushes", () => {
+    const h = createHarness();
+
+    h.emit(promptEcho(1, 1_000));
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    h.emit(promptResponse(1, 6_000));
+    h.updateSession(RUN_ID, { isPromptPending: false, promptStartedAt: null });
+    vi.advanceTimersByTime(FLUSH_MS);
+
+    expect(h.notifyPromptComplete).toHaveBeenCalledWith(
+      "Local Task",
+      "end_turn",
+      TASK_ID,
+      5_000,
+    );
   });
 });

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1781,6 +1781,9 @@ export class SessionService {
         // above. Cloud sessions never see that response.
         const session = this.getSessionByRunId(taskRunId);
         if (session?.isCloud) {
+          const turnStartedAtTs =
+            this.liveTurnContent.get(taskRunId)?.startedAtTs ??
+            session.promptStartedAt;
           this.d.store.updateSession(taskRunId, {
             isPromptPending: false,
             promptStartedAt: null,
@@ -1793,9 +1796,7 @@ export class SessionService {
                 session.taskTitle,
                 "end_turn",
                 session.taskId,
-                session.promptStartedAt
-                  ? acpMsg.ts - session.promptStartedAt
-                  : undefined,
+                turnStartedAtTs ? acpMsg.ts - turnStartedAtTs : undefined,
               );
             }
             this.d.taskViewedApi.markActivity(session.taskId);
@@ -1886,6 +1887,9 @@ export class SessionService {
     } else {
       this.d.store.appendEvents(taskRunId, [acpMsg]);
     }
+    const turnStartedAtTs =
+      this.liveTurnContent.get(taskRunId)?.startedAtTs ??
+      session.promptStartedAt;
     this.updatePromptStateFromEvents(taskRunId, [acpMsg], { isLive: true });
 
     const msg = acpMsg.message;
@@ -1917,9 +1921,7 @@ export class SessionService {
           session.taskTitle,
           stopReason,
           session.taskId,
-          session.promptStartedAt
-            ? acpMsg.ts - session.promptStartedAt
-            : undefined,
+          turnStartedAtTs ? acpMsg.ts - turnStartedAtTs : undefined,
         );
       }
 


### PR DESCRIPTION
## What

The "Scale sound speed with task length" setting stopped working for local tasks: every completion sound played at 1x regardless of turn duration. This restores the scaling.

## Root cause

For local tasks, two parallel signals report turn completion:

1. The `agent.prompt` tRPC mutation resolves and immediately runs `updateSession({ isPromptPending: false, promptStartedAt: null })`.
2. The streamed JSON-RPC response event (same stopReason, via the agent-server tap) fires `notifyPromptComplete`, computing the duration as `acpMsg.ts - session.promptStartedAt`.

When the feature shipped (#3026), stream events were handled on arrival, so (2) read `promptStartedAt` before (1) cleared it. #3063 then started buffering stream events on a 16ms flush timer — the mutation callback now reliably wins the race, so the response event always saw `promptStartedAt: null`, passed `durationMs: undefined`, and the notification bus fell back to `playbackRate = 1`. The notification itself still fired (the mutation doesn't touch `currentPromptId`, so the notify guard passed), which matched the symptom exactly: sound plays, never scaled.

## How

`handleSessionEvent` now reads the turn start from `liveTurnContent` — the per-turn tally keyed by the prompt echo's timestamp, which the mutation callback never touches — captured before `updatePromptStateFromEvents` finalizes it, with `session.promptStartedAt` as the fallback for a mid-turn reconnect (echo replayed from history, so no tally, but also no in-flight mutation to race).

The cloud `turn_complete` path gets the same capture-before-clear treatment. It previously read `session.promptStartedAt` *after* the `updateSession` that nulls it, working only because the Immer store is copy-on-write — the test harness's in-place-mutating fake store lost the value, which is why the existing cloud test asserted `durationMs === undefined` (documenting broken behavior).

## Testing

- New regression test in `sessionEventBatching.test.ts` reproducing the exact race (prompt echo → mutation clears state → buffered response flushes) — verified failing without the fix, asserts the notification carries `durationMs = 5000`. The harness's fake `updateSession` is now copy-on-write to match the real Immer store's semantics.
- `cloudTaskUpdateNotifications.test.ts` fixtures now carry explicit timestamps and the payload test asserts `45_000` instead of `undefined`.
- Full `@posthog/core` suite green (1926 tests), typecheck clean, biome clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*