### PR TITLE
fix(sessions): recover and resend prompts after "session not found"

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -2402,7 +2402,7 @@ export class SessionService {
     session: AgentSession,
     blocks: ContentBlock[],
     promptText: string,
-    options: { optimisticApplied?: boolean } = {},
+    options: { optimisticApplied?: boolean; isRecoveryResend?: boolean } = {},
   ): Promise<{ stopReason: string }> {
     if (!options.optimisticApplied) {
       this.applyOptimisticPrompt(session.taskRunId, blocks, promptText);
@@ -2444,14 +2444,33 @@ export class SessionService {
           errorMessage,
           errorDetails,
         });
-        this.startAutoRecoverLocalSession(
-          session.taskId,
-          session.taskRunId,
-          session.taskTitle,
-          errorDetails || errorMessage,
-          errorDetails ||
-            "Session connection lost. Please retry or start a new session.",
-        );
+        if (!options.isRecoveryResend) {
+          const resent = await this.recoverAndResendPrompt(
+            session,
+            blocks,
+            promptText,
+            errorDetails || errorMessage,
+          );
+          if (resent) {
+            return resent;
+          }
+        }
+        // Recovery failed (or this already was the post-recovery resend):
+        // surface the error state so the user can retry manually.
+        const latest = this.d.store.getSessionByTaskId(session.taskId);
+        if (
+          latest?.taskRunId === session.taskRunId &&
+          latest.status !== "error"
+        ) {
+          this.setErrorSession(
+            session.taskId,
+            session.taskRunId,
+            session.taskTitle,
+            errorDetails ||
+              "Session connection lost. Please retry or start a new session.",
+            "Connection lost",
+          );
+        }
       } else {
         this.d.store.updateSession(session.taskRunId, {
           isPromptPending: false,
@@ -2462,6 +2481,60 @@ export class SessionService {
 
       throw error;
     }
+  }
+
+  /**
+   * A fatal prompt failure (e.g. "Session not found") usually means the
+   * backend agent was idle-killed or the host process restarted while the
+   * renderer still shows the session as connected. Recover the session in
+   * place and resend the prompt once, so a reply to a stale session lands
+   * instead of erroring and losing the user's message.
+   *
+   * Returns the resend result, or null when recovery (or the refreshed
+   * session lookup) failed and the caller should surface the original error.
+   */
+  private async recoverAndResendPrompt(
+    session: AgentSession,
+    blocks: ContentBlock[],
+    promptText: string,
+    reason: string,
+  ): Promise<{ stopReason: string } | null> {
+    let recovered = false;
+    try {
+      recovered = await this.tryAutoRecoverLocalSession(
+        session.taskId,
+        session.taskRunId,
+        reason,
+      );
+    } catch (recoveryError) {
+      this.d.log.warn("Session recovery threw while resending prompt", {
+        taskId: session.taskId,
+        taskRunId: session.taskRunId,
+        error:
+          recoveryError instanceof Error
+            ? recoveryError.message
+            : String(recoveryError),
+      });
+      return null;
+    }
+    if (!recovered) return null;
+
+    const refreshed = this.d.store.getSessionByTaskId(session.taskId);
+    if (
+      !refreshed ||
+      refreshed.taskRunId !== session.taskRunId ||
+      refreshed.status !== "connected"
+    ) {
+      return null;
+    }
+
+    this.d.log.info("Resending prompt after session recovery", {
+      taskId: session.taskId,
+      taskRunId: session.taskRunId,
+    });
+    return this.sendLocalPrompt(refreshed, blocks, promptText, {
+      isRecoveryResend: true,
+    });
   }
 
   /**

--- a/packages/core/src/sessions/sessionServicePromptRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServicePromptRecovery.test.ts
@@ -1,0 +1,137 @@
+import type { AgentSession } from "@posthog/shared";
+import { describe, expect, it, vi } from "vitest";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+const TASK_ID = "task-1";
+const TASK_RUN_ID = `run-${TASK_ID}`;
+
+function makeSession(): AgentSession {
+  return {
+    taskRunId: TASK_RUN_ID,
+    taskId: TASK_ID,
+    taskTitle: "Test task",
+    channel: "",
+    events: [],
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+  } as AgentSession;
+}
+
+function createHarness() {
+  const sessions: Record<string, AgentSession> = {
+    [TASK_RUN_ID]: makeSession(),
+  };
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    setSession: vi.fn((session: AgentSession) => {
+      sessions[session.taskRunId] = session;
+    }),
+    updateSession: vi.fn((taskRunId: string, patch: Partial<AgentSession>) => {
+      const existing = sessions[taskRunId];
+      if (existing) sessions[taskRunId] = { ...existing, ...patch };
+    }),
+    appendOptimisticItem: vi.fn(),
+    clearOptimisticItems: vi.fn(),
+  };
+  const promptMutate = vi.fn();
+  const deps = {
+    store,
+    h: { extractSkillButtonId: () => undefined },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    toast: { error: vi.fn(), info: vi.fn() },
+    track: vi.fn(),
+    getIsOnline: () => true,
+    addDirectoryDialog: { open: false },
+    usageLimit: { show: vi.fn() },
+    trpc: {
+      agent: {
+        prompt: { mutate: promptMutate },
+        cancel: { mutate: vi.fn().mockResolvedValue(undefined) },
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  const recoverSpy = vi.spyOn(
+    service as unknown as {
+      tryAutoRecoverLocalSession: (
+        taskId: string,
+        taskRunId: string,
+        reason: string,
+      ) => Promise<boolean>;
+    },
+    "tryAutoRecoverLocalSession",
+  );
+  return { service, sessions, store, promptMutate, recoverSpy };
+}
+
+describe("SessionService prompt recovery on fatal session errors", () => {
+  it("recovers the session and resends the prompt once", async () => {
+    const { service, promptMutate, recoverSpy } = createHarness();
+    promptMutate
+      .mockRejectedValueOnce(new Error(`Session not found: ${TASK_RUN_ID}`))
+      .mockResolvedValueOnce({ stopReason: "end_turn" });
+    recoverSpy.mockResolvedValue(true);
+
+    const result = await service.sendPrompt(TASK_ID, "hello again");
+
+    expect(result).toEqual({ stopReason: "end_turn" });
+    expect(recoverSpy).toHaveBeenCalledTimes(1);
+    expect(promptMutate).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces the error state when recovery fails", async () => {
+    const { service, store, promptMutate, recoverSpy } = createHarness();
+    promptMutate.mockRejectedValue(
+      new Error(`Session not found: ${TASK_RUN_ID}`),
+    );
+    recoverSpy.mockResolvedValue(false);
+
+    await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
+      "Session not found",
+    );
+    expect(promptMutate).toHaveBeenCalledTimes(1);
+    expect(store.setSession).toHaveBeenCalledWith(
+      expect.objectContaining({ taskRunId: TASK_RUN_ID, status: "error" }),
+    );
+  });
+
+  it("does not loop when the resend hits another fatal error", async () => {
+    const { service, promptMutate, recoverSpy } = createHarness();
+    promptMutate.mockRejectedValue(
+      new Error(`Session not found: ${TASK_RUN_ID}`),
+    );
+    recoverSpy.mockResolvedValue(true);
+
+    await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
+      "Session not found",
+    );
+    expect(recoverSpy).toHaveBeenCalledTimes(1);
+    expect(promptMutate).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows recovery exceptions and rethrows the original error", async () => {
+    const { service, promptMutate, recoverSpy } = createHarness();
+    promptMutate.mockRejectedValue(
+      new Error(`Session not found: ${TASK_RUN_ID}`),
+    );
+    recoverSpy.mockRejectedValue(new Error("auth restoring"));
+
+    await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
+      "Session not found",
+    );
+    expect(promptMutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/sessions/sessionServicePromptRecovery.test.ts
+++ b/packages/core/src/sessions/sessionServicePromptRecovery.test.ts
@@ -77,6 +77,8 @@ function createHarness() {
   return { service, sessions, store, promptMutate, recoverSpy };
 }
 
+type RecoverSpy = ReturnType<typeof createHarness>["recoverSpy"];
+
 describe("SessionService prompt recovery on fatal session errors", () => {
   it("recovers the session and resends the prompt once", async () => {
     const { service, promptMutate, recoverSpy } = createHarness();
@@ -92,46 +94,40 @@ describe("SessionService prompt recovery on fatal session errors", () => {
     expect(promptMutate).toHaveBeenCalledTimes(2);
   });
 
-  it("surfaces the error state when recovery fails", async () => {
-    const { service, store, promptMutate, recoverSpy } = createHarness();
-    promptMutate.mockRejectedValue(
-      new Error(`Session not found: ${TASK_RUN_ID}`),
-    );
-    recoverSpy.mockResolvedValue(false);
+  it.each([
+    {
+      case: "recovery fails",
+      setupRecovery: (spy: RecoverSpy) => spy.mockResolvedValue(false),
+      expectedPromptCalls: 1,
+    },
+    {
+      case: "the resend hits another fatal error",
+      setupRecovery: (spy: RecoverSpy) => spy.mockResolvedValue(true),
+      expectedPromptCalls: 2,
+    },
+    {
+      case: "recovery throws",
+      setupRecovery: (spy: RecoverSpy) =>
+        spy.mockRejectedValue(new Error("auth restoring")),
+      expectedPromptCalls: 1,
+    },
+  ])(
+    "surfaces the error state and rethrows when $case",
+    async ({ setupRecovery, expectedPromptCalls }) => {
+      const { service, store, promptMutate, recoverSpy } = createHarness();
+      promptMutate.mockRejectedValue(
+        new Error(`Session not found: ${TASK_RUN_ID}`),
+      );
+      setupRecovery(recoverSpy);
 
-    await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
-      "Session not found",
-    );
-    expect(promptMutate).toHaveBeenCalledTimes(1);
-    expect(store.setSession).toHaveBeenCalledWith(
-      expect.objectContaining({ taskRunId: TASK_RUN_ID, status: "error" }),
-    );
-  });
-
-  it("does not loop when the resend hits another fatal error", async () => {
-    const { service, promptMutate, recoverSpy } = createHarness();
-    promptMutate.mockRejectedValue(
-      new Error(`Session not found: ${TASK_RUN_ID}`),
-    );
-    recoverSpy.mockResolvedValue(true);
-
-    await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
-      "Session not found",
-    );
-    expect(recoverSpy).toHaveBeenCalledTimes(1);
-    expect(promptMutate).toHaveBeenCalledTimes(2);
-  });
-
-  it("swallows recovery exceptions and rethrows the original error", async () => {
-    const { service, promptMutate, recoverSpy } = createHarness();
-    promptMutate.mockRejectedValue(
-      new Error(`Session not found: ${TASK_RUN_ID}`),
-    );
-    recoverSpy.mockRejectedValue(new Error("auth restoring"));
-
-    await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
-      "Session not found",
-    );
-    expect(promptMutate).toHaveBeenCalledTimes(1);
-  });
+      await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
+        "Session not found",
+      );
+      expect(recoverSpy).toHaveBeenCalledTimes(1);
+      expect(promptMutate).toHaveBeenCalledTimes(expectedPromptCalls);
+      expect(store.setSession).toHaveBeenCalledWith(
+        expect.objectContaining({ taskRunId: TASK_RUN_ID, status: "error" }),
+      );
+    },
+  );
 });

--- a/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
@@ -1,4 +1,8 @@
 import {
+  isContentEmpty,
+  xmlToContent,
+} from "@posthog/core/message-editor/content";
+import {
   combineQueuedCloudPrompts,
   promptToQueuedEditorContent,
 } from "@posthog/core/sessions/cloudPrompt";
@@ -106,6 +110,13 @@ export function useSessionCallbacks({
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Failed to send message";
+        // The composer clears optimistically on submit, so a failed send
+        // would otherwise lose the typed prompt. Restore it — unless the
+        // user has already started typing a new message.
+        if (isContentEmpty(useDraftStore.getState().drafts[taskId] ?? null)) {
+          setPendingContent(taskId, xmlToContent(text));
+          requestFocus(taskId);
+        }
         toast.error(message);
         log.error("Failed to send prompt", error);
       }
@@ -119,6 +130,8 @@ export function useSessionCallbacks({
       sessionService,
       hostClient,
       messagingMode,
+      setPendingContent,
+      requestFocus,
     ],
   );
 


### PR DESCRIPTION
## Problem

Replying to a local (or worktree) task that has been idle for a while sometimes fails with "Session not found" — and the typed prompt is lost, forcing the user to re-type it.

Local agent sessions are idle-killed by the workspace server after 15 minutes. The renderer normally gets notified and reconnects, but when it misses that event (laptop sleep, dropped subscription, host restart) the UI still shows the session as connected. The reply then hits the dead session, the server throws `Session not found`, and the error path only showed a toast — while the composer had already cleared the prompt optimistically on submit.

## Changes

- **`@posthog/core` `SessionService.sendLocalPrompt`**: on a fatal prompt failure (e.g. "session not found"), await the existing in-place auto-recovery and resend the prompt once on the recovered session, so replies to stale sessions land instead of erroring. An `isRecoveryResend` guard prevents retry loops; if recovery fails, the session is put into the error state with the Retry UI as before.
- **`@posthog/ui` `useSessionCallbacks.handleSendPrompt`**: if a send still fails for any reason, restore the typed prompt into the composer (`xmlToContent` + `setPendingContent`, the same mechanism the cancel flow uses) and refocus it — skipped if the user has already started typing a new message.

## How did you test this?

- New unit tests in `packages/core/src/sessions/sessionServicePromptRecovery.test.ts`: recover-and-resend succeeds, recovery failure surfaces the error state, no retry loop when the resend also hits a fatal error, and recovery exceptions don't mask the original error.
- Ran the full core sessions suite (29 files, 264 tests) and UI sessions/message-editor suites (32 files, 353 tests) — all passing.
- `pnpm --filter @posthog/core typecheck`, `pnpm --filter @posthog/ui typecheck`, and `biome lint packages/core` (zero `noRestrictedImports`) — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

🤖 Generated with [Claude Code](https://claude.com/claude-code)