### PR TITLE
fix(updates): make changelog cache and loading state version-aware

### DIFF
--- a/packages/host-router/src/routers/github-releases.router.ts
+++ b/packages/host-router/src/routers/github-releases.router.ts
@@ -1,14 +1,18 @@
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
 import type { GitHubReleasesService } from "@posthog/workspace-server/services/github-releases/github-releases";
 import { GITHUB_RELEASES_SERVICE } from "@posthog/workspace-server/services/github-releases/identifiers";
-import { listReleasesOutput } from "@posthog/workspace-server/services/github-releases/schemas";
+import {
+  listReleasesInput,
+  listReleasesOutput,
+} from "@posthog/workspace-server/services/github-releases/schemas";
 
 export const githubReleasesRouter = router({
   list: publicProcedure
+    .input(listReleasesInput)
     .output(listReleasesOutput)
-    .query(({ ctx }) =>
+    .query(({ ctx, input }) =>
       ctx.container
         .get<GitHubReleasesService>(GITHUB_RELEASES_SERVICE)
-        .listReleases(),
+        .listReleases(input?.expectVersion),
     ),
 });

--- a/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -62,12 +62,14 @@ export function UpdateAvailableModal() {
   const downloadMutation = useMutation(
     hostTRPC.updates.download.mutationOptions(),
   );
+  const targetVersion = version ?? availableVersion;
   const { data: releasesData, isPending: isPendingReleases } = useQuery({
-    ...hostTRPC.githubReleases.list.queryOptions(),
+    ...hostTRPC.githubReleases.list.queryOptions(
+      targetVersion ? { expectVersion: targetVersion } : undefined,
+    ),
     enabled: isOpen,
   });
 
-  const targetVersion = version ?? availableVersion;
   const percent = Math.round(downloadPercent ?? 0);
   const sizeLabel = formatSize(downloadSizeBytes);
   const isDownloading = status === "downloading";

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -45,7 +45,11 @@ export function WhatsNewModal() {
   const { data: currentVersion } = useQuery(
     hostTRPC.os.getAppVersion.queryOptions(),
   );
-  const { data, isLoading, isError } = useQuery({
+  const {
+    data,
+    isPending: isLoading,
+    isError,
+  } = useQuery({
     ...hostTRPC.githubReleases.list.queryOptions(
       currentVersion ? { expectVersion: currentVersion } : undefined,
     ),

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -42,19 +42,20 @@ export function WhatsNewModal() {
   const isOpen = useWhatsNewStore((state) => state.isOpen);
   const close = useWhatsNewStore((state) => state.close);
   const hostTRPC = useHostTRPC();
-  const { data: currentVersion } = useQuery(
+  const { data: currentVersion, isError: isVersionError } = useQuery(
     hostTRPC.os.getAppVersion.queryOptions(),
   );
   const {
     data,
-    isPending: isLoading,
-    isError,
+    isPending,
+    isError: isReleasesError,
   } = useQuery({
     ...hostTRPC.githubReleases.list.queryOptions(
       currentVersion ? { expectVersion: currentVersion } : undefined,
     ),
     enabled: isOpen && currentVersion !== undefined,
   });
+  const isError = isVersionError || isReleasesError;
 
   const groups = groupReleases(data?.releases ?? []);
 
@@ -82,7 +83,7 @@ export function WhatsNewModal() {
           </Dialog.Close>
         </Flex>
 
-        {isLoading ? (
+        {isPending ? (
           <ChangelogSkeleton />
         ) : isError ? (
           <Text color="gray" size="2">

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -42,13 +42,15 @@ export function WhatsNewModal() {
   const isOpen = useWhatsNewStore((state) => state.isOpen);
   const close = useWhatsNewStore((state) => state.close);
   const hostTRPC = useHostTRPC();
-  const { data, isLoading, isError } = useQuery({
-    ...hostTRPC.githubReleases.list.queryOptions(),
-    enabled: isOpen,
-  });
   const { data: currentVersion } = useQuery(
     hostTRPC.os.getAppVersion.queryOptions(),
   );
+  const { data, isLoading, isError } = useQuery({
+    ...hostTRPC.githubReleases.list.queryOptions(
+      currentVersion ? { expectVersion: currentVersion } : undefined,
+    ),
+    enabled: isOpen && currentVersion !== undefined,
+  });
 
   const groups = groupReleases(data?.releases ?? []);
 

--- a/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -53,7 +53,7 @@ export function WhatsNewModal() {
     ...hostTRPC.githubReleases.list.queryOptions(
       currentVersion ? { expectVersion: currentVersion } : undefined,
     ),
-    enabled: isOpen && currentVersion !== undefined,
+    enabled: isOpen && !!currentVersion,
   });
   const isError = isVersionError || isReleasesError;
 
@@ -83,12 +83,12 @@ export function WhatsNewModal() {
           </Dialog.Close>
         </Flex>
 
-        {isPending ? (
-          <ChangelogSkeleton />
-        ) : isError ? (
+        {isError ? (
           <Text color="gray" size="2">
             Could not load releases. Please try again later.
           </Text>
+        ) : isPending ? (
+          <ChangelogSkeleton />
         ) : groups.length === 0 ? (
           <Text color="gray" size="2">
             No releases found.

--- a/packages/workspace-server/src/services/github-releases/github-releases.test.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.test.ts
@@ -69,11 +69,75 @@ describe("GitHubReleasesService", () => {
     });
   });
 
-  it("caches results within the TTL", async () => {
+  it.each([
+    { expectVersion: undefined, expectedFetches: 1 },
+    { expectVersion: "1.2.0", expectedFetches: 1 },
+    { expectVersion: "1.3.0", expectedFetches: 2 },
+  ])(
+    "a fresh cache is a hit for expectVersion $expectVersion only when it contains it ($expectedFetches fetches)",
+    async ({ expectVersion, expectedFetches }) => {
+      const service = new GitHubReleasesService();
+      await service.listReleases();
+      await service.listReleases(expectVersion);
+      expect(fetchMock).toHaveBeenCalledTimes(expectedFetches);
+    },
+  );
+
+  it("caches the refetched list once it contains the expected version", async () => {
     const service = new GitHubReleasesService();
     await service.listReleases();
-    await service.listReleases();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          tag_name: "v1.3.0",
+          name: "v1.3.0",
+          body: "new",
+          draft: false,
+          prerelease: false,
+          published_at: "2026-06-30T00:00:00Z",
+          html_url: "https://github.com/PostHog/code/releases/tag/v1.3.0",
+        },
+        ...sampleReleases,
+      ],
+    });
+    const second = await service.listReleases("1.3.0");
+    expect(second.releases[0].version).toBe("1.3.0");
+
+    const third = await service.listReleases("1.3.0");
+    expect(third).toEqual(second);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits out a cooldown before refetching a still-missing version", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
+    const service = new GitHubReleasesService();
+    await service.listReleases("9.9.9");
+    await service.listReleases("9.9.9");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockReturnValue(61_000);
+    await service.listReleases("9.9.9");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+
+  it("serves stale cache when a version-miss refetch fails, without retrying within the cooldown", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
+    const service = new GitHubReleasesService();
+    const first = await service.listReleases();
+
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    const second = await service.listReleases("1.3.0");
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const third = await service.listReleases("1.3.0");
+    expect(third).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
   });
 
   it("throws on non-ok responses", async () => {

--- a/packages/workspace-server/src/services/github-releases/github-releases.test.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.test.ts
@@ -111,6 +111,17 @@ describe("GitHubReleasesService", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("dedupes concurrent cache misses into a single fetch", async () => {
+    const service = new GitHubReleasesService();
+    const [first, second] = await Promise.all([
+      service.listReleases(),
+      service.listReleases("1.3.0"),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("waits out a cooldown before refetching a still-missing version", async () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
     const service = new GitHubReleasesService();

--- a/packages/workspace-server/src/services/github-releases/github-releases.test.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.test.ts
@@ -122,6 +122,22 @@ describe("GitHubReleasesService", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("concurrent callers both reject when the shared fetch fails, and inFlight is cleared so subsequent calls retry", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network error"));
+    const service = new GitHubReleasesService();
+
+    const [result1, result2] = await Promise.allSettled([
+      service.listReleases(),
+      service.listReleases("1.2.0"),
+    ]);
+
+    expect(result1.status).toBe("rejected");
+    expect(result2.status).toBe("rejected");
+    // inFlight must be cleared so the next call retries rather than hanging
+    await service.listReleases();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("waits out a cooldown before refetching a still-missing version", async () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
     const service = new GitHubReleasesService();

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -22,10 +22,11 @@ export class GitHubReleasesService {
     }
 
     // The fetch is version-agnostic, so any concurrent caller can share it.
-    if (this.inFlight === null) {
-      this.inFlight = this.fetchAndCacheReleases(now);
+    let promise = this.inFlight;
+    if (promise === null) {
+      promise = this.fetchAndCacheReleases();
+      this.inFlight = promise;
     }
-    const promise = this.inFlight!;
     try {
       const data = await promise;
       this.updateMissingVersionCooldown(normalizedVersion, now);
@@ -43,9 +44,7 @@ export class GitHubReleasesService {
     }
   }
 
-  private async fetchAndCacheReleases(
-    now: number,
-  ): Promise<ListReleasesOutput> {
+  private async fetchAndCacheReleases(): Promise<ListReleasesOutput> {
     const response = await fetch(RELEASES_URL, {
       headers: { Accept: "application/vnd.github+json" },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -70,7 +69,7 @@ export class GitHubReleasesService {
       }));
 
     const data: ListReleasesOutput = { releases };
-    this.cache = { fetchedAt: now, data };
+    this.cache = { fetchedAt: Date.now(), data };
     return data;
   }
 

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -21,9 +21,13 @@ export class GitHubReleasesService {
       return cached;
     }
 
+    // The fetch is version-agnostic, so any concurrent caller can share it.
+    if (this.inFlight === null) {
+      this.inFlight = this.fetchAndCacheReleases(now);
+    }
+    const promise = this.inFlight!;
     try {
-      this.inFlight ??= this.fetchAndCacheReleases(now);
-      const data = await this.inFlight;
+      const data = await promise;
       this.updateMissingVersionCooldown(normalizedVersion, now);
       return data;
     } catch (error) {
@@ -33,7 +37,9 @@ export class GitHubReleasesService {
       }
       throw error;
     } finally {
-      this.inFlight = null;
+      if (this.inFlight === promise) {
+        this.inFlight = null;
+      }
     }
   }
 

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -4,14 +4,22 @@ import { githubReleasesApiResponse, type ListReleasesOutput } from "./schemas";
 const RELEASES_URL =
   "https://api.github.com/repos/PostHog/code/releases?per_page=30";
 const CACHE_TTL_MS = 10 * 60_000;
+const MISSING_VERSION_RETRY_MS = 60_000;
 const FETCH_TIMEOUT_MS = 10_000;
 
 @injectable()
 export class GitHubReleasesService {
   private cache: { fetchedAt: number; data: ListReleasesOutput } | null = null;
+  private missingVersionRefetchNotBefore = 0;
 
-  async listReleases(): Promise<ListReleasesOutput> {
-    if (this.cache && Date.now() - this.cache.fetchedAt < CACHE_TTL_MS) {
+  async listReleases(expectVersion?: string): Promise<ListReleasesOutput> {
+    if (
+      this.cache &&
+      Date.now() - this.cache.fetchedAt < CACHE_TTL_MS &&
+      (expectVersion === undefined ||
+        this.cacheContains(expectVersion) ||
+        Date.now() < this.missingVersionRefetchNotBefore)
+    ) {
       return this.cache.data;
     }
 
@@ -41,12 +49,31 @@ export class GitHubReleasesService {
 
       const data: ListReleasesOutput = { releases };
       this.cache = { fetchedAt: Date.now(), data };
+      this.updateMissingVersionCooldown(expectVersion);
       return data;
     } catch (error) {
       if (this.cache) {
+        this.updateMissingVersionCooldown(expectVersion);
         return this.cache.data;
       }
       throw error;
+    }
+  }
+
+  private cacheContains(version: string): boolean {
+    return (
+      this.cache?.data.releases.some(
+        (release) => release.version === version,
+      ) ?? false
+    );
+  }
+
+  private updateMissingVersionCooldown(
+    expectVersion: string | undefined,
+  ): void {
+    if (expectVersion !== undefined && !this.cacheContains(expectVersion)) {
+      this.missingVersionRefetchNotBefore =
+        Date.now() + MISSING_VERSION_RETRY_MS;
     }
   }
 }

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -13,10 +13,11 @@ export class GitHubReleasesService {
   private missingVersionRefetchNotBefore = 0;
 
   async listReleases(expectVersion?: string): Promise<ListReleasesOutput> {
+    const now = Date.now();
     const normalizedVersion = expectVersion?.replace(/^v/, "");
-    if (this.canServeFromCache(normalizedVersion)) {
-      // biome-ignore lint/style/noNonNullAssertion: cache is non-null when canServeFromCache returns true
-      return this.cache!.data;
+    const cached = this.cachedData(normalizedVersion, now);
+    if (cached !== null) {
+      return cached;
     }
 
     try {
@@ -44,12 +45,12 @@ export class GitHubReleasesService {
         }));
 
       const data: ListReleasesOutput = { releases };
-      this.cache = { fetchedAt: Date.now(), data };
-      this.updateMissingVersionCooldown(normalizedVersion);
+      this.cache = { fetchedAt: now, data };
+      this.updateMissingVersionCooldown(normalizedVersion, now);
       return data;
     } catch (error) {
       if (this.cache) {
-        this.updateMissingVersionCooldown(normalizedVersion);
+        this.updateMissingVersionCooldown(normalizedVersion, now);
         return this.cache.data;
       }
       throw error;
@@ -59,19 +60,22 @@ export class GitHubReleasesService {
   // The cooldown only ever matters within an already-valid TTL window:
   // once the cache expires the TTL check short-circuits first, so the
   // cooldown naturally resets on the next successful fetch.
-  private canServeFromCache(expectVersion?: string): boolean {
-    if (!this.cache || Date.now() - this.cache.fetchedAt >= CACHE_TTL_MS) {
-      return false;
+  private cachedData(
+    expectVersion: string | undefined,
+    now: number,
+  ): ListReleasesOutput | null {
+    if (!this.cache || now - this.cache.fetchedAt >= CACHE_TTL_MS) {
+      return null;
     }
     // No version requirement: any fresh cache is fine.
-    if (expectVersion === undefined) return true;
+    if (expectVersion === undefined) return this.cache.data;
     // Version present in cache: serve it.
-    if (this.cacheContains(expectVersion)) return true;
+    if (this.cacheContains(expectVersion)) return this.cache.data;
     // Version missing but cooldown active: suppress the refetch.
     // The cooldown is a single scalar (not keyed per version) — safe because
     // cacheContains already short-circuits above when the version is found,
     // so the cooldown is only consulted while the version is absent.
-    return Date.now() < this.missingVersionRefetchNotBefore;
+    return now < this.missingVersionRefetchNotBefore ? this.cache.data : null;
   }
 
   private cacheContains(version: string): boolean {
@@ -84,10 +88,10 @@ export class GitHubReleasesService {
 
   private updateMissingVersionCooldown(
     expectVersion: string | undefined,
+    now: number,
   ): void {
     if (expectVersion !== undefined && !this.cacheContains(expectVersion)) {
-      this.missingVersionRefetchNotBefore =
-        Date.now() + MISSING_VERSION_RETRY_MS;
+      this.missingVersionRefetchNotBefore = now + MISSING_VERSION_RETRY_MS;
     }
   }
 }

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -11,6 +11,7 @@ const FETCH_TIMEOUT_MS = 10_000;
 export class GitHubReleasesService {
   private cache: { fetchedAt: number; data: ListReleasesOutput } | null = null;
   private missingVersionRefetchNotBefore = 0;
+  private inFlight: Promise<ListReleasesOutput> | null = null;
 
   async listReleases(expectVersion?: string): Promise<ListReleasesOutput> {
     const now = Date.now();
@@ -21,31 +22,8 @@ export class GitHubReleasesService {
     }
 
     try {
-      const response = await fetch(RELEASES_URL, {
-        headers: { Accept: "application/vnd.github+json" },
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      });
-      if (!response.ok) {
-        throw new Error(`GitHub releases fetch failed: ${response.status}`);
-      }
-
-      const parsed = githubReleasesApiResponse.parse(await response.json());
-      const releases = parsed
-        .filter((release) => !release.draft)
-        .map((release) => ({
-          version: release.tag_name.replace(/^v/, ""),
-          name:
-            release.name && release.name.length > 0
-              ? release.name
-              : release.tag_name,
-          notes: release.body ?? "",
-          date: release.published_at,
-          isPrerelease: release.prerelease,
-          htmlUrl: release.html_url,
-        }));
-
-      const data: ListReleasesOutput = { releases };
-      this.cache = { fetchedAt: now, data };
+      this.inFlight ??= this.fetchAndCacheReleases(now);
+      const data = await this.inFlight;
       this.updateMissingVersionCooldown(normalizedVersion, now);
       return data;
     } catch (error) {
@@ -54,7 +32,40 @@ export class GitHubReleasesService {
         return this.cache.data;
       }
       throw error;
+    } finally {
+      this.inFlight = null;
     }
+  }
+
+  private async fetchAndCacheReleases(
+    now: number,
+  ): Promise<ListReleasesOutput> {
+    const response = await fetch(RELEASES_URL, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub releases fetch failed: ${response.status}`);
+    }
+
+    const parsed = githubReleasesApiResponse.parse(await response.json());
+    const releases = parsed
+      .filter((release) => !release.draft)
+      .map((release) => ({
+        version: release.tag_name.replace(/^v/, ""),
+        name:
+          release.name && release.name.length > 0
+            ? release.name
+            : release.tag_name,
+        notes: release.body ?? "",
+        date: release.published_at,
+        isPrerelease: release.prerelease,
+        htmlUrl: release.html_url,
+      }));
+
+    const data: ListReleasesOutput = { releases };
+    this.cache = { fetchedAt: now, data };
+    return data;
   }
 
   // The cooldown only ever matters within an already-valid TTL window:

--- a/packages/workspace-server/src/services/github-releases/github-releases.ts
+++ b/packages/workspace-server/src/services/github-releases/github-releases.ts
@@ -13,14 +13,10 @@ export class GitHubReleasesService {
   private missingVersionRefetchNotBefore = 0;
 
   async listReleases(expectVersion?: string): Promise<ListReleasesOutput> {
-    if (
-      this.cache &&
-      Date.now() - this.cache.fetchedAt < CACHE_TTL_MS &&
-      (expectVersion === undefined ||
-        this.cacheContains(expectVersion) ||
-        Date.now() < this.missingVersionRefetchNotBefore)
-    ) {
-      return this.cache.data;
+    const normalizedVersion = expectVersion?.replace(/^v/, "");
+    if (this.canServeFromCache(normalizedVersion)) {
+      // biome-ignore lint/style/noNonNullAssertion: cache is non-null when canServeFromCache returns true
+      return this.cache!.data;
     }
 
     try {
@@ -49,15 +45,33 @@ export class GitHubReleasesService {
 
       const data: ListReleasesOutput = { releases };
       this.cache = { fetchedAt: Date.now(), data };
-      this.updateMissingVersionCooldown(expectVersion);
+      this.updateMissingVersionCooldown(normalizedVersion);
       return data;
     } catch (error) {
       if (this.cache) {
-        this.updateMissingVersionCooldown(expectVersion);
+        this.updateMissingVersionCooldown(normalizedVersion);
         return this.cache.data;
       }
       throw error;
     }
+  }
+
+  // The cooldown only ever matters within an already-valid TTL window:
+  // once the cache expires the TTL check short-circuits first, so the
+  // cooldown naturally resets on the next successful fetch.
+  private canServeFromCache(expectVersion?: string): boolean {
+    if (!this.cache || Date.now() - this.cache.fetchedAt >= CACHE_TTL_MS) {
+      return false;
+    }
+    // No version requirement: any fresh cache is fine.
+    if (expectVersion === undefined) return true;
+    // Version present in cache: serve it.
+    if (this.cacheContains(expectVersion)) return true;
+    // Version missing but cooldown active: suppress the refetch.
+    // The cooldown is a single scalar (not keyed per version) — safe because
+    // cacheContains already short-circuits above when the version is found,
+    // so the cooldown is only consulted while the version is absent.
+    return Date.now() < this.missingVersionRefetchNotBefore;
   }
 
   private cacheContains(version: string): boolean {

--- a/packages/workspace-server/src/services/github-releases/schemas.ts
+++ b/packages/workspace-server/src/services/github-releases/schemas.ts
@@ -21,6 +21,10 @@ export const releaseItem = z.object({
   htmlUrl: z.string(),
 });
 
+export const listReleasesInput = z
+  .object({ expectVersion: z.string().optional() })
+  .optional();
+
 export const listReleasesOutput = z.object({
   releases: z.array(releaseItem),
 });


### PR DESCRIPTION
## Problem

Opening the "What's New" modal (changelog notification -> click the version number) briefly shows the previously cached releases list before the fresh one loads. On a slow network this stale flash is confusing.

Two cache layers were version-blind:

1. **Renderer (TanStack Query)** — `githubReleases.list` had no input, so the query key was static: any prior cache entry rendered instantly while a background refetch swapped content underneath.
2. **Main process** — `GitHubReleasesService` served any cache within its 10-minute TTL, even when it predated the release being viewed. `UpdateAvailableModal` then silently fell back to the wrong ("latest") release's notes.

## Fix

Thread an optional `expectVersion` through `githubReleases.list`:

- The version joins the renderer query key, so a new app version gets a cold cache and the existing skeleton shows instead of stale content. Reopening on the same version stays an instant cache hit.
- The service refetches when its cache lacks the expected version, with a 60s cooldown so an unpublished release (or a local dev build version) doesn't hammer the GitHub API. Failure fallback to stale cache is unchanged.
- `WhatsNewModal` passes the current app version; `UpdateAvailableModal` passes the incoming update's version (also fixing its silent wrong-notes fallback).

## Tests

Parameterized cache-validity matrix plus discrete tests for the resolved-miss, cooldown, and failure-fallback paths in `github-releases.test.ts`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*