### PR TITLE
fix(tasks): survive workspace-server respawns during task creation

### DIFF
--- a/apps/code/src/main/index.ts
+++ b/apps/code/src/main/index.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import os from "node:os";
 import { TypedEventEmitter } from "@posthog/shared";
 import type { WorkspaceClient } from "@posthog/workspace-client/client";
-import { createWorkspaceClient } from "@posthog/workspace-client/client";
+import { createReconnectingWorkspaceClient } from "@posthog/workspace-client/client";
 import type { FileWatcherEvent } from "@posthog/workspace-client/types";
 import { app, BrowserWindow, dialog, session } from "electron";
 import log from "electron-log/main";
@@ -80,7 +80,11 @@ import {
   focusSessionStore,
   focusWorktreePaths,
 } from "./services/focus/desktop-adapters";
-import type { WorkspaceServerService } from "./services/workspace-server/service";
+import {
+  WorkspaceServerEvent,
+  type WorkspaceServerService,
+  WorkspaceServerStatus,
+} from "./services/workspace-server/service";
 import {
   collectMemorySnapshot,
   flattenMemorySnapshot,
@@ -127,6 +131,19 @@ export class FileWatcherBridge extends TypedEventEmitter<FileWatcherEventsByKind
     if (!sub) return;
     sub.unsubscribe();
     this.subs.delete(repoPath);
+  }
+
+  /**
+   * Tear down and re-create every active watch. The workspace-server child
+   * respawns on a new port after a crash; the old SSE subscriptions keep
+   * retrying the dead port forever, so the boot wiring calls this when the
+   * server reports ready again.
+   */
+  resubscribeAll(): void {
+    for (const repoPath of [...this.subs.keys()]) {
+      this.stopWatching(repoPath);
+      this.startWatching(repoPath);
+    }
   }
 }
 
@@ -350,13 +367,25 @@ app.whenReady().then(async () => {
   const wsServer = container.get<WorkspaceServerService>(
     WORKSPACE_SERVER_SERVICE,
   );
-  const connection = await wsServer.start();
-  const workspaceClient = createWorkspaceClient(connection);
+  await wsServer.start();
+  // The workspace-server child respawns on a new port/secret after a crash;
+  // a reconnecting client follows the current connection so main-process
+  // callers don't keep hitting the dead port for the rest of the session.
+  const workspaceClient = createReconnectingWorkspaceClient(() =>
+    wsServer.getConnection(),
+  );
   container.bind(WORKSPACE_CLIENT).toConstantValue(workspaceClient);
   container.bind(GIT_WORKSPACE_CLIENT).toConstantValue(workspaceClient);
   container.bind(CONNECTIVITY_CLIENT).toConstantValue(workspaceClient);
   container.bind(ENVIRONMENT_CLIENT).toConstantValue(workspaceClient);
   const fileWatcherBridge = new FileWatcherBridge(workspaceClient);
+  // Re-establish live watches after a workspace-server respawn — the old SSE
+  // subscriptions keep retrying the dead port and never recover on their own.
+  wsServer.on(WorkspaceServerEvent.StatusChanged, ({ status }) => {
+    if (status === WorkspaceServerStatus.Ready) {
+      fileWatcherBridge.resubscribeAll();
+    }
+  });
   container.bind(FILE_WATCHER_SERVICE).toConstantValue(fileWatcherBridge);
   container.bind(FILE_WATCHER_CONTROL).toConstantValue(fileWatcherBridge);
   container.bind(FOCUS_WORKSPACE_CLIENT).toConstantValue(workspaceClient);

--- a/apps/code/src/main/services/auth/port-adapters.ts
+++ b/apps/code/src/main/services/auth/port-adapters.ts
@@ -26,8 +26,14 @@ import {
   AUTH_PREFERENCE_REPOSITORY,
   AUTH_SESSION_REPOSITORY,
   WORKSPACE_CLIENT,
+  WORKSPACE_SERVER_SERVICE,
 } from "../../di/tokens";
 import { decrypt, encrypt } from "../../utils/encryption";
+import {
+  WorkspaceServerEvent,
+  type WorkspaceServerService,
+  WorkspaceServerStatus,
+} from "../workspace-server/service";
 
 @injectable()
 export class TokenCipherPortAdapter implements IAuthTokenCipher {
@@ -149,12 +155,26 @@ export class AuthPreferencePortAdapter implements IAuthPreferenceStore {
 export class ConnectivityPortAdapter implements IAuthConnectivity {
   private isOnline = true;
   private readonly handlers = new Set<(status: ConnectivityStatus) => void>();
+  private sub: { unsubscribe: () => void } | null = null;
 
   constructor(
     @inject(WORKSPACE_CLIENT)
     private readonly workspace: WorkspaceClient,
+    @inject(WORKSPACE_SERVER_SERVICE)
+    workspaceServer: WorkspaceServerService,
   ) {
-    this.workspace.connectivity.onStatusChange.subscribe(undefined, {
+    this.subscribe();
+    // The workspace-server child respawns on a new port after a crash; the
+    // old SSE subscription keeps retrying the dead port forever, so re-
+    // establish it against the current connection once the server is healthy.
+    workspaceServer.on(WorkspaceServerEvent.StatusChanged, ({ status }) => {
+      if (status === WorkspaceServerStatus.Ready) this.subscribe();
+    });
+  }
+
+  private subscribe(): void {
+    this.sub?.unsubscribe();
+    this.sub = this.workspace.connectivity.onStatusChange.subscribe(undefined, {
       onData: (status) => {
         this.isOnline = status.isOnline;
         for (const handler of this.handlers) {

--- a/apps/code/src/main/services/auth/port-adapters.ts
+++ b/apps/code/src/main/services/auth/port-adapters.ts
@@ -156,20 +156,37 @@ export class ConnectivityPortAdapter implements IAuthConnectivity {
   private isOnline = true;
   private readonly handlers = new Set<(status: ConnectivityStatus) => void>();
   private sub: { unsubscribe: () => void } | null = null;
+  private readonly onServerStatusChanged = ({
+    status,
+  }: {
+    status: WorkspaceServerStatus;
+  }): void => {
+    if (status === WorkspaceServerStatus.Ready) this.subscribe();
+  };
 
   constructor(
     @inject(WORKSPACE_CLIENT)
     private readonly workspace: WorkspaceClient,
     @inject(WORKSPACE_SERVER_SERVICE)
-    workspaceServer: WorkspaceServerService,
+    private readonly workspaceServer: WorkspaceServerService,
   ) {
     this.subscribe();
     // The workspace-server child respawns on a new port after a crash; the
     // old SSE subscription keeps retrying the dead port forever, so re-
     // establish it against the current connection once the server is healthy.
-    workspaceServer.on(WorkspaceServerEvent.StatusChanged, ({ status }) => {
-      if (status === WorkspaceServerStatus.Ready) this.subscribe();
-    });
+    this.workspaceServer.on(
+      WorkspaceServerEvent.StatusChanged,
+      this.onServerStatusChanged,
+    );
+  }
+
+  dispose(): void {
+    this.workspaceServer.off(
+      WorkspaceServerEvent.StatusChanged,
+      this.onServerStatusChanged,
+    );
+    this.sub?.unsubscribe();
+    this.sub = null;
   }
 
   private subscribe(): void {

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -776,6 +776,25 @@ describe("TaskCreationSaga", () => {
     );
   });
 
+  it("creates the task without a repository when repo detection fails", async () => {
+    const createTaskMock = vi.fn().mockResolvedValue(createTask());
+    mockHost.addFolder.mockResolvedValue({ id: "folder-1", path: "/repo" });
+    mockHost.detectRepo.mockRejectedValue(new TypeError("fetch failed"));
+
+    const saga = makeSaga({ createTask: createTaskMock });
+
+    const result = await saga.run({
+      content: "Ship the fix",
+      repoPath: "/repo",
+      workspaceMode: "worktree",
+    });
+
+    expect(result.success).toBe(true);
+    expect(createTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: undefined }),
+    );
+  });
+
   it("rolls back the import snapshot and tracking row when a later step fails", async () => {
     const createdTask = createTask();
     const createTaskMock = vi.fn().mockResolvedValue(createdTask);

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -600,8 +600,18 @@ export class TaskCreationSaga extends Saga<
 
     const repoPathForDetection = input.repoPath;
     if (!repository && repoPathForDetection) {
+      // Detection only fills the org/repo metadata on the task; a transient
+      // failure (e.g. the workspace-server transport dropping mid-call) must
+      // not abort task creation, so degrade to an untagged task instead.
       const detected = await this.readOnlyStep("repo_detection", () =>
-        this.deps.host.detectRepo({ directoryPath: repoPathForDetection }),
+        this.deps.host
+          .detectRepo({ directoryPath: repoPathForDetection })
+          .catch((error) => {
+            this.log.warn("Repo detection failed; creating task without one", {
+              error,
+            });
+            return null;
+          }),
       );
       if (detected) {
         repository = `${detected.organization}/${detected.repository}`;

--- a/packages/workspace-client/package.json
+++ b/packages/workspace-client/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "node ../../scripts/rimraf.mjs .turbo"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "@trpc/tanstack-react-query": "catalog:",
     "@types/react": "catalog:",
     "react": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/workspace-client/src/client.test.ts
+++ b/packages/workspace-client/src/client.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createReconnectingWorkspaceClient,
+  type WorkspaceClient,
+  type WorkspaceConnection,
+} from "./client";
+
+const connA: WorkspaceConnection = {
+  url: "http://127.0.0.1:1111",
+  secret: "secret-a",
+};
+const connB: WorkspaceConnection = {
+  url: "http://127.0.0.1:2222",
+  secret: "secret-b",
+};
+
+function makeFakeClient(name: string): WorkspaceClient {
+  return { name } as unknown as WorkspaceClient;
+}
+
+describe("createReconnectingWorkspaceClient", () => {
+  it("builds one client per connection and reuses it across accesses", () => {
+    const buildClient = vi.fn(() => makeFakeClient("a"));
+    const client = createReconnectingWorkspaceClient(() => connA, buildClient);
+
+    expect(Reflect.get(client, "name")).toBe("a");
+    expect(Reflect.get(client, "name")).toBe("a");
+    expect(buildClient).toHaveBeenCalledTimes(1);
+    expect(buildClient).toHaveBeenCalledWith(connA);
+  });
+
+  it("rebuilds the client when the connection changes (server respawn)", () => {
+    let current = connA;
+    const buildClient = vi
+      .fn()
+      .mockReturnValueOnce(makeFakeClient("a"))
+      .mockReturnValueOnce(makeFakeClient("b"));
+    const client = createReconnectingWorkspaceClient(
+      () => current,
+      buildClient,
+    );
+
+    expect(Reflect.get(client, "name")).toBe("a");
+    current = connB;
+    expect(Reflect.get(client, "name")).toBe("b");
+    expect(buildClient).toHaveBeenCalledTimes(2);
+    expect(buildClient).toHaveBeenLastCalledWith(connB);
+  });
+
+  it("keeps using the last known client while the server is down", () => {
+    let current: WorkspaceConnection | null = connA;
+    const buildClient = vi.fn(() => makeFakeClient("a"));
+    const client = createReconnectingWorkspaceClient(
+      () => current,
+      buildClient,
+    );
+
+    expect(Reflect.get(client, "name")).toBe("a");
+    current = null;
+    expect(Reflect.get(client, "name")).toBe("a");
+    expect(buildClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when accessed before any connection is established", () => {
+    const buildClient = vi.fn();
+    const client = createReconnectingWorkspaceClient(() => null, buildClient);
+
+    expect(() => Reflect.get(client, "name")).toThrow(
+      "workspace-server connection is not established yet",
+    );
+    expect(buildClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workspace-client/src/client.ts
+++ b/packages/workspace-client/src/client.ts
@@ -16,6 +16,47 @@ export interface WorkspaceConnection {
 
 export type WorkspaceClient = ReturnType<typeof createWorkspaceClient>;
 
+/**
+ * A workspace client that follows the host's current connection. The
+ * workspace-server child can crash and be respawned on a new port with a new
+ * secret; a client built once at boot would keep calling the dead port
+ * ("fetch failed") for the rest of the app session. This proxy re-reads the
+ * connection at the start of every call chain and rebuilds the underlying
+ * client whenever it changes. While the server is down (`getConnection`
+ * returns null) the last known client is used, so calls fail fast against the
+ * old port instead of hanging.
+ */
+export function createReconnectingWorkspaceClient(
+  getConnection: () => WorkspaceConnection | null,
+  buildClient: (
+    connection: WorkspaceConnection,
+  ) => WorkspaceClient = createWorkspaceClient,
+): WorkspaceClient {
+  let built: {
+    connection: WorkspaceConnection;
+    client: WorkspaceClient;
+  } | null = null;
+
+  const resolve = (): WorkspaceClient => {
+    const connection = getConnection() ?? built?.connection;
+    if (!connection) {
+      throw new Error("workspace-server connection is not established yet");
+    }
+    if (
+      !built ||
+      built.connection.url !== connection.url ||
+      built.connection.secret !== connection.secret
+    ) {
+      built = { connection, client: buildClient(connection) };
+    }
+    return built.client;
+  };
+
+  return new Proxy({} as WorkspaceClient, {
+    get: (_target, prop) => Reflect.get(resolve() as object, prop),
+  });
+}
+
 export function createWorkspaceClient(connection: WorkspaceConnection) {
   const url = `${connection.url.replace(/\/$/, "")}/trpc`;
   const headers = { [SECRET_HEADER]: connection.secret };

--- a/packages/workspace-client/src/client.ts
+++ b/packages/workspace-client/src/client.ts
@@ -54,6 +54,8 @@ export function createReconnectingWorkspaceClient(
 
   return new Proxy({} as WorkspaceClient, {
     get: (_target, prop) => Reflect.get(resolve() as object, prop),
+    has: (_target, prop) => Reflect.has(resolve() as object, prop),
+    getPrototypeOf: () => Reflect.getPrototypeOf(resolve() as object),
   });
 }
 

--- a/packages/workspace-client/vitest.config.ts
+++ b/packages/workspace-client/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    ...trunkTestOptions,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1419,6 +1419,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/workspace-server:
     dependencies:


### PR DESCRIPTION
## Problem

Starting a worktree task would sometimes fail with a "Failed to detect repository: fetch failed" toast, even though repo detection is only optional metadata.

Root cause: the workspace-server child respawns on a **new random port and secret** after a crash (and `serve.ts` has no `uncaughtException`/`unhandledRejection` handlers, so any stray rejection kills it). The renderer rebuilds its client on reconnect, but the Electron main process built its tRPC client **once at boot** and bound it as a DI constant. After any respawn, every main-process call — repo detection during task creation, file watching, connectivity — kept hitting the dead port with `fetch failed` until the app was relaunched.

## Changes

- **`packages/core`** — repo detection in `TaskCreationSaga` is now best-effort: it only fills the `org/repo` metadata tag on the task, so a transport failure logs a warning and creates the task untagged instead of aborting the saga and toasting.
- **`packages/workspace-client`** — new `createReconnectingWorkspaceClient(getConnection)`: a proxy that re-reads the current connection at the start of every call chain and rebuilds the underlying client when the port/secret changes. While the server is down it falls back to the last known client so calls fail fast instead of hanging.
- **`apps/code` main** — all main-process workspace-client bindings now use the reconnecting client. The two long-lived SSE subscriptions (`FileWatcherBridge`, `ConnectivityPortAdapter`) resubscribe when `WorkspaceServerService` reports ready again, since the old streams retry the dead port forever.

## How did you test this?

- New unit test: `TaskCreationSaga` creates the task without a repository when `detectRepo` rejects with `fetch failed` (21 saga tests pass).
- New `@posthog/workspace-client` test suite (vitest added to the package) covering the reconnecting client: build-once caching, rebuild on connection change, fallback while the server is down, error before first connection.
- Empirically reproduced the exact failure: a workspace client pointed at a dead localhost port throws `TRPCClientError: fetch failed`, matching the toast verbatim.
- All 273 `apps/code` unit tests pass; `@posthog/core`, `@posthog/workspace-client`, and `apps/code` typecheck clean; Biome clean; `check-host-boundaries.mjs` reports no new violations.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?