### PR TITLE
fix(cloud-task): deliver first-message skill bundles through prewarmed runs

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1549,6 +1549,12 @@ export class AgentServer {
         ? this.getInitialPromptOverride(taskRun)
         : null;
       const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
+      // A prewarmed run gets its first message forwarded as a user_message
+      // signal on activation; building one from task.description here too
+      // would deliver it twice (and without the forwarded artifacts).
+      const prewarmed = !!(
+        taskRun?.state as Record<string, unknown> | undefined
+      )?.prewarmed;
       let initialPrompt: ContentBlock[] = [];
       let initialPromptMeta: Record<string, unknown> | undefined;
       if (pendingUserPrompt?.prompt.length) {
@@ -1556,12 +1562,16 @@ export class AgentServer {
         initialPromptMeta = pendingUserPrompt.meta;
       } else if (initialPromptOverride) {
         initialPrompt = [{ type: "text", text: initialPromptOverride }];
-      } else if (task.description) {
+      } else if (task.description && !prewarmed) {
         initialPrompt = [{ type: "text", text: task.description }];
       }
 
       if (initialPrompt.length === 0) {
-        this.logger.debug("Task has no description, skipping initial message");
+        this.logger.debug(
+          prewarmed
+            ? "Prewarmed run awaits its forwarded first message, skipping initial message"
+            : "Task has no description, skipping initial message",
+        );
         return;
       }
 

--- a/packages/agent/src/server/question-relay.test.ts
+++ b/packages/agent/src/server/question-relay.test.ts
@@ -629,6 +629,38 @@ describe("Question relay", () => {
       });
     });
 
+    it("does not build a description prompt for a prewarmed run awaiting its forwarded message", async () => {
+      vi.spyOn(server.posthogAPI, "getTask").mockResolvedValue({
+        id: "test-task-id",
+        title: "t",
+        description: "/millie readme this skill",
+      } as unknown as Task);
+      vi.spyOn(server.posthogAPI, "getTaskRun").mockResolvedValue({
+        id: "test-run-id",
+        task: "test-task-id",
+        state: { prewarmed: true },
+      } as unknown as TaskRun);
+
+      const promptSpy = vi.fn().mockResolvedValue({ stopReason: "end_turn" });
+      server.session = {
+        payload: TEST_PAYLOAD,
+        acpSessionId: "acp-session",
+        clientConnection: { prompt: promptSpy },
+        logWriter: {
+          flushAll: vi.fn().mockResolvedValue(undefined),
+          getFullAgentResponse: vi.fn().mockReturnValue(null),
+          resetTurnMessages: vi.fn(),
+          appendRawLine: vi.fn(),
+          flush: vi.fn().mockResolvedValue(undefined),
+          isRegistered: vi.fn().mockReturnValue(true),
+        },
+      };
+
+      await server.sendInitialTaskMessage(TEST_PAYLOAD);
+
+      expect(promptSpy).not.toHaveBeenCalled();
+    });
+
     it("does not replay a transient upstream termination before any session activity", async () => {
       vi.spyOn(server.posthogAPI, "getTask").mockResolvedValue({
         id: "test-task-id",

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2218,6 +2218,8 @@ export class PostHogAPIClient {
         model?: string | null;
         reasoning_effort?: string | null;
         channel?: string | null;
+        pending_user_message?: string;
+        pending_user_artifact_ids?: string[];
       },
   ) {
     const teamId = await this.getTeamId();

--- a/packages/core/src/task-detail/taskCreationHost.ts
+++ b/packages/core/src/task-detail/taskCreationHost.ts
@@ -112,6 +112,20 @@ export interface ITaskCreationHost {
    * too, or a typed `/my-skill` reaches the sandbox with no bundle attached.
    */
   resolveLocalSkillCommandPrompt(prompt: string): Promise<string>;
+  /**
+   * Return-and-clear the pre-warmed sandbox lease matching the composer
+   * selection, if one was provisioned while the user typed. The saga uploads
+   * first-message attachments (skill bundles, files) to this run before
+   * createTask so the backend's warm activation can forward them; null means
+   * no warm run is known client-side.
+   */
+  takeWarmTaskLease(args: {
+    repository: string;
+    branch?: string | null;
+    runtimeAdapter?: string | null;
+    model?: string | null;
+    reasoningEffort?: string | null;
+  }): { taskId: string; runId: string } | null;
   uploadRunAttachments(
     client: TaskCreationApiClient,
     taskId: string,

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -21,6 +21,9 @@ const mockHost = vi.hoisted(() => ({
   detectRepo: vi.fn(),
   getCloudPromptTransport: vi.fn(),
   resolveLocalSkillCommandPrompt: vi.fn(async (prompt: string) => prompt),
+  takeWarmTaskLease: vi.fn(
+    (): { taskId: string; runId: string } | null => null,
+  ),
   uploadRunAttachments: vi.fn(),
   setProvisioningActive: vi.fn(),
   clearProvisioning: vi.fn(),
@@ -515,6 +518,167 @@ describe("TaskCreationSaga", () => {
       );
     },
   );
+
+  it("uploads skill bundles to the warm run and passes pending fields through createTask", async () => {
+    const skillTag =
+      '<skill name="my-skill" source="user" path="/skills/my-skill" /> do it';
+    mockHost.resolveLocalSkillCommandPrompt.mockResolvedValue(skillTag);
+    mockHost.getCloudPromptTransport.mockReturnValue({
+      filePaths: [],
+      skillBundles: [
+        { name: "my-skill", source: "user", path: "/skills/my-skill" },
+      ],
+      messageText: "/my-skill do it",
+      promptText: "/my-skill do it",
+    });
+    mockHost.takeWarmTaskLease.mockReturnValue({
+      taskId: "warm-task",
+      runId: "warm-run",
+    });
+    mockHost.uploadRunAttachments.mockResolvedValue(["skill-artifact-1"]);
+
+    const warmActivatedTask = createTask({
+      id: "warm-task",
+      latest_run: createRun({ id: "warm-run", task: "warm-task" }),
+    });
+    const createTaskMock = vi.fn().mockResolvedValue(warmActivatedTask);
+    const createTaskRunMock = vi.fn();
+    const startTaskRunMock = vi.fn();
+    const saga = makeSaga({
+      createTask: createTaskMock,
+      createTaskRun: createTaskRunMock,
+      startTaskRun: startTaskRunMock,
+    });
+
+    const result = await saga.run({
+      content: "/my-skill do it",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockHost.takeWarmTaskLease).toHaveBeenCalledWith({
+      repository: "posthog/posthog",
+      branch: "main",
+      runtimeAdapter: null,
+      model: null,
+      reasoningEffort: null,
+    });
+    // The bundle must land on the warm run before createTask triggers activation.
+    expect(mockHost.uploadRunAttachments).toHaveBeenCalledWith(
+      expect.anything(),
+      "warm-task",
+      "warm-run",
+      [],
+      [{ name: "my-skill", source: "user", path: "/skills/my-skill" }],
+    );
+    expect(createTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        branch: "main",
+        pending_user_message: "/my-skill do it",
+        pending_user_artifact_ids: ["skill-artifact-1"],
+      }),
+    );
+    // Warm-activated at create time: no fresh run is created or started.
+    expect(createTaskRunMock).not.toHaveBeenCalled();
+    expect(startTaskRunMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses warm reuse when attachments exist but no warm lease is known", async () => {
+    const skillTag =
+      '<skill name="my-skill" source="user" path="/skills/my-skill" /> do it';
+    mockHost.resolveLocalSkillCommandPrompt.mockResolvedValue(skillTag);
+    mockHost.getCloudPromptTransport.mockReturnValue({
+      filePaths: [],
+      skillBundles: [
+        { name: "my-skill", source: "user", path: "/skills/my-skill" },
+      ],
+      messageText: "/my-skill do it",
+      promptText: "/my-skill do it",
+    });
+    mockHost.takeWarmTaskLease.mockReturnValue(null);
+    mockHost.uploadRunAttachments.mockResolvedValue(["skill-artifact-1"]);
+
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+    const saga = makeSaga({
+      createTask: createTaskMock,
+      createTaskRun: createTaskRunMock,
+      startTaskRun: startTaskRunMock,
+    });
+
+    const result = await saga.run({
+      content: "/my-skill do it",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    expect(result.success).toBe(true);
+    // No lease to upload to: omit the warm-reuse branch hint so the backend
+    // cannot activate a warm run this client can't attach the bundle to.
+    expect(createTaskMock.mock.calls[0][0].branch).toBeUndefined();
+    // Cold path proceeds and delivers the bundle through the run start.
+    expect(startTaskRunMock).toHaveBeenCalledWith("task-123", "run-123", {
+      pendingUserMessage: "/my-skill do it",
+      pendingUserArtifactIds: ["skill-artifact-1"],
+    });
+  });
+
+  it("falls back to cold creation when the warm-run upload fails", async () => {
+    const skillTag =
+      '<skill name="my-skill" source="user" path="/skills/my-skill" /> do it';
+    mockHost.resolveLocalSkillCommandPrompt.mockResolvedValue(skillTag);
+    mockHost.getCloudPromptTransport.mockReturnValue({
+      filePaths: [],
+      skillBundles: [
+        { name: "my-skill", source: "user", path: "/skills/my-skill" },
+      ],
+      messageText: "/my-skill do it",
+      promptText: "/my-skill do it",
+    });
+    mockHost.takeWarmTaskLease.mockReturnValue({
+      taskId: "warm-task",
+      runId: "warm-run",
+    });
+    mockHost.uploadRunAttachments
+      .mockRejectedValueOnce(new Error("warm upload failed"))
+      .mockResolvedValueOnce(["skill-artifact-1"]);
+
+    const createdTask = createTask();
+    const startedTask = createTask({ latest_run: createRun() });
+    const createTaskMock = vi.fn().mockResolvedValue(createdTask);
+    const createTaskRunMock = vi.fn().mockResolvedValue(createRun());
+    const startTaskRunMock = vi.fn().mockResolvedValue(startedTask);
+    const saga = makeSaga({
+      createTask: createTaskMock,
+      createTaskRun: createTaskRunMock,
+      startTaskRun: startTaskRunMock,
+    });
+
+    const result = await saga.run({
+      content: "/my-skill do it",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      branch: "main",
+    });
+
+    // The failed pre-upload must not fail creation or activate warm without
+    // the bundle: warm reuse is suppressed and the cold path re-uploads.
+    expect(result.success).toBe(true);
+    expect(createTaskMock.mock.calls[0][0].branch).toBeUndefined();
+    expect(
+      createTaskMock.mock.calls[0][0].pending_user_artifact_ids,
+    ).toBeUndefined();
+    expect(startTaskRunMock).toHaveBeenCalledWith("task-123", "run-123", {
+      pendingUserMessage: "/my-skill do it",
+      pendingUserArtifactIds: ["skill-artifact-1"],
+    });
+  });
 
   it("uses the selected user GitHub integration for cloud task creation", async () => {
     const createdTask = createTask({

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -20,6 +20,7 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import type { TaskCreationApiClient } from "./taskCreationApiClient";
 import type {
+  CloudPromptTransport,
   ImportedClaudeCliSession,
   ITaskCreationHost,
 } from "./taskCreationHost";
@@ -30,6 +31,41 @@ export interface TaskCreationDeps {
   sessionService: SessionService;
   onTaskReady?: (output: TaskCreationOutput) => void;
   track: (event: string, props?: Record<string, unknown>) => void;
+}
+
+interface WarmActivationPayload {
+  transport: CloudPromptTransport;
+  pendingUserMessage?: string;
+  pendingUserArtifactIds?: string[];
+  suppressWarmReuse: boolean;
+  augmented: boolean;
+}
+
+// The local connect path appends channel CONTEXT.md to initialPrompt and gets
+// the user's personalization via the workspace-server system prompt; cloud
+// sends its first message as text and has no client-side system-prompt seam,
+// so fold both blocks into the first message here. Order: user's message, then
+// personalization (user-level), then channel context (workspace-level).
+// Personalization is folded only when there is message text to augment.
+function buildCloudFirstMessage(
+  messageText: string | undefined,
+  input: TaskCreationInput,
+): { pendingUserMessage?: string; augmented: boolean } {
+  const customInstructionsText = messageText
+    ? buildCustomInstructionsText(input.customInstructions)
+    : null;
+  const channelContextText = buildChannelContextText(
+    input.channelContext,
+    input.channelName,
+  );
+  const pendingUserMessage =
+    [messageText, customInstructionsText, channelContextText]
+      .filter((part): part is string => !!part)
+      .join("\n\n") || undefined;
+  return {
+    pendingUserMessage,
+    augmented: !!(customInstructionsText || channelContextText),
+  };
 }
 
 export class TaskCreationSaga extends Saga<
@@ -56,11 +92,16 @@ export class TaskCreationSaga extends Saga<
 
     const importedClaude = await this.importClaudeSession(input);
 
+    const warmPayload =
+      !taskId && input.workspaceMode === "cloud"
+        ? await this.prepareWarmActivation(input)
+        : null;
+
     let task = taskId
       ? await this.readOnlyStep("fetch_task", () =>
           this.deps.posthogClient.getTask(taskId),
         )
-      : await this.createTask(input);
+      : await this.createTask(input, warmPayload);
 
     // Session reconcile auto-recovers run-less local tasks; mark this one as
     // mid-creation so the recovery doesn't race the agent_session step below.
@@ -243,6 +284,23 @@ export class TaskCreationSaga extends Saga<
 
     const shouldStartCloudRun = workspaceMode === "cloud" && !task.latest_run;
 
+    // Warm-activated at create time: the backend already forwarded the first
+    // message (with any uploaded artifacts) to the pre-warmed run.
+    if (!taskId && warmPayload && task.latest_run) {
+      if (warmPayload.augmented && warmPayload.pendingUserMessage) {
+        this.deps.sessionService.rememberInitialCloudPrompt(
+          task.id,
+          warmPayload.pendingUserMessage,
+        );
+      }
+      this.deps.track(ANALYTICS_EVENTS.PROMPT_SENT, {
+        task_id: task.id,
+        is_initial: true,
+        execution_type: "cloud",
+        prompt_length_chars: warmPayload.transport.messageText?.length ?? 0,
+      });
+    }
+
     // Channels "generic chat box": a repo-less local/worktree task still starts
     // an agent, in a per-task scratch dir. Provision it before signalling the
     // task is ready so the task view resolves the scratch dir as its cwd (a
@@ -292,54 +350,39 @@ export class TaskCreationSaga extends Saga<
           // bundle is collected and uploaded with the very first cloud message.
           // Without this a first-message `/my-skill` reaches the sandbox with no
           // bundle and is rejected as an unknown command (only a follow-up,
-          // which already resolves, would work).
-          const resolvedContent = input.content
-            ? await this.deps.host.resolveLocalSkillCommandPrompt(input.content)
-            : input.content;
+          // which already resolves, would work). prepareWarmActivation already
+          // did this for fresh cloud creations; reuse its transport.
+          const buildTransport =
+            async (): Promise<CloudPromptTransport | null> => {
+              if (
+                !(input.content || input.filePaths?.length) ||
+                workspaceMode !== "cloud"
+              ) {
+                return null;
+              }
+              const resolvedContent = input.content
+                ? await this.deps.host.resolveLocalSkillCommandPrompt(
+                    input.content,
+                  )
+                : "";
+              return this.deps.host.getCloudPromptTransport(
+                resolvedContent,
+                input.filePaths,
+              );
+            };
+          const transport = warmPayload
+            ? warmPayload.transport
+            : await buildTransport();
 
-          const transport =
-            (input.content || input.filePaths?.length) &&
-            workspaceMode === "cloud"
-              ? this.deps.host.getCloudPromptTransport(
-                  resolvedContent ?? "",
-                  input.filePaths,
-                )
-              : null;
-
-          // The local connect path appends channel CONTEXT.md to initialPrompt
-          // and gets the user's personalization via the workspace-server system
-          // prompt; cloud sends its first message as text and has no client-side
-          // system-prompt seam, so fold both blocks into pendingUserMessage here.
-          // The conversation UI parses them identically. Order: user's message,
-          // then personalization (user-level), then channel context (workspace-
-          // level background).
-          const messageText = transport?.messageText;
-          // Personalization augments the user's first message — fold it in only
-          // when there is message text to augment. A file-only upload with no
-          // typed text has nothing to personalize, and a block-only message
-          // would strip to an empty bubble in the UI and get deduped against the
-          // sandbox echo, leaving a blank placeholder. Channel context renders as
-          // a chip even alone, so it isn't gated this way.
-          const customInstructionsText = messageText
-            ? buildCustomInstructionsText(input.customInstructions)
-            : null;
-          const channelContextText = buildChannelContextText(
-            input.channelContext,
-            input.channelName,
-          );
-          const pendingUserMessage =
-            [messageText, customInstructionsText, channelContextText]
-              .filter((part): part is string => !!part)
-              .join("\n\n") || undefined;
+          const { pendingUserMessage, augmented } = warmPayload
+            ? warmPayload
+            : buildCloudFirstMessage(transport?.messageText, input);
 
           // The sandbox echoes pendingUserMessage back once it boots; until then
           // the optimistic placeholder would show the bare task description with
           // no CONTEXT.md / personalization chip. Hand the augmented message to
           // the session service so it seeds the placeholder right away.
-          if (
-            (channelContextText || customInstructionsText) &&
-            pendingUserMessage
-          ) {
+          if (augmented && pendingUserMessage) {
             this.deps.sessionService.rememberInitialCloudPrompt(
               task.id,
               pendingUserMessage,
@@ -595,7 +638,82 @@ export class TaskCreationSaga extends Saga<
       });
   }
 
-  private async createTask(input: TaskCreationInput): Promise<Task> {
+  // Resolve the first message and pre-upload its attachments (skill bundles,
+  // files) to the pre-warmed run before createTask, so the backend's warm
+  // activation can forward them with the message. When attachments exist but
+  // no warm lease is known, warm reuse is suppressed (branch omitted) and the
+  // cold path uploads to the real run instead — a warm activation must never
+  // deliver the first message without its attachments.
+  private async prepareWarmActivation(
+    input: TaskCreationInput,
+  ): Promise<WarmActivationPayload | null> {
+    if (!input.content && !input.filePaths?.length) {
+      return null;
+    }
+
+    const resolvedContent = input.content
+      ? await this.deps.host.resolveLocalSkillCommandPrompt(input.content)
+      : "";
+    const transport = this.deps.host.getCloudPromptTransport(
+      resolvedContent,
+      input.filePaths,
+    );
+    const { pendingUserMessage, augmented } = buildCloudFirstMessage(
+      transport.messageText,
+      input,
+    );
+    const base: WarmActivationPayload = {
+      transport,
+      pendingUserMessage,
+      suppressWarmReuse: false,
+      augmented,
+    };
+
+    const lease = input.repository
+      ? this.deps.host.takeWarmTaskLease({
+          repository: input.repository,
+          branch: input.branch ?? null,
+          runtimeAdapter: input.adapter ?? null,
+          model: input.model ?? null,
+          reasoningEffort: input.reasoningLevel ?? null,
+        })
+      : null;
+
+    const needsAttachments =
+      transport.filePaths.length > 0 || transport.skillBundles.length > 0;
+    if (!needsAttachments) {
+      return base;
+    }
+    if (!lease) {
+      return { ...base, suppressWarmReuse: true };
+    }
+
+    try {
+      const artifactIds = await this.deps.host.uploadRunAttachments(
+        this.deps.posthogClient,
+        lease.taskId,
+        lease.runId,
+        transport.filePaths,
+        transport.skillBundles,
+      );
+      return {
+        ...base,
+        pendingUserArtifactIds:
+          artifactIds.length > 0 ? artifactIds : undefined,
+      };
+    } catch (error) {
+      this.log.warn(
+        "Failed to upload attachments to warm run; falling back to cold creation",
+        { taskId: lease.taskId, runId: lease.runId, error },
+      );
+      return { ...base, suppressWarmReuse: true };
+    }
+  }
+
+  private async createTask(
+    input: TaskCreationInput,
+    warmPayload: WarmActivationPayload | null,
+  ): Promise<Task> {
     let repository = input.repository;
 
     const repoPathForDetection = input.repoPath;
@@ -631,7 +749,7 @@ export class TaskCreationSaga extends Saga<
           // The server associates the task with the report and records the implementation
           // task_run artefact — no relationship label is sent (associations are unlabelled).
           branch:
-            input.workspaceMode === "cloud"
+            input.workspaceMode === "cloud" && !warmPayload?.suppressWarmReuse
               ? (input.branch ?? null)
               : undefined,
           runtime_adapter:
@@ -646,6 +764,8 @@ export class TaskCreationSaga extends Saga<
               : undefined,
           signal_report: input.signalReportId ?? undefined,
           channel: input.channelId ?? undefined,
+          pending_user_message: warmPayload?.pendingUserMessage,
+          pending_user_artifact_ids: warmPayload?.pendingUserArtifactIds,
         });
         return result as unknown as Task;
       },

--- a/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
+++ b/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
@@ -6,6 +6,7 @@ import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authCl
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useEffect, useRef } from "react";
 import { logger } from "../../../shell/logger";
+import { buildWarmTaskLeaseKey, rememberWarmTaskLease } from "./warmTaskLease";
 
 const log = logger.scope("warm-task");
 
@@ -52,7 +53,13 @@ export function useWarmTask({
     !editorIsEmpty;
   const key =
     selectedRepository && githubIntegrationId !== undefined
-      ? `${githubIntegrationId}:${selectedRepository}:${normalizedBranch ?? ""}:${normalizedRuntimeAdapter ?? ""}:${normalizedModel ?? ""}:${normalizedReasoningEffort ?? ""}`
+      ? `${githubIntegrationId}:${buildWarmTaskLeaseKey({
+          repository: selectedRepository,
+          branch: normalizedBranch,
+          runtimeAdapter: normalizedRuntimeAdapter,
+          model: normalizedModel,
+          reasoningEffort: normalizedReasoningEffort,
+        })}`
       : null;
 
   useEffect(() => {
@@ -88,6 +95,20 @@ export function useWarmTask({
           runtime_adapter: warmRuntimeAdapter,
           model: warmModel,
           reasoning_effort: warmReasoningEffort,
+        })
+        .then((warm) => {
+          if (warm) {
+            rememberWarmTaskLease(
+              buildWarmTaskLeaseKey({
+                repository,
+                branch: warmBranch,
+                runtimeAdapter: warmRuntimeAdapter,
+                model: warmModel,
+                reasoningEffort: warmReasoningEffort,
+              }),
+              { taskId: warm.task_id, runId: warm.run_id },
+            );
+          }
         })
         .catch((error) => {
           lastWarmedKeyRef.current = null;

--- a/packages/ui/src/features/task-detail/hooks/warmTaskLease.ts
+++ b/packages/ui/src/features/task-detail/hooks/warmTaskLease.ts
@@ -1,0 +1,39 @@
+export interface WarmTaskLease {
+  taskId: string;
+  runId: string;
+}
+
+export interface WarmTaskLeaseKeyParts {
+  repository: string;
+  branch?: string | null;
+  runtimeAdapter?: string | null;
+  model?: string | null;
+  reasoningEffort?: string | null;
+}
+
+export function buildWarmTaskLeaseKey(parts: WarmTaskLeaseKeyParts): string {
+  return [
+    parts.repository,
+    parts.branch ?? "",
+    parts.runtimeAdapter ?? "",
+    parts.model ?? "",
+    parts.reasoningEffort ?? "",
+  ].join(":");
+}
+
+let currentLease: { key: string; lease: WarmTaskLease } | null = null;
+
+export function rememberWarmTaskLease(key: string, lease: WarmTaskLease): void {
+  currentLease = { key, lease };
+}
+
+export function takeWarmTaskLease(
+  parts: WarmTaskLeaseKeyParts,
+): WarmTaskLease | null {
+  const stored = currentLease;
+  currentLease = null;
+  if (!stored || stored.key !== buildWarmTaskLeaseKey(parts)) {
+    return null;
+  }
+  return stored.lease;
+}

--- a/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
+++ b/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
@@ -33,6 +33,7 @@ import { resolveLocalSkillPrompt } from "../message-editor/commands";
 import { DEFAULT_PANEL_IDS } from "../panels/panelConstants";
 import { usePanelLayoutStore } from "../panels/panelLayoutStore";
 import { useProvisioningStore } from "../provisioning/store";
+import { takeWarmTaskLease } from "./hooks/warmTaskLease";
 
 interface EnvironmentHostClient {
   environment: {
@@ -153,6 +154,16 @@ export class TrpcTaskCreationHost implements ITaskCreationHost {
         hostClient().skills.list.query(),
       )) ?? prompt
     );
+  }
+
+  takeWarmTaskLease(args: {
+    repository: string;
+    branch?: string | null;
+    runtimeAdapter?: string | null;
+    model?: string | null;
+    reasoningEffort?: string | null;
+  }): { taskId: string; runId: string } | null {
+    return takeWarmTaskLease(args);
   }
 
   uploadRunAttachments(


### PR DESCRIPTION
## Problem

#3056 made a typed first-message `/my-skill` upload its bundle but only on the cold creation path. With sandbox prewarm active, the backend activates the warm run inside `createTask`, the returned task already has `latest_run`, and the saga's `cloud_run` step (skill resolution, bundle upload, `pendingUserMessage`) never executes