### PR TITLE
feat(mobile): warn before continuing a stale, costly conversation (port #3122)

### DIFF
--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -31,12 +31,14 @@ import {
   type ReasoningEffort,
 } from "@/features/tasks/composer/options";
 import { QueuedMessagesDock } from "@/features/tasks/composer/QueuedMessagesDock";
+import { StaleConversationCostNotice } from "@/features/tasks/composer/StaleConversationCostNotice";
 import { TaskChatComposer } from "@/features/tasks/composer/TaskChatComposer";
 import {
   useMessagingMode,
   useQueuedCount,
   useToggleMessagingMode,
 } from "@/features/tasks/hooks/useMessagingMode";
+import { useStaleConversationGate } from "@/features/tasks/hooks/useStaleConversationGate";
 import { taskKeys } from "@/features/tasks/hooks/useTasks";
 import {
   type QueuedMessage,
@@ -48,7 +50,7 @@ import {
 } from "@/features/tasks/stores/pendingTaskPromptStore";
 import { useTaskSessionStore } from "@/features/tasks/stores/taskSessionStore";
 import { useTaskStore } from "@/features/tasks/stores/taskStore";
-import type { Task } from "@/features/tasks/types";
+import type { SessionEvent, Task } from "@/features/tasks/types";
 import { getSessionActivityPhase } from "@/features/tasks/utils/sessionActivity";
 import { useScreenInsets } from "@/hooks/useScreenInsets";
 import {
@@ -60,6 +62,10 @@ import { logger } from "@/lib/logger";
 import { useThemeColors } from "@/lib/theme";
 
 const log = logger.scope("task-detail");
+
+// Stable reference so the stale-gate memos don't recompute while no session
+// has attached yet.
+const EMPTY_EVENTS: SessionEvent[] = [];
 
 function getFirstParam(value?: string | string[]): string | undefined {
   return Array.isArray(value) ? value[0] : value;
@@ -117,6 +123,13 @@ export default function TaskDetailScreen() {
   useActiveTaskAnalyticsContext(task?.signal_report ?? null);
 
   const session = taskId ? getSessionForTask(taskId) : undefined;
+
+  // Warn PostHog staff before continuing a large, idle conversation whose
+  // prompt cache has likely expired (see useStaleConversationGate).
+  const staleGate = useStaleConversationGate(
+    taskId,
+    session?.events ?? EMPTY_EVENTS,
+  );
 
   // Optimistic echo set by the new-task screen (or the terminal-resume path
   // below) so the user's prompt appears in the thread immediately, before
@@ -678,25 +691,36 @@ export default function TaskDetailScreen() {
               onDiscard={handleDiscardQueued}
             />
           ) : null}
-          <TaskChatComposer
-            onSend={handleSendPrompt}
-            restoredDraft={restoredDraft}
-            onStop={handleStop}
-            isUserTurn={!(session?.isPromptPending ?? true)}
-            placeholder={
-              session?.terminalStatus ? "Resume this task..." : "Ask a question"
-            }
-            initialMessage={initialComposerMessage}
-            mode={composerMode}
-            model={composerModel}
-            reasoning={composerReasoning}
-            onModeChange={handleModeChange}
-            onModelChange={handleModelChange}
-            onReasoningChange={handleReasoningChange}
-            messagingMode={messagingMode}
-            queuedCount={queuedCount}
-            onToggleMessagingMode={toggleMessagingMode}
-          />
+          {staleGate.active ? (
+            <StaleConversationCostNotice
+              usedTokens={staleGate.usedTokens}
+              lastActivityAt={staleGate.lastActivityAt}
+              costUsd={staleGate.costUsd}
+              onContinue={staleGate.onContinue}
+            />
+          ) : (
+            <TaskChatComposer
+              onSend={handleSendPrompt}
+              restoredDraft={restoredDraft}
+              onStop={handleStop}
+              isUserTurn={!(session?.isPromptPending ?? true)}
+              placeholder={
+                session?.terminalStatus
+                  ? "Resume this task..."
+                  : "Ask a question"
+              }
+              initialMessage={initialComposerMessage}
+              mode={composerMode}
+              model={composerModel}
+              reasoning={composerReasoning}
+              onModeChange={handleModeChange}
+              onModelChange={handleModelChange}
+              onReasoningChange={handleReasoningChange}
+              messagingMode={messagingMode}
+              queuedCount={queuedCount}
+              onToggleMessagingMode={toggleMessagingMode}
+            />
+          )}
         </Animated.View>
       </Animated.View>
     </View>

--- a/apps/mobile/src/features/tasks/composer/StaleConversationCostNotice.tsx
+++ b/apps/mobile/src/features/tasks/composer/StaleConversationCostNotice.tsx
@@ -1,0 +1,59 @@
+import { Warning } from "phosphor-react-native";
+import { Pressable, Text, View } from "react-native";
+import { formatRelativeTime } from "@/lib/format";
+import { useThemeColors } from "@/lib/theme";
+
+interface StaleConversationCostNoticeProps {
+  usedTokens: number;
+  lastActivityAt: number | null;
+  costUsd: number | null;
+  onContinue: () => void;
+}
+
+function formatTokens(tokens: number): string {
+  return tokens >= 1000 ? `${Math.round(tokens / 1000)}k` : String(tokens);
+}
+
+/**
+ * Blocking composer state shown when PostHog staff return to a large, idle
+ * conversation whose prompt cache has likely expired. Replaces the prompt input
+ * until the user chooses to continue.
+ */
+export function StaleConversationCostNotice({
+  usedTokens,
+  lastActivityAt,
+  costUsd,
+  onContinue,
+}: StaleConversationCostNoticeProps) {
+  const themeColors = useThemeColors();
+  const activity =
+    lastActivityAt !== null
+      ? `was last active ${formatRelativeTime(lastActivityAt)}`
+      : "has been idle";
+  const spent =
+    costUsd !== null ? ` (≈$${costUsd.toFixed(2)} spent so far)` : "";
+
+  return (
+    <View className="mx-3 rounded-2xl border border-accent-6 bg-accent-2 p-4">
+      <View className="mb-2 flex-row items-center gap-2">
+        <Warning size={16} color={themeColors.accent[9]} weight="fill" />
+        <Text className="font-medium text-[15px] text-gray-12">
+          Continue this large, idle conversation?
+        </Text>
+      </View>
+      <Text className="text-[13px] text-gray-11 leading-5">
+        This conversation holds about {formatTokens(usedTokens)} tokens and{" "}
+        {activity}. Its prompt cache has likely expired, so the next message
+        re-processes everything at full input price{spent}.
+      </Text>
+      <Pressable
+        onPress={onContinue}
+        className="mt-3 rounded-lg bg-gray-12 px-4 py-2.5 active:opacity-80"
+      >
+        <Text className="text-center font-medium text-background">
+          Continue anyway
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/tasks/hooks/useStaleConversationGate.test.tsx
+++ b/apps/mobile/src/features/tasks/hooks/useStaleConversationGate.test.tsx
@@ -70,8 +70,12 @@ describe("useStaleConversationGate", () => {
     expect(gate.usedTokens).toBe(150_000);
   });
 
-  it("never engages for non-staff", () => {
-    mockUseUserQuery.mockReturnValue({ data: { is_staff: false } });
+  it.each([
+    { name: "non-staff", data: { is_staff: false } },
+    { name: "is_staff undefined", data: {} },
+    { name: "query still loading", data: null },
+  ])("never engages when the user is $name", ({ data }) => {
+    mockUseUserQuery.mockReturnValue({ data });
     const { gate } = render("t1", [usageEvent(150_000)]);
     expect(gate.active).toBe(false);
     expect(useStaleConversationGateStore.getState().engagedSessions.size).toBe(

--- a/apps/mobile/src/features/tasks/hooks/useStaleConversationGate.test.tsx
+++ b/apps/mobile/src/features/tasks/hooks/useStaleConversationGate.test.tsx
@@ -1,0 +1,98 @@
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseUserQuery = vi.fn();
+vi.mock("@/features/auth", () => ({
+  useUserQuery: () => mockUseUserQuery(),
+}));
+
+import { useStaleConversationGateStore } from "../stores/staleConversationGateStore";
+import type { SessionEvent } from "../types";
+import {
+  type StaleConversationGate,
+  useStaleConversationGate,
+} from "./useStaleConversationGate";
+
+// ts=1 is effectively epoch, so `now - lastActivityAt` is always well past the
+// 60-minute stale bound.
+function usageEvent(used: number, ts = 1): SessionEvent {
+  return {
+    type: "session_update",
+    ts,
+    notification: {
+      update: { sessionUpdate: "usage_update", used, size: 1_000_000 },
+    },
+  };
+}
+
+function freshEvent(ts: number): SessionEvent {
+  return { type: "acp_message", direction: "agent", ts, message: {} };
+}
+
+function render(taskId: string, events: SessionEvent[]) {
+  let gate: StaleConversationGate | undefined;
+  function Harness() {
+    gate = useStaleConversationGate(taskId, events);
+    return null;
+  }
+  let renderer: ReturnType<typeof create> | null = null;
+  act(() => {
+    renderer = create(createElement(Harness));
+  });
+  return {
+    get gate() {
+      if (!gate) throw new Error("gate not captured");
+      return gate;
+    },
+    rerender(next: SessionEvent[]) {
+      events = next;
+      act(() => {
+        renderer?.update(createElement(Harness));
+      });
+    },
+  };
+}
+
+describe("useStaleConversationGate", () => {
+  beforeEach(() => {
+    useStaleConversationGateStore.setState({
+      engagedSessions: new Map(),
+      acknowledgedSessions: new Set(),
+    });
+    mockUseUserQuery.mockReset();
+  });
+
+  it("engages for staff on a large, stale conversation", () => {
+    mockUseUserQuery.mockReturnValue({ data: { is_staff: true } });
+    const { gate } = render("t1", [usageEvent(150_000)]);
+    expect(gate.active).toBe(true);
+    expect(gate.usedTokens).toBe(150_000);
+  });
+
+  it("never engages for non-staff", () => {
+    mockUseUserQuery.mockReturnValue({ data: { is_staff: false } });
+    const { gate } = render("t1", [usageEvent(150_000)]);
+    expect(gate.active).toBe(false);
+    expect(useStaleConversationGateStore.getState().engagedSessions.size).toBe(
+      0,
+    );
+  });
+
+  it("stays engaged when reconnect events make the conversation look fresh", () => {
+    mockUseUserQuery.mockReturnValue({ data: { is_staff: true } });
+    const view = render("t1", [usageEvent(150_000)]);
+    expect(view.gate.active).toBe(true);
+    view.rerender([usageEvent(150_000), freshEvent(Date.now())]);
+    expect(view.gate.active).toBe(true);
+  });
+
+  it("releases the gate once acknowledged", () => {
+    mockUseUserQuery.mockReturnValue({ data: { is_staff: true } });
+    const view = render("t1", [usageEvent(150_000)]);
+    act(() => {
+      view.gate.onContinue();
+    });
+    expect(view.gate.active).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/tasks/hooks/useStaleConversationGate.ts
+++ b/apps/mobile/src/features/tasks/hooks/useStaleConversationGate.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { useUserQuery } from "@/features/auth";
+import { useStaleConversationGateStore } from "../stores/staleConversationGateStore";
+import type { SessionEvent } from "../types";
+import {
+  extractContextUsage,
+  extractLastActivityAt,
+  shouldWarnStaleCostlyConversation,
+} from "../utils/contextUsage";
+
+export interface StaleConversationGate {
+  /** Gate engaged — block the composer until the user chooses. */
+  active: boolean;
+  usedTokens: number;
+  /** Last activity as observed when the gate engaged, not the live value. */
+  lastActivityAt: number | null;
+  costUsd: number | null;
+  /** "Continue anyway" — permanently acknowledge the warning for this task. */
+  onContinue: () => void;
+}
+
+/**
+ * Gates continuation of a large, idle conversation for PostHog staff, whose
+ * prompt cache has likely expired (see {@link shouldWarnStaleCostlyConversation}).
+ *
+ * The gate latches: opening a stale task reconnects the agent, which
+ * immediately emits freshly-stamped events, so the raw staleness check flips
+ * back off before the user sees the warning. Once engaged, only acknowledging
+ * releases it.
+ */
+export function useStaleConversationGate(
+  taskId: string | undefined,
+  events: SessionEvent[],
+): StaleConversationGate {
+  const { data: currentUser } = useUserQuery();
+  const isStaff = currentUser?.is_staff === true;
+
+  const engaged = useStaleConversationGateStore((s) =>
+    taskId ? s.engagedSessions.has(taskId) : false,
+  );
+  const engagedLastActivityAt = useStaleConversationGateStore((s) =>
+    taskId ? s.engagedSessions.get(taskId) : undefined,
+  );
+  const acknowledged = useStaleConversationGateStore((s) =>
+    taskId ? s.acknowledgedSessions.has(taskId) : false,
+  );
+  const engage = useStaleConversationGateStore((s) => s.engage);
+  const acknowledge = useStaleConversationGateStore((s) => s.acknowledge);
+
+  const { usage, lastActivityAt } = useMemo(
+    () => ({
+      usage: extractContextUsage(events),
+      lastActivityAt: extractLastActivityAt(events),
+    }),
+    [events],
+  );
+  const usedTokens = usage?.used ?? 0;
+
+  // `!engaged` short-circuits the staleness re-check once the gate has latched.
+  const shouldEngage =
+    !!taskId &&
+    isStaff &&
+    !acknowledged &&
+    !engaged &&
+    shouldWarnStaleCostlyConversation({
+      usedTokens,
+      lastActivityAt,
+      now: Date.now(),
+    });
+
+  useEffect(() => {
+    if (taskId && shouldEngage) engage(taskId, lastActivityAt);
+  }, [shouldEngage, engage, taskId, lastActivityAt]);
+
+  const onContinue = useCallback(() => {
+    if (taskId) acknowledge(taskId);
+  }, [acknowledge, taskId]);
+
+  return {
+    // shouldEngage covers the first paint before the effect latches; engaged
+    // covers every render after (reconnect events flip shouldEngage back off).
+    active: shouldEngage || engaged,
+    usedTokens,
+    lastActivityAt: engaged ? (engagedLastActivityAt ?? null) : lastActivityAt,
+    costUsd: usage?.cost?.amount ?? null,
+    onContinue,
+  };
+}

--- a/apps/mobile/src/features/tasks/stores/staleConversationGateStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/staleConversationGateStore.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useStaleConversationGateStore } from "./staleConversationGateStore";
+
+const state = () => useStaleConversationGateStore.getState();
+const engaged = (id: string) => state().engagedSessions.has(id);
+const acknowledged = (id: string) => state().acknowledgedSessions.has(id);
+
+describe("staleConversationGateStore", () => {
+  beforeEach(() => {
+    useStaleConversationGateStore.setState({
+      engagedSessions: new Map(),
+      acknowledgedSessions: new Set(),
+    });
+  });
+
+  it("starts with nothing engaged or acknowledged", () => {
+    expect(engaged("t1")).toBe(false);
+    expect(acknowledged("t1")).toBe(false);
+  });
+
+  it("latches the last-activity snapshot from the first engage", () => {
+    state().engage("t1", 1000);
+    state().engage("t1", 2000);
+    expect(state().engagedSessions.get("t1")).toBe(1000);
+  });
+
+  it("acknowledging releases the engagement and stays released", () => {
+    state().engage("t1", 1000);
+    state().acknowledge("t1");
+    expect(engaged("t1")).toBe(false);
+    expect(acknowledged("t1")).toBe(true);
+    // Re-engaging after acknowledgement is a no-op for the app run.
+    state().engage("t1", 2000);
+    expect(engaged("t1")).toBe(false);
+  });
+
+  it("keeps other sessions untouched when one acknowledges", () => {
+    state().engage("t1", 1000);
+    state().engage("t2", 1000);
+    state().acknowledge("t1");
+    expect(engaged("t2")).toBe(true);
+    expect(acknowledged("t2")).toBe(false);
+  });
+
+  it("is idempotent when acknowledging twice", () => {
+    state().acknowledge("t1");
+    const first = state().acknowledgedSessions;
+    state().acknowledge("t1");
+    expect(state().acknowledgedSessions).toBe(first);
+  });
+});

--- a/apps/mobile/src/features/tasks/stores/staleConversationGateStore.ts
+++ b/apps/mobile/src/features/tasks/stores/staleConversationGateStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+
+interface StaleConversationGateState {
+  /**
+   * Tasks where the gate engaged, keyed to the last-activity time observed at
+   * that moment (null when none was observed). Latched: reconnecting to a stale
+   * task immediately appends freshly-stamped events (usage updates, handshakes)
+   * that would otherwise make the conversation look active again and dismiss
+   * the warning before the user has chosen.
+   */
+  engagedSessions: Map<string, number | null>;
+  /** Tasks where the user accepted the "large + idle = costly" warning. */
+  acknowledgedSessions: Set<string>;
+}
+
+interface StaleConversationGateActions {
+  engage: (taskId: string, lastActivityAt: number | null) => void;
+  acknowledge: (taskId: string) => void;
+}
+
+export type StaleConversationGateStore = StaleConversationGateState &
+  StaleConversationGateActions;
+
+/**
+ * Ephemeral (not persisted) view state: both maps only need to last for the
+ * current app run.
+ */
+export const useStaleConversationGateStore =
+  create<StaleConversationGateStore>()((set) => ({
+    engagedSessions: new Map(),
+    acknowledgedSessions: new Set(),
+
+    engage: (taskId, lastActivityAt) =>
+      set((state) => {
+        if (
+          state.engagedSessions.has(taskId) ||
+          state.acknowledgedSessions.has(taskId)
+        ) {
+          return state;
+        }
+        const next = new Map(state.engagedSessions);
+        next.set(taskId, lastActivityAt);
+        return { engagedSessions: next };
+      }),
+
+    acknowledge: (taskId) =>
+      set((state) => {
+        if (state.acknowledgedSessions.has(taskId)) return state;
+        const nextAcknowledged = new Set(state.acknowledgedSessions);
+        nextAcknowledged.add(taskId);
+        if (!state.engagedSessions.has(taskId)) {
+          return { acknowledgedSessions: nextAcknowledged };
+        }
+        const nextEngaged = new Map(state.engagedSessions);
+        nextEngaged.delete(taskId);
+        return {
+          acknowledgedSessions: nextAcknowledged,
+          engagedSessions: nextEngaged,
+        };
+      }),
+  }));

--- a/apps/mobile/src/features/tasks/types.ts
+++ b/apps/mobile/src/features/tasks/types.ts
@@ -96,6 +96,10 @@ export interface SessionNotificationAttachment {
 export interface SessionNotification {
   update?: {
     sessionUpdate?: string;
+    // Present on "usage_update" notifications: running context-window usage.
+    used?: number;
+    size?: number;
+    cost?: { amount: number; currency: string } | null;
     content?: { type: string; text: string };
     // Sidecar carrying user-uploaded attachments on user_message_chunk events.
     // The wire format embeds the bytes themselves in a separate serialized

--- a/apps/mobile/src/features/tasks/utils/contextUsage.test.ts
+++ b/apps/mobile/src/features/tasks/utils/contextUsage.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEvent } from "../types";
+import {
+  DEFAULT_STALE_COSTLY_THRESHOLD,
+  extractContextUsage,
+  extractLastActivityAt,
+  shouldWarnStaleCostlyConversation,
+} from "./contextUsage";
+
+function usageEvent(
+  used: number,
+  ts = 1,
+  cost?: { amount: number; currency: string },
+): SessionEvent {
+  return {
+    type: "session_update",
+    ts,
+    notification: {
+      update: { sessionUpdate: "usage_update", used, size: 200_000, cost },
+    },
+  };
+}
+
+function chunkEvent(ts = 1): SessionEvent {
+  return {
+    type: "session_update",
+    ts,
+    notification: {
+      update: { sessionUpdate: "agent_message_chunk" },
+    },
+  };
+}
+
+function acpEvent(ts: number): SessionEvent {
+  return { type: "acp_message", direction: "agent", ts, message: {} };
+}
+
+describe("extractContextUsage", () => {
+  it("returns null with no usage event", () => {
+    expect(extractContextUsage([])).toBeNull();
+    expect(extractContextUsage([chunkEvent()])).toBeNull();
+  });
+
+  it("derives usage from the latest usage_update", () => {
+    const result = extractContextUsage([
+      usageEvent(20_000),
+      usageEvent(50_000),
+    ]);
+    expect(result).toEqual({ used: 50_000, cost: null });
+  });
+
+  it("extracts cost when present", () => {
+    const result = extractContextUsage([
+      usageEvent(50_000, 1, { amount: 1.23, currency: "USD" }),
+    ]);
+    expect(result?.cost).toEqual({ amount: 1.23, currency: "USD" });
+  });
+
+  it("ignores usage_update events with non-numeric fields", () => {
+    const bad: SessionEvent = {
+      type: "session_update",
+      ts: 1,
+      notification: { update: { sessionUpdate: "usage_update" } },
+    };
+    expect(extractContextUsage([bad])).toBeNull();
+  });
+});
+
+describe("extractLastActivityAt", () => {
+  it("returns null for an empty list", () => {
+    expect(extractLastActivityAt([])).toBeNull();
+  });
+
+  it("returns the maximum ts across event types and order", () => {
+    expect(
+      extractLastActivityAt([usageEvent(1, 30), acpEvent(10), chunkEvent(20)]),
+    ).toBe(30);
+  });
+});
+
+describe("shouldWarnStaleCostlyConversation", () => {
+  const now = 1_000_000_000;
+  const threshold = { tokens: 40_000, staleMs: 5 * 60 * 1000 };
+
+  it.each([
+    {
+      name: "large + stale → warn",
+      used: 50_000,
+      idleMs: 10 * 60_000,
+      out: true,
+    },
+    { name: "large + fresh → no", used: 50_000, idleMs: 60_000, out: false },
+    {
+      name: "small + stale → no",
+      used: 10_000,
+      idleMs: 10 * 60_000,
+      out: false,
+    },
+    {
+      name: "at both thresholds → warn",
+      used: 40_000,
+      idleMs: 5 * 60_000,
+      out: true,
+    },
+    {
+      name: "one ms below stale → no",
+      used: 50_000,
+      idleMs: 5 * 60_000 - 1,
+      out: false,
+    },
+  ])("$name", ({ used, idleMs, out }) => {
+    expect(
+      shouldWarnStaleCostlyConversation({
+        usedTokens: used,
+        lastActivityAt: now - idleMs,
+        now,
+        threshold,
+      }),
+    ).toBe(out);
+  });
+
+  it("never warns without a last-activity timestamp", () => {
+    expect(
+      shouldWarnStaleCostlyConversation({
+        usedTokens: 1_000_000,
+        lastActivityAt: null,
+        now,
+        threshold,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a future timestamp (clock skew) as fresh", () => {
+    expect(
+      shouldWarnStaleCostlyConversation({
+        usedTokens: 50_000,
+        lastActivityAt: now + 60_000,
+        now,
+        threshold,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the default threshold", () => {
+    expect(
+      shouldWarnStaleCostlyConversation({
+        usedTokens: DEFAULT_STALE_COSTLY_THRESHOLD.tokens,
+        lastActivityAt: now - DEFAULT_STALE_COSTLY_THRESHOLD.staleMs,
+        now,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/mobile/src/features/tasks/utils/contextUsage.ts
+++ b/apps/mobile/src/features/tasks/utils/contextUsage.ts
@@ -1,0 +1,74 @@
+import type { SessionEvent } from "../types";
+
+export interface ContextUsage {
+  used: number;
+  cost: { amount: number; currency: string } | null;
+}
+
+/**
+ * Most recent context-usage aggregate reported by the agent, or null when the
+ * session has emitted no `usage_update` yet.
+ */
+export function extractContextUsage(
+  events: SessionEvent[],
+): ContextUsage | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.type !== "session_update") continue;
+    const update = event.notification.update;
+    if (
+      update?.sessionUpdate === "usage_update" &&
+      typeof update.used === "number"
+    ) {
+      return { used: update.used, cost: update.cost ?? null };
+    }
+  }
+  return null;
+}
+
+/**
+ * Most recent (maximum) `ts` among events, or null for an empty list. Scans for
+ * the max rather than trusting order, and loops rather than spreading into
+ * `Math.max` (which overflows the stack on long lists). A heuristic proxy for
+ * prompt-cache freshness, not a billing signal.
+ */
+export function extractLastActivityAt(events: SessionEvent[]): number | null {
+  if (events.length === 0) return null;
+  let latest = events[0].ts;
+  for (let i = 1; i < events.length; i++) {
+    if (events[i].ts > latest) latest = events[i].ts;
+  }
+  return latest;
+}
+
+export interface StaleCostlyThreshold {
+  tokens: number;
+  staleMs: number;
+}
+
+export const DEFAULT_STALE_COSTLY_THRESHOLD: StaleCostlyThreshold = {
+  tokens: 100_000,
+  // 60min is the long bound of Anthropic's prompt-cache TTL: we deliberately
+  // err toward not warning while the cache may still be warm, since nagging
+  // about a continuation that is in fact cheap is the worse failure.
+  staleMs: 60 * 60 * 1000,
+};
+
+/**
+ * True when continuing a conversation is likely costly: it is both large
+ * (>= `threshold.tokens`) and stale (idle >= `threshold.staleMs`). Pure and
+ * time-injected — a null `lastActivityAt` never warns, and a future timestamp
+ * (clock skew) reads as fresh.
+ */
+export function shouldWarnStaleCostlyConversation(args: {
+  usedTokens: number;
+  lastActivityAt: number | null;
+  now: number;
+  threshold?: StaleCostlyThreshold;
+}): boolean {
+  const { usedTokens, lastActivityAt, now } = args;
+  const threshold = args.threshold ?? DEFAULT_STALE_COSTLY_THRESHOLD;
+  if (lastActivityAt === null) return false;
+  if (usedTokens < threshold.tokens) return false;
+  return now - lastActivityAt >= threshold.staleMs;
+}


### PR DESCRIPTION
## What

Ports the desktop cost guardrail to the **mobile app** (`apps/mobile`). Desktop shipped this across #3122 (core), #3152 (blocking prompt-input state), and #3154 (compact rendering).

When a PostHog **staff** user opens a conversation that is both **large** (context usage ≥ 100k tokens) and **stale** (idle ≥ 60 minutes — the Anthropic prompt cache has very likely gone cold), the mobile composer is **blocked** and warns that continuing will be costly (a cold prefix rebuild at full input price). It shows the used-token count, the idle time, and the estimated USD cost when available. The user can **"Continue anyway"** to permanently acknowledge the warning for that task for the app run.

Non-staff users never see the warning.

## How

Follows the repo architecture rules — pure logic in a util, view state in a store, the component only renders:

- **`features/tasks/utils/contextUsage.ts`** — pure, time-injected helpers: `extractContextUsage`, `extractLastActivityAt`, and `shouldWarnStaleCostlyConversation`, with the **same thresholds and null-safe semantics as desktop** (100k tokens, 60min stale, `now` injected — no `Date.now()` inside the predicate). Reimplemented rather than imported, since mobile does not depend on `@posthog/core`. Reads `used`/`cost` from mobile's `usage_update` `SessionEvent`s.
- **`features/tasks/stores/staleConversationGateStore.ts`** — ephemeral (non-persisted) zustand store reproducing the **latch**: reconnecting to a stale task immediately appends freshly-stamped events that would otherwise make the conversation look active again and dismiss the warning before the user chooses. Once engaged, only acknowledging releases it (per-task, for the app run).
- **`features/tasks/hooks/useStaleConversationGate.ts`** — wires context usage + `is_staff` (from the existing me query) + the gate store; returns `{ active, usedTokens, lastActivityAt, costUsd, onContinue }`.
- **`features/tasks/composer/StaleConversationCostNotice.tsx`** — blocking notice that replaces the prompt input on the task screen while the gate is active, using mobile theming.

## Tests

Unit tests (Vitest) cover:
- the pure predicate — large+stale warns, large+fresh no, small+stale no, null last-activity no, future/skewed timestamp reads as fresh, threshold boundaries;
- usage / last-activity extraction from mobile events;
- the latch — engaged stays engaged across appended reconnect events; acknowledge releases and stays released;
- the staff gate — non-staff never engages.

Full mobile suite: **417 passing**. `tsc` clean, Biome clean. Ran `/simplify` over the diff and applied its suggestions.